### PR TITLE
interfaces: add intel-qat interface

### DIFF
--- a/interfaces/builtin/intel_qat.go
+++ b/interfaces/builtin/intel_qat.go
@@ -21,6 +21,10 @@ package builtin
 
 const intelQatSummary = `allows access to Intel QuickAssist Technology (QAT)`
 
+// Support for Intel QAT, see:
+// - kernel support: https://elixir.bootlin.com/linux/v6.10.3/source/drivers/crypto/intel/qat
+// - userspace manager: https://github.com/intel/qatlib
+
 const intelQatBaseDeclarationSlots = `
   intel-qat:
     allow-installation:
@@ -51,6 +55,10 @@ const intelQatConnectedPlugAppArmor = `
 
 # QAT Manager Unix socket used for inter-process communication
 # between qatmgr and applications (e.g. libqat)
+#
+# For reference:
+# https://github.com/intel/qatlib/blob/6117838/quickassist/lookaside/access_layer/src/qat_direct/vfio/qat_mgr.h#L59
+#
 /run/qat/qatmgr.sock rw,
 `
 

--- a/interfaces/builtin/intel_qat.go
+++ b/interfaces/builtin/intel_qat.go
@@ -46,7 +46,8 @@ const intelQatConnectedPlugAppArmor = `
 
 # IOMMU group information needed by VFIO.
 /sys/kernel/iommu_groups/{,**} r,
-/sys/devices/pci*/**/device r,
+/sys/devices/pci*/**/{device,vendor} r,
+/sys/bus/pci/drivers/4xxx/{,**} r,
 
 # Acceleration driver framework
 # Character device providing a number of ioctls for

--- a/interfaces/builtin/intel_qat.go
+++ b/interfaces/builtin/intel_qat.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const intelQatSummary = `allows access to Intel QuickAssist Technology (QAT)`
+
+const intelQatBaseDeclarationSlots = `
+  intel-qat:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const intelQatConnectedPlugAppArmor = `
+# Description: Provide permissions for accessing VFIO, IOMMU, and QAT_ADF_CTL node
+
+# Access to VFIO group character devices such as /dev/vfio/<group>
+# where <group> is the group number. Also provides access to /dev/vfio/vfio,
+# which is a character device exposing a container class for IOMMU groups.
+#
+# https://docs.kernel.org/driver-api/vfio.html
+#
+/dev/vfio/* rw,
+
+# IOMMU group information needed by VFIO.
+/sys/kernel/iommu_groups/{,**} r,
+/sys/devices/pci*/**/device r,
+
+# Acceleration driver framework
+# Character device providing a number of ioctls for
+# configuring, resetting, and managing QAT devices.
+/dev/qat_adf_ctl rw,
+
+# QAT Manager Unix socket used for inter-process communication
+# between qatmgr and applications (e.g. libqat)
+/run/qat/qatmgr.sock rw,
+`
+
+var intelQatConnectedPlugUDev = []string{
+	`SUBSYSTEM=="vfio", KERNEL=="*"`,
+	`SUBSYSTEM=="misc", KERNEL=="vfio"`,
+	`SUBSYSTEM=="qat_adf_ctl", KERNEL=="qat_adf_ctl"`,
+}
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "intel-qat",
+		summary:               intelQatSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  intelQatBaseDeclarationSlots,
+		connectedPlugAppArmor: intelQatConnectedPlugAppArmor,
+		connectedPlugUDev:     intelQatConnectedPlugUDev,
+	})
+}

--- a/interfaces/builtin/intel_qat_test.go
+++ b/interfaces/builtin/intel_qat_test.go
@@ -1,0 +1,146 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type intelQatSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+const intelQatMockPlugSnapInfoYaml = `name: qat
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [intel-qat]
+`
+
+const intelQatCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  intel-qat:
+`
+
+var _ = Suite(&intelQatSuite{
+	iface: builtin.MustInterface("intel-qat"),
+})
+
+func (s *intelQatSuite) SetUpTest(c *C) {
+	s.slot, s.slotInfo = MockConnectedSlot(c, intelQatCoreYaml, nil, "intel-qat")
+	s.plug, s.plugInfo = MockConnectedPlug(c, intelQatMockPlugSnapInfoYaml, nil, "intel-qat")
+}
+
+func (s *intelQatSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "intel-qat")
+}
+
+func (s *intelQatSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
+
+	// connected plugs have a nil security snippet for seccomp
+	appSet, err = interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	seccompSpec := seccomp.NewSpecification(appSet)
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.Snippets(), HasLen, 0)
+}
+
+func (s *intelQatSuite) TestConnectedPlugSnippet(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.qat.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/dev/vfio/* rw,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/sys/kernel/iommu_groups/{,**} r,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/sys/devices/pci*/**/device r,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/dev/qat_adf_ctl rw,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/run/qat/qatmgr.sock rw,\n")
+
+	appSet, err = interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	seccompSpec := seccomp.NewSpecification(appSet)
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string(nil))
+}
+
+func (s *intelQatSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *intelQatSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *intelQatSuite) TestUDevConnectedPlug(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := udev.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 4)
+	c.Assert(spec.Snippets(), testutil.Contains, `# intel-qat
+SUBSYSTEM=="vfio", KERNEL=="*", TAG+="snap_qat_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# intel-qat
+SUBSYSTEM=="misc", KERNEL=="vfio", TAG+="snap_qat_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# intel-qat
+SUBSYSTEM=="qat_adf_ctl", KERNEL=="qat_adf_ctl", TAG+="snap_qat_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
+		`TAG=="snap_qat_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_qat_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *intelQatSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to Intel QuickAssist Technology (QAT)`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *intelQatSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/intel_qat_test.go
+++ b/interfaces/builtin/intel_qat_test.go
@@ -97,7 +97,8 @@ func (s *intelQatSuite) TestConnectedPlugSnippet(c *C) {
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.qat.app"})
 	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/dev/vfio/* rw,\n")
 	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/sys/kernel/iommu_groups/{,**} r,\n")
-	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/sys/devices/pci*/**/device r,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/sys/devices/pci*/**/{device,vendor} r,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/sys/bus/pci/drivers/4xxx/{,**} r,\n")
 	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/dev/qat_adf_ctl rw,\n")
 	c.Assert(apparmorSpec.SnippetForTag("snap.qat.app"), testutil.Contains, "/run/qat/qatmgr.sock rw,\n")
 

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -83,6 +83,9 @@ apps:
   intel-mei:
     command: bin/run
     plugs: [ intel-mei ]
+  intel-qat:
+    command: bin/run
+    plugs: [ intel-qat ]
   io-ports-control:
     command: bin/run
     plugs: [ io-ports-control ]


### PR DESCRIPTION
This adds an interface for Intel QuickAssist Technology (QAT) devices. There are at least a few snapped applications maintained by Canonical (MicroCeph, OpenSearch) that require this interface, and integration and benchmarking efforts with QAT are ongoing this cycle (for now, the snaps are being run in dev mode). 

In addition to the tests included in this PR, I have also tested with a [simple openssl snap](https://github.com/canonical/intel-quickassist-technology) on a server containing QAT devices.

I have also created a spec (`PE-PEK020`) that I would welcome your review on!
