### PR TITLE
overlord/snapstate: remove unused field in fake backend operations

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -92,8 +92,8 @@ type fakeOp struct {
 	dirOpts  *dirs.SnapDirOptions
 	undoInfo *backend.UndoInfo
 
-	compsToInstall, currentComps []*snap.ComponentSideInfo
-	compsToRemove, finalComps    []*snap.ComponentSideInfo
+	currentComps []*snap.ComponentSideInfo
+	finalComps   []*snap.ComponentSideInfo
 
 	containerName     string
 	containerFileName string


### PR DESCRIPTION
Remove unused fields:

overlord/snapstate/backend_test.go:95:2: field `compsToInstall` is unused (unused)
        compsToInstall, currentComps []*snap.ComponentSideInfo
        ^
overlord/snapstate/backend_test.go:96:2: field `compsToRemove` is unused (unused)
        compsToRemove, finalComps    []*snap.ComponentSideInfo
        ^

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
