### PR TITLE
github: bump golangci-lint version to 1.60.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,7 +205,7 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
         # to use the latest version
-        version: v1.55.2
+        version: v1.60.1
         working-directory: ./src/github.com/snapcore/snapd
         # show only new issues
         # use empty path prefix to make annotations work


### PR DESCRIPTION
Bump version of golangci-lint to 1.60.1 for Go 1.23 compatibility fixes. See https://github.com/golangci/golangci-lint/issues/4837

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
