### PR TITLE
snapmgr: periodically remove unneeded base snaps 

### DIFF
--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -78,6 +78,7 @@ func (s *snapshotSuite) SetUpTest(c *check.C) {
 		return nil, nil
 	}
 	s.AddCleanup(osutil.MockMountInfo(""))
+	s.AddCleanup(snapstatetest.UseFallbackDeviceModel())
 }
 
 func (s *snapshotSuite) TearDownTest(c *check.C) {
@@ -404,9 +405,6 @@ func (snapshotSuite) createConflictingChange(c *check.C) (st *state.State, resto
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
-
-	r := snapstatetest.UseFallbackDeviceModel()
-	defer r()
 
 	chg := st.NewChange("rm foo", "...")
 	rmTasks, err := snapstate.Remove(st, "foo", snap.R(0), nil)

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -629,7 +629,6 @@ func (snapshotSuite) TestSaveIntegration(c *check.C) {
 	o.AddManager(o.TaskRunner())
 
 	st.Lock()
-	defer st.Unlock()
 
 	snapshotOptions := map[string]*snap.SnapshotOptions{
 		"one-snap": {Exclude: []string{"$SNAP_COMMON/exclude-a-snap", "$SNAP_DATA/exclude-a-snap"}},
@@ -674,6 +673,7 @@ func (snapshotSuite) TestSaveIntegration(c *check.C) {
 	c.Assert(o.Settle(5*time.Second), check.IsNil)
 	st.Lock()
 	c.Check(change.Err(), check.IsNil)
+	defer st.Unlock()
 
 	tf := time.Now()
 	c.Assert(backend.Iter(context.TODO(), func(r *backend.Reader) error {
@@ -746,7 +746,6 @@ exec /bin/tar "$@"
 	o.AddManager(o.TaskRunner())
 
 	st.Lock()
-	defer st.Unlock()
 
 	for i, name := range []string{"one-snap", "too-snap", "tri-snap"} {
 		sideInfo := &snap.SideInfo{RealName: name, Revision: snap.R(i + 1)}
@@ -779,6 +778,7 @@ exec /bin/tar "$@"
 	c.Assert(o.Settle(5*time.Second), check.IsNil)
 	st.Lock()
 	c.Check(change.Err(), check.NotNil)
+	defer st.Unlock()
 	tasks := change.Tasks()
 	c.Assert(tasks, check.HasLen, 3)
 
@@ -852,7 +852,6 @@ exec /bin/tar "$@"
 	o.AddManager(o.TaskRunner())
 
 	st.Lock()
-	defer st.Unlock()
 
 	sideInfo := &snap.SideInfo{RealName: "tar-fail-snap", Revision: snap.R(1)}
 	snapstate.Set(st, "tar-fail-snap", &snapstate.SnapState{
@@ -879,6 +878,7 @@ exec /bin/tar "$@"
 	c.Assert(o.Settle(testutil.HostScaledTimeout(5*time.Second)), check.IsNil)
 	st.Lock()
 	c.Check(change.Err(), check.NotNil)
+	defer st.Unlock()
 	tasks := change.Tasks()
 	c.Assert(tasks, check.HasLen, 1)
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -142,6 +142,8 @@ var (
 	ReRefreshSummary                = reRefreshSummary
 
 	MaybeFindTasksetForSnap = maybeFindTasksetForSnap
+
+	CreateDependencyRemovalTasks = createDependencyRemovalTasks
 )
 
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -118,6 +118,10 @@ type Flags struct {
 	// setup, making them be applied immediately when the security backend(s)
 	// are being set up.
 	NoDelayedSideEffects bool `json:"no-delayed-effects,omitempty"`
+
+	// ImplicitlyInstalled indicates whether a snap is being
+	// implicitly installed, or being installed by the user.
+	ImplicitlyInstalled bool `json:"implicitly-installed,omitempty"`
 }
 
 // DevModeAllowed returns whether a snap can be installed with devmode

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1914,6 +1914,9 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (retErr error) {
 	}
 	// keep instance key
 	snapst.InstanceKey = snapsup.InstanceKey
+
+	// propagate!
+	snapst.ImplicitlyInstalled = snapsup.ImplicitlyInstalled
 
 	// don't keep the old state because, if we fail, we may or may not be able to
 	// revert the migration. We set the migration status after undoing any

--- a/overlord/snapstate/handlers_error_test.go
+++ b/overlord/snapstate/handlers_error_test.go
@@ -73,6 +73,7 @@ func (s *taskErrorSuite) SetUpTest(c *C) {
 	s.snapmgr, err = snapstate.Manager(s.state, s.runner)
 	c.Assert(err, IsNil)
 	snapstate.SetStoreCacheCleanNext(s.snapmgr, time.Now().Add(time.Hour))
+	s.AddCleanup(snapstatetest.UseFallbackDeviceModel())
 
 	s.se = overlord.NewStateEngine(s.state)
 	s.se.AddManager(s.snapmgr)

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -102,6 +102,9 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		// is to inject the tasksets into the current change, set the flag to
 		// avoid generating one
 		NoDelayedSideEffects: true,
+
+		// any snap being installed as a prerequisite is implicitly installed
+		ImplicitlyInstalled: true,
 	}
 	if flags.Transaction == client.TransactionAllSnaps {
 		lanes := t.Lanes()

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -279,8 +279,9 @@ const (
 )
 
 // checkForInFlightPrereqTasks checks whether a link-snap task for
-// prerequisiteName is already in flight and reports how the caller should handle
-// the prerequisite.
+// prerequisiteName is already in flight, or whether prerequisiteName is
+// otherwise involved in another in-flight change (e.g. being removed), and
+// reports how the caller should handle the prerequisite.
 func checkForInFlightPrereqTasks(prereqs *state.Task, prerequisiteName string, basePrerequisite bool) (prereqInFlightAction, error) {
 	st := prereqs.State()
 
@@ -289,8 +290,14 @@ func checkForInFlightPrereqTasks(prereqs *state.Task, prerequisiteName string, b
 		return 0, err
 	}
 
-	// no link-snap task is in flight for this prerequisite snap, proceed
+	// no link-snap task is in flight for this prerequisite snap, but it
+	// could still be concurrently removed by another change (e.g.
+	// automatic removal of a now-unneeded implicit base). retry rather
+	// than proceeding against a prerequisite that is about to disappear.
 	if link == nil {
+		if err := CheckChangeConflictMany(st, []string{prerequisiteName}, prereqs.Change().ID()); err != nil {
+			return prereqRetry, nil
+		}
 		return prereqProceed, nil
 	}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1704,6 +1704,11 @@ func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 
 	var removeList []string
 
+	deviceCtx, err := DeviceCtxFromState(m.state, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	for _, installedSnap := range snapList {
 		var snapst SnapState
 		err = Get(m.state, installedSnap.SnapName(), &snapst)
@@ -1718,11 +1723,6 @@ func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 
 		if !snapst.ImplicitlyInstalled {
 			continue
-		}
-
-		deviceCtx, err := DeviceCtxFromState(m.state, nil)
-		if err != nil {
-			return nil, nil, err
 		}
 
 		snapInfo, err := Info(m.state, installedSnap.SnapName(), installedSnap.Revision)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1692,7 +1692,7 @@ func (m *SnapManager) ensureStoreDownloadsCacheCleaned() error {
 	return nil
 }
 
-func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, error) {
+func createDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, error) {
 	if changeInFlight(m.state) {
 		return nil, nil, nil
 	}
@@ -1773,7 +1773,7 @@ func (m *SnapManager) ensureDependencyRemoval() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	snapNames, taskSetList, err := CreateDependencyRemovalTasks(m)
+	snapNames, taskSetList, err := createDependencyRemovalTasks(m)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1699,6 +1699,7 @@ func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 	for _, change := range changeList {
 		// Only run when there are no pending changes, since we can't know if
 		// a snap is required by changes that are pending
+		// TODO: Use changeInFlight?
 		if !change.IsReady() {
 			return nil, nil, nil
 		}
@@ -1758,6 +1759,9 @@ func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 			return nil, nil, err
 		}
 
+		// We need logic which checks the slot information of a snap to see if it can
+		// be potentially connected to a snap installed or being installed on a system. For
+		// now, bail if the snap isn't a base.
 		if snapType != snap.TypeBase {
 			continue
 		}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1777,11 +1777,15 @@ func (m *SnapManager) ensureDependencyRemoval() error {
 		return err
 	}
 
+	if len(taskSetList) == 0 {
+		return nil
+	}
+
 	change := m.state.NewChange("orphan-removal", "Remove implicitly installed snaps that are no longer required")
 	for _, taskSet := range taskSetList {
 		change.AddAll(taskSet)
 	}
-	if snapNames != nil {
+	if len(snapNames) != 0 {
 		change.Set("snap-names", snapNames)
 	}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1706,6 +1706,10 @@ func createDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 
 	deviceCtx, err := DeviceCtxFromState(m.state, nil)
 	if err != nil {
+		if _, ok := err.(*ChangeConflictError); ok {
+			// likely just too early, retry at next Ensure
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 
@@ -1770,6 +1774,8 @@ func (m *SnapManager) ensureDependencyRemoval() error {
 	if len(taskSetList) == 0 {
 		return nil
 	}
+
+	logger.Trace("ensure", "manager", "SnapManager", "func", "ensureDependencyRemoval")
 
 	change := m.state.NewChange("orphan-removal", "Remove implicitly installed snaps that are no longer required")
 	for _, taskSet := range taskSetList {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1697,7 +1697,7 @@ func createDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 		return nil, nil, nil
 	}
 
-	snapList, _, err := InstalledSnaps(m.state)
+	allStates, err := All(m.state)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1709,23 +1709,12 @@ func createDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 		return nil, nil, err
 	}
 
-	for _, installedSnap := range snapList {
-		var snapst SnapState
-		err = Get(m.state, installedSnap.SnapName(), &snapst)
-
-		if err != nil {
-			// If the snap has already been removed, don't add it to the list
-			if errors.Is(err, state.ErrNoState) {
-				continue
-			}
-			return nil, nil, err
-		}
-
+	for name, snapst := range allStates {
 		if !snapst.ImplicitlyInstalled {
 			continue
 		}
 
-		snapInfo, err := Info(m.state, installedSnap.SnapName(), installedSnap.Revision)
+		snapInfo, err := snapst.CurrentInfo()
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1744,13 +1733,13 @@ func createDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 
 		removeAll := true
 		removals := map[string]bool{snapst.InstanceName(): true}
-		err = canRemove(m.state, snapInfo, &snapst, removeAll, deviceCtx, removals)
+		err = canRemove(m.state, snapInfo, snapst, removeAll, deviceCtx, removals)
 		if err != nil {
-			logger.Debugf("cannot auto-remove implicitly installed snap %q: %v", installedSnap.SnapName(), err)
+			logger.Debugf("cannot auto-remove implicitly installed snap %q: %v", name, err)
 			continue
 		}
 
-		removeList = append(removeList, installedSnap.SnapName())
+		removeList = append(removeList, name)
 	}
 
 	if len(removeList) == 0 {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1746,6 +1746,7 @@ func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 		removals := map[string]bool{snapst.InstanceName(): true}
 		err = canRemove(m.state, snapInfo, &snapst, removeAll, deviceCtx, removals)
 		if err != nil {
+			logger.Debugf("cannot auto-remove implicitly installed snap %q: %v", installedSnap.SnapName(), err)
 			continue
 		}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1714,11 +1714,6 @@ func createDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 			continue
 		}
 
-		snapInfo, err := snapst.CurrentInfo()
-		if err != nil {
-			return nil, nil, err
-		}
-
 		snapType, err := snapst.Type()
 		if err != nil {
 			return nil, nil, err
@@ -1729,6 +1724,11 @@ func createDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, e
 		// now, bail if the snap isn't a base.
 		if snapType != snap.TypeBase {
 			continue
+		}
+
+		snapInfo, err := snapst.CurrentInfo()
+		if err != nil {
+			return nil, nil, err
 		}
 
 		removeAll := true

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1693,32 +1693,8 @@ func (m *SnapManager) ensureStoreDownloadsCacheCleaned() error {
 }
 
 func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, error) {
-	changeList := m.state.Changes()
-
-	var latestChange *state.Change
-	for _, change := range changeList {
-		// Only run when there are no pending changes, since we can't know if
-		// a snap is required by changes that are pending
-		// TODO: Use changeInFlight?
-		if !change.IsReady() {
-			return nil, nil, nil
-		}
-
-		if latestChange == nil {
-			latestChange = change
-			continue
-		}
-
-		if change.SpawnTime().After(latestChange.SpawnTime()) {
-			latestChange = change
-		}
-	}
-
-	if latestChange != nil {
-		fiveMinutesAgo := time.Now().Add(-5 * time.Minute)
-		if latestChange.SpawnTime().Before(fiveMinutesAgo) {
-			return nil, nil, nil
-		}
+	if changeInFlight(m.state) {
+		return nil, nil, nil
 	}
 
 	snapList, _, err := InstalledSnaps(m.state)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1692,6 +1692,122 @@ func (m *SnapManager) ensureStoreDownloadsCacheCleaned() error {
 	return nil
 }
 
+func CreateDependencyRemovalTasks(m *SnapManager) ([]string, []*state.TaskSet, error) {
+	changeList := m.state.Changes()
+
+	var latestChange *state.Change
+	for _, change := range changeList {
+		// Only run when there are no pending changes, since we can't know if
+		// a snap is required by changes that are pending
+		if !change.IsReady() {
+			return nil, nil, nil
+		}
+
+		if latestChange == nil {
+			latestChange = change
+			continue
+		}
+
+		if change.SpawnTime().After(latestChange.SpawnTime()) {
+			latestChange = change
+		}
+	}
+
+	if latestChange != nil {
+		fiveMinutesAgo := time.Now().Add(-5 * time.Minute)
+		if latestChange.SpawnTime().Before(fiveMinutesAgo) {
+			return nil, nil, nil
+		}
+	}
+
+	snapList, _, err := InstalledSnaps(m.state)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var removeList []string
+
+	for _, installedSnap := range snapList {
+		var snapst SnapState
+		err = Get(m.state, installedSnap.SnapName(), &snapst)
+
+		if err != nil {
+			// If the snap has already been removed, don't add it to the list
+			if errors.Is(err, state.ErrNoState) {
+				continue
+			}
+			return nil, nil, err
+		}
+
+		if !snapst.ImplicitlyInstalled {
+			continue
+		}
+
+		deviceCtx, err := DeviceCtxFromState(m.state, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		snapInfo, err := Info(m.state, installedSnap.SnapName(), installedSnap.Revision)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		snapType, err := snapst.Type()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if snapType != snap.TypeBase {
+			continue
+		}
+
+		removeAll := true
+		removals := map[string]bool{snapst.InstanceName(): true}
+		err = canRemove(m.state, snapInfo, &snapst, removeAll, deviceCtx, removals)
+		if err != nil {
+			continue
+		}
+
+		removeList = append(removeList, installedSnap.SnapName())
+	}
+
+	if len(removeList) == 0 {
+		return nil, nil, nil
+	}
+
+	snapNames, taskSetList, err := RemoveMany(m.state, removeList, &RemoveFlags{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(taskSetList) == 0 {
+		return nil, nil, nil
+	}
+
+	return snapNames, taskSetList, nil
+}
+
+func (m *SnapManager) ensureDependencyRemoval() error {
+	m.state.Lock()
+	defer m.state.Unlock()
+
+	snapNames, taskSetList, err := CreateDependencyRemovalTasks(m)
+	if err != nil {
+		return err
+	}
+
+	change := m.state.NewChange("orphan-removal", "Remove implicitly installed snaps that are no longer required")
+	for _, taskSet := range taskSetList {
+		change.AddAll(taskSet)
+	}
+	if snapNames != nil {
+		change.Set("snap-names", snapNames)
+	}
+
+	return nil
+}
+
 // Ensure implements StateManager.Ensure.
 func (m *SnapManager) Ensure() error {
 	if m.preseed {
@@ -1715,6 +1831,7 @@ func (m *SnapManager) Ensure() error {
 		m.ensureDesktopFilesUpdated(),
 		m.ensureDownloadsCleaned(),
 		m.ensureStoreDownloadsCacheCleaned(),
+		m.ensureDependencyRemoval(),
 	}
 
 	//FIXME: use firstErr helper

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -2534,6 +2534,45 @@ func (s *snapmgrTestSuite) TestRemoveManyWithPurge(c *C) {
 	}
 }
 
+func (s *snapmgrTestSuite) TestEnsureDependencyRemovalBaseSnap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+			RealName: "some-base",
+			SnapID:   "some-base-id",
+			Revision: snap.R(1),
+		}}),
+		Flags: snapstate.Flags{
+			ImplicitlyInstalled: true,
+		},
+		Current:  snap.R(1),
+		SnapType: "base",
+		Active:   true,
+	})
+
+	removedSnaps, taskSets, err := snapstate.CreateDependencyRemovalTasks(s.snapmgr)
+
+	c.Check(removedSnaps, DeepEquals, []string{"some-base"})
+	c.Assert(err, IsNil)
+	c.Check(taskSets, NotNil)
+	c.Assert(len(taskSets), Equals, 1)
+
+	for _, set := range taskSets {
+		c.Assert(taskKinds(set.Tasks()), DeepEquals, []string{
+			"stop-snap-services",
+			"run-hook[remove]",
+			"auto-disconnect",
+			"remove-aliases",
+			"unlink-snap",
+			"remove-profiles",
+			"clear-snap",
+			"discard-snap",
+		})
+	}
+}
+
 func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 	const snapName = "snap1"
 	const comp1name = "comp1"

--- a/tests/main/implicit-dependency-flag-not-changed/task.yaml
+++ b/tests/main/implicit-dependency-flag-not-changed/task.yaml
@@ -1,0 +1,14 @@
+summary: Check that an explicitly installed remains marked as explicitly installed after refresh
+
+prepare: |
+  snap install --devmode jq
+  tests.cleanup defer snap remove jq
+
+execute: |
+  snap install --revision=2790 core18
+  tests.cleanup defer snap remove core18
+
+  jq -r '.data.snaps.core18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false
+
+  snap refresh core18
+  jq -r '.data.snaps.core18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false

--- a/tests/main/implicit-dependency-flag-not-changed/task.yaml
+++ b/tests/main/implicit-dependency-flag-not-changed/task.yaml
@@ -1,4 +1,9 @@
-summary: Check that an explicitly installed remains marked as explicitly installed after refresh
+summary: Check that an explicitly installed snap remains marked as explicitly installed after refresh
+
+details: |
+  Snaps which are explicitly installed by the user should never have the
+  implicitly-installed flag set to true on them. This test shows that snaps
+  which are refreshed do not have this flag added.
 
 prepare: |
   snap install --devmode jq

--- a/tests/main/implicit-dependency-flag-set/task.yaml
+++ b/tests/main/implicit-dependency-flag-set/task.yaml
@@ -1,0 +1,15 @@
+summary: Check that the implicitly-installed flag is properly set
+
+prepare: |
+  snap install --devmode jq
+  snap pack "$TESTSLIB/snaps/basic18"
+  snap install --dangerous basic18_1.0_all.snap
+
+execute: |
+  jq -r '.data.snaps.core18["implicitly-installed"]'  /var/lib/snapd/state.json | MATCH true
+  jq -r '.data.snaps.basic18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false
+
+cleanup: |
+  snap remove --purge jq
+  snap remove --purge basic18
+  snap remove --purge core18

--- a/tests/main/implicit-dependency-flag-set/task.yaml
+++ b/tests/main/implicit-dependency-flag-set/task.yaml
@@ -12,11 +12,11 @@ prepare: |
   snap pack "$TESTSLIB/snaps/basic18"
   snap install --dangerous basic18_1.0_all.snap
 
-execute: |
-  jq -r '.data.snaps.core18["implicitly-installed"]'  /var/lib/snapd/state.json | MATCH true
-  jq -r '.data.snaps.basic18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false
-
 restore: |
   snap remove --purge jq
   snap remove --purge basic18
   snap remove --purge core18
+
+execute: |
+  jq -r '.data.snaps.core18["implicitly-installed"]'  /var/lib/snapd/state.json | MATCH true
+  jq -r '.data.snaps.basic18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false

--- a/tests/main/implicit-dependency-flag-set/task.yaml
+++ b/tests/main/implicit-dependency-flag-set/task.yaml
@@ -16,7 +16,7 @@ execute: |
   jq -r '.data.snaps.core18["implicitly-installed"]'  /var/lib/snapd/state.json | MATCH true
   jq -r '.data.snaps.basic18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false
 
-cleanup: |
+restore: |
   snap remove --purge jq
   snap remove --purge basic18
   snap remove --purge core18

--- a/tests/main/implicit-dependency-flag-set/task.yaml
+++ b/tests/main/implicit-dependency-flag-set/task.yaml
@@ -1,5 +1,12 @@
 summary: Check that the implicitly-installed flag is properly set
 
+details: |
+  Prerequisite snaps in the form of a base or a default-provider for a content
+  plug will be automatically installed by snapd. This test demonstrates that
+  those implicitly installed dependencies have a flag set to true on them,
+  enabling their automatic removal if they are no longer required (e.g., the
+  snap which triggered their installation is no longer present).
+
 prepare: |
   snap install --devmode jq
   snap pack "$TESTSLIB/snaps/basic18"

--- a/tests/main/implicit-dependency-kept-on-refresh/task.yaml
+++ b/tests/main/implicit-dependency-kept-on-refresh/task.yaml
@@ -1,0 +1,16 @@
+summary: Check that an explicitly installed "dependency" remains marked explicitly installed
+
+prepare: |
+  snap install --devmode jq
+  snap install core18
+  tests.cleanup defer snap remove core18
+  tests.cleanup defer snap remove jq
+
+execute: |
+  snap pack "$TESTSLIB/snaps/basic18"
+  snap install --dangerous basic18_1.0_all.snap
+
+  jq -r '.data.snaps.core18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false
+
+  snap remove basic18
+  jq -r '.data.snaps.core18["implicitly-installed"]' /var/lib/snapd/state.json | MATCH false

--- a/tests/main/implicit-dependency-kept-on-refresh/task.yaml
+++ b/tests/main/implicit-dependency-kept-on-refresh/task.yaml
@@ -1,5 +1,13 @@
 summary: Check that an explicitly installed "dependency" remains marked explicitly installed
 
+details: |
+  There are cases where a user wants a snap which was previously installed
+  implicitly to be installed explicitly (that is to say, they explicitly install
+  it). Similarly to how package managers such as apt manage this is by marking a
+  package as explicitly installed if the user attempts to install it. This test
+  shows that if a snap was installed implicitly but is later explicitly installed,
+  the implicitly-installed flag updates.
+
 prepare: |
   snap install --devmode jq
   snap install core18


### PR DESCRIPTION
Snaps have two types of dependencies: hard dependency and soft dependency.

* A hard dependency is the most salient: the snap declares a `base:` and that base snap must be installed on the system for that snap to be installed.

* A soft dependency is a bit looser: primarily these dependencies are things which provide a content interface for arbitrary snaps to leverage in their execution. This dependency is made stronger if a snap declares a content provider as _the_ `default-provider` for that interface. In such a case, that snap will always be installed as a prerequisite.

In cases where a user installs a snap which has a dependency, it's feasible that the user does not care about whether or not that dependency is installed. Specifically, a user may not care if `core20` is installed, just that `firefox` works when it is. In cases where users remove the snap they care about, they may forget about this dependency relationship and forget to remove that now orphaned snap.

This PR aims to clean up so-called orphans on a periodic basis utilizing `Ensure()`. 

We accomplish this by flagging any snap installed as a dependency of some other snap as being `implicitly-installed: true` and all others as `implicitly-installed: false`.
Just in case a snap is marked as `implicitly-installed: true`, a new task called `orphan-removals` is spawned to remove that snap.

**NOTE**: currently, if a snap is not of `type: base`, it won't be removed by this functionality. (line 1185 of `snapmgr.go` in this PR). The reason for this is explained in the comment on that check: the work of identifying if a non-base dependency is being _used_ still has to be done.

Otherewise, everything tends to work as expected.

SNAPDENG-37045