### PR TITLE
snap: allow kernel-modules components only in kernel snaps

### DIFF
--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -149,14 +149,18 @@ func createTestSnapInfoForComponent(c *C, snapName string, snapRev snap.Revision
 	return createTestSnapInfoForComponentWithType(c, snapName, snapRev, compName, "test")
 }
 
-func createTestSnapInfoForComponentWithType(c *C, snapName string, snapRev snap.Revision, compName, typ string) *snap.Info {
+func createTestSnapInfoForComponentWithType(c *C, snapName string, snapRev snap.Revision, compName, compType string) *snap.Info {
+	snapType := "app"
+	if compType == "kernel-modules" {
+		snapType = "kernel"
+	}
 	snapYaml := fmt.Sprintf(`name: %s
-type: app
+type: %s
 version: 1.1
 components:
   %s:
     type: %s
-`, snapName, compName, typ)
+`, snapName, snapType, compName, compType)
 	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 	info.SideInfo = snap.SideInfo{RealName: snapName, Revision: snapRev}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6712,7 +6712,7 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyInstanceRunThrough(c
 	const (
 		undo        = false
 		snapName    = "test-snap"
-		instanceKey = "key"
+		instanceKey = ""
 		removePaths = false
 	)
 	s.testInstallComponentsFromPathRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo, removePaths)
@@ -6721,8 +6721,8 @@ func (s *snapmgrTestSuite) TestInstallComponentsFromPathManyInstanceRunThrough(c
 func (s *snapmgrTestSuite) TestInstallComponentsFromPathInstanceRunThroughUndo(c *C) {
 	const (
 		undo        = true
-		snapName    = "test-snap"
-		instanceKey = "key"
+		snapName    = "some-kernel"
+		instanceKey = ""
 		removePaths = false
 	)
 	s.testInstallComponentsFromPathRunThrough(c, snapName, instanceKey, []string{"test-component", "kernel-modules-component"}, undo, removePaths)
@@ -6793,6 +6793,7 @@ version: 1.0
 
 	snapPath := makeTestSnap(c, `name: test-snap
 version: 1.0
+type: kernel
 components:
   test-component:
     type: test
@@ -6870,6 +6871,10 @@ components:
 	}
 
 	expected = append(expected, []fakeOp{{
+		op:    "update-gadget-assets:Doing",
+		name:  instanceName,
+		revno: snapRevision,
+	}, {
 		op:   "copy-data",
 		path: filepath.Join(dirs.SnapMountDir, filepath.Join(instanceName, snapRevision.String())),
 		old:  "<no-old>",

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -227,6 +228,7 @@ func (s *TargetTestSuite) TestInstallWithComponentsFromPath(c *C) {
 		compName = "test-component"
 		snapYaml = `name: some-snap
 version: 1.0
+type: kernel
 components:
   test-component:
     type: test
@@ -262,8 +264,9 @@ version: 1.0
 
 	c.Check(info.InstanceName(), Equals, snapName)
 	c.Check(info.Components[compName].Name, Equals, compName)
+	release.OnClassic = false
 
-	verifyInstallTasksWithComponents(c, snap.TypeApp, localSnap, 0, []string{compName}, ts)
+	verifyInstallTasksWithComponents(c, snap.TypeKernel, localSnap, 0, []string{compName}, ts)
 }
 
 func (s *TargetTestSuite) TestUpdateSnapNotInstalled(c *C) {

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -489,7 +489,7 @@ components:
 
 func (s *componentSuite) TestReadComponentInfoInconsistentTypes(c *C) {
 	const componentYaml = `component: snap+component
-type: test
+type: kernel-modules
 version: 1.0
 summary: short description
 description: long description
@@ -504,14 +504,27 @@ description: long description
 name: snap
 components:
   component:
-    type: kernel-modules
+    type: test
 `
 
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadComponentInfoFromContainer(compf, snapInfo, nil)
-	c.Assert(err, ErrorMatches, `inconsistent component type \("kernel-modules" in snap, "test" in component\)`)
+	c.Assert(err, ErrorMatches, `inconsistent component type \("test" in snap, "kernel-modules" in component\)`)
+}
+
+func (s *componentSuite) TestReadComponentInfoKernelModulesInNonKernelSnap(c *C) {
+	const snapYaml = `
+name: snap
+components:
+  component:
+    type: kernel-modules
+`
+
+	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
+	c.Assert(snapInfo, IsNil)
+	c.Assert(err, ErrorMatches, "kernel-modules components can exist only for kernel snaps")
 }
 
 func (s *componentSuite) TestHooksForPlug(c *C) {

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -318,7 +318,26 @@ func setComponentsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) erro
 		snap.Components = make(map[string]*Component, len(y.Components))
 	}
 
+	// Some componen types are valid only for some snap types,
+	// check this with this table. If the component type is not in
+	// the table it is valid for any snap type.
+	compToValidSnapType := map[ComponentType][]Type{
+		KernelModulesComponent: {TypeKernel},
+	}
 	for name, data := range y.Components {
+		if validTypes, ok := compToValidSnapType[data.Type]; ok {
+			isValid := false
+			for _, tp := range validTypes {
+				if tp == snap.Type() {
+					isValid = true
+					break
+				}
+			}
+			if !isValid {
+				return fmt.Errorf("%s components can exist only for %s snaps",
+					KernelModulesComponent, TypeKernel)
+			}
+		}
 		component := Component{
 			Name:        name,
 			Type:        data.Type,

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -84,7 +84,7 @@ const (
         "size": 20000021,
         "url": "https://api.snapcraft.io/api/v1/snaps/download/ABCEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
       },
-      "type": "component/kernel-modules",
+      "type": "component/test",
       "name": "some-component",
       "revision": 1,
       "version": "1.0",
@@ -171,7 +171,7 @@ const (
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\ncomponents:\n  some-component:\n    type: kernel-modules\n    name: some-component\n    description: Some component\n    summary: Component summary\n    hooks:\n      install:",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\ncomponents:\n  some-component:\n    type: test\n    name: some-component\n    description: Some component\n    summary: Component summary\n    hooks:\n      install:",
   "store-url": "https://snapcraft.io/thingy",
   "summary": "useful thingy",
   "title": "This Is The Most Fantastical Snap of Thingy",
@@ -190,7 +190,7 @@ const (
           "size": 20000021,
           "url": "https://api.snapcraft.io/api/v1/snaps/download/ABCEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap"
       },
-      "type": "component/kernel-modules",
+      "type": "component/test",
       "name": "some-component",
       "revision": 1,
       "version": "1.0",
@@ -269,7 +269,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimpleAndLegacy(c *C) {
 		Components: map[string]*snap.Component{
 			"some-component": {
 				Name:        "some-component",
-				Type:        snap.KernelModulesComponent,
+				Type:        snap.TestComponent,
 				Description: "Some component",
 			},
 		},
@@ -396,7 +396,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 
 	c.Check(someComponent, DeepEquals, snap.Component{
 		Name:        "some-component",
-		Type:        snap.KernelModulesComponent,
+		Type:        snap.TestComponent,
 		Description: "Some component",
 		Summary:     "Component summary",
 	})
@@ -520,7 +520,7 @@ func fillStruct(a interface{}, c *C) {
 			}
 		case []storeResource:
 			x = []storeResource{{
-				Type: "component/kernel-modules",
+				Type: "component/test",
 				Download: storeDownload{
 					URL:      "http://example.com/resource",
 					Size:     42,


### PR DESCRIPTION
With this change, "snap pack" and "snap install" will fail if the target snap defines kernel-modules components and it is not of type kernel.

Thanks to @andrewphelpsj for noticing.