### PR TITLE
interfaces/apparmor/template: add setpriv to the base template

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -612,6 +612,7 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}bin/run-parts ixr,
   /{,usr/}bin/sed ixr,
   /{,usr/}bin/seq ixr,
+  /{,usr/}bin/setpriv ixr,
   /{,usr/}bin/sha{1,224,256,384,512}sum ixr,
   /{,usr/}bin/shuf ixr,
   /{,usr/}bin/sleep ixr,


### PR DESCRIPTION
The Snapcraft documentation on [system usernames](https://snapcraft.io/docs/system-usernames#dropping-privileges) states that snap developers can use `setpriv` to drop privileges and run a snapped daemon as a non-root user, such as `_daemon_`.

Whilst `setpriv` is present in the core20/core22/core24 base snaps, it isn't possible to run the base snap's copy within the environment of a strictly confined snap. (The documentation doesn't refer to this particular issue, but it does suggest that developers add the `util-linux` package to the daemon snap.) This PR seeks to overcome this issue by adding `/usr/bin/setpriv` to the AppArmor template.

If there are any reasons against doing this - particularly if there is a better way to run a snapped daemon as a non-root user (or if there *will* be a better way soon) - then please let me know, and I would be more than happy for this PR to be closed off.

For completeness, this PR relates to [Launchpad issue #2072987](https://bugs.launchpad.net/snapd/+bug/2072987/+activity).