### PR TITLE
t/n/m/uc-update-assets-secure: sign new grub also with old key [backport]

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -415,10 +415,24 @@ nested_secboot_remove_signature() {
 }
 
 nested_secboot_sign_file() {
-    local FILE="$1"
-    local KEY="$2"
-    local CERT="$3"
-    nested_secboot_remove_signature "$FILE"
+    local keep_signatures
+    args=()
+    while [ "${#}" -gt 0 ]; do
+        case "${1}" in
+            --keep-signatures)
+                keep_signatures=1
+                ;;
+            *)
+                args+=("${1}")
+        esac
+        shift
+    done
+    local FILE="${args[0]}"
+    local KEY="${args[1]}"
+    local CERT="${args[2]}"
+    if [ "${keep_signatures+set}" != set ]; then
+        nested_secboot_remove_signature "$FILE"
+    fi
     sbsign --key "$KEY" --cert "$CERT" --output "$FILE" "$FILE"
 }
 

--- a/tests/nested/manual/uc-update-assets-secure/task.yaml
+++ b/tests/nested/manual/uc-update-assets-secure/task.yaml
@@ -30,36 +30,52 @@ prepare: |
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
 
-  # Save the shim before resigning
-  cp pc/shim.efi.signed shim.efi.signed
+  # Remove signatures
+  cp pc/shim.efi.signed shim.efi
+  tests.nested secboot-remove-signature shim.efi
 
-  # Repack pc gadget for the initial image
-  tests.nested secboot-sign file pc/shim.efi.signed "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-  tests.nested secboot-sign file pc/grubx64.efi "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  # Use a new key to sign grub instead of snakeoil key
+  openssl req -new -x509 -newkey rsa:2048 -subj "/CN=old vendor certificate/" -keyout old-cert.key -out old-cert.crt -days 3650 -nodes -sha256
+  openssl x509 -outform der -in old-cert.crt -out old-cert
+  python3 generate_vendor_cert_section.py old-section old-cert
+  objcopy --update-section .vendor_cert=old-section shim.efi shim.efi.old
+
+  cp shim.efi.old pc/shim.efi.signed
+
+  tests.nested secboot-sign file pc/shim.efi.signed "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  tests.nested secboot-sign file pc/grubx64.efi "old-cert.key" "old-cert.crt"
+
   old_shim_sha="$(sha256sum pc/shim.efi.signed | sed "s/ .*//")"
   old_grub_sha="$(sha256sum pc/grubx64.efi | sed "s/ .*//")"
-  snap pack pc "$(tests.nested get extra-snaps-path)"
 
-  # Remove signatures
-  cp shim.efi.signed shim.efi
-  tests.nested secboot-remove-signature shim.efi
+  # This is the the gadget for the initial image
+  snap pack pc "$(tests.nested get extra-snaps-path)"
 
   # Add a different vendor certificate
   openssl req -new -x509 -newkey rsa:2048 -subj "/CN=new vendor certificate/" -keyout new-cert.key -out new-cert.crt -days 3650 -nodes -sha256
   openssl x509 -outform der -in new-cert.crt -out new-cert
-  python3 generate_vendor_cert_section.py new-section new-cert
-  objcopy --update-section .vendor_cert=new-section shim.efi shim.efi.out
 
-  # Sign modified shim
-  cp shim.efi.out pc/shim.efi.signed
+  # When we do not update the boot, but we do update the seed, then we
+  # should not expect a new key, because the old shim would not be
+  # able to boot the new grub. So in that case we keep the old shim
+  # (though the new grub will be installed in the seed).
+  if [ "${UPDATE_BOOT}" != true ] && [ "${UPDATE_SEED}" = true ]; then
+    cp shim.efi.old pc/shim.efi.signed
+  else
+    python3 generate_vendor_cert_section.py new-section new-cert
+    objcopy --update-section .vendor_cert=new-section shim.efi shim.efi.new
+    cp shim.efi.new pc/shim.efi.signed
+  fi
+
   tests.nested secboot-sign file pc/shim.efi.signed "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  # Even if we install a new seed, the grub has to be signed with the
+  # key so that we do not break on a reset in the middle of the upate.
+  # (old shim must always be able to boot the new grub).
+  tests.nested secboot-sign file pc/grubx64.efi "old-cert.key" "old-cert.crt"
 
   if [ "${UPDATE_SEED}" = true ]; then
-    # Resign grub with new vendor key
-    tests.nested secboot-sign file pc/grubx64.efi "new-cert.key" "new-cert.crt"
-  else
-    # If shim is not installed in seed, then we need to keep the snakeoil signature
-    tests.nested secboot-sign file pc/grubx64.efi "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+    # Resign grub with new vendor key. But we keep the signature with the old one.
+    tests.nested secboot-sign file --keep-signatures pc/grubx64.efi "new-cert.key" "new-cert.crt"
   fi
 
   new_shim_sha="$(sha256sum pc/shim.efi.signed | sed "s/ .*//")"

--- a/tests/nested/manual/uc-update-assets-secure/task.yaml
+++ b/tests/nested/manual/uc-update-assets-secure/task.yaml
@@ -34,6 +34,11 @@ prepare: |
   cp pc/shim.efi.signed shim.efi
   tests.nested secboot-remove-signature shim.efi
 
+  if os.query is-ubuntu-ge 24.04; then
+     tests.nested secboot-remove-signature pc/fb.efi
+     tests.nested secboot-sign file pc/fb.efi "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  fi
+
   # Use a new key to sign grub instead of snakeoil key
   openssl req -new -x509 -newkey rsa:2048 -subj "/CN=old vendor certificate/" -keyout old-cert.key -out old-cert.crt -days 3650 -nodes -sha256
   openssl x509 -outform der -in old-cert.crt -out old-cert


### PR DESCRIPTION
Backport of https://github.com/canonical/snapd/pull/14252 from fde manager branch.

Plus a fix for uc24 to re-sign the fallback binary correctly.