### PR TITLE
o/snapstate, daemon: allow installing components for already installed snap

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -139,7 +139,6 @@ func storeFrom(d *Daemon) snapstate.StoreService {
 
 var (
 	snapstateStoreInstallGoal               = snapstate.StoreInstallGoal
-	snapstateInstallOne                     = snapstate.InstallOne
 	snapstateInstallWithGoal                = snapstate.InstallWithGoal
 	snapstateInstallPath                    = snapstate.InstallPath
 	snapstateInstallPathMany                = snapstate.InstallPathMany

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -143,6 +143,7 @@ var (
 	snapstateInstallPath                    = snapstate.InstallPath
 	snapstateInstallPathMany                = snapstate.InstallPathMany
 	snapstateInstallComponentPath           = snapstate.InstallComponentPath
+	snapstateInstallComponents              = snapstate.InstallComponents
 	snapstateRefreshCandidates              = snapstate.RefreshCandidates
 	snapstateTryPath                        = snapstate.TryPath
 	snapstateUpdate                         = snapstate.Update

--- a/daemon/api_aliases_test.go
+++ b/daemon/api_aliases_test.go
@@ -590,11 +590,11 @@ func (s *aliasesSuite) TestAliases(c *check.C) {
 func (s *aliasesSuite) TestInstallUnaliased(c *check.C) {
 	var calledFlags snapstate.Flags
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		calledFlags = opts.Flags
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)
@@ -617,11 +617,11 @@ func (s *aliasesSuite) TestInstallUnaliased(c *check.C) {
 func (s *aliasesSuite) TestInstallIgnoreRunning(c *check.C) {
 	var calledFlags snapstate.Flags
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		calledFlags = opts.Flags
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)
@@ -644,11 +644,11 @@ func (s *aliasesSuite) TestInstallIgnoreRunning(c *check.C) {
 func (s *aliasesSuite) TestInstallPrefer(c *check.C) {
 	var calledFlags snapstate.Flags
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		calledFlags = opts.Flags
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -204,7 +204,7 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 		return &snap.Info{SuggestedName: mockedName}, nil
 	})()
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, check.HasLen, 1)
@@ -214,7 +214,7 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 		installQueue = append(installQueue, goal.snaps[0].InstanceName)
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags, prqt snapstate.PrereqTracker) (*state.TaskSet, *snap.Info, error) {
@@ -1315,7 +1315,7 @@ func (s *trySuite) TestTrySnap(c *check.C) {
 			return state.NewTaskSet(t), nil
 		})()
 
-		defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+		defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 			goal, ok := g.(*storeInstallGoalRecorder)
 			c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 			c.Assert(goal.snaps, check.HasLen, 1)
@@ -1325,7 +1325,7 @@ func (s *trySuite) TestTrySnap(c *check.C) {
 			}
 
 			t := st.NewTask("fake-install-snap", "Doing a fake install")
-			return &snap.Info{}, state.NewTaskSet(t), nil
+			return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 		})()
 
 		// try the snap (without an installed core)

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -854,6 +854,11 @@ func installationTaskSets(ctx context.Context, st *state.State, inst *snapInstru
 		opts.Flags.Transaction = inst.Transaction
 	}
 
+	revOpts := snapstate.RevisionOptions{}
+	if expectOneSnap {
+		revOpts = *inst.revnoOpts()
+	}
+
 	var (
 		tss   []*state.TaskSet
 		snaps []snapstate.StoreSnap
@@ -882,11 +887,6 @@ func installationTaskSets(ctx context.Context, st *state.State, inst *snapInstru
 			tss = append(tss, ts...)
 
 			continue
-		}
-
-		revOpts := snapstate.RevisionOptions{}
-		if expectOneSnap {
-			revOpts = *inst.revnoOpts()
 		}
 
 		snaps = append(snaps, snapstate.StoreSnap{

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -3970,3 +3970,125 @@ func (s *snapsSuite) TestInstallManyWithComponents(c *check.C) {
 	c.Check(chg.Kind(), check.Equals, "install-snap")
 	c.Check(chg.Summary(), check.Equals, `Install snaps "some-snap" (with components "some-comp1", "some-comp2"), "other-snap" (with component "other-comp1")`)
 }
+
+func (s *snapsSuite) TestInstallWithComponentsAlreadyInstalled(c *check.C) {
+	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
+		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
+		c.Check(info.InstanceName(), check.Equals, "some-snap")
+		t := st.NewTask("fake-install-component", "Doing a fake components install")
+		return []*state.TaskSet{state.NewTaskSet(t)}, nil
+	})()
+
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
+		c.Fatal("unexpected call to snapstateInstallWithGoal")
+		return nil, nil, nil
+	})()
+
+	d := s.daemonWithFakeSnapManager(c)
+
+	r := strings.NewReader(`{"action": "install", "components": ["comp1", "comp2"]}`)
+	req, err := http.NewRequest("POST", "/v2/snaps/some-snap", r)
+	c.Assert(err, check.IsNil)
+
+	st := d.Overlord().State()
+	st.Lock()
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+	}
+
+	snapstate.Set(st, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{sequence.NewRevisionSideState(si, nil)},
+		),
+		Current: snap.R(1),
+	})
+	st.Unlock()
+
+	rsp := s.asyncReq(c, req, nil)
+
+	st.Lock()
+
+	chg := st.Change(rsp.Change)
+	c.Assert(chg, check.NotNil)
+
+	c.Check(chg.Tasks(), check.HasLen, 1)
+
+	st.Unlock()
+	s.waitTrivialChange(c, chg)
+	st.Lock()
+
+	c.Check(chg.Status(), check.Equals, state.DoneStatus)
+	c.Check(err, check.IsNil)
+	c.Check(chg.Kind(), check.Equals, "install-snap")
+	c.Check(chg.Summary(), check.Equals, `Install "some-snap" snap with components "comp1", "comp2"`)
+}
+
+func (s *snapsSuite) TestManyInstallWithComponentsAlreadyInstalled(c *check.C) {
+	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
+		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
+		c.Check(info.InstanceName(), check.Equals, "some-snap-with-components")
+		t := st.NewTask("fake-install-component", "Doing a fake components install")
+		return []*state.TaskSet{state.NewTaskSet(t)}, nil
+	})()
+
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
+		goal, ok := g.(*storeInstallGoalRecorder)
+		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
+		c.Assert(goal.snaps, check.HasLen, 1)
+
+		c.Check(goal.snaps[0].InstanceName, check.Equals, "some-snap")
+		c.Check(goal.snaps[0].Components, check.HasLen, 0)
+
+		t := st.NewTask("fake-install-snap", "Doing a fake install")
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
+	})()
+
+	d := s.daemonWithFakeSnapManager(c)
+
+	r := strings.NewReader(`{"action": "install", "snaps": ["some-snap", "some-snap-with-components"], "components": {"some-snap-with-components": ["comp1", "comp2"]}}`)
+	req, err := http.NewRequest("POST", "/v2/snaps", r)
+	c.Assert(err, check.IsNil)
+	req.Header.Set("Content-Type", "application/json")
+
+	st := d.Overlord().State()
+	st.Lock()
+	si := &snap.SideInfo{
+		RealName: "some-snap-with-components",
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+	}
+
+	snapstate.Set(st, "some-snap-with-components", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{sequence.NewRevisionSideState(si, nil)},
+		),
+		Current: snap.R(1),
+	})
+	st.Unlock()
+
+	rsp := s.asyncReq(c, req, nil)
+
+	st.Lock()
+
+	chg := st.Change(rsp.Change)
+	c.Assert(chg, check.NotNil)
+
+	c.Check(chg.Tasks(), check.HasLen, 2)
+
+	st.Unlock()
+	s.waitTrivialChange(c, chg)
+	st.Lock()
+
+	c.Check(chg.Status(), check.Equals, state.DoneStatus)
+	c.Check(err, check.IsNil)
+	c.Check(chg.Kind(), check.Equals, "install-snap")
+
+	// TODO: decide if we want to have a better summary that indicates that
+	// the component was installed for an already installed snap. more
+	// complicated code, but it could be nice to have.
+	c.Check(chg.Summary(), check.Equals, `Install snaps "some-snap", "some-snap-with-components" (with components "comp1", "comp2")`)
+}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -3971,7 +3971,7 @@ func (s *snapsSuite) TestInstallManyWithComponents(c *check.C) {
 	c.Check(chg.Summary(), check.Equals, `Install snaps "some-snap" (with components "some-comp1", "some-comp2"), "other-snap" (with component "other-comp1")`)
 }
 
-func (s *snapsSuite) TestInstallWithComponentsAlreadyInstalled(c *check.C) {
+func (s *snapsSuite) TestInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
 	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
 		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
 		c.Check(info.InstanceName(), check.Equals, "some-snap")
@@ -4026,7 +4026,7 @@ func (s *snapsSuite) TestInstallWithComponentsAlreadyInstalled(c *check.C) {
 	c.Check(chg.Summary(), check.Equals, `Install "some-snap" snap with components "comp1", "comp2"`)
 }
 
-func (s *snapsSuite) TestManyInstallWithComponentsAlreadyInstalled(c *check.C) {
+func (s *snapsSuite) TestManyInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
 	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
 		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
 		c.Check(info.InstanceName(), check.Equals, "some-snap-with-components")

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1981,7 +1981,7 @@ func (s *snapsSuite) testPostSnap(c *check.C, extraJSON string, checkOpts func(o
 	defer restore()
 
 	checked := false
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, check.HasLen, 1)
@@ -1991,7 +1991,7 @@ func (s *snapsSuite) testPostSnap(c *check.C, extraJSON string, checkOpts func(o
 		}
 		checked = true
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	var buf *bytes.Buffer
@@ -2168,11 +2168,11 @@ func (s *snapsSuite) TestPostSnapSetsUser(c *check.C) {
 	defer restore()
 
 	checked := false
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		c.Check(opts.UserID, check.Equals, 1)
 		checked = true
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	state := d.Overlord().State()
@@ -2233,7 +2233,7 @@ func (s *snapsSuite) TestPostSnapOptionsUnsupportedAction(c *check.C) {
 func (s *snapsSuite) TestInstall(c *check.C) {
 	var calledName string
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, check.HasLen, 1)
@@ -2241,7 +2241,7 @@ func (s *snapsSuite) TestInstall(c *check.C) {
 		calledName = goal.snaps[0].InstanceName
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)
@@ -2263,11 +2263,11 @@ func (s *snapsSuite) TestInstall(c *check.C) {
 func (s *snapsSuite) TestInstallWithQuotaGroup(c *check.C) {
 	var calledFlags snapstate.Flags
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		calledFlags = opts.Flags
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)
@@ -2288,11 +2288,11 @@ func (s *snapsSuite) TestInstallWithQuotaGroup(c *check.C) {
 func (s *snapsSuite) TestInstallDevMode(c *check.C) {
 	var calledFlags snapstate.Flags
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		calledFlags = opts.Flags
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)
@@ -2315,11 +2315,11 @@ func (s *snapsSuite) TestInstallDevMode(c *check.C) {
 func (s *snapsSuite) TestInstallJailMode(c *check.C) {
 	var calledFlags snapstate.Flags
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		calledFlags = opts.Flags
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)
@@ -2376,7 +2376,7 @@ func (s *snapsSuite) TestInstallCohort(c *check.C) {
 	var calledName string
 	var calledCohort string
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, check.HasLen, 1)
@@ -2385,7 +2385,7 @@ func (s *snapsSuite) TestInstallCohort(c *check.C) {
 		calledCohort = goal.snaps[0].RevOpts.CohortKey
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemon(c)
@@ -2409,7 +2409,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 	var calledFlags snapstate.Flags
 	installQueue := []string{}
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, check.HasLen, 1)
@@ -2418,7 +2418,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 		calledFlags = opts.Flags
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
 		return nil
@@ -2447,7 +2447,7 @@ func (s *snapsSuite) TestInstallIgnoreValidation(c *check.C) {
 }
 
 func (s *snapsSuite) TestInstallEmptyName(c *check.C) {
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		return nil, nil, errors.New("should not be called")
 	})()
 
@@ -2480,7 +2480,7 @@ func (s *snapsSuite) testInstall(c *check.C, forcedDevmode bool, flags snapstate
 	restore := sandbox.MockForceDevMode(forcedDevmode)
 	defer restore()
 
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, check.HasLen, 1)
@@ -2490,7 +2490,7 @@ func (s *snapsSuite) testInstall(c *check.C, forcedDevmode bool, flags snapstate
 		c.Check(revision, check.Equals, goal.snaps[0].RevOpts.Revision)
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemonWithFakeSnapManager(c)
@@ -2527,10 +2527,10 @@ func (s *snapsSuite) testInstall(c *check.C, forcedDevmode bool, flags snapstate
 }
 
 func (s *snapsSuite) TestInstallUserAgentContextCreated(c *check.C) {
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		s.ctx = ctx
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	s.daemonWithFakeSnapManager(c)
@@ -2549,9 +2549,9 @@ func (s *snapsSuite) TestInstallUserAgentContextCreated(c *check.C) {
 }
 
 func (s *snapsSuite) TestInstallFails(c *check.C) {
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		t := st.NewTask("fake-install-snap-error", "Install task")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemonWithFakeSnapManager(c)
@@ -3883,7 +3883,7 @@ func (s *snapsSuite) TestPostComponentsManyRemoveCompsAndSnap(c *check.C) {
 }
 
 func (s *snapsSuite) TestInstallWithComponents(c *check.C) {
-	defer daemon.MockSnapstateInstallOne(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) (*snap.Info, *state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, check.Equals, true, check.Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, check.HasLen, 1)
@@ -3892,7 +3892,7 @@ func (s *snapsSuite) TestInstallWithComponents(c *check.C) {
 		c.Check(goal.snaps[0].Components, check.DeepEquals, []string{"comp1", "comp2"})
 
 		t := st.NewTask("fake-install-snap", "Doing a fake install")
-		return &snap.Info{}, state.NewTaskSet(t), nil
+		return []*snap.Info{{}}, []*state.TaskSet{state.NewTaskSet(t)}, nil
 	})()
 
 	d := s.daemonWithFakeSnapManager(c)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -139,14 +139,6 @@ func MockAssertstateTryEnforceValidationSets(f func(st *state.State, validationS
 	return r
 }
 
-func MockSnapstateInstallOne(mock func(context.Context, *state.State, snapstate.InstallGoal, snapstate.Options) (*snap.Info, *state.TaskSet, error)) (restore func()) {
-	old := snapstateInstallOne
-	snapstateInstallOne = mock
-	return func() {
-		snapstateInstallOne = old
-	}
-}
-
 func MockSnapstateInstallWithGoal(mock func(ctx context.Context, st *state.State, goal snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error)) (restore func()) {
 	old := snapstateInstallWithGoal
 	snapstateInstallWithGoal = mock

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -147,6 +147,14 @@ func MockSnapstateInstallWithGoal(mock func(ctx context.Context, st *state.State
 	}
 }
 
+func MockSnapstateInstallComponents(mock func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
+	old := snapstateInstallComponents
+	snapstateInstallComponents = mock
+	return func() {
+		snapstateInstallComponents = old
+	}
+}
+
 func MockSnapstateStoreInstallGoal(mock func(snaps ...snapstate.StoreSnap) snapstate.InstallGoal) (restore func()) {
 	old := snapstateStoreInstallGoal
 	snapstateStoreInstallGoal = mock

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -32,7 +32,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/store"
-	"github.com/snapcore/snapd/strutil"
 )
 
 // InstallComponents installs all of the components in the given names list. The
@@ -50,14 +49,9 @@ func InstallComponents(ctx context.Context, st *state.State, names []string, inf
 		return nil, err
 	}
 
-	currentComps, err := snapst.CurrentComponentInfos()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, comp := range currentComps {
-		if strutil.ListContains(names, comp.Component.ComponentName) {
-			return nil, fmt.Errorf("cannot install already installed component: %q", comp.Component)
+	for _, comp := range names {
+		if snapst.CurrentComponentSideInfo(naming.NewComponentRef(info.SnapName(), comp)) != nil {
+			return nil, snap.AlreadyInstalledComponentError{Component: comp}
 		}
 	}
 

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -192,9 +192,10 @@ func installComponentAction(st *state.State, snapst SnapState, opts Options) (*s
 	// we send a refresh action, since that is what the store requested that
 	// we do in this case
 	action := &store.SnapAction{
-		Action:       "refresh",
-		SnapID:       si.SnapID,
-		InstanceName: snapst.InstanceName(),
+		Action:          "refresh",
+		SnapID:          si.SnapID,
+		InstanceName:    snapst.InstanceName(),
+		ResourceInstall: true,
 	}
 
 	// we send an action that contains the current channel and revision so

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -91,7 +91,7 @@ func InstallComponents(ctx context.Context, st *state.State, names []string, inf
 
 		// here we share the setupSecurity and kmodSetup tasks between all of
 		// the component task chains. this results in multiple parallel tasks
-		// (one per copmonent) that have syncronization points at the
+		// (one per copmonent) that have synchronization points at the
 		// setupSecurity and kmodSetup tasks.
 		componentTS, err := doInstallComponent(st, &snapst, compsup, snapsup, setupSecurity.ID(), setupSecurity, kmodSetup, opts.FromChange)
 		if err != nil {

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -38,6 +38,8 @@ import (
 // InstallComponents installs all of the components in the given names list. The
 // snap represented by info must already be installed, and all of the components
 // in names should not be installed prior to calling this function.
+//
+// TODO:COMPS: respect the transaction that is passed to this function
 func InstallComponents(ctx context.Context, st *state.State, names []string, info *snap.Info, opts Options) ([]*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, info.InstanceName(), &snapst)

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -118,9 +118,11 @@ func InstallComponents(ctx context.Context, st *state.State, names []string, inf
 
 	setupSecurity.Set("component-setup-tasks", compSetupIDs)
 
-	tss = append(tss, state.NewTaskSet(setupSecurity, kmodSetup))
-
-	return tss, nil
+	ts := state.NewTaskSet(setupSecurity)
+	if kmodSetup != nil {
+		ts.AddTask(kmodSetup)
+	}
+	return append(tss, ts), nil
 }
 
 func componentSetupsForInstall(ctx context.Context, st *state.State, names []string, info *snap.Info, opts Options) ([]ComponentSetup, error) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3635,7 +3635,7 @@ func removeInactiveRevision(st *state.State, snapst *SnapState, name, snapID str
 			CompSideInfo: &cinfo.ComponentSideInfo,
 			CompType:     cinfo.Type,
 			componentInstallFlags: componentInstallFlags{
-				JointSnapComponentsInstall: true,
+				MultiComponentInstall: true,
 			},
 		}
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -436,7 +436,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 		}
 	}
 
-	tasksBeforePreRefreshHook, tasksAfterLinkSnap, tasksAfterPostOpHook, compSetupIDs, err := splitComponentTasksForInstall(
+	tasksBeforePreRefreshHook, tasksAfterLinkSnap, tasksAfterPostOpHook, tasksBeforeDiscard, compSetupIDs, err := splitComponentTasksForInstall(
 		compsups, st, snapst, snapsup, prepare.ID(), fromChange,
 	)
 	if err != nil {
@@ -614,6 +614,12 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 	startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q%s services"), snapsup.InstanceName(), revisionStr))
 	addTask(startSnapServices)
 
+	// TODO:COMPS: test discarding components during a snap refresh (coming
+	// soon!)
+	for _, t := range tasksBeforeDiscard {
+		addTask(t)
+	}
+
 	// Do not do that if we are reverting to a local revision
 	var cleanupTask *state.Task
 	if snapst.IsInstalled() && !snapsup.Flags.Revert {
@@ -750,23 +756,26 @@ func splitComponentTasksForInstall(
 	snapSetupTaskID string,
 	fromChange string,
 ) (
-	tasksBeforePreRefreshHook, tasksAfterLinkSnap, tasksAfterPostOpHook []*state.Task,
+	tasksBeforePreRefreshHook, tasksAfterLinkSnap, tasksAfterPostOpHook, tasksBeforeDiscard []*state.Task,
 	compSetupIDs []string,
 	err error,
 ) {
 	for _, compsup := range compsups {
 		componentTS, err := doInstallComponent(st, snapst, compsup, snapsup, snapSetupTaskID, fromChange)
 		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)
 		}
 
-		compSetupIDs = append(compSetupIDs, componentTS.compSetupTask.ID())
+		compSetupIDs = append(compSetupIDs, componentTS.compSetupTaskID)
 
 		tasksBeforePreRefreshHook = append(tasksBeforePreRefreshHook, componentTS.beforeLink...)
-		tasksAfterLinkSnap = append(tasksAfterLinkSnap, componentTS.linkToHook...)
+		tasksAfterLinkSnap = append(tasksAfterLinkSnap, componentTS.linkTask)
 		tasksAfterPostOpHook = append(tasksAfterPostOpHook, componentTS.postOpHookAndAfter...)
+		if componentTS.discardTask != nil {
+			tasksBeforeDiscard = append(tasksBeforeDiscard, componentTS.discardTask)
+		}
 	}
-	return tasksBeforePreRefreshHook, tasksAfterLinkSnap, tasksAfterPostOpHook, compSetupIDs, nil
+	return tasksBeforePreRefreshHook, tasksAfterLinkSnap, tasksAfterPostOpHook, tasksBeforeDiscard, compSetupIDs, nil
 }
 
 func NeedsKernelSetup(model *asserts.Model) bool {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -761,7 +761,7 @@ func splitComponentTasksForInstall(
 	err error,
 ) {
 	for _, compsup := range compsups {
-		componentTS, err := doInstallComponent(st, snapst, compsup, snapsup, snapSetupTaskID, fromChange)
+		componentTS, err := doInstallComponent(st, snapst, compsup, snapsup, snapSetupTaskID, nil, nil, fromChange)
 		if err != nil {
 			return nil, nil, nil, nil, nil, fmt.Errorf("cannot install component %q: %v", compsup.CompSideInfo.Component, err)
 		}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -110,7 +110,7 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 
 	var tasksBeforeCurrentUnlink, tasksAfterLinkSnap, tasksAfterPostOpHook []string
 	for range components {
-		compOpts := compOptSkipSecurity | compOptSkipKernelModulesSetup
+		compOpts := compOptMultiCompInstall
 		if opts&localSnap != 0 {
 			compOpts |= compOptIsLocal
 		}

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -611,13 +611,7 @@ func storeUpdatePlanCore(
 
 	enforcedSetsFunc := cachedEnforcedValidationSets(st)
 
-	var fallbackID int
-	// normalize fallback user
-	if !user.HasStoreAuth() {
-		user = nil
-	} else {
-		fallbackID = user.ID
-	}
+	fallbackID := fallbackUserID(user)
 
 	// hasLocalRevision keeps track of snaps that already have a local revision
 	// matching the requested revision. there are two distinct cases here:
@@ -686,7 +680,7 @@ func storeUpdatePlanCore(
 
 		// TODO:COMPS: handle components losing a resource that is currently
 		// installed
-		compTargets, err := componentTargetsFromActionResult(sar, compNames)
+		compTargets, err := componentTargetsFromActionResult("refresh", sar, compNames)
 		if err != nil {
 			return updatePlan{}, fmt.Errorf("cannot extract components from snap resources: %w", err)
 		}
@@ -774,6 +768,13 @@ func componentTargetsFromLocalRevision(snapst *SnapState, snapRev snap.Revision)
 		})
 	}
 	return components, nil
+}
+
+func fallbackUserID(user *auth.UserState) int {
+	if !user.HasStoreAuth() {
+		return 0
+	}
+	return user.ID
 }
 
 func collectCurrentSnapsAndActions(

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -62,6 +62,13 @@ func userIDForSnap(st *state.State, snapst *SnapState, fallbackUserID int) (int,
 	return fallbackUserID, nil
 }
 
+func fallbackUserID(user *auth.UserState) int {
+	if !user.HasStoreAuth() {
+		return 0
+	}
+	return user.ID
+}
+
 // userFromUserID returns the first valid user from a series of userIDs
 // used as successive fallbacks.
 func userFromUserID(st *state.State, userIDs ...int) (*auth.UserState, error) {
@@ -768,13 +775,6 @@ func componentTargetsFromLocalRevision(snapst *SnapState, snapRev snap.Revision)
 		})
 	}
 	return components, nil
-}
-
-func fallbackUserID(user *auth.UserState) int {
-	if !user.HasStoreAuth() {
-		return 0
-	}
-	return user.ID
 }
 
 func collectCurrentSnapsAndActions(

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -370,6 +370,8 @@ func componentTargetsFromActionResult(action string, sar store.SnapActionResult,
 	for _, comp := range requested {
 		res, ok := mapping[comp]
 		if !ok {
+			// TODO:COMPS: make sure this branch is tested when we add support for
+			// losing components during a refresh
 			// during a refresh, we will not install components that don't exist
 			// in the new revision
 			if action == "refresh" {

--- a/snap/errors.go
+++ b/snap/errors.go
@@ -31,6 +31,14 @@ func (e AlreadyInstalledError) Error() string {
 	return fmt.Sprintf("snap %q is already installed", e.Snap)
 }
 
+type AlreadyInstalledComponentError struct {
+	Component string
+}
+
+func (e AlreadyInstalledComponentError) Error() string {
+	return fmt.Sprintf("component %q is already installed", e.Component)
+}
+
 type NotInstalledError struct {
 	Snap string
 	Rev  Revision

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -698,6 +698,16 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			}
 			rrev := snap.R(res.Snap.Revision)
 
+			// here we check a few things to decide if the snap truly has no
+			// updates.
+			// * if the action is defined as a resource install, then the
+			//   caller is just interested in the list of components so we
+			//   do not return an error
+			// * then, we check if the snap exactly matches the snap that is
+			//   currently installed. this considers the revision of the snap and
+			//   its resources that are currently installed. if that isn't true,
+			//   then we check if the snap's revision is in the list of blocked
+			//   revisions.
 			if !refreshes[res.InstanceKey].ResourceInstall && (currentSnapMatchesStoreSnap(cur, res.Snap) || findRev(rrev, cur.Block)) {
 				refreshErrors[cur.InstanceName] = ErrNoUpdateAvailable
 				continue

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -107,14 +107,18 @@ const (
 )
 
 type SnapAction struct {
-	Action          string
-	InstanceName    string
-	SnapID          string
-	Channel         string
-	Revision        snap.Revision
-	CohortKey       string
-	Flags           SnapActionFlags
-	Epoch           snap.Epoch
+	Action       string
+	InstanceName string
+	SnapID       string
+	Channel      string
+	Revision     snap.Revision
+	CohortKey    string
+	Flags        SnapActionFlags
+	Epoch        snap.Epoch
+	// ResourceInstall is a flag that indicates that this action is being used
+	// to fetch the list of resources that are available for a snap. This flag
+	// impacts how we decide to report an error if the snap has no updates
+	// available.
 	ResourceInstall bool
 	// ValidationSets is an optional array of validation set primary keys
 	// (relevant for install and refresh actions).

--- a/tests/main/component-from-store/task.yaml
+++ b/tests/main/component-from-store/task.yaml
@@ -19,5 +19,12 @@ execute: |
   # while this component is defined in the snap, it should not be installed
   not snap run test-snap-with-components three
 
+  # test installing a component for a snap that is already installed
+  snap install test-snap-with-components+three
+
+  for comp in one two three; do
+      snap run test-snap-with-components ${comp}
+  done
+
   # TODO:COMPS: test variations of installing snap with components at specific
   # revisions once PR to enable installing with revision and channel is merged


### PR DESCRIPTION
This adds support for installing components for snaps that are already installed. Based on https://github.com/snapcore/snapd/pull/14241, for now.