### PR TITLE
i/builtin: add access to wpa_supplicant's dbus api to the network-control plug

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -138,6 +138,18 @@ dbus (receive)
      member=PropertiesChanged
      peer=(label=unconfined),
 
+# Allow access to wpa-supplicant for managing WiFi networks
+dbus (receive, send)
+    bus=system
+    path=/fi/w1/wpa_supplicant1{,/**}
+    interface=fi.w1.wpa_supplicant1*
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=system
+    path=/fi/w1/wpa_supplicant1{,/**}
+    interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
+
 #include <abstractions/ssl_certs>
 
 capability net_admin,


### PR DESCRIPTION
Unsure on how we'd normally do tests for a change like this, it doesn't seem we have coverage of the functionality of this plug right now.