### PR TITLE
spread.yaml: switch to using ubuntu-image from latest/edge

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -43,7 +43,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/candidate"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
     UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'


### PR DESCRIPTION
Now ubuntu-image is statically compiled so the issues with libc should be gone. Also, it has been detected that 2/stable creates partitions with unsupported features in older systems as it is shipping mkfs.ext4 in the snap, which comes from 20.04, but the one in latest is not shipping it.