### PR TITLE
many: check for apparmor prompting support when enabling the experimental feature

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -221,14 +221,17 @@ func (f SnapdFeature) ConfigOption() (snapName, confName string) {
 	return "core", "experimental." + f.String()
 }
 
-// IsSupported returns true if the feature's supported callback returns true,
-// or if it has no supportedCallback.
-func (f SnapdFeature) IsSupported() bool {
+// IsSupported returns true if the feature's supported callback returns true, or
+// if it has no supportedCallback. If the feature is unsupported, the returned
+// string details as to why.
+func (f SnapdFeature) IsSupported() (supported bool, whyNot string) {
 	if callback, exists := featuresSupportedCallbacks[f]; exists {
-		supported, _ := callback() // discard unsupported reason
-		return supported
+		supported, whyNot = callback() // discard unsupported reason
+		if !supported {
+			return false, whyNot
+		}
 	}
-	return true
+	return true, ""
 }
 
 // IsEnabled checks if a given exported snapd feature is enabled.

--- a/features/features.go
+++ b/features/features.go
@@ -226,7 +226,7 @@ func (f SnapdFeature) ConfigOption() (snapName, confName string) {
 // string details as to why.
 func (f SnapdFeature) IsSupported() (supported bool, whyNot string) {
 	if callback, exists := featuresSupportedCallbacks[f]; exists {
-		supported, whyNot = callback() // discard unsupported reason
+		supported, whyNot = callback()
 		if !supported {
 			return false, whyNot
 		}

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -223,7 +223,9 @@ func (*featureSuite) TestIsSupported(c *C) {
 	fakeFeature := features.SnapdFeature(len(features.KnownFeatures()))
 
 	// Check that feature without callback always returns true
-	c.Check(fakeFeature.IsSupported(), Equals, true)
+	is, why := fakeFeature.IsSupported()
+	c.Check(is, Equals, true)
+	c.Check(why, Equals, "")
 
 	var fakeSupported bool
 	var fakeReason string
@@ -237,21 +239,29 @@ func (*featureSuite) TestIsSupported(c *C) {
 
 	fakeSupported = true
 	fakeReason = ""
-	c.Check(fakeFeature.IsSupported(), Equals, true)
+	is, why = fakeFeature.IsSupported()
+	c.Check(is, Equals, true)
+	c.Check(why, Equals, "")
 
 	// Check that a non-empty reason is ignored
 	fakeSupported = true
 	fakeReason = "foo"
-	c.Check(fakeFeature.IsSupported(), Equals, true)
+	is, why = fakeFeature.IsSupported()
+	c.Check(is, Equals, true)
+	c.Check(why, Equals, "")
 
 	fakeSupported = false
 	fakeReason = "foo"
-	c.Check(fakeFeature.IsSupported(), Equals, false)
+	is, why = fakeFeature.IsSupported()
+	c.Check(is, Equals, false)
+	c.Check(why, Equals, "foo")
 
 	// Check that unsupported value does not require reason
 	fakeSupported = false
 	fakeReason = ""
-	c.Check(fakeFeature.IsSupported(), Equals, false)
+	is, why = fakeFeature.IsSupported()
+	c.Check(is, Equals, false)
+	c.Check(why, Equals, "")
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -212,11 +212,8 @@ func (*featureSuite) TestAppArmorPromptingSupportedCallback(c *C) {
 	restore := apparmor.MockFeatures(kernelFeatures, nil, parserFeatures, nil)
 	defer restore()
 	supported, reason := callback()
-	//c.Check(supported, Equals, true)
-	//c.Check(reason, Equals, "")
-	// TODO: change once prompting is fully supported
-	c.Check(supported, Equals, false)
-	c.Check(reason, Equals, "requires newer version of snapd")
+	c.Check(supported, Equals, true)
+	c.Check(reason, Equals, "")
 }
 
 func (*featureSuite) TestIsSupported(c *C) {

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -101,7 +101,7 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, remoteFSHome, overlay
 	restore = cgroup.MockVersion(1, nil)
 	defer restore()
 
-	promptingSupported := features.AppArmorPrompting.IsSupported()
+	promptingSupported, _ := features.AppArmorPrompting.IsSupported()
 	promptingEnabled := true
 	extraData := interfaces.SystemKeyExtraData{
 		AppArmorPrompting: promptingEnabled,

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -21,6 +21,8 @@
 package configcore
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/restart"
@@ -47,6 +49,16 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 	}
 	if prompting == prevPrompting {
 		return nil
+	}
+
+	if prompting {
+		if is, whyNot := features.AppArmorPrompting.IsSupported(); !is {
+			if whyNot == "" {
+				// we don't have details as to why
+				return fmt.Errorf("prompting feature is not supported by the system")
+			}
+			return fmt.Errorf("prompting feature is not supported by the system, reason: %s", whyNot)
+		}
 	}
 
 	// No matter whether prompting is supported or not, request a restart of

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -62,7 +62,7 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 				// we don't have details as to why
 				return fmt.Errorf("cannot enable prompting feature as it is not supported by the system")
 			}
-			return fmt.Errorf("cannot enable prompting feature as it is not supported by the system, reason: %s", whyNot)
+			return fmt.Errorf("cannot enable prompting feature as it is not supported by the system: %s", whyNot)
 		}
 	}
 

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -53,6 +53,8 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 	}
 
 	if prompting {
+		// TODO support for preseeding
+
 		if !release.OnClassic && !release.OnCoreDesktop {
 			return fmt.Errorf("cannot enable prompting feature as it is not supported on Ubuntu Core systems")
 		}

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/release"
 )
 
 var restartRequest = restart.Request
@@ -52,12 +53,16 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 	}
 
 	if prompting {
+		if !release.OnClassic && !release.OnCoreDesktop {
+			return fmt.Errorf("cannot enable prompting feature as it is not supported on Ubuntu Core systems")
+		}
+
 		if is, whyNot := features.AppArmorPrompting.IsSupported(); !is {
 			if whyNot == "" {
 				// we don't have details as to why
-				return fmt.Errorf("prompting feature is not supported by the system")
+				return fmt.Errorf("cannot enable prompting feature as it is not supported by the system")
 			}
-			return fmt.Errorf("prompting feature is not supported by the system, reason: %s", whyNot)
+			return fmt.Errorf("cannot enable prompting feature as it is not supported by the system, reason: %s", whyNot)
 		}
 	}
 

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -221,7 +221,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingUnsupportedKernel(c 
 	})
 	defer restore()
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature as it is not supported by the system, reason: apparmor kernel features do not support prompting")
+		"cannot enable prompting feature as it is not supported by the system: apparmor kernel features do not support prompting")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingUnsupportedParser(c *C) {
@@ -236,7 +236,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingUnsupportedParser(c 
 	})
 	defer restore()
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature as it is not supported by the system, reason: apparmor parser does not support the prompt qualifier")
+		"cannot enable prompting feature as it is not supported by the system: apparmor parser does not support the prompt qualifier")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingOnCoreUnsupported(c *C) {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -168,8 +168,9 @@ func (m *InterfaceManager) useAppArmorPrompting() bool {
 	m.useAppArmorPromptingChecker.Do(func() {
 		tr := config.NewTransaction(m.state)
 		if promptingEnabled, err := features.Flag(tr, features.AppArmorPrompting); err == nil {
+			supported, _ := features.AppArmorPrompting.IsSupported()
 			// If error while getting AppArmorPrompting flag, don't include it
-			m.useAppArmorPromptingValue = promptingEnabled && features.AppArmorPrompting.IsSupported()
+			m.useAppArmorPromptingValue = promptingEnabled && supported
 		}
 	})
 	return m.useAppArmorPromptingValue

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -439,9 +439,7 @@ func PromptingSupportedByFeatures(apparmorFeatures *FeaturesSupported) (bool, st
 	if !strutil.ListContains(apparmorFeatures.ParserFeatures, "prompt") {
 		return false, "apparmor parser does not support the prompt qualifier"
 	}
-	// TODO: return true once the prompting API is merged and ready
-	// return true, ""
-	return false, "requires newer version of snapd"
+	return true, ""
 }
 
 // probe related code

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -645,11 +645,8 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 	defer restore()
 
 	supported, reason := apparmor.PromptingSupported()
-	// TODO: change this once snapd supports prompting
-	c.Check(supported, Equals, false)
-	c.Check(reason, Equals, "requires newer version of snapd")
-	// c.Check(supported, Equals, true)
-	// c.Check(reason, Equals, "")
+	c.Check(supported, Equals, true)
+	c.Check(reason, Equals, "")
 }
 
 func (s *apparmorSuite) TestValidateFreeFromAAREUnhappy(c *C) {

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -100,7 +100,22 @@ execute: |
         check_prompting_setting "false"
     fi
 
-    echo "Enable prompting via snap client"
+    echo "Enable prompting via snap client where possible"
+    if os.query is-core || os.query is-ubuntu-lt 24.04; then
+        # prompting is disabled on Ubuntu Core
+        # TODO on releases < 24.04 we need the snapd snap for testing
+        not snap set system experimental.apparmor-prompting=true >& err.out
+        if os.query is-core ; then
+            MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
+        else
+            MATCH "cannot enable prompting feature as it is not supported by the system" < err.out
+        fi
+
+        # even if unsupported setting it to false should succeed
+        snap set system experimental.apparmor-prompting=false
+        exit 0
+    fi
+
     snap set system experimental.apparmor-prompting=true || reset_start_limit
 
     echo "Check that snapd restarted after prompting set to true via snap client"

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -36,7 +36,23 @@ execute: |
     echo "Check snap can access system info via /v2/system-info"
     api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."status-code"' | MATCH '^200$'
 
-    echo "Ensure AppArmor Prompting experimental feature is marked as enabled"
+    echo "Ensure AppArmor Prompting experimental feature can be enabled where possible"
+    # prompting is disabled everywhere but the Ubuntu systems
+    # TODO on Ubuntu releases < 24.04 we need the snapd snap for testing
+    if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
+        not snap set system experimental.apparmor-prompting=true >& err.out
+        if os.query is-core; then
+            # there is a more specific error on Ubuntu Core
+            MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
+        else
+            MATCH "cannot enable prompting feature as it is not supported by the system" < err.out
+        fi
+
+        # even if unsupported setting it to false should succeed
+        snap set system experimental.apparmor-prompting=false
+        exit 0
+    fi
+
     snap set system experimental.apparmor-prompting=true
 
     echo 'Check "apparmor-prompting" is shown as enabled in /v2/system-info'


### PR DESCRIPTION
When attempting to enable apparmor prompting experimental feature, first check whether it is supported by the system at all.

Related: SNAPDENG-22972

~~Note that this basically enables the prompting feature if both kernel and parser support it. Perhaps we should still gate this with an environment flag, eg SNAPD_APPARMOR_PROMPTING_ENABLE=1 ?~~