### PR TITLE
osutil: introduce verity device resolver

### DIFF
--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -30,6 +30,10 @@ type Options struct {
 	// IsDecryptedDevice indicates that the mountpoint is referring to a
 	// decrypted device.
 	IsDecryptedDevice bool
+
+	// IsVerityDevice indicates that the mountpoint is referring to
+	// device mounted with verity data.
+	IsVerityDevice bool
 }
 
 // Disk is a single physical disk device that contains partitions.
@@ -216,8 +220,15 @@ var (
 	_ = error(PartitionNotFoundError{})
 )
 
+type deviceMapperBackResolversOpts struct {
+	dmUUID []byte
+	dmName []byte
+	// this is needed by the verity device resolver
+	idFsUUID string
+}
+
 // TODO: simplify this away as now we have only LUKS?
-var deviceMapperBackResolvers = map[string]func(dmUUID, dmName []byte) (dev string, ok bool){}
+var deviceMapperBackResolvers = map[string]func(opts *deviceMapperBackResolversOpts) (dev string, ok bool){}
 
 // RegisterDeviceMapperBackResolver takes a callback function which is used when
 // the disks package through some of it's various methods to locate/create a
@@ -229,7 +240,7 @@ var deviceMapperBackResolvers = map[string]func(dmUUID, dmName []byte) (dev stri
 // for the mapper device and true. If the handler does not match a provided
 // device mapper, the function should return "ok" as false.
 // The name of the handler is currently only used in tests.
-func RegisterDeviceMapperBackResolver(name string, f func(dmUUID, dmName []byte) (dev string, ok bool)) {
+func RegisterDeviceMapperBackResolver(name string, f func(opts *deviceMapperBackResolversOpts) (dev string, ok bool)) {
 	deviceMapperBackResolvers[name] = f
 }
 

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -459,7 +459,7 @@ func parentPartitionPropsForOptions(props map[string]string) (map[string]string,
 	// 2. have dm files in the sysfs entry for the maj:min of the device
 	if props["DEVTYPE"] != "disk" {
 		// not a decrypted or verity device
-		return nil, fmt.Errorf("not a decrypted or verity device: devtype is not disk (is %s)", props["DEVTYPE"])
+		return nil, fmt.Errorf("devtype is not disk (is %s)", props["DEVTYPE"])
 	}
 
 	// TODO:UC20: currently, we effectively parse the DM_UUID env variable
@@ -483,7 +483,7 @@ func parentPartitionPropsForOptions(props map[string]string) (map[string]string,
 	//            or not, given that these variables have been observed to
 	//            be missing from the initrd previously, and are not
 	//            available at all during userspace on UC20 for some reason
-	errFmt := "not a decrypted or verity device: could not read device mapper metadata: %v"
+	errFmt := "could not read device mapper metadata: %v"
 
 	if props["MAJOR"] == "" {
 		return nil, fmt.Errorf("incomplete udev output missing required property \"MAJOR\"")

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -522,7 +522,7 @@ func parentPartitionPropsForOptions(props map[string]string) (map[string]string,
 		}
 	}
 
-	return nil, fmt.Errorf("internal error: no back resolver supports decrypted device mapper with UUID %q and name %q", dmUUID, dmName)
+	return nil, fmt.Errorf("internal error: no back resolver supports device mapper with UUID %q and name %q", dmUUID, dmName)
 }
 
 func diskFromPartUDevProps(props map[string]string) (*disk, error) {

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -516,7 +516,7 @@ func parentPartitionPropsForOptions(props map[string]string) (map[string]string,
 		if dev, ok := resolver(opts); ok {
 			props, err = udevPropertiesForName(dev)
 			if err != nil {
-				return nil, fmt.Errorf("cannot get udev properties for encrypted partition %s: %v", dev, err)
+				return nil, fmt.Errorf("cannot get udev properties for partition %s: %v", dev, err)
 			}
 			return props, nil
 		}

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -502,7 +502,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `cannot process properties of /dev/vda4 parent device: not a decrypted device: devtype is not disk \(is partition\)`)
+	c.Assert(err, ErrorMatches, `cannot process properties of /dev/vda4 parent device: devtype is not disk \(is partition\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) {
@@ -530,7 +530,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot process properties of /dev/mapper/something parent device: not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot process properties of /dev/mapper/something parent device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
 }
 
 func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitionsInSysfs(c *C) {

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -760,7 +760,7 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedLUKSDeviceVolumeHappy(c *C)
 	}()
 
 	_, err = disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `cannot process properties of /dev/mapper/something parent device: internal error: no back resolver supports decrypted device mapper with UUID "CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-something" and name "something"`)
+	c.Assert(err, ErrorMatches, `cannot process properties of /dev/mapper/something parent device: internal error: no back resolver supports device mapper with UUID "CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-something" and name "something"`)
 
 	// but when it is available it works
 	disks.RegisterDeviceMapperBackResolver("crypt-luks2", disks.CryptLuks2DeviceMapperBackResolver)
@@ -2106,7 +2106,7 @@ func (s *diskSuite) TestDiskFromMountPointIsVerityDeviceVolumeHappy(c *C) {
 	}()
 
 	_, err = disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `cannot process properties of /dev/mapper/something parent device: internal error: no back resolver supports decrypted device mapper with UUID "CRYPT-VERITY-5a522809c87e4dfa81a88dc5667d1304-something" and name "something"`)
+	c.Assert(err, ErrorMatches, `cannot process properties of /dev/mapper/something parent device: internal error: no back resolver supports device mapper with UUID "CRYPT-VERITY-5a522809c87e4dfa81a88dc5667d1304-something" and name "something"`)
 
 	// but when it is available it works
 	disks.RegisterDeviceMapperBackResolver("crypt-verity", disks.CryptVerityDeviceMapperBackResolver)

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -2096,7 +2096,7 @@ func (s *diskSuite) TestDiskFromMountPointIsVerityDeviceVolumeHappy(c *C) {
 	err = os.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
 	c.Assert(err, IsNil)
 
-	opts := &disks.Options{IsDecryptedDevice: true}
+	opts := &disks.Options{IsVerityDevice: true}
 
 	// when the handler is not available, we can't handle the mapper
 	disks.UnregisterDeviceMapperBackResolver("crypt-verity")

--- a/osutil/disks/luks.go
+++ b/osutil/disks/luks.go
@@ -39,8 +39,8 @@ var (
 	luksUUIDPatternRe = regexp.MustCompile(`^CRYPT-LUKS2-([0-9a-f]{32})$`)
 )
 
-func cryptLuks2DeviceMapperBackResolver(dmUUID, dmName []byte) (dev string, ok bool) {
-	if !strings.HasPrefix(string(dmUUID), "CRYPT-LUKS") {
+func cryptLuks2DeviceMapperBackResolver(opts *deviceMapperBackResolversOpts) (dev string, ok bool) {
+	if !strings.HasPrefix(string(opts.dmUUID), "CRYPT-LUKS") {
 		return "", false
 	}
 
@@ -53,8 +53,8 @@ func cryptLuks2DeviceMapperBackResolver(dmUUID, dmName []byte) (dev string, ok b
 	// we are extra safe here since the dm name could be hypothetically user
 	// controlled via an external USB disk with LVM partition names, etc.
 	dmUUIDSafe := bytes.TrimSuffix(
-		bytes.TrimSpace(dmUUID),
-		append([]byte("-"), bytes.TrimSpace(dmName)...),
+		bytes.TrimSpace(opts.dmUUID),
+		append([]byte("-"), bytes.TrimSpace(opts.dmName)...),
 	)
 	matches := luksUUIDPatternRe.FindSubmatch(dmUUIDSafe)
 	if len(matches) != 2 {

--- a/osutil/disks/luks.go
+++ b/osutil/disks/luks.go
@@ -40,6 +40,10 @@ var (
 )
 
 func cryptLuks2DeviceMapperBackResolver(opts *deviceMapperBackResolversOpts) (dev string, ok bool) {
+	if opts == nil {
+		return "", false
+	}
+
 	if !strings.HasPrefix(string(opts.dmUUID), "CRYPT-LUKS") {
 		return "", false
 	}

--- a/osutil/disks/verity.go
+++ b/osutil/disks/verity.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/osutil/disks/verity.go
+++ b/osutil/disks/verity.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2021 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,12 +19,22 @@
 
 package disks
 
-var (
-	UnregisterDeviceMapperBackResolver = unregisterDeviceMapperBackResolver
-
-	CryptLuks2DeviceMapperBackResolver = cryptLuks2DeviceMapperBackResolver
-
-	CryptVerityDeviceMapperBackResolver = cryptVerityDeviceMapperBackResolver
-
-	FilesystemTypeForPartition = filesystemTypeForPartition
+import (
+	"path/filepath"
+	"strings"
 )
+
+func cryptVerityDeviceMapperBackResolver(opts *deviceMapperBackResolversOpts) (dev string, ok bool) {
+	if !strings.HasPrefix(string(opts.dmUUID), "CRYPT-VERITY") {
+		return "", false
+	}
+
+	// this is a verity mounted device
+
+	byUUIDPath := filepath.Join("/dev/disk/by-uuid", opts.idFsUUID)
+	return byUUIDPath, true
+}
+
+func init() {
+	RegisterDeviceMapperBackResolver("crypt-verity", cryptVerityDeviceMapperBackResolver)
+}

--- a/osutil/disks/verity.go
+++ b/osutil/disks/verity.go
@@ -31,6 +31,16 @@ func cryptVerityDeviceMapperBackResolver(opts *deviceMapperBackResolversOpts) (d
 
 	// this is a verity mounted device
 
+	// this matches a very specific setup we are asked to resolve a dm-verity device eg.
+	// /dev/mapper/foo into an actual device node eg. /dev/sdb2; in contrast to  LUKS where
+	// there is a LUKS volume with a specific UUID which is then repeated in the dm-crypt
+	// device UUID, in case of verity the UUID included in dm-verity device UUID corresponds
+	// to the hash tree device and not the back store device with the content we want to protect;
+	// ideally the resolver should be able to perform what `veritysetup status <dev>` does, but
+	// for simplicity use the fact that backing store device contains a filesystem with its own UUID
+	// which shows up as ID_FS_UUID on the dm-verity device and can be used to resolve back to
+	// the actual fs device.
+	// XXX this will cease to work if the backing store filesystem has no UUID, eg squashfs
 	byUUIDPath := filepath.Join("/dev/disk/by-uuid", opts.idFsUUID)
 	return byUUIDPath, true
 }

--- a/osutil/disks/verity.go
+++ b/osutil/disks/verity.go
@@ -25,6 +25,10 @@ import (
 )
 
 func cryptVerityDeviceMapperBackResolver(opts *deviceMapperBackResolversOpts) (dev string, ok bool) {
+	if opts == nil {
+		return "", false
+	}
+
 	if !strings.HasPrefix(string(opts.dmUUID), "CRYPT-VERITY") {
 		return "", false
 	}


### PR DESCRIPTION
this commit leverages an existing snapd API that allows registration of different resolvers for device mapper devices which currently only supports luks. It introduces a new resolver for device mapper devices for dm-verity. This resolver uses the `ID_FS_UUID` udev property to map a verity device to its data partition.

This is potentially a more universal approach to solving the same issue https://github.com/snapcore/snapd/pull/14180 attempted to solve with a workaround.

Jira: https://warthogs.atlassian.net/browse/FR-8353
