### PR TITLE
interfaces/login_session_observe: Allow to also introspect

### DIFF
--- a/interfaces/builtin/login_session_observe.go
+++ b/interfaces/builtin/login_session_observe.go
@@ -70,6 +70,12 @@ dbus (send)
     interface=org.freedesktop.DBus.Properties
     member=Get{,All},
 
+dbus (send)
+    bus=system
+    path=/org/freedesktop/login1{,/seat/*,/session/*,/user/*}
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect,
+
 dbus (receive)
     bus=system
     path=/org/freedesktop/login1


### PR DESCRIPTION
Currently GetAll can be called on seats, sessions and users, but not the full introspection. This commit allows it.
