### PR TITLE
o/configstate/configcore: check whether prompts handler is present and connected

### DIFF
--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -123,7 +123,7 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 		}
 
 		if len(handlers) == 0 {
-			return fmt.Errorf("cannot enable prompting feature no interfaces requests handlers are installed")
+			return fmt.Errorf("cannot enable prompting feature no interfaces requests handler services are installed")
 		}
 
 		// TODO start handlers as a change and wait for completion

--- a/overlord/configstate/configcore/prompting.go
+++ b/overlord/configstate/configcore/prompting.go
@@ -24,12 +24,62 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
 )
 
 var restartRequest = restart.Request
+
+func findPromptingRequestsHandlers(st *state.State) ([]*snap.AppInfo, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	conns, err := ifacestate.ConnectionStates(st)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: cannot get connections: %w", err)
+	}
+
+	var handlers []*snap.AppInfo
+
+	for connId, connState := range conns {
+		if connState.Interface != "snap-interfaces-requests-control" || !connState.Active() {
+			continue
+		}
+
+		connRef, err := interfaces.ParseConnRef(connId)
+		if err != nil {
+			return nil, err
+		}
+
+		handler, ok := connState.StaticPlugAttrs["handler-service"].(string)
+		if !ok {
+			// does not have a handler service
+			continue
+		}
+
+		sn := connRef.PlugRef.Snap
+		si, err := snapstate.CurrentInfo(st, sn)
+		if err != nil {
+			return nil, err
+		}
+
+		// this should not fail as plug's before prepare should have validated that such app exists
+		app := si.Apps[handler]
+		if app == nil {
+			return nil, fmt.Errorf("internal error: cannot find app %q in snap %q", app, sn)
+		}
+
+		handlers = append(handlers, app)
+	}
+
+	return handlers, nil
+}
 
 // Trigger a security profile regeneration by restarting snapd if the
 // experimental apparmor-prompting flag changed.
@@ -66,6 +116,17 @@ func doExperimentalApparmorPromptingDaemonRestart(c RunTransaction, opts *fsOnly
 			}
 			return fmt.Errorf("cannot enable prompting feature as it is not supported by the system: %s", whyNot)
 		}
+
+		handlers, err := findPromptingRequestsHandlers(st)
+		if err != nil {
+			return err
+		}
+
+		if len(handlers) == 0 {
+			return fmt.Errorf("cannot enable prompting feature no interfaces requests handlers are installed")
+		}
+
+		// TODO start handlers as a change and wait for completion
 	}
 
 	// No matter whether prompting is supported or not, request a restart of

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -322,7 +322,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersNone(c
 	defer restore()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature no interfaces requests handlers are installed")
+		"cannot enable prompting feature no interfaces requests handler services are installed")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersManyButNoHandlerApp(c *C) {
@@ -339,7 +339,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersManyBu
 	defer restore()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature no interfaces requests handlers are installed")
+		"cannot enable prompting feature no interfaces requests handler services are installed")
 }
 
 func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDisconnected(c *C) {
@@ -368,7 +368,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDiscon
 	s.state.Unlock()
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
-		"cannot enable prompting feature no interfaces requests handlers are installed")
+		"cannot enable prompting feature no interfaces requests handler services are installed")
 }
 
 func (s *promptingSuite) mockSnapd(c *C) {

--- a/tests/lib/snaps/test-snapd-prompt-handler/bin/start
+++ b/tests/lib/snaps/test-snapd-prompt-handler/bin/start
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do
+    echo "running"
+    sleep 10 || break
+done

--- a/tests/lib/snaps/test-snapd-prompt-handler/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-prompt-handler/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: test-snapd-prompt-handler
+version: 1.0
+base: core24
+apps:
+    prompt-handler:
+        command: bin/start
+        daemon: simple
+        daemon-scope: user
+
+plugs:
+    snap-interfaces-requests-control:
+      handler-service: prompt-handler

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -19,6 +19,10 @@ prepare: |
         snap install --devmode --edge test-snapd-curl
         snap alias test-snapd-curl.curl curl
     fi
+    # prerequisite for having a prompts handler service
+    snap set system experimental.user-daemons=true
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
+    snap connect test-snapd-prompt-handler:snap-interfaces-requests-control
 
 restore: |
     echo "Restore: Reset start limit so that other queries can succeed"

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -9,7 +9,8 @@ details: |
 
 systems:
   - ubuntu-16.04-*
-  - ubuntu-18.04-*
+  # skip 18.04-32 as one of the test snaps uses core24 which has no i386 build
+  - ubuntu-18.04-64
   - ubuntu-2*
   - ubuntu-core-*
 

--- a/tests/main/interfaces-snap-interfaces-requests-control/api-client/bin/start
+++ b/tests/main/interfaces-snap-interfaces-requests-control/api-client/bin/start
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#!/bin/sh
+
+while true; do
+    echo "running"
+    sleep 10 || break
+done

--- a/tests/main/interfaces-snap-interfaces-requests-control/api-client/meta/snap.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/api-client/meta/snap.yaml
@@ -4,5 +4,12 @@ base: core18
 apps:
   api-client:
     command: bin/api-client.py
-    plugs:
-      - snap-interfaces-requests-control
+
+  prompt-handler:
+    command: bin/start
+    daemon: simple
+    daemon-scope: user
+
+plugs:
+  snap-interfaces-requests-control:
+    handler-service: prompt-handler

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -18,6 +18,8 @@ environment:
 
 prepare: |
     snap install --edge jq
+    # prerequisite for having a prompts handler service
+    snap set system experimental.user-daemons=true
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local api-client


### PR DESCRIPTION
Based on #14340. This is a WIP branch, the tests aren't passing yet.