### PR TITLE
snap-confine: add WSL2 GPU support to strict confinement

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -269,6 +269,8 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/cookie-support.h \
 	snap-confine/mount-support-nvidia.c \
 	snap-confine/mount-support-nvidia.h \
+	snap-confine/mount-support-wsl2-gpu.c \
+	snap-confine/mount-support-wsl2-gpu.h \
 	snap-confine/mount-support.c \
 	snap-confine/mount-support.h \
 	snap-confine/ns-support.c \

--- a/cmd/snap-confine/mount-support-test.c
+++ b/cmd/snap-confine/mount-support-test.c
@@ -18,6 +18,8 @@
 #include "mount-support.h"
 #include "mount-support-nvidia.c"
 #include "mount-support-nvidia.h"
+#include "mount-support-wsl2-gpu.c"
+#include "mount-support-wsl2-gpu.h"
 #include "mount-support.c"
 
 #include <glib.h>

--- a/cmd/snap-confine/mount-support-wsl2-gpu.c
+++ b/cmd/snap-confine/mount-support-wsl2-gpu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Canonical Ltd
+ * Copyright (C) 2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/cmd/snap-confine/mount-support-wsl2-gpu.c
+++ b/cmd/snap-confine/mount-support-wsl2-gpu.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mount-support-wsl2-gpu.h"
+#include "config.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <glob.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+/* POSIX version of basename() and dirname() */
+#include <libgen.h>
+
+#include "../libsnap-confine-private/classic.h"
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/mount-opt.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
+#include "mount-support.h"
+
+#define SC_WSL_GPU_DIR SC_EXTRA_LIB_DIR "/wsl"
+
+#define SC_HOST_WSL_DIR "/usr/lib/wsl/lib"
+
+void sc_mount_wsl2_gpu_driver(const char *rootfs) {
+    /* If WSL2 GPU libraries aren't mounted in the host, don't attempt to mount the drivers */
+    if (access(SC_HOST_WSL_DIR, F_OK) != 0) {
+        return;
+    }
+    if (sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755, 0, 0) != 0) {
+        die("cannot create " SC_EXTRA_LIB_DIR);
+    }
+    if (sc_ensure_mkdir(SC_WSL_GPU_DIR, 0755, 0, 0) != 0) {
+        die("cannot create directory %s", SC_WSL_GPU_DIR);
+    }
+    // Bind mount the binary WSL2 GPU driver into $dst_dir (i.e. /var/lib/snapd/lib/wsl).
+    debug("bind mounting WSL2 GPU driver %s -> %s", SC_HOST_WSL_DIR, SC_WSL_GPU_DIR);
+    sc_do_mount(SC_HOST_WSL_DIR, SC_WSL_GPU_DIR, NULL, MS_BIND, NULL);
+}

--- a/cmd/snap-confine/mount-support-wsl2-gpu.h
+++ b/cmd/snap-confine/mount-support-wsl2-gpu.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_MOUNT_SUPPORT_WSL2_GPU_H
+#define SNAP_CONFINE_MOUNT_SUPPORT_WSL2_GPU_H
+
+/**
+ * Make the WSL2 OpenGL driver from the classic distribution available in the snap
+ * execution environment.
+ *
+ * This function is designed to be called before pivot_root() switched the root
+ * filesystem.
+ *
+ * On WSL2, the host GPU libraries and drivers are mounted to /usr/lib/wsl. This
+ * directory is bind mounted to /var/lib/snapd/lib/wsl relative to the location of
+ * the root filesystem directory provided as an argument.
+ **/
+void sc_mount_wsl2_gpu_driver(const char *rootfs_dir);
+
+#endif

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -49,6 +49,7 @@
 #include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
 #include "mount-support-nvidia.h"
+#include "mount-support-wsl2-gpu.h"
 
 #define MAX_BUF 1000
 #define SNAP_PRIVATE_TMP_ROOT_DIR "/tmp/snap-private-tmp"
@@ -728,6 +729,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config) {
     // pre-pivot filesystem.
     if (config->distro == SC_DISTRO_CLASSIC) {
         sc_mount_nvidia_driver(scratch_dir, config->base_snap_name);
+        sc_mount_wsl2_gpu_driver(scratch_dir);
     }
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     //                    pivot_root

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -390,6 +390,11 @@
     mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
     mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
 
+    # WSL2 GPU
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/wsl/{,*} w,
+    mount options=(rw bind) /usr/lib/wsl/lib/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/wsl/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/wsl/,
+
     # create gl dirs as needed
     /tmp/snap.rootfs_*/ r,
     /tmp/snap.rootfs_*/var/ r,
@@ -402,6 +407,8 @@
     /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/** rw,
     /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/ r,
     /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/** rw,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/wsl/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/wsl/** rw,
 
     ## nvidia libraries exported by a snap
     # read source paths

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -44,6 +44,8 @@ const openglConnectedPlugAppArmor = `
 # specific gl libs
 /var/lib/snapd/lib/gl{,32}/ r,
 /var/lib/snapd/lib/gl{,32}/** rm,
+/var/lib/snapd/lib/wsl/ r,
+/var/lib/snapd/lib/wsl/** rm,
 
 # libdrm data files
 /usr/share/libdrm/amdgpu.ids r,

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -185,7 +185,7 @@ func buildLibPath() string {
 			logger.Noticef("while reading %q: %v", path, err)
 		}
 	}
-	snapLibPath := "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32"
+	snapLibPath := "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/lib/wsl"
 	// If we have libPaths, Nvidia libraries are provided by snaps and we
 	// do not use the gl/gl32 folders used if libs are provided by debian
 	// packages.

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -112,7 +112,7 @@ func (ts *HTestSuite) TestBasic(c *C) {
 		"SNAP_VERSION":       "1.0",
 		"SNAP_REVISION":      "17",
 		"SNAP_ARCH":          arch.DpkgArchitecture(),
-		"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32",
+		"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/lib/wsl",
 		"SNAP_REEXEC":        os.Getenv("SNAP_REEXEC"),
 		"SNAP_UID":           fmt.Sprint(sys.Getuid()),
 		"SNAP_EUID":          fmt.Sprint(sys.Geteuid()),
@@ -247,7 +247,7 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 			"SNAP_VERSION":       "1.0",
 			"SNAP_REVISION":      "42",
 			"SNAP_ARCH":          arch.DpkgArchitecture(),
-			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32",
+			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/lib/wsl",
 			"SNAP_REEXEC":        os.Getenv("SNAP_REEXEC"),
 			"SNAP_USER_COMMON":   fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
 			"SNAP_USER_DATA":     fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
@@ -292,7 +292,7 @@ func (s *HTestSuite) TestParallelInstallSnapRunSnapExecEnv(c *C) {
 			"SNAP_VERSION":       "1.0",
 			"SNAP_REVISION":      "42",
 			"SNAP_ARCH":          arch.DpkgArchitecture(),
-			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32",
+			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/lib/wsl",
 			"SNAP_REEXEC":        os.Getenv("SNAP_REEXEC"),
 			// User's data directories are not mapped to
 			// snap-specific ones

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -44,7 +44,7 @@ execute: |
     # parallel-installs: global snap directories are remapped to $SNAP_NAME
     MATCH '^SNAP_COMMON=/var/snap/test-snapd-tools/common$'               < snap-vars.txt
     MATCH '^SNAP_DATA=/var/snap/test-snapd-tools/x1$'                     < snap-vars.txt
-    MATCH '^SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32$' < snap-vars.txt
+    MATCH '^SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/lib/wsl$' < snap-vars.txt
     # XXX: probably not something we ought to test
     # egrep -q '^SNAP_REEXEC=0$' snap-vars.txt
     MATCH '^SNAP_REVISION=x1$'                                            < snap-vars.txt


### PR DESCRIPTION
* Add WSL knowledge to `snap-confine`
* Add `/var/lib/snapd/lib/wsl/` access permissions to `opengl` interface
* Add `/var/lib/snapd/lib/wsl/lib` to `SNAP_LIBRARY_PATH` environment
  variable in `snapenv`

To test this you should have a kernel with apparmor patches added that the MS kernel doesn't carry and systemd obviously need to be operating. I've automated the install with a script at https://github.com/diddledani/one-script-wsl2-systemd. Run it in Windows PowerShell with:

```powershell
./install.ps1 -NoGPG -Distro Ubuntu
```

The full synopsis is:

```powershell
./install.ps1 [-NoGPG] [-NoKernel] [-Distro <distro name>]
```

The kernel I'm using, and is installed by the above script, is available at https://github.com/diddlesnaps/WSL2-Linux-Kernel/releases/tag/linux-msft-snapd-5.10.102.1

I've updated this PR to match changes in PR #11786.