### PR TITLE
o/snapstate: allow updating snaps with components from local files

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -236,7 +236,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 		CompSideInfo: csi,
 		CompType:     compInfo.Type,
 		CompPath:     path,
-		componentInstallFlags: componentInstallFlags{
+		ComponentInstallFlags: ComponentInstallFlags{
 			// The file passed around is temporary, make sure it gets removed.
 			RemoveComponentPath: true,
 		},
@@ -250,7 +250,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 	return componentTS.taskSet(), nil
 }
 
-type componentInstallFlags struct {
+type ComponentInstallFlags struct {
 	RemoveComponentPath   bool `json:"remove-component-path,omitempty"`
 	MultiComponentInstall bool `json:"joint-snap-components-install,omitempty"`
 }

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -59,11 +59,11 @@ const (
 
 // opts is a bitset with compOpt* as possible values.
 func expectedComponentInstallTasks(opts int) []string {
-	beforeLink, linkToHook, postOpHooksAndAfter := expectedComponentInstallTasksSplit(opts)
-	return append(append(beforeLink, linkToHook...), postOpHooksAndAfter...)
+	beforeLink, link, postOpHooksAndAfter, discard := expectedComponentInstallTasksSplit(opts)
+	return append(append(append(beforeLink, link...), postOpHooksAndAfter...), discard...)
 }
 
-func expectedComponentInstallTasksSplit(opts int) (beforeLink []string, linkToHook []string, postOpHooksAndAfter []string) {
+func expectedComponentInstallTasksSplit(opts int) (beforeLink, link, postOpHooksAndAfter, discard []string) {
 	if opts&compOptIsLocal != 0 {
 		beforeLink = []string{"prepare-component"}
 	} else {
@@ -89,7 +89,7 @@ func expectedComponentInstallTasksSplit(opts int) (beforeLink []string, linkToHo
 	}
 
 	// link-component is always present
-	linkToHook = []string{"link-component"}
+	link = []string{"link-component"}
 
 	// expect the install hook if the snap wasn't already installed
 	if opts&compOptIsActive == 0 {
@@ -103,10 +103,10 @@ func expectedComponentInstallTasksSplit(opts int) (beforeLink []string, linkToHo
 	}
 
 	if opts&compCurrentIsDiscarded != 0 {
-		postOpHooksAndAfter = append(postOpHooksAndAfter, "discard-component")
+		discard = append(discard, "discard-component")
 	}
 
-	return beforeLink, linkToHook, postOpHooksAndAfter
+	return beforeLink, link, postOpHooksAndAfter, discard
 }
 
 func checkSetupTasks(c *C, ts *state.TaskSet) {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -225,9 +225,9 @@ type ComponentSetup struct {
 	// DownloadInfo contains information about how to download this component.
 	// Will be nil if the component should be sourced from a local file.
 	DownloadInfo *snap.DownloadInfo `json:"download-info,omitempty"`
-	// componentInstallFlags is a set of flags that control the behavior of the
+	// ComponentInstallFlags is a set of flags that control the behavior of the
 	// component's installation/update.
-	componentInstallFlags
+	ComponentInstallFlags
 }
 
 func NewComponentSetup(csi *snap.ComponentSideInfo, compType snap.ComponentType, compPath string) *ComponentSetup {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3640,7 +3640,7 @@ func removeInactiveRevision(st *state.State, snapst *SnapState, name, snapID str
 		compsup := ComponentSetup{
 			CompSideInfo: &cinfo.ComponentSideInfo,
 			CompType:     cinfo.Type,
-			componentInstallFlags: componentInstallFlags{
+			ComponentInstallFlags: ComponentInstallFlags{
 				MultiComponentInstall: true,
 			},
 		}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6748,7 +6748,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 			},
 		})
 	}
-	checkComponentSetupTasks(c, ts, compsups)
+	checkComponentSetupTasks(c, ts, compsups, "download-component")
 
 	// start with an easier-to-read error if this fails:
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
@@ -7061,7 +7061,7 @@ components:
 			},
 		})
 	}
-	checkComponentSetupTasks(c, ts, compsups)
+	checkComponentSetupTasks(c, ts, compsups, "prepare-component")
 
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/store/storetest"
 
 	// So it registers Configure.
 	_ "github.com/snapcore/snapd/overlord/configstate"
@@ -6827,6 +6828,9 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyRemovePaths(c *C) {
 func (s *snapmgrTestSuite) testInstallComponentsFromPathRunThrough(c *C, snapName, instanceKey string, compNames []string, undo bool, removePaths bool) {
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// make sure that the store is never hit
+	snapstate.ReplaceStore(s.state, &storetest.Store{})
 
 	sort.Strings(compNames)
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6758,6 +6758,17 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, snapName, insta
 			SnapID:   snapID,
 		})
 
+		var compst []*sequence.ComponentState
+		for i, compName := range components {
+			compst = append(compst, &sequence.ComponentState{
+				SideInfo: &snap.ComponentSideInfo{
+					Component: naming.NewComponentRef(snapName, compName),
+					Revision:  snap.R(i + 1),
+				},
+				CompType: componentNameToType(c, compName),
+			})
+		}
+
 		// make sure that all of our components are accounted for
 		c.Assert(snapst.Sequence.Revisions[0].Components, DeepEquals, componentStates)
 
@@ -6871,7 +6882,7 @@ func (s *snapmgrTestSuite) testInstallComponentsFromPathRunThrough(c *C, snapNam
 		componentYaml := fmt.Sprintf(`component: %s
 type: %s
 version: 1.0
-`, csi.Component, compNameToType(compName))
+`, csi.Component, componentNameToType(c, compName))
 
 		components[csi] = snaptest.MakeTestComponent(c, componentYaml)
 		componentStates = append(componentStates, sequence.NewComponentState(csi, compNameToType(compName)))

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -14552,7 +14552,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 			},
 		})
 	}
-	checkComponentSetupTasks(c, ts, compsups)
+	checkComponentSetupTasks(c, ts, compsups, "download-component")
 
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
@@ -15137,7 +15137,7 @@ components:
 			},
 		})
 	}
-	checkComponentSetupTasks(c, ts, compsups)
+	checkComponentSetupTasks(c, ts, compsups, "prepare-component")
 
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
@@ -15175,11 +15175,15 @@ components:
 	}
 }
 
-func checkComponentSetupTasks(c *C, ts *state.TaskSet, expected []snapstate.ComponentSetup) {
+func checkComponentSetupTasks(c *C, ts *state.TaskSet, expected []snapstate.ComponentSetup, taskKind string) {
 	found := make([]snapstate.ComponentSetup, 0, len(expected))
 	for _, t := range ts.Tasks() {
 		if !t.Has("component-setup") {
 			continue
+		}
+
+		if t.Kind() != taskKind {
+			c.Errorf("component-setup found on unexpected task kind %q", t.Kind())
 		}
 
 		var compsup snapstate.ComponentSetup

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -14262,9 +14262,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		InstanceKey:     opts.instanceKey,
 	})
 
-	ts, err := snapstate.Update(s.state, instanceName, nil, s.user.ID, snapstate.Flags{
-		NoReRefresh: true,
-	})
+	ts, err := snapstate.Update(s.state, instanceName, nil, s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
 	chg := s.state.NewChange("refresh", "refresh a snap")
@@ -14753,4 +14751,398 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithComponentsRemoved(c *C) {
 	err = tasks[i].Get("component-setup", &compSup)
 	c.Assert(err, IsNil)
 	c.Check(compSup.CompSideInfo.Component, Equals, cref2)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathRunThrough(c *C) {
+	const (
+		instanceKey           = ""
+		refreshAppAwarenessUX = true
+		undo                  = false
+	)
+	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, []string{"test-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathRunThroughUndo(c *C) {
+	const (
+		instanceKey           = ""
+		refreshAppAwarenessUX = true
+		undo                  = true
+	)
+	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, []string{"test-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
+}
+
+func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, instanceKey string, compNames []string, refreshAppAwarenessUX, undo bool) {
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	if refreshAppAwarenessUX {
+		s.enableRefreshAppAwarenessUX()
+	}
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+		channel  = "channel-for-components"
+	)
+
+	currentSnapRev := snap.R(7)
+	newSnapRev := snap.R(11)
+	instanceName := snap.InstanceName(snapName, instanceKey)
+
+	sort.Strings(compNames)
+
+	compNameToType := func(name string) snap.ComponentType {
+		typ, ok := strings.CutSuffix(name, "-component")
+		if !ok {
+			c.Fatalf("unexpected component name %q", name)
+		}
+		return snap.ComponentType(typ)
+	}
+
+	si := snap.SideInfo{
+		RealName: snapName,
+		Revision: currentSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &si)
+
+	restore := snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	now, err := time.Parse(time.RFC3339, "2021-06-10T10:00:00Z")
+	c.Assert(err, IsNil)
+
+	restore = snapstate.MockTimeNow(func() time.Time {
+		return now
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// make sure that the store is never hit
+	snapstate.ReplaceStore(s.state, &storetest.Store{})
+
+	if instanceKey != "" {
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "experimental.parallel-instances", true)
+		tr.Commit()
+	}
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si})
+
+	for i, comp := range compNames {
+		err := seq.AddComponentForRevision(currentSnapRev, &sequence.ComponentState{
+			SideInfo: &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, comp),
+				Revision:  snap.R(i + 1),
+			},
+			CompType: compNameToType(comp),
+		})
+		c.Assert(err, IsNil)
+	}
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string, info *snap.Info, csi *snap.ComponentSideInfo,
+	) (*snap.ComponentInfo, error) {
+		return &snap.ComponentInfo{
+			Component:         csi.Component,
+			Type:              compNameToType(csi.Component.ComponentName),
+			Version:           "1.0",
+			ComponentSideInfo: *csi,
+		}, nil
+	}))
+
+	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
+		Active:          true,
+		Sequence:        seq,
+		Current:         si.Revision,
+		SnapType:        "app",
+		TrackingChannel: channel,
+		InstanceKey:     instanceKey,
+	})
+
+	components := make(map[*snap.ComponentSideInfo]string, len(compNames))
+	for i, compName := range compNames {
+		csi := &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(i + 2),
+		}
+
+		componentYaml := fmt.Sprintf(`component: %s
+type: %s
+version: 1.0
+`, csi.Component, compNameToType(compName))
+
+		components[csi] = snaptest.MakeTestComponent(c, componentYaml)
+	}
+
+	snapPath := makeTestSnap(c, fmt.Sprintf(`name: %s
+version: some-snapVer
+type: kernel
+epoch: 1*
+components:
+  test-component:
+    type: test
+  kernel-modules-component:
+    type: kernel-modules
+    `, snapName))
+
+	newSI := si
+	newSI.Revision = newSnapRev
+
+	goal := snapstate.PathUpdateGoal(snapstate.PathSnap{
+		Path:         snapPath,
+		InstanceName: instanceName,
+		SideInfo:     &newSI,
+		Components:   components,
+	})
+
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
+		Flags: snapstate.Flags{
+			Transaction:    client.TransactionPerSnap,
+			RemoveSnapPath: true,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("refresh", "refresh a snap")
+	chg.AddAll(ts)
+
+	if undo {
+		last := lastWithLane(ts.Tasks())
+		c.Assert(last, NotNil)
+
+		terr := s.state.NewTask("error-trigger", "provoking total undo")
+		terr.WaitFor(last)
+		terr.JoinLane(last.Lanes()[0])
+		chg.AddTask(terr)
+	}
+
+	// check unlink-reason
+	unlinkTask := findLastTask(chg, "unlink-current-snap")
+	c.Assert(unlinkTask, NotNil)
+	var unlinkReason string
+	unlinkTask.Get("unlink-reason", &unlinkReason)
+	c.Check(unlinkReason, Equals, "refresh")
+
+	// local modifications, edge must be set
+	te := ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(te, NotNil)
+	c.Assert(te.Kind(), Equals, "prepare-snap")
+
+	s.settle(c)
+
+	if undo {
+		c.Assert(chg.Err(), NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	} else {
+		c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	}
+
+	expected := fakeOps{
+		{
+			op:  "current",
+			old: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:    "setup-snap",
+			name:  instanceName,
+			path:  snapPath,
+			revno: newSnapRev,
+		},
+	}
+
+	if !refreshAppAwarenessUX {
+		expected = append(expected, fakeOp{
+			op:   "remove-snap-aliases",
+			name: instanceName,
+		})
+	}
+
+	for i, compName := range compNames {
+		containerName := fmt.Sprintf("%s+%s", instanceName, compName)
+		filename := fmt.Sprintf("%s_%v.comp", containerName, snap.R(i+2))
+
+		expected = append(expected, fakeOp{
+			op:                "setup-component",
+			containerName:     containerName,
+			containerFileName: filename,
+		})
+	}
+
+	expected = append(expected, fakeOps{
+		{
+			op:          "run-inhibit-snap-for-unlink",
+			name:        instanceName,
+			inhibitHint: "refresh",
+		},
+		{
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+			unlinkSkipBinaries: refreshAppAwarenessUX,
+		},
+		{
+			op:    "update-gadget-assets:Doing",
+			name:  instanceName,
+			revno: newSnapRev,
+		},
+		{
+			op:   "copy-data",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
+			old:  filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:   "setup-snap-save-data",
+			path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+		},
+	}...)
+
+	expected = append(expected, fakeOps{
+		{
+			op:    "setup-profiles:Doing",
+			name:  instanceName,
+			revno: snap.R(11),
+		},
+		{
+			op: "candidate",
+			sinfo: snap.SideInfo{
+				RealName: snapName,
+				SnapID:   snapID,
+				Channel:  channel,
+				Revision: snap.R(11),
+			},
+		},
+		{
+			op:   "link-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
+		},
+	}...)
+
+	for i, compName := range compNames {
+		expected = append(expected, fakeOp{
+			op:   "link-component",
+			path: snap.ComponentMountDir(compName, snap.R(i+2), instanceName),
+		})
+	}
+
+	expected = append(expected, fakeOps{
+		{
+			op:    "auto-connect:Doing",
+			name:  instanceName,
+			revno: snap.R(11),
+		},
+		{
+			op: "update-aliases",
+		},
+	}...)
+
+	currentKmodComps := make([]*snap.ComponentSideInfo, 0, len(components))
+	newKmodComps := make([]*snap.ComponentSideInfo, 0, len(components))
+	for i, compName := range compNames {
+		if strings.HasPrefix(compName, string(snap.KernelModulesComponent)) {
+			currentKmodComps = append(currentKmodComps, &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, compName),
+				Revision:  snap.R(i + 1),
+			})
+			newKmodComps = append(newKmodComps, &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, compName),
+				Revision:  snap.R(i + 2),
+			})
+		}
+	}
+
+	if len(currentKmodComps) > 0 || len(newKmodComps) > 0 {
+		expected = append(expected, fakeOp{
+			op:           "prepare-kernel-modules-components",
+			currentComps: currentKmodComps,
+			finalComps:   newKmodComps,
+		})
+	}
+
+	if undo {
+		expected = append(expected, undoOps(instanceName, newSnapRev, currentSnapRev, compNames, compNames)...)
+	} else {
+		expected = append(expected, fakeOp{
+			op:    "cleanup-trash",
+			name:  instanceName,
+			revno: newSnapRev,
+		})
+	}
+
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	// check progress
+	task := ts.Tasks()[1]
+
+	// verify snapSetup info
+	var snapsup snapstate.SnapSetup
+	err = task.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
+		Channel:   channel,
+		SnapPath:  snapPath,
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeKernel,
+		Version:   "some-snapVer",
+		PlugsOnly: true,
+		Flags: snapstate.Flags{
+			Transaction:    client.TransactionPerSnap,
+			RemoveSnapPath: true,
+		},
+		InstanceKey:                     instanceKey,
+		PreUpdateKernelModuleComponents: currentKmodComps,
+	})
+	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
+		RealName: snapName,
+		Revision: newSnapRev,
+		Channel:  channel,
+		SnapID:   snapID,
+	})
+
+	// verify snaps in the system state
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, instanceName, &snapst)
+	c.Assert(err, IsNil)
+
+	if !undo {
+		c.Assert(snapst.LastRefreshTime, NotNil)
+		c.Check(snapst.LastRefreshTime.Equal(now), Equals, true)
+		c.Assert(snapst.Active, Equals, true)
+		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[0])
+
+		cand := sequence.NewRevisionSideState(&snap.SideInfo{
+			RealName: snapName,
+			Channel:  channel,
+			SnapID:   snapID,
+			Revision: newSnapRev,
+		}, nil)
+
+		for i, comp := range compNames {
+			cand.Components = append(cand.Components, &sequence.ComponentState{
+				SideInfo: &snap.ComponentSideInfo{
+					Component: naming.NewComponentRef(snapName, comp),
+					Revision:  snap.R(i + 2),
+				},
+				CompType: compNameToType(comp),
+			})
+		}
+
+		// add our new revision to the sequence
+		seq.Revisions = append(seq.Revisions, cand)
+
+		c.Assert(snapst.Sequence, DeepEquals, seq)
+
+		c.Check(snapPath, testutil.FileAbsent)
+		for _, compPath := range components {
+			c.Check(compPath, testutil.FileAbsent)
+		}
+	} else {
+		// make sure everything is back to how it started
+		c.Assert(snapst.Active, Equals, true)
+		c.Assert(snapst.Sequence.Revisions, HasLen, 1)
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[0])
+	}
 }

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -1003,6 +1003,14 @@ func UpdateWithGoal(ctx context.Context, st *state.State, goal UpdateGoal, filte
 		return nil, nil, err
 	}
 
+	for _, t := range plan.targets {
+		// sort the components by name to ensure we always install components in the
+		// same order
+		sort.Slice(t.components, func(i, j int) bool {
+			return t.components[i].ComponentName() < t.components[j].ComponentName()
+		})
+	}
+
 	if opts.ExpectOneSnap && len(plan.targets) != 1 {
 		return nil, nil, ErrExpectedOneSnap
 	}

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -98,7 +98,7 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 			CompPath:     comp.CompPath,
 			DownloadInfo: comp.DownloadInfo,
 
-			componentInstallFlags: componentInstallFlags{
+			ComponentInstallFlags: ComponentInstallFlags{
 				// if we're removing the snap, then we should remove the
 				// components too
 				RemoveComponentPath:   opts.Flags.RemoveSnapPath,

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -1247,10 +1247,6 @@ func (p *pathUpdateGoal) toUpdate(_ context.Context, st *state.State, opts Optio
 			return updatePlan{}, err
 		}
 
-		// TODO:COMPS: remove this once we are ready to handle components during
-		// refresh
-		t.components = nil
-
 		targets = append(targets, t)
 		names = append(names, sn.InstanceName)
 	}
@@ -1286,7 +1282,7 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 		return target{}, fmt.Errorf("cannot install local snap %q: %v != %v (revision mismatch)", update.InstanceName, update.RevOpts.Revision, si.Revision)
 	}
 
-	if update.RevOpts.Channel != "" && update.SideInfo.Channel != "" && update.RevOpts.Channel != update.SideInfo.Channel {
+	if update.RevOpts.Channel != "" && si.Channel != "" && update.RevOpts.Channel != si.Channel {
 		return target{}, fmt.Errorf("cannot install local snap %q: %v != %v (channel mismatch)", update.InstanceName, update.RevOpts.Channel, si.Channel)
 	}
 
@@ -1304,8 +1300,7 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 		update.RevOpts.Channel = update.SideInfo.Channel
 	}
 
-	channel, err := resolveChannel(update.InstanceName, trackingChannel, update.RevOpts.Channel, opts.DeviceCtx)
-	if err != nil {
+	if err := update.RevOpts.resolveChannel(update.InstanceName, trackingChannel, opts.DeviceCtx); err != nil {
 		return target{}, err
 	}
 
@@ -1317,7 +1312,7 @@ func targetForPathSnap(update PathSnap, snapst SnapState, opts Options) (target,
 	return target{
 		setup: SnapSetup{
 			SnapPath:  update.Path,
-			Channel:   channel,
+			Channel:   update.RevOpts.Channel,
 			CohortKey: update.RevOpts.CohortKey,
 		},
 		info:       info,

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -589,6 +589,14 @@ func InstallOne(ctx context.Context, st *state.State, goal InstallGoal, opts Opt
 	return infos[0], tasksets[0], nil
 }
 
+func sortComponentsOnTargets(targets []target) {
+	for _, t := range targets {
+		sort.Slice(t.components, func(i, j int) bool {
+			return t.components[i].ComponentName() < t.components[j].ComponentName()
+		})
+	}
+}
+
 // InstallWithGoal installs the snap/set of snaps specified by the given
 // InstallGoal.
 //
@@ -627,13 +635,7 @@ func InstallWithGoal(ctx context.Context, st *state.State, goal InstallGoal, opt
 		return nil, nil, ErrExpectedOneSnap
 	}
 
-	for _, t := range targets {
-		// sort the components by name to ensure we always install components in the
-		// same order
-		sort.Slice(t.components, func(i, j int) bool {
-			return t.components[i].ComponentName() < t.components[j].ComponentName()
-		})
-	}
+	sortComponentsOnTargets(targets)
 
 	installInfos := make([]minimalInstallInfo, 0, len(targets))
 	for _, t := range targets {
@@ -1003,13 +1005,7 @@ func UpdateWithGoal(ctx context.Context, st *state.State, goal UpdateGoal, filte
 		return nil, nil, err
 	}
 
-	for _, t := range plan.targets {
-		// sort the components by name to ensure we always install components in the
-		// same order
-		sort.Slice(t.components, func(i, j int) bool {
-			return t.components[i].ComponentName() < t.components[j].ComponentName()
-		})
-	}
+	sortComponentsOnTargets(plan.targets)
 
 	if opts.ExpectOneSnap && len(plan.targets) != 1 {
 		return nil, nil, ErrExpectedOneSnap

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -3,9 +3,13 @@ package snapstate_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
-	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -13,13 +17,13 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type TargetTestSuite struct {
+type targetTestSuite struct {
 	snapmgrBaseTest
 }
 
-var _ = Suite(&TargetTestSuite{})
+var _ = Suite(&targetTestSuite{})
 
-func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
+func (s *targetTestSuite) TestInstallWithComponents(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -70,7 +74,7 @@ func (s *TargetTestSuite) TestInstallWithComponents(c *C) {
 	c.Check(compsups[0].CompSideInfo.Component.ComponentName, Equals, compName)
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -108,7 +112,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsMissingResource(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot find component "%s" in snap resources`, compName))
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsWrongType(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsWrongType(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -148,7 +152,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsWrongType(c *C) {
 	))
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsOtherResource(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsOtherResource(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -187,7 +191,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsOtherResource(c *C) {
 		`.*"otherresource/restype" is not a component resource`))
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -225,7 +229,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsMissingInInfo(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*"%s" is not a component for snap "%s"`, compName, snapName))
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsFromPath(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsFromPath(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -234,8 +238,8 @@ func (s *TargetTestSuite) TestInstallWithComponentsFromPath(c *C) {
 		snapID   = "some-snap-id"
 		compName = "test-component"
 		snapYaml = `name: some-snap
-version: 1.0
 type: kernel
+version: 1.0
 components:
   test-component:
     type: test
@@ -271,12 +275,11 @@ version: 1.0
 
 	c.Check(info.InstanceName(), Equals, snapName)
 	c.Check(info.Components[compName].Name, Equals, compName)
-	release.OnClassic = false
 
-	verifyInstallTasksWithComponents(c, snap.TypeKernel, localSnap, 0, []string{compName}, ts)
+	verifyInstallTasksWithComponents(c, snap.TypeKernel, localSnap|updatesGadgetAssets, 0, []string{compName}, ts)
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsMixedAssertedCompsAndUnassertedSnap(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsMixedAssertedCompsAndUnassertedSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -319,7 +322,7 @@ version: 1.0
 	c.Assert(err, ErrorMatches, "cannot mix unasserted snap and asserted components")
 }
 
-func (s *TargetTestSuite) TestInstallWithComponentsMixedUnassertedCompsAndAssertedSnap(c *C) {
+func (s *targetTestSuite) TestInstallWithComponentsMixedUnassertedCompsAndAssertedSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -364,7 +367,7 @@ version: 1.0
 	c.Assert(err, ErrorMatches, "cannot mix asserted snap and unasserted components")
 }
 
-func (s *TargetTestSuite) TestUpdateSnapNotInstalled(c *C) {
+func (s *targetTestSuite) TestUpdateSnapNotInstalled(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -379,7 +382,7 @@ func (s *TargetTestSuite) TestUpdateSnapNotInstalled(c *C) {
 	c.Assert(err, ErrorMatches, `snap "some-snap" is not installed`)
 }
 
-func (s *TargetTestSuite) TestInvalidPathGoals(c *C) {
+func (s *targetTestSuite) TestInvalidPathGoals(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -439,7 +442,7 @@ func (s *TargetTestSuite) TestInvalidPathGoals(c *C) {
 	}
 }
 
-func (s *TargetTestSuite) TestInstallFromStoreDefaultChannel(c *C) {
+func (s *targetTestSuite) TestInstallFromStoreDefaultChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -458,7 +461,7 @@ func (s *TargetTestSuite) TestInstallFromStoreDefaultChannel(c *C) {
 	c.Check(snapsup.Channel, Equals, "stable")
 }
 
-func (s *TargetTestSuite) TestInstallFromPathDefaultChannel(c *C) {
+func (s *targetTestSuite) TestInstallFromPathDefaultChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -487,7 +490,51 @@ components:
 	c.Check(snapsup.Channel, Equals, "")
 }
 
-func (s *TargetTestSuite) TestInstallFromPathSideInfoChannel(c *C) {
+func (s *targetTestSuite) TestInstallComponentsFromPathInvalidComponentFile(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	const (
+		snapID        = "test-snap-id"
+		snapName      = "test-snap"
+		componentName = "test-component"
+	)
+	snapRevision := snap.R(11)
+
+	csi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, componentName),
+		Revision:  snap.R(1),
+	}
+
+	compPath := filepath.Join(c.MkDir(), "invalid-component")
+	err := os.WriteFile(compPath, []byte("invalid-component"), 0644)
+	c.Assert(err, IsNil)
+
+	components := map[*snap.ComponentSideInfo]string{
+		&csi: compPath,
+	}
+
+	snapPath := makeTestSnap(c, `name: test-snap
+version: 1.0
+components:
+  test-component:
+    type: test
+`)
+	si := &snap.SideInfo{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snapRevision,
+	}
+
+	goal := snapstate.PathInstallGoal(snapName, snapPath, si, components, snapstate.RevisionOptions{})
+	_, _, err = snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`.*cannot process snap or snapdir: file "%s" is invalid.*`, compPath))
+}
+
+func (s *targetTestSuite) TestInstallFromPathSideInfoChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -517,7 +564,7 @@ components:
 	c.Check(snapsup.Channel, Equals, "edge")
 }
 
-func (s *TargetTestSuite) TestInstallFromPathRevOptsChannel(c *C) {
+func (s *targetTestSuite) TestInstallFromPathRevOptsChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -551,7 +598,7 @@ components:
 	c.Check(snapsup.Channel, Equals, "edge")
 }
 
-func (s *TargetTestSuite) TestInstallFromPathRevOptsSideInfoChannelMismatch(c *C) {
+func (s *targetTestSuite) TestInstallFromPathRevOptsSideInfoChannelMismatch(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -576,7 +623,7 @@ components:
 	c.Assert(err, ErrorMatches, `cannot install local snap "some-snap": edge != stable \(channel mismatch\)`)
 }
 
-func (s *TargetTestSuite) TestInstallFromStoreRevisionAndChannel(c *C) {
+func (s *targetTestSuite) TestInstallFromStoreRevisionAndChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -600,7 +647,7 @@ func (s *TargetTestSuite) TestInstallFromStoreRevisionAndChannel(c *C) {
 	c.Check(snapsup.Revision(), Equals, snap.R(7))
 }
 
-func (s *TargetTestSuite) TestInstallFromStoreRevisionAndChannelWithRedirectChannel(c *C) {
+func (s *targetTestSuite) TestInstallFromStoreRevisionAndChannelWithRedirectChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -626,4 +673,75 @@ func (s *TargetTestSuite) TestInstallFromStoreRevisionAndChannelWithRedirectChan
 	c.Assert(err, IsNil)
 	c.Check(snapsup.Channel, Equals, "2.0/stable")
 	c.Check(snapsup.Revision(), Equals, snap.R(7))
+}
+
+func (s *targetTestSuite) TestUpdateComponents(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const (
+		snapName = "some-snap"
+		snapID   = "some-snap-id"
+		compName = "test-component"
+		channel  = "channel-for-components"
+	)
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: snapName,
+		SnapID:   snapID,
+		Revision: snap.R(7),
+	}})
+
+	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.TestComponent,
+	})
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string, info *snap.Info, csi *snap.ComponentSideInfo,
+	) (*snap.ComponentInfo, error) {
+		return &snap.ComponentInfo{
+			Component:         naming.NewComponentRef(info.SnapName(), compName),
+			Type:              snap.TestComponent,
+			Version:           "1.0",
+			ComponentSideInfo: *csi,
+		}, nil
+	}))
+
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: channel,
+		Sequence:        seq,
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.SnapName(), DeepEquals, snapName)
+
+		return []store.SnapResourceResult{
+			{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: fmt.Sprintf("http://example.com/%s", snapName),
+				},
+				Name:      compName,
+				Revision:  2,
+				Type:      fmt.Sprintf("component/%s", snap.TestComponent),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			},
+		}
+	}
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: snapName,
+	})
+
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	verifyUpdateTasksWithComponents(c, snap.TypeApp, doesReRefresh, 0, []string{compName}, ts)
 }


### PR DESCRIPTION
This enables us to update snaps with components from local snap and component files.