### PR TITLE
many: add apparmorprompting interface manager

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -198,7 +199,7 @@ func AbstractPermissionsFromAppArmorPermissions(iface string, permissions any) (
 		}
 	}
 	if filePerms != notify.FilePermission(0) {
-		return nil, fmt.Errorf("cannot map AppArmor permission to abstract permission for the %s interface: %q", iface, filePerms)
+		logger.Noticef("cannot map AppArmor permission to abstract permission for the %s interface: %q", iface, filePerms)
 	}
 	return abstractPerms, nil
 }

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -21,11 +21,13 @@ package prompting_test
 
 import (
 	"fmt"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 )
 
@@ -438,7 +440,7 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsHappy(c
 }
 
 func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy(c *C) {
-	cases := []struct {
+	for _, testCase := range []struct {
 		iface  string
 		perms  any
 		errStr string
@@ -458,21 +460,36 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy
 			notify.AA_MAY_READ,
 			"cannot map the given interface to list of available permissions.*",
 		},
+	} {
+		perms, err := prompting.AbstractPermissionsFromAppArmorPermissions(testCase.iface, testCase.perms)
+		c.Check(perms, IsNil, Commentf("received unexpected non-nil permissions list for test case: %+v", testCase))
+		c.Check(err, ErrorMatches, testCase.errStr)
+	}
+	for _, testCase := range []struct {
+		iface    string
+		perms    any
+		abstract []string
+		errStr   string
+	}{
 		{
 			"home",
 			notify.FilePermission(1 << 17),
-			"cannot map AppArmor permission to abstract permission for the home interface.*",
+			[]string{},
+			`.*cannot map AppArmor permission to abstract permission for the home interface: "0x20000"`,
 		},
 		{
 			"home",
 			notify.AA_MAY_GETCRED | notify.AA_MAY_READ,
-			"cannot map AppArmor permission to abstract permission for the home interface.*",
+			[]string{"read"},
+			`.*cannot map AppArmor permission to abstract permission for the home interface: "get-cred"`,
 		},
-	}
-	for _, testCase := range cases {
+	} {
+		logbuf, restore := logger.MockLogger()
+		defer restore()
 		perms, err := prompting.AbstractPermissionsFromAppArmorPermissions(testCase.iface, testCase.perms)
-		c.Check(perms, IsNil, Commentf("received unexpected non-nil permissions list for test case: %+v", testCase))
-		c.Check(err, ErrorMatches, testCase.errStr)
+		c.Check(err, IsNil)
+		c.Check(perms, DeepEquals, testCase.abstract)
+		c.Check(fmt.Errorf("%s", strings.TrimSpace(logbuf.String())), ErrorMatches, testCase.errStr)
 	}
 }
 

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -21,7 +21,6 @@ package prompting_test
 
 import (
 	"fmt"
-	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type constraintsSuite struct{}
@@ -475,13 +475,13 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy
 			"home",
 			notify.FilePermission(1 << 17),
 			[]string{},
-			`.*cannot map AppArmor permission to abstract permission for the home interface: "0x20000"`,
+			` cannot map AppArmor permission to abstract permission for the home interface: "0x20000"`,
 		},
 		{
 			"home",
 			notify.AA_MAY_GETCRED | notify.AA_MAY_READ,
 			[]string{"read"},
-			`.*cannot map AppArmor permission to abstract permission for the home interface: "get-cred"`,
+			` cannot map AppArmor permission to abstract permission for the home interface: "get-cred"`,
 		},
 	} {
 		logbuf, restore := logger.MockLogger()
@@ -489,7 +489,7 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy
 		perms, err := prompting.AbstractPermissionsFromAppArmorPermissions(testCase.iface, testCase.perms)
 		c.Check(err, IsNil)
 		c.Check(perms, DeepEquals, testCase.abstract)
-		c.Check(fmt.Errorf("%s", strings.TrimSpace(logbuf.String())), ErrorMatches, testCase.errStr)
+		c.Check(logbuf.String(), testutil.Contains, testCase.errStr)
 	}
 }
 

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -337,8 +337,8 @@ func constructPermissionsMaps() []map[string]map[string]any {
 
 func (s *constraintsSuite) TestInterfacesAndPermissionsCompleteness(c *C) {
 	permissionsMaps := constructPermissionsMaps()
-	// Check that every interface in interfacePriorities is also in
-	// interfacePermissionsAvailable and exactly one of the permissions maps.
+	// Check that every interface in interfacePermissionsAvailable is in
+	// exactly one of the permissions maps.
 	// Also, check that the permissions for a given interface in
 	// interfacePermissionsAvailable are identical to the permissions in the
 	// interface's permissions map.

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -23,17 +23,9 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/interfaces/prompting"
-	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
-	"github.com/snapcore/snapd/testutil"
 )
 
 const MaxOutstandingPromptsPerUser = maxOutstandingPromptsPerUser
-
-func MockSendReply(f func(listenerReq *listener.Request, reply *listener.Response) error) (restore func()) {
-	restore = testutil.Backup(&sendReply)
-	sendReply = f
-	return restore
-}
 
 func NewPrompt(id prompting.IDType, timestamp time.Time, snap string, iface string, path string, remainingPermissions []string, availablePermissions []string, originalPermissions []string) *Prompt {
 	constraints := &promptConstraints{

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -35,14 +35,6 @@ func MockSendReply(f func(listenerReq *listener.Request, reply *listener.Respons
 	return restore
 }
 
-func (pc *promptConstraints) Path() string {
-	return pc.path
-}
-
-func (pc *promptConstraints) RemainingPermissions() []string {
-	return pc.remainingPermissions
-}
-
 func NewPrompt(id prompting.IDType, timestamp time.Time, snap string, iface string, path string, remainingPermissions []string, availablePermissions []string, originalPermissions []string) *Prompt {
 	constraints := &promptConstraints{
 		path:                 path,

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -111,6 +111,18 @@ func (pc *promptConstraints) subtractPermissions(permissions []string) (modified
 	return false
 }
 
+// Path returns the path associated with the request to which the receiving
+// prompt constraints apply.
+func (pc *promptConstraints) Path() string {
+	return pc.path
+}
+
+// Permissions returns the remaining unsatisfied permissions associated with
+// the prompt.
+func (pc *promptConstraints) RemainingPermissions() []string {
+	return pc.remainingPermissions
+}
+
 // userPromptDB maps prompt IDs to prompts for a single user.
 type userPromptDB struct {
 	// ids maps from id to the corresponding prompt's index in the prompts list.
@@ -217,7 +229,7 @@ func New(notifyPrompt func(userID uint32, promptID prompting.IDType, data map[st
 //
 // The caller must ensure that the given permissions are in the order in which
 // they appear in the available permissions list for the given interface.
-func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, permissions []string, listenerReq *listener.Request) (*Prompt, bool, error) {
+func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, requestedPermissions []string, remainingPermissions []string, listenerReq *listener.Request) (*Prompt, bool, error) {
 	availablePermissions, err := prompting.AvailablePermissions(metadata.Interface)
 	if err != nil {
 		// Error should be impossible, since caller has already validated that
@@ -243,9 +255,9 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, permi
 
 	constraints := &promptConstraints{
 		path:                 path,
-		remainingPermissions: permissions,
+		remainingPermissions: remainingPermissions,
 		availablePermissions: availablePermissions,
-		originalPermissions:  permissions,
+		originalPermissions:  requestedPermissions,
 	}
 
 	// Search for an identical existing prompt, merge if found

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -489,3 +489,14 @@ func (pdb *PromptDB) Close() error {
 	pdb.perUser = nil
 	return nil
 }
+
+// MockSendReply mocks the function to send a reply back to the listener so
+// tests, both for this package and for consumers of this package, can mock
+// the listener.
+func MockSendReply(f func(listenerReq *listener.Request, response *listener.Response) error) (restore func()) {
+	orig := sendReply
+	sendReply = f
+	return func() {
+		sendReply = orig
+	}
+}

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -275,7 +275,7 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	c.Assert(stored, IsNil)
 
 	before := time.Now()
-	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq1)
+	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq1)
 	c.Assert(err, IsNil)
 	after := time.Now()
 	c.Assert(merged, Equals, false)
@@ -285,7 +285,7 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	s.checkNewNoticesSimple(c, []prompting.IDType{prompt1.ID}, nil)
 	s.checkWrittenMaxID(c, expectedID)
 
-	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq2)
+	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq2)
 	c.Assert(err, IsNil)
 	c.Assert(merged, Equals, true)
 	c.Assert(prompt2, Equals, prompt1)
@@ -315,7 +315,7 @@ func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
 	// Looking up prompt should not record notice
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq3)
+	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq3)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, true)
 	c.Check(prompt3, Equals, prompt1)
@@ -386,7 +386,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 	for i := 0; i < requestprompts.MaxOutstandingPromptsPerUser; i++ {
 		path := fmt.Sprintf("/home/test/Documents/%d.txt", i)
 		listenerReq := &listener.Request{}
-		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
+		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq)
 		c.Assert(err, IsNil)
 		c.Assert(prompt, Not(IsNil))
 		c.Assert(merged, Equals, false)
@@ -407,7 +407,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 
 	// Check that adding a new unmerged prompt fails once limit is reached
 	for i := 0; i < 5; i++ {
-		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, lr)
+		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, lr)
 		c.Check(err, Equals, requestprompts.ErrTooManyPrompts)
 		c.Check(prompt, IsNil)
 		c.Check(merged, Equals, false)
@@ -423,7 +423,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 	for i := 0; i < requestprompts.MaxOutstandingPromptsPerUser; i++ {
 		path := fmt.Sprintf("/home/test/Documents/%d.txt", i)
 		listenerReq := &listener.Request{}
-		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
+		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq)
 		c.Assert(err, IsNil)
 		c.Assert(prompt, Not(IsNil))
 		c.Assert(merged, Equals, true)
@@ -455,7 +455,7 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 
 	listenerReq := &listener.Request{}
 
-	prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
+	prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
@@ -503,13 +503,13 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 		listenerReq1 := &listener.Request{}
 		listenerReq2 := &listener.Request{}
 
-		prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq1)
+		prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq1)
 		c.Assert(err, IsNil)
 		c.Check(merged, Equals, false)
 
 		s.checkNewNoticesSimple(c, []prompting.IDType{prompt1.ID}, nil)
 
-		prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq2)
+		prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq2)
 		c.Assert(err, IsNil)
 		c.Check(merged, Equals, true)
 		c.Check(prompt2, Equals, prompt1)
@@ -577,7 +577,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 
 	listenerReq := &listener.Request{}
 
-	prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
+	prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
@@ -621,25 +621,25 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 
 	permissions1 := []string{"read", "write", "execute"}
 	listenerReq1 := &listener.Request{}
-	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions1, listenerReq1)
+	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions1, permissions1, listenerReq1)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
 	permissions2 := []string{"read", "write"}
 	listenerReq2 := &listener.Request{}
-	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions2, listenerReq2)
+	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions2, permissions2, listenerReq2)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
 	permissions3 := []string{"read"}
 	listenerReq3 := &listener.Request{}
-	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions3, listenerReq3)
+	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions3, permissions3, listenerReq3)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
 	permissions4 := []string{"open"}
 	listenerReq4 := &listener.Request{}
-	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions4, listenerReq4)
+	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions4, permissions4, listenerReq4)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
@@ -750,25 +750,25 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 
 	permissions1 := []string{"read", "write", "execute"}
 	listenerReq1 := &listener.Request{}
-	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions1, listenerReq1)
+	prompt1, merged, err := pdb.AddOrMerge(metadata, path, permissions1, permissions1, listenerReq1)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
 	permissions2 := []string{"read", "write"}
 	listenerReq2 := &listener.Request{}
-	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions2, listenerReq2)
+	prompt2, merged, err := pdb.AddOrMerge(metadata, path, permissions2, permissions2, listenerReq2)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
 	permissions3 := []string{"read"}
 	listenerReq3 := &listener.Request{}
-	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions3, listenerReq3)
+	prompt3, merged, err := pdb.AddOrMerge(metadata, path, permissions3, permissions3, listenerReq3)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
 	permissions4 := []string{"open"}
 	listenerReq4 := &listener.Request{}
-	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions4, listenerReq4)
+	prompt4, merged, err := pdb.AddOrMerge(metadata, path, permissions4, permissions4, listenerReq4)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
@@ -848,7 +848,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	path := "/home/test/Documents/foo.txt"
 	permissions := []string{"read"}
 	listenerReq := &listener.Request{}
-	prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
+	prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 
@@ -969,7 +969,7 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 	prompts := make([]*requestprompts.Prompt, 0, 3)
 	for _, path := range paths {
 		listenerReq := &listener.Request{}
-		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, listenerReq)
+		prompt, merged, err := pdb.AddOrMerge(metadata, path, permissions, permissions, listenerReq)
 		c.Assert(err, IsNil)
 		c.Assert(merged, Equals, false)
 		prompts = append(prompts, prompt)
@@ -1012,7 +1012,7 @@ func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
 	c.Check(nextID, Equals, prompting.IDType(0))
 
 	metadata := prompting.Metadata{Interface: "home"}
-	result, merged, err := pdb.AddOrMerge(&metadata, "", nil, nil)
+	result, merged, err := pdb.AddOrMerge(&metadata, "", nil, nil, nil)
 	c.Check(err, Equals, requestprompts.ErrClosed)
 	c.Check(result, IsNil)
 	c.Check(merged, Equals, false)

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -24,18 +24,6 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func MockPromptingEnabled(f func() bool) (restore func()) {
-	restore = testutil.Backup(&PromptingEnabled)
-	PromptingEnabled = f
-	return restore
-}
-
-func MockNotifySupportAvailable(f func() bool) (restore func()) {
-	restore = testutil.Backup(&notifySupportAvailable)
-	notifySupportAvailable = f
-	return restore
-}
-
 func MockListenerRegister(f func() (*listener.Listener, error)) (restore func()) {
 	restore = testutil.Backup(&listenerRegister)
 	listenerRegister = f
@@ -61,9 +49,6 @@ func MockListenerClose(f func(l *listener.Listener) error) (restore func()) {
 }
 
 func MockListener() (restore func()) {
-	restoreSupport := MockNotifySupportAvailable(func() bool {
-		return true
-	})
 	closeChan := make(chan *listener.Request)
 	restoreRegister := MockListenerRegister(func() (*listener.Listener, error) {
 		return &listener.Listener{}, nil
@@ -85,7 +70,6 @@ func MockListener() (restore func()) {
 		return nil
 	})
 	return func() {
-		restoreSupport()
 		restoreRegister()
 		restoreRun()
 		restoreReqs()

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -27,27 +27,19 @@ import (
 )
 
 func MockListenerRegister(f func() (*listener.Listener, error)) (restore func()) {
-	restore = testutil.Backup(&listenerRegister)
-	listenerRegister = f
-	return restore
+	return testutil.Mock(&listenerRegister, f)
 }
 
 func MockListenerRun(f func(l *listener.Listener) error) (restore func()) {
-	restore = testutil.Backup(&listenerRun)
-	listenerRun = f
-	return restore
+	return testutil.Mock(&listenerRun, f)
 }
 
 func MockListenerReqs(f func(l *listener.Listener) <-chan *listener.Request) (restore func()) {
-	restore = testutil.Backup(&listenerRun)
-	listenerReqs = f
-	return restore
+	return testutil.Mock(&listenerReqs, f)
 }
 
 func MockListenerClose(f func(l *listener.Listener) error) (restore func()) {
-	restore = testutil.Backup(&listenerClose)
-	listenerClose = f
-	return restore
+	return testutil.Mock(&listenerClose, f)
 }
 
 type RequestResponse struct {

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmorprompting
+
+import (
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func MockPromptingEnabled(f func() bool) (restore func()) {
+	restore = testutil.Backup(&PromptingEnabled)
+	PromptingEnabled = f
+	return restore
+}
+
+func MockNotifySupportAvailable(f func() bool) (restore func()) {
+	restore = testutil.Backup(&notifySupportAvailable)
+	notifySupportAvailable = f
+	return restore
+}
+
+func MockListenerRegister(f func() (*listener.Listener, error)) (restore func()) {
+	restore = testutil.Backup(&listenerRegister)
+	listenerRegister = f
+	return restore
+}
+
+func MockListenerRun(f func(l *listener.Listener) error) (restore func()) {
+	restore = testutil.Backup(&listenerRun)
+	listenerRun = f
+	return restore
+}
+
+func MockListenerReqs(f func(l *listener.Listener) <-chan *listener.Request) (restore func()) {
+	restore = testutil.Backup(&listenerRun)
+	listenerReqs = f
+	return restore
+}
+
+func MockListenerClose(f func(l *listener.Listener) error) (restore func()) {
+	restore = testutil.Backup(&listenerClose)
+	listenerClose = f
+	return restore
+}
+
+func MockListener() (restore func()) {
+	restoreSupport := MockNotifySupportAvailable(func() bool {
+		return true
+	})
+	closeChan := make(chan *listener.Request)
+	restoreRegister := MockListenerRegister(func() (*listener.Listener, error) {
+		return &listener.Listener{}, nil
+	})
+	restoreRun := MockListenerRun(func(l *listener.Listener) error {
+		<-closeChan
+		return listener.ErrClosed
+	})
+	restoreReqs := MockListenerReqs(func(l *listener.Listener) <-chan *listener.Request {
+		return closeChan
+	})
+	restoreClose := MockListenerClose(func(l *listener.Listener) error {
+		select {
+		case <-closeChan:
+			return listener.ErrAlreadyClosed
+		default:
+			close(closeChan)
+		}
+		return nil
+	})
+	return func() {
+		restoreSupport()
+		restoreRegister()
+		restoreRun()
+		restoreReqs()
+		restoreClose()
+	}
+}

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -138,14 +138,13 @@ func (m *InterfacesRequestsManager) run() error {
 	m.lock.Unlock()
 
 	m.tomb.Go(func() error {
-		logger.Noticef("starting listener")
+		logger.Debugf("starting listener")
 		if err := listenerRun(currentListener); err != listener.ErrClosed {
 			return err
 		}
 		return nil
 	})
 
-	logger.Noticef("ready for prompts")
 run_loop:
 	for {
 		logger.Debugf("waiting prompt loop")
@@ -156,13 +155,13 @@ run_loop:
 				// In either case, the listener Close() method has already
 				// been called, and the tomb error will be set to the return
 				// value of the Run() call from the previous tracked goroutine.
-				logger.Noticef("listener closed requests channel")
+				logger.Debugf("listener closed requests channel")
 				break run_loop
 			}
 
 			// XXX: this debug log leaks information about internal activity
 			logger.Debugf("Got from kernel req chan: %v", req)
-			if err := m.handleListenerReq(req); err != nil { // no use multithreading, since IsPathAllowed locks
+			if err := m.handleListenerReq(req); err != nil {
 				// XXX: this log leaks information about internal activity
 				logger.Noticef("Error while handling request: %+v", err)
 			}
@@ -223,7 +222,7 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 			}
 		} else {
 			if !errors.Is(err, requestrules.ErrNoMatchingRule) {
-				logger.Noticef("cannot check path permissions: %v", err)
+				logger.Noticef("error while checking request against existing rules: %v", err)
 			}
 			// No matching rule found
 			remainingPerms = append(remainingPerms, perm)
@@ -438,7 +437,7 @@ func (m *InterfacesRequestsManager) HandleReply(userID uint32, promptID promptin
 		// return an error.
 
 		// XXX: this log leaks information about internal activity
-		logger.Noticef("WARNING: error when handling new rule as a result of reply: %v", err)
+		logger.Noticef("error when handling new rule as a result of reply: %v", err)
 	}
 
 	return satisfiedPromptIDs, nil
@@ -495,7 +494,7 @@ func (m *InterfacesRequestsManager) AddRule(userID uint32, snap string, iface st
 		// down, so don't actually return an error.
 
 		// XXX: this log leaks information about internal activity
-		logger.Noticef("WARNING: error when handling new rule as a result of AddRule: %v", err)
+		logger.Noticef("error when handling new rule as a result of AddRule: %v", err)
 	}
 	return newRule, nil
 }
@@ -550,7 +549,7 @@ func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.ID
 		// down, so don't actually return an error.
 
 		// XXX: this log leaks information about internal activity
-		logger.Noticef("WARNING: error when handling new rule as a result of PatchRule: %v", err)
+		logger.Noticef("error when handling new rule as a result of PatchRule: %v", err)
 	}
 	return patchedRule, nil
 }

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -1,0 +1,406 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmorprompting
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/requestprompts"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/requestrules"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
+)
+
+var (
+	ErrPromptingNotEnabled = errors.New("AppArmor Prompting is not enabled")
+)
+
+// TODO: replace with the following in ifacemgr.go:
+//func (m *InterfaceManager) AppArmorPromptingRunning() bool {
+//	return m.useAppArmorPrompting()
+//}
+var PromptingEnabled = func() bool {
+	return features.AppArmorPrompting.IsEnabled() && notify.SupportAvailable()
+}
+
+type Interface interface {
+	Connect() error
+	Run() error
+	Stop() error
+}
+
+type Prompting struct {
+	tomb     tomb.Tomb
+	listener *listener.Listener
+	prompts  *requestprompts.PromptDB
+	rules    *requestrules.RuleDB
+
+	notifyPrompt func(userID uint32, promptID string, options *state.AddNoticeOptions) error
+	notifyRule   func(userID uint32, ruleID string, options *state.AddNoticeOptions) error
+}
+
+func New(s *state.State) Interface {
+	notifyPrompt := func(userID uint32, promptID string, options *state.AddNoticeOptions) error {
+		s.Lock()
+		defer s.Unlock()
+		_, err := s.AddNotice(&userID, state.RequestsPromptNotice, promptID, options)
+		return err
+	}
+	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+		s.Lock()
+		defer s.Unlock()
+		_, err := s.AddNotice(&userID, state.RequestsRuleUpdateNotice, ruleID, options)
+		return err
+	}
+	p := &Prompting{
+		notifyPrompt: notifyPrompt,
+		notifyRule:   notifyRule,
+	}
+	return p
+}
+
+func (p *Prompting) Connect() error {
+	if !PromptingEnabled() {
+		return nil
+	}
+	if p.prompts != nil {
+		return fmt.Errorf("cannot connect: listener is already registered")
+	}
+	l, err := listenerRegister()
+	if err != nil {
+		return fmt.Errorf("cannot register prompting listener: %v", err)
+	}
+	p.listener = l
+	p.prompts = requestprompts.New(p.notifyPrompt)
+	p.rules, _ = requestrules.New(p.notifyRule) // ignore error (failed to load existing rules)
+	return nil
+}
+
+var (
+	notifySupportAvailable = notify.SupportAvailable
+	listenerRegister       = listener.Register
+)
+
+func (p *Prompting) disconnect() error {
+	if p.listener == nil {
+		return nil
+	}
+	defer func() {
+		p.listener = nil
+	}()
+	if err := listenerClose(p.listener); err != nil {
+		return err
+	}
+	return nil
+}
+
+var listenerClose = func(l *listener.Listener) error {
+	return l.Close()
+}
+
+func (p *Prompting) Run() error {
+	if !PromptingEnabled() {
+		return nil
+	}
+	p.tomb.Go(func() error {
+		if p.listener == nil {
+			logger.Noticef("listener is nil, exiting Prompting.Run() early")
+			return fmt.Errorf("listener is nil, cannot run AppArmor prompting")
+		}
+		p.tomb.Go(func() error {
+			logger.Noticef("starting listener")
+			if err := listenerRun(p.listener); err != listener.ErrClosed {
+				return err
+			}
+			return nil
+		})
+
+		logger.Noticef("ready for prompts")
+		for {
+			logger.Debugf("waiting prompt loop")
+			select {
+			case req, ok := <-listenerReqs(p.listener):
+				if !ok {
+					// Reqs() closed, so either errored or Stop() was called.
+					// In either case, the listener Close() method has already
+					// been called, and the tomb error will be set to the return
+					// value of the Run() call from the previous tracked goroutine.
+					logger.Noticef("listener closed requests channel")
+					return p.disconnect()
+				}
+				logger.Noticef("Got from kernel req chan: %v", req)
+				if err := p.handleListenerReq(req); err != nil { // no use multithreading, since IsPathAllowed locks
+					logger.Noticef("Error while handling request: %+v", err)
+				}
+			case <-p.tomb.Dying():
+				logger.Noticef("Prompting tomb is dying, disconnecting")
+				return p.disconnect()
+			}
+		}
+	})
+	return nil // TODO: finish this function (is it finished??)
+}
+
+var (
+	listenerRun = func(l *listener.Listener) error {
+		return l.Run()
+	}
+	listenerReqs = func(l *listener.Listener) <-chan *listener.Request {
+		return l.Reqs()
+	}
+)
+
+func (p *Prompting) handleListenerReq(req *listener.Request) error {
+	userID := uint32(req.SubjectUID())
+	snap, err := common.LabelToSnap(req.Label())
+	if err != nil {
+		// the triggering process is not a snap, so treat apparmor label as snap field
+	}
+
+	iface := common.SelectSingleInterface(req.Interfaces())
+
+	path := req.Path()
+
+	permissions, err := common.AbstractPermissionsFromAppArmorPermissions(iface, req.Permission())
+	if err != nil {
+		logger.Noticef("error while parsing AppArmor permissions: %v", err)
+		// XXX: is it better to auto-deny here or auto-allow?
+		return req.Reply(false)
+	}
+
+	remainingPerms := make([]string, 0, len(permissions))
+	for _, perm := range permissions {
+		if yesNo, err := p.rules.IsPathAllowed(userID, snap, iface, path, perm); err == nil {
+			if !yesNo {
+				logger.Noticef("request denied by existing rule: %+v", req)
+				// TODO: the response puts all original permissions in the
+				// Deny field, do we want to differentiate the denied bits from
+				// the others?
+				return req.Reply(false)
+			}
+		} else {
+			// No matching rule found
+			remainingPerms = append(remainingPerms, perm)
+		}
+	}
+	if len(remainingPerms) == 0 {
+		logger.Noticef("request allowed by existing rule: %+v", req)
+		return req.Reply(true)
+	}
+
+	newPrompt, merged := p.prompts.AddOrMerge(userID, snap, iface, path, remainingPerms, req)
+	if merged {
+		logger.Noticef("new prompt merged with identical existing prompt: %+v", newPrompt)
+		return nil
+	}
+
+	logger.Noticef("adding prompt to internal storage: %+v", newPrompt)
+
+	return nil
+}
+
+func (p *Prompting) Stop() error {
+	p.tomb.Kill(nil)
+	return p.tomb.Wait()
+}
+
+// GetPrompts returns all prompts for the user with the given user ID.
+func (p *Prompting) GetPrompts(userID uint32) ([]*requestprompts.Prompt, error) {
+	// TODO: when we switch from o/i/a/requestprompts to i/p/requestprompts,
+	// return error from Prompts() instead of nil
+	return p.prompts.Prompts(userID), nil
+}
+
+// GetPromptWithID returns the prompt with the given ID for the given user.
+func (p *Prompting) GetPromptWithID(userID uint32, promptID string) (*requestprompts.Prompt, error) {
+	return p.prompts.PromptWithID(userID, promptID)
+}
+
+// HandleReply checks that the given reply contents are valid, satisfies the
+// original request, and does not conflict with any existing rules (if lifespan
+// is not "single"). If all of these are true, sends a reply for the prompt with
+// the given ID, and both creates a new rule and checks any outstanding prompts
+// against it, if the lifespan is not "single".
+func (p *Prompting) HandleReply(userID uint32, promptID string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (satisfiedPromptIDs []string, retErr error) {
+	prompt, err := p.prompts.PromptWithID(userID, promptID)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: when we switch from o/i/a/common to i/prompting, no need to
+	// validate outcome and lifespan, as OutcomeType and LifespanType are both
+	// validated while unmarshalling, and duration is validated when the rule
+	// is being added. Path pattern (within constraints) is also validated, so
+	// the only manual validation required is permissions, which can be done
+	// via constraints.ValidateForInterface()
+	if _, err := common.ValidateConstraintsOutcomeLifespanDuration(prompt.Interface, constraints, outcome, lifespan, duration); err != nil {
+		return nil, err
+	}
+
+	// Check that constraints matches original requested path.
+	// AppArmor is responsible for pre-vetting that all paths which appear
+	// in requests from the kernel are allowed by the appropriate
+	// interfaces, so we do not assert anything else particular about the
+	// constraints, such as check that the path pattern does not match
+	// any paths not granted by the interface.
+	// TODO: Should this be reconsidered?
+	matches, err := constraints.Match(prompt.Constraints.Path)
+	if err != nil {
+		return nil, err
+	}
+	if !matches {
+		return nil, fmt.Errorf("constraints in reply do not match original request: '%v' does not match '%v'; please try again", constraints, prompt.Constraints)
+	}
+
+	// TODO: once support for sending back bitmask of allowed permissions lands,
+	// do we want to allow only replying to a select subset of permissions, and
+	// auto-deny the rest?
+	contained := constraints.ContainPermissions(prompt.Constraints.Permissions)
+	if !contained {
+		return nil, fmt.Errorf("replied permissions do not include all requested permissions: requested %v, replied %v; please try again", prompt.Constraints.Permissions, constraints.Permissions)
+	}
+
+	// TODO: a lock should be held while checking for conflicts with other rules
+	// so that if the rule is eventually removed due to an error, no prompts can
+	// have been matched against it in the meantime.
+	// A RWMutex over prompts and rules should work well, and could potentially
+	// replace the internal mutexes in those packages.
+	var newRule *requestrules.Rule
+	if lifespan != common.LifespanSingle {
+		// Check that adding the rule doesn't conflict with other rules
+		newRule, err = p.rules.AddRule(userID, prompt.Snap, prompt.Interface, constraints, outcome, lifespan, duration)
+		if err != nil {
+			// Rule conflicts with existing rule (at least one identical pattern
+			// variant and permission). This should be considered a bad reply,
+			// since the user should only be prompted for permissions and paths
+			// which are not already covered.
+
+			// TODO: there are scenarios where this could reasonably happen, so
+			// better to retry adding the new rule after removing any conflicts
+			// with existing rules. Likely, the new rule should replace the old.
+			// A new requestrules.ForceAddRule() might be the best way.
+
+			return nil, err
+		}
+
+		defer func() {
+			if retErr != nil || lifespan == common.LifespanSingle {
+				p.rules.RemoveRule(userID, newRule.ID)
+			}
+		}()
+	}
+
+	prompt, retErr = p.prompts.Reply(userID, promptID, outcome)
+	if retErr != nil {
+		return nil, retErr
+	}
+
+	if lifespan == common.LifespanSingle {
+		return []string{}, nil
+	}
+
+	// Apply new rule to outstanding prompts.
+	satisfiedPromptIDs, err = p.prompts.HandleNewRule(userID, newRule.Snap, newRule.Interface, newRule.Constraints, newRule.Outcome)
+	if err != nil {
+		// Should not occur, as outcome and constraints have already been
+		// validated. However, it's possible an error could occur if the prompt
+		// DB was already closed. This should be an internal error. However, we
+		// can't un-send the reply, and this should only be the case if the
+		// prompting system is shutting down, so don't actually return an error.
+		logger.Noticef("WARNING: error when handling new rule as a result of reply: %v", err)
+	}
+
+	return satisfiedPromptIDs, nil
+}
+
+// GetRules returns all rules for the user with the given user ID and,
+// optionally, only those for the given snap and/or interface.
+func (p *Prompting) GetRules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error) {
+	if snap != "" {
+		if iface != "" {
+			rules := p.rules.RulesForSnapInterface(userID, snap, iface)
+			return rules, nil
+		}
+		rules := p.rules.RulesForSnap(userID, snap)
+		return rules, nil
+	}
+	if iface != "" {
+		rules := p.rules.RulesForInterface(userID, iface)
+		return rules, nil
+	}
+	rules := p.rules.Rules(userID)
+	return rules, nil
+}
+
+// AddRule creates a new rule with the given contents and then checks it against
+// outstanding prompts, resolving any prompts which it satisfies.
+func (p *Prompting) AddRule(userID uint32, snap string, iface string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*requestrules.Rule, error) {
+	newRule, err := p.rules.AddRule(userID, snap, iface, constraints, outcome, lifespan, duration)
+	if err != nil {
+		return nil, err
+	}
+	// Apply new rule to outstanding prompts.
+	if _, err = p.prompts.HandleNewRule(userID, newRule.Snap, newRule.Interface, newRule.Constraints, newRule.Outcome); err != nil {
+		// Should not occur, as outcome and constraints have already been
+		// validated. However, it's possible an error could occur if the prompt
+		// DB was already closed. This should be an internal error. However,
+		// this should only be the case if the prompting system is shutting
+		// down, so don't actually return an error.
+		logger.Noticef("WARNING: error when handling new rule as a result of reply: %v", err)
+	}
+	return newRule, nil
+}
+
+// RemoveRules removes all rules for the user with the given user ID and the
+// given snap and, optionally, only those for the given interface.
+func (p *Prompting) RemoveRules(userID uint32, snap string, iface string) []*requestrules.Rule {
+	var removedRules []*requestrules.Rule
+	// Already checked that snap != ""
+	if iface != "" {
+		removedRules = p.rules.RemoveRulesForSnapInterface(userID, snap, iface)
+	} else {
+		removedRules = p.rules.RemoveRulesForSnap(userID, snap)
+	}
+	return removedRules
+}
+
+// GetRule returns the rule with the given ID for the given user.
+func (p *Prompting) GetRule(userID uint32, ruleID string) (*requestrules.Rule, error) {
+	rule, err := p.rules.RuleWithID(userID, ruleID)
+	return rule, err
+}
+
+// PatchRule updates the rule with the given ID using the provided contents.
+// Any of the given fields which are empty/nil are not updated in the rule.
+func (p *Prompting) PatchRule(userID uint32, ruleID string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*requestrules.Rule, error) {
+	return p.rules.PatchRule(userID, ruleID, constraints, outcome, lifespan, duration)
+}
+
+func (p *Prompting) RemoveRule(userID uint32, ruleID string) (*requestrules.Rule, error) {
+	rule, err := p.rules.RemoveRule(userID, ruleID)
+	return rule, err
+}

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -305,13 +305,13 @@ func (m *InterfacesRequestsManager) Stop() error {
 	return m.tomb.Wait()
 }
 
-// GetPrompts returns all prompts for the user with the given user ID.
-func (m *InterfacesRequestsManager) GetPrompts(userID uint32) ([]*requestprompts.Prompt, error) {
+// Prompts returns all prompts for the user with the given user ID.
+func (m *InterfacesRequestsManager) Prompts(userID uint32) ([]*requestprompts.Prompt, error) {
 	return m.prompts.Prompts(userID)
 }
 
-// GetPromptWithID returns the prompt with the given ID for the given user.
-func (m *InterfacesRequestsManager) GetPromptWithID(userID uint32, promptID prompting.IDType) (*requestprompts.Prompt, error) {
+// PromptWithID returns the prompt with the given ID for the given user.
+func (m *InterfacesRequestsManager) PromptWithID(userID uint32, promptID prompting.IDType) (*requestprompts.Prompt, error) {
 	return m.prompts.PromptWithID(userID, promptID)
 }
 
@@ -415,9 +415,9 @@ func (m *InterfacesRequestsManager) HandleReply(userID uint32, promptID promptin
 	return satisfiedPromptIDs, nil
 }
 
-// GetRules returns all rules for the user with the given user ID and,
+// Rules returns all rules for the user with the given user ID and,
 // optionally, only those for the given snap and/or interface.
-func (m *InterfacesRequestsManager) GetRules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error) {
+func (m *InterfacesRequestsManager) Rules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error) {
 	if snap != "" {
 		if iface != "" {
 			rules := m.rules.RulesForSnapInterface(userID, snap, iface)
@@ -476,8 +476,8 @@ func (m *InterfacesRequestsManager) RemoveRules(userID uint32, snap string, ifac
 	return m.rules.RemoveRulesForInterface(userID, iface)
 }
 
-// GetRule returns the rule with the given ID for the given user.
-func (m *InterfacesRequestsManager) GetRule(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error) {
+// RuleWithID returns the rule with the given ID for the given user.
+func (m *InterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error) {
 	rule, err := m.rules.RuleWithID(userID, ruleID)
 	return rule, err
 }

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -230,13 +230,13 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 	if matchedDenyRule {
 		logger.Debugf("request denied by existing rule: %+v", req)
 
-		// At least some permissions were allowed, but others were denied.
-		// Respond with this information by allowing all the permissions which
-		// were explicitly allowed, and let the kernel auto-deny the denied
-		// permissions, and any which not matched by allow rules.
+		// Respond with this information by allowing any requested permissions
+		// which were explicitly allowed by existing rules (there may be no
+		// such permissions) and let the listener deny all permissions which
+		// were not explicitly included in the allowed permissions.
 		responsePermissions, _ := prompting.AbstractPermissionsToAppArmorPermissions(iface, satisfiedPerms)
 		// Error should not occur, but if it does, responsePermissions are set
-		// to none, leaving it to AppArmor to default deny.
+		// to none, leaving it to the listener to default deny all permissions.
 		response := listener.Response{
 			Allow:      true,
 			Permission: responsePermissions,
@@ -250,11 +250,12 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 		// We don't want to just send back req.Permission() here, since that
 		// could include unrecognized permissions which were discarded, and
 		// were not matched by an existing rule. So only respond with the
-		// permissions which were matched and allowed, the kernel will
-		// auto-deny any which are not included.
+		// permissions which were matched and allowed, the listener will
+		// deny any permissions which were not explicitly included in the
+		// allowed permissions.
 		responsePermissions, _ := prompting.AbstractPermissionsToAppArmorPermissions(iface, satisfiedPerms)
 		// Error should not occur, but if it does, responsePermissions are set
-		// to none, leaving it to AppArmor to default deny.
+		// to none, leaving it to the listener to default deny all permissions.
 
 		response := listener.Response{
 			Allow:      true,
@@ -277,10 +278,10 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 
 		// We weren't able to create a new prompt, so respond with the best
 		// information we have, which is to allow any permissions which were
-		// automatically allowed by existing rules, and auto-deny the rest.
+		// allowed by existing rules, and let the listener deny the rest.
 		responsePermissions, _ := prompting.AbstractPermissionsToAppArmorPermissions(iface, satisfiedPerms)
 		// Error should not occur, but if it does, responsePermissions are set
-		// to none, leaving it to AppArmor to default deny.
+		// to none, leaving it to the listener to default deny all permissions.
 		response := listener.Response{
 			Allow:      true,
 			Permission: responsePermissions,

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -25,27 +25,18 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
+	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
-	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/requestprompts"
-	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/requestrules"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 var (
 	ErrPromptingNotEnabled = errors.New("AppArmor Prompting is not enabled")
 )
-
-// TODO: replace with the following in ifacemgr.go:
-//func (m *InterfaceManager) AppArmorPromptingRunning() bool {
-//	return m.useAppArmorPrompting()
-//}
-var PromptingEnabled = func() bool {
-	return features.AppArmorPrompting.IsEnabled() && notify.SupportAvailable()
-}
 
 type Interface interface {
 	Connect() error
@@ -59,21 +50,31 @@ type Prompting struct {
 	prompts  *requestprompts.PromptDB
 	rules    *requestrules.RuleDB
 
-	notifyPrompt func(userID uint32, promptID string, options *state.AddNoticeOptions) error
-	notifyRule   func(userID uint32, ruleID string, options *state.AddNoticeOptions) error
+	notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error
+	notifyRule   func(userID uint32, ruleID prompting.IDType, data map[string]string) error
 }
 
 func New(s *state.State) Interface {
-	notifyPrompt := func(userID uint32, promptID string, options *state.AddNoticeOptions) error {
+	notifyPrompt := func(userID uint32, promptID prompting.IDType, data map[string]string) error {
+		// TODO: add some sort of queue so that notifyPrompt function can return
+		// quickly without waiting for state lock and AddNotice() to return.
 		s.Lock()
 		defer s.Unlock()
-		_, err := s.AddNotice(&userID, state.RequestsPromptNotice, promptID, options)
+		options := state.AddNoticeOptions{
+			Data: data,
+		}
+		_, err := s.AddNotice(&userID, state.InterfacesRequestsPromptNotice, promptID.String(), &options)
 		return err
 	}
-	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
+	notifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
+		// TODO: add some sort of queue so that notifyPrompt function can return
+		// quickly without waiting for state lock and AddNotice() to return.
 		s.Lock()
 		defer s.Unlock()
-		_, err := s.AddNotice(&userID, state.RequestsRuleUpdateNotice, ruleID, options)
+		options := state.AddNoticeOptions{
+			Data: data,
+		}
+		_, err := s.AddNotice(&userID, state.InterfacesRequestsRuleUpdateNotice, ruleID.String(), &options)
 		return err
 	}
 	p := &Prompting{
@@ -83,26 +84,40 @@ func New(s *state.State) Interface {
 	return p
 }
 
-func (p *Prompting) Connect() error {
-	if !PromptingEnabled() {
-		return nil
-	}
+func (p *Prompting) Connect() (retErr error) {
 	if p.prompts != nil {
 		return fmt.Errorf("cannot connect: listener is already registered")
 	}
-	l, err := listenerRegister()
+	listenerBackend, err := listenerRegister()
 	if err != nil {
-		return fmt.Errorf("cannot register prompting listener: %v", err)
+		return fmt.Errorf("cannot register prompting listener: %w", err)
 	}
-	p.listener = l
-	p.prompts = requestprompts.New(p.notifyPrompt)
-	p.rules, _ = requestrules.New(p.notifyRule) // ignore error (failed to load existing rules)
+	defer func() {
+		if retErr != nil {
+			listenerBackend.Close()
+		}
+	}()
+	promptsBackend, err := requestprompts.New(p.notifyPrompt)
+	if err != nil {
+		return fmt.Errorf("cannot open request prompts backend: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			promptsBackend.Close()
+		}
+	}()
+	rulesBackend, err := requestrules.New(p.notifyRule)
+	if err != nil {
+		return fmt.Errorf("cannot open request rules backend: %w", err)
+	}
+	p.listener = listenerBackend
+	p.prompts = promptsBackend
+	p.rules = rulesBackend
 	return nil
 }
 
 var (
-	notifySupportAvailable = notify.SupportAvailable
-	listenerRegister       = listener.Register
+	listenerRegister = listener.Register
 )
 
 func (p *Prompting) disconnect() error {
@@ -123,9 +138,6 @@ var listenerClose = func(l *listener.Listener) error {
 }
 
 func (p *Prompting) Run() error {
-	if !PromptingEnabled() {
-		return nil
-	}
 	p.tomb.Go(func() error {
 		if p.listener == nil {
 			logger.Noticef("listener is nil, exiting Prompting.Run() early")
@@ -152,8 +164,10 @@ func (p *Prompting) Run() error {
 					logger.Noticef("listener closed requests channel")
 					return p.disconnect()
 				}
-				logger.Noticef("Got from kernel req chan: %v", req)
+				// XXX: this debug log leaks information about internal activity
+				logger.Debugf("Got from kernel req chan: %v", req)
 				if err := p.handleListenerReq(req); err != nil { // no use multithreading, since IsPathAllowed locks
+					// XXX: this log leaks information about internal activity
 					logger.Noticef("Error while handling request: %+v", err)
 				}
 			case <-p.tomb.Dying():
@@ -162,7 +176,7 @@ func (p *Prompting) Run() error {
 			}
 		}
 	})
-	return nil // TODO: finish this function (is it finished??)
+	return nil
 }
 
 var (
@@ -176,31 +190,45 @@ var (
 
 func (p *Prompting) handleListenerReq(req *listener.Request) error {
 	userID := uint32(req.SubjectUID())
-	snap, err := common.LabelToSnap(req.Label())
+	var snap string
+	tag, err := naming.ParseSecurityTag(req.Label())
 	if err != nil {
 		// the triggering process is not a snap, so treat apparmor label as snap field
+		snap = req.Label()
+	} else {
+		snap = tag.InstanceName()
 	}
 
-	iface := common.SelectSingleInterface(req.Interfaces())
+	// TODO: when we support interfaces beyond "home", do a proper selection here
+	iface := "home"
 
 	path := req.Path()
 
-	permissions, err := common.AbstractPermissionsFromAppArmorPermissions(iface, req.Permission())
+	permissions, err := prompting.AbstractPermissionsFromAppArmorPermissions(iface, req.Permission())
 	if err != nil {
+		// XXX: this log leaks information about internal activity
 		logger.Noticef("error while parsing AppArmor permissions: %v", err)
-		// XXX: is it better to auto-deny here or auto-allow?
-		return req.Reply(false)
+		response := listener.Response{
+			Allow:      false,
+			Permission: req.Permission(),
+		}
+		return req.Reply(&response)
 	}
 
 	remainingPerms := make([]string, 0, len(permissions))
+	satisfiedPerms := make([]string, 0, len(permissions))
 	for _, perm := range permissions {
 		if yesNo, err := p.rules.IsPathAllowed(userID, snap, iface, path, perm); err == nil {
 			if !yesNo {
-				logger.Noticef("request denied by existing rule: %+v", req)
-				// TODO: the response puts all original permissions in the
-				// Deny field, do we want to differentiate the denied bits from
-				// the others?
-				return req.Reply(false)
+				// XXX: this debug log leaks information about internal activity
+				logger.Debugf("request denied by existing rule: %+v", req)
+				response := listener.Response{
+					Allow:      false,
+					Permission: req.Permission(),
+				}
+				return req.Reply(&response)
+			} else {
+				satisfiedPerms = append(satisfiedPerms, perm)
 			}
 		} else {
 			// No matching rule found
@@ -208,35 +236,63 @@ func (p *Prompting) handleListenerReq(req *listener.Request) error {
 		}
 	}
 	if len(remainingPerms) == 0 {
-		logger.Noticef("request allowed by existing rule: %+v", req)
-		return req.Reply(true)
+		// XXX: this debug log leaks information about internal activity
+		logger.Debugf("request allowed by existing rule: %+v", req)
+		responsePermissions, _ := prompting.AbstractPermissionsToAppArmorPermissions(iface, satisfiedPerms)
+		// Error should not occur, but if it does, responsePermissions are set
+		// to none, leaving it to AppArmor to default deny
+		response := listener.Response{
+			Allow:      true,
+			Permission: responsePermissions,
+		}
+		return req.Reply(&response)
 	}
 
-	newPrompt, merged := p.prompts.AddOrMerge(userID, snap, iface, path, remainingPerms, req)
+	metadata := &prompting.Metadata{
+		User:      userID,
+		Snap:      snap,
+		Interface: iface,
+	}
+
+	newPrompt, merged, err := p.prompts.AddOrMerge(metadata, path, permissions, remainingPerms, req)
+	if err != nil {
+		// XXX: this debug log leaks information about internal activity
+		logger.Debugf("error while adding prompt to prompt DB: %+v: %v", req, err)
+		// Allow any satisfied permissions, AppArmor will auto-deny the rest
+		responsePermissions, _ := prompting.AbstractPermissionsToAppArmorPermissions(iface, satisfiedPerms)
+		// Error should not occur, but if it does, responsePermissions are set
+		// to none, leaving it to AppArmor to default deny
+		response := listener.Response{
+			Allow:      true,
+			Permission: responsePermissions,
+		}
+		return req.Reply(&response)
+	}
 	if merged {
-		logger.Noticef("new prompt merged with identical existing prompt: %+v", newPrompt)
+		// XXX: this debug log leaks information about internal activity
+		logger.Debugf("new prompt merged with identical existing prompt: %+v", newPrompt)
 		return nil
 	}
 
-	logger.Noticef("adding prompt to internal storage: %+v", newPrompt)
+	// XXX: this debug log leaks information about internal activity
+	logger.Debugf("adding prompt to internal storage: %+v", newPrompt)
 
 	return nil
 }
 
 func (p *Prompting) Stop() error {
 	p.tomb.Kill(nil)
+	p.prompts.Close()
 	return p.tomb.Wait()
 }
 
 // GetPrompts returns all prompts for the user with the given user ID.
 func (p *Prompting) GetPrompts(userID uint32) ([]*requestprompts.Prompt, error) {
-	// TODO: when we switch from o/i/a/requestprompts to i/p/requestprompts,
-	// return error from Prompts() instead of nil
-	return p.prompts.Prompts(userID), nil
+	return p.prompts.Prompts(userID)
 }
 
 // GetPromptWithID returns the prompt with the given ID for the given user.
-func (p *Prompting) GetPromptWithID(userID uint32, promptID string) (*requestprompts.Prompt, error) {
+func (p *Prompting) GetPromptWithID(userID uint32, promptID prompting.IDType) (*requestprompts.Prompt, error) {
 	return p.prompts.PromptWithID(userID, promptID)
 }
 
@@ -245,19 +301,16 @@ func (p *Prompting) GetPromptWithID(userID uint32, promptID string) (*requestpro
 // is not "single"). If all of these are true, sends a reply for the prompt with
 // the given ID, and both creates a new rule and checks any outstanding prompts
 // against it, if the lifespan is not "single".
-func (p *Prompting) HandleReply(userID uint32, promptID string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (satisfiedPromptIDs []string, retErr error) {
+func (p *Prompting) HandleReply(userID uint32, promptID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (satisfiedPromptIDs []prompting.IDType, retErr error) {
 	prompt, err := p.prompts.PromptWithID(userID, promptID)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: when we switch from o/i/a/common to i/prompting, no need to
-	// validate outcome and lifespan, as OutcomeType and LifespanType are both
-	// validated while unmarshalling, and duration is validated when the rule
-	// is being added. Path pattern (within constraints) is also validated, so
-	// the only manual validation required is permissions, which can be done
-	// via constraints.ValidateForInterface()
-	if _, err := common.ValidateConstraintsOutcomeLifespanDuration(prompt.Interface, constraints, outcome, lifespan, duration); err != nil {
+	// Outcome and lifesnap are validated while unmarshalling, and duration is
+	// validated when the rule is being added. So only need to validate
+	// constraints.
+	if err := constraints.ValidateForInterface(prompt.Interface); err != nil {
 		return nil, err
 	}
 
@@ -268,7 +321,7 @@ func (p *Prompting) HandleReply(userID uint32, promptID string, constraints *com
 	// constraints, such as check that the path pattern does not match
 	// any paths not granted by the interface.
 	// TODO: Should this be reconsidered?
-	matches, err := constraints.Match(prompt.Constraints.Path)
+	matches, err := constraints.Match(prompt.Constraints.Path())
 	if err != nil {
 		return nil, err
 	}
@@ -279,9 +332,9 @@ func (p *Prompting) HandleReply(userID uint32, promptID string, constraints *com
 	// TODO: once support for sending back bitmask of allowed permissions lands,
 	// do we want to allow only replying to a select subset of permissions, and
 	// auto-deny the rest?
-	contained := constraints.ContainPermissions(prompt.Constraints.Permissions)
+	contained := constraints.ContainPermissions(prompt.Constraints.RemainingPermissions())
 	if !contained {
-		return nil, fmt.Errorf("replied permissions do not include all requested permissions: requested %v, replied %v; please try again", prompt.Constraints.Permissions, constraints.Permissions)
+		return nil, fmt.Errorf("replied permissions do not include all requested permissions: requested %v, replied %v; please try again", prompt.Constraints.RemainingPermissions(), constraints.Permissions)
 	}
 
 	// TODO: a lock should be held while checking for conflicts with other rules
@@ -290,7 +343,7 @@ func (p *Prompting) HandleReply(userID uint32, promptID string, constraints *com
 	// A RWMutex over prompts and rules should work well, and could potentially
 	// replace the internal mutexes in those packages.
 	var newRule *requestrules.Rule
-	if lifespan != common.LifespanSingle {
+	if lifespan != prompting.LifespanSingle {
 		// Check that adding the rule doesn't conflict with other rules
 		newRule, err = p.rules.AddRule(userID, prompt.Snap, prompt.Interface, constraints, outcome, lifespan, duration)
 		if err != nil {
@@ -308,7 +361,7 @@ func (p *Prompting) HandleReply(userID uint32, promptID string, constraints *com
 		}
 
 		defer func() {
-			if retErr != nil || lifespan == common.LifespanSingle {
+			if retErr != nil || lifespan == prompting.LifespanSingle {
 				p.rules.RemoveRule(userID, newRule.ID)
 			}
 		}()
@@ -319,18 +372,25 @@ func (p *Prompting) HandleReply(userID uint32, promptID string, constraints *com
 		return nil, retErr
 	}
 
-	if lifespan == common.LifespanSingle {
-		return []string{}, nil
+	if lifespan == prompting.LifespanSingle {
+		return []prompting.IDType{}, nil
 	}
 
 	// Apply new rule to outstanding prompts.
-	satisfiedPromptIDs, err = p.prompts.HandleNewRule(userID, newRule.Snap, newRule.Interface, newRule.Constraints, newRule.Outcome)
+	metadata := &prompting.Metadata{
+		User:      userID,
+		Snap:      newRule.Snap,
+		Interface: newRule.Interface,
+	}
+	satisfiedPromptIDs, err = p.prompts.HandleNewRule(metadata, newRule.Constraints, newRule.Outcome)
 	if err != nil {
 		// Should not occur, as outcome and constraints have already been
 		// validated. However, it's possible an error could occur if the prompt
 		// DB was already closed. This should be an internal error. However, we
 		// can't un-send the reply, and this should only be the case if the
 		// prompting system is shutting down, so don't actually return an error.
+
+		// XXX: this log leaks information about internal activity
 		logger.Noticef("WARNING: error when handling new rule as a result of reply: %v", err)
 	}
 
@@ -358,49 +418,59 @@ func (p *Prompting) GetRules(userID uint32, snap string, iface string) ([]*reque
 
 // AddRule creates a new rule with the given contents and then checks it against
 // outstanding prompts, resolving any prompts which it satisfies.
-func (p *Prompting) AddRule(userID uint32, snap string, iface string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*requestrules.Rule, error) {
+func (p *Prompting) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
 	newRule, err := p.rules.AddRule(userID, snap, iface, constraints, outcome, lifespan, duration)
 	if err != nil {
 		return nil, err
 	}
 	// Apply new rule to outstanding prompts.
-	if _, err = p.prompts.HandleNewRule(userID, newRule.Snap, newRule.Interface, newRule.Constraints, newRule.Outcome); err != nil {
+	metadata := &prompting.Metadata{
+		User:      userID,
+		Snap:      newRule.Snap,
+		Interface: newRule.Interface,
+	}
+	if _, err = p.prompts.HandleNewRule(metadata, newRule.Constraints, newRule.Outcome); err != nil {
 		// Should not occur, as outcome and constraints have already been
 		// validated. However, it's possible an error could occur if the prompt
 		// DB was already closed. This should be an internal error. However,
 		// this should only be the case if the prompting system is shutting
 		// down, so don't actually return an error.
+
+		// XXX: this log leaks information about internal activity
 		logger.Noticef("WARNING: error when handling new rule as a result of reply: %v", err)
 	}
 	return newRule, nil
 }
 
 // RemoveRules removes all rules for the user with the given user ID and the
-// given snap and, optionally, only those for the given interface.
-func (p *Prompting) RemoveRules(userID uint32, snap string, iface string) []*requestrules.Rule {
-	var removedRules []*requestrules.Rule
-	// Already checked that snap != ""
-	if iface != "" {
-		removedRules = p.rules.RemoveRulesForSnapInterface(userID, snap, iface)
-	} else {
-		removedRules = p.rules.RemoveRulesForSnap(userID, snap)
+// given snap and/or interface. Snap and iface can't both be unspecified.
+func (p *Prompting) RemoveRules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error) {
+	if snap == "" && iface == "" {
+		return nil, fmt.Errorf("cannot remove rules for unspecified snap and interface")
 	}
-	return removedRules
+	if snap != "" {
+		if iface != "" {
+			return p.rules.RemoveRulesForSnapInterface(userID, snap, iface)
+		} else {
+			return p.rules.RemoveRulesForSnap(userID, snap)
+		}
+	}
+	return p.rules.RemoveRulesForInterface(userID, iface)
 }
 
 // GetRule returns the rule with the given ID for the given user.
-func (p *Prompting) GetRule(userID uint32, ruleID string) (*requestrules.Rule, error) {
+func (p *Prompting) GetRule(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error) {
 	rule, err := p.rules.RuleWithID(userID, ruleID)
 	return rule, err
 }
 
 // PatchRule updates the rule with the given ID using the provided contents.
 // Any of the given fields which are empty/nil are not updated in the rule.
-func (p *Prompting) PatchRule(userID uint32, ruleID string, constraints *common.Constraints, outcome common.OutcomeType, lifespan common.LifespanType, duration string) (*requestrules.Rule, error) {
+func (p *Prompting) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
 	return p.rules.PatchRule(userID, ruleID, constraints, outcome, lifespan, duration)
 }
 
-func (p *Prompting) RemoveRule(userID uint32, ruleID string) (*requestrules.Rule, error) {
+func (p *Prompting) RemoveRule(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error) {
 	rule, err := p.rules.RemoveRule(userID, ruleID)
 	return rule, err
 }

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -175,7 +175,14 @@ run_loop:
 
 func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) error {
 	userID := uint32(req.SubjectUID)
-	// TODO: immediately deny if req.SubjectUID() == 0 (root)
+	if userID == 0 {
+		// Deny any request for the root user
+		response := listener.Response{
+			Allow:      false,
+			Permission: req.Permission,
+		}
+		return requestReply(req, &response)
+	}
 	snap := req.Label // Default to apparmor label, in case process is not a snap
 	tag, err := naming.ParseSecurityTag(req.Label)
 	if err == nil {

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -20,25 +20,391 @@
 package apparmorprompting_test
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/interfaces/prompting/patterns"
+	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
+	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
 )
 
 func Test(t *testing.T) { TestingT(t) }
 
-type apparmorPromptingSuite struct {
+type apparmorpromptingSuite struct {
 	testutil.BaseTest
+
+	st *state.State
+
+	defaultUser uint32
 }
 
-var _ = Suite(&apparmorPromptingSuite{})
+var _ = Suite(&apparmorpromptingSuite{})
 
-func (s *apparmorPromptingSuite) SetUpTest(c *C) {
+func (s *apparmorpromptingSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
+	os.MkdirAll(dirs.SnapRunDir, 0o755)
+
+	s.st = state.New(nil)
+	s.defaultUser = 1000
+}
+
+func (s *apparmorpromptingSuite) TestNew(c *C) {
+	_, _, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, IsNil)
+
+	err = mgr.Stop()
+	c.Assert(err, IsNil)
+}
+
+func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
+	registerFailure := fmt.Errorf("failed to register listener")
+	restore := apparmorprompting.MockListenerRegister(func() (*listener.Listener, error) {
+		return nil, registerFailure
+	})
+	defer restore()
+
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register request listener: %v", registerFailure))
+	c.Assert(mgr, IsNil)
+}
+
+func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
+	reqChan, _, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	// Prevent prompt backend from opening successfully
+	maxIDFilepath := filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
+	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0o700), IsNil)
+	f, err := os.Create(maxIDFilepath)
+	c.Assert(err, IsNil)
+	c.Assert(f.Chmod(0o400), IsNil)
+	defer f.Chmod(0o600)
+
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, ErrorMatches, "cannot open request prompts backend:.*")
+	c.Assert(mgr, IsNil)
+
+	checkListenerClosed(c, reqChan)
+}
+
+func checkListenerClosed(c *C, reqChan <-chan *listener.Request) {
+	select {
+	case _, ok := <-reqChan:
+		// reqChan was already closed
+		c.Check(ok, Equals, false)
+	case <-time.NewTimer(100 * time.Millisecond).C:
+		c.Errorf("listener was not closed")
+	}
+}
+
+func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
+	reqChan, _, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	// Prevent rule backend from opening successfully
+	maxIDFilepath := filepath.Join(prompting.StateDir(), "request-rule-max-id")
+	c.Assert(os.MkdirAll(prompting.StateDir(), 0o700), IsNil)
+	f, err := os.Create(maxIDFilepath)
+	c.Assert(err, IsNil)
+	c.Assert(f.Chmod(0o400), IsNil)
+	defer f.Chmod(0o600)
+
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, ErrorMatches, "cannot open request rules backend:.*")
+	c.Assert(mgr, IsNil)
+
+	// Check that listener was closed
+	checkListenerClosed(c, reqChan)
+	// Ideally, we'd check that the prompt DB is also closed, but since the
+	// InterfaceManager was never returned, it and the prompt DB pointed to
+	// by it should be garbage collected, at least. The code calls Close(),
+	// so we're pretty confident all is well.
+}
+
+func (s *apparmorpromptingSuite) TestStop(c *C) {
+	reqChan, _, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, IsNil)
+
+	promptDB := mgr.PromptDB()
+	c.Assert(promptDB, NotNil)
+	ruleDB := mgr.RuleDB()
+	c.Assert(ruleDB, NotNil)
+
+	err = mgr.Stop()
+	c.Check(err, IsNil)
+
+	// Check that the listener and prompt and rule backends were closed
+	checkListenerClosed(c, reqChan)
+	c.Check(promptDB.Close(), Equals, requestprompts.ErrClosed)
+	c.Check(ruleDB.Close(), Equals, requestrules.ErrClosed)
+
+	// Check that current backends are nil
+	c.Check(mgr.PromptDB(), IsNil)
+	c.Check(mgr.RuleDB(), IsNil)
+}
+
+func (s *apparmorpromptingSuite) TestHandleListenerErrors(c *C) {
+	reqChan, _, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, IsNil)
+
+	prompts, err := mgr.Prompts(s.defaultUser)
+	c.Check(err, IsNil)
+	c.Check(prompts, HasLen, 0)
+
+	// Send request with invalid permissions
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+	req := &listener.Request{
+		// Most fields don't matter here
+		Permission: notify.FilePermission(0),
+	}
+	reqChan <- req
+	time.Sleep(100 * time.Millisecond)
+	c.Check(fmt.Errorf("%#v", logbuf.String()), ErrorMatches, ".*error while parsing AppArmor permissions: cannot get abstract permissions from empty AppArmor permissions.*")
+
+	// Fill the requestprompts backend until we hit its outstanding prompt
+	// count limit
+	maxOutstandingPromptsPerUser := 1000 // from requestprompts package
+	for i := 0; i < maxOutstandingPromptsPerUser; i++ {
+		req := &listener.Request{
+			Label:      "snap.firefox.firefox",
+			SubjectUID: s.defaultUser,
+			Path:       fmt.Sprintf("/home/test/%d", i),
+			Class:      notify.AA_CLASS_FILE,
+			Permission: notify.AA_MAY_APPEND,
+		}
+		reqChan <- req
+	}
+	prompts, err = mgr.Prompts(s.defaultUser)
+	c.Assert(err, IsNil)
+	c.Assert(len(prompts), Equals, maxOutstandingPromptsPerUser)
+	// Now try to add one more request, it should fail
+	logbuf, restore = logger.MockLogger()
+	defer restore()
+	req = &listener.Request{
+		Label:      "snap.firefox.firefox",
+		SubjectUID: s.defaultUser,
+		Path:       fmt.Sprintf("/home/test/%d", maxOutstandingPromptsPerUser),
+		Class:      notify.AA_CLASS_FILE,
+		Permission: notify.AA_MAY_APPEND,
+	}
+	reqChan <- req
+	time.Sleep(100 * time.Millisecond)
+	c.Check(fmt.Errorf("%#v", logbuf.String()), ErrorMatches, ".*Error while handling request: cannot get abstract permissions from empty AppArmor permissions.*")
+}
+
+func (s *apparmorpromptingSuite) TestHandleReplySimple(c *C) {
+	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	mgr, req, prompt := s.prepManagerWithSinglePrompt(c, reqChan)
+
+	// Reply to the request
+	constraints := prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, "/home/test/**"),
+		Permissions: []string{"read"},
+	}
+	satisfied, err := mgr.HandleReply(s.defaultUser, prompt.ID, &constraints, prompting.OutcomeAllow, prompting.LifespanSingle, "")
+	c.Check(err, IsNil)
+	c.Check(satisfied, HasLen, 0)
+
+	// Simulate the listener receiving the response
+	resp, err := waitForReply(replyChan)
+	c.Assert(err, IsNil)
+
+	c.Check(resp.Request, Equals, req)
+	c.Check(resp.Response.Allow, Equals, true)
+	aaPerms, err := prompting.AbstractPermissionsToAppArmorPermissions("home", constraints.Permissions)
+	c.Check(err, IsNil)
+	c.Check(resp.Response.Permission, Equals, aaPerms)
+}
+
+func (s *apparmorpromptingSuite) prepManagerWithSinglePrompt(c *C, reqChan chan *listener.Request) (*apparmorprompting.InterfacesRequestsManager, *listener.Request, *requestprompts.Prompt) {
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, IsNil)
+
+	prompts, err := mgr.Prompts(s.defaultUser)
+	c.Check(err, IsNil)
+	c.Check(prompts, HasLen, 0)
+
+	path := "/home/test/foo"
+
+	// Simulate request from the kernel
+	req := &listener.Request{
+		Label:      "snap.firefox.firefox",
+		SubjectUID: s.defaultUser,
+		Path:       path,
+		Class:      notify.AA_CLASS_FILE,
+		Permission: notify.AA_MAY_READ,
+	}
+	reqChan <- req
+
+	// Check that prompt exists
+	prompts, err = mgr.Prompts(s.defaultUser)
+	c.Assert(err, IsNil)
+	c.Assert(prompts, HasLen, 1)
+	prompt := prompts[0]
+	c.Check(prompt.Snap, Equals, "firefox")
+	c.Check(prompt.Interface, Equals, "home")
+	c.Check(prompt.Constraints.Path(), Equals, path)
+	c.Check(prompt.Constraints.RemainingPermissions(), DeepEquals, []string{"read"})
+
+	// Check that we can query that prompt by ID
+	promptByID, err := mgr.PromptWithID(s.defaultUser, prompt.ID)
+	c.Check(err, IsNil)
+	c.Check(promptByID, Equals, prompt)
+
+	// Return manager, request, and prompt
+	return mgr, req, prompt
+}
+
+func mustParsePathPattern(c *C, pattern string) *patterns.PathPattern {
+	parsed, err := patterns.ParsePathPattern(pattern)
+	c.Assert(err, IsNil)
+	return parsed
+}
+
+var errNoReply = errors.New("no reply received")
+
+func waitForReply(replyChan chan apparmorprompting.RequestResponse) (*apparmorprompting.RequestResponse, error) {
+	select {
+	case resp := <-replyChan:
+		return &resp, nil
+	case <-time.NewTimer(100 * time.Millisecond).C:
+		return nil, errNoReply
+	}
+}
+
+func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
+	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	mgr, _, prompt := s.prepManagerWithSinglePrompt(c, reqChan)
+
+	// Wrong user ID
+	result, err := mgr.HandleReply(s.defaultUser+1, prompt.ID, nil, prompting.OutcomeAllow, prompting.LifespanSingle, "")
+	c.Check(err, Equals, requestprompts.ErrNotFound)
+	c.Check(result, IsNil)
+
+	// Wrong prompt ID
+	result, err = mgr.HandleReply(s.defaultUser, prompt.ID+1, nil, prompting.OutcomeAllow, prompting.LifespanSingle, "")
+	c.Check(err, Equals, requestprompts.ErrNotFound)
+	c.Check(result, IsNil)
+
+	// Invalid constraints
+	invalidConstraints := prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, "/home/test/**"),
+		Permissions: []string{"foo"},
+	}
+	result, err = mgr.HandleReply(s.defaultUser, prompt.ID, &invalidConstraints, prompting.OutcomeAllow, prompting.LifespanSingle, "")
+	c.Check(err, ErrorMatches, "invalid constraints.*")
+	c.Check(result, IsNil)
+
+	// Path not matched
+	badPatternConstraints := prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, "/home/test/other"),
+		Permissions: []string{"read"},
+	}
+	result, err = mgr.HandleReply(s.defaultUser, prompt.ID, &badPatternConstraints, prompting.OutcomeAllow, prompting.LifespanSingle, "")
+	c.Check(err, ErrorMatches, "constraints in reply do not match original request.*")
+	c.Check(result, IsNil)
+
+	// Permissions not matched
+	badPermissionConstraints := prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, "/home/test/foo"),
+		Permissions: []string{"write"},
+	}
+	result, err = mgr.HandleReply(s.defaultUser, prompt.ID, &badPermissionConstraints, prompting.OutcomeAllow, prompting.LifespanSingle, "")
+	c.Check(err, ErrorMatches, "replied permissions do not include all requested permissions.*")
+	c.Check(result, IsNil)
+
+	// Conflicting rule
+	// For this, need to add another rule to the DB first, then try to reply
+	// with a rule which conflicts with it. Reuse badPatternConstraints.
+	newRule, err := mgr.AddRule(s.defaultUser, "firefox", "home", &badPatternConstraints, prompting.OutcomeAllow, prompting.LifespanTimespan, "10s")
+	c.Assert(err, IsNil)
+	c.Assert(newRule, NotNil)
+	conflictingConstraints := prompting.Constraints{
+		PathPattern: mustParsePathPattern(c, "/home/test/{foo,other}"),
+		Permissions: []string{"read"},
+	}
+	result, err = mgr.HandleReply(s.defaultUser, prompt.ID, &conflictingConstraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	c.Check(err, ErrorMatches, "cannot add rule.*")
+	c.Check(result, IsNil)
+
+	// Should not have received a reply
+	_, err = waitForReply(replyChan)
+	c.Assert(err, NotNil)
+}
+
+func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
+	// Requests with identical *original* abstract permissions are merged into
+	// the existing prompt
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
+	// If rules allow all of a request's permissions, that request is auto-allowed
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) {
+	// If rules allow some of a request's permissions, a prompt should be
+	// created for the remaining permissions, but the full list of original
+	// permissions (including those satisfied by existing rules) should be
+	// preserved in the prompt, and replying to the prompt should result in a
+	// response to the kernel with all (recognized) permissions from the
+	// original request.
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) {
+	// Partial denial should result in immediate request denial
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestNewRuleHandlesExistingPrompt(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestRules(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestRemoveRules(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
+	c.Fatalf("TODO")
 }

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -86,7 +86,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register request listener: %v", registerFailure))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register prompting listener: %v", registerFailure))
 	c.Assert(mgr, IsNil)
 }
 
@@ -1148,7 +1148,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 	c.Assert(retrieved, Equals, patched)
 
 	// Check that prompt has been satisfied
-	retrievedPrompt, err = mgr.PromptWithID(s.defaultUser, prompt.ID)
+	_, err = mgr.PromptWithID(s.defaultUser, prompt.ID)
 	c.Assert(err, Equals, requestprompts.ErrNotFound)
 	s.checkRecordedPromptNotices(c, whenPatched, 1)
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmorprompting_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type apparmorPromptingSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&apparmorPromptingSuite{})
+
+func (s *apparmorPromptingSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func (s *apparmorPromptingSuite) TestSmoke(c *C) {
+	restorePromptingEnabled := apparmorprompting.MockPromptingEnabled(func() bool {
+		return true
+	})
+	defer restorePromptingEnabled()
+	restoreListener := apparmorprompting.MockListener()
+	defer restoreListener()
+	st := state.New(nil)
+	p := apparmorprompting.New(st)
+	c.Assert(p, NotNil)
+	c.Assert(p.Connect(), IsNil)
+	c.Assert(p.Run(), IsNil)
+	c.Assert(p.Stop(), IsNil)
+}

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -185,7 +185,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerErrors(c *C) {
 		Permission: notify.FilePermission(0),
 	}
 	reqChan <- req
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(fmt.Errorf("%#v", logbuf.String()), ErrorMatches, ".*error while parsing AppArmor permissions: cannot get abstract permissions from empty AppArmor permissions.*")
 
 	// Fill the requestprompts backend until we hit its outstanding prompt
@@ -201,6 +201,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerErrors(c *C) {
 		}
 		reqChan <- req
 	}
+	time.Sleep(10 * time.Millisecond)
 	prompts, err = mgr.Prompts(s.defaultUser)
 	c.Assert(err, IsNil)
 	c.Assert(len(prompts), Equals, maxOutstandingPromptsPerUser)
@@ -215,7 +216,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerErrors(c *C) {
 		Permission: notify.AA_MAY_APPEND,
 	}
 	reqChan <- req
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(fmt.Errorf("%#v", logbuf.String()), ErrorMatches, ".*Error while handling request: cannot get abstract permissions from empty AppArmor permissions.*")
 }
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2023 Canonical Ltd
+ * Copyright (C) 2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,8 +25,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
-	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -43,19 +41,4 @@ func (s *apparmorPromptingSuite) SetUpTest(c *C) {
 
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
-}
-
-func (s *apparmorPromptingSuite) TestSmoke(c *C) {
-	restorePromptingEnabled := apparmorprompting.MockPromptingEnabled(func() bool {
-		return true
-	})
-	defer restorePromptingEnabled()
-	restoreListener := apparmorprompting.MockListener()
-	defer restoreListener()
-	st := state.New(nil)
-	p := apparmorprompting.New(st)
-	c.Assert(p, NotNil)
-	c.Assert(p.Connect(), IsNil)
-	c.Assert(p.Run(), IsNil)
-	c.Assert(p.Stop(), IsNil)
 }

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/schema"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -125,6 +126,30 @@ func MockCreateUDevMonitor(new func(udevmonitor.DeviceAddedFunc, udevmonitor.Dev
 	createUDevMonitor = new
 	return func() {
 		createUDevMonitor = old
+	}
+}
+
+func MockCreateInterfacesRequestsManager(new func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
+	old := createInterfacesRequestsManager
+	createInterfacesRequestsManager = new
+	return func() {
+		createInterfacesRequestsManager = old
+	}
+}
+
+func MockInterfacesRequestsManagerStop(new func(m *apparmorprompting.InterfacesRequestsManager) error) (restore func()) {
+	old := interfacesRequestsManagerStop
+	interfacesRequestsManagerStop = new
+	return func() {
+		interfacesRequestsManagerStop = old
+	}
+}
+
+func MockUseAppArmorPrompting(new func(m *InterfaceManager) bool) (restore func()) {
+	old := useAppArmorPrompting
+	useAppArmorPrompting = new
+	return func() {
+		useAppArmorPrompting = old
 	}
 }
 

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -130,27 +130,15 @@ func MockCreateUDevMonitor(new func(udevmonitor.DeviceAddedFunc, udevmonitor.Dev
 }
 
 func MockCreateInterfacesRequestsManager(new func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
-	old := createInterfacesRequestsManager
-	createInterfacesRequestsManager = new
-	return func() {
-		createInterfacesRequestsManager = old
-	}
+	return testutil.Mock(&createInterfacesRequestsManager, new)
 }
 
 func MockInterfacesRequestsManagerStop(new func(m *apparmorprompting.InterfacesRequestsManager) error) (restore func()) {
-	old := interfacesRequestsManagerStop
-	interfacesRequestsManagerStop = new
-	return func() {
-		interfacesRequestsManagerStop = old
-	}
+	return testutil.Mock(&interfacesRequestsManagerStop, new)
 }
 
 func MockUseAppArmorPrompting(new func(m *InterfaceManager) bool) (restore func()) {
-	old := useAppArmorPrompting
-	useAppArmorPrompting = new
-	return func() {
-		useAppArmorPrompting = old
-	}
+	return testutil.Mock(&useAppArmorPrompting, new)
 }
 
 func MockUDevInitRetryTimeout(t time.Duration) (restore func()) {

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -68,10 +68,9 @@ var (
 )
 
 func NewInterfaceManagerWithAppArmorPrompting(useAppArmorPrompting bool) *InterfaceManager {
-	m := &InterfaceManager{}
-	m.useAppArmorPromptingChecker.Do(func() {
-		m.useAppArmorPromptingValue = useAppArmorPrompting
-	})
+	m := &InterfaceManager{
+		useAppArmorPrompting: useAppArmorPrompting,
+	}
 	return m
 }
 
@@ -137,8 +136,8 @@ func MockInterfacesRequestsManagerStop(new func(m *apparmorprompting.InterfacesR
 	return testutil.Mock(&interfacesRequestsManagerStop, new)
 }
 
-func MockUseAppArmorPrompting(new func(m *InterfaceManager) bool) (restore func()) {
-	return testutil.Mock(&useAppArmorPrompting, new)
+func MockAssessAppArmorPrompting(new func(m *InterfaceManager) bool) (restore func()) {
+	return testutil.Mock(&assessAppArmorPrompting, new)
 }
 
 func MockUDevInitRetryTimeout(t time.Duration) (restore func()) {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -92,7 +92,7 @@ func (m *InterfaceManager) buildConfinementOptions(st *state.State, snapInfo *sn
 		JailMode:          flags.JailMode,
 		Classic:           flags.Classic,
 		ExtraLayouts:      extraLayouts,
-		AppArmorPrompting: m.useAppArmorPrompting(),
+		AppArmorPrompting: m.useAppArmorPrompting,
 	}, nil
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -199,8 +199,7 @@ func (m *InterfaceManager) StartUp() error {
 			// be regenerated if prompting is newly supported and the backends were
 			// successfully created.
 			// TODO: also set "apparmor-prompting" flag to false?
-			// XXX: should this log an error, rather than returning error?
-			return err
+			logger.Noticef("failed to start interfaces requests manager: %v", err)
 		}
 	}
 	if m.profilesNeedRegeneration() {

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -60,17 +60,17 @@ type InterfaceManager struct {
 	// maps sysfs path -> [(interface name, device key)...]
 	hotplugDevicePaths map[string][]deviceData
 
-	promptingMu sync.Mutex
-	prompting   apparmorprompting.Interface
-
 	// extras
 	extraInterfaces []interfaces.Interface
 	extraBackends   []interfaces.SecurityBackend
 
-	// AppArmor Prompting -- these values should never be used directly.
+	// AppArmor Prompting
+	// These values should never be used directly.
 	// Always check useAppArmorPrompting().
 	useAppArmorPromptingValue   bool
 	useAppArmorPromptingChecker sync.Once
+	interfacesRequestsManagerMu sync.Mutex
+	interfacesRequestsManager   *apparmorprompting.InterfacesRequestsManager
 
 	preseed bool
 }
@@ -146,8 +146,8 @@ func (m *InterfaceManager) AppArmorPromptingRunning() bool {
 	return m.useAppArmorPrompting()
 }
 
-func (m *InterfaceManager) Prompting() *apparmorprompting.Prompting {
-	return (m.prompting).(*apparmorprompting.Prompting)
+func (m *InterfaceManager) InterfacesRequestsManager() *apparmorprompting.InterfacesRequestsManager {
+	return m.interfacesRequestsManager
 }
 
 // StartUp implements StateStarterUp.Startup.
@@ -187,6 +187,11 @@ func (m *InterfaceManager) StartUp() error {
 	if _, err := m.reloadConnections(""); err != nil {
 		return err
 	}
+	if m.useAppArmorPrompting() {
+		if err := m.initInterfacesRequestsManager(); err != nil {
+			return err
+		}
+	}
 	if m.profilesNeedRegeneration() {
 		if err := m.regenerateAllSecurityProfiles(perfTimings); err != nil {
 			return err
@@ -208,21 +213,7 @@ Run "systemctl enable --now snapd.apparmor" to correct this.`)
 }
 
 // Ensure implements StateManager.Ensure.
-func (m *InterfaceManager) Ensure() (err error) {
-	if udevMonErr := m.ensureUDevMon(); udevMonErr != nil {
-		defer func() {
-			if err != nil {
-				err = fmt.Errorf("%w; %v", udevMonErr, err)
-			} else {
-				err = udevMonErr
-			}
-		}()
-	}
-	err = m.ensurePrompting()
-	return err
-}
-
-func (m *InterfaceManager) ensureUDevMon() error {
+func (m *InterfaceManager) Ensure() error {
 	// do not worry about udev monitor in preseeding mode
 	if m.preseed {
 		return nil
@@ -256,42 +247,11 @@ func (m *InterfaceManager) ensureUDevMon() error {
 	return nil
 }
 
-func (m *InterfaceManager) ensurePrompting() error {
-	if !m.AppArmorPromptingRunning() {
-		m.stopPrompting()
-		return nil
-	}
-	m.promptingMu.Lock()
-	prompting := m.prompting
-	m.promptingMu.Unlock()
-	if prompting != nil {
-		// Prompting is already running, so stop it, in case an internal error
-		// has occurred, which we have no way of checking since we can only
-		// define/use methods which match the apparmorprompting.Interface type.
-		prompting.Stop()
-		// XXX: this throws away pending request prompts, so we probably want
-		// to figure out a way to either:
-		// 1. tell whether the prompting instance has actually encountered an
-		// error, and let it happily continue if not; or
-		// 2. gracefully transfer pending prompting requests from the old
-		// listener to the new one, likely by writing to and reading from disk.
-
-		// TODO: I think this is the source of the disappearing prompts. With
-		// changes in overlord/ifacestate/apparmorprompting/prompting.go, we
-		// should now successfully call requestprompts.Close() when stopping
-		// the prompting InterfaceManager, so at least we'll get the notices
-		// now. But this whole section should be rewritten so we're not using
-		// Ensure() to start prompting -- prompting should be started once on
-		// snapd startup, or throw an error if this fails.
-	}
-	return m.initPrompting()
-}
-
 // Stop implements StateStopper. It stops the udev monitor and prompting,
 // if running.
 func (m *InterfaceManager) Stop() {
 	m.stopUDevMon()
-	m.stopPrompting()
+	m.stopInterfacesRequestsManager()
 }
 
 func (m *InterfaceManager) stopUDevMon() {
@@ -309,20 +269,20 @@ func (m *InterfaceManager) stopUDevMon() {
 	m.udevMon = nil
 }
 
-func (m *InterfaceManager) stopPrompting() {
-	m.promptingMu.Lock()
-	defer m.promptingMu.Unlock()
-	// May as well hold the prompting lock while stopping prompting, so that
+func (m *InterfaceManager) stopInterfacesRequestsManager() {
+	m.interfacesRequestsManagerMu.Lock()
+	defer m.interfacesRequestsManagerMu.Unlock()
+	// May as well hold the interfacesRequestsManager lock while stopping prompting, so that
 	// we don't try to use or overwrite this prompting instance while it is
 	// stopping.
-	prompting := m.prompting
-	if prompting == nil {
+	interfacesRequestsManager := m.interfacesRequestsManager
+	if interfacesRequestsManager == nil {
 		return
 	}
-	if err := prompting.Stop(); err != nil {
+	if err := interfacesRequestsManager.Stop(); err != nil {
 		logger.Noticef("Cannot stop prompting: %s", err)
 	}
-	m.prompting = nil
+	m.interfacesRequestsManager = nil
 }
 
 // Repository returns the interface repository used internally by the manager.
@@ -532,9 +492,9 @@ func (m *InterfaceManager) DisableUDevMonitor() {
 }
 
 var (
-	udevInitRetryTimeout = time.Minute * 5
-	createUDevMonitor    = udevmonitor.New
-	createPrompting      = apparmorprompting.New
+	udevInitRetryTimeout            = time.Minute * 5
+	createUDevMonitor               = udevmonitor.New
+	createInterfacesRequestsManager = apparmorprompting.New
 )
 
 func (m *InterfaceManager) initUDevMonitor() error {
@@ -552,21 +512,16 @@ func (m *InterfaceManager) initUDevMonitor() error {
 	return nil
 }
 
-// initPrompting should only be called if prompting is supported and enabled,
-// and any existing prompting instance should already be stopped, as it will be
-// overridden.
-func (m *InterfaceManager) initPrompting() error {
-	prompt := createPrompting(m.state)
-	if err := prompt.Connect(); err != nil {
+// initInterfacesRequestsManager should only be called if prompting is
+// supported and enabled.
+func (m *InterfaceManager) initInterfacesRequestsManager() error {
+	m.interfacesRequestsManagerMu.Lock()
+	defer m.interfacesRequestsManagerMu.Unlock()
+	interfacesRequestsManager, err := createInterfacesRequestsManager(m.state)
+	if err != nil {
 		return err
 	}
-	if err := prompt.Run(); err != nil {
-		return err
-	}
-
-	m.promptingMu.Lock()
-	defer m.promptingMu.Unlock()
-	m.prompting = prompt
+	m.interfacesRequestsManager = interfacesRequestsManager
 	return nil
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -58,6 +59,9 @@ type InterfaceManager struct {
 	enumerationDone      bool
 	// maps sysfs path -> [(interface name, device key)...]
 	hotplugDevicePaths map[string][]deviceData
+
+	promptingMu sync.Mutex
+	prompting   apparmorprompting.Interface
 
 	// extras
 	extraInterfaces []interfaces.Interface
@@ -137,6 +141,10 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	return m, nil
 }
 
+func (m *InterfaceManager) Prompting() *apparmorprompting.Prompting {
+	return (m.prompting).(*apparmorprompting.Prompting)
+}
+
 // StartUp implements StateStarterUp.Startup.
 func (m *InterfaceManager) StartUp() error {
 	s := m.state
@@ -195,7 +203,21 @@ Run "systemctl enable --now snapd.apparmor" to correct this.`)
 }
 
 // Ensure implements StateManager.Ensure.
-func (m *InterfaceManager) Ensure() error {
+func (m *InterfaceManager) Ensure() (err error) {
+	if udevMonErr := m.ensureUDevMon(); udevMonErr != nil {
+		defer func() {
+			if err != nil {
+				err = fmt.Errorf("%w; %v", udevMonErr, err)
+			} else {
+				err = udevMonErr
+			}
+		}()
+	}
+	err = m.ensurePrompting()
+	return err
+}
+
+func (m *InterfaceManager) ensureUDevMon() error {
 	// do not worry about udev monitor in preseeding mode
 	if m.preseed {
 		return nil
@@ -229,9 +251,37 @@ func (m *InterfaceManager) Ensure() error {
 	return nil
 }
 
-// Stop implements StateStopper. It stops the udev monitor,
+func (m *InterfaceManager) ensurePrompting() error {
+	if !apparmorprompting.PromptingEnabled() {
+		m.stopPrompting()
+		return nil
+	}
+	m.promptingMu.Lock()
+	prompting := m.prompting
+	m.promptingMu.Unlock()
+	if prompting != nil {
+		// Prompting is already running, so stop it, in case an internal error
+		// has occurred, which we have no way of checking since we can only
+		// define/use methods which match the apparmorprompting.Interface type.
+		prompting.Stop()
+		// XXX: this throws away pending prompting requests, so we probably want
+		// to figure out a way to either:
+		// 1. tell whether the prompting instance has actually encountered an
+		// error, and let it happily continue if not; or
+		// 2. gracefully transfer pending prompting requests from the old
+		// listener to the new one, likely by writing to and reading from disk.
+	}
+	return m.initPrompting()
+}
+
+// Stop implements StateStopper. It stops the udev monitor and prompting,
 // if running.
 func (m *InterfaceManager) Stop() {
+	m.stopUDevMon()
+	m.stopPrompting()
+}
+
+func (m *InterfaceManager) stopUDevMon() {
 	m.udevMonMu.Lock()
 	udevMon := m.udevMon
 	m.udevMonMu.Unlock()
@@ -244,6 +294,22 @@ func (m *InterfaceManager) Stop() {
 	m.udevMonMu.Lock()
 	defer m.udevMonMu.Unlock()
 	m.udevMon = nil
+}
+
+func (m *InterfaceManager) stopPrompting() {
+	m.promptingMu.Lock()
+	defer m.promptingMu.Unlock()
+	// May as well hold the prompting lock while stopping prompting, so that
+	// we don't try to use or overwrite this prompting instance while it is
+	// stopping.
+	prompting := m.prompting
+	if prompting == nil {
+		return
+	}
+	if err := prompting.Stop(); err != nil {
+		logger.Noticef("Cannot stop prompting: %s", err)
+	}
+	m.prompting = nil
 }
 
 // Repository returns the interface repository used internally by the manager.
@@ -455,6 +521,7 @@ func (m *InterfaceManager) DisableUDevMonitor() {
 var (
 	udevInitRetryTimeout = time.Minute * 5
 	createUDevMonitor    = udevmonitor.New
+	createPrompting      = apparmorprompting.New
 )
 
 func (m *InterfaceManager) initUDevMonitor() error {
@@ -469,6 +536,24 @@ func (m *InterfaceManager) initUDevMonitor() error {
 	m.udevMonMu.Lock()
 	defer m.udevMonMu.Unlock()
 	m.udevMon = mon
+	return nil
+}
+
+// initPrompting should only be called if prompting is supported and enabled,
+// and any existing prompting instance should already be stopped, as it will be
+// overridden.
+func (m *InterfaceManager) initPrompting() error {
+	prompt := createPrompting(m.state)
+	if err := prompt.Connect(); err != nil {
+		return err
+	}
+	if err := prompt.Run(); err != nil {
+		return err
+	}
+
+	m.promptingMu.Lock()
+	defer m.promptingMu.Unlock()
+	m.prompting = prompt
 	return nil
 }
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -370,7 +370,7 @@ func (s *interfaceManagerSuite) TestSmoke(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
-	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+	restore := ifacestate.MockAssessAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
 		return true
 	})
 	defer restore()
@@ -399,7 +399,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
-	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+	restore := ifacestate.MockAssessAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
 		return false
 	})
 	defer restore()
@@ -6978,7 +6978,7 @@ func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
-	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+	restore := ifacestate.MockAssessAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
 		return true
 	})
 	defer restore()
@@ -7004,7 +7004,7 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
-	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+	restore := ifacestate.MockAssessAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
 		return true
 	})
 	defer restore()
@@ -7027,7 +7027,7 @@ func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
 
 	mgr.Stop()
 
-	c.Check(fmt.Errorf("%v", strings.TrimSpace(logbuf.String())), ErrorMatches, fmt.Sprintf(".*%v", fakeError))
+	c.Check(logbuf.String(), testutil.Contains, " Cannot stop prompting: custom error")
 
 	c.Assert(mgr.InterfacesRequestsManager(), IsNil)
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -295,6 +296,17 @@ slots:
 		// pretend the snapd.apparmor.service is enabled
 		return false
 	}))
+
+	s.BaseTest.AddCleanup(ifacestate.MockCreateInterfacesRequestsManager(fakeCreateInterfacesRequestsManager))
+	s.BaseTest.AddCleanup(ifacestate.MockInterfacesRequestsManagerStop(fakeInterfacesRequestsManagerStop))
+}
+
+var fakeCreateInterfacesRequestsManager = func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	return nil, nil
+}
+
+var fakeInterfacesRequestsManagerStop = func(m *apparmorprompting.InterfacesRequestsManager) error {
+	return nil
 }
 
 func (s *interfaceManagerSuite) TearDownTest(c *C) {
@@ -355,6 +367,62 @@ func (s *interfaceManagerSuite) TestSmoke(c *C) {
 	s.manager(c)
 	s.se.Ensure()
 	s.se.Wait()
+}
+
+func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
+	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+		return true
+	})
+	defer restore()
+	createCount := 0
+	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+		createCount++
+		return fakeManager, nil
+	})
+	defer restore()
+	stopCount := 0
+	restore = ifacestate.MockInterfacesRequestsManagerStop(func(m *apparmorprompting.InterfacesRequestsManager) error {
+		stopCount++
+		return nil
+	})
+	defer restore()
+
+	mgr := s.manager(c)
+	c.Check(createCount, Equals, 1)
+	c.Check(mgr.AppArmorPromptingRunning(), Equals, true)
+	c.Check(mgr.InterfacesRequestsManager(), Equals, fakeManager)
+	c.Check(stopCount, Equals, 0)
+	mgr.Stop()
+	c.Check(stopCount, Equals, 1)
+	c.Check(mgr.InterfacesRequestsManager(), IsNil)
+}
+
+func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
+	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+		return false
+	})
+	defer restore()
+	createCount := 0
+	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+		createCount++
+		return fakeManager, fmt.Errorf("should not have been called")
+	})
+	defer restore()
+	stopCount := 0
+	restore = ifacestate.MockInterfacesRequestsManagerStop(func(m *apparmorprompting.InterfacesRequestsManager) error {
+		stopCount++
+		return nil
+	})
+	defer restore()
+
+	mgr := s.manager(c)
+	c.Check(createCount, Equals, 0)
+	c.Check(mgr.AppArmorPromptingRunning(), Equals, false)
+	c.Check(mgr.InterfacesRequestsManager(), IsNil)
+	mgr.Stop()
+	c.Check(stopCount, Equals, 0)
 }
 
 func (s *interfaceManagerSuite) TestRepoAvailable(c *C) {
@@ -6907,6 +6975,52 @@ func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {
 			},
 		},
 	})
+}
+
+func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
+	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+		return true
+	})
+	defer restore()
+	createError := fmt.Errorf("custom error")
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+		return nil, createError
+	})
+	defer restore()
+
+	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	c.Assert(err, IsNil)
+	err = mgr.StartUp()
+	c.Check(err, Equals, createError)
+}
+
+func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
+	restore := ifacestate.MockUseAppArmorPrompting(func(m *ifacestate.InterfaceManager) bool {
+		return true
+	})
+	defer restore()
+	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+		return fakeManager, nil
+	})
+	defer restore()
+	fakeError := fmt.Errorf("custom error")
+	restore = ifacestate.MockInterfacesRequestsManagerStop(func(m *apparmorprompting.InterfacesRequestsManager) error {
+		return fakeError
+	})
+	defer restore()
+
+	mgr := s.manager(c)
+	c.Check(mgr.InterfacesRequestsManager(), Equals, fakeManager)
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	mgr.Stop()
+
+	c.Check(fmt.Errorf("%v", strings.TrimSpace(logbuf.String())), ErrorMatches, fmt.Sprintf(".*%v", fakeError))
+
+	c.Assert(mgr.InterfacesRequestsManager(), IsNil)
 }
 
 func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKeyFile(c *C) {

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -37,7 +37,7 @@ func ExitOnError() (restore func()) {
 
 func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan *Response) *Request {
 	return &Request{
-		class:     class,
+		Class:     class,
 		replyChan: replyChan,
 	}
 }

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -29,6 +29,12 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+func ExitOnError() (restore func()) {
+	restore = testutil.Backup(&exitOnError)
+	exitOnError = true
+	return restore
+}
+
 func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan *Response) *Request {
 	return &Request{
 		class:     class,

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -310,7 +310,7 @@ func (l *Listener) Run() error {
 				if exitOnError {
 					return err
 				} else {
-					logger.Noticef("error in listener run loop: %v", err)
+					logger.Noticef("error in prompting listener run loop: %v", err)
 				}
 			}
 		}
@@ -399,7 +399,7 @@ func (l *Listener) handleRequestAaClassFile(buf []byte) error {
 	if err := fmsg.UnmarshalBinary(buf); err != nil {
 		return err
 	}
-	logger.Debugf("Received access request from the kernel: %+v", fmsg)
+	logger.Debugf("received prompt request from the kernel: %+v", fmsg)
 	req, err := newRequest(&fmsg)
 	if err != nil {
 		return err
@@ -452,7 +452,7 @@ func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotifi
 		// msg.Error is field from MsgNotificationResponse, and is unused.
 		// msg.MsgNotification.Error is also ignored in responses.
 	}
-	logger.Debugf("Sending access response back to the kernel: %+v", resp)
+	logger.Debugf("sending request response back to the kernel: %+v", resp)
 	return l.encodeAndSendResponse(&resp)
 }
 

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -299,6 +299,10 @@ func (l *Listener) Reqs() <-chan *Request {
 	return l.reqs
 }
 
+// Allow tests to kill the listener instead of logging errors so that tests
+// don't have race condition failures.
+var exitOnError = false
+
 // Run reads and dispatches kernel requests until the listener is closed.
 //
 // Run should only be called once per listener object. If called more than once,
@@ -323,18 +327,20 @@ func (l *Listener) Run() error {
 	// is called) return and close the tomb's dead channel, as it is the last
 	// and only tracked goroutine.
 	l.tomb.Go(func() error {
-		var err error
 		for {
-			err = l.tomb.Err()
-			if err != tomb.ErrStillAlive {
+			if l.tomb.Err() != tomb.ErrStillAlive {
 				break
 			}
-			err = l.runOnce()
+			err := l.runOnce()
 			if err != nil {
-				break
+				if exitOnError {
+					return err
+				} else {
+					logger.Noticef("error in listener run loop: %v", err)
+				}
 			}
 		}
-		return err
+		return nil
 	})
 	// Wait for an error to occur or the listener to be explicitly closed.
 	<-l.tomb.Dying()
@@ -431,7 +437,11 @@ func (l *Listener) handleRequestAaClassFile(buf []byte) error {
 		return l.tomb.Err()
 	}
 	l.tomb.Go(func() error {
-		return l.waitAndRespondAaClassFile(req, &fmsg)
+		err := l.waitAndRespondAaClassFile(req, &fmsg)
+		if err != nil {
+			logger.Noticef("error while responding to kernel: %v", err)
+		}
+		return nil
 	})
 	return nil
 }
@@ -445,7 +455,7 @@ func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotifi
 	case response = <-req.replyChan:
 		break
 	case <-l.tomb.Dying():
-		// don't bother sending deny response, kernel will handle this
+		// don't bother sending deny response, kernel will auto-deny if needed
 		return nil
 	}
 	allow := response.Allow

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -440,10 +440,12 @@ func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotifi
 		allow = false
 	}
 	if allow {
-		// allow permissions which kernel initially allowed, along with those
+		// Allow permissions which AppArmor initially allowed, along with those
 		// which the were initially denied but the user explicitly allowed.
+		// Any permissions which are omitted from both the allow and deny
+		// fields will be automatically denied by the kernel.
 		resp.Allow = msg.Allow | (uint32(perms) & msg.Deny)
-		resp.Deny = 0
+		resp.Deny = 0 // TODO: switch to equivalent but clearer ~uint32(perms) & msg.Deny
 		resp.Error = 0
 	} else {
 		resp.Allow = msg.Allow

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -299,7 +299,8 @@ func (l *Listener) Run() error {
 	// and only tracked goroutine.
 	l.tomb.Go(func() error {
 		for {
-			if l.tomb.Err() != tomb.ErrStillAlive {
+			if err := l.tomb.Err(); err != tomb.ErrStillAlive {
+				logger.Noticef("exiting listener run loop: %v", err)
 				break
 			}
 			err := l.runOnce()

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -300,7 +300,9 @@ func (l *Listener) Run() error {
 	l.tomb.Go(func() error {
 		for {
 			if err := l.tomb.Err(); err != tomb.ErrStillAlive {
-				logger.Noticef("exiting listener run loop: %v", err)
+				// Do not log error here, as the only error from outside of
+				// runOnce should be when listener was deliberately closed,
+				// and we don't want a log message for that.
 				break
 			}
 			err := l.runOnce()

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -638,6 +638,8 @@ func newMsgNotificationResponse(id uint64, allow, deny uint32) *notify.MsgNotifi
 }
 
 func (*listenerSuite) TestRunErrors(c *C) {
+	listener.ExitOnError()
+
 	restoreOpen := listener.MockOsOpenWithSocket()
 	defer restoreOpen()
 
@@ -701,6 +703,8 @@ func (*listenerSuite) TestRunErrors(c *C) {
 		select {
 		case r := <-l.Reqs():
 			c.Check(r, IsNil, Commentf("should not have received non-nil request; expected error: %v", testCase.err))
+		case <-time.NewTimer(time.Second).C:
+			c.Error("done waiting for expected error", testCase.err)
 		case <-t.Dying():
 		}
 		err = t.Wait()

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -286,12 +286,12 @@ func (*listenerSuite) TestRunSimple(c *C) {
 
 		select {
 		case req := <-l.Reqs():
-			c.Assert(req.PID(), Equals, msg.Pid)
-			c.Assert(req.Label(), Equals, label)
-			c.Assert(req.SubjectUID(), Equals, msg.SUID)
-			c.Assert(req.Path(), Equals, path)
-			c.Assert(req.Class(), Equals, notify.AA_CLASS_FILE)
-			perm, ok := req.Permission().(notify.FilePermission)
+			c.Assert(req.PID, Equals, msg.Pid)
+			c.Assert(req.Label, Equals, label)
+			c.Assert(req.SubjectUID, Equals, msg.SUID)
+			c.Assert(req.Path, Equals, path)
+			c.Assert(req.Class, Equals, notify.AA_CLASS_FILE)
+			perm, ok := req.Permission.(notify.FilePermission)
 			c.Assert(ok, Equals, true)
 			c.Assert(perm, Equals, notify.FilePermission(dBits))
 			requests = append(requests, req)
@@ -374,7 +374,7 @@ func (*listenerSuite) TestRegisterWriteRun(c *C) {
 	select {
 	case req, ok := <-l.Reqs():
 		c.Assert(ok, Equals, true)
-		c.Assert(req.Path(), Equals, path)
+		c.Assert(req.Path, Equals, path)
 	case <-l.Dying():
 		c.Fatalf("listener encountered unexpected error: %v", l.Err())
 	case <-timer.C:
@@ -421,7 +421,7 @@ func (*listenerSuite) TestRunMultipleRequestsInBuffer(c *C) {
 		timer := time.NewTimer(100 * time.Millisecond)
 		select {
 		case req := <-l.Reqs():
-			c.Assert(req.Path(), DeepEquals, path)
+			c.Assert(req.Path, DeepEquals, path)
 		case <-l.Dying():
 			c.Fatalf("listener encountered unexpected error during request %d: %v", i, l.Err())
 		case <-timer.C:
@@ -482,7 +482,7 @@ func (*listenerSuite) TestRunEpoll(c *C) {
 	requestTimer := time.NewTimer(time.Second)
 	select {
 	case req := <-l.Reqs():
-		c.Assert(req.Path(), Equals, path)
+		c.Assert(req.Path, Equals, path)
 	case <-l.Dying():
 		c.Fatalf("listener encountered unexpected error: %v", l.Err())
 	case <-requestTimer.C:


### PR DESCRIPTION
This PR is based on the current outstanding prompting PRs, which are aggregated under #14314. Only the last few commits are relevant to the PR, others will be removed as the preceding PRs are merged.

The code in this PR was originally based on the udevmonitor package. Much of this PR should be rewritten and simplified, as there's no reason for this manager to be governed by the `Connect`, `Run`, `Stop` methods and repeatedly restarted via `Ensure`.

-----

Add the `apparmorprompting` interface manager to start and manage interactions between the listener, prompts backend, and rules backend.

This package mediates interactions between the prompting API and these backends, and between the listener and these backends.

This PR is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-10089