### PR TITLE
release: 2.61.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,6 +92,7 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
+      GITHUB_PROJECT_URL: ${{ github.server_url }}/${{ github.repository }}
       GITHUB_PULL_REQUEST: ${{ github.event.number }}
 
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
 name: Tests
 on:
   pull_request:
-    branches: [ "master", "release/**" ]
+    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
   push:
     # we trigger runs on master branch, but we do not run spread on master 
     # branch, the master branch runs are just for unit tests + codecov.io
-    branches: [ "master","release/**" ]
+    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -599,9 +599,9 @@ jobs:
           fi
 
     - name: Run spread tests
-      # run if the commit is pushed to the release/* branch or there is a 'Run
-      # nested' label set on the PR
-      if: "contains(github.event.pull_request.labels.*.name, 'Run nested') || contains(github.event.pull_request.labels.*.name, 'Run nested -auto-') || contains(github.ref, 'refs/heads/release/')"
+      # run if there is a 'Run nested' label set on the PR or the commit is pushed to one of the recognised release branches
+      # "release/**", "core-snap-security-release/**" or "security-release/**"
+      if: "contains(github.event.pull_request.labels.*.name, 'Run nested') || contains(github.ref, 'refs/heads/release/') || contains(github.ref, 'refs/heads/core-snap-security-release/') || contains(github.ref, 'refs/heads/security-release/')"
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,8 +92,7 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PROJECT_URL: ${{ github.server_url }}/${{ github.repository }}
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
+      GITHUB_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
 
     strategy:
       # we cache successful runs so it's fine to keep going
@@ -200,7 +199,6 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
     strategy:
       # we cache successful runs so it's fine to keep going
       fail-fast: false      
@@ -327,7 +325,6 @@ jobs:
       # version of go.
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
     steps:
     - name: Download the coverage files
       uses: actions/download-artifact@v3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# New in snapd 2.61.4:
+* Fix not checking file type when extracting a snap
+* Fix not checking destination of symbolic link when extracting a snap
+* Fix unexpected mount points in /var/lib/snapd/hostfs on the initial mount namespace
+* home interface: deny creation of $HOME/bin
+
 # New in snapd 2.61.3:
 * Install systemd files in correct location for 24.04
 

--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -2,9 +2,6 @@
 
 import argparse
 import re
-import urllib.request
-
-from html.parser import HTMLParser
 
 
 class InvalidPRTitle(Exception):
@@ -12,62 +9,25 @@ class InvalidPRTitle(Exception):
         self.invalid_title = invalid_title
 
 
-class GithubTitleParser(HTMLParser):
-    def __init__(self):
-        HTMLParser.__init__(self)
-        self._cur_tag = ""
-        self.title = ""
-
-    def handle_starttag(self, tag, attributes):
-        self._cur_tag = tag
-
-    def handle_endtag(self, tag):
-        self._cur_tag = ""
-
-    def handle_data(self, data):
-        if self._cur_tag == "title":
-            self.title = data
-
-
-def check_pr_title(project_url: str, pr_number: int):
-    # ideally we would use the github API - however we can't because:
-    # a) its rate limiting and travis IPs hit the API a lot so we regularly
-    #    get errors
-    # b) using a API token is tricky because travis will not allow the secure
-    #    vars for forks
-    # so instead we just scrape the html title which is unlikely to change
-    # radically
-    parser = GithubTitleParser()
-    with urllib.request.urlopen(
-        "{}/pull/{}".format(project_url, pr_number)
-    ) as f:
-        parser.feed(f.read().decode("utf-8"))
-    # the title has the format:
-    #  "Added api endpoint for downloading snaps by glower · Pull Request #6958 · snapcore/snapd · GitHub"
-    # so we rsplit() once to get the title (rsplit to not get confused by
-    # possible "by" words in the real title)
-    title = parser.title.rsplit(" by ", maxsplit=1)[0]
-    print(title)
+def check_pr_title(pr_title: str):
+    print(pr_title)
     # cover most common cases:
     # package: foo
     # package, otherpackage/subpackage: this is a title
     # tests/regression/lp-12341234: foo
     # [RFC] foo: bar
-    if not re.match(r"[a-zA-Z0-9_\-\*/,. \[\]{}]+: .*", title):
-        raise InvalidPRTitle(title)
+    if not re.match(r"[a-zA-Z0-9_\-\*/,. \[\](){}]+: .*", pr_title):
+        raise InvalidPRTitle(pr_title)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "project_url", metavar="Project url", help="the github project url to check"
-    )
-    parser.add_argument(
-        "pr_number", metavar="PR number", help="the github PR number to check"
+        "pr_title", metavar="PR title", help="the github title to check"
     )
     args = parser.parse_args()
     try:
-        check_pr_title(args.project_url, args.pr_number)
+        check_pr_title(args.pr_title)
     except InvalidPRTitle as e:
         print('Invalid PR title: "{}"\n'.format(e.invalid_title))
         print("Please provide a title in the following format:")

--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -29,7 +29,7 @@ class GithubTitleParser(HTMLParser):
             self.title = data
 
 
-def check_pr_title(pr_number: int):
+def check_pr_title(project_url: str, pr_number: int):
     # ideally we would use the github API - however we can't because:
     # a) its rate limiting and travis IPs hit the API a lot so we regularly
     #    get errors
@@ -39,7 +39,7 @@ def check_pr_title(pr_number: int):
     # radically
     parser = GithubTitleParser()
     with urllib.request.urlopen(
-        "https://github.com/snapcore/snapd/pull/{}".format(pr_number)
+        "{}/pull/{}".format(project_url, pr_number)
     ) as f:
         parser.feed(f.read().decode("utf-8"))
     # the title has the format:
@@ -60,11 +60,14 @@ def check_pr_title(pr_number: int):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "project_url", metavar="Project url", help="the github project url to check"
+    )
+    parser.add_argument(
         "pr_number", metavar="PR number", help="the github PR number to check"
     )
     args = parser.parse_args()
     try:
-        check_pr_title(args.pr_number)
+        check_pr_title(args.project_url, args.pr_number)
     except InvalidPRTitle as e:
         print('Invalid PR title: "{}"\n'.format(e.invalid_title))
         print("Please provide a title in the following format:")

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -919,7 +919,8 @@ static struct sc_mount *sc_homedir_mounts(const struct sc_invocation *inv)
 	for (int i = 0; i < inv->num_homedirs; i++) {
 		debug("Adding homedir: %s", inv->homedirs[i]);
 		mounts[i].path = sc_strdup(inv->homedirs[i]);
-		mounts[i].is_bidirectional = true;
+		// Note that we are not setting bidirectional flag, so anything mounted
+		// here will not propagate to the host.
 	}
 	return mounts;
 }

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1034,24 +1034,7 @@ echo "stdout output 2"
 	s.ResetStdStreams()
 	sudoCmd.ForgetCalls()
 
-	// try again without filtering
-	rest, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--strace=--raw", "--", "snapname.app", "--arg1", "arg2"})
-	c.Assert(err, check.IsNil)
-	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
-	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
-		{
-			"sudo", "-E",
-			filepath.Join(straceCmd.BinDir(), "strace"),
-			"-u", user.Username,
-			"-f",
-			"-e", strace.ExcludedSyscalls,
-			filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
-			"snap.snapname.app",
-			filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
-			"snapname.app", "--arg1", "arg2",
-		},
-	})
-	c.Check(s.Stdout(), check.Equals, "stdout output 1\nstdout output 2\n")
+	// unfiltered output cases
 	expectedFullFmt := `execve("/path/to/snap-confine")
 snap-confine/snap-exec strace stuff
 getuid() = 1000
@@ -1098,7 +1081,6 @@ and more
 		c.Check(s.Stdout(), check.Equals, "stdout output 1\nstdout output 2\n")
 		c.Check(s.Stderr(), check.Equals, expectedFull)
 	}
-	c.Check(s.Stderr(), check.Equals, fmt.Sprintf(expectedFullFmt, dirs.SnapMountDir))
 }
 
 func (s *RunSuite) TestSnapRunAppWithStraceOptions(c *check.C) {

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -79,6 +79,7 @@ owner /run/user/[0-9]*/gvfs/*/**  w,
 # Disallow writes to the well-known directory included in
 # the user's PATH on several distributions
 audit deny @{HOME}/bin/{,**} wl,
+audit deny @{HOME}/bin wl,
 `
 
 const homeConnectedPlugAppArmorWithAllRead = `

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -146,6 +146,7 @@ func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithoutAttrib(c *C) {
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `owner @{HOME}/ r,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `audit deny @{HOME}/bin/{,**} wl,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `audit deny @{HOME}/bin wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), Not(testutil.Contains), `# Allow non-owner read`)
 }
 
@@ -168,6 +169,7 @@ apps:
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.home-plug-snap.app2"})
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `audit deny @{HOME}/bin/{,**} wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `owner @{HOME}/ r,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `audit deny @{HOME}/bin wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `# Allow non-owner read`)
 }
 

--- a/osutil/strace/strace.go
+++ b/osutil/strace/strace.go
@@ -50,8 +50,8 @@ var ExcludedSyscalls = getExcludedSyscalls()
 
 func findStrace(u *user.User) (stracePath string, userOpts []string, err error) {
 	if path := filepath.Join(dirs.SnapMountDir, "strace-static", "current", "bin", "strace"); osutil.FileExists(path) {
-		// strace-static cannot resolve usernames, pass uid/gid instead
-		return path, []string{"--uid", u.Uid, "--gid", u.Gid}, nil
+		// Strace v6.9 supports -u UID:GID which avoids the need to resolve usernames with nss.
+		return path, []string{"-u", fmt.Sprintf("%s:%s", u.Uid, u.Gid)}, nil
 	}
 
 	stracePath, err = exec.LookPath("strace")

--- a/osutil/strace/strace.go
+++ b/osutil/strace/strace.go
@@ -74,16 +74,13 @@ func Command(extraStraceOpts []string, traceeCmd ...string) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("cannot use strace without sudo: %s", err)
 	}
 
-	// Try strace from the snap first, we use new syscalls like
-	// "_newselect" that are known to not work with the strace of e.g.
-	// ubuntu 14.04.
+	// Try strace from the snap first, we use new syscalls like "_newselect"
+	// that are known to not work with the strace of e.g. Ubuntu 14.04.
 	//
-	// TODO: some architectures do not have some syscalls (e.g.
-	// s390x does not have _newselect). In
-	// https://github.com/strace/strace/issues/57 options are
-	// discussed.  We could use "-e trace=?syscall" but that is
-	// only available since strace 4.17 which is not even in
-	// ubutnu 17.10.
+	// TODO: some architectures do not have some syscalls (e.g. s390x does not
+	// have _newselect). In https://github.com/strace/strace/issues/57 options
+	// are discussed. We could use "-e trace=?syscall" but that is only
+	// available since strace 4.17 which is not even in Ubuntu 17.10.
 	stracePath, userOpts, err := findStrace(current)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find an installed strace, please try 'snap install strace-static'")

--- a/osutil/strace/strace_test.go
+++ b/osutil/strace/strace_test.go
@@ -89,7 +89,7 @@ func (s *straceSuite) TestStraceCommandHappyFromSnap(c *C) {
 	c.Check(cmd.Args, DeepEquals, []string{
 		s.mockSudo.Exe(), "-E",
 		mockStraceStatic.Exe(),
-		"--uid", u.Uid, "--gid", u.Gid,
+		"-u", u.Uid + ":" + u.Gid,
 		"-f",
 		"-e", strace.ExcludedSyscalls,
 		// the command

--- a/osutil/strace/strace_test.go
+++ b/osutil/strace/strace_test.go
@@ -73,6 +73,30 @@ func (s *straceSuite) TestStraceCommandHappy(c *C) {
 	})
 }
 
+func (s *straceSuite) TestStraceCommandHappyFromSnap(c *C) {
+	u, err := user.Current()
+	c.Assert(err, IsNil)
+
+	straceStaticPath := filepath.Join(dirs.SnapMountDir, "strace-static", "current", "bin", "strace")
+	err = os.MkdirAll(filepath.Dir(straceStaticPath), 0755)
+	c.Assert(err, IsNil)
+	mockStraceStatic := testutil.MockCommand(c, straceStaticPath, "")
+	defer mockStraceStatic.Restore()
+
+	cmd, err := strace.Command(nil, "foo")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Path, Equals, s.mockSudo.Exe())
+	c.Check(cmd.Args, DeepEquals, []string{
+		s.mockSudo.Exe(), "-E",
+		mockStraceStatic.Exe(),
+		"--uid", u.Uid, "--gid", u.Gid,
+		"-f",
+		"-e", strace.ExcludedSyscalls,
+		// the command
+		"foo",
+	})
+}
+
 func (s *straceSuite) TestStraceCommandNoSudo(c *C) {
 	origPath := os.Getenv("PATH")
 	defer func() { os.Setenv("PATH", origPath) }()

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.61.3
+pkgver=2.61.4
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,15 @@
+snapd (2.61.4-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2024007
+    - Fix not checking file type when extracting a snap
+    - Fix not checking destination of symbolic link when extracting a
+      snap
+    - Fix unexpected mount points in /var/lib/snapd/hostfs on the
+      initial mount namespace
+    - home interface: deny creation of $HOME/bin
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 05 Jun 2024 00:58:39 +0200
+
 snapd (2.61.3-1) unstable; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -102,7 +102,7 @@
 %endif
 
 Name:           snapd
-Version:        2.61.3
+Version:        2.61.4
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -991,6 +991,15 @@ fi
 
 
 %changelog
+* Wed Jun 05 2024 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.61.4
+ - Fix not checking file type when extracting a snap
+ - Fix not checking destination of symbolic link when extracting a
+   snap
+ - Fix unexpected mount points in /var/lib/snapd/hostfs on the
+   initial mount namespace
+ - home interface: deny creation of $HOME/bin
+
 * Wed Mar 06 2024 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.61.3
  - Install systemd files in correct location for 24.04

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 04 22:58:39 UTC 2024 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.61.4
+
+-------------------------------------------------------------------
 Wed Mar 06 21:18:11 UTC 2024 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.61.3

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.61.3
+Version:        2.61.4
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,15 @@
+snapd (2.61.4~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2024007
+    - Fix not checking file type when extracting a snap
+    - Fix not checking destination of symbolic link when extracting a
+      snap
+    - Fix unexpected mount points in /var/lib/snapd/hostfs on the
+      initial mount namespace
+    - home interface: deny creation of $HOME/bin
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 05 Jun 2024 00:58:39 +0200
+
 snapd (2.61.3~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,15 @@
+snapd (2.61.4) xenial; urgency=medium
+
+  * New upstream release, LP: #2024007
+    - Fix not checking file type when extracting a snap
+    - Fix not checking destination of symbolic link when extracting a
+      snap
+    - Fix unexpected mount points in /var/lib/snapd/hostfs on the
+      initial mount namespace
+    - home interface: deny creation of $HOME/bin
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 05 Jun 2024 00:58:39 +0200
+
 snapd (2.61.3) xenial; urgency=medium
 
   * New upstream release, LP: #2039017

--- a/run-checks
+++ b/run-checks
@@ -146,9 +146,11 @@ if [ "$STATIC" = 1 ]; then
 
     # XXX: remove once we can use an action, see workflows/test.yaml for
     #      details why we still use this script
-    if [ -n "${GITHUB_PULL_REQUEST:-}" ] && [ "${GITHUB_PULL_REQUEST:-}" != "false" ]; then
+    if [ -n "${GITHUB_PULL_REQUEST_TITLE:-}" ]; then
         echo Checking pull request summary
-        ./check-pr-title.py "${GITHUB_PROJECT_URL:-https://github.com/snapcore/snapd}" "$GITHUB_PULL_REQUEST"
+        ./check-pr-title.py "${GITHUB_PULL_REQUEST_TITLE}"
+    else
+	echo Skipping pull request summary check: not a pull request
     fi
 
     # check commit author/committer name for unicode

--- a/run-checks
+++ b/run-checks
@@ -148,7 +148,7 @@ if [ "$STATIC" = 1 ]; then
     #      details why we still use this script
     if [ -n "${GITHUB_PULL_REQUEST:-}" ] && [ "${GITHUB_PULL_REQUEST:-}" != "false" ]; then
         echo Checking pull request summary
-        ./check-pr-title.py "$GITHUB_PULL_REQUEST"
+        ./check-pr-title.py "${GITHUB_PROJECT_URL:-https://github.com/snapcore/snapd}" "$GITHUB_PULL_REQUEST"
     fi
 
     # check commit author/committer name for unicode

--- a/snap/container.go
+++ b/snap/container.go
@@ -21,6 +21,7 @@ package snap
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -43,6 +44,12 @@ type Container interface {
 
 	// ReadFile returns the content of a single file from the snap.
 	ReadFile(relative string) ([]byte, error)
+
+	// ReadLink returns the destination of the named symbolic link.
+	ReadLink(relative string) (string, error)
+
+	// Lstat is like os.Lstat.
+	Lstat(relative string) (os.FileInfo, error)
 
 	// Walk is like filepath.Walk, without the ordering guarantee.
 	Walk(relative string, walkFn filepath.WalkFunc) error
@@ -77,6 +84,142 @@ var (
 	// ErrMissingPaths is returned by ValidateContainer when the container is missing required files or directories
 	ErrMissingPaths = errors.New("snap is unusable due to missing files")
 )
+
+type symlinkInfo struct {
+	// target is the furthest target we could evaluate.
+	target string
+	// targetMode is the mode of the final symlink target.
+	targetMode os.FileMode
+	// naiveTarget is the first symlink target.
+	naiveTarget string
+	// isExternal determines if the symlink is considered external
+	// relative to its container.
+	isExternal bool
+}
+
+// evalSymlink follows symlinks inside given container and returns
+// information about it's target.
+//
+// The symlink is followed inside the container until we cannot
+// continue further either due to absolute symlinks or symlinks
+// that escape the container.
+//
+//       max depth reached?<------
+//               /\               \
+//            yes  no              \
+//            /      \              \
+//           V        V              \
+//        error      path             \
+//                    │                \
+//                    V                 \
+//                read target            \
+//                    │                   \
+//                    V                    \
+//               is absolute?               \
+//                   /\                      \
+//                yes  no                     \
+//                /      \                     \
+//               V        V                     \
+//       isExternal     eval relative target     \
+//           +               \                    \
+//     return target          V                    \
+//                     escapes container?           \
+//                           /\                      \
+//                        yes  no                     \
+//                       /      \                      |
+//                      V        V                     |
+//              isExternal      is symlink?            |
+//                   +                /\               |
+//             return target       yes  no             │
+//                                /      \             │
+//                               V        V            │
+//                       !isExternal    path = target  │
+//                            +             \----------│
+//                      return target
+//
+func evalSymlink(c Container, path string) (symlinkInfo, error) {
+	var naiveTarget string
+
+	const maxDepth = 10
+	currentDepth := 0
+	for currentDepth < maxDepth {
+		currentDepth++
+		target, err := c.ReadLink(path)
+		if err != nil {
+			return symlinkInfo{}, err
+		}
+		// record first symlink target
+		if currentDepth == 1 {
+			naiveTarget = target
+		}
+
+		target = filepath.Clean(target)
+		// don't follow absolute targets
+		if filepath.IsAbs(target) {
+			return symlinkInfo{target, os.FileMode(0), naiveTarget, true}, nil
+		}
+
+		// evaluate target relative to symlink directory
+		target = filepath.Join(filepath.Dir(path), target)
+
+		// target escapes container, cannot evaluate further, let's return
+		if strings.Split(target, string(os.PathSeparator))[0] == ".." {
+			return symlinkInfo{target, os.FileMode(0), naiveTarget, true}, nil
+		}
+
+		info, err := c.Lstat(target)
+		// cannot follow bad targets
+		if err != nil {
+			return symlinkInfo{}, err
+		}
+
+		// non-symlink, let's return
+		if info.Mode().Type() != os.ModeSymlink {
+			return symlinkInfo{target, info.Mode(), naiveTarget, false}, nil
+		}
+
+		// we have another symlink
+		path = target
+	}
+
+	return symlinkInfo{}, fmt.Errorf("too many levels of symbolic links")
+}
+
+func shouldValidateSymlink(path string) bool {
+	// we only check meta directory for now
+	pathTokens := strings.Split(path, string(os.PathSeparator))
+	if pathTokens[0] == "meta" {
+		return true
+	}
+	return false
+}
+
+func evalAndValidateSymlink(c Container, path string) (symlinkInfo, error) {
+	pathTokens := strings.Split(path, string(os.PathSeparator))
+	// check if meta directory is a symlink
+	if len(pathTokens) == 1 && pathTokens[0] == "meta" {
+		return symlinkInfo{}, fmt.Errorf("meta directory cannot be a symlink")
+	}
+
+	info, err := evalSymlink(c, path)
+	if err != nil {
+		return symlinkInfo{}, err
+	}
+
+	if info.isExternal {
+		return symlinkInfo{}, fmt.Errorf("external symlink found: %s -> %s", path, info.naiveTarget)
+	}
+
+	// symlinks like this don't look innocent
+	badTargets := []string{".", "meta"}
+	for _, badTarget := range badTargets {
+		if info.target == badTarget {
+			return symlinkInfo{}, fmt.Errorf("bad symlink found: %s -> %s", path, info.naiveTarget)
+		}
+	}
+
+	return info, nil
+}
 
 // ValidateContainer does a minimal quick check on the container.
 func ValidateContainer(c Container, s *Info, logf func(format string, v ...interface{})) error {
@@ -172,20 +315,33 @@ func ValidateContainer(c Container, s *Info, logf func(format string, v ...inter
 			return nil
 		}
 
-		if needsrx[path] || mode.IsDir() {
+		// check symlinks for bad behavior
+		if mode&os.ModeSymlink != 0 && shouldValidateSymlink(path) {
+			symlinkInfo, err := evalAndValidateSymlink(c, path)
+			if err != nil {
+				logf("%s", err)
+				hasBadModes = true
+			} else {
+				// use target mode for checks below
+				mode = symlinkInfo.targetMode
+			}
+		}
+
+		if mode.IsDir() {
 			if mode.Perm()&0555 != 0555 {
 				logf("in snap %q: %q should be world-readable and executable, and isn't: %s", s.InstanceName(), path, mode)
 				hasBadModes = true
 			}
 		} else {
-			if needsf[path] {
-				// this assumes that if it's a symlink it's OK. Arguably we
-				// should instead follow the symlink.  We'd have to expose
-				// Lstat(), and guard against loops, and ...  huge can of
-				// worms, and as this validator is meant as a developer aid
-				// more than anything else, not worth it IMHO (as I can't
-				// imagine this happening by accident).
-				if mode&(os.ModeDir|os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
+			if needsrx[path] {
+				if mode.Perm()&0555 != 0555 {
+					logf("in snap %q: %q should be world-readable and executable, and isn't: %s", s.InstanceName(), path, mode)
+					hasBadModes = true
+				}
+			}
+			// XXX: do we need to match other directories?
+			if needsf[path] || strings.HasPrefix(path, "meta/") {
+				if mode&(os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
 					logf("in snap %q: %q should be a regular file (or a symlink) and isn't", s.InstanceName(), path)
 					hasBadModes = true
 				}

--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -19,16 +19,24 @@
 
 package snap
 
+import "os"
+
 var (
 	ValidateSocketName           = validateSocketName
 	ValidateDescription          = validateDescription
 	ValidateTitle                = validateTitle
 	InfoFromSnapYamlWithSideInfo = infoFromSnapYamlWithSideInfo
 	GetAttribute                 = getAttribute
+	EvalAndValidateSymlink       = evalAndValidateSymlink
+	ShouldValidateSymlink        = shouldValidateSymlink
 )
 
 func (info *Info) ForceRenamePlug(oldName, newName string) {
 	info.forceRenamePlug(oldName, newName)
+}
+
+func (symlinkInfo *symlinkInfo) Mode() os.FileMode {
+	return symlinkInfo.targetMode
 }
 
 func NewScopedTracker() *scopedTracker {

--- a/snap/snapdir/snapdir.go
+++ b/snap/snapdir/snapdir.go
@@ -88,9 +88,18 @@ func (s *SnapDir) ReadFile(file string) (content []byte, err error) {
 	return ioutil.ReadFile(filepath.Join(s.path, file))
 }
 
+func (s *SnapDir) ReadLink(file string) (string, error) {
+	return os.Readlink(filepath.Join(s.path, file))
+}
+
+func (s *SnapDir) Lstat(file string) (os.FileInfo, error) {
+	return os.Lstat(filepath.Join(s.path, file))
+}
+
 func littleWalk(dirPath string, dirHandle *os.File, dirstack *[]string, walkFn filepath.WalkFunc) error {
 	const numSt = 100
 
+	// XXX: check if os.ReadDir is more efficient
 	sts, err := dirHandle.Readdir(numSt)
 	if err != nil {
 		return err

--- a/spread.yaml
+++ b/spread.yaml
@@ -52,7 +52,7 @@ environment:
     # Channel for kernel cannot be edge as that one is not signed with Canonical keys
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-beta}")'
     GADGET_CHANNEL: '$(HOST: echo "${SPREAD_GADGET_CHANNEL:-beta}")'
-    SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
+    SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-stable}")'
     REMOTE_STORE: '$(HOST: echo "${SPREAD_REMOTE_STORE:-production}")'
     SNAPPY_USE_STAGING_STORE: '$(HOST: if [ "$SPREAD_REMOTE_STORE" = staging ]; then echo 1; else echo 0; fi)'
     DELTA_REF: 2.52

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -59,7 +59,16 @@ execute: |
 
         echo "Verify that a random signal does not trigger the failure handling"
         echo "and snapd is just restarted"
-        systemctl kill --signal=SIGKILL snapd.service
+
+        if os.query is-core-le 22; then
+            systemctl kill --signal=SIGKILL snapd.service
+        else
+            # Work around systemctl kill issue, where it may fail when the cgroup
+            # is recycled after the main process is killed. This seems to be a bug
+            # in systemd made more common by faster cgroup recycling by the kernel.
+            # shellcheck disable=SC2046
+            kill -9 $(cat /sys/fs/cgroup/system.slice/snapd.service/cgroup.procs)
+        fi
 
         started_after_rand_sig="$("$TESTSTOOLS"/journal-state get-log -u snapd.failure | grep -c 'Started Failure handling of the snapd snap.' || true)"
 

--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -171,7 +171,7 @@ repack_snapd_deb_into_snap() {
 }
 
 # This function will re-pack the current core snap as the snapd snap,
-# using the snapd snap from edge as the set of files to use from the core snap.
+# using the snapd snap from stable as the set of files to use from the core snap.
 # This is primarily meant to be used in UC16 tests that need to use the snapd
 # snap because neither the snapd snap, nor the snapd deb built for the spread
 # run are seeded on the image
@@ -184,7 +184,7 @@ repack_core_snap_into_snapd_snap() {
 
     # get the snap.yaml and a list of all the snapd snap files using edge
     # NOTE: this may break if a spread run adds files to the snapd snap that
-    # don't exist in the snapd snap on edge and those files are necessary
+    # don't exist in the snapd snap on stable and those files are necessary
     # for snapd to run or revert, etc.
     local core_snap current
     if [ $# -eq 0 ]; then
@@ -198,7 +198,7 @@ repack_core_snap_into_snapd_snap() {
         fi
     fi
 
-    snap download snapd --basename=snapd-upstream --edge
+    snap download snapd --basename=snapd-upstream --stable
     unsquashfs -d ./snapd-upstream snapd-upstream.snap
     rm snapd-upstream.snap
     (

--- a/tests/main/bad-meta-file-types/task.yaml
+++ b/tests/main/bad-meta-file-types/task.yaml
@@ -1,0 +1,72 @@
+summary: Check that bad file types under meta directory are detected
+
+details: |
+  Check that a malicious snap that has non-regular (e.g. pipe/symlink)
+  files disguised under meta directory are detected and cause "snap pack"
+  and "snap install" to fail.
+
+execute: |
+    # pipe desktop files
+    mkdir -p test-bad-file-types/meta/gui/
+    mkfifo test-bad-file-types/meta/gui/test-bad-file-types.desktop
+    # snap pack should fail
+    echo "Packing snap with pipe disguised as a desktop file should fail"
+    not snap pack test-bad-file-types > pack.out 2>&1
+    MATCH "\"meta/gui/test-bad-file-types.desktop\" should be a regular file \(or a symlink\) and isn't" < pack.out
+    # snap install should also fail
+    echo "Installing snap with pipe disguised as a desktop file should fail"
+    mksquashfs test-bad-file-types test-bad-file-types.snap
+    not snap install --dangerous test-bad-file-types.snap
+    journalctl -u snapd | MATCH "\"meta/gui/test-bad-file-types.desktop\" should be a regular file \(or a symlink\) and isn't"
+    # clean up
+    rm test-bad-file-types.snap
+    rm test-bad-file-types/meta/gui/test-bad-file-types.desktop
+
+    # symlink desktop files
+    ln -s /etc/shadow test-bad-file-types/meta/gui/test-bad-file-types.desktop
+    # snap pack should fail
+    echo "Packing snap with symlink disguised as a desktop file should fail"
+    not snap pack test-bad-file-types > pack.out 2>&1
+    MATCH "external symlink found: meta/gui/test-bad-file-types.desktop -> /etc/shadow" < pack.out
+    # snap install should also fail
+    echo "Installing snap with symlink disguised as a desktop file should fail"
+    mksquashfs test-bad-file-types test-bad-file-types.snap
+    not snap install --dangerous test-bad-file-types.snap
+    journalctl -u snapd | MATCH "external symlink found: meta/gui/test-bad-file-types.desktop -> /etc/shadow"
+    # clean up
+    rm test-bad-file-types.snap
+    rm test-bad-file-types/meta/gui/test-bad-file-types.desktop
+
+    # pipe icon files
+    mkdir -p test-bad-file-types/meta/gui/icons
+    mkfifo test-bad-file-types/meta/gui/icons/snap.test-bad-file-types.png
+    # snap pack should fail
+    echo "Packing snap with pipe disguised as an icon file should fail"
+    not snap pack test-bad-file-types > pack.out 2>&1
+    MATCH "\"meta/gui/icons/snap.test-bad-file-types.png\" should be a regular file \(or a symlink\) and isn't" < pack.out
+    # snap install should also fail
+    echo "Installing snap with pipe disguised as an icon file should fail"
+    mksquashfs test-bad-file-types test-bad-file-types.snap
+    not snap install --dangerous test-bad-file-types.snap
+    journalctl -u snapd | MATCH "\"meta/gui/icons/snap.test-bad-file-types.png\" should be a regular file \(or a symlink\) and isn't"
+    # clean up
+    rm test-bad-file-types.snap
+    rm test-bad-file-types/meta/gui/icons/snap.test-bad-file-types.png
+
+    # symlink icon files
+    mkdir -p test-bad-file-types/meta/gui/icons
+    ln -s /etc/shadow test-bad-file-types/meta/gui/icons/snap.test-bad-file-types.png
+    # snap pack should fail
+    echo "Packing snap with symlink disguised as an icon file should fail"
+    not snap pack test-bad-file-types > pack.out 2>&1
+    MATCH "external symlink found: meta/gui/icons/snap.test-bad-file-types.png -> /etc/shadow" < pack.out
+    # snap install should also fail
+    echo "Installing snap with symlink disguised as an icon file should fail"
+    mksquashfs test-bad-file-types test-bad-file-types.snap
+    not snap install --dangerous test-bad-file-types.snap
+    journalctl -u snapd | MATCH "external symlink found: meta/gui/icons/snap.test-bad-file-types.png -> /etc/shadow"
+    # clean up
+    rm test-bad-file-types.snap
+    rm test-bad-file-types/meta/gui/icons/snap.test-bad-file-types.png
+
+    # TODO: Test other files that can be placed under meta directory like polkit policies and udev files

--- a/tests/main/bad-meta-file-types/test-bad-file-types/meta/snap.yaml
+++ b/tests/main/bad-meta-file-types/test-bad-file-types/meta/snap.yaml
@@ -1,0 +1,4 @@
+name: test-bad-file-types
+base: none
+version: 1.0
+summary: A bad test snap that has non-regular files disguised under meta directory

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -48,11 +48,7 @@ execute: |
         echo "snap run with an invalid strace option should fail but it did not"
         exit 1
     fi
-    if os.query is-arch-linux || os.query is-opensuse tumbleweed || os.query is-fedora; then
-        MATCH "Cannot find executable 'invalid'" < stderr
-    else
-        MATCH "Can't stat 'invalid': No such file or directory" < stderr
-    fi
+    MATCH "Cannot find executable 'invalid'" < stderr || MATCH "Can't stat 'invalid': No such file or directory" < stderr
 
     if os.query is-arch-linux || os.query is-opensuse tumbleweed; then
         # Arch linux and Opensuse tumbleweed run the mainline kernel, strace

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -6,7 +6,7 @@ systems:
   - -*-s390x
 
 environment:
-    STRACE_STATIC_CHANNEL: edge
+    STRACE_STATIC_CHANNEL: candidate
   
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local basic-run

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -4,11 +4,9 @@ systems:
   # strace does not support _newselect on s390x
   # (https://github.com/strace/strace/issues/57)
   - -*-s390x
-  # TODO: segfault on core22
-  - -ubuntu-core-22-*
 
 environment:
-    STRACE_STATIC_CHANNEL: beta
+    STRACE_STATIC_CHANNEL: edge
   
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local basic-run

--- a/tests/regression/exploding-namespace/task.yaml
+++ b/tests/regression/exploding-namespace/task.yaml
@@ -1,0 +1,21 @@
+summary: Ensure that namespaces do not leak through homedirs
+
+details: |
+    Ensure that layouts on /var/lib/subdir coupled with homedirs=/var/lib
+    do not cause hostfs to leak to the initial mount namespace.
+
+systems:
+    - -ubuntu-core-*
+
+prepare: |
+    snap set system homedirs=/var/lib
+    # This snap has a layout for /var/lib/demo, which is relevant here.
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-layout
+
+restore: |
+    snap unset system homedirs
+
+execute: |
+    NOMATCH hostfs </proc/self/mountinfo
+    test-snapd-layout.sh -c "true"
+    NOMATCH hostfs </proc/self/mountinfo


### PR DESCRIPTION
Making private snapd release 2.61.4 public.
Refer to [counterpart private PR](https://github.com/snapcore/snapd-security-release/pull/3).

Important:
- Merge commit only to retain commit history
- Push tag from counterpart private PR after merge
