### PR TITLE
release: 2.63.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -421,7 +421,7 @@ jobs:
     # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     name: ${{ matrix.group }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, spread-enabled]
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -461,12 +461,15 @@ jobs:
           - group: ubuntu-focal-jammy
             backend: google
             systems: 'ubuntu-20.04-64 ubuntu-22.04-64'
+          - group: ubuntu-noble
+            backend: google
+            systems: 'ubuntu-24.04-64'
           - group: ubuntu-no-lts
             backend: google
             systems: 'ubuntu-23.10-64'
           - group: ubuntu-daily
             backend: google
-            systems: 'ubuntu-24.04-64'
+            systems: 'ubuntu-24.10-64'
           - group: ubuntu-core-16
             backend: google
             systems: 'ubuntu-core-16-64'

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -78,6 +78,20 @@ static const size_t egl_vendor_globs_len =
 // FIXME: this doesn't yet work with libGLX and libglvnd redirector
 // FIXME: this still doesn't work with the 361 driver
 static const char *nvidia_globs[] = {
+	"gbm/nvidia-drm_gbm.so*",
+	"libnvidia-allocator.so*",
+	"libnvidia-api.so*",
+	"libnvidia-cbl.so*",
+	"libnvidia-cfg.so*",
+	"libnvidia-compiler-next.so*",
+	"libnvidia-egl-gbm.so*",
+	"libnvidia-ngx.so*",
+	"libnvidia-nscq.so*",
+	"libnvidia-nvvm.so*",
+	"libnvidia-pkcs11-openssl3.so*",
+	"libnvidia-pkcs11.so*",
+	"libnvidia-vulkan-producer.so*",
+
 	"libEGL_nvidia.so*",
 	"libGLESv1_CM_nvidia.so*",
 	"libGLESv2_nvidia.so*",

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -61,6 +61,8 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}vdpau/libvdpau_nvidia.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnv{rm,dc,imp,os}*.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}gbm/nvidia-drm_gbm.so{,.*} rm,
+
 # CUDA libs
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnpp{c,ig,ial,icc,idei,ist,if,im,itc}*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcublas{,Lt}*.so{,.*} rm,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -218,16 +218,11 @@ capability setpcap,
 `
 
 const steamSupportConnectedPlugSecComp = `
-# Description: additional permissions needed by Steam
+# Description: allow steam to run without a seccomp profile so that
+# steam's internal sandbox can use any features available on the system
+# without having to perpetually update the snapd interface side.
 
-# Allow Steam to set up "pressure-vessel" containers to run games in.
-mount
-umount2
-pivot_root
-
-# Native games using QtWebEngineProcess -
-# https://forum.snapcraft.io/t/autoconnect-request-steam-network-control/34267
-unshare CLONE_NEWNS
+@unrestricted
 `
 
 const steamSupportSteamInputUDevRules = `

--- a/interfaces/builtin/steam_support_test.go
+++ b/interfaces/builtin/steam_support_test.go
@@ -86,7 +86,7 @@ func (s *SteamSupportInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *SteamSupportInterfaceSuite) TestSecCompSpec(c *C) {
 	spec := seccomp.NewSpecification(interfaces.NewSnapAppSet(s.plug.Snap()))
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow Steam to set up \"pressure-vessel\" containers to run games in.\nmount\numount2\npivot_root\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "@unrestricted\n")
 }
 
 func (s *SteamSupportInterfaceSuite) TestInterfaces(c *C) {

--- a/spread.yaml
+++ b/spread.yaml
@@ -126,6 +126,9 @@ backends:
             - ubuntu-20.04-64:
                   storage: 12G
                   workers: 8
+            - ubuntu-24.10-64:
+                  storage: 12G
+                  workers: 8
             - ubuntu-core-16-64:
                   image: ubuntu-16.04-64
                   workers: 6


### PR DESCRIPTION
This release is a minimum change to improve steam performance and nvidia support for steam. 
It is a deb only release targeting Noble 24.04.1.

**Outstanding content:** 
 - [Backport of AppArmor allow all](https://github.com/canonical/snapd/pull/14307)
 - Related integration tests

TODO Generate changelogs with:
DEBEMAIL="Ernest Lotter <ernest.lotter@canonical.com>" release-tools/changelog.py 2.63.1 2061179 NEWS.md

https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2061179