### PR TITLE
snap: allow `zstd` compression in `snap pack`

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -15,6 +15,8 @@ build-base: core
 package-repositories:
   - type: apt
     ppa: snappy-dev/image
+  - type: apt
+    ppa: xnox/nonvirt
 grade: stable
 license: GPL-3.0
 

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -81,7 +81,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"filename": i18n.G("Output to this filename"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"compression": i18n.G("Compression to use (e.g. xz or lzo)"),
+			"compression": i18n.G("Compression to use (e.g. xz, lzo or zstd)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"append-integrity-data": i18n.G("Generate and append dm-verity data"),
 		}, nil)

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -134,7 +134,7 @@ printf "hello world"
 func (s *SnapSuite) TestPackPacksASnapWithCompressionHappy(c *check.C) {
 	snapDir := makeSnapDirForPack(c, "name: hello\nversion: 1.0")
 
-	for _, comp := range []string{"xz", "lzo"} {
+	for _, comp := range []string{"xz", "lzo", "zstd"} {
 		_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--compression", comp, snapDir, snapDir})
 		c.Assert(err, check.IsNil)
 
@@ -149,7 +149,7 @@ func (s *SnapSuite) TestPackPacksASnapWithCompressionHappy(c *check.C) {
 func (s *SnapSuite) TestPackPacksASnapWithCompressionUnhappy(c *check.C) {
 	snapDir := makeSnapDirForPack(c, "name: hello\nversion: 1.0")
 
-	for _, comp := range []string{"gzip", "zstd", "silly"} {
+	for _, comp := range []string{"gzip", "silly"} {
 		_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--compression", comp, snapDir, snapDir})
 		c.Assert(err, check.ErrorMatches, fmt.Sprintf(`cannot pack "/.*": cannot use compression %q`, comp))
 	}

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -205,7 +205,7 @@ func Pack(sourceDir string, opts *Options) (string, error) {
 		opts = &Options{}
 	}
 	switch opts.Compression {
-	case "xz", "lzo", "":
+	case "xz", "lzo", "zstd", "":
 		// fine
 	default:
 		return "", fmt.Errorf("cannot use compression %q", opts.Compression)

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -515,7 +515,7 @@ volumes:
 func (s *packSuite) TestPackWithCompressionHappy(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 
-	for _, comp := range []string{"", "xz", "lzo"} {
+	for _, comp := range []string{"", "xz", "lzo", "zstd"} {
 		snapfile, err := pack.Pack(sourceDir, &pack.Options{
 			TargetDir:   c.MkDir(),
 			Compression: comp,
@@ -528,7 +528,7 @@ func (s *packSuite) TestPackWithCompressionHappy(c *C) {
 func (s *packSuite) TestPackWithCompressionUnhappy(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 
-	for _, comp := range []string{"gzip", "zstd", "silly"} {
+	for _, comp := range []string{"gzip", "silly"} {
 		snapfile, err := pack.Pack(sourceDir, &pack.Options{
 			TargetDir:   c.MkDir(),
 			Compression: comp,

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -1031,7 +1031,7 @@ func (s *SquashfsTestSuite) TestBuildWithCompressionHappy(c *C) {
 	c.Assert(err, IsNil)
 
 	defaultComp := "xz"
-	for _, comp := range []string{"", "xz", "gzip", "lzo"} {
+	for _, comp := range []string{"", "xz", "gzip", "lzo", "zstd"} {
 		sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
 		err = sn.Build(buildDir, &squashfs.BuildOpts{
 			Compression: comp,

--- a/syscheck/export_test.go
+++ b/syscheck/export_test.go
@@ -20,11 +20,11 @@
 package syscheck
 
 var (
-	CheckSquashfsMount  = checkSquashfsMount
-	CheckKernelVersion  = checkKernelVersion
-	CheckApparmorUsable = checkApparmorUsable
-	CheckWSL            = checkWSL
-	CheckCgroup         = checkCgroup
+	CheckSquashfsXzMount = checkSquashfsXzMount
+	CheckKernelVersion   = checkKernelVersion
+	CheckApparmorUsable  = checkApparmorUsable
+	CheckWSL             = checkWSL
+	CheckCgroup          = checkCgroup
 
 	CheckFuse = firstCheckFuse
 )

--- a/syscheck/squashfs.go
+++ b/syscheck/squashfs.go
@@ -49,7 +49,7 @@ func init() {
 //
 // The squashfs was generated with:
 // EOF
-// cat $0 >> canary.txt
+// cat $OLDPWD/$0 >> canary.txt
 //
 // mksquashfs . /tmp/canary.squashfs -noappend -comp xz -no-xattrs -no-fragments >/dev/null
 // cat /tmp/canary.squashfs | gzip - | base64

--- a/syscheck/squashfs.go
+++ b/syscheck/squashfs.go
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	checks = append(checks, checkSquashfsMount)
+	checks = append(checks, checkSquashfsXzMount, checkSquashfsZstdMount)
 }
 
 // This image was created using:
@@ -53,7 +53,7 @@ func init() {
 //
 // mksquashfs . /tmp/canary.squashfs -noappend -comp xz -no-xattrs -no-fragments >/dev/null
 // cat /tmp/canary.squashfs | gzip - | base64
-var b64SquashfsImage = []byte(`
+var b64SquashfsXzImage = []byte(`
 H4sIAGxdFVsAA8soLixmYmBgyIkVjWZgALEYGFgYBBkuMDECaQYGFQYI4INIMbBB6f9Q0MAI4R+D
 0s+g9A8o/de8KiKKgYExU+meGfOB54wzmBUZuYDiVhPYbR4wTme4H8ugJcWpniK5waL4VLewwsUC
 PgdVnS/pCycWn34g1rpj6bIywdLqaQdZFYQcYr7/vR1w9dTbDivRH3GahXc578hdW3Ri7mu9+KeF
@@ -63,6 +63,18 @@ R9XSJUxv/7/y2f2zid0+OnGi1+ey1/vatzDPvfbq+0LLwIu1Wx/u+m6/c8IN21vNCQwMX2dtWsHA
 +BvodwaGpcmXftsZ8HaDg5ExMsqlgYlhCTisQDEAYiRAQxckNgMooADEjAwH4GqgEQCOK0UgBhrK
 INcAFWRghMtyMiQn5iUWVeqVVJQIwOVh8QmLJ5aGF8wMsIgfBaNgFIyCUTAKRsEoGAWjYBSMglEw
 bAEA+f+YuAAQAAA=
+`)
+
+// This image is similar to the one above, except that it is using zstd compressor.
+var b64SquashfsZstdImage = []byte(`
+H4sIAAAAAAAAA8soLixmYmBguHFKPI2BAcRiYGBjEGS4wMTIwAJkqzBAwBlGCH0ESv+HAm8ovwVK
+L4HS26C0xlb9vwlrGHjZGTad05V36JfjWRX9Kyl1u/bam9N+Vk48emT7QebHtnZvzxWETmc+U5CR
+7nlby/BSmsarRX2XLji+9q/2ynHN+7t56cHyM9ci926bULY25uKzVzXbz5tIRnPcWvbAwvXJwgyL
+OW2cEn2tChMrTtuLd2vaZ8yXz+bYkDv372UZi7OHjq/btuVvmdjdQM3CBgbnI9Ontv7NMc3NnKst
+q9hjq/txyuvAkn1q+/ZMuB11Kj8x9dVvmfrl1z/mfuW+vT7Xy+21kRMTH4NOw+ofB/h7d3Y0Gm84
+x9SUluyiqLBNeoPYNWCQKU3medRS/qCM0RzsWQWXUkaGTc6cQhfSeVtcWvyTWQ/4Mm7p3OmbwsUv
+z17fcOt62r93756EuQTlq3MwMti3VjHJNUADmQEaaMB44GRITsxLLKrUK6koEYDLw2IDFsosDS+Y
+GRj2wbSNglEwCkbBKBgFo2AUjIJRMApGwSgYBTgAAGPYjbIAEAAA
 `)
 
 var fuseBinary = "mount.fuse"
@@ -76,7 +88,16 @@ func firstCheckFuse() error {
 	return nil
 }
 
-func checkSquashfsMount() error {
+func checkSquashfsXzMount() error {
+	return doCheckSquashfsMount(b64SquashfsXzImage)
+}
+
+func checkSquashfsZstdMount() error {
+	return doCheckSquashfsMount(b64SquashfsZstdImage)
+}
+
+// XXX: tests are sensitive to functions with prefix "check".
+func doCheckSquashfsMount(blob []byte) error {
 	if err := firstCheckFuse(); err != nil {
 		return err
 	}

--- a/syscheck/squashfs.go
+++ b/syscheck/squashfs.go
@@ -51,7 +51,7 @@ func init() {
 // EOF
 // cat $0 >> canary.txt
 //
-// mksquashfs . /tmp/canary.squashfs -noappend -comp xz -no-xattrs -no-fragments >/dev/nul
+// mksquashfs . /tmp/canary.squashfs -noappend -comp xz -no-xattrs -no-fragments >/dev/null
 // cat /tmp/canary.squashfs | gzip - | base64
 var b64SquashfsImage = []byte(`
 H4sIAGxdFVsAA8soLixmYmBgyIkVjWZgALEYGFgYBBkuMDECaQYGFQYI4INIMbBB6f9Q0MAI4R+D

--- a/syscheck/squashfs.go
+++ b/syscheck/squashfs.go
@@ -94,7 +94,7 @@ func checkSquashfsMount() error {
 	defer os.RemoveAll(tmpMountDir)
 
 	// write the squashfs image
-	b64dec := base64.NewDecoder(base64.StdEncoding, bytes.NewBuffer(b64SquashfsImage))
+	b64dec := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(blob))
 	gzReader, err := gzip.NewReader(b64dec)
 	if err != nil {
 		return err

--- a/syscheck/squashfs_test.go
+++ b/syscheck/squashfs_test.go
@@ -39,7 +39,7 @@ func (s *syscheckSuite) TestCheckSquashfsMountHappy(c *C) {
 	mockUmount := testutil.MockCommand(c, "umount", "")
 	defer mockUmount.Restore()
 
-	err := syscheck.CheckSquashfsMount()
+	err := syscheck.CheckSquashfsXzMount()
 	c.Check(err, IsNil)
 
 	c.Check(mockMount.Calls(), HasLen, 1)
@@ -65,7 +65,7 @@ func (s *syscheckSuite) TestCheckSquashfsMountNotHappy(c *C) {
 	mockUmount := testutil.MockCommand(c, "umount", "")
 	defer mockUmount.Restore()
 
-	err := syscheck.CheckSquashfsMount()
+	err := syscheck.CheckSquashfsXzMount()
 	c.Check(err, ErrorMatches, "cannot mount squashfs image using.*")
 
 	c.Check(mockMount.Calls(), HasLen, 1)
@@ -88,7 +88,7 @@ func (s *syscheckSuite) TestCheckSquashfsMountWrongContent(c *C) {
 	mockUmount := testutil.MockCommand(c, "umount", "")
 	defer mockUmount.Restore()
 
-	err := syscheck.CheckSquashfsMount()
+	err := syscheck.CheckSquashfsXzMount()
 	c.Check(err, ErrorMatches, `unexpected squashfs canary content: "wrong content\\n"`)
 
 	c.Check(mockMount.Calls(), HasLen, 1)
@@ -108,7 +108,7 @@ func (s *syscheckSuite) TestCheckSquashfsMountSELinuxContext(c *C) {
 	mockSELinux := selinux.MockIsEnabled(func() (bool, error) { return true, nil })
 	defer mockSELinux()
 
-	err := syscheck.CheckSquashfsMount()
+	err := syscheck.CheckSquashfsXzMount()
 	c.Assert(err, ErrorMatches, `squashfs mount returned no err but canary file cannot be read`)
 
 	c.Check(mockMount.Calls(), HasLen, 1)

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -68,3 +68,13 @@ execute: |
     lxd.lxc file push --quiet test-snapd-sh-lzo.snap "my-ubuntu/$GOHOME/test-snapd-sh-lzo.snap"
     lxd.lxc exec my-ubuntu -- snap install --dangerous "$GOHOME/test-snapd-sh-lzo.snap"
     lxd.lxc exec my-ubuntu -- test-snapd-sh.sh -c "echo hello-lzo" | MATCH "hello-lzo"
+
+    snap pack --compression=zstd "$TESTSLIB/snaps/test-snapd-sh" . --filename test-snapd-sh-zstd.snap
+    test -e test-snapd-sh-zstd.snap
+    unsquashfs -l test-snapd-sh-zstd.snap
+    unsquashfs -s test-snapd-sh-zstd.snap | MATCH "Compression zstd"
+
+    echo "zstd compressed snaps can be used normally inside the lxd container"
+    lxd.lxc file push --quiet test-snapd-sh-zstd.snap "my-ubuntu/$GOHOME/test-snapd-sh-zstd.snap"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous "$GOHOME/test-snapd-sh-zstd.snap"
+    lxd.lxc exec my-ubuntu -- test-snapd-sh.sh -c "echo hello-zstd" | MATCH "hello-zstd"

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -64,7 +64,7 @@ execute: |
     unsquashfs -l test-snapd-sh-lzo.snap
     unsquashfs -s test-snapd-sh-lzo.snap | MATCH "Compression lzo"
 
-    echo "lzo compressed snaps can be used normally inside the lxd container"    
+    echo "lzo compressed snaps can be used normally inside the lxd container"
     lxd.lxc file push --quiet test-snapd-sh-lzo.snap "my-ubuntu/$GOHOME/test-snapd-sh-lzo.snap"
     lxd.lxc exec my-ubuntu -- snap install --dangerous "$GOHOME/test-snapd-sh-lzo.snap"
     lxd.lxc exec my-ubuntu -- test-snapd-sh.sh -c "echo hello-lzo" | MATCH "hello-lzo"

--- a/tests/main/snap-pack/task.yaml
+++ b/tests/main/snap-pack/task.yaml
@@ -6,6 +6,7 @@ details: |
 
 restore: |
     snap remove test-snapd-sh-lzo
+    snap remove test-snapd-sh-zstd
 
 execute: |
     echo "Packing a simple snap works"
@@ -35,3 +36,13 @@ execute: |
     echo "The lzo snap can be used normally"
     snap install --dangerous test-snapd-sh-lzo.snap
     test-snapd-sh.sh -c "echo hello-lzo" | MATCH "hello-lzo"
+
+    echo "Packing a simple snap with zstd works"
+    snap pack --compression=zstd "$TESTSLIB/snaps/test-snapd-sh" . --filename test-snapd-sh-zstd.snap
+    test -e test-snapd-sh-zstd.snap
+    unsquashfs -l test-snapd-sh-zstd.snap
+    unsquashfs -s test-snapd-sh-zstd.snap | MATCH "Compression zstd"
+
+    echo "The zstd snap can be used normally"
+    snap install --dangerous test-snapd-sh-zstd.snap
+    test-snapd-sh.sh -c "echo hello-zstd" | MATCH "hello-zstd"


### PR DESCRIPTION
WIP

TODO:
- [ ] add zstd / squashfs-tools / squashfuse backports to snappy-dev PPA
- [ ] add support to detect zstd support / lack of it in the kernel, and use fuse fallback