### PR TITLE
snap-confine: Add nvidia-drm_gbm.so to the list of NVIDIA libraries

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -78,12 +78,14 @@ static const size_t egl_vendor_globs_len =
 // FIXME: this doesn't yet work with libGLX and libglvnd redirector
 // FIXME: this still doesn't work with the 361 driver
 static const char *nvidia_globs[] = {
+	"gbm/nvidia-drm_gbm.so",
 	"libEGL_nvidia.so*",
 	"libGLESv1_CM_nvidia.so*",
 	"libGLESv2_nvidia.so*",
 	"libGLX_nvidia.so*",
 	"libXvMCNVIDIA.so*",
 	"libXvMCNVIDIA_dynamic.so*",
+	"libnvidia-allocator.so*",
 	"libnvidia-cfg.so*",
 	"libnvidia-compiler.so*",
 	"libnvidia-eglcore.so*",


### PR DESCRIPTION
NVIDIA implements the libgbm backend interface in $libdir/gbm/nvidia-drm_gbm.so which is a symlink to ../libnvidia-allocator.so.1

To be discovered by libgbm it needs the $GBM_BACKENDS_PATH environment variable pointing to $libdir/gbm