### PR TITLE
o/snapstate: prevent mixed unasserted comps and snaps

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -488,7 +488,7 @@ func earlyChecks(st *state.State, snapst *SnapState, update *snap.Info, comps []
 func ensureSnapAndComponentsAssertionStatus(si snap.SideInfo, comps []snap.ComponentSideInfo) error {
 	snapAsserted := si.SnapID != ""
 	for _, comp := range comps {
-		compAsserted := !comp.Revision.Local() && !comp.Revision.Unset()
+		compAsserted := comp.Revision.Store()
 		if snapAsserted && !compAsserted {
 			return errors.New("cannot mix asserted snap and unasserted components")
 		}

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -486,7 +486,7 @@ func earlyChecks(st *state.State, snapst *SnapState, update *snap.Info, comps []
 }
 
 func ensureSnapAndComponentsAssertionStatus(si snap.SideInfo, comps []snap.ComponentSideInfo) error {
-	snapAsserted := !si.Revision.Local() && !si.Revision.Unset()
+	snapAsserted := si.SnapID != ""
 	for _, comp := range comps {
 		compAsserted := !comp.Revision.Local() && !comp.Revision.Unset()
 		if snapAsserted && !compAsserted {

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -288,6 +288,12 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup ComponentS
 
 	// TODO check for experimental flag that will hide temporarily components
 
+	if err := ensureSnapAndComponentsAssertionStatus(
+		*snapsup.SideInfo, []snap.ComponentSideInfo{*compSetup.CompSideInfo},
+	); err != nil {
+		return componentInstallTaskSet{}, err
+	}
+
 	snapSi := snapsup.SideInfo
 	compSi := compSetup.CompSideInfo
 

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -202,7 +202,17 @@ components:
 
 	info, err := snap.InfoFromSnapYaml(b.Bytes())
 	c.Assert(err, IsNil)
-	info.SideInfo = snap.SideInfo{RealName: snapName, Revision: snapRev}
+
+	var snapID string
+	if !snapRev.Unset() && !snapRev.Local() {
+		snapID = snapName + "-id"
+	}
+
+	info.SideInfo = snap.SideInfo{
+		RealName: snapName,
+		Revision: snapRev,
+		SnapID:   snapID,
+	}
 
 	return info
 }

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -248,6 +248,8 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	// TODO we might want a checkComponents doing checks for some
 	// component types (see checkSnap and checkSnapCallbacks slice)
 
+	// this check should be a duplicate check, but it is here to ensure that we
+	// don't mistakenly forget to enforce this invariant
 	if err := ensureSnapAndComponentsAssertionStatus(
 		*snapsup.SideInfo, []snap.ComponentSideInfo{*compSetup.CompSideInfo},
 	); err != nil {

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -248,6 +248,12 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	// TODO we might want a checkComponents doing checks for some
 	// component types (see checkSnap and checkSnapCallbacks slice)
 
+	if err := ensureSnapAndComponentsAssertionStatus(
+		*snapsup.SideInfo, []snap.ComponentSideInfo{*compSetup.CompSideInfo},
+	); err != nil {
+		return err
+	}
+
 	csi := compSetup.CompSideInfo
 	cpi := snap.MinimalComponentContainerPlaceInfo(compSetup.ComponentName(),
 		csi.Revision, snapsup.InstanceName())

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -275,6 +275,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 		SideInfo: snap.SideInfo{
 			RealName: "other-snap",
 			Revision: snap.R(2),
+			SnapID:   "other-snap-id",
 		},
 		DownloadInfo: snap.DownloadInfo{
 			Size: int64(88),
@@ -308,6 +309,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 		SideInfo: snap.SideInfo{
 			RealName: "some-snap",
 			Revision: snap.R(1),
+			SnapID:   "some-snap-id",
 		},
 		DownloadInfo: snap.DownloadInfo{
 			Size: int64(99),
@@ -370,6 +372,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 		SideInfo: &snap.SideInfo{
 			RealName: "some-snap",
 			Revision: snap.R(1),
+			SnapID:   "some-snap-id",
 		},
 		PlugsOnly: true,
 		CohortKey: "cohort",
@@ -395,6 +398,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 		SideInfo: &snap.SideInfo{
 			RealName: "other-snap",
 			Revision: snap.R(2),
+			SnapID:   "other-snap-id",
 		},
 		Prereq:             []string{"foo-snap"},
 		PrereqContentAttrs: map[string][]string{"foo-snap": {"some-content"}},


### PR DESCRIPTION
Based on https://github.com/canonical/snapd/pull/14347, since that changes how some of the code that calls earlyChecks looks.