### PR TITLE
interfaces/builtin: correct pscd, ros_opt_data and steam_support summaries

### DIFF
--- a/interfaces/builtin/pcscd.go
+++ b/interfaces/builtin/pcscd.go
@@ -19,8 +19,7 @@
 
 package builtin
 
-const pcscdSummary = `allows interacting with PCSD daemon
-(e.g. for the PS/SC API library).`
+const pcscdSummary = `allows interacting with PCSD daemon (e.g. for the PS/SC API library).`
 
 const pcscdBaseDeclarationSlots = `
   pcscd:

--- a/interfaces/builtin/pcscd_test.go
+++ b/interfaces/builtin/pcscd_test.go
@@ -87,7 +87,6 @@ func (s *pcscdInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-	c.Assert(si.Summary, Equals, `allows interacting with PCSD daemon
-(e.g. for the PS/SC API library).`)
+	c.Assert(si.Summary, Equals, `allows interacting with PCSD daemon (e.g. for the PS/SC API library).`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "pcscd")
 }

--- a/interfaces/builtin/ros_opt_data.go
+++ b/interfaces/builtin/ros_opt_data.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const rosOptDataSummary = `Allows read-only access to the static data such as xacro,yaml,urdf,stl,... in the standard /opt/ros folder`
+const rosOptDataSummary = `allows read-only access to the static data such as xacro,yaml,urdf,stl,... in the standard /opt/ros folder`
 
 const rosOptDataBaseDeclarationSlots = `
   ros-opt-data:

--- a/interfaces/builtin/ros_opt_data_test.go
+++ b/interfaces/builtin/ros_opt_data_test.go
@@ -92,7 +92,7 @@ func (s *rosOptDataInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-	c.Assert(si.Summary, testutil.Contains, `Allows read-only access`)
+	c.Assert(si.Summary, testutil.Contains, `allows read-only access`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "ros-opt-data")
 }
 

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -28,7 +28,7 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-const steamSupportSummary = `allow Steam to configure pressure-vessel containers`
+const steamSupportSummary = `allows Steam to configure pressure-vessel containers`
 
 const steamSupportBaseDeclarationPlugs = `
   steam-support:

--- a/interfaces/builtin/steam_support_test.go
+++ b/interfaces/builtin/steam_support_test.go
@@ -126,6 +126,6 @@ func (s *SteamSupportInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, release.OnCoreDesktop)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-	c.Assert(si.Summary, Equals, `allow Steam to configure pressure-vessel containers`)
+	c.Assert(si.Summary, Equals, `allows Steam to configure pressure-vessel containers`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "steam-support")
 }


### PR DESCRIPTION
Correct summaries that break uniformity to ensure that `snap interface --all` looks correct/uniform

Tweaks:
- pcscd: introduced newline that complicates parsing of output (overflows into the first column "name")
- ros: "Allows read-only" -> "allows ..."
- steam: "allow Steam" -> "allows Steam"

Part of https://warthogs.atlassian.net/browse/SNAPDENG-26156
Relates to https://github.com/canonical/snapd/pull/14273
