### PR TITLE
cmd: snap: image: expose 'validation' parameter

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -99,7 +99,7 @@ For preparing classic images it supports a --classic mode`),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"customize": i18n.G("Image customizations specified as JSON file."),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"validation": i18n.G("Control whether validations should be ignored or enforced."),
+			"validation": i18n.G("Control whether validations should be ignored or enforced. (default: ignore)"),
 		}, []argDesc{
 			{
 				// TRANSLATORS: This needs to begin with < and end with >
@@ -123,8 +123,10 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	// level for "snap" command, for seed/seedwriter used by image however
 	// we want real validation.
 	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
-	imageCustomizations := *new(image.Customizations)
-	imageCustomizations.Validation = x.Validation
+	imageCustomizations := image.Customizations{
+		Validation: x.Validation,
+	}
+
 	opts := &image.Options{
 		Snaps:            x.ExtraSnaps,
 		ModelFile:        x.Positional.ModelAssertionFn,

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -58,6 +58,7 @@ type cmdPrepareImage struct {
 	ExtraSnaps         []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED
 	RevisionsFile      string   `long:"revisions"`
 	WriteRevisionsFile string   `long:"write-revisions" optional:"true" optional-value:"./seed.manifest"`
+	Validation         string   `long:"validation" choice:"ignore" choice:"enforce"`
 }
 
 func init() {
@@ -97,6 +98,8 @@ For preparing classic images it supports a --classic mode`),
 			"channel": i18n.G("The channel to use"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"customize": i18n.G("Image customizations specified as JSON file."),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"validation": i18n.G("Control whether validations should be ignored or enforced."),
 		}, []argDesc{
 			{
 				// TRANSLATORS: This needs to begin with < and end with >
@@ -120,13 +123,15 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	// level for "snap" command, for seed/seedwriter used by image however
 	// we want real validation.
 	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
-
+	imageCustomizations := *new(image.Customizations)
+	imageCustomizations.Validation = x.Validation
 	opts := &image.Options{
 		Snaps:            x.ExtraSnaps,
 		ModelFile:        x.Positional.ModelAssertionFn,
 		Channel:          x.Channel,
 		Architecture:     x.Architecture,
 		SeedManifestPath: x.WriteRevisionsFile,
+		Customizations:   imageCustomizations,
 	}
 
 	if x.RevisionsFile != "" {

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -123,9 +123,6 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	// level for "snap" command, for seed/seedwriter used by image however
 	// we want real validation.
 	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
-	imageCustomizations := image.Customizations{
-		Validation: x.Validation,
-	}
 
 	opts := &image.Options{
 		Snaps:            x.ExtraSnaps,
@@ -133,7 +130,6 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 		Channel:          x.Channel,
 		Architecture:     x.Architecture,
 		SeedManifestPath: x.WriteRevisionsFile,
-		Customizations:   imageCustomizations,
 	}
 
 	if x.RevisionsFile != "" {
@@ -150,6 +146,16 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 			return err
 		}
 		opts.Customizations = *custo
+	}
+
+	if x.Validation != "" {
+		if opts.Customizations.Validation == "" {
+			opts.Customizations.Validation = x.Validation
+		} else {
+			opts.Customizations = image.Customizations{
+				Validation: x.Validation,
+			}
+		}
 	}
 
 	snaps := make([]string, 0, len(x.Snaps)+len(x.ExtraSnaps))

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -149,13 +149,8 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	}
 
 	if x.Validation != "" {
-		if opts.Customizations.Validation == "" {
-			opts.Customizations.Validation = x.Validation
-		} else {
-			opts.Customizations = image.Customizations{
-				Validation: x.Validation,
-			}
-		}
+		// validation passed in the command line overrides customizations
+		opts.Customizations.Validation = x.Validation
 	}
 
 	snaps := make([]string, 0, len(x.Snaps)+len(x.ExtraSnaps))

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -294,7 +294,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImageWriteRevisions(c *C) {
 	})
 }
 
-func (s *SnapPrepareImageSuite) TestPrepareImagValidation(c *C) {
+func (s *SnapPrepareImageSuite) TestPrepareImageValidation(c *C) {
 	var opts *image.Options
 	prep := func(o *image.Options) error {
 		opts = o


### PR DESCRIPTION
Expose the `validation` parameter when preparing the image.
This seems to be forgotten to be exposed when `validation` support for image preparation was implemented.
