### PR TITLE
t/core/*-single-reboot: extend to core20+, use sideload instead of refresh for robustness

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -88,6 +88,8 @@ environment:
     SNAPD_STATE_LOCK_TRACE_THRESHOLD_MS: '$(HOST: echo "${SPREAD_SNAPD_STATE_LOCK_TRACE_THRESHOLD_MS:-0}")'
     # Allow mismatch in snapd/kernel versions
     SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH: '$(HOST: echo "${SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH:-true}")'
+    # Option for core18 to have an unasserted gadget snap with debug output
+    CORE18_GADGET_REPACK: '$(HOST: echo "${SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH:-false}")'
 
     # Directory where the nested images and test assets are stored
     NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/var/tmp/work-dir}")'

--- a/tests/core/kernel-base-gadget-pair-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-pair-single-reboot-failover/task.yaml
@@ -127,7 +127,7 @@ execute: |
             fi
         elif os.query is-core20; then
             if [[ "$SNAP_ONE" == "pc-kernel" ]] || [[ "$SNAP_TWO" == "pc-kernel" ]]; then
-                stat /boot/grub/try-kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+                stat /boot/grub/try-kernel.efi | MATCH 'pc-kernel.*.snap/kernel.efi'
                 stat -L /boot/grub/try-kernel.efi
             fi
             if [[ "$SNAP_ONE" == *"core"* ]] || [[ "$SNAP_TWO" == *"core"* ]]; then

--- a/tests/core/kernel-base-gadget-pair-single-reboot/task.yaml
+++ b/tests/core/kernel-base-gadget-pair-single-reboot/task.yaml
@@ -5,8 +5,7 @@ details: |
     together with a single reboot. The test then reverts each of the snaps to ensure system is left
     in untouched state. (Otherwise our spread checks will complain).
 
-# TODO make the test work with ubuntu-core-20
-systems: [ubuntu-core-18-*]
+systems: [ubuntu-core-18-*, ubuntu-core-2*]
 
 environment:
     SNAP_ONE/kernel_base: core
@@ -18,42 +17,43 @@ environment:
     SNAP_ONE/kernel_gadget: pc
     SNAP_TWO/kernel_gadget: pc-kernel
 
-    BLOB_DIR: $(pwd)/fake-store-blobdir
+    GADGET_CHANNEL: edge
+    CORE18_GADGET_REPACK: true
+
+    # We are uploading too much in terms of size for the snaps
+    # we sideload. On UC18 this is disabled automatically, but
+    # on UC20+ this has proved to be an issue
+    SNAPD_NO_MEMORY_LIMIT: 1
 
 prepare: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
+    # To get VERSION_ID defined
+    . /etc/os-release
 
-    core_snap=core20
-    if os.query is-core18; then
-        core_snap=core18
-    fi
+    # does not work for 16, but we don't support 16 for this
+    core_snap="core${VERSION_ID}"
 
     # read all for simplification
     readlink /snap/pc-kernel/current > pc-kernel.rev
     readlink "/snap/$core_snap/current" > core.rev
-    readlink "/snap/pc/current" > pc.rev
+    readlink /snap/pc/current > pc.rev
 
-restore: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
-    "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
+debug: |
+    change_id="$(cat refresh-change-id)"
+    snap debug state --change "$change_id" /var/lib/snapd/state.json
 
 execute: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
+    # To get VERSION_ID defined
+    . /etc/os-release
+
+    if not snap list pc; then
+        echo "This test needs a host using 'pc' gadget snap"
+        exit 1
     fi
 
-    core_snap=core20
-    if os.query is-core18; then
-        core_snap=core18
-    fi
-
+    # does not work for 16, but we don't support 16 for this
+    core_snap="core${VERSION_ID}"
+    
+    # correct the naming based on the system we are testing
     if [ "$SNAP_ONE" = "core" ]; then
         SNAP_ONE=$core_snap
     elif [ "$SNAP_TWO" = "core" ]; then
@@ -61,13 +61,41 @@ execute: |
     fi
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
-        "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
+        echo Downloading snaps needed
+        snap download pc-kernel --channel="$VERSION_ID"/edge
 
-        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" "$SNAP_ONE"
-        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" "$SNAP_TWO"
+        snap download "$core_snap" --edge
+        unsquashfs -d base-snap "${core_snap}"_*.snap
+        rm "${core_snap}"_*
+        snap pack base-snap
 
-        snap refresh --no-wait "$SNAP_ONE" "$SNAP_TWO" > refresh-change-id
+        # prepare gadget update if gadget variant
+        if [[ "$SNAP_ONE" == "pc" ]] || [[ "$SNAP_TWO" == "pc" ]]; then
+            # unsquash gadget for modification
+            cp /var/lib/snapd/snaps/pc_*.snap gadget.snap
+            unsquashfs -d pc-snap gadget.snap
+
+            cp pc-snap/meta/gadget.yaml gadget.yaml.orig
+
+            system_seed=""
+            if os.query is-core-ge 20; then
+                system_seed="--system-seed"
+            fi
+
+            # prepare update
+            python3 ../gadget-update-pc/generate.py ./gadget.yaml.orig v1 $system_seed > pc-snap/meta/gadget.yaml
+            echo 'this is foo-x2' > foo-x2.img
+            cp foo-x2.img pc-snap/foo.img
+            echo 'this is foo.cfg' > pc-snap/foo.cfg
+            if os.query is-core-ge 20; then
+                echo 'this is foo-seed.cfg' > pc-snap/foo-seed.cfg
+            fi
+            sed -i -e 's/^version: \(.*\)-1/version: \1-2/' pc-snap/meta/snap.yaml
+            snap pack pc-snap --filename=pc_x1.snap
+        fi
+
+        snap install "$(ls ${SNAP_ONE}_*.snap)" "$(ls ${SNAP_TWO}_*.snap)" --dangerous --no-wait > refresh-change-id
+
         test -n "$(cat refresh-change-id)"
         change_id="$(cat refresh-change-id)"
         
@@ -97,13 +125,13 @@ execute: |
                 MATCH 'snap_mode=try' < boot-vars.dump
                 MATCH 'snap_try_kernel=pc-kernel_.*.snap' < boot-vars.dump
             fi
-        elif os.query is-core20; then
+        elif os.query is-core-ge 20; then
             if [[ "$SNAP_ONE" == "pc-kernel" ]] || [[ "$SNAP_TWO" == "pc-kernel" ]]; then
-                stat /boot/grub/try-kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+                stat /boot/grub/try-kernel.efi | MATCH 'pc-kernel.*.snap/kernel.efi'
                 stat -L /boot/grub/try-kernel.efi
             fi
             if [[ "$SNAP_ONE" == *"core"* ]] || [[ "$SNAP_TWO" == *"core"* ]]; then
-                MATCH 'try_base=core20_.*.snap' < /var/lib/snapd/modeenv
+                MATCH "try_base=core${VERSION_ID}_.*.snap" < /var/lib/snapd/modeenv
             fi
         else
             echo "unsupported Ubuntu Core system"
@@ -115,14 +143,12 @@ execute: |
         change_id="$(cat refresh-change-id)"
         # XXX: is this sufficiently robust?
         snap watch "$change_id" || true
-        snap changes | MATCH "$change_id\s+(Done|Error)"
-        # we expect re-refresh to fail since the tests uses a fake store
+        snap changes | MATCH "$change_id\s+Done"
         snap change "$change_id" > tasks.done
-        MATCH '^Error .* Monitoring .* to determine whether extra refresh steps are required' < tasks.done
-        # no other errors
-        grep -v 'Monitoring .* to determine whether extra refresh steps are required' < tasks.done | NOMATCH '^Error'
+        # nothing has failed
+        NOMATCH '^Error' < tasks.done
         # nothing was undone
-        grep -v 'Monitoring .* to determine whether extra refresh steps are required' < tasks.done | NOMATCH '^Undone'
+        NOMATCH '^Undone' < tasks.done
         # we did not even try to hijack shutdown (/bin/systemctl) because that
         # could race with snapd (if that wanted to call it), so just check that
         # the system is in a stable state once we have already determined that
@@ -134,26 +160,27 @@ execute: |
         # fake refreshes generate revision numbers that are n+1
         # verify that current points to new revisions
         if [[ "$SNAP_ONE" == *"core"* ]] || [[ "$SNAP_TWO" == *"core"* ]]; then
-            expecting_core="$(($(cat core.rev) + 1))"
+            expecting_core="x2"
+            if os.query is-core18; then
+                expecting_core="x1"
+            fi
             test "$(readlink /snap/$core_snap/current)" = "$expecting_core"
         fi
         if [[ "$SNAP_ONE" == "pc" ]] || [[ "$SNAP_TWO" == "pc" ]]; then
-            expecting_gadget="$(($(cat pc.rev) + 1))"
-            test "$(readlink /snap/pc/current)" = "$expecting_gadget"
+            test "$(readlink /snap/pc/current)" = "x2"
         fi
         if [[ "$SNAP_ONE" == "pc-kernel" ]] || [[ "$SNAP_TWO" == "pc-kernel" ]]; then
-            expecting_kernel="$(($(cat pc-kernel.rev) + 1))"
-            test "$(readlink /snap/pc-kernel/current)" = "$expecting_kernel"
+            test "$(readlink /snap/pc-kernel/current)" = "x2"
         fi
 
         # now we need to revert both snaps for restore to behave properly, go from
         # reverse order
-        snap revert "$SNAP_TWO" --revision "$(cat ${SNAP_TWO}.rev)"
+        snap revert "$SNAP_TWO"
         REBOOT
     elif [ "$SPREAD_REBOOT" = 2 ]; then
         snap watch --last=revert\?
         # now the first
-        snap revert "$SNAP_ONE" --revision "$(cat ${SNAP_ONE}.rev)"
+        snap revert "$SNAP_ONE"
         REBOOT
     elif [ "$SPREAD_REBOOT" = 3 ]; then
         snap watch --last=revert\?

--- a/tests/core/kernel-base-gadget-single-reboot/task.yaml
+++ b/tests/core/kernel-base-gadget-single-reboot/task.yaml
@@ -1,55 +1,89 @@
 summary: Verify that updating all of base, gadget and kernel only needs one reboot
 
 details: |
-    Check that when all of base, gadget and kernel are refreshed together, only one reboot
-    is needed. Verify that all the refreshed snaps can be reverted to the initial version.
+    Test ensures that all three of the essential snaps (base, gadget and kernel) can be updated
+    together with a single reboot. The test then reverts each of the snaps to ensure system is left
+    in untouched state. (Otherwise our spread checks will complain).
 
-# TODO make the test work with ubuntu-core-20
-systems: [ubuntu-core-18-*]
+systems: [ubuntu-core-18-*, ubuntu-core-2*]
 
 environment:
-    BLOB_DIR: $(pwd)/fake-store-blobdir
+    UPDATE_VARIANT/gadget_reboot: reboot
+    UPDATE_VARIANT/gadget_noreboot: no-reboot
+
+    GADGET_CHANNEL: edge
+    CORE18_GADGET_REPACK: true
+
+    # We are uploading too much in terms of size for the snaps
+    # we sideload. On UC18 this is disabled automatically, but
+    # on UC20+ this has proved to be an issue
+    SNAPD_NO_MEMORY_LIMIT: 1
 
 prepare: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
+    # To get VERSION_ID defined
+    . /etc/os-release
+
+    # does not work for 16, but we don't support 16 for this
+    core_snap="core${VERSION_ID}"
 
     readlink "/snap/pc-kernel/current" > pc-kernel.rev
-    readlink "/snap/core18/current" > core.rev
+    readlink "/snap/$core_snap/current" > core.rev
     readlink "/snap/pc/current" > pc.rev
-    
-restore: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
-    fi
-    "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
-    
+
 execute: |
-    if [ "$TRUST_TEST_KEYS" = "false" ]; then
-        echo "This test needs test keys to be trusted"
-        exit
+    # To get VERSION_ID defined
+    . /etc/os-release
+
+    if not snap list pc; then
+        echo "This test needs a host using 'pc' gadget snap"
+        exit 1
     fi
 
-    core_snap=core20
-    if os.query is-core18; then
-        core_snap=core18
-    fi
+    # does not work for 16, but we don't support 16 for this
+    core_snap="core${VERSION_ID}"
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
-        "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
+        echo Downloading snaps needed
+        snap download pc-kernel --channel="$VERSION_ID"/edge
 
-        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" pc-kernel
-        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" "$core_snap"
-        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" pc
+        snap download "${core_snap}" --edge
+        unsquashfs -d base-snap "${core_snap}"_*.snap
+        rm "${core_snap}"_*
+        snap pack base-snap
 
-        snap refresh --no-wait core18 pc pc-kernel > refresh-change-id
+        # We run one with a vanilla gadget, and one with another gadget
+        cp /var/lib/snapd/snaps/pc_*.snap gadget.snap
+        unsquashfs -d pc-snap gadget.snap        
+        
+        if [ "$UPDATE_VARIANT" = "no-reboot" ]; then
+            # prepare a vanilla version
+            sed -i -e 's/^version: \(.*\)/version: \1-1/' pc-snap/meta/snap.yaml
+            snap pack pc-snap --filename=pc_x1.snap
+        else
+            cp pc-snap/meta/gadget.yaml gadget.yaml.orig
+
+            system_seed=""
+            if os.query is-core-ge 20; then
+                system_seed="--system-seed"
+            fi
+
+            # prepare update
+            python3 ../gadget-update-pc/generate.py ./gadget.yaml.orig v1 $system_seed > pc-snap/meta/gadget.yaml
+            echo 'this is foo-x2' > foo-x2.img
+            cp foo-x2.img pc-snap/foo.img
+            echo 'this is foo.cfg' > pc-snap/foo.cfg
+            if os.query is-core-ge 20; then
+                echo 'this is foo-seed.cfg' > pc-snap/foo-seed.cfg
+            fi
+            sed -i -e 's/^version: \(.*\)-1/version: \1-2/' pc-snap/meta/snap.yaml
+            snap pack pc-snap --filename=pc_x1.snap
+        fi
+
+        snap install "$(ls ${core_snap}_*.snap)" "$(ls pc_*.snap)" "$(ls pc-kernel_*.snap)" --dangerous --no-wait > refresh-change-id
+        
         test -n "$(cat refresh-change-id)"
         change_id="$(cat refresh-change-id)"
-        
+
         # wait for the link task to be done for base
         retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
 
@@ -74,10 +108,10 @@ execute: |
             MATCH 'snap_mode=try' < boot-vars.dump
             MATCH 'snap_try_core=core18_.*.snap' < boot-vars.dump
             MATCH 'snap_try_kernel=pc-kernel_.*.snap' < boot-vars.dump
-        elif os.query is-core20; then
-            stat /boot/grub/kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+        elif os.query is-core-ge 20; then
+            stat /boot/grub/kernel.efi | MATCH 'pc-kernel.*.snap/kernel.efi'
             stat -L /boot/grub/kernel.efi
-            stat /boot/grub/try-kernel.efi | MATCH 'pc_kernel.*.snap/kernel.efi'
+            stat /boot/grub/try-kernel.efi | MATCH 'pc-kernel.*.snap/kernel.efi'
             stat -L /boot/grub/try-kernel.efi
         else
             echo "unsupported Ubuntu Core system"
@@ -89,14 +123,12 @@ execute: |
         change_id="$(cat refresh-change-id)"
         # XXX: is this sufficiently robust?
         snap watch "$change_id" || true
-        snap changes | MATCH "$change_id\s+(Done|Error)"
-        # we expect re-refresh to fail since the tests uses a fake store
+        snap changes | MATCH "$change_id\s+Done"
         snap change "$change_id" > tasks.done
-        MATCH '^Error .* Monitoring .* to determine whether extra refresh steps are required' < tasks.done
-        # no other errors
-        grep -v 'Monitoring .* to determine whether extra refresh steps are required' < tasks.done | NOMATCH '^Error'
+        # nothing has failed
+        NOMATCH '^Error' < tasks.done
         # nothing was undone
-        grep -v 'Monitoring .* to determine whether extra refresh steps are required' < tasks.done | NOMATCH '^Undone'
+        NOMATCH '^Undone' < tasks.done
         # we did not even try to hijack shutdown (/bin/systemctl) because that
         # could race with snapd (if that wanted to call it), so just check that
         # the system is in a stable state once we have already determined that
@@ -105,29 +137,29 @@ execute: |
         # Note: on bionic, is-system-running does not support --wait
         retry -n 30 sh -c '(systemctl is-system-running || true) | MATCH "(running|degraded)"'
 
-        # fake refreshes generate revision numbers that are n+1
-        expecting_kernel="$(($(cat pc-kernel.rev) + 1))"
-        expecting_core="$(($(cat core.rev) + 1))"
-        expecting_gadget="$(($(cat pc.rev) + 1))"
+        # expect generate revision numbers that are n+1
+        expecting_kernel="$(($(grep -o -E '[0-9]+' < pc-kernel.rev) + 1))"
+        expecting_gadget="$(($(grep -o -E '[0-9]+' < pc.rev) + 1))"
+        expecting_core="$(($(grep -o -E '[0-9]+' < core.rev) + 1))"
 
         # verify that current points to new revisions
-        test "$(readlink /snap/pc-kernel/current)" = "$expecting_kernel"
-        test "$(readlink /snap/pc/current)" = "$expecting_gadget"
-        test "$(readlink /snap/$core_snap/current)" = "$expecting_core"
+        test "$(readlink /snap/pc-kernel/current | grep -o -E '[0-9]+')" = "$expecting_kernel"
+        test "$(readlink /snap/pc/current | grep -o -E '[0-9]+')" = "$expecting_gadget"
+        test "$(readlink /snap/$core_snap/current | grep -o -E '[0-9]+')" = "$expecting_core"
 
         # now we need to revert both snaps for restore to behave properly, start
         # with the kernel
-        snap revert pc-kernel --revision "$(cat pc-kernel.rev)"
+        snap revert pc-kernel
         REBOOT
     elif [ "$SPREAD_REBOOT" = 2 ]; then
         snap watch --last=revert\?
         # now the gadget
-        snap revert pc --revision "$(cat pc.rev)"
+        snap revert pc
         REBOOT
     elif [ "$SPREAD_REBOOT" = 3 ]; then
         snap watch --last=revert\?
         # now the base
-        snap revert "$core_snap" --revision "$(cat core.rev)"
+        snap revert "$core_snap"
         REBOOT
     elif [ "$SPREAD_REBOOT" = 4 ]; then
         snap watch --last=revert\?

--- a/tests/core/kernel-base-gadget-single-reboot/task.yaml
+++ b/tests/core/kernel-base-gadget-single-reboot/task.yaml
@@ -144,7 +144,7 @@ execute: |
         
         # we start with an asserted base on core18
         if os.query is-core18; then
-            expecting_core="x1"
+            expecting_core="1"
         fi
 
         # verify that current points to new revisions

--- a/tests/core/kernel-base-gadget-single-reboot/task.yaml
+++ b/tests/core/kernel-base-gadget-single-reboot/task.yaml
@@ -141,6 +141,11 @@ execute: |
         expecting_kernel="$(($(grep -o -E '[0-9]+' < pc-kernel.rev) + 1))"
         expecting_gadget="$(($(grep -o -E '[0-9]+' < pc.rev) + 1))"
         expecting_core="$(($(grep -o -E '[0-9]+' < core.rev) + 1))"
+        
+        # we start with an asserted base on core18
+        if os.query is-core18; then
+            expecting_core="x1"
+        fi
 
         # verify that current points to new revisions
         test "$(readlink /snap/pc-kernel/current | grep -o -E '[0-9]+')" = "$expecting_kernel"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1325,7 +1325,7 @@ EOF
 
         # also add debug command line parameters to the kernel command line via
         # the gadget in case things go side ways and we need to debug
-        snap download --basename=pc --channel="${BRANCH}/${KERNEL_CHANNEL}" pc
+        snap download --basename=pc --channel="${BRANCH}/${GADGET_CHANNEL}" pc
         test -e pc.snap
         unsquashfs -d pc-gadget pc.snap
         # TODO: it would be desirable when we need to do in-depth debugging of
@@ -1364,6 +1364,20 @@ EOF
         SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
 
         nested_secboot_sign_gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+        snap pack --filename=pc-repacked.snap pc-gadget 
+        mv pc-repacked.snap $IMAGE_HOME/pc-repacked.snap
+        EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $IMAGE_HOME/pc-repacked.snap"
+    fi
+
+    # for core18 if we need an unasserted gadget, allow this
+    if [ "$CORE18_GADGET_REPACK" = "true" ]; then
+        snap download --basename=pc --channel="18/${GADGET_CHANNEL}" pc
+        test -e pc.snap
+        unsquashfs -d pc-gadget pc.snap
+        
+        # enable debug
+        sed -i 's/panic=-1/panic=-1 snapd.debug=1/' pc-gadget/grub.cfg
+
         snap pack --filename=pc-repacked.snap pc-gadget 
         mv pc-repacked.snap $IMAGE_HOME/pc-repacked.snap
         EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $IMAGE_HOME/pc-repacked.snap"


### PR DESCRIPTION
Switch to a side-load approach where it's easier to control the update behaviour and use unasserted snaps on UC18 to provide consistent updates. Before sometimes the core18 base would not update due to same revision in the image and in edge. (And we could not update gadget/kernel with unasserted snaps as they were asserted in image). This also improved the complexity of the tests.

This does not touch the failover tests, i'll probably do a separate PR for those