### PR TITLE
[4/X] Integrity data for snaps: Ubuntu Core support, run mode for essential snaps

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1688,8 +1688,15 @@ func generateMountsCommonInstallRecoverStart(mst *initramfsMountsState) (model *
 	for _, essentialSnap := range essSnaps {
 		systemSnaps[essentialSnap.EssentialType] = essentialSnap
 		dir := snapTypeToMountDir[essentialSnap.EssentialType]
+
+		mountOptions := *mountReadOnlyOptions
+		err = mst.GetVerityOptionsForSeedSnap(essentialSnap, &mountOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		// TODO:UC20: we need to cross-check the kernel path with snapd_recovery_kernel used by grub
-		if err := doSystemdMount(essentialSnap.Path, filepath.Join(boot.InitramfsRunMntDir, dir), mountReadOnlyOptions); err != nil {
+		if err := doSystemdMount(essentialSnap.Path, filepath.Join(boot.InitramfsRunMntDir, dir), &mountOptions); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -159,3 +159,17 @@ func (mst *initramfsMountsState) EphemeralModeenvForModel(model *asserts.Model, 
 		//            kernel command lines?
 	}, nil
 }
+
+// GetVerityOptionsForSeedSnap returns additional dm-verity options for a seed snap.
+func (mst *initramfsMountsState) GetVerityOptionsForSeedSnap(snap *seed.Snap, mountOptions *systemdMountOptions) error {
+	if snap.IntegrityData == nil {
+		// TODO: return error if integrity data should be required
+		return nil
+	}
+
+	mountOptions.VerityHashDevice = snap.IntegrityData.SourceFilePath
+	mountOptions.VerityRootHash = snap.IntegrityData.Header.DmVerity.RootHash
+	mountOptions.VerityHashOffset = snap.IntegrityData.Offset
+
+	return nil
+}

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -77,6 +77,13 @@ type systemdMountOptions struct {
 	Private bool
 	// Umount the mountpoint
 	Umount bool
+	// dm-verity hash device
+	VerityHashDevice string
+	// dm-verity root hash
+	VerityRootHash string
+	// dm-verity hash offset. Need to be specified if only verity data are
+	// appended to the snap. Defaults to 0 in mount command
+	VerityHashOffset uint64
 }
 
 // doSystemdMount will mount "what" at "where" using systemd-mount(1) with
@@ -150,6 +157,11 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	}
 	if opts.Private {
 		options = append(options, "private")
+	}
+	if len(opts.VerityHashDevice) > 0 && len(opts.VerityRootHash) > 0 {
+		options = append(options, fmt.Sprintf("verity.roothash=%s", opts.VerityRootHash))
+		options = append(options, fmt.Sprintf("verity.hashdevice=%s", opts.VerityHashDevice))
+		options = append(options, fmt.Sprintf("verity.hashoffset=%d", opts.VerityHashOffset))
 	}
 	if len(options) > 0 {
 		args = append(args, "--options="+strings.Join(options, ","))

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -322,6 +322,11 @@ func SnapSaveDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "save")
 }
 
+// SnapAssertsDBDirUnder returns the path to assertions directory under rootdir.
+func SnapAssertsDBDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "assertions")
+}
+
 // SnapFDEDirUnderSave returns the path to full disk encryption state directory
 // inside the given save tree dir.
 func SnapFDEDirUnderSave(savedir string) string {

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/integrity"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -56,6 +57,8 @@ type Snap struct {
 	Channel string
 	DevMode bool
 	Classic bool
+
+	IntegrityData *integrity.IntegrityData
 }
 
 func (s *Snap) SnapName() string {

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -137,8 +137,7 @@ func (ss *SeedSnaps) makeAssertedSnap(c *C, snapYaml string, snapFilePath string
 	}
 
 	for _, db := range dbs {
-		err := db.Add(declA)
-		c.Assert(err, IsNil)
+		db.Add(declA)
 		err = db.Add(revA)
 		c.Assert(err, IsNil)
 	}

--- a/snap/integrity/dmverity/veritysetup.go
+++ b/snap/integrity/dmverity/veritysetup.go
@@ -22,6 +22,7 @@ package dmverity
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
@@ -47,7 +48,7 @@ type Info struct {
 func getVal(line string) (string, error) {
 	parts := strings.SplitN(line, ":", 2)
 	if len(parts) != 2 {
-		return "", fmt.Errorf("internal error: unexpected veritysetup output format")
+		return "", errors.New("internal error: unexpected veritysetup output format")
 	}
 	return strings.TrimSpace(parts[1]), nil
 }
@@ -68,7 +69,7 @@ func getRootHashFromOutput(output []byte) (rootHash string, err error) {
 				return "", err
 			}
 			if hashAlgo != "sha256" {
-				return "", fmt.Errorf("internal error: unexpected hash algorithm")
+				return "", errors.New("internal error: unexpected hash algorithm")
 			}
 		}
 	}
@@ -78,7 +79,7 @@ func getRootHashFromOutput(output []byte) (rootHash string, err error) {
 	}
 
 	if len(rootHash) != 64 {
-		return "", fmt.Errorf("internal error: unexpected root hash length")
+		return "", errors.New("internal error: unexpected root hash length")
 	}
 
 	return rootHash, nil

--- a/snap/integrity/dmverity/veritysetup.go
+++ b/snap/integrity/dmverity/veritysetup.go
@@ -22,6 +22,7 @@ package dmverity
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -78,7 +79,7 @@ func getRootHashFromOutput(output []byte) (rootHash string, err error) {
 		return "", err
 	}
 
-	if len(rootHash) != 64 {
+	if len(rootHash) != sha256.BlockSize {
 		return "", errors.New("internal error: unexpected root hash length")
 	}
 

--- a/snap/integrity/integrity.go
+++ b/snap/integrity/integrity.go
@@ -21,13 +21,19 @@ package integrity
 
 import (
 	"bytes"
+	"crypto"
+	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap/integrity/dmverity"
+	"github.com/snapcore/snapd/snap/squashfs"
 )
 
 const (
@@ -36,6 +42,8 @@ const (
 	// the header size is always gonna be less than blockSize and will always get aligned
 	// to blockSize.
 	HeaderSize = 4096
+	// https://github.com/plougher/squashfs-tools/blob/master/squashfs-tools/squashfs_fs.h#L289
+	squashfsSuperblockBytesUsedOffset = 40
 )
 
 var (
@@ -46,6 +54,126 @@ var (
 // align aligns input `size` to closest `blockSize` value
 func align(size uint64) uint64 {
 	return (size + blockSize - 1) / blockSize * blockSize
+}
+
+// An IntegrityData structure represents a snap's integrity data and
+// contains information useful for locating it.
+type IntegrityData struct {
+	Header         *IntegrityDataHeader
+	Offset         uint64
+	SourceFilePath string
+}
+
+// FindIntegrityData returns integrity data information given a snap filename.
+// It currently supports only integrity data attached at the end of snap files.
+func FindIntegrityData(snapPath string) (*IntegrityData, error) {
+	integrityData := IntegrityData{}
+
+	snapFile, err := os.OpenFile(snapPath, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer snapFile.Close()
+
+	snapFileInfo, err := snapFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if !squashfs.FileHasSquashfsHeader(snapPath) {
+		return nil, errors.New("input file does not contain a SquashFS filesystem")
+	}
+
+	// Seek to bytes_used field of SquashFS superblock
+	_, err = snapFile.Seek(squashfsSuperblockBytesUsedOffset, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	var squashFSSize uint64
+	if err := binary.Read(snapFile, binary.LittleEndian, &squashFSSize); err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("SquashFS bytes used: %d", squashFSSize)
+
+	// Align squashFSSize to blockSize
+	offset := align(squashFSSize)
+
+	if offset == uint64(snapFileInfo.Size()) {
+		return nil, fmt.Errorf("integrity data not found for snap %s", snapPath)
+	}
+
+	integrityData.SourceFilePath = snapPath
+	// TODO check for integrity data in separate file
+
+	_, err = snapFile.Seek(int64(offset), io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	integrityDataBytes := make([]byte, uint64(HeaderSize))
+	_, err = io.ReadFull(snapFile, integrityDataBytes)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read integrity data: %s", err)
+	}
+
+	integrityDataHeader, err := extractIntegrityDataHeader(integrityDataBytes)
+	if err != nil {
+		return nil, err
+	}
+	integrityData.Header = integrityDataHeader
+	integrityData.Offset = offset
+
+	return &integrityData, nil
+}
+
+// Validate checks integrity data against a snap-revision assertion.
+// The entire integrity data including the header gets hashed and compared to the hash
+// included in the integrity stanza in a snap-revision assertion.
+func (integrityData IntegrityData) Validate(snapRev asserts.SnapRevision) error {
+	integrityDataHash, err := integrityData.SHA3_384()
+	if err != nil {
+		return err
+	}
+
+	snapRevIntegrityData := snapRev.SnapIntegrity()
+	if snapRevIntegrityData == nil {
+		return fmt.Errorf("Snap revision assertion does not contain an integrity stanza")
+	}
+
+	if integrityDataHash != snapRevIntegrityData.SHA3_384 {
+		return fmt.Errorf("integrity data hash mismatch")
+	}
+	return nil
+}
+
+// extractIntegrityDataHeader parses a byte array containing integrity data header information
+// into an IntegrityDataHeader structure.
+func extractIntegrityDataHeader(integrityDataBytes []byte) (*IntegrityDataHeader, error) {
+	integrityDataHeader := IntegrityDataHeader{}
+
+	err := integrityDataHeader.Decode(integrityDataBytes[:HeaderSize])
+	if err != nil {
+		return nil, err
+	}
+
+	return &integrityDataHeader, nil
+}
+
+// SHA3_384 computes the SHA3-384 digest of the integrity data and encodes it in the hash format used
+// by snap assertions.
+func (integrityData IntegrityData) SHA3_384() (string, error) {
+	digest, _, err := osutil.PartialFileDigest(integrityData.SourceFilePath, crypto.SHA3_384, integrityData.Offset)
+	if err != nil {
+		return "", err
+	}
+
+	sha3_384, err := asserts.EncodeDigest(crypto.SHA3_384, digest)
+	if err != nil {
+		return "", fmt.Errorf("cannot encode snap's %q integrity data digest: %v", integrityData.SourceFilePath, err)
+	}
+	return sha3_384, nil
 }
 
 // IntegrityDataHeader gets appended first at the end of a squashfs packed snap

--- a/snap/integrity/integrity.go
+++ b/snap/integrity/integrity.go
@@ -139,11 +139,11 @@ func (integrityData IntegrityData) Validate(snapRev asserts.SnapRevision) error 
 
 	snapRevIntegrityData := snapRev.SnapIntegrity()
 	if snapRevIntegrityData == nil {
-		return fmt.Errorf("Snap revision assertion does not contain an integrity stanza")
+		return errors.New("Snap revision assertion does not contain an integrity stanza")
 	}
 
 	if integrityDataHash != snapRevIntegrityData.SHA3_384 {
-		return fmt.Errorf("integrity data hash mismatch")
+		return errors.New("integrity data hash mismatch")
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ func (integrityDataHeader IntegrityDataHeader) Encode() ([]byte, error) {
 
 	actualHeaderSize := align(uint64(len(magic) + len(jsonHeader) + 1))
 	if actualHeaderSize > HeaderSize {
-		return nil, fmt.Errorf("internal error: invalid integrity data header: wrong size")
+		return nil, errors.New("internal error: invalid integrity data header: wrong size")
 	}
 
 	header := make([]byte, HeaderSize)
@@ -220,12 +220,12 @@ func (integrityDataHeader IntegrityDataHeader) Encode() ([]byte, error) {
 // IntegrityDataHeader struct.
 func (integrityDataHeader *IntegrityDataHeader) Decode(input []byte) error {
 	if !bytes.HasPrefix(input, magic) {
-		return fmt.Errorf("invalid integrity data header: invalid magic value")
+		return errors.New("invalid integrity data header: invalid magic value")
 	}
 
 	firstNull := bytes.IndexByte(input, '\x00')
 	if firstNull == -1 {
-		return fmt.Errorf("invalid integrity data header: no null byte found at end of input")
+		return errors.New("invalid integrity data header: no null byte found at end of input")
 	}
 
 	err := json.Unmarshal(input[len(magic):firstNull], &integrityDataHeader)

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/integrity"
+	"github.com/snapcore/snapd/snap/integrity/dmverity"
 	"github.com/snapcore/snapd/snap/pack"
 	"github.com/snapcore/snapd/snap/snapdir"
 )
@@ -371,4 +372,20 @@ func MockContainer(c *check.C, files [][]string) snap.Container {
 	files = append([][]string{{"meta/snap.yaml", ""}}, files...)
 	PopulateDir(d, files)
 	return snapdir.New(d)
+}
+
+func MockIntegrityDataHeaderBytes(c *check.C, rootHash string) []byte {
+	dmVerityInfo := &dmverity.Info{
+		RootHash: rootHash,
+	}
+	integrityDataHeader := &integrity.IntegrityDataHeader{
+		Type:     "integrity",
+		Size:     integrity.HeaderSize * 2,
+		DmVerity: *dmVerityInfo,
+	}
+
+	integrityDataHeaderBytes, err := integrityDataHeader.Encode()
+	c.Assert(err, check.IsNil)
+
+	return integrityDataHeaderBytes
 }


### PR DESCRIPTION
This depends on https://github.com/snapcore/snapd/pull/12664. Also submitting for early review.

New commits start from https://github.com/snapcore/snapd/pull/12671/commits/7d454da9422241a7585c1bf0bd2549581ab91278