### PR TITLE
tests: support running tests in github agents with spread-enabled

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -618,7 +618,7 @@ jobs:
     # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     name: ${{ matrix.group }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, spread-enabled]
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems


### PR DESCRIPTION
This is a backport of #14210
