### PR TITLE
many: change seed.SnapHandler to a seed.ContainerHandler

### DIFF
--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -123,11 +123,11 @@ func (fs *FakeSeed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Mea
 	return fs.LoadMetaErr
 }
 
-func (fs *FakeSeed) LoadEssentialMetaWithSnapHandler(essentialTypes []snap.Type, handler seed.SnapHandler, tm timings.Measurer) error {
+func (fs *FakeSeed) LoadEssentialMetaWithSnapHandler(essentialTypes []snap.Type, handler seed.ContainerHandler, tm timings.Measurer) error {
 	return fs.LoadMetaErr
 }
 
-func (fs *FakeSeed) LoadMeta(mode string, handler seed.SnapHandler, tm timings.Measurer) error {
+func (fs *FakeSeed) LoadMeta(mode string, handler seed.ContainerHandler, tm timings.Measurer) error {
 	return fs.LoadMetaErr
 }
 

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -711,11 +711,11 @@ func (*fakeSeed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measur
 	return nil
 }
 
-func (*fakeSeed) LoadEssentialMetaWithSnapHandler([]snap.Type, seed.SnapHandler, timings.Measurer) error {
+func (*fakeSeed) LoadEssentialMetaWithSnapHandler([]snap.Type, seed.ContainerHandler, timings.Measurer) error {
 	return nil
 }
 
-func (*fakeSeed) LoadMeta(string, seed.SnapHandler, timings.Measurer) error {
+func (*fakeSeed) LoadMeta(string, seed.ContainerHandler, timings.Measurer) error {
 	return nil
 }
 

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -531,24 +531,22 @@ type preseedSnapHandler struct {
 	writableDir string
 }
 
-func (p *preseedSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) (string, error) {
-	pinfo := snap.MinimalPlaceInfo(name, snap.Revision{N: -1})
-	targetPath := filepath.Join(p.writableDir, pinfo.MountFile())
-	mountDir := filepath.Join(p.writableDir, pinfo.MountDir())
+func (p *preseedSnapHandler) HandleUnassertedContainer(cpi snap.ContainerPlaceInfo, path string, _ timings.Measurer) (string, error) {
+	targetPath := filepath.Join(p.writableDir, cpi.MountFile())
+	mountDir := filepath.Join(p.writableDir, cpi.MountDir())
 
 	sq := squashfs.New(path)
 	opts := &snap.InstallOptions{MustNotCrossDevices: true}
 	if _, err := sq.Install(targetPath, mountDir, opts); err != nil {
-		return "", fmt.Errorf("cannot install snap %q: %v", name, err)
+		return "", fmt.Errorf("cannot install snap %q: %v", cpi.ContainerName(), err)
 	}
 
 	return targetPath, nil
 }
 
-func (p *preseedSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, snapRev *asserts.SnapRevision, _ func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, string, uint64, error) {
-	pinfo := snap.MinimalPlaceInfo(name, snap.Revision{N: snapRev.SnapRevision()})
-	targetPath := filepath.Join(p.writableDir, pinfo.MountFile())
-	mountDir := filepath.Join(p.writableDir, pinfo.MountDir())
+func (p *preseedSnapHandler) HandleAndDigestAssertedContainer(cpi snap.ContainerPlaceInfo, path string, _ timings.Measurer) (string, string, uint64, error) {
+	targetPath := filepath.Join(p.writableDir, cpi.MountFile())
+	mountDir := filepath.Join(p.writableDir, cpi.MountDir())
 
 	logger.Debugf("copying: %q to %q; mount dir=%q", path, targetPath, mountDir)
 
@@ -579,7 +577,7 @@ func (p *preseedSnapHandler) HandleAndDigestAssertedSnap(name, path string, essT
 		return "", "", 0, err
 	}
 	if err := destFile.Commit(); err != nil {
-		return "", "", 0, fmt.Errorf("cannot copy snap %q: %v", name, err)
+		return "", "", 0, fmt.Errorf("cannot copy snap %q: %v", cpi.ContainerName(), err)
 	}
 
 	sq := squashfs.New(targetPath)
@@ -587,7 +585,7 @@ func (p *preseedSnapHandler) HandleAndDigestAssertedSnap(name, path string, essT
 	// since Install target path is the same as source path passed to squashfs.New,
 	// Install isn't going to copy the blob, but we call it to set up mount directory etc.
 	if _, err := sq.Install(targetPath, mountDir, opts); err != nil {
-		return "", "", 0, fmt.Errorf("cannot install snap %q: %v", name, err)
+		return "", "", 0, fmt.Errorf("cannot install snap %q: %v", cpi.ContainerName(), err)
 	}
 
 	sha3_384, err := asserts.EncodeDigest(crypto.SHA3_384, h.Sum(nil))

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -1541,11 +1541,11 @@ func (*fakeSeed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measur
 	return nil
 }
 
-func (*fakeSeed) LoadEssentialMetaWithSnapHandler([]snap.Type, seed.SnapHandler, timings.Measurer) error {
+func (*fakeSeed) LoadEssentialMetaWithSnapHandler([]snap.Type, seed.ContainerHandler, timings.Measurer) error {
 	return nil
 }
 
-func (*fakeSeed) LoadMeta(string, seed.SnapHandler, timings.Measurer) error {
+func (*fakeSeed) LoadMeta(string, seed.ContainerHandler, timings.Measurer) error {
 	return nil
 }
 

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -155,11 +155,11 @@ func findBrand(seed Seed, db asserts.RODatabase) (*asserts.Account, error) {
 
 type defaultSnapHandler struct{}
 
-func (h defaultSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) (string, error) {
+func (h defaultSnapHandler) HandleUnassertedContainer(_ snap.ContainerPlaceInfo, path string, _ timings.Measurer) (string, error) {
 	return path, nil
 }
 
-func (h defaultSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, _ *asserts.SnapRevision, _ func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, string, uint64, error) {
+func (h defaultSnapHandler) HandleAndDigestAssertedContainer(_ snap.ContainerPlaceInfo, path string, _ timings.Measurer) (string, string, uint64, error) {
 	sha3_384, size, err := asserts.SnapFileSHA3_384(path)
 	if err != nil {
 		return "", "", 0, err

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -120,7 +120,7 @@ type Seed interface {
 	// handling at the same time as digest computation.
 	// No caching of essential snaps across Load*Meta* methods is
 	// performed if a handler is provided.
-	LoadEssentialMetaWithSnapHandler(essentialTypes []snap.Type, handler SnapHandler, tm timings.Measurer) error
+	LoadEssentialMetaWithSnapHandler(essentialTypes []snap.Type, handler ContainerHandler, tm timings.Measurer) error
 
 	// LoadMeta loads the seed and seed's snaps metadata while
 	// verifying the underlying snaps against assertions. It can
@@ -135,7 +135,7 @@ type Seed interface {
 	// seed snap handling at the same time as digest computation.
 	// No caching of essential snaps across Load*Meta* methods is
 	// performed if a handler is provided.
-	LoadMeta(mode string, handler SnapHandler, tm timings.Measurer) error
+	LoadMeta(mode string, handler ContainerHandler, tm timings.Measurer) error
 
 	// UsesSnapdSnap returns whether the system as defined by the
 	// seed will use the snapd snap, after LoadMeta.
@@ -160,26 +160,22 @@ type Seed interface {
 	Iter(f func(sn *Snap) error) error
 }
 
-// A SnapHandler can be used to perform any dedicated handling of seed
-// snaps and their digest computation while seed snap metadata loading
-// and verification is being performed.
-type SnapHandler interface {
-	// HandleAndDigestAssertedSnap should compute the digest of
-	// the given snap and perform any dedicated
-	// handling. essentialType is provided only for essential
-	// snaps.
-	// snapRev is provided by UC20+ seeds.
-	// deriveRev is provided by UC16/18 seeds, it can be used
-	// to get early access to the snap revision based on the digest.
-	// A different path can be returned if the snap has been copied
-	// elsewhere.
-	HandleAndDigestAssertedSnap(name, path string, essentialType snap.Type, snapRev *asserts.SnapRevision, deriveRev func(snapSHA3_384 string, snapSize uint64) (snap.Revision, error), tm timings.Measurer) (newPath, snapSHA3_384 string, snapSize uint64, err error)
+// A ContainerHandler can be used to perform any dedicated handling of seed
+// snaps/components and their digest computation while seed snap/component
+// metadata loading and verification is being performed.
+type ContainerHandler interface {
+	// HandleAndDigestAssertedContainer should compute the digest of the
+	// given container and perform any dedicated handling. A different path
+	// can be returned if the container has been copied elsewhere.
+	// NOTE: for uc16/18 the revision in cpi will be not correct.
+	HandleAndDigestAssertedContainer(cpi snap.ContainerPlaceInfo, path string,
+		tm timings.Measurer) (newPath, snapSHA3_384 string, snapSize uint64, err error)
 
-	// HandleUnassertedSnap should perfrom any dedicated handling
-	// for the given unasserted snap.
-	// A different path can be returned if the snap has been copied
-	// elsewhere.
-	HandleUnassertedSnap(name, path string, tm timings.Measurer) (newPath string, err error)
+	// HandleUnassertedContainer should perform any dedicated handling for
+	// the given unasserted snap/component. A different path can be
+	// returned if the container has been copied elsewhere.
+	HandleUnassertedContainer(cpi snap.ContainerPlaceInfo, path string,
+		tm timings.Measurer) (newPath string, err error)
 }
 
 // A AutoImportAssertionsLoaderSeed can be used to import all auto import assertions

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -1022,10 +1022,10 @@ func (s *seed16Suite) TestLoadMetaCore18SnapHandler(c *C) {
 	})
 
 	c.Check(h.asserted, DeepEquals, map[string]string{
-		"snapd":     "snaps/snapd_1.0_all.snap:snapd:1",
-		"pc-kernel": "snaps/pc-kernel_1.0_all.snap:kernel:1",
-		"core18":    "snaps/core18_1.0_all.snap:base:1",
-		"pc":        "snaps/pc_1.0_all.snap:gadget:1",
+		"snapd":     "snaps/snapd_1.0_all.snap",
+		"pc-kernel": "snaps/pc-kernel_1.0_all.snap",
+		"core18":    "snaps/core18_1.0_all.snap",
+		"pc":        "snaps/pc_1.0_all.snap",
 	})
 	c.Check(h.unasserted, DeepEquals, map[string]string{
 		"required18": "snaps/required18_1.0_all.snap",
@@ -1103,10 +1103,10 @@ func (s *seed16Suite) TestLoadMetaCore18SnapHandlerChangePath(c *C) {
 	})
 
 	c.Check(h.asserted, DeepEquals, map[string]string{
-		"snapd":     "snaps/snapd_1.0_all.snap:snapd:1",
-		"pc-kernel": "snaps/pc-kernel_1.0_all.snap:kernel:1",
-		"core18":    "snaps/core18_1.0_all.snap:base:1",
-		"pc":        "snaps/pc_1.0_all.snap:gadget:1",
+		"snapd":     "snaps/snapd_1.0_all.snap",
+		"pc-kernel": "snaps/pc-kernel_1.0_all.snap",
+		"core18":    "snaps/core18_1.0_all.snap",
+		"pc":        "snaps/pc_1.0_all.snap",
 	})
 	c.Check(h.unasserted, DeepEquals, map[string]string{
 		"required18": "snaps/required18_1.0_all.snap",
@@ -1467,10 +1467,10 @@ func (s *seed16Suite) TestLoadEssentialMetaWithSnapHandlerCore18(c *C) {
 	c.Check(essSnaps, DeepEquals, expected)
 
 	c.Check(h.asserted, DeepEquals, map[string]string{
-		"snapd":     "snaps/snapd_1.0_all.snap:snapd:1",
-		"pc-kernel": "snaps/pc-kernel_1.0_all.snap:kernel:1",
-		"core18":    "snaps/core18_1.0_all.snap:base:1",
-		"pc":        "snaps/pc_1.0_all.snap:gadget:1",
+		"snapd":     "snaps/snapd_1.0_all.snap",
+		"pc-kernel": "snaps/pc-kernel_1.0_all.snap",
+		"core18":    "snaps/core18_1.0_all.snap",
+		"pc":        "snaps/pc_1.0_all.snap",
 	})
 }
 


### PR DESCRIPTION
We want to treat in the same way snaps and component containers when
reading a seed. Additionally, remove parameters from the interface
methods that were not used.