### PR TITLE
daemon: add /v2/icons/{snap}/icon/{app} endpoint to return app icons

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -42,6 +42,7 @@ var api = []*Command{
 	loginCmd,
 	logoutCmd,
 	snapIconCmd,
+	snapAppIconCmd,
 	findCmd,
 	snapsCmd,
 	snapCmd,

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -43,6 +43,7 @@ var api = []*Command{
 	logoutCmd,
 	snapIconCmd,
 	snapAppIconCmd,
+	snapAppIconNameCmd,
 	findCmd,
 	snapsCmd,
 	snapCmd,

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2022 Canonical Ltd
+ * Copyright (C) 2015-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -41,7 +41,7 @@ var api = []*Command{
 	sysInfoCmd,
 	loginCmd,
 	logoutCmd,
-	appIconCmd,
+	snapIconCmd,
 	findCmd,
 	snapsCmd,
 	snapCmd,

--- a/daemon/api_icons.go
+++ b/daemon/api_icons.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -30,14 +30,14 @@ import (
 )
 
 var (
-	appIconCmd = &Command{
+	snapIconCmd = &Command{
 		Path:       "/v2/icons/{name}/icon",
-		GET:        appIconGet,
+		GET:        snapIconGet,
 		ReadAccess: openAccess{},
 	}
 )
 
-func appIconGet(c *Command, r *http.Request, user *auth.UserState) Response {
+func snapIconGet(c *Command, r *http.Request, user *auth.UserState) Response {
 	vars := muxVars(r)
 	name := vars["name"]
 

--- a/daemon/api_icons_test.go
+++ b/daemon/api_icons_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -37,7 +37,7 @@ type iconsSuite struct {
 	apiBaseSuite
 }
 
-func (s *iconsSuite) TestAppIconGet(c *check.C) {
+func (s *iconsSuite) TestSnapIconGet(c *check.C) {
 	d := s.daemon(c)
 
 	// have an active foo in the system
@@ -58,7 +58,7 @@ func (s *iconsSuite) TestAppIconGet(c *check.C) {
 	c.Check(rec.Body.String(), check.Equals, "ick")
 }
 
-func (s *iconsSuite) TestAppIconGetInactive(c *check.C) {
+func (s *iconsSuite) TestSnapIconGetInactive(c *check.C) {
 	d := s.daemon(c)
 
 	// have an *in*active foo in the system
@@ -79,7 +79,7 @@ func (s *iconsSuite) TestAppIconGetInactive(c *check.C) {
 	c.Check(rec.Body.String(), check.Equals, "ick")
 }
 
-func (s *iconsSuite) TestAppIconGetNoIcon(c *check.C) {
+func (s *iconsSuite) TestSnapIconGetNoIcon(c *check.C) {
 	d := s.daemon(c)
 
 	// have an *in*active foo in the system
@@ -98,7 +98,7 @@ func (s *iconsSuite) TestAppIconGetNoIcon(c *check.C) {
 	c.Check(rec.Code/100, check.Equals, 4)
 }
 
-func (s *iconsSuite) TestAppIconGetNoApp(c *check.C) {
+func (s *iconsSuite) TestSnapIconGetNoApp(c *check.C) {
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/icons/foo/icon", nil)

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -101,7 +101,7 @@ func webify(result *client.Snap, resource string) *client.Snap {
 	}
 	result.Icon = ""
 
-	route := appIconCmd.d.router.Get(appIconCmd.Path)
+	route := snapIconCmd.d.router.Get(snapIconCmd.Path)
 	if route != nil {
 		url, err := route.URL("name", result.Name)
 		if err == nil {

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2024 Canonical Ltd
+ * Copyright (C) 2015-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,14 +20,11 @@
 package daemon
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/client"
@@ -349,30 +346,4 @@ func snapIcon(info snap.PlaceInfo) string {
 	}
 
 	return found[0]
-}
-
-var iconMatcher = regexp.MustCompile("^Icon=(.*)$")
-
-// iconPathFromDesktopFile opens the given filepath and searches for a line
-// starting with `Icon=`, returning the icon path.
-func iconPathFromDesktopFile(filepath string) (string, error) {
-	desktopFile, err := os.Open(filepath)
-	if err != nil {
-		return "", fmt.Errorf("cannot open desktop file: %v", err)
-	}
-
-	scanner := bufio.NewScanner(desktopFile)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		matches := iconMatcher.FindSubmatch(line)
-		if matches == nil {
-			continue
-		}
-
-		iconPath := strings.TrimSpace(string(matches[1]))
-
-		return iconPath, nil
-	}
-
-	return "", fmt.Errorf("cannot find icon path in desktop file: %q", filepath)
 }


### PR DESCRIPTION
This PR adds the `/v2/icons/{snap}/icon/{app}` endpoint to the snapd API, which returns the icon for the given snap and app.

Currently, several Desktop applications look through `.desktop` files in `/snap/*/*/meta/gui` to try to find the `Icon=` field of the particular snap/app. This requires access to `/snap/*/*` both to read the `.desktop` file in `meta/gui` and to find the icon file, which might be anywhere in the snap mount directory.

This PR grants a means to acquire the app icon without the application needing direct access to the filesystem. Ideally, I believe access to this new endpoint, in addition to `/v2/snaps` and `/v2/snaps/{name}`, should be used in place of `/snap/*/*/**` for interfaces which grant access to snap metadata, such as `desktop-launch`.

This endpoint could be switched to `interfaceOpenAccess` for `desktop-launch` or other interfaces.

A follow-up PR could be introduced to add a new `desktop-metadata` interface, which grants access to `/v2/icons/{name}/icon`, `/v2/icons/{snap}/icon/{app}, `/v2/snaps`, `/v2/snaps/{name}`, and potentially `/var/lib/snapd/desktop/applications{,/*}`, if access to `.desktop` files is required. We should avoid looking for `.desktop` files in `/snap/*/*/meta/gui`.