### PR TITLE
secboot: add installation key abstraction

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -37,7 +37,7 @@ import (
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -256,7 +256,7 @@ func isAssetHashTrackedInMap(bam bootAssetsMap, assetName, assetHash string) boo
 type TrustedAssetsInstallObserver interface {
 	BootLoaderSupportsEfiVariables() bool
 	ObserveExistingTrustedRecoveryAssets(recoveryRootDir string) error
-	ChosenEncryptionKeys(key, saveKey keys.EncryptionKey)
+	SetBootstrappedContainers(key, saveKey secboot.BootstrappedContainer)
 	UpdateBootEntry() error
 	Observe(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error)
 }
@@ -279,9 +279,9 @@ type trustedAssetsInstallObserverImpl struct {
 	trustedRecoveryAssets map[string]string
 	trackedRecoveryAssets bootAssetsMap
 
-	useEncryption     bool
-	dataEncryptionKey keys.EncryptionKey
-	saveEncryptionKey keys.EncryptionKey
+	useEncryption             bool
+	dataBootstrappedContainer secboot.BootstrappedContainer
+	saveBootstrappedContainer secboot.BootstrappedContainer
 
 	seedBootloader bootloader.Bootloader
 }
@@ -368,10 +368,10 @@ func (o *trustedAssetsInstallObserverImpl) currentTrustedRecoveryBootAssetsMap()
 	return o.trackedRecoveryAssets
 }
 
-func (o *trustedAssetsInstallObserverImpl) ChosenEncryptionKeys(key, saveKey keys.EncryptionKey) {
+func (o *trustedAssetsInstallObserverImpl) SetBootstrappedContainers(key, saveKey secboot.BootstrappedContainer) {
 	o.useEncryption = true
-	o.dataEncryptionKey = key
-	o.saveEncryptionKey = saveKey
+	o.dataBootstrappedContainer = key
+	o.saveBootstrappedContainer = saveKey
 }
 
 func (o *trustedAssetsInstallObserverImpl) UpdateBootEntry() error {

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/snapcore/snapd/logger"
 	fdeBackend "github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -479,13 +478,16 @@ func (s *assetsSuite) TestInstallObserverNonTrustedBootloader(c *C) {
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, useEncryption)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
-	obs.ChosenEncryptionKeys(keys.EncryptionKey{1, 2, 3, 4}, keys.EncryptionKey{5, 6, 7, 8})
+	dataBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
+	saveBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
+	c.Assert(dataBootstrappedContainer, Not(Equals), saveBootstrappedContainer)
+	obs.SetBootstrappedContainers(dataBootstrappedContainer, saveBootstrappedContainer)
 
 	observerImpl, ok := obs.(*boot.TrustedAssetsInstallObserverImpl)
 	c.Assert(ok, Equals, true)
 
-	c.Check(observerImpl.CurrentDataEncryptionKey(), DeepEquals, keys.EncryptionKey{1, 2, 3, 4})
-	c.Check(observerImpl.CurrentSaveEncryptionKey(), DeepEquals, keys.EncryptionKey{5, 6, 7, 8})
+	c.Check(observerImpl.CurrentDataBootstrappedContainer(), DeepEquals, dataBootstrappedContainer)
+	c.Check(observerImpl.CurrentSaveBootstrappedContainer(), DeepEquals, saveBootstrappedContainer)
 }
 
 func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
@@ -504,13 +506,15 @@ func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, useEncryption)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
-	obs.ChosenEncryptionKeys(keys.EncryptionKey{1, 2, 3, 4}, keys.EncryptionKey{5, 6, 7, 8})
+	dataBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
+	saveBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
+	obs.SetBootstrappedContainers(dataBootstrappedContainer, saveBootstrappedContainer)
 
 	observerImpl, ok := obs.(*boot.TrustedAssetsInstallObserverImpl)
 	c.Assert(ok, Equals, true)
 
-	c.Check(observerImpl.CurrentDataEncryptionKey(), DeepEquals, keys.EncryptionKey{1, 2, 3, 4})
-	c.Check(observerImpl.CurrentSaveEncryptionKey(), DeepEquals, keys.EncryptionKey{5, 6, 7, 8})
+	c.Check(observerImpl.CurrentDataBootstrappedContainer(), DeepEquals, dataBootstrappedContainer)
+	c.Check(observerImpl.CurrentSaveBootstrappedContainer(), DeepEquals, saveBootstrappedContainer)
 }
 
 func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -104,12 +103,12 @@ func (o *trustedAssetsInstallObserverImpl) CurrentTrustedRecoveryBootAssetsMap()
 	return o.currentTrustedRecoveryBootAssetsMap()
 }
 
-func (o *trustedAssetsInstallObserverImpl) CurrentDataEncryptionKey() keys.EncryptionKey {
-	return o.dataEncryptionKey
+func (o *trustedAssetsInstallObserverImpl) CurrentDataBootstrappedContainer() secboot.BootstrappedContainer {
+	return o.dataBootstrappedContainer
 }
 
-func (o *trustedAssetsInstallObserverImpl) CurrentSaveEncryptionKey() keys.EncryptionKey {
-	return o.saveEncryptionKey
+func (o *trustedAssetsInstallObserverImpl) CurrentSaveBootstrappedContainer() secboot.BootstrappedContainer {
+	return o.saveBootstrappedContainer
 }
 
 func MockSecbootProvisionTPM(f func(mode secboot.TPMProvisionMode, lockoutAuthFile string) error) (restore func()) {

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -554,7 +554,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 			flags.SnapsDir = snapBlobDir
 		}
 		// seal the encryption key to the parameters specified in modeenv
-		if err := sealKeyToModeenv(observerImpl.dataEncryptionKey, observerImpl.saveEncryptionKey, model, modeenv, flags); err != nil {
+		if err := sealKeyToModeenv(observerImpl.dataBootstrappedContainer, observerImpl.saveBootstrappedContainer, model, modeenv, flags); err != nil {
 			return err
 		}
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -357,7 +357,7 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 	}
 
 	if useEncryption {
-		if err := install.PrepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
+		if err := install.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, trustedInstallObserver); err != nil {
 			return err
 		}
 	}

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -95,7 +95,7 @@ func CheckEncryptionSetupData(encryptSetup *EncryptionSetupData, labelToEncDevic
 			return fmt.Errorf("encrypted device in EncryptionSetupData (%q) different to expected (%q)",
 				encryptSetup.parts[label].encryptedDevice, labelToEncDevice[label])
 		}
-		if len(part.encryptionKey) == 0 {
+		if len(part.installKey.LegacyKeptKey()) == 0 {
 			return fmt.Errorf("encryption key for %q is empty", label)
 		}
 	}

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -55,7 +54,7 @@ func EncryptPartitions(onVolumes map[string]*gadget.Volume, encryptionType secbo
 	return nil, fmt.Errorf("build without secboot support")
 }
 
-func KeysForRole(setupData *EncryptionSetupData) map[string]keys.EncryptionKey {
+func BootstrappedContainersForRole(setupData *EncryptionSetupData) map[string]secboot.BootstrappedContainer {
 	return nil
 }
 

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -44,7 +44,6 @@ import (
 	installLogic "github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
@@ -528,7 +527,7 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 			return nil
 		})
 		s.AddCleanup(restore)
-		restore = boot.MockSealKeyToModeenv(func(key, saveKey keys.EncryptionKey, model *asserts.Model, modeenv *boot.Modeenv, flags boot.MockSealKeyToModeenvFlags) error {
+		restore = boot.MockSealKeyToModeenv(func(key, saveKey secboot.BootstrappedContainer, model *asserts.Model, modeenv *boot.Modeenv, flags boot.MockSealKeyToModeenvFlags) error {
 			c.Check(model.Classic(), Equals, opts.installClassic)
 			// Note that we cannot compare the full structure and we check
 			// separately bits as the types for these are not exported.

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -255,15 +255,15 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		brOpts = options
 		installSealingObserver = obs
 		installRunCalled++
-		var keyForRole map[string]keys.EncryptionKey
+		var installKeyForRole map[string]secboot.BootstrappedContainer
 		if tc.encrypt {
-			keyForRole = map[string]keys.EncryptionKey{
-				gadget.SystemData: dataEncryptionKey,
-				gadget.SystemSave: saveKey,
+			installKeyForRole = map[string]secboot.BootstrappedContainer{
+				gadget.SystemData: secboot.CreateBootstrappedContainer(dataEncryptionKey, ""),
+				gadget.SystemSave: secboot.CreateBootstrappedContainer(saveKey, ""),
 			}
 		}
 		return &install.InstalledSystemSideData{
-			KeyForRole: keyForRole,
+			BootstrappedContainerForRole: installKeyForRole,
 		}, nil
 	})
 	defer restore()
@@ -1210,7 +1210,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallEncryptionValidityChecksNoSystemD
 		// no keys set
 		return &install.InstalledSystemSideData{
 			// empty map
-			KeyForRole: map[string]keys.EncryptionKey{},
+			BootstrappedContainerForRole: map[string]secboot.BootstrappedContainer{},
 		}, nil
 	})
 	defer restore()
@@ -1568,11 +1568,11 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 		brOpts = options
 		installSealingObserver = obs
 		installFactoryResetCalled++
-		var keyForRole map[string]keys.EncryptionKey
+		var installKeyForRole map[string]secboot.BootstrappedContainer
 		if tc.encrypt {
-			keyForRole = map[string]keys.EncryptionKey{
-				gadget.SystemData: dataEncryptionKey,
-				gadget.SystemSave: saveKey,
+			installKeyForRole = map[string]secboot.BootstrappedContainer{
+				gadget.SystemData: secboot.CreateBootstrappedContainer(dataEncryptionKey, ""),
+				gadget.SystemSave: secboot.CreateBootstrappedContainer(saveKey, ""),
 			}
 		}
 		devForRole := map[string]string{
@@ -1583,8 +1583,8 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 		}
 		c.Assert(os.MkdirAll(dirs.SnapDeviceDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")), 0755), IsNil)
 		return &install.InstalledSystemSideData{
-			KeyForRole:    keyForRole,
-			DeviceForRole: devForRole,
+			BootstrappedContainerForRole: installKeyForRole,
+			DeviceForRole:                devForRole,
 		}, nil
 	})
 	defer restore()

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -299,7 +299,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if useEncryption {
-		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
+		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -615,13 +615,15 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 			return fmt.Errorf("internal error: no system-save device")
 		}
 
+		saveBootstrappedContainer := secboot.CreateBootstrappedContainer(saveEncryptionKey, saveNode)
+
 		if err := secbootStageEncryptionKeyChange(saveNode, saveEncryptionKey); err != nil {
 			return fmt.Errorf("cannot change encryption keys: %v", err)
 		}
 		// keep track of the new ubuntu-save encryption key
-		installedSystem.KeyForRole[gadget.SystemSave] = saveEncryptionKey
+		installedSystem.BootstrappedContainerForRole[gadget.SystemSave] = saveBootstrappedContainer
 
-		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
+		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -1085,7 +1087,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 
 	if useEncryption {
 		if trustedInstallObserver != nil {
-			if err := installLogic.PrepareEncryptedSystemData(systemAndSnaps.Model, install.KeysForRole(encryptSetupData), trustedInstallObserver); err != nil {
+			if err := installLogic.PrepareEncryptedSystemData(systemAndSnaps.Model, install.BootstrappedContainersForRole(encryptSetupData), trustedInstallObserver); err != nil {
 				return err
 			}
 		}

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -893,11 +893,11 @@ func (s *installSuite) TestPrepareEncryptedSystemData(c *C) {
 	err = to.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir)
 	c.Assert(err, IsNil)
 
-	keyForRole := map[string]keys.EncryptionKey{
-		gadget.SystemData: dataEncryptionKey,
-		gadget.SystemSave: saveKey,
+	installKeyForRole := map[string]secboot.BootstrappedContainer{
+		gadget.SystemData: secboot.CreateBootstrappedContainer(dataEncryptionKey, ""),
+		gadget.SystemSave: secboot.CreateBootstrappedContainer(saveKey, ""),
 	}
-	err = install.PrepareEncryptedSystemData(mockModel, keyForRole, to)
+	err = install.PrepareEncryptedSystemData(mockModel, installKeyForRole, to)
 	c.Assert(err, IsNil)
 
 	c.Check(filepath.Join(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde"), "ubuntu-save.key"), testutil.FileEquals, []byte(saveKey))

--- a/secboot/bootstrap_container.go
+++ b/secboot/bootstrap_container.go
@@ -1,0 +1,105 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type DiskUnlockKey = []byte
+
+type KeyDataWriter interface {
+	// TODO: this will typically have a function that takes a key
+	// data as input
+}
+
+// BootstrappedContainer is an abstraction for an encrypted container
+// along with a key that is able to enroll other keys.  This key is
+// meant to be an initial key that is removed after all required keys
+// are enrolled, by calling RemoveBootstrapKey.
+type BootstrappedContainer interface {
+	//LegacyKeptKey is only temporary until we have moved to using multiple keys
+	LegacyKeptKey() DiskUnlockKey
+	//AddKey adds a key "newKey" to "slotName"
+	//If "token", the a KeyDataWriter is returned to write key data to the token of the new key slot
+	AddKey(slotName string, newKey []byte, token bool) (KeyDataWriter, error)
+	//RemoveBootstrapKey removes the bootstrap key
+	RemoveBootstrapKey() error
+}
+
+type legacyBootstrappedContainer struct {
+	key      DiskUnlockKey
+	finished bool
+}
+
+func (l *legacyBootstrappedContainer) LegacyKeptKey() DiskUnlockKey {
+	if l.finished {
+		panic("internal error: trying to access installation key after being removed")
+	}
+	return l.key
+}
+
+func (l *legacyBootstrappedContainer) AddKey(slotName string, newKey []byte, token bool) (KeyDataWriter, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (l *legacyBootstrappedContainer) RemoveBootstrapKey() error {
+	l.finished = true
+	return nil
+}
+
+// CreateBootstrappedContainer creates a new BootstrappedContainer for a given device
+// path and bootstrap unlock key. The unlock key must be valid to
+// unlock the device.
+// TODO: devicePath might use an abstraction for key slot container,
+// instead of a path
+// TODO: key should probably be optional and generated instead
+func CreateBootstrappedContainer(key DiskUnlockKey, devicePath string) BootstrappedContainer {
+	return &legacyBootstrappedContainer{
+		key:      key,
+		finished: false,
+	}
+}
+
+type mockBootstrappedContainer struct {
+	finished bool
+}
+
+func (l *mockBootstrappedContainer) LegacyKeptKey() DiskUnlockKey {
+	panic("not implemented")
+}
+
+func (l *mockBootstrappedContainer) AddKey(slotName string, newKey []byte, token bool) (KeyDataWriter, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (l *mockBootstrappedContainer) RemoveBootstrapKey() error {
+	l.finished = true
+	return nil
+}
+
+func CreateMockBootstrappedContainer() BootstrappedContainer {
+	osutil.MustBeTestBinary("CreateMockBootstrappedContainer can be only called from tests")
+	return &mockBootstrappedContainer{
+		finished: false,
+	}
+}

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -66,8 +66,8 @@ func NewLoadChain(bf bootloader.BootFile, next ...*LoadChain) *LoadChain {
 }
 
 type SealKeyRequest struct {
-	// The key to seal
-	Key keys.EncryptionKey
+	// The installation key to enroll a new key slot
+	BootstrappedContainer BootstrappedContainer
 	// The key name; identical keys should have identical names
 	KeyName string
 	// The path to store the sealed key file. The same Key/KeyName

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -51,7 +51,9 @@ func init() {
 func SealKeysWithFDESetupHook(runHook fde.RunSetupHookFunc, keys []SealKeyRequest, params *SealKeysWithFDESetupHookParams) error {
 	auxKey := params.AuxKey[:]
 	for _, skr := range keys {
-		payload := sb.MarshalKeys([]byte(skr.Key), auxKey)
+		// TODO: enroll a new keyslot instead of reusing the bootstrap key
+		key := skr.BootstrappedContainer.LegacyKeptKey()
+		payload := sb.MarshalKeys([]byte(key), auxKey)
 		keyParams := &fde.InitialSetupParams{
 			Key:     payload,
 			KeyName: skr.KeyName,

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -395,8 +395,11 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) error {
 
 	sbKeys := make([]*sb_tpm2.SealKeyRequest, 0, len(keys))
 	for i := range keys {
+		// TODO: we will create a new sealed key here and add
+		// it to a key slot instead of sealing the bootstrap
+		// key.
 		sbKeys = append(sbKeys, &sb_tpm2.SealKeyRequest{
-			Key:  keys[i].Key,
+			Key:  keys[i].BootstrappedContainer.LegacyKeptKey(),
 			Path: keys[i].KeyFile,
 		})
 	}

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 )
@@ -57,7 +56,7 @@ func (o *simpleObserver) Observe(op gadget.ContentOperation, partRole, root, dst
 	return gadget.ChangeApply, nil
 }
 
-func (o *simpleObserver) ChosenEncryptionKey(key keys.EncryptionKey) {}
+func (o *simpleObserver) ChosenBootstrappedContainer(key secboot.BootstrappedContainer) {}
 
 type uc20Constraints struct{}
 
@@ -97,20 +96,20 @@ func main() {
 	}
 
 	if args.Encrypt {
-		if installSideData == nil || len(installSideData.KeyForRole) == 0 {
+		if installSideData == nil || len(installSideData.BootstrappedContainerForRole) == 0 {
 			panic("expected encryption keys")
 		}
-		dataKey := installSideData.KeyForRole[gadget.SystemData]
+		dataKey := installSideData.BootstrappedContainerForRole[gadget.SystemData]
 		if dataKey == nil {
 			panic("ubuntu-data encryption key is unset")
 		}
-		saveKey := installSideData.KeyForRole[gadget.SystemSave]
+		saveKey := installSideData.BootstrappedContainerForRole[gadget.SystemSave]
 		if saveKey == nil {
 			panic("ubuntu-save encryption key is unset")
 		}
 		toWrite := map[string][]byte{
-			"unsealed-key": dataKey[:],
-			"save-key":     saveKey[:],
+			"unsealed-key": dataKey.LegacyKeptKey()[:],
+			"save-key":     saveKey.LegacyKeptKey()[:],
 		}
 		for keyFileName, keyData := range toWrite {
 			if err := os.WriteFile(keyFileName, keyData, 0644); err != nil {


### PR DESCRIPTION
Because we will need to enroll multiple keys, we need to make the first key at volume creation an installation key that we remove in the end.  This commit does not implement it, but it does add the abstraction where to allow us to do it.
