### PR TITLE
uc20: add dtbo partition support for lk boot loader

### DIFF
--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -422,6 +422,19 @@ func (l *Env) FindFreeKernelBootPartition(kernel string) (string, error) {
 	return matr.findFreeBootPartition(installedKernels, kernel)
 }
 
+// FindDtboPartition finds a dtbo image partition to be used for
+// a dtbo image revision based on used boot image partition.
+// each boot partition has dedicated dtbo partition.
+// This optional feature and return string can be empty for not-supported
+func (l *Env) FindDtboPartition(bootPartition string) (string, error) {
+	matr, err := l.variant.dtboImgKernelMatrix()
+	if err != nil {
+		return "", err
+	}
+
+	return matr.getBootPartWithValue(bootPartition)
+}
+
 // GetKernelBootPartition returns the first found boot image partition label
 // that contains a reference to the given kernel revision. If the revision was
 // not found, a non-nil error is returned.
@@ -528,6 +541,12 @@ func (l *Env) GetBootImageName() string {
 		return fn
 	}
 	return BOOTIMG_DEFAULT_NAME
+}
+
+// GetDtboImageName return expected boot image file name in kernel snap. If
+// unset, it will return empty string as dtbo is not in use
+func (l *Env) GetDtboImageName() string {
+	return l.Get("dtboimg_file_name")
 }
 
 // common matrix helper methods which operate on the boot image matrix, which is

--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -139,6 +139,11 @@ type envVariant interface {
 	// partitions. The boot image matrix is used for various recovery system
 	// methods such as FindFreeRecoverySystemBootPartition(), etc.
 	bootImgRecoverySystemMatrix() (bootimgMatrixGeneric, error)
+
+	// dtboImgKernelMatrix returns the dtbo to boot partition maping from the
+	// relavant environment. The dtbo to boot image matrix is used for the
+	// mapping of the correct dtbo partition for used boot image partition.
+	dtboImgKernelMatrix() (bootimgMatrixGeneric, error)
 }
 
 var (

--- a/bootloader/lkenv/lkenv_v1.go
+++ b/bootloader/lkenv/lkenv_v1.go
@@ -216,3 +216,7 @@ func (v1 *SnapBootSelect_v1) bootImgKernelMatrix() (bootimgMatrixGeneric, error)
 func (v1 *SnapBootSelect_v1) bootImgRecoverySystemMatrix() (bootimgMatrixGeneric, error) {
 	return nil, fmt.Errorf("internal error: v1 lkenv has no boot image partition recovery system matrix")
 }
+
+func (v1 *SnapBootSelect_v1) dtboImgKernelMatrix() (bootimgMatrixGeneric, error) {
+	return nil, fmt.Errorf("internal error: v1 lkenv has no dtbo to boot partition matrix")
+}

--- a/bootloader/lkenv/lkenv_v2.go
+++ b/bootloader/lkenv/lkenv_v2.go
@@ -196,6 +196,10 @@ func (v2recovery *SnapBootSelect_v2_recovery) bootImgRecoverySystemMatrix() (boo
 	return (bootimgMatrixGeneric)((&v2recovery.Bootimg_matrix)[:]), nil
 }
 
+func (v2recovery *SnapBootSelect_v2_recovery) dtboImgKernelMatrix() (bootimgMatrixGeneric, error) {
+	return (bootimgMatrixGeneric)((&v2recovery.Bootimg_to_dtboimg_matrix)[:]), nil
+}
+
 func (v2recovery *SnapBootSelect_v2_recovery) bootImgKernelMatrix() (bootimgMatrixGeneric, error) {
 	return nil, fmt.Errorf("internal error: v2 recovery lkenv has no boot image partition kernel matrix")
 }
@@ -364,6 +368,10 @@ func (v2run *SnapBootSelect_v2_run) set(key, value string) {
 
 func (v2run *SnapBootSelect_v2_run) bootImgKernelMatrix() (bootimgMatrixGeneric, error) {
 	return (bootimgMatrixGeneric)((&v2run.Bootimg_matrix)[:]), nil
+}
+
+func (v2run *SnapBootSelect_v2_run) dtboImgKernelMatrix() (bootimgMatrixGeneric, error) {
+	return (bootimgMatrixGeneric)((&v2run.Bootimg_to_dtboimg_matrix)[:]), nil
 }
 
 func (v2run *SnapBootSelect_v2_run) bootImgRecoverySystemMatrix() (bootimgMatrixGeneric, error) {

--- a/bootloader/lkenv/lkenv_v2.go
+++ b/bootloader/lkenv/lkenv_v2.go
@@ -114,12 +114,21 @@ type SnapBootSelect_v2_recovery struct {
 	 */
 	Recovery_system_status [SNAP_FILE_NAME_MAX_LEN]byte
 
+	/**
+	 * Matrix mapping boot partition to the optional dtbo partition
+	 * This matrix is optional and if not populated dtbo is not extracted
+	 * If defined, dtbo image will be extracted to the partions based on used
+	 * bootimg partition
+	 * [ <bootimg 1 part label> ] [ <dtbo 1 part label> ]
+	 * [ <bootimg 2 part label> ] [ <dtbo 2 part label> ]
+	 */
+	Bootimg_to_dtboimg_matrix [SNAP_RUN_BOOTIMG_PART_NUM][2][SNAP_FILE_NAME_MAX_LEN]byte
+
+	/* name of the dtbo image from kernel snap to be used for extraction
+	when not defined or empty, default dtbo.img will be used */
+	Dtboimg_file_name [SNAP_FILE_NAME_MAX_LEN]byte
+
 	/* unused placeholders for additional parameters in the future */
-	Unused_key_01 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_02 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_03 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_04 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_05 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_06 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_07 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_08 [SNAP_FILE_NAME_MAX_LEN]byte
@@ -269,12 +278,21 @@ type SnapBootSelect_v2_run struct {
 	 */
 	Gadget_asset_matrix [SNAP_RUN_BOOTIMG_PART_NUM][2][SNAP_FILE_NAME_MAX_LEN]byte
 
+	/**
+	 * Matrix mapping boot partition to the optional dtbo partition
+	 * This matrix is optional and if not populated dtbo is not extracted
+	 * If defined, dtbo image will be extracted to the partions based on used
+	 * bootimg partition
+	 * [ <bootimg 1 part label> ] [ <dtbo 1 part label> ]
+	 * [ <bootimg 2 part label> ] [ <dtbo 2 part label> ]
+	 */
+	Bootimg_to_dtboimg_matrix [SNAP_RUN_BOOTIMG_PART_NUM][2][SNAP_FILE_NAME_MAX_LEN]byte
+
+	/* name of the dtbo image from kernel snap to be used for extraction
+	when not defined or empty, default dtbo.img will be used */
+	Dtboimg_file_name [SNAP_FILE_NAME_MAX_LEN]byte
+
 	/* unused placeholders for additional parameters in the future */
-	Unused_key_01 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_02 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_03 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_04 [SNAP_FILE_NAME_MAX_LEN]byte
-	Unused_key_05 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_06 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_07 [SNAP_FILE_NAME_MAX_LEN]byte
 	Unused_key_08 [SNAP_FILE_NAME_MAX_LEN]byte

--- a/bootloader/lkenv/lkenv_v2.go
+++ b/bootloader/lkenv/lkenv_v2.go
@@ -169,6 +169,8 @@ func (v2recovery *SnapBootSelect_v2_recovery) get(key string) string {
 		return cToGoString(v2recovery.Snapd_recovery_system[:])
 	case "bootimg_file_name":
 		return cToGoString(v2recovery.Bootimg_file_name[:])
+	case "dtboimg_file_name":
+		return cToGoString(v2recovery.Dtboimg_file_name[:])
 	case "try_recovery_system":
 		return cToGoString(v2recovery.Try_recovery_system[:])
 	case "recovery_system_status":
@@ -185,6 +187,8 @@ func (v2recovery *SnapBootSelect_v2_recovery) set(key, value string) {
 		copyString(v2recovery.Snapd_recovery_system[:], value)
 	case "bootimg_file_name":
 		copyString(v2recovery.Bootimg_file_name[:], value)
+	case "dtboimg_file_name":
+		copyString(v2recovery.Dtboimg_file_name[:], value)
 	case "try_recovery_system":
 		copyString(v2recovery.Try_recovery_system[:], value)
 	case "recovery_system_status":
@@ -345,6 +349,8 @@ func (v2run *SnapBootSelect_v2_run) get(key string) string {
 		return cToGoString(v2run.Snap_try_gadget[:])
 	case "bootimg_file_name":
 		return cToGoString(v2run.Bootimg_file_name[:])
+	case "dtboimg_file_name":
+		return cToGoString(v2run.Dtboimg_file_name[:])
 	}
 	return ""
 }
@@ -363,6 +369,8 @@ func (v2run *SnapBootSelect_v2_run) set(key, value string) {
 		copyString(v2run.Snap_try_gadget[:], value)
 	case "bootimg_file_name":
 		copyString(v2run.Bootimg_file_name[:], value)
+	case "dtboimg_file_name":
+		copyString(v2run.Dtboimg_file_name[:], value)
 	}
 }
 

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -55,6 +55,9 @@ const (
 	// extracted kernels for all uc systems
 	bootImage = "system-boot-image"
 
+	// extracted dtb overlay image for all uc systems
+	dtboImage = "system-dtbo-image"
+
 	// extracted kernels for recovery kernels for uc20 specifically
 	seedBootImage = "system-seed-image"
 
@@ -766,7 +769,7 @@ func validateRole(vs *VolumeStructure, vol *Volume) error {
 		if vs.Filesystem != "" && vs.Filesystem != "none" {
 			return errors.New("mbr structures must not specify a file system")
 		}
-	case SystemBoot, bootImage, bootSelect, seedBootSelect, seedBootImage, "":
+	case SystemBoot, dtboImage, bootImage, bootSelect, seedBootSelect, seedBootImage, "":
 		// noop
 	case legacyBootImage, legacyBootSelect:
 		// noop

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -441,20 +441,30 @@ volumes:
         size: 31457280
         type: 20117F86-E985-4357-B9EE-374BC1D8487D
         role: system-boot-image
-      - name: ubuntu-boot
+      - name: dtbo_a
         offset: 135266304
+        size: 1048576
+        type: 20117F86-E985-4357-B9EE-374BC1D8487D
+        role: system-dtbo-image
+      - name: dtbo_b
+        offset: 136314880
+        size: 1048576
+        type: 20117F86-E985-4357-B9EE-374BC1D8487D
+        role: system-dtbo-image
+      - name: ubuntu-boot
+        offset: 137363456
         filesystem: ext4
         size: 10485760
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         role: system-boot
       - name: ubuntu-seed
-        offset: 145752064
+        offset: 147849216
         filesystem: ext4
         size: 500M
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         role: system-seed
       - name: ubuntu-data
-        offset: 670040064
+        offset: 672137216
         filesystem: ext4
         size: 1G
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4

--- a/include/lk/snappy_boot_v2.h
+++ b/include/lk/snappy_boot_v2.h
@@ -102,12 +102,21 @@ typedef struct SNAP_RUN_BOOT_SELECTION {
      */
     char gadget_asset_matrix[SNAP_RUN_BOOTIMG_PART_NUM][2][SNAP_NAME_MAX_LEN];
 
+    /**
+     * Matrix mapping boot partition to the optional dtbo partition
+     * This matrix is optional and if not populated dtbo is not extracted
+     * If defined, dtbo image will be extracted to the partions based on used
+     * bootimg partition
+     * [ <bootimg 1 part label> ] [ <dtbo 1 part label> ]
+     * [ <bootimg 2 part label> ] [ <dtbo 2 part label> ]
+     */
+    char bootimg_to_dtboimg_matrix[SNAP_RUN_BOOTIMG_PART_NUM][2][SNAP_NAME_MAX_LEN];
+
+    /* name of the dtbo image from kernel snap to be used for extraction
+       when not defined or empty, default dtbo.img will be used */
+    char dtboimg_file_name[SNAP_NAME_MAX_LEN];
+
     /* unused placeholders for additional parameters to be used  in the future */
-    char unused_key_01[SNAP_NAME_MAX_LEN];
-    char unused_key_02[SNAP_NAME_MAX_LEN];
-    char unused_key_03[SNAP_NAME_MAX_LEN];
-    char unused_key_04[SNAP_NAME_MAX_LEN];
-    char unused_key_05[SNAP_NAME_MAX_LEN];
     char unused_key_06[SNAP_NAME_MAX_LEN];
     char unused_key_07[SNAP_NAME_MAX_LEN];
     char unused_key_08[SNAP_NAME_MAX_LEN];
@@ -209,12 +218,21 @@ typedef struct SNAP_RECOVERY_BOOT_SELECTION {
      */
     char recovery_system_status[SNAP_NAME_MAX_LEN];
 
+    /**
+     * Matrix mapping boot partition to the optional dtbo partition
+     * This matrix is optional and if not populated dtbo is not extracted
+     * If defined, dtbo image will be extracted to the partions based on used
+     * bootimg partition
+     * [ <bootimg 1 part label> ] [ <dtbo 1 part label> ]
+     * [ <bootimg 2 part label> ] [ <dtbo 2 part label> ]
+     */
+    char bootimg_to_dtboimg_matrix[SNAP_RUN_BOOTIMG_PART_NUM][2][SNAP_NAME_MAX_LEN];
+
+    /* name of the dtbo image from kernel snap to be used for extraction
+       when not defined or empty, default dtbo.img will be used */
+    char dtboimg_file_name[SNAP_NAME_MAX_LEN];
+
     /* unused placeholders for additional parameters to be used  in the future */
-    char unused_key_01[SNAP_NAME_MAX_LEN];
-    char unused_key_02[SNAP_NAME_MAX_LEN];
-    char unused_key_03[SNAP_NAME_MAX_LEN];
-    char unused_key_04[SNAP_NAME_MAX_LEN];
-    char unused_key_05[SNAP_NAME_MAX_LEN];
     char unused_key_06[SNAP_NAME_MAX_LEN];
     char unused_key_07[SNAP_NAME_MAX_LEN];
     char unused_key_08[SNAP_NAME_MAX_LEN];


### PR DESCRIPTION
Some devices use dtbo image, which is stored in separate partition from where boot image is
This requires lk bootloader plugin to extract correct file from the kernel snap to the correct partition.

We use spare slots in lkenv to define mapping matrix(`Bootimg_to_dtboimg_matrix`). This tells snapd which `dtbo_*` partition is to be used for which `boot_*` partition. Additionally there is also value for dtbo filename (`Dtboimg_file_name`).
Since this is optional feature, defining value for `Dtboimg_file_name` is used to control if in use.

Both `Dtboimg_file_name` and `Bootimg_to_dtboimg_matrix` are static and defined at gadget build time. Snapd does not change or alter any of those values.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
