### PR TITLE
tests/snapshot-content-interface: check snapshot behavior

### DIFF
--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -372,6 +373,12 @@ func (r *Reader) Restore(ctx context.Context, current snap.Revision, usernames [
 
 		sz.Reset()
 		hasher.Reset()
+	}
+
+	// We need to discard the consumer namespace!!
+	logger.Noticef("discarding namespace for %q", r.Snap)
+	if err := mount.DiscardSnapNamespace("test-cons"); err != nil {
+		return rs, fmt.Errorf("cannot discard namespace: %v", err)
 	}
 
 	return rs, nil

--- a/tests/main/snapshot-content-interface/cons/bin/test.sh
+++ b/tests/main/snapshot-content-interface/cons/bin/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+# Simple check for file and content
+grep test "$SNAP_DATA"/data-c/data/test

--- a/tests/main/snapshot-content-interface/cons/meta/snap.yaml
+++ b/tests/main/snapshot-content-interface/cons/meta/snap.yaml
@@ -1,0 +1,16 @@
+name: test-cons
+version: '1.0'
+summary: Test consume content interface
+description: |
+  Test consume content interface
+base: core22
+confinement: strict
+grade: stable
+
+plugs:
+    ciiface:
+        interface: content
+        target: $SNAP_DATA/data-c
+apps:
+  test:
+    command: bin/test.sh

--- a/tests/main/snapshot-content-interface/prod/bin/test.sh
+++ b/tests/main/snapshot-content-interface/prod/bin/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+mkdir -p "$SNAP_DATA"/data
+printf "test\n" > "$SNAP_DATA"/data/test

--- a/tests/main/snapshot-content-interface/prod/meta/snap.yaml
+++ b/tests/main/snapshot-content-interface/prod/meta/snap.yaml
@@ -1,0 +1,18 @@
+name: test-prod
+version: '1.0'
+summary: Test content interface
+description: |
+  Test content interface
+base: core22
+confinement: strict
+grade: stable
+
+slots:
+    ciiface:
+        interface: content
+        source:
+          write:
+            - $SNAP_DATA/data
+apps:
+  test:
+    command: bin/test.sh

--- a/tests/main/snapshot-content-interface/task.yaml
+++ b/tests/main/snapshot-content-interface/task.yaml
@@ -1,0 +1,28 @@
+summary: Check that snapshots work with content interfaces
+
+environment:
+    # tar invoked when creating snapshots triggers OOM
+    SNAPD_NO_MEMORY_LIMIT: 1
+
+debug: |
+    snap list || true
+    snap saved || true
+
+execute: |
+  snap pack prod
+  snap pack cons
+
+  snap install --dangerous test-prod_1.0_all.snap
+  snap install --dangerous test-cons_1.0_all.snap
+  snap connect test-cons:ciiface test-prod:ciiface
+
+  # Writes a file in the shared folder
+  sudo test-prod.test
+  # Reads it
+  sudo test-cons.test
+
+  set_id=$(snap save test-prod | tail -n1 | cut -d' ' -f1)
+  snap restore "$set_id" test-prod
+
+  # Still can read after save/restore
+  sudo test-cons.test


### PR DESCRIPTION
Check snapshot behavior when there is a content interface used to share information between two snaps.

This is a reproducer, the test is failing at the moment.