### PR TITLE
interfaces: allow pcscd to read opensc.conf.

### DIFF
--- a/interfaces/builtin/pcscd.go
+++ b/interfaces/builtin/pcscd.go
@@ -33,6 +33,8 @@ const pcscdBaseDeclarationSlots = `
 const pcscdConnectedPlugAppArmor = `
 # Socket for communication between PCSCD and PS/SC API library
 /{var/,}run/pcscd/pcscd.comm rw,
+# Configuration file for OPENSC
+/etc/{opensc/,}opensc.conf r,
 `
 
 func init() {

--- a/interfaces/builtin/pcscd_test.go
+++ b/interfaces/builtin/pcscd_test.go
@@ -77,6 +77,7 @@ func (s *pcscdInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
 	c.Assert(spec.SnippetForTag("snap.other.app"), testutil.Contains, "/{var/,}run/pcscd/pcscd.comm rw")
+	c.Assert(spec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/{opensc/,}opensc.conf r")
 }
 
 func (s *pcscdInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
The Opensc-Pkcs11 module needs to read this configuration file. https://bugs.launchpad.net/ubuntu/+source/firefox/+bug/1967632/comments/74.

As Debian has a patch that changes /etc/opensc.conf->/etc/opensc/opensc.conf, I'm keeping the two paths in the proposal.

