### PR TITLE
treewide: Basic Ubuntu Touch & Halium enablement

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -269,6 +269,8 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/cookie-support.h \
 	snap-confine/mount-support-nvidia.c \
 	snap-confine/mount-support-nvidia.h \
+	snap-confine/mount-support-hybris.c \
+	snap-confine/mount-support-hybris.h \
 	snap-confine/mount-support.c \
 	snap-confine/mount-support.h \
 	snap-confine/ns-support.c \

--- a/cmd/snap-confine/mount-support-hybris.c
+++ b/cmd/snap-confine/mount-support-hybris.c
@@ -52,7 +52,7 @@
 #define SC_HYBRIS_LINKERCONFIG_SYMLINK_TARGET "/android/linkerconfig"
 
 static void sc_hybris_mount_android_rootfs(const char *rootfs_dir) {
-    // Bind mount a tmpfs on $rootfs_dir/$tgt_dir (i.e. /var/lib/snapd/lib/gl)
+    // Bind mount the Halium rootfs as set up by the host, in /android
     char path_buf[PATH_MAX] = {0};
     sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_ROOTFS);
     const char *android_rootfs_dir = path_buf;
@@ -226,18 +226,12 @@ int sc_mount_is_halium_system(void) {
 }
 
 void sc_mount_hybris_driver(const char *rootfs_dir, const char *base_snap_name) {
-    // Only proceed if this has been identified as a Halium system
+    // Only proceed if this has been identified as a Halium system, on Ubuntu Touch
+    // we require access to a lot of unvetted libraries and unmediated IPC, and
+    // misc required files. No executable bits allowed, this is the most fine-grained
+    // while future-resiliant as patched-in, shipped and used set of rules and requirements.
     if (!sc_mount_is_halium_system()) {
         return;
-    }
-
-    int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755, 0, 0);
-    if (res != 0) {
-        die("cannot create " SC_EXTRA_LIB_DIR);
-    }
-    if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
-        // Adjust the ownership only if we created the directory.
-        die("cannot change ownership of " SC_EXTRA_LIB_DIR);
     }
 
     sc_hybris_mount_android_rootfs(rootfs_dir);

--- a/cmd/snap-confine/mount-support-hybris.c
+++ b/cmd/snap-confine/mount-support-hybris.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+#include "mount-support-hybris.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <glob.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <unistd.h>
+/* POSIX version of basename() and dirname() */
+#include <libgen.h>
+
+#include "../libsnap-confine-private/classic.h"
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
+#include "mount-support.h"
+
+#define SC_LIBGL_DIR   SC_EXTRA_LIB_DIR "/gl"
+#define SC_VULKAN_DIR  SC_EXTRA_LIB_DIR "/vulkan"
+#define SC_GLVND_DIR  SC_EXTRA_LIB_DIR "/glvnd"
+
+#define SC_HYBRIS_ROOTFS "/android"
+#define SC_HYBRIS_SYSTEM_SYMLINK "/system"
+#define SC_HYBRIS_VENDOR_SYMLINK "/vendor"
+#define SC_HYBRIS_ODM_SYMLINK "/odm"
+#define SC_HYBRIS_APEX_SYMLINK "/apex"
+#define SC_HYBRIS_LINKERCONFIG_SYMLINK "/linkerconfig"
+#define SC_HYBRIS_SYSTEM_SYMLINK_TARGET "/android/system"
+#define SC_HYBRIS_VENDOR_SYMLINK_TARGET "/android/vendor"
+#define SC_HYBRIS_ODM_SYMLINK_TARGET "/android/odm"
+#define SC_HYBRIS_APEX_SYMLINK_TARGET "/android/apex"
+#define SC_HYBRIS_LINKERCONFIG_SYMLINK_TARGET "/android/linkerconfig"
+
+static void sc_hybris_mount_android_rootfs(const char *rootfs_dir)
+{
+	// Bind mount a tmpfs on $rootfs_dir/$tgt_dir (i.e. /var/lib/snapd/lib/gl)
+	char path_buf[PATH_MAX] = { 0 };
+	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_ROOTFS);
+	const char *android_rootfs_dir = path_buf;
+
+	int res = mkdir(android_rootfs_dir, 0755);
+	if (res != 0 && errno != EEXIST) {
+		die("cannot create bind-mount target %s", android_rootfs_dir);
+	}
+	if (res == 0 && (chown(android_rootfs_dir, 0, 0) < 0)) {
+		// Adjust the ownership only if we created the directory.
+		die("cannot change ownership of %s", android_rootfs_dir);
+	}
+
+	if (mount(SC_HYBRIS_ROOTFS, android_rootfs_dir, NULL, MS_BIND | MS_REC | MS_RDONLY, NULL)) {
+		die("Cannot mount Halium environment into target");
+	}
+
+	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_SYSTEM_SYMLINK);
+	const char *android_system_symlink = path_buf;
+	if (symlink(SC_HYBRIS_SYSTEM_SYMLINK_TARGET, android_system_symlink)) {
+		die("Cannot set symlink for %s", SC_HYBRIS_SYSTEM_SYMLINK);
+	}
+
+	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_VENDOR_SYMLINK);
+	const char *android_vendor_symlink = path_buf;
+	if (symlink(SC_HYBRIS_VENDOR_SYMLINK_TARGET, android_vendor_symlink)) {
+		die("Cannot set symlink for %s", SC_HYBRIS_VENDOR_SYMLINK);
+	}
+
+	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_ODM_SYMLINK);
+	const char *android_odm_symlink = path_buf;
+	if (symlink(SC_HYBRIS_ODM_SYMLINK_TARGET, android_odm_symlink)) {
+		die("Cannot set symlink for %s", SC_HYBRIS_ODM_SYMLINK);
+	}
+
+	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_APEX_SYMLINK);
+	const char *android_apex_symlink = path_buf;
+	if (symlink(SC_HYBRIS_APEX_SYMLINK_TARGET, android_apex_symlink)) {
+		die("Cannot set symlink for %s", SC_HYBRIS_APEX_SYMLINK);
+	}
+
+	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_LINKERCONFIG_SYMLINK);
+	const char* android_linkerconfig_symlink = path_buf;
+	if (symlink(SC_HYBRIS_LINKERCONFIG_SYMLINK_TARGET, android_linkerconfig_symlink)) {
+		die("Cannot set symlink for %s", SC_HYBRIS_LINKERCONFIG_SYMLINK);
+	}
+}
+
+void sc_mount_hybris_driver(const char *rootfs_dir, const char *base_snap_name)
+{
+	int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755, 0, 0);
+	if (res != 0) {
+		die("cannot create " SC_EXTRA_LIB_DIR);
+	}
+	if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
+		// Adjust the ownership only if we created the directory.
+		die("cannot change ownership of " SC_EXTRA_LIB_DIR);
+	}
+
+	sc_hybris_mount_android_rootfs(rootfs_dir);
+}

--- a/cmd/snap-confine/mount-support-hybris.c
+++ b/cmd/snap-confine/mount-support-hybris.c
@@ -101,70 +101,6 @@ static void sc_hybris_mount_android_rootfs(const char *rootfs_dir) {
     }
 }
 
-static bool has_mounted_halium_path(const char *path) {
-    // Halium system image existance
-    FILE *mounts = NULL;
-    char *line = NULL;
-    int character = 0;
-    unsigned int i = 0;
-    unsigned int line_size = 0;
-    static const unsigned int line_increase = 64;
-    bool found = false;
-
-    // Check whether the Halium system image has been mounted.
-    mounts = fopen("/proc/mounts", "r");
-    if (!mounts) {
-        return false;
-    }
-
-    line = (char *)malloc(sizeof(char) * line_increase);
-    if (!line) {
-        fclose(mounts);
-        return false;
-    }
-
-    line_size = line_increase;
-    line[0] = '\0';
-
-    // Files in /proc don't expose their size, so read into a buffer character-by-character.
-    while ((character = fgetc(mounts)) != EOF) {
-        if (i >= line_size) {
-            line = (char *)realloc(line, sizeof(char) * (line_size + line_increase));
-            if (!line) {
-                fclose(mounts);
-                return false;
-            }
-
-            line_size += line_increase;
-            line[line_size - 1] = '\0';
-        }
-
-        line[i] = (char)character;
-
-        if (line[i] == '\n') line[i] = '\0';
-
-        // Judge the line we read now
-        if (line[i] == '\0') {
-            // These must exist on disk, not on some tmpfs,
-            // using filesystems prominently used on Android.
-            if ((strncmp(line, " ext4 ", 6) == 0 || strncmp(line, " f2fs ", 6) == 0) &&
-                strncmp(line, path, strlen(path)) == 0) {
-                found = true;
-                break;
-            }
-
-            line[0] = '\0';
-            i = 0;
-        } else {
-            ++i;
-        }
-    }
-
-    fclose(mounts);
-    free(line);
-    return found;
-}
-
 int sc_mount_is_halium_system(void) {
     // Halium-typical paths to check for
     // snapd's "opengl" interface takes care of exposing it all
@@ -177,11 +113,7 @@ int sc_mount_is_halium_system(void) {
         "/system/lib/libEGL.so"
 #endif
     };
-    static const char *halium_mountpoints[] = {
-        " /android/vendor ",
-        " /android/data ",
-        " /android/cache ",
-    };
+    static const char *halium_mountpoints[] = {"/android/vendor", "/android/data", "/android/cache"};
     static const char *halium_symlinks[] = {"/system", "/vendor", "/odm", "/data"};
     static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder",
                                          "/dev/hwbinder"};
@@ -201,7 +133,8 @@ int sc_mount_is_halium_system(void) {
 
     // These are required mountpoints which are used by our Halium LXC container
     for (long unsigned int i = 0; i < sizeof(halium_mountpoints) / sizeof(halium_mountpoints[0]); i++) {
-        if (!has_mounted_halium_path(halium_mountpoints[i])) {
+        struct stat info;
+        if (stat(halium_mountpoints[i], &info) != 0) {
             return 0;
         }
     }
@@ -229,7 +162,7 @@ void sc_mount_hybris_driver(const char *rootfs_dir, const char *base_snap_name) 
     // Only proceed if this has been identified as a Halium system, on Ubuntu Touch
     // we require access to a lot of unvetted libraries and unmediated IPC, and
     // misc required files. No executable bits allowed, this is the most fine-grained
-    // while future-resiliant as patched-in, shipped and used set of rules and requirements.
+    // while future-resiliant as patched-in, shipped and used by Ubuntu Touch users.
     if (!sc_mount_is_halium_system()) {
         return;
     }

--- a/cmd/snap-confine/mount-support-hybris.c
+++ b/cmd/snap-confine/mount-support-hybris.c
@@ -15,18 +15,18 @@
  *
  */
 
-#include "config.h"
 #include "mount-support-hybris.h"
+#include "config.h"
 
 #include <errno.h>
 #include <fcntl.h>
 #include <glob.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <stdint.h>
 #include <unistd.h>
 /* POSIX version of basename() and dirname() */
 #include <libgen.h>
@@ -37,83 +37,208 @@
 #include "../libsnap-confine-private/utils.h"
 #include "mount-support.h"
 
-#define SC_LIBGL_DIR   SC_EXTRA_LIB_DIR "/gl"
-#define SC_VULKAN_DIR  SC_EXTRA_LIB_DIR "/vulkan"
-#define SC_GLVND_DIR  SC_EXTRA_LIB_DIR "/glvnd"
-
 #define SC_HYBRIS_ROOTFS "/android"
+
 #define SC_HYBRIS_SYSTEM_SYMLINK "/system"
 #define SC_HYBRIS_VENDOR_SYMLINK "/vendor"
 #define SC_HYBRIS_ODM_SYMLINK "/odm"
 #define SC_HYBRIS_APEX_SYMLINK "/apex"
 #define SC_HYBRIS_LINKERCONFIG_SYMLINK "/linkerconfig"
+
 #define SC_HYBRIS_SYSTEM_SYMLINK_TARGET "/android/system"
 #define SC_HYBRIS_VENDOR_SYMLINK_TARGET "/android/vendor"
 #define SC_HYBRIS_ODM_SYMLINK_TARGET "/android/odm"
 #define SC_HYBRIS_APEX_SYMLINK_TARGET "/android/apex"
 #define SC_HYBRIS_LINKERCONFIG_SYMLINK_TARGET "/android/linkerconfig"
 
-static void sc_hybris_mount_android_rootfs(const char *rootfs_dir)
-{
-	// Bind mount a tmpfs on $rootfs_dir/$tgt_dir (i.e. /var/lib/snapd/lib/gl)
-	char path_buf[PATH_MAX] = { 0 };
-	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_ROOTFS);
-	const char *android_rootfs_dir = path_buf;
+static void sc_hybris_mount_android_rootfs(const char *rootfs_dir) {
+    // Bind mount a tmpfs on $rootfs_dir/$tgt_dir (i.e. /var/lib/snapd/lib/gl)
+    char path_buf[PATH_MAX] = {0};
+    sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_ROOTFS);
+    const char *android_rootfs_dir = path_buf;
 
-	int res = mkdir(android_rootfs_dir, 0755);
-	if (res != 0 && errno != EEXIST) {
-		die("cannot create bind-mount target %s", android_rootfs_dir);
-	}
-	if (res == 0 && (chown(android_rootfs_dir, 0, 0) < 0)) {
-		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of %s", android_rootfs_dir);
-	}
+    int res = mkdir(android_rootfs_dir, 0755);
+    if (res != 0 && errno != EEXIST) {
+        die("cannot create bind-mount target %s", android_rootfs_dir);
+    }
+    if (res == 0 && (chown(android_rootfs_dir, 0, 0) < 0)) {
+        // Adjust the ownership only if we created the directory.
+        die("cannot change ownership of %s", android_rootfs_dir);
+    }
 
-	if (mount(SC_HYBRIS_ROOTFS, android_rootfs_dir, NULL, MS_BIND | MS_REC | MS_RDONLY, NULL)) {
-		die("Cannot mount Halium environment into target");
-	}
+    if (mount(SC_HYBRIS_ROOTFS, android_rootfs_dir, NULL, MS_BIND | MS_REC | MS_RDONLY, NULL)) {
+        die("Cannot mount Halium environment into target");
+    }
 
-	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_SYSTEM_SYMLINK);
-	const char *android_system_symlink = path_buf;
-	if (symlink(SC_HYBRIS_SYSTEM_SYMLINK_TARGET, android_system_symlink)) {
-		die("Cannot set symlink for %s", SC_HYBRIS_SYSTEM_SYMLINK);
-	}
+    sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_SYSTEM_SYMLINK);
+    const char *android_system_symlink = path_buf;
+    if (symlink(SC_HYBRIS_SYSTEM_SYMLINK_TARGET, android_system_symlink)) {
+        die("Cannot set symlink for %s", SC_HYBRIS_SYSTEM_SYMLINK);
+    }
 
-	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_VENDOR_SYMLINK);
-	const char *android_vendor_symlink = path_buf;
-	if (symlink(SC_HYBRIS_VENDOR_SYMLINK_TARGET, android_vendor_symlink)) {
-		die("Cannot set symlink for %s", SC_HYBRIS_VENDOR_SYMLINK);
-	}
+    sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_VENDOR_SYMLINK);
+    const char *android_vendor_symlink = path_buf;
+    if (symlink(SC_HYBRIS_VENDOR_SYMLINK_TARGET, android_vendor_symlink)) {
+        die("Cannot set symlink for %s", SC_HYBRIS_VENDOR_SYMLINK);
+    }
 
-	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_ODM_SYMLINK);
-	const char *android_odm_symlink = path_buf;
-	if (symlink(SC_HYBRIS_ODM_SYMLINK_TARGET, android_odm_symlink)) {
-		die("Cannot set symlink for %s", SC_HYBRIS_ODM_SYMLINK);
-	}
+    sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_ODM_SYMLINK);
+    const char *android_odm_symlink = path_buf;
+    if (symlink(SC_HYBRIS_ODM_SYMLINK_TARGET, android_odm_symlink)) {
+        die("Cannot set symlink for %s", SC_HYBRIS_ODM_SYMLINK);
+    }
 
-	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_APEX_SYMLINK);
-	const char *android_apex_symlink = path_buf;
-	if (symlink(SC_HYBRIS_APEX_SYMLINK_TARGET, android_apex_symlink)) {
-		die("Cannot set symlink for %s", SC_HYBRIS_APEX_SYMLINK);
-	}
+    sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_APEX_SYMLINK);
+    const char *android_apex_symlink = path_buf;
+    if (symlink(SC_HYBRIS_APEX_SYMLINK_TARGET, android_apex_symlink)) {
+        die("Cannot set symlink for %s", SC_HYBRIS_APEX_SYMLINK);
+    }
 
-	sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_LINKERCONFIG_SYMLINK);
-	const char* android_linkerconfig_symlink = path_buf;
-	if (symlink(SC_HYBRIS_LINKERCONFIG_SYMLINK_TARGET, android_linkerconfig_symlink)) {
-		die("Cannot set symlink for %s", SC_HYBRIS_LINKERCONFIG_SYMLINK);
-	}
+    sc_must_snprintf(path_buf, sizeof(path_buf), "%s%s", rootfs_dir, SC_HYBRIS_LINKERCONFIG_SYMLINK);
+    const char *android_linkerconfig_symlink = path_buf;
+    if (symlink(SC_HYBRIS_LINKERCONFIG_SYMLINK_TARGET, android_linkerconfig_symlink)) {
+        die("Cannot set symlink for %s", SC_HYBRIS_LINKERCONFIG_SYMLINK);
+    }
 }
 
-void sc_mount_hybris_driver(const char *rootfs_dir, const char *base_snap_name)
-{
-	int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755, 0, 0);
-	if (res != 0) {
-		die("cannot create " SC_EXTRA_LIB_DIR);
-	}
-	if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
-		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of " SC_EXTRA_LIB_DIR);
-	}
+static bool has_mounted_halium_path(const char *path) {
+    // Halium system image existance
+    FILE *mounts = NULL;
+    char *line = NULL;
+    int character = 0;
+    unsigned int i = 0;
+    unsigned int line_size = 0;
+    static const unsigned int line_increase = 64;
+    bool found = false;
 
-	sc_hybris_mount_android_rootfs(rootfs_dir);
+    // Check whether the Halium system image has been mounted.
+    mounts = fopen("/proc/mounts", "r");
+    if (!mounts) {
+        return false;
+    }
+
+    line = (char *)malloc(sizeof(char) * line_increase);
+    if (!line) {
+        fclose(mounts);
+        return false;
+    }
+
+    line_size = line_increase;
+    line[0] = '\0';
+
+    // Files in /proc don't expose their size, so read into a buffer character-by-character.
+    while ((character = fgetc(mounts)) != EOF) {
+        if (i >= line_size) {
+            line = (char *)realloc(line, sizeof(char) * (line_size + line_increase));
+            if (!line) {
+                fclose(mounts);
+                return false;
+            }
+
+            line_size += line_increase;
+            line[line_size - 1] = '\0';
+        }
+
+        line[i] = (char)character;
+
+        if (line[i] == '\n') line[i] = '\0';
+
+        // Judge the line we read now
+        if (line[i] == '\0') {
+            // These must exist on disk, not on some tmpfs,
+            // using filesystems prominently used on Android.
+            if ((strncmp(line, " ext4 ", 6) == 0 || strncmp(line, " f2fs ", 6) == 0) &&
+                strncmp(line, path, strlen(path)) == 0) {
+                found = true;
+                break;
+            }
+
+            line[0] = '\0';
+            i = 0;
+        } else {
+            ++i;
+        }
+    }
+
+    fclose(mounts);
+    free(line);
+    return found;
+}
+
+int sc_mount_is_halium_system(void) {
+    // Halium-typical paths to check for
+    // snapd's "opengl" interface takes care of exposing it all
+    // to the confined environment
+    static const char *halium_paths[] = {
+        "/system/build.prop",
+#ifdef __LP64__
+        "/system/lib64/libEGL.so",
+#else
+        "/system/lib/libEGL.so"
+#endif
+    };
+    static const char *halium_mountpoints[] = {
+        " /android/vendor ",
+        " /android/data ",
+        " /android/cache ",
+    };
+    static const char *halium_symlinks[] = {"/system", "/vendor", "/odm", "/data"};
+    static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder",
+                                         "/dev/hwbinder"};
+
+    // Check if this is running on a system with binder devices, which all Halium systems do.
+    bool has_binder = false;
+    for (long unsigned int i = 0; i < sizeof(binder_paths) / sizeof(binder_paths[0]); i++) {
+        struct stat info;
+        if (stat(binder_paths[i], &info) == 0) {
+            has_binder = true;
+            break;
+        }
+    }
+    if (!has_binder) {
+        return 0;
+    }
+
+    // These are required mountpoints which are used by our Halium LXC container
+    for (long unsigned int i = 0; i < sizeof(halium_mountpoints) / sizeof(halium_mountpoints[0]); i++) {
+        if (!has_mounted_halium_path(halium_mountpoints[i])) {
+            return 0;
+        }
+    }
+
+    // Next check for commonly required host-side files we want to pass
+    for (long unsigned int i = 0; i < sizeof(halium_paths) / sizeof(halium_paths[0]); i++) {
+        struct stat info;
+        if (stat(halium_paths[i], &info) != 0) {
+            return 0;
+        }
+    }
+
+    // These symlinks must exist in GNU/Linux Land for hybris to work
+    for (long unsigned int i = 0; i < sizeof(halium_symlinks) / sizeof(halium_symlinks[0]); i++) {
+        struct stat info;
+        if (lstat(halium_symlinks[i], &info) != 0) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+void sc_mount_hybris_driver(const char *rootfs_dir, const char *base_snap_name) {
+    // Only proceed if this has been identified as a Halium system
+    if (!sc_mount_is_halium_system()) {
+        return;
+    }
+
+    int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755, 0, 0);
+    if (res != 0) {
+        die("cannot create " SC_EXTRA_LIB_DIR);
+    }
+    if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
+        // Adjust the ownership only if we created the directory.
+        die("cannot change ownership of " SC_EXTRA_LIB_DIR);
+    }
+
+    sc_hybris_mount_android_rootfs(rootfs_dir);
 }

--- a/cmd/snap-confine/mount-support-hybris.c
+++ b/cmd/snap-confine/mount-support-hybris.c
@@ -101,6 +101,70 @@ static void sc_hybris_mount_android_rootfs(const char *rootfs_dir) {
     }
 }
 
+static bool has_mounted_halium_path(const char *path) {
+    // Halium system image existance
+    FILE *mounts = NULL;
+    char *line = NULL;
+    int character = 0;
+    unsigned int i = 0;
+    unsigned int line_size = 0;
+    static const unsigned int line_increase = 64;
+    bool found = false;
+
+    // Check whether the Halium system image has been mounted.
+    mounts = fopen("/proc/mounts", "r");
+    if (!mounts) {
+        return false;
+    }
+
+    line = (char *)malloc(sizeof(char) * line_increase);
+    if (!line) {
+        fclose(mounts);
+        return false;
+    }
+
+    line_size = line_increase;
+    line[0] = '\0';
+
+    // Files in /proc don't expose their size, so read into a buffer character-by-character.
+    while ((character = fgetc(mounts)) != EOF) {
+        if (i >= line_size) {
+            line = (char *)realloc(line, sizeof(char) * (line_size + line_increase));
+            if (!line) {
+                fclose(mounts);
+                return false;
+            }
+
+            line_size += line_increase;
+            line[line_size - 1] = '\0';
+        }
+
+        line[i] = (char)character;
+
+        if (line[i] == '\n') line[i] = '\0';
+
+        // Judge the line we read now
+        if (line[i] == '\0') {
+            // These must exist on disk, not on some tmpfs,
+            // using filesystems prominently used on Android.
+            if ((strncmp(line, " ext4 ", 6) == 0 || strncmp(line, " f2fs ", 6) == 0) &&
+                strncmp(line, path, strlen(path)) == 0) {
+                found = true;
+                break;
+            }
+
+            line[0] = '\0';
+            i = 0;
+        } else {
+            ++i;
+        }
+    }
+
+    fclose(mounts);
+    free(line);
+    return found;
+}
+
 int sc_mount_is_halium_system(void) {
     // Halium-typical paths to check for
     // snapd's "opengl" interface takes care of exposing it all
@@ -113,7 +177,11 @@ int sc_mount_is_halium_system(void) {
         "/system/lib/libEGL.so"
 #endif
     };
-    static const char *halium_mountpoints[] = {"/android/vendor", "/android/data", "/android/cache"};
+    static const char *halium_mountpoints[] = {
+        " /android/vendor ",
+        " /android/data ",
+        " /android/cache ",
+    };
     static const char *halium_symlinks[] = {"/system", "/vendor", "/odm", "/data"};
     static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder",
                                          "/dev/hwbinder"};
@@ -133,8 +201,7 @@ int sc_mount_is_halium_system(void) {
 
     // These are required mountpoints which are used by our Halium LXC container
     for (long unsigned int i = 0; i < sizeof(halium_mountpoints) / sizeof(halium_mountpoints[0]); i++) {
-        struct stat info;
-        if (stat(halium_mountpoints[i], &info) != 0) {
+        if (!has_mounted_halium_path(halium_mountpoints[i])) {
             return 0;
         }
     }
@@ -162,7 +229,7 @@ void sc_mount_hybris_driver(const char *rootfs_dir, const char *base_snap_name) 
     // Only proceed if this has been identified as a Halium system, on Ubuntu Touch
     // we require access to a lot of unvetted libraries and unmediated IPC, and
     // misc required files. No executable bits allowed, this is the most fine-grained
-    // while future-resiliant as patched-in, shipped and used by Ubuntu Touch users.
+    // while future-resiliant as patched-in, shipped and used set of rules and requirements.
     if (!sc_mount_is_halium_system()) {
         return;
     }

--- a/cmd/snap-confine/mount-support-hybris.h
+++ b/cmd/snap-confine/mount-support-hybris.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_MOUNT_SUPPORT_HYBRIS_H
+#define SNAP_CONFINE_MOUNT_SUPPORT_HYBRIS_H
+
+/**
+ * Make the libhybris drivers from the classic distribution available in the snap
+ * execution environment.
+ *
+ * libhybris allows for ABI guarantees as long as their wrappers can be linked or
+ * dlopen()'ed because it is the library loader, it resolves the symbols and links them.
+ * /android needs to live inside the Snap environment too for the actual bionic-built
+ * libraries to be found, loaded and their functions executed.
+ *
+ * /android and the respective compatibility symlinks from /system to /android/system
+ * etc. allow for loading the appropriate userspace components for proper use
+ * (assuming AppArmor plays along).
+ **/
+void sc_mount_hybris_driver(const char *rootfs_dir, const char *base_snap_name);
+
+#endif

--- a/cmd/snap-confine/mount-support-hybris.h
+++ b/cmd/snap-confine/mount-support-hybris.h
@@ -19,6 +19,17 @@
 #define SNAP_CONFINE_MOUNT_SUPPORT_HYBRIS_H
 
 /**
+ * Check whether the running system looks like a regular Halium distribution
+ *
+ * Distributions using Halium have an Android Generic System Image mounted at /android,
+ * with symlinks pointing to various Android-typical directories, like /system & /vendor,
+ * and they make extensive use of Binder IPC.
+ *
+ * Verify this system's environment matches expectations of a Halium system and return.
+ **/
+int sc_mount_is_halium_system(void);
+
+/**
  * Make the libhybris drivers from the classic distribution available in the snap
  * execution environment.
  *

--- a/cmd/snap-confine/mount-support-test.c
+++ b/cmd/snap-confine/mount-support-test.c
@@ -18,6 +18,8 @@
 #include "mount-support.h"
 #include "mount-support-nvidia.c"
 #include "mount-support-nvidia.h"
+#include "mount-support-hybris.c"
+#include "mount-support-hybris.h"
 #include "mount-support.c"
 
 #include <glib.h>

--- a/cmd/snap-confine/mount-support-test.c
+++ b/cmd/snap-confine/mount-support-test.c
@@ -16,10 +16,10 @@
  */
 
 #include "mount-support.h"
-#include "mount-support-nvidia.c"
-#include "mount-support-nvidia.h"
 #include "mount-support-hybris.c"
 #include "mount-support-hybris.h"
+#include "mount-support-nvidia.c"
+#include "mount-support-nvidia.h"
 #include "mount-support.c"
 
 #include <glib.h>

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -49,6 +49,7 @@
 #include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
 #include "mount-support-nvidia.h"
+#include "mount-support-hybris.h"
 
 #define MAX_BUF 1000
 #define SNAP_PRIVATE_TMP_ROOT_DIR "/tmp/snap-private-tmp"
@@ -753,6 +754,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config) {
     // pre-pivot filesystem.
     if (config->distro == SC_DISTRO_CLASSIC) {
         sc_mount_nvidia_driver(scratch_dir, config->base_snap_name);
+        sc_mount_hybris_driver(scratch_dir, config->base_snap_name);
     }
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     //                    pivot_root

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -48,8 +48,8 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
-#include "mount-support-nvidia.h"
 #include "mount-support-hybris.h"
+#include "mount-support-nvidia.h"
 
 #define MAX_BUF 1000
 #define SNAP_PRIVATE_TMP_ROOT_DIR "/tmp/snap-private-tmp"

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -270,6 +270,9 @@ profile @LIBEXECDIR@/snap-confine flags=(attach_disconnected) {
     mount options=(rw rbind) /mnt/ -> /tmp/snap.rootfs_*/mnt/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/mnt/,
 
+    mount options=(ro rbind) /android/ -> /tmp/snap.rootfs_*/android/,
+    mount options=(ro rslave) -> /tmp/snap.rootfs_*/android/,
+
     # allow making host snap-exec available inside base snaps
     mount options=(rw bind) @LIBEXECDIR@/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -98,6 +98,10 @@ profile @LIBEXECDIR@/snap-confine flags=(attach_disconnected) {
     /sys/kernel/mm/transparent_hugepage/enabled r,
     /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
 
+    # mount-support-hybris: Checks for vendor-provided partitions
+    # to ensure additional paths are only mounted on Halium systems
+    @{PROC}/{,self/,@{pid}/}mounts r,
+
     # cgroup: reading own cgroup
     @{PROC}/@{pid}/cgroup r,
 

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -114,8 +114,7 @@ static void sc_udev_allow_nvidia(sc_device_cgroup *cgroup) {
  *
  * Note: Binder devices on newer Android kernels reside inside of their own binderfs mountpount.
  **/
-static void sc_udev_allow_hybris(sc_device_cgroup *cgroup)
-{
+static void sc_udev_allow_hybris(sc_device_cgroup *cgroup) {
     /* Only go on here if this has been identified as a Halium/libhybris system
      *
      * In case the host happens to have binder available, but isn't identified as
@@ -128,10 +127,11 @@ static void sc_udev_allow_hybris(sc_device_cgroup *cgroup)
         return;
     }
 
-    static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder", "/dev/hwbinder"};
+    static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder",
+                                         "/dev/hwbinder"};
 
     // If everything looks alright, allow access to binder IPC via the device cgroup
-    for (long unsigned int i = 0; i < sizeof(binder_paths)/sizeof(binder_paths[0]); i++) {
+    for (long unsigned int i = 0; i < sizeof(binder_paths) / sizeof(binder_paths[0]); i++) {
         struct stat sbuf;
         if (stat(binder_paths[i], &sbuf) == 0) {
             sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -107,6 +107,57 @@ static void sc_udev_allow_nvidia(sc_device_cgroup *cgroup) {
     }
 }
 
+/** Allow access to hybris devices.
+ *
+ * Required by Halium-based GNU/Linux adaptations to make use of certain device nodes.
+ *
+ * Note: Binder devices on newer Android kernels reside inside of their own binderfs mountpount.
+ **/
+static void sc_udev_allow_hybris(sc_device_cgroup *cgroup)
+{
+    /* Only go on here if this has been identified as a Halium/libhybris system
+     *
+     * In case the host happens to have binder available, but isn't identified as
+     * a system requiring it to drive host-residing Android drivers, then return early,
+     * otherwise we would open a hole between confined apps and unconfined Anbox or other
+     * which causes them to communicate over a potentially unmediated IPC interface.
+     * So only proceed if this has been identified as a Halium distribution.
+     */
+    static const char *halium_paths[] = {"/android", "/system", "/vendor", "/odm", "/system/build.prop"};
+    static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder", "/dev/hwbinder"};
+
+    // First check if this is running on a system with binder devices, which all Halium systems do.
+    bool has_binder = false;
+    for (long unsigned int i = 0; i < sizeof(binder_paths)/sizeof(binder_paths[0]); i++) {
+        struct stat binderbuf;
+        if (stat(binder_paths[i], &binderbuf) == 0) {
+            has_binder = true;
+            break;
+        }
+    }
+
+    if (!has_binder) {
+        return;
+    }
+
+    // Next check for commonly required host-side directories and symlinks
+    for (long unsigned int i = 0; i < sizeof(halium_paths)/sizeof(halium_paths[0]); i++) {
+        struct stat haliumbuf;
+        // The host-side symlinks might exist but Halium-side mountpoints might not, hence check with lstat().
+        if (lstat(halium_paths[i], &haliumbuf) != 0) {
+            return;
+        }
+    }
+
+    // If everything looks alright, allow access to binder IPC via the device cgroup
+    for (long unsigned int i = 0; i < sizeof(binder_paths)/sizeof(binder_paths[0]); i++) {
+        struct stat sbuf;
+        if (stat(binder_paths[i], &sbuf) == 0) {
+            sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));
+        }
+    }
+}
+
 /**
  * Allow access to /dev/uhid.
  *
@@ -182,6 +233,7 @@ static void sc_udev_setup_acls_common(sc_device_cgroup *cgroup) {
     sc_udev_allow_common(cgroup);
     sc_udev_allow_pty_slaves(cgroup);
     sc_udev_allow_nvidia(cgroup);
+    sc_udev_allow_hybris(cgroup);
     sc_udev_allow_uhid(cgroup);
     sc_udev_allow_dev_net_tun(cgroup);
 }

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -37,6 +37,7 @@
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
+#include "mount-support-hybris.h"
 #include "udev-support.h"
 
 /* Allow access to common devices. */
@@ -123,31 +124,11 @@ static void sc_udev_allow_hybris(sc_device_cgroup *cgroup)
      * which causes them to communicate over a potentially unmediated IPC interface.
      * So only proceed if this has been identified as a Halium distribution.
      */
-    static const char *halium_paths[] = {"/android", "/system", "/vendor", "/odm", "/system/build.prop"};
-    static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder", "/dev/hwbinder"};
-
-    // First check if this is running on a system with binder devices, which all Halium systems do.
-    bool has_binder = false;
-    for (long unsigned int i = 0; i < sizeof(binder_paths)/sizeof(binder_paths[0]); i++) {
-        struct stat binderbuf;
-        if (stat(binder_paths[i], &binderbuf) == 0) {
-            has_binder = true;
-            break;
-        }
-    }
-
-    if (!has_binder) {
+    if (!sc_mount_is_halium_system()) {
         return;
     }
 
-    // Next check for commonly required host-side directories and symlinks
-    for (long unsigned int i = 0; i < sizeof(halium_paths)/sizeof(halium_paths[0]); i++) {
-        struct stat haliumbuf;
-        // The host-side symlinks might exist but Halium-side mountpoints might not, hence check with lstat().
-        if (lstat(halium_paths[i], &haliumbuf) != 0) {
-            return;
-        }
-    }
+    static const char *binder_paths[] = {"/dev/binderfs/binder", "/dev/binderfs/hwbinder", "/dev/binder", "/dev/hwbinder"};
 
     // If everything looks alright, allow access to binder IPC via the device cgroup
     for (long unsigned int i = 0; i < sizeof(binder_paths)/sizeof(binder_paths[0]); i++) {

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -228,7 +228,7 @@ func logoutUser(c *Command, r *http.Request, user *auth.UserState) Response {
 }
 
 // this might need to become a function, if having user admin becomes a config option
-var hasUserAdmin = !release.OnClassic
+var hasUserAdmin = !release.OnClassic || release.OnTouch
 
 const noUserAdmin = "system user administration via snapd is not allowed on this system"
 

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -21,6 +21,8 @@ package builtin
 
 import (
 	"strings"
+
+	"github.com/snapcore/snapd/release"
 )
 
 const cameraSummary = `allows access to all cameras`
@@ -56,6 +58,26 @@ const cameraConnectedPlugAppArmor = `
 /sys/devices/platform/**/usb*/**/video4linux/** r,
 `
 
+const cameraConnectedPlugTouchAppArmor = `
+# Support for Android-based Camera stack on Ubuntu Touch
+/android{,/**} r,
+/{,android/}system/build.prop r,
+/{,android/}vendor/build.prop r,
+/{,android/}odm/build.prop    r,
+
+# libcamera_compat_layer doesn't require proprietary vendor blobs
+/{,android/}system/lib{,64}/** r,
+/{,android/}system/lib{,64}/**.so m,
+
+# Commonly expected Android paths
+/{,dev/}socket/property_service rw,
+/{,dev/}socket/logdw rw,
+/{,dev/}__properties__/** r,
+
+# Allow access to the CameraService on app-only binder
+/dev/{,binderfs/}binder rw,
+`
+
 // DetectCameraFromPath returns true if the given path corresponds to an
 // AppArmor rule with the prompt prefix from the camera interface.
 //
@@ -74,13 +96,18 @@ var cameraConnectedPlugUDev = []string{
 }
 
 func init() {
+	connectedPlugAppArmor := cameraConnectedPlugAppArmor
+	if release.OnTouch {
+		connectedPlugAppArmor += cameraConnectedPlugTouchAppArmor
+	}
+
 	registerIface(&commonInterface{
 		name:                  "camera",
 		summary:               cameraSummary,
 		implicitOnCore:        true,
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  cameraBaseDeclarationSlots,
-		connectedPlugAppArmor: cameraConnectedPlugAppArmor,
+		connectedPlugAppArmor: connectedPlugAppArmor,
 		connectedPlugUDev:     cameraConnectedPlugUDev,
 	})
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -723,6 +723,24 @@ ptrace (read, trace) peer=unconfined,
 ###EXCL{<> rwlix,:/snap/snapd/*/usr/lib/snapd/snap-confine,/snap/core/*/usr/lib/snapd/snap-confine}###
 `
 
+const dockerSupportConnectedPlugAppArmorTouch = `
+# Description: allow docker daemon to change profile
+
+# OnTouch doesn't use AAREExclusionPatterns due to parser/kernel bugs,
+# so allow accesses and change_profile the regular way.
+/** rwlix,
+change_profile unsafe /** -> docker-default,
+change_profile unsafe /** -> cri-containerd.apparmor.d,
+`
+
+const dockerSupportPrivilegedAppArmorTouch = `
+# Description: allow docker daemon to run privileged
+
+# OnTouch doesn't use AAREExclusionPatterns due to parser/kernel bugs,
+# so allow change_profile the regular way.
+change_profile unsafe /**,
+`
+
 const dockerSupportPrivilegedSecComp = `
 # Description: allow docker daemon to run privileged containers. This gives
 # full access to all resources on the system and thus gives device ownership to
@@ -749,6 +767,7 @@ func (iface *dockerSupportInterface) KModConnectedPlug(spec *kmod.Specification,
 
 func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	var privileged bool
+	var err error
 	_ = plug.Attr("privileged-containers", &privileged)
 
 	// The 'change_profile unsafe' rules conflict with the 'ix' rules in
@@ -762,71 +781,82 @@ func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	// snaps.
 	spec.SetSuppressPycacheDeny()
 
-	defaultSnippet, err := apparmor_sandbox.InsertAAREExclusionPatterns(
-		dockerSupportConnectedPlugAppArmor,
-		[]string{
-			"/snap/snapd/*/usr/lib/snapd/snap-confine",
-			"/snap/core/*/usr/lib/snapd/snap-confine",
-		},
-		&apparmor_sandbox.AAREExclusionPatternsOptions{
-			Prefix: "change_profile unsafe ",
-			Suffix: " -> docker-default,",
-		},
-	)
-	if err != nil {
-		return err
-	}
+	defaultSnippet := dockerSupportConnectedPlugAppArmor
 
-	defaultSnippet, err = apparmor_sandbox.InsertAAREExclusionPatterns(
-		defaultSnippet,
-		[]string{
-			"/snap/snapd/*/usr/lib/snapd/snap-confine",
-			"/snap/core/*/usr/lib/snapd/snap-confine",
-		},
-		&apparmor_sandbox.AAREExclusionPatternsOptions{
-			Prefix: "change_profile unsafe ",
-			Suffix: " -> cri-containerd.apparmor.d,",
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	spec.AddSnippet(defaultSnippet)
-	if privileged {
-		privilegedSnippet, err := apparmor_sandbox.InsertAAREExclusionPatterns(
-			dockerSupportPrivilegedAppArmor,
+	if !release.OnTouch {
+		defaultSnippet, err = apparmor_sandbox.InsertAAREExclusionPatterns(
+			dockerSupportConnectedPlugAppArmor,
 			[]string{
 				"/snap/snapd/*/usr/lib/snapd/snap-confine",
 				"/snap/core/*/usr/lib/snapd/snap-confine",
 			},
 			&apparmor_sandbox.AAREExclusionPatternsOptions{
 				Prefix: "change_profile unsafe ",
-				Suffix: ",",
+				Suffix: " -> docker-default,",
 			},
 		)
 		if err != nil {
 			return err
 		}
 
-		privilegedSnippet, err = apparmor_sandbox.InsertAAREExclusionPatterns(
-			privilegedSnippet,
+		defaultSnippet, err = apparmor_sandbox.InsertAAREExclusionPatterns(
+			defaultSnippet,
 			[]string{
 				"/snap/snapd/*/usr/lib/snapd/snap-confine",
 				"/snap/core/*/usr/lib/snapd/snap-confine",
 			},
 			&apparmor_sandbox.AAREExclusionPatternsOptions{
-				Prefix: "",
-				Suffix: " rwlix,",
+				Prefix: "change_profile unsafe ",
+				Suffix: " -> cri-containerd.apparmor.d,",
 			},
 		)
 		if err != nil {
 			return err
 		}
+	} else {
+		spec.AddSnippet(dockerSupportConnectedPlugAppArmorTouch)
+	}
 
+	spec.AddSnippet(defaultSnippet)
+
+	if privileged {
+		privilegedSnippet := dockerSupportPrivilegedAppArmor
+		if !release.OnTouch {
+			privilegedSnippet, err = apparmor_sandbox.InsertAAREExclusionPatterns(
+				dockerSupportPrivilegedAppArmor,
+				[]string{
+					"/snap/snapd/*/usr/lib/snapd/snap-confine",
+					"/snap/core/*/usr/lib/snapd/snap-confine",
+				},
+				&apparmor_sandbox.AAREExclusionPatternsOptions{
+					Prefix: "change_profile unsafe ",
+					Suffix: ",",
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			privilegedSnippet, err = apparmor_sandbox.InsertAAREExclusionPatterns(
+				privilegedSnippet,
+				[]string{
+					"/snap/snapd/*/usr/lib/snapd/snap-confine",
+					"/snap/core/*/usr/lib/snapd/snap-confine",
+				},
+				&apparmor_sandbox.AAREExclusionPatternsOptions{
+					Prefix: "",
+					Suffix: " rwlix,",
+				},
+			)
+			if err != nil {
+				return err
+			}
+		} else {
+			spec.AddSnippet(dockerSupportPrivilegedAppArmorTouch)
+		}
 		spec.AddSnippet(privilegedSnippet)
 	}
-	if !release.OnClassic {
+	if !release.OnClassic || release.OnTouch {
 		spec.AddSnippet(dockerSupportConnectedPlugAppArmorCore)
 	}
 	// if apparmor supports userns mediation then add this too

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 )
 
 const openglSummary = `allows access to OpenGL stack`
@@ -220,6 +221,36 @@ unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 /run/nvidia-persistenced/socket rw,
 `
 
+const openglHybrisConnectedPlugAppArmor = `
+# Support for non-redistributable Android GL drivers on Halium systems
+# These drivers are built against Android's bionic libc, located on
+# vendor-provided partitions, and generally loaded using libhybris on
+# GNU/Linux systems, like via hybris-2404.
+/android{,/**} r,
+/{,android/}system/build.prop r,
+/{,android/}vendor/build.prop r,
+/{,android/}odm/build.prop    r,
+/{,android/}vendor/lib{,64}/**           r,
+/{,android/}vendor/lib{,64}/**.so        m,
+/{,android/}system/lib{,64}/**           r,
+/{,android/}system/lib{,64}/**.so        m,
+/{,android/}system/vendor/lib{,64}/**    r,
+/{,android/}system/vendor/lib{,64}/**.so m,
+/{,android/}odm/lib{,64}/**    r,
+/{,android/}odm/lib{,64}/**.so m,
+/{,android/}apex/com.android.*/lib{,64}/**     r,
+/{,android/}apex/com.android.*/lib{,64}/**.so  m,
+/{,dev/}socket/property_service rw, # attach_disconnected path
+/{,dev/}socket/logdw rw, # attach_disconnected path
+/{,dev/}__properties__/** r, # attach_disconnected path
+/dev/{,binderfs/}binder rw,
+/dev/{,binderfs/}hwbinder rw,
+/dev/ashmem rw,
+/dev/ion rw,
+/dev/kgsl-3d0 rw,
+/sys/devices/platform/soc/**/kgsl/kgsl-3d0/gpu_model rw,
+`
+
 type openglInterface struct {
 	commonInterface
 }
@@ -265,6 +296,14 @@ const (
 	wslDirInMountNs        = "/usr/lib/wsl"
 )
 
+// Set up hybris/Halium device access for GLES to work on Touch
+var openglHybrisConnectedPlugUDev = []string{
+	`KERNEL=="kgsl-3d0"`,
+	`KERNEL=="ion"`,
+	`KERNEL=="binder"`,
+	`KERNEL=="hwbinder"`,
+}
+
 func (iface *openglInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	spec.AddSnippet(openglConnectedPlugAppArmor)
 
@@ -300,6 +339,11 @@ func (iface *openglInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 		)
 	}
 
+	// Ensure Ubuntu Touch allows for use of non-redistributable EGL & Vulkan drivers
+	if release.OnTouch {
+		spec.AddSnippet(openglHybrisConnectedPlugAppArmor)
+	}
+
 	return nil
 }
 
@@ -333,6 +377,10 @@ func (iface *openglInterface) MountConnectedPlug(spec *mount.Specification, plug
 }
 
 func init() {
+	connectedPlugUDev := openglConnectedPlugUDev
+	if release.OnTouch {
+		connectedPlugUDev = append(openglConnectedPlugUDev, openglHybrisConnectedPlugUDev...)
+	}
 	registerIface(&openglInterface{
 		commonInterface: commonInterface{
 			name:                 "opengl",
@@ -340,7 +388,7 @@ func init() {
 			implicitOnCore:       true,
 			implicitOnClassic:    true,
 			baseDeclarationSlots: openglBaseDeclarationSlots,
-			connectedPlugUDev:    openglConnectedPlugUDev,
+			connectedPlugUDev:    connectedPlugUDev,
 		},
 	})
 }

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -230,25 +230,41 @@ const openglHybrisConnectedPlugAppArmor = `
 /{,android/}system/build.prop r,
 /{,android/}vendor/build.prop r,
 /{,android/}odm/build.prop    r,
-/{,android/}vendor/lib{,64}/**           r,
-/{,android/}vendor/lib{,64}/**.so        m,
-/{,android/}system/lib{,64}/**           r,
-/{,android/}system/lib{,64}/**.so        m,
-/{,android/}system/vendor/lib{,64}/**    r,
-/{,android/}system/vendor/lib{,64}/**.so m,
+
+# Top-level lib64 usually contains common libraries
+/{,android/}{,system/}vendor/lib{,64}/*    r,
+/{,android/}{,system/}vendor/lib{,64}/*.so m,
 /{,android/}odm/lib{,64}/**    r,
 /{,android/}odm/lib{,64}/**.so m,
+
+# APEXes ship their own lib64
 /{,android/}apex/com.android.*/lib{,64}/**     r,
 /{,android/}apex/com.android.*/lib{,64}/**.so  m,
-/{,dev/}socket/property_service rw, # attach_disconnected path
-/{,dev/}socket/logdw rw, # attach_disconnected path
-/{,dev/}__properties__/** r, # attach_disconnected path
-/dev/{,binderfs/}binder rw,
+
+# GLESv2 & EGL are in egl/
+/{,android/}{,system/}vendor/lib{,64}/egl/**    r,
+/{,android/}{,system/}vendor/lib{,64}/egl/**.so m,
+
+# /system is Halium and is Free and Open Source Software,
+# but only places required libraries in the lib64 top level.
+/{,android/}system/lib{,64}/*            r,
+/{,android/}system/lib{,64}/*.so         m,
+
+# Common Android services the blobs talk to
+/{,dev/}socket/property_service rw,
+/{,dev/}socket/logdw rw,
+/{,dev/}__properties__/** r,
+
+# Only allow access to hardware-related binder services
 /dev/{,binderfs/}hwbinder rw,
+
+# Memory creation and sharing
 /dev/ashmem rw,
 /dev/ion rw,
+
+# Qualcomm kernel interface
 /dev/kgsl-3d0 rw,
-/sys/devices/platform/soc/**/kgsl/kgsl-3d0/gpu_model rw,
+/sys/devices/platform/soc/**/kgsl/kgsl-3d0/gpu_model r,
 `
 
 type openglInterface struct {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -194,4 +195,16 @@ func (s *OpenglInterfaceSuite) TestMountSpec(c *C) {
 	c.Check(entries[1].Name, Equals, filepath.Join(hostfs, tmpdir, "/usr/lib/wsl"))
 	c.Check(entries[1].Dir, Equals, "/usr/lib/wsl")
 	c.Check(entries[1].Options, DeepEquals, []string{"rbind"})
+}
+
+func (s *OpenglInterfaceSuite) TestUbuntuTouchWithHalium(c *C) {
+	restore := release.MockOnTouch(true);
+	defer restore()
+
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/{,binderfs/}hwbinder rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/android{,/**} r,`)
 }

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -137,7 +137,7 @@ func RemoveUser(st *state.State, username string, opts *RemoveUserOptions) (*aut
 
 	// first remove the system user
 	delUseropts := &osutil.DelUserOptions{
-		ExtraUsers: !release.OnClassic,
+		ExtraUsers: !release.OnClassic || release.OnTouch,
 		Force:      opts.Force,
 	}
 	if err := osutilDelUser(username, delUseropts); err != nil {

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -492,7 +492,7 @@ func checkAndCreateSystemUsernames(si *snap.Info) error {
 
 	// then create
 	// TODO: move user creation to a more appropriate place like "link-snap"
-	extrausers := !release.OnClassic
+	extrausers := !release.OnClassic || release.OnTouch
 	for _, user := range si.SystemUsernames {
 		id := snap.SupportedSystemUsernames[user.Name].Id
 		switch user.Scope {

--- a/release/release.go
+++ b/release/release.go
@@ -205,6 +205,11 @@ var OnClassic bool
 // OnCoreDesktop states whether the process is running inside a Core Desktop image.
 var OnCoreDesktop bool
 
+// OnTouch states whether the process is running inside a Touch image
+// with a classic (but mostly read-only) filesystem layout.
+// It is a narrowed down variant of OnClassic
+var OnTouch bool
+
 // OnWSL states whether the process is running inside the Windows
 // Subsystem for Linux
 var OnWSL bool
@@ -222,6 +227,8 @@ func init() {
 	OnClassic = (ReleaseInfo.ID != "ubuntu-core")
 
 	OnCoreDesktop = (ReleaseInfo.ID == "ubuntu-core" && ReleaseInfo.VariantID == "desktop")
+
+	OnTouch = (OnClassic && ReleaseInfo.VariantID == "touch")
 
 	WSLVersion = getWSLVersion()
 	OnWSL = WSLVersion != 0
@@ -241,6 +248,14 @@ func MockOnCoreDesktop(onCoreDesktop bool) (restore func()) {
 	old := OnCoreDesktop
 	OnCoreDesktop = onCoreDesktop
 	return func() { OnCoreDesktop = old }
+}
+
+// MockOnTouch forces the process to appear inside an Ubuntu Touch
+// system for testing purposes.
+func MockOnTouch(onTouch bool) (restore func()) {
+        old := OnTouch
+        OnTouch = onTouch
+        return func() { OnTouch = old }
 }
 
 // MockReleaseInfo fakes a given information to appear in ReleaseInfo,


### PR DESCRIPTION
This PR contains:

- Release's VARIANT_ID being detected as "touch" variant of Ubuntu
- Enabling extrausers for that
- Enabling Docker to work on Ubuntu Touch by avoiding problematic Docker AppArmor insertions
- snap-confine working to set up /android and required symlinks pointing to Halium-side libraries

For more information about Halium: https://halium.org

Diverged greatly from the NVIDIA support code it's based on and provides a working environment for confined Qt5, Qt6, SDL, GTK and Flutter Snaps (as long as a GLES renderer is available) like QML Creator (`sudo snap install qmlcreator`) with the `hybris-2404` GNU/Linux drivers.

SNAPDENG-36010