### PR TITLE
interfaces: Improving use of existing interfaces on core

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -507,6 +507,51 @@ dbus (receive, send)
 /etc/xdg/user-dirs.conf r,
 /etc/xdg/user-dirs.defaults r,
 /run/udev/tags/seat{,/**} r,
+
+# KDE Plasma specific extension
+
+# Used by the KCrash handler
+@{PROC}/sys/kernel/core_pattern r,
+
+# So that KSplash disappears when appropriate
+dbus (receive, send)
+    bus=session
+    path=/KSplash
+    interface=org.kde.KSplash
+    member=setStage
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    path=/KSplash
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+dbus (receive, send)
+    bus=session
+    path=/KSMServer
+    interface=org.kde.KSMServerInterface
+    member=restoreSession
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    path=/KSMServer
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+dbus (receive, send)
+    bus=session
+    path=/kcminit
+    interface=org.kde.KCMInit
+    member=runPhase1
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=session
+    path=/kcminit
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
 `
 
 type desktopInterface struct {

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -51,7 +51,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.login1.Manager
-    member={Inhibit,PowerOff,Reboot,Suspend,Hibernate,SuspendThenHibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage,SetRebootParameter}
+    member={ListInhibitors,Inhibit,PowerOff,Reboot,Suspend,Hibernate,SuspendThenHibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage,SetRebootParameter}
     peer=(label=unconfined),
 
 # Allow clients to introspect

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -51,7 +51,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.login1.Manager
-    member={Inhibit,PowerOff,Reboot,Suspend,Hibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage,SetRebootParameter}
+    member={Inhibit,PowerOff,Reboot,Suspend,Hibernate,SuspendThenHibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage,SetRebootParameter}
     peer=(label=unconfined),
 
 # Allow clients to introspect

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -143,7 +143,7 @@ dbus (send)
 # Allow clients to enumerate DBus connection names on common buses
 dbus (send)
     bus={session,system}
-    path=/org/freedesktop/DBus
+    path={/,/org/freedesktop/DBus}
     interface=org.freedesktop.DBus
     member={ListNames,ListActivatableNames}
     peer=(label=unconfined),

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -100,7 +100,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/login1{,/**}
     interface=org.freedesktop.login1.Manager
-    member={CanPowerOff,CanSuspend,CanHibernate,CanHybridSleep,PowerOff,Suspend,Hibernate,HybridSleep,Inhibit}
+    member={CanPowerOff,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,PowerOff,Suspend,Hibernate,SuspendThenHybernate,HybridSleep,Inhibit}
     peer=(label=unconfined),
 `
 

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -100,7 +100,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/login1{,/**}
     interface=org.freedesktop.login1.Manager
-    member={CanPowerOff,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,PowerOff,Suspend,Hibernate,SuspendThenHybernate,HybridSleep,Inhibit}
+    member={CanPowerOff,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,PowerOff,Suspend,Hibernate,SuspendThenHybernate,HybridSleep,ListInhibitors,Inhibit}
     peer=(label=unconfined),
 `
 


### PR DESCRIPTION
This is extracting the commits from #13920 not related with the `systemd-user-control` interface as requested by @zyga.

It is mostly about
* adding a few missing members on already exposed interfaces
* exposing a few interfaces on core which were missing
* doing a couple of adjustments for KDE Plasma based sessions in the `desktop` interface
