### PR TITLE
osutil: recognize SNAPD_HOME_REMOTE_FS=1

### DIFF
--- a/osutil/nfs_linux.go
+++ b/osutil/nfs_linux.go
@@ -37,7 +37,7 @@ var isHomeUsingRemoteFS = func() (bool, error) {
 	// This case allows us to have a way to tell snapd that /home is going to
 	// be remote but the mount operation happens inside a non-trivial
 	// component, such as deep in pam_mount, without having to arrange snapd to
-	// be restarte after that mount finishes.
+	// be restarted after that mount finishes.
 	if GetenvBool("SNAPD_HOME_REMOTE_FS") {
 		return true, nil
 	}

--- a/osutil/nfs_linux_test.go
+++ b/osutil/nfs_linux_test.go
@@ -20,6 +20,8 @@
 package osutil_test
 
 import (
+	"os"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil"
@@ -105,4 +107,16 @@ func (s *nfsSuite) TestIsHomeUsingRemoteFS(c *C) {
 		}
 		c.Assert(isRemoteFS, Equals, tc.isRemoteFS)
 	}
+
+	os.Setenv("SNAPD_HOME_REMOTE_FS", "1")
+	defer os.Unsetenv("SNAPD_HOME_REMOTE_FS")
+	restore := osutil.MockMountInfo("")
+	defer restore()
+	restore = osutil.MockEtcFstab("")
+	defer restore()
+
+	isRemoteFS, err := osutil.IsHomeUsingRemoteFS()
+	c.Assert(err, IsNil)
+	c.Assert(isRemoteFS, Equals, true)
+
 }


### PR DESCRIPTION
When SNAPD_HOME_REMOTE_FS is set to a "true" value such as "1", then snapd assumes that /home is a remote file system mounted in ways more complex than static entry in /etc/fstab.

This allows us to support cifs-mounted home handled by pam_mount, without having to restart snapd to get correct sandbox permissions (and to re-compile every profile again) during the login process.


This is related to ongoing work to support cifs-mounted home, handled with pam_mount, as
smoothly as we can: https://forum.snapcraft.io/t/using-snapd-with-cifs-smb3-mounted-home-directory/39616