### PR TITLE
snapcraft.yaml: pack snap-bootstrap because of uc20

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -240,6 +240,10 @@ parts:
 
       CMDS=(bin/snap
             lib/snapd/snapd
+            # core-initrd for UC20 still depends on snap-bootstrap
+            # being started from snap because of broken re-execution
+            # and fixes that were not yet backported
+            lib/snapd/snap-bootstrap
             lib/snapd/snap-exec
             lib/snapd/snap-failure
             lib/snapd/snap-fde-keymgr
@@ -299,9 +303,8 @@ parts:
         if [ -f fips-build ]; then
           case "${cmd}" in
             # per snapd FIPS spec, FIPS build tags are only relevant for snapd,
-            # snap, snap-repair and snap-bootstrap (where snap-bootstrap isn't
-            # part of the snapd snap)
-            bin/snap|lib/snapd/snapd|lib/snapd/snap-repair)
+            # snap, snap-repair and snap-bootstrap
+            bin/snap|lib/snapd/snapd|lib/snapd/snap-repair|lib/snapd/snap-bootstrap)
               TAGS+=(goexperiment.opensslcrypto)
               ;;
           esac


### PR DESCRIPTION
core-initrd for UC20 is missing the following fixes:
 * https://github.com/snapcore/core-initrd/pull/64
 * https://github.com/snapcore/core-initrd/pull/70
 * https://github.com/snapcore/core-initrd/pull/97

Because of that, it still kills recovery-chooser-trigger from initrd, and expects it to re-run from snapd snap. Until those fixes are backported, we need to keep on building snap-bootstrap.

This is not needed by UC22+

Bug: https://bugs.launchpad.net/snapd/+bug/2075323
