### PR TITLE
o/snapstate, o/ifacestate: consider comps in pending security

### DIFF
--- a/interfaces/snap_app_set.go
+++ b/interfaces/snap_app_set.go
@@ -32,6 +32,11 @@ func (a *SnapAppSet) Info() *snap.Info {
 	return a.info
 }
 
+// Components returns the components that this SnapAppSet was created with.
+func (a *SnapAppSet) Components() []*snap.ComponentInfo {
+	return a.components
+}
+
 // InstanceName returns the instance name of the snap that this SnapAppSet is
 // based on.
 func (a *SnapAppSet) InstanceName() string {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
 )
@@ -1102,8 +1103,23 @@ func snapsWithSecurityProfiles(st *state.State) ([]*interfaces.SnapAppSet, error
 				continue
 			}
 
-			// TODO:COMPS: add components to SnapState.PendingSecurity
-			set, err := interfaces.NewSnapAppSet(snapInfo, nil)
+			components := make([]*snap.ComponentInfo, 0, len(snapst.PendingSecurity.Components))
+			for _, csi := range snapst.PendingSecurity.Components {
+				cpi := snap.MinimalComponentContainerPlaceInfo(
+					csi.Component.ComponentName,
+					csi.Revision,
+					instanceName,
+				)
+				container := snapdir.New(cpi.MountDir())
+				ci, err := snap.ReadComponentInfoFromContainer(container, snapInfo, csi)
+				if err != nil {
+					logger.Noticef("cannot read component info for snap %q: %s", instanceName, err)
+					continue
+				}
+				components = append(components, ci)
+			}
+
+			set, err := interfaces.NewSnapAppSet(snapInfo, components)
 			if err != nil {
 				logger.Noticef("cannot build app set for snap %q: %s", instanceName, err)
 				continue

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -570,7 +570,8 @@ func OnSnapLinkageChanged(st *state.State, snapsup *snapstate.SnapSetup) error {
 		// track the revision that was just unlinked that has
 		// still profiles
 		snapst.PendingSecurity = &snapstate.PendingSecurityState{
-			SideInfo: snapst.CurrentSideInfo(),
+			SideInfo:   snapst.CurrentSideInfo(),
+			Components: snapst.CurrentComponentSideInfos(),
 		}
 	}
 	snapstate.Set(st, instanceName, &snapst)

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -273,9 +273,6 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup ComponentS
 		addTask(discardComp)
 	}
 
-	// TODO:COMPS: do we need to set restart boundaries here? (probably for
-	// kernel-modules components if installed along the kernel)
-
 	return componentTS, nil
 }
 

--- a/overlord/snapstate/component_test.go
+++ b/overlord/snapstate/component_test.go
@@ -118,6 +118,7 @@ components:
 	foundCi2, err := snapSt.CurrentComponentInfo(cref2)
 	c.Check(err, IsNil)
 	c.Check(foundCi2, NotNil)
+	c.Check(snapSt.CurrentComponentSideInfos(), DeepEquals, []*snap.ComponentSideInfo{csi2, csi})
 
 	comps, err := snapSt.CurrentComponentInfos()
 	c.Assert(err, IsNil)
@@ -147,6 +148,7 @@ components:
 	comps, err = snapSt.CurrentComponentInfos()
 	c.Assert(err, IsNil)
 	c.Check(comps, HasLen, 0)
+	c.Check(snapSt.CurrentComponentSideInfos(), HasLen, 0)
 
 	comps, err = snapSt.ComponentInfosForRevision(ssi2.Revision)
 	c.Assert(err, IsNil)
@@ -173,6 +175,7 @@ components:
 	comps, err = snapSt.CurrentComponentInfos()
 	c.Assert(err, IsNil)
 	c.Check(comps, HasLen, 0)
+	c.Check(snapSt.CurrentComponentSideInfos(), HasLen, 0)
 
 	snapSt = &snapstate.SnapState{
 		Active: true,
@@ -199,6 +202,7 @@ components:
 	comps, err = snapSt.CurrentComponentInfos()
 	c.Assert(err, IsNil)
 	c.Check(comps, testutil.DeepUnsortedMatches, []*snap.ComponentInfo{foundCi})
+	c.Check(snapSt.CurrentComponentSideInfos(), DeepEquals, []*snap.ComponentSideInfo{csi})
 
 	comps, err = snapSt.ComponentInfosForRevision(snapRev2)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -381,7 +381,8 @@ type SnapState struct {
 type PendingSecurityState struct {
 	// SideInfo of the revision for which security profiles are or
 	// should be set up if any.
-	SideInfo *snap.SideInfo `json:"side-info,omitempty"`
+	SideInfo   *snap.SideInfo            `json:"side-info,omitempty"`
+	Components []*snap.ComponentSideInfo `json:"components,omitempty"`
 }
 
 func (snapst *SnapState) SetTrackingChannel(s string) error {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -465,6 +465,23 @@ func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {
 	panic("cannot find snapst.Current in the snapst.Sequence.Revisions")
 }
 
+// CurrentComponentSideInfos returns the component side infos for the revision
+// indicated by snapst.Current in the snap revision sequence, if there is one.
+func (snapst *SnapState) CurrentComponentSideInfos() []*snap.ComponentSideInfo {
+	if !snapst.IsInstalled() {
+		return nil
+	}
+	if idx := snapst.LastIndex(snapst.Current); idx >= 0 {
+		comps := snapst.Sequence.Revisions[idx].Components
+		csis := make([]*snap.ComponentSideInfo, 0, len(comps))
+		for _, comp := range comps {
+			csis = append(csis, comp.SideInfo)
+		}
+		return csis
+	}
+	panic("cannot find snapst.Current in the snapst.Sequence.Revisions")
+}
+
 // CurrentComponentSideInfo returns the component side info for the revision indicated by
 // snapst.Current in the snap revision sequence if there is one.
 func (snapst *SnapState) CurrentComponentSideInfo(cref naming.ComponentRef) *snap.ComponentSideInfo {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -258,9 +258,6 @@ func (compsu *ComponentSetup) Revision() snap.Revision {
 // * Installing/refreshing a snap with components
 // * Installing/refreshing a snap without any components
 func ComponentSetupsForTask(t *state.Task) ([]*ComponentSetup, error) {
-	// TODO:COMPS: handle remaining cases in this switch:
-	// * installing multiple components for an already installed snap
-	// * installing/refreshing a snap with components
 	switch {
 	case t.Has("component-setup") || t.Has("component-setup-task"):
 		// task comes from a singular component installation for an already

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -469,15 +469,13 @@ func (snapst *SnapState) CurrentComponentSideInfos() []*snap.ComponentSideInfo {
 	if !snapst.IsInstalled() {
 		return nil
 	}
-	if idx := snapst.LastIndex(snapst.Current); idx >= 0 {
-		comps := snapst.Sequence.Revisions[idx].Components
-		csis := make([]*snap.ComponentSideInfo, 0, len(comps))
-		for _, comp := range comps {
-			csis = append(csis, comp.SideInfo)
-		}
-		return csis
+
+	compStates := snapst.Sequence.ComponentsForRevision(snapst.Current)
+	comps := make([]*snap.ComponentSideInfo, 0, len(compStates))
+	for _, comp := range compStates {
+		comps = append(comps, comp.SideInfo)
 	}
-	panic("cannot find snapst.Current in the snapst.Sequence.Revisions")
+	return comps
 }
 
 // CurrentComponentSideInfo returns the component side info for the revision indicated by


### PR DESCRIPTION
This adds the set of being-setup-components to the PendingSecurity struct that we use to track security changes that have happened for inactive snap revisions.