### PR TITLE
overload/fdestate/backend: implement FDE hook resealing

### DIFF
--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -2136,7 +2136,7 @@ func (s *sealSuite) TestWithBootChains(c *C) {
 	err = boot.WithBootChains(func(ch *boot.ResealKeyForBootChainsParams) error {
 		chains = ch
 		return nil
-	})
+	}, device.SealingMethodTPM)
 	c.Assert(err, IsNil)
 
 	c.Check(chains, DeepEquals, &boot.ResealKeyForBootChainsParams{

--- a/overlord/fdestate/backend/export_test.go
+++ b/overlord/fdestate/backend/export_test.go
@@ -19,10 +19,22 @@
 
 package backend
 
+import (
+	"github.com/snapcore/snapd/secboot"
+)
+
 func MockSecbootReleasePCRResourceHandles(f func(handles ...uint32) error) (restore func()) {
 	old := secbootReleasePCRResourceHandles
 	secbootReleasePCRResourceHandles = f
 	return func() {
 		secbootReleasePCRResourceHandles = old
+	}
+}
+
+func MockSecbootResealKeysWithFDESetupHook(f func(keyFiles []string, primaryKeyFile string, models []secboot.ModelForSealing) error) (restore func()) {
+	old := secbootResealKeysWithFDESetupHook
+	secbootResealKeysWithFDESetupHook = f
+	return func() {
+		secbootResealKeysWithFDESetupHook = old
 	}
 }

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -21,6 +21,8 @@
 package secboot
 
 import (
+	"io"
+
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
 	sb_efi "github.com/snapcore/secboot/efi"
@@ -347,5 +349,13 @@ func MockNewLUKS2KeyDataWriter(f func(devicePath string, name string) (KeyDataWr
 	newLUKS2KeyDataWriter = f
 	return func() {
 		newLUKS2KeyDataWriter = old
+	}
+}
+
+func MockSetAuthorizedSnapModelsOnHooksKeydata(f func(kd *sb_hooks.KeyData, rand io.Reader, key sb.PrimaryKey, models ...sb.SnapModel) error) (restore func()) {
+	old := setAuthorizedSnapModelsOnHooksKeydata
+	setAuthorizedSnapModelsOnHooksKeydata = f
+	return func() {
+		setAuthorizedSnapModelsOnHooksKeydata = old
 	}
 }

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -98,3 +98,7 @@ func GetPrimaryKeyHMAC(devicePath string, alg crypto.Hash) ([]byte, []byte, erro
 func VerifyPrimaryKeyHMAC(devicePath string, alg crypto.Hash, salt []byte, digest []byte) (bool, error) {
 	return false, errBuildWithoutSecboot
 }
+
+func ResealKeysWithFDESetupHook(keyFiles []string, primaryKeyFile string, models []ModelForSealing) error {
+	return errBuildWithoutSecboot
+}

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -20,6 +20,7 @@
 package store
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -68,6 +69,8 @@ type Store struct {
 	fallback       *store.Store
 
 	srv *http.Server
+
+	channelRepository *ChannelRepository
 }
 
 // NewStore creates a new store server serving snaps from the given top directory and assertions from topDir/asserts. If assertFallback is true missing assertions are looked up in the main online store.
@@ -90,6 +93,9 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 			Addr:    addr,
 			Handler: mux,
 		},
+		channelRepository: &ChannelRepository{
+			rootDir: filepath.Join(topDir, "channels"),
+		},
 	}
 
 	mux.HandleFunc("/", rootEndpoint)
@@ -97,6 +103,10 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	mux.HandleFunc("/api/v1/snaps/details/", store.detailsEndpoint)
 	mux.HandleFunc("/api/v1/snaps/metadata", store.bulkEndpoint)
 	mux.Handle("/download/", http.StripPrefix("/download/", http.FileServer(http.Dir(topDir))))
+
+	mux.HandleFunc("/api/v1/snaps/auth/nonces", store.nonceEndpoint)
+	mux.HandleFunc("/api/v1/snaps/auth/sessions", store.sessionEndpoint)
+
 	// v2
 	mux.HandleFunc("/v2/assertions/", store.assertionsEndpoint)
 	mux.HandleFunc("/v2/snaps/refresh", store.snapActionEndpoint)
@@ -109,6 +119,14 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 // URL returns the base-url that the store is listening on
 func (s *Store) URL() string {
 	return s.url
+}
+
+func (s *Store) RealURL(req *http.Request) string {
+	if req.Host == "" {
+		return s.url
+	} else {
+		return fmt.Sprintf("http://%s", req.Host)
+	}
 }
 
 func (s *Store) SnapsDir() string {
@@ -181,7 +199,7 @@ type essentialInfo struct {
 
 var errInfo = errors.New("cannot get info")
 
-func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Backstore) (*essentialInfo, error) {
+func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Backstore, cs *ChannelRepository) (*essentialInfo, error) {
 	f, err := snapfile.Open(fn)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot read: %v: %v", fn, err), 400)
@@ -360,7 +378,7 @@ func (s *Store) detailsEndpoint(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	essInfo, err := snapEssentialInfo(w, fn, "", bs)
+	essInfo, err := snapEssentialInfo(w, fn, "", bs, s.channelRepository)
 	if essInfo == nil {
 		if err != errInfo {
 			panic(err)
@@ -374,8 +392,8 @@ func (s *Store) detailsEndpoint(w http.ResponseWriter, req *http.Request) {
 		PackageName:     essInfo.Name,
 		Developer:       essInfo.DevelName,
 		DeveloperID:     essInfo.DeveloperID,
-		AnonDownloadURL: fmt.Sprintf("%s/download/%s", s.URL(), filepath.Base(fn)),
-		DownloadURL:     fmt.Sprintf("%s/download/%s", s.URL(), filepath.Base(fn)),
+		AnonDownloadURL: fmt.Sprintf("%s/download/%s", s.RealURL(req), filepath.Base(fn)),
+		DownloadURL:     fmt.Sprintf("%s/download/%s", s.RealURL(req), filepath.Base(fn)),
 		Version:         essInfo.Version,
 		Revision:        essInfo.Revision,
 		DownloadDigest:  hexify(essInfo.Digest),
@@ -417,6 +435,19 @@ func (s *Store) collectSnaps() (map[string]string, error) {
 		// TODO: Prefer newer file for the same snap instead of blindly
 		// overwriting
 		snaps[info.SnapName()] = fn
+
+		digest, _, err := asserts.SnapFileSHA3_384(fn)
+		if err != nil {
+			return nil, err
+		}
+		channels, err := s.channelRepository.findSnapChannels(digest)
+		if err != nil {
+			return nil, err
+		}
+		for _, channel := range channels {
+			snaps[fmt.Sprintf("%s|%s", info.SnapName(), channel)] = fn
+		}
+
 		logger.Debugf("found snap %q at %v", info.SnapName(), fn)
 	}
 
@@ -501,7 +532,7 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 		}
 
 		if fn, ok := snaps[name]; ok {
-			essInfo, err := snapEssentialInfo(w, fn, pkg.SnapID, bs)
+			essInfo, err := snapEssentialInfo(w, fn, pkg.SnapID, bs, s.channelRepository)
 			if essInfo == nil {
 				if err != errInfo {
 					panic(err)
@@ -515,8 +546,8 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 				PackageName:     essInfo.Name,
 				Developer:       essInfo.DevelName,
 				DeveloperID:     essInfo.DeveloperID,
-				DownloadURL:     fmt.Sprintf("%s/download/%s", s.URL(), filepath.Base(fn)),
-				AnonDownloadURL: fmt.Sprintf("%s/download/%s", s.URL(), filepath.Base(fn)),
+				DownloadURL:     fmt.Sprintf("%s/download/%s", s.RealURL(req), filepath.Base(fn)),
+				AnonDownloadURL: fmt.Sprintf("%s/download/%s", s.RealURL(req), filepath.Base(fn)),
 				Version:         essInfo.Version,
 				Revision:        essInfo.Revision,
 				DownloadDigest:  hexify(essInfo.Digest),
@@ -577,8 +608,9 @@ func (s *Store) collectAssertions() (asserts.Backstore, error) {
 }
 
 type currentSnap struct {
-	SnapID      string `json:"snap-id"`
-	InstanceKey string `json:"instance-key"`
+	SnapID          string `json:"snap-id"`
+	InstanceKey     string `json:"instance-key"`
+	TrackingChannel string `json:"tracking-channel"`
 }
 
 type snapAction struct {
@@ -587,6 +619,7 @@ type snapAction struct {
 	SnapID      string `json:"snap-id"`
 	Name        string `json:"name"`
 	Revision    int    `json:"revision,omitempty"`
+	Channel     string `json:"channel,omitempty"`
 }
 
 type snapActionRequest struct {
@@ -669,6 +702,7 @@ func (s *Store) snapActionEndpoint(w http.ResponseWriter, req *http.Request) {
 				Action:      "refresh",
 				SnapID:      s.SnapID,
 				InstanceKey: s.InstanceKey,
+				Channel:     s.TrackingChannel,
 			}
 		}
 	}
@@ -690,8 +724,22 @@ func (s *Store) snapActionEndpoint(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		if fn, ok := snaps[name]; ok {
-			essInfo, err := snapEssentialInfo(w, fn, snapID, bs)
+		var snapPath string
+		var foundSnap bool
+		if a.Channel != "" {
+			snapPath, foundSnap = snaps[fmt.Sprintf("%s|%s", name, a.Channel)]
+		}
+		if !foundSnap {
+			// FIXME: It is possible that many tests do
+			// not use channels correctly. So we have to
+			// fallback to searching for snaps by just
+			// name, without channel. Maybe we should
+			// remove that, and fix all the tests instead.
+			snapPath, foundSnap = snaps[name]
+		}
+
+		if foundSnap {
+			essInfo, err := snapEssentialInfo(w, snapPath, snapID, bs, s.channelRepository)
 			if essInfo == nil {
 				if err != errInfo {
 					panic(err)
@@ -718,7 +766,7 @@ func (s *Store) snapActionEndpoint(w http.ResponseWriter, req *http.Request) {
 			logger.Debugf("requested snap %q revision %d", essInfo.Name, a.Revision)
 			res.Snap.Publisher.ID = essInfo.DeveloperID
 			res.Snap.Publisher.Username = essInfo.DevelName
-			res.Snap.Download.URL = fmt.Sprintf("%s/download/%s", s.URL(), filepath.Base(fn))
+			res.Snap.Download.URL = fmt.Sprintf("%s/download/%s", s.RealURL(req), filepath.Base(snapPath))
 			res.Snap.Download.Sha3_384 = hexify(essInfo.Digest)
 			res.Snap.Download.Size = essInfo.Size
 			replyData.Results = append(replyData.Results, res)
@@ -878,4 +926,41 @@ func findSnapRevision(snapDigest string, bs asserts.Backstore) (*asserts.SnapRev
 	devAcct := a.(*asserts.Account)
 
 	return snapRev, devAcct, nil
+}
+
+func (s *Store) nonceEndpoint(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	w.Write([]byte(`{"nonce": "blah"}`))
+	return
+}
+
+func (s *Store) sessionEndpoint(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	w.Write([]byte(`{"macaroon": "blahblah"}`))
+	return
+}
+
+type ChannelRepository struct {
+	rootDir string
+}
+
+func (cr *ChannelRepository) findSnapChannels(snapDigest string) ([]string, error) {
+	dataPath := filepath.Join(cr.rootDir, snapDigest)
+	fd, err := os.Open(dataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
+	} else {
+		sc := bufio.NewScanner(fd)
+		var lines []string
+		for sc.Scan() {
+			lines = append(lines, sc.Text())
+		}
+		return lines, nil
+	}
 }

--- a/tests/lib/tools/store-state
+++ b/tests/lib/tools/store-state
@@ -9,6 +9,7 @@ show_help() {
     echo "       store-state teardown-staging-store"
     echo "       store-state make-snap-installable [--noack ] [--extra-decl-json FILE] <DIR> <SNAP_PATH> [SNAP_ID]"
     echo "       store-state init-fake-refreshes <DIR>"
+    echo "       store-state add-to-channel <DIR> <FILENAME> <CHANNEL>"
 }
 
 _configure_store_backends(){
@@ -189,6 +190,15 @@ teardown_fake_store(){
         systemctl daemon-reload
         systemctl start snapd.socket
     fi
+}
+
+add_to_channel() {
+    local BLOB_DIR=$1
+    local FILENAME=$2
+    local CHANNEL=$3
+    SUM="$(snap info --verbose "$(realpath "${FILENAME}")" | sed '/^sha3-384: */{;s///;q;};d')"
+    mkdir -p "${BLOB_DIR}/channels"
+    echo "${CHANNEL}" >"${BLOB_DIR}/channels/${SUM}"
 }
 
 main() {

--- a/tests/nested/manual/remodel-uc-to-next-version-fakestore/prepare-device
+++ b/tests/nested/manual/remodel-uc-to-next-version-fakestore/prepare-device
@@ -1,0 +1,3 @@
+#!/bin/sh
+# 10.0.2.2 is the host from a nested VM
+snapctl set device-service.url=http://10.0.2.2:11029

--- a/tests/nested/manual/remodel-uc-to-next-version-fakestore/repack-kernel.sh
+++ b/tests/nested/manual/remodel-uc-to-next-version-fakestore/repack-kernel.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -eu
+
+version=$1
+branch=$2
+
+tmpd=$(mktemp -d)
+cleanup() {
+    rm -rf "${tmpd}"
+}
+trap cleanup EXIT
+
+waited=0
+while ! resolvectl query api.launchpad.net; do
+    waited=$((waited+1))
+    if [ "${waited}" -gt 120 ]; then
+        break
+    fi
+    sleep 1
+done
+
+add-apt-repository ppa:snappy-dev/image -y
+apt-get install -y golang ubuntu-core-initramfs
+
+snap download pc-kernel --channel="${version}/${branch}" --basename=pc-kernel --target-directory="${tmpd}"
+unsquashfs -d "${tmpd}/pc-kernel" "${tmpd}/pc-kernel.snap"
+
+objcopy -O binary -j .initrd "${tmpd}/pc-kernel/kernel.efi" "${tmpd}/initrd"
+objcopy -O binary -j .linux "${tmpd}/pc-kernel/kernel.efi" "${tmpd}/linux"
+objcopy -O binary -j .uname "${tmpd}/pc-kernel/kernel.efi" "${tmpd}/kver"
+
+mkdir "${tmpd}/early"
+mkdir "${tmpd}/main"
+( (cd "${tmpd}/early"; cpio -id) ; (cd "${tmpd}/main"; zstdcat | cpio -id) ) <"${tmpd}/initrd"
+
+if [ "${BUILD_FDE_HOOK-}" = 1 ]; then
+    go build -o "${tmpd}/main/usr/bin/fde-reveal-key" /project/tests/lib/fde-setup-hook
+fi
+
+go build -tags 'nomanagers withtestkeys faultinject' -o "${tmpd}/main/usr/lib/snapd/snap-bootstrap" /project/cmd/snap-bootstrap
+
+(cd "${tmpd}/early"; find . | cpio --create --quiet --format=newc --owner=0:0) >"${tmpd}/new-initrd"
+(cd "${tmpd}/main"; find . | cpio --create --quiet --format=newc --owner=0:0 | zstd -1 -T0) >>"${tmpd}/new-initrd"
+
+ubuntu-core-initramfs create-efi \
+                      --kernelver "" \
+                      --initrd "${tmpd}/new-initrd" \
+                      --kernel "${tmpd}/linux" \
+                      --key "${SNAKEOIL_KEY}" \
+                      --cert "${SNAKEOIL_CERT}" \
+                      --output "${tmpd}/pc-kernel/kernel.efi"
+
+
+if [ "${BUILD_FDE_HOOK-}" = 1 ]; then
+    go build -o "${tmpd}/pc-kernel/meta/hooks/fde-setup" /project/tests/lib/fde-setup-hook
+fi
+
+snap pack "${tmpd}/pc-kernel" --filename="pc-kernel-modified.snap"

--- a/tests/nested/manual/remodel-uc-to-next-version-fakestore/task.yaml
+++ b/tests/nested/manual/remodel-uc-to-next-version-fakestore/task.yaml
@@ -1,0 +1,171 @@
+summary: verify remodel from UC20 to UC22
+details: |
+  Verify remodel from UC20 to UC22. This verifies unencrypted, tpm and
+  fde hook modes. This uses the fakestore only for update of snaps
+  during remodel.
+
+systems: [ubuntu-20.04-64]
+
+environment:
+  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-dangerous.model
+
+  # encrypted case
+  NESTED_ENABLE_TPM/encrypted: true
+  NESTED_ENABLE_SECURE_BOOT/encrypted: true
+  DISK_IS_ENCRYPTED/encrypted: true
+  BUILD_FDE_HOOK/encrypted: '0'
+  # unencrypted case
+  NESTED_ENABLE_TPM/notencrypted: false
+  NESTED_ENABLE_SECURE_BOOT/notencrypted: false
+  DISK_IS_ENCRYPTED/notencrypted: false
+  BUILD_FDE_HOOK/notencrypted: '0'
+
+  NESTED_ENABLE_TPM/hook: false
+  NESTED_ENABLE_SECURE_BOOT/hook: false
+  DISK_IS_ENCRYPTED/hook: true
+  BUILD_FDE_HOOK/hook: '1'
+
+  NESTED_SIGN_SNAPS_FAKESTORE: true
+  # for the fake store
+  NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
+  NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+  REMOTE_SAS_URL: http://10.0.2.2:11028
+
+prepare: |
+  snap install jq remarshal
+  snap install test-snapd-swtpm --edge
+
+  snap install lxd
+  lxd init --auto
+
+  mkdir -p updates/
+
+  "${TESTSTOOLS}/store-state" setup-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+  cp "${TESTSLIB}/assertions/developer1.account" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+  cp "${TESTSLIB}/assertions/developer1.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+  cp "${TESTSLIB}/assertions/testrootorg-store.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+
+  KEY_NAME=$(tests.nested download snakeoil-key)
+
+  lxc launch "ubuntu:22.04" builder-for-22
+  lxcdir="/project/$(realpath --relative-to="${PROJECT_PATH}" "${PWD}")"
+  lxc config device add builder-for-22 project disk source="${PROJECT_PATH}" path=/project shift=true
+  lxc exec --cwd "${lxcdir}" \
+           --env SNAKEOIL_KEY="${lxcdir}/${KEY_NAME}.key" \
+           --env SNAKEOIL_CERT="${lxcdir}/${KEY_NAME}.pem" \
+           --env "BUILD_FDE_HOOK=${BUILD_FDE_HOOK}" \
+           builder-for-22 -- bash -x repack-kernel.sh 22 beta
+
+  mv pc-kernel-modified.snap updates/pc-kernel-22.snap
+
+  snap download --channel="latest/edge" --basename="original-core22" "core22"
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB/prepare.sh"
+  repack_core_snap_with_tweaks original-core22.snap updates/core22.snap
+  rm -f original-core22.{snap,assert}
+
+  snap download --channel="22/edge" --basename="original-pc-22" "pc"
+  unsquashfs -d pc original-pc-22.snap
+  rm -f original-pc-22.{snap,assert}
+  SNAKEOIL_KEY="${PWD}/${KEY_NAME}.key"
+  SNAKEOIL_CERT="${PWD}/${KEY_NAME}.pem"
+  # shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+  nested_secboot_sign_gadget pc "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  echo "7777" > pc/serial
+  mkdir -p pc/meta/hooks/
+  cp prepare-device pc/meta/hooks/
+  echo "console=ttyS0 systemd.journald.forward_to_console=1" >>pc/cmdline.extra
+  snap pack pc updates/ --filename="pc-22.snap"
+  rm -rf pc
+
+  "$TESTSTOOLS"/store-state make-snap-installable --noack --revision 2 "${NESTED_FAKESTORE_BLOB_DIR}" "updates/core22.snap" "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+  "$TESTSTOOLS"/store-state make-snap-installable --noack --revision 2 "${NESTED_FAKESTORE_BLOB_DIR}" "updates/pc-kernel-22.snap" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+  "$TESTSTOOLS"/store-state make-snap-installable --noack --revision 3 "${NESTED_FAKESTORE_BLOB_DIR}" "updates/pc-22.snap" "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+
+  getassert() {
+    FILENAME=$1
+    ID=$2
+    SUM="$(snap info --verbose "$(realpath "${FILENAME}")" | sed '/^sha3-384: */{;s///;q;};d')"
+    cat "${TESTSLIB}/assertions/developer1.account-key"
+    echo
+    SNAPPY_FORCE_SAS_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}" snap known --remote snap-declaration snap-id="${ID}" series=16
+    echo
+    SNAPPY_FORCE_SAS_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}" snap known --remote snap-revision snap-sha3-384="${SUM}"
+  }
+
+  getassert "updates/core22.snap" "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT" >"updates/core22.assert"
+  getassert "updates/pc-kernel-22.snap" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza" >"updates/pc-kernel-22.assert"
+  getassert "updates/pc-22.snap" "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH" >"updates/pc-22.assert"
+
+  if [ "${BUILD_FDE_HOOK-}" = 1 ]; then
+    mkdir -p ./extra-initrd/usr/bin/
+    go build -o ./extra-initrd/usr/bin/fde-reveal-key "$TESTSLIB"/fde-setup-hook/fde-setup.go
+    mkdir -p ./extra-kernel-snap/meta/hooks
+    go build -o ./extra-kernel-snap/meta/hooks/fde-setup "$TESTSLIB"/fde-setup-hook/fde-setup.go
+  fi
+
+  tests.nested prepare-essential-snaps
+  unsquashfs -d pc-20 "$(tests.nested get extra-snaps-path)/pc.snap"
+  echo "7777" > pc-20/serial
+  mkdir -p pc-20/meta/hooks/
+  cp prepare-device pc-20/meta/hooks/
+  rm "$(tests.nested get extra-snaps-path)/pc.snap"
+  echo "console=ttyS0 systemd.journald.forward_to_console=1" >>pc-20/cmdline.extra
+  snap pack pc-20/ --filename="$(tests.nested get extra-snaps-path)/pc.snap"
+  "$TESTSTOOLS"/store-state make-snap-installable --noack --revision 2 "${NESTED_FAKESTORE_BLOB_DIR}" "$(tests.nested get extra-snaps-path)/pc.snap" "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+
+  "$TESTSTOOLS"/store-state add-to-channel "${NESTED_FAKESTORE_BLOB_DIR}" updates/pc-kernel-22.snap 22/edge
+  "$TESTSTOOLS"/store-state add-to-channel "${NESTED_FAKESTORE_BLOB_DIR}" updates/pc-22.snap 22/edge
+  "$TESTSTOOLS"/store-state add-to-channel "${NESTED_FAKESTORE_BLOB_DIR}" "$(tests.nested get extra-snaps-path)/pc-kernel.snap" 20/edge
+  "$TESTSTOOLS"/store-state add-to-channel "${NESTED_FAKESTORE_BLOB_DIR}" "$(tests.nested get extra-snaps-path)/pc.snap" 20/edge
+
+  for snap in "$(tests.nested get extra-snaps-path)"/snapd*.snap; do
+    "$TESTSTOOLS"/store-state add-to-channel "${NESTED_FAKESTORE_BLOB_DIR}" "${snap}" latest/stable
+  done
+  "$TESTSTOOLS"/store-state add-to-channel "${NESTED_FAKESTORE_BLOB_DIR}" updates/core22.snap latest/stable
+
+  # start fake device svc
+  systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
+
+  NESTED_BUILD_SNAPD_FROM_CURRENT=false tests.nested build-image core
+  tests.nested create-vm core
+
+  cat <<EOF >snapd-override.conf
+  [Service]
+  Environment=SNAPPY_FORCE_API_URL=${REMOTE_SAS_URL}
+  EOF
+  remote.push snapd-override.conf
+  remote.exec sudo mkdir -p /etc/systemd/system/snapd.service.d
+  remote.exec sudo cp snapd-override.conf /etc/systemd/system/snapd.service.d/
+  remote.exec sudo systemctl daemon-reload
+  remote.exec sudo systemctl restart snapd
+
+restore: |
+  # stop fake device svc
+  systemctl stop fakedevicesvc
+
+  "${TESTSTOOLS}/store-state" teardown-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+
+  rm -rf updates/
+
+execute: |
+  if [ "${DISK_IS_ENCRYPTED}" = true ]; then
+    remote.exec "ls /dev/mapper/ubuntu-data*"
+    remote.exec "ls /dev/mapper/ubuntu-save*"
+  fi
+
+  remote.push "${TESTSLIB}/assertions/developer1-22-dangerous.model"
+
+  remote.exec "snap model --assertion" | MATCH '^model: testkeys-snapd-dangerous-core-20-amd64$'
+  remote.exec "snap model --assertion" | NOMATCH '^model: testkeys-snapd-dangerous-core-22-amd64$'
+
+  boot_id="$(tests.nested boot-id)"
+  change_id="$(remote.exec sudo snap remodel --no-wait developer1-22-dangerous.model)"
+  remote.wait-for reboot "${boot_id}"
+
+  retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | MATCH '^${change_id}\s+(Done|Undone|Error)'"
+  remote.exec "sudo snap changes" | MATCH "^${change_id}\s+Done"
+
+  remote.exec "snap model --assertion" | MATCH '^model: testkeys-snapd-dangerous-core-22-amd64$'
+  remote.exec "snap model --assertion" | NOMATCH '^model: testkeys-snapd-dangerous-core-20-amd64$'


### PR DESCRIPTION
This also adds:
 * tests/lib/fakestore: add support for tracking channels
 * tests: add remodeling test using fakestore