### PR TITLE
o/snapstate: support user-services when refreshing snaps

### DIFF
--- a/client/clientutil/session.go
+++ b/client/clientutil/session.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package clientutil
+
+import (
+	"path/filepath"
+	"strconv"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+// AvailableUserSessions returns a list of available user-session targets for
+// snapd, by probing the available snapd-session-agent sockets in the
+// XDG runtime directory.
+func AvailableUserSessions() ([]int, error) {
+	sockets, err := filepath.Glob(filepath.Join(dirs.XdgRuntimeDirGlob, "snapd-session-agent.socket"))
+	if err != nil {
+		return nil, err
+	}
+
+	var uids []int
+	for _, sock := range sockets {
+		uidStr := filepath.Base(filepath.Dir(sock))
+		uid, err := strconv.Atoi(uidStr)
+		if err != nil {
+			// Ignore directories that do not
+			// appear to be valid XDG runtime dirs
+			// (i.e. /run/user/NNNN).
+			continue
+		}
+		uids = append(uids, uid)
+	}
+	return uids, nil
+}

--- a/client/clientutil/session_test.go
+++ b/client/clientutil/session_test.go
@@ -26,15 +26,19 @@ import (
 
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/testutil"
 	. "gopkg.in/check.v1"
 )
 
-type sessionSuite struct{}
+type sessionSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&sessionSuite{})
 
 func (s *sessionSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
 }
 
 func (s *sessionSuite) TestAvailableUserSessionsHappy(c *C) {

--- a/client/clientutil/session_test.go
+++ b/client/clientutil/session_test.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package clientutil_test
+
+import (
+	"os"
+	"path"
+	"sort"
+
+	"github.com/snapcore/snapd/client/clientutil"
+	"github.com/snapcore/snapd/dirs"
+	. "gopkg.in/check.v1"
+)
+
+type sessionSuite struct{}
+
+var _ = Suite(&sessionSuite{})
+
+func (s *sessionSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *sessionSuite) TestAvailableUserSessionsHappy(c *C) {
+	// fake two sockets, one for 0 and one for 1000
+	err := os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "0", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "1000", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "1337", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+
+	res, err := clientutil.AvailableUserSessions()
+	c.Assert(err, IsNil)
+	c.Check(res, HasLen, 3)
+	sort.Ints(res)
+	c.Check(res, DeepEquals, []int{
+		0,
+		1000,
+		1337,
+	})
+}
+
+func (s *sessionSuite) TestAvailableUserSessionsIgnoresBadUids(c *C) {
+	// fake two sockets, one for 0 and one for 1000
+	err := os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "hello", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "*34i8932", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "3", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+
+	res, err := clientutil.AvailableUserSessions()
+	c.Assert(err, IsNil)
+	c.Check(res, HasLen, 1)
+	sort.Ints(res)
+	c.Check(res, DeepEquals, []int{
+		3,
+	})
+}

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -74,13 +74,6 @@ func MockSyscallSettimeofday(f func(*syscall.Timeval) error) (restore func()) {
 	}
 }
 
-func MockUserLookup(mock func(name string) (*user.User, error)) func() {
-	realUserLookup := userLookup
-	userLookup = mock
-
-	return func() { userLookup = realUserLookup }
-}
-
 func MockUserCurrent(mock func() (*user.User, error)) func() {
 	realUserCurrent := userCurrent
 	userCurrent = mock

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -415,6 +415,9 @@ func MockUserLookup(mock func(name string) (*user.User, error)) func() {
 	return func() { userLookup = realUserLookup }
 }
 
+// UsernamesToUids converts a list of usernames to map indexed
+// by their UID, i.e the call
+// UsernamesToUids([]string{"root"}) may return { 0, "root" }
 func UsernamesToUids(users []string) (map[int]string, error) {
 	uids := make(map[int]string)
 	for _, username := range users {

--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -20,8 +20,6 @@
 package servicestate
 
 import (
-	"os/user"
-
 	tomb "gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/overlord/state"
@@ -76,11 +74,5 @@ func MockOsutilBootID(mockID string) (restore func()) {
 func MockResourcesCheckFeatureRequirements(f func(*quota.Resources) error) (restore func()) {
 	r := testutil.Backup(&resourcesCheckFeatureRequirements)
 	resourcesCheckFeatureRequirements = f
-	return r
-}
-
-func MockUserLookup(f func(string) (*user.User, error)) (restore func()) {
-	r := testutil.Backup(&userLookup)
-	userLookup = f
 	return r
 }

--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -20,6 +20,8 @@
 package servicestate
 
 import (
+	"os/user"
+
 	tomb "gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/overlord/state"
@@ -74,5 +76,11 @@ func MockOsutilBootID(mockID string) (restore func()) {
 func MockResourcesCheckFeatureRequirements(f func(*quota.Resources) error) (restore func()) {
 	r := testutil.Backup(&resourcesCheckFeatureRequirements)
 	resourcesCheckFeatureRequirements = f
+	return r
+}
+
+func MockUserLookup(f func(string) (*user.User, error)) (restore func()) {
+	r := testutil.Backup(&userLookup)
+	userLookup = f
 	return r
 }

--- a/overlord/servicestate/helpers.go
+++ b/overlord/servicestate/helpers.go
@@ -21,25 +21,74 @@ package servicestate
 
 import (
 	"fmt"
+	"os/user"
+	"path/filepath"
 	"sort"
+	"strconv"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/wrappers"
 )
 
-// updateSnapstateServices uses ServicesEnabledByHooks and ServicesDisabledByHooks in
-// snapstate and the provided enabled or disabled list to update the state of services in snapstate.
-// It is meant for doServiceControl to help track enabling and disabling of services.
-func updateSnapstateServices(snapst *snapstate.SnapState, enable, disable []*snap.AppInfo) (bool, error) {
-	if len(enable) > 0 && len(disable) > 0 {
-		// We do one op at a time for given service-control task; we could in
-		// theory support both at the same time here, but service-control
-		// ops are run sequentially so we always either enable or disable at
-		// any given time. Not having to worry about that simplifies the
-		// problem of ordering of enable vs disable.
-		return false, fmt.Errorf("internal error: cannot handle enabled and disabled services at the same time")
+var userLookup = user.Lookup
+
+// availableUsers returns a list of available valid user-session targets for
+// snapd.
+func availableUsers() ([]int, error) {
+	sockets, err := filepath.Glob(filepath.Join(dirs.XdgRuntimeDirGlob, "snapd-session-agent.socket"))
+	if err != nil {
+		return nil, err
 	}
 
+	var uids []int
+	for _, sock := range sockets {
+		uidStr := filepath.Base(filepath.Dir(sock))
+		uid, err := strconv.Atoi(uidStr)
+		if err != nil {
+			// Ignore directories that do not
+			// appear to be valid XDG runtime dirs
+			// (i.e. /run/user/NNNN).
+			continue
+		}
+		uids = append(uids, uid)
+	}
+	return uids, nil
+}
+
+// usernamesToUids converts a list of usernames, to a list of uids
+func usernamesToUids(usernames []string) ([]int, error) {
+	uids := make([]int, 0, len(usernames))
+	for _, username := range usernames {
+		usr, err := userLookup(username)
+		if err != nil {
+			return nil, err
+		}
+		uid, err := strconv.Atoi(usr.Uid)
+		if err != nil {
+			return nil, err
+		}
+		uids = append(uids, uid)
+	}
+	return uids, nil
+}
+
+func splitServicesIntoSystemAndUser(apps []*snap.AppInfo) (sys, usr []*snap.AppInfo) {
+	for _, app := range apps {
+		if !app.IsService() {
+			continue
+		}
+		if app.DaemonScope == snap.SystemDaemon {
+			sys = append(sys, app)
+		} else {
+			usr = append(usr, app)
+		}
+	}
+	return sys, usr
+}
+
+func updateSnapstateSystemServices(snapst *snapstate.SnapState, apps []*snap.AppInfo, enable bool) bool {
 	// populate helper lookups of already enabled/disabled services from
 	// snapst.
 	alreadyEnabled := map[string]bool{}
@@ -69,15 +118,14 @@ func updateSnapstateServices(snapst *snapstate.SnapState, enable, disable []*sna
 	// we are not disabling and enabling the services at the same time as
 	// checked in the function entry, only one path is possible
 	fromState, toState := alreadyDisabled, alreadyEnabled
-	which := enable
-	if len(disable) > 0 {
+	if !enable {
 		fromState, toState = alreadyEnabled, alreadyDisabled
-		which = disable
 	}
-	if changed := toggleServices(which, fromState, toState); !changed {
+	if changed := toggleServices(apps, fromState, toState); !changed {
 		// nothing changed
-		return false, nil
+		return false
 	}
+
 	// reset and recreate the state
 	snapst.ServicesEnabledByHooks = nil
 	snapst.ServicesDisabledByHooks = nil
@@ -95,5 +143,149 @@ func updateSnapstateServices(snapst *snapstate.SnapState, enable, disable []*sna
 		}
 		sort.Strings(snapst.ServicesDisabledByHooks)
 	}
+	return true
+}
+
+func updateSnapstateUserServices(snapst *snapstate.SnapState, apps []*snap.AppInfo, enable bool, users []string) (bool, error) {
+	var uids []int
+	var err error
+	if len(users) == 0 {
+		uids, err = availableUsers()
+	} else {
+		uids, err = usernamesToUids(users)
+	}
+	if err != nil {
+		return false, nil
+	}
+
+	uidTargets := make(map[int]bool, len(users))
+	for _, uid := range uids {
+		uidTargets[uid] = true
+	}
+
+	// populate helper lookups of already enabled/disabled services from
+	// snapst.
+	alreadyEnabled := make(map[int]map[string]bool)
+	alreadyDisabled := make(map[int]map[string]bool)
+	for uid, names := range snapst.UserServicesEnabledByHooks {
+		alreadyEnabled[uid] = make(map[string]bool)
+		for _, name := range names {
+			alreadyEnabled[uid][name] = true
+		}
+	}
+	for uid, names := range snapst.UserServicesDisabledByHooks {
+		alreadyDisabled[uid] = make(map[string]bool)
+		for _, name := range names {
+			alreadyDisabled[uid][name] = true
+		}
+	}
+
+	toggleServices := func(services []*snap.AppInfo, fromState map[int]map[string]bool, toState map[int]map[string]bool) (changed bool) {
+		// we are affecting specific users, so migrate given
+		// services from one map to another, if they do
+		// not exist in the target map
+		for _, service := range services {
+			for uid := range toState {
+				// otherwise migrate only if the user is a match
+				if !uidTargets[uid] {
+					continue
+				}
+
+				if !toState[uid][service.Name] {
+					toState[uid][service.Name] = true
+					if fromState[uid][service.Name] {
+						delete(fromState[uid], service.Name)
+					}
+					changed = true
+				}
+			}
+		}
+		return changed
+	}
+
+	// we are not disabling and enabling the services at the same time as
+	// checked in the function entry, only one path is possible
+	fromState, toState := alreadyDisabled, alreadyEnabled
+	if !enable {
+		fromState, toState = alreadyEnabled, alreadyDisabled
+	}
+
+	// ensure uids are in target
+	for _, uid := range uids {
+		if toState[uid] == nil {
+			toState[uid] = make(map[string]bool)
+		}
+	}
+
+	if changed := toggleServices(apps, fromState, toState); !changed {
+		// nothing changed
+		return false, nil
+	}
+
+	// reset and recreate the state
+	snapst.UserServicesEnabledByHooks = nil
+	snapst.UserServicesDisabledByHooks = nil
+	if len(alreadyEnabled) != 0 {
+		snapst.UserServicesEnabledByHooks = make(map[int][]string, len(alreadyEnabled))
+		for uid, svcs := range alreadyEnabled {
+			l := make([]string, 0, len(svcs))
+			for srv := range svcs {
+				l = append(l, srv)
+			}
+			sort.Strings(l)
+			snapst.UserServicesEnabledByHooks[uid] = l
+		}
+	}
+	if len(alreadyDisabled) != 0 {
+		snapst.UserServicesDisabledByHooks = make(map[int][]string, len(alreadyDisabled))
+		for uid, svcs := range alreadyDisabled {
+			l := make([]string, 0, len(svcs))
+			for srv := range svcs {
+				l = append(l, srv)
+			}
+			sort.Strings(l)
+			snapst.UserServicesDisabledByHooks[uid] = l
+		}
+	}
 	return true, nil
+}
+
+// updateSnapstateServices uses {User,}ServicesEnabledByHooks and {User,}ServicesDisabledByHooks in
+// snapstate and the provided enabled or disabled list to update the state of services in snapstate.
+// It is meant for doServiceControl to help track enabling and disabling of services.
+func updateSnapstateServices(snapst *snapstate.SnapState, enable, disable []*snap.AppInfo, scopeOpts wrappers.ScopeOptions) (bool, error) {
+	if len(enable) > 0 && len(disable) > 0 {
+		// We do one op at a time for given service-control task; we could in
+		// theory support both at the same time here, but service-control
+		// ops are run sequentially so we always either enable or disable at
+		// any given time. Not having to worry about that simplifies the
+		// problem of ordering of enable vs disable.
+		return false, fmt.Errorf("internal error: cannot handle enabled and disabled services at the same time")
+	}
+
+	// Split into system and user services, and deal with them there
+	var sys, usr []*snap.AppInfo
+	if len(enable) > 0 {
+		sys, usr = splitServicesIntoSystemAndUser(enable)
+	} else {
+		sys, usr = splitServicesIntoSystemAndUser(disable)
+	}
+
+	var sysChanged, usrChanged bool
+	isEnable := len(enable) > 0
+	switch scopeOpts.Scope {
+	case wrappers.ServiceScopeAll:
+		// Update user-services first as that one can error out
+		if changed, err := updateSnapstateUserServices(snapst, usr, isEnable, scopeOpts.Users); err != nil {
+			return false, err
+		} else {
+			usrChanged = changed
+		}
+		sysChanged = updateSnapstateSystemServices(snapst, sys, isEnable)
+	case wrappers.ServiceScopeSystem:
+		sysChanged = updateSnapstateSystemServices(snapst, sys, isEnable)
+	case wrappers.ServiceScopeUser:
+		return updateSnapstateUserServices(snapst, sys, isEnable, scopeOpts.Users)
+	}
+	return sysChanged || usrChanged, nil
 }

--- a/overlord/servicestate/helpers.go
+++ b/overlord/servicestate/helpers.go
@@ -51,6 +51,12 @@ func usernamesToUids(usernames []string) ([]int, error) {
 	return uids, nil
 }
 
+// affectedUids is used to determine the currently active user-sessions.
+// This is primarily used to determine which users are going to be affected
+// by user service changes. This is inherently racy, i. e this can easily become
+// out of sync by the time we actually invoke the user-session agents, where
+// a user may have gone offline, or one come online (i. e worst case we may miss
+// a user, if someone goes offline the user is ignored).
 func affectedUids(users []string) (map[int]bool, error) {
 	var uids []int
 	var err error
@@ -142,6 +148,12 @@ func updateSnapstateSystemServices(snapst *snapstate.SnapState, apps []*snap.App
 	return true
 }
 
+// updateSnapstateUserServices performs a best-effort to keep track of service changes
+// during hooks for user services. The weakness in this approach is that we can only keep
+// track of users that are currently logged in. Due to the inherent need of communicating with
+// the per-user service agent, we cannot deal with users that are not currently online.
+// In practice, this may pose limited challenges, and most likely it will result in a service
+// not being started/stopped for that user correctly, which can be corrected by the user.
 func updateSnapstateUserServices(snapst *snapstate.SnapState, apps []*snap.AppInfo, enable bool, uids map[int]bool) bool {
 	// populate helper lookups of already enabled/disabled services from
 	// snapst.
@@ -252,26 +264,26 @@ func updateSnapstateServices(snapst *snapstate.SnapState, enable, disable []*sna
 		sys, usr = splitServicesIntoSystemAndUser(disable)
 	}
 
+	// Currently, because the default is to only affect system services, it's unlikely
+	// that user code paths are hit by hooks.
 	isEnable := len(enable) > 0
 	switch scopeOpts.Scope {
 	case wrappers.ServiceScopeAll:
-		// Retrieve the uids affected
-		affectedUids, err := affectedUids(scopeOpts.Users)
+		uids, err := affectedUids(scopeOpts.Users)
 		if err != nil {
 			return false, err
 		}
 		sysChanged := updateSnapstateSystemServices(snapst, sys, isEnable)
-		usrChanged := updateSnapstateUserServices(snapst, usr, isEnable, affectedUids)
+		usrChanged := updateSnapstateUserServices(snapst, usr, isEnable, uids)
 		return sysChanged || usrChanged, nil
 	case wrappers.ServiceScopeSystem:
 		return updateSnapstateSystemServices(snapst, sys, isEnable), nil
 	case wrappers.ServiceScopeUser:
-		// Retrieve the uids affected
-		affectedUids, err := affectedUids(scopeOpts.Users)
+		uids, err := affectedUids(scopeOpts.Users)
 		if err != nil {
 			return false, err
 		}
-		return updateSnapstateUserServices(snapst, sys, isEnable, affectedUids), nil
+		return updateSnapstateUserServices(snapst, sys, isEnable, uids), nil
 	}
 	return false, nil
 }

--- a/overlord/servicestate/helpers.go
+++ b/overlord/servicestate/helpers.go
@@ -55,7 +55,7 @@ func usernamesToUids(usernames []string) ([]int, error) {
 // This is primarily used to determine which users are going to be affected
 // by user service changes. This is inherently racy, i. e this can easily become
 // out of sync by the time we actually invoke the user-session agents, where
-// a user may have logged out, or one come online (i. e worst case we may miss
+// a user may have logged out, or one logged in (i. e worst case we may miss
 // a user, if someone logged out the user is ignored).
 func affectedUids(users []string) (map[int]bool, error) {
 	var uids []int
@@ -90,6 +90,10 @@ func splitServicesIntoSystemAndUser(apps []*snap.AppInfo) (sys, usr []*snap.AppI
 	return sys, usr
 }
 
+// updateSnapstateUserServices keeps track of service changes during hooks for
+// system services. It does so by keeping track of which services where previously
+// enabled/disabled in the snap state. Then based on the current action for the provided
+// list of services, will update the list of services in the snap state.
 func updateSnapstateSystemServices(snapst *snapstate.SnapState, apps []*snap.AppInfo, enable bool) (changed bool) {
 	// populate helper lookups of already enabled/disabled services from
 	// snapst.

--- a/overlord/servicestate/service_control.go
+++ b/overlord/servicestate/service_control.go
@@ -145,7 +145,7 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 			if err := snapstate.Get(st, sc.SnapName, &snapst); err != nil {
 				return err
 			}
-			changed, err := updateSnapstateServices(&snapst, nil, services)
+			changed, err := updateSnapstateServices(&snapst, nil, services, sc.ScopeOptions)
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 			if err := snapstate.Get(st, sc.SnapName, &snapst); err != nil {
 				return err
 			}
-			changed, err := updateSnapstateServices(&snapst, startupOrdered, nil)
+			changed, err := updateSnapstateServices(&snapst, startupOrdered, nil, sc.ScopeOptions)
 			if err != nil {
 				return err
 			}

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -1404,7 +1404,6 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServices(c *C) {
 			disable: []string{"a"},
 			users:   []string{"root"},
 			expectedSnapstateEnabled: map[int][]string{
-				0:    {},
 				1000: {"a"},
 			},
 			expectedSnapstateDisabled: map[int][]string{
@@ -1420,10 +1419,8 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServices(c *C) {
 				0:    {"a", "c"},
 				1000: {"a"},
 			},
-			expectedSnapstateDisabled: map[int][]string{
-				0: {},
-			},
-			changed: true,
+			expectedSnapstateDisabled: map[int][]string{},
+			changed:                   true,
 		},
 		// We now mix it up with disabling for everyone
 		{

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -20,7 +20,10 @@
 package servicestate_test
 
 import (
+	"fmt"
 	"os"
+	"os/user"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -1253,7 +1256,7 @@ func (s *serviceControlSuite) TestConflict(c *C) {
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "service-control" change in progress`)
 }
 
-func (s *serviceControlSuite) TestUpdateSnapstateServices(c *C) {
+func (s *serviceControlSuite) TestUpdateSnapstateSystemServices(c *C) {
 	var tests = []struct {
 		enable                    []string
 		disable                   []string
@@ -1306,12 +1309,20 @@ func (s *serviceControlSuite) TestUpdateSnapstateServices(c *C) {
 	for _, tst := range tests {
 		var enable, disable []*snap.AppInfo
 		for _, srv := range tst.enable {
-			enable = append(enable, &snap.AppInfo{Name: srv})
+			enable = append(enable, &snap.AppInfo{
+				Name:        srv,
+				Daemon:      "simple",
+				DaemonScope: snap.SystemDaemon,
+			})
 		}
 		for _, srv := range tst.disable {
-			disable = append(disable, &snap.AppInfo{Name: srv})
+			disable = append(disable, &snap.AppInfo{
+				Name:        srv,
+				Daemon:      "simple",
+				DaemonScope: snap.SystemDaemon,
+			})
 		}
-		result, err := servicestate.UpdateSnapstateServices(&snapst, enable, disable)
+		result, err := servicestate.UpdateSnapstateServices(&snapst, enable, disable, wrappers.ScopeOptions{})
 		c.Assert(err, IsNil)
 		c.Check(result, Equals, tst.changed)
 		c.Check(snapst.ServicesEnabledByHooks, DeepEquals, tst.expectedSnapstateEnabled)
@@ -1319,6 +1330,167 @@ func (s *serviceControlSuite) TestUpdateSnapstateServices(c *C) {
 	}
 
 	services := []*snap.AppInfo{{Name: "foo"}}
-	_, err := servicestate.UpdateSnapstateServices(nil, services, services)
+	_, err := servicestate.UpdateSnapstateServices(nil, services, services, wrappers.ScopeOptions{})
 	c.Assert(err, ErrorMatches, `internal error: cannot handle enabled and disabled services at the same time`)
+}
+
+func (s *serviceControlSuite) TestUpdateSnapstateUserServices(c *C) {
+	// fake two sockets, one for 0 and one for 1000
+	err := os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "0", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "1000", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+
+	servicestate.MockUserLookup(func(s string) (*user.User, error) {
+		switch s {
+		case "root":
+			return &user.User{
+				Uid: "0",
+			}, nil
+		case "test":
+			return &user.User{
+				Uid: "1000",
+			}, nil
+		default:
+			return nil, fmt.Errorf("unknown user %s", s)
+		}
+	})
+
+	var tests = []struct {
+		enable                    []string
+		disable                   []string
+		users                     []string
+		expectedSnapstateEnabled  map[int][]string
+		expectedSnapstateDisabled map[int][]string
+		changed                   bool
+	}{
+		// These test scenarios share a single SnapState instance and accumulate
+		// changes to ServicesEnabledByHooks and ServicesDisabledByHooks.
+		{
+			changed: false,
+		},
+		// first one affects specific users
+		{
+			enable: []string{"a"},
+			users:  []string{"root", "test"},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {"a"},
+				1000: {"a"},
+			},
+			changed: true,
+		},
+		// second one enables for all, should cause no change
+		{
+			enable: []string{"a"},
+			users:  []string{},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {"a"},
+				1000: {"a"},
+			},
+			changed: false,
+		},
+		// third enable for a specific user again does nothing
+		{
+			enable: []string{"a"},
+			users:  []string{"test"},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {"a"},
+				1000: {"a"},
+			},
+			changed: false,
+		},
+		// next up we disable one for a specific user
+		{
+			disable: []string{"a"},
+			users:   []string{"root"},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {},
+				1000: {"a"},
+			},
+			expectedSnapstateDisabled: map[int][]string{
+				0: {"a"},
+			},
+			changed: true,
+		},
+		// now we re-enable multiple for specific user
+		{
+			enable: []string{"a", "c"},
+			users:  []string{"root"},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {"a", "c"},
+				1000: {"a"},
+			},
+			expectedSnapstateDisabled: map[int][]string{
+				0: {},
+			},
+			changed: true,
+		},
+		// We now mix it up with disabling for everyone
+		{
+			disable: []string{"b"},
+			users:   []string{},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {"a", "c"},
+				1000: {"a"},
+			},
+			expectedSnapstateDisabled: map[int][]string{
+				0:    {"b"},
+				1000: {"b"},
+			},
+			changed: true,
+		},
+		// We now mix it up with disabling an existing one that only is
+		// enabled for one user
+		{
+			disable: []string{"c"},
+			users:   []string{},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {"a"},
+				1000: {"a"},
+			},
+			expectedSnapstateDisabled: map[int][]string{
+				0:    {"b", "c"},
+				1000: {"b", "c"},
+			},
+			changed: true,
+		},
+		{
+			disable: []string{"b", "c"},
+			users:   []string{},
+			expectedSnapstateEnabled: map[int][]string{
+				0:    {"a"},
+				1000: {"a"},
+			},
+			expectedSnapstateDisabled: map[int][]string{
+				0:    {"b", "c"},
+				1000: {"b", "c"},
+			},
+			changed: false,
+		},
+	}
+
+	snapst := snapstate.SnapState{}
+
+	for _, tst := range tests {
+		var enable, disable []*snap.AppInfo
+		for _, srv := range tst.enable {
+			enable = append(enable, &snap.AppInfo{
+				Name:        srv,
+				Daemon:      "simple",
+				DaemonScope: snap.UserDaemon,
+			})
+		}
+		for _, srv := range tst.disable {
+			disable = append(disable, &snap.AppInfo{
+				Name:        srv,
+				Daemon:      "simple",
+				DaemonScope: snap.UserDaemon,
+			})
+		}
+		result, err := servicestate.UpdateSnapstateServices(&snapst, enable, disable, wrappers.ScopeOptions{Users: tst.users})
+		c.Assert(err, IsNil)
+		c.Assert(result, Equals, tst.changed)
+		c.Assert(snapst.UserServicesEnabledByHooks, DeepEquals, tst.expectedSnapstateEnabled)
+		c.Assert(snapst.UserServicesDisabledByHooks, DeepEquals, tst.expectedSnapstateDisabled)
+	}
 }

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -1378,7 +1379,7 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServices(c *C) {
 	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "1000", "snapd-session-agent.socket"), 0700)
 	c.Assert(err, IsNil)
 
-	servicestate.MockUserLookup(func(s string) (*user.User, error) {
+	osutil.MockUserLookup(func(s string) (*user.User, error) {
 		switch s {
 		case "root":
 			return &user.User{
@@ -1536,7 +1537,7 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServicesFailsOnUserError(c 
 	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "1000", "snapd-session-agent.socket"), 0700)
 	c.Assert(err, IsNil)
 
-	servicestate.MockUserLookup(func(s string) (*user.User, error) {
+	osutil.MockUserLookup(func(s string) (*user.User, error) {
 		return nil, fmt.Errorf("unknown user %s", s)
 	})
 
@@ -1566,7 +1567,7 @@ func (s *serviceControlSuite) TestUpdateSnapstateUserServicesFailsOnInvalidUID(c
 	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "1000", "snapd-session-agent.socket"), 0700)
 	c.Assert(err, IsNil)
 
-	servicestate.MockUserLookup(func(s string) (*user.User, error) {
+	osutil.MockUserLookup(func(s string) (*user.User, error) {
 		return &user.User{
 			Uid:      "wups",
 			Username: s,

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -80,8 +80,9 @@ type fakeOp struct {
 	unlinkSkipBinaries     bool
 	skipKernelExtraction   bool
 
-	services         []string
-	disabledServices []string
+	services             []string
+	disabledServices     []string
+	disabledUserServices map[int][]string
 
 	vitalityRank int
 
@@ -903,7 +904,8 @@ type fakeSnappyBackend struct {
 	copySnapDataFailTrigger string
 	emptyContainer          snap.Container
 
-	servicesCurrentlyDisabled []string
+	servicesCurrentlyDisabled     []string
+	userServicesCurrentlyDisabled map[int][]string
 
 	lockDir string
 
@@ -1318,27 +1320,44 @@ func (f *fakeSnappyBackend) KillSnapApps(snapName string, reason snap.AppKillRea
 }
 
 func (f *fakeSnappyBackend) QueryDisabledServices(info *snap.Info, meter progress.Meter) (*wrappers.DisabledServices, error) {
-	var l []string
-
 	// return the disabled services as disabled and nothing else
 	m := make(map[string]bool)
 	for _, svc := range f.servicesCurrentlyDisabled {
-		m[svc] = false
+		m[svc] = true
 	}
 
-	for name, enabled := range m {
-		if !enabled {
-			l = append(l, name)
+	um := make(map[int]map[string]bool)
+	for uid, svcs := range f.userServicesCurrentlyDisabled {
+		umi := make(map[string]bool)
+		for _, svc := range svcs {
+			umi[svc] = true
+		}
+		um[uid] = umi
+	}
+
+	var l []string
+	ul := make(map[int][]string)
+	for _, svc := range info.Services() {
+		if m[svc.Name] {
+			l = append(l, svc.Name)
+		} else {
+			for uid, umi := range um {
+				if umi[svc.Name] {
+					ul[uid] = append(ul[uid], svc.Name)
+				}
+			}
 		}
 	}
 
 	f.appendOp(&fakeOp{
-		op:               "current-snap-service-states",
-		disabledServices: f.servicesCurrentlyDisabled,
+		op:                   "current-snap-service-states",
+		disabledServices:     f.servicesCurrentlyDisabled,
+		disabledUserServices: f.userServicesCurrentlyDisabled,
 	})
 
 	return &wrappers.DisabledServices{
 		SystemServices: l,
+		UserServices:   ul,
 	}, f.maybeErrForLastOp()
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1295,8 +1295,13 @@ func (f *fakeSnappyBackend) StartServices(svcs []*snap.AppInfo, disabledSvcs *wr
 		services: services,
 	}
 	// only add the services to the op if there's something to add
-	if disabledSvcs != nil && len(disabledSvcs.SystemServices) != 0 {
-		op.disabledServices = disabledSvcs.SystemServices
+	if disabledSvcs != nil {
+		if len(disabledSvcs.SystemServices) != 0 {
+			op.disabledServices = disabledSvcs.SystemServices
+		}
+		if len(disabledSvcs.UserServices) != 0 {
+			op.disabledUserServices = disabledSvcs.UserServices
+		}
 	}
 	f.appendOp(&op)
 	return f.maybeErrForLastOp()

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -336,6 +336,7 @@ var (
 )
 
 type AuxStoreInfo = auxStoreInfo
+type DisabledServices = disabledServices
 
 // link, misc handlers
 var (

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1949,33 +1949,48 @@ func writeSeqFile(name string, snapst *SnapState) error {
 	return osutil.AtomicWriteFile(p, b, 0644, 0)
 }
 
-// missingDisabledServices returns a list of services that are present in
-// this snap info and should be disabled as well as a list of disabled
+type disabledServices struct {
+	MissingSystemServices []string
+	FoundSystemServices   []string
+	MissingUserServices   map[int][]string
+	FoundUserServices     map[int][]string
+}
+
+// missingDisabledServices returns lists of services that are present in
+// this snap info and should be disabled as well as lists of disabled
 // services that are currently missing (i.e. they were renamed).
 // present in this snap info.
-// the first arg is the disabled services when the snap was last active
-func missingDisabledServices(svcs []string, info *snap.Info) ([]string, []string, error) {
-	// make a copy of all the previously disabled services that we will remove
-	// from, as well as an empty list to add to for the found services
-	missingSvcs := []string{}
-	foundSvcs := []string{}
-
-	// for all the previously disabled services, check if they are in the
-	// current snap info revision as services or not
-	for _, disabledSvcName := range svcs {
-		// check if the service is an app _and_ is a service
-		if app, ok := info.Apps[disabledSvcName]; ok && app.IsService() {
-			foundSvcs = append(foundSvcs, disabledSvcName)
-		} else {
-			missingSvcs = append(missingSvcs, disabledSvcName)
-		}
+// the first arg is the disabled system services when the snap was last active
+// the second arg is the disabled user services when the snap was last active
+func missingDisabledServices(sysSvcs []string, userSvcs map[int][]string, info *snap.Info) (*disabledServices, error) {
+	overview := &disabledServices{
+		MissingUserServices: make(map[int][]string),
+		FoundUserServices:   make(map[int][]string),
 	}
 
-	// sort the lists for easier testing
-	sort.Strings(missingSvcs)
-	sort.Strings(foundSvcs)
+	categorize := func(names []string) ([]string, []string) {
+		foundSvcs := []string{}
+		missingSvcs := []string{}
+		for _, name := range names {
+			// check if the service is an app _and_ is a service
+			if app, ok := info.Apps[name]; ok && app.IsService() {
+				foundSvcs = append(foundSvcs, name)
+			} else {
+				missingSvcs = append(missingSvcs, name)
+			}
+		}
+		sort.Strings(missingSvcs)
+		sort.Strings(foundSvcs)
+		return foundSvcs, missingSvcs
+	}
 
-	return foundSvcs, missingSvcs, nil
+	overview.FoundSystemServices, overview.MissingSystemServices = categorize(sysSvcs)
+	for uid, svcs := range userSvcs {
+		found, missing := categorize(svcs)
+		overview.FoundUserServices[uid] = found
+		overview.MissingUserServices[uid] = missing
+	}
+	return overview, nil
 }
 
 // LinkSnapParticipant is an interface for interacting with snap link/unlink
@@ -3009,6 +3024,11 @@ func (m *SnapManager) startSnapServices(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	logger.Noticef("previously disabled system-services: %v", snapst.LastActiveDisabledServices)
+	for uid, svcs := range snapst.LastActiveDisabledUserServices {
+		logger.Noticef("previously disabled user-services [%d]: %v", uid, svcs)
+	}
+
 	// check if any previously disabled services are now no longer services and
 	// log messages about that
 	for _, svc := range snapst.LastActiveDisabledServices {
@@ -3024,29 +3044,39 @@ func (m *SnapManager) startSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	// as well as the services which are not present in this revision, but were
 	// present and disabled in a previous one and as such should be kept inside
 	// snapst for persistent storage
-	svcsToDisable, svcsToSave, err := missingDisabledServices(snapst.LastActiveDisabledServices, currentInfo)
+	missingSvcsOverview, err := missingDisabledServices(
+		snapst.LastActiveDisabledServices,
+		snapst.LastActiveDisabledUserServices,
+		currentInfo)
 	if err != nil {
 		return err
 	}
 
 	// check what services with "InstallMode: disable" need to be disabled
-	svcsToDisableFromInstallMode, err := installModeDisabledServices(st, snapst, currentInfo)
+	svcsToDisable, err := installModeDisabledServices(st, snapst, currentInfo)
 	if err != nil {
 		return err
 	}
-	svcsToDisable = append(svcsToDisable, svcsToDisableFromInstallMode...)
-
 	// append services that were disabled by hooks (they should not get re-enabled)
 	svcsToDisable = append(svcsToDisable, snapst.ServicesDisabledByHooks...)
+
+	// Insert it into the overview, into the 'found' list. Re-use the entire
+	// list for all users (-1) as there won't be any difference between users
+	// in this specific case (and to allow us to keep a singular list of services
+	// that need to be disabled).
+	missingSvcsOverview.FoundSystemServices = append(missingSvcsOverview.FoundSystemServices, svcsToDisable...)
+	missingSvcsOverview.FoundUserServices[-1] = svcsToDisable
 
 	// save the current last-active-disabled-services before we re-write it in case we
 	// need to undo this
 	t.Set("old-last-active-disabled-services", snapst.LastActiveDisabledServices)
+	t.Set("old-last-active-disabled-user-services", snapst.LastActiveDisabledUserServices)
 
 	// commit the missing services to state so when we unlink this revision and
 	// go to a different revision with potentially different service names, the
 	// currently missing service names will be re-disabled if they exist later
-	snapst.LastActiveDisabledServices = svcsToSave
+	snapst.LastActiveDisabledServices = missingSvcsOverview.MissingSystemServices
+	snapst.LastActiveDisabledUserServices = missingSvcsOverview.MissingUserServices
 
 	// reset services tracked by operations from hooks
 	snapst.ServicesDisabledByHooks = nil
@@ -3066,8 +3096,13 @@ func (m *SnapManager) startSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	pb := NewTaskProgressAdapterUnlocked(t)
 
 	st.Unlock()
+	logger.Noticef("ignore system-services: %v", missingSvcsOverview.FoundSystemServices)
+	for uid, svcs := range missingSvcsOverview.FoundUserServices {
+		logger.Noticef("ignore user-services [%d]: %v", uid, svcs)
+	}
 	err = m.backend.StartServices(startupOrdered, &wrappers.DisabledServices{
-		SystemServices: svcsToDisable,
+		SystemServices: missingSvcsOverview.FoundSystemServices,
+		UserServices:   missingSvcsOverview.FoundUserServices,
 	}, pb, perfTimings)
 	st.Lock()
 
@@ -3093,10 +3128,16 @@ func (m *SnapManager) undoStartSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	var oldLastActiveDisabledServices []string
+	var oldLastActiveDisabledUserServices map[int][]string
 	if err := t.Get("old-last-active-disabled-services", &oldLastActiveDisabledServices); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
+	if err := t.Get("old-last-active-disabled-user-services", &oldLastActiveDisabledUserServices); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
 	snapst.LastActiveDisabledServices = oldLastActiveDisabledServices
+	snapst.LastActiveDisabledUserServices = oldLastActiveDisabledUserServices
+
 	Set(st, snapsup.InstanceName(), snapst)
 
 	svcs := currentInfo.Services()
@@ -3171,6 +3212,7 @@ func (m *SnapManager) stopSnapServices(t *state.Task, _ *tomb.Tomb) error {
 
 	// for undo
 	t.Set("old-last-active-disabled-services", snapst.LastActiveDisabledServices)
+	t.Set("old-last-active-disabled-user-services", snapst.LastActiveDisabledUserServices)
 	// undo could queryDisabledServices, but this avoids it
 	t.Set("disabled-services", disabledServices)
 
@@ -3184,6 +3226,20 @@ func (m *SnapManager) stopSnapServices(t *state.Task, _ *tomb.Tomb) error {
 		snapst.LastActiveDisabledServices,
 		disabledServices.SystemServices...,
 	)
+	// Merge the two user-services maps, ideally we would have one struct but we must
+	// preserve the backwards-compat with the json layout
+	if len(snapst.LastActiveDisabledUserServices) > 0 {
+		for uid, svcs := range disabledServices.UserServices {
+			snapst.LastActiveDisabledUserServices[uid] = append(snapst.LastActiveDisabledUserServices[uid], svcs...)
+		}
+	} else {
+		snapst.LastActiveDisabledUserServices = disabledServices.UserServices
+	}
+
+	logger.Noticef("queried disabled system-services: %v", disabledServices.SystemServices)
+	for uid, svcs := range disabledServices.UserServices {
+		logger.Noticef("queried disabled user-services [%d]: %v", uid, svcs)
+	}
 
 	// reset services tracked by operations from hooks
 	snapst.ServicesDisabledByHooks = nil
@@ -3221,11 +3277,16 @@ func (m *SnapManager) undoStopSnapServices(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var lastActiveDisabled []string
-	if err := t.Get("old-last-active-disabled-services", &lastActiveDisabled); err != nil && !errors.Is(err, state.ErrNoState) {
+	var oldLastActiveDisabledServices []string
+	var oldLastActiveDisabledUserServices map[int][]string
+	if err := t.Get("old-last-active-disabled-services", &oldLastActiveDisabledServices); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
-	snapst.LastActiveDisabledServices = lastActiveDisabled
+	if err := t.Get("old-last-active-disabled-user-services", &oldLastActiveDisabledUserServices); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	snapst.LastActiveDisabledServices = oldLastActiveDisabledServices
+	snapst.LastActiveDisabledUserServices = oldLastActiveDisabledUserServices
 	Set(st, snapsup.InstanceName(), snapst)
 
 	var disabledServices wrappers.DisabledServices

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3030,11 +3030,6 @@ func installModeDisabledUserServices(snapst *SnapState, currentInfo *snap.Info, 
 // "install-mode: disabled" should be disabled. Only services
 // seen for the first time are considered.
 func installModeDisabledServices(st *state.State, snapst *SnapState, currentInfo *snap.Info) (sysSvcsToDisable []string, usrSvcsToDisable map[int][]string, err error) {
-	enabledByHookSvcs := map[string]bool{}
-	for _, svcName := range snapst.ServicesEnabledByHooks {
-		enabledByHookSvcs[svcName] = true
-	}
-
 	// find what services the previous snap had
 	prevCurrentSvcs := map[string]bool{}
 	if psi := snapst.previousSideInfo(); psi != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2988,6 +2988,12 @@ func installModeDisabledSystemServices(snapst *SnapState, currentInfo *snap.Info
 	return svcsToDisable
 }
 
+// installModeDisabledUserServices returns a map of currently active users
+// with user services that have been marked for 'install-mode: disable', which
+// were not already disabled for each of the active users.
+// The reason we are doing this only for currently online users, is because we
+// do a best-effort handling of user sewrvices - we can only query the user service
+// agent for users that have it running.
 func installModeDisabledUserServices(snapst *SnapState, currentInfo *snap.Info, prevCurrentSvcs map[string]bool) (map[int][]string, error) {
 	availableUids, err := clientutil.AvailableUserSessions()
 	if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2992,7 +2992,7 @@ func installModeDisabledSystemServices(snapst *SnapState, currentInfo *snap.Info
 // with user services that have been marked for 'install-mode: disable', which
 // were not already disabled for each of the active users.
 // The reason we are doing this only for users currently logged in, is because we
-// do a best-effort handling of user sewrvices - we can only query the user service
+// do a best-effort handling of user services - we can only query the user service
 // agent for users that have it running.
 func installModeDisabledUserServices(snapst *SnapState, currentInfo *snap.Info, prevCurrentSvcs map[string]bool) (map[int][]string, error) {
 	availableUids, err := clientutil.AvailableUserSessions()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -320,7 +320,8 @@ type SnapState struct {
 	// in the snap are removed from this list on link-snap, so that we can
 	// remember services that were disabled in another revision and then renamed
 	// or otherwise removed from the snap in a future refresh.
-	LastActiveDisabledServices []string `json:"last-active-disabled-services,omitempty"`
+	LastActiveDisabledServices     []string         `json:"last-active-disabled-services,omitempty"`
+	LastActiveDisabledUserServices map[int][]string `json:"last-active-disabled-user-services,omitempty"`
 
 	// tracking services enabled and disabled by hooks
 	ServicesEnabledByHooks  []string `json:"services-enabled-by-hooks,omitempty"`

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -324,8 +324,10 @@ type SnapState struct {
 	LastActiveDisabledUserServices map[int][]string `json:"last-active-disabled-user-services,omitempty"`
 
 	// tracking services enabled and disabled by hooks
-	ServicesEnabledByHooks  []string `json:"services-enabled-by-hooks,omitempty"`
-	ServicesDisabledByHooks []string `json:"services-disabled-by-hooks,omitempty"`
+	ServicesEnabledByHooks      []string         `json:"services-enabled-by-hooks,omitempty"`
+	UserServicesEnabledByHooks  map[int][]string `json:"user-services-enabled-by-hooks,omitempty"`
+	ServicesDisabledByHooks     []string         `json:"services-disabled-by-hooks,omitempty"`
+	UserServicesDisabledByHooks map[int][]string `json:"user-services-disabled-by-hooks,omitempty"`
 
 	// Current indicates the current active revision if Active is
 	// true or the last active revision if Active is false

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -320,7 +320,9 @@ type SnapState struct {
 	// in the snap are removed from this list on link-snap, so that we can
 	// remember services that were disabled in another revision and then renamed
 	// or otherwise removed from the snap in a future refresh.
-	LastActiveDisabledServices     []string         `json:"last-active-disabled-services,omitempty"`
+	LastActiveDisabledServices []string `json:"last-active-disabled-services,omitempty"`
+	// LastActiveDisabledUserServices, like LastActiveDisabledServices is a map of user-services
+	// that were disabled in the snap when it was last active. The same rules apply.
 	LastActiveDisabledUserServices map[int][]string `json:"last-active-disabled-user-services,omitempty"`
 
 	// tracking services enabled and disabled by hooks

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7577,6 +7577,7 @@ func (s *snapmgrTestSuite) TestStopSnapServicesUndo(c *C) {
 	c.Check(t.Get("disabled-services", &disabled), IsNil)
 	c.Check(disabled, DeepEquals, wrappers.DisabledServices{
 		SystemServices: []string{"svc1"},
+		UserServices:   map[int][]string{},
 	})
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7868,8 +7868,8 @@ func (s *snapmgrTestSuite) TestInstallModeDisableFreshInstallEnabledByHookMixedS
 	c.Assert(op, Not(IsNil))
 	c.Check(op.disabledServices, DeepEquals, []string{"svc-disable-foo"})
 	c.Check(op.disabledUserServices, testutil.DeepUnsortedMatches, map[int][]string{
-		// Because it was disabled specifically for user 0, and the available users
-		// are 0 and 1000
+		// Because it was enabled specifically for user 0, and the available users
+		// are 0 and 1000, then it must now be disabled just for 1000
 		1000: {"svc-disable-bar-user"},
 	})
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -7807,6 +7808,70 @@ func (s *snapmgrTestSuite) TestInstallModeDisableFreshInstallEnabledByHook(c *C)
 	op := s.fakeBackend.ops.First("start-snap-services")
 	c.Assert(op, Not(IsNil))
 	c.Check(op.disabledServices, HasLen, 0)
+}
+
+func (s *snapmgrTestSuite) TestInstallModeDisableFreshInstallEnabledByHookMixedServices(c *C) {
+	// fake two sockets, one for 0 and one for 1000
+	err := os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "0", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(path.Join(dirs.XdgRuntimeDirBase, "1000", "snapd-session-agent.socket"), 0700)
+	c.Assert(err, IsNil)
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	oldServicesSnapYaml := servicesSnapYaml
+	servicesSnapYaml += `
+  svc-disable-foo:
+    daemon: simple
+    install-mode: disable
+  svc-disable-bar:
+    daemon: simple
+    install-mode: disable
+  svc-disable-bar-user:
+    daemon: simple
+    daemon-scope: user
+    install-mode: disable
+`
+	defer func() { servicesSnapYaml = oldServicesSnapYaml }()
+
+	// pretent we have a hook that enables the service on install
+	runner := s.o.TaskRunner()
+	runner.AddHandler("run-hook", func(t *state.Task, _ *tomb.Tomb) error {
+		var snapst snapstate.SnapState
+		st.Lock()
+		err := snapstate.Get(st, "services-snap", &snapst)
+		st.Unlock()
+		c.Assert(err, IsNil)
+		snapst.ServicesEnabledByHooks = []string{"svc-disable-bar"}
+		snapst.UserServicesEnabledByHooks = map[int][]string{
+			0: {"svc-disable-bar-user"},
+		}
+		st.Lock()
+		snapstate.Set(st, "services-snap", &snapst)
+		st.Unlock()
+		return nil
+	}, nil)
+
+	installChg := s.state.NewChange("install", "...")
+	installTs, err := snapstate.Install(context.Background(), s.state, "services-snap", nil, 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	installChg.AddAll(installTs)
+
+	s.settle(c)
+
+	c.Assert(installChg.Err(), IsNil)
+	c.Assert(installChg.IsReady(), Equals, true)
+
+	op := s.fakeBackend.ops.First("start-snap-services")
+	c.Assert(op, Not(IsNil))
+	c.Check(op.disabledServices, DeepEquals, []string{"svc-disable-foo"})
+	c.Check(op.disabledUserServices, testutil.DeepUnsortedMatches, map[int][]string{
+		// Because it was disabled specifically for user 0, and the available users
+		// are 0 and 1000
+		1000: {"svc-disable-bar-user"},
+	})
 }
 
 func (s *snapmgrTestSuite) TestSnapdRefreshTasks(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6384,7 +6384,7 @@ func (s *snapmgrTestSuite) TestStartSnapServicesCorrectlyKeepsDisabledByHooks(c 
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		fakeOp{
 			op:                   "start-snap-services",
-			path:                 "/tmp/check-237257918/0/snap/services-snap/11",
+			path:                 filepath.Join(dirs.SnapMountDir, "services-snap/11"),
 			services:             []string{"svc1", "svc3", "svc2"},
 			disabledServices:     []string{"svc1"},
 			disabledUserServices: map[int][]string{1000: {"svc3"}},

--- a/tests/lib/snaps/test-snapd-mixed-service-v2/bin/start
+++ b/tests/lib/snaps/test-snapd-mixed-service-v2/bin/start
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do
+    echo "running"
+    sleep 10
+done

--- a/tests/lib/snaps/test-snapd-mixed-service-v2/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-mixed-service-v2/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-mixed-service
+version: 2.0
+apps:
+    sys-service:
+        command: bin/start
+        daemon: simple
+    user-service:
+        command: bin/start
+        daemon: simple
+        daemon-scope: user

--- a/tests/lib/snaps/test-snapd-mixed-service/bin/start
+++ b/tests/lib/snaps/test-snapd-mixed-service/bin/start
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do
+    echo "running"
+    sleep 10
+done

--- a/tests/lib/snaps/test-snapd-mixed-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-mixed-service/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-mixed-service
+version: 1.0
+apps:
+    sys-service:
+        command: bin/start
+        daemon: simple
+    user-service:
+        command: bin/start
+        daemon: simple
+        daemon-scope: user

--- a/tests/lib/snaps/test-snapd-user-service-disabled/bin/start
+++ b/tests/lib/snaps/test-snapd-user-service-disabled/bin/start
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do
+    echo "running"
+    sleep 10
+done

--- a/tests/lib/snaps/test-snapd-user-service-disabled/meta/hooks/install
+++ b/tests/lib/snaps/test-snapd-user-service-disabled/meta/hooks/install
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "enable user-service-two for all users"
+snapctl start --enable --users=all test-snapd-user-service-disabled.user-service-two
+
+# hooks run in root user context so we cannot enable
+# anything for just the current user ('--user') as that
+# would not affect the user actually installing the snap.
+#

--- a/tests/lib/snaps/test-snapd-user-service-disabled/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-user-service-disabled/meta/snap.yaml
@@ -1,0 +1,16 @@
+name: test-snapd-user-service-disabled
+version: 1.0
+apps:
+    user-service:
+        command: bin/start
+        daemon: simple
+        daemon-scope: user
+        install-mode: disable
+    user-service-two:
+        command: bin/start
+        daemon: simple
+        daemon-scope: user
+        install-mode: disable
+
+hooks:
+  install:

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -20,7 +20,18 @@ prepare: |
         useradd --extrausers -m -d /home/test2 test2
     fi
 
-    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    # rules are only supported from 23.10+
+    if [ -d /etc/polkit-1/localauthority/50-local.d ]; then
+        cat <<\EOF >/etc/polkit-1/localauthority/50-local.d/spread.pkla
+    [Normal Staff Permissions]
+    Identity=unix-user:test;unix-user:test2
+    Action=io.snapcraft.snapd.manage
+    ResultAny=yes
+    ResultInactive=no
+    ResultActive=yes
+    EOF
+    else
+        cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
     polkit.addRule(function(action, subject) {
         if (action.id == "io.snapcraft.snapd.manage" &&
             (subject.user == "test" || subject.user == "test2")) {
@@ -28,6 +39,7 @@ prepare: |
         }
     });
     EOF
+    fi
 
 restore: |
     tests.session -u test restore
@@ -36,7 +48,8 @@ restore: |
         userdel --extrausers -rf test2
     fi
     snap unset system experimental.user-daemons
-    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    rm -f /etc/polkit-1/localauthority/50-local.d/spread.pkla || true
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules || true
 
 debug: |
     tests.session dump

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -6,8 +6,7 @@ details: |
     when performing these operations.
 
 # Only run on systems with polkit rules are supported
-# TODO: add 24 once stable
-systems: [ ubuntu-20.04-64, ubuntu-22.04-64 ]
+systems: [ ubuntu-20.04-64, ubuntu-22.04-64, ubuntu-24.04-64 ]
 
 prepare: |
     snap set system experimental.user-daemons=true
@@ -21,13 +20,13 @@ prepare: |
         useradd --extrausers -m -d /home/test2 test2
     fi
 
-    cat <<\EOF >/etc/polkit-1/localauthority/50-local.d/spread.pkla
-    [Normal Staff Permissions]
-    Identity=unix-user:test;unix-user:test2
-    Action=io.snapcraft.snapd.manage
-    ResultAny=yes
-    ResultInactive=no
-    ResultActive=yes
+    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    polkit.addRule(function(action, subject) {
+        if (action.id == "io.snapcraft.snapd.manage" &&
+            (subject.user == "test" || subject.user == "test2")) {
+                return polkit.Result.YES;
+        }
+    });
     EOF
 
 restore: |
@@ -37,7 +36,7 @@ restore: |
         userdel --extrausers -rf test2
     fi
     snap unset system experimental.user-daemons
-    rm -f /etc/polkit-1/localauthority/50-local.d/spread.pkla
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
 
 debug: |
     tests.session dump

--- a/tests/main/snap-user-service-enabled-after-install/task.yaml
+++ b/tests/main/snap-user-service-enabled-after-install/task.yaml
@@ -54,6 +54,9 @@ prepare: |
 
 restore: |
     tests.session -u test2 restore || true
+    if ! userdel -rf test2; then
+        userdel --extrausers -rf test2 || true
+    fi
     tests.session -u test restore
     snap unset system experimental.user-daemons
     if [ -f agent-was-enabled ]; then

--- a/tests/main/snap-user-service-enabled-after-install/task.yaml
+++ b/tests/main/snap-user-service-enabled-after-install/task.yaml
@@ -1,0 +1,106 @@
+summary: Check that enabling of user services is working correctly across user sessions
+
+details: |
+    Given a snap that has user services with install-mode: disabled, but
+    enables one of these services as a part of a hook for all users, 
+    that we can verify this behavior for a user session that only 
+    exists after the snap install.
+
+# Only run on systems with polkit rules are supported, otherwise
+# are not able to test 'snap xxx --user' functionality as it needs
+# sudo access, and if its run with sudo then the user will be root
+# and not the user we are testing with
+systems: [ ubuntu-20.04-64, ubuntu-22.04-64, ubuntu-24.04-64 ]
+
+kill-timeout: 10m
+
+prepare: |
+    # Ensure that snapd.session-agent.socket is enabled.  This may not
+    # be the case on distributions where presets have been used to
+    # disable it.
+    if [ ! -L /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket ] &&
+            ! systemctl --user --global is-enabled snapd.session-agent.socket; then
+        systemctl --user --global enable snapd.session-agent.socket
+        touch agent-was-enabled
+    fi
+    snap set system experimental.user-daemons=true
+    tests.session kill-leaked
+    tests.session -u test prepare
+
+    if ! useradd -m -d /home/test2 test2; then
+        # Ubuntu Core requires using extrausers db
+        useradd --extrausers -m -d /home/test2 test2
+    fi
+
+    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    polkit.addRule(function(action, subject) {
+        if (action.id == "io.snapcraft.snapd.manage" && subject.user == "test") {
+            return polkit.Result.YES;
+        }
+    });
+    EOF
+
+restore: |
+    tests.session -u test2 restore || true
+    tests.session -u test restore
+    snap unset system experimental.user-daemons
+    if [ -f agent-was-enabled ]; then
+        systemctl --user --global disable snapd.session-agent.socket
+        rm agent-was-enabled
+    fi
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+
+debug: |
+    tests.session dump
+    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
+    tests.session -u test exec journalctl --user || true
+
+execute: |
+    function systemctl_as_test() {
+      tests.session -u test exec systemctl --user "$@"
+    }
+    function snap_as_test() {
+      tests.session -u test exec snap "$@"
+    }
+
+    echo "Install the a snap with user services while a user session is active"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-user-service-disabled
+
+    # expect that two runs and is enabled for all users
+    # expect that three runs and is enabled for current user
+
+    # expect that the system service is not running/enabled
+    systemctl is-active snap.test-snapd-user-service-disabled.sys-service | MATCH "inactive"
+    systemctl is-enabled snap.test-snapd-user-service-disabled.sys-service | MATCH "disabled"
+
+    echo "Verify status of running services after install"
+    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service | MATCH "inactive"
+    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "disabled"
+
+    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service-two | MATCH "active"
+    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service-two | MATCH "enabled"
+
+    echo "Enable the first user service for just us"
+    snap_as_test start --user --enable test-snapd-user-service-disabled.user-service
+
+    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service | MATCH "active"
+    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "enabled"
+
+    function systemctl_as_test2() {
+      tests.session -u test exec systemctl --user "$@"
+    }
+
+    echo "Setup new user session and expect correct initial state"
+    # make a new user session and verify that -two is enabled and running
+    # but the first one is not
+    tests.session -u test2 prepare
+
+    # the first user-service that we started and enabled for just user
+    # 'test' should not be running 
+    systemctl_as_test2 is-active snap.test-snapd-user-service-disabled.user-service | MATCH "inactive"
+    systemctl_as_test2 is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "disabled"
+
+    # the second one which was enabled globally by the install hook should
+    # be running
+    systemctl_as_test2 is-active snap.test-snapd-user-service-disabled.user-service-two | MATCH "active"
+    systemctl_as_test2 is-enabled snap.test-snapd-user-service-disabled.user-service-two | MATCH "enabled"

--- a/tests/main/snap-user-service-enabled-after-install/task.yaml
+++ b/tests/main/snap-user-service-enabled-after-install/task.yaml
@@ -32,13 +32,25 @@ prepare: |
         useradd --extrausers -m -d /home/test2 test2
     fi
 
-    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    # rules are only supported from 23.10+
+    if [ -d /etc/polkit-1/localauthority/50-local.d ]; then
+        cat <<\EOF >/etc/polkit-1/localauthority/50-local.d/spread.pkla
+    [Normal Staff Permissions]
+    Identity=unix-user:test
+    Action=io.snapcraft.snapd.manage
+    ResultAny=yes
+    ResultInactive=no
+    ResultActive=yes
+    EOF
+    else
+        cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
     polkit.addRule(function(action, subject) {
         if (action.id == "io.snapcraft.snapd.manage" && subject.user == "test") {
             return polkit.Result.YES;
         }
     });
     EOF
+    fi
 
 restore: |
     tests.session -u test2 restore || true
@@ -48,7 +60,8 @@ restore: |
         systemctl --user --global disable snapd.session-agent.socket
         rm agent-was-enabled
     fi
-    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    rm -f /etc/polkit-1/localauthority/50-local.d/spread.pkla || true
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules || true
 
 debug: |
     tests.session dump
@@ -69,10 +82,6 @@ execute: |
     # expect that two runs and is enabled for all users
     # expect that three runs and is enabled for current user
 
-    # expect that the system service is not running/enabled
-    systemctl is-active snap.test-snapd-user-service-disabled.sys-service | MATCH "inactive"
-    systemctl is-enabled snap.test-snapd-user-service-disabled.sys-service | MATCH "disabled"
-
     echo "Verify status of running services after install"
     systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service | MATCH "inactive"
     systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "disabled"
@@ -87,7 +96,7 @@ execute: |
     systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "enabled"
 
     function systemctl_as_test2() {
-      tests.session -u test exec systemctl --user "$@"
+      tests.session -u test2 exec systemctl --user "$@"
     }
 
     echo "Setup new user session and expect correct initial state"

--- a/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
@@ -1,0 +1,99 @@
+summary: Check the expected behavior of a mixed service snap refresh
+
+details: |
+    Given a snap that has a mix of system-services and user-services,
+    we can disable and stop those (for all users), and then a refresh
+    correctly preserves this state. 
+
+# Only run on systems with polkit rules are supported, otherwise
+# are not able to test 'snap xxx --user' functionality as it needs
+# sudo access, and if its run with sudo then the user will be root
+# and not the user we are testing with
+systems: [ ubuntu-20.04-64, ubuntu-22.04-64, ubuntu-24.04-64 ]
+
+kill-timeout: 10m
+
+prepare: |
+    # Ensure that snapd.session-agent.socket is enabled.  This may not
+    # be the case on distributions where presets have been used to
+    # disable it.
+    if [ ! -L /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket ] &&
+            ! systemctl --user --global is-enabled snapd.session-agent.socket; then
+        systemctl --user --global enable snapd.session-agent.socket
+        touch agent-was-enabled
+    fi
+    snap set system experimental.user-daemons=true
+    tests.session kill-leaked
+    tests.session -u test prepare
+
+    # add a second user to test with
+    if ! useradd -m -d /home/test2 test2; then
+        # Ubuntu Core requires using extrausers db
+        useradd --extrausers -m -d /home/test2 test2
+    fi
+    tests.session -u test2 prepare
+
+    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    polkit.addRule(function(action, subject) {
+        if (action.id == "io.snapcraft.snapd.manage" && subject.user == "test") {
+            return polkit.Result.YES;
+        }
+    });
+    EOF
+
+restore: |
+    tests.session -u test2 restore
+    tests.session -u test restore
+    snap unset system experimental.user-daemons
+    if [ -f agent-was-enabled ]; then
+        systemctl --user --global disable snapd.session-agent.socket
+        rm agent-was-enabled
+    fi
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+
+execute: |
+    function systemctl_as_test() {
+      tests.session -u test exec systemctl --user "$@"
+    }
+    function systemctl_as_test2() {
+      tests.session -u test2 exec systemctl --user "$@"
+    }
+
+    echo "Install the a snap with user services while a user session is active"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service
+
+    echo "Verify status of running services after install"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+
+    # stop and disable both services, scope of user one for all
+    snap stop --disable --system --users=all test-snapd-mixed-service
+
+    # verify this worked
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "inactive"
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "disabled"
+
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+
+    # now refresh snap to a new version
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service-v2
+    
+    # verify nothing changed
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "inactive"
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "disabled"
+
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"

--- a/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
@@ -55,6 +55,9 @@ prepare: |
 
 restore: |
     tests.session -u test2 restore
+    if ! userdel -rf test2; then
+        userdel --extrausers -rf test2
+    fi
     tests.session -u test restore
     snap unset system experimental.user-daemons
     if [ -f agent-was-enabled ]; then

--- a/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
@@ -33,13 +33,25 @@ prepare: |
     fi
     tests.session -u test2 prepare
 
-    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    # rules are only supported from 23.10+
+    if [ -d /etc/polkit-1/localauthority/50-local.d ]; then
+        cat <<\EOF >/etc/polkit-1/localauthority/50-local.d/spread.pkla
+    [Normal Staff Permissions]
+    Identity=unix-user:test
+    Action=io.snapcraft.snapd.manage
+    ResultAny=yes
+    ResultInactive=no
+    ResultActive=yes
+    EOF
+    else
+        cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
     polkit.addRule(function(action, subject) {
         if (action.id == "io.snapcraft.snapd.manage" && subject.user == "test") {
             return polkit.Result.YES;
         }
     });
     EOF
+    fi
 
 restore: |
     tests.session -u test2 restore
@@ -49,7 +61,8 @@ restore: |
         systemctl --user --global disable snapd.session-agent.socket
         rm agent-was-enabled
     fi
-    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    rm -f /etc/polkit-1/localauthority/50-local.d/spread.pkla || true
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules || true
 
 execute: |
     function systemctl_as_test() {

--- a/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
@@ -90,6 +90,11 @@ execute: |
 
     # stop and disable user services, but the scope of the disable
     # for users should only affect the current user.
+    # OBS: Currently this will not work, the way user-services are enabled
+    # is by --global enable, which means that any attempt to individually disable
+    # services will be a no-op.
+    # TODO: Switch to a user-preset approach and scrap the --global enable/disable
+    # for user-services specifically
     snap_as_test stop --disable --user test-snapd-mixed-service
 
     # verify this worked
@@ -97,7 +102,8 @@ execute: |
     systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
 
     systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
-    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+    # this should be "disabled", but it will not be currently
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
 
     systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
     systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
@@ -105,7 +111,7 @@ execute: |
     # now refresh snap to a new version
     "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service-v2
     
-    # verify nothing changed
+    # verify that things now look as we expect
     systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
     systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
 

--- a/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
@@ -1,0 +1,103 @@
+summary: Check the expected behavior of a mixed service snap refresh
+
+details: |
+    Given a snap that has a mix of system-services and user-services,
+    we can disable and stop those (for current user), and then a refresh
+    correctly preserves this state. 
+
+# Only run on systems with polkit rules are supported, otherwise
+# are not able to test 'snap xxx --user' functionality as it needs
+# sudo access, and if its run with sudo then the user will be root
+# and not the user we are testing with
+systems: [ ubuntu-20.04-64, ubuntu-22.04-64, ubuntu-24.04-64 ]
+
+kill-timeout: 10m
+
+prepare: |
+    # Ensure that snapd.session-agent.socket is enabled.  This may not
+    # be the case on distributions where presets have been used to
+    # disable it.
+    if [ ! -L /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket ] &&
+            ! systemctl --user --global is-enabled snapd.session-agent.socket; then
+        systemctl --user --global enable snapd.session-agent.socket
+        touch agent-was-enabled
+    fi
+    snap set system experimental.user-daemons=true
+    tests.session kill-leaked
+    tests.session -u test prepare
+
+    # add a second user to test with
+    if ! useradd -m -d /home/test2 test2; then
+        # Ubuntu Core requires using extrausers db
+        useradd --extrausers -m -d /home/test2 test2
+    fi
+    tests.session -u test2 prepare
+
+    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    polkit.addRule(function(action, subject) {
+        if (action.id == "io.snapcraft.snapd.manage" && subject.user == "test") {
+            return polkit.Result.YES;
+        }
+    });
+    EOF
+
+restore: |
+    tests.session -u test2 restore
+    tests.session -u test restore
+    snap unset system experimental.user-daemons
+    if [ -f agent-was-enabled ]; then
+        systemctl --user --global disable snapd.session-agent.socket
+        rm agent-was-enabled
+    fi
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+
+execute: |
+    function systemctl_as_test() {
+      tests.session -u test exec systemctl --user "$@"
+    }
+    function snap_as_test() {
+      tests.session -u test exec snap "$@"
+    }
+    function systemctl_as_test2() {
+      tests.session -u test2 exec systemctl --user "$@"
+    }
+
+    echo "Install the a snap with user services while a user session is active"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service
+
+    echo "Verify status of running services after install"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+
+    # stop and disable user services, but the scope of the disable
+    # for users should only affect the current user.
+    snap_as_test stop --disable --user test-snapd-mixed-service
+
+    # verify this worked
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+
+    # now refresh snap to a new version
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service-v2
+    
+    # verify nothing changed
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"

--- a/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
@@ -55,6 +55,9 @@ prepare: |
 
 restore: |
     tests.session -u test2 restore
+    if ! userdel -rf test2; then
+        userdel --extrausers -rf test2
+    fi
     tests.session -u test restore
     snap unset system experimental.user-daemons
     if [ -f agent-was-enabled ]; then

--- a/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
@@ -33,13 +33,25 @@ prepare: |
     fi
     tests.session -u test2 prepare
 
-    cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    # rules are only supported from 23.10+
+    if [ -d /etc/polkit-1/localauthority/50-local.d ]; then
+        cat <<\EOF >/etc/polkit-1/localauthority/50-local.d/spread.pkla
+    [Normal Staff Permissions]
+    Identity=unix-user:test
+    Action=io.snapcraft.snapd.manage
+    ResultAny=yes
+    ResultInactive=no
+    ResultActive=yes
+    EOF
+    else
+        cat <<\EOF >/etc/polkit-1/rules.d/io.snapcraft.snapd.rules
     polkit.addRule(function(action, subject) {
         if (action.id == "io.snapcraft.snapd.manage" && subject.user == "test") {
             return polkit.Result.YES;
         }
     });
     EOF
+    fi
 
 restore: |
     tests.session -u test2 restore
@@ -49,7 +61,8 @@ restore: |
         systemctl --user --global disable snapd.session-agent.socket
         rm agent-was-enabled
     fi
-    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules
+    rm -f /etc/polkit-1/localauthority/50-local.d/spread.pkla || true
+    rm -f /etc/polkit-1/rules.d/io.snapcraft.snapd.rules || true
 
 execute: |
     function systemctl_as_test() {

--- a/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
@@ -96,8 +96,8 @@ execute: |
     # OBS: Currently this will not work, the way user-services are enabled
     # is by --global enable, which means that any attempt to individually disable
     # services will be a no-op.
-    # TODO: Switch to a user-preset approach and scrap the --global enable/disable
-    # for user-services specifically
+    # NOTE: Consider supporting masking of user-services to support per-user disable
+    # of user-services.
     snap_as_test stop --disable --user test-snapd-mixed-service
 
     # verify this worked

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -364,6 +364,7 @@ type ClientServicesStartOptions struct {
 	Enable bool
 	// DisabledServices is a list of services per-uid that can be provided
 	// which will then be ignored for the start or enable operation.
+	// Using the uid index '-1' will be used to filter services for all user clients.
 	DisabledServices map[int][]string
 }
 

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -333,19 +333,8 @@ func (client *Client) ServicesDaemonReload(ctx context.Context) error {
 	return err
 }
 
-func filterDisabledServices(all []string, disabledSvcs map[int][]string, uid int) []string {
+func filterDisabledServices(all, disabled []string) []string {
 	var filtered []string
-	var disabled []string
-
-	// Any services marked for all users
-	if svcs, ok := disabledSvcs[-1]; ok {
-		disabled = append(disabled, svcs...)
-	}
-	// Any services marked for this one
-	if svcs, ok := disabledSvcs[uid]; ok {
-		disabled = append(disabled, svcs...)
-	}
-
 ServiceLoop:
 	for _, svc := range all {
 		for _, disabledSvc := range disabled {
@@ -364,7 +353,6 @@ type ClientServicesStartOptions struct {
 	Enable bool
 	// DisabledServices is a list of services per-uid that can be provided
 	// which will then be ignored for the start or enable operation.
-	// Using the uid index '-1' will be used to filter services for all user clients.
 	DisabledServices map[int][]string
 }
 
@@ -398,7 +386,7 @@ func (client *Client) ServicesStart(ctx context.Context, services []string, opts
 
 	for _, uid := range uids {
 		headers := map[string]string{"Content-Type": "application/json"}
-		filtered := filterDisabledServices(services, opts.DisabledServices, uid)
+		filtered := filterDisabledServices(services, opts.DisabledServices[uid])
 		if len(filtered) == 0 {
 			// Save an expensive call
 			continue

--- a/usersession/client/client_test.go
+++ b/usersession/client/client_test.go
@@ -249,9 +249,9 @@ func (s *clientSuite) TestServicesStartWithDisabledServices(c *C) {
 		var inst client.ServiceInstruction
 		c.Assert(decoder.Decode(&inst), IsNil)
 		if r.Host == "42" {
-			c.Check(inst.Services, DeepEquals, []string{"service2.service"})
+			c.Check(inst.Services, DeepEquals, []string{"service2.service", "service3.service"})
 		} else if r.Host == "1000" {
-			c.Check(inst.Services, DeepEquals, []string{"service1.service"})
+			c.Check(inst.Services, DeepEquals, []string{"service1.service", "service3.service"})
 		} else {
 			c.FailNow()
 		}
@@ -264,9 +264,11 @@ func (s *clientSuite) TestServicesStartWithDisabledServices(c *C) {
 	})
 	startFailures, stopFailures, err := s.cli.ServicesStart(
 		context.Background(),
-		[]string{"service1.service", "service2.service"},
+		[]string{"service1.service", "service2.service", "service3.service", "service4.service"},
 		client.ClientServicesStartOptions{
 			DisabledServices: map[int][]string{
+				// This one must affect both 42 and 1000
+				-1:   {"service4.service"},
 				42:   {"service1.service"},
 				1000: {"service2.service"},
 			},

--- a/usersession/client/client_test.go
+++ b/usersession/client/client_test.go
@@ -249,9 +249,9 @@ func (s *clientSuite) TestServicesStartWithDisabledServices(c *C) {
 		var inst client.ServiceInstruction
 		c.Assert(decoder.Decode(&inst), IsNil)
 		if r.Host == "42" {
-			c.Check(inst.Services, DeepEquals, []string{"service2.service", "service3.service"})
+			c.Check(inst.Services, DeepEquals, []string{"service2.service"})
 		} else if r.Host == "1000" {
-			c.Check(inst.Services, DeepEquals, []string{"service1.service", "service3.service"})
+			c.Check(inst.Services, DeepEquals, []string{"service1.service"})
 		} else {
 			c.FailNow()
 		}
@@ -264,11 +264,9 @@ func (s *clientSuite) TestServicesStartWithDisabledServices(c *C) {
 	})
 	startFailures, stopFailures, err := s.cli.ServicesStart(
 		context.Background(),
-		[]string{"service1.service", "service2.service", "service3.service", "service4.service"},
+		[]string{"service1.service", "service2.service"},
 		client.ClientServicesStartOptions{
 			DisabledServices: map[int][]string{
-				// This one must affect both 42 and 1000
-				-1:   {"service4.service"},
 				42:   {"service1.service"},
 				1000: {"service2.service"},
 			},

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -20,11 +20,9 @@
 package wrappers
 
 import (
-	"os/user"
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/testutil"
 )
 
 // some internal helper exposed for testing
@@ -39,7 +37,6 @@ var (
 	IsValidDesktopFileLine = isValidDesktopFileLine
 
 	// daemons
-	UsersToUids               = usersToUids
 	NewUserServiceClientNames = newUserServiceClientNames
 
 	// icons
@@ -60,10 +57,4 @@ func MockEnsureDirState(f func(dir string, glob string, content map[string]osuti
 	return func() {
 		ensureDirState = oldEnsureDirState
 	}
-}
-
-func MockUserLookup(f func(username string) (*user.User, error)) (restore func()) {
-	restore = testutil.Backup(&userLookup)
-	userLookup = f
-	return restore
 }

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1310,7 +1310,9 @@ func RestartServices(apps []*snap.AppInfo, explicitServices []string,
 // in one instance per user.
 type DisabledServices struct {
 	SystemServices []string
-	UserServices   map[int][]string
+	// UserServices is a map of services that should stay disabled on a per-user basis
+	// and is indexed by a users uid. To affect all users, use the index '-1'.
+	UserServices map[int][]string
 }
 
 func disabledServiceNames(sts []*internal.ServiceStatus) []string {

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -185,26 +185,58 @@ func serviceIsSlotActivated(app *snap.AppInfo) bool {
 	return len(app.ActivatesOn) > 0
 }
 
-func filterServicesForStart(apps []*snap.AppInfo, disabledSvcs *DisabledServices, scope ServiceScope) []*snap.AppInfo {
+func filterServicesForStart(apps []*snap.AppInfo, disabledSvcs *DisabledServices, scope ServiceScope) (sys []*snap.AppInfo, usr []*snap.AppInfo) {
 	isSystemSvcDisabled := func(name string) bool {
 		return disabledSvcs != nil && strutil.ListContains(disabledSvcs.SystemServices, name)
 	}
 
-	var filteredApps []*snap.AppInfo
 	for _, app := range apps {
 		if !app.IsService() {
 			continue
 		}
+
 		// Verify that scope covers this service
 		if !scope.matches(app.DaemonScope) {
 			continue
 		}
-		if isSystemSvcDisabled(app.Name) {
+
+		if app.DaemonScope == snap.SystemDaemon {
+			// For system-services we can just filter on the name
+			// and disable it if it matches
+			if isSystemSvcDisabled(app.Name) {
+				continue
+			}
+			sys = append(sys, app)
+		} else if app.DaemonScope == snap.UserDaemon {
+			usr = append(usr, app)
+		}
+	}
+	return sys, usr
+}
+
+// filterUserServicesNotInDisabledMap filters the given list of user services
+// against the map of disabled services. The goal is to get a list of all services
+// that do not have a current state of disabled.
+func filterUserServicesNotInDisabledMap(disabledSvcs *DisabledServices, originalSvcs []*snap.AppInfo) []*snap.AppInfo {
+	if disabledSvcs == nil {
+		return originalSvcs
+	}
+
+	combined := make(map[string]bool)
+	for _, svcs := range disabledSvcs.UserServices {
+		for _, svc := range svcs {
+			combined[svc] = true
+		}
+	}
+
+	var filtered []*snap.AppInfo
+	for _, svc := range originalSvcs {
+		if ok := combined[svc.Name]; ok {
 			continue
 		}
-		filteredApps = append(filteredApps, app)
+		filtered = append(filtered, svc)
 	}
-	return filteredApps
+	return filtered
 }
 
 // StartServicesOptions carries additional parameters for StartService.
@@ -233,8 +265,10 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, opts *S
 	// not need to be enabled, we can save that.
 	const includeActivatedServices = false
 
-	filteredApps := filterServicesForStart(apps, disabledSvcs, opts.Scope)
-	systemServices, userServices := categorizeServices(filteredApps, includeActivatedServices)
+	sysApps, userApps := filterServicesForStart(apps, disabledSvcs, opts.Scope)
+	systemServices := serviceUnitsFromApps(sysApps, includeActivatedServices)
+	userAppsForGlobalEnable := filterUserServicesNotInDisabledMap(disabledSvcs, userApps)
+	userServicesForGlobalEnable := serviceUnitsFromApps(userAppsForGlobalEnable, includeActivatedServices)
 	var undoStart bool
 	defer func() {
 		if err == nil {
@@ -243,20 +277,16 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, opts *S
 
 		// Undo logic for user services is handled by user session agent,
 		// we only handle undo logic for system services in this function
-		if undoStart && len(systemServices) > 0 {
+		if undoStart && len(sysApps) > 0 {
 			// filteredApps could have been sorted according to their startup
 			// ordering, stop them in reverse order
-			for i, j := 0, len(filteredApps)-1; i < j; i, j = i+1, j-1 {
-				filteredApps[i], filteredApps[j] = filteredApps[j], filteredApps[i]
+			for i, j := 0, len(sysApps)-1; i < j; i, j = i+1, j-1 {
+				sysApps[i], sysApps[j] = sysApps[j], sysApps[i]
 			}
 
 			// Stop them one-by-one to maintain order, the issue is if we just send all of them down
 			// to systemd, it will spawn a process for each stop anyway, just simultaneously.
-			for _, app := range filteredApps {
-				if app.DaemonScope != snap.SystemDaemon {
-					continue
-				}
-
+			for _, app := range sysApps {
 				// when collecting service units again here, for stopping, we want to ensure
 				// we include activated service units this time, as they might have been started
 				// in the mean time.
@@ -279,9 +309,9 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, opts *S
 			}
 
 			// Do a global disable for user services if the scope was all users
-			if len(userServices) > 0 && len(opts.Users) == 0 {
-				if e := userGlobalSysd.DisableNoReload(userServices); e != nil {
-					inter.Notify(fmt.Sprintf("While trying to disable previously enabled user services %q: %v", userServices, e))
+			if len(userServicesForGlobalEnable) > 0 && len(opts.Users) == 0 {
+				if e := userGlobalSysd.DisableNoReload(userServicesForGlobalEnable); e != nil {
+					inter.Notify(fmt.Sprintf("While trying to disable previously enabled user services %q: %v", userServicesForGlobalEnable, e))
 				}
 			}
 		}
@@ -300,8 +330,10 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, opts *S
 			}
 
 			// Do a global enable for user services if the scope was all users
-			if len(userServices) != 0 && len(opts.Users) == 0 {
-				if err = userGlobalSysd.EnableNoReload(userServices); err == nil {
+			// and the service is new (i.e it does not appear in the disabled
+			// service list)
+			if len(userServicesForGlobalEnable) != 0 && len(opts.Users) == 0 {
+				if err = userGlobalSysd.EnableNoReload(userServicesForGlobalEnable); err == nil {
 					// make sure we atleast disable them again if we successfully enabled
 					// them
 					undoStart = true
@@ -337,6 +369,7 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, opts *S
 		return err
 	}
 
+	userServices := serviceUnitsFromApps(userApps, includeActivatedServices)
 	if len(userServices) != 0 {
 		var disabledUserSvcs map[int][]string
 		if disabledSvcs != nil {
@@ -860,20 +893,13 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 	return context.reloadModified()
 }
 
-// categorizeServices returns a list of system and user services
-// ordered by the same order that 'app' is passed into.
-func categorizeServices(apps []*snap.AppInfo, includeActivatedServices bool) (systemServices []string, userServices []string) {
+// serviceUnitsFromApps returns a list of service units ordered by
+// the same order that 'app' is passed into.
+func serviceUnitsFromApps(apps []*snap.AppInfo, includeActivatedServices bool) []string {
 	// process all services of the snap in the order specified by the
 	// caller; before batched calls were introduced, the sockets and timers
 	// were started first, followed by other non-activated services
-	markServices := func(svcs []string, scope snap.DaemonScope) {
-		switch scope {
-		case snap.SystemDaemon:
-			systemServices = append(systemServices, svcs...)
-		case snap.UserDaemon:
-			userServices = append(userServices, svcs...)
-		}
-	}
+	var markedServices []string
 	// first, gather all socket and timer units
 	for _, app := range apps {
 		// Get all units for the service, but we only deal with
@@ -883,7 +909,7 @@ func categorizeServices(apps []*snap.AppInfo, includeActivatedServices bool) (sy
 			// just skip if there are no activated units
 			continue
 		}
-		markServices(activators, app.DaemonScope)
+		markedServices = append(markedServices, activators...)
 	}
 
 	// now collect all services
@@ -891,10 +917,9 @@ func categorizeServices(apps []*snap.AppInfo, includeActivatedServices bool) (sy
 		if serviceIsActivated(app) && !includeActivatedServices {
 			continue
 		}
-		svcName := app.ServiceName()
-		markServices([]string{svcName}, app.DaemonScope)
+		markedServices = append(markedServices, app.ServiceName())
 	}
-	return systemServices, userServices
+	return markedServices
 }
 
 // filterAppsForStop filters a list of a snap apps based on the following criteria
@@ -905,9 +930,9 @@ func categorizeServices(apps []*snap.AppInfo, includeActivatedServices bool) (sy
 //  4. The services must match the provided scope in flags.Scope
 //     (i. e) whether we are restarting user or system services (or both)
 //
-// The result is then a list of snap service apps that are valid for being stopped.
-func filterAppsForStop(apps []*snap.AppInfo, reason snap.ServiceStopReason, opts *StopServicesOptions) []*snap.AppInfo {
-	var filteredApps []*snap.AppInfo
+// The result is then two lists of snap service apps, separated by system/user type
+// that are valid for being stopped.
+func filterAppsForStop(apps []*snap.AppInfo, reason snap.ServiceStopReason, opts *StopServicesOptions) (sys []*snap.AppInfo, usr []*snap.AppInfo) {
 	for _, app := range apps {
 		// Handle the case where service file doesn't exist and don't try to stop it as it will fail.
 		// This can happen with snap try when snap.yaml is modified on the fly and a daemon line is added.
@@ -933,9 +958,13 @@ func filterAppsForStop(apps []*snap.AppInfo, reason snap.ServiceStopReason, opts
 		if opts.Disable && serviceIsSlotActivated(app) {
 			logger.Noticef("Disabling %s may not have the intended effect as the service is currently always activated by a slot", app.Name)
 		}
-		filteredApps = append(filteredApps, app)
+		if app.DaemonScope == snap.SystemDaemon {
+			sys = append(sys, app)
+		} else if app.DaemonScope == snap.UserDaemon {
+			usr = append(usr, app)
+		}
 	}
-	return filteredApps
+	return sys, usr
 }
 
 // StopServicesOptions carries additional parameters for StopServices.
@@ -969,8 +998,9 @@ func StopServices(apps []*snap.AppInfo, opts *StopServicesOptions, reason snap.S
 	// doing this on a 'static' service is a no-op anyway, so no harm here.
 	const includeActivatedServices = true
 
-	filteredApps := filterAppsForStop(apps, reason, opts)
-	systemServices, userServices := categorizeServices(filteredApps, includeActivatedServices)
+	sysApps, userApps := filterAppsForStop(apps, reason, opts)
+	systemServices := serviceUnitsFromApps(sysApps, includeActivatedServices)
+	userServices := serviceUnitsFromApps(userApps, includeActivatedServices)
 
 	// Save any potentionally expensive calls if there is no need
 	if len(userServices) != 0 {

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1311,7 +1311,7 @@ func RestartServices(apps []*snap.AppInfo, explicitServices []string,
 type DisabledServices struct {
 	SystemServices []string
 	// UserServices is a map of services that should stay disabled on a per-user basis
-	// and is indexed by a users uid. To affect all users, use the index '-1'.
+	// and is indexed by a users uid.
 	UserServices map[int][]string
 }
 


### PR DESCRIPTION
Implements the remaining functionality to support user-services when refreshing snaps. SnapState now also keeps track of the last disabled services for user-services.