### PR TITLE
sandbox/apparmor: add GenerateAAREExclusionPatterns

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -129,6 +129,9 @@
     # LD_PRELOAD to be set to a library which is in a directory configured by
     # ld.so.conf, but access to those locations is mediated by this profile
     # (which requires rules for specific locations).
+    # TODO: use GenerateAAREExclusionPatterns for this, though the first
+    # rule and the fact that the generative aspect is not an absolute filepath
+    # complicate using that function directly
     change_profile unsafe /** -> [^u/]**,
     change_profile unsafe /** -> u[^n]**,
     change_profile unsafe /** -> un[^c]**,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -669,6 +669,7 @@ var defaultOtherBaseTemplateRules = `
   # - /lib/modules
   #
   # Everything but /lib/firmware and /lib/modules
+  # TODO: use GenerateAAREExclusionPatterns for this
   /{,usr/}lib/ r,
   /{,usr/}lib/[^fm]** mrklix,
   /{,usr/}lib/{f[^i],m[^o]}** mrklix,
@@ -697,6 +698,7 @@ var defaultOtherBaseTemplateRules = `
   #
   # Everything but /usr/lib and /usr/src, which are handled elsewhere.
   /usr/ r,
+  # TODO: use GenerateAAREExclusionPatterns for this
   /usr/[^ls]** mrklix,
   /usr/{l[^i],s[^r]}** mrklix,
   /usr/{li[^b],sr[^c]}** mrklix,

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -177,156 +178,20 @@ pivot_root,
 # when the AppArmor parser bugs are fixed) this can go back to the much simpler
 # rule:
 # change_profile unsafe /** -> docker-default,
-# but until then we are stuck with:
-change_profile unsafe /[^s]** -> docker-default,
-change_profile unsafe /s[^n]** -> docker-default,
-change_profile unsafe /sn[^a]** -> docker-default,
-change_profile unsafe /sna[^p]** -> docker-default,
-change_profile unsafe /snap[^/]** -> docker-default,
-change_profile unsafe /snap/[^sc]** -> docker-default,
-change_profile unsafe /snap/{s[^n],c[^o]}** -> docker-default,
-change_profile unsafe /snap/{sn[^a],co[^r]}** -> docker-default,
-change_profile unsafe /snap/{sna[^p],cor[^e]}** -> docker-default,
-
-# branch for the /snap/core/... paths
-change_profile unsafe /snap/core[^/]** -> docker-default,
-change_profile unsafe /snap/core/*/[^u]** -> docker-default,
-change_profile unsafe /snap/core/*/u[^s]** -> docker-default,
-change_profile unsafe /snap/core/*/us[^r]** -> docker-default,
-change_profile unsafe /snap/core/*/usr[^/]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/[^l]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/l[^i]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/li[^b]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib[^/]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/[^s]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/s[^n]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/sn[^a]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/sna[^p]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snap[^d]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd[^/]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/[^s]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/s[^n]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/sn[^a]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/sna[^p]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap[^-]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-[^c]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-c[^o]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-co[^n]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-con[^f]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-conf[^i]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-confi[^n]** -> docker-default,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-confin[^e]** -> docker-default,
-
-# branch for the /snap/snapd/... paths
-change_profile unsafe /snap/snap[^d]** -> docker-default,
-change_profile unsafe /snap/snapd[^/]** -> docker-default,
-change_profile unsafe /snap/snapd/*/[^u]** -> docker-default,
-change_profile unsafe /snap/snapd/*/u[^s]** -> docker-default,
-change_profile unsafe /snap/snapd/*/us[^r]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr[^/]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/[^l]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/l[^i]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/li[^b]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib[^/]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/[^s]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/s[^n]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/sn[^a]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/sna[^p]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snap[^d]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd[^/]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/[^s]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/s[^n]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/sn[^a]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/sna[^p]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap[^-]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-[^c]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-c[^o]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-co[^n]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-con[^f]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-conf[^i]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-confi[^n]** -> docker-default,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-confin[^e]** -> docker-default,
-
+# below are auto-generated rules using GenerateAAREExclusionPatterns
+%s
 
 # signal/tracing rules too
 signal (send) peer=docker-default,
 ptrace (read, trace) peer=docker-default,
-
 
 # defaults for containerd
 # TODO: When we drop support for executing other snaps from devmode snaps (or 
 # when the AppArmor parser bugs are fixed) this can go back to the much simpler
 # rule:	
 # change_profile unsafe /** -> cri-containerd.apparmor.d,
-# see above comment, we need this because we can't have nice things
-change_profile unsafe /[^s]** -> cri-containerd.apparmor.d,
-change_profile unsafe /s[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /sn[^a]** -> cri-containerd.apparmor.d,
-change_profile unsafe /sna[^p]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/[^sc]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/{s[^n],c[^o]}** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/{sn[^a],co[^r]}** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/{sna[^p],cor[^e]}** -> cri-containerd.apparmor.d,
-
-# branch for the /snap/core/... paths
-change_profile unsafe /snap/core[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/[^u]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/u[^s]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/us[^r]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/[^l]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/l[^i]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/li[^b]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/[^s]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/s[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/sn[^a]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/sna[^p]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snap[^d]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/[^s]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/s[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/sn[^a]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/sna[^p]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap[^-]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-[^c]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-c[^o]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-co[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-con[^f]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-conf[^i]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-confi[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-confin[^e]** -> cri-containerd.apparmor.d,
-
-# branch for the /snap/snapd/... paths
-change_profile unsafe /snap/snap[^d]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/[^u]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/u[^s]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/us[^r]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/[^l]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/l[^i]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/li[^b]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/[^s]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/s[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/sn[^a]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/sna[^p]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snap[^d]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd[^/]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/[^s]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/s[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/sn[^a]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/sna[^p]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap[^-]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-[^c]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-c[^o]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-co[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-con[^f]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-conf[^i]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-confi[^n]** -> cri-containerd.apparmor.d,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-confin[^e]** -> cri-containerd.apparmor.d,
+# below are auto-generated rules using GenerateAAREExclusionPatterns
+%s
 
 # signal/tracing rules too
 signal (send) peer=cri-containerd.apparmor.d,
@@ -816,74 +681,8 @@ const dockerSupportPrivilegedAppArmor = `
 # but until then we need this set of rules to avoid exec transition conflicts.
 # See also the comment above the "change_profile unsafe /** -> docker-default," 
 # rule for more context.
-change_profile unsafe /[^s]**,
-change_profile unsafe /s[^n]**,
-change_profile unsafe /sn[^a]**,
-change_profile unsafe /sna[^p]**,
-change_profile unsafe /snap[^/]**,
-change_profile unsafe /snap/[^sc]**,
-change_profile unsafe /snap/{s[^n],c[^o]}**,
-change_profile unsafe /snap/{sn[^a],co[^r]}**,
-change_profile unsafe /snap/{sna[^p],cor[^e]}**,
-
-# branch for the /snap/core/... paths
-change_profile unsafe /snap/core[^/]**,
-change_profile unsafe /snap/core/*/[^u]**,
-change_profile unsafe /snap/core/*/u[^s]**,
-change_profile unsafe /snap/core/*/us[^r]**,
-change_profile unsafe /snap/core/*/usr[^/]**,
-change_profile unsafe /snap/core/*/usr/[^l]**,
-change_profile unsafe /snap/core/*/usr/l[^i]**,
-change_profile unsafe /snap/core/*/usr/li[^b]**,
-change_profile unsafe /snap/core/*/usr/lib[^/]**,
-change_profile unsafe /snap/core/*/usr/lib/[^s]**,
-change_profile unsafe /snap/core/*/usr/lib/s[^n]**,
-change_profile unsafe /snap/core/*/usr/lib/sn[^a]**,
-change_profile unsafe /snap/core/*/usr/lib/sna[^p]**,
-change_profile unsafe /snap/core/*/usr/lib/snap[^d]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd[^/]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/[^s]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/s[^n]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/sn[^a]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/sna[^p]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap[^-]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-[^c]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-c[^o]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-co[^n]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-con[^f]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-conf[^i]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-confi[^n]**,
-change_profile unsafe /snap/core/*/usr/lib/snapd/snap-confin[^e]**,
-
-# branch for the /snap/snapd/... paths
-change_profile unsafe /snap/snap[^d]**,
-change_profile unsafe /snap/snapd[^/]**,
-change_profile unsafe /snap/snapd/*/[^u]**,
-change_profile unsafe /snap/snapd/*/u[^s]**,
-change_profile unsafe /snap/snapd/*/us[^r]**,
-change_profile unsafe /snap/snapd/*/usr[^/]**,
-change_profile unsafe /snap/snapd/*/usr/[^l]**,
-change_profile unsafe /snap/snapd/*/usr/l[^i]**,
-change_profile unsafe /snap/snapd/*/usr/li[^b]**,
-change_profile unsafe /snap/snapd/*/usr/lib[^/]**,
-change_profile unsafe /snap/snapd/*/usr/lib/[^s]**,
-change_profile unsafe /snap/snapd/*/usr/lib/s[^n]**,
-change_profile unsafe /snap/snapd/*/usr/lib/sn[^a]**,
-change_profile unsafe /snap/snapd/*/usr/lib/sna[^p]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snap[^d]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd[^/]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/[^s]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/s[^n]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/sn[^a]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/sna[^p]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap[^-]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-[^c]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-c[^o]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-co[^n]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-con[^f]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-conf[^i]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-confi[^n]**,
-change_profile unsafe /snap/snapd/*/usr/lib/snapd/snap-confin[^e]**,
+# below are auto-generated rules using GenerateAAREExclusionPatterns
+%s
 
 # allow signaling and tracing any unconfined process since if containers are 
 # launched without confinement docker still needs to trace them
@@ -906,73 +705,8 @@ ptrace (read, trace) peer=unconfined,
 # but until then we need this set of rules to avoid exec transition conflicts.
 # See also the comment above the "change_profile unsafe /** -> docker-default," 
 # rule for more context.
-/[^s]** rwlix,
-/s[^n]** rwlix,
-/sn[^a]** rwlix,
-/sna[^p]** rwlix,
-/snap/[^sc]** rwlix,
-/snap/{s[^n],c[^o]}** rwlix,
-/snap/{sn[^a],co[^r]}** rwlix,
-/snap/{sna[^p],cor[^e]}** rwlix,
-
-# branch for the /snap/core/... paths
-/snap/core[^/]** rwlix,
-/snap/core/*/[^u]** rwlix,
-/snap/core/*/u[^s]** rwlix,
-/snap/core/*/us[^r]** rwlix,
-/snap/core/*/usr[^/]** rwlix,
-/snap/core/*/usr/[^l]** rwlix,
-/snap/core/*/usr/l[^i]** rwlix,
-/snap/core/*/usr/li[^b]** rwlix,
-/snap/core/*/usr/lib[^/]** rwlix,
-/snap/core/*/usr/lib/[^s]** rwlix,
-/snap/core/*/usr/lib/s[^n]** rwlix,
-/snap/core/*/usr/lib/sn[^a]** rwlix,
-/snap/core/*/usr/lib/sna[^p]** rwlix,
-/snap/core/*/usr/lib/snap[^d]** rwlix,
-/snap/core/*/usr/lib/snapd[^/]** rwlix,
-/snap/core/*/usr/lib/snapd/[^s]** rwlix,
-/snap/core/*/usr/lib/snapd/s[^n]** rwlix,
-/snap/core/*/usr/lib/snapd/sn[^a]** rwlix,
-/snap/core/*/usr/lib/snapd/sna[^p]** rwlix,
-/snap/core/*/usr/lib/snapd/snap[^-]** rwlix,
-/snap/core/*/usr/lib/snapd/snap-[^c]** rwlix,
-/snap/core/*/usr/lib/snapd/snap-c[^o]** rwlix,
-/snap/core/*/usr/lib/snapd/snap-co[^n]** rwlix,
-/snap/core/*/usr/lib/snapd/snap-con[^f]** rwlix,
-/snap/core/*/usr/lib/snapd/snap-conf[^i]** rwlix,
-/snap/core/*/usr/lib/snapd/snap-confi[^n]** rwlix,
-/snap/core/*/usr/lib/snapd/snap-confin[^e]** rwlix,
-
-# branch for the /snap/snapd/... paths
-/snap/snap[^d]** rwlix,
-/snap/snapd[^/]** rwlix,
-/snap/snapd/*/[^u]** rwlix,
-/snap/snapd/*/u[^s]** rwlix,
-/snap/snapd/*/us[^r]** rwlix,
-/snap/snapd/*/usr[^/]** rwlix,
-/snap/snapd/*/usr/[^l]** rwlix,
-/snap/snapd/*/usr/l[^i]** rwlix,
-/snap/snapd/*/usr/li[^b]** rwlix,
-/snap/snapd/*/usr/lib[^/]** rwlix,
-/snap/snapd/*/usr/lib/[^s]** rwlix,
-/snap/snapd/*/usr/lib/s[^n]** rwlix,
-/snap/snapd/*/usr/lib/sn[^a]** rwlix,
-/snap/snapd/*/usr/lib/sna[^p]** rwlix,
-/snap/snapd/*/usr/lib/snap[^d]** rwlix,
-/snap/snapd/*/usr/lib/snapd[^/]** rwlix,
-/snap/snapd/*/usr/lib/snapd/[^s]** rwlix,
-/snap/snapd/*/usr/lib/snapd/s[^n]** rwlix,
-/snap/snapd/*/usr/lib/snapd/sn[^a]** rwlix,
-/snap/snapd/*/usr/lib/snapd/sna[^p]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap[^-]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap-[^c]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap-c[^o]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap-co[^n]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap-con[^f]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap-conf[^i]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap-confi[^n]** rwlix,
-/snap/snapd/*/usr/lib/snapd/snap-confin[^e]** rwlix,
+# below are auto-generated rules using GenerateAAREExclusionPatterns
+%s
 `
 
 const dockerSupportPrivilegedSecComp = `
@@ -1006,9 +740,68 @@ func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	// The 'change_profile unsafe' rules conflict with the 'ix' rules in
 	// the home interface, so suppress them (LP: #1797786)
 	spec.SetSuppressHomeIx()
-	spec.AddSnippet(dockerSupportConnectedPlugAppArmor)
+
+	dockerDefaultTransitionRules, err := apparmor_sandbox.GenerateAAREExclusionPatterns(
+		[]string{
+			"/snap/snapd/*/usr/lib/snapd/snap-confine",
+			"/snap/core/*/usr/lib/snapd/snap-confine",
+		},
+		&apparmor_sandbox.AAREExclusionPatternsOptions{
+			Prefix: "change_profile unsafe ",
+			Suffix: " -> docker-default,",
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	containerdTransitionRules, err := apparmor_sandbox.GenerateAAREExclusionPatterns(
+		[]string{
+			"/snap/snapd/*/usr/lib/snapd/snap-confine",
+			"/snap/core/*/usr/lib/snapd/snap-confine",
+		},
+		&apparmor_sandbox.AAREExclusionPatternsOptions{
+			Prefix: "change_profile unsafe ",
+			Suffix: " -> docker-default,",
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	defaultSnippet := fmt.Sprintf(dockerSupportConnectedPlugAppArmor, dockerDefaultTransitionRules, containerdTransitionRules)
+	spec.AddSnippet(defaultSnippet)
 	if privileged {
-		spec.AddSnippet(dockerSupportPrivilegedAppArmor)
+		changeProfileAnythingRules, err := apparmor_sandbox.GenerateAAREExclusionPatterns(
+			[]string{
+				"/snap/snapd/*/usr/lib/snapd/snap-confine",
+				"/snap/core/*/usr/lib/snapd/snap-confine",
+			},
+			&apparmor_sandbox.AAREExclusionPatternsOptions{
+				Prefix: "change_profile unsafe ",
+				Suffix: ",",
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		inheritExecAnythingRules, err := apparmor_sandbox.GenerateAAREExclusionPatterns(
+			[]string{
+				"/snap/snapd/*/usr/lib/snapd/snap-confine",
+				"/snap/core/*/usr/lib/snapd/snap-confine",
+			},
+			&apparmor_sandbox.AAREExclusionPatternsOptions{
+				Prefix: "",
+				Suffix: " rwlix,",
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		privilegedSnippet := fmt.Sprintf(dockerSupportPrivilegedAppArmor, changeProfileAnythingRules, inheritExecAnythingRules)
+		spec.AddSnippet(privilegedSnippet)
 	}
 	if !release.OnClassic {
 		spec.AddSnippet(dockerSupportConnectedPlugAppArmorCore)

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -56,6 +56,9 @@ owner @{HOME}/ r,
 
 # Allow read/write access to all files in @{HOME}, except snap application
 # data in @{HOME}/snap and toplevel hidden directories in @{HOME}.
+# TODO: use GenerateAAREExclusionPatterns for this - though the first
+# rule here complicates using it slightly from the inclusion of the "." to 
+# prevent reading dotfiles
 owner @{HOME}/[^s.]**             rwkl###HOME_IX###,
 owner @{HOME}/s[^n]**             rwkl###HOME_IX###,
 owner @{HOME}/sn[^a]**            rwkl###HOME_IX###,
@@ -84,6 +87,9 @@ audit deny @{HOME}/bin/{,**} wl,
 const homeConnectedPlugAppArmorWithAllRead = `
 # Allow non-owner read to non-hidden and non-snap files and directories
 capability dac_read_search,
+# TODO: use GenerateAAREExclusionPatterns for this - though the first
+# rule here complicates using it slightly from the inclusion of the "." to 
+# prevent reading dotfiles
 @{HOME}/               r,
 @{HOME}/[^s.]**        r,
 @{HOME}/s[^n]**        r,

--- a/interfaces/builtin/system_backup.go
+++ b/interfaces/builtin/system_backup.go
@@ -34,6 +34,7 @@ const systemBackupConnectedPlugAppArmor = `
 capability dac_read_search,
 
 # read access to everything except items under /dev, /sys and /proc
+# TODO: use GenerateAAREExclusionPatterns for this
 /{,var/lib/snapd/hostfs/}[^dsp]** r,
 /{,var/lib/snapd/hostfs/}{d[^e],s[^y],p[^r]}** r,
 /{,var/lib/snapd/hostfs/}{de[^v],sy[^s],pr[^o]}** r,

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -134,6 +134,8 @@ func verifySlotPathAttribute(slotRef *interfaces.SlotRef, attrs interfaces.Attre
 //   "f[^o]*",
 //   "fo[^o]*",
 // }
+// For a more generic version of this see GenerateAAREExclusionPatterns
+// TODO: can this be rewritten to use/share code with that function instead?
 func aareExclusivePatterns(orig string) []string {
 	// This function currently is only intended to be used with desktop
 	// prefixes as calculated by info.DesktopPrefix (the snap name and

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -273,7 +273,7 @@ charLoop:
 				return "", fmt.Errorf("internal erorr: all excluded patterns are the same")
 			}
 
-			negGroup := []rune("[^")
+			negGroup := []rune{}
 			for c := range chars {
 				negGroup = append(negGroup, c)
 			}
@@ -281,7 +281,7 @@ charLoop:
 			sort.Slice(negGroup, func(i, j int) bool {
 				return negGroup[i] < negGroup[j]
 			})
-			negGroup = append(negGroup, ']')
+			negGroup = append([]rune("[^"), append(negGroup, ']')...)
 
 			res := fmt.Sprintf("%s%s%s**%s\n", opts.Prefix, lastCommonPrefix, string(negGroup), opts.Suffix)
 			builder.WriteString(res)
@@ -327,6 +327,14 @@ charLoop:
 			for patternIndex, excludePattern = range stillPresentPatterns {
 				break
 			}
+
+			// TODO: when AAREExclusionPatternsOptions has an option for
+			// supporting non-absolute filepaths, use that option here to
+			// generate the rules with generateAAREExclusionPatternsSingle to
+			// reuse that loop by effectively dropping the part of
+			// excludePattern up to "k" we calculate below, and adding that to
+			// the prefix passed to generateAAREExclusionPatternsSingle and then
+			// this is the same exact case
 
 			for k := indexPerPattern[patternIndex]; k < len(excludePattern); k++ {
 				c := excludePattern[k]

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -21,6 +21,7 @@ package apparmor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -46,6 +47,401 @@ func ValidateNoAppArmorRegexp(s string) error {
 		return fmt.Errorf("%q contains a reserved apparmor char from %s", s, AARE)
 	}
 	return nil
+}
+
+func GenerateAAREExclusionPatternsSingle(excludePattern []rune, opts *AAREExclusionPatternsOptions) (string, error) {
+	// no error checking of input as that was already done in
+	// GenerateAAREExclusionPatterns
+
+	// TODO: this logic could be combined with some of the more complex logic in
+	// GenerateAAREExclusionPatternsGenericImpl but those loops are
+	// subtly more complex so that is left for another time
+	builder := &strings.Builder{}
+	for i := 1; i < len(excludePattern); i++ {
+		c := excludePattern[i]
+		switch c {
+		case '*':
+			// skip this element, this is the regular expression
+			continue
+		case '/':
+			// check if the previous element was a "*" in which case we
+			// skip this one too
+			if excludePattern[i-1] == '*' {
+				continue
+			}
+		}
+		res := fmt.Sprintf("%s%s[^%c]**%s\n", opts.Prefix, string(excludePattern[:i]), c, opts.Suffix)
+		builder.WriteString(res)
+	}
+	return builder.String(), nil
+}
+
+type AAREExclusionPatternsOptions struct {
+	// Prefix is a string to include on every line in the permutations before
+	// the exclusion permutation itself.
+	Prefix string
+	// Suffix is a string to include on every line in the permutations after
+	// the exclusion permutation itself.
+	Suffix string
+
+	// TODO: add options for generating non-filepaths like what we need for the
+	// unconfined profile transition exclusion in snap-confine's profile as well
+	// as an option for adding an extra character to the very first rule like we
+	// need in the home interface
+}
+
+// GenerateAAREExclusionPatterns generates a series of valid AppArmor
+// regular expression negation rules such that anything except the specific
+// excludePatterns will match with the specified prefix and suffix rules. For
+// example to allow reading any file except those matching /usr/*/foo, you would
+// call this function with "/usr/*/foo" as the first argument, "" as the prefix
+// and " r," as the suffix (the suffix being the main part of the read rule) and
+// this function would return the following multi-line string with the relevant
+// rules:
+//
+// /[^u]** r,
+// /u[^s]** r,
+// /us[^r]** r,
+// /usr[^/]** r,
+// /usr/*/[^f]** r,
+// /usr/*/f[^o]** r,
+// /usr/*/fo[^o]** r,
+//
+// This function only treats '*' specially in the string and does not handle any
+// other alternations etc. that AARE may more generally support, and all
+// patterns provided must be absolute filepaths that are at least 2 runes long.
+//
+// This function also works with multiple exclude patterns such as specifying to
+// exclude "/usr/lib/snapd" and "/var/lib/snapd" with suffix " r," would yield:
+//
+// /[^uv]** r,
+// /{u[^s],v[^a]}** r,
+// /{us[^r],va[^r]}** r,
+// /{usr[^/],var[^/]}** r,
+// /{usr/[^l],var/[^l]}** r,
+// /{usr/l[^i],var/l[^i]}** r,
+// /{usr/li[^b],var/li[^b]}** r,
+// /{usr/lib[^/],var/lib[^/]}** r,
+// /{usr/lib/[^s],var/lib/[^s]}** r,
+// /{usr/lib/s[^n],var/lib/s[^n]}** r,
+// /{usr/lib/sn[^a],var/lib/sn[^a]}** r,
+// /{usr/lib/sna[^p],var/lib/sna[^p]}** r,
+// /{usr/lib/snap[^d],var/lib/snap[^d]}** r,
+//
+func GenerateAAREExclusionPatterns(excludePatterns []string, opts *AAREExclusionPatternsOptions) (string, error) {
+	seen := map[string]bool{}
+	runeSlices := make([][]rune, 0, len(excludePatterns))
+	for _, patt := range excludePatterns {
+		// check for duplicates
+		if seen[patt] {
+			return "", errors.New("exclude patterns contain duplicates")
+		}
+		seen[patt] = true
+
+		// check if it is at least legnth 1
+		if len(patt) < 2 {
+			return "", errors.New("exclude patterns must be at least length 2")
+		}
+
+		// check that it starts as an absolute path
+		if patt[0] != '/' {
+			return "", errors.New("exclude patterns must be absolute filepaths")
+		}
+
+		// TODO: we use runes here because Go makes it easy but does AppArmor
+		// actually understand UTF-8/Unicode properly? perhaps we should
+		// validate that all runes in the pattern are supported by apparmor roo?
+
+		// TODO: should we also validate that the only character in the pattern
+		// from AARE is "*" ?
+
+		runeSlices = append(runeSlices, []rune(patt))
+	}
+	if opts == nil {
+		opts = &AAREExclusionPatternsOptions{}
+	}
+	return GenerateAAREExclusionPatternsGenericImpl(runeSlices, opts)
+}
+
+func GenerateAAREExclusionPatternsGenericImpl(excludePatterns [][]rune, opts *AAREExclusionPatternsOptions) (string, error) {
+	switch len(excludePatterns) {
+	case 0:
+		return "", fmt.Errorf("no patterns provided")
+	case 1:
+		// single pattern generation is simpler and doesn't need to consider
+		// generating alternatives like in /foo/{a[^b],c[^d]} etc. so we do that
+		// case separately for easier reasoning about the generic case
+		return GenerateAAREExclusionPatternsSingle(excludePatterns[0], opts)
+	}
+
+	// figure out the shortest and longest strings for setting loop ranges below
+	shortestStrLen := len(excludePatterns[0])
+	longestStrLen := len(excludePatterns[0])
+	for _, patt := range excludePatterns {
+		// save the shortest pattern length for computing the longest common substring below
+		if len(patt) < shortestStrLen {
+			shortestStrLen = len(patt)
+		}
+		if len(patt) > longestStrLen {
+			longestStrLen = len(patt)
+		}
+	}
+
+	builder := &strings.Builder{}
+
+	// find the longest common prefix in all the patterns
+	endCommonPrefix := 0
+
+commonSubStrLoop:
+	for i := 0; i < shortestStrLen; i++ {
+		// ok to use 0 index here since by definition the first exclude
+		// pattern's common prefix is common with all other patterns
+		pattChar := excludePatterns[0][i]
+		for _, patt := range excludePatterns[1:] {
+			if patt[i] != pattChar {
+				break commonSubStrLoop
+			}
+		}
+		endCommonPrefix = i + 1
+	}
+
+	// for keeping track of the last rule for the common case before we get to
+	// the overlapping cases
+	var lastCommonPrefix string
+
+	// iterate up to the longest string we have - saving the iteration variable
+	// for the case when we get past the common substrings and do a separate
+	// kind of loop below, mainly just for readability to avoid nesting things
+	// too deeply
+	var i int
+charLoop:
+	for i = 0; i < longestStrLen; i++ {
+		switch {
+		case i < endCommonPrefix:
+			// then generate common simple rules
+			c := excludePatterns[0][i]
+			switch c {
+			case '*':
+				// skip this element, this is the wildcard
+				continue
+			case '/':
+				// check if this is the first character or if the previous
+				// element was a "*" in which case we skip this one too
+				if i == 0 {
+					// this is for the case where the only common character is
+					// actually the first "/" character
+					lastCommonPrefix = string(c)
+					continue
+				}
+				if excludePatterns[0][i-1] == '*' {
+					// this is for the case where the last common characters are
+					// "*/" if there are other common characters after this, it
+					// will get overwritten on the next iteration
+					lastCommonPrefix = lastCommonPrefix + "*/"
+					continue
+				}
+			}
+			// snippet up to this character so far - again since this is the
+			// common prefix we can just use the first pattern
+			snippet := string(excludePatterns[0][:i])
+			res := fmt.Sprintf("%s%s[^%c]**%s\n", opts.Prefix, snippet, c, opts.Suffix)
+
+			builder.WriteString(res)
+
+			// save this as the most recent common sub string pattern
+			lastCommonPrefix = snippet + string(c)
+		case i == endCommonPrefix:
+			// this is the last bit of the common substring, so get all the
+			// characters for each pattern and just make a negative match for
+			// all of those characters
+
+			// note we use a map because there could be duplicate characters,
+			// for example we could have 3 strings like "abcd1", "abcd2", "abceee",
+			// where after the first common characters among the 3, there is
+			// another common character with first 2 exclude patterns not in the
+			// third
+			chars := map[rune]bool{}
+			for _, pattern := range excludePatterns {
+				if i >= len(pattern) {
+					continue
+				}
+				chars[pattern[i]] = true
+			}
+			if len(chars) == 0 {
+				// shouldn't happen in practice, we check for duplicates above
+				// but just be on the safe side
+				return "", fmt.Errorf("internal erorr: all excluded patterns are the same")
+			}
+
+			negGroup := []rune("[^")
+			for c := range chars {
+				negGroup = append(negGroup, c)
+			}
+			// make sure the runs are sorted for consistency
+			sort.Slice(negGroup, func(i, j int) bool {
+				return negGroup[i] < negGroup[j]
+			})
+			negGroup = append(negGroup, ']')
+
+			res := fmt.Sprintf("%s%s%s**%s\n", opts.Prefix, lastCommonPrefix, string(negGroup), opts.Suffix)
+			builder.WriteString(res)
+
+		case i > endCommonPrefix:
+			// we break and use a separate loop because here we now need to
+			// handle indexes per pattern because "*" could be in different
+			// locations in each of the exclude patterns and we can no longer
+			// use one index for all patterns
+			break charLoop
+		}
+	}
+
+	// each pattern starts at i
+	indexPerPattern := make([]int, len(excludePatterns))
+	for i2 := range excludePatterns {
+		indexPerPattern[i2] = i
+	}
+
+	// this loop iterates up until the longestStrLen is reached or until we
+	// reach only one pattern left which then collapses into a simpler special
+	// case
+	for j := i; j < longestStrLen; j++ {
+		// check what patterns still have characters left
+		stillPresentPatterns := map[int][]rune{}
+		for patternIndex, excludePattern := range excludePatterns {
+			charIndex := indexPerPattern[patternIndex]
+			if charIndex >= len(excludePattern) {
+				continue
+			}
+			stillPresentPatterns[patternIndex] = excludePattern
+		}
+
+		// maybe we only have one pattern left which means we can take a
+		// shortcut
+		if len(stillPresentPatterns) == 1 {
+			// there is only one group left from here and we can do the simple
+			// generation with this pattern for the rest of the rules
+
+			// we know it's of length one so this is a short cut to get the vars
+			var patternIndex int
+			var excludePattern []rune
+			for patternIndex, excludePattern = range stillPresentPatterns {
+				break
+			}
+
+			for k := indexPerPattern[patternIndex]; k < len(excludePattern); k++ {
+				c := excludePattern[k]
+				switch c {
+				case '*':
+					// skip this element, this is the wildcard
+					continue
+				case '/':
+					// check if the previous element was a "*" in which case we
+					// skip this one too
+					if excludePattern[k-1] == '*' {
+						continue
+					}
+				}
+				res := fmt.Sprintf("%s%s[^%c]**%s\n", opts.Prefix, string(excludePattern[:k]), c, opts.Suffix)
+				builder.WriteString(res)
+			}
+
+			// TODO: maybe a return here would be more readable?
+			// all rules have been generated we are done
+			break
+		}
+
+		// otherwise there are still multiple patterns left so collect the
+		// previous characters up to this alternation and this specific
+		// character for each of the exclude patterns
+		negCharsByAllowChars := map[string]*strutil.OrderedSet{}
+		// meh if Go had deterministic loop iteration we wouldn't need this var
+		allPrevs := strutil.OrderedSet{}
+		for patternIndex := range excludePatterns {
+			excludePattern, ok := stillPresentPatterns[patternIndex]
+			if !ok {
+				// not present
+				continue
+			}
+
+			charIndex := indexPerPattern[patternIndex]
+			c := excludePattern[charIndex]
+			// increment this character, regardless of whether it is a wildcard
+			// or not we consumed it this iteration
+			indexPerPattern[patternIndex]++
+
+			switch c {
+			case '*':
+				// skip this element, this is the wildcard
+				continue
+			case '/':
+				// check if the previous element was a "*" in which case we
+				// skip this one too
+				if excludePattern[charIndex-1] == '*' {
+					continue
+				}
+			}
+
+			// trim the common prefix from the exclude pattern since it is
+			// common and will be outside the alternation leaving us just with
+			// the unique previous characters for this exclude pattern
+			prev := strings.TrimPrefix(string(excludePattern[:charIndex]), lastCommonPrefix)
+
+			// append into a list of runes to be excluded since there could be
+			// multiple individual characters which are excluded which share the
+			// same previous character, this shows up for example with "/a/bc"
+			// and "/a/bd" - AppArmor does not like this pattern:
+			// /a/{b[^c],b[^d]}
+			// but finds this one acceptable:
+			// /a/b[^cd]
+			if negCharsByAllowChars[prev] == nil {
+				negCharsByAllowChars[prev] = &strutil.OrderedSet{}
+			}
+			negCharsByAllowChars[prev].Put(string(c))
+			allPrevs.Put(prev)
+		}
+
+		// now actually generate the sub rule either with a {<FOO>,<BAR>}
+		// or just with [FOO] or nothing if the previous characters were "*/"
+		var subPattern string
+		switch len(negCharsByAllowChars) {
+		case 0:
+			// no characters at all, meaning that the "*" likely just happened
+			// at the same spot for multiple patterns
+			continue
+		case 1:
+			// only one pattern meaning we don't use "{}"
+			var prevAllowChar string
+			var negCharsSet *strutil.OrderedSet
+			for prevAllowChar, negCharsSet = range negCharsByAllowChars {
+				break
+			}
+			allNegChars := ""
+			for _, negChar := range negCharsSet.Items() {
+				allNegChars += string(negChar)
+			}
+			subPattern = fmt.Sprintf("%s[^%s]", prevAllowChar, allNegChars)
+		default:
+			// join the various alternations together with {}
+			alternations := []string{}
+			// sort for a consistent order
+			allPrevsSlice := allPrevs.Items()
+			sort.Strings(allPrevsSlice)
+			for _, prev := range allPrevsSlice {
+				negCharsSet := negCharsByAllowChars[prev]
+				allNegChars := ""
+				for _, negChar := range negCharsSet.Items() {
+					allNegChars += string(negChar)
+				}
+				alternations = append(alternations, fmt.Sprintf("%s[^%s]", prev, allNegChars))
+			}
+			subPattern = fmt.Sprintf("{%s}", strings.Join(alternations, ","))
+		}
+
+		res := fmt.Sprintf("%s%s%s**%s\n", opts.Prefix, lastCommonPrefix, subPattern, opts.Suffix)
+		builder.WriteString(res)
+	}
+
+	return builder.String(), nil
 }
 
 // LevelType encodes the kind of support for apparmor

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -49,7 +49,7 @@ func ValidateNoAppArmorRegexp(s string) error {
 	return nil
 }
 
-func GenerateAAREExclusionPatternsSingle(excludePattern []rune, opts *AAREExclusionPatternsOptions) (string, error) {
+func generateAAREExclusionPatternsSingle(excludePattern []rune, opts *AAREExclusionPatternsOptions) (string, error) {
 	// no error checking of input as that was already done in
 	// GenerateAAREExclusionPatterns
 
@@ -160,10 +160,10 @@ func GenerateAAREExclusionPatterns(excludePatterns []string, opts *AAREExclusion
 	if opts == nil {
 		opts = &AAREExclusionPatternsOptions{}
 	}
-	return GenerateAAREExclusionPatternsGenericImpl(runeSlices, opts)
+	return generateAAREExclusionPatternsGenericImpl(runeSlices, opts)
 }
 
-func GenerateAAREExclusionPatternsGenericImpl(excludePatterns [][]rune, opts *AAREExclusionPatternsOptions) (string, error) {
+func generateAAREExclusionPatternsGenericImpl(excludePatterns [][]rune, opts *AAREExclusionPatternsOptions) (string, error) {
 	switch len(excludePatterns) {
 	case 0:
 		return "", fmt.Errorf("no patterns provided")
@@ -171,7 +171,7 @@ func GenerateAAREExclusionPatternsGenericImpl(excludePatterns [][]rune, opts *AA
 		// single pattern generation is simpler and doesn't need to consider
 		// generating alternatives like in /foo/{a[^b],c[^d]} etc. so we do that
 		// case separately for easier reasoning about the generic case
-		return GenerateAAREExclusionPatternsSingle(excludePatterns[0], opts)
+		return generateAAREExclusionPatternsSingle(excludePatterns[0], opts)
 	}
 
 	// figure out the shortest and longest strings for setting loop ranges below

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -449,6 +449,14 @@ pre /a[^b]** suf
 `[1:],
 		},
 		{
+			comment:         "same length overlap",
+			excludePatterns: []string{"/AB", "/AC"},
+			expRule: `
+/[^A]**
+/A[^BC]**
+`[1:],
+		},
+		{
 			comment:         "same length overlap with wildcard",
 			excludePatterns: []string{"/ab/*/c", "/ad/*/c"},
 			expRule: `

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -375,3 +375,351 @@ func (s *apparmorSuite) TestValidateFreeFromAAREhappy(c *C) {
 		c.Check(apparmor.ValidateNoAppArmorRegexp(s), IsNil, Commentf("%q raised an error but shouldn't", s))
 	}
 }
+
+func (s *apparmorSuite) TestGenerateAAREExclusionPatterns(c *C) {
+	tt := []struct {
+		comment         string
+		excludePatterns []string
+		prefix          string
+		suffix          string
+		err             string
+		expRule         string
+	}{
+		// simple single pattern cases
+		{
+			comment:         "single shortest",
+			excludePatterns: []string{"/ab"},
+			prefix:          "pre ",
+			suffix:          " suf",
+			expRule: `
+pre /[^a]** suf
+pre /a[^b]** suf
+`[1:],
+		},
+		{
+			comment:         "single simple with wildcard",
+			excludePatterns: []string{"/a/*/bc"},
+			expRule: `
+/[^a]**
+/a[^/]**
+/a/*/[^b]**
+/a/*/b[^c]**
+`[1:],
+		},
+
+		// multiple pattern cases
+		{
+			comment:         "same length no overlap shortest",
+			excludePatterns: []string{"/a", "/d"},
+			expRule: `
+/[^ad]**
+`[1:],
+		},
+		{
+			comment:         "diff length no overlap shortest",
+			excludePatterns: []string{"/a", "/dc"},
+			expRule: `
+/[^ad]**
+/d[^c]**
+`[1:],
+		},
+		{
+			comment:         "diff length overlap",
+			excludePatterns: []string{"/ad", "/adc"},
+			expRule: `
+/[^a]**
+/a[^d]**
+/ad[^c]**
+`[1:],
+		},
+		{
+			comment:         "same length no overlap",
+			excludePatterns: []string{"/ab", "/de"},
+			expRule: `
+/[^ad]**
+/{a[^b],d[^e]}**
+`[1:],
+		},
+		{
+			comment:         "same length overlap",
+			excludePatterns: []string{"/ab", "/ac"},
+			expRule: `
+/[^a]**
+/a[^bc]**
+`[1:],
+		},
+		{
+			comment:         "same length overlap with wildcard",
+			excludePatterns: []string{"/ab/*/c", "/ad/*/c"},
+			expRule: `
+/[^a]**
+/a[^bd]**
+/a{b[^/],d[^/]}**
+/a{b/*/[^c],d/*/[^c]}**
+`[1:],
+		},
+		{
+			comment: "different length same overlap with extra nonoverlapping",
+			// this is special because if we weren't using an OrderedSet and
+			// instead had a []rune in the negCharsByAllowChars impl, we would
+			// get rules like
+			// /a/{b[^cc],f[^g]}
+			// instead of the correct one which is de-duplicated like
+			// /a/{b[^c],f[^g]}
+			// apparmor doesn't like the former and only accepts the latter
+			excludePatterns: []string{"/a/bc/d", "/a/bc/e", "/a/fg"},
+			expRule: `
+/[^a]**
+/a[^/]**
+/a/[^bf]**
+/a/{b[^c],f[^g]}**
+/a/bc[^/]**
+/a/bc/[^de]**
+`[1:],
+		},
+		{
+			comment:         "diff length overlap with wildcard",
+			excludePatterns: []string{"/abc/*/c", "/ad/*/c"},
+			expRule: `
+/[^a]**
+/a[^bd]**
+/a{b[^c],d[^/]}**
+/abc[^/]**
+/ad/*/[^c]**
+/abc/*/[^c]**
+`[1:],
+		},
+		{
+			comment:         "more diff length overlap with wildcard",
+			excludePatterns: []string{"/abc/*/c", "/ad/*/c", "/ab/*/e"},
+			expRule: `
+/[^a]**
+/a[^bd]**
+/a{b[^c/],d[^/]}**
+/abc[^/]**
+/a{b/*/[^e],d/*/[^c]}**
+/abc/*/[^c]**
+`[1:],
+		},
+		{
+			comment:         "very diff length overlap with wildcard after diff length",
+			excludePatterns: []string{"/abc/*/c/*/e", "/ad/*/c"},
+			expRule: `
+/[^a]**
+/a[^bd]**
+/a{b[^c],d[^/]}**
+/abc[^/]**
+/ad/*/[^c]**
+/abc/*/[^c]**
+/abc/*/c[^/]**
+/abc/*/c/*/[^e]**
+`[1:],
+		},
+		{
+			comment:         "same length overlap with wildcard in overlap",
+			excludePatterns: []string{"/a/*/b", "/a/*/c"},
+			expRule: `
+/[^a]**
+/a[^/]**
+/a/*/[^bc]**
+`[1:],
+		},
+
+		// unhappy cases
+		{
+			comment:         "duplicates",
+			excludePatterns: []string{"/ab/*/c", "/ad/*/c", "/ad/*/c"},
+			err:             "exclude patterns contain duplicates",
+		},
+		{
+			comment:         "nothing",
+			excludePatterns: []string{},
+			err:             "no patterns provided",
+		},
+		{
+			comment:         "relative path",
+			excludePatterns: []string{"foo"},
+			err:             "exclude patterns must be absolute filepaths",
+		},
+
+		// specific cases used around codebase
+		{
+			comment: "any file inherit exec rules except snap-confine for devmode snap executing other snaps",
+			excludePatterns: []string{
+				"/snap/snapd/*/usr/lib/snapd/snap-confine",
+				"/snap/core/*/usr/lib/snapd/snap-confine",
+			},
+			prefix: "",
+			suffix: " rwlix,",
+			expRule: `
+/[^s]** rwlix,
+/s[^n]** rwlix,
+/sn[^a]** rwlix,
+/sna[^p]** rwlix,
+/snap[^/]** rwlix,
+/snap/[^cs]** rwlix,
+/snap/{c[^o],s[^n]}** rwlix,
+/snap/{co[^r],sn[^a]}** rwlix,
+/snap/{cor[^e],sna[^p]}** rwlix,
+/snap/{core[^/],snap[^d]}** rwlix,
+/snap/snapd[^/]** rwlix,
+/snap/core/*/[^u]** rwlix,
+/snap/{core/*/u[^s],snapd/*/[^u]}** rwlix,
+/snap/{core/*/us[^r],snapd/*/u[^s]}** rwlix,
+/snap/{core/*/usr[^/],snapd/*/us[^r]}** rwlix,
+/snap/{core/*/usr/[^l],snapd/*/usr[^/]}** rwlix,
+/snap/{core/*/usr/l[^i],snapd/*/usr/[^l]}** rwlix,
+/snap/{core/*/usr/li[^b],snapd/*/usr/l[^i]}** rwlix,
+/snap/{core/*/usr/lib[^/],snapd/*/usr/li[^b]}** rwlix,
+/snap/{core/*/usr/lib/[^s],snapd/*/usr/lib[^/]}** rwlix,
+/snap/{core/*/usr/lib/s[^n],snapd/*/usr/lib/[^s]}** rwlix,
+/snap/{core/*/usr/lib/sn[^a],snapd/*/usr/lib/s[^n]}** rwlix,
+/snap/{core/*/usr/lib/sna[^p],snapd/*/usr/lib/sn[^a]}** rwlix,
+/snap/{core/*/usr/lib/snap[^d],snapd/*/usr/lib/sna[^p]}** rwlix,
+/snap/{core/*/usr/lib/snapd[^/],snapd/*/usr/lib/snap[^d]}** rwlix,
+/snap/{core/*/usr/lib/snapd/[^s],snapd/*/usr/lib/snapd[^/]}** rwlix,
+/snap/{core/*/usr/lib/snapd/s[^n],snapd/*/usr/lib/snapd/[^s]}** rwlix,
+/snap/{core/*/usr/lib/snapd/sn[^a],snapd/*/usr/lib/snapd/s[^n]}** rwlix,
+/snap/{core/*/usr/lib/snapd/sna[^p],snapd/*/usr/lib/snapd/sn[^a]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap[^-],snapd/*/usr/lib/snapd/sna[^p]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap-[^c],snapd/*/usr/lib/snapd/snap[^-]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap-c[^o],snapd/*/usr/lib/snapd/snap-[^c]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap-co[^n],snapd/*/usr/lib/snapd/snap-c[^o]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap-con[^f],snapd/*/usr/lib/snapd/snap-co[^n]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap-conf[^i],snapd/*/usr/lib/snapd/snap-con[^f]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap-confi[^n],snapd/*/usr/lib/snapd/snap-conf[^i]}** rwlix,
+/snap/{core/*/usr/lib/snapd/snap-confin[^e],snapd/*/usr/lib/snapd/snap-confi[^n]}** rwlix,
+/snap/snapd/*/usr/lib/snapd/snap-confin[^e]** rwlix,
+`[1:],
+		},
+		{
+			comment:         "anything except /lib/{firmware,modules} for non-core base template",
+			excludePatterns: []string{"/lib/modules", "/lib/firmware"},
+			suffix:          " mrklix,",
+			expRule: `
+/[^l]** mrklix,
+/l[^i]** mrklix,
+/li[^b]** mrklix,
+/lib[^/]** mrklix,
+/lib/[^fm]** mrklix,
+/lib/{f[^i],m[^o]}** mrklix,
+/lib/{fi[^r],mo[^d]}** mrklix,
+/lib/{fir[^m],mod[^u]}** mrklix,
+/lib/{firm[^w],modu[^l]}** mrklix,
+/lib/{firmw[^a],modul[^e]}** mrklix,
+/lib/{firmwa[^r],module[^s]}** mrklix,
+/lib/firmwar[^e]** mrklix,
+`[1:],
+		},
+		{
+			comment:         "anything except /usr/src, /usr/lib/{firmware,snapd,modules} for non-core base template",
+			excludePatterns: []string{"/usr/lib/firmware", "/usr/lib/snapd", "/usr/lib/modules"},
+			suffix:          " mrklix,",
+			expRule: `
+/[^u]** mrklix,
+/u[^s]** mrklix,
+/us[^r]** mrklix,
+/usr[^/]** mrklix,
+/usr/[^l]** mrklix,
+/usr/l[^i]** mrklix,
+/usr/li[^b]** mrklix,
+/usr/lib[^/]** mrklix,
+/usr/lib/[^fms]** mrklix,
+/usr/lib/{f[^i],m[^o],s[^n]}** mrklix,
+/usr/lib/{fi[^r],mo[^d],sn[^a]}** mrklix,
+/usr/lib/{fir[^m],mod[^u],sna[^p]}** mrklix,
+/usr/lib/{firm[^w],modu[^l],snap[^d]}** mrklix,
+/usr/lib/{firmw[^a],modul[^e]}** mrklix,
+/usr/lib/{firmwa[^r],module[^s]}** mrklix,
+/usr/lib/firmwar[^e]** mrklix,
+`[1:],
+		},
+		{
+			comment: "anything except /var/lib/{dhcp,extrausers,jenkins,snapd} /var/log /var/snap and /var/tmp for non-core base template",
+			excludePatterns: []string{
+				"/var/lib/dhcp",
+				"/var/lib/extrausers",
+				"/var/lib/jenkins",
+				"/var/lib/snapd",
+				"/var/log",
+				"/var/snap",
+				"/var/tmp",
+			},
+			suffix: " mrklix,",
+			expRule: `
+/[^v]** mrklix,
+/v[^a]** mrklix,
+/va[^r]** mrklix,
+/var[^/]** mrklix,
+/var/[^lst]** mrklix,
+/var/{l[^io],s[^n],t[^m]}** mrklix,
+/var/{li[^b],lo[^g],sn[^a],tm[^p]}** mrklix,
+/var/{lib[^/],sna[^p]}** mrklix,
+/var/lib/[^dejs]** mrklix,
+/var/{lib/d[^h],lib/e[^x],lib/j[^e],lib/s[^n]}** mrklix,
+/var/{lib/dh[^c],lib/ex[^t],lib/je[^n],lib/sn[^a]}** mrklix,
+/var/{lib/dhc[^p],lib/ext[^r],lib/jen[^k],lib/sna[^p]}** mrklix,
+/var/{lib/extr[^a],lib/jenk[^i],lib/snap[^d]}** mrklix,
+/var/{lib/extra[^u],lib/jenki[^n]}** mrklix,
+/var/{lib/extrau[^s],lib/jenkin[^s]}** mrklix,
+/var/lib/extraus[^e]** mrklix,
+/var/lib/extrause[^r]** mrklix,
+/var/lib/extrauser[^s]** mrklix,
+`[1:],
+		},
+		{
+			comment: "everything except {/var/lib/snapd/hostfs,}/{dev,proc,sys} for system-backup",
+			excludePatterns: []string{
+				"/dev/",
+				"/proc/",
+				"/sys/",
+				"/var/lib/snapd/hostfs/dev/",
+				"/var/lib/snapd/hostfs/proc/",
+				"/var/lib/snapd/hostfs/sys/",
+			},
+			expRule: `
+/[^dpsv]**
+/{d[^e],p[^r],s[^y],v[^a]}**
+/{de[^v],pr[^o],sy[^s],va[^r]}**
+/{dev[^/],pro[^c],sys[^/],var[^/]}**
+/{proc[^/],var/[^l]}**
+/var/l[^i]**
+/var/li[^b]**
+/var/lib[^/]**
+/var/lib/[^s]**
+/var/lib/s[^n]**
+/var/lib/sn[^a]**
+/var/lib/sna[^p]**
+/var/lib/snap[^d]**
+/var/lib/snapd[^/]**
+/var/lib/snapd/[^h]**
+/var/lib/snapd/h[^o]**
+/var/lib/snapd/ho[^s]**
+/var/lib/snapd/hos[^t]**
+/var/lib/snapd/host[^f]**
+/var/lib/snapd/hostf[^s]**
+/var/lib/snapd/hostfs[^/]**
+/var/lib/snapd/hostfs/[^dps]**
+/{var/lib/snapd/hostfs/d[^e],var/lib/snapd/hostfs/p[^r],var/lib/snapd/hostfs/s[^y]}**
+/{var/lib/snapd/hostfs/de[^v],var/lib/snapd/hostfs/pr[^o],var/lib/snapd/hostfs/sy[^s]}**
+/{var/lib/snapd/hostfs/dev[^/],var/lib/snapd/hostfs/pro[^c],var/lib/snapd/hostfs/sys[^/]}**
+/var/lib/snapd/hostfs/proc[^/]**
+`[1:],
+		},
+	}
+
+	for _, t := range tt {
+		comment := Commentf(t.comment)
+		opts := &apparmor.AAREExclusionPatternsOptions{
+			Prefix: t.prefix,
+			Suffix: t.suffix,
+		}
+		res, err := apparmor.GenerateAAREExclusionPatterns(t.excludePatterns, opts)
+		if t.err != "" {
+			c.Assert(err, ErrorMatches, t.err, comment)
+			continue
+		}
+		c.Assert(err, IsNil)
+		c.Assert(res, Equals, t.expRule, comment)
+	}
+}


### PR DESCRIPTION
I just couldn't resist the l33tcodeness of the problem of generating these rules with a helper so I fell into a hole and wrote this complex monster of a helper function. 

Hope this helps! :smile: 

I only changed the docker-support interface to use this new helper and left TODO's elsewhere in the codebase that it could be used for future followups in the interest of time. Also happy to drop the docker-support changes to land this more quickly if reviewing it is too complex but I think it's also useful to see here how it's used in a prototypical manner.

---------------------------------

This function is generic (and complex) enough to be able to handle all of the
overlapping and wildcard behavior we need in docker-support, and it could also
serve to replace numerous other places in the codebase where we need this sort
of complex behavior. It is a generalization of the existing
aareExclusionPatterns helper, though it's actually unclear if this exact
implementation will currently be able to serve the use case from that helper
directly or if more options/adjustments are needed to enable that use case as
well.

To keep the diff smaller, this patch does not actually change any of the
profiles/interfaces, just TODO's are left for where to use it.

Note that the generated rules are slightly more condensed in terms of number of
rules but significantly more verbose in terms of alternations, not sharing more
of repeated substrings between alternations inside the patterns. This was done
explicitly to keep the generating code simpler and easier to understand, but it
may prove to have performance effects, either detrimental or benevolent but
that should be measured before deciding to make the generation code even more
complex than it already is.
