### PR TITLE
o/state: add notice types for request prompts and request rules

### DIFF
--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -205,11 +205,20 @@ const (
 	// Recorded by "snap run" command when it is inhibited from running a
 	// a snap due an ongoing refresh.
 	SnapRunInhibitNotice NoticeType = "snap-run-inhibit"
+
+	// Recorded whenever a prompt request is created or resolved. The key for
+	// interfaces-prompting-request notices is the request ID.
+	PromptingRequestNotice NoticeType = "interfaces-prompting-request"
+
+	// Recorded whenever a prompting rule is created, modified, deleted, or
+	// expired. The key for interfaces-prompting-rule-update notices is the
+	// rule ID.
+	PromptingRuleUpdateNotice NoticeType = "interfaces-prompting-rule-update"
 )
 
 func (t NoticeType) Valid() bool {
 	switch t {
-	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice, SnapRunInhibitNotice:
+	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice, SnapRunInhibitNotice, PromptingRequestNotice, PromptingRuleUpdateNotice:
 		return true
 	}
 	return false

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -208,17 +208,17 @@ const (
 
 	// Recorded whenever a request prompt is created or resolved. The key for
 	// interfaces-requests-prompt notices is the request prompt ID.
-	RequestsPromptNotice NoticeType = "interfaces-requests-prompt"
+	InterfacesRequestsPromptNotice NoticeType = "interfaces-requests-prompt"
 
 	// Recorded whenever a request rule is created, modified, deleted, or
 	// expired. The key for interfaces-requests-rule-update notices is the
 	// rule ID.
-	RequestsRuleUpdateNotice NoticeType = "interfaces-requests-rule-update"
+	InterfacesRequestsRuleUpdateNotice NoticeType = "interfaces-requests-rule-update"
 )
 
 func (t NoticeType) Valid() bool {
 	switch t {
-	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice, SnapRunInhibitNotice, RequestsPromptNotice, RequestsRuleUpdateNotice:
+	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice, SnapRunInhibitNotice, InterfacesRequestsPromptNotice, InterfacesRequestsRuleUpdateNotice:
 		return true
 	}
 	return false

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -206,19 +206,19 @@ const (
 	// a snap due an ongoing refresh.
 	SnapRunInhibitNotice NoticeType = "snap-run-inhibit"
 
-	// Recorded whenever a prompt request is created or resolved. The key for
-	// interfaces-prompting-request notices is the request ID.
-	PromptingRequestNotice NoticeType = "interfaces-prompting-request"
+	// Recorded whenever a request prompt is created or resolved. The key for
+	// interfaces-requests-prompt notices is the request prompt ID.
+	RequestsPromptNotice NoticeType = "interfaces-requests-prompt"
 
-	// Recorded whenever a prompting rule is created, modified, deleted, or
-	// expired. The key for interfaces-prompting-rule-update notices is the
+	// Recorded whenever a request rule is created, modified, deleted, or
+	// expired. The key for interfaces-requests-rule-update notices is the
 	// rule ID.
-	PromptingRuleUpdateNotice NoticeType = "interfaces-prompting-rule-update"
+	RequestsRuleUpdateNotice NoticeType = "interfaces-requests-rule-update"
 )
 
 func (t NoticeType) Valid() bool {
 	switch t {
-	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice, SnapRunInhibitNotice, PromptingRequestNotice, PromptingRuleUpdateNotice:
+	case ChangeUpdateNotice, WarningNotice, RefreshInhibitNotice, SnapRunInhibitNotice, RequestsPromptNotice, RequestsRuleUpdateNotice:
 		return true
 	}
 	return false

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -282,7 +282,7 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 
 	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.RequestsPromptNotice, "443", nil)
+	addNotice(c, st, nil, state.InterfacesRequestsPromptNotice, "443", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
@@ -331,7 +331,7 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	// Multiple types
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{
 		state.ChangeUpdateNotice,
-		state.RequestsPromptNotice,
+		state.InterfacesRequestsPromptNotice,
 	}})
 	c.Assert(notices, HasLen, 2)
 	n = noticeToMap(c, notices[0])

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -282,7 +282,7 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 
 	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.PromptingRequestNotice, "443", nil)
+	addNotice(c, st, nil, state.RequestsPromptNotice, "443", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
@@ -331,12 +331,12 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	// Multiple types
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{
 		state.ChangeUpdateNotice,
-		state.PromptingRequestNotice,
+		state.RequestsPromptNotice,
 	}})
 	c.Assert(notices, HasLen, 2)
 	n = noticeToMap(c, notices[0])
 	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "interfaces-prompting-request")
+	c.Check(n["type"], Equals, "interfaces-requests-prompt")
 	c.Check(n["key"], Equals, "443")
 	n = noticeToMap(c, notices[1])
 	c.Check(n["user-id"], Equals, nil)

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -282,6 +282,8 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 
 	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	time.Sleep(time.Microsecond)
+	addNotice(c, st, nil, state.PromptingRequestNotice, "443", nil)
+	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.WarningNotice, "Warning 1!", nil)
@@ -292,11 +294,11 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 
 	// No filter
 	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 5)
+	c.Assert(notices, HasLen, 6)
 
 	// No types
 	notices = st.Notices(&state.NoticeFilter{})
-	c.Assert(notices, HasLen, 5)
+	c.Assert(notices, HasLen, 6)
 
 	// One type
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}})
@@ -309,14 +311,6 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 2!")
-
-	// Another type
-	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
-	c.Assert(notices, HasLen, 1)
-	n = noticeToMap(c, notices[0])
-	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "change-update")
-	c.Check(n["key"], Equals, "123")
 
 	// Another type
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.RefreshInhibitNotice}})
@@ -337,13 +331,13 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	// Multiple types
 	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{
 		state.ChangeUpdateNotice,
-		state.RefreshInhibitNotice,
+		state.PromptingRequestNotice,
 	}})
 	c.Assert(notices, HasLen, 2)
 	n = noticeToMap(c, notices[0])
 	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "refresh-inhibit")
-	c.Check(n["key"], Equals, "-")
+	c.Check(n["type"], Equals, "interfaces-prompting-request")
+	c.Check(n["key"], Equals, "443")
 	n = noticeToMap(c, notices[1])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")


### PR DESCRIPTION
Add the prompting-related notice types:
- `interfaces-requests-prompt`
- `interfaces-requests-rule-update`

These should be recorded when a request prompt or request rule is created, modified, or removed.

This is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-26287 .