### PR TITLE
tests: fix mix-revision-and-channel to use revisions independent of architecture

### DIFF
--- a/tests/main/mix-revision-and-channel/task.yaml
+++ b/tests/main/mix-revision-and-channel/task.yaml
@@ -9,20 +9,23 @@ restore: |
   snap remove test-snap-with-channel-and-revision
 
 execute: |
+  rev_stable="$(snap info test-snap-with-channel-and-revision | grep 'latest/stable' | awk '{ gsub("[()]", " "); print $4 }')"
+  rev_candidate="$(snap info test-snap-with-channel-and-revision | grep 'latest/candidate' | awk '{ gsub("[()]", " "); print $4 }')"
+
   # install a snap with a channel and revision from a channel that is missing
   # the revision, should fail
-  not snap install --channel=latest/stable --revision=2 test-snap-with-channel-and-revision
+  not snap install --channel=latest/stable --revision="${rev_candidate}" test-snap-with-channel-and-revision
 
   # install a snap with a channel and revision
-  snap install --channel=latest/stable --revision=1 test-snap-with-channel-and-revision
-  snap list test-snap-with-channel-and-revision | MATCH '1\s+latest/stable'
+  snap install --channel=latest/stable --revision="${rev_stable}" test-snap-with-channel-and-revision
+  snap list test-snap-with-channel-and-revision | MATCH "${rev_stable}\s+latest/stable"
 
   snap remove test-snap-with-channel-and-revision
 
   # revision 1 isn't the tip of candidate, but it was released to the channel,
   # so we should be able to install it
-  snap install --channel=latest/candidate --revision=1 test-snap-with-channel-and-revision
-  snap list test-snap-with-channel-and-revision | MATCH '1\s+latest/candidate'
+  snap install --channel=latest/candidate --revision="${rev_stable}" test-snap-with-channel-and-revision
+  snap list test-snap-with-channel-and-revision | MATCH "${rev_stable}\s+latest/candidate"
 
   snap refresh test-snap-with-channel-and-revision
-  snap list test-snap-with-channel-and-revision | MATCH '2\s+latest/candidate'
+  snap list test-snap-with-channel-and-revision | MATCH "${rev_candidate}\s+latest/candidate"


### PR DESCRIPTION
This was failing because arm didn't have revisions uploaded. This is fixed now, and this change will help with maintainability. Thanks, @sergiocazzolato!