### PR TITLE
tests: drop uses of test-snapd-curl where possible, replace with snap debug api

### DIFF
--- a/tests/core/snapd-maintenance-msg/task.yaml
+++ b/tests/core/snapd-maintenance-msg/task.yaml
@@ -7,8 +7,6 @@ details: |
 systems: [ubuntu-core-20-64]
 
 prepare: |
-    # devmode as the snap does not have snapd-control
-    snap install test-snapd-curl --devmode --edge
     snap install jq
 
     # make sure that the snapd daemon gives us time for comms before
@@ -17,7 +15,7 @@ prepare: |
     systemctl restart snapd
 
 restore: |
-    snap remove test-snapd-curl jq
+    snap remove jq
 
     # remove SNAPD_SHUTDOWN_DELAY from /etc/environment again
     #shellcheck disable=SC2005
@@ -33,7 +31,7 @@ execute: |
         # closed so we need to catch it in that timeframe.
         echo "Testing maintenance message for daemon restarts"
         snap install --dangerous "$SNAPD_SNAP" &
-        retry -n 20 --wait 0.5 sh -c 'test-snapd-curl.curl -sS --unix-socket /run/snapd.socket http://localhost/v2/changes?select=all | jq ".maintenance" | MATCH "daemon is restarting"'
+        retry -n 20 --wait 0.5 sh -c 'snap debug api "/v2/changes?select=all" | jq ".maintenance" | MATCH "daemon is restarting"'
         wait
 
         echo "Restoring the snapd snap"
@@ -41,7 +39,7 @@ execute: |
 
         echo "Testing maintenance message for system reboots"
         snap refresh core20 --channel=stable --amend &
-        retry -n 20 --wait 0.5 sh -c 'test-snapd-curl.curl -sS --unix-socket /run/snapd.socket http://localhost/v2/changes?select=all | jq ".maintenance" | MATCH "system is restarting"'
+        retry -n 20 --wait 0.5 sh -c 'snap debug api "/v2/changes?select=all" | jq ".maintenance" | MATCH "system is restarting"'
         wait
 
         REBOOT

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -35,16 +35,14 @@ execute: |
         echo "In run mode"
 
         snap install --edge jq
-        # devmode as the snap does not have snapd-control
-        snap install test-snapd-curl --devmode --edge
 
         MATCH 'snapd_recovery_mode=run' < /proc/cmdline
         # verify we are in run mode via the API
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        snap debug api /v2/system-info > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
         echo "Obtain available systems"
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
+        snap debug api /v2/systems > systems.json
         # TODO:UC20: there is only one system for now
         jq .result.systems[0].current < systems.json | MATCH 'true'
         label="$(jq -r .result.systems[0].label < systems.json)"
@@ -67,7 +65,7 @@ execute: |
         # host data should be accessible
         test -e /host/ubuntu-data/systems.json.run
 
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
+        snap debug api /v2/systems > systems.json
         jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install run'
 
         label="$(cat /host/ubuntu-data/systems.label)"
@@ -80,7 +78,7 @@ execute: |
         transition_to_run_mode "$label"
     elif [ "$SPREAD_REBOOT" == "2" ]; then
         echo "In run mode again"
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        snap debug api /v2/system-info > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
         # now go back to recover mode so we can test that a simple reboot 
@@ -108,6 +106,6 @@ execute: |
         REBOOT
     elif [ "$SPREAD_REBOOT" == "4" ]; then
         echo "In run mode again again"
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        snap debug api /v2/system-info > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'run'
     fi

--- a/tests/lib/uc20-recovery.sh
+++ b/tests/lib/uc20-recovery.sh
@@ -130,10 +130,9 @@ prepare_recover_mode() {
 
     # we're running in an ephemeral system and thus have to re-install snaps
     snap install --edge jq
-    snap install test-snapd-curl --devmode --edge
 
     MATCH 'snapd_recovery_mode=recover' < /proc/cmdline
     # verify we are in recovery mode via the API
-    test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+    snap debug api /v2/system-info > system-info
     jq -r '.result["system-mode"]' < system-info | MATCH 'recover'
 }

--- a/tests/main/api-get-systems-label/task.yaml
+++ b/tests/main/api-get-systems-label/task.yaml
@@ -9,15 +9,13 @@ systems:
 
 execute: |
   snap install --edge jq
-  # devmode as the snap does not have snapd-control
-  snap install test-snapd-curl --devmode --edge
 
   echo "Find what systems are available"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems
+  snap debug api /v2/systems > systems
   current_label=$(jq -r '.result.systems[0]["label"]' < systems)
 
   echo "Get details for a specific system"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$current_label" > current-system
+  snap debug api "/v2/systems/$current_label" > current-system
   echo "Ensure the result contains a model assertion"
   jq -r '.result.model.type' < current-system | MATCH model
   jq -r '.result.model.series' < current-system | MATCH 16

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -15,10 +15,6 @@ systems:
 
 prepare: |
     snap install jq
-    if ! command -v curl; then
-        snap install --devmode --edge test-snapd-curl
-        snap alias test-snapd-curl.curl curl
-    fi
 
 restore: |
     echo "Restore: Reset start limit so that other queries can succeed"
@@ -43,7 +39,7 @@ debug: |
     retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
 
     echo "Debug: Report system info"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq
+    snap debug api /v2/system-info | jq
 
 execute: |
     . /etc/os-release
@@ -84,9 +80,9 @@ execute: |
         echo "Check that snap CLI reports prompting flag set correctly"
         snap get system experimental.apparmor-prompting | MATCH "$1"
         echo "Check that /v2/snaps/system/conf reports prompting flag set correctly"
-        curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
+        snap debug api /v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
         echo "Check that /v2/system-info reports prompting correctly"
-        curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
+        snap debug api /v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
     }
 
     echo "Precondition check that snapd is active"
@@ -115,16 +111,16 @@ execute: |
     check_prompting_setting "false"
 
     echo "Enable prompting via API request"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": true}' | jq -r '.status' | MATCH "Accepted" || reset_start_limit
+    echo '{"experimental.apparmor-prompting": true}' | snap debug api /v2/snaps/system/conf -X PUT | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
-    echo "Check that snapd restarted after prompting set to true via curl"
+    echo "Check that snapd restarted after prompting set to true via API"
     check_snapd_restarted
     check_prompting_setting "true"
 
     echo "Disable prompting via API request"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": false}' | jq -r '.status' | MATCH "Accepted" || reset_start_limit
+    echo '{"experimental.apparmor-prompting": false}' | snap debug api /v2/snaps/system/conf -X PUT | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
-    echo "Check that snapd restarted after prompting set to false via curl"
+    echo "Check that snapd restarted after prompting set to false via API"
     check_snapd_restarted
     check_prompting_setting "false"
 

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -19,7 +19,6 @@ systems:
 
 prepare: |
   snap install go-example-webserver jq remarshal hello-world
-  snap install test-snapd-curl --edge --devmode
 
 execute: |
   echo "Create a group with a snap in it"
@@ -81,7 +80,7 @@ execute: |
       exit 1
   fi
 
-  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-one | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-one | jq -r '.result.current.memory')"
   kernelSaysMemUsage="$(cat "$cgroupMemFile")"
 
   pyCmd="import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))"
@@ -176,7 +175,7 @@ execute: |
   # in reporting it's memory usage on old systemd versions
   snap set-quota group-five --memory=10MB --parent=group-four hello-world
 
-  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-five | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-five | jq -r '.result.current.memory')"
   # both 0 and up to 12KiB values are expected here, 0 is for older systemd/kernels 
   # where an empty cgroup has exactly 0, but on newer systems there is some 
   # minimum amount of accounting memory for an empty cgroup, which is observed
@@ -190,7 +189,7 @@ execute: |
           exit 1
   esac
 
-  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-four | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-four | jq -r '.result.current.memory')"
   case "$snapdSaysMemUsage" in
       null|0|4096|8192|12288)
           # expected

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -16,7 +16,6 @@ systems:
 
 prepare: |
   snap install test-snapd-stressd --edge --devmode
-  snap install test-snapd-curl --edge --devmode
 
 restore: |
   echo "Stop the service"

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -7,16 +7,6 @@ details: |
 prepare: |
     snap pack "$TESTSLIB"/snaps/snapctl-hooks
     snap install --dangerous snapctl-hooks_1.0_all.snap
-    # ensure curl is available (needed for e.g. core18)
-    if ! command -v curl; then
-        snap install --devmode --edge test-snapd-curl
-        snap alias test-snapd-curl.curl curl
-    fi
-
-restore: |
-    if snap list test-snapd-curl; then
-        snap remove --purge test-snapd-curl
-    fi
 
 execute: |
     echo "Verify that snapctl -h runs without a context"
@@ -47,7 +37,7 @@ execute: |
     echo "Verify that the snapd API is only available via the snapd socket"
     if ! printf 'GET /v2/snaps HTTP/1.0\r\n\r\n' | nc -U -w 1 /run/snapd.socket | grep '200 OK'; then
         echo "Expected snapd API to be available on the snapd socket"
-        echo "Got: $(curl -s --unix-socket /run/snapd.socket http:/v2/snaps)"
+        echo "Got: $(snap debug api /v2/snaps)"
         exit 1
     fi
 

--- a/tests/nested/core/core20-basic/task.yaml
+++ b/tests/nested/core/core20-basic/task.yaml
@@ -69,8 +69,7 @@ execute: |
     fi
 
     # the remove API isn't exposed by snap recovery yet
-    remote.exec "sudo snap install --devmode --edge test-snapd-curl"
-    remote.exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
+    remote.exec "echo '{\"action\":\"remove\"}' | sudo snap debug api -X POST /v2/system-recovery-keys"
 
     # keys were removed
     remote.exec "test ! -f /var/lib/snapd/device/fde/recovery.key"

--- a/tests/nested/core/core20-create-recovery/task.yaml
+++ b/tests/nested/core/core20-create-recovery/task.yaml
@@ -6,14 +6,11 @@ details: |
 
 systems: [ubuntu-2*]
 
-prepare: |
-    remote.exec sudo snap install test-snapd-curl --edge --devmode
-
 execute: |
     echo "Create a recovery system with a typical recovery system label"
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | \
-        remote.exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+        remote.exec sudo snap debug api -X POST /v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     remote.wait-for reboot "${boot_id}"
     remote.exec sudo snap watch "${REMOTE_CHG_ID}"
@@ -29,7 +26,7 @@ execute: |
     echo "Create a recovery system with an alternative recovery system label"
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | \
-        remote.exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+        remote.exec sudo snap debug api -X POST /v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     remote.wait-for reboot "${boot_id}"
     remote.exec sudo snap watch "${REMOTE_CHG_ID}"

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -29,8 +29,7 @@ execute: |
     remote.exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
 
     echo "verify that recovery key can be removed"
-    remote.exec "sudo snap install --devmode --edge test-snapd-curl"
-    remote.exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
+    remote.exec "echo '{\"action\":\"remove\"}' | sudo snap debug api -X POST /v2/system-recovery-keys"
     echo "and the key is no longer available"
     remote.exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
 

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -28,7 +28,6 @@ prepare: |
       exit
   fi
   echo "Install used snaps"
-  snap install test-snapd-curl --devmode --edge
   snap install jq --devmode --edge
   if [ -d /var/lib/snapd/seed ]; then
       mv /var/lib/snapd/seed /var/lib/snapd/seed.orig
@@ -110,8 +109,8 @@ execute: |
   cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
   # do some light checking that the system is valid
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$LABEL" > system
+  snap debug api /v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
+  snap debug api "/v2/systems/$LABEL" > system
   jq '.result.model.distribution' system | MATCH "ubuntu"
 
   # build muinstaller and put in place

--- a/tests/nested/manual/recovery-system-offline/task.yaml
+++ b/tests/nested/manual/recovery-system-offline/task.yaml
@@ -34,7 +34,7 @@ execute: |
     shift 2
 
     # shellcheck disable=SC2059
-    printf "${template}" "$@" | remote.exec "sudo test-snapd-curl.curl -X POST -H 'Content-Type: application/json' --unix-socket /run/snapd.socket -d @- http://localhost${route}" | jq .
+    printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}" | jq .
   }
 
   #shellcheck source=tests/lib/core-config.sh

--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -36,7 +36,7 @@ execute: |
     shift 2
 
     # shellcheck disable=SC2059
-    response=$(printf "${template}" "$@" | remote.exec "sudo test-snapd-curl.curl -X POST -H 'Content-Type: application/json' --unix-socket /run/snapd.socket -d @- http://localhost${route}")
+    response=$(printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}")
     if ! jq -e .change <<< "${response}"; then
       echo "could not get change id from response: ${response}"
       false
@@ -47,8 +47,6 @@ execute: |
   . "$TESTSLIB"/core-config.sh
 
   wait_for_first_boot_change
-
-  remote.exec sudo snap install --edge --devmode test-snapd-curl
 
   boot_id="$(tests.nested boot-id)"
 
@@ -105,8 +103,6 @@ execute: |
 
     # new system should be the default recovery system and the current system
     remote.exec 'sudo snap recovery' | awk '$1 == "new-system" { print $4 }' | MATCH 'current,default-recovery'
-
-    remote.exec sudo snap install --edge --devmode test-snapd-curl
 
     # since out new system is now the default and the current recovery system,
     # we should be able to remove the old one

--- a/tests/nested/manual/recovery-system/task.yaml
+++ b/tests/nested/manual/recovery-system/task.yaml
@@ -37,7 +37,7 @@ execute: |
     shift 2
 
     # shellcheck disable=SC2059
-    response=$(printf "${template}" "$@" | remote.exec "sudo test-snapd-curl.curl -X POST -H 'Content-Type: application/json' --unix-socket /run/snapd.socket -d @- http://localhost${route}")
+    response=$(printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}")
     if ! jq -e .change <<< "${response}"; then
       echo "could not get change id from response: ${response}"
       false
@@ -48,8 +48,6 @@ execute: |
   . "$TESTSLIB"/core-config.sh
 
   wait_for_first_boot_change
-
-  remote.exec sudo snap install --edge --devmode test-snapd-curl
 
   boot_id="$(tests.nested boot-id)"
 

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -25,7 +25,6 @@ prepare: |
       exit
   fi
   echo "Install used snaps"
-  snap install test-snapd-curl --devmode --edge
   snap install jq --devmode --edge
   if [ -d /var/lib/snapd/seed ]; then
     mv /var/lib/snapd/seed /var/lib/snapd/seed.orig
@@ -101,8 +100,8 @@ execute: |
   cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
   # do some light checking that the system is valid
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$LABEL" > system
+  snap debug api /v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
+  snap debug api "/v2/systems/$LABEL" > system
   jq '.result.model.distribution' system | MATCH "ubuntu"
   # build muinstaller and put in place
   go build -o muinstaller "$TESTSLIB"/muinstaller/main.go


### PR DESCRIPTION
This builds on top of #14116 which add `snap debug api`. I've updated the tests to not use `test-snapd-curl` where possible. We still use `jq` quite a bit, and given the prettified output of `snap debug api`, perhaps there's a way to skip that too.