### PR TITLE
o/i/ifacemgr: do not check for apparmor through systemd

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -184,7 +184,7 @@ purge() {
     done
 
     # stop snapd services
-    for serv in snapd.autoimport.service snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target; do
+    for serv in snapd.autoimport.service snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target snapd.system-services-pre.target; do
         systemctl_stop "$serv"
     done
 

--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -27,6 +27,3 @@ ExecStart=@libexecdir@/snapd/snapd-apparmor start
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 EnvironmentFile=-/var/lib/snapd/environment/snapd.conf
 RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target

--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -3,8 +3,10 @@ Description=Snap Daemon
 After=snapd.socket
 After=time-set.target
 After=snapd.mounts.target
+After=snapd.apparmor.service
 Wants=time-set.target
 Wants=snapd.mounts.target
+Wants=snapd.apparmor.service
 Requires=snapd.socket
 OnFailure=snapd.failure.service
 # This is handled by snapd

--- a/data/systemd/snapd.system-services-pre.target
+++ b/data/systemd/snapd.system-services-pre.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Preparation for snap system services
+Wants=snapd.apparmor.service
+Wants=network.target

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -108,12 +108,6 @@ func MockRemoveStaleConnections(f func(st *state.State) error) (restore func()) 
 	return func() { removeStaleConnections = old }
 }
 
-func MockSnapdAppArmorServiceIsDisabled(f func() bool) (restore func()) {
-	r := testutil.Backup(&snapdAppArmorServiceIsDisabled)
-	snapdAppArmorServiceIsDisabled = f
-	return r
-}
-
 func MockContentLinkRetryTimeout(d time.Duration) (restore func()) {
 	old := contentLinkRetryTimeout
 	contentLinkRetryTimeout = d

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -43,7 +43,6 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -52,8 +51,6 @@ func init() {
 }
 
 var (
-	snapdAppArmorServiceIsDisabled = snapdAppArmorServiceIsDisabledImpl
-
 	writeSystemKey = interfaces.WriteSystemKey
 )
 
@@ -202,14 +199,6 @@ func (m *InterfaceManager) assessAppArmorPrompting() bool {
 		return promptingEnabled && supported
 	}
 	return false
-}
-
-// snapdAppArmorServiceIsDisabledImpl returns true if the snapd.apparmor
-// service unit exists but is disabled
-func snapdAppArmorServiceIsDisabledImpl() bool {
-	sysd := systemd.New(systemd.SystemMode, nil)
-	isEnabled, err := sysd.IsEnabled("snapd.apparmor")
-	return err == nil && !isEnabled
 }
 
 // regenerateAllSecurityProfiles will regenerate all security profiles. This

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -21,6 +21,7 @@ package ifacestate
 
 import (
 	"fmt"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -248,9 +249,31 @@ func (m *InterfaceManager) StartUp() error {
 			return err
 		}
 	}
-	if hasAppArmorBackend(m.repo.Backends()) && snapdAppArmorServiceIsDisabled() {
-		s.Warnf(`the snapd.apparmor service is disabled; snap applications will likely not start.
-Run "systemctl enable --now snapd.apparmor" to correct this.`)
+
+	if hasAppArmorBackend(m.repo.Backends()) {
+		all, err := snapstate.All(s)
+		if err != nil {
+			return err
+		}
+		for name, sn := range all {
+			if (sn.SnapType == string(snap.TypeApp)) && sn.Active {
+				info, err := sn.CurrentInfo()
+				if err != nil {
+					return err
+				}
+				// We do not check hooks. But this is informal.
+				for _, app := range info.Apps {
+					glob := fmt.Sprintf("/sys/kernel/security/apparmor/policy/profiles/snap.%s.%s.*", name, app.Name)
+					matches, err := filepath.Glob(glob)
+					if err != nil {
+						return err
+					}
+					if len(matches) == 0 {
+						s.Warnf("the snapd.apparmor service is not running; snap applications will likely not start.")
+					}
+				}
+			}
+		}
 	}
 
 	ifacerepo.Replace(s, m.repo)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -303,10 +303,6 @@ slots:
 	s.consumerPlug = s.consumer.Info().Plugs["plug"]
 	s.producer = ifacetest.MockInfoAndAppSet(c, producerYaml4, nil, nil)
 	s.producerSlot = s.producer.Info().Slots["slot"]
-	s.AddCleanup(ifacestate.MockSnapdAppArmorServiceIsDisabled(func() bool {
-		// pretend the snapd.apparmor.service is enabled
-		return false
-	}))
 
 	s.BaseTest.AddCleanup(ifacestate.MockCreateInterfacesRequestsManager(fakeCreateInterfacesRequestsManager))
 	s.BaseTest.AddCleanup(ifacestate.MockInterfacesRequestsManagerStop(fakeInterfacesRequestsManagerStop))
@@ -7495,38 +7491,6 @@ func (s *interfaceManagerSuite) TestStartupTimings(c *C) {
 	tags, ok := allTimings[0]["tags"]
 	c.Assert(ok, Equals, true)
 	c.Check(tags, DeepEquals, map[string]any{"startup": "ifacemgr"})
-}
-
-func (s *interfaceManagerSuite) TestStartupWarningForDisabledAppArmorWithAppArmor(c *C) {
-	invocationCount := 0
-	restore := ifacestate.MockSnapdAppArmorServiceIsDisabled(func() bool {
-		invocationCount++
-		return true
-	})
-	defer restore()
-	s.extraBackends = append(s.extraBackends, &ifacetest.TestSecurityBackend{
-		// pretend apparmor backend is present
-		BackendName: interfaces.SecurityAppArmor,
-	})
-	_ = s.manager(c)
-
-	c.Check(invocationCount, Equals, 1)
-
-	warns := s.state.AllWarnings()
-	c.Assert(warns, HasLen, 1)
-	c.Check(warns[0].String(), Matches, `the snapd\.apparmor service is disabled.*\nRun .* to correct this\.`)
-}
-
-func (s *interfaceManagerSuite) TestStartupWarningForDisabledAppArmorNoAppArmor(c *C) {
-	restore := ifacestate.MockSnapdAppArmorServiceIsDisabled(func() bool {
-		return true
-	})
-	defer restore()
-	// no apparmor support, no warning, even if snapd.apparmor is disabled
-	_ = s.manager(c)
-
-	warns := s.state.AllWarnings()
-	c.Assert(warns, HasLen, 0)
 }
 
 func (s *interfaceManagerSuite) TestAutoconnectSelf(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -10439,8 +10439,8 @@ apps:
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application test-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 %[2]s=usr-lib-snapd.mount
 After=usr-lib-snapd.mount
 X-Snappy=yes
@@ -10673,8 +10673,8 @@ apps:
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application test-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 %[2]s=usr-lib-snapd.mount
 After=usr-lib-snapd.mount
 X-Snappy=yes

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -157,8 +157,8 @@ var (
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application test-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 %[2]sX-Snappy=yes
 
 [Service]

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -65,7 +65,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs      snapd.service snapd.socket snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target
+%global snappy_svcs      snapd.service snapd.socket snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target snapd.system-services-pre.target
 %global snappy_user_svcs snapd.session-agent.service snapd.session-agent.socket
 
 # Note that packaging for Fedora does omit cap_setgid and cap_setuid that are
@@ -841,6 +841,7 @@ make -C data -k check
 %{_unitdir}/snapd.apparmor.service
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
+%{_unitdir}/snapd.system-services-pre.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 %{_tmpfilesdir}/snapd.conf

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -650,6 +650,7 @@ fi
 %{_unitdir}/snapd.socket
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
+%{_unitdir}/snapd.system-services-pre.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 %ghost /tmp/snap-private-tmp

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -497,7 +497,7 @@ const (
 	ServicesTarget = "multi-user.target"
 
 	// the target prerequisite for systemd units we generate
-	PrerequisiteTarget = "network.target"
+	PrerequisiteTarget = "snapd.system-services-pre.target"
 
 	// the default target for systemd socket units that we generate
 	SocketsTarget = "sockets.target"

--- a/tests/core/core-to-snapd-failover16/task.yaml
+++ b/tests/core/core-to-snapd-failover16/task.yaml
@@ -62,6 +62,7 @@ execute: |
     test ! -e /etc/systemd/system/usr-lib-snapd.mount
     test ! -e /etc/systemd/system/snapd.mounts.target
     test ! -e /etc/systemd/system/snapd.mounts-pre.target
+    test ! -e /etc/systemd/system/snapd.system-services-pre.target
     test ! -e /etc/systemd/system/snap-snapd-x1.mount
     test ! -e /snap/snapd/x1
   done

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -123,7 +123,6 @@ execute: |
   MATCH "^etc/systemd/system/snapd.service.wants/usr-lib-snapd.mount" < files.log
   MATCH "^etc/systemd/system/snapd.autoimport.service" < files.log
   MATCH "^etc/systemd/system/final.target.wants/snapd.system-shutdown.service" < files.log
-  MATCH "^etc/systemd/system/snapd.apparmor.service" < files.log
   MATCH "^etc/systemd/system/dbus-org.freedesktop.timesync1.service" < files.log
   MATCH "^etc/systemd/system/sshd.service" < files.log
   MATCH "^etc/systemd/system/snapd.socket" < files.log
@@ -144,7 +143,6 @@ execute: |
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-pc.*kernel-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snap-pc.*kernel-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.autoimport.service" < files.log
-  MATCH "^etc/systemd/system/multi-user.target.wants/snapd.apparmor.service" < files.log
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-core20-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snap-core20-.*.mount" < files.log
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-snapd-.*.mount" < files.log

--- a/wrappers/internal/service_timer_gen_test.go
+++ b/wrappers/internal/service_timer_gen_test.go
@@ -110,8 +110,8 @@ func (s *serviceTimerUnitGenSuite) TestServiceTimerServiceUnit(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -332,7 +332,6 @@ WantedBy={{.ServicesTarget}}
 		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(dirs.StripRootDir(appInfo.Snap.MountDir())))
 		wrapperData.Requires = append(wrapperData.Requires, wrapperData.MountUnit)
 		wrapperData.WorkingDir = dirs.StripRootDir(appInfo.Snap.DataDir())
-		wrapperData.After = append(wrapperData.After, "snapd.apparmor.service")
 	case snap.UserDaemon:
 		wrapperData.ServicesTarget = systemd.UserServicesTarget
 		// FIXME: ideally use UserDataDir("%h"), but then the

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -54,8 +54,8 @@ const expectedServiceFmt = `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -113,8 +113,8 @@ var (
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application xkcd-webserver.xkcd-webserver
 Requires=%s-xkcd\x2dwebserver-44.mount
-Wants=network.target
-After=%s-xkcd\x2dwebserver-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-xkcd\x2dwebserver-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -171,8 +171,8 @@ func (s *serviceUnitGenSuite) TestGenerateSnapServiceOnCore(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application foo.app
 Requires=snap-foo-44.mount
-Wants=network.target
-After=snap-foo-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=snap-foo-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -228,8 +228,8 @@ apps:
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application foo.app
 Requires=snap-foo-44.mount
-Wants=network.target
-After=snap-foo-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=snap-foo-44.mount snapd.system-services-pre.target
 Wants=usr-lib-snapd.mount
 After=usr-lib-snapd.mount
 X-Snappy=yes
@@ -523,8 +523,8 @@ func (s *serviceUnitGenSuite) TestServiceAfterBefore(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target %s snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target %s
 Before=%s
 X-Snappy=yes
 
@@ -631,8 +631,8 @@ func (s *serviceUnitGenSuite) TestKillModeSig(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -673,8 +673,8 @@ func (s *serviceUnitGenSuite) TestRestartDelay(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -714,8 +714,8 @@ func (s *serviceUnitGenSuite) TestVitalityScore(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -758,8 +758,8 @@ func (s *serviceUnitGenSuite) TestQuotaGroupSlice(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -801,8 +801,8 @@ func (s *serviceUnitGenSuite) TestQuotaGroupLogNamespace(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=systemd-journald@snap-foo.socket %s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target systemd-journald@snap-foo.socket snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-snap-44.mount snapd.system-services-pre.target systemd-journald@snap-foo.socket
 X-Snappy=yes
 
 [Service]
@@ -927,8 +927,8 @@ apps:
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application foo.app
 Requires=%s-foo-44.mount
-Wants=network.target
-After=%s-foo-44.mount network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%s-foo-44.mount snapd.system-services-pre.target
 X-Unit-Snippet-1=true
 X-Unit-Snippet-2=true
 X-Snappy=yes

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -140,8 +140,8 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -207,8 +207,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAdds(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -253,8 +253,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -355,8 +355,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountQuotas(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -453,8 +453,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountAndCpuSetQuota
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -544,8 +544,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalNamespaceOnly(c *C)
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=systemd-journald@snap-foogroup.socket %[1]s
-Wants=network.target
-After=%[1]s network.target systemd-journald@snap-foogroup.socket snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target systemd-journald@snap-foogroup.socket
 X-Snappy=yes
 
 [Service]
@@ -658,8 +658,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotas(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=systemd-journald@snap-foogroup.socket %[1]s
-Wants=network.target
-After=%[1]s network.target systemd-journald@snap-foogroup.socket snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target systemd-journald@snap-foogroup.socket
 X-Snappy=yes
 
 [Service]
@@ -775,8 +775,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotaRateAsZero(c *
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=systemd-journald@snap-foogroup.socket %[1]s
-Wants=network.target
-After=%[1]s network.target systemd-journald@snap-foogroup.socket snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target systemd-journald@snap-foogroup.socket
 X-Snappy=yes
 
 [Service]
@@ -920,8 +920,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSnapServices(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=systemd-journald@snap-my-root.socket %[1]s
-Wants=network.target
-After=%[1]s network.target systemd-journald@snap-my-root.socket snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target systemd-journald@snap-my-root.socket
 X-Snappy=yes
 
 [Service]
@@ -945,8 +945,8 @@ WantedBy=multi-user.target
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc2
 Requires=systemd-journald@snap-my-root.socket %[1]s
-Wants=network.target
-After=%[1]s network.target systemd-journald@snap-my-root.socket snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target systemd-journald@snap-my-root.socket
 X-Snappy=yes
 
 [Service]
@@ -1112,8 +1112,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithIncludeServices(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc2
 Requires=systemd-journald@snap-my-root.socket %[1]s
-Wants=network.target
-After=%[1]s network.target systemd-journald@snap-my-root.socket snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target systemd-journald@snap-my-root.socket
 X-Snappy=yes
 
 [Service]
@@ -1327,8 +1327,8 @@ TasksAccounting=true
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -1428,8 +1428,8 @@ TasksMax=%[3]d
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -1605,8 +1605,8 @@ TasksAccounting=true
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application %[1]s.svc1
 Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[2]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -1724,8 +1724,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application %[1]s.svc1
 Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[2]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -1837,8 +1837,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesPreseedingHappy(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -1914,8 +1914,8 @@ apps:
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application %[1]s.svc1
 Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[2]s snapd.system-services-pre.target
 Wants=usr-lib-snapd.mount
 After=usr-lib-snapd.mount
 X-Snappy=yes
@@ -1967,8 +1967,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesCallback(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.%[1]s
 Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[2]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2057,8 +2057,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAddsNewSvc(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.%[1]s
 Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[2]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2126,8 +2126,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesNoChangeNoop(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2193,8 +2193,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesChanges(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2255,8 +2255,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRollsback(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2337,8 +2337,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRemovesNewAddOnRollback(c *C) 
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2414,8 +2414,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesOnlyRemovesNewAddOnRollback(c 
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.%[1]s
 Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[2]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2638,8 +2638,8 @@ plugs:
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 X-Snappy=yes
 
 [Service]
@@ -2704,8 +2704,8 @@ plugs:
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
 Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
+Wants=snapd.system-services-pre.target
+After=%[1]s snapd.system-services-pre.target
 After=snapd.gpio-chardev-setup.target
 Wants=snapd.gpio-chardev-setup.target
 X-Snappy=yes


### PR DESCRIPTION
This is done during the boot, before notifying systemd the daemon is ready, when systemd is busy. On cloud VMs, this can take several seconds.