### PR TITLE
snap-confine: run as ordinary user, with capabilitiesFeature/snap confine caps (revived)

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -95,7 +95,7 @@ fmt:: $(filter-out $(addprefix %,$(new_format)),$(foreach dir,$(subdirs),$(wildc
 # installing a fresh copy of snap confine and the appropriate apparmor profile.
 .PHONY: hack
 hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp snap-discard-ns/snap-discard-ns snap-device-helper/snap-device-helper snapd-apparmor/snapd-apparmor
-	sudo install -D -m 4755 snap-confine/snap-confine-debug $(DESTDIR)$(libexecdir)/snap-confine
+	sudo install -D -m 6755 snap-confine/snap-confine-debug $(DESTDIR)$(libexecdir)/snap-confine
 	if [ -d /etc/apparmor.d ]; then sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine.real; fi
 	sudo install -d -m 755 $(DESTDIR)/var/lib/snapd/apparmor/snap-confine/
 	if [ "$$(command -v apparmor_parser)" != "" ]; then sudo apparmor_parser -r snap-confine/snap-confine.apparmor; fi
@@ -396,8 +396,8 @@ install-data-local::
 	install -d -m 111 $(DESTDIR)/var/lib/snapd/void
 
 install-exec-hook::
-# Ensure that snap-confine is u+s (setuid)
-	chmod 4755 $(DESTDIR)$(libexecdir)/snap-confine
+# Ensure that snap-confine is u+s,g+s (setuid and setgid)
+	chmod 6755 $(DESTDIR)$(libexecdir)/snap-confine
 
 ##
 ## snap-mgmt

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -39,14 +39,15 @@ void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid) 
     if (parent_fd < 0) {
         die("cannot open cgroup hierarchy %s", parent);
     }
-    // Since we may be running from a setuid but not setgid executable, switch
-    // to the effective group to root so that the mkdirat call creates a cgroup
-    // that is always owned by root.root.
-    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-    if (mkdirat(parent_fd, name, 0755) < 0 && errno != EEXIST) {
+    if (mkdirat(parent_fd, name, 0000) < 0 && errno != EEXIST) {
         die("cannot create cgroup hierarchy %s/%s", parent, name);
     }
-    (void)sc_set_effective_identity(old);
+    if (errno == 0) {
+        if (fchownat(parent_fd, name, 0, 0, 0) < 0 ||
+            fchmodat(parent_fd, name, 0700, 0) < 0) {
+            die("cannot change mode/ownership to cgroup directory");
+        }
+    }
     int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
     hierarchy_fd = openat(parent_fd, name, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
     if (hierarchy_fd < 0) {

--- a/cmd/libsnap-confine-private/device-cgroup-support.c
+++ b/cmd/libsnap-confine-private/device-cgroup-support.c
@@ -717,8 +717,8 @@ static int sc_udev_open_cgroup_v1(const char *security_tag, int flags, sc_cgroup
             if (fchownat(devices_fd, security_tag_relpath, 0, 0, AT_SYMLINK_NOFOLLOW) < 0) {
                 die("cannot set root ownership on %s/%s/%s", cgroup_path, devices_relpath, security_tag_relpath);
             }
-            if (fchmodat(devices_fd, security_tag_relpath, 0755, 0) < 0) {
-                die("cannot set 0755 permissions on %s/%s/%s", cgroup_path, devices_relpath, security_tag_relpath);
+            if (fchmodat(devices_fd, security_tag_relpath, 0700, 0) < 0) {
+                die("cannot set 0700 permissions on %s/%s/%s", cgroup_path, devices_relpath, security_tag_relpath);
             }
         } else if (errno != EEXIST) {
             die("cannot create directory %s/%s/%s", cgroup_path, devices_relpath, security_tag_relpath);

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -66,7 +66,7 @@ void sc_enable_sanity_timeout(void)
 		die("cannot install signal handler for SIGALRM");
 	}
 	alarm(SANITY_TIMEOUT);
-	debug("sanity timeout initialized and set for %i seconds",
+	debug("sanity timeout initialized and set for %i seconds\n",
 	      SANITY_TIMEOUT);
 }
 

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -66,7 +66,7 @@ void sc_enable_sanity_timeout(void)
 		die("cannot install signal handler for SIGALRM");
 	}
 	alarm(SANITY_TIMEOUT);
-	debug("sanity timeout initialized and set for %i seconds\n",
+	debug("sanity timeout initialized and set for %i seconds",
 	      SANITY_TIMEOUT);
 }
 

--- a/cmd/libsnap-confine-private/privs.c
+++ b/cmd/libsnap-confine-private/privs.c
@@ -76,3 +76,19 @@ void sc_privs_drop(void)
 		die("cannot set user identifier to %d", uid);
 	}
 }
+
+void sc_set_capabilities(const sc_capabilities *capabilities)
+{
+	struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
+	struct __user_cap_data_struct cap_data[2] = { {0} };
+
+	cap_data[0].effective = capabilities->effective & 0xffffffff;
+	cap_data[1].effective = capabilities->effective >> 32;
+	cap_data[0].permitted = capabilities->permitted & 0xffffffff;
+	cap_data[1].permitted = capabilities->permitted >> 32;
+	cap_data[0].inheritable = capabilities->inheritable & 0xffffffff;
+	cap_data[1].inheritable = capabilities->inheritable >> 32;
+	if (capset(&hdr, cap_data) != 0) {
+		die("capset failed");
+	}
+}

--- a/cmd/libsnap-confine-private/privs.c
+++ b/cmd/libsnap-confine-private/privs.c
@@ -22,8 +22,10 @@
 #include <unistd.h>
 
 #include <grp.h>
+#include <linux/securebits.h>
 #include <stdbool.h>
 #include <sys/capability.h>
+#include <sys/prctl.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -77,6 +79,11 @@ void sc_privs_drop(void)
 	}
 }
 
+void sc_set_keep_caps_flag()
+{
+	prctl(PR_SET_KEEPCAPS, 1);
+}
+
 void sc_set_capabilities(const sc_capabilities *capabilities)
 {
 	struct __user_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_3, 0 };
@@ -90,5 +97,45 @@ void sc_set_capabilities(const sc_capabilities *capabilities)
 	cap_data[1].inheritable = capabilities->inheritable >> 32;
 	if (capset(&hdr, cap_data) != 0) {
 		die("capset failed");
+	}
+}
+
+void sc_set_ambient_capabilities(sc_cap_mask capabilities)
+{
+	// Ubuntu trusty has a 4.4 kernel, but these macros are not defined
+#ifndef PR_CAP_AMBIENT
+#  define PR_CAP_AMBIENT          47
+#  define PR_CAP_AMBIENT_IS_SET      1
+#  define PR_CAP_AMBIENT_RAISE       2
+#  define PR_CAP_AMBIENT_LOWER       3
+#  define PR_CAP_AMBIENT_CLEAR_ALL   4
+#endif
+
+	/* We would like to use cap_set_ambient(), but it's not in Debian 10; so
+	 * use prctl() instead.
+	 */
+	debug("setting ambient capabilities %lx", capabilities);
+	if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) < 0) {
+		die("cannot reset ambient capabilities");
+	}
+	for (int i = 0; i < CAP_LAST_CAP; i++) {
+		if (capabilities & SC_CAP_TO_MASK(i)) {
+			debug("setting ambient capability %d", i);
+			if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, i, 0, 0) < 0) {
+				die("cannot set ambient capability %d", i);
+			}
+		}
+	}
+}
+
+void sc_debug_capabilities(const char *msg_prefix)
+{
+	if (sc_is_debug_enabled()) {
+		cap_t caps;
+		caps = cap_get_proc();
+		char *caps_as_str = cap_to_text(caps, NULL);
+		debug("%s: %s", msg_prefix, caps_as_str);
+		cap_free(caps_as_str);
+		cap_free(caps);
 	}
 }

--- a/cmd/libsnap-confine-private/privs.h
+++ b/cmd/libsnap-confine-private/privs.h
@@ -54,9 +54,19 @@ typedef struct sc_capabilities {
     sc_cap_mask inheritable;
 } sc_capabilities;
 
+void sc_set_keep_caps_flag(void);
+
 /**
  * Set the given capabilities on the current process.
  */
 void sc_set_capabilities(const sc_capabilities *capabilities);
+
+/* This is a separate function because the kernel API to set ambient
+ * capabilities is very different; note that also libcap has this as a separate
+ * method, so we are not an outlier.
+ */
+void sc_set_ambient_capabilities(sc_cap_mask capabilities);
+
+void sc_debug_capabilities(const char *msg_prefix);
 
 #endif

--- a/cmd/libsnap-confine-private/privs.h
+++ b/cmd/libsnap-confine-private/privs.h
@@ -18,6 +18,8 @@
 #ifndef SNAP_CONFINE_PRIVS_H
 #define SNAP_CONFINE_PRIVS_H
 
+#include <stdint.h>
+
 /**
  * Permanently drop elevated permissions.
  *
@@ -34,5 +36,27 @@
  * nothing at all.
  **/
 void sc_privs_drop(void);
+
+/**
+ * sc_cap_mask is the type we use to store a mask of capabilities.
+ *
+ * It works similar to the masks defined in the cap_user_data_t structure used
+ * by capset(), except that it is a 64 bit one and therefore can accommodate
+ * all currently defined capabilities. At the moment all capabilities used by
+ * snap-confine are anyway located in the lower 32 bits, but we try to be open
+ * to future changes. */
+typedef uint64_t sc_cap_mask;
+#define SC_CAP_TO_MASK(cap) ((sc_cap_mask)1 << cap)
+
+typedef struct sc_capabilities {
+    sc_cap_mask effective;
+    sc_cap_mask permitted;
+    sc_cap_mask inheritable;
+} sc_capabilities;
+
+/**
+ * Set the given capabilities on the current process.
+ */
+void sc_set_capabilities(const sc_capabilities *capabilities);
 
 #endif

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -91,11 +91,9 @@ void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
 
 	/* Switch the group to root so that directories, files and locks created by
 	 * snap-update-ns are owned by the root group. */
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
 	sc_call_snapd_tool_with_apparmor(snap_update_ns_fd,
 					 "snap-update-ns", apparmor,
 					 aa_profile, argv, envp);
-	(void)sc_set_effective_identity(old);
 }
 
 void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -178,20 +178,20 @@ static void _test_sc_nonfatal_mkpath(const gchar *dirname,
 	// Use sc_nonfatal_mkpath to create the directory and ensure that it worked
 	// as expected.
 	g_test_queue_destroy((GDestroyNotify) my_rmdir, (char *)dirname);
-	int err = sc_nonfatal_mkpath(dirname, 0755);
+	int err = sc_nonfatal_mkpath(dirname, 0755, -1, -1);
 	g_assert_cmpint(err, ==, 0);
 	g_assert_cmpint(errno, ==, 0);
 	g_assert_true(g_file_test(dirname, G_FILE_TEST_EXISTS |
 				  G_FILE_TEST_IS_REGULAR));
 	// Use same function again to try to create the same directory and ensure
 	// that it didn't fail and properly retained EEXIST in errno.
-	err = sc_nonfatal_mkpath(dirname, 0755);
+	err = sc_nonfatal_mkpath(dirname, 0755, -1, -1);
 	g_assert_cmpint(err, ==, 0);
 	g_assert_cmpint(errno, ==, EEXIST);
 	// Now create a sub-directory of the original directory and observe the
 	// results. We should no longer see errno of EEXIST!
 	g_test_queue_destroy((GDestroyNotify) my_rmdir, (char *)subdirname);
-	err = sc_nonfatal_mkpath(subdirname, 0755);
+	err = sc_nonfatal_mkpath(subdirname, 0755, -1, -1);
 	g_assert_cmpint(err, ==, 0);
 	g_assert_cmpint(errno, ==, 0);
 }

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -107,10 +107,14 @@ void write_string_to_file(const char *filepath, const char *buf);
  * and the next directory is created using mkdirat(2), this sequence continues
  * while there are more directories to process.
  *
+ * The directory will be owned by the given user and group, unless these
+ * parameters are set to -1 (in which case they are not altered).
+ *
  * The function returns -1 in case of any error.
  **/
 __attribute__((warn_unused_result))
-int sc_nonfatal_mkpath(const char *const path, mode_t mode);
+int sc_nonfatal_mkpath(const char *const path, mode_t mode,
+                       uid_t uid, uid_t gid);
 
 /**
  * Return true if path is a valid path for the snap-confine binary

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -227,13 +227,10 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 			sc_must_snprintf(prefix_dir, sizeof prefix_dir,
 					 "%s%s", libgl_dir,
 					 &directory_name[source_dir_len]);
-			sc_identity old =
-			    sc_set_effective_identity(sc_root_group_identity());
-			if (sc_nonfatal_mkpath(prefix_dir, 0755) != 0) {
+			if (sc_nonfatal_mkpath(prefix_dir, 0755, 0, 0) != 0) {
 				die("failed to create prefix path: %s",
 				    prefix_dir);
 			}
-			(void)sc_set_effective_identity(old);
 		}
 
 		struct stat stat_buf;
@@ -588,16 +585,10 @@ void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
 		return;
 	}
 
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755);
+	int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755, 0, 0);
 	if (res != 0) {
 		die("cannot create " SC_EXTRA_LIB_DIR);
 	}
-	if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
-		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of " SC_EXTRA_LIB_DIR);
-	}
-	(void)sc_set_effective_identity(old);
 
 #if defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 	/* We include the globs for the glvnd libraries for old snaps

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -134,7 +134,6 @@ static void setup_private_tmp(const char *snap_instance)
 	if (mkdirat(base_dir_fd, "tmp", 01777) < 0 && errno != EEXIST) {
 		die("cannot create private tmp directory %s/tmp", base);
 	}
-	(void)sc_set_effective_identity(old);
 	tmp_dir_fd = openat(base_dir_fd, "tmp",
 			    O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
 	if (tmp_dir_fd < 0) {
@@ -254,12 +253,9 @@ static void sc_do_mounts(const char *scratch_dir, const struct sc_mount *mounts)
 	     mnt++) {
 
 		if (mnt->is_bidirectional) {
-			sc_identity old =
-			    sc_set_effective_identity(sc_root_group_identity());
 			if (mkdir(mnt->path, 0755) < 0 && errno != EEXIST) {
 				die("cannot create %s", mnt->path);
 			}
-			(void)sc_set_effective_identity(old);
 		}
 		sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir,
 				 mnt->path);
@@ -1090,9 +1086,7 @@ void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	// to slave mode, so we see changes from the parent namespace
 	// but don't propagate our own changes.
 	sc_do_mount("none", "/", NULL, MS_REC | MS_SLAVE, NULL);
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
 	sc_call_snap_update_ns_as_user(snap_update_ns_fd, snap_name, apparmor);
-	(void)sc_set_effective_identity(old);
 }
 
 void sc_ensure_snap_dir_shared_mounts(void)

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -125,11 +125,9 @@ void sc_initialize_mount_ns(unsigned int experimental_features)
 	debug("unsharing snap namespace directory");
 
 	/* Ensure that /run/snapd/ns is a directory. */
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	if (sc_nonfatal_mkpath(sc_ns_dir, 0755) < 0) {
+	if (sc_nonfatal_mkpath(sc_ns_dir, 0755, 0, 0) < 0) {
 		die("cannot create directory %s", sc_ns_dir);
 	}
-	(void)sc_set_effective_identity(old);
 
 	/* Read and analyze the mount table. We need to see whether /run/snapd/ns
 	 * is a mount point with private event propagation. */

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -454,6 +454,7 @@
     /run/snapd/lock/*.lock rwk,
 
     # support for the mount namespace sharing
+    capability fowner,
     capability sys_ptrace,
     # allow snap-confine to read /proc/1/ns/mnt
     ptrace read peer=unconfined,
@@ -531,6 +532,7 @@
         /dev/random r,
         /dev/urandom r,
 
+        capability dac_override,
         capability sys_ptrace,
         capability sys_admin,
         # This allows us to read and bind mount the namespace file

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -322,6 +322,7 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 int main(int argc, char **argv)
 {
 	log_startup_stage("snap-confine enter");
+	sc_debug_capabilities("caps at startup");
 	// Use our super-defensive parser to figure out what we've been asked to do.
 	sc_error *err = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
@@ -372,6 +373,8 @@ int main(int argc, char **argv)
 	 * setup the capabilities that we want to retain.
 	 */
 	bool use_capabilities = real_uid != 0;
+
+	sc_debug_capabilities("initial caps");
 
 	static const sc_cap_mask snap_confine_caps =
 		SC_CAP_TO_MASK(CAP_DAC_OVERRIDE) |
@@ -777,6 +780,7 @@ static void enter_non_classic_execution_environment(sc_invocation *inv,
 	   join. We need to construct a new mount namespace ourselves.
 	   To capture it we will need a helper process so make one. */
 	sc_fork_helper(group, aa);
+	sc_debug_capabilities("caps on join");
 	int retval = sc_join_preserved_ns(group, aa, inv, snap_discard_ns_fd);
 	if (retval == ESRCH) {
 		/* Create and populate the mount namespace. This performs all

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -332,11 +332,6 @@ int main(int argc, char **argv)
 	args = sc_nonfatal_parse_args(&argc, &argv, &err);
 	sc_die_on_error(err);
 
-	// Remember certain properties of the process that are clobbered by
-	// snap-confine during execution. Those are restored just before calling
-	// execv.
-	sc_preserve_and_sanitize_process_state(&proc_state);
-
 	// We've been asked to print the version string so let's just do that.
 	if (sc_args_is_version_query(args)) {
 		printf("%s %s\n", PACKAGE, PACKAGE_VERSION);
@@ -435,6 +430,11 @@ int main(int argc, char **argv)
 		sc_set_capabilities(&caps);
 		sc_set_ambient_capabilities(snap_update_ns_caps);
 	}
+
+	// Remember certain properties of the process that are clobbered by
+	// snap-confine during execution. Those are restored just before calling
+	// execv.
+	sc_preserve_and_sanitize_process_state(&proc_state);
 
 	char *snap_context SC_CLEANUP(sc_cleanup_string) = NULL;
 	// Do no get snap context value if running a hook (we don't want to overwrite hook's SNAP_COOKIE)

--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -37,7 +37,7 @@ void setup_user_data(void)
 	}
 
 	debug("creating user data directory: %s", user_data);
-	if (sc_nonfatal_mkpath(user_data, 0755) < 0) {
+	if (sc_nonfatal_mkpath(user_data, 0755, -1, -1) < 0) {
 		if ((errno == EROFS || errno == EACCES)
 		    && !sc_startswith(user_data, "/home/")) {
 			// clear errno or it will be displayed in die()
@@ -62,7 +62,7 @@ void setup_user_xdg_runtime_dir(void)
 
 	errno = 0;
 	debug("creating user XDG_RUNTIME_DIR directory: %s", xdg_runtime_dir);
-	if (sc_nonfatal_mkpath(xdg_runtime_dir, 0755) < 0) {
+	if (sc_nonfatal_mkpath(xdg_runtime_dir, 0755, -1, -1) < 0) {
 		die("cannot create user XDG_RUNTIME_DIR directory: %s",
 		    xdg_runtime_dir);
 	}

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -115,11 +115,3 @@ func (upCtx *CommonProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProf
 	}
 	return profile, nil
 }
-
-// SaveCurrentProfile saves the current mount profile.
-func (upCtx *CommonProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
-	if err := profile.Save(upCtx.currentProfilePath); err != nil {
-		return fmt.Errorf("cannot save current mount profile of snap %q: %s", upCtx.instanceName, err)
-	}
-	return nil
-}

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/cgroup"
-	"github.com/snapcore/snapd/testutil"
 )
 
 type commonSuite struct {
@@ -155,21 +154,4 @@ func (s *commonSuite) TestLoadCurrentProfile(c *C) {
 
 	// The profile is returned unchanged.
 	c.Check(builder.String(), Equals, text)
-}
-
-func (s *commonSuite) TestSaveCurrentProfile(c *C) {
-	upCtx := s.upCtx
-	text := "tmpfs /tmp tmpfs defaults 0 0\n"
-
-	// Prepare a mount profile to be saved.
-	profile, err := osutil.LoadMountProfileText(text)
-	c.Assert(err, IsNil)
-
-	// Prepare the directory for saving the profile.
-	path := upCtx.CurrentProfilePath()
-	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-
-	// Ask the common profile update to write the current profile.
-	c.Assert(upCtx.SaveCurrentProfile(profile), IsNil)
-	c.Check(path, testutil.FileEquals, text)
 }

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -296,3 +296,9 @@ func NewCommonProfileUpdateContext(instanceName string, fromSnapConfine bool, cu
 		desiredProfilePath: desiredProfilePath,
 	}
 }
+
+func MockSaveMountProfile(f func(p *osutil.MountProfile, fname string, uid sys.UserID, gid sys.GroupID) error) (restore func()) {
+	r := testutil.Backup(&osutilSaveMountProfile)
+	osutilSaveMountProfile = f
+	return r
+}

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -24,7 +24,12 @@ import (
 	"os"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+)
+
+var (
+	osutilSaveMountProfile = osutil.SaveMountProfile
 )
 
 // SystemProfileUpdateContext contains information about update to system-wide mount namespace.
@@ -90,6 +95,14 @@ func (upCtx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	// the right permissions.
 	as.AddModeHint("/dev/shm/snap.*", 0777|os.ModeSticky)
 	return as
+}
+
+// SaveCurrentProfile saves the current mount profile.
+func (upCtx *SystemProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	if err := osutilSaveMountProfile(profile, upCtx.currentProfilePath, 0, 0); err != nil {
+		return fmt.Errorf("cannot save current mount profile of snap %q: %s", upCtx.instanceName, err)
+	}
+	return nil
 }
 
 // desiredSystemProfilePath returns the path of the fstab-like file with the desired, system-wide mount profile for a snap.

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -24,6 +24,8 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
+var newMountProfile = func() osutil.MountProfile { return osutil.MountProfile{} }
+
 // MountProfileUpdateContext provides the context of a mount namespace update.
 // The context provides a way to synchronize the operation with other users of
 // the snap system, to load and save the mount profiles and to provide the file
@@ -92,7 +94,7 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 
 	// Compute the new current profile so that it contains only changes that were made
 	// and save it back for next runs.
-	var currentAfter osutil.MountProfile
+	currentAfter := newMountProfile()
 	for _, change := range changesMade {
 		if change.Action == Mount || change.Action == Keep {
 			currentAfter.Entries = append(currentAfter.Entries, change.Entry)

--- a/osutil/mountprofile_linux.go
+++ b/osutil/mountprofile_linux.go
@@ -26,6 +26,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/snapcore/snapd/osutil/sys"
 )
 
 // MountProfile represents an array of mount entries.
@@ -64,12 +66,14 @@ func SaveMountProfileText(p *MountProfile) (string, error) {
 
 // Save saves a mount profile (fstab-like) to a given file.
 // The profile is saved with an atomic write+rename+sync operation.
-func (p *MountProfile) Save(fname string) error {
+// If you don't want to alter the uid and gid of the created file, pass
+// osutil.NoChown.
+func SaveMountProfile(p *MountProfile, fname string, uid sys.UserID, gid sys.GroupID) error {
 	var buf bytes.Buffer
 	if _, err := p.WriteTo(&buf); err != nil {
 		return err
 	}
-	return AtomicWriteFile(fname, buf.Bytes(), 0644, AtomicWriteFlags(0))
+	return AtomicWriteFileChown(fname, buf.Bytes(), 0644, AtomicWriteFlags(0), uid, gid)
 }
 
 // ReadMountProfile reads and parses a mount profile.

--- a/osutil/mountprofile_linux_test.go
+++ b/osutil/mountprofile_linux_test.go
@@ -103,7 +103,7 @@ func (s *profileSuite) TestSaveMountProfile1(c *C) {
 			{Name: "name-1", Dir: "dir-1", Type: "type-1", Options: []string{"options-1"}, DumpFrequency: 1, CheckPassNumber: 1},
 		},
 	}
-	err := p.Save(fname)
+	err := osutil.SaveMountProfile(p, fname, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 
 	stat, err := os.Stat(fname)

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -900,7 +900,7 @@ popd
 %dir %{_libexecdir}/snapd
 # For now, we can't use caps
 # FIXME: Switch to "%%attr(0755,root,root) %%caps(cap_sys_admin=pe)" asap!
-%attr(4755,root,root) %{_libexecdir}/snapd/snap-confine
+%attr(6755,root,root) %{_libexecdir}/snapd/snap-confine
 %{_libexecdir}/snapd/snap-device-helper
 %{_libexecdir}/snapd/snap-discard-ns
 %{_libexecdir}/snapd/snap-gdb-shim

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -437,7 +437,7 @@ fi
 %ghost %{_sharedstatedir}/snapd/state.json
 %ghost %{_sharedstatedir}/snapd/system-key
 %ghost %{snap_mount_dir}/README
-%verify(not user group mode) %attr(04755,root,root) %{_libexecdir}/snapd/snap-confine
+%verify(not user group mode) %attr(06755,root,root) %{_libexecdir}/snapd/snap-confine
 %{_bindir}/snap
 %{_bindir}/snapctl
 %{_datadir}/applications/io.snapcraft.SessionAgent.desktop

--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -1,5 +1,8 @@
 summary: the snap-{run,confine,exec} chain does not create files with undesired properties.
 
+details: |
+    Verify that snap-{run,confine,exec} chain does not create any files that has unexpected properties.
+
 # ubuntu-14.04: the test sets up a user session, which requires more recent systemd
 systems: [-ubuntu-14.04-*]
 

--- a/tests/main/snap-confine-undesired-mode-group/task.yaml
+++ b/tests/main/snap-confine-undesired-mode-group/task.yaml
@@ -28,10 +28,14 @@ execute: |
     # the group of the calling user and did not manage that properly.
     for dname in /run/snapd /sys/fs/cgroup /tmp/snap-private-tmp/snap.*; do
         # Filter out cgroups that are expected to be owned by the test user.
+        # Also ignore leaf files; we'll check below that the parent directory
+        # is not writable to non-root users.
         # Since we are a looking at sysfs, which is modified asynchronously,
         # ignore errors of the kind where readdir and stat race with a
         # concurrent mutator.
-        find "$dname" -ignore_readdir_race -user test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' >> wrong-user.txt
+        find "$dname" -ignore_readdir_race -user test ! -path '*/user@12345.service*' ! -path '*/user-12345.slice*' \
+            ! \( -path '/sys/fs/cgroup/*' -type f \) \
+            >> wrong-user.txt
         # Filter out the following elements:
         # - regular files found under the cgroup tree which are not writable to
         #   the group, because even if the group is wrong we don't care as long
@@ -66,4 +70,20 @@ execute: |
         cat world-writable.txt
         ret=1
     fi
+
+    # Check that cgroups created by snap-confine don't have execute permissions
+    # for others than the owner; this is because the files created inside these
+    # groups will be owned by the user who ran snap-confine, and we don't want
+    # the users to be able to edit or even viewing the cgroups.
+    # Filter out .mount and .service files, which are not created by snap-confine
+    find /sys/fs/cgroup -ignore_readdir_race -path '*/snap.*' -type d -perm /g+x,o+x \
+        ! -path '*.mount' \
+        ! -path '*.service' \
+        >> group-writable.txt
+    if test -s group-writable.txt; then
+        echo "the following files should not be world-writable or group-writable"
+        cat group-writable.txt
+        ret=1
+    fi
+
     exit "$ret"


### PR DESCRIPTION
Original PR from mardy (https://github.com/snapcore/snapd/pull/12304)

I revived this as we keep getting reports of issues with NFS mounted drives, where the core of the issue is that we run as root, and not as the actual user. The original PR had some issues related to running under LXD which is fixed in this PR. (We needed to escalate to root while creating the cgroup freezer).

Re-opened so we can discuss whether this is something that we want, and also to give it another chance for cleanup and review.

Related: [SNAPDENG-23251](https://warthogs.atlassian.net/browse/SNAPDENG-23251)

[SNAPDENG-23251]: https://warthogs.atlassian.net/browse/SNAPDENG-23251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ