### PR TITLE
o/configstate/configcore: enable and start prompting handlers

### DIFF
--- a/overlord/configstate/configcore/export_test.go
+++ b/overlord/configstate/configcore/export_test.go
@@ -20,12 +20,18 @@
 package configcore
 
 import (
+	"os/user"
+	"time"
+
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
+	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -86,4 +92,12 @@ func MockLoggerSimpleSetup(f func(opts *logger.LoggerOptions) error) func() {
 
 func MockRestartRequest(f func(st *state.State, t restart.RestartType, rebootInfo *boot.RebootInfo)) func() {
 	return testutil.Mock(&restartRequest, f)
+}
+
+func MockServicestateControl(f func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, cu *user.User, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error)) func() {
+	return testutil.Mock(&servicestateControl, f)
+}
+
+func MockServicestateChangeTimeout(v time.Duration) func() {
+	return testutil.Mock(&serviceStartChangeTimeout, v)
 }

--- a/overlord/configstate/configcore/export_test.go
+++ b/overlord/configstate/configcore/export_test.go
@@ -53,59 +53,37 @@ func FilesystemOnlyRun(dev sysconfig.Device, cfg ConfGetter) error {
 }
 
 func MockFindGid(f func(string) (uint64, error)) func() {
-	old := osutilFindGid
-	osutilFindGid = f
-	return func() {
-		osutilFindGid = old
-	}
+	return testutil.Mock(&osutilFindGid, f)
 }
 
 func MockChownPath(f func(string, sys.UserID, sys.GroupID) error) func() {
-	old := sysChownPath
-	sysChownPath = f
-	return func() {
-		sysChownPath = old
-	}
+	return testutil.Mock(&sysChownPath, f)
 }
 
 func MockEnsureFileState(f func(string, osutil.FileState) error) func() {
-	r := testutil.Backup(&osutilEnsureFileState)
-	osutilEnsureFileState = f
-	return r
+	return testutil.Mock(&osutilEnsureFileState, f)
 }
 
 func MockDirExists(f func(string) (bool, bool, error)) func() {
-	r := testutil.Backup(&osutilDirExists)
-	osutilDirExists = f
-	return r
+	return testutil.Mock(&osutilDirExists, f)
 }
 
 func MockApparmorUpdateHomedirsTunable(f func([]string) error) func() {
-	r := testutil.Backup(&apparmorUpdateHomedirsTunable)
-	apparmorUpdateHomedirsTunable = f
-	return r
+	return testutil.Mock(&apparmorUpdateHomedirsTunable, f)
 }
 
 func MockApparmorSetupSnapConfineSnippets(f func() (bool, error)) func() {
-	r := testutil.Backup(&apparmorSetupSnapConfineSnippets)
-	apparmorSetupSnapConfineSnippets = f
-	return r
+	return testutil.Mock(&apparmorSetupSnapConfineSnippets, f)
 }
 
 func MockApparmorReloadAllSnapProfiles(f func() error) func() {
-	r := testutil.Backup(&apparmorReloadAllSnapProfiles)
-	apparmorReloadAllSnapProfiles = f
-	return r
+	return testutil.Mock(&apparmorReloadAllSnapProfiles, f)
 }
 
 func MockLoggerSimpleSetup(f func(opts *logger.LoggerOptions) error) func() {
-	r := testutil.Backup(&loggerSimpleSetup)
-	loggerSimpleSetup = f
-	return r
+	return testutil.Mock(&loggerSimpleSetup, f)
 }
 
 func MockRestartRequest(f func(st *state.State, t restart.RestartType, rebootInfo *boot.RebootInfo)) func() {
-	r := testutil.Backup(&restartRequest)
-	restartRequest = f
-	return r
+	return testutil.Mock(&restartRequest, f)
 }

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -20,18 +20,26 @@
 package configcore_test
 
 import (
+	"errors"
 	"fmt"
+	"os/user"
+	"time"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -44,7 +52,8 @@ import (
 type promptingSuite struct {
 	configcoreSuite
 
-	repo *interfaces.Repository
+	repo     *interfaces.Repository
+	overlord *overlord.Overlord
 }
 
 var _ = Suite(&promptingSuite{})
@@ -56,6 +65,24 @@ func (s *promptingSuite) SetUpTest(c *C) {
 		[]string{"policy:permstable32:prompt"}, nil,
 		[]string{"prompt"}, nil,
 	))
+
+	s.overlord = overlord.MockWithState(nil)
+	// override state set up by configcoreSuite
+	s.state = s.overlord.State()
+	s.overlord.AddManager(s.overlord.TaskRunner())
+
+	// default handler for mock task
+	s.overlord.TaskRunner().AddHandler("service-command",
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil },
+		nil)
+
+	// mock a reasonable handler so that tests not checking this specific
+	// bit can stay relatively simple
+	restore := configcore.MockServicestateControl(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, cu *user.User, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
+		tsk := st.NewTask("service-command", "mock task")
+		return []*state.TaskSet{state.NewTaskSet(tsk)}, nil
+	})
+	s.AddCleanup(restore)
 
 	s.repo = interfaces.NewRepository()
 	for _, iface := range builtin.Interfaces() {
@@ -79,6 +106,12 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartNoPrist
 
 	s.mockSnapd(c)
 	s.mockPromptingHandler(c, mockPromptingHandlerOpts{snapName: "test-snap", hasHandler: true})
+
+	c.Assert(s.overlord.StartUp(), IsNil)
+	s.overlord.Loop()
+	defer func() {
+		c.Assert(s.overlord.Stop(), IsNil)
+	}()
 
 	snap, confName := features.AppArmorPrompting.ConfigOption()
 
@@ -124,6 +157,12 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartWithPri
 	s.mockSnapd(c)
 	s.mockPromptingHandler(c, mockPromptingHandlerOpts{snapName: "test-snap", hasHandler: true})
 
+	c.Assert(s.overlord.StartUp(), IsNil)
+	s.overlord.Loop()
+	defer func() {
+		c.Assert(s.overlord.Stop(), IsNil)
+	}()
+
 	snap, confName := features.AppArmorPrompting.ConfigOption()
 
 	testCases := []struct {
@@ -147,6 +186,7 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingDaemonRestartWithPri
 			true,
 		},
 	}
+
 	for _, testCase := range testCases {
 		s.state.Lock()
 		rt := configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
@@ -296,6 +336,12 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingOnCoreDesktop(c *C) 
 	})
 	defer restore()
 
+	c.Assert(s.overlord.StartUp(), IsNil)
+	s.overlord.Loop()
+	defer func() {
+		c.Assert(s.overlord.Stop(), IsNil)
+	}()
+
 	snap, confName := features.AppArmorPrompting.ConfigOption()
 
 	// one cannot enable prompting if it's not supported
@@ -369,6 +415,131 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDiscon
 
 	s.testDoExperimentalApparmorPromptingUnsupported(c,
 		"cannot enable prompting feature no interfaces requests handler services are installed")
+}
+
+type promptEnableWithServicesTestCase struct {
+	serviceControlErr error
+	taskErr           error
+
+	expectedError string
+
+	timeout bool
+}
+
+func (s *promptingSuite) testDoExperimentalApparmorPromptingHandlerServices(c *C, tc promptEnableWithServicesTestCase) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	s.mockSnapd(c)
+	s.mockPromptingHandler(c, mockPromptingHandlerOpts{snapName: "test-snap1", hasHandler: true})
+	s.mockPromptingHandler(c, mockPromptingHandlerOpts{snapName: "test-snap2", hasHandler: true})
+
+	restartCalled := 0
+	restore = configcore.MockRestartRequest(func(st *state.State, t restart.RestartType, rebootInfo *boot.RebootInfo) {
+		restartCalled++
+	})
+	defer restore()
+
+	if tc.timeout {
+		restore = configcore.MockServicestateChangeTimeout(time.Microsecond)
+		defer restore()
+	}
+
+	s.overlord.TaskRunner().AddHandler("service-command",
+		func(task *state.Task, tomb *tomb.Tomb) error {
+			if tc.timeout {
+				time.Sleep(time.Second)
+			}
+			return tc.taskErr
+		},
+		nil)
+
+	servicestateControlCalls := 0
+	restore = configcore.MockServicestateControl(
+		func(
+			st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction,
+			cu *user.User, flags *servicestate.Flags, context *hookstate.Context,
+		) ([]*state.TaskSet, error) {
+			servicestateControlCalls++
+
+			c.Check(cu, IsNil)
+			c.Assert(inst, NotNil)
+			c.Check(inst.Action, Equals, "start")
+			c.Check(inst.Enable, Equals, true)
+			c.Check(inst.Scope, DeepEquals, client.ScopeSelector([]string{"user"}))
+
+			// 2 mock handlers
+			seen := map[string]bool{}
+			for _, ai := range appInfos {
+				seen[ai.String()] = true
+			}
+
+			c.Check(seen, DeepEquals, map[string]bool{
+				"test-snap1.prompts-handler": true,
+				"test-snap2.prompts-handler": true,
+			})
+
+			if tc.serviceControlErr != nil {
+				return nil, tc.serviceControlErr
+			}
+
+			tsk := st.NewTask("service-command", "mock task")
+			return []*state.TaskSet{state.NewTaskSet(tsk)}, nil
+		})
+	defer restore()
+
+	c.Assert(s.overlord.StartUp(), IsNil)
+	s.overlord.Loop()
+	defer func() {
+		c.Assert(s.overlord.Stop(), IsNil)
+	}()
+
+	snap, confName := features.AppArmorPrompting.ConfigOption()
+
+	// one cannot enable prompting if it's not supported
+	s.state.Lock()
+	rt := configcore.NewRunTransaction(config.NewTransaction(s.state), nil)
+	rt.Set(snap, confName, true)
+	s.state.Unlock()
+
+	err := configcore.DoExperimentalApparmorPromptingDaemonRestart(rt, nil)
+	if tc.expectedError != "" {
+		c.Check(err, ErrorMatches, tc.expectedError)
+		c.Check(restartCalled, Equals, 0)
+	} else {
+		c.Check(err, IsNil)
+		c.Check(restartCalled, Equals, 1)
+	}
+
+	c.Check(servicestateControlCalls, Equals, 1)
+}
+
+func (s *promptingSuite) TestDoExperimentalApparmorPromptingHandlerServicesHappy(c *C) {
+	s.testDoExperimentalApparmorPromptingHandlerServices(c, promptEnableWithServicesTestCase{})
+}
+
+func (s *promptingSuite) TestDoExperimentalApparmorPromptingHandlerServicesActivationFails(c *C) {
+	s.testDoExperimentalApparmorPromptingHandlerServices(c, promptEnableWithServicesTestCase{
+		taskErr: fmt.Errorf("mock start error"),
+
+		expectedError: `(?s)cannot enable prompting, unable to start prompting handlers: cannot perform the following tasks:.- mock task \(mock start error\)`,
+	})
+}
+
+func (s *promptingSuite) TestDoExperimentalApparmorPromptingHandlerServicesServiceStateFails(c *C) {
+	s.testDoExperimentalApparmorPromptingHandlerServices(c, promptEnableWithServicesTestCase{
+		serviceControlErr: fmt.Errorf("mock error"),
+
+		expectedError: "cannot enable prompting, unable to start prompting handlers: mock error",
+	})
+}
+
+func (s *promptingSuite) TestDoExperimentalApparmorPromptingHandlerServicesTimeout(c *C) {
+	s.testDoExperimentalApparmorPromptingHandlerServices(c, promptEnableWithServicesTestCase{
+		timeout: true,
+
+		expectedError: "cannot enable prompting, unable to start prompting handlers: timeout waiting for handler services start to complete",
+	})
 }
 
 func (s *promptingSuite) mockSnapd(c *C) {
@@ -450,10 +621,20 @@ plugs:
 		plugStatic["handler-service"] = "prompts-handler"
 	}
 
-	s.state.Set("conns", map[string]interface{}{
-		fmt.Sprintf("%s:snap-interfaces-requests-control core:snap-interfaces-requests-control", name): map[string]interface{}{
-			"interface":   "snap-interfaces-requests-control",
-			"plug-static": plugStatic,
-		},
-	})
+	var conns map[string]interface{}
+	err := s.state.Get("conns", &conns)
+	if err != nil {
+		if errors.Is(err, state.ErrNoState) {
+			conns = map[string]interface{}{}
+		} else {
+			c.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	conns[fmt.Sprintf("%s:snap-interfaces-requests-control core:snap-interfaces-requests-control", name)] = map[string]interface{}{
+		"interface":   "snap-interfaces-requests-control",
+		"plug-static": plugStatic,
+	}
+
+	s.state.Set("conns", conns)
 }

--- a/tests/lib/snaps/test-snapd-prompt-handler/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-prompt-handler/meta/snap.yaml
@@ -6,6 +6,7 @@ apps:
         command: bin/start
         daemon: simple
         daemon-scope: user
+        install-mode: disable
 
 plugs:
     snap-interfaces-requests-control:

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -1,0 +1,67 @@
+summary: Check that enabling prompting requests will activate handler services
+
+details: |
+    The test verifies that activation of apparmor prompting feature will
+    activate handler services.
+
+systems:
+  - ubuntu-2*
+
+prepare: |
+    # prerequisite for having a prompts handler service
+    snap set system experimental.user-daemons=true
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
+    snap connect test-snapd-prompt-handler:snap-interfaces-requests-control
+    tests.session -u test prepare
+
+restore: |
+    tests.session -u test restore
+
+execute: |
+    echo "Enable prompting via snap client where possible"
+    if os.query is-core || os.query is-ubuntu-lt 24.04; then
+        # prompting is disabled on Ubuntu Core
+        # TODO on releases < 24.04 we need the snapd snap for testing
+        not snap set system experimental.apparmor-prompting=true >& err.out
+        if os.query is-core ; then
+            MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
+        else
+            MATCH "cannot enable prompting feature as it is not supported by the system" < err.out
+        fi
+
+        # even if unsupported setting it to false should succeed
+        snap set system experimental.apparmor-prompting=false
+        exit 0
+    fi
+
+    not tests.session -u test exec systemctl --user is-active \
+        snap.test-snapd-prompt-handler.prompt-handler.service
+    not tests.session -u test exec systemctl --user is-enabled \
+        snap.test-snapd-prompt-handler.prompt-handler.service
+
+    echo "Check status of user session service"
+    tests.session -u test exec systemctl --user is-active snapd.session-agent.socket
+
+    echo "...and ensure it is stopped"
+    tests.session -u test exec systemctl --user stop snapd.session-agent.socket
+
+    echo "Check that the prompting feature cannot be enabled"
+    # due to failure starting the handler service
+    if ! snap set system experimental.apparmor-prompting=true 2> err.out ; then
+        MATCH "unable to start prompting handlers" < err.out
+    else
+        echo "unexpected success enabling apparmor prompting"
+        exit 1
+    fi
+
+    echo "Start user session agent socket again"
+    tests.session -u test exec systemctl --user start snapd.session-agent.socket
+
+    echo "Check that the prompting feature can be successfully enabled now"
+    snap set system experimental.apparmor-prompting=true
+
+    echo "And handler services have been started"
+    tests.session -u test exec systemctl --user is-active \
+        snap.test-snapd-prompt-handler.prompt-handler.service
+    tests.session -u test exec systemctl --user is-enabled \
+        snap.test-snapd-prompt-handler.prompt-handler.service


### PR DESCRIPTION
Attempt to enable and start prompting handlers whenever prompting is enabled.

Based on top of #14342 

Related: SNAPDENG-22972