### PR TITLE
cmd/snap-failure: consider distro release info when choosing the fallback target

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -129,20 +129,38 @@ func (c *cmdSnapd) Execute(args []string) error {
 	prevRev, err := prevRevision("snapd")
 	switch err {
 	case errNoSnapd:
+		logger.Noticef("no snapd snap in the system")
 		// the snapd snap is not installed
 		return nil
 	case errNoPrevious:
-		// this is the first revision of snapd to be installed on the
-		// system, either a remodel or a plain snapd installation, call
-		// the snapd from the core snap
-		snapdPath = filepath.Join(dirs.SnapMountDir, "core", "current", "/usr/lib/snapd/snapd")
-		if !osutil.FileExists(snapdPath) {
-			// it is possible that the core snap is not installed at
-			// all, in which case we should try the snapd snap
-			snapdPath = filepath.Join(dirs.SnapMountDir, "snapd", "current", "/usr/lib/snapd/snapd")
+		logger.Noticef("no previous revision of snapd installed in the system")
+		// snapd is being installed for the first time, or there is simply a single
+		// revision of snapd in the system
+		snapdFromCurrentCorePath := filepath.Join(dirs.SnapMountDir, "core", "current", "/usr/lib/snapd/snapd")
+		snapdFromCurrentSnapdPath := filepath.Join(dirs.SnapMountDir, "snapd", "current", "/usr/lib/snapd/snapd")
+
+		if !release.OnClassic {
+			// on a Core system check whether it's a UC16 where we
+			// can fall back to snapd from the core snap, or a newer
+			// release where we should only consider the snapd snap
+			if release.ReleaseInfo.VersionID == "16" {
+				logger.Noticef("on Ubuntu Core system with the core snap")
+				snapdPath = snapdFromCurrentCorePath
+			} else {
+				logger.Noticef("on Ubuntu Core system with the snapd snap")
+				snapdPath = snapdFromCurrentSnapdPath
+			}
+		} else {
+			// on a classic system allow falling back to snapd from
+			// core if it is present
+			snapdPath = snapdFromCurrentCorePath
+			if !osutil.FileExists(snapdPath) {
+				snapdPath = snapdFromCurrentSnapdPath
+			}
 		}
 		prevRev = "0"
 	case nil:
+		logger.Noticef("found previous revision of snapd snap: %v", prevRev)
 		// the snapd snap was installed before, use the previous revision
 		snapdPath = filepath.Join(dirs.SnapMountDir, "snapd", prevRev, "/usr/lib/snapd/snapd")
 	default:

--- a/cmd/snap-failure/export_test.go
+++ b/cmd/snap-failure/export_test.go
@@ -19,7 +19,9 @@
 
 package main
 
-import "time"
+import (
+	"time"
+)
 
 var (
 	Run       = run

--- a/cmd/snap-failure/main_test.go
+++ b/cmd/snap-failure/main_test.go
@@ -68,7 +68,10 @@ func (r *failureSuite) SetUpTest(c *C) {
 
 	log, restore := logger.MockLogger()
 	r.log = log
-	r.AddCleanup(restore)
+	r.AddCleanup(func() {
+		c.Logf("logs:\n%s", log.String())
+		restore()
+	})
 
 	r.systemctlCmd = testutil.MockCommand(c, "systemctl", "")
 	r.AddCleanup(r.systemctlCmd.Restore)


### PR DESCRIPTION
When there is just one revision of snapd installed in the system, snap-failure
would always fall back to run snapd from core during recovery process if the
core snap is installed. However, on Ubuntu Core systems where the snapd snap is
present by default, such as UC18+, the fallback mechanism should only consider
calling binaries from the snapd snap. On classic, we still allow falling back to
the core snap binaries.

Related: SNAPDENG-22792