### PR TITLE
tests/main/snap-quota-thread: fix thread spawn wait counter

### DIFF
--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -73,9 +73,17 @@ execute: |
   # the group is double escaped
   systemctl show --property=ControlGroup snap.test-snapd-stressd.spawner.service | MATCH 'ControlGroup=/snap.group(.*)one.slice/snap.test-snapd-stressd.spawner.service'
 
-  # verify that 'snap quota' is reporting the correct usage
+  # verify that 'snap quota' is reporting the correct new usage
   echo "Verify the number of threads is correct (=16)"
-  threadUsage="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
+  n=0
+  until [ "$n" -ge 10 ]; do
+      threadUsage="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
+      if [ "$threadUsage" -eq 16 ]; then
+          break
+      fi
+      sleep 1
+      (( n++ ))
+  done
   if ! [ "$threadUsage" -eq 16 ]; then
     echo "thread usage reported does not equal the expected quota usage $threadUsage"
     exit 1
@@ -93,6 +101,7 @@ execute: |
           break
       fi
       sleep 1
+      (( n++ ))
   done
   if ! [ "$threadUsage" -eq 24 ]; then
     echo "thread usage reported does not equal the expected quota usage $threadUsage"

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -78,7 +78,7 @@ execute: |
   n=0
   until [ "$n" -ge 10 ]; do
       threadUsage="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
-      if [ "$threadUsage" -eq 16 ]; then
+      if [ "$threadUsage" -ge 16 ]; then
           break
       fi
       sleep 1
@@ -97,7 +97,7 @@ execute: |
   n=0
   until [ "$n" -ge 10 ]; do
       threadUsage="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
-      if [ "$threadUsage" -eq 24 ]; then
+      if [ "$threadUsage" -ge 24 ]; then
           break
       fi
       sleep 1


### PR DESCRIPTION
Fix the test to work as intended and have 10 second timeout waiting for threads to increase from 16 to 24. Currently it loops infinitely up to spread timeout.

For robustness, also implemented the same wait mechanism for ramping from zero to 16 threads, which currently seems to just hope for sufficient delays up the the point of checking.

Failure mode:
![image](https://github.com/user-attachments/assets/ab5c6d3a-d1e0-4657-8298-5ede2c74dc30)

Note: I am investigating an issue, may result in more changes...