### PR TITLE
tests: fix debian-sid tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -11,7 +11,7 @@ environment:
     GOPROXY: https://proxy.golang.org,direct
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
-    PATH: $GOHOME/bin:/snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/bin
+    PATH: $PROJECT_PATH/tests/bin:$GOHOME/bin:/snap/bin:$PATH:/var/lib/snapd/snap/bin
     TESTSLIB: $PROJECT_PATH/tests/lib
     TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
     TESTSTMP: /var/tmp/snapd-tools


### PR DESCRIPTION
In debian sid there is a retry (related to autopkgtests) command already installed, which is making our tests fail because it conflicts with our retry tool.

This change makes sure that in our tests, the testing tools are located before the preinstalled binaries by updating the PATH in the spread.yaml
