### PR TITLE
i/b/network-control: add capability dac_read_search for wpa_cli

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -144,6 +144,7 @@ capability net_admin,
 capability net_raw,
 capability setuid, # ping
 capability net_broadcast, # openvswitchd
+capability dac_read_search, # wpa_cli needs to place the client socket a different directory
 
 # Allow protocols except those that we blacklist in
 # /etc/modprobe.d/blacklist-rare-network.conf


### PR DESCRIPTION
We have a customer case where they are snapping wpa_cli but communicating with the host wpa_supplicant. Initially the issue was that the host wpasupplicant couldn't see the client socket created by the inside wpa_cli, but wpa_cli supports a custom location for this socket. (They described their use-case [https://bugs.launchpad.net/shiner/+bug/2072748/comments/4](here)).

Placing this under `/var/run/wpa_supplicant/` where wpasupplicant can see it, will result in an apparmor denial:

```
Aug 05 16:24:28 aydogar-ws kernel: audit: type=1400 audit(1722864268.577:4564): apparmor="DENIED" operation="capable" class="cap" profile="snap.hello-snap.hello" pid=219259 comm="wpa_cli" capability=2  capname="dac_read_search"
```

Running it with --devmode results in it working (and specifying a different socket path), so the remaining issue here is this denial

Jira: SNAPDENG-26033