### PR TITLE
many: consider asserted components when building a seed

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snapfile"
 )
 
@@ -290,6 +291,27 @@ func CheckProvenanceWithVerifiedRevision(snapPath string, verifiedRev *asserts.S
 	return nil
 }
 
+// CheckComponentProvenanceWithVerifiedRevision checks that the given component
+// has the same provenance as of the provided resource-revision. It is intended
+// to be called safely on components for which a matching and authorized
+// resource-revision has been already found. Its purpose is to check that a
+// blob has not been re-signed under an inappropriate provenance.
+func CheckComponentProvenanceWithVerifiedRevision(compPath string, verifiedRev *asserts.SnapResourceRevision) error {
+
+	compf, err := snapfile.Open(compPath)
+	if err != nil {
+		return err
+	}
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil, nil)
+	if err != nil {
+		return err
+	}
+	if verifiedRev.Provenance() != ci.Provenance() {
+		return fmt.Errorf("component %q has been signed under provenance %q different from the metadata one: %q", compPath, verifiedRev.Provenance(), ci.Provenance())
+	}
+	return nil
+}
+
 // DeriveSideInfo tries to construct a SideInfo for the given snap
 // using its digest to find the relevant snap assertions with the
 // information in the given database. It will fail with an
@@ -365,6 +387,58 @@ func SideInfoFromSnapAssertions(snapDecl *asserts.SnapDeclaration, snapRev *asse
 	}
 }
 
+// DeriveComponentSideInfoFromDigestAndSize tries to construct a
+// ComponentSideInfo using digest and size for a component and ID/name for the
+// snap to find the relevant assertions with the information in the given
+// database. It will fail with an asserts.NotFoundError if it cannot find them.
+func DeriveComponentSideInfoFromDigestAndSize(resName, snapName, snapID string, compPath, snapSHA3_384 string, resSize uint64, model *asserts.Model, db Finder) (*snap.ComponentSideInfo, error) {
+	// get relevant assertions and reconstruct metadata
+	headers := map[string]string{
+		"snap-id":           snapID,
+		"resource-name":     resName,
+		"resource-sha3-384": snapSHA3_384,
+	}
+	a, err := db.Find(asserts.SnapResourceRevisionType, headers)
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
+		return nil, err
+	}
+	if a == nil {
+		// non-default provenance?
+		cands, err := db.FindMany(asserts.SnapResourceRevisionType, headers)
+		if err != nil {
+			return nil, err
+		}
+		if len(cands) != 1 {
+			return nil, fmt.Errorf("safely handling resources with different provenance but same hash not yet supported")
+		}
+		a = cands[0]
+	}
+
+	resRev := a.(*asserts.SnapResourceRevision)
+
+	if resRev.ResourceSize() != resSize {
+		return nil, fmt.Errorf("resource %q does not have the expected size according to signatures (broken or tampered): %d != %d", resName, resSize, resRev.ResourceSize())
+	}
+
+	snapDecl, err := findSnapDeclaration(snapID, snapName, db)
+	if err != nil {
+		return nil, err
+	}
+	err = crossCheckResourceProvenance(resRev, snapDecl, model, db)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := CheckComponentProvenanceWithVerifiedRevision(compPath, resRev); err != nil {
+		return nil, err
+	}
+
+	return &snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, resName),
+		Revision:  snap.R(resRev.ResourceRevision()),
+	}, nil
+}
+
 // FetchSnapAssertions fetches the assertions matching the snap file digest and optional provenance using the given fetcher.
 func FetchSnapAssertions(f asserts.Fetcher, snapSHA3_384, provenance string) error {
 	// for now starting from the snap-revision will get us all other relevant assertions
@@ -379,34 +453,40 @@ func FetchSnapAssertions(f asserts.Fetcher, snapSHA3_384, provenance string) err
 	return f.Fetch(ref)
 }
 
+func FetchResourceRevisionAssertion(f asserts.Fetcher, si *snap.SideInfo, resName, hash, provenance string) error {
+	ref := &asserts.Ref{
+		Type:       asserts.SnapResourceRevisionType,
+		PrimaryKey: []string{si.SnapID, resName, hash},
+	}
+	if provenance != "" {
+		ref.PrimaryKey = append(ref.PrimaryKey, provenance)
+	}
+	return f.Fetch(ref)
+}
+
+func FetchResourcePairAssertion(f asserts.Fetcher, si *snap.SideInfo, resName string, resRev snap.Revision, provenance string) error {
+	ref := &asserts.Ref{
+		Type:       asserts.SnapResourcePairType,
+		PrimaryKey: []string{si.SnapID, resName, resRev.String(), si.Revision.String()},
+	}
+	if provenance != "" {
+		ref.PrimaryKey = append(ref.PrimaryKey, provenance)
+	}
+	return f.Fetch(ref)
+}
+
 // FetchComponentAssertions fetches the assertions matching the information
 // described in the given SideInfo and ComponentSideInfo using the given
 // fetcher.
 func FetchComponentAssertions(f asserts.Fetcher, si *snap.SideInfo, csi *snap.ComponentSideInfo, hash, provenance string) error {
 	// for now starting from the snap-resource-revision will get us all other relevant assertions
-	ref := &asserts.Ref{
-		Type:       asserts.SnapResourceRevisionType,
-		PrimaryKey: []string{si.SnapID, csi.Component.ComponentName, hash},
-	}
-	if provenance != "" {
-		ref.PrimaryKey = append(ref.PrimaryKey, provenance)
-	}
-
-	if err := f.Fetch(ref); err != nil {
+	if err := FetchResourceRevisionAssertion(
+		f, si, csi.Component.ComponentName, hash, provenance); err != nil {
 		return err
 	}
 
 	// fetch the snap-resource-pair as well
-	ref = &asserts.Ref{
-		Type:       asserts.SnapResourcePairType,
-		PrimaryKey: []string{si.SnapID, csi.Component.ComponentName, csi.Revision.String(), si.Revision.String()},
-	}
-
-	if provenance != "" {
-		ref.PrimaryKey = append(ref.PrimaryKey, provenance)
-	}
-
-	return f.Fetch(ref)
+	return FetchResourcePairAssertion(f, si, csi.Component.ComponentName, csi.Revision, provenance)
 }
 
 // FetchSnapDeclaration fetches the snap declaration and its prerequisites for the given snap id using the given fetcher.

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -644,6 +644,61 @@ version: 1
 
 }
 
+func (s *snapassertsSuite) TestCheckComponentProvenanceWithVerifiedRevision(c *C) {
+	digest := makeDigest(12)
+	size := uint64(len(fakeSnap(12)))
+	snapResRev := assertstest.FakeAssertion(map[string]interface{}{
+		"type":              "snap-resource-revision",
+		"authority-id":      s.dev1Acct.AccountID(),
+		"snap-id":           "snap-id-1",
+		"resource-name":     "comp1",
+		"resource-sha3-384": digest,
+		"developer-id":      s.dev1Acct.AccountID(),
+		"provenance":        "prov",
+		"resource-revision": "22",
+		"resource-size":     fmt.Sprintf("%d", size),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}).(*asserts.SnapResourceRevision)
+	snapResRev2 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":              "snap-resource-revision",
+		"authority-id":      s.dev1Acct.AccountID(),
+		"snap-id":           "snap-id-1",
+		"resource-name":     "comp1",
+		"resource-sha3-384": digest,
+		"developer-id":      s.dev1Acct.AccountID(),
+		"provenance":        "global-upload",
+		"resource-revision": "22",
+		"resource-size":     fmt.Sprintf("%d", size),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}).(*asserts.SnapResourceRevision)
+	compPath := snaptest.MakeTestComponentWithFiles(c, "comp1", `component: snap+comp1
+type: test
+provenance: prov
+version: 1.0.2
+`, nil)
+	compPath2 := snaptest.MakeTestComponentWithFiles(c, "comp1", `component: snap+comp1
+type: test
+version: 1.0.2
+`, nil)
+
+	// matching
+	c.Check(snapasserts.CheckComponentProvenanceWithVerifiedRevision(compPath, snapResRev), IsNil)
+	c.Check(snapasserts.CheckComponentProvenanceWithVerifiedRevision(compPath2, snapResRev2), IsNil)
+
+	// mismatches
+	mismatches := []struct {
+		path         string
+		snapRev      *asserts.SnapResourceRevision
+		metadataProv string
+	}{
+		{compPath, snapResRev2, "prov"},
+		{compPath2, snapResRev, "global-upload"},
+	}
+	for _, mism := range mismatches {
+		c.Check(snapasserts.CheckComponentProvenanceWithVerifiedRevision(mism.path, mism.snapRev), ErrorMatches, fmt.Sprintf("component %q has been signed under provenance %q different from the metadata one: %q", mism.path, mism.snapRev.Provenance(), mism.metadataProv))
+	}
+}
+
 func (s *snapassertsSuite) TestDeriveSideInfoFromDigestAndSizeDelegatedSnap(c *C) {
 	withProv := snaptest.MakeTestSnapWithFiles(c, `name: with-prov
 version: 1
@@ -790,6 +845,215 @@ provenance: prov`, nil)
 
 	_, err = snapasserts.DeriveSideInfoFromDigestAndSize(withProv, digest, size, nil, s.localDB)
 	c.Check(err, ErrorMatches, `safely handling snaps with different provenance but same hash not yet supported`)
+}
+
+func assertedSnapID(snapName string) string {
+	snapID := naming.WellKnownSnapID(snapName)
+	if snapID != "" {
+		return snapID
+	}
+	return snaptest.AssertedSnapID(snapName)
+}
+
+func (s *snapassertsSuite) makeUC20Model(c *C, extraHeaders map[string]interface{}) *asserts.Model {
+	comps := map[string]interface{}{
+		"comp1": "required",
+		"comp2": "optional",
+	}
+	headers := map[string]interface{}{
+		"brand-id":     s.dev1Acct.AccountID(),
+		"series":       "16",
+		"model":        "dev-model",
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              assertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              assertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":       "required20",
+				"id":         assertedSnapID("required20"),
+				"components": comps,
+			}},
+	}
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
+
+	model, err := s.dev1Signing.Sign(asserts.ModelType, headers, nil, "")
+	c.Assert(err, IsNil)
+	return model.(*asserts.Model)
+}
+
+func (s *snapassertsSuite) TestDeriveComponentSideInfoFromDigestAndSize(c *C) {
+	model := s.makeUC20Model(c, nil)
+
+	compPath := snaptest.MakeTestComponentWithFiles(c, "comp1", `component: snap+comp1
+type: test
+version: 1.0.2
+`, nil)
+	digest, size, err := asserts.SnapFileSHA3_384(compPath)
+	c.Assert(err, IsNil)
+
+	// Make sure we error if no assertion
+	csi, err := snapasserts.DeriveComponentSideInfoFromDigestAndSize(
+		"comp1", "snap", "snap-id-1", compPath, digest, size, model, s.localDB)
+	c.Check(err, ErrorMatches, "snap-resource-revision assertion not found")
+	c.Check(csi, IsNil)
+
+	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+		"type":              "snap-resource-revision",
+		"authority-id":      "can0nical",
+		"snap-id":           "snap-id-1",
+		"resource-name":     "comp1",
+		"resource-sha3-384": digest,
+		"developer-id":      s.dev1Acct.AccountID(),
+		"provenance":        "global-upload",
+		"resource-revision": "22",
+		"resource-size":     fmt.Sprintf("%d", size),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(resRev)
+	c.Assert(err, IsNil)
+
+	csi, err = snapasserts.DeriveComponentSideInfoFromDigestAndSize(
+		"comp1", "snap", "snap-id-1", compPath, digest, size, model, s.localDB)
+	c.Check(err, IsNil)
+	c.Check(csi, DeepEquals, &snap.ComponentSideInfo{
+		Component: naming.NewComponentRef("snap", "comp1"),
+		Revision:  snap.R(22),
+	})
+}
+
+func (s *snapassertsSuite) TestDeriveComponentSideInfoFromDigestAndSizeWrongSize(c *C) {
+	model := s.makeUC20Model(c, nil)
+	compPath := snaptest.MakeTestComponentWithFiles(c, "comp1", `component: snap+comp1
+type: test
+version: 1.0.2
+`, nil)
+	digest, size, err := asserts.SnapFileSHA3_384(compPath)
+	c.Assert(err, IsNil)
+
+	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+		"type":              "snap-resource-revision",
+		"authority-id":      "can0nical",
+		"snap-id":           "snap-id-1",
+		"resource-name":     "comp1",
+		"resource-sha3-384": digest,
+		"developer-id":      s.dev1Acct.AccountID(),
+		"provenance":        "global-upload",
+		"resource-revision": "22",
+		"resource-size":     fmt.Sprintf("%d", size+1),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(resRev)
+	c.Assert(err, IsNil)
+
+	csi, err := snapasserts.DeriveComponentSideInfoFromDigestAndSize(
+		"comp1", "snap", "snap-id-1", compPath, digest, size, model, s.localDB)
+	c.Check(err, ErrorMatches, fmt.Sprintf(`resource "comp1" does not have the expected size according to signatures \(broken or tampered\): %d != %d`, size, size+1))
+	c.Check(csi, IsNil)
+}
+
+func (s *snapassertsSuite) TestDeriveComponentSideInfoFromDigestAndSizeWithProvenance(c *C) {
+	model := s.makeUC20Model(c, map[string]interface{}{"store": "store1"})
+	compPath := snaptest.MakeTestComponentWithFiles(c, "comp1", `component: snap+comp1
+type: test
+provenance: prov
+version: 1.0.2
+`, nil)
+	digest, size, err := asserts.SnapFileSHA3_384(compPath)
+	c.Assert(err, IsNil)
+
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "snap-id-1",
+		"snap-name":    "foo",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"revision":     "1",
+		"revision-authority": []interface{}{
+			map[string]interface{}{
+				"account-id": s.dev1Acct.AccountID(),
+				"provenance": []interface{}{
+					"prov",
+					"prov2",
+				},
+				"on-store": []interface{}{
+					"store1",
+				},
+			},
+		},
+		"timestamp": time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(snapDecl)
+	c.Assert(err, IsNil)
+
+	// Ok result
+	resRev, err := s.dev1Signing.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+		"type":              "snap-resource-revision",
+		"authority-id":      s.dev1Acct.AccountID(),
+		"snap-id":           "snap-id-1",
+		"resource-name":     "comp1",
+		"resource-sha3-384": digest,
+		"developer-id":      s.dev1Acct.AccountID(),
+		"provenance":        "prov",
+		"resource-revision": "22",
+		"resource-size":     fmt.Sprintf("%d", size),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(resRev)
+	c.Assert(err, IsNil)
+
+	csi, err := snapasserts.DeriveComponentSideInfoFromDigestAndSize(
+		"comp1", "snap", "snap-id-1", compPath, digest, size, model, s.localDB)
+	c.Check(err, IsNil)
+	c.Check(csi, DeepEquals, &snap.ComponentSideInfo{
+		Component: naming.NewComponentRef("snap", "comp1"),
+		Revision:  snap.R(22),
+	})
+
+	// Model not for the right store
+	modelNoStore := s.makeUC20Model(c, nil)
+	csi, err = snapasserts.DeriveComponentSideInfoFromDigestAndSize(
+		"comp1", "snap", "snap-id-1", compPath, digest, size, modelNoStore, s.localDB)
+	c.Assert(err, ErrorMatches, `snap resource "comp1" revision assertion with provenance "prov" is not signed by an authority authorized on this device:.*`)
+	c.Check(csi, IsNil)
+
+	// Same hash but different provenance
+	resRev2, err := s.dev1Signing.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+		"type":              "snap-resource-revision",
+		"authority-id":      s.dev1Acct.AccountID(),
+		"snap-id":           "snap-id-1",
+		"resource-name":     "comp1",
+		"resource-sha3-384": digest,
+		"developer-id":      s.dev1Acct.AccountID(),
+		"provenance":        "prov2",
+		"resource-revision": "22",
+		"resource-size":     fmt.Sprintf("%d", size),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(resRev2)
+	c.Assert(err, IsNil)
+	csi, err = snapasserts.DeriveComponentSideInfoFromDigestAndSize(
+		"comp1", "snap", "snap-id-1", compPath, digest, size, model, s.localDB)
+	c.Check(err, ErrorMatches, "safely handling resources with different provenance but same hash not yet supported")
+	c.Check(csi, IsNil)
 }
 
 func (s *snapassertsSuite) TestCrossCheckResource(c *C) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -4355,6 +4355,130 @@ func (s *imageSuite) TestLocalSnapRevisionMatchingStoreRevision(c *C) {
 	})
 }
 
+func (s *imageSuite) TestLocalSnapWithCompsRevisionMatchingStoreRevision(c *C) {
+	bootloader.Force(nil)
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	prepareDir := c.MkDir()
+
+	s.makeSnap(c, "snapd", [][]string{snapdInfoFile}, snap.R(1), "")
+	s.makeSnap(c, "core20", nil, snap.R(20), "")
+	s.makeSnap(c, "pc-kernel=20", nil, snap.R(1), "")
+	gadgetContent := [][]string{
+		{"grub-recovery.conf", "# recovery grub.cfg"},
+		{"grub.conf", "# boot grub.cfg"},
+		{"meta/gadget.yaml", pcUC20GadgetYaml},
+	}
+	s.makeSnap(c, "pc=20", gadgetContent, snap.R(22), "")
+	comRevs := map[string]snap.Revision{
+		"comp1": snap.R(22),
+		"comp2": snap.R(33),
+	}
+	s.SeedSnaps.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["required20"], nil,
+		snap.R(21), comRevs, "other", s.StoreSigning.Database)
+
+	model := s.makeUC20Model(nil)
+
+	opts := &image.Options{
+		Snaps: []string{
+			s.AssertedSnap("required20"),
+		},
+		Components: []string{
+			s.AssertedSnap("required20+comp1"),
+			s.AssertedSnap("required20+comp2"),
+		},
+		PrepareDir: prepareDir,
+		Customizations: image.Customizations{
+			Validation: "ignore",
+		},
+	}
+
+	err := image.SetupSeed(s.tsto, model, opts)
+	c.Assert(err, IsNil)
+
+	// check seed
+	seeddir := filepath.Join(prepareDir, "system-seed")
+	seedsnapsdir := filepath.Join(seeddir, "snaps")
+	essSnaps, runSnaps, roDB := s.loadSeed(c, seeddir)
+	c.Check(essSnaps, HasLen, 4)
+	c.Check(runSnaps, HasLen, 1)
+
+	// check the files are in place
+	essChannel := []string{"latest/stable", "20", "latest/stable", "20"}
+	essNames := []string{"snapd", "pc-kernel", "core20", "pc"}
+	for i, name := range essNames {
+		info := s.AssertedSnapInfo(name)
+		fn := info.Filename()
+		p := filepath.Join(seedsnapsdir, fn)
+		c.Check(p, testutil.FilePresent)
+		c.Check(essSnaps[i], DeepEquals, &seed.Snap{
+			Path:          p,
+			SideInfo:      &info.SideInfo,
+			EssentialType: info.Type(),
+			Essential:     true,
+			Required:      true,
+			Channel:       essChannel[i],
+		})
+	}
+	c.Check(runSnaps[0], DeepEquals, &seed.Snap{
+		Path:     filepath.Join(seedsnapsdir, "required20_21.snap"),
+		Required: true,
+		SideInfo: &snap.SideInfo{
+			RealName: "required20",
+			SnapID:   s.AssertedSnapID("required20"),
+			Revision: snap.R(21),
+		},
+		Channel: "latest/stable",
+	})
+	c.Check(runSnaps[0].Path, testutil.FilePresent)
+	// Check components exist
+	// TODO:COMPS: check components when added to seed.Snap type
+	c.Check(filepath.Join(seedsnapsdir, "required20+comp1_22.comp"), testutil.FilePresent)
+	c.Check(filepath.Join(seedsnapsdir, "required20+comp2_33.comp"), testutil.FilePresent)
+
+	l, err := os.ReadDir(seedsnapsdir)
+	c.Assert(err, IsNil)
+	c.Check(l, HasLen, 7)
+
+	// check assertions
+	decls, err := roDB.FindMany(asserts.SnapDeclarationType, nil)
+	c.Assert(err, IsNil)
+	c.Check(decls, HasLen, 5)
+
+	resRevs, err := roDB.FindMany(asserts.SnapResourceRevisionType, nil)
+	c.Assert(err, IsNil)
+	c.Check(resRevs, HasLen, 2)
+	resPairRevs, err := roDB.FindMany(asserts.SnapResourcePairType, nil)
+	c.Assert(err, IsNil)
+	c.Check(resPairRevs, HasLen, 2)
+
+	// check the downloads, make sure no downloads for required20 and its
+	// components are present as we are using local files for this.
+	c.Check(s.storeActionsBunchSizes, DeepEquals, []int{4})
+	for i := range s.storeActions {
+		c.Check(s.storeActions[i], DeepEquals, &store.SnapAction{
+			Action:       "download",
+			InstanceName: essNames[i],
+			Channel:      essChannel[i],
+			Flags:        store.SnapActionIgnoreValidation,
+		})
+	}
+
+	// Verify that the local file is of correct revision
+	c.Check(s.curSnaps, HasLen, 1)
+	c.Check(s.curSnaps[0], DeepEquals, []*store.CurrentSnap{
+		{
+			InstanceName:     "required20",
+			SnapID:           s.AssertedSnapID("required20"),
+			Revision:         snap.R(21),
+			TrackingChannel:  "stable",
+			Epoch:            snap.E("0"),
+			IgnoreValidation: true,
+		},
+	})
+}
+
 func (s *imageSuite) setupValidationSet(c *C, name string, snaps []interface{}) *asserts.ValidationSet {
 	vs, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
 		"type":         "validation-set",

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -293,7 +293,7 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 			return "", err
 		}
 	}
-	if err := w.SetOptionsSnaps(optsSnaps, nil); err != nil {
+	if err := w.SetOptionsSnaps(optsSnaps); err != nil {
 		return "", err
 	}
 
@@ -322,6 +322,7 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 	}
 	// past this point the system directory is present
 
+	// TODO:COMPS: take into account local components
 	localSnaps, err := w.LocalSnaps()
 	if err != nil {
 		return recoverySystemDir, err

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -388,7 +388,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	w, err := seedwriter.New(model, &opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps(optSnaps, nil)
+	err = w.SetOptionsSnaps(optSnaps)
 	c.Assert(err, IsNil)
 
 	err = w.Start(db, sf)

--- a/seed/seedwriter/helpers.go
+++ b/seed/seedwriter/helpers.go
@@ -135,7 +135,7 @@ func DeriveSideInfo(snapPath string, model *asserts.Model, sf SeedAssertionFetch
 // component using its digest to fetch the relevant assertions. It will fail
 // with an asserts.NotFoundError if it cannot find them. model is used to cross
 // check that the found snap-resource-revision is applicable on the device.
-func DeriveComponentSideInfo(compPath string, compInfo *snap.ComponentInfo, info *snap.Info, sf SeedAssertionFetcher, db asserts.RODatabase) (*snap.ComponentSideInfo, []*asserts.Ref, error) {
+func DeriveComponentSideInfo(compPath string, compInfo *snap.ComponentInfo, info *snap.Info, model *asserts.Model, sf SeedAssertionFetcher, db asserts.RODatabase) (*snap.ComponentSideInfo, []*asserts.Ref, error) {
 	// We assume provenance cross-checks for the snap-revision already
 	// happened, and here we just check that provenance is consistent
 	// between snap and component.
@@ -157,7 +157,7 @@ func DeriveComponentSideInfo(compPath string, compInfo *snap.ComponentInfo, info
 
 	csi, err := snapasserts.DeriveComponentSideInfoFromDigestAndSize(
 		compInfo.Component.ComponentName, compInfo.Component.SnapName,
-		info.ID(), compPath, digest, size, db)
+		info.ID(), compPath, digest, size, model, db)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -301,7 +301,7 @@ func (s writerSuite) TestSetOptionsSnapsErrors(c *C) {
 		w, err := seedwriter.New(model, s.opts)
 		c.Assert(err, IsNil)
 
-		c.Check(w.SetOptionsSnaps(t.snaps, nil), ErrorMatches, t.err)
+		c.Check(w.SetOptionsSnaps(t.snaps), ErrorMatches, t.err)
 	}
 }
 
@@ -317,7 +317,7 @@ func (s *writerSuite) TestSnapsToDownloadCore16(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -347,7 +347,7 @@ func (s *writerSuite) TestSnapsToDownloadOptionTrack(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "track/edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "track/edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -378,7 +378,7 @@ func (s *writerSuite) TestDownloadedCore16(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -425,7 +425,7 @@ func (s *writerSuite) TestDownloadedCore18(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -475,7 +475,7 @@ func (s *writerSuite) TestSnapsToDownloadCore18IncompatibleTrack(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc-kernel", Channel: "18.1"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc-kernel", Channel: "18.1"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -506,7 +506,7 @@ func (s *writerSuite) TestSnapsToDownloadDefaultChannel(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -534,7 +534,7 @@ func (s *writerSuite) upToDownloaded(c *C, model *asserts.Model, fill func(c *C,
 	c.Assert(err, IsNil)
 
 	if len(optSnaps) != 0 {
-		err := w.SetOptionsSnaps(optSnaps, nil)
+		err := w.SetOptionsSnaps(optSnaps)
 		c.Assert(err, IsNil)
 	}
 
@@ -634,7 +634,7 @@ func (s *writerSuite) TestOutOfOrderWithLocalSnaps(c *C) {
 
 	requiredFn := s.makeLocalSnap(c, "required")
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -841,7 +841,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore16(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -956,7 +956,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -1120,7 +1120,7 @@ func (s *writerSuite) TestLocalSnaps(c *C) {
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},
 		{Path: contConsumerFn},
-	}, nil)
+	})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -1163,7 +1163,7 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 		{Path: pcKernelFn},
 		{Path: s.AssertedSnap("cont-producer")},
 		{Path: contConsumerFn},
-	}, nil)
+	})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -1299,7 +1299,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaDefaultTrackCore18(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "required18", Channel: "candidate"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "required18", Channel: "candidate"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -1402,7 +1402,7 @@ func (s *writerSuite) TestInfoDerivedInfosNotSet(c *C) {
 		{Path: core18Fn},
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},
-	}, nil)
+	})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -1413,73 +1413,6 @@ func (s *writerSuite) TestInfoDerivedInfosNotSet(c *C) {
 
 	err = w.InfoDerived()
 	c.Assert(err, ErrorMatches, `internal error: before seedwriter.Writer.InfoDerived snap ".*/core18.*.snap" Info should have been set`)
-}
-
-func (s *writerSuite) TestInfoDerivedLocalCompButNoLocalSnap(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
-		"display-name":   "my model",
-		"architecture":   "amd64",
-		"base":           "core18",
-		"gadget":         "pc=18",
-		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
-	})
-
-	s.makeSnap(c, "snapd", "")
-	s.makeSnap(c, "cont-producer", "developerid")
-
-	core18Fn := s.makeLocalSnap(c, "core18")
-	pcKernelFn := s.makeLocalSnap(c, "pc-kernel=18")
-	pcFn := s.makeLocalSnap(c, "pc=18")
-	contConsumerFn := s.makeLocalSnap(c, "cont-consumer")
-
-	w, err := seedwriter.New(model, s.opts)
-	c.Assert(err, IsNil)
-
-	pathToLocalComp := map[string]*snap.ComponentInfo{
-		"/path1/local1.comp": {
-			Component: naming.ComponentRef{
-				SnapName: "pc-kernel", ComponentName: "comp1"},
-		},
-		"/path2/local2.comp": {
-			Component: naming.ComponentRef{
-				SnapName: "foo", ComponentName: "comp1"},
-		},
-	}
-
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
-		{Path: core18Fn},
-		{Name: "pc-kernel", Channel: "candidate"},
-		{Path: pcFn, Channel: "edge"},
-		{Path: pcKernelFn},
-		{Path: s.AssertedSnap("cont-producer")},
-		{Path: contConsumerFn},
-	}, pathToLocalComp)
-	c.Assert(err, IsNil)
-
-	err = w.Start(s.db, s.rf)
-	c.Assert(err, IsNil)
-
-	localSnaps, err := w.LocalSnaps()
-	c.Assert(err, IsNil)
-	c.Assert(localSnaps, HasLen, 5)
-
-	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
-		if !errors.Is(err, &asserts.NotFoundError{}) {
-			c.Assert(err, IsNil)
-		}
-		f, err := snapfile.Open(sn.Path)
-		c.Assert(err, IsNil)
-		info, err := snap.ReadInfoFromSnapFile(f, si)
-		c.Assert(err, IsNil)
-		w.SetInfo(sn, info, nil)
-		s.aRefs[sn.SnapName()] = aRefs
-	}
-
-	err = w.InfoDerived()
-	c.Assert(err, ErrorMatches, `missing local snaps:
-"/path2/local2.comp" local component does not have a matching local snap`)
 }
 
 func (s *writerSuite) TestInfoDerivedRepeatedLocalSnap(c *C) {
@@ -1504,7 +1437,7 @@ func (s *writerSuite) TestInfoDerivedRepeatedLocalSnap(c *C) {
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},
 		{Path: core18Fn},
-	}, nil)
+	})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -1548,7 +1481,7 @@ func (s *writerSuite) TestInfoDerivedInconsistentChannel(c *C) {
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},
 		{Name: "pc", Channel: "beta"},
-	}, nil)
+	})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -1586,7 +1519,7 @@ func (s *writerSuite) TestSetRedirectChannelLocalError(c *C) {
 
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
 		{Path: core18Fn},
-	}, nil)
+	})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -2030,7 +1963,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaExtraSnaps(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "required", Channel: "beta"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "required", Channel: "beta"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -2155,7 +2088,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -2929,7 +2862,7 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 		w, err := seedwriter.New(model, s.opts)
 		c.Assert(err, IsNil)
 
-		err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{t.optSnap}, nil)
+		err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{t.optSnap})
 		if err != nil {
 			c.Check(err, ErrorMatches, expectedErr)
 			continue
@@ -3054,19 +2987,7 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	pathToCompInfo := map[string]*snap.ComponentInfo{}
-	var pathComp1, pathComp2 string
-	if withComps {
-		cref1 := naming.NewComponentRef("required20", "comp1")
-		cinfo1 := snap.NewComponentInfo(cref1, snap.TestComponent, "1.0", "", "", "", nil)
-		pathComp1 = s.makeLocalComponent(c, "required20+comp1")
-		cref2 := naming.NewComponentRef("required20", "comp2")
-		cinfo2 := snap.NewComponentInfo(cref2, snap.TestComponent, "2.0", "", "", "", nil)
-		pathComp2 = s.makeLocalComponent(c, "required20+comp2")
-		pathToCompInfo[pathComp1] = cinfo1
-		pathToCompInfo[pathComp2] = cinfo2
-	}
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}}, pathToCompInfo)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -3076,6 +2997,7 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 	c.Assert(err, IsNil)
 	c.Assert(localSnaps, HasLen, 1)
 
+	var pathComp1, pathComp2 string
 	for _, sn := range localSnaps {
 		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 		c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
@@ -3083,7 +3005,7 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, nil)
 		c.Assert(err, IsNil)
-		cinfos := map[string]*snap.ComponentInfo{}
+		seedComps := map[string]*seedwriter.SeedComponent{}
 		if withComps {
 			cref1 := naming.NewComponentRef("required20", "comp1")
 			cinfo1 := snap.NewComponentInfo(cref1, snap.TestComponent, "1.0", "", "", "", nil)
@@ -3091,10 +3013,18 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 			cref2 := naming.NewComponentRef("required20", "comp2")
 			cinfo2 := snap.NewComponentInfo(cref2, snap.TestComponent, "2.0", "", "", "", nil)
 			pathComp2 = s.makeLocalComponent(c, "required20+comp2")
-			cinfos["comp1"] = cinfo1
-			cinfos["comp2"] = cinfo2
+			seedComps["comp1"] = &seedwriter.SeedComponent{
+				ComponentRef: cref1,
+				Path:         pathComp1,
+				Info:         cinfo1,
+			}
+			seedComps["comp2"] = &seedwriter.SeedComponent{
+				ComponentRef: cref2,
+				Path:         pathComp2,
+				Info:         cinfo2,
+			}
 		}
-		c.Assert(w.SetInfo(sn, info, cinfos), IsNil)
+		c.Assert(w.SetInfo(sn, info, seedComps), IsNil)
 	}
 
 	err = w.InfoDerived()
@@ -3268,7 +3198,7 @@ func (s *writerSuite) TestSetComponentOptionsBad(c *C) {
 		err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{
 			Path:       requiredFn,
 			Components: tc.comps,
-		}}, nil)
+		}})
 		if tc.err == "" {
 			c.Check(err, IsNil)
 		} else {
@@ -3328,7 +3258,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ChannelOverrides(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -3533,7 +3463,7 @@ func (s *writerSuite) TestSnapsToDownloadCore20OptionalSnaps(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "optional20-b"}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "optional20-b"}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -3581,7 +3511,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "cont-producer", Channel: "edge"}, {Name: "core18"}, {Path: contConsumerFn}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "cont-producer", Channel: "edge"}, {Name: "core18"}, {Path: contConsumerFn}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -3753,7 +3683,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalAssertedSnaps(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: s.AssertedSnap("pc"), Channel: "edge"}, {Path: s.AssertedSnap("required20")}}, nil)
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: s.AssertedSnap("pc"), Channel: "edge"}, {Path: s.AssertedSnap("required20")}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -3844,6 +3774,16 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalAssertedSnaps(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C) {
+	withComps := false
+	s.testSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c, withComps)
+}
+
+func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnapsWithComps(c *C) {
+	withComps := true
+	s.testSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c, withComps)
+}
+
+func (s *writerSuite) testSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C, withComps bool) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
@@ -3861,7 +3801,12 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
-			}},
+			},
+			map[string]interface{}{
+				"name": "required20",
+				"id":   s.AssertedSnapID("required20"),
+			},
+		},
 	})
 
 	// soundness
@@ -3871,13 +3816,20 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 	s.makeSnap(c, "core20", "")
 	s.makeSnap(c, "pc-kernel=20", "")
 	s.makeSnap(c, "pc=20", "")
+	comRevs := map[string]snap.Revision{
+		"comp1": snap.R(22),
+		"comp2": snap.R(33),
+	}
+	s.SeedSnaps.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["required20"], nil,
+		snap.R(21), comRevs, "canonical", s.StoreSigning.Database)
 
 	s.opts.Label = "20191122"
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	// use a local asserted snap with signed, which is supported
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: s.AssertedSnap("pc")}}, nil)
+	// use local asserted snaps with signed, which is supported
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: s.AssertedSnap("pc")},
+		{Path: s.AssertedSnap("required20")}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -3885,7 +3837,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 
 	localSnaps, err := w.LocalSnaps()
 	c.Assert(err, IsNil)
-	c.Assert(localSnaps, HasLen, 1)
+	c.Assert(localSnaps, HasLen, 2)
 
 	for _, sn := range localSnaps {
 		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
@@ -3894,7 +3846,27 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, si)
 		c.Assert(err, IsNil)
-		w.SetInfo(sn, info, nil)
+
+		seedComps := map[string]*seedwriter.SeedComponent{}
+		if withComps && info.SnapName() == "required20" {
+			for _, comp := range []string{"comp1", "comp2"} {
+				cref := naming.NewComponentRef("required20", comp)
+				cinfo := snap.NewComponentInfo(cref, snap.TestComponent,
+					"1.0", "", "", "", nil)
+				pathComp := s.AssertedSnap(cref.String())
+				csi, _, err := seedwriter.DeriveComponentSideInfo(
+					pathComp, cinfo, info, s.rf, s.db)
+				c.Assert(err, IsNil)
+				cinfo.ComponentSideInfo = *csi
+				seedComps[comp] = &seedwriter.SeedComponent{
+					ComponentRef: cref,
+					Path:         pathComp,
+					Info:         cinfo,
+				}
+			}
+		}
+
+		w.SetInfo(sn, info, seedComps)
 		s.aRefs[sn.SnapName()] = aRefs
 	}
 
@@ -3935,10 +3907,19 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 
 	l, err := os.ReadDir(filepath.Join(s.opts.SeedDir, "snaps"))
 	c.Assert(err, IsNil)
-	c.Check(l, HasLen, 4)
+	expectLen := 5
+	if withComps {
+		expectLen += 2
+	}
+	c.Check(l, HasLen, expectLen)
 
-	// local asserted model snap was put in /snaps
+	// local asserted snaps/components were put in /snaps
 	c.Check(filepath.Join(s.opts.SeedDir, "snaps", "pc_1.snap"), testutil.FilePresent)
+	c.Check(filepath.Join(s.opts.SeedDir, "snaps", "required20_21.snap"), testutil.FilePresent)
+	if withComps {
+		c.Check(filepath.Join(s.opts.SeedDir, "snaps", "required20+comp1_22.comp"), testutil.FilePresent)
+		c.Check(filepath.Join(s.opts.SeedDir, "snaps", "required20+comp2_33.comp"), testutil.FilePresent)
+	}
 
 	// no options file was created
 	c.Check(filepath.Join(systemDir, "options.yaml"), testutil.FileAbsent)
@@ -4909,7 +4890,7 @@ func (s *writerSuite) TestOptionalComponentNotIncluded(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps(nil, nil)
+	err = w.SetOptionsSnaps(nil)
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -4931,7 +4912,7 @@ func (s *writerSuite) TestOptionalComponentNotIncluded(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{
 		Name:       "required20",
 		Components: []seedwriter.OptionsComponent{{Name: "comp1"}},
-	}}, nil)
+	}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -4952,7 +4933,7 @@ func (s *writerSuite) TestOptionalComponentNotIncluded(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{
 		Name:       "required20",
 		Components: []seedwriter.OptionsComponent{{Name: "comp2"}},
-	}}, nil)
+	}})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -4970,4 +4951,95 @@ func (s *writerSuite) TestOptionalComponentNotIncluded(c *C) {
 		{ComponentRef: cref1},
 		{ComponentRef: cref2},
 	})
+}
+
+func (s *writerSuite) TestSeedSnapsWriteMetaCore20BadLocalComps(c *C) {
+	// add store assertion
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":       "my-store",
+		"operator-id": "canonical",
+		"timestamp":   time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = s.StoreSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"store":        "my-store",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "required20",
+				"id":   s.AssertedSnapID("required20"),
+			},
+		},
+	})
+
+	// validity
+	c.Assert(model.Grade(), Equals, asserts.ModelDangerous)
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	requiredFn := s.makeLocalSnap(c, "required20")
+
+	s.opts.Label = "20191030"
+	w, err := seedwriter.New(model, s.opts)
+	c.Assert(err, IsNil)
+
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
+	c.Assert(err, IsNil)
+
+	err = w.Start(s.db, s.rf)
+	c.Assert(err, IsNil)
+
+	localSnaps, err := w.LocalSnaps()
+	c.Assert(err, IsNil)
+	c.Assert(localSnaps, HasLen, 1)
+
+	sn := localSnaps[0]
+	_, _, err = seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
+	f, err := snapfile.Open(sn.Path)
+	c.Assert(err, IsNil)
+	info, err := snap.ReadInfoFromSnapFile(f, nil)
+	c.Assert(err, IsNil)
+
+	seedComps := map[string]*seedwriter.SeedComponent{}
+	cref1 := naming.NewComponentRef("required20", "comp-undefined")
+	cinfo1 := snap.NewComponentInfo(cref1, snap.TestComponent, "1.0", "", "", "", nil)
+	seedComps["comp-undefined"] = &seedwriter.SeedComponent{
+		ComponentRef: cref1,
+		Path:         "/some/path/file.comp",
+		Info:         cinfo1,
+	}
+	c.Assert(w.SetInfo(sn, info, seedComps), ErrorMatches,
+		`component comp-undefined is not defined by snap required20`)
+
+	seedComps = map[string]*seedwriter.SeedComponent{}
+	cref1 = naming.NewComponentRef("required20", "comp1")
+	cinfo1 = snap.NewComponentInfo(cref1, snap.KernelModulesComponent, "1.0", "", "", "", nil)
+	seedComps["comp1"] = &seedwriter.SeedComponent{
+		ComponentRef: cref1,
+		Path:         "/some/path/file.comp",
+		Info:         cinfo1,
+	}
+	c.Assert(w.SetInfo(sn, info, seedComps), ErrorMatches,
+		`component comp1 has type kernel-modules while snap required20 defines type test for it`)
 }

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -3855,7 +3855,7 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C,
 					"1.0", "", "", "", nil)
 				pathComp := s.AssertedSnap(cref.String())
 				csi, _, err := seedwriter.DeriveComponentSideInfo(
-					pathComp, cinfo, info, s.rf, s.db)
+					pathComp, cinfo, info, model, s.rf, s.db)
 				c.Assert(err, IsNil)
 				cinfo.ComponentSideInfo = *csi
 				seedComps[comp] = &seedwriter.SeedComponent{


### PR DESCRIPTION
Consider asserted components when building a seed, so they can be specified as local files but considered asserted if matching assertions are found in the store.