### PR TITLE
interfaces: grant access to gcin socket location in desktop-legacy

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -158,6 +158,11 @@ unix (connect, receive, send)
      type=stream
      peer=(addr="@tmp/.mozc.*"),
 
+# gcin
+# allow communicating with gcin server
+unix (connect, receive, send)
+     type=stream
+     peer=(addr="@tmp/gcin-*/socket*"),
 
 # fcitx
 # allow communicating with fcitx dbus service


### PR DESCRIPTION
gcin should use socket for this