### PR TITLE
tests: prioritised conf overrides and add invariant check

### DIFF
--- a/tests/core/debug/task.yaml
+++ b/tests/core/debug/task.yaml
@@ -7,6 +7,9 @@ details: |
 # Some systemctl calls are not supported on UC16
 systems: [-ubuntu-core-16-*]
 
+environment:
+  CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
+
 execute: |
   get_log_level() {
       if os.query is-core-le 18; then
@@ -18,7 +21,12 @@ execute: |
 
   if [ "$SPREAD_REBOOT" = 0 ]; then
       # Remove the variable introduced by prepare.sh
-      sed -i 's/SNAPD_DEBUG=1//' /etc/systemd/system/snapd.service.d/local.conf
+      cp /etc/systemd/system/snapd.service.d/00-prepare.conf "$CONF_OVERRIDE"
+      sed -i 's/SNAPD_DEBUG=1//' "$CONF_OVERRIDE"
+      tests.cleanup defer rm "$CONF_OVERRIDE"
+      tests.cleanup systemctl defer daemon-reload
+      tests.cleanup systemctl defer restart snapd
+
       systemctl daemon-reload
       systemctl restart snapd
       NOMATCH SNAPD_DEBUG=1 < /proc/"$(pgrep snapd)"/environ

--- a/tests/core/gadget-kernel-refs-update-pc/task.yaml
+++ b/tests/core/gadget-kernel-refs-update-pc/task.yaml
@@ -22,6 +22,7 @@ environment:
     START_REVISION: 1000
     # uploading a large snap makes OOM kill snapd
     SNAPD_NO_MEMORY_LIMIT: 1
+    CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -92,7 +93,10 @@ prepare: |
 
     # make sure that the snapd daemon gives us time for comms before
     # closing the socket
-    sed -i '/^Environment=/ s/$/ SNAPD_SHUTDOWN_DELAY=1/' /etc/systemd/system/snapd.service.d/local.conf
+    cp /etc/systemd/system/snapd.service.d/00-prepare.conf "$CONF_OVERRIDE"
+    sed -i '/^Environment=/ s/$/ SNAPD_SHUTDOWN_DELAY=1/' "$CONF_OVERRIDE"
+
+    systemctl daemon-reload
     systemctl restart snapd
     
 restore: |
@@ -109,7 +113,8 @@ restore: |
     #      restore requires a reboot :/
 
     # remove SNAPD_SHUTDOWN_DELAY again
-    sed -i 's/SNAPD_SHUTDOWN_DELAY=1//g' /etc/systemd/system/snapd.service.d/local.conf
+    rm "$CONF_OVERRIDE"
+    systemctl daemon-reload
     systemctl restart snapd
     
 execute: |

--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -16,6 +16,7 @@ systems: [ubuntu-core-2*]
 
 environment:
   SVC_UNIT: /etc/systemd/system/snap.test-snapd-simple-service.test-snapd-simple-service.service
+  CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
 
 prepare: |
   if not os.query is-pc-amd64; then
@@ -45,12 +46,15 @@ prepare: |
   
   # make sure that the snapd daemon gives us time for comms before
   # closing the socket
-  sed -i '/^Environment=/ s/$/ SNAPD_SHUTDOWN_DELAY=1/' /etc/systemd/system/snapd.service.d/local.conf
+  cp /etc/systemd/system/snapd.service.d/00-prepare.conf "$CONF_OVERRIDE"
+  sed -i '/^Environment=/ s/$/ SNAPD_SHUTDOWN_DELAY=1/' "$CONF_OVERRIDE"
+  systemctl daemon-reload
   systemctl restart snapd
 
 restore: |
   # remove SNAPD_SHUTDOWN_DELAY again
-  sed -i 's/SNAPD_SHUTDOWN_DELAY=1//g' /etc/systemd/system/snapd.service.d/local.conf
+  rm "$CONF_OVERRIDE"
+  systemctl daemon-reload
   systemctl restart snapd
 
 execute: |

--- a/tests/lib/external/snapd-testing-tools/utils/spread-shellcheck
+++ b/tests/lib/external/snapd-testing-tools/utils/spread-shellcheck
@@ -127,6 +127,7 @@ def checksection(data, env: Dict[str, str]):
     script_data.append('export SPREAD_SYSTEM_PASSWORD=placeholder')
     script_data.append('export SPREAD_SYSTEM_ADDRESS=placeholder')
     script_data.append('export SPREAD_REBOOT=123')
+    script_data.append('export SPREAD_TASK=placeholder')
 
     for key, value in env.items():
         value = str(value)

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -120,7 +120,7 @@ disable_refreshes() {
 
 setup_systemd_snapd_overrides() {
     mkdir -p /etc/systemd/system/snapd.service.d
-    cat <<EOF > /etc/systemd/system/snapd.service.d/local.conf
+    cat <<EOF > /etc/systemd/system/snapd.service.d/00-prepare.conf
 [Service]
 Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_REBOOT_DELAY=10m SNAPD_CONFIGURE_HOOK_TIMEOUT=30s SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE
 ExecStartPre=/bin/touch /dev/iio:device0
@@ -279,7 +279,7 @@ prepare_memory_limit_override() {
 
     if [ "$set_limit" = "0" ]; then
         # make sure the file does not exist then
-        rm -f /etc/systemd/system/snapd.service.d/memory-max.conf
+        rm -f /etc/systemd/system/snapd.service.d/05-memory-max.conf
     else
         mkdir -p /etc/systemd/system/snapd.service.d
         # Use MemoryMax to set the memory limit for snapd.service, that is the
@@ -291,7 +291,7 @@ prepare_memory_limit_override() {
         # This ought to set MemoryMax, but on systems with older systemd we need to
         # use MemoryLimit, which is deprecated and replaced by MemoryMax now, but
         # systemd is backwards compatible so the limit is still set.
-        cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf
+        cat <<EOF > /etc/systemd/system/snapd.service.d/05-memory-max.conf
 [Service]
 MemoryLimit=200M
 EOF
@@ -303,7 +303,7 @@ EOF
 }
 
 prepare_reexec_override() {
-    local reexec_file=/etc/systemd/system/snapd.service.d/reexec.conf
+    local reexec_file=/etc/systemd/system/snapd.service.d/09-reexec.conf
  
     # First time it is needed to save the initial env var value
     if not tests.env is-set initial SNAP_REEXEC; then
@@ -330,8 +330,8 @@ EOF
 }
 
 prepare_each_classic() {
-    if [ ! -f /etc/systemd/system/snapd.service.d/local.conf ]; then
-        echo "/etc/systemd/system/snapd.service.d/local.conf vanished!"
+    if [ ! -f /etc/systemd/system/snapd.service.d/00-prepare.conf ]; then
+        echo "/etc/systemd/system/snapd.service.d/00-prepare.conf vanished!"
         exit 1
     fi
 

--- a/tests/lib/tools/store-state
+++ b/tests/lib/tools/store-state
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-STORE_CONFIG=/etc/systemd/system/snapd.service.d/store.conf
+STORE_CONFIG=/etc/systemd/system/snapd.service.d/35-store.conf
 
 show_help() {
     echo "usage: store-state setup-fake-store <DIR>"

--- a/tests/lib/tools/suite/tests.invariant/task.yaml
+++ b/tests/lib/tools/suite/tests.invariant/task.yaml
@@ -69,3 +69,26 @@ execute: |
         systemctl stop superfluous-dbus.service
         tests.invariant check stray-dbus-daemon 2>&1 | MATCH 'tests.invariant: stray-dbus-daemon ok'
     fi
+    
+    # check we don't fail if the directory is missing
+    tests.invariant check snapd-svc-conf
+
+    mkdir -p /etc/systemd/system/snapd.service.d 
+    tests.cleanup defer rm -r /etc/systemd/system/snapd.service.d
+ 
+    # we expect **some** 0X file to exist
+    tests.invariant check snapd-svc-conf | MATCH "tests.invariant.snapd-svc-conf: /etc/systemd/system/snapd.service.d must contain a base conf file (e.g., 00-prepare.conf)"
+
+    # if it only contains non-test harness files, list them
+    touch /etc/systemd/system/snapd.service.d/15-fail-check.conf
+    tests.invariant check snapd-svc-conf | MATCH "tests.invariant.snapd-svc-conf: /etc/systemd/system/snapd.service.d must contain a base conf file (e.g., 00-prepare.conf) but instead contains: 15-fail-check.conf"
+
+    # fail if we have an expected file but a test didn't clean up a config
+    touch /etc/systemd/system/snapd.service.d/05-no-fail-check.conf
+    tests.invariant check snapd-svc-conf | MATCH "tests.invariant.snapd-svc-conf: /etc/systemd/system/snapd.service.d contains unexpected files: 15-fail-check.conf"
+    rm /etc/systemd/system/snapd.service.d/15-fail-check.conf
+
+    # if the directory only contains a base 0X-<name>.conf file, the check passes
+    tests.invariant check snapd-svc-conf
+    
+    tests.cleanup restore

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -199,12 +199,47 @@ check_segmentation_violations() {
 	fi
 }
 
-check_fakestore_cleaned() {
-    # Check if fakestore was properly cleaned to avoid leaking into other tests.
-    if [ -f "/etc/systemd/system/snapd.service.d/35-store.conf" ]; then
-        echo "/etc/systemd/system/snapd.service.d/35-store.conf was not cleaned properly"
-        exit 1
-    fi
+# Check that there is only configuration files left are created by the test
+# harness (0X-xyz.conf) since others might override its values and affect tests
+check_snapd_svc_conf() {
+	local n="$1" # invariant name
+	local conf_dir="/etc/systemd/system/snapd.service.d/"
+
+	# some test suites don't configure snapd so don't fail (prepare.sh already
+	# fails when this is missing)
+	if [ ! -d "$conf_dir" ]; then
+			exit 0
+	fi
+
+	local leaked_files
+	local found_prepare_conf="false"
+	for file_path in /etc/systemd/system/snapd.service.d/*; do
+		local file_name
+		file_name="$(basename "$file_path")"
+
+		# ignore config files added by the test harness
+		if echo "$file_name" | grep -q -v "^0[0-9]-.*\.conf"; then
+			leaked_files="$leaked_files $file_name"
+		else
+			found_prepare_conf="true"
+		fi
+	done
+
+	if [ "$found_prepare_conf" = "false" ]; then
+		echo -n "tests.invariant.$n: $conf_dir must contain a base conf file (e.g., 00-prepare.conf)"
+		if [ -n "$leaked_files" ]; then
+			echo "but instead contains unexpected files:$leaked_files"
+		else
+			echo ""
+		fi
+
+		exit 1
+	fi
+
+	if [ -n "$leaked_files" ]; then
+		echo "tests.invariant.$n: $conf_dir contains:$leaked_files"
+		exit 1
+	fi
 }
 
 check_invariant() {
@@ -233,8 +268,8 @@ check_invariant() {
 		segmentation-violations)
 			check_segmentation_violations "$1"
 			;;
-		check-fakestore-cleaned)
-			check_fakestore_cleaned
+		snapd-svc-conf)
+			check_snapd_svc_conf "$1"
 			;;
 		*)
 			echo "tests.invariant: unknown invariant $1" >&2
@@ -244,7 +279,7 @@ check_invariant() {
 }
 
 main() {
-	ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon leftover-defer-sh broken-snaps cgroup-scopes segmentation-violations check-fakestore-cleaned"
+	ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon leftover-defer-sh broken-snaps cgroup-scopes segmentation-violations snapd-svc-conf"
 
 	case "$action" in
 		check)

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -201,8 +201,8 @@ check_segmentation_violations() {
 
 check_fakestore_cleaned() {
     # Check if fakestore was properly cleaned to avoid leaking into other tests.
-    if [ -f "/etc/systemd/system/snapd.service.d/store.conf" ]; then
-        echo "/etc/systemd/system/snapd.service.d/store.conf was not cleaned properly"
+    if [ -f "/etc/systemd/system/snapd.service.d/35-store.conf" ]; then
+        echo "/etc/systemd/system/snapd.service.d/35-store.conf was not cleaned properly"
         exit 1
     fi
 }

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -7,10 +7,12 @@ details: |
 # apt hook only available on 18.04+ and aws-cli only for amd64
 systems: [ubuntu-18.04-64, ubuntu-2*-64]
 
+environment:
+    CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
+
 prepare: |
-    cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
     # enable catalog refresh requests
-    cat <<EOF >> /etc/systemd/system/snapd.service.d/local.conf
+    cat <<EOF >> "$CONF_OVERRIDE"
     # added by apt-hooks test
     [Service]
     Environment=SNAPD_CATALOG_REFRESH=1
@@ -19,7 +21,7 @@ prepare: |
     systemctl restart snapd.socket
 
 restore: |
-    mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
+    rm "$CONF_OVERRIDE"
     systemctl daemon-reload
     systemctl restart snapd.socket
 

--- a/tests/main/auto-refresh-retry/task.yaml
+++ b/tests/main/auto-refresh-retry/task.yaml
@@ -6,11 +6,14 @@ details: |
 
 systems: [-ubuntu-14.04-*]
 
+environment:
+    CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
+
 prepare: |
     snap install --devmode jq
 
 restore: |
-    rm -f /etc/systemd/system/snapd.service.d/override.conf
+    rm -f "$CONF_OVERRIDE"
     ip netns delete testns || true
     umount /run/netns || true
 
@@ -36,9 +39,9 @@ execute: |
 
     # restart snapd in a network namespace
     ip netns add testns
-    echo "[Service]" > /etc/systemd/system/snapd.service.d/override.conf
-    echo "ExecStart=" >> /etc/systemd/system/snapd.service.d/override.conf
-    systemctl cat snapd.service | sed 's+ExecStart=\(.*\)+ExecStart=/usr/bin/nsenter --net=/var/run/netns/testns \1+' >> /etc/systemd/system/snapd.service.d/override.conf
+    echo "[Service]" > "$CONF_OVERRIDE"
+    echo "ExecStart=" >> "$CONF_OVERRIDE"
+    systemctl cat snapd.service | sed 's+ExecStart=\(.*\)+ExecStart=/usr/bin/nsenter --net=/var/run/netns/testns \1+' >> "$CONF_OVERRIDE"
     systemctl daemon-reload
     systemctl start snapd.{socket,service}
 
@@ -56,7 +59,7 @@ execute: |
 
     # restart snapd with network access back
     systemctl stop snapd.{service,socket}
-    rm -f /etc/systemd/system/snapd.service.d/override.conf
+    rm -f "$CONF_OVERRIDE"
     systemctl daemon-reload
     systemctl start snapd.{socket,service}
 

--- a/tests/main/download-timeout/task.yaml
+++ b/tests/main/download-timeout/task.yaml
@@ -13,7 +13,7 @@ environment:
   # window).
   SNAPD_MIN_DOWNLOAD_SPEED: 99000
   SNAPD_DOWNLOAD_MEAS_WINDOW: 15s
-  OVERRIDES_FILE: /etc/systemd/system/snapd.service.d/local.conf
+  CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
 
 prepare: |
   if not os.query is-pc-amd64; then
@@ -21,8 +21,8 @@ prepare: |
       exit
   fi
 
-  cp "$OVERRIDES_FILE" "$OVERRIDES_FILE".bak
-  sed "s/Environment=/Environment=SNAPD_MIN_DOWNLOAD_SPEED=${SNAPD_MIN_DOWNLOAD_SPEED} SNAPD_DOWNLOAD_MEAS_WINDOW=${SNAPD_DOWNLOAD_MEAS_WINDOW} /" -i "$OVERRIDES_FILE"
+  cp /etc/systemd/system/snapd.service.d/00-prepare.conf "$CONF_OVERRIDE"
+  sed "s/Environment=/Environment=SNAPD_MIN_DOWNLOAD_SPEED=${SNAPD_MIN_DOWNLOAD_SPEED} SNAPD_DOWNLOAD_MEAS_WINDOW=${SNAPD_DOWNLOAD_MEAS_WINDOW} /" -i "$CONF_OVERRIDE"
 
   systemctl daemon-reload
   systemctl restart snapd.{socket,service}
@@ -40,7 +40,7 @@ restore: |
   fi
   tc qdisc del dev ens4 ingress
 
-  mv "$OVERRIDES_FILE".bak "$OVERRIDES_FILE"
+  rm -f "$CONF_OVERRIDE"
   systemctl daemon-reload
   systemctl restart snapd.{socket,service}
 

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -26,6 +26,7 @@ environment:
     CHANNEL/edge: 1.25-strict/edge
     # apparmor profile of microk8s can make snapd exceed its spread memory limit
     SNAPD_NO_MEMORY_LIMIT: 1
+    CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
 
 prepare: |
     # ensure curl is available (needed for Ubuntu Core)
@@ -38,9 +39,9 @@ prepare: |
     # The default timeout for the configure hook is 5min - however in the
     # testsuite this is lowered to 30 seconds. We need to undo this for the
     # microk8s spread test because it really take a bit to get configured.
-    cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
-    sed 's/SNAPD_CONFIGURE_HOOK_TIMEOUT=.*s/SNAPD_CONFIGURE_HOOK_TIMEOUT=180s/g' -i /etc/systemd/system/snapd.service.d/local.conf
-    tests.cleanup defer mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
+    cp /etc/systemd/system/snapd.service.d/00-prepare.conf "$CONF_OVERRIDE"
+    sed 's/SNAPD_CONFIGURE_HOOK_TIMEOUT=.*s/SNAPD_CONFIGURE_HOOK_TIMEOUT=180s/g' -i "$CONF_OVERRIDE"
+    tests.cleanup defer rm "$CONF_OVERRIDE"
     systemctl daemon-reload
     tests.cleanup defer systemctl daemon-reload
     systemctl restart snapd.socket

--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -25,7 +25,7 @@ prepare: |
     "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
     # undo the setup through envvars
     systemctl stop snapd.service snapd.socket
-    rm /etc/systemd/system/snapd.service.d/store.conf
+    rm /etc/systemd/system/snapd.service.d/35-store.conf
     systemctl daemon-reload
     systemctl start snapd.socket
 

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -20,16 +20,15 @@ systems:
     - ubuntu-2*
     - ubuntu-core-16*
 
+environment:
+    CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
+
 prepare: |
     if ! os.query is-core16 && [ -e /usr/lib/command-not-found ]; then
         mv /usr/lib/command-not-found /usr/lib/command-not-found.orig
     fi
-    if [ -e /etc/systemd/system/snapd.service.d/local.conf ]; then
-        cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
-    fi
-    mkdir -p /etc/systemd/system/snapd.service.d
     # enable catalog refresh requests
-    cat <<EOF >> /etc/systemd/system/snapd.service.d/local.conf
+    cat <<EOF >> "$CONF_OVERRIDE"
     # added by snap-advise-command test
     [Service]
     Environment=SNAPD_CATALOG_REFRESH=1
@@ -41,9 +40,7 @@ restore: |
     if [ -e /usr/lib/command-not-found.orig ]; then
         mv /usr/lib/command-not-found.orig /usr/lib/command-not-found
     fi
-    if [ -e /etc/systemd/system/snapd.service.d/local.conf.bak ]; then
-        mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
-    fi
+    rm "$CONF_OVERRIDE"
     systemctl daemon-reload
     systemctl restart snapd.socket
 

--- a/tests/main/snapd-slow-startup/task.yaml
+++ b/tests/main/snapd-slow-startup/task.yaml
@@ -10,10 +10,14 @@ details: |
 
 systems: [ubuntu-18.04-64]
 
+environment:
+    CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
+
 restore: |
     # extra cleanup in case something in this test went wrong
-    rm -f /etc/systemd/system/snapd.service.d/slow-startup.conf
-    systemctl stop snapd.service snapd.socket
+    rm -f "$CONF_OVERRIDE"
+    systemctl daemon-reload
+    systemctl restart snapd.socket
 
 debug: |
     ls /etc/systemd/system/snapd.service.d
@@ -35,7 +39,7 @@ execute: |
 
     echo "Simulate a slow startup"
     systemctl stop snapd.service snapd.socket
-    cat > /etc/systemd/system/snapd.service.d/slow-startup.conf <<EOF
+    cat > "$CONF_OVERRIDE" <<EOF
     [Service]
     Environment=SNAPD_SLOW_STARTUP=55s
     Restart=no

--- a/tests/nightly/install-snaps/task.yaml
+++ b/tests/nightly/install-snaps/task.yaml
@@ -66,10 +66,11 @@ environment:
     SNAP/snapcraft: snapcraft
     SNAP/solc: solc
     SNAP/vault: vault
+    CONF_OVERRIDE: /etc/systemd/system/snapd.service.d/90-$(basename $SPREAD_TASK).conf
 
 prepare: |
-    cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
-    sed 's/SNAPD_CONFIGURE_HOOK_TIMEOUT=.*s/SNAPD_CONFIGURE_HOOK_TIMEOUT=180s/g' -i /etc/systemd/system/snapd.service.d/local.conf
+    cp /etc/systemd/system/snapd.service.d/00-prepare.conf "$CONF_OVERRIDE"
+    sed 's/SNAPD_CONFIGURE_HOOK_TIMEOUT=.*s/SNAPD_CONFIGURE_HOOK_TIMEOUT=180s/g' -i "$CONF_OVERRIDE"
     systemctl daemon-reload
     systemctl restart snapd.socket
 
@@ -79,7 +80,7 @@ prepare: |
     fi
 
 restore: |
-    mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
+    rm "$CONF_OVERRIDE"
     systemctl daemon-reload
     systemctl restart snapd.socket
 


### PR DESCRIPTION
[5e4242c](https://github.com/snapcore/snapd/pull/13985/commits/5e4242c8f1ebe306639d0a74c227221278b08a69) changes our configuration files to use a numbered prefix. This stems from https://github.com/snapcore/snapd/pull/13967 which had a config override that was not being applied due to the file being sorted before the local.conf. This commit changes files created by the test harness to be formatted as 0X-<name>.conf while test-specific overrides have higher numbers and are also named after the test (so we can find the culprit easily if an override is not removed). [054cfe3](https://github.com/snapcore/snapd/pull/13985/commits/054cfe38c823c1a073fe67b688500ab155cfd7ea) adds an invariant check that fails if configuration overrides are left by tests