### PR TITLE
seedwriter: check if the optionSnap channel is same as model assert

### DIFF
--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -427,8 +427,25 @@ func (w *Writer) SetOptionsSnaps(optSnaps []*OptionsSnap) error {
 			if err != nil {
 				return fmt.Errorf("cannot use option channel for snap %q: %v", whichSnap, err)
 			}
-			if err := w.policy.checkSnapChannel(ch, whichSnap); err != nil {
+
+			// Check whether the channel defined in the model assertion
+			// is same as the option snap(--snap=SNAP_NAME=CHANNEL)
+			modSnaps, err := w.modSnaps()
+			if err != nil {
 				return err
+			}
+			for _, modSnap := range modSnaps {
+				if sn.Name != modSnap.Name {
+					continue
+				}
+
+				if modSnap.Presence == "optional" && sn.Channel == modSnap.DefaultChannel {
+					continue
+				} else {
+					if err := w.policy.checkSnapChannel(ch, whichSnap); err != nil {
+						return err
+					}
+				}
 			}
 		}
 		if local {


### PR DESCRIPTION

If we define `presence: optional` for an app snap in model assertion, and the default channel is `24/stable` for example, then when we pass `--snap=SNAP=24/stable` to `snap prepare-image` with a model assertion that has model grade higher than dangerous, I will get an error `error: cannot override channels, add devmode snaps, local snaps, or extra snaps with a model of grade higher than dangerous`

However, I am expecting that snapd should check whether the channel for option snap is same as the channel defined in model assertion, maybe snapd should only return error if channel is not the same and the model grade is higher than dangerous

