### PR TITLE
cmd/snap-confine: add libnvidia-vksc-core.so support

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -91,6 +91,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-pkcs11-openssl3.so*",
 	"libnvidia-pkcs11.so*",
 	"libnvidia-vulkan-producer.so*",
+	"libnvidia-vksc-core.so.*",
 
 	"libEGL_nvidia.so*",
 	"libGLESv1_CM_nvidia.so*",


### PR DESCRIPTION
Vulkan has a safety-critical (SC) variant for engineering and medical applications. The Nvidia driver version 560 contains an implementation that should be exposed to snap applications.
