### PR TITLE
tests: spread metadata used to filter and categorize tests

### DIFF
--- a/spread.meta.yaml
+++ b/spread.meta.yaml
@@ -1,0 +1,29 @@
+# This file is used to define which features, groups and tags are available in spread tests
+# All these definitions are cross-checked to ensure tests integrity.
+# These definitions can be used to define a subset of tests to run but also as a way
+# of coverage documentation.
+
+definitions:
+    # Features refer to product caracteristics being tested
+    # The main porpoise is to know the features testing coverage
+    features: [
+        interfaces,           # snap interfaces
+        snap_refresh,         # snap refresh and snap auto refreshes
+        snap_install          # snap install command
+        ]
+
+    # Groups are set of tests orthogonal to the suites definition
+    # The main porpoise is to run an independent subset of tests to avoid test duplication 
+    groups: [
+        core_validation,      # Set of tests used to validate ubuntu core images
+        sanity                # Minimal set of tests used to validate a system with more coverage than the smoke tests
+        ]
+
+    # Tags are free labels used to identify group of tests
+    # Those can be used to identify tests that are exercising specific OS features, or are interacting with
+    # an external dependency among others. 
+    tags: [
+        networking,           # OS networking, network managers 
+        os_errors             # system errors, segmentation faults, panics, etc 
+        ]
+  

--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -3,6 +3,10 @@ summary: Check auto-refresh from a pre-download change
 details: |
   Verify that an inhibited auto-refresh triggers a pre-download change and resumes on close
 
+meta:
+    features: []
+    groups: []
+    tags: []
 
 # Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
 systems: [-ubuntu-14.04-*]

--- a/tests/main/auto-refresh-private/task.yaml
+++ b/tests/main/auto-refresh-private/task.yaml
@@ -8,9 +8,9 @@ details: |
     they are not present then only the negative check is performed.
 
 meta:
-    features: [refresh] # available features are listed in spread.meta.yaml
-    groups: [smoke, core-validation] # available groups are listed in spread.meta.yaml
-    tags: [] # tags are free labels used to identify the test
+    features: [snap_refresh]
+    groups: [sanity, core-validation]
+    tags: []
 
 # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
 systems: [-ubuntu-core-*]

--- a/tests/main/auto-refresh-private/task.yaml
+++ b/tests/main/auto-refresh-private/task.yaml
@@ -7,6 +7,11 @@ details: |
     snap set in the environment variables SPREAD_STORE_USER and SPREAD_STORE_PASSWORD, if
     they are not present then only the negative check is performed.
 
+meta:
+    features: [refresh] # available features are listed in spread.meta.yaml
+    groups: [smoke, core-validation] # available groups are listed in spread.meta.yaml
+    tags: [] # tags are free labels used to identify the test
+
 # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
 systems: [-ubuntu-core-*]
 


### PR DESCRIPTION
This change introduces metadata on spread tests, this metadata is divided in features, groups and tags.

In all cases the metadata can be used to filter tests to be executed in different circunstancies, but also to know test coverage.

The file spread.meta.yaml includes the values allowed to include in the tests. These values will be cross-checked in the ci to check the tests integrity.

The tests updated are just done as an example in order to understand how tests are going to looks like.