### PR TITLE
interfaces: allow reading memory.max by default

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -297,6 +297,7 @@ var templateCommon = `
   /sys/fs/cgroup/memory/{,user.slice/}memory.limit_in_bytes r,
   /sys/fs/cgroup/memory/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.limit_in_bytes r,
   /sys/fs/cgroup/memory/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.stat r,
+  /sys/fs/cgroup/system.slice/snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.max r,
   /sys/fs/cgroup/cpu,cpuacct/{,user.slice/}cpu.cfs_{period,quota}_us r,
   /sys/fs/cgroup/cpu,cpuacct/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/cpu.cfs_{period,quota}_us r,
   /sys/fs/cgroup/cpu,cpuacct/{,user.slice/}cpu.shares r,


### PR DESCRIPTION
A customer reported an AppArmor denial related to the jdk trying to read /sys/fs/cgroup/.../memory.max. At least on [OpenJDK](https://github.com/openjdk/jdk/blob/156f0b4332bf076165898417cf6678d2fc32df5c/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp#L220) that seems plausible and like something we might reasonably allow by default. The internal SF case is attached to this ticket SNAPDENG-26289