### PR TITLE
interfaces/udisks2: Make it available on Core

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -404,6 +404,7 @@ func (iface *udisks2Interface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              udisks2Summary,
 		ImplicitOnClassic:    true,
+		ImplicitOnCore:       true,
 		BaseDeclarationSlots: udisks2BaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -353,7 +353,7 @@ func (s *UDisks2InterfaceSuite) TestSecCompSpecOnClassic(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnCore, Equals, true)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows operating as or interacting with the UDisks2 service`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "udisks2")


### PR DESCRIPTION
Otherwise processes can't talk to it even if provided by the base snap and started.
