### PR TITLE
interfaces/builtin: allow desktop-launch on Core

### DIFF
--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -90,6 +90,7 @@ func (iface *desktopLaunchInterface) Name() string {
 func (iface *desktopLaunchInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              desktopLaunchSummary,
+		ImplicitOnCore:       true,
 		ImplicitOnClassic:    true,
 		BaseDeclarationPlugs: desktopLaunchBaseDeclarationPlugs,
 		BaseDeclarationSlots: desktopLaunchBaseDeclarationSlots,
@@ -112,7 +113,8 @@ func (iface *desktopLaunchInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo)
 	return true
 }
 
-// Only implicitOnClassic since userd isn't yet usable on core
+// Available on both Core and Classic to allow access to app metadata,
+// despite userd being unusable on Core
 func init() {
 	registerIface(&desktopLaunchInterface{})
 }

--- a/interfaces/builtin/desktop_launch_test.go
+++ b/interfaces/builtin/desktop_launch_test.go
@@ -92,7 +92,7 @@ func (s *desktopLaunchSuite) TestInterfaces(c *C) {
 
 func (s *desktopLaunchSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnCore, Equals, true)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows snaps to identify and launch desktop applications in (or from) other snaps`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "desktop-launch")


### PR DESCRIPTION
Despite userd being unusable on Core, access to app metadata is still desirable.