### PR TITLE
i/b/desktop: add support for kdeglobals

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -170,6 +170,9 @@ owner @{HOME}/.config/gtk-3.0/*.css r,
 # Note: this leaks directory names that wouldn't otherwise be known to the snap
 owner @{HOME}/.config/gtk-3.0/bookmarks r,
 
+# kde theming support
+owner @{HOME}/.config/kdeglobals r,
+
 /usr/share/icons/                          r,
 /usr/share/icons/**                        r,
 /usr/share/icons/*/index.theme             rk,


### PR DESCRIPTION
According to this [forum post](https://forum.snapcraft.io/t/kde-all-applications-personal-files-request/40885/9) by @ScarlettGatelyMoore, kde apps need to read the `.config/kdeglobals` file to properly select the correct theme. This PR fixes this for classic systems.


Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
