### PR TITLE
interfaces/builtin: add interface for bcache

### DIFF
--- a/interfaces/builtin/bcache.go
+++ b/interfaces/builtin/bcache.go
@@ -1,0 +1,30 @@
+package builtin
+
+const bcacheSummary = `allows access to bcache kernel interfaces`
+
+const bcacheBaseDeclarationSlots = `
+  bcache:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const bcacheConnectedPlugAppArmor = `
+# Description: Can access kernel bcache interfaces in sysfs
+
+# Allow read/write access to kernel bcache interfaces in sysfs
+# includes items in /sys/fs/bcache, /sys/block and /sys/devices
+/sys**bcache** rwk,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "bcache",
+		summary:               bcacheSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  bcacheBaseDeclarationSlots,
+		connectedPlugAppArmor: bcacheConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/bcache_test.go
+++ b/interfaces/builtin/bcache_test.go
@@ -1,0 +1,77 @@
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type BcacheInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&BcacheInterfaceSuite{
+	iface: builtin.MustInterface("bcache"),
+})
+
+const bcacheConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+   plugs: [bcache]
+   `
+
+const bcacheCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  bcache:
+`
+
+func (s *BcacheInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, bcacheConsumerYaml, nil, "bcache")
+	s.slot, s.slotInfo = MockConnectedSlot(c, bcacheCoreYaml, nil, "bcache")
+}
+
+func (s *BcacheInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "bcache")
+}
+
+func (s *BcacheInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *BcacheInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *BcacheInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys**bcache** rwk,`)
+}
+
+func (s *BcacheInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to bcache kernel interfaces`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "bcache")
+}
+
+func (s *BcacheInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *BcacheInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}


### PR DESCRIPTION
Interface for providing access to kernel bcache interfaces in sysfs to allow creation, registration and modification of bcache block devs.
