### PR TITLE
fake/change: test reference for 2.63.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -421,7 +421,7 @@ jobs:
     # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     name: ${{ matrix.group }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, spread-enabled]
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -461,12 +461,15 @@ jobs:
           - group: ubuntu-focal-jammy
             backend: google
             systems: 'ubuntu-20.04-64 ubuntu-22.04-64'
+          - group: ubuntu-noble
+            backend: google
+            systems: 'ubuntu-24.04-64'
           - group: ubuntu-no-lts
             backend: google
             systems: 'ubuntu-23.10-64'
           - group: ubuntu-daily
             backend: google
-            systems: 'ubuntu-24.04-64'
+            systems: 'ubuntu-24.10-64'
           - group: ubuntu-core-16
             backend: google
             systems: 'ubuntu-core-16-64'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# Test reference for 2.63.1
+
 # New in snapd 2.63:
 * Support for snap services to show the current status of user services (experimental)
 * Refresh app awareness: record snap-run-inhibit notice when starting app from snap that is busy with refresh (experimental)

--- a/osutil/strace/strace.go
+++ b/osutil/strace/strace.go
@@ -50,8 +50,8 @@ var ExcludedSyscalls = getExcludedSyscalls()
 
 func findStrace(u *user.User) (stracePath string, userOpts []string, err error) {
 	if path := filepath.Join(dirs.SnapMountDir, "strace-static", "current", "bin", "strace"); osutil.FileExists(path) {
-		// strace-static cannot resolve usernames, pass uid/gid instead
-		return path, []string{"--uid", u.Uid, "--gid", u.Gid}, nil
+		// Strace v6.9 supports -u UID:GID which avoids the need to resolve usernames with nss.
+		return path, []string{"-u", fmt.Sprintf("%s:%s", u.Uid, u.Gid)}, nil
 	}
 
 	stracePath, err = exec.LookPath("strace")

--- a/osutil/strace/strace_test.go
+++ b/osutil/strace/strace_test.go
@@ -89,7 +89,7 @@ func (s *straceSuite) TestStraceCommandHappyFromSnap(c *C) {
 	c.Check(cmd.Args, DeepEquals, []string{
 		s.mockSudo.Exe(), "-E",
 		mockStraceStatic.Exe(),
-		"--uid", u.Uid, "--gid", u.Gid,
+		"-u", u.Uid + ":" + u.Gid,
 		"-f",
 		"-e", strace.ExcludedSyscalls,
 		// the command

--- a/spread.yaml
+++ b/spread.yaml
@@ -53,7 +53,7 @@ environment:
     # Channel for kernel cannot be edge as that one is not signed with Canonical keys
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-beta}")'
     GADGET_CHANNEL: '$(HOST: echo "${SPREAD_GADGET_CHANNEL:-beta}")'
-    SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
+    SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-stable}")'
     REMOTE_STORE: '$(HOST: echo "${SPREAD_REMOTE_STORE:-production}")'
     SNAPPY_USE_STAGING_STORE: '$(HOST: if [ "$SPREAD_REMOTE_STORE" = staging ]; then echo 1; else echo 0; fi)'
     DELTA_REF: 2.52

--- a/spread.yaml
+++ b/spread.yaml
@@ -126,6 +126,9 @@ backends:
             - ubuntu-20.04-64:
                   storage: 12G
                   workers: 8
+            - ubuntu-24.10-64:
+                  storage: 12G
+                  workers: 8
             - ubuntu-core-16-64:
                   image: ubuntu-16.04-64
                   workers: 6

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -59,7 +59,16 @@ execute: |
 
         echo "Verify that a random signal does not trigger the failure handling"
         echo "and snapd is just restarted"
-        systemctl kill --signal=SIGKILL snapd.service
+
+        if os.query is-core-le 22; then
+            systemctl kill --signal=SIGKILL snapd.service
+        else
+            # Work around systemctl kill issue, where it may fail when the cgroup
+            # is recycled after the main process is killed. This seems to be a bug
+            # in systemd made more common by faster cgroup recycling by the kernel.
+            # shellcheck disable=SC2046
+            kill -9 $(cat /sys/fs/cgroup/system.slice/snapd.service/cgroup.procs)
+        fi
 
         started_after_rand_sig="$("$TESTSTOOLS"/journal-state get-log -u snapd.failure | grep -c 'Started Failure handling of the snapd snap.' || true)"
 

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -1,5 +1,13 @@
 summary: Check that snapd failure handling works
 
+details: |
+    Snapd has a failure handling mechanism to auto revert when a refresh process fails.
+    This test verifies this mechanism by trying to install a broken snapd snap
+    multiple times to validate that if a device wants to keep trying a refresh to a
+    broken snapd snap for some reason, it will be able to revert and fallback
+    as many times as needed. Also checks that after the revert, the snapd snap
+    revision has to be the same as before the broken one was installed.
+
 prepare: |
     # on UC16, we should transition to using the snapd snap before running the 
     # test because it by default uses the core snap

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -79,7 +79,7 @@ execute: |
   
   # Ensure that the new size is printed in the journal logs. We requested 64MB but
   # this will most likely print out as 61.0M, so lets be a bit flexible
-  "$TESTSTOOLS"/journal-state get-log --namespace snap-group-one | MATCH "max 6[0-9].[0-9]M,"
+  "$TESTSTOOLS"/journal-state get-log --namespace snap-group-one | MATCH "max 6[0-9](\.[0-9]+)?M,"
 
   # Ensure that the unit file is correct
   echo "Ensuring the unit file is correct"

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -53,11 +53,7 @@ execute: |
         echo "snap run with an invalid strace option should fail but it did not"
         exit 1
     fi
-    if os.query is-arch-linux || os.query is-opensuse tumbleweed || os.query is-fedora || os.query is-ubuntu-ge 24.04; then
-        MATCH "Cannot find executable 'invalid'" < stderr
-    else
-        MATCH "Can't stat 'invalid': No such file or directory" < stderr
-    fi
+    MATCH "Cannot find executable 'invalid'" < stderr || MATCH "Can't stat 'invalid': No such file or directory" < stderr
 
     if os.query is-arch-linux || os.query is-opensuse tumbleweed; then
         # Arch linux and Opensuse tumbleweed run the mainline kernel, strace

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -18,11 +18,11 @@ prepare: |
     useradd -b /remote/users -m -U "$USERNAME"
 
     # Download current snapd edge
-    snap download --edge snapd --basename=snapd_edge
+    snap download --stable snapd --basename=snapd_stable
 
     # Repack it with currently built snapd
     unpackdir=/tmp/snapd-current-snap
-    unsquashfs -no-progress -d "${unpackdir}" snapd_edge.snap
+    unsquashfs -no-progress -d "${unpackdir}" snapd_stable.snap
     dpkg-deb -x "${GOHOME}"/snapd_*.deb "${unpackdir}"
     snap pack "${unpackdir}" --filename snapd_modified.snap
     rm -rf "${unpackdir}"

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -252,8 +252,16 @@ execute: |
     done
 
     echo "Ensure we support posix mqueue and userns in the internal apparmor_parser"
-    snap debug sandbox-features --required apparmor:parser:mqueue
-    snap debug sandbox-features --required apparmor:parser:userns
+    log_bookmark=$(journalctl -u snapd -n 0 --show-cursor | tail -n 1 | awk '{print $3}')
+    # restart to capture AppArmor probe debug information
+    systemctl restart snapd
+    if ! snap debug sandbox-features --required apparmor:parser:mqueue; then
+        journalctl --after-cursor "$log_bookmark" | MATCH "skipping apparmor feature check for mqueue due to insufficient version"
+    fi
+
+    if ! snap debug sandbox-features --required apparmor:parser:userns; then
+        journalctl --cursor "$log_bookmark" | MATCH "skipping apparmor feature check for userns due to insufficient version"
+    fi
     
     echo "Then we should be able to compile policy using the internal apparmor_parser"
     /snap/snapd/current/usr/lib/snapd/apparmor_parser \

--- a/tests/main/sudo-env/task.yaml
+++ b/tests/main/sudo-env/task.yaml
@@ -11,7 +11,7 @@ systems: [ -ubuntu-14.04-* ]
 environment:
     # list of regular expressions that match systems where sudo is set up to use
     # secure_path without snap bindir
-    SECURE_PATH_SUDO_NO_SNAP: "centos-.* amazon-linux-2-64 opensuse-.* debian-.*"
+    SECURE_PATH_SUDO_NO_SNAP: "centos-.* amazon-linux-2-64 opensuse-.* debian-.* arch-linux-.*"
 
 prepare: |
     tests.session -u test prepare
@@ -47,3 +47,15 @@ execute: |
     fi
     # in either case, the location should be listed in a login shell
     MATCH ":${SNAP_MOUNT_DIR}/bin:" < sudo-login.path
+
+    if [ "$secure_path" = "yes" ]; then
+       # add a snippet we recommend using as a workaround
+       # https://wiki.archlinux.org/title/Snap#Sudo
+       echo "Defaults:test secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/bin:${SNAP_MOUNT_DIR}/bin\"" > /etc/sudoers.d/90_snap
+       tests.cleanup defer rm -f /etc/sudoers.d/90_snap
+
+       # and try again
+       # shellcheck disable=SC2016
+       tests.session -u test exec sudo sh -c 'echo :$PATH:' > sudo.path
+       MATCH ":${SNAP_MOUNT_DIR}/bin:" < sudo.path
+    fi


### PR DESCRIPTION
Test reference for 2.63.1

In theory, the failure diff compared to https://github.com/canonical/snapd/pull/13828 is external dependencies that changed.
