### PR TITLE
interfaces/prompting/patterns: add checks for duplicate pattern variants

### DIFF
--- a/interfaces/prompting/patterns/render.go
+++ b/interfaces/prompting/patterns/render.go
@@ -80,10 +80,9 @@ func renderAllVariants(n renderNode, observe func(index int, variant PatternVari
 		if err != nil {
 			// This should never occur
 			logger.Noticef("patterns: cannot parse pattern variant '%s': %v", variant, err)
-			length, lengthUnchanged, moreRemain = v.NextVariant()
-			continue
+		} else {
+			observe(i, variant)
 		}
-		observe(i, variant)
 		length, lengthUnchanged, moreRemain = v.NextVariant()
 	}
 }

--- a/interfaces/prompting/patterns/render.go
+++ b/interfaces/prompting/patterns/render.go
@@ -80,6 +80,7 @@ func renderAllVariants(n renderNode, observe func(index int, variant PatternVari
 		if err != nil {
 			// This should never occur
 			logger.Noticef("patterns: cannot parse pattern variant '%s': %v", variant, err)
+			length, lengthUnchanged, moreRemain = v.NextVariant()
 			continue
 		}
 		observe(i, variant)

--- a/interfaces/prompting/patterns/render_internal_test.go
+++ b/interfaces/prompting/patterns/render_internal_test.go
@@ -95,6 +95,28 @@ func (s *renderSuite) TestRenderAllVariants(c *C) {
 	c.Check(variants, HasLen, parsed.NumVariants())
 }
 
+func (s *renderSuite) TestRenderAllVariantsConflicts(c *C) {
+	// all variants are the exact same path
+	pattern := "/{fo{obar},foo{b{ar,ar},bar,{ba}r}}"
+	scanned, err := scan(pattern)
+	c.Assert(err, IsNil)
+	parsed, err := parse(scanned)
+	c.Assert(err, IsNil)
+
+	expectedVariants := []string{
+		"/foobar",
+	}
+
+	variants := make([]string, 0, len(expectedVariants))
+	renderAllVariants(parsed, func(index int, variant PatternVariant) {
+		variants = append(variants, variant.String())
+	})
+
+	c.Check(variants, DeepEquals, expectedVariants)
+	c.Check(variants, HasLen, parsed.NumVariants())
+	c.Check(variants, HasLen, 1)
+}
+
 func (s *renderSuite) TestNextVariant(c *C) {
 	pattern := "/{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so*"
 	scanned, err := scan(pattern)

--- a/interfaces/prompting/patterns/render_internal_test.go
+++ b/interfaces/prompting/patterns/render_internal_test.go
@@ -130,6 +130,22 @@ func (s *renderSuite) TestRenderAllVariantsConflicts(c *C) {
 	}
 }
 
+func (s *renderSuite) TestRenderAllVariantsError(c *C) {
+	badNodes := seq{
+		literal("/"),
+		alt{
+			literal("good"),
+			literal("bad[path]"),
+			literal("great"),
+		},
+	}
+	variants := make([]string, 0, 1)
+	renderAllVariants(badNodes, func(index int, variant PatternVariant) {
+		variants = append(variants, variant.String())
+	})
+	c.Check(variants, DeepEquals, []string{"/good", "/great"})
+}
+
 func (s *renderSuite) TestNextVariant(c *C) {
 	pattern := "/{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so*"
 	scanned, err := scan(pattern)

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -461,6 +461,9 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string) []prom
 		switch {
 		case !exists:
 			newVariantEntries[variantStr] = newEntry
+		case conflictingVariantEntry.RuleID == rule.ID:
+			// Rule has duplicate variant, so ignore it
+			return
 		case rdb.isRuleWithIDExpired(conflictingVariantEntry.RuleID, rule.Timestamp):
 			expiredRules[conflictingVariantEntry.RuleID] = true
 			newVariantEntries[variantStr] = newEntry

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -461,13 +461,16 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string) []prom
 		switch {
 		case !exists:
 			newVariantEntries[variantStr] = newEntry
-		case conflictingVariantEntry.RuleID == rule.ID:
-			// Rule has duplicate variant, so ignore it
-			return
 		case rdb.isRuleWithIDExpired(conflictingVariantEntry.RuleID, rule.Timestamp):
 			expiredRules[conflictingVariantEntry.RuleID] = true
 			newVariantEntries[variantStr] = newEntry
 		default:
+			// XXX: If we ever switch to adding variants directly to the real
+			// variant entries map instead of a new map, check that the
+			// "conflicting" entry does not belong to the same rule that we're
+			// in the process of adding, which is possible if the rule's path
+			// pattern can render to duplicate variants. Ignore self-conflicts.
+
 			// Exists and is not expired, so there's a conflict
 			conflicts = append(conflicts, prompting_errors.RuleConflict{
 				Permission:    permission,

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -617,7 +617,7 @@ func addRuleFromTemplate(c *C, rdb *requestrules.RuleDB, template *addRuleConten
 	return rdb.AddRule(partial.User, partial.Snap, partial.Interface, constraints, partial.Outcome, partial.Lifespan, partial.Duration)
 }
 
-func (s *requestrulesSuite) TestAddRuleDuplicateVariants(c *C) {
+func (s *requestrulesSuite) TestAddRuleRemoveRuleDuplicateVariants(c *C) {
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -632,6 +632,8 @@ func (s *requestrulesSuite) TestAddRuleDuplicateVariants(c *C) {
 		Duration:    "",
 	}
 
+	// Test that rule with a pattern which renders into duplicate variants does
+	// not conflict with itself while adding
 	var addedRules []*requestrules.Rule
 	rule, err := addRuleFromTemplate(c, rdb, ruleContents, ruleContents)
 	c.Check(err, IsNil)
@@ -639,6 +641,27 @@ func (s *requestrulesSuite) TestAddRuleDuplicateVariants(c *C) {
 	addedRules = append(addedRules, rule)
 	s.checkWrittenRuleDB(c, addedRules)
 	s.checkNewNoticesSimple(c, nil, rule)
+
+	// Test that the rule exists
+	found, err := rdb.RuleWithID(rule.User, rule.ID)
+	c.Assert(err, IsNil)
+	c.Check(found, DeepEquals, rule)
+	// Test that the rule's path pattern really renders to duplicate variants
+	variantList := make([]string, 0, found.Constraints.PathPattern.NumVariants())
+	variantSet := make(map[string]int, found.Constraints.PathPattern.NumVariants())
+	found.Constraints.PathPattern.RenderAllVariants(func(index int, variant patterns.PatternVariant) {
+		variantStr := variant.String()
+		variantList = append(variantList, variantStr)
+		variantSet[variantStr] += 1
+	})
+	c.Check(variantSet, Not(HasLen), len(variantList), Commentf("variant list: %q\nvariant set: %q", variantList, variantSet))
+
+	// Test that rule with a pattern which renders into duplicate variants does
+	// not cause an error while removing by trying to remove the same variant
+	// twice and finding it already removed the second time
+	removed, err := rdb.RemoveRule(rule.User, rule.ID)
+	c.Assert(err, IsNil)
+	c.Check(removed, DeepEquals, rule)
 }
 
 func (s *requestrulesSuite) TestAddRuleErrors(c *C) {

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -617,6 +617,30 @@ func addRuleFromTemplate(c *C, rdb *requestrules.RuleDB, template *addRuleConten
 	return rdb.AddRule(partial.User, partial.Snap, partial.Interface, constraints, partial.Outcome, partial.Lifespan, partial.Duration)
 }
 
+func (s *requestrulesSuite) TestAddRuleDuplicateVariants(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	ruleContents := &addRuleContents{
+		User:        s.defaultUser,
+		Snap:        "nextcloud",
+		Interface:   "home",
+		PathPattern: "/home/test/{{foo/{bar,baz},123},{123,foo{/bar,/baz}}}",
+		Permissions: []string{"read"},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanForever,
+		Duration:    "",
+	}
+
+	var addedRules []*requestrules.Rule
+	rule, err := addRuleFromTemplate(c, rdb, ruleContents, ruleContents)
+	c.Check(err, IsNil)
+	c.Check(rule, NotNil)
+	addedRules = append(addedRules, rule)
+	s.checkWrittenRuleDB(c, addedRules)
+	s.checkNewNoticesSimple(c, nil, rule)
+}
+
 func (s *requestrulesSuite) TestAddRuleErrors(c *C) {
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Add a specific unit for parsing and then rendering a pattern which produces many identical variants.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
