### PR TITLE
interfaces/apparmor/template: account for snap-exec from snapd when in jailmode

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1229,6 +1229,9 @@ profile "snap.samba.smbd" flags=(attach_disconnected,mediate_deleted) {
 
   # For snappy reexec on 4.8+ kernels
   @{INSTALL_DIR}/core/*/usr/lib/snapd/snap-exec m,
+  # Same as above but accounting for the case when the
+  # snapd snap is installed and executes the snap application.
+  @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snap-exec rm,
 
 snippet
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -887,6 +887,9 @@ var classicJailmodeSnippet = `
 
   # For snappy reexec on 4.8+ kernels
   @{INSTALL_DIR}/core/*/usr/lib/snapd/snap-exec m,
+  # Same as above but accounting for the case when the
+  # snapd snap is installed and executes the snap application.
+  @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snap-exec rm,
 `
 
 var ptraceTraceDenySnippet = `


### PR DESCRIPTION
Account for snap-exec coming from the snapd snap when starting a confined process with jailmode.

Cherry picked from #14294