### PR TITLE
i/p/requestprompts,s/a/n/listener: include explicit permissions in replies

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -34,6 +34,10 @@ var (
 	ErrUnrecognizedFilePermission = errors.New("file permissions mask contains unrecognized permission")
 )
 
+// Constraints hold information about the applicability of a rule to particular
+// paths or permissions. A request matches the constraints if the requested path
+// is matched by the path pattern (according to bash's globstar matching) and
+// the requested permissions are contained in the constraints' permissions.
 type Constraints struct {
 	PathPattern *patterns.PathPattern `json:"path-pattern,omitempty"`
 	Permissions []string              `json:"permissions,omitempty"`
@@ -156,7 +160,7 @@ func AvailablePermissions(iface string) ([]string, error) {
 
 // AbstractPermissionsFromAppArmorPermissions returns the list of permissions
 // corresponding to the given AppArmor permissions for the given interface.
-func AbstractPermissionsFromAppArmorPermissions(iface string, permissions interface{}) ([]string, error) {
+func AbstractPermissionsFromAppArmorPermissions(iface string, permissions any) ([]string, error) {
 	filePerms, ok := permissions.(notify.FilePermission)
 	if !ok {
 		return nil, fmt.Errorf("cannot parse the given permissions as file permissions: %v", permissions)
@@ -201,7 +205,7 @@ func AbstractPermissionsFromAppArmorPermissions(iface string, permissions interf
 
 // AbstractPermissionsToAppArmorPermissions returns AppArmor permissions
 // corresponding to the given permissions for the given interface.
-func AbstractPermissionsToAppArmorPermissions(iface string, permissions []string) (interface{}, error) {
+func AbstractPermissionsToAppArmorPermissions(iface string, permissions []string) (any, error) {
 	if len(permissions) == 0 {
 		return notify.FilePermission(0), ErrPermissionsListEmpty
 	}

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -320,12 +320,12 @@ func (s *constraintsSuite) TestConstraintsContainPermissions(c *C) {
 	}
 }
 
-func constructPermissionsMaps() []map[string]map[string]interface{} {
-	var permissionsMaps []map[string]map[string]interface{}
+func constructPermissionsMaps() []map[string]map[string]any {
+	var permissionsMaps []map[string]map[string]any
 	// interfaceFilePermissionsMaps
-	filePermissionsMaps := make(map[string]map[string]interface{})
+	filePermissionsMaps := make(map[string]map[string]any)
 	for iface, permsMap := range prompting.InterfaceFilePermissionsMaps {
-		filePermissionsMaps[iface] = make(map[string]interface{}, len(permsMap))
+		filePermissionsMaps[iface] = make(map[string]any, len(permsMap))
 		for perm, val := range permsMap {
 			filePermissionsMaps[iface][perm] = val
 		}
@@ -396,7 +396,7 @@ func (s *constraintsSuite) TestAvailablePermissions(c *C) {
 func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsHappy(c *C) {
 	cases := []struct {
 		iface string
-		perms interface{}
+		perms any
 		list  []string
 	}{
 		{
@@ -440,7 +440,7 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsHappy(c
 func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy(c *C) {
 	cases := []struct {
 		iface  string
-		perms  interface{}
+		perms  any
 		errStr string
 	}{
 		{
@@ -480,7 +480,7 @@ func (s *constraintsSuite) TestAbstractPermissionsToAppArmorPermissionsHappy(c *
 	cases := []struct {
 		iface string
 		list  []string
-		perms interface{}
+		perms any
 	}{
 		{
 			"home",

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -20,6 +20,8 @@
 package requestprompts
 
 import (
+	"time"
+
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
@@ -31,6 +33,31 @@ func MockSendReply(f func(listenerReq *listener.Request, reply *listener.Respons
 	restore = testutil.Backup(&sendReply)
 	sendReply = f
 	return restore
+}
+
+func (pc *promptConstraints) Path() string {
+	return pc.path
+}
+
+func (pc *promptConstraints) RemainingPermissions() []string {
+	return pc.remainingPermissions
+}
+
+func NewPrompt(id prompting.IDType, timestamp time.Time, snap string, iface string, path string, remainingPermissions []string, availablePermissions []string, originalPermissions []string) *Prompt {
+	constraints := &promptConstraints{
+		path:                 path,
+		remainingPermissions: remainingPermissions,
+		availablePermissions: availablePermissions,
+		originalPermissions:  originalPermissions,
+	}
+	return &Prompt{
+		ID:           id,
+		Timestamp:    timestamp,
+		Snap:         snap,
+		Interface:    iface,
+		Constraints:  constraints,
+		listenerReqs: nil,
+	}
 }
 
 func (pdb *PromptDB) PerUser() map[uint32]*userPromptDB {

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -27,7 +27,7 @@ import (
 
 const MaxOutstandingPromptsPerUser = maxOutstandingPromptsPerUser
 
-func MockSendReply(f func(listenerReq *listener.Request, reply interface{}) error) (restore func()) {
+func MockSendReply(f func(listenerReq *listener.Request, reply *listener.Response) error) (restore func()) {
 	restore = testutil.Backup(&sendReply)
 	sendReply = f
 	return restore

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -20,6 +20,7 @@
 package requestprompts
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -51,29 +52,65 @@ type Prompt struct {
 	Timestamp    time.Time          `json:"timestamp"`
 	Snap         string             `json:"snap"`
 	Interface    string             `json:"interface"`
-	Constraints  *PromptConstraints `json:"constraints"`
+	Constraints  *promptConstraints `json:"constraints"`
 	listenerReqs []*listener.Request
 }
 
-// PromptConstraints are like prompting.Constraints, but have a "path" field
+// promptConstraintsJSON are like prompting.Constraints, but have a "path" field
 // instead of a "path-pattern", and include the available permissions for the
-// interface corresponding to the prompt.
-type PromptConstraints struct {
-	Path                 string   `json:"path"`
-	Permissions          []string `json:"permissions"`
+// interface corresponding to the prompt, so that the client has the ability to
+// reply with a broader list of permissions than was originally requested.
+type promptConstraintsJSON struct {
+	// Path is the path to which the application is requesting access.
+	Path string `json:"path"`
+	// Permissions are the remaining unsatisfied permissions for which the
+	// application is requesting access.
+	Permissions []string `json:"permissions"`
+	// AvailablePermissions are the permissions which are supported by the
+	// interface associated with the prompt to which the constraints apply.
 	AvailablePermissions []string `json:"available-permissions"`
-	// Preserve originally-requested permissions. A prompt's permissions may be
-	// partially satisfied over time as new rules are added, but we need to
-	// keep track of the originally-requested permissions so that we can still
-	// send back a response to the kernel with all of the permissions which
-	// were included in the request from the kernel (aside from any which we
-	// didn't recognize).
+}
+
+// promptConstraints store the path which was requested, along with three
+// lists of permissions: the original permissions associated with the request,
+// the remaining unsatisfied permissions (as rules may satisfy some of the
+// permissions from a prompt before the prompt is fully resolved), and the
+// available permissions for the interface associated with the prompt, so that
+// the client may reply with a broader set of permissions than was originally
+// requested.
+type promptConstraints struct {
+	// path is the path to which the application is requesting access.
+	path string
+	// remainingPermissions are the remaining unsatisfied permissions for which
+	// the application is requesting access.
+	remainingPermissions []string
+	// availablePermissions are the permissions which are supported by the
+	// interface associated with the prompt to which the constraints apply.
+	availablePermissions []string
+	// originalPermissions preserve the permissions corresponding to the
+	// original request. A prompt's permissions may be partially satisfied over
+	// time as new rules are added, but we need to keep track of the originally
+	// requested permissions so that we can still send back a response to the
+	// kernel with all of the permissions which were included in the request
+	// from the kernel (aside from any which we didn't recognize).
 	originalPermissions []string
 }
 
-// equals returns true if the two prompt constraints are identical.
-func (pc *PromptConstraints) equals(other *PromptConstraints) bool {
-	if pc.Path != other.Path || len(pc.originalPermissions) != len(other.originalPermissions) {
+func (pc *promptConstraints) MarshalJSON() ([]byte, error) {
+	externalPromptConstraints := &promptConstraintsJSON{
+		Path:                 pc.path,
+		Permissions:          pc.remainingPermissions,
+		AvailablePermissions: pc.availablePermissions,
+	}
+	return json.Marshal(externalPromptConstraints)
+}
+
+// equals returns true if the two prompt constraints apply to the same path and
+// were created with the same originally requested permissions. That implies
+// that the request which triggered the creation of the two prompts were
+// duplicates, the application attempting to do the same action multiple times.
+func (pc *promptConstraints) equals(other *promptConstraints) bool {
+	if pc.path != other.path || len(pc.originalPermissions) != len(other.originalPermissions) {
 		return false
 	}
 	// Avoid using reflect.DeepEquals to compare []string contents
@@ -87,15 +124,15 @@ func (pc *PromptConstraints) equals(other *PromptConstraints) bool {
 
 // subtractPermissions removes all of the given permissions from the list of
 // permissions in the constraints.
-func (pc *PromptConstraints) subtractPermissions(permissions []string) (modified bool) {
-	newPermissions := make([]string, 0, len(pc.Permissions))
-	for _, perm := range pc.Permissions {
+func (pc *promptConstraints) subtractPermissions(permissions []string) (modified bool) {
+	newPermissions := make([]string, 0, len(pc.remainingPermissions))
+	for _, perm := range pc.remainingPermissions {
 		if !strutil.ListContains(permissions, perm) {
 			newPermissions = append(newPermissions, perm)
 		}
 	}
-	if len(newPermissions) != len(pc.Permissions) {
-		pc.Permissions = newPermissions
+	if len(newPermissions) != len(pc.remainingPermissions) {
+		pc.remainingPermissions = newPermissions
 		return true
 	}
 	return false
@@ -288,10 +325,10 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, permi
 		userEntry = pdb.perUser[metadata.User]
 	}
 
-	constraints := &PromptConstraints{
-		Path:                 path,
-		Permissions:          permissions,
-		AvailablePermissions: availablePermissions,
+	constraints := &promptConstraints{
+		path:                 path,
+		remainingPermissions: permissions,
+		availablePermissions: availablePermissions,
 		originalPermissions:  permissions,
 	}
 
@@ -331,7 +368,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, permi
 	return prompt, false, nil
 }
 
-func responseForInterfaceConstraintsOutcome(iface string, constraints *PromptConstraints, outcome prompting.OutcomeType) *listener.Response {
+func responseForInterfaceConstraintsOutcome(iface string, constraints *promptConstraints, outcome prompting.OutcomeType) *listener.Response {
 	allow, err := outcome.AsBool()
 	if err != nil {
 		// This should not occur, but if so, default to deny
@@ -466,7 +503,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 		if !(prompt.Snap == metadata.Snap && prompt.Interface == metadata.Interface) {
 			continue
 		}
-		matched, err := constraints.Match(prompt.Constraints.Path)
+		matched, err := constraints.Match(prompt.Constraints.path)
 		if err != nil {
 			return nil, err
 		}
@@ -478,7 +515,7 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 			continue
 		}
 		id := prompt.ID
-		if len(prompt.Constraints.Permissions) > 0 && allow == true {
+		if len(prompt.Constraints.remainingPermissions) > 0 && allow == true {
 			pdb.notifyPrompt(metadata.User, id, nil)
 			continue
 		}

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -62,9 +62,12 @@ type PromptConstraints struct {
 	Path                 string   `json:"path"`
 	Permissions          []string `json:"permissions"`
 	AvailablePermissions []string `json:"available-permissions"`
-	// Preserve originally-requested permissions so we can send a response with
-	// explicitly-allowed/denied permissions, even if some permissions were
-	// previously satisfied.
+	// Preserve originally-requested permissions. A prompt's permissions may be
+	// partially satisfied over time as new rules are added, but we need to
+	// keep track of the originally-requested permissions so that we can still
+	// send back a response to the kernel with all of the permissions which
+	// were included in the request from the kernel (aside from any which we
+	// didn't recognize).
 	originalPermissions []string
 }
 

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -20,7 +20,6 @@
 package requestprompts
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -48,27 +47,12 @@ var (
 // Prompt contains information about a request for which a user should be
 // prompted.
 type Prompt struct {
-	ID           prompting.IDType   `json:"id"`
-	Timestamp    time.Time          `json:"timestamp"`
-	Snap         string             `json:"snap"`
-	Interface    string             `json:"interface"`
-	Constraints  *promptConstraints `json:"constraints"`
+	ID           prompting.IDType
+	Timestamp    time.Time
+	Snap         string
+	Interface    string
+	Constraints  *promptConstraints
 	listenerReqs []*listener.Request
-}
-
-// promptConstraintsJSON are like prompting.Constraints, but have a "path" field
-// instead of a "path-pattern", and include the available permissions for the
-// interface corresponding to the prompt, so that the client has the ability to
-// reply with a broader list of permissions than was originally requested.
-type promptConstraintsJSON struct {
-	// Path is the path to which the application is requesting access.
-	Path string `json:"path"`
-	// Permissions are the remaining unsatisfied permissions for which the
-	// application is requesting access.
-	Permissions []string `json:"permissions"`
-	// AvailablePermissions are the permissions which are supported by the
-	// interface associated with the prompt to which the constraints apply.
-	AvailablePermissions []string `json:"available-permissions"`
 }
 
 // promptConstraints store the path which was requested, along with three
@@ -94,15 +78,6 @@ type promptConstraints struct {
 	// kernel with all of the permissions which were included in the request
 	// from the kernel (aside from any which we didn't recognize).
 	originalPermissions []string
-}
-
-func (pc *promptConstraints) MarshalJSON() ([]byte, error) {
-	externalPromptConstraints := &promptConstraintsJSON{
-		Path:                 pc.path,
-		Permissions:          pc.remainingPermissions,
-		AvailablePermissions: pc.availablePermissions,
-	}
-	return json.Marshal(externalPromptConstraints)
 }
 
 // equals returns true if the two prompt constraints apply to the same path and

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -169,7 +169,7 @@ func (s *requestpromptsSuite) TestNewInvalidMaxID(c *C) {
 }
 
 func (s *requestpromptsSuite) TestNewNextIDUniqueIDs(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -229,7 +229,7 @@ func (s *requestpromptsSuite) checkWrittenMaxID(c *C, id uint64) {
 }
 
 func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -346,7 +346,7 @@ func sortSliceParams(list []*noticeInfo) ([]*noticeInfo, func(i, j int) bool) {
 }
 
 func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -379,11 +379,9 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 	path := fmt.Sprintf("/home/test/Documents/%d.txt", requestprompts.MaxOutstandingPromptsPerUser)
 	lr := &listener.Request{}
 
-	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		c.Assert(listenerReq, Equals, lr)
-		allowed, ok := reply.(bool)
-		c.Assert(ok, Equals, true)
-		c.Assert(allowed, Equals, false)
+		c.Assert(reply.Allow, Equals, false)
 		return nil
 	})
 	defer restore()
@@ -418,7 +416,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 }
 
 func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -462,8 +460,8 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 
 func (s *requestpromptsSuite) TestReply(c *C) {
 	listenerReqChan := make(chan *listener.Request, 2)
-	replyChan := make(chan interface{}, 2)
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	replyChan := make(chan *listener.Response, 2)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		listenerReqChan <- listenerReq
 		replyChan <- reply
 		return nil
@@ -504,14 +502,20 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 		c.Check(err, IsNil)
 		c.Check(repliedPrompt, Equals, prompt1)
 		for _, listenerReq := range []*listener.Request{listenerReq1, listenerReq2} {
-			receivedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+			receivedReq, response, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
 			c.Check(err, IsNil)
 			c.Check(receivedReq, Equals, listenerReq)
-			allowed, ok := result.(bool)
-			c.Check(ok, Equals, true)
 			expected, err := outcome.AsBool()
 			c.Check(err, IsNil)
-			c.Check(allowed, Equals, expected)
+			c.Check(response.Allow, Equals, expected)
+			// Check that permissions in response map to prompt's permissions
+			abstractPermissions, err := prompting.AbstractPermissionsFromAppArmorPermissions(prompt1.Interface, response.Permission)
+			c.Check(err, IsNil)
+			c.Check(abstractPermissions, DeepEquals, prompt1.Constraints.Permissions)
+			// Check that prompt's permissions map to response's permissions
+			expectedPerm, err := prompting.AbstractPermissionsToAppArmorPermissions(prompt1.Interface, prompt1.Constraints.Permissions)
+			c.Check(err, IsNil)
+			c.Check(response.Permission, DeepEquals, expectedPerm)
 		}
 
 		expectedData := map[string]string{"resolved": "replied"}
@@ -519,7 +523,7 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 	}
 }
 
-func (s *requestpromptsSuite) waitForListenerReqAndReply(c *C, listenerReqChan <-chan *listener.Request, replyChan <-chan interface{}) (req *listener.Request, reply interface{}, err error) {
+func (s *requestpromptsSuite) waitForListenerReqAndReply(c *C, listenerReqChan <-chan *listener.Request, replyChan <-chan *listener.Response) (req *listener.Request, reply *listener.Response, err error) {
 	select {
 	case req = <-listenerReqChan:
 	case <-time.NewTimer(10 * time.Second).C:
@@ -535,7 +539,7 @@ func (s *requestpromptsSuite) waitForListenerReqAndReply(c *C, listenerReqChan <
 
 func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	fakeError := fmt.Errorf("fake reply error")
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		return fakeError
 	})
 	defer restore()
@@ -568,9 +572,6 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	_, err = pdb.Reply(metadata.User+1, prompt.ID, outcome)
 	c.Check(err, Equals, requestprompts.ErrNotFound)
 
-	_, err = pdb.Reply(metadata.User, prompt.ID, prompting.OutcomeUnset)
-	c.Check(err, ErrorMatches, `internal error: invalid outcome.*`)
-
 	_, err = pdb.Reply(metadata.User, prompt.ID, outcome)
 	c.Check(err, Equals, fakeError)
 
@@ -580,8 +581,8 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 
 func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	listenerReqChan := make(chan *listener.Request, 2)
-	replyChan := make(chan interface{}, 2)
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	replyChan := make(chan *listener.Response, 2)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		listenerReqChan <- listenerReq
 		replyChan <- reply
 		return nil
@@ -599,27 +600,27 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	}
 	path := "/home/test/Documents/foo.txt"
 
-	permissions := []string{"read", "write", "execute"}
+	permissions1 := []string{"read", "write", "execute"}
 	listenerReq1 := &listener.Request{}
-	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq1)
+	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions1, listenerReq1)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
-	permissions = []string{"read", "write"}
+	permissions2 := []string{"read", "write"}
 	listenerReq2 := &listener.Request{}
-	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq2)
+	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions2, listenerReq2)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
-	permissions = []string{"read"}
+	permissions3 := []string{"read"}
 	listenerReq3 := &listener.Request{}
-	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq3)
+	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions3, listenerReq3)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
-	permissions = []string{"open"}
+	permissions4 := []string{"open"}
 	listenerReq4 := &listener.Request{}
-	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq4)
+	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions4, listenerReq4)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
@@ -631,7 +632,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 
 	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
 	c.Assert(err, IsNil)
-	permissions = []string{"read", "write", "append"}
+	permissions := []string{"read", "write", "append"}
 	constraints := &prompting.Constraints{
 		PathPattern: pathPattern,
 		Permissions: permissions,
@@ -653,14 +654,21 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	s.checkNewNoticesUnordered(c, expectedNotices)
 
 	for i := 0; i < 2; i++ {
-		satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+		satisfiedReq, response, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
 		c.Check(err, IsNil)
-		if satisfiedReq != listenerReq2 && satisfiedReq != listenerReq3 {
+		var perms []string
+		switch satisfiedReq {
+		case listenerReq2:
+			perms = permissions2
+		case listenerReq3:
+			perms = permissions3
+		default:
 			c.Errorf("unexpected request satisfied by new rule")
 		}
-		allowed, ok := result.(bool)
-		c.Check(ok, Equals, true)
-		c.Check(allowed, Equals, true)
+		expectedPerm, err := prompting.AbstractPermissionsToAppArmorPermissions(metadata.Interface, perms)
+		c.Check(err, IsNil)
+		c.Check(response.Allow, Equals, true)
+		c.Check(response.Permission, DeepEquals, expectedPerm)
 	}
 
 	stored, err = pdb.Prompts(metadata.User)
@@ -682,12 +690,13 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	expectedData := map[string]string{"resolved": "satisfied"}
 	s.checkNewNoticesSimple(c, []prompting.IDType{prompt1.ID}, expectedData)
 
-	satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+	satisfiedReq, response, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
 	c.Check(err, IsNil)
 	c.Check(satisfiedReq, Equals, listenerReq1)
-	allowed, ok := result.(bool)
-	c.Check(ok, Equals, true)
-	c.Check(allowed, Equals, true)
+	expectedPerm, err := prompting.AbstractPermissionsToAppArmorPermissions(metadata.Interface, permissions1)
+	c.Check(err, IsNil)
+	c.Check(response.Allow, Equals, true)
+	c.Check(response.Permission, DeepEquals, expectedPerm)
 }
 
 func promptIDListContains(haystack []prompting.IDType, needle prompting.IDType) bool {
@@ -701,8 +710,8 @@ func promptIDListContains(haystack []prompting.IDType, needle prompting.IDType) 
 
 func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	listenerReqChan := make(chan *listener.Request, 3)
-	replyChan := make(chan interface{}, 3)
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	replyChan := make(chan *listener.Response, 3)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		listenerReqChan <- listenerReq
 		replyChan <- reply
 		return nil
@@ -720,27 +729,27 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	}
 	path := "/home/test/Documents/foo.txt"
 
-	permissions := []string{"read", "write", "execute"}
+	permissions1 := []string{"read", "write", "execute"}
 	listenerReq1 := &listener.Request{}
-	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq1)
+	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions1, listenerReq1)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
-	permissions = []string{"read", "write"}
+	permissions2 := []string{"read", "write"}
 	listenerReq2 := &listener.Request{}
-	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq2)
+	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions2, listenerReq2)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
-	permissions = []string{"read"}
+	permissions3 := []string{"read"}
 	listenerReq3 := &listener.Request{}
-	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq3)
+	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions3, listenerReq3)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
-	permissions = []string{"open"}
+	permissions4 := []string{"open"}
 	listenerReq4 := &listener.Request{}
-	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq4)
+	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions4, listenerReq4)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
@@ -752,7 +761,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 
 	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
 	c.Assert(err, IsNil)
-	permissions = []string{"read", "write", "append"}
+	permissions := []string{"read"}
 	constraints := &prompting.Constraints{
 		PathPattern: pathPattern,
 		Permissions: permissions,
@@ -771,14 +780,23 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	s.checkNewNoticesUnorderedSimple(c, []prompting.IDType{prompt1.ID, prompt2.ID, prompt3.ID}, expectedData)
 
 	for i := 0; i < 3; i++ {
-		satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+		satisfiedReq, response, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
 		c.Check(err, IsNil)
-		if satisfiedReq != listenerReq1 && satisfiedReq != listenerReq2 && satisfiedReq != listenerReq3 {
+		var perms []string
+		switch satisfiedReq {
+		case listenerReq1:
+			perms = permissions1
+		case listenerReq2:
+			perms = permissions2
+		case listenerReq3:
+			perms = permissions3
+		default:
 			c.Errorf("unexpected request satisfied by new rule")
 		}
-		allowed, ok := result.(bool)
-		c.Check(ok, Equals, true)
-		c.Check(allowed, Equals, false)
+		expectedPerm, err := prompting.AbstractPermissionsToAppArmorPermissions(metadata.Interface, perms)
+		c.Check(err, IsNil)
+		c.Check(response.Allow, Equals, false)
+		c.Check(response.Permission, DeepEquals, expectedPerm)
 	}
 
 	stored, err = pdb.Prompts(metadata.User)
@@ -788,8 +806,8 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 
 func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	listenerReqChan := make(chan *listener.Request, 1)
-	replyChan := make(chan interface{}, 1)
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	replyChan := make(chan *listener.Response, 1)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		listenerReqChan <- listenerReq
 		replyChan <- reply
 		return nil
@@ -893,12 +911,13 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	expectedData := map[string]string{"resolved": "satisfied"}
 	s.checkNewNoticesSimple(c, []prompting.IDType{prompt.ID}, expectedData)
 
-	satisfiedReq, result, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
+	satisfiedReq, response, err := s.waitForListenerReqAndReply(c, listenerReqChan, replyChan)
 	c.Check(err, IsNil)
 	c.Check(satisfiedReq, Equals, listenerReq)
-	allowed, ok := result.(bool)
-	c.Check(ok, Equals, true)
-	c.Check(allowed, Equals, true)
+	expectedPerm, err := prompting.AbstractPermissionsToAppArmorPermissions(metadata.Interface, permissions)
+	c.Check(err, IsNil)
+	c.Check(response.Allow, Equals, true)
+	c.Check(response.Permission, DeepEquals, expectedPerm)
 
 	stored, err = pdb.Prompts(metadata.User)
 	c.Check(err, IsNil)
@@ -906,7 +925,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 }
 
 func (s *requestpromptsSuite) TestClose(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -957,7 +976,7 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 }
 
 func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply interface{}) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, reply *listener.Response) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -20,7 +20,6 @@
 package requestprompts_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -73,24 +72,6 @@ func (s *requestpromptsSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(s.tmpdir)
 	s.maxIDPath = filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
 	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0700), IsNil)
-}
-
-func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
-	id := prompting.IDType(0x0123456789ABCDEF)
-	timestamp := time.Now()
-	snap := "mysnap"
-	iface := "special-access"
-	path := "/home/me/myfile.txt"
-	remainingPermissions := []string{"foo", "bar"}
-	availablePermissions := []string{"baz", "qux"}
-	originalPermissions := []string{"fizz", "buzz"}
-
-	prompt := requestprompts.NewPrompt(id, timestamp, snap, iface, path, remainingPermissions, availablePermissions, originalPermissions)
-
-	marshalled, err := json.Marshal(prompt)
-	c.Assert(err, IsNil)
-	expected := fmt.Sprintf(`{"id":"0123456789ABCDEF","timestamp":"%s","snap":"mysnap","interface":"special-access","constraints":{"path":"/home/me/myfile.txt","permissions":["foo","bar"],"available-permissions":["baz","qux"]}}`, timestamp.Format(time.RFC3339Nano))
-	c.Assert(marshalled, DeepEquals, []byte(expected), Commentf("\nexpected: %s\nreceived: %s", expected, string(marshalled)))
 }
 
 func (s *requestpromptsSuite) TestNew(c *C) {

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2023 Canonical Ltd
+ * Copyright (C) 2023-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -29,7 +29,7 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan interface{}) *Request {
+func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan *Response) *Request {
 	return &Request{
 		class:     class,
 		replyChan: replyChan,

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2023 Canonical Ltd
+ * Copyright (C) 2023-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -57,6 +57,13 @@ var (
 	notifyIoctl = notify.Ioctl
 )
 
+// Response includes whether the request is allowed or denied, along with the
+// permissions for which the decision should apply.
+type Response struct {
+	Allow      bool
+	Permission interface{}
+}
+
 // Request is a high-level representation of an apparmor prompting message.
 //
 // Each request must be replied to by writing a boolean to the YesNo channel.
@@ -75,7 +82,7 @@ type Request struct {
 	// permission is the opaque permission that is being requested.
 	permission interface{}
 	// replyChan is a channel for writing the response.
-	replyChan chan interface{}
+	replyChan chan *Response
 	// replied indicates whether a reply has already been sent for this request.
 	replied uint32
 }
@@ -101,7 +108,7 @@ func newRequest(msg *notify.MsgNotificationFile) (*Request, error) {
 		class:      msg.Class,
 		permission: perm,
 
-		replyChan: make(chan interface{}, 1),
+		replyChan: make(chan *Response, 1),
 	}, nil
 }
 
@@ -136,21 +143,21 @@ func (r *Request) Permission() interface{} {
 }
 
 // Reply sends the given response back to the kernel.
-func (r *Request) Reply(response interface{}) error {
+func (r *Request) Reply(response *Response) error {
 	if !atomic.CompareAndSwapUint32(&r.replied, 0, 1) {
 		return ErrAlreadyReplied
 	}
 	var ok bool
 	switch r.Class() {
 	case notify.AA_CLASS_FILE:
-		_, ok = response.(bool)
+		_, ok = response.Permission.(notify.FilePermission)
 	default:
 		// should not occur, since the request was created in this package
 		return fmt.Errorf("internal error: unsupported mediation class: %v", r.Class())
 	}
 	if !ok {
 		expectedType := expectedResponseTypeForClass(r.Class())
-		return fmt.Errorf("invalid reply: response must be of type %s", expectedType)
+		return fmt.Errorf("invalid reply: response permission must be of type %s", expectedType)
 	}
 	r.replyChan <- response
 	return nil
@@ -159,7 +166,7 @@ func (r *Request) Reply(response interface{}) error {
 func expectedResponseTypeForClass(class notify.MediationClass) string {
 	switch class {
 	case notify.AA_CLASS_FILE:
-		return "bool"
+		return "notify.FilePermission"
 	default:
 		// This should never occur, as caller should return an error before
 		// calling this if the class is unsupported.
@@ -433,23 +440,25 @@ func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotifi
 	resp := notify.ResponseForRequest(&msg.MsgNotification)
 	resp.MsgNotification.Error = 0 // ignored in responses
 	resp.MsgNotification.NoCache = 1
-	var allow bool
+	var response *Response
 	select {
-	case reply := <-req.replyChan:
-		var ok bool
-		allow, ok = reply.(bool)
-		if !ok {
-			// should not occur, Reply() checks that type is correct
-			logger.Debugf("invalid reply from client: %v; denying request", reply)
-			allow = false
-		}
+	case response = <-req.replyChan:
+		break
 	case <-l.tomb.Dying():
 		// don't bother sending deny response, kernel will handle this
 		return nil
 	}
+	allow := response.Allow
+	perms, ok := response.Permission.(notify.FilePermission)
+	if !ok {
+		// should not occur, Reply() checks that type is correct
+		logger.Debugf("invalid reply from client: %+v; denying request", response)
+		allow = false
+	}
 	if allow {
-		// allow permissions which kernel initially denied, along with those which were already allowed
-		resp.Allow = msg.Allow | msg.Deny
+		// allow permissions which kernel initially allowed, along with those
+		// which the were initially denied but the user explicitly allowed.
+		resp.Allow = msg.Allow | (uint32(perms) & msg.Deny)
 		resp.Deny = 0
 		resp.Error = 0
 	} else {

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -61,7 +61,7 @@ var (
 // permissions for which the decision should apply.
 type Response struct {
 	Allow      bool
-	Permission interface{}
+	Permission any
 }
 
 // Request is a high-level representation of an apparmor prompting message.
@@ -80,7 +80,7 @@ type Request struct {
 	// class is the mediation class corresponding to this request.
 	class notify.MediationClass
 	// permission is the opaque permission that is being requested.
-	permission interface{}
+	permission any
 	// replyChan is a channel for writing the response.
 	replyChan chan *Response
 	// replied indicates whether a reply has already been sent for this request.
@@ -88,7 +88,7 @@ type Request struct {
 }
 
 func newRequest(msg *notify.MsgNotificationFile) (*Request, error) {
-	var perm interface{}
+	var perm any
 	switch msg.Class {
 	case notify.AA_CLASS_FILE:
 		_, missingPerms, err := msg.DecodeFilePermissions()
@@ -138,7 +138,7 @@ func (r *Request) Class() notify.MediationClass {
 }
 
 // Permission returns the opaque permission that is being requested.
-func (r *Request) Permission() interface{} {
+func (r *Request) Permission() any {
 	return r.permission
 }
 


### PR DESCRIPTION
Include the AppArmor permissions allowed/denied by the user along with the allow/deny decision in the response sent back to the listener. This way, the listener can allow only the permissions which were explicitly granted by the user, rather than automatically granting all requested permissions.

One reason to do so is that if a request is received for several AppArmor permissions and at least one of those permissions has no mapping to an abstract permission for the interface in question, then those unknown permissions can be discarded. If the request is eventually allowed, then only the AppArmor permissions matching the abstract permissions which the user explicitly approved are allowed, and the unknown permissions are implicitly denied.

On the listener side, the listener receives two permissions bitmasks from the kernel (for mediation class file): Allow and Deny.

If the user grants the requested permissions, then the allowed bits are `(Allow | (Deny & approved))`, while the denied bits are `0`.

If the user denies the requested permissions, then the allowed bits are `Allow` and the denied bits are `Deny` (same as what was received).


~~This PR is based on the requestprompts PR #13981, and only the final commit(s) are relevant.~~

This task is tracked internally by SNAPDENG-10122.