### PR TITLE
wrappers: update desktop helpers to support desktop IDs

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9125,11 +9125,15 @@ Name=test
 Exec=test-snap
 `[1:]), 0o644), IsNil)
 
+	var mockOldDesktopFile = []byte(`
+[Desktop Entry]
+Name=old-content
+X-SnapInstanceName=test-snap`)
 	desktopFile := filepath.Join(dirs.SnapDesktopFilesDir, "test-snap_test-snap.desktop")
 	otherDesktopFile := filepath.Join(dirs.SnapDesktopFilesDir, "test-snap_other.desktop")
 	c.Assert(os.MkdirAll(dirs.SnapDesktopFilesDir, 0o755), IsNil)
-	c.Assert(os.WriteFile(desktopFile, []byte("old content"), 0o644), IsNil)
-	c.Assert(os.WriteFile(otherDesktopFile, []byte("other old content"), 0o644), IsNil)
+	c.Assert(os.WriteFile(desktopFile, mockOldDesktopFile, 0o644), IsNil)
+	c.Assert(os.WriteFile(otherDesktopFile, mockOldDesktopFile, 0o644), IsNil)
 
 	err := s.snapmgr.Ensure()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
`{Ensure,Remove}SnapDesktopFiles` are updated to support desktop file IDs.

Snaps are allowed to have their desktop files copied without name mangling (snap name prefix) if the file name is listed under `desktop-file-ids` attribute in their `desktop` interface declartion.

This is needed to support desktop IDs detailed in [SD170](https://docs.google.com/document/d/1j4flP303OJKrSxSCjkeZkh-9COuahVmo_EK_ye09RxQ/edit#heading=h.v7nluroo4fyr) spec.
