### PR TITLE
interfaces/desktop: Improve launch entry and systray integration with session

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -174,6 +174,63 @@ dbus (send)
 # Allow access to the ICC profiles in the home directory to
 # be referred to from colord
 owner @{HOME}/.local/share/icc r,
+
+
+# Allow to send updates to the desktop session about ongoing jobs
+# (for progress display in the task list)
+dbus (send)
+    bus=session
+    interface=com.canonical.Unity.LauncherEntry
+    member=Update
+    peer=(label=###SLOT_SECURITY_TAGS###),
+
+# Allow to send updates to the desktop session about ongoing jobs
+# (for KDE Plasma specific details)
+dbus (send)
+    bus=session
+    interface=org.kde.JobViewServer{,V2}
+    path=/JobViewServer
+    member=requestView
+    peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (send)
+    bus=session
+    interface=org.kde.JobView{,V2,V3}
+    path=/org/kde/notificationmanager/jobs/*
+    member={update,terminate}
+    peer=(label=###SLOT_SECURITY_TAGS###),
+
+# Allow to display Status Notifier Items in the KDE Plasma systray
+# (including supporting context menu)
+dbus (send)
+    bus=session
+    interface=org.kde.StatusNotifierWatcher
+    path=/StatusNotifierWatcher
+    member=RegisterStatusNotifierItem
+    peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/StatusNotifierWatcher
+    member=Get
+    peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (receive)
+    bus=session
+    interface=org.kde.StatusNotifierItem
+    path=/StatusNotifierItem
+    member={ProvideXdgActivationToken,Activate}
+    peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (receive)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/StatusNotifierItem
+    member=GetAll
+    peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (receive)
+    bus=session
+    interface=com.canonical.dbusmenu
+    path=/MenuBar
+    member={AboutToShow,GetLayout,Event}
+    peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
 const desktopConnectedPlugAppArmorClassic = `
@@ -391,6 +448,64 @@ dbus (send, receive)
       path=/{,org/freedesktop/portal/}inputcontext/**
       interface=org.fcitx.Fcitx.InputContext1
       peer=(label=unconfined),
+`
+
+const desktopConnectedSlotAppArmor = `
+# Allow to receive updates from applications to the desktop session about ongoing jobs
+# (for progress display in the task list)
+dbus (receive)
+    bus=session
+    interface=com.canonical.Unity.LauncherEntry
+    member=Update
+    peer=(label=###PLUG_SECURITY_TAGS###),
+
+# Allow to receive updates from applications to the desktop session about ongoing jobs
+# (for KDE Plasma specific details)
+dbus (receive)
+    bus=session
+    interface=org.kde.JobViewServer{,V2}
+    path=/JobViewServer
+    member=requestView
+    peer=(label=###PLUG_SECURITY_TAGS###),
+dbus (receive)
+    bus=session
+    interface=org.kde.JobView{,V2,V3}
+    path=/org/kde/notificationmanager/jobs/*
+    member={update,terminate}
+    peer=(label=###PLUG_SECURITY_TAGS###),
+
+# Allow to display Status Notifier Items in the KDE Plasma systray
+# (including supporting context menu)
+dbus (receive)
+    bus=session
+    interface=org.kde.StatusNotifierWatcher
+    path=/StatusNotifierWatcher
+    member=RegisterStatusNotifierItem
+    peer=(label=###PLUG_SECURITY_TAGS###),
+dbus (receive)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/StatusNotifierWatcher
+    member=Get
+    peer=(label=###PLUG_SECURITY_TAGS###),
+dbus (send)
+    bus=session
+    interface=org.kde.StatusNotifierItem
+    path=/StatusNotifierItem
+    member={ProvideXdgActivationToken,Activate}
+    peer=(label=###PLUG_SECURITY_TAGS###),
+dbus (send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/StatusNotifierItem
+    member=GetAll
+    peer=(label=###PLUG_SECURITY_TAGS###),
+dbus (send)
+    bus=session
+    interface=com.canonical.dbusmenu
+    path=/MenuBar
+    member={AboutToShow,GetLayout,Event}
+    peer=(label=###PLUG_SECURITY_TAGS###),
 `
 
 const desktopPermanentSlotAppArmor = `
@@ -632,6 +747,17 @@ func (iface *desktopInterface) MountConnectedPlug(spec *mount.Specification, plu
 func (iface *desktopInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 	if !implicitSystemPermanentSlot(slot) {
 		spec.AddSnippet(desktopPermanentSlotAppArmor)
+	}
+	return nil
+}
+
+func (iface *desktopInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Only apply slot snippet when running as application snap
+	// on classic, slot side can be system or application
+	if !implicitSystemConnectedSlot(slot) {
+		old := "###PLUG_SECURITY_TAGS###"
+		new := plug.LabelExpression()
+		spec.AddSnippet(strings.Replace(desktopConnectedSlotAppArmor, old, new, -1))
 	}
 	return nil
 }


### PR DESCRIPTION
This allows applications to notify the session about job progression and implement the status notifier item protocol.
