### PR TITLE
o/snapstate: do not discard components if we are refreshing to the same revision already installed

### DIFF
--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -390,7 +390,9 @@ func (s *snapmgrTestSuite) TestInstallComponentPathCompRevisionPresent(c *C) {
 		snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	verifyComponentInstallTasks(c, compOptIsLocal|compOptRevisionPresent|compOptIsActive|compCurrentIsDiscarded, ts)
+	// note that we don't discard the component here, since the component
+	// revision is the same as the one we install
+	verifyComponentInstallTasks(c, compOptIsLocal|compOptRevisionPresent|compOptIsActive, ts)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	// Temporary file is deleted as component file is already in the system
 	c.Assert(osutil.FileExists(compPath), Equals, false)


### PR DESCRIPTION
We were discarding the component that was just installed (and also previously installed) when doing something like a `snap refresh --revision=n <snap>`, where `n` is the current revision, and no component revisions change.