### PR TITLE
i/prompting/requestrules: add package to manage prompting rules

### DIFF
--- a/interfaces/prompting/dirs.go
+++ b/interfaces/prompting/dirs.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package prompting
 
 import (

--- a/interfaces/prompting/dirs.go
+++ b/interfaces/prompting/dirs.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package prompting
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+// StateDir returns the path to the prompting state directory.
+func StateDir() string {
+	return filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "interfaces-requests")
+}
+
+// EnsureStateDir creates the state directory with appropriate permissions.
+func EnsureStateDir() error {
+	return os.MkdirAll(StateDir(), 0o755)
+}

--- a/interfaces/prompting/dirs.go
+++ b/interfaces/prompting/dirs.go
@@ -19,6 +19,7 @@
 package prompting
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -32,5 +33,10 @@ func StateDir() string {
 
 // EnsureStateDir creates the state directory with appropriate permissions.
 func EnsureStateDir() error {
-	return os.MkdirAll(StateDir(), 0o755)
+	stateDir := StateDir()
+	err := os.MkdirAll(stateDir, 0o755)
+	if err != nil {
+		return fmt.Errorf("cannot create interfaces requests state directory '%s': %w", stateDir, err)
+	}
+	return nil
 }

--- a/interfaces/prompting/dirs_test.go
+++ b/interfaces/prompting/dirs_test.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package prompting_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type promptingDirsSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&promptingDirsSuite{})
+
+func (s *promptingDirsSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func (s *promptingDirsSuite) TestStateDir(c *C) {
+	c.Check(prompting.StateDir(), Equals, filepath.Join(dirs.GlobalRootDir, "var/lib/snapd/interfaces-requests"))
+
+	_, err := os.Stat(prompting.StateDir())
+	c.Assert(err, ErrorMatches, "stat .*var/lib/snapd/interfaces-requests: no such file or directory")
+	err = prompting.EnsureStateDir()
+	c.Assert(err, IsNil)
+
+	fi, err := os.Stat(prompting.StateDir())
+	c.Assert(err, IsNil)
+	c.Check(fi.IsDir(), Equals, true)
+}

--- a/interfaces/prompting/dirs_test.go
+++ b/interfaces/prompting/dirs_test.go
@@ -53,3 +53,17 @@ func (s *promptingDirsSuite) TestStateDir(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fi.IsDir(), Equals, true)
 }
+
+func (s *promptingDirsSuite) TestEnsureStateDirError(c *C) {
+	_, err := os.Stat(prompting.StateDir())
+	c.Assert(err, ErrorMatches, "stat .*var/lib/snapd/interfaces-requests: no such file or directory")
+
+	parent := filepath.Dir(prompting.StateDir())
+	c.Assert(os.MkdirAll(parent, 0o755), IsNil)
+	f, err := os.Create(prompting.StateDir())
+	c.Assert(err, IsNil)
+	f.Close()
+
+	err = prompting.EnsureStateDir()
+	c.Assert(err, ErrorMatches, "cannot create interfaces requests state directory.*")
+}

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap.go
@@ -40,6 +40,7 @@ var (
 	ErrMaxIDMmapClosed = fmt.Errorf("cannot compute next ID on max ID mmap which has already been closed")
 )
 
+// MaxIDMmap is a wrapper for ID tracked backed by a mmap'ed file.
 type MaxIDMmap []byte
 
 // OpenMaxIDMmap opens and mmaps the given maxIDFilepath, returning the

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap.go
@@ -49,7 +49,7 @@ type MaxIDMmap []byte
 // reset to an 8-byte file with a max ID of 0. If the file cannot be created,
 // opened, or mmaped, returns an error and a nil MaxIDMmap.
 func OpenMaxIDMmap(maxIDFilepath string) (MaxIDMmap, error) {
-	maxIDFile, err := os.OpenFile(maxIDFilepath, os.O_RDWR|os.O_CREATE, 0600)
+	maxIDFile, err := os.OpenFile(maxIDFilepath, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open max ID file: %w", err)
 	}

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap.go
@@ -1,0 +1,134 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package maxidmmap
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/logger"
+)
+
+const (
+	// maxIDFileSize should be enough bytes to encode the maximum prompt ID.
+	maxIDFileSize int = 8
+)
+
+var (
+	ErrMaxIDMmapClosed = fmt.Errorf("cannot compute next ID on max ID mmap which has already been closed")
+)
+
+type MaxIDMmap []byte
+
+// OpenMaxIDMmap opens and mmaps the given maxIDFilepath, returning the
+// corresponding MaxIDMmap.
+//
+// If the maxIDFilepath does not exist, or if the file is malformed, it is
+// reset to an 8-byte file with a max ID of 0. If the file cannot be created,
+// opened, or mmaped, returns an error and a nil MaxIDMmap.
+func OpenMaxIDMmap(maxIDFilepath string) (MaxIDMmap, error) {
+	maxIDFile, err := os.OpenFile(maxIDFilepath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open max ID file: %w", err)
+	}
+	// The file/FD can be safely closed once the mmap is created. See mmap(2).
+	defer maxIDFile.Close()
+	fileInfo, err := maxIDFile.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat max ID file: %w", err)
+	}
+	if fileInfo.Size() != int64(maxIDFileSize) {
+		if fileInfo.Size() != 0 {
+			// Max ID file malformed, best to reset it
+			logger.Debugf("max ID file malformed; re-initializing")
+		}
+		if err = initializeMaxIDFile(maxIDFile); err != nil {
+			return nil, err
+		}
+	}
+	conn, err := maxIDFile.SyscallConn()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get raw file for maxIDFile: %w", err)
+	}
+	var maxIDMmap []byte
+	var controlErr error
+	err = conn.Control(func(fd uintptr) {
+		// Use Control() so that the file/fd is not garbage collected during
+		// the syscall.
+		maxIDMmap, controlErr = unix.Mmap(int(fd), 0, maxIDFileSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot call control function on maxIDFile conn: %w", err)
+	}
+	if controlErr != nil {
+		return nil, fmt.Errorf("cannot mmap max ID file: %w", controlErr)
+	}
+	return MaxIDMmap(maxIDMmap), nil
+}
+
+// initializeMaxIDFile truncates the given file to maxIDFileSize bytes of zeros.
+func initializeMaxIDFile(maxIDFile *os.File) (err error) {
+	initial := [maxIDFileSize]byte{}
+	if err = maxIDFile.Truncate(int64(len(initial))); err != nil {
+		return fmt.Errorf("cannot truncate max ID file: %w", err)
+	}
+	if _, err = maxIDFile.WriteAt(initial[:], 0); err != nil {
+		return fmt.Errorf("cannot initialize max ID file: %w", err)
+	}
+	return nil
+}
+
+// NextID increments the monotonic max ID integer and returns the corresponding
+// ID.
+//
+// The caller must ensure that any relevant lock is held.
+func (mim MaxIDMmap) NextID() (prompting.IDType, error) {
+	if mim == nil {
+		return 0, ErrMaxIDMmapClosed
+	}
+	// Byte order will be consistent, and want atomic increment
+	id := atomic.AddUint64((*uint64)(unsafe.Pointer(&mim[0])), 1)
+	return prompting.IDType(id), nil
+}
+
+// Munmap unmaps the underlying byte slice corresponding to the receiving
+// max ID mmap, if it has not already been unmapped.
+//
+// The caller must ensure that any relevant lock is held.
+func (mim *MaxIDMmap) Munmap() {
+	if *mim == nil {
+		return
+	}
+	unix.Munmap(*mim)
+	*mim = nil
+}
+
+// IsClosed returns whether the receiving max ID mmap has been unmapped and
+// closed, which is indicated by the underlying byte slice being nil.
+//
+// The caller must ensure that any relevant lock is held.
+func (mim *MaxIDMmap) IsClosed() bool {
+	return *mim == nil
+}

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap.go
@@ -17,6 +17,8 @@
  *
  */
 
+// Package maxidmmap provides a type for working with atomically unique
+// prompting-related IDs, backed by a memory mapped file.
 package maxidmmap
 
 import (

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap.go
@@ -113,16 +113,19 @@ func (mim MaxIDMmap) NextID() (prompting.IDType, error) {
 	return prompting.IDType(id), nil
 }
 
-// Munmap unmaps the underlying byte slice corresponding to the receiving
+// Close unmaps the underlying byte slice corresponding to the receiving
 // max ID mmap, if it has not already been unmapped.
 //
 // The caller must ensure that any relevant lock is held.
-func (mim *MaxIDMmap) Munmap() {
+func (mim *MaxIDMmap) Close() error {
 	if *mim == nil {
-		return
+		return nil
 	}
-	unix.Munmap(*mim)
+	if err := unix.Munmap(*mim); err != nil {
+		return err
+	}
 	*mim = nil
+	return nil
 }
 
 // IsClosed returns whether the receiving max ID mmap has been unmapped and

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap_test.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap_test.go
@@ -46,7 +46,7 @@ func (s *maxidmmapSuite) SetUpTest(c *C) {
 	s.maxIDPath = filepath.Join(s.tmpdir, "max-id")
 }
 
-func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDMunmapInvalid(c *C) {
+func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDCloseInvalid(c *C) {
 	// First try with no existin max ID file
 	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(s.maxIDPath)
 	c.Check(err, IsNil)
@@ -57,7 +57,7 @@ func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDMunmapInvalid(c *C) {
 	c.Check(id, Equals, prompting.IDType(1))
 	s.checkWrittenMaxID(c, 1)
 
-	maxIDMmap.Munmap()
+	maxIDMmap.Close()
 
 	// Now try with various invalid max ID files
 	for _, initial := range [][]byte{
@@ -76,11 +76,11 @@ func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDMunmapInvalid(c *C) {
 		c.Check(err, IsNil)
 		c.Check(id, Equals, prompting.IDType(1))
 		s.checkWrittenMaxID(c, 1)
-		maxIDMmap.Munmap()
+		maxIDMmap.Close()
 	}
 }
 
-func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDMunmapValid(c *C) {
+func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDCloseValid(c *C) {
 	for _, testCase := range []struct {
 		initial uint64
 		nextID  prompting.IDType
@@ -117,7 +117,7 @@ func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDMunmapValid(c *C) {
 		c.Check(err, IsNil)
 		c.Check(id, Equals, testCase.nextID)
 		s.checkWrittenMaxID(c, uint64(testCase.nextID))
-		maxIDMmap.Munmap()
+		maxIDMmap.Close()
 	}
 }
 
@@ -129,14 +129,14 @@ func (s *maxidmmapSuite) checkWrittenMaxID(c *C, id uint64) {
 	c.Assert(writtenID, Equals, id)
 }
 
-func (s *maxidmmapSuite) TestMaxIDMmapMunmap(c *C) {
+func (s *maxidmmapSuite) TestMaxIDMmapClose(c *C) {
 	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(s.maxIDPath)
 	c.Check(err, IsNil)
 	c.Check(maxIDMmap, NotNil)
 	c.Check(maxIDMmap.IsClosed(), Equals, false)
-	maxIDMmap.Munmap()
+	maxIDMmap.Close()
 	c.Check(maxIDMmap.IsClosed(), Equals, true)
 	_, err = maxIDMmap.NextID()
 	c.Check(err, Equals, maxidmmap.ErrMaxIDMmapClosed)
-	maxIDMmap.Munmap() // Munmap should be idempotent
+	maxIDMmap.Close() // Close should be idempotent
 }

--- a/interfaces/prompting/internal/maxidmmap/maxidmmap_test.go
+++ b/interfaces/prompting/internal/maxidmmap/maxidmmap_test.go
@@ -1,0 +1,142 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package maxidmmap_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/internal/maxidmmap"
+	"github.com/snapcore/snapd/osutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type maxidmmapSuite struct {
+	tmpdir    string
+	maxIDPath string
+}
+
+var _ = Suite(&maxidmmapSuite{})
+
+func (s *maxidmmapSuite) SetUpTest(c *C) {
+	s.tmpdir = c.MkDir()
+	s.maxIDPath = filepath.Join(s.tmpdir, "max-id")
+}
+
+func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDMunmapInvalid(c *C) {
+	// First try with no existin max ID file
+	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(s.maxIDPath)
+	c.Check(err, IsNil)
+	c.Check(maxIDMmap, NotNil)
+	s.checkWrittenMaxID(c, 0)
+	id, err := maxIDMmap.NextID()
+	c.Check(err, IsNil)
+	c.Check(id, Equals, prompting.IDType(1))
+	s.checkWrittenMaxID(c, 1)
+
+	maxIDMmap.Munmap()
+
+	// Now try with various invalid max ID files
+	for _, initial := range [][]byte{
+		[]byte(""),
+		[]byte("foo"),
+		[]byte("1234"),
+		[]byte("1234567"),
+		[]byte("123456789"),
+	} {
+		osutil.AtomicWriteFile(s.maxIDPath, initial, 0600, 0)
+		maxIDMmap, err = maxidmmap.OpenMaxIDMmap(s.maxIDPath)
+		c.Check(err, IsNil)
+		c.Check(maxIDMmap, NotNil)
+		s.checkWrittenMaxID(c, 0)
+		id, err := maxIDMmap.NextID()
+		c.Check(err, IsNil)
+		c.Check(id, Equals, prompting.IDType(1))
+		s.checkWrittenMaxID(c, 1)
+		maxIDMmap.Munmap()
+	}
+}
+
+func (s *maxidmmapSuite) TestMaxIDMmapOpenNextIDMunmapValid(c *C) {
+	for _, testCase := range []struct {
+		initial uint64
+		nextID  prompting.IDType
+	}{
+		{
+			0,
+			1,
+		},
+		{
+			1,
+			2,
+		},
+		{
+			0x1000000000000001,
+			0x1000000000000002,
+		},
+		{
+			0x0123456789ABCDEF,
+			0x0123456789ABCDF0,
+		},
+		{
+			0xDEADBEEFDEADBEEF,
+			0xDEADBEEFDEADBEF0,
+		},
+	} {
+		var initialData [8]byte
+		*(*uint64)(unsafe.Pointer(&initialData[0])) = testCase.initial
+		osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0600, 0)
+		maxIDMmap, err := maxidmmap.OpenMaxIDMmap(s.maxIDPath)
+		c.Check(err, IsNil)
+		c.Check(maxIDMmap, NotNil)
+		s.checkWrittenMaxID(c, testCase.initial)
+		id, err := maxIDMmap.NextID()
+		c.Check(err, IsNil)
+		c.Check(id, Equals, testCase.nextID)
+		s.checkWrittenMaxID(c, uint64(testCase.nextID))
+		maxIDMmap.Munmap()
+	}
+}
+
+func (s *maxidmmapSuite) checkWrittenMaxID(c *C, id uint64) {
+	data, err := os.ReadFile(s.maxIDPath)
+	c.Assert(err, IsNil)
+	c.Assert(data, HasLen, 8)
+	writtenID := *(*uint64)(unsafe.Pointer(&data[0]))
+	c.Assert(writtenID, Equals, id)
+}
+
+func (s *maxidmmapSuite) TestMaxIDMmapMunmap(c *C) {
+	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(s.maxIDPath)
+	c.Check(err, IsNil)
+	c.Check(maxIDMmap, NotNil)
+	c.Check(maxIDMmap.IsClosed(), Equals, false)
+	maxIDMmap.Munmap()
+	c.Check(maxIDMmap.IsClosed(), Equals, true)
+	_, err = maxIDMmap.NextID()
+	c.Check(err, Equals, maxidmmap.ErrMaxIDMmapClosed)
+	maxIDMmap.Munmap() // Munmap should be idempotent
+}

--- a/interfaces/prompting/patterns/patterns.go
+++ b/interfaces/prompting/patterns/patterns.go
@@ -17,6 +17,8 @@
  *
  */
 
+// Package patterns provides types and functions for working with path patterns
+// for request rules related to AppArmor Prompting.
 package patterns
 
 import (

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -22,12 +22,25 @@ package prompting
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
+	"sync/atomic"
 	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/logger"
+)
+
+const (
+	// maxIDFileSize should be enough bytes to encode the maximum prompt ID.
+	maxIDFileSize int = 8
 )
 
 var (
 	ErrExpirationInThePast = fmt.Errorf("cannot have expiration time in the past")
+	ErrMaxIDMmapClosed     = fmt.Errorf("cannot compute next ID on max ID mmap which has already been closed")
 )
 
 // Metadata stores information about the origin or applicability of a prompt or
@@ -62,6 +75,93 @@ func (i *IDType) UnmarshalJSON(b []byte) error {
 	}
 	*i = IDType(value)
 	return nil
+}
+
+type MaxIDMmap []byte
+
+func OpenMaxIDMmap(maxIDFilepath string) (MaxIDMmap, error) {
+	maxIDFile, err := os.OpenFile(maxIDFilepath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open max ID file: %w", err)
+	}
+	// The file/FD can be safely closed once the mmap is created. See mmap(2).
+	defer maxIDFile.Close()
+	fileInfo, err := maxIDFile.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat max ID file: %w", err)
+	}
+	if fileInfo.Size() != int64(maxIDFileSize) {
+		if fileInfo.Size() != 0 {
+			// Max ID file malformed, best to reset it
+			logger.Debugf("max ID file malformed; re-initializing")
+		}
+		if err = initializeMaxIDFile(maxIDFile); err != nil {
+			return nil, err
+		}
+	}
+	conn, err := maxIDFile.SyscallConn()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get raw file for maxIDFile: %w", err)
+	}
+	var maxIDMmap []byte
+	var controlErr error
+	err = conn.Control(func(fd uintptr) {
+		// Use Control() so that the file/fd is not garbage collected during
+		// the syscall.
+		maxIDMmap, controlErr = unix.Mmap(int(fd), 0, maxIDFileSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot call control function on maxIDFile conn: %w", err)
+	}
+	if controlErr != nil {
+		return nil, fmt.Errorf("cannot mmap max ID file: %w", controlErr)
+	}
+	return MaxIDMmap(maxIDMmap), nil
+}
+
+// initializeMaxIDFile truncates the given file to maxIDFileSize bytes of zeros.
+func initializeMaxIDFile(maxIDFile *os.File) (err error) {
+	initial := [maxIDFileSize]byte{}
+	if err = maxIDFile.Truncate(int64(len(initial))); err != nil {
+		return fmt.Errorf("cannot truncate max ID file: %w", err)
+	}
+	if _, err = maxIDFile.WriteAt(initial[:], 0); err != nil {
+		return fmt.Errorf("cannot initialize max ID file: %w", err)
+	}
+	return nil
+}
+
+// NextID increments the monotonic max ID integer and returns the corresponding
+// ID.
+//
+// The caller must ensure that any relevant lock is held.
+func (mim MaxIDMmap) NextID() (IDType, error) {
+	if mim == nil {
+		return 0, ErrMaxIDMmapClosed
+	}
+	// Byte order will be consistent, and want atomic increment
+	id := atomic.AddUint64((*uint64)(unsafe.Pointer(&mim[0])), 1)
+	return IDType(id), nil
+}
+
+// Munmap unmaps the underlying byte slice corresponding to the receiving
+// max ID mmap, if it has not already been unmapped.
+//
+// The caller must ensure that any relevant lock is held.
+func (mim *MaxIDMmap) Munmap() {
+	if *mim == nil {
+		return
+	}
+	unix.Munmap(*mim)
+	*mim = nil
+}
+
+// IsClosed returns whether the receiving max ID mmap has been unmapped and
+// closed, which is indicated by the underlying byte slice being nil.
+//
+// The caller must ensure that any relevant lock is held.
+func (mim *MaxIDMmap) IsClosed() bool {
+	return *mim == nil
 }
 
 // OutcomeType describes the outcome associated with a reply or rule.

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -17,6 +17,8 @@
  *
  */
 
+// Package prompting provides common types and functions related to AppArmor
+// prompting.
 package prompting
 
 import (

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -26,6 +26,10 @@ import (
 	"time"
 )
 
+var (
+	ErrExpirationInThePast = fmt.Errorf("cannot have expiration time in the past")
+)
+
 // Metadata stores information about the origin or applicability of a prompt or
 // rule.
 type Metadata struct {
@@ -152,7 +156,7 @@ func (lifespan LifespanType) ValidateExpiration(expiration time.Time, currTime t
 			return fmt.Errorf(`cannot have unspecified expiration when lifespan is %q`, lifespan)
 		}
 		if currTime.After(expiration) {
-			return fmt.Errorf("cannot have expiration time in the past: %q", expiration)
+			return fmt.Errorf("%w: %q", ErrExpirationInThePast, expiration)
 		}
 	default:
 		// Should not occur, since lifespan is validated when unmarshalled

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -121,10 +121,8 @@ const (
 	// LifespanTimespan indicates that a reply/rule should apply for a given
 	// duration or until a given expiration timestamp.
 	LifespanTimespan LifespanType = "timespan"
-	// LifespanSession indicates that a reply/rule should apply for the duration
-	// of the application session.
-	// XXX: application session or user session?
-	LifespanSession LifespanType = "session"
+	// TODO: add LifespanSession which expires after the user logs out
+	// LifespanSession  LifespanType = "session"
 )
 
 func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
@@ -136,8 +134,6 @@ func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
 	switch value {
 	case LifespanForever, LifespanSingle, LifespanTimespan:
 		*lifespan = value
-	case LifespanSession:
-		return fmt.Errorf(`cannot have lifespan "session": not yet supported`)
 	default:
 		return fmt.Errorf(`cannot have lifespan other than %q, %q, or %q: %q`, LifespanForever, LifespanSingle, LifespanTimespan, value)
 	}
@@ -152,7 +148,7 @@ func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
 // any of the above are invalid.
 func (lifespan LifespanType) ValidateExpiration(expiration time.Time, currTime time.Time) error {
 	switch lifespan {
-	case LifespanForever, LifespanSingle, LifespanSession:
+	case LifespanForever, LifespanSingle:
 		if !expiration.IsZero() {
 			return fmt.Errorf(`cannot have specified expiration when lifespan is %q: %q`, lifespan, expiration)
 		}
@@ -181,7 +177,7 @@ func (lifespan LifespanType) ValidateExpiration(expiration time.Time, currTime t
 func (lifespan LifespanType) ParseDuration(duration string, currTime time.Time) (time.Time, error) {
 	var expiration time.Time
 	switch lifespan {
-	case LifespanForever, LifespanSingle, LifespanSession:
+	case LifespanForever, LifespanSingle:
 		if duration != "" {
 			return expiration, fmt.Errorf(`cannot have specified duration when lifespan is %q: %q`, lifespan, duration)
 		}

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -22,25 +22,13 @@ package prompting
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
-	"sync/atomic"
 	"time"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
-
-	"github.com/snapcore/snapd/logger"
-)
-
-const (
-	// maxIDFileSize should be enough bytes to encode the maximum prompt ID.
-	maxIDFileSize int = 8
 )
 
 var (
+	// ErrExpirationInThePast may be wrapped with the invalid expiration.
 	ErrExpirationInThePast = fmt.Errorf("cannot have expiration time in the past")
-	ErrMaxIDMmapClosed     = fmt.Errorf("cannot compute next ID on max ID mmap which has already been closed")
 )
 
 // Metadata stores information about the origin or applicability of a prompt or
@@ -75,93 +63,6 @@ func (i *IDType) UnmarshalJSON(b []byte) error {
 	}
 	*i = IDType(value)
 	return nil
-}
-
-type MaxIDMmap []byte
-
-func OpenMaxIDMmap(maxIDFilepath string) (MaxIDMmap, error) {
-	maxIDFile, err := os.OpenFile(maxIDFilepath, os.O_RDWR|os.O_CREATE, 0600)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open max ID file: %w", err)
-	}
-	// The file/FD can be safely closed once the mmap is created. See mmap(2).
-	defer maxIDFile.Close()
-	fileInfo, err := maxIDFile.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("cannot stat max ID file: %w", err)
-	}
-	if fileInfo.Size() != int64(maxIDFileSize) {
-		if fileInfo.Size() != 0 {
-			// Max ID file malformed, best to reset it
-			logger.Debugf("max ID file malformed; re-initializing")
-		}
-		if err = initializeMaxIDFile(maxIDFile); err != nil {
-			return nil, err
-		}
-	}
-	conn, err := maxIDFile.SyscallConn()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get raw file for maxIDFile: %w", err)
-	}
-	var maxIDMmap []byte
-	var controlErr error
-	err = conn.Control(func(fd uintptr) {
-		// Use Control() so that the file/fd is not garbage collected during
-		// the syscall.
-		maxIDMmap, controlErr = unix.Mmap(int(fd), 0, maxIDFileSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot call control function on maxIDFile conn: %w", err)
-	}
-	if controlErr != nil {
-		return nil, fmt.Errorf("cannot mmap max ID file: %w", controlErr)
-	}
-	return MaxIDMmap(maxIDMmap), nil
-}
-
-// initializeMaxIDFile truncates the given file to maxIDFileSize bytes of zeros.
-func initializeMaxIDFile(maxIDFile *os.File) (err error) {
-	initial := [maxIDFileSize]byte{}
-	if err = maxIDFile.Truncate(int64(len(initial))); err != nil {
-		return fmt.Errorf("cannot truncate max ID file: %w", err)
-	}
-	if _, err = maxIDFile.WriteAt(initial[:], 0); err != nil {
-		return fmt.Errorf("cannot initialize max ID file: %w", err)
-	}
-	return nil
-}
-
-// NextID increments the monotonic max ID integer and returns the corresponding
-// ID.
-//
-// The caller must ensure that any relevant lock is held.
-func (mim MaxIDMmap) NextID() (IDType, error) {
-	if mim == nil {
-		return 0, ErrMaxIDMmapClosed
-	}
-	// Byte order will be consistent, and want atomic increment
-	id := atomic.AddUint64((*uint64)(unsafe.Pointer(&mim[0])), 1)
-	return IDType(id), nil
-}
-
-// Munmap unmaps the underlying byte slice corresponding to the receiving
-// max ID mmap, if it has not already been unmapped.
-//
-// The caller must ensure that any relevant lock is held.
-func (mim *MaxIDMmap) Munmap() {
-	if *mim == nil {
-		return
-	}
-	unix.Munmap(*mim)
-	*mim = nil
-}
-
-// IsClosed returns whether the receiving max ID mmap has been unmapped and
-// closed, which is indicated by the underlying byte slice being nil.
-//
-// The caller must ensure that any relevant lock is held.
-func (mim *MaxIDMmap) IsClosed() bool {
-	return *mim == nil
 }
 
 // OutcomeType describes the outcome associated with a reply or rule.

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -121,8 +121,10 @@ const (
 	// LifespanTimespan indicates that a reply/rule should apply for a given
 	// duration or until a given expiration timestamp.
 	LifespanTimespan LifespanType = "timespan"
-	// TODO: add LifespanSession which expires after the user logs out
-	// LifespanSession  LifespanType = "session"
+	// LifespanSession indicates that a reply/rule should apply for the duration
+	// of the application session.
+	// XXX: application session or user session?
+	LifespanSession LifespanType = "session"
 )
 
 func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
@@ -134,6 +136,8 @@ func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
 	switch value {
 	case LifespanForever, LifespanSingle, LifespanTimespan:
 		*lifespan = value
+	case LifespanSession:
+		return fmt.Errorf(`cannot have lifespan "session": not yet supported`)
 	default:
 		return fmt.Errorf(`cannot have lifespan other than %q, %q, or %q: %q`, LifespanForever, LifespanSingle, LifespanTimespan, value)
 	}
@@ -148,7 +152,7 @@ func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
 // any of the above are invalid.
 func (lifespan LifespanType) ValidateExpiration(expiration time.Time, currTime time.Time) error {
 	switch lifespan {
-	case LifespanForever, LifespanSingle:
+	case LifespanForever, LifespanSingle, LifespanSession:
 		if !expiration.IsZero() {
 			return fmt.Errorf(`cannot have specified expiration when lifespan is %q: %q`, lifespan, expiration)
 		}
@@ -177,7 +181,7 @@ func (lifespan LifespanType) ValidateExpiration(expiration time.Time, currTime t
 func (lifespan LifespanType) ParseDuration(duration string, currTime time.Time) (time.Time, error) {
 	var expiration time.Time
 	switch lifespan {
-	case LifespanForever, LifespanSingle:
+	case LifespanForever, LifespanSingle, LifespanSession:
 		if duration != "" {
 			return expiration, fmt.Errorf(`cannot have specified duration when lifespan is %q: %q`, lifespan, duration)
 		}

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -39,8 +39,12 @@ type Metadata struct {
 
 type IDType uint64
 
+func (i IDType) String() string {
+	return fmt.Sprintf("%016X", uint64(i))
+}
+
 func (i *IDType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(fmt.Sprintf("%016X", *i))
+	return json.Marshal(i.String())
 }
 
 func (i *IDType) UnmarshalJSON(b []byte) error {

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -157,12 +157,6 @@ func (s *promptingSuite) TestUnmarshalLifespanUnhappy(c *C) {
 		err = json.Unmarshal(data, &flw2)
 		c.Check(err, ErrorMatches, `cannot have lifespan other than.*`, Commentf("data: %v", string(data)))
 	}
-
-	// TODO: remove this when lifespan "session" is supported
-	var flw fakeLifespanWrapper
-	data := []byte(fmt.Sprintf(`{"field1": "%s"}`, prompting.LifespanSession))
-	err := json.Unmarshal(data, &flw)
-	c.Check(err, ErrorMatches, `cannot have lifespan "session": not yet supported`, Commentf("data: %v", string(data)))
 }
 
 func (s *promptingSuite) TestValidateExpiration(c *C) {
@@ -174,7 +168,6 @@ func (s *promptingSuite) TestValidateExpiration(c *C) {
 	for _, lifespan := range []prompting.LifespanType{
 		prompting.LifespanForever,
 		prompting.LifespanSingle,
-		prompting.LifespanSession,
 	} {
 		err := lifespan.ValidateExpiration(unsetExpiration, currTime)
 		c.Check(err, IsNil)
@@ -206,7 +199,6 @@ func (s *promptingSuite) TestParseDuration(c *C) {
 	for _, lifespan := range []prompting.LifespanType{
 		prompting.LifespanForever,
 		prompting.LifespanSingle,
-		prompting.LifespanSession,
 	} {
 		expiration, err := lifespan.ParseDuration(unsetDuration, currTime)
 		c.Check(expiration.IsZero(), Equals, true)

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -157,6 +157,12 @@ func (s *promptingSuite) TestUnmarshalLifespanUnhappy(c *C) {
 		err = json.Unmarshal(data, &flw2)
 		c.Check(err, ErrorMatches, `cannot have lifespan other than.*`, Commentf("data: %v", string(data)))
 	}
+
+	// TODO: remove this when lifespan "session" is supported
+	var flw fakeLifespanWrapper
+	data := []byte(fmt.Sprintf(`{"field1": "%s"}`, prompting.LifespanSession))
+	err := json.Unmarshal(data, &flw)
+	c.Check(err, ErrorMatches, `cannot have lifespan "session": not yet supported`, Commentf("data: %v", string(data)))
 }
 
 func (s *promptingSuite) TestValidateExpiration(c *C) {
@@ -168,6 +174,7 @@ func (s *promptingSuite) TestValidateExpiration(c *C) {
 	for _, lifespan := range []prompting.LifespanType{
 		prompting.LifespanForever,
 		prompting.LifespanSingle,
+		prompting.LifespanSession,
 	} {
 		err := lifespan.ValidateExpiration(unsetExpiration, currTime)
 		c.Check(err, IsNil)
@@ -199,6 +206,7 @@ func (s *promptingSuite) TestParseDuration(c *C) {
 	for _, lifespan := range []prompting.LifespanType{
 		prompting.LifespanForever,
 		prompting.LifespanSingle,
+		prompting.LifespanSession,
 	} {
 		expiration, err := lifespan.ParseDuration(unsetDuration, currTime)
 		c.Check(expiration.IsZero(), Equals, true)

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -36,17 +36,19 @@ type promptingSuite struct{}
 
 var _ = Suite(&promptingSuite{})
 
-func (s *promptingSuite) TestIDTypeMarshalUnmarshalJSON(c *C) {
+func (s *promptingSuite) TestIDTypeStringMarshalUnmarshalJSON(c *C) {
 	for _, testCase := range []struct {
 		id         prompting.IDType
+		str        string
 		marshalled []byte
 	}{
-		{0, []byte(`"0000000000000000"`)},
-		{1, []byte(`"0000000000000001"`)},
-		{0x1000000000000000, []byte(`"1000000000000000"`)},
-		{0xDEADBEEFDEADBEEF, []byte(`"DEADBEEFDEADBEEF"`)},
-		{0xFFFFFFFFFFFFFFFF, []byte(`"FFFFFFFFFFFFFFFF"`)},
+		{0, "0000000000000000", []byte(`"0000000000000000"`)},
+		{1, "0000000000000001", []byte(`"0000000000000001"`)},
+		{0x1000000000000000, "1000000000000000", []byte(`"1000000000000000"`)},
+		{0xDEADBEEFDEADBEEF, "DEADBEEFDEADBEEF", []byte(`"DEADBEEFDEADBEEF"`)},
+		{0xFFFFFFFFFFFFFFFF, "FFFFFFFFFFFFFFFF", []byte(`"FFFFFFFFFFFFFFFF"`)},
 	} {
+		c.Check(testCase.id.String(), Equals, testCase.str)
 		marshalled, err := testCase.id.MarshalJSON()
 		c.Check(err, IsNil)
 		c.Check(marshalled, DeepEquals, testCase.marshalled)

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -22,31 +22,19 @@ package prompting_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
-	"unsafe"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces/prompting"
-	"github.com/snapcore/snapd/osutil"
 )
 
 func Test(t *testing.T) { TestingT(t) }
 
-type promptingSuite struct {
-	tmpdir    string
-	maxIDPath string
-}
+type promptingSuite struct{}
 
 var _ = Suite(&promptingSuite{})
-
-func (s *promptingSuite) SetUpTest(c *C) {
-	s.tmpdir = c.MkDir()
-	s.maxIDPath = filepath.Join(s.tmpdir, "max-id")
-}
 
 func (s *promptingSuite) TestIDTypeStringMarshalUnmarshalJSON(c *C) {
 	for _, testCase := range []struct {
@@ -69,101 +57,6 @@ func (s *promptingSuite) TestIDTypeStringMarshalUnmarshalJSON(c *C) {
 		c.Check(err, IsNil)
 		c.Check(id, Equals, testCase.id)
 	}
-}
-
-func (s *promptingSuite) TestMaxIDMmapOpenNextIDMunmapInvalid(c *C) {
-	// First try with no existin max ID file
-	maxIDMmap, err := prompting.OpenMaxIDMmap(s.maxIDPath)
-	c.Check(err, IsNil)
-	c.Check(maxIDMmap, NotNil)
-	s.checkWrittenMaxID(c, 0)
-	id, err := maxIDMmap.NextID()
-	c.Check(err, IsNil)
-	c.Check(id, Equals, prompting.IDType(1))
-	s.checkWrittenMaxID(c, 1)
-
-	maxIDMmap.Munmap()
-
-	// Now try with various invalid max ID files
-	for _, initial := range [][]byte{
-		[]byte(""),
-		[]byte("foo"),
-		[]byte("1234"),
-		[]byte("1234567"),
-		[]byte("123456789"),
-	} {
-		osutil.AtomicWriteFile(s.maxIDPath, initial, 0600, 0)
-		maxIDMmap, err = prompting.OpenMaxIDMmap(s.maxIDPath)
-		c.Check(err, IsNil)
-		c.Check(maxIDMmap, NotNil)
-		s.checkWrittenMaxID(c, 0)
-		id, err := maxIDMmap.NextID()
-		c.Check(err, IsNil)
-		c.Check(id, Equals, prompting.IDType(1))
-		s.checkWrittenMaxID(c, 1)
-		maxIDMmap.Munmap()
-	}
-}
-
-func (s *promptingSuite) TestMaxIDMmapOpenNextIDMunmapValid(c *C) {
-	for _, testCase := range []struct {
-		initial uint64
-		nextID  prompting.IDType
-	}{
-		{
-			0,
-			1,
-		},
-		{
-			1,
-			2,
-		},
-		{
-			0x1000000000000001,
-			0x1000000000000002,
-		},
-		{
-			0x0123456789ABCDEF,
-			0x0123456789ABCDF0,
-		},
-		{
-			0xDEADBEEFDEADBEEF,
-			0xDEADBEEFDEADBEF0,
-		},
-	} {
-		var initialData [8]byte
-		*(*uint64)(unsafe.Pointer(&initialData[0])) = testCase.initial
-		osutil.AtomicWriteFile(s.maxIDPath, initialData[:], 0600, 0)
-		maxIDMmap, err := prompting.OpenMaxIDMmap(s.maxIDPath)
-		c.Check(err, IsNil)
-		c.Check(maxIDMmap, NotNil)
-		s.checkWrittenMaxID(c, testCase.initial)
-		id, err := maxIDMmap.NextID()
-		c.Check(err, IsNil)
-		c.Check(id, Equals, testCase.nextID)
-		s.checkWrittenMaxID(c, uint64(testCase.nextID))
-		maxIDMmap.Munmap()
-	}
-}
-
-func (s *promptingSuite) checkWrittenMaxID(c *C, id uint64) {
-	data, err := os.ReadFile(s.maxIDPath)
-	c.Assert(err, IsNil)
-	c.Assert(data, HasLen, 8)
-	writtenID := *(*uint64)(unsafe.Pointer(&data[0]))
-	c.Assert(writtenID, Equals, id)
-}
-
-func (s *promptingSuite) TestMaxIDMmapMunmap(c *C) {
-	maxIDMmap, err := prompting.OpenMaxIDMmap(s.maxIDPath)
-	c.Check(err, IsNil)
-	c.Check(maxIDMmap, NotNil)
-	c.Check(maxIDMmap.IsClosed(), Equals, false)
-	maxIDMmap.Munmap()
-	c.Check(maxIDMmap.IsClosed(), Equals, true)
-	_, err = maxIDMmap.NextID()
-	c.Check(err, Equals, prompting.ErrMaxIDMmapClosed)
-	maxIDMmap.Munmap() // Munmap should be idempotent
 }
 
 func (s *promptingSuite) TestOutcomeAsBool(c *C) {

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -65,5 +65,5 @@ func (pdb *PromptDB) PerUser() map[uint32]*userPromptDB {
 }
 
 func (pdb *PromptDB) NextID() (prompting.IDType, error) {
-	return pdb.nextID()
+	return pdb.maxIDMmap.NextID()
 }

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -459,7 +459,7 @@ func (pdb *PromptDB) Close() error {
 	}
 
 	if err := pdb.maxIDMmap.Close(); err != nil {
-		return fmt.Errorf("error while closing max ID mmap: %w", err)
+		return fmt.Errorf("cannot close max ID mmap: %w", err)
 	}
 
 	// TODO: if in the future we persist prompts across snapd restarts, we do

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/internal/maxidmmap"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/strutil"
@@ -167,7 +168,7 @@ type PromptDB struct {
 	// maxIDMmap is the byte slice which is memory mapped to the max ID file in
 	// order to avoid unnecessary syscalls.
 	// If maxIDMmap is closed, then the prompt DB has already been closed.
-	maxIDMmap prompting.MaxIDMmap
+	maxIDMmap maxidmmap.MaxIDMmap
 	// perUser maps UID to the DB of prompts for that user.
 	perUser map[uint32]*userPromptDB
 	// notifyPrompt is a closure which will be called to record a notice when a
@@ -189,7 +190,7 @@ const (
 // for a substantial amount of time (such as to lock and modify snapd state).
 func New(notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error) (*PromptDB, error) {
 	maxIDFilepath := filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
-	maxIDMmap, err := prompting.OpenMaxIDMmap(maxIDFilepath)
+	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(maxIDFilepath)
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -17,6 +17,8 @@
  *
  */
 
+// Package requestrules provides the manager for request prompting related to
+// AppArmor prompting.
 package requestprompts
 
 import (

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -21,6 +21,7 @@ package requestprompts
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"time"
@@ -457,6 +458,10 @@ func (pdb *PromptDB) Close() error {
 		return ErrClosed
 	}
 
+	if err := pdb.maxIDMmap.Close(); err != nil {
+		return fmt.Errorf("error while closing max ID mmap: %w", err)
+	}
+
 	// TODO: if in the future we persist prompts across snapd restarts, we do
 	// not want to send {"resolved": "cancelled"} in the notice data.
 	data := map[string]string{"resolved": "cancelled"}
@@ -468,6 +473,5 @@ func (pdb *PromptDB) Close() error {
 
 	// Clear all outstanding prompts
 	pdb.perUser = nil
-	pdb.maxIDMmap.Munmap()
 	return nil
 }

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -17,8 +17,8 @@
  *
  */
 
-// Package requestrules provides the manager for request prompting related to
-// AppArmor prompting.
+// Package requestrules provides support for holding outstanding request
+// prompts for AppArmor prompting.
 package requestprompts
 
 import (

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/internal/maxidmmap"
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/osutil"
@@ -1007,7 +1008,7 @@ func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
 	c.Assert(err, IsNil)
 
 	nextID, err := pdb.NextID()
-	c.Check(err, Equals, prompting.ErrMaxIDMmapClosed)
+	c.Check(err, Equals, maxidmmap.ErrMaxIDMmapClosed)
 	c.Check(nextID, Equals, prompting.IDType(0))
 
 	metadata := prompting.Metadata{Interface: "home"}

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -1007,7 +1007,7 @@ func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
 	c.Assert(err, IsNil)
 
 	nextID, err := pdb.NextID()
-	c.Check(err, Equals, requestprompts.ErrClosed)
+	c.Check(err, Equals, prompting.ErrMaxIDMmapClosed)
 	c.Check(nextID, Equals, prompting.IDType(0))
 
 	metadata := prompting.Metadata{Interface: "home"}

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -20,19 +20,13 @@
 package requestrules
 
 import (
-	"github.com/snapcore/snapd/interfaces/prompting"
+	"time"
 )
 
 var JoinInternalErrors = joinInternalErrors
 
-func (rdb *RuleDB) Load() error {
-	return rdb.load()
-}
+type RulesDBJSON rulesDBJSON
 
-func (rdb *RuleDB) PerUser() map[uint32]*userDB {
-	return rdb.perUser
-}
-
-func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {
-	return rdb.makeNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
+func (rule *Rule) Validate(currTime time.Time) error {
+	return rule.validate(currTime)
 }

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -34,5 +34,5 @@ func (rdb *RuleDB) PerUser() map[uint32]*userDB {
 }
 
 func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {
-	return rdb.populateNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	return rdb.makeNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
 }

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -19,6 +19,10 @@
 
 package requestrules
 
+import (
+	"github.com/snapcore/snapd/interfaces/prompting"
+)
+
 var JoinInternalErrors = joinInternalErrors
 
 func (rdb *RuleDB) InjectRule(rule *Rule) {
@@ -28,4 +32,12 @@ func (rdb *RuleDB) InjectRule(rule *Rule) {
 
 func (rdb *RuleDB) PerUser() map[uint32]*userDB {
 	return rdb.perUser
+}
+
+func (rdb *RuleDB) RefreshTreeEnforceConsistency(notifyEveryRule bool) {
+	rdb.refreshTreeEnforceConsistency(notifyEveryRule)
+}
+
+func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {
+	return rdb.populateNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
 }

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package requestrules
+
+var JoinInternalErrors = joinInternalErrors

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -20,3 +20,12 @@
 package requestrules
 
 var JoinInternalErrors = joinInternalErrors
+
+func (rdb *RuleDB) InjectRule(rule *Rule) {
+	rdb.rules = append(rdb.rules, rule)
+	rdb.ids[rule.ID] = len(rdb.rules) - 1
+}
+
+func (rdb *RuleDB) PerUser() map[uint32]*userDB {
+	return rdb.perUser
+}

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -20,6 +20,8 @@
 package requestrules
 
 import (
+	"time"
+
 	"github.com/snapcore/snapd/interfaces/prompting"
 )
 
@@ -34,8 +36,8 @@ func (rdb *RuleDB) PerUser() map[uint32]*userDB {
 	return rdb.perUser
 }
 
-func (rdb *RuleDB) RefreshTreeEnforceConsistency(notifyEveryRule bool) {
-	rdb.refreshTreeEnforceConsistency(notifyEveryRule)
+func (rdb *RuleDB) RefreshTreeEnforceConsistency(rules []*Rule, currTime time.Time, notifyEveryRule bool) {
+	rdb.refreshTreeEnforceConsistency(rules, currTime, notifyEveryRule)
 }
 
 func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -20,24 +20,17 @@
 package requestrules
 
 import (
-	"time"
-
 	"github.com/snapcore/snapd/interfaces/prompting"
 )
 
 var JoinInternalErrors = joinInternalErrors
 
-func (rdb *RuleDB) InjectRule(rule *Rule) {
-	rdb.rules = append(rdb.rules, rule)
-	rdb.ids[rule.ID] = len(rdb.rules) - 1
+func (rdb *RuleDB) Load() error {
+	return rdb.load()
 }
 
 func (rdb *RuleDB) PerUser() map[uint32]*userDB {
 	return rdb.perUser
-}
-
-func (rdb *RuleDB) RefreshTreeEnforceConsistency(rules []*Rule, currTime time.Time, notifyEveryRule bool) {
-	rdb.refreshTreeEnforceConsistency(rules, currTime, notifyEveryRule)
 }
 
 func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -193,7 +193,7 @@ func (rdb *RuleDB) save() error {
 		return fmt.Errorf("cannot marshal rule DB: %w", err)
 	}
 	target := rdb.dbpath()
-	return osutil.AtomicWriteFile(target, b, 0600, 0)
+	return osutil.AtomicWriteFile(target, b, 0o600, 0)
 }
 
 // dbpath returns the path of the database file.
@@ -292,7 +292,7 @@ type RuleConflict struct {
 // addRulePermissionToTree adds all the path pattern variants for the given
 // rule to the map for the given permission.
 //
-// If there are conflicting pattern variant froms other rules, all variants
+// If there are conflicting pattern variants from other rules, all variants
 // which were previously added during this function call are removed
 // from the path map, and an error is returned along with a list of the
 // conflicting variants and the IDs of the conflicting rules.

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -147,7 +147,10 @@ func New(notifyRule func(userID uint32, ruleID prompting.IDType, data map[string
 		perUser:    make(map[uint32]*userDB),
 		notifyRule: notifyRule,
 	}
-	return rdb, rdb.load()
+	if err = rdb.load(); err != nil {
+		logger.Noticef("%v; using new empty rule database", err)
+	}
+	return rdb, nil
 }
 
 // load reads the stored rules from the database file and populates the

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -17,8 +17,8 @@
  *
  */
 
-// Package requestrules provides the manager for request rules related to
-// AppArmor prompting.
+// Package requestrules provides support for storing request rules for AppArmor
+// prompting.
 package requestrules
 
 import (

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -156,7 +156,7 @@ func New(notifyRule func(userID uint32, ruleID prompting.IDType, data map[string
 		notifyRule: notifyRule,
 	}
 	if err = rdb.load(); err != nil {
-		logger.Noticef("%v; using new empty rule database", err)
+		logger.Noticef("cannot load rules DB: %v; using new empty rule database", err)
 	}
 	return rdb, nil
 }

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/internal/maxidmmap"
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -117,7 +118,7 @@ type userDB struct {
 // searchable by user, snap, interface, permission, and pattern variant.
 type RuleDB struct {
 	mutex     sync.Mutex
-	maxIDMmap prompting.MaxIDMmap
+	maxIDMmap maxidmmap.MaxIDMmap
 	ids       map[prompting.IDType]int
 	rules     []*Rule
 	perUser   map[uint32]*userDB
@@ -135,7 +136,7 @@ type RuleDB struct {
 // substantial amount of time (such as to lock and modify snapd state).
 func New(notifyRule func(userID uint32, ruleID prompting.IDType, data map[string]string) error) (*RuleDB, error) {
 	maxIDFilepath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "request-rule-max-id")
-	maxIDMmap, err := prompting.OpenMaxIDMmap(maxIDFilepath)
+	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(maxIDFilepath)
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -618,7 +618,6 @@ func (rdb *RuleDB) refreshTreeEnforceConsistency(rules []*Rule, currTime time.Ti
 		for {
 			err, conflicts, conflictingPermission := rdb.addRuleToTree(rule)
 			if err == nil {
-				needToSave = true
 				break
 			}
 			// err must be ErrPathPatternConflict.

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -178,6 +179,9 @@ func (rdb *RuleDB) load() error {
 	target := rdb.dbpath()
 	f, err := os.Open(target)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
 		return fmt.Errorf("cannot open rules database file: %w", err)
 	}
 	defer f.Close()

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -1,3 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package requestrules
 
 import (

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -484,10 +484,10 @@ func (rdb *RuleDB) isRuleWithIDExpired(id prompting.IDType, currTime time.Time) 
 	return rule.Expired(currTime)
 }
 
-// removeExistingRuleNoError removes provided rule from permissions tree and
+// removeExistingRule removes provided rule from permissions tree and
 // from rules DB. As a precodition the called must have confirmed that the rule
 // exists as errors are ignored.
-func (rdb *RuleDB) removeExistingRuleNoError(rule *Rule) {
+func (rdb *RuleDB) removeExistingRule(rule *Rule) {
 	rdb.removeRuleFromTree(rule) // if error occurs, rule still fully removed
 	rdb.removeRuleWithID(rule.ID)
 }
@@ -752,7 +752,7 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 	rdb.addRule(newRule)
 
 	if err := rdb.save(); err != nil {
-		rdb.removeExistingRuleNoError(newRule)
+		rdb.removeExistingRule(newRule)
 		return nil, err
 	}
 

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -1,0 +1,695 @@
+package requestrules
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var (
+	ErrInternalInconsistency = errors.New("internal error: prompting rules database left inconsistent")
+	ErrRuleIDNotFound        = errors.New("rule ID is not found")
+	ErrPathPatternConflict   = errors.New("a rule with conflicting path pattern and permission already exists in the rules database")
+	ErrNoMatchingRule        = errors.New("no rules match the given path")
+	ErrUserNotAllowed        = errors.New("the given user is not allowed to request the rule with the given ID")
+)
+
+type Rule struct {
+	ID               string              `json:"id"`
+	Timestamp        time.Time           `json:"timestamp"`
+	User             uint32              `json:"user"`
+	Snap             string              `json:"snap"`
+	Interface        string              `json:"interface"`
+	Constraints      *common.Constraints `json:"constraints"`
+	expandedPatterns []string            `json:"-"`
+	Outcome          common.OutcomeType  `json:"outcome"`
+	Lifespan         common.LifespanType `json:"lifespan"`
+	Expiration       time.Time           `json:"expiration,omitempty"`
+}
+
+func (rule *Rule) removePermission(permission string) error {
+	if err := rule.Constraints.RemovePermission(permission); err != nil {
+		return err
+	}
+	if len(rule.Constraints.Permissions) == 0 {
+		return common.ErrPermissionsListEmpty
+	}
+	return nil
+}
+
+func (rule *Rule) Expired(currentTime time.Time) (bool, error) {
+	switch rule.Lifespan {
+	case common.LifespanTimespan:
+		if rule.Expiration.IsZero() {
+			// Should not occur
+			return false, fmt.Errorf("encountered rule with lifespan timespan but no expiration")
+		}
+		if currentTime.After(rule.Expiration) {
+			return true, nil
+		}
+		return false, nil
+	case common.LifespanSession:
+		// TODO: return true if the user session has changed
+	}
+	return false, nil
+}
+
+type permissionDB struct {
+	// permissionDB contains a map from expanded path pattern to rule ID
+	PathRules map[string]string
+}
+
+type interfaceDB struct {
+	// interfaceDB contains a map from permission to permissionDB for a particular interface
+	PerPermission map[string]*permissionDB
+}
+
+type snapDB struct {
+	// snapDB contains a map from interface to interfaceDB for a particular snap
+	PerInterface map[string]*interfaceDB
+}
+
+type userDB struct {
+	// userDB contains a map from snap to snapDB for a particular user
+	PerSnap map[string]*snapDB
+}
+
+type RuleDB struct {
+	ByID    map[string]*Rule
+	PerUser map[uint32]*userDB
+	mutex   sync.Mutex
+	// Function to issue a notice for a change in a rule
+	notifyRule func(userID uint32, ruleID string, options *state.AddNoticeOptions) error
+}
+
+// Creates a new rule database, loads existing rules from the path given by
+// dbpath(), and returns the populated database.
+func New(notifyRule func(userID uint32, ruleID string, options *state.AddNoticeOptions) error) (*RuleDB, error) {
+	rdb := &RuleDB{
+		ByID:       make(map[string]*Rule),
+		PerUser:    make(map[uint32]*userDB),
+		notifyRule: notifyRule,
+	}
+	return rdb, rdb.load()
+}
+
+func (rdb *RuleDB) dbpath() string {
+	return filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "request-rules.json")
+}
+
+func (rdb *RuleDB) permissionDBForUserSnapInterfacePermission(user uint32, snap string, iface string, permission string) *permissionDB {
+	userSnaps := rdb.PerUser[user]
+	if userSnaps == nil {
+		userSnaps = &userDB{
+			PerSnap: make(map[string]*snapDB),
+		}
+		rdb.PerUser[user] = userSnaps
+	}
+	snapInterfaces := userSnaps.PerSnap[snap]
+	if snapInterfaces == nil {
+		snapInterfaces = &snapDB{
+			PerInterface: make(map[string]*interfaceDB),
+		}
+		userSnaps.PerSnap[snap] = snapInterfaces
+	}
+	interfacePerms := snapInterfaces.PerInterface[iface]
+	if interfacePerms == nil {
+		interfacePerms = &interfaceDB{
+			PerPermission: make(map[string]*permissionDB),
+		}
+		snapInterfaces.PerInterface[iface] = interfacePerms
+	}
+	permPaths := interfacePerms.PerPermission[permission]
+	if permPaths == nil {
+		permPaths = &permissionDB{
+			PathRules: make(map[string]string),
+		}
+		interfacePerms.PerPermission[permission] = permPaths
+	}
+	return permPaths
+}
+
+// Add all the expanded path patterns for the rule to the map for the given
+// permission. If there is a conflicting path pattern from another rule, all
+// patterns which were previously added during this function call are removed
+// from the path map, and returns an error along with the ID of the conflicting
+// rule.
+func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string) (error, string) {
+	permPaths := rdb.permissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
+	for i, pathPattern := range rule.expandedPatterns {
+		if id, exists := permPaths.PathRules[pathPattern]; exists {
+			for _, prevPattern := range rule.expandedPatterns[:i] {
+				delete(permPaths.PathRules, prevPattern)
+			}
+			return ErrPathPatternConflict, id
+		}
+		permPaths.PathRules[pathPattern] = rule.ID
+	}
+	return nil, ""
+}
+
+// Remove all the expanded path patterns for the rule to the map for the given
+// permission. If an expanded pattern is not found or maps to a different rule
+// ID than that of the given rule, continue to remove all other expanded paths
+// from the permission map (unless they map to a different rule ID), and return
+// a slice of all errors which occurred.
+func (rdb *RuleDB) removeRulePermissionFromTree(rule *Rule, permission string) []error {
+	permPaths := rdb.permissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
+	var errs []error
+	for _, pathPattern := range rule.expandedPatterns {
+		id, exists := permPaths.PathRules[pathPattern]
+		if !exists {
+			// Database was left inconsistent, should not occur
+			errs = append(errs, fmt.Errorf(`expanded path pattern not found in the rule tree: %q`, pathPattern))
+			continue
+		}
+		if id != rule.ID {
+			// Database was left inconsistent, should not occur
+			errs = append(errs, fmt.Errorf(`expanded path pattern maps to different rule ID: %q: %s`, pathPattern, id))
+			continue
+		}
+		delete(permPaths.PathRules, pathPattern)
+	}
+	return errs
+}
+
+func (rdb *RuleDB) addRuleToTree(rule *Rule) (error, string, string) {
+	// If there is a conflicting path pattern from another rule, returns an
+	// error along with the ID of the conflicting rule and the permission for
+	// which the conflict occurred
+	addedPermissions := make([]string, 0, len(rule.Constraints.Permissions))
+	for _, permission := range rule.Constraints.Permissions {
+		if err, conflictingID := rdb.addRulePermissionToTree(rule, permission); err != nil {
+			for _, prevPerm := range addedPermissions {
+				rdb.removeRulePermissionFromTree(rule, prevPerm)
+			}
+			return err, conflictingID, permission
+		}
+		addedPermissions = append(addedPermissions, permission)
+	}
+	return nil, "", ""
+}
+
+func (rdb *RuleDB) removeRuleFromTree(rule *Rule) error {
+	// Fully removes the rule from the tree, even if an error occurs
+	var errs []error
+	for _, permission := range rule.Constraints.Permissions {
+		if es := rdb.removeRulePermissionFromTree(rule, permission); len(es) > 0 {
+			// Database was left inconsistent, should not occur.
+			// Store the errors, but keep removing.
+			errs = append(errs, es...)
+		}
+	}
+	return joinInternalErrors(errs)
+}
+
+func joinInternalErrors(errs []error) error {
+	joinedErr := errorsJoin(errs...)
+	if joinedErr == nil {
+		return nil
+	}
+	// TODO: wrap joinedErr as well once we're on golang v1.20+
+	return fmt.Errorf("%w\n%v", ErrInternalInconsistency, joinedErr)
+}
+
+// errorsJoin returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// errorsJoin returns nil if every value in errs is nil.
+//
+// TODO: replace with errors.Join() once we're on golang v1.20+
+func errorsJoin(errs ...error) error {
+	var nonNilErrs []error
+	for _, e := range errs {
+		if e != nil {
+			nonNilErrs = append(nonNilErrs, e)
+		}
+	}
+	if len(nonNilErrs) == 0 {
+		return nil
+	}
+	err := nonNilErrs[0]
+	for _, e := range nonNilErrs[1:] {
+		err = fmt.Errorf("%w\n%v", err, e)
+	}
+	return err
+}
+
+// TODO: unexport (probably)
+// This function is only required if database is left inconsistent (should not
+// occur) or when loading, in case the stored rules on disk were corrupted.
+//
+// By default, issues a notice for each rule which is modified or removed as a
+// result of a conflict with another rule. If notifyEveryRule is true, issues
+// a notice for every rule which was in the database prior to the beginning of
+// the function. In either case, at most one notice is issued for each rule.
+//
+// Discards the current rule tree, then iterates through the rules in rdb.ByID
+// and re-populates the tree. If there are any conflicts between rules (that
+// is, rules share the same path pattern and one or more of the same
+// permissions), the conflicting permission is removed from the rule with the
+// earlier timestamp. When the function returns, the database should be fully
+// internally consistent and without conflicting rules.
+func (rdb *RuleDB) RefreshTreeEnforceConsistency(notifyEveryRule bool) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	needToSave := false
+	defer func() {
+		if needToSave {
+			rdb.save()
+		}
+	}()
+	modifiedUserRuleIDs := make(map[uint32]map[string]bool)
+	defer func() {
+		for user, ruleIDs := range modifiedUserRuleIDs {
+			for ruleID := range ruleIDs {
+				rdb.notifyRule(user, ruleID, nil)
+			}
+		}
+	}()
+	currTime := time.Now()
+	newByID := make(map[string]*Rule)
+	rdb.PerUser = make(map[uint32]*userDB)
+	for id, rule := range rdb.ByID {
+		_, exists := modifiedUserRuleIDs[rule.User]
+		if !exists {
+			modifiedUserRuleIDs[rule.User] = make(map[string]bool)
+		}
+		if notifyEveryRule {
+			modifiedUserRuleIDs[rule.User][id] = true
+		}
+		if err := common.ValidateConstraintsOutcomeLifespanExpiration(rule.Interface, rule.Constraints, rule.Outcome, rule.Lifespan, rule.Expiration, currTime); err != nil {
+			// Invalid rule, discard it
+			needToSave = true
+			modifiedUserRuleIDs[rule.User][id] = true
+			continue
+		}
+		expandedPatterns, err := common.ExpandPathPattern(rule.Constraints.PathPattern)
+		if err != nil {
+			// Invalid path pattern, discard this rule
+			// This should not occur, since previous validation should catch invalid patterns.
+			needToSave = true
+			modifiedUserRuleIDs[rule.User][id] = true
+			continue
+		}
+		rule.expandedPatterns = expandedPatterns
+		for {
+			err, conflictingID, conflictingPermission := rdb.addRuleToTree(rule)
+			if err == nil {
+				break
+			}
+			// Err must be ErrPathPatternConflict.
+			// Prioritize newer rules by pruning permission from old rule until no conflicts remain.
+			conflictingRule := rdb.ByID[conflictingID] // must exist
+			if rule.Timestamp.After(conflictingRule.Timestamp) {
+				rdb.removeRulePermissionFromTree(conflictingRule, conflictingPermission) // must return nil
+				if conflictingRule.removePermission(conflictingPermission) == common.ErrPermissionsListEmpty {
+					delete(newByID, conflictingID)
+				}
+				modifiedUserRuleIDs[conflictingRule.User][conflictingID] = true
+			} else {
+				rule.removePermission(conflictingPermission) // ignore error
+				modifiedUserRuleIDs[rule.User][id] = true
+			}
+			needToSave = true
+		}
+		if len(rule.Constraints.Permissions) > 0 {
+			newByID[id] = rule
+		} else {
+			needToSave = true
+			modifiedUserRuleIDs[rule.User][id] = true
+		}
+	}
+	rdb.ByID = newByID
+}
+
+func (rdb *RuleDB) load() error {
+	target := rdb.dbpath()
+	f, err := os.Open(target)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	ruleList := make([]*Rule, 0, 256)    // pre-allocate a large array to reduce memcpys
+	json.NewDecoder(f).Decode(&ruleList) // TODO: handle errors
+
+	rdb.ByID = make(map[string]*Rule) // clear out any existing rules in ByID
+	for _, rule := range ruleList {
+		rdb.ByID[rule.ID] = rule
+	}
+
+	notifyEveryRule := true
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+
+	return nil
+}
+
+func (rdb *RuleDB) save() error {
+	ruleList := make([]*Rule, 0, len(rdb.ByID))
+	for _, rule := range rdb.ByID {
+		ruleList = append(ruleList, rule)
+	}
+	b, err := json.Marshal(ruleList)
+	if err != nil {
+		return err
+	}
+	target := rdb.dbpath()
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(target, b, 0600, 0)
+}
+
+// TODO: unexport (probably, avoid confusion with AddRule)
+// Users of requestrules should probably autofill rules from JSON and never call
+// this function directly.
+//
+// Constructs a new rule with the given parameters as values, with the
+// exception of duration. Uses the given duration, in addition to the current
+// time, to compute the expiration time for the rule, and stores that as part
+// of the rule which is returned. If any of the given parameters are invalid,
+// returns a corresponding error.
+func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*Rule, error) {
+	expiration, err := common.ValidateConstraintsOutcomeLifespanDuration(iface, constraints, outcome, lifespan, duration)
+	if err != nil {
+		return nil, err
+	}
+	expandedPatterns, err := common.ExpandPathPattern(constraints.PathPattern)
+	if err != nil {
+		return nil, err
+	}
+	id, timestamp := common.NewIDAndTimestamp()
+	newRule := Rule{
+		ID:               id,
+		Timestamp:        timestamp,
+		User:             user,
+		Snap:             snap,
+		Interface:        iface,
+		Constraints:      constraints,
+		expandedPatterns: expandedPatterns,
+		Outcome:          outcome,
+		Lifespan:         lifespan,
+		Expiration:       expiration,
+	}
+	return &newRule, nil
+}
+
+// Checks whether the given path with the given permission is allowed or
+// denied by existing rules for the given user, snap, and interface.
+// If no rule applies, returns ErrNoMatchingRule.
+func (rdb *RuleDB) IsPathAllowed(user uint32, snap string, iface string, path string, permission string) (bool, error) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	needToSave := false
+	defer func() {
+		if needToSave {
+			rdb.save()
+		}
+	}()
+	pathMap := rdb.permissionDBForUserSnapInterfacePermission(user, snap, iface, permission).PathRules
+	matchingPatterns := make([]string, 0)
+	// Make sure all rules use the same expiration timestamp, so a rule with
+	// an earlier expiration cannot outlive another rule with a later one.
+	currTime := time.Now()
+	for pathPattern, id := range pathMap {
+		matchingRule, exists := rdb.ByID[id]
+		if !exists {
+			// Database was left inconsistent, should not occur
+			delete(pathMap, id)
+			// Issue a notice for the offending rule, just in case
+			rdb.notifyRule(user, id, nil)
+			continue
+		}
+		expired, err := matchingRule.Expired(currTime)
+		if err != nil {
+			return false, err
+		}
+		if expired {
+			needToSave = true
+			rdb.removeRuleFromTree(matchingRule)
+			delete(rdb.ByID, id)
+			rdb.notifyRule(user, id, nil)
+			continue
+		}
+		// Need to compare the expanded path pattern, not the rule's path
+		// pattern, so that only expanded patterns which match are included,
+		// and the highest precedence expanded pattern can be computed.
+		matched, err := common.PathPatternMatch(pathPattern, path)
+		if err != nil {
+			// Only possible error is ErrBadPattern, which should not occur
+			return false, err
+		}
+		if matched {
+			matchingPatterns = append(matchingPatterns, pathPattern)
+		}
+	}
+	if len(matchingPatterns) == 0 {
+		return false, ErrNoMatchingRule
+	}
+	highestPrecedencePattern, err := common.GetHighestPrecedencePattern(matchingPatterns)
+	if err != nil {
+		return false, err
+	}
+	matchingID := pathMap[highestPrecedencePattern]
+	matchingRule, exists := rdb.ByID[matchingID]
+	if !exists {
+		// Database was left inconsistent, should not occur
+		return false, ErrRuleIDNotFound
+	}
+	if matchingRule.Lifespan == common.LifespanSingle {
+		rdb.removeRuleFromTree(matchingRule)
+		delete(rdb.ByID, matchingID)
+		rdb.notifyRule(user, matchingID, nil)
+		needToSave = true
+	}
+	return matchingRule.Outcome.AsBool()
+}
+
+func (rdb *RuleDB) ruleWithIDInternal(user uint32, id string) (*Rule, error) {
+	rule, exists := rdb.ByID[id]
+	if !exists {
+		return nil, ErrRuleIDNotFound
+	}
+	if rule.User != user {
+		return nil, ErrUserNotAllowed
+	}
+	return rule, nil
+}
+
+// Returns the rule with the given ID.
+// If the rule is not found, returns ErrRuleNotFound.
+// If the rule does not apply to the given user, returns ErrUserNotAllowed.
+func (rdb *RuleDB) RuleWithID(user uint32, id string) (*Rule, error) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	return rdb.ruleWithIDInternal(user, id)
+}
+
+// Creates a rule with the given information and adds it to the rule database.
+// If any of the given parameters are invalid, returns an error. Otherwise,
+// returns the newly-added rule, and saves the database to disk.
+func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*Rule, error) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	newRule, err := rdb.PopulateNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	if err != nil {
+		return nil, err
+	}
+	if err, conflictingID, conflictingPermission := rdb.addRuleToTree(newRule); err != nil {
+		return nil, fmt.Errorf("%w: ID: '%s', Permission: '%s'", err, conflictingID, conflictingPermission)
+	}
+	rdb.ByID[newRule.ID] = newRule
+	rdb.save()
+	rdb.notifyRule(user, newRule.ID, nil)
+	return newRule, nil
+}
+
+// RemoveRule the rule with the given ID from the rules database. If the rule
+// does not apply to the given user, returns ErrUserNotAllowed. If successful,
+// saves the database to disk.
+func (rdb *RuleDB) RemoveRule(user uint32, id string) (*Rule, error) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	rule, err := rdb.ruleWithIDInternal(user, id)
+	if err != nil {
+		return nil, err
+	}
+	err = rdb.removeRuleFromTree(rule)
+	// If error occurs, rule was still fully removed from tree
+	delete(rdb.ByID, id)
+	rdb.save()
+	rdb.notifyRule(user, id, nil)
+	return rule, err
+}
+
+// RemoveRulesForSnap removes all rules pertaining to the given snap for the
+// user with the given user ID.
+func (rdb *RuleDB) RemoveRulesForSnap(user uint32, snap string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Snap == snap
+	}
+	rules := rdb.rulesInternal(ruleFilter)
+	rdb.removeRulesInternal(user, rules)
+	return rules
+}
+
+func (rdb *RuleDB) removeRulesInternal(user uint32, rules []*Rule) {
+	for _, rule := range rules {
+		rdb.removeRuleFromTree(rule)
+		// If error occurs, rule was still fully removed from tree
+		delete(rdb.ByID, rule.ID)
+		rdb.notifyRule(user, rule.ID, nil)
+	}
+	rdb.save()
+}
+
+// RemoveRulesForSnapInterface removes all rules pertaining to the given snap
+// and interface for the user with the given user ID.
+func (rdb *RuleDB) RemoveRulesForSnapInterface(user uint32, snap string, iface string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Snap == snap && rule.Interface == iface
+	}
+	rules := rdb.rulesInternal(ruleFilter)
+	rdb.removeRulesInternal(user, rules)
+	return rules
+}
+
+// Patches the rule with the given ID. The rule is modified by constructing a
+// new rule based on the given parameters, and then replacing the old rule with
+// the same ID with the new rule. Any of the parameters which are equal to the
+// default/unset value for their types are replaced by the corresponding values
+// in the existing rule. Even if the given new rule contents exactly match the
+// existing rule contents, the timestamp of the rule is updated to the current
+// time. If there is any error while adding the patched rule to the database,
+// rolls back to the previous unmodified rule, leaving the databse unchanged.
+// If the database is changed, it is saved to disk.
+func (rdb *RuleDB) PatchRule(user uint32, id string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*Rule, error) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	changeOccurred := false
+	defer func() {
+		if changeOccurred {
+			rdb.save()
+			rdb.notifyRule(user, id, nil)
+		}
+	}()
+	origRule, err := rdb.ruleWithIDInternal(user, id)
+	if err != nil {
+		return nil, err
+	}
+	if constraints == nil {
+		constraints = origRule.Constraints
+	}
+	if outcome == common.OutcomeUnset {
+		outcome = origRule.Outcome
+	}
+	if lifespan == common.LifespanUnset {
+		lifespan = origRule.Lifespan
+	}
+	if err = rdb.removeRuleFromTree(origRule); err != nil {
+		// If error occurs, rule is fully removed from tree
+		changeOccurred = true
+		return nil, err
+	}
+	newRule, err := rdb.PopulateNewRule(user, origRule.Snap, origRule.Interface, constraints, outcome, lifespan, duration)
+	if err != nil {
+		rdb.addRuleToTree(origRule) // ignore any new error, should not occur
+		// origRule was successfully removed before, so it should now be able
+		// to be successfully re-added without error, and all is unchanged.
+		changeOccurred = false
+		return nil, err
+	}
+	newRule.ID = origRule.ID
+	err, conflictingID, conflictingPermission := rdb.addRuleToTree(newRule)
+	if err != nil {
+		rdb.addRuleToTree(origRule) // ignore any new error
+		// origRule was successfully removed before, so it should now be able
+		// to be successfully re-added without error, and all is unchanged.
+		changeOccurred = false
+		return nil, fmt.Errorf("%w: ID: '%s', Permission: '%s'", err, conflictingID, conflictingPermission)
+	}
+	rdb.ByID[newRule.ID] = newRule
+	changeOccurred = true
+	return newRule, nil
+}
+
+// Returns all rules which apply to the given user.
+func (rdb *RuleDB) Rules(user uint32) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user
+	}
+	return rdb.rulesInternal(ruleFilter)
+}
+
+func (rdb *RuleDB) rulesInternal(ruleFilter func(rule *Rule) bool) []*Rule {
+	rules := make([]*Rule, 0)
+	currTime := time.Now()
+	needToSave := false
+	defer func() {
+		if needToSave {
+			rdb.save()
+		}
+	}()
+	for id, rule := range rdb.ByID {
+		expired, err := rule.Expired(currTime)
+		if err != nil {
+			// Issue with expiration, this should not occur
+		}
+		if expired {
+			needToSave = true
+			rdb.removeRuleFromTree(rule)
+			delete(rdb.ByID, id)
+			rdb.notifyRule(rule.User, id, nil)
+			continue
+		}
+		if ruleFilter(rule) {
+			rules = append(rules, rule)
+		}
+	}
+	return rules
+}
+
+// Returns all rules which apply to the given user and snap.
+func (rdb *RuleDB) RulesForSnap(user uint32, snap string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Snap == snap
+	}
+	return rdb.rulesInternal(ruleFilter)
+}
+
+// Returns all rules which apply to the given user and interface.
+func (rdb *RuleDB) RulesForInterface(user uint32, iface string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Interface == iface
+	}
+	return rdb.rulesInternal(ruleFilter)
+}
+
+// Returns all rules which apply to the given user, snap, and interface.
+func (rdb *RuleDB) RulesForSnapInterface(user uint32, snap string, iface string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Snap == snap && rule.Interface == iface
+	}
+	return rdb.rulesInternal(ruleFilter)
+}

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/patterns"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
-	"github.com/snapcore/snapd/overlord/state"
 )
 
 var (
@@ -23,32 +24,38 @@ var (
 	ErrUserNotAllowed        = errors.New("the given user is not allowed to request the rule with the given ID")
 )
 
+// Rule stores the contents of a request rule.
 type Rule struct {
-	ID               string              `json:"id"`
-	Timestamp        time.Time           `json:"timestamp"`
-	User             uint32              `json:"user"`
-	Snap             string              `json:"snap"`
-	Interface        string              `json:"interface"`
-	Constraints      *common.Constraints `json:"constraints"`
-	expandedPatterns []string            `json:"-"`
-	Outcome          common.OutcomeType  `json:"outcome"`
-	Lifespan         common.LifespanType `json:"lifespan"`
-	Expiration       time.Time           `json:"expiration,omitempty"`
+	ID          prompting.IDType       `json:"id"`
+	Timestamp   time.Time              `json:"timestamp"`
+	User        uint32                 `json:"user"`
+	Snap        string                 `json:"snap"`
+	Interface   string                 `json:"interface"`
+	Constraints *prompting.Constraints `json:"constraints"`
+	Outcome     prompting.OutcomeType  `json:"outcome"`
+	Lifespan    prompting.LifespanType `json:"lifespan"`
+	Expiration  time.Time              `json:"expiration,omitempty"`
 }
 
+// removePermission removes the given permission from the rule's list of
+// permissions.
 func (rule *Rule) removePermission(permission string) error {
 	if err := rule.Constraints.RemovePermission(permission); err != nil {
 		return err
 	}
 	if len(rule.Constraints.Permissions) == 0 {
-		return common.ErrPermissionsListEmpty
+		return prompting.ErrPermissionsListEmpty
 	}
 	return nil
 }
 
+// Expired returns true if the receiving rule has a lifespan of timespan and
+// the current time is after the rule's expiration time.
+//
+// Returns an error if the rule's expiration time is invalid.
 func (rule *Rule) Expired(currentTime time.Time) (bool, error) {
 	switch rule.Lifespan {
-	case common.LifespanTimespan:
+	case prompting.LifespanTimespan:
 		if rule.Expiration.IsZero() {
 			// Should not occur
 			return false, fmt.Errorf("encountered rule with lifespan timespan but no expiration")
@@ -57,55 +64,129 @@ func (rule *Rule) Expired(currentTime time.Time) (bool, error) {
 			return true, nil
 		}
 		return false, nil
-	case common.LifespanSession:
+		// TODO: add lifespan session
+		//case prompting.LifespanSession:
 		// TODO: return true if the user session has changed
 	}
 	return false, nil
 }
 
-type permissionDB struct {
-	// permissionDB contains a map from expanded path pattern to rule ID
-	PathRules map[string]string
+// variantEntry stores the variant struct and the ID of its corresponding rule.
+//
+// This is necessary since multiple variants might render to the same string,
+// and it would be necessary to make a deep comparison of two variants to tell
+// that they are the same. Since we want to map from variant to rule ID, we need
+// to use the variant string as the key.
+type variantEntry struct {
+	Variant patterns.PatternVariant
+	RuleID  prompting.IDType
 }
 
+// permissionDB stores a map from path pattern variant to the ID of the rule
+// associated with the variant for the permission associated with the permission
+// DB.
+type permissionDB struct {
+	// permissionDB contains a map from path pattern variant to rule ID
+	VariantEntries map[string]variantEntry
+}
+
+// interfaceDB stores a map from permission to the DB of rules pertaining to that
+// permission for the interface associated with the interface DB.
 type interfaceDB struct {
 	// interfaceDB contains a map from permission to permissionDB for a particular interface
 	PerPermission map[string]*permissionDB
 }
 
+// snapDB stores a map from interface name to the DB of rules pertaining to that
+// interface for the snap associated with the snap DB.
 type snapDB struct {
 	// snapDB contains a map from interface to interfaceDB for a particular snap
 	PerInterface map[string]*interfaceDB
 }
 
+// userDB stores a map from snap name to the DB of rules pertaining to that
+// snap for the user associated with the user DB.
 type userDB struct {
 	// userDB contains a map from snap to snapDB for a particular user
 	PerSnap map[string]*snapDB
 }
 
+// RuleDB stores a mapping from rule ID to rule, and a tree of rule IDs
+// searchable by user, snap, interface, permission, and pattern variant.
 type RuleDB struct {
-	ByID    map[string]*Rule
-	PerUser map[uint32]*userDB
 	mutex   sync.Mutex
-	// Function to issue a notice for a change in a rule
-	notifyRule func(userID uint32, ruleID string, options *state.AddNoticeOptions) error
+	ByID    map[prompting.IDType]*Rule
+	PerUser map[uint32]*userDB
+	// notifyRule is a closure which will be called to record a notice when a
+	// rule is added, patched, or removed.
+	notifyRule func(userID uint32, ruleID prompting.IDType, data map[string]string) error
 }
 
-// Creates a new rule database, loads existing rules from the path given by
-// dbpath(), and returns the populated database.
-func New(notifyRule func(userID uint32, ruleID string, options *state.AddNoticeOptions) error) (*RuleDB, error) {
+// New creates a new rule database, loads existing rules from the database file,
+// and returns the populated database.
+func New(notifyRule func(userID uint32, ruleID prompting.IDType, data map[string]string) error) (*RuleDB, error) {
 	rdb := &RuleDB{
-		ByID:       make(map[string]*Rule),
+		ByID:       make(map[prompting.IDType]*Rule),
 		PerUser:    make(map[uint32]*userDB),
 		notifyRule: notifyRule,
 	}
 	return rdb, rdb.load()
 }
 
+// load reads the stored rules from the database file and populates the
+// receiving rule database.
+//
+// If an error occurs, does not modify the rule database.
+func (rdb *RuleDB) load() error {
+	target := rdb.dbpath()
+	f, err := os.Open(target)
+	if err != nil {
+		return fmt.Errorf("cannot open rules database file: %w", err)
+	}
+	defer f.Close()
+
+	var ruleList []*Rule
+	err = json.NewDecoder(f).Decode(&ruleList)
+	if err != nil {
+		// TODO: store rules separately per-user, so a corrupted rule for one
+		// user can't impact rules for another user.
+		return fmt.Errorf("cannot read stored prompting rules: %w", err)
+	}
+
+	rdb.ByID = make(map[prompting.IDType]*Rule) // clear out any existing rules in ByID
+	for _, rule := range ruleList {
+		rdb.ByID[rule.ID] = rule
+	}
+
+	notifyEveryRule := true
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+
+	return nil
+}
+
+// save writes the current state of the rule database to the database file.
+func (rdb *RuleDB) save() error {
+	// TODO: store rules in slice so this is wayyy faster
+	ruleList := make([]*Rule, 0, len(rdb.ByID))
+	for _, rule := range rdb.ByID {
+		ruleList = append(ruleList, rule)
+	}
+	b, err := json.Marshal(ruleList)
+	if err != nil {
+		logger.Noticef("cannot marshal rule DB: %v", err)
+		return fmt.Errorf("cannot marshal rule DB: %w", err)
+	}
+	target := rdb.dbpath()
+	return osutil.AtomicWriteFile(target, b, 0600, 0)
+}
+
+// dbpath returns the path of the database file.
 func (rdb *RuleDB) dbpath() string {
 	return filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "request-rules.json")
 }
 
+// permissionDBForUserSnapInterfacePermission returns the permission DB for the
+// given user, snap, interface, and permission.
 func (rdb *RuleDB) permissionDBForUserSnapInterfacePermission(user uint32, snap string, iface string, permission string) *permissionDB {
 	userSnaps := rdb.PerUser[user]
 	if userSnaps == nil {
@@ -128,79 +209,111 @@ func (rdb *RuleDB) permissionDBForUserSnapInterfacePermission(user uint32, snap 
 		}
 		snapInterfaces.PerInterface[iface] = interfacePerms
 	}
-	permPaths := interfacePerms.PerPermission[permission]
-	if permPaths == nil {
-		permPaths = &permissionDB{
-			PathRules: make(map[string]string),
+	permVariants := interfacePerms.PerPermission[permission]
+	if permVariants == nil {
+		permVariants = &permissionDB{
+			VariantEntries: make(map[string]variantEntry),
 		}
-		interfacePerms.PerPermission[permission] = permPaths
+		interfacePerms.PerPermission[permission] = permVariants
 	}
-	return permPaths
+	return permVariants
 }
 
-// Add all the expanded path patterns for the rule to the map for the given
-// permission. If there is a conflicting path pattern from another rule, all
-// patterns which were previously added during this function call are removed
-// from the path map, and returns an error along with the ID of the conflicting
-// rule.
-func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string) (error, string) {
-	permPaths := rdb.permissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
-	for i, pathPattern := range rule.expandedPatterns {
-		if id, exists := permPaths.PathRules[pathPattern]; exists {
-			for _, prevPattern := range rule.expandedPatterns[:i] {
-				delete(permPaths.PathRules, prevPattern)
+// RuleConflict stores the rendered variant which conflicted with that of
+// another rule, along with the ID of that conflicting rule.
+type RuleConflict struct {
+	Variant       string           `json:"pattern-variant"`
+	ConflictingID prompting.IDType `json:"conflicting-rule-id"`
+}
+
+// addRulePermissionToTree adds all the path pattern variants for the given
+// rule to the map for the given permission.
+//
+// If there are conflicting pattern variant froms other rules, all variants
+// which were previously added during this function call are removed
+// from the path map, and an error is returned along with a list of the
+// conflicting variants and the IDs of the conflicting rules.
+func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string) (error, []RuleConflict) {
+	permVariants := rdb.permissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
+	conflicts := make([]RuleConflict, 0, rule.Constraints.PathPattern.NumVariants())
+	addVariant := func(index int, variant patterns.PatternVariant) {
+		if conflictingVariantEntry, exists := permVariants.VariantEntries[variant.String()]; exists {
+			conflicts = append(conflicts, RuleConflict{
+				Variant:       variant.String(),
+				ConflictingID: conflictingVariantEntry.RuleID,
+			})
+		} else {
+			permVariants.VariantEntries[variant.String()] = variantEntry{
+				Variant: variant,
+				RuleID:  rule.ID,
 			}
-			return ErrPathPatternConflict, id
 		}
-		permPaths.PathRules[pathPattern] = rule.ID
 	}
-	return nil, ""
+	rule.Constraints.PathPattern.RenderAllVariants(addVariant)
+	if len(conflicts) == 0 {
+		return nil, nil
+	}
+	// There were conflicts, so remove any variants which were added to the tree
+	nextMatchIndex := 0
+	removeVariant := func(index int, variant patterns.PatternVariant) {
+		if nextMatchIndex < len(conflicts) && conflicts[nextMatchIndex].Variant == variant.String() {
+			nextMatchIndex++
+		} else {
+			delete(permVariants.VariantEntries, variant.String())
+		}
+	}
+	rule.Constraints.PathPattern.RenderAllVariants(removeVariant)
+	return ErrPathPatternConflict, conflicts
 }
 
-// Remove all the expanded path patterns for the rule to the map for the given
-// permission. If an expanded pattern is not found or maps to a different rule
-// ID than that of the given rule, continue to remove all other expanded paths
-// from the permission map (unless they map to a different rule ID), and return
-// a slice of all errors which occurred.
+// removeRulePermissionFromTree removes all the path patterns variants for the
+// given rule from the map for the given permission.
+//
+// If a pattern variant is not found or maps to a different rule ID than that
+// of the given rule, continue to remove all other variants from the permission
+// map (unless they map to a different rule ID), and return a slice of all
+// errors which occurred.
 func (rdb *RuleDB) removeRulePermissionFromTree(rule *Rule, permission string) []error {
-	permPaths := rdb.permissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
+	permVariants := rdb.permissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
 	var errs []error
-	for _, pathPattern := range rule.expandedPatterns {
-		id, exists := permPaths.PathRules[pathPattern]
+	removeVariant := func(index int, variant patterns.PatternVariant) {
+		variantEntry, exists := permVariants.VariantEntries[variant.String()]
 		if !exists {
 			// Database was left inconsistent, should not occur
-			errs = append(errs, fmt.Errorf(`expanded path pattern not found in the rule tree: %q`, pathPattern))
-			continue
-		}
-		if id != rule.ID {
+			errs = append(errs, fmt.Errorf(`path pattern variant not found in the rule tree: %q`, variant))
+		} else if variantEntry.RuleID != rule.ID {
 			// Database was left inconsistent, should not occur
-			errs = append(errs, fmt.Errorf(`expanded path pattern maps to different rule ID: %q: %s`, pathPattern, id))
-			continue
+			errs = append(errs, fmt.Errorf(`path pattern variant maps to different rule ID: %q: %s`, variant, variantEntry.RuleID.String()))
+		} else {
+			delete(permVariants.VariantEntries, variant.String())
 		}
-		delete(permPaths.PathRules, pathPattern)
 	}
+	rule.Constraints.PathPattern.RenderAllVariants(removeVariant)
 	return errs
 }
 
-func (rdb *RuleDB) addRuleToTree(rule *Rule) (error, string, string) {
-	// If there is a conflicting path pattern from another rule, returns an
-	// error along with the ID of the conflicting rule and the permission for
-	// which the conflict occurred
+// addRuleToTree adds the given rule to the rule tree.
+//
+// If there is a conflicting path pattern from another rule, returns an
+// error along with the ID of the conflicting rule and the permission for
+// which the conflict occurred
+func (rdb *RuleDB) addRuleToTree(rule *Rule) (error, []RuleConflict, string) {
 	addedPermissions := make([]string, 0, len(rule.Constraints.Permissions))
 	for _, permission := range rule.Constraints.Permissions {
-		if err, conflictingID := rdb.addRulePermissionToTree(rule, permission); err != nil {
+		if err, conflicts := rdb.addRulePermissionToTree(rule, permission); err != nil {
 			for _, prevPerm := range addedPermissions {
 				rdb.removeRulePermissionFromTree(rule, prevPerm)
 			}
-			return err, conflictingID, permission
+			return err, conflicts, permission
 		}
 		addedPermissions = append(addedPermissions, permission)
 	}
-	return nil, "", ""
+	return nil, nil, ""
 }
 
+// removeRuleFromTree fully removes the given rule from the tree, even if an
+// error occurs.
 func (rdb *RuleDB) removeRuleFromTree(rule *Rule) error {
-	// Fully removes the rule from the tree, even if an error occurs
 	var errs []error
 	for _, permission := range rule.Constraints.Permissions {
 		if es := rdb.removeRulePermissionFromTree(rule, permission); len(es) > 0 {
@@ -212,6 +325,9 @@ func (rdb *RuleDB) removeRuleFromTree(rule *Rule) error {
 	return joinInternalErrors(errs)
 }
 
+// joinInternalErrors wraps an ErrInternalInconsistency with the given errors.
+//
+// If there are no non-nil errors in the given errs list, return nil.
 func joinInternalErrors(errs []error) error {
 	joinedErr := errorsJoin(errs...)
 	if joinedErr == nil {
@@ -243,7 +359,9 @@ func errorsJoin(errs ...error) error {
 	return err
 }
 
-// TODO: unexport (probably)
+// RefreshTreeEnforceConsistency rebuilds the rule tree, resolving any
+// conflicting pattern variants and permissions by pruning the offending
+//
 // This function is only required if database is left inconsistent (should not
 // occur) or when loading, in case the stored rules on disk were corrupted.
 //
@@ -258,6 +376,8 @@ func errorsJoin(errs ...error) error {
 // permissions), the conflicting permission is removed from the rule with the
 // earlier timestamp. When the function returns, the database should be fully
 // internally consistent and without conflicting rules.
+//
+// TODO: unexport (probably)
 func (rdb *RuleDB) RefreshTreeEnforceConsistency(notifyEveryRule bool) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
@@ -267,7 +387,7 @@ func (rdb *RuleDB) RefreshTreeEnforceConsistency(notifyEveryRule bool) {
 			rdb.save()
 		}
 	}()
-	modifiedUserRuleIDs := make(map[uint32]map[string]bool)
+	modifiedUserRuleIDs := make(map[uint32]map[prompting.IDType]bool)
 	defer func() {
 		for user, ruleIDs := range modifiedUserRuleIDs {
 			for ruleID := range ruleIDs {
@@ -276,54 +396,56 @@ func (rdb *RuleDB) RefreshTreeEnforceConsistency(notifyEveryRule bool) {
 		}
 	}()
 	currTime := time.Now()
-	newByID := make(map[string]*Rule)
+	newByID := make(map[prompting.IDType]*Rule)
 	rdb.PerUser = make(map[uint32]*userDB)
 	for id, rule := range rdb.ByID {
 		_, exists := modifiedUserRuleIDs[rule.User]
 		if !exists {
-			modifiedUserRuleIDs[rule.User] = make(map[string]bool)
+			modifiedUserRuleIDs[rule.User] = make(map[prompting.IDType]bool)
 		}
 		if notifyEveryRule {
 			modifiedUserRuleIDs[rule.User][id] = true
 		}
-		if err := common.ValidateConstraintsOutcomeLifespanExpiration(rule.Interface, rule.Constraints, rule.Outcome, rule.Lifespan, rule.Expiration, currTime); err != nil {
+		if rule.Constraints.ValidateForInterface(rule.Interface) != nil || rule.Lifespan.ValidateExpiration(rule.Expiration, currTime) != nil {
 			// Invalid rule, discard it
 			needToSave = true
 			modifiedUserRuleIDs[rule.User][id] = true
 			continue
 		}
-		expandedPatterns, err := common.ExpandPathPattern(rule.Constraints.PathPattern)
-		if err != nil {
-			// Invalid path pattern, discard this rule
-			// This should not occur, since previous validation should catch invalid patterns.
-			needToSave = true
-			modifiedUserRuleIDs[rule.User][id] = true
-			continue
-		}
-		rule.expandedPatterns = expandedPatterns
 		for {
-			err, conflictingID, conflictingPermission := rdb.addRuleToTree(rule)
+			err, conflicts, conflictingPermission := rdb.addRuleToTree(rule)
 			if err == nil {
 				break
 			}
 			// Err must be ErrPathPatternConflict.
-			// Prioritize newer rules by pruning permission from old rule until no conflicts remain.
-			conflictingRule := rdb.ByID[conflictingID] // must exist
-			if rule.Timestamp.After(conflictingRule.Timestamp) {
-				rdb.removeRulePermissionFromTree(conflictingRule, conflictingPermission) // must return nil
-				if conflictingRule.removePermission(conflictingPermission) == common.ErrPermissionsListEmpty {
-					delete(newByID, conflictingID)
+			// Prioritize newer rules by pruning permission from old rule until
+			// no conflicts remain.
+			// XXX: this results in the permission being dropped for all other
+			// variants of the older rule.
+			// TODO: split older rule into two rules, preserving all except the
+			// directly conflicting variant/permission combination.
+			// XXX: there's no way to do this, since patterns can have sequential
+			// groups, and there's no way to remove only a single variant.
+			for _, conflict := range conflicts {
+				conflictingID := conflict.ConflictingID
+				conflictingRule := rdb.ByID[conflictingID] // must exist
+				if rule.Timestamp.After(conflictingRule.Timestamp) {
+					rdb.removeRulePermissionFromTree(conflictingRule, conflictingPermission) // must return nil
+					if conflictingRule.removePermission(conflictingPermission) == prompting.ErrPermissionsListEmpty {
+						delete(newByID, conflictingID)
+					}
+					modifiedUserRuleIDs[conflictingRule.User][conflictingID] = true
+				} else {
+					rule.removePermission(conflictingPermission) // ignore error
+					modifiedUserRuleIDs[rule.User][id] = true
 				}
-				modifiedUserRuleIDs[conflictingRule.User][conflictingID] = true
-			} else {
-				rule.removePermission(conflictingPermission) // ignore error
-				modifiedUserRuleIDs[rule.User][id] = true
+				needToSave = true
 			}
-			needToSave = true
 		}
 		if len(rule.Constraints.Permissions) > 0 {
 			newByID[id] = rule
 		} else {
+			// TODO: record status of the rule ("removed") in modifiedUserRuleIDs
 			needToSave = true
 			modifiedUserRuleIDs[rule.User][id] = true
 		}
@@ -331,45 +453,8 @@ func (rdb *RuleDB) RefreshTreeEnforceConsistency(notifyEveryRule bool) {
 	rdb.ByID = newByID
 }
 
-func (rdb *RuleDB) load() error {
-	target := rdb.dbpath()
-	f, err := os.Open(target)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	ruleList := make([]*Rule, 0, 256)    // pre-allocate a large array to reduce memcpys
-	json.NewDecoder(f).Decode(&ruleList) // TODO: handle errors
-
-	rdb.ByID = make(map[string]*Rule) // clear out any existing rules in ByID
-	for _, rule := range ruleList {
-		rdb.ByID[rule.ID] = rule
-	}
-
-	notifyEveryRule := true
-	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
-
-	return nil
-}
-
-func (rdb *RuleDB) save() error {
-	ruleList := make([]*Rule, 0, len(rdb.ByID))
-	for _, rule := range rdb.ByID {
-		ruleList = append(ruleList, rule)
-	}
-	b, err := json.Marshal(ruleList)
-	if err != nil {
-		return err
-	}
-	target := rdb.dbpath()
-	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-		return err
-	}
-	return osutil.AtomicWriteFile(target, b, 0600, 0)
-}
-
-// TODO: unexport (probably, avoid confusion with AddRule)
+// PopulateNewRule creates a new Rule with the given contents.
+//
 // Users of requestrules should probably autofill rules from JSON and never call
 // this function directly.
 //
@@ -378,33 +463,46 @@ func (rdb *RuleDB) save() error {
 // time, to compute the expiration time for the rule, and stores that as part
 // of the rule which is returned. If any of the given parameters are invalid,
 // returns a corresponding error.
-func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*Rule, error) {
-	expiration, err := common.ValidateConstraintsOutcomeLifespanDuration(iface, constraints, outcome, lifespan, duration)
+//
+// TODO: unexport (probably, avoid confusion with AddRule)
+func (rdb *RuleDB) PopulateNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {
+	if err := constraints.ValidateForInterface(iface); err != nil {
+		return nil, err
+	}
+	if _, err := outcome.AsBool(); err != nil {
+		// This should not occur, since PopulateNewRule should only be called
+		// on values which were validated while unmarshalling
+		return nil, err
+	}
+	id, _ := rdb.nextID()
+	currTime := time.Now()
+	expiration, err := lifespan.ParseDuration(duration, currTime)
 	if err != nil {
 		return nil, err
 	}
-	expandedPatterns, err := common.ExpandPathPattern(constraints.PathPattern)
-	if err != nil {
-		return nil, err
-	}
-	id, timestamp := common.NewIDAndTimestamp()
 	newRule := Rule{
-		ID:               id,
-		Timestamp:        timestamp,
-		User:             user,
-		Snap:             snap,
-		Interface:        iface,
-		Constraints:      constraints,
-		expandedPatterns: expandedPatterns,
-		Outcome:          outcome,
-		Lifespan:         lifespan,
-		Expiration:       expiration,
+		ID:          id,
+		Timestamp:   currTime,
+		User:        user,
+		Snap:        snap,
+		Interface:   iface,
+		Constraints: constraints,
+		Outcome:     outcome,
+		Lifespan:    lifespan,
+		Expiration:  expiration,
 	}
 	return &newRule, nil
 }
 
-// Checks whether the given path with the given permission is allowed or
-// denied by existing rules for the given user, snap, and interface.
+func (rdb *RuleDB) nextID() (prompting.IDType, error) {
+	// XXX: this is not guaranteed to be be unique!
+	// TODO: persist max ID to disk and monotonically increase, as with requestprompts.
+	currTime := time.Now()
+	return prompting.IDType(uint64(currTime.UnixNano())), nil
+}
+
+// IsPathAllowed checks whether the given path with the given permission is
+// allowed or denied by existing rules for the given user, snap, and interface.
 // If no rule applies, returns ErrNoMatchingRule.
 func (rdb *RuleDB) IsPathAllowed(user uint32, snap string, iface string, path string, permission string) (bool, error) {
 	rdb.mutex.Lock()
@@ -415,66 +513,74 @@ func (rdb *RuleDB) IsPathAllowed(user uint32, snap string, iface string, path st
 			rdb.save()
 		}
 	}()
-	pathMap := rdb.permissionDBForUserSnapInterfacePermission(user, snap, iface, permission).PathRules
-	matchingPatterns := make([]string, 0)
+	variantMap := rdb.permissionDBForUserSnapInterfacePermission(user, snap, iface, permission).VariantEntries
+	matchingVariants := make([]patterns.PatternVariant, 0)
 	// Make sure all rules use the same expiration timestamp, so a rule with
 	// an earlier expiration cannot outlive another rule with a later one.
 	currTime := time.Now()
-	for pathPattern, id := range pathMap {
-		matchingRule, exists := rdb.ByID[id]
+	for variantStr, variantEntry := range variantMap {
+		matchingRule, exists := rdb.ByID[variantEntry.RuleID]
 		if !exists {
 			// Database was left inconsistent, should not occur
-			delete(pathMap, id)
-			// Issue a notice for the offending rule, just in case
-			rdb.notifyRule(user, id, nil)
+			delete(variantMap, variantStr)
+			// Record a notice for the offending rule, just in case
+			rdb.notifyRule(user, variantEntry.RuleID, nil)
 			continue
 		}
 		expired, err := matchingRule.Expired(currTime)
-		if err != nil {
-			return false, err
-		}
-		if expired {
+		switch {
+		case err != nil:
+			// Should not occur
+			logger.Noticef("error while checking whether rule had expired: %v", err)
+			fallthrough
+		case expired:
 			needToSave = true
 			rdb.removeRuleFromTree(matchingRule)
-			delete(rdb.ByID, id)
-			rdb.notifyRule(user, id, nil)
+			delete(rdb.ByID, variantEntry.RuleID)
+			// TODO: include removed reason in notice data
+			rdb.notifyRule(user, variantEntry.RuleID, nil)
 			continue
 		}
-		// Need to compare the expanded path pattern, not the rule's path
-		// pattern, so that only expanded patterns which match are included,
-		// and the highest precedence expanded pattern can be computed.
-		matched, err := common.PathPatternMatch(pathPattern, path)
+		// Need to compare the path pattern variant, not the rule's path
+		// pattern, so that only variants which match are included,
+		// and the highest precedence variant can be computed.
+		matched, err := patterns.PathPatternMatches(variantStr, path)
 		if err != nil {
 			// Only possible error is ErrBadPattern, which should not occur
 			return false, err
 		}
 		if matched {
-			matchingPatterns = append(matchingPatterns, pathPattern)
+			matchingVariants = append(matchingVariants, variantEntry.Variant)
 		}
 	}
-	if len(matchingPatterns) == 0 {
+	if len(matchingVariants) == 0 {
 		return false, ErrNoMatchingRule
 	}
-	highestPrecedencePattern, err := common.GetHighestPrecedencePattern(matchingPatterns)
+	highestPrecedenceVariant, err := patterns.HighestPrecedencePattern(matchingVariants, path)
 	if err != nil {
 		return false, err
 	}
-	matchingID := pathMap[highestPrecedencePattern]
+	matchingEntry := variantMap[highestPrecedenceVariant.String()]
+	matchingID := matchingEntry.RuleID
 	matchingRule, exists := rdb.ByID[matchingID]
 	if !exists {
 		// Database was left inconsistent, should not occur
 		return false, ErrRuleIDNotFound
 	}
-	if matchingRule.Lifespan == common.LifespanSingle {
+	if matchingRule.Lifespan == prompting.LifespanSingle {
+		// XXX: we should never add rules with lifespan single to the rule DB
 		rdb.removeRuleFromTree(matchingRule)
 		delete(rdb.ByID, matchingID)
+		// TODO: include removed reason in notice data
 		rdb.notifyRule(user, matchingID, nil)
 		needToSave = true
 	}
 	return matchingRule.Outcome.AsBool()
 }
 
-func (rdb *RuleDB) ruleWithIDInternal(user uint32, id string) (*Rule, error) {
+// ruleWithIDInternal returns the rule with the given ID, if it exists, for the
+// given user. Otherwise, returns an error.
+func (rdb *RuleDB) ruleWithIDInternal(user uint32, id prompting.IDType) (*Rule, error) {
 	rule, exists := rdb.ByID[id]
 	if !exists {
 		return nil, ErrRuleIDNotFound
@@ -485,10 +591,10 @@ func (rdb *RuleDB) ruleWithIDInternal(user uint32, id string) (*Rule, error) {
 	return rule, nil
 }
 
-// Returns the rule with the given ID.
+// RuleWithID returns the rule with the given ID.
 // If the rule is not found, returns ErrRuleNotFound.
 // If the rule does not apply to the given user, returns ErrUserNotAllowed.
-func (rdb *RuleDB) RuleWithID(user uint32, id string) (*Rule, error) {
+func (rdb *RuleDB) RuleWithID(user uint32, id prompting.IDType) (*Rule, error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	return rdb.ruleWithIDInternal(user, id)
@@ -497,15 +603,15 @@ func (rdb *RuleDB) RuleWithID(user uint32, id string) (*Rule, error) {
 // Creates a rule with the given information and adds it to the rule database.
 // If any of the given parameters are invalid, returns an error. Otherwise,
 // returns the newly-added rule, and saves the database to disk.
-func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*Rule, error) {
+func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	newRule, err := rdb.PopulateNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
 	if err != nil {
 		return nil, err
 	}
-	if err, conflictingID, conflictingPermission := rdb.addRuleToTree(newRule); err != nil {
-		return nil, fmt.Errorf("%w: ID: '%s', Permission: '%s'", err, conflictingID, conflictingPermission)
+	if err, conflicts, conflictingPermission := rdb.addRuleToTree(newRule); err != nil {
+		return nil, fmt.Errorf("%w: conflicts: %+v, Permission: '%s'", err, conflicts, conflictingPermission)
 	}
 	rdb.ByID[newRule.ID] = newRule
 	rdb.save()
@@ -516,7 +622,7 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 // RemoveRule the rule with the given ID from the rules database. If the rule
 // does not apply to the given user, returns ErrUserNotAllowed. If successful,
 // saves the database to disk.
-func (rdb *RuleDB) RemoveRule(user uint32, id string) (*Rule, error) {
+func (rdb *RuleDB) RemoveRule(user uint32, id prompting.IDType) (*Rule, error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	rule, err := rdb.ruleWithIDInternal(user, id)
@@ -527,6 +633,7 @@ func (rdb *RuleDB) RemoveRule(user uint32, id string) (*Rule, error) {
 	// If error occurs, rule was still fully removed from tree
 	delete(rdb.ByID, id)
 	rdb.save()
+	// TODO: include removed reason in the notice data
 	rdb.notifyRule(user, id, nil)
 	return rule, err
 }
@@ -544,11 +651,14 @@ func (rdb *RuleDB) RemoveRulesForSnap(user uint32, snap string) []*Rule {
 	return rules
 }
 
+// removeRulesInternal removes all of the given rules from the rule DB and
+// records a notice for each one.
 func (rdb *RuleDB) removeRulesInternal(user uint32, rules []*Rule) {
 	for _, rule := range rules {
 		rdb.removeRuleFromTree(rule)
 		// If error occurs, rule was still fully removed from tree
 		delete(rdb.ByID, rule.ID)
+		// TODO: include removed reason in notice data
 		rdb.notifyRule(user, rule.ID, nil)
 	}
 	rdb.save()
@@ -567,16 +677,16 @@ func (rdb *RuleDB) RemoveRulesForSnapInterface(user uint32, snap string, iface s
 	return rules
 }
 
-// Patches the rule with the given ID. The rule is modified by constructing a
-// new rule based on the given parameters, and then replacing the old rule with
-// the same ID with the new rule. Any of the parameters which are equal to the
-// default/unset value for their types are replaced by the corresponding values
-// in the existing rule. Even if the given new rule contents exactly match the
-// existing rule contents, the timestamp of the rule is updated to the current
-// time. If there is any error while adding the patched rule to the database,
-// rolls back to the previous unmodified rule, leaving the databse unchanged.
-// If the database is changed, it is saved to disk.
-func (rdb *RuleDB) PatchRule(user uint32, id string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*Rule, error) {
+// PatchRule modifies the rule with the given ID by updating the rule's fields
+// corresponding to any of the given parameters which are set/non-empty.
+//
+// Any of the parameters which are equal to the default/unset value for their
+// types are left unchanged from the existing rule. Even if the given new rule
+// contents exactly match the existing rule contents, the timestamp of the rule
+// is updated to the current time. If there is any error while modifying the
+// rule, the rule is rolled back to its previous unmodified state, leaving the
+// database unchanged. If the database is changed, it is saved to disk.
+func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*Rule, error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	changeOccurred := false
@@ -593,10 +703,10 @@ func (rdb *RuleDB) PatchRule(user uint32, id string, constraints *common.Constra
 	if constraints == nil {
 		constraints = origRule.Constraints
 	}
-	if outcome == common.OutcomeUnset {
+	if outcome == prompting.OutcomeUnset {
 		outcome = origRule.Outcome
 	}
-	if lifespan == common.LifespanUnset {
+	if lifespan == prompting.LifespanUnset {
 		lifespan = origRule.Lifespan
 	}
 	if err = rdb.removeRuleFromTree(origRule); err != nil {
@@ -613,20 +723,20 @@ func (rdb *RuleDB) PatchRule(user uint32, id string, constraints *common.Constra
 		return nil, err
 	}
 	newRule.ID = origRule.ID
-	err, conflictingID, conflictingPermission := rdb.addRuleToTree(newRule)
+	err, conflicts, conflictingPermission := rdb.addRuleToTree(newRule)
 	if err != nil {
 		rdb.addRuleToTree(origRule) // ignore any new error
 		// origRule was successfully removed before, so it should now be able
 		// to be successfully re-added without error, and all is unchanged.
 		changeOccurred = false
-		return nil, fmt.Errorf("%w: ID: '%s', Permission: '%s'", err, conflictingID, conflictingPermission)
+		return nil, fmt.Errorf("%w: conflicts: %+v, Permission: '%s'", err, conflicts, conflictingPermission)
 	}
 	rdb.ByID[newRule.ID] = newRule
 	changeOccurred = true
 	return newRule, nil
 }
 
-// Returns all rules which apply to the given user.
+// Rules returns all rules which apply to the given user.
 func (rdb *RuleDB) Rules(user uint32) []*Rule {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
@@ -636,6 +746,12 @@ func (rdb *RuleDB) Rules(user uint32) []*Rule {
 	return rdb.rulesInternal(ruleFilter)
 }
 
+// rulesInternal returns all rules matching the given filter.
+//
+// TODO: store rules separately per user, snap, and interface, so actions which
+// look up or delete all rules for a given user/snap/interface are much faster.
+// This is safe, since rules must each apply to exactly one user, snap and
+// interface, but may apply to multiple permissions.
 func (rdb *RuleDB) rulesInternal(ruleFilter func(rule *Rule) bool) []*Rule {
 	rules := make([]*Rule, 0)
 	currTime := time.Now()
@@ -654,6 +770,7 @@ func (rdb *RuleDB) rulesInternal(ruleFilter func(rule *Rule) bool) []*Rule {
 			needToSave = true
 			rdb.removeRuleFromTree(rule)
 			delete(rdb.ByID, id)
+			// TODO: include reason rule was removed ("expired")
 			rdb.notifyRule(rule.User, id, nil)
 			continue
 		}
@@ -664,7 +781,7 @@ func (rdb *RuleDB) rulesInternal(ruleFilter func(rule *Rule) bool) []*Rule {
 	return rules
 }
 
-// Returns all rules which apply to the given user and snap.
+// RulesForSnap returns all rules which apply to the given user and snap.
 func (rdb *RuleDB) RulesForSnap(user uint32, snap string) []*Rule {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
@@ -674,7 +791,8 @@ func (rdb *RuleDB) RulesForSnap(user uint32, snap string) []*Rule {
 	return rdb.rulesInternal(ruleFilter)
 }
 
-// Returns all rules which apply to the given user and interface.
+// RulesForInterface returns all rules which apply to the given user and
+// interface.
 func (rdb *RuleDB) RulesForInterface(user uint32, iface string) []*Rule {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
@@ -684,7 +802,8 @@ func (rdb *RuleDB) RulesForInterface(user uint32, iface string) []*Rule {
 	return rdb.rulesInternal(ruleFilter)
 }
 
-// Returns all rules which apply to the given user, snap, and interface.
+// RulesForSnapInterface returns all rules which apply to the given user, snap,
+// and interface.
 func (rdb *RuleDB) RulesForSnapInterface(user uint32, snap string, iface string) []*Rule {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -130,6 +130,9 @@ type RuleDB struct {
 // New creates a new rule database, loads existing rules from the database file,
 // and returns the populated database.
 //
+// The given notifyRule closure may be called before `New()` returns, if a
+// previously-saved rule has expired or if there are conflicts between rules.
+//
 // The given notifyRule closure will be called when a rule is added, modified,
 // expired, or removed. In order to guarantee the order of notices, notifyRule
 // is called with the prompt DB lock held, so it should not block for a

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -800,15 +798,11 @@ func copyPermissions(permissions []string) []string {
 }
 
 func (s *requestrulesSuite) TestNewSaveLoad(c *C) {
-	logbuf, restore := logger.MockLogger()
-	defer restore()
-
 	doNotNotifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
 		return nil
 	}
 	rdb, err := requestrules.New(doNotNotifyRule)
 	c.Assert(err, IsNil)
-	c.Assert(fmt.Errorf("%s", strings.TrimSpace(logbuf.String())), ErrorMatches, ".*cannot open rules database file:.*")
 
 	snap := "lxd"
 	iface := "home"

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -1005,11 +1005,6 @@ func (s *requestrulesSuite) TestRuleExpiration(c *C) {
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 }
 
-type userAndID struct {
-	userID uint32
-	ruleID prompting.IDType
-}
-
 func (s *requestrulesSuite) TestRulesLookup(c *C) {
 	rdb, _ := requestrules.New(s.defaultNotifyRule)
 

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
+	"github.com/snapcore/snapd/logger"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -772,11 +774,15 @@ func copyPermissions(permissions []string) []string {
 }
 
 func (s *requestrulesSuite) TestNewSaveLoad(c *C) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
 	doNotNotifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
 		return nil
 	}
 	rdb, err := requestrules.New(doNotNotifyRule)
-	c.Check(err, ErrorMatches, "cannot open rules database file:.*")
+	c.Check(err, IsNil)
+	c.Check(fmt.Errorf("%s", strings.TrimSpace(logbuf.String())), ErrorMatches, ".*cannot open rules database file:.*")
 
 	snap := "lxd"
 	iface := "home"

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -530,12 +530,6 @@ func (s *requestrulesSuite) TestRuleWithID(c *C) {
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 }
 
-func copyPermissions(permissions []string) []string {
-	newPermissions := make([]string, len(permissions))
-	copy(newPermissions, permissions)
-	return newPermissions
-}
-
 func (s *requestrulesSuite) TestNewSaveLoad(c *C) {
 	doNotNotifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
 		return nil

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -389,7 +389,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 		Permissions: conflictingPermissions,
 	}
 	output, err = rdb.PatchRule(s.defaultUser, storedRule.ID, conflictingConstraints, newOutcome, newLifespan, newDuration)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("^%s.*%s.*%s.*", requestrules.ErrPathPatternConflict, otherRule.ID.String(), conflictingPermission))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("^cannot patch rule: %s.*%s.*%s.*", requestrules.ErrPathPatternConflict, otherRule.ID.String(), conflictingPermission))
 	c.Assert(output, IsNil)
 	c.Assert(rdb.Rules(s.defaultUser), HasLen, 2)
 

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -1,0 +1,1225 @@
+package requestrules_test
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/requestrules"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/strutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type requestrulesSuite struct {
+	tmpdir string
+}
+
+var _ = Suite(&requestrulesSuite{})
+
+func (s *requestrulesSuite) SetUpTest(c *C) {
+	s.tmpdir = c.MkDir()
+	dirs.SetRootDir(s.tmpdir)
+}
+
+func (s *requestrulesSuite) TestJoinInternalErrors(c *C) {
+	ErrFoo := errors.New("foo")
+	ErrBar := errors.New("bar")
+	ErrBaz := errors.New("baz")
+
+	// Check that empty list or list of nil error(s) result in nil error.
+	for _, errs := range [][]error{
+		{},
+		{nil},
+		{nil, nil, nil},
+	} {
+		err := requestrules.JoinInternalErrors(errs)
+		c.Check(err, IsNil)
+	}
+
+	errs := []error{nil, ErrFoo, nil}
+	err := requestrules.JoinInternalErrors(errs)
+	c.Check(errors.Is(err, requestrules.ErrInternalInconsistency), Equals, true)
+	// XXX: check the following when we're on golang v1.20+
+	// c.Check(errors.Is(err, ErrFoo), Equals, true)
+	c.Check(errors.Is(err, ErrBar), Equals, false)
+	c.Check(fmt.Sprintf("%v", err), Equals, fmt.Sprintf("%v\n%v", requestrules.ErrInternalInconsistency, ErrFoo))
+
+	errs = append(errs, ErrBar, ErrBaz)
+	err = requestrules.JoinInternalErrors(errs)
+	c.Check(errors.Is(err, requestrules.ErrInternalInconsistency), Equals, true)
+	// XXX: check the following when we're on golang v1.20+
+	// c.Check(errors.Is(err, ErrFoo), Equals, true)
+	// c.Check(errors.Is(err, ErrBar), Equals, true)
+	// c.Check(errors.Is(err, ErrBaz), Equals, true)
+	c.Check(fmt.Sprintf("%v", err), Equals, fmt.Sprintf("%v\n%v\n%v\n%v", requestrules.ErrInternalInconsistency, ErrFoo, ErrBar, ErrBaz))
+}
+
+func (s *requestrulesSuite) TestPopulateNewRule(c *C) {
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Errorf("unexpected rule notice with user %d and ID %s", userID, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	var user uint32 = 1000
+	snap := "lxd"
+	iface := "home"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanSession
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+
+	for _, pattern := range []string{
+		"/home/test/Documents/**",
+		"/home/test/**/*.pdf",
+		"/home/test/*",
+	} {
+		constraints := &common.Constraints{
+			PathPattern: pattern,
+			Permissions: permissions,
+		}
+		rule, err := rdb.PopulateNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
+		c.Check(err, IsNil)
+		c.Check(rule.User, Equals, user)
+		c.Check(rule.Snap, Equals, snap)
+		c.Check(rule.Constraints, Equals, constraints)
+		c.Check(rule.Outcome, Equals, outcome)
+		c.Check(rule.Lifespan, Equals, lifespan)
+		c.Check(rule.Expiration.IsZero(), Equals, true)
+	}
+
+	for _, pattern := range []string{
+		`/home/test/**/foo.[abc]onf`,
+		`/home/test/*/**\`,
+		`/home/test/*{/*.txt`,
+	} {
+		constraints := &common.Constraints{
+			PathPattern: pattern,
+			Permissions: permissions,
+		}
+		rule, err := rdb.PopulateNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
+		c.Assert(err, ErrorMatches, "invalid path pattern.*")
+		c.Assert(rule, IsNil)
+	}
+}
+
+func (s *requestrulesSuite) TestAddRemoveRuleSimple(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 2)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+
+	rule, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	c.Assert(rdb.ByID, HasLen, 1)
+	storedRule, exists := rdb.ByID[rule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(storedRule, DeepEquals, rule)
+
+	c.Assert(rdb.PerUser, HasLen, 1)
+
+	userEntry, exists := rdb.PerUser[user]
+	c.Assert(exists, Equals, true)
+	c.Assert(userEntry.PerSnap, HasLen, 1)
+
+	snapEntry, exists := userEntry.PerSnap[snap]
+	c.Assert(exists, Equals, true)
+	c.Assert(snapEntry.PerInterface, HasLen, 1)
+
+	interfaceEntry, exists := snapEntry.PerInterface[iface]
+	c.Assert(exists, Equals, true)
+	c.Assert(interfaceEntry.PerPermission, HasLen, 3)
+
+	for _, permission := range permissions {
+		permissionEntry, exists := interfaceEntry.PerPermission[permission]
+		c.Assert(exists, Equals, true)
+		c.Assert(permissionEntry.PathRules, HasLen, 1)
+
+		pathID, exists := permissionEntry.PathRules[pathPattern]
+		c.Assert(exists, Equals, true)
+		c.Assert(pathID, Equals, rule.ID)
+	}
+
+	removedRule, err := rdb.RemoveRule(user, rule.ID)
+	c.Assert(err, IsNil)
+	c.Assert(removedRule, DeepEquals, rule)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, removedRule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	c.Assert(rdb.ByID, HasLen, 0)
+	c.Assert(rdb.PerUser, HasLen, 1)
+
+	userEntry, exists = rdb.PerUser[user]
+	c.Assert(exists, Equals, true)
+	c.Assert(userEntry.PerSnap, HasLen, 1)
+
+	snapEntry, exists = userEntry.PerSnap[snap]
+	c.Assert(exists, Equals, true)
+	c.Assert(snapEntry.PerInterface, HasLen, 1)
+
+	interfaceEntry, exists = snapEntry.PerInterface[iface]
+	c.Assert(exists, Equals, true)
+	c.Assert(interfaceEntry.PerPermission, HasLen, 3)
+
+	for _, permission := range permissions {
+		permissionEntry, exists := interfaceEntry.PerPermission[permission]
+		c.Assert(exists, Equals, true)
+		c.Assert(permissionEntry.PathRules, HasLen, 0)
+	}
+}
+
+func (s *requestrulesSuite) TestAddRuleUnhappy(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 1)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+
+	storedRule, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, storedRule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	conflictingPermissions := permissions[:1]
+	conflictingConstraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: conflictingPermissions,
+	}
+	_, err = rdb.AddRule(user, snap, iface, conflictingConstraints, outcome, lifespan, duration)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("^%s.*%s.*%s.*", requestrules.ErrPathPatternConflict, storedRule.ID, conflictingPermissions[0]))
+
+	// Error while adding rule should cause no notice to be issued
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+
+	badPattern := "bad/pattern"
+	badConstraints := &common.Constraints{
+		PathPattern: badPattern,
+		Permissions: permissions,
+	}
+	_, err = rdb.AddRule(user, snap, iface, badConstraints, outcome, lifespan, duration)
+	c.Assert(err, ErrorMatches, "invalid path pattern.*")
+
+	// Error while adding rule should cause no notice to be issued
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+
+	badPermissions := []string{"foo"}
+	badConstraints = &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: badPermissions,
+	}
+	_, err = rdb.AddRule(user, snap, iface, badConstraints, outcome, lifespan, duration)
+	c.Assert(err, ErrorMatches, "unsupported permission.*")
+
+	// Error while adding rule should cause no notice to be issued
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+
+	badOutcome := common.OutcomeType("secret third thing")
+	_, err = rdb.AddRule(user, snap, iface, constraints, badOutcome, lifespan, duration)
+	c.Assert(err, ErrorMatches, `invalid outcome.*`)
+
+	// Error while adding rule should cause no notice to be issued
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+}
+
+func (s *requestrulesSuite) TestPatchRule(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 5)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+
+	storedRule, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rdb.ByID, HasLen, 1)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, storedRule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	conflictingPermission := "write"
+
+	otherPathPattern := "/home/test/Pictures/**/*.png"
+	otherPermissions := []string{
+		conflictingPermission,
+	}
+	otherConstraints := &common.Constraints{
+		PathPattern: otherPathPattern,
+		Permissions: otherPermissions,
+	}
+	otherRule, err := rdb.AddRule(user, snap, iface, otherConstraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rdb.ByID, HasLen, 2)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, otherRule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	// Check that patching with the original values results in an identical rule
+	unchangedRule1, err := rdb.PatchRule(user, storedRule.ID, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	// Timestamp should be different, the rest should be the same
+	unchangedRule1.Timestamp = storedRule.Timestamp
+	c.Assert(unchangedRule1, DeepEquals, storedRule)
+	c.Assert(rdb.ByID, HasLen, 2)
+
+	// Though rule was patched with the same values as it originally had, the
+	// timestamp was changed, and thus a notice should be issued for it.
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, unchangedRule1.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	// Check that patching with unset values results in an identical rule
+	unchangedRule2, err := rdb.PatchRule(user, storedRule.ID, nil, common.OutcomeUnset, common.LifespanUnset, "")
+	c.Assert(err, IsNil)
+	// Timestamp should be different, the rest should be the same
+	unchangedRule2.Timestamp = storedRule.Timestamp
+	c.Assert(unchangedRule2, DeepEquals, storedRule)
+	c.Assert(rdb.ByID, HasLen, 2)
+
+	// Though rule was patched with unset values, and thus was unchanged aside
+	// from the timestamp, a notice should be issued for it.
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, unchangedRule2.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	newPathPattern := otherPathPattern
+	newOutcome := common.OutcomeDeny
+	newLifespan := common.LifespanTimespan
+	newDuration := "1s"
+	newPermissions := []string{"execute"}
+	newConstraints := &common.Constraints{
+		PathPattern: newPathPattern,
+		Permissions: newPermissions,
+	}
+	patchedRule, err := rdb.PatchRule(user, storedRule.ID, newConstraints, newOutcome, newLifespan, newDuration)
+	c.Assert(err, IsNil)
+	c.Assert(rdb.ByID, HasLen, 2)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, patchedRule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	badPathPattern := "bad/pattern"
+	badConstraints := &common.Constraints{
+		PathPattern: badPathPattern,
+		Permissions: permissions,
+	}
+	output, err := rdb.PatchRule(user, storedRule.ID, badConstraints, outcome, lifespan, duration)
+	c.Assert(err, ErrorMatches, "invalid path pattern.*")
+	c.Assert(output, IsNil)
+	c.Assert(rdb.ByID, HasLen, 2)
+
+	// Error while patching rule should cause no notice to be issued
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+
+	currentRule, exists := rdb.ByID[storedRule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(currentRule, DeepEquals, patchedRule)
+
+	conflictingPermissions := append(newPermissions, conflictingPermission)
+	conflictingConstraints := &common.Constraints{
+		PathPattern: newPathPattern,
+		Permissions: conflictingPermissions,
+	}
+	output, err = rdb.PatchRule(user, storedRule.ID, conflictingConstraints, newOutcome, newLifespan, newDuration)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("^%s.*%s.*%s.*", requestrules.ErrPathPatternConflict, otherRule.ID, conflictingPermission))
+	c.Assert(output, IsNil)
+	c.Assert(rdb.ByID, HasLen, 2)
+
+	// Permission conflicts while patching rule should cause no notice to be issued
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+
+	currentRule, exists = rdb.ByID[storedRule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(currentRule, DeepEquals, patchedRule)
+}
+
+func (s *requestrulesSuite) TestRemoveRulesForSnap(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 5)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	otherSnap := "nextcloud"
+	iface := "home"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions[:1],
+	}
+	otherConstraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions[1:],
+	}
+
+	rule1, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rule1, NotNil)
+
+	rule2, err := rdb.AddRule(user, otherSnap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rule2, NotNil)
+
+	rule3, err := rdb.AddRule(user, snap, iface, otherConstraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rule3, NotNil)
+
+	c.Assert(ruleNoticeIDs, HasLen, 3, Commentf("ruleNoticeIDs: %v; rdb.ByID: %v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule1.ID)
+	c.Check(ruleNoticeIDs[1], Equals, rule2.ID)
+	c.Check(ruleNoticeIDs[2], Equals, rule3.ID)
+	ruleNoticeIDs = ruleNoticeIDs[3:]
+
+	removed := rdb.RemoveRulesForSnap(user, snap)
+	c.Check(removed, HasLen, 2, Commentf("expected to remove 2 rules but instead removed: %+v", removed))
+	c.Check(removed[0] == rule1 || removed[0] == rule3, Equals, true, Commentf("unexpected rule: %+v", removed[0]))
+	c.Check(removed[1] == rule1 || removed[1] == rule3, Equals, true, Commentf("unexpected rule: %+v", removed[1]))
+	c.Check(removed[0] != removed[1], Equals, true, Commentf("removed duplicate rules: %+v", removed))
+
+	c.Assert(ruleNoticeIDs, HasLen, 2, Commentf("ruleNoticeIDs: %v; rdb.ByID: %v", ruleNoticeIDs, rdb.ByID))
+	c.Check(strutil.ListContains(ruleNoticeIDs, rule1.ID), Equals, true)
+	c.Check(strutil.ListContains(ruleNoticeIDs, rule3.ID), Equals, true)
+	ruleNoticeIDs = ruleNoticeIDs[2:]
+}
+
+func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 5)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	otherSnap := "nextcloud"
+	iface := "home"
+	otherIface := "camera"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions[:1],
+	}
+	otherConstraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions[1:],
+	}
+
+	rule1, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rule1, NotNil)
+
+	rule2, err := rdb.AddRule(user, otherSnap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rule2, NotNil)
+
+	rule3, err := rdb.AddRule(user, snap, iface, otherConstraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(rule3, NotNil)
+
+	// For now, impossible to add a rule for an interface other than "home", so
+	// must adjust it after it's been added.
+	rule3.Interface = otherIface
+
+	c.Assert(ruleNoticeIDs, HasLen, 3, Commentf("ruleNoticeIDs: %v; rdb.ByID: %v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule1.ID)
+	c.Check(ruleNoticeIDs[1], Equals, rule2.ID)
+	c.Check(ruleNoticeIDs[2], Equals, rule3.ID)
+	ruleNoticeIDs = ruleNoticeIDs[3:]
+
+	removed := rdb.RemoveRulesForSnapInterface(user, snap, iface)
+	c.Check(removed, HasLen, 1, Commentf("expected to remove 2 rules but instead removed: %+v", removed))
+	c.Check(removed[0] == rule1, Equals, true, Commentf("unexpected rule: %+v", removed[0]))
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule1.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+}
+
+func (s *requestrulesSuite) TestRuleWithID(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 1)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+
+	newRule, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	c.Assert(newRule, NotNil)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, newRule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	accessedRule, err := rdb.RuleWithID(user, newRule.ID)
+	c.Check(err, IsNil)
+	c.Check(accessedRule, DeepEquals, newRule)
+
+	accessedRule, err = rdb.RuleWithID(user, "nonexistent")
+	c.Check(err, Equals, requestrules.ErrRuleIDNotFound)
+	c.Check(accessedRule, IsNil)
+
+	accessedRule, err = rdb.RuleWithID(user+1, newRule.ID)
+	c.Check(err, Equals, requestrules.ErrUserNotAllowed)
+	c.Check(accessedRule, IsNil)
+
+	// Reading (or failing to read) a notice should not record a notice
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+}
+
+func (s *requestrulesSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 1)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	pathPattern := "/home/test/{Documents,Downloads}/**"
+	expandedPatterns, err := common.ExpandPathPattern(pathPattern)
+	c.Assert(err, IsNil)
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+
+	rule, err := rdb.PopulateNewRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	rdb.ByID[rule.ID] = rule
+	notifyEveryRule := true
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+
+	// Test that RefreshTreeEnforceConsistency results in a single notice
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	c.Assert(rdb.PerUser, HasLen, 1)
+
+	userEntry, exists := rdb.PerUser[user]
+	c.Assert(exists, Equals, true)
+	c.Assert(userEntry.PerSnap, HasLen, 1)
+
+	snapEntry, exists := userEntry.PerSnap[snap]
+	c.Assert(exists, Equals, true)
+	c.Assert(snapEntry.PerInterface, HasLen, 1)
+
+	interfaceEntry, exists := snapEntry.PerInterface[iface]
+	c.Assert(exists, Equals, true)
+	c.Assert(interfaceEntry.PerPermission, HasLen, 3)
+
+	for _, permission := range permissions {
+		permissionEntry, exists := interfaceEntry.PerPermission[permission]
+		c.Assert(exists, Equals, true)
+		c.Assert(permissionEntry.PathRules, HasLen, 2)
+
+		for _, pattern := range expandedPatterns {
+			pathID, exists := permissionEntry.PathRules[pattern]
+			c.Check(exists, Equals, true)
+			c.Check(pathID, Equals, rule.ID)
+		}
+	}
+}
+
+func (s *requestrulesSuite) TestRefreshTreeEnforceConsistencyComplex(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 6)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	// Make sure all expanded path patterns include "/home/test/Documents/**/foo.txt"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+
+	// Create two rules with early
+	constraints1 := &common.Constraints{
+		PathPattern: "/home/test/{Documents,Downloads}/**/foo.txt",
+		Permissions: copyPermissions(permissions[:1]),
+	}
+	badTsRule1, err := rdb.PopulateNewRule(user, snap, iface, constraints1, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	var timeZero time.Time
+	badTsRule1.Timestamp = timeZero
+	time.Sleep(time.Millisecond)
+	constraints2 := &common.Constraints{
+		PathPattern: "/home/test/{Downloads,Documents/**}/foo.txt",
+		Permissions: copyPermissions(permissions[:1]),
+	}
+	badTsRule2, err := rdb.PopulateNewRule(user, snap, iface, constraints2, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	badTsRule2.Timestamp = timeZero.Add(time.Second)
+	rdb.ByID[badTsRule1.ID] = badTsRule1
+	rdb.ByID[badTsRule2.ID] = badTsRule2
+
+	c.Assert(badTsRule1, Not(Equals), badTsRule2)
+
+	// The former should be overwritten by RefreshTreeEnforceConsistency
+	notifyEveryRule := false
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+	c.Assert(rdb.ByID, HasLen, 1, Commentf("rdb.ByID: %+v", rdb.ByID))
+	_, exists := rdb.ByID[badTsRule2.ID]
+	c.Assert(exists, Equals, true)
+	// The latter should be overwritten by any conflicting rule which has a later timestamp
+
+	// Since notifyEveryRule = false, only one notice should be issued, for the overwritten rule
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, badTsRule1.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	// Create a rule with the earliest timestamp, which will be totally overwritten when attempting to add later
+	earliestConstraints := &common.Constraints{
+		PathPattern: "/home/test/Documents/**/{foo,bar,baz}.txt",
+		Permissions: copyPermissions(permissions),
+	}
+	earliestRule, err := rdb.PopulateNewRule(user, snap, iface, earliestConstraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	// Create and add a rule which will overwrite the rule with bad timestamp
+	initialPathPattern := "/home/test/{Music,Pictures,Videos,Documents}/**/foo.txt"
+	initialConstraints := &common.Constraints{
+		PathPattern: initialPathPattern,
+		Permissions: copyPermissions(permissions),
+	}
+	initialRule, err := rdb.PopulateNewRule(user, snap, iface, initialConstraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	rdb.ByID[initialRule.ID] = initialRule
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+
+	// Expect notice for rule with bad timestamp, not initialRule
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, badTsRule2.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	// Check that rule with bad timestamp was overwritten
+	c.Assert(rdb.ByID, HasLen, 1, Commentf("rdb.ByID: %+v", rdb.ByID))
+	initialRuleRet, exists := rdb.ByID[initialRule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(initialRuleRet.Constraints.Permissions, DeepEquals, permissions)
+
+	// Create rule with expiration in the past, which will be immediately be discarded without conflicting with other rules
+	expiredConstraints := &common.Constraints{
+		PathPattern: "/home/test/Documents/**/foo.txt",
+		Permissions: copyPermissions(permissions),
+	}
+	expiredRule, err := rdb.PopulateNewRule(user, snap, iface, expiredConstraints, outcome, common.LifespanTimespan, "1s")
+	c.Assert(err, IsNil)
+	expiredRule.Expiration = time.Now().Add(-10 * time.Second)
+
+	rdb.ByID[expiredRule.ID] = expiredRule
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+
+	// Expect notice for only expiredRule
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(strutil.ListContains(ruleNoticeIDs, expiredRule.ID), Equals, true)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	c.Assert(rdb.ByID, HasLen, 1, Commentf("rdb.ByID: %+v", rdb.ByID))
+
+	_, exists = rdb.ByID[expiredRule.ID]
+	c.Assert(exists, Equals, false)
+
+	initialRuleRet, exists = rdb.ByID[initialRule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(initialRuleRet.Constraints.Permissions, DeepEquals, permissions)
+
+	// Create rule with invalid path pattern, which will be immediately be discarded without conflicting with other rules
+	invalidConstraints := &common.Constraints{
+		PathPattern: "/home/test/Documents/**/foo.txt",
+		Permissions: copyPermissions(permissions),
+	}
+	invalidRule, err := rdb.PopulateNewRule(user, snap, iface, invalidConstraints, outcome, common.LifespanTimespan, "1s")
+	c.Assert(err, IsNil)
+	invalidRule.Constraints.PathPattern = "/home/test/Documents/**/foo.txt{"
+
+	rdb.ByID[invalidRule.ID] = invalidRule
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+
+	// Expect notice for only invalidRule
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(strutil.ListContains(ruleNoticeIDs, invalidRule.ID), Equals, true)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	c.Assert(rdb.ByID, HasLen, 1, Commentf("rdb.ByID: %+v", rdb.ByID))
+
+	_, exists = rdb.ByID[invalidRule.ID]
+	c.Assert(exists, Equals, false)
+
+	initialRuleRet, exists = rdb.ByID[initialRule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(initialRuleRet.Constraints.Permissions, DeepEquals, permissions)
+
+	// Create newer rule which will overwrite all but the first permission of initialRule
+	newPathPattern := "/home/test/Documents{,/,/**/foo.{txt,md,pdf}}"
+	newRulePermissions := permissions[1:]
+	newConstraints := &common.Constraints{
+		PathPattern: newPathPattern,
+		Permissions: copyPermissions(newRulePermissions),
+	}
+	newRule, err := rdb.PopulateNewRule(user, snap, iface, newConstraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	rdb.ByID[newRule.ID] = newRule
+	rdb.ByID[earliestRule.ID] = earliestRule
+	rdb.RefreshTreeEnforceConsistency(notifyEveryRule)
+
+	// Expect notice for initialRule and earliestRule, not newRule
+	c.Assert(ruleNoticeIDs, HasLen, 2, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(strutil.ListContains(ruleNoticeIDs, initialRule.ID), Equals, true)
+	c.Check(strutil.ListContains(ruleNoticeIDs, earliestRule.ID), Equals, true)
+	ruleNoticeIDs = ruleNoticeIDs[2:]
+
+	c.Assert(rdb.ByID, HasLen, 2, Commentf("rdb.ByID: %+v", rdb.ByID))
+
+	_, exists = rdb.ByID[earliestRule.ID]
+	c.Assert(exists, Equals, false)
+
+	initialRuleRet, exists = rdb.ByID[initialRule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(initialRuleRet.Constraints.Permissions, DeepEquals, permissions[:1])
+
+	newRuleRet, exists := rdb.ByID[newRule.ID]
+	c.Assert(exists, Equals, true)
+	c.Assert(newRuleRet.Constraints.Permissions, DeepEquals, newRulePermissions, Commentf("newRulePermissions: %+v", newRulePermissions))
+
+	c.Assert(rdb.PerUser, HasLen, 1)
+
+	userEntry, exists := rdb.PerUser[user]
+	c.Assert(exists, Equals, true)
+	c.Assert(userEntry.PerSnap, HasLen, 1)
+
+	snapEntry, exists := userEntry.PerSnap[snap]
+	c.Assert(exists, Equals, true)
+	c.Assert(snapEntry.PerInterface, HasLen, 1)
+
+	interfaceEntry, exists := snapEntry.PerInterface[iface]
+	c.Assert(exists, Equals, true)
+	c.Assert(interfaceEntry.PerPermission, HasLen, 3)
+
+	expandedInitialPathPatterns, err := common.ExpandPathPattern(initialPathPattern)
+	c.Assert(err, IsNil)
+	expandedNewPathPatterns, err := common.ExpandPathPattern(newPathPattern)
+	c.Assert(err, IsNil)
+	for i, permission := range permissions {
+		permissionEntry, exists := interfaceEntry.PerPermission[permission]
+		c.Assert(exists, Equals, true)
+		var expandedPatterns []string
+		var ruleID string
+		if i == 0 {
+			expandedPatterns = expandedInitialPathPatterns
+			ruleID = initialRule.ID
+		} else {
+			expandedPatterns = expandedNewPathPatterns
+			ruleID = newRule.ID
+		}
+		c.Assert(permissionEntry.PathRules, HasLen, len(expandedPatterns))
+		for _, expanded := range expandedPatterns {
+			pathID, exists := permissionEntry.PathRules[expanded]
+			c.Check(exists, Equals, true)
+			c.Check(pathID, Equals, ruleID)
+		}
+	}
+}
+
+func copyPermissions(permissions []string) []string {
+	newPermissions := make([]string, len(permissions))
+	copy(newPermissions, permissions)
+	return newPermissions
+}
+
+func (s *requestrulesSuite) TestNewSaveLoad(c *C) {
+	doNotNotifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		return nil
+	}
+	rdb, _ := requestrules.New(doNotNotifyRule)
+
+	var user uint32 = 1000
+	snap := "lxd"
+	iface := "home"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+
+	constraints1 := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions[:1],
+	}
+	rule1, err := rdb.AddRule(user, snap, iface, constraints1, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	constraints2 := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions[1:2],
+	}
+	rule2, err := rdb.AddRule(user, snap, iface, constraints2, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+	constraints3 := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions[2:],
+	}
+	rule3, err := rdb.AddRule(user, snap, iface, constraints3, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	ruleIDs := []string{rule1.ID, rule2.ID, rule3.ID}
+	previous := make([]string, 0, 3)
+
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		c.Check(strutil.ListContains(ruleIDs, ruleID), Equals, true, Commentf("unexpected rule ID: %s", ruleID))
+		c.Check(strutil.ListContains(previous, ruleID), Equals, false, Commentf("repeated rule ID: %s", ruleID))
+		previous = append(previous, ruleID)
+		return nil
+	}
+	loadedRdb, err := requestrules.New(notifyRule)
+	c.Assert(err, IsNil)
+	// DeepEquals does not treat time.Time well, so manually validate them and
+	// set them to be explicitly equal so the DeepEquals check succeeds.
+	c.Check(loadedRdb.ByID, HasLen, len(rdb.ByID))
+	for id, rule := range rdb.ByID {
+		loadedRule, exists := loadedRdb.ByID[id]
+		c.Assert(exists, Equals, true, Commentf("missing rule after loading: %+v", rule))
+		c.Check(rule.Timestamp.Equal(loadedRule.Timestamp), Equals, true, Commentf("%s != %s", rule.Timestamp, loadedRule.Timestamp))
+		rule.Timestamp = loadedRule.Timestamp
+	}
+	c.Check(rdb.ByID, DeepEquals, loadedRdb.ByID)
+	c.Check(rdb.PerUser, DeepEquals, loadedRdb.PerUser)
+}
+
+func (s *requestrulesSuite) TestIsPathAllowed(c *C) {
+	var user uint32 = 1000
+	patterns := make(map[string]common.OutcomeType)
+	patterns["/home/test/Documents/**"] = common.OutcomeAllow
+	patterns["/home/test/Documents/foo/**"] = common.OutcomeDeny
+	patterns["/home/test/Documents/foo/bar/**"] = common.OutcomeAllow
+	patterns["/home/test/Documents/foo/bar/baz/**"] = common.OutcomeDeny
+	patterns["/home/test/Documents/foo/bar/baz/**/{fizz,buzz}"] = common.OutcomeAllow
+	patterns["/home/test/**/*.png"] = common.OutcomeAllow
+	patterns["/home/test/**/*.jpg"] = common.OutcomeDeny
+
+	ruleNoticeIDs := make([]string, 0, len(patterns))
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+
+	for pattern, outcome := range patterns {
+		newConstraints := &common.Constraints{
+			PathPattern: pattern,
+			Permissions: permissions,
+		}
+		newRule, err := rdb.AddRule(user, snap, iface, newConstraints, outcome, lifespan, duration)
+		c.Assert(err, IsNil)
+
+		c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+		c.Check(ruleNoticeIDs[0], Equals, newRule.ID)
+		ruleNoticeIDs = ruleNoticeIDs[1:]
+	}
+
+	cases := make(map[string]bool)
+	cases["/home/test/Documents"] = true
+	cases["/home/test/Documents/file"] = true
+	cases["/home/test/Documents/foo"] = false
+	cases["/home/test/Documents/foo/file"] = false
+	cases["/home/test/Documents/foo/bar"] = true
+	cases["/home/test/Documents/foo/bar/file"] = true
+	cases["/home/test/Documents/foo/bar/baz"] = false
+	cases["/home/test/Documents/foo/bar/baz/file"] = false
+	cases["/home/test/file.png"] = true
+	cases["/home/test/file.jpg"] = false
+	cases["/home/test/Documents/file.png"] = true
+	cases["/home/test/Documents/file.jpg"] = true
+	cases["/home/test/Documents/foo/file.png"] = false
+	cases["/home/test/Documents/foo/file.jpg"] = false
+	cases["/home/test/Documents/foo/bar/file.png"] = true
+	cases["/home/test/Documents/foo/bar/file.jpg"] = true
+	cases["/home/test/Documents/foo/bar/baz/file.png"] = false
+	cases["/home/test/Documents/foo/bar/baz/file.jpg"] = false
+	cases["/home/test/Documents.png"] = true
+	cases["/home/test/Documents.jpg"] = false
+	cases["/home/test/Documents/foo.png"] = true
+	cases["/home/test/Documents/foo.jpg"] = true
+	cases["/home/test/Documents/foo.txt"] = true
+	cases["/home/test/Documents/foo/bar.png"] = false
+	cases["/home/test/Documents/foo/bar.jpg"] = false
+	cases["/home/test/Documents/foo/bar.txt"] = false
+	cases["/home/test/Documents/foo/bar/baz.png"] = true
+	cases["/home/test/Documents/foo/bar/baz.jpg"] = true
+	cases["/home/test/Documents/foo/bar/baz.png"] = true
+	cases["/home/test/Documents/foo/bar/baz/file.png"] = false
+	cases["/home/test/Documents/foo/bar/baz/file.jpg"] = false
+	cases["/home/test/Documents/foo/bar/baz/file.txt"] = false
+	cases["/home/test/Documents/foo/bar/baz/fizz"] = true
+	cases["/home/test/Documents/foo/bar/baz/buzz"] = true
+	cases["/home/test/file.jpg.png"] = true
+	cases["/home/test/file.png.jpg"] = false
+
+	for path, expected := range cases {
+		result, err := rdb.IsPathAllowed(user, snap, iface, path, permissions[0])
+		c.Assert(err, IsNil, Commentf("path: %s: error: %v\nrdb.ByID: %+v", path, err, rdb.ByID))
+		c.Assert(result, Equals, expected, Commentf("path: %s: expected %b but got %b\nrdb.ByID: %+v", path, expected, result, rdb.ByID))
+
+		// Matching against rules should not cause any notices
+		c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	}
+}
+
+func (s *requestrulesSuite) TestRuleExpiration(c *C) {
+	var user uint32 = 1000
+	ruleNoticeIDs := make([]string, 0, 6)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		c.Check(userID, Equals, user)
+		ruleNoticeIDs = append(ruleNoticeIDs, ruleID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	snap := "lxd"
+	iface := "home"
+	permissions := []string{"read", "write", "execute"}
+
+	pathPattern := "/home/test/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanSingle
+	duration := ""
+	constraints1 := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+	rule1, err := rdb.AddRule(user, snap, iface, constraints1, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule1.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	pathPattern = "/home/test/Pictures/**"
+	outcome = common.OutcomeDeny
+	lifespan = common.LifespanTimespan
+	duration = "2s"
+	constraints2 := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+	rule2, err := rdb.AddRule(user, snap, iface, constraints2, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule2.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	pathPattern = "/home/test/Pictures/**/*.png"
+	outcome = common.OutcomeAllow
+	lifespan = common.LifespanTimespan
+	duration = "1s"
+	constraints3 := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+	rule3, err := rdb.AddRule(user, snap, iface, constraints3, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule3.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	path1 := "/home/test/Pictures/img.png"
+	path2 := "/home/test/Pictures/img.jpg"
+
+	allowed, err := rdb.IsPathAllowed(user, snap, iface, path1, "read")
+	c.Assert(err, IsNil)
+	c.Assert(allowed, Equals, true, Commentf("rdb.ByID: %+v", rdb.ByID))
+	allowed, err = rdb.IsPathAllowed(user, snap, iface, path2, "read")
+	c.Assert(err, IsNil)
+	c.Assert(allowed, Equals, false)
+
+	// No rules expired, so should not cause a notice
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+
+	time.Sleep(time.Second)
+
+	// rule 3 should have expired, check that it's not included when getting rules
+	rules := rdb.Rules(user)
+	c.Check(rules, HasLen, 2, Commentf("rules: %+v", rules))
+	c.Check(rules[0] == rule1 || rules[0] == rule2, Equals, true, Commentf("unexpected rule: %+v", rules[0]))
+	c.Check(rules[1] == rule1 || rules[1] == rule2, Equals, true, Commentf("unexpected rule: %+v", rules[1]))
+	c.Check(rules[0] != rules[1], Equals, true, Commentf("Rules returned duplicate rules: %+v", rules))
+
+	allowed, err = rdb.IsPathAllowed(user, snap, iface, path1, "read")
+	c.Assert(err, IsNil)
+	c.Assert(allowed, Equals, false)
+
+	// rule3 expiration should have recorded a notice
+	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(ruleNoticeIDs[0], Equals, rule3.ID)
+	ruleNoticeIDs = ruleNoticeIDs[1:]
+
+	allowed, err = rdb.IsPathAllowed(user, snap, iface, path2, "read")
+	c.Assert(err, IsNil)
+	c.Assert(allowed, Equals, false)
+
+	// No rules newly expired, so should not cause a notice
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+
+	time.Sleep(time.Second)
+
+	// Matches rule1, which has lifetime single, which thus expires.
+	// Meanwhile, rule2 also expires.
+	allowed, err = rdb.IsPathAllowed(user, snap, iface, path1, "read")
+	c.Assert(err, Equals, nil)
+	c.Assert(allowed, Equals, true)
+
+	c.Assert(ruleNoticeIDs, HasLen, 2, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+	c.Check(strutil.ListContains(ruleNoticeIDs, rule1.ID), Equals, true)
+	c.Check(strutil.ListContains(ruleNoticeIDs, rule2.ID), Equals, true)
+	ruleNoticeIDs = ruleNoticeIDs[2:]
+
+	allowed, err = rdb.IsPathAllowed(user, snap, iface, path2, "read")
+	c.Assert(err, Equals, requestrules.ErrNoMatchingRule)
+	c.Assert(allowed, Equals, false)
+
+	allowed, err = rdb.IsPathAllowed(user, snap, iface, path1, "read")
+	c.Assert(err, Equals, requestrules.ErrNoMatchingRule)
+	c.Assert(allowed, Equals, false)
+	allowed, err = rdb.IsPathAllowed(user, snap, iface, path2, "read")
+	c.Assert(err, Equals, requestrules.ErrNoMatchingRule)
+	c.Assert(allowed, Equals, false)
+
+	// No rules newly expired, so should not cause a notice
+	c.Assert(ruleNoticeIDs, HasLen, 0, Commentf("ruleNoticeIDs: %v; rdb.ByID: %+v", ruleNoticeIDs, rdb.ByID))
+}
+
+type userAndID struct {
+	userID uint32
+	ruleID string
+}
+
+func (s *requestrulesSuite) TestRulesLookup(c *C) {
+	ruleNotices := make([]*userAndID, 0, 4)
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		newUserAndID := &userAndID{
+			userID: userID,
+			ruleID: ruleID,
+		}
+		ruleNotices = append(ruleNotices, newUserAndID)
+		return nil
+	}
+	rdb, _ := requestrules.New(notifyRule)
+
+	var origUser uint32 = 1000
+	snap := "lxd"
+	iface := "home"
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	lifespan := common.LifespanForever
+	duration := ""
+	permissions := []string{"read", "write", "execute"}
+	constraints := &common.Constraints{
+		PathPattern: pathPattern,
+		Permissions: permissions,
+	}
+
+	origIface := iface
+
+	rule1, err := rdb.AddRule(origUser, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNotices, HasLen, 1, Commentf("ruleNoticeIDs: %+v; rdb.ByID: %+v", ruleNotices, rdb.ByID))
+	c.Check(ruleNotices[0].userID, Equals, origUser)
+	c.Check(ruleNotices[0].ruleID, Equals, rule1.ID)
+	ruleNotices = ruleNotices[1:]
+
+	user := origUser + 1
+	rule2, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNotices, HasLen, 1, Commentf("ruleNoticeIDs: %+v; rdb.ByID: %+v", ruleNotices, rdb.ByID))
+	c.Check(ruleNotices[0].userID, Equals, user)
+	c.Check(ruleNotices[0].ruleID, Equals, rule2.ID)
+	ruleNotices = ruleNotices[1:]
+
+	snap = "nextcloud"
+	rule3, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNotices, HasLen, 1, Commentf("ruleNoticeIDs: %+v; rdb.ByID: %+v", ruleNotices, rdb.ByID))
+	c.Check(ruleNotices[0].userID, Equals, user)
+	c.Check(ruleNotices[0].ruleID, Equals, rule3.ID)
+	ruleNotices = ruleNotices[1:]
+
+	iface = "camera"
+	constraints.Permissions = []string{"access"}
+	rule4, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
+	c.Assert(err, IsNil)
+
+	c.Assert(ruleNotices, HasLen, 1, Commentf("ruleNoticeIDs: %+v; rdb.ByID: %+v", ruleNotices, rdb.ByID))
+	c.Check(ruleNotices[0].userID, Equals, user)
+	c.Check(ruleNotices[0].ruleID, Equals, rule4.ID)
+	ruleNotices = ruleNotices[1:]
+
+	origUserRules := rdb.Rules(origUser)
+	c.Assert(origUserRules, HasLen, 1)
+	c.Assert(origUserRules[0], DeepEquals, rule1)
+
+	userRules := rdb.Rules(user)
+	c.Check(userRules, HasLen, 3)
+OUTER_LOOP_USER:
+	for _, rule := range []*requestrules.Rule{rule2, rule3, rule4} {
+		for _, userRule := range userRules {
+			if reflect.DeepEqual(rule, userRule) {
+				continue OUTER_LOOP_USER
+			}
+		}
+		c.Errorf("rule not found in userRules:\nrule: %+v\nuserRules: %+v", rule, userRules)
+	}
+
+	userSnapRules := rdb.RulesForSnap(user, snap)
+	c.Check(userSnapRules, HasLen, 2)
+OUTER_LOOP_USER_SNAP:
+	for _, rule := range []*requestrules.Rule{rule3, rule4} {
+		for _, userRule := range userSnapRules {
+			if reflect.DeepEqual(rule, userRule) {
+				continue OUTER_LOOP_USER_SNAP
+			}
+		}
+		c.Errorf("rule not found in userRules:\nrule: %+v\nuserSnapRules: %+v", rule, userRules)
+	}
+
+	userInterfaceRules := rdb.RulesForInterface(user, origIface)
+	c.Check(userInterfaceRules, HasLen, 2)
+OUTER_LOOP_USER_INTERFACE:
+	for _, rule := range []*requestrules.Rule{rule2, rule3} {
+		for _, userRule := range userInterfaceRules {
+			if reflect.DeepEqual(rule, userRule) {
+				continue OUTER_LOOP_USER_INTERFACE
+			}
+		}
+		c.Errorf("rule not found in userRules:\nrule: %+v\nuserInterfaceRules: %+v", rule, userRules)
+	}
+
+	userInterfaceRules = rdb.RulesForInterface(user, iface)
+	c.Check(userInterfaceRules, HasLen, 1)
+	c.Check(userInterfaceRules[0], DeepEquals, rule4)
+
+	userSnapInterfaceRules := rdb.RulesForSnapInterface(user, snap, iface)
+	c.Check(userSnapInterfaceRules, HasLen, 1)
+	c.Check(userSnapInterfaceRules[0], DeepEquals, rule4)
+
+	// Looking up these rules should not cause any notices
+	c.Check(ruleNotices, HasLen, 0, Commentf("ruleNoticeIDs: %+v; rdb.ByID: %+v", ruleNotices, rdb.ByID))
+}

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -1065,8 +1065,8 @@ func (s *requestrulesSuite) TestRulesLookup(c *C) {
 	c.Check(userRules, HasLen, 3)
 OUTER_LOOP_USER:
 	for _, rule := range []*requestrules.Rule{rule2, rule3, rule4} {
-		for _, userRule := range userRules {
-			if reflect.DeepEqual(rule, userRule) {
+		for _, expected := range userRules {
+			if reflect.DeepEqual(rule, expected) {
 				continue OUTER_LOOP_USER
 			}
 		}
@@ -1077,8 +1077,8 @@ OUTER_LOOP_USER:
 	c.Check(userSnapRules, HasLen, 2)
 OUTER_LOOP_USER_SNAP:
 	for _, rule := range []*requestrules.Rule{rule3, rule4} {
-		for _, userRule := range userSnapRules {
-			if reflect.DeepEqual(rule, userRule) {
+		for _, expected := range userSnapRules {
+			if reflect.DeepEqual(rule, expected) {
 				continue OUTER_LOOP_USER_SNAP
 			}
 		}
@@ -1093,8 +1093,8 @@ OUTER_LOOP_USER_INTERFACE:
 	// TODO: remove rule4 when rule4 is for another interface
 	// for _, rule := range []*requestrules.Rule{rule2, rule3} {
 	for _, rule := range []*requestrules.Rule{rule2, rule3, rule4} {
-		for _, userRule := range userInterfaceRules {
-			if reflect.DeepEqual(rule, userRule) {
+		for _, expected := range userInterfaceRules {
+			if reflect.DeepEqual(rule, expected) {
 				continue OUTER_LOOP_USER_INTERFACE
 			}
 		}
@@ -1105,6 +1105,19 @@ OUTER_LOOP_USER_INTERFACE:
 	// userInterfaceRules = rdb.RulesForInterface(user, iface)
 	// c.Check(userInterfaceRules, HasLen, 1)
 	// c.Check(userInterfaceRules[0], DeepEquals, rule4)
+
+	userSnapInterfaceRules := rdb.RulesForSnapInterface(user, snap, origIface)
+	// TODO: make this 1 when rule4 is for another interface
+	c.Check(userSnapRules, HasLen, 2)
+OUTER_LOOP_USER_SNAP_INTERFACE:
+	for _, rule := range []*requestrules.Rule{rule3, rule4} {
+		for _, expected := range userSnapInterfaceRules {
+			if reflect.DeepEqual(rule, expected) {
+				continue OUTER_LOOP_USER_SNAP_INTERFACE
+			}
+		}
+		c.Errorf("rule not found in userRules:\nrule: %+v\nuserSnapRules: %+v", rule, userRules)
+	}
 
 	// userSnapInterfaceRules := rdb.RulesForSnapInterface(user, snap, iface)
 	// c.Check(userSnapInterfaceRules, HasLen, 1)

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -484,7 +484,8 @@ func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
 
 	s.checkNewNoticesSimple(c, []prompting.IDType{rule1.ID, rule2.ID, rule3.ID}, nil)
 
-	removed := rdb.RemoveRulesForSnapInterface(s.defaultUser, snap, iface)
+	removed, err := rdb.RemoveRulesForSnapInterface(s.defaultUser, snap, iface)
+	c.Assert(err, IsNil)
 	c.Check(removed, HasLen, 1, Commentf("expected to remove 2 rules but instead removed: %+v", removed))
 	c.Check(removed[0] == rule1, Equals, true, Commentf("unexpected rule: %+v", removed[0]))
 

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -6,8 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -32,11 +32,11 @@ func (ni *noticeInfo) String() string {
 }
 
 type requestrulesSuite struct {
+	testutil.BaseTest
+
 	defaultNotifyRule func(userID uint32, ruleID prompting.IDType, data map[string]string) error
 	defaultUser       uint32
 	ruleNotices       []*noticeInfo
-
-	tmpdir string
 }
 
 var _ = Suite(&requestrulesSuite{})
@@ -53,90 +53,59 @@ func (s *requestrulesSuite) SetUpTest(c *C) {
 		return nil
 	}
 	s.ruleNotices = make([]*noticeInfo, 0)
-	s.tmpdir = c.MkDir()
-	dirs.SetRootDir(s.tmpdir)
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
 	c.Assert(os.MkdirAll(dirs.SnapdStateDir(dirs.GlobalRootDir), 0700), IsNil)
 }
 
-func (s *requestrulesSuite) TestJoinInternalErrors(c *C) {
-	ErrFoo := errors.New("foo")
-	ErrBar := errors.New("bar")
-	ErrBaz := errors.New("baz")
-
-	// Check that empty list or list of nil error(s) result in nil error.
-	for _, errs := range [][]error{
-		{},
-		{nil},
-		{nil, nil, nil},
-	} {
-		err := requestrules.JoinInternalErrors(errs)
-		c.Check(err, IsNil)
-	}
-
-	errs := []error{nil, ErrFoo, nil}
-	err := requestrules.JoinInternalErrors(errs)
-	c.Check(errors.Is(err, requestrules.ErrInternalInconsistency), Equals, true)
-	// XXX: check the following when we're on golang v1.20+
-	// c.Check(errors.Is(err, ErrFoo), Equals, true)
-	c.Check(errors.Is(err, ErrBar), Equals, false)
-	c.Check(fmt.Sprintf("%v", err), Equals, fmt.Sprintf("%v\n%v", requestrules.ErrInternalInconsistency, ErrFoo))
-
-	errs = append(errs, ErrBar, ErrBaz)
-	err = requestrules.JoinInternalErrors(errs)
-	c.Check(errors.Is(err, requestrules.ErrInternalInconsistency), Equals, true)
-	// XXX: check the following when we're on golang v1.20+
-	// c.Check(errors.Is(err, ErrFoo), Equals, true)
-	// c.Check(errors.Is(err, ErrBar), Equals, true)
-	// c.Check(errors.Is(err, ErrBaz), Equals, true)
-	c.Check(fmt.Sprintf("%v", err), Equals, fmt.Sprintf("%v\n%v\n%v\n%v", requestrules.ErrInternalInconsistency, ErrFoo, ErrBar, ErrBaz))
-}
-
-func (s *requestrulesSuite) TestPopulateNewRule(c *C) {
-	notifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
-		c.Errorf("unexpected rule notice with user %d and ID %s", userID, ruleID)
-		return nil
-	}
-	rdb, _ := requestrules.New(notifyRule)
-
-	snap := "lxd"
+func (s *requestrulesSuite) TestRuleValidate(c *C) {
 	iface := "home"
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
+	pathPattern := mustParsePathPattern(c, "/home/test/**")
 
-	for _, pattern := range []*patterns.PathPattern{
-		mustParsePathPattern(c, "/home/test/Documents/**"),
-		mustParsePathPattern(c, "/home/test/**/*.pdf"),
-		mustParsePathPattern(c, "/home/test/*"),
-	} {
-		constraints := &prompting.Constraints{
-			PathPattern: pattern,
-			Permissions: permissions,
-		}
-		rule, err := rdb.PopulateNewRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
-		c.Check(err, IsNil)
-		c.Check(rule.User, Equals, s.defaultUser)
-		c.Check(rule.Snap, Equals, snap)
-		c.Check(rule.Constraints, Equals, constraints)
-		c.Check(rule.Outcome, Equals, outcome)
-		c.Check(rule.Lifespan, Equals, lifespan)
-		c.Check(rule.Expiration.IsZero(), Equals, true)
+	validConstraints := &prompting.Constraints{
+		PathPattern: pathPattern,
+		Permissions: []string{"read"},
+	}
+	invalidConstraints := &prompting.Constraints{
+		PathPattern: pathPattern,
+		Permissions: []string{"foo"},
 	}
 
-	pathPattern := mustParsePathPattern(c, "/home/test/Pictures/**/*.{jpg,png,svg,tiff}")
-	for _, perms := range [][]string{
-		{"read", "fly", "write"},
-		{"foo"},
-	} {
-		constraints := &prompting.Constraints{
-			PathPattern: pathPattern,
-			Permissions: perms,
-		}
-		rule, err := rdb.PopulateNewRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
-		c.Check(err, ErrorMatches, "invalid constraints: unsupported permission for home interface:.*")
-		c.Check(rule, IsNil)
+	validOutcome := prompting.OutcomeAllow
+	invalidOutcome := prompting.OutcomeUnset
+
+	validLifespan := prompting.LifespanTimespan
+	invalidLifespan := prompting.LifespanSingle
+
+	currTime := time.Now()
+
+	validExpiration := currTime.Add(time.Millisecond)
+	invalidExpiration := currTime.Add(-time.Millisecond)
+
+	rule := requestrules.Rule{
+		// ID is not validated
+		// Timestamp is not validated
+		// User is not validated
+		// Snap is not validated
+		Interface:   iface,
+		Constraints: validConstraints,
+		Outcome:     validOutcome,
+		Lifespan:    validLifespan,
+		Expiration:  validExpiration,
 	}
+	c.Check(rule.Validate(currTime), IsNil)
+
+	rule.Expiration = invalidExpiration
+	c.Check(rule.Validate(currTime), ErrorMatches, fmt.Sprintf("%v:.*", prompting.ErrExpirationInThePast))
+
+	rule.Lifespan = invalidLifespan
+	c.Check(rule.Validate(currTime), Equals, requestrules.ErrLifespanSingle)
+
+	rule.Outcome = invalidOutcome
+	c.Check(rule.Validate(currTime), ErrorMatches, "internal error: invalid outcome:.*")
+
+	rule.Constraints = invalidConstraints
+	c.Check(rule.Validate(currTime), ErrorMatches, "invalid constraints:.*")
 }
 
 func mustParsePathPattern(c *C, patternStr string) *patterns.PathPattern {
@@ -145,51 +114,86 @@ func mustParsePathPattern(c *C, patternStr string) *patterns.PathPattern {
 	return pattern
 }
 
-func (s *requestrulesSuite) TestAddRemoveRuleSimple(c *C) {
-	c.Check(filepath.Join(prompting.StateDir(), "request-rule-max-id"), testutil.FileAbsent)
-
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
-
-	// ID file initialized
-	c.Check(filepath.Join(prompting.StateDir(), "request-rule-max-id"), testutil.FileEquals,
-		[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
-	// no rules yet
-	c.Check(filepath.Join(prompting.StateDir(), "request-rules.json"), testutil.FileAbsent)
-
-	snap := "lxd"
-	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
-	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
+func (s *requestrulesSuite) TestRuleExpired(c *C) {
+	currTime := time.Now()
+	rule := requestrules.Rule{
+		// Other fields are not relevant
+		Lifespan:   prompting.LifespanTimespan,
+		Expiration: currTime,
 	}
+	c.Check(rule.Expired(currTime), Equals, false)
+	c.Check(rule.Expired(currTime.Add(time.Millisecond)), Equals, true)
+}
 
-	rule, err := rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
+func (s *requestrulesSuite) TestNew(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+}
+
+func (s *requestrulesSuite) TestNewErrors(c *C) {
+	// Create file at prompting.StateDir so that EnsureStateDir fails
+	stateDir := prompting.StateDir()
+	f, err := os.Create(stateDir)
+	c.Assert(err, IsNil)
+	f.Close() // No need to keep the file open
+
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, ErrorMatches, "cannot create interfaces requests state directory.*") // Error from os.MkdirAll
+	c.Assert(rdb, IsNil)
+
+	// Remove the state dir file so we can continue
+	c.Assert(os.Remove(stateDir), IsNil)
+
+	// Create directory to conflict with max ID mmap
+	maxIDFilepath := filepath.Join(prompting.StateDir(), "request-rule-max-id")
+	c.Assert(os.MkdirAll(maxIDFilepath, 0o700), IsNil)
+
+	rdb, err = requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, ErrorMatches, "cannot open max ID file:.*")
+	c.Assert(rdb, IsNil)
+
+	// Remove the conflicting directory so we can continue
+	c.Assert(os.Remove(maxIDFilepath), IsNil)
+}
+
+// prepDBPath creates the the prompting state dir and returns the path of the
+// rule DB.
+func (s *requestrulesSuite) prepDBPath(c *C) string {
+	dbPath := filepath.Join(prompting.StateDir(), "request-rules.json")
+	parent := filepath.Dir(dbPath)
+	c.Assert(os.MkdirAll(parent, 0o700), IsNil)
+	return dbPath
+}
+
+func (s *requestrulesSuite) testLoadError(c *C, expectedErr string, expectedNoticeRuleIDs []prompting.IDType, checkWritten bool) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Check(err, IsNil)
+	c.Check(rdb, NotNil)
+	logErr := fmt.Errorf("%s", strings.TrimSpace(logbuf.String()))
+	c.Check(logErr, ErrorMatches, fmt.Sprintf(".*cannot load rule database: %s; using new empty rule database", expectedErr))
+	if checkWritten {
+		s.checkWrittenRuleDB(c, nil)
+	}
+	data := map[string]string{"removed": "dropped"}
+	s.checkNewNoticesSimple(c, expectedNoticeRuleIDs, data)
+}
+
+func (s *requestrulesSuite) checkWrittenRuleDB(c *C, expectedRules []*requestrules.Rule) {
+	dbPath := filepath.Join(prompting.StateDir(), "request-rules.json")
+
+	if expectedRules == nil {
+		expectedRules = []*requestrules.Rule{}
+	}
+	wrapper := requestrules.RulesDBJSON{Rules: expectedRules}
+	marshalled, err := json.Marshal(wrapper)
 	c.Assert(err, IsNil)
 
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
-
-	c.Check(filepath.Join(prompting.StateDir(), "request-rules.json"), testutil.FilePresent)
-
-	storedRule, err := rdb.RuleWithID(s.defaultUser, rule.ID)
-	c.Assert(err, IsNil)
-	c.Assert(storedRule, DeepEquals, rule)
-
-	removedRule, err := rdb.RemoveRule(s.defaultUser, rule.ID)
-	c.Assert(err, IsNil)
-	c.Assert(removedRule, DeepEquals, rule)
-
-	// no rules, so only a top level JSON serialization artifact
-	c.Check(filepath.Join(prompting.StateDir(), "request-rules.json"), testutil.FileEquals, `{"rules":[]}`)
-
-	expectedData := map[string]string{"removed": "removed"}
-	s.checkNewNoticesSimple(c, []prompting.IDType{removedRule.ID}, expectedData)
-
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 0)
+	writtenData, err := os.ReadFile(dbPath)
+	c.Check(err, IsNil)
+	c.Check(string(writtenData), Equals, string(marshalled))
 }
 
 func (s *requestrulesSuite) checkNewNoticesSimple(c *C, expectedRuleIDs []prompting.IDType, expectedData map[string]string) {
@@ -213,284 +217,735 @@ func (s *requestrulesSuite) checkNewNotices(c *C, expectedNotices []*noticeInfo)
 	s.ruleNotices = s.ruleNotices[:0]
 }
 
-func (s *requestrulesSuite) checkNewNoticesUnorderedSimple(c *C, expectedRuleIDs []prompting.IDType, expectedData map[string]string) {
-	s.checkNewNoticesUnordered(c, applyNotices(expectedRuleIDs, expectedData))
+func (s *requestrulesSuite) TestLoadErrorOpen(c *C) {
+	dbPath := s.prepDBPath(c)
+	// Create unreadable DB file to cause open failure
+	f, err := os.Create(dbPath)
+	c.Assert(err, IsNil)
+	c.Assert(f.Chmod(0o000), IsNil)
+	checkWritten := false
+	s.testLoadError(c, "cannot open rule database file:.*", nil, checkWritten)
 }
 
-func (s *requestrulesSuite) checkNewNoticesUnordered(c *C, expectedNotices []*noticeInfo) {
-	sort.Slice(sortSliceParams(s.ruleNotices))
-	sort.Slice(sortSliceParams(expectedNotices))
-	s.checkNewNotices(c, expectedNotices)
+func (s *requestrulesSuite) TestLoadErrorUnmarshal(c *C) {
+	dbPath := s.prepDBPath(c)
+	// Create malformed file in place of DB to cause unmarshal failure
+	c.Assert(os.WriteFile(dbPath, []byte("foo"), 0o700), IsNil)
+	checkWritten := true
+	s.testLoadError(c, "cannot read stored request rules:.*", nil, checkWritten)
 }
 
-func sortSliceParams(list []*noticeInfo) ([]*noticeInfo, func(i, j int) bool) {
-	less := func(i, j int) bool {
-		return list[i].ruleID < list[j].ruleID
+func (s *requestrulesSuite) TestLoadErrorValidate(c *C) {
+	dbPath := s.prepDBPath(c)
+	good1 := s.ruleTemplate(c, prompting.IDType(1))
+	bad := s.ruleTemplate(c, prompting.IDType(2))
+	bad.Interface = "foo" // will cause validate() to fail with invalid constraints
+	good2 := s.ruleTemplate(c, prompting.IDType(3))
+	// Doesn't matter that rules have conflicting patterns/permissions,
+	// validate() should catch invalid rule and exit before attempting to add.
+
+	rules := []*requestrules.Rule{good1, bad, good2}
+	s.writeRules(c, dbPath, rules)
+
+	checkWritten := true
+	s.testLoadError(c, "internal error: invalid constraints: unsupported interface: foo.*", []prompting.IDType{good1.ID, bad.ID, good2.ID}, checkWritten)
+}
+
+// ruleTemplate returns a rule with valid contents, intended to be customized.
+func (s *requestrulesSuite) ruleTemplate(c *C, id prompting.IDType) *requestrules.Rule {
+	constraints := prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, "/home/test/foo"),
+		Permissions: []string{"read"},
 	}
-	return list, less
+	rule := requestrules.Rule{
+		ID:          id,
+		Timestamp:   time.Now(),
+		User:        s.defaultUser,
+		Snap:        "firefox",
+		Interface:   "home",
+		Constraints: &constraints,
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		// Skip Expiration
+	}
+	return &rule
 }
 
-func (s *requestrulesSuite) TestAddRuleUnhappy(c *C) {
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
+func (s *requestrulesSuite) writeRules(c *C, dbPath string, rules []*requestrules.Rule) {
+	if rules == nil {
+		rules = []*requestrules.Rule{}
+	}
+	wrapper := requestrules.RulesDBJSON{Rules: rules}
+	marshalled, err := json.Marshal(wrapper)
+	c.Assert(err, IsNil)
+	c.Assert(os.WriteFile(dbPath, marshalled, 0o600), IsNil)
+}
 
-	snap := "lxd"
-	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
+func (s *requestrulesSuite) TestLoadErrorConflictingID(c *C) {
+	dbPath := s.prepDBPath(c)
+	currTime := time.Now()
+	good := s.ruleTemplate(c, prompting.IDType(1))
+	// Expired rules should still get a {"removed": "dropped"} notice, even if they don't conflict
+	expired := s.ruleTemplate(c, prompting.IDType(2))
+	setPathPatternAndExpiration(c, expired, "/home/test/other", currTime.Add(-10*time.Second))
+	// Add rule which conflicts with IDs but doesn't otherwise conflict
+	conflicting := s.ruleTemplate(c, prompting.IDType(1))
+	conflicting.Constraints.PathPattern = mustParsePathPattern(c, "/home/test/another")
+
+	rules := []*requestrules.Rule{good, expired, conflicting}
+	s.writeRules(c, dbPath, rules)
+
+	checkWritten := true
+	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v.*", requestrules.ErrRuleIDConflict), []prompting.IDType{good.ID, expired.ID, conflicting.ID}, checkWritten)
+}
+
+func setPathPatternAndExpiration(c *C, rule *requestrules.Rule, pathPattern string, expiration time.Time) {
+	rule.Constraints.PathPattern = mustParsePathPattern(c, pathPattern)
+	rule.Lifespan = prompting.LifespanTimespan
+	rule.Expiration = expiration
+}
+
+func (s *requestrulesSuite) TestLoadErrorConflictingPattern(c *C) {
+	dbPath := s.prepDBPath(c)
+	currTime := time.Now()
+	good := s.ruleTemplate(c, prompting.IDType(1))
+	// Expired rules should still get a {"removed": "dropped"} notice, even if they don't conflict
+	expired := s.ruleTemplate(c, prompting.IDType(2))
+	setPathPatternAndExpiration(c, expired, "/home/test/other", currTime.Add(-10*time.Second))
+	// Add rule with conflicting pattern and permissions but not conflicting ID.
+	conflicting := s.ruleTemplate(c, prompting.IDType(3))
+	// Even with not all permissions being in conflict, still error
+	conflicting.Constraints.Permissions = []string{"read", "write"}
+
+	rules := []*requestrules.Rule{good, expired, conflicting}
+	s.writeRules(c, dbPath, rules)
+
+	checkWritten := true
+	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v.*", requestrules.ErrPathPatternConflict), []prompting.IDType{good.ID, expired.ID, conflicting.ID}, checkWritten)
+}
+
+func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
+	dbPath := s.prepDBPath(c)
+	currTime := time.Now()
+
+	good1 := s.ruleTemplate(c, prompting.IDType(1))
+
+	// At the moment, expired rules with conflicts are discarded without error,
+	// but we don't want to test this as part of our contract
+
+	expired1 := s.ruleTemplate(c, prompting.IDType(2))
+	setPathPatternAndExpiration(c, expired1, "/home/test/other", currTime.Add(-10*time.Second))
+
+	// Rules with same pattern but non-conflicting permissions do not conflict
+	good2 := s.ruleTemplate(c, prompting.IDType(3))
+	good2.Constraints.Permissions = []string{"write"}
+
+	expired2 := s.ruleTemplate(c, prompting.IDType(4))
+	setPathPatternAndExpiration(c, expired2, "/home/test/another", currTime.Add(-time.Nanosecond))
+
+	// Rules with different pattern and conflicting permissions do not conflict
+	good3 := s.ruleTemplate(c, prompting.IDType(5))
+	good3.Constraints.PathPattern = mustParsePathPattern(c, "/home/test/no-conflict")
+
+	rules := []*requestrules.Rule{good1, expired1, good2, expired2, good3}
+	s.writeRules(c, dbPath, rules)
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Check(err, IsNil)
+	c.Check(rdb, NotNil)
+	// Check that no error was logged
+	c.Check(logbuf.String(), HasLen, 0)
+
+	expectedWrittenRules := []*requestrules.Rule{good1, good2, good3}
+	s.checkWrittenRuleDB(c, expectedWrittenRules)
+
+	expectedNoticeInfo := []*noticeInfo{
+		{
+			ruleID: good1.ID,
+			data:   nil,
+		},
+		{
+			ruleID: expired1.ID,
+			data:   map[string]string{"removed": "expired"},
+		},
+		{
+			ruleID: good2.ID,
+			data:   nil,
+		},
+		{
+			ruleID: expired2.ID,
+			data:   map[string]string{"removed": "expired"},
+		},
+		{
+			ruleID: good3.ID,
+			data:   nil,
+		},
+	}
+	s.checkNewNotices(c, expectedNoticeInfo)
+}
+
+func (s *requestrulesSuite) TestLoadHappy(c *C) {
+	dbPath := s.prepDBPath(c)
+
+	good1 := s.ruleTemplate(c, prompting.IDType(1))
+
+	// Rules with different users don't conflict
+	good2 := s.ruleTemplate(c, prompting.IDType(2))
+	good2.User = s.defaultUser + 1
+
+	// Rules with different snaps don't conflict
+	good3 := s.ruleTemplate(c, prompting.IDType(3))
+	good3.Snap = "thunderbird"
+
+	rules := []*requestrules.Rule{good1, good2, good3}
+	s.writeRules(c, dbPath, rules)
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Check(err, IsNil)
+	c.Check(rdb, NotNil)
+	// Check that no error was logged
+	c.Check(logbuf.String(), HasLen, 0)
+
+	s.checkWrittenRuleDB(c, rules)
+	s.checkNewNoticesSimple(c, rulesToIDs(rules), nil)
+}
+
+func rulesToIDs(rules []*requestrules.Rule) []prompting.IDType {
+	ids := make([]prompting.IDType, len(rules))
+	for i, rule := range rules {
+		ids[i] = rule.ID
+	}
+	return ids
+}
+
+func (s *requestrulesSuite) TestJoinInternalErrors(c *C) {
+	// Check that empty list or list of nil error(s) result in nil error.
+	for _, errs := range [][]error{
+		{},
+		{nil},
+		{nil, nil, nil},
+	} {
+		err := requestrules.JoinInternalErrors(errs)
+		c.Check(err, IsNil)
+	}
+
+	errFoo := errors.New("foo")
+	errBar := errors.New("bar")
+	errBaz := errors.New("baz")
+
+	// Check that a list containing non-nil errors results in a joined error
+	// which is ErrInternalInconsistency
+	errs := []error{nil, errFoo, nil}
+	err := requestrules.JoinInternalErrors(errs)
+	c.Check(errors.Is(err, requestrules.ErrInternalInconsistency), Equals, true)
+	// XXX: check the following when we're on golang v1.20+
+	// c.Check(errors.Is(err, errFoo), Equals, true)
+	c.Check(errors.Is(err, errBar), Equals, false)
+	c.Check(fmt.Sprintf("%v", err), Equals, fmt.Sprintf("%v\n%v", requestrules.ErrInternalInconsistency, errFoo))
+
+	errs = append(errs, errBar, errBaz)
+	err = requestrules.JoinInternalErrors(errs)
+	c.Check(errors.Is(err, requestrules.ErrInternalInconsistency), Equals, true)
+	// XXX: check the following when we're on golang v1.20+
+	// c.Check(errors.Is(err, errFoo), Equals, true)
+	// c.Check(errors.Is(err, errBar), Equals, true)
+	// c.Check(errors.Is(err, errBaz), Equals, true)
+	c.Check(fmt.Sprintf("%v", err), Equals, fmt.Sprintf("%v\n%v\n%v\n%v", requestrules.ErrInternalInconsistency, errFoo, errBar, errBaz))
+}
+
+type addRuleContents struct {
+	User        uint32
+	Snap        string
+	Interface   string
+	PathPattern string
+	Permissions []string
+	Outcome     prompting.OutcomeType
+	Lifespan    prompting.LifespanType
+	Duration    string
+}
+
+func (s *requestrulesSuite) TestAddRuleHappy(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	template := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "lxd",
+		Interface:   "home",
+		PathPattern: "/home/test/Pictures/**/*.{jpg,png,svg}",
+		Permissions: []string{"write"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
+	}
+
+	var addedRules []*requestrules.Rule
+
+	// Add one rule matching template, then a rule with one differing field for
+	// each conflict-defining field, to check that all rules add without error.
+	for _, ruleContents := range []*addRuleContents{
+		{}, // use template
+		{User: s.defaultUser + 1},
+		{Snap: "thunderbird"},
+		// Can't change interface, as only "home" is supported for now (TODO: update)
+		{PathPattern: "/home/test/**/*.{jpg,png,svg}"}, // no /Pictures/
+		{Permissions: []string{"read", "execute"}},
+		// Differing Outcome, Lifespan or Duration does not prevent conflict
+		{PathPattern: "/home/test/1", Outcome: prompting.OutcomeDeny},
+		{PathPattern: "/home/test/2", Lifespan: prompting.LifespanTimespan, Duration: "10s"},
+	} {
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Check(err, IsNil)
+		c.Check(rule, NotNil)
+		addedRules = append(addedRules, rule)
+		s.checkWrittenRuleDB(c, addedRules)
+		s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	}
+}
+
+// addRuleFromTemplate takes a template contents and a partial contents and,
+// for every empty field in the partial contents, fills it with the details
+// from the template contents, and then calls rdb.AddRule with the fields from
+// the filled-in contents, and returns the results.
+func addRuleFromTemplate(c *C, rdb *requestrules.RuleDB, template *addRuleContents, partial *addRuleContents) (*requestrules.Rule, error) {
+	if partial == nil {
+		partial = &addRuleContents{}
+	}
+	if partial.User == 0 {
+		partial.User = template.User
+	}
+	if partial.Snap == "" {
+		partial.Snap = template.Snap
+	}
+	if partial.Interface == "" {
+		partial.Interface = template.Interface
+	}
+	if partial.PathPattern == "" {
+		partial.PathPattern = template.PathPattern
+	}
+	if partial.Permissions == nil {
+		partial.Permissions = template.Permissions
+	}
+	if partial.Outcome == prompting.OutcomeUnset {
+		partial.Outcome = template.Outcome
+	}
+	if partial.Lifespan == prompting.LifespanUnset {
+		partial.Lifespan = template.Lifespan
+	}
+	// Duration default is empty string, so just use partial.Duration
 	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
+		PathPattern: mustParsePathPattern(c, partial.PathPattern),
+		Permissions: partial.Permissions,
 	}
-
-	storedRule, err := rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{storedRule.ID}, nil)
-
-	conflictingPermissions := permissions[:1]
-	conflictingConstraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: conflictingPermissions,
-	}
-	_, err = rdb.AddRule(s.defaultUser, snap, iface, conflictingConstraints, outcome, lifespan, duration)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("^cannot add rule: %s.*%s.*%s.*", requestrules.ErrPathPatternConflict, storedRule.ID.String(), conflictingPermissions[0]))
-
-	// Error while adding rule should cause no notice to be issued
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
-
-	badPermissions := []string{"foo"}
-	badConstraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: badPermissions,
-	}
-	_, err = rdb.AddRule(s.defaultUser, snap, iface, badConstraints, outcome, lifespan, duration)
-	c.Assert(err, ErrorMatches, "invalid constraints: unsupported permission for home interface:.*")
-
-	// Error while adding rule should cause no notice to be issued
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
-
-	badOutcome := prompting.OutcomeType("secret third thing")
-	_, err = rdb.AddRule(s.defaultUser, snap, iface, constraints, badOutcome, lifespan, duration)
-	c.Assert(err, ErrorMatches, `internal error: invalid outcome.*`, Commentf("rdb.Rules(): %s", s.marshalRules(c, rdb)))
-
-	// Error while adding rule should cause no notice to be issued
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
-
-	badLifespan := prompting.LifespanSingle
-	_, err = rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, badLifespan, duration)
-	c.Assert(err, Equals, requestrules.ErrLifespanSingle, Commentf("rdb.Rules(): %s", s.marshalRules(c, rdb)))
+	return rdb.AddRule(partial.User, partial.Snap, partial.Interface, constraints, partial.Outcome, partial.Lifespan, partial.Duration)
 }
 
-func (s *requestrulesSuite) marshalRules(c *C, rdb *requestrules.RuleDB) string {
-	rules := rdb.Rules(s.defaultUser)
-	marshalled, err := json.Marshal(rules)
+func (s *requestrulesSuite) TestAddRuleErrors(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
-	return string(marshalled)
+
+	template := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "lxd",
+		Interface:   "home",
+		PathPattern: "/home/test/Pictures/**/*.{jpg,png,svg}",
+		Permissions: []string{"write"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
+	}
+
+	// Add one good rule
+	good, err := addRuleFromTemplate(c, rdb, template, template)
+	c.Assert(err, IsNil)
+	c.Assert(good, NotNil)
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{good})
+	s.checkNewNoticesSimple(c, []prompting.IDType{good.ID}, nil)
+
+	// Preserve final error so it can be checked later
+	var finalErr error
+
+	for _, testCase := range []struct {
+		contents *addRuleContents
+		errStr   string
+	}{
+		{ // Non-empty duration with lifespan Forever
+			&addRuleContents{Duration: "10m"},
+			"cannot have specified duration.*",
+		},
+		{ // Empty duration with lifespan Timespan
+			&addRuleContents{Lifespan: prompting.LifespanTimespan},
+			"cannot have unspecified duration.*",
+		},
+		{ // Invalid duration
+			&addRuleContents{Lifespan: prompting.LifespanTimespan, Duration: "invalid"},
+			"cannot parse duration:.*",
+		},
+		{ // Negative duration
+			&addRuleContents{Lifespan: prompting.LifespanTimespan, Duration: "-10s"},
+			"cannot have zero or negative duration:.*",
+		},
+		{ // Invalid lifespan
+			&addRuleContents{Lifespan: prompting.LifespanType("invalid")},
+			"internal error: invalid lifespan:.*",
+		},
+		{ // Invalid outcome
+			&addRuleContents{Outcome: prompting.OutcomeType("invalid")},
+			"internal error: invalid outcome:.*",
+		},
+		{ // Invalid lifespan (for rules)
+			&addRuleContents{Lifespan: prompting.LifespanSingle},
+			fmt.Sprintf("%v", requestrules.ErrLifespanSingle),
+		},
+		{ // Conflicting rule
+			&addRuleContents{
+				PathPattern: "/home/test/Pictures/**/*.{svg,jpg}",
+				Permissions: []string{"read", "write"},
+			},
+			fmt.Sprintf("cannot add rule: %v: conflicts:.* permission: 'write'", requestrules.ErrPathPatternConflict),
+		},
+	} {
+		result, err := addRuleFromTemplate(c, rdb, template, testCase.contents)
+		c.Check(err, ErrorMatches, testCase.errStr)
+		c.Check(result, IsNil)
+		// Check that rule DB was unchanged and no notices were recorded
+		s.checkWrittenRuleDB(c, []*requestrules.Rule{good})
+		s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+		finalErr = err
+	}
+
+	// Check that the conflicting rule error can be unwrapped as ErrPathPatternConflict
+	c.Check(errors.Is(finalErr, requestrules.ErrPathPatternConflict), Equals, true)
+
+	// Failure to save rule DB should roll-back adding the rule and leave the
+	// DB unchanged. Set DB parent directory as read-only.
+	c.Assert(os.Chmod(prompting.StateDir(), 0o500), IsNil)
+	defer os.Chmod(prompting.StateDir(), 0o700)
+	result, err := addRuleFromTemplate(c, rdb, template, &addRuleContents{Permissions: []string{"execute"}})
+	c.Check(err, NotNil)
+	c.Check(result, IsNil)
+	// Failure should result in no changes to written rules and no notices
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{good})
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 }
 
-func (s *requestrulesSuite) TestPatchRule(c *C) {
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
+func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
 
-	snap := "lxd"
+	template := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "lxd",
+		Interface:   "home",
+		PathPattern: "/home/test/**/{private,secret}/**",
+		Permissions: []string{"write"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
+	}
+
+	// Add unrelated rule which should stick around throughout the test.
+	good, err := addRuleFromTemplate(c, rdb, template, &addRuleContents{Snap: "gimp"})
+	c.Assert(err, IsNil)
+	c.Assert(good, NotNil)
+
+	// Add initial rule which will expire quickly
+	prev, err := addRuleFromTemplate(c, rdb, template, &addRuleContents{
+		Lifespan: prompting.LifespanTimespan,
+		Duration: "1ms",
+	})
+	c.Assert(err, IsNil)
+	c.Assert(prev, NotNil)
+	time.Sleep(time.Millisecond)
+
+	// Both rules should be on disk and have notices
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{good, prev})
+	s.checkNewNoticesSimple(c, []prompting.IDType{good.ID, prev.ID}, nil)
+
+	// Add rules which all conflict but each expire before the next is added,
+	// thus causing the prior one to be removed and not causing a conflict error.
+	for _, ruleContents := range []*addRuleContents{
+		{}, // use template
+		{PathPattern: "/home/test/{**/secret,**/private}/**"},
+		{PathPattern: "/home/test/**/{sec,priv}{ret,ate}/**", Permissions: []string{"read", "write"}},
+		{Permissions: []string{"write", "execute"}},
+	} {
+		ruleContents.Lifespan = prompting.LifespanTimespan
+		ruleContents.Duration = "1ms"
+		newRule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Check(err, IsNil)
+		c.Check(newRule, NotNil)
+		s.checkWrittenRuleDB(c, []*requestrules.Rule{good, newRule})
+		expectedNoticeInfo := []*noticeInfo{
+			{
+				ruleID: prev.ID,
+				data:   map[string]string{"removed": "expired"},
+			},
+			{
+				ruleID: newRule.ID,
+				data:   nil,
+			},
+		}
+		s.checkNewNotices(c, expectedNoticeInfo)
+		time.Sleep(time.Millisecond)
+		// Store newRule as prev for next iteration
+		prev = newRule
+	}
+
+	// Lastly, add a rule with a lifespan of forever which would also conflict
+	// if not for the previous rules having expired.
+	final, err := addRuleFromTemplate(c, rdb, template, template)
+	c.Assert(err, IsNil)
+	c.Assert(final, NotNil)
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{good, final})
+	expectedNoticeInfo := []*noticeInfo{
+		{
+			ruleID: prev.ID,
+			data:   map[string]string{"removed": "expired"},
+		},
+		{
+			ruleID: final.ID,
+			data:   nil,
+		},
+	}
+	s.checkNewNotices(c, expectedNoticeInfo)
+}
+
+func (s *requestrulesSuite) TestIsPathAllowedSimple(c *C) {
+	// Target
+	user := s.defaultUser
+	snap := "firefox"
 	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read"}
-	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
+	path := "/home/test/path/to/file.txt"
+	permission := "read"
+
+	template := &addRuleContents{
+		User:        user,
+		Snap:        snap,
+		Interface:   iface,
+		PathPattern: path,
+		Permissions: []string{permission},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
 	}
 
-	storedRule, err := rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 1)
+	for _, testCase := range []struct {
+		ruleContents *addRuleContents
+		allowed      bool
+		err          error
+	}{
+		{ // No rules
+			ruleContents: nil,
+			allowed:      false,
+			err:          requestrules.ErrNoMatchingRule,
+		},
+		{ // Matching allow rule
+			ruleContents: template,
+			allowed:      true,
+			err:          nil,
+		},
+		{ // Matching deny rule
+			ruleContents: &addRuleContents{Outcome: prompting.OutcomeDeny},
+			allowed:      false,
+			err:          nil,
+		},
+		{ // Matching allow rule with expiration
+			ruleContents: &addRuleContents{Lifespan: prompting.LifespanTimespan, Duration: "10s"},
+			allowed:      true,
+			err:          nil,
+		},
+		{ // Matching deny rule with expiration
+			ruleContents: &addRuleContents{Outcome: prompting.OutcomeDeny, Lifespan: prompting.LifespanTimespan, Duration: "24h"},
+			allowed:      false,
+			err:          nil,
+		},
+		{ // Rule with wrong user
+			ruleContents: &addRuleContents{User: s.defaultUser + 1},
+			allowed:      false,
+			err:          requestrules.ErrNoMatchingRule,
+		},
+		{ // Rule with wrong snap
+			ruleContents: &addRuleContents{Snap: "thunderbird"},
+			allowed:      false,
+			err:          requestrules.ErrNoMatchingRule,
+		},
+		{ // Rule with wrong pattern
+			ruleContents: &addRuleContents{PathPattern: "/home/test/path/to/other.txt"},
+			allowed:      false,
+			err:          requestrules.ErrNoMatchingRule,
+		},
+		{ // Rule with wrong permissions
+			ruleContents: &addRuleContents{Permissions: []string{"write"}},
+			allowed:      false,
+			err:          requestrules.ErrNoMatchingRule,
+		},
+	} {
+		rdb, err := requestrules.New(s.defaultNotifyRule)
+		c.Assert(err, IsNil)
+		c.Assert(rdb, NotNil)
 
-	s.checkNewNoticesSimple(c, []prompting.IDType{storedRule.ID}, nil)
+		if testCase.ruleContents != nil {
+			rule, err := addRuleFromTemplate(c, rdb, template, testCase.ruleContents)
+			c.Assert(err, IsNil)
+			c.Assert(rule, NotNil)
+			s.checkWrittenRuleDB(c, []*requestrules.Rule{rule})
+			s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+		}
 
-	conflictingPermission := "write"
+		allowed, err := rdb.IsPathAllowed(user, snap, iface, path, permission)
+		c.Check(err, Equals, testCase.err)
+		c.Check(allowed, Equals, testCase.allowed)
+		// Check that no notices were recorded when checking
+		s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	otherPathPattern := mustParsePathPattern(c, "/home/test/Pictures/**/*.png")
-	otherPermissions := []string{
-		conflictingPermission,
+		if testCase.ruleContents != nil {
+			// Clean up the rules DB so the next rdb has a clean slate
+			dbPath := filepath.Join(prompting.StateDir(), "request-rules.json")
+			c.Assert(os.Remove(dbPath), IsNil)
+		}
 	}
-	otherConstraints := &prompting.Constraints{
-		PathPattern: otherPathPattern,
-		Permissions: otherPermissions,
-	}
-	otherRule, err := rdb.AddRule(s.defaultUser, snap, iface, otherConstraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 2)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{otherRule.ID}, nil)
-
-	// Check that patching with the original values results in an identical rule
-	unchangedRule1, err := rdb.PatchRule(s.defaultUser, storedRule.ID, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	// Timestamp should be different, the rest should be the same
-	unchangedRule1.Timestamp = storedRule.Timestamp
-	c.Assert(unchangedRule1, DeepEquals, storedRule)
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 2, Commentf("rdb.Rules(): %s", s.marshalRules(c, rdb)))
-
-	// Though rule was patched with the same values as it originally had, the
-	// timestamp was changed, and thus a notice should be issued for it.
-	s.checkNewNoticesSimple(c, []prompting.IDType{unchangedRule1.ID}, nil)
-
-	// Check that patching with unset values results in an identical rule
-	unchangedRule2, err := rdb.PatchRule(s.defaultUser, storedRule.ID, nil, prompting.OutcomeUnset, prompting.LifespanUnset, "")
-	c.Assert(err, IsNil)
-	// Timestamp should be different, the rest should be the same
-	unchangedRule2.Timestamp = storedRule.Timestamp
-	c.Assert(unchangedRule2, DeepEquals, storedRule)
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 2)
-
-	// Though rule was patched with unset values, and thus was unchanged aside
-	// from the timestamp, a notice should be issued for it.
-	s.checkNewNoticesSimple(c, []prompting.IDType{unchangedRule2.ID}, nil)
-
-	newPathPattern := otherPathPattern
-	newOutcome := prompting.OutcomeDeny
-	newLifespan := prompting.LifespanTimespan
-	newDuration := "1s"
-	newPermissions := []string{"execute"}
-	newConstraints := &prompting.Constraints{
-		PathPattern: newPathPattern,
-		Permissions: newPermissions,
-	}
-	patchedRule, err := rdb.PatchRule(s.defaultUser, storedRule.ID, newConstraints, newOutcome, newLifespan, newDuration)
-	c.Assert(err, IsNil)
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 2)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{patchedRule.ID}, nil)
-
-	badConstraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: []string{"fly"},
-	}
-	output, err := rdb.PatchRule(s.defaultUser, storedRule.ID, badConstraints, outcome, lifespan, duration)
-	c.Assert(err, ErrorMatches, "invalid constraints: unsupported permission.*")
-	c.Assert(output, IsNil)
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 2, Commentf("rdb.Rules(): %s", s.marshalRules(c, rdb)))
-
-	// Error while patching rule should cause no notice to be issued
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
-
-	currentRule, err := rdb.RuleWithID(s.defaultUser, storedRule.ID)
-	c.Assert(err, IsNil)
-	c.Assert(currentRule, DeepEquals, patchedRule)
-
-	conflictingPermissions := append(newPermissions, conflictingPermission)
-	conflictingConstraints := &prompting.Constraints{
-		PathPattern: newPathPattern,
-		Permissions: conflictingPermissions,
-	}
-	output, err = rdb.PatchRule(s.defaultUser, storedRule.ID, conflictingConstraints, newOutcome, newLifespan, newDuration)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("^cannot patch rule: %s.*%s.*%s.*", requestrules.ErrPathPatternConflict, otherRule.ID.String(), conflictingPermission))
-	c.Assert(output, IsNil)
-	c.Assert(rdb.Rules(s.defaultUser), HasLen, 2)
-
-	// Permission conflicts while patching rule should cause no notice to be issued
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
-
-	currentRule, err = rdb.RuleWithID(s.defaultUser, storedRule.ID)
-	c.Assert(err, IsNil)
-	c.Assert(currentRule, DeepEquals, patchedRule)
 }
 
-func (s *requestrulesSuite) TestRemoveRulesForSnap(c *C) {
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
-
-	snap := "lxd"
-	otherSnap := "nextcloud"
+func (s *requestrulesSuite) TestIsPathAllowedPrecedence(c *C) {
+	// Target
+	user := s.defaultUser
+	snap := "firefox"
 	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
-	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions[:1],
+	path := "/home/test/Documents/foo/bar/baz/file.txt"
+	permission := "read"
+
+	template := &addRuleContents{
+		User:        user,
+		Snap:        snap,
+		Interface:   iface,
+		PathPattern: path,
+		Permissions: []string{permission},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
 	}
-	otherConstraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions[1:],
+
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	var addedRules []*requestrules.Rule
+
+	// Add these rules in order, where each has higher precedence than prior
+	// rules. After adding each, check whether file is allowed. Result should
+	// always match the most recent rule contents.
+	for i, ruleContents := range []*addRuleContents{
+		{PathPattern: "/home/test/**"},
+		{PathPattern: "/home/test/Doc*/**"},
+		{PathPattern: "/home/test/Documents/**"},
+		{PathPattern: "/home/test/Documents/foo/**"},
+		{PathPattern: "/home/test/Documents/foo/**/ba?/*.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/ba?/file.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/**"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/**"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/*"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/*.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/{somewhere/else,baz}/file.txt"},
+		{PathPattern: "/home/test/Documents/foo/*/baz/file.{txt,md,pdf}"},
+		{PathPattern: "/home/test/{Documents,Pictures}/foo/bar/baz/file.{txt,md,pdf,png,jpg,svg}"},
+	} {
+		if i%2 == 0 {
+			ruleContents.Outcome = prompting.OutcomeAllow
+		} else {
+			ruleContents.Outcome = prompting.OutcomeDeny
+		}
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Assert(err, IsNil)
+		c.Assert(rule, NotNil)
+		addedRules = append(addedRules, rule)
+		s.checkWrittenRuleDB(c, addedRules)
+		s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+
+		mostRecentOutcome, err := ruleContents.Outcome.AsBool()
+		c.Check(err, IsNil)
+
+		allowed, err := rdb.IsPathAllowed(user, snap, iface, path, permission)
+		c.Check(err, IsNil)
+		c.Check(allowed, Equals, mostRecentOutcome, Commentf("most recent: %+v", ruleContents))
 	}
-
-	rule1, err := rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rule1, NotNil)
-
-	rule2, err := rdb.AddRule(s.defaultUser, otherSnap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rule2, NotNil)
-
-	rule3, err := rdb.AddRule(s.defaultUser, snap, iface, otherConstraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rule3, NotNil)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule1.ID, rule2.ID, rule3.ID}, nil)
-
-	removed := rdb.RemoveRulesForSnap(s.defaultUser, snap)
-	c.Check(removed, HasLen, 2, Commentf("expected to remove 2 rules but instead removed: %+v", removed))
-	c.Check(removed[0] == rule1 || removed[0] == rule3, Equals, true, Commentf("unexpected rule: %+v", removed[0]))
-	c.Check(removed[1] == rule1 || removed[1] == rule3, Equals, true, Commentf("unexpected rule: %+v", removed[1]))
-	c.Check(removed[0] != removed[1], Equals, true, Commentf("removed duplicate rules: %+v", removed))
-
-	expectedData := map[string]string{"removed": "removed"}
-	s.checkNewNoticesUnorderedSimple(c, []prompting.IDType{rule1.ID, rule3.ID}, expectedData)
 }
 
-func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
-
-	snap := "lxd"
-	otherSnap := "nextcloud"
+func (s *requestrulesSuite) TestIsPathAllowedExpiration(c *C) {
+	// Target
+	user := s.defaultUser
+	snap := "firefox"
 	iface := "home"
-	otherIface := "camera"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
-	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions[:1],
+	path := "/home/test/Documents/foo/bar/baz/file.txt"
+	permission := "read"
+
+	template := &addRuleContents{
+		User:        user,
+		Snap:        snap,
+		Interface:   iface,
+		PathPattern: path,
+		Permissions: []string{permission},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanTimespan,
+		Duration:    "1h",
 	}
-	otherConstraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions[1:],
+
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	var addedRules []*requestrules.Rule
+
+	// Add these rules, where each has higher precedence than prior rules.
+	// Then, from last to first, mark the rule as expired by setting the
+	// expiration timestamp to the past, and then test that the
+	// always match the most recent rule contents.
+	for i, ruleContents := range []*addRuleContents{
+		{Duration: "1h", PathPattern: "/home/test/**"},
+		{Duration: "1h", PathPattern: "/home/test/Doc*/**"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/**"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/ba?/*.txt"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/ba?/file.txt"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/**"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/baz/**"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/baz/*"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/baz/*.txt"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/{somewhere/else,baz}/file.txt"},
+		{Duration: "1h", PathPattern: "/home/test/Documents/foo/*/baz/file.{txt,md,pdf}"},
+		{Duration: "1h", PathPattern: "/home/test/{Documents,Pictures}/foo/bar/baz/file.{txt,md,pdf,png,jpg,svg}"},
+	} {
+		if i%2 == 0 {
+			ruleContents.Outcome = prompting.OutcomeAllow
+		} else {
+			ruleContents.Outcome = prompting.OutcomeDeny
+		}
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Assert(err, IsNil)
+		c.Assert(rule, NotNil)
+		addedRules = append(addedRules, rule)
+		s.checkWrittenRuleDB(c, addedRules)
+		s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
 	}
 
-	rule1, err := rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rule1, NotNil)
+	for i := len(addedRules) - 1; i >= 0; i-- {
+		rule := addedRules[i]
+		expectedOutcome, err := rule.Outcome.AsBool()
+		c.Check(err, IsNil)
 
-	rule2, err := rdb.AddRule(s.defaultUser, otherSnap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rule2, NotNil)
+		// Check that the outcome of the most specific unexpired rule has precedence
+		allowed, err := rdb.IsPathAllowed(user, snap, iface, path, permission)
+		c.Check(err, IsNil)
+		c.Check(allowed, Equals, expectedOutcome, Commentf("last unexpired: %+v", rule))
 
-	rule3, err := rdb.AddRule(s.defaultUser, snap, iface, otherConstraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	c.Assert(rule3, NotNil)
+		// Check that no new notices are recorded from lookup or expiration
+		s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// For now, impossible to add a rule for an interface other than "home", so
-	// must adjust it after it's been added.
-	rule3.Interface = otherIface
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule1.ID, rule2.ID, rule3.ID}, nil)
-
-	removed, err := rdb.RemoveRulesForSnapInterface(s.defaultUser, snap, iface)
-	c.Assert(err, IsNil)
-	c.Check(removed, HasLen, 1, Commentf("expected to remove 2 rules but instead removed: %+v", removed))
-	c.Check(removed[0] == rule1, Equals, true, Commentf("unexpected rule: %+v", removed[0]))
-
-	expectedData := map[string]string{"removed": "removed"}
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule1.ID}, expectedData)
+		// Expire the highest precedence rule
+		rule.Expiration = time.Now()
+	}
 }
 
 func (s *requestrulesSuite) TestRuleWithID(c *C) {
@@ -498,31 +953,33 @@ func (s *requestrulesSuite) TestRuleWithID(c *C) {
 
 	snap := "lxd"
 	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
+	constraints := &prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, "/home/test/Documents/**"),
+		Permissions: []string{"read", "write", "execute"},
+	}
 	outcome := prompting.OutcomeAllow
 	lifespan := prompting.LifespanForever
 	duration := ""
-	permissions := []string{"read", "write", "execute"}
-	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
-	}
 
-	newRule, err := rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
+	rule, err := rdb.AddRule(s.defaultUser, snap, iface, constraints, outcome, lifespan, duration)
 	c.Assert(err, IsNil)
-	c.Assert(newRule, NotNil)
+	c.Assert(rule, NotNil)
 
-	s.checkNewNoticesSimple(c, []prompting.IDType{newRule.ID}, nil)
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{rule})
+	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
 
-	accessedRule, err := rdb.RuleWithID(s.defaultUser, newRule.ID)
+	// Should find correct rule for user and ID
+	accessedRule, err := rdb.RuleWithID(s.defaultUser, rule.ID)
 	c.Check(err, IsNil)
-	c.Check(accessedRule, DeepEquals, newRule)
+	c.Check(accessedRule, DeepEquals, rule)
 
+	// Should not find rule for correct user and incorrect ID
 	accessedRule, err = rdb.RuleWithID(s.defaultUser, prompting.IDType(1234567890))
 	c.Check(err, Equals, requestrules.ErrRuleIDNotFound)
 	c.Check(accessedRule, IsNil)
 
-	accessedRule, err = rdb.RuleWithID(s.defaultUser+1, newRule.ID)
+	// Should not find rule for incorrect user and correct ID
+	accessedRule, err = rdb.RuleWithID(s.defaultUser+1, rule.ID)
 	c.Check(err, Equals, requestrules.ErrUserNotAllowed)
 	c.Check(accessedRule, IsNil)
 
@@ -530,407 +987,567 @@ func (s *requestrulesSuite) TestRuleWithID(c *C) {
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 }
 
-func (s *requestrulesSuite) TestNewSaveLoad(c *C) {
-	doNotNotifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
-		return nil
-	}
-	rdb, err := requestrules.New(doNotNotifyRule)
+func (s *requestrulesSuite) TestRules(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
 
-	snap := "lxd"
-	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
+	c.Check(rdb.Rules(s.defaultUser), HasLen, 0)
 
-	constraints1 := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions[:1],
-	}
-	rule1, err := rdb.AddRule(s.defaultUser, snap, iface, constraints1, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	constraints2 := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions[1:2],
-	}
-	rule2, err := rdb.AddRule(s.defaultUser, snap, iface, constraints2, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-	constraints3 := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions[2:],
-	}
-	rule3, err := rdb.AddRule(s.defaultUser, snap, iface, constraints3, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
 
-	loadedRdb, err := requestrules.New(s.defaultNotifyRule)
-	c.Assert(err, IsNil)
+	// The final rule is for another user, and should be excluded
+	c.Check(rdb.Rules(s.defaultUser), DeepEquals, rules[:4])
 
-	s.checkNewNoticesUnorderedSimple(c, []prompting.IDType{rule1.ID, rule2.ID, rule3.ID}, nil)
-
-	// DeepEquals does not treat time.Time well, so manually validate them and
-	// set them to be explicitly equal so the DeepEquals check succeeds.
-	c.Check(loadedRdb.Rules(s.defaultUser), HasLen, len(rdb.Rules(s.defaultUser)))
-	for _, rule := range rdb.Rules(s.defaultUser) {
-		loadedRule, err := loadedRdb.RuleWithID(s.defaultUser, rule.ID)
-		c.Assert(err, IsNil, Commentf("missing rule after loading: %+v", rule))
-		c.Check(rule.Timestamp.Equal(loadedRule.Timestamp), Equals, true, Commentf("%s != %s", rule.Timestamp, loadedRule.Timestamp))
-		rule.Timestamp = loadedRule.Timestamp
-	}
-	c.Check(rdb.Rules(s.defaultUser), DeepEquals, loadedRdb.Rules(s.defaultUser))
-	c.Check(rdb.PerUser(), DeepEquals, loadedRdb.PerUser())
+	// Getting rules should cause no notices
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 }
 
-func (s *requestrulesSuite) TestIsPathAllowed(c *C) {
-	patterns := make(map[string]prompting.OutcomeType)
-	patterns["/home/test/Documents/**"] = prompting.OutcomeAllow
-	patterns["/home/test/Documents/foo/**"] = prompting.OutcomeDeny
-	patterns["/home/test/Documents/foo/bar/**"] = prompting.OutcomeAllow
-	patterns["/home/test/Documents/foo/bar/baz/**"] = prompting.OutcomeDeny
-	patterns["/home/test/Documents/foo/bar/baz/**/{fizz,buzz}"] = prompting.OutcomeAllow
-	patterns["/home/test/**/*.png"] = prompting.OutcomeAllow
-	patterns["/home/test/**/*.jpg"] = prompting.OutcomeDeny
-
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
-
-	snap := "lxd"
-	iface := "home"
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
-
-	for pattern, outcome := range patterns {
-		newConstraints := &prompting.Constraints{
-			PathPattern: mustParsePathPattern(c, pattern),
-			Permissions: permissions,
-		}
-		newRule, err := rdb.AddRule(s.defaultUser, snap, iface, newConstraints, outcome, lifespan, duration)
-		c.Assert(err, IsNil)
-
-		s.checkNewNoticesSimple(c, []prompting.IDType{newRule.ID}, nil)
+func (s *requestrulesSuite) prepRuleDBForRulesForSnapInterface(c *C, rdb *requestrules.RuleDB) []*requestrules.Rule {
+	template := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "spotify",
+		Interface:   "home",
+		PathPattern: "/home/test/Music/**/*.{flac,mp3,aac,m4a}",
+		Permissions: []string{"read"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
 	}
 
-	cases := make(map[string]bool)
-	cases["/home/test/Documents"] = true
-	cases["/home/test/Documents/file"] = true
-	cases["/home/test/Documents/foo"] = false
-	cases["/home/test/Documents/foo/file"] = false
-	cases["/home/test/Documents/foo/bar"] = true
-	cases["/home/test/Documents/foo/bar/file"] = true
-	cases["/home/test/Documents/foo/bar/baz"] = false
-	cases["/home/test/Documents/foo/bar/baz/file"] = false
-	cases["/home/test/file.png"] = true
-	cases["/home/test/file.jpg"] = false
-	cases["/home/test/Documents/file.png"] = true
-	cases["/home/test/Documents/file.jpg"] = true
-	cases["/home/test/Documents/foo/file.png"] = false
-	cases["/home/test/Documents/foo/file.jpg"] = false
-	cases["/home/test/Documents/foo/bar/file.png"] = true
-	cases["/home/test/Documents/foo/bar/file.jpg"] = true
-	cases["/home/test/Documents/foo/bar/baz/file.png"] = false
-	cases["/home/test/Documents/foo/bar/baz/file.jpg"] = false
-	cases["/home/test/Documents.png"] = true
-	cases["/home/test/Documents.jpg"] = false
-	cases["/home/test/Documents/foo.png"] = true
-	cases["/home/test/Documents/foo.jpg"] = true
-	cases["/home/test/Documents/foo.txt"] = true
-	cases["/home/test/Documents/foo/bar.png"] = false
-	cases["/home/test/Documents/foo/bar.jpg"] = false
-	cases["/home/test/Documents/foo/bar.txt"] = false
-	cases["/home/test/Documents/foo/bar/baz.png"] = true
-	cases["/home/test/Documents/foo/bar/baz.jpg"] = true
-	cases["/home/test/Documents/foo/bar/baz.png"] = true
-	cases["/home/test/Documents/foo/bar/baz/file.png"] = false
-	cases["/home/test/Documents/foo/bar/baz/file.jpg"] = false
-	cases["/home/test/Documents/foo/bar/baz/file.txt"] = false
-	cases["/home/test/Documents/foo/bar/baz/fizz"] = true
-	cases["/home/test/Documents/foo/bar/baz/buzz"] = true
-	cases["/home/test/file.jpg.png"] = true
-	cases["/home/test/file.png.jpg"] = false
+	var addedRules []*requestrules.Rule
 
-	for path, expected := range cases {
-		result, err := rdb.IsPathAllowed(s.defaultUser, snap, iface, path, permissions[0])
-		c.Assert(err, IsNil, Commentf("path: %s: error: %v\nrdb.Rules(): %s", path, err, s.marshalRules(c, rdb)))
-		c.Assert(result, Equals, expected, Commentf("path: %s: expected %b but got %b\nrdb.Rules(): %s", path, expected, result, s.marshalRules(c, rdb)))
+	for _, ruleContents := range []*addRuleContents{
+		{},
+		{Permissions: []string{"write"}},
+		{Snap: "amberol"},
+		{Snap: "amberol", Permissions: []string{"write"}}, // change interface later
+		{User: s.defaultUser + 1},
+	} {
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Check(err, IsNil)
+		c.Check(rule, NotNil)
+		addedRules = append(addedRules, rule)
+		s.checkWrittenRuleDB(c, addedRules)
+		s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	}
 
-		// Matching against rules should not cause any notices
-		s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+	// Change final rule interface
+	addedRules[3].Interface = "audio-playback"
+
+	return addedRules
+}
+
+func (s *requestrulesSuite) TestRulesExpired(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	c.Check(rdb.Rules(s.defaultUser), HasLen, 0)
+
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	// Set some rules to be expired
+	rules[0].Lifespan = prompting.LifespanTimespan
+	rules[0].Expiration = time.Now()
+	rules[2].Lifespan = prompting.LifespanTimespan
+	rules[2].Expiration = time.Now()
+	rules[4].Lifespan = prompting.LifespanTimespan
+	rules[4].Expiration = time.Now()
+
+	// Expired rules are excluded from the Rules*() functions
+	c.Check(rdb.Rules(s.defaultUser), DeepEquals, []*requestrules.Rule{rules[1], rules[3]})
+
+	// Getting rules should cause no notices
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+}
+
+func (s *requestrulesSuite) TestRulesForSnap(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	c.Check(rdb.Rules(s.defaultUser), HasLen, 0)
+
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	c.Check(rdb.RulesForSnap(s.defaultUser, "amberol"), DeepEquals, rules[2:4])
+
+	// Getting rules should cause no notices
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+}
+
+func (s *requestrulesSuite) TestRulesForInterface(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	c.Check(rdb.Rules(s.defaultUser), HasLen, 0)
+
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	c.Check(rdb.RulesForInterface(s.defaultUser, "home"), DeepEquals, rules[:3])
+
+	// Getting rules should cause no notices
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+}
+
+func (s *requestrulesSuite) TestRulesForSnapInterface(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	c.Check(rdb.Rules(s.defaultUser), HasLen, 0)
+
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	c.Check(rdb.RulesForSnapInterface(s.defaultUser, "amberol", "audio-playback"), DeepEquals, []*requestrules.Rule{rules[3]})
+
+	// Getting rules should cause no notices
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+}
+
+func (s *requestrulesSuite) TestRemoveRuleForward(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	addedRules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	for _, rule := range addedRules {
+		s.testRemoveRule(c, rdb, rule)
 	}
 }
 
-func (s *requestrulesSuite) TestRuleExpiration(c *C) {
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
-
-	snap := "lxd"
-	iface := "home"
-	permissions := []string{"read", "write", "execute"}
-
-	pathPattern := mustParsePathPattern(c, "/home/test/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	constraints1 := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
-	}
-	rule1, err := rdb.AddRule(s.defaultUser, snap, iface, constraints1, outcome, lifespan, duration)
+func (s *requestrulesSuite) TestRemoveRuleBackward(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule1.ID}, nil)
+	addedRules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
 
-	pathPattern = mustParsePathPattern(c, "/home/test/Pictures/**")
-	outcome = prompting.OutcomeDeny
-	lifespan = prompting.LifespanTimespan
-	duration = "200ms"
-	constraints2 := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
+	for i := len(addedRules) - 1; i >= 0; i-- {
+		rule := addedRules[i]
+		s.testRemoveRule(c, rdb, rule)
 	}
-	rule2, err := rdb.AddRule(s.defaultUser, snap, iface, constraints2, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
+}
 
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule2.ID}, nil)
-
-	pathPattern = mustParsePathPattern(c, "/home/test/Pictures/**/*.png")
-	outcome = prompting.OutcomeAllow
-	lifespan = prompting.LifespanTimespan
-	duration = "100ms"
-	constraints3 := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
-	}
-	rule3, err := rdb.AddRule(s.defaultUser, snap, iface, constraints3, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule3.ID}, nil)
-
-	path1 := "/home/test/Pictures/img.png"
-	path2 := "/home/test/Pictures/img.jpg"
-
-	allowed, err := rdb.IsPathAllowed(s.defaultUser, snap, iface, path1, "read")
+func (s *requestrulesSuite) testRemoveRule(c *C, rdb *requestrules.RuleDB, rule *requestrules.Rule) {
+	// Pre-check that rule exists
+	found, err := rdb.RuleWithID(rule.User, rule.ID)
 	c.Check(err, IsNil)
-	c.Check(allowed, Equals, true, Commentf("rdb.Rules(): %s", s.marshalRules(c, rdb)))
-	allowed, err = rdb.IsPathAllowed(s.defaultUser, snap, iface, path2, "read")
-	c.Check(err, IsNil)
-	c.Check(allowed, Equals, false)
+	c.Check(found, DeepEquals, rule)
 
-	// No rules expired, so should not cause a notice
+	// Remove the rule
+	removed, err := rdb.RemoveRule(rule.User, rule.ID)
+	c.Check(err, IsNil)
+	c.Check(removed, DeepEquals, rule)
+
+	// Notice should be recorded immediately
+	s.checkNewNoticesSimple(c, []prompting.IDType{removed.ID}, map[string]string{"removed": "removed"})
+
+	// Post-check that rule no longer exists
+	missing, err := rdb.RuleWithID(rule.User, rule.ID)
+	c.Check(err, Equals, requestrules.ErrRuleIDNotFound)
+	c.Check(missing, IsNil)
+}
+
+func (s *requestrulesSuite) TestRemoveRuleErrors(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	addedRules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+	rule := addedRules[0]
+
+	// Attempt to remove rule with wrong user
+	result, err := rdb.RemoveRule(rule.User+1, rule.ID)
+	c.Check(err, Equals, requestrules.ErrUserNotAllowed)
+	c.Check(result, IsNil)
+
+	// Attempt to remove rule with wrong ID
+	result, err = rdb.RemoveRule(rule.User, rule.ID+1234)
+	c.Check(err, Equals, requestrules.ErrRuleIDNotFound)
+	c.Check(result, IsNil)
+
+	// Failure to save rule DB should roll-back removal and leave DB unchanged.
+	// Set DB parent directory as read-only.
+	c.Assert(os.Chmod(prompting.StateDir(), 0o500), IsNil)
+	result, err = rdb.RemoveRule(rule.User, rule.ID)
+	c.Check(err, NotNil)
+	c.Check(result, IsNil)
+	c.Assert(os.Chmod(prompting.StateDir(), 0o700), IsNil)
+
+	// Check that rule remains and no notices have been recorded
+	accessed, err := rdb.RuleWithID(rule.User, rule.ID)
+	c.Check(err, IsNil)
+	c.Check(accessed, DeepEquals, rule)
+	s.checkNewNoticesSimple(c, nil, nil)
+
+	// Corrupt rules to trigger internal errors, which aren't returned.
+	// Internal errors while removing are ignored and the rule is still removed.
+	// Cause "path pattern variant maps to different rule ID"
+	addedRules[1].Snap = addedRules[0].Snap
+	result, err = rdb.RemoveRule(addedRules[1].User, addedRules[1].ID)
+	c.Check(err, IsNil)
+	c.Check(result, DeepEquals, addedRules[1])
+	// Cause "variant not found in rule tree"
+	addedRules[2].Constraints.PathPattern = mustParsePathPattern(c, "/path/to/nowhere")
+	result, err = rdb.RemoveRule(addedRules[2].User, addedRules[2].ID)
+	c.Check(err, IsNil)
+	c.Check(result, DeepEquals, addedRules[2])
+	// Cause "no rules in rule tree for..."
+	addedRules[3].Snap = "invalid"
+	result, err = rdb.RemoveRule(addedRules[3].User, addedRules[3].ID)
+	c.Check(err, IsNil)
+	c.Check(result, DeepEquals, addedRules[3])
+
+	// Since removal succeeded for all corrupted rules (despite internal errors),
+	// should get "removed" notices for each removed rule.
+	s.checkNewNoticesSimple(c, rulesToIDs(addedRules[1:4]), map[string]string{"removed": "removed"})
+}
+
+func (s *requestrulesSuite) TestRemoveRulesForSnap(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	removed, err := rdb.RemoveRulesForSnap(s.defaultUser, "amberol")
+	c.Check(err, IsNil)
+
+	c.Check(removed, DeepEquals, rules[2:4])
+
+	s.checkWrittenRuleDB(c, append(rules[:2], rules[4]))
+	s.checkNewNoticesSimple(c, rulesToIDs(removed), map[string]string{"removed": "removed"})
+}
+
+func (s *requestrulesSuite) TestRemoveRulesForInterface(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	removed, err := rdb.RemoveRulesForInterface(s.defaultUser, "home")
+	c.Check(err, IsNil)
+
+	c.Check(removed, DeepEquals, rules[:3])
+
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{rules[4], rules[3]}) // removal reorders
+	s.checkNewNoticesSimple(c, rulesToIDs(removed), map[string]string{"removed": "removed"})
+}
+
+func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+
+	removed, err := rdb.RemoveRulesForSnapInterface(s.defaultUser, "amberol", "audio-playback")
+	c.Check(err, IsNil)
+
+	c.Check(removed, DeepEquals, []*requestrules.Rule{rules[3]})
+
+	s.checkWrittenRuleDB(c, append(rules[:3], rules[4]))
+	s.checkNewNoticesSimple(c, rulesToIDs(removed), map[string]string{"removed": "removed"})
+}
+
+func (s *requestrulesSuite) TestRemoveRulesForSnapInterfaceErrors(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	// Removing when no rules exist should not be an error
+	removed, err := rdb.RemoveRulesForSnap(s.defaultUser, "foo")
+	c.Check(err, IsNil)
+	c.Check(removed, HasLen, 0)
+	removed, err = rdb.RemoveRulesForInterface(s.defaultUser, "foo")
+	c.Check(err, IsNil)
+	c.Check(removed, HasLen, 0)
+	removed, err = rdb.RemoveRulesForSnapInterface(s.defaultUser, "foo", "bar")
+	c.Check(err, IsNil)
+	c.Check(removed, HasLen, 0)
+
+	// Add some rules with different snaps and interfaces
+	rules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
+	c.Assert(rules, HasLen, 5)
+
+	// Failure to save rule DB should roll-back removing the rules and leave the
+	// DB unchanged. Set DB parent directory as read-only.
+	c.Assert(os.Chmod(prompting.StateDir(), 0o500), IsNil)
+	defer os.Chmod(prompting.StateDir(), 0o700)
+
+	removed, err = rdb.RemoveRulesForSnap(s.defaultUser, "amberol")
+	c.Check(err, NotNil)
+	c.Check(removed, IsNil)
+	c.Check(rdb.Rules(s.defaultUser), DeepEquals, rules[:4])
+
+	removed, err = rdb.RemoveRulesForInterface(s.defaultUser, "audio-playback")
+	c.Check(err, NotNil)
+	c.Check(removed, IsNil)
+	c.Check(rdb.Rules(s.defaultUser), DeepEquals, rules[:4])
+
+	removed, err = rdb.RemoveRulesForSnapInterface(s.defaultUser, "amberol", "audio-playback")
+	c.Check(err, NotNil)
+	c.Check(removed, IsNil)
+	c.Check(rdb.Rules(s.defaultUser), DeepEquals, rules[:4])
+
+	// Check that original rules are still on disk, and no notices were recorded.
+	// Be careful, since no write has occurred, the manually-edited rules[3]
+	// still has "home" interface on disk.
+	rules[3].Interface = "home"
+	s.checkWrittenRuleDB(c, rules)
+	s.checkNewNoticesSimple(c, rulesToIDs(removed), map[string]string{"removed": "removed"})
+}
+
+func (s *requestrulesSuite) TestPatchRule(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	template := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "thunderbird",
+		Interface:   "home",
+		PathPattern: "/home/test/{Downloads,Documents}/**/*.{ical,mail,txt,gpg}",
+		Permissions: []string{"write"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
+	}
+
+	var rules []*requestrules.Rule
+
+	for _, ruleContents := range []*addRuleContents{
+		{},
+		{Permissions: []string{"read"}},
+	} {
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Check(err, IsNil)
+		c.Check(rule, NotNil)
+		rules = append(rules, rule)
+		s.checkWrittenRuleDB(c, rules)
+		s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	}
+
+	// Patch last rule in various ways, then patch it back to its original state
+	rule := rules[len(rules)-1]
+	origRule := *rule
+
+	// Check that patching with no changes works fine, and updates timestamp
+	patched, err := rdb.PatchRule(rule.User, rule.ID, nil, prompting.OutcomeUnset, prompting.LifespanUnset, "")
+	c.Assert(err, IsNil)
+	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
+	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	// Check that timestamp has changed
+	c.Check(patched.Timestamp.Equal(rule.Timestamp), Equals, false)
+	// After making timestamp the same again, check that the rules are identical
+	patched.Timestamp = rule.Timestamp
+	c.Check(patched, DeepEquals, rule)
+
+	rule = patched
+
+	// Check that patching with identical content works fine, and updates timestamp
+	patched, err = rdb.PatchRule(rule.User, rule.ID, rule.Constraints, rule.Outcome, rule.Lifespan, "")
+	c.Assert(err, IsNil)
+	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
+	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	// Check that timestamp has changed
+	c.Check(patched.Timestamp.Equal(rule.Timestamp), Equals, false)
+	// After making timestamp the same again, check that the rules are identical
+	patched.Timestamp = origRule.Timestamp
+	c.Check(patched, DeepEquals, &origRule)
+
+	rule = patched
+
+	newConstraints := &prompting.Constraints{
+		PathPattern: rule.Constraints.PathPattern,
+		Permissions: []string{"read", "execute"},
+	}
+	patched, err = rdb.PatchRule(rule.User, rule.ID, newConstraints, prompting.OutcomeUnset, prompting.LifespanUnset, "")
+	c.Assert(err, IsNil)
+	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
+	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	// Check that timestamp has changed
+	c.Check(patched.Timestamp.Equal(rule.Timestamp), Equals, false)
+	// After making timestamp the same again, check that the rules are identical
+	patched.Timestamp = rule.Timestamp
+	rule.Constraints = newConstraints
+	c.Check(patched, DeepEquals, rule)
+
+	rule = patched
+
+	patched, err = rdb.PatchRule(rule.User, rule.ID, nil, prompting.OutcomeDeny, prompting.LifespanUnset, "")
+	c.Assert(err, IsNil)
+	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
+	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	// Check that timestamp has changed
+	c.Check(patched.Timestamp.Equal(rule.Timestamp), Equals, false)
+	// After making timestamp the same again, check that the rules are identical
+	patched.Timestamp = rule.Timestamp
+	rule.Outcome = prompting.OutcomeDeny
+	c.Check(patched, DeepEquals, rule)
+
+	rule = patched
+
+	patched, err = rdb.PatchRule(rule.User, rule.ID, nil, prompting.OutcomeUnset, prompting.LifespanTimespan, "10s")
+	c.Assert(err, IsNil)
+	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
+	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	// Check that timestamp has changed
+	c.Check(patched.Timestamp.Equal(rule.Timestamp), Equals, false)
+	// After making timestamp the same again, check that the rules are identical
+	patched.Timestamp = rule.Timestamp
+	rule.Lifespan = prompting.LifespanTimespan
+	rule.Expiration = patched.Expiration
+	c.Check(patched, DeepEquals, rule)
+
+	rule = patched
+
+	patched, err = rdb.PatchRule(rule.User, rule.ID, origRule.Constraints, origRule.Outcome, origRule.Lifespan, "")
+	c.Assert(err, IsNil)
+	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
+	s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	// Check that timestamp has changed
+	c.Check(patched.Timestamp.Equal(rule.Timestamp), Equals, false)
+	// After making timestamp the same again, check that the rules are identical
+	patched.Timestamp = origRule.Timestamp
+	c.Check(patched, DeepEquals, &origRule)
+}
+
+func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	template := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "thunderbird",
+		Interface:   "home",
+		PathPattern: "/home/test/{Downloads,Documents}/**/*.{ical,mail,txt,gpg}",
+		Permissions: []string{"write"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
+	}
+
+	var rules []*requestrules.Rule
+
+	for _, ruleContents := range []*addRuleContents{
+		{},
+		{Permissions: []string{"read"}},
+	} {
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Check(err, IsNil)
+		c.Check(rule, NotNil)
+		rules = append(rules, rule)
+		s.checkWrittenRuleDB(c, rules)
+		s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	}
+
+	// Patch last rule in various ways, then patch it back to its original state
+	rule := rules[len(rules)-1]
+
+	// Wrong user
+	result, err := rdb.PatchRule(rule.User+1, rule.ID, nil, prompting.OutcomeUnset, prompting.LifespanUnset, "")
+	c.Check(err, Equals, requestrules.ErrUserNotAllowed)
+	c.Check(result, IsNil)
+	s.checkWrittenRuleDB(c, rules)
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	time.Sleep(100 * time.Millisecond)
+	// Wrong ID
+	result, err = rdb.PatchRule(rule.User, prompting.IDType(1234), nil, prompting.OutcomeUnset, prompting.LifespanUnset, "")
+	c.Check(err, Equals, requestrules.ErrRuleIDNotFound)
+	c.Check(result, IsNil)
+	s.checkWrittenRuleDB(c, rules)
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// rule 3 should have expired, check that it's not included when getting rules
-	rules := rdb.Rules(s.defaultUser)
-	c.Check(rules, HasLen, 2, Commentf("rules: %+v", rules))
-	c.Check(rules[0] == rule1 || rules[0] == rule2, Equals, true, Commentf("unexpected rule: %+v", rules[0]))
-	c.Check(rules[1] == rule1 || rules[1] == rule2, Equals, true, Commentf("unexpected rule: %+v", rules[1]))
-	c.Check(rules[0] != rules[1], Equals, true, Commentf("Rules returned duplicate rules: %+v", rules))
+	// Invalid lifespan
+	result, err = rdb.PatchRule(rule.User, rule.ID, nil, prompting.OutcomeUnset, prompting.LifespanSingle, "")
+	c.Check(err, Equals, requestrules.ErrLifespanSingle)
+	c.Check(result, IsNil)
+	s.checkWrittenRuleDB(c, rules)
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	allowed, err = rdb.IsPathAllowed(s.defaultUser, snap, iface, path1, "read")
-	c.Check(err, IsNil)
-	c.Check(allowed, Equals, false)
+	// Conflicting rule
+	conflictingConstraints := &prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, template.PathPattern),
+		Permissions: []string{"read", "write", "execute"},
+	}
+	result, err = rdb.PatchRule(rule.User, rule.ID, conflictingConstraints, prompting.OutcomeUnset, prompting.LifespanUnset, "")
+	c.Check(err, ErrorMatches, fmt.Sprintf("cannot patch rule: %v: conflicts:.* permission: 'write'", requestrules.ErrPathPatternConflict))
+	c.Check(result, IsNil)
+	s.checkWrittenRuleDB(c, rules)
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// Add rule which conflicts with rule3 in order to force it to be pruned.
-	// New rule should expire almost immediately as well, but won't trigger
-	// notice until refreshTreeEnforceConsistency or a conflict occurs.
-	// By waiting to get current rules until after it expires, and calling
-	// refreshTreeEnforceConsistency with that list, we won't get a notice for
-	// it ever.
-	rule4, err := rdb.AddRule(s.defaultUser, snap, iface, constraints3, prompting.OutcomeDeny, lifespan, "1ms")
-	// Despite conflict, error should be nil, because conflicted permission is expired
+	// Save fails
+	c.Assert(os.Chmod(prompting.StateDir(), 0o500), IsNil)
+	defer os.Chmod(prompting.StateDir(), 0o700)
+	result, err = rdb.PatchRule(rule.User, rule.ID, nil, prompting.OutcomeUnset, prompting.LifespanUnset, "")
+	c.Check(err, NotNil)
+	c.Check(result, IsNil)
+	s.checkWrittenRuleDB(c, rules)
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+}
+
+func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
+
+	template := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "thunderbird",
+		Interface:   "home",
+		PathPattern: "/home/test/{Downloads,Documents}/**/*.{ical,mail,txt,gpg}",
+		Permissions: []string{"write"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
+	}
+
+	var rules []*requestrules.Rule
+
+	for _, ruleContents := range []*addRuleContents{
+		{Lifespan: prompting.LifespanTimespan, Duration: "1ms"},
+		{Lifespan: prompting.LifespanTimespan, Duration: "1ms", Permissions: []string{"read"}},
+		{Permissions: []string{"execute"}},
+	} {
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Check(err, IsNil)
+		c.Check(rule, NotNil)
+		rules = append(rules, rule)
+		s.checkWrittenRuleDB(c, rules)
+		s.checkNewNoticesSimple(c, []prompting.IDType{rule.ID}, nil)
+	}
 
 	time.Sleep(time.Millisecond)
 
-	// rule3 expiration should have recorded a notice
+	// Patching doesn't conflict with already-expired rules
+	rule := rules[2]
+	newConstraints := &prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, template.PathPattern),
+		Permissions: []string{"read", "write", "execute"},
+	}
+	patched, err := rdb.PatchRule(rule.User, rule.ID, newConstraints, prompting.OutcomeUnset, prompting.LifespanUnset, "")
+	c.Assert(err, IsNil)
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{patched})
 	expectedNotices := []*noticeInfo{
 		{
-			ruleID: rule3.ID,
+			ruleID: rules[1].ID,
 			data:   map[string]string{"removed": "expired"},
 		},
 		{
-			ruleID: rule4.ID,
-			data:   nil,
-		},
-	}
-	s.checkNewNoticesUnordered(c, expectedNotices)
-
-	// Re-load DB from disk to force expired rule4 to be pruned
-	err = rdb.Load()
-	c.Assert(err, IsNil)
-
-	expectedNotices = []*noticeInfo{
-		{
-			ruleID: rule1.ID,
-			data:   nil,
-		},
-		{
-			ruleID: rule2.ID,
-			data:   nil,
-		},
-		{
-			ruleID: rule4.ID,
+			ruleID: rules[0].ID,
 			data:   map[string]string{"removed": "expired"},
 		},
-	}
-	s.checkNewNoticesUnordered(c, expectedNotices)
-
-	allowed, err = rdb.IsPathAllowed(s.defaultUser, snap, iface, path2, "read")
-	c.Check(err, IsNil)
-	c.Check(allowed, Equals, false)
-
-	// No rules newly expired, so should not cause a notice
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
-
-	time.Sleep(100 * time.Millisecond)
-
-	// Matches rule1.
-	// Meanwhile, rule2 expires.
-	allowed, err = rdb.IsPathAllowed(s.defaultUser, snap, iface, path1, "read")
-	c.Check(err, Equals, nil)
-	c.Check(allowed, Equals, true)
-
-	// Re-load DB from disk to force expired rule2 to be pruned
-	err = rdb.Load()
-	c.Assert(err, IsNil)
-
-	// As a result, get notices for rule1 and rule4 again, plus rule2 expiration
-	expectedNotices = []*noticeInfo{
 		{
-			ruleID: rule1.ID,
+			ruleID: rules[2].ID,
 			data:   nil,
-		},
-		{
-			ruleID: rule2.ID,
-			data:   map[string]string{"removed": "expired"},
 		},
 	}
 	s.checkNewNotices(c, expectedNotices)
-
-	allowed, err = rdb.IsPathAllowed(s.defaultUser, snap, iface, path2, "read")
-	c.Check(err, IsNil)
-	c.Check(allowed, Equals, true)
-
-	allowed, err = rdb.IsPathAllowed(s.defaultUser, snap, iface, path1, "read")
-	c.Check(err, IsNil)
-	c.Check(allowed, Equals, true)
-
-	// No rules newly expired, so should not cause a notice
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
-}
-
-func (s *requestrulesSuite) TestRulesLookup(c *C) {
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
-
-	var origUser uint32 = s.defaultUser
-	snap := "lxd"
-	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/home/test/Documents/**")
-	outcome := prompting.OutcomeAllow
-	lifespan := prompting.LifespanForever
-	duration := ""
-	permissions := []string{"read", "write", "execute"}
-	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: permissions,
-	}
-
-	origIface := iface
-
-	rule1, err := rdb.AddRule(origUser, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule1.ID}, nil)
-
-	user := origUser + 1
-	rule2, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule2.ID}, nil)
-
-	snap = "nextcloud"
-	rule3, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule3.ID}, nil)
-
-	// TODO: add rule for other interface once other interfaces are supported
-	// iface = "camera"
-	// constraints.Permissions = []string{"access"}
-	iface = "home"
-	constraints.PathPattern = mustParsePathPattern(c, "/home/test/foo")
-	rule4, err := rdb.AddRule(user, snap, iface, constraints, outcome, lifespan, duration)
-	c.Assert(err, IsNil)
-
-	s.checkNewNoticesSimple(c, []prompting.IDType{rule4.ID}, nil)
-
-	origUserRules := rdb.Rules(origUser)
-	c.Assert(origUserRules, HasLen, 1)
-	c.Assert(origUserRules[0], DeepEquals, rule1)
-
-	userRules := rdb.Rules(user)
-	c.Check(userRules, HasLen, 3)
-OUTER_LOOP_USER:
-	for _, rule := range []*requestrules.Rule{rule2, rule3, rule4} {
-		for _, expected := range userRules {
-			if reflect.DeepEqual(rule, expected) {
-				continue OUTER_LOOP_USER
-			}
-		}
-		c.Errorf("rule not found in userRules:\nrule: %+v\nuserRules: %+v", rule, userRules)
-	}
-
-	userSnapRules := rdb.RulesForSnap(user, snap)
-	c.Check(userSnapRules, HasLen, 2)
-OUTER_LOOP_USER_SNAP:
-	for _, rule := range []*requestrules.Rule{rule3, rule4} {
-		for _, expected := range userSnapRules {
-			if reflect.DeepEqual(rule, expected) {
-				continue OUTER_LOOP_USER_SNAP
-			}
-		}
-		c.Errorf("rule not found in userRules:\nrule: %+v\nuserSnapRules: %+v", rule, userRules)
-	}
-
-	userInterfaceRules := rdb.RulesForInterface(user, origIface)
-	// TODO: make this 2 when rule4 is for another interface
-	// c.Check(userInterfaceRules, HasLen, 2)
-	c.Check(userInterfaceRules, HasLen, 3)
-OUTER_LOOP_USER_INTERFACE:
-	// TODO: remove rule4 when rule4 is for another interface
-	// for _, rule := range []*requestrules.Rule{rule2, rule3} {
-	for _, rule := range []*requestrules.Rule{rule2, rule3, rule4} {
-		for _, expected := range userInterfaceRules {
-			if reflect.DeepEqual(rule, expected) {
-				continue OUTER_LOOP_USER_INTERFACE
-			}
-		}
-		c.Errorf("rule not found in userRules:\nrule: %+v\nuserInterfaceRules: %+v", rule, userRules)
-	}
-
-	// TODO: check these once rule4 is for another interface
-	// userInterfaceRules = rdb.RulesForInterface(user, iface)
-	// c.Check(userInterfaceRules, HasLen, 1)
-	// c.Check(userInterfaceRules[0], DeepEquals, rule4)
-
-	userSnapInterfaceRules := rdb.RulesForSnapInterface(user, snap, origIface)
-	// TODO: make this 1 when rule4 is for another interface
-	c.Check(userSnapRules, HasLen, 2)
-OUTER_LOOP_USER_SNAP_INTERFACE:
-	for _, rule := range []*requestrules.Rule{rule3, rule4} {
-		for _, expected := range userSnapInterfaceRules {
-			if reflect.DeepEqual(rule, expected) {
-				continue OUTER_LOOP_USER_SNAP_INTERFACE
-			}
-		}
-		c.Errorf("rule not found in userRules:\nrule: %+v\nuserSnapRules: %+v", rule, userRules)
-	}
-
-	// userSnapInterfaceRules := rdb.RulesForSnapInterface(user, snap, iface)
-	// c.Check(userSnapInterfaceRules, HasLen, 1)
-	// c.Check(userSnapInterfaceRules[0], DeepEquals, rule4)
-
-	// Looking up these rules should not cause any notices
-	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+	// Check that timestamp has changed
+	c.Check(patched.Timestamp.Equal(rule.Timestamp), Equals, false)
+	// After making timestamp the same again, check that the rules are identical
+	patched.Timestamp = rule.Timestamp
+	rule.Constraints = newConstraints
+	c.Check(patched, DeepEquals, rule)
 }

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -1,3 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package requestrules_test
 
 import (

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -256,7 +256,7 @@ func (s *requestrulesSuite) TestAddRuleUnhappy(c *C) {
 		Permissions: conflictingPermissions,
 	}
 	_, err = rdb.AddRule(s.defaultUser, snap, iface, conflictingConstraints, outcome, lifespan, duration)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("^%s.*%s.*%s.*", requestrules.ErrPathPatternConflict, storedRule.ID.String(), conflictingPermissions[0]))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("^cannot add rule: %s.*%s.*%s.*", requestrules.ErrPathPatternConflict, storedRule.ID.String(), conflictingPermissions[0]))
 
 	// Error while adding rule should cause no notice to be issued
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)


### PR DESCRIPTION
Add package for storing request rules. This is very much akin to the requestprompts package, which was added in #13981.

This also relates to https://github.com/olivercalder/snapd/pull/37, and some discussion of rule handling there is relevant here as well.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-8328
