### PR TITLE
interfaces: added default doc url for all builtin interfaces

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -50,6 +50,10 @@ type Repository struct {
 	appSets map[string]*SnapAppSet
 }
 
+// defaultIfaceDocURLTemplate is used as template for generating the default interface
+// documentation URL by inserting the interface name
+const defaultIfaceDocURLTemplate = "https://snapcraft.io/docs/%s-interface"
+
 // NewRepository creates an empty plug repository.
 func NewRepository() *Repository {
 	repo := &Repository{
@@ -155,7 +159,11 @@ func (r *Repository) interfaceInfo(iface Interface, opts *InfoOptions) *Info {
 	}
 	if opts != nil && opts.Doc {
 		// Collect documentation URL
-		ii.DocURL = si.DocURL
+		if si.DocURL != "" {
+			ii.DocURL = si.DocURL
+		} else {
+			ii.DocURL = fmt.Sprintf(defaultIfaceDocURLTemplate, ifaceName)
+		}
 	}
 	if opts != nil && opts.Plugs {
 		// Collect all plugs of this interface type.

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1906,7 +1906,7 @@ func (s *RepositorySuite) TestInfo(c *C) {
 	// Add some test interfaces.
 	i1 := &ifacetest.TestInterface{InterfaceName: "i1", InterfaceStaticInfo: StaticInfo{Summary: "i1 summary", DocURL: "http://example.com/i1"}}
 	i2 := &ifacetest.TestInterface{InterfaceName: "i2", InterfaceStaticInfo: StaticInfo{Summary: "i2 summary", DocURL: "http://example.com/i2"}}
-	i3 := &ifacetest.TestInterface{InterfaceName: "i3", InterfaceStaticInfo: StaticInfo{Summary: "i3 summary", DocURL: "http://example.com/i3"}}
+	i3 := &ifacetest.TestInterface{InterfaceName: "i3", InterfaceStaticInfo: StaticInfo{Summary: "i3 summary", DocURL: ""}}
 	c.Assert(r.AddInterface(i1), IsNil)
 	c.Assert(r.AddInterface(i2), IsNil)
 	c.Assert(r.AddInterface(i3), IsNil)
@@ -1981,9 +1981,10 @@ apps:
 	})
 
 	// We can ask for documentation.
-	infos = r.Info(&InfoOptions{Names: []string{"i2"}, Doc: true})
+	infos = r.Info(&InfoOptions{Names: []string{"i2", "i3"}, Doc: true})
 	c.Assert(infos, DeepEquals, []*Info{
 		{Name: "i2", Summary: "i2 summary", DocURL: "http://example.com/i2"},
+		{Name: "i3", Summary: "i3 summary", DocURL: "https://snapcraft.io/docs/i3-interface"},
 	})
 
 	// We can ask for a list of plugs.


### PR DESCRIPTION
Provide default doc URL for `snap interface` <name>.

This quick attempt to demonstrate one simple approach that does not require modifying all of the interfaces.

https://warthogs.atlassian.net/browse/SNAPDENG-26156
Related to: https://github.com/canonical/snapd/pull/14337

Follow-up PR will add nightly test check all URLs are reachable.