### PR TITLE
i/builtin: make locale-control interface implicit on Core Desktop

### DIFF
--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+import "github.com/snapcore/snapd/release"
+
 const localeControlSummary = `allows control over system locale`
 
 const localeControlBaseDeclarationSlots = `
@@ -70,6 +72,7 @@ func init() {
 		name:                  "locale-control",
 		summary:               localeControlSummary,
 		implicitOnClassic:     true,
+		implicitOnCore:        release.OnCoreDesktop,
 		baseDeclarationSlots:  localeControlBaseDeclarationSlots,
 		connectedPlugAppArmor: localeControlConnectedPlugAppArmor,
 	})


### PR DESCRIPTION
In Core Desktop, like in Classic, locale-control is required to be implicit. This complements the already merged PR https://github.com/snapcore/snapd/pull/13027

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
