### PR TITLE
cmd/snap: add debug command for investigating execution aspects of the snap toolchain

### DIFF
--- a/cmd/snap/cmd_debug_execution.go
+++ b/cmd/snap/cmd_debug_execution.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/snapdtool"
+)
+
+type cmdDebugExec struct {
+	Tool        string `long:"tool"`
+	Positionals struct {
+		What string `required:"yes" positional-arg-name:"<what>"`
+	} `positional-args:"true"`
+}
+
+func init() {
+	addDebugCommand("execution",
+		"Obtain information about execution aspects of snap toolchain commands",
+		`Display debugging information about aspects of snap toolchain execution, such
+as reexecution, tools location etc.`,
+		func() flags.Commander { return &cmdDebugExec{} },
+		map[string]string{
+			"tool": "Internal tool name",
+		}, []argDesc{{
+			name: "<what>",
+			desc: "What aspect, one of: snap, apparmor, internal-tool",
+		}})
+}
+
+func (x *cmdDebugExec) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	switch x.Positionals.What {
+	case "snap":
+		fmt.Fprintf(Stdout, "distro-supports-reexec: %v\n", snapdtool.DistroSupportsReExec())
+		fmt.Fprintf(Stdout, "is-reexec-enabled: %v\n", snapdtool.IsReexecEnabled())
+		fmt.Fprintf(Stdout, "is-reexec-explicitly-enabled: %v\n", snapdtool.IsReexecExplicitlyEnabled())
+
+		isReexecd, err := snapdtool.IsReexecd()
+		if err == nil {
+			fmt.Fprintf(Stdout, "is-reexecd: %v\n", isReexecd)
+		} else {
+			fmt.Fprintf(Stdout, "is-reexecd: error:%v\n", err)
+		}
+
+		exe, err := os.Readlink("/proc/self/exe")
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(Stdout, "self-exe: %v\n", exe)
+
+	case "apparmor":
+		cmd, internal, err := apparmor.AppArmorParser()
+		if err != nil {
+			fmt.Fprintf(Stdout, "apparmor-parser: error:%s\n", err.Error())
+			fmt.Fprint(Stdout, "internal: false\n")
+			return err
+		} else {
+			fmt.Fprintf(Stdout, "apparmor-parser: %s\n", cmd.Path)
+			fmt.Fprintf(Stdout, "internal: %v\n", internal)
+		}
+
+	case "internal-tool":
+		if x.Tool == "" {
+			return fmt.Errorf("tool name is missing")
+		}
+
+		tool, err := snapdtool.InternalToolPath(x.Tool)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(Stdout, "%s: %s\n", x.Tool, tool)
+	}
+	return nil
+}

--- a/cmd/snap/cmd_debug_execution.go
+++ b/cmd/snap/cmd_debug_execution.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/snapcore/snapd/sandbox/apparmor"
@@ -61,6 +62,7 @@ func (x *cmdDebugExecAppArmor) Execute(args []string) error {
 		return err
 	} else {
 		fmt.Fprintf(Stdout, "apparmor-parser: %s\n", cmd.Path)
+		fmt.Fprintf(Stdout, "apparmor-parser-command: %s\n", strings.Join(cmd.Args, " "))
 		fmt.Fprintf(Stdout, "internal: %v\n", internal)
 	}
 	return nil

--- a/cmd/snap/cmd_debug_execution.go
+++ b/cmd/snap/cmd_debug_execution.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -28,73 +29,84 @@ import (
 	"github.com/snapcore/snapd/snapdtool"
 )
 
-type cmdDebugExec struct {
-	Tool        string `long:"tool"`
-	Positionals struct {
-		What string `required:"yes" positional-arg-name:"<what>"`
-	} `positional-args:"true"`
-}
+type cmdDebugExec struct{}
 
 func init() {
-	addDebugCommand("execution",
+	cmd := addDebugCommand("execution",
 		"Obtain information about execution aspects of snap toolchain commands",
 		`Display debugging information about aspects of snap toolchain execution, such
 as reexecution, tools location etc.`,
 		func() flags.Commander { return &cmdDebugExec{} },
-		map[string]string{
-			"tool": "Internal tool name",
-		}, []argDesc{{
-			name: "<what>",
-			desc: "What aspect, one of: snap, apparmor, internal-tool",
-		}})
+		nil,
+		nil,
+	)
+	cmd.extra = func(c *flags.Command) {
+		c.AddCommand("apparmor", "Show apparmor", "", &cmdDebugExecAppArmor{})
+		c.AddCommand("snap", "Show snap execution info", "", &cmdDebugExecSnap{})
+		c.AddCommand("internal-tool", "Show internal tool execution info", "", &cmdDebugExecInternalTool{})
+	}
 }
 
 func (x *cmdDebugExec) Execute(args []string) error {
-	if len(args) > 0 {
-		return ErrExtraArgs
+	return flag.ErrHelp
+}
+
+type cmdDebugExecAppArmor struct{}
+
+func (x *cmdDebugExecAppArmor) Execute(args []string) error {
+	cmd, internal, err := apparmor.AppArmorParser()
+	if err != nil {
+		fmt.Fprintf(Stdout, "apparmor-parser: error:%s\n", err.Error())
+		fmt.Fprint(Stdout, "internal: false\n")
+		return err
+	} else {
+		fmt.Fprintf(Stdout, "apparmor-parser: %s\n", cmd.Path)
+		fmt.Fprintf(Stdout, "internal: %v\n", internal)
 	}
-	switch x.Positionals.What {
-	case "snap":
-		fmt.Fprintf(Stdout, "distro-supports-reexec: %v\n", snapdtool.DistroSupportsReExec())
-		fmt.Fprintf(Stdout, "is-reexec-enabled: %v\n", snapdtool.IsReexecEnabled())
-		fmt.Fprintf(Stdout, "is-reexec-explicitly-enabled: %v\n", snapdtool.IsReexecExplicitlyEnabled())
+	return nil
+}
 
-		isReexecd, err := snapdtool.IsReexecd()
-		if err == nil {
-			fmt.Fprintf(Stdout, "is-reexecd: %v\n", isReexecd)
-		} else {
-			fmt.Fprintf(Stdout, "is-reexecd: error:%v\n", err)
-		}
+type cmdDebugExecSnap struct{}
 
-		exe, err := os.Readlink("/proc/self/exe")
-		if err != nil {
-			return err
-		}
+func (x *cmdDebugExecSnap) Execute(args []string) error {
+	fmt.Fprintf(Stdout, "distro-supports-reexec: %v\n", snapdtool.DistroSupportsReExec())
+	fmt.Fprintf(Stdout, "is-reexec-enabled: %v\n", snapdtool.IsReexecEnabled())
+	fmt.Fprintf(Stdout, "is-reexec-explicitly-enabled: %v\n", snapdtool.IsReexecExplicitlyEnabled())
 
-		fmt.Fprintf(Stdout, "self-exe: %v\n", exe)
-
-	case "apparmor":
-		cmd, internal, err := apparmor.AppArmorParser()
-		if err != nil {
-			fmt.Fprintf(Stdout, "apparmor-parser: error:%s\n", err.Error())
-			fmt.Fprint(Stdout, "internal: false\n")
-			return err
-		} else {
-			fmt.Fprintf(Stdout, "apparmor-parser: %s\n", cmd.Path)
-			fmt.Fprintf(Stdout, "internal: %v\n", internal)
-		}
-
-	case "internal-tool":
-		if x.Tool == "" {
-			return fmt.Errorf("tool name is missing")
-		}
-
-		tool, err := snapdtool.InternalToolPath(x.Tool)
-		if err != nil {
-			return err
-		}
-
-		fmt.Fprintf(Stdout, "%s: %s\n", x.Tool, tool)
+	isReexecd, err := snapdtool.IsReexecd()
+	if err == nil {
+		fmt.Fprintf(Stdout, "is-reexecd: %v\n", isReexecd)
+	} else {
+		fmt.Fprintf(Stdout, "is-reexecd: error:%v\n", err)
 	}
+
+	exe, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, "self-exe: %v\n", exe)
+
+	return nil
+}
+
+type cmdDebugExecInternalTool struct {
+	Positionals struct {
+		Tool string `required:"yes" positional-arg-name:"<tool>" description:"internal tool name"`
+	} `positional-args:"true"`
+}
+
+func (x *cmdDebugExecInternalTool) Execute(args []string) error {
+	if x.Positionals.Tool == "" {
+		return fmt.Errorf("tool name is missing")
+	}
+
+	tool, err := snapdtool.InternalToolPath(x.Positionals.Tool)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, "%s: %s\n", x.Positionals.Tool, tool)
+
 	return nil
 }

--- a/snapdtool/tool_other.go
+++ b/snapdtool/tool_other.go
@@ -47,3 +47,26 @@ func InternalToolPath(tool string) (string, error) {
 func IsReexecd() (bool, error) {
 	return false, errUnsupported
 }
+
+// DistroSupportsReExec returns true if the distribution we are running on can use re-exec.
+//
+// On this OS this is a stub and always returns false.
+func DistroSupportsReExec() bool {
+	return false
+}
+
+// IsReexecEnabled checks the environment and configuration to assert whether
+// reexec has been explicitly enabled/disabled.
+//
+// On this OS this is a stub and always returns false.
+func IsReexecEnabled() bool {
+	return false
+}
+
+// IsReexecExplicitlyEnabled is a stronger check than IsReexecEnabled as it
+// really expects the relevant environment variable to be set.
+//
+// On this OS this is a stub and always returns false.
+func IsReexecExplicitlyEnabled() bool {
+	return false
+}

--- a/tests/main/debug-execution/task.yaml
+++ b/tests/main/debug-execution/task.yaml
@@ -16,7 +16,7 @@ execute: |
     (snap debug execution apparmor || true) > snap-apparmor-default.out
     (SNAP_REEXEC=0 snap debug execution apparmor || true) > snap-apparmor-no-reexec.out
 
-    snap debug execution internal-tool --tool snap-update-ns > snap-uns-default.out
+    snap debug execution internal-tool snap-update-ns > snap-uns-default.out
 
     case "$SPREAD_SYSTEM" in
         ubuntu-core-*)
@@ -64,6 +64,7 @@ execute: |
                 MATCH 'internal: false' < snap-apparmor-default.out
             else
                 MATCH 'apparmor-parser: /snap/snapd/.*/usr/lib/snapd/apparmor_parser' < snap-apparmor-default.out
+                MATCH 'apparmor-parser-command: /snap/snapd/.*/apparmor_parser --config-file /snap/snapd/.*/usr/lib/snapd/apparmor/parser.conf --base /snap/snapd/.*/usr/lib/snapd/apparmor\.d --policy-features /snap/snapd/.*/usr/lib/snapd/apparmor\.d/abi/4\.0' < snap-apparmor-default.out
                 MATCH 'internal: true' < snap-apparmor-default.out
             fi
             ;;

--- a/tests/main/debug-execution/task.yaml
+++ b/tests/main/debug-execution/task.yaml
@@ -1,0 +1,163 @@
+summary: Verify snap debug execution command
+
+details: |
+    This test checks that the command `snap debug execution` shows right
+    outputs, but also verifies their correctness on the target systems
+
+debug: |
+    grep -n '' snap-*.out || true
+
+execute: |
+    snap debug execution snap > snap-default.out
+    SNAP_REEXEC=0 snap debug execution snap > snap-no-reexec.out
+    SNAP_REEXEC=1 snap debug execution snap > snap-yes-reexec.out
+
+    # this may fail when apparmor isn't found at all
+    (snap debug execution apparmor || true) > snap-apparmor-default.out
+    (SNAP_REEXEC=0 snap debug execution apparmor || true) > snap-apparmor-no-reexec.out
+
+    snap debug execution internal-tool --tool snap-update-ns > snap-uns-default.out
+
+    case "$SPREAD_SYSTEM" in
+        ubuntu-core-*)
+            echo "Checking Ubuntu Core default scenario"
+            MATCH 'distro-supports-reexec: false' < snap-default.out
+            MATCH 'is-reexec-enabled: true' < snap-default.out
+            MATCH 'is-reexec-explicitly-enabled: false' < snap-default.out
+            if os.query is-core16; then
+                # snap is part of the core snap
+                MATCH 'is-reexecd: false' < snap-default.out
+                MATCH 'self-exe: /usr/bin/snap' < snap-default.out
+            else
+                # UC18+ with snapd snap
+                MATCH 'is-reexecd: true' < snap-default.out
+                MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-default.out
+            fi
+
+            echo "Checking Ubuntu Core with reexec scenario"
+            MATCH 'distro-supports-reexec: false' < snap-yes-reexec.out
+            MATCH 'is-reexec-enabled: true' < snap-yes-reexec.out
+            MATCH 'is-reexec-explicitly-enabled: true' < snap-yes-reexec.out
+            MATCH 'is-reexecd: true' < snap-yes-reexec.out
+            if os.query is-core16; then
+                MATCH 'self-exe: /snap/core/.*/usr/bin/snap' < snap-yes-reexec.out
+            else
+                MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-yes-reexec.out
+            fi
+
+            echo "Checking Ubuntu Core without reexec scenario"
+            MATCH 'distro-supports-reexec: false' < snap-no-reexec.out
+            MATCH 'is-reexec-explicitly-enabled: false' < snap-no-reexec.out
+            if os.query is-core16; then
+                MATCH 'is-reexec-enabled: false' < snap-no-reexec.out
+                MATCH 'is-reexecd: false' < snap-no-reexec.out
+                MATCH 'self-exe: /usr/bin/snap' < snap-no-reexec.out
+            else
+                MATCH 'is-reexec-enabled: true' < snap-no-reexec.out
+                MATCH 'is-reexecd: true' < snap-no-reexec.out
+                MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-no-reexec.out
+            fi
+
+            echo "Checking Ubuntu Core AppArmor"
+            if os.query is-core16; then
+                MATCH 'apparmor-parser: /sbin/apparmor_parser' < snap-apparmor-default.out
+                MATCH 'internal: false' < snap-apparmor-default.out
+            else
+                MATCH 'apparmor-parser: /snap/snapd/.*/usr/lib/snapd/apparmor_parser' < snap-apparmor-default.out
+                MATCH 'internal: true' < snap-apparmor-default.out
+            fi
+            ;;
+        ubuntu-*|debian-*)
+            echo "Checking default scenario"
+            MATCH 'distro-supports-reexec: true' < snap-default.out
+            MATCH 'is-reexec-enabled: true' < snap-default.out
+            MATCH 'is-reexec-explicitly-enabled: false' < snap-default.out
+            MATCH 'is-reexecd: true' < snap-default.out
+            # TODO: once snapd snap lands the output wlll be different:
+            # MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-default.out
+            MATCH 'self-exe: /snap/core/.*/usr/bin/snap' < snap-default.out
+
+            echo "Checking without reeexec scenario"
+            MATCH 'distro-supports-reexec: true' < snap-no-reexec.out
+            MATCH 'is-reexec-enabled: false' < snap-no-reexec.out
+            MATCH 'is-reexec-explicitly-enabled: false' < snap-no-reexec.out
+            MATCH 'is-reexecd: false' < snap-no-reexec.out
+            MATCH 'self-exe: /usr/bin/snap' < snap-no-reexec.out
+
+            echo "Checking AppArmor"
+            # TODO: once snapd snap lands, this will use internal parser
+            # MATCH 'apparmor-parser: /snap/snapd/.*/usr/lib/snapd/apparmor_parser' < snap-apparmor-default.out
+            # MATCH 'internal: true' < snap-apparmor-default.out
+            if os.query is-xenial || os.query is-bionic; then
+                # Ubuntu < 20.04 does not have usr-merge
+                MATCH 'apparmor-parser: /sbin/apparmor_parser' < snap-apparmor-default.out
+                MATCH 'internal: false' < snap-apparmor-default.out
+                MATCH 'apparmor-parser: /sbin/apparmor_parser' < snap-apparmor-no-reexec.out
+                MATCH 'internal: false' < snap-apparmor-no-reexec.out
+            else
+                MATCH 'apparmor-parser: /usr/sbin/apparmor_parser' < snap-apparmor-default.out
+                MATCH 'internal: false' < snap-apparmor-default.out
+                MATCH 'apparmor-parser: /usr/sbin/apparmor_parser' < snap-apparmor-no-reexec.out
+                MATCH 'internal: false' < snap-apparmor-no-reexec.out
+            fi
+
+            # TODO: once snapd snap lands, this will use snap-update-ns from
+            # snapd snap
+            MATCH 'snap-update-ns: /snap/core/.*/usr/lib/snapd/snap-update-ns' < snap-uns-default.out
+            ;;
+        *)
+            echo "Checking default scenario"
+            MATCH 'distro-supports-reexec: false' < snap-default.out
+            MATCH 'is-reexec-enabled: true' < snap-default.out
+            MATCH 'is-reexec-explicitly-enabled: false' < snap-default.out
+            MATCH 'is-reexecd: false' < snap-default.out
+            MATCH 'self-exe: /usr/bin/snap' < snap-default.out
+
+            echo "Checking with reexec scenario"
+            MATCH 'distro-supports-reexec: false' < snap-yes-reexec.out
+            MATCH 'is-reexec-enabled: true' < snap-yes-reexec.out
+            MATCH 'is-reexec-explicitly-enabled: true' < snap-yes-reexec.out
+            # actual outcome depends on whether there is a /snap ->
+            # /var/lib/snapd/snap symlink on systems where snaps are not mounted
+            # under /snap
+
+            # TODO: once snapd snap lands the output wlll be different:
+            # MATCH 'is-reexecd: false' < snap-yes-reexec.out
+            # MATCH 'self-exe: /snap/snapd/.*/usr/bin/snap' < snap-yes-reexec.out
+            case "$SPREAD_SYSTEM" in
+                arch-linux-*|fedora-*|centos-*)
+                    # no /snap -> /var/lib/snapd/snap symlink by default
+                    MATCH 'is-reexecd: false' < snap-yes-reexec.out
+                    MATCH 'self-exe: /usr/bin/snap' < snap-yes-reexec.out
+                    ;;
+                opensuse-*)
+                    # snap mount dir is /snap
+                    MATCH 'is-reexecd: true' < snap-yes-reexec.out
+                    MATCH 'self-exe: /snap/core/.*/usr/bin/snap' < snap-yes-reexec.out
+                    ;;
+                amazon-linux-*)
+                    # has /snap -> /var/lib/snapd symlink
+                    MATCH 'is-reexecd: true' < snap-yes-reexec.out
+                    MATCH 'self-exe: /var/lib/snapd/snap/core/.*/usr/bin/snap' < snap-yes-reexec.out
+                    ;;
+                *)
+                    echo "unexpected distro $SPREAD_SYSTEM"
+                    exit 1
+                    ;;
+            esac
+
+            echo "Checking AppArmor"
+            case "$SPREAD_SYSTEM" in
+                fedora-*|centos-*|amazon-linux-*)
+                    MATCH 'apparmor-parser: error:file does not exist' < snap-apparmor-default.out
+                    ;;
+                *)
+                    MATCH 'apparmor-parser: (/usr)?/sbin/apparmor_parser' < snap-apparmor-default.out
+                    ;;
+            esac
+            MATCH 'internal: false' < snap-apparmor-default.out
+
+            MATCH 'snap-update-ns: /usr/lib(exec)?/snapd/snap-update-ns' < snap-uns-default.out
+            ;;
+    esac
+


### PR DESCRIPTION
Add a debug command for investigating various execution aspects of snap related
commands.

Related: SNAPDENG-25499