### PR TITLE
cmd/snap-confine: improve compatibility with nvidia drivers

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -226,7 +226,16 @@ parts:
       cd "${CRAFT_PART_BUILD}/cmd"
 
       autoreconf -fvi
-      ./configure --prefix=/usr --libexec=/usr/lib/snapd --without-unit-tests --enable-static-libapparmor --disable-host-binaries
+      ./configure \
+        --prefix=/usr \
+        --libexec=/usr/lib/snapd \
+        --without-unit-tests \
+        --enable-static-libapparmor \
+        --disable-host-binaries \
+        --enable-nvidia-multiarch \
+        --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+        $(test "$(uname -m)" = x86_64 && echo --with-host-arch-32bit-triplet=$(dpkg-architecture -ai386 -qDEB_HOST_MULTIARCH))
+
       make -j"${CRAFT_PARALLEL_BUILD_COUNT}"
       make DESTDIR="${CRAFT_PART_INSTALL}" install
 

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -78,6 +78,20 @@ static const size_t egl_vendor_globs_len =
 // FIXME: this doesn't yet work with libGLX and libglvnd redirector
 // FIXME: this still doesn't work with the 361 driver
 static const char *nvidia_globs[] = {
+	"gbm/nvidia-drm_gbm.so*",
+	"libnvidia-allocator.so*",
+	"libnvidia-api.so*",
+	"libnvidia-cbl.so*",
+	"libnvidia-cfg.so*",
+	"libnvidia-compiler-next.so*",
+	"libnvidia-egl-gbm.so*",
+	"libnvidia-ngx.so*",
+	"libnvidia-nscq.so*",
+	"libnvidia-nvvm.so*",
+	"libnvidia-pkcs11-openssl3.so*",
+	"libnvidia-pkcs11.so*",
+	"libnvidia-vulkan-producer.so*",
+
 	"libEGL_nvidia.so*",
 	"libGLESv1_CM_nvidia.so*",
 	"libGLESv2_nvidia.so*",

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -61,6 +61,8 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}vdpau/libvdpau_nvidia.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnv{rm,dc,imp,os}*.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}gbm/nvidia-drm_gbm.so{,.*} rm,
+
 # CUDA libs
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnpp{c,ig,ial,icc,idei,ist,if,im,itc}*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcublas{,Lt}*.so{,.*} rm,


### PR DESCRIPTION
There are two small fixes related to driver bitrot and a somewhat shocking omission from our snapd snap build configuration. This was tested on Ubuntu 24.10 with RTX 2080 in an eGPU and the result was dramatically better support for using steam snap.

Co-Authored-With: Maciej Borzecki <maciej.borzecki@canonical.com>