### PR TITLE
interfaces: remove leftover reservedForOS

### DIFF
--- a/interfaces/builtin/login_session_observe.go
+++ b/interfaces/builtin/login_session_observe.go
@@ -102,6 +102,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  loginSessionObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: loginSessionObserveConnectedPlugAppArmor,
-		reservedForOS:         true,
 	}})
 }


### PR DESCRIPTION
In one of the recent PRs the reservedForOS part of commonInterface
got removed. Apparently some later commit brought another instance
of this back so this commit fixes that.

