### PR TITLE
tests: conditionally reset-failed snapd.failure.service

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -767,9 +767,13 @@ restore_suite_each() {
     done
 
     if [[ "$variant" = full ]]; then
-        # reset the failed status of snapd, snapd.socket, and snapd.failure.socket
-        # to prevent hitting the system restart rate-limit for these services
-        systemctl reset-failed snapd.service snapd.socket snapd.failure.service
+        # Reset the failed status of snapd, snapd.socket, and snapd.failure.socket
+        # to prevent hitting the system restart rate-limit for these services.
+        systemctl reset-failed snapd.service snapd.socket
+        # This unit may not be present, it is masked on some systems.
+        if systemctl status snapd.failure.service; then
+            systemctl reset-failed snapd.failure.service
+        fi
     fi
 
     if [[ "$variant" = full ]]; then


### PR DESCRIPTION
I've ran across a test failure caused by attempt to use systemctl to reset the failed status of a service that was not loaded due to being masked.

    + systemctl reset-failed snapd.service snapd.socket snapd.failure.service
    Failed to reset failed state of unit snapd.failure.service: Unit
    snapd.failure.service not loaded.

Use systemctl status as a way to check if a service is known before attempting to reset it.
