### PR TITLE
seed/seedwriter: fix issue that base snaps set in option will be ignored

### DIFF
--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -92,7 +92,7 @@ func (pol *policy16) extraSnapDefaultChannel() string {
 	return "stable"
 }
 
-func (pol *policy16) checkBase(info *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet) error {
+func (pol *policy16) checkBase(info *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet, optionsSnaps []*OptionsSnap) error {
 	availableSnaps := availableByMode["run"]
 	// snap needs no base (or it simply needs core which is never listed explicitly): nothing to do
 	if info.Base == "" {

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -93,7 +93,7 @@ func (pol *policy20) extraSnapDefaultChannel() string {
 	return "latest/stable"
 }
 
-func (pol *policy20) checkBase(info *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet) error {
+func (pol *policy20) checkBase(info *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet, optionsSnaps []*OptionsSnap) error {
 	base := info.Base
 	if base == "" {
 		if info.Type() != snap.TypeGadget && info.Type() != snap.TypeApp {
@@ -104,6 +104,14 @@ func (pol *policy20) checkBase(info *snap.Info, modes []string, availableByMode 
 
 	if pol.checkAvailable(naming.Snap(base), modes, availableByMode) {
 		return nil
+	}
+
+	for _, optSnap := range optionsSnaps {
+		if base == optSnap.Name {
+			return nil
+		} else if base == "" && optSnap.Name == "core" {
+			return nil
+		}
 	}
 
 	whichBase := fmt.Sprintf("its base %q", base)

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -236,7 +236,7 @@ type policy interface {
 	modelSnapDefaultChannel() string
 	extraSnapDefaultChannel() string
 
-	checkBase(s *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet) error
+	checkBase(s *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet, optionsSnaps []*OptionsSnap) error
 
 	checkClassicSnap(sn *SeedSnap) error
 
@@ -961,7 +961,7 @@ func (w *Writer) checkBase(info *snap.Info, modes []string) error {
 		return nil
 	}
 
-	return w.policy.checkBase(info, modes, w.availableByMode)
+	return w.policy.checkBase(info, modes, w.availableByMode, w.optionsSnaps)
 }
 
 func (w *Writer) recordUsageWithThePolicy(modSnaps []*asserts.ModelSnap) {


### PR DESCRIPTION
Hi,

When using the following model assertion to build image with command `snap prepare-image --channel=stable --snap=core22=latest/stable --snap=network-manager=22/stable --snap=modem-manager=latest/stable --snap=core=latest/stable model.assert work/unpack`, I will get this error `error: cannot add snap "modem-manager" without also adding its base "core" explicitly`

```
type: model
authority-id: V2yG6LAupEYdeTz6jHQLLOMkHGd1ZG44
revision: 1
series: 16
brand-id: V2yG6LAupEYdeTz6jHQLLOMkHGd1ZG44
model: ubuntu-core-20-amd64-dangerous
architecture: amd64
base: core20
grade: dangerous
snaps:
  -
    default-channel: 20/edge
    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
    name: pc
    type: gadget
  -
    default-channel: 20/edge
    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
    name: pc-kernel
    type: kernel
  -
    default-channel: latest/edge
    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
    name: core20
    type: base
  -
    default-channel: latest/edge
    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
    name: snapd
    type: snapd
  -
    default-channel: 20/stable
    id: KtwxgRlwCAVKFw92BUdt1WloH1Va3QPo
    name: modem-manager
    type: app
  -
    default-channel: 20/stable
    id: RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy
    name: network-manager
    type: app
timestamp: 2023-03-29T11:18:00.0Z
sign-key-sha3-384: J-RYIwjKa7kBS5WpVNM036ri24pNeOaAM3nbDzyv8q55iMF6Y3nJqsVYiBtI56vE

AcLBcwQAAQoAHRYhBBP9k65i7BkdXwGeTA1TXkI+U5x2BQJkO9deAAoJEA1TXkI+U5x20BAQAI3y
mzGeGn8UMD6XDukDG24tErrc/CpHQbEHxaK8HjuSUni2O5XPxLMb8bz1X0rk9PDcWm/fesRysOKE
CLNITvGoL8gpU4qCI7tZ4mVwjfRYfjCgAX4/lKWVxeqgrVgYDmVkfEvApnLulctaIKwCMwHDjy9J
uwmTYkacWPA3aajIW7ArGNPigYgnnq23mPF2ilRbFjGwT1cGf6wxO6OIOJd30Ih+5Fr+6XV6bEr0
PVO+NJGsHlZFm0Hwkc8GwKVbTDVolQodtktBjJ9KdUjlvOgu3Czyh8nol67F81FVUEEzjtvsp4rW
BRzGi9TzvUsQ78rEpSVKwFZQEyHMplw0w4HdZfSxoLte6SDJir/yaeErHHxq4yNdSrfsMJABTb3i
ZhcCJxJZ/3Vls07VUzyN5uSZhVN/G4KeL9Pg8k/MEgva9nLJicPSwe3xs6Cmf9QCcQcvllGH2hQd
5/M1pICViBWEiYKEP0hUTAvCxaZlxTFJIpNxo6TH+zSTJZhzDtd3I53PBLFZNzhzfXx3GGI1t5tY
s4NqAcksf5gvvOocdG3mLZdZtqimCt66tYueKLkxMx1Q3Od6l0vz250Ve28EAPqXF6bNsNl3O2jv
J4VZvfHWRMiydvwhxWkC9geYqo/Gdlo/cj8vmeSa0cscrrOc2f6I+N9MZ9+VcuvdoTWwtLm8
```

Apparently, I do set the `core` and `core22` snap in option, but they are somehow ignored by snapd. If using the same command with the following model assertion, there is no such a issue

```
type: model
authority-id: canonical
revision: 1
series: 16
brand-id: canonical
model: ubuntu-core-20-amd64-dangerous
architecture: amd64
base: core20
grade: dangerous
snaps:
  -
    default-channel: 20/edge
    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
    name: pc
    type: gadget
  -
    default-channel: 20/edge
    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
    name: pc-kernel
    type: kernel
  -
    default-channel: latest/edge
    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
    name: core20
    type: base
  -
    default-channel: latest/edge
    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
    name: snapd
    type: snapd
timestamp: 2020-04-29T11:18:00.0Z
sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn

AcLBXAQAAQoABgUCXqmLygAKCRDgT5vottzAEjtpD/976igsvImmT56zho47BLbkJYPuC/lgvI+8
84Z9Oi3Oq7oRapm9Fn8AnpKu+0K98XWv4okdjgRrp0fo2ClXcWfQLjMKAtT9dm003hVEjB1IEk1n
SJ2kwmIDvnmFLNA//tteZ5DsAIOUNS6Ug9jEsyMNCgKCKGe2Lprxeukn2VcqrVym1d0chGPsz/VT
Jtwm9WGkUrBqLWj8vfzOaEToqLBDxC7AU5SnrsQpNwgsrnnjFJfY8CBYbcktCC1T7x4Vo+5qEqmA
B99nQPBBHLgT4lA4pQwW/n4h1qJPQvt5SMwtYjPfFpaVSM+Qvs8j4ZBOli0xeP4oIDNJ2qRZ6nkb
hdr2abPWh7wQlmLW04qfJRN7iMBX8vCMWRBlJzFADzfdYHtKs00MSbQoUEtF6mB3Aq84TUdZ40RG
g4ylkYgG5XGAQch3vYwS4LTlqXosXWoPhiMHvrYWlJQBeqyUXD+onK/J1QNM9ff5twH15jy11v9F
ODVTufUV42f70aA6y43cv4Kt8uc0GmHEmMhwYq3NBiOZuLEjKI2IFLJcZchYsZck3/NLMbVi2KrN
aMzgJqkgefM4WbuOpVR+PhfMx5vTnL7b4IFMH6z4tsXKkIRxX+wUgrSIhjE1Dpl4jnHuQM2pF2oq
pbrXk+N/WD0PgoPFDXilYqpqj3kw0B/jVUiWhUZXBA==
```

Thanks for spending time review this PR, it may not be the best solution due to my lack of understanding of the whole mechanism, feel free to give me any suggestions, thanks!

Sorry that I am still quite new to golang, I have tried to run the test case with command `go test -v ./seed/seedwriter/`, but I will get the following error, not sure if I did anything incorrectly
```sh
$ go test -v ./seed/seedwriter/
# github.com/snapcore/secboot/tpm2
../../go/pkg/mod/github.com/snapcore/secboot@v0.0.0-20230412230736-498906f93ad3/tpm2/pcr_profile.go:1127:12: assignment mismatch: 2 variables but values[0].SelectionList returns 1 values
FAIL	github.com/snapcore/snapd/seed/seedwriter [build failed]
FAIL
```