### PR TITLE
many: remove unnecessary formatting in prints, logs and errors (#14363) [backport]

### DIFF
--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -20,6 +20,7 @@
 package boot_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -820,7 +821,7 @@ func (s *initramfsSuite) TestInitramfsRunModeUpdateBootloaderVarsErrOnGetBootVar
 	defer bootloader.Force(nil)
 
 	errMsg := "cannot get boot environment"
-	bloader.GetErr = fmt.Errorf(errMsg)
+	bloader.GetErr = errors.New(errMsg)
 
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
 	err := os.WriteFile(cmdlineFile, []byte("kernel_status=trying"), 0644)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -674,7 +674,7 @@ func (r *recoverDegradedState) partition(part string) *partitionState {
 func (r *recoverDegradedState) LogErrorf(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
 	r.ErrorLog = append(r.ErrorLog, msg)
-	logger.Noticef(msg)
+	logger.Notice(msg)
 }
 
 func (r *recoverDegradedState) serializeTo(name string) error {

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -226,7 +227,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 				c.Errorf(e)
 				// we want the test to fail at some point and not run forever, so
 				// move time way forward to make it for sure time out
-				return false, fmt.Errorf(e)
+				return false, errors.New(e)
 			}
 			return t.isMountedReturns[isMountedCalls-1], nil
 		})

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -569,7 +569,7 @@ func neededChanges(currentProfile, desiredProfile *osutil.MountProfile) []*Chang
 	copy(unsortedCurrent, current)
 
 	dumpMountEntries := func(entries []osutil.MountEntry, pfx string) {
-		logger.Debugf(pfx)
+		logger.Debug(pfx)
 		for _, en := range entries {
 			logger.Debugf("- %v", en)
 		}

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -291,7 +291,7 @@ func advisePkg(pkgName string) error {
 	if match != nil {
 		fmt.Fprintf(Stdout, i18n.G("Packages matching %q:\n"), pkgName)
 		fmt.Fprintf(Stdout, " * %s - %s\n", match.Snap, match.Summary)
-		fmt.Fprintf(Stdout, i18n.G("Try: snap install <selected snap>\n"))
+		fmt.Fprint(Stdout, i18n.G("Try: snap install <selected snap>\n"))
 	}
 
 	// FIXME: find mispells

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -63,11 +64,11 @@ func (x *cmdBuy) Execute(args []string) error {
 func buySnap(cli *client.Client, snapName string) error {
 	user := cli.LoggedInUser()
 	if user == nil {
-		return fmt.Errorf(i18n.G("You need to be logged in to purchase software. Please run 'snap login' and try again."))
+		return errors.New(i18n.G("You need to be logged in to purchase software. Please run 'snap login' and try again."))
 	}
 
 	if strings.ContainsAny(snapName, ":*") {
-		return fmt.Errorf(i18n.G("cannot buy snap: invalid characters in name"))
+		return errors.New(i18n.G("cannot buy snap: invalid characters in name"))
 	}
 
 	snap, resultInfo, err := cli.FindOne(snapName)
@@ -86,7 +87,7 @@ func buySnap(cli *client.Client, snapName string) error {
 	}
 
 	if snap.Status == "available" {
-		return fmt.Errorf(i18n.G("cannot buy snap: it has already been bought"))
+		return errors.New(i18n.G("cannot buy snap: it has already been bought"))
 	}
 
 	err = cli.ReadyToBuy()
@@ -121,7 +122,7 @@ for %s. Press ctrl-c to cancel.`), snap.Name, snap.Publisher.Username, formatPri
 		if e, ok := err.(*client.Error); ok {
 			switch e.Kind {
 			case client.ErrorKindPaymentDeclined:
-				return fmt.Errorf(i18n.G(`Sorry, your payment method has been declined by the issuer. Please review your
+				return errors.New(i18n.G(`Sorry, your payment method has been declined by the issuer. Please review your
 payment details at https://my.ubuntu.com/payment/edit and try again.`))
 			}
 		}

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -115,7 +115,7 @@ func (c *cmdChanges) Execute(args []string) error {
 
 	w := tabWriter()
 
-	fmt.Fprintf(w, i18n.G("ID\tStatus\tSpawn\tReady\tSummary\n"))
+	fmt.Fprint(w, i18n.G("ID\tStatus\tSpawn\tReady\tSummary\n"))
 	for _, chg := range changes {
 		spawnTime := c.fmtTime(chg.SpawnTime)
 		readyTime := c.fmtTime(chg.ReadyTime)
@@ -162,7 +162,7 @@ func (c *cmdTasks) showChange(chid string) error {
 
 	w := tabWriter()
 
-	fmt.Fprintf(w, i18n.G("Status\tSpawn\tReady\tSummary\n"))
+	fmt.Fprint(w, i18n.G("Status\tSpawn\tReady\tSummary\n"))
 	for _, t := range chg.Tasks {
 		spawnTime := c.fmtTime(t.SpawnTime)
 		readyTime := c.fmtTime(t.ReadyTime)

--- a/cmd/snap/cmd_connections.go
+++ b/cmd/snap/cmd_connections.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -144,7 +145,7 @@ func (x *cmdConnections) Execute(args []string) error {
 		if x.All {
 			// passing a snap name already implies --all, error out
 			// when it was passed explicitly
-			return fmt.Errorf(i18n.G("cannot use --all with snap name"))
+			return errors.New(i18n.G("cannot use --all with snap name"))
 		}
 		// when asking for a single snap, include its disconnected plugs
 		// and slots

--- a/cmd/snap/cmd_debug_migrate.go
+++ b/cmd/snap/cmd_debug_migrate.go
@@ -75,6 +75,6 @@ func (x *cmdMigrateHome) Execute(args []string) error {
 		msg = fmt.Sprintf(i18n.G("%s migrated their home directories to ~/Snap\n"), strutil.Quoted(snaps))
 	}
 
-	fmt.Fprintf(Stdout, msg)
+	fmt.Fprint(Stdout, msg)
 	return nil
 }

--- a/cmd/snap/cmd_debug_migrate_test.go
+++ b/cmd/snap/cmd_debug_migrate_test.go
@@ -60,7 +60,7 @@ func serverWithChange(chgRsp string, c *C) func(w http.ResponseWriter, r *http.R
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/12")
-			fmt.Fprintf(w, chgRsp)
+			fmt.Fprint(w, chgRsp)
 
 		default:
 			failRequest(fmt.Sprintf("server expected to get 2 requests, now on %d", n+1), w, c)

--- a/cmd/snap/cmd_debug_stacktraces.go
+++ b/cmd/snap/cmd_debug_stacktraces.go
@@ -43,6 +43,6 @@ func (x *cmdGetStacktraces) Execute(args []string) error {
 	if err := x.client.Debug("stacktraces", nil, &stacktraces); err != nil {
 		return err
 	}
-	fmt.Fprintf(Stdout, stacktraces)
+	fmt.Fprint(Stdout, stacktraces)
 	return nil
 }

--- a/cmd/snap/cmd_delete_key.go
+++ b/cmd/snap/cmd_delete_key.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/jessevdk/go-flags"
@@ -66,7 +67,7 @@ func (x *cmdDeleteKey) Execute(args []string) error {
 	keyName := string(x.Positional.KeyName)
 	err = keypairMgr.DeleteByName(keyName)
 	if _, ok := err.(*asserts.ExternalUnsupportedOpError); ok {
-		return fmt.Errorf(i18n.G("cannot delete external keypair manager key via snap command, use the appropriate external procedure"))
+		return errors.New(i18n.G("cannot delete external keypair manager key via snap command, use the appropriate external procedure"))
 	}
 	if err != nil {
 		return fmt.Errorf("cannot delete key named %q: %v", keyName, err)

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -87,8 +87,7 @@ func (x *cmdDisconnect) Execute(args []string) error {
 	id, err := x.client.Disconnect(offer.Snap, offer.Name, use.Snap, use.Name, opts)
 	if err != nil {
 		if client.IsInterfacesUnchangedError(err) {
-			fmt.Fprintf(Stdout, i18n.G("No connections to disconnect"))
-			fmt.Fprintf(Stdout, "\n")
+			fmt.Fprintln(Stdout, i18n.G("No connections to disconnect"))
 			return nil
 		}
 		return err

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -154,7 +155,7 @@ func (x *cmdDownload) downloadFromStore(snapName string, revision snap.Revision)
 
 func (x *cmdDownload) Execute(args []string) error {
 	if strings.ContainsRune(x.Basename, filepath.Separator) {
-		return fmt.Errorf(i18n.G("cannot specify a path in basename (use --target-dir for that)"))
+		return errors.New(i18n.G("cannot specify a path in basename (use --target-dir for that)"))
 	}
 	if err := x.setChannelFromCommandline(); err != nil {
 		return err
@@ -169,10 +170,10 @@ func (x *cmdDownload) Execute(args []string) error {
 		revision = snap.R(0)
 	} else {
 		if x.Channel != "" {
-			return fmt.Errorf(i18n.G("cannot specify both channel and revision"))
+			return errors.New(i18n.G("cannot specify both channel and revision"))
 		}
 		if x.CohortKey != "" {
-			return fmt.Errorf(i18n.G("cannot specify both cohort and revision"))
+			return errors.New(i18n.G("cannot specify both cohort and revision"))
 		}
 		var err error
 		revision, err = snap.ParseRevision(x.Revision)

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -141,11 +141,11 @@ func showSections(cli *client.Client) error {
 	}
 	sort.Strings(sections)
 
-	fmt.Fprintf(Stdout, i18n.G("No section specified. Available sections:\n"))
+	fmt.Fprint(Stdout, i18n.G("No section specified. Available sections:\n"))
 	for _, sec := range sections {
 		fmt.Fprintf(Stdout, " * %s\n", sec)
 	}
-	fmt.Fprintf(Stdout, i18n.G("Please try 'snap find --section=<selected section>'\n"))
+	fmt.Fprint(Stdout, i18n.G("Please try 'snap find --section=<selected section>'\n"))
 	return nil
 }
 

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -219,7 +219,7 @@ func (x *cmdGet) outputDefault(conf map[string]interface{}, snapName string, con
 
 		// TODO: remove this conditional and the warning below
 		// after a transition period.
-		fmt.Fprintf(Stderr, i18n.G(`WARNING: The output of 'snap get' will become a list with columns - use -d or -l to force the output format.\n`))
+		fmt.Fprint(Stderr, i18n.G(`WARNING: The output of 'snap get' will become a list with columns - use -d or -l to force the output format.\n`))
 		return x.outputJson(confToPrint)
 	}
 

--- a/cmd/snap/cmd_get_base_declaration.go
+++ b/cmd/snap/cmd_get_base_declaration.go
@@ -64,7 +64,7 @@ func (x *cmdGetBaseDeclaration) Execute(args []string) error {
 	}
 	fmt.Fprintf(Stdout, "%s\n", resp.BaseDeclaration)
 	if x.get {
-		fmt.Fprintf(Stderr, i18n.G("'snap debug get-base-declaration' is deprecated; use 'snap debug base-declaration'."))
+		fmt.Fprint(Stderr, i18n.G("'snap debug get-base-declaration' is deprecated; use 'snap debug base-declaration'."))
 	}
 	return nil
 }

--- a/cmd/snap/cmd_handle_link.go
+++ b/cmd/snap/cmd_handle_link.go
@@ -20,7 +20,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"syscall"
 	"time"
@@ -67,7 +67,7 @@ func (x *cmdHandleLink) ensureSnapStoreInstalled() error {
 			Footer:  i18n.G("This dialog will close automatically after 5 minutes of inactivity."),
 		})
 	if !answeredYes {
-		return fmt.Errorf(i18n.G("Snap Store required"))
+		return errors.New(i18n.G("Snap Store required"))
 	}
 
 	changeID, err := x.client.Install("snap-store", nil)

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -158,7 +159,7 @@ func (cmd cmdHelp) Execute(args []string) error {
 	}
 	if cmd.All {
 		if len(cmd.Positional.Subs) > 0 {
-			return fmt.Errorf(i18n.G("help accepts a command, or '--all', but not both."))
+			return errors.New(i18n.G("help accepts a command, or '--all', but not both."))
 		}
 		printLongHelp(cmd.parser)
 		return nil

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -662,7 +663,7 @@ func (x *infoCmd) Execute([]string) error {
 				return fmt.Errorf("no snap found for %q", snapName)
 			}
 
-			fmt.Fprintf(w, fmt.Sprintf(i18n.G("warning:\tno snap found for %q\n"), snapName))
+			fmt.Fprintf(w, i18n.G("warning:\tno snap found for %q\n"), snapName)
 			continue
 		}
 		noneOK = false
@@ -696,7 +697,7 @@ func (x *infoCmd) Execute([]string) error {
 	w.Flush()
 
 	if noneOK {
-		return fmt.Errorf(i18n.G("no valid snaps given"))
+		return errors.New(i18n.G("no valid snaps given"))
 	}
 
 	return nil

--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -83,7 +84,7 @@ func (x *cmdInterface) Execute(args []string) error {
 			return err
 		}
 		if len(ifaces) == 0 {
-			return fmt.Errorf(i18n.G("no such interface"))
+			return errors.New(i18n.G("no such interface"))
 		}
 		x.showOneInterface(ifaces[0])
 	} else {
@@ -96,9 +97,9 @@ func (x *cmdInterface) Execute(args []string) error {
 		}
 		if len(ifaces) == 0 {
 			if x.ShowAll {
-				return fmt.Errorf(i18n.G("no interfaces found"))
+				return errors.New(i18n.G("no interfaces found"))
 			}
-			return fmt.Errorf(i18n.G("no interfaces currently connected"))
+			return errors.New(i18n.G("no interfaces currently connected"))
 		}
 		x.showManyInterfaces(ifaces)
 	}

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/jessevdk/go-flags"
@@ -90,7 +91,7 @@ func (x *cmdInterfaces) Execute(args []string) error {
 		return err
 	}
 	if len(ifaces.Plugs) == 0 && len(ifaces.Slots) == 0 {
-		return fmt.Errorf(i18n.G("no interfaces found"))
+		return errors.New(i18n.G("no interfaces found"))
 	}
 
 	defer fmt.Fprintln(Stderr, "\n"+fill(interfacesDeprecationNotice, 0))

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -97,7 +98,7 @@ func (x *packCmd) Execute([]string) error {
 	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
 
 	if x.Positional.TargetDir != "" && x.Filename != "" && filepath.IsAbs(x.Filename) {
-		return fmt.Errorf(i18n.G("you can't specify an absolute filename while also specifying target dir."))
+		return errors.New(i18n.G("you can't specify an absolute filename while also specifying target dir."))
 	}
 
 	if x.Positional.SnapDir == "" {

--- a/cmd/snap/cmd_reboot.go
+++ b/cmd/snap/cmd_reboot.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/jessevdk/go-flags"
@@ -92,7 +93,7 @@ func (x *cmdReboot) modeFromCommandline() (string, error) {
 			continue
 		}
 		if mode != "" {
-			return "", fmt.Errorf(i18n.G("Please specify a single mode"))
+			return "", errors.New(i18n.G("Please specify a single mode"))
 		}
 		mode = arg.mode
 	}
@@ -122,7 +123,7 @@ func (x *cmdReboot) Execute(args []string) error {
 	case mode != "":
 		fmt.Fprintf(Stdout, i18n.G("Reboot into %q mode.\n"), mode)
 	default:
-		fmt.Fprintf(Stdout, i18n.G("Reboot\n"))
+		fmt.Fprint(Stdout, i18n.G("Reboot\n"))
 	}
 
 	return nil

--- a/cmd/snap/cmd_recovery.go
+++ b/cmd/snap/cmd_recovery.go
@@ -104,7 +104,7 @@ func (x *cmdRecovery) Execute(args []string) error {
 		return err
 	}
 	if len(systems) == 0 {
-		fmt.Fprintf(Stderr, i18n.G("No recovery systems available.\n"))
+		fmt.Fprint(Stderr, i18n.G("No recovery systems available.\n"))
 		return nil
 	}
 

--- a/cmd/snap/cmd_repair_repairs.go
+++ b/cmd/snap/cmd_repair_repairs.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -36,7 +37,7 @@ func runSnapRepair(cmdStr string, args []string) error {
 	// do not even try to run snap-repair on classic, some distros
 	// may not even package it
 	if release.OnClassic {
-		return fmt.Errorf(i18n.G("repairs are not available on a classic system"))
+		return errors.New(i18n.G("repairs are not available on a classic system"))
 	}
 
 	snapRepairPath := filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir, "snap-repair")

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -220,7 +220,7 @@ func (x *cmdRun) Usage() string {
 
 func (x *cmdRun) Execute(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf(i18n.G("need the application to run as argument"))
+		return errors.New(i18n.G("need the application to run as argument"))
 	}
 	snapApp := args[0]
 	args = args[1:]
@@ -237,7 +237,7 @@ func (x *cmdRun) Execute(args []string) error {
 	}
 
 	if x.Revision != "unset" && x.Revision != "" && x.HookName == "" {
-		return fmt.Errorf(i18n.G("-r can only be used with --hook"))
+		return errors.New(i18n.G("-r can only be used with --hook"))
 	}
 	if x.HookName != "" && len(args) > 0 {
 		// TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
@@ -948,7 +948,7 @@ func (x *cmdRun) runCmdUnderGdbserver(origCmd []string, envForExec envForExecFun
 	// XXX: should we provide a helper here instead? something like
 	//      `snap run --attach-debugger` or similar? The downside
 	//      is that attaching a gdb frontend is harder?
-	fmt.Fprintf(Stdout, fmt.Sprintf(gdbServerWelcomeFmt, addr))
+	fmt.Fprintf(Stdout, gdbServerWelcomeFmt, addr)
 	// note that only gdbserver needs to run as root, the application
 	// keeps running as the user
 	gdbSrvCmd := exec.Command("sudo", "-E", "gdbserver", "--attach", addr, strconv.Itoa(gcmd.Process.Pid))
@@ -1237,7 +1237,7 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 			logger.Noticef("WARNING: skipping running hook %q of %q: missing snap-confine", runner.Hook().Name, runner.Target())
 			return nil
 		}
-		return fmt.Errorf(i18n.G("missing snap-confine: try updating your core/snapd package"))
+		return errors.New(i18n.G("missing snap-confine: try updating your core/snapd package"))
 	}
 
 	logger.Debugf("executing snap-confine from %s", snapConfine)

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os/user"
 	"strconv"
@@ -144,7 +145,7 @@ func (s *svcStatus) showGlobalEnablement(u *user.User) bool {
 func (s *svcStatus) validateArguments() error {
 	// can't use --global and --user together
 	if s.Global && s.User {
-		return fmt.Errorf(i18n.G("cannot combine --global and --user switches."))
+		return errors.New(i18n.G("cannot combine --global and --user switches."))
 	}
 	return nil
 }
@@ -196,7 +197,7 @@ func (s *svcLogs) Execute(args []string) error {
 	if s.N != "all" {
 		n, err := strconv.ParseInt(s.N, 0, 32)
 		if n < 0 || err != nil {
-			return fmt.Errorf(i18n.G("invalid argument for flag ‘-n’: expected a non-negative integer argument, or “all”."))
+			return errors.New(i18n.G("invalid argument for flag ‘-n’: expected a non-negative integer argument, or “all”."))
 		}
 		sN = int(n)
 	}

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -90,7 +91,7 @@ func init() {
 
 func (x *cmdSet) Execute([]string) error {
 	if x.String && x.Typed {
-		return fmt.Errorf(i18n.G("cannot use -t and -s together"))
+		return errors.New(i18n.G("cannot use -t and -s together"))
 	}
 
 	patchValues := make(map[string]interface{})
@@ -163,7 +164,7 @@ func validateRegistryViewID(id string) error {
 	parts := strings.Split(id, "/")
 	for _, part := range parts {
 		if part == "" {
-			return fmt.Errorf(i18n.G("registry identifier must conform to format: <account-id>/<registry>/<view>"))
+			return errors.New(i18n.G("registry identifier must conform to format: <account-id>/<registry>/<view>"))
 		}
 	}
 

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -139,7 +139,7 @@ func (x *cmdSign) Execute(args []string) error {
 		}
 	} else {
 		if accountKey == nil {
-			fmt.Fprintf(Stderr, i18n.G("WARNING: could not fetch account-key to cross-check signed assertion with key constraints.\n"))
+			fmt.Fprint(Stderr, i18n.G("WARNING: could not fetch account-key to cross-check signed assertion with key constraints.\n"))
 		}
 	}
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -682,7 +682,7 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 	isLocal := isLocalContainer(names[0])
 	for _, name := range names {
 		if isLocalContainer(name) != isLocal {
-			return fmt.Errorf(i18n.G("cannot install local and store snaps at the same time"))
+			return errors.New(i18n.G("cannot install local and store snaps at the same time"))
 		}
 	}
 
@@ -1116,7 +1116,7 @@ func (x *cmdRefresh) unholdRefreshes() (err error) {
 	}
 
 	if len(names) == 0 {
-		fmt.Fprintf(Stdout, i18n.G("Removed auto-refresh hold on all snaps\n"))
+		fmt.Fprint(Stdout, i18n.G("Removed auto-refresh hold on all snaps\n"))
 	} else {
 		fmt.Fprintf(Stdout, i18n.G("Removed general refresh hold of %s\n"), strutil.Quoted(names))
 	}
@@ -1164,7 +1164,7 @@ func (x *cmdTry) Execute([]string) error {
 			}
 		}
 		if name == "" {
-			return fmt.Errorf(i18n.G("error: the `<snap-dir>` argument was not provided and couldn't be inferred"))
+			return errors.New(i18n.G("error: the `<snap-dir>` argument was not provided and couldn't be inferred"))
 		}
 	}
 
@@ -1199,7 +1199,7 @@ func (x *cmdTry) Execute([]string) error {
 		return fmt.Errorf(i18n.G("cannot extract the snap-name from local file %q: %v"), name, err)
 	}
 	if len(changedSnaps.names) != 1 {
-		return fmt.Errorf(i18n.G("internal error, wrong number of snaps in change"))
+		return errors.New(i18n.G("internal error, wrong number of snaps in change"))
 	}
 
 	name = changedSnaps.names[0]
@@ -1361,10 +1361,10 @@ func (x cmdSwitch) Execute(args []string) error {
 	// the 5 valid cases are handled by showDone.
 	if switchCohort && x.LeaveCohort {
 		// this one counts as two (no channel filter)
-		return fmt.Errorf(i18n.G("cannot specify both --cohort and --leave-cohort"))
+		return errors.New(i18n.G("cannot specify both --cohort and --leave-cohort"))
 	}
 	if !switchCohort && !x.LeaveCohort && !switchChannel {
-		return fmt.Errorf(i18n.G("nothing to switch; specify --channel (and/or one of --cohort/--leave-cohort)"))
+		return errors.New(i18n.G("nothing to switch; specify --channel (and/or one of --cohort/--leave-cohort)"))
 	}
 
 	opts := &client.SnapOptions{

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -210,7 +210,7 @@ func (cmd *cmdValidate) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(Stdout, fmtValid(vset))
+		fmt.Fprint(Stdout, fmtValid(vset))
 		// XXX: exit status 1 if invalid?
 	}
 

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -524,7 +525,7 @@ func (snapshotID) Complete(match string) []flags.Completion {
 func (s snapshotID) ToUint() (uint64, error) {
 	setID, err := strconv.ParseUint((string)(s), 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf(i18n.G("invalid argument for snapshot set id: expected a non-negative integer argument (see 'snap help saved')"))
+		return 0, errors.New(i18n.G("invalid argument for snapshot set id: expected a non-negative integer argument (see 'snap help saved')"))
 	}
 	return setID, nil
 }

--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -53,12 +53,12 @@ var noChangeFoundOK = errors.New("no change found but that's ok")
 
 func (l *changeIDMixin) GetChangeID() (string, error) {
 	if l.Positional.ID == "" && l.LastChangeType == "" {
-		return "", fmt.Errorf(i18n.G("please provide change ID or type with --last=<type>"))
+		return "", errors.New(i18n.G("please provide change ID or type with --last=<type>"))
 	}
 
 	if l.Positional.ID != "" {
 		if l.LastChangeType != "" {
-			return "", fmt.Errorf(i18n.G("cannot use change ID and type together"))
+			return "", errors.New(i18n.G("cannot use change ID and type together"))
 		}
 
 		return string(l.Positional.ID), nil
@@ -94,7 +94,7 @@ func (l *changeIDMixin) GetChangeID() (string, error) {
 		if optional {
 			return "", noChangeFoundOK
 		}
-		return "", fmt.Errorf(i18n.G("no changes found"))
+		return "", errors.New(i18n.G("no changes found"))
 	}
 	chg := findLatestChangeByKind(changes, kind)
 	if chg == nil {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -76,7 +77,7 @@ type argDesc struct {
 var optionsData options
 
 // ErrExtraArgs is returned  if extra arguments to a command are found
-var ErrExtraArgs = fmt.Errorf(i18n.G("too many arguments for command"))
+var ErrExtraArgs = errors.New(i18n.G("too many arguments for command"))
 
 // cmdInfo holds information needed to call parser.AddCommand(...).
 type cmdInfo struct {

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -69,7 +69,7 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 		}
 		_, err := wmx.client.Abort(id)
 		if err != nil {
-			fmt.Fprintf(Stderr, err.Error()+"\n")
+			fmt.Fprint(Stderr, err.Error()+"\n")
 		}
 	}()
 

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -449,7 +449,7 @@ func modeFlags(devMode, jailMode, classic bool) (snapstate.Flags, error) {
 
 func snapInstall(ctx context.Context, inst *snapInstruction, st *state.State) (string, []*state.TaskSet, error) {
 	if len(inst.Snaps[0]) == 0 {
-		return "", nil, fmt.Errorf(i18n.G("cannot install snap with empty name"))
+		return "", nil, errors.New(i18n.G("cannot install snap with empty name"))
 	}
 
 	flags, err := inst.installFlags()

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -531,7 +531,7 @@ func (s *snapsSuite) TestPostSnapsOptionsOtherErrors(c *check.C) {
 	}
 
 	for name, test := range testMap {
-		buf := strings.NewReader(fmt.Sprintf(test.post))
+		buf := strings.NewReader(fmt.Sprint(test.post))
 		req, err := http.NewRequest("POST", "/v2/snaps", buf)
 		c.Assert(err, check.IsNil)
 		req.Header.Set("Content-Type", "application/json")

--- a/gadget/validate_test.go
+++ b/gadget/validate_test.go
@@ -244,7 +244,7 @@ func (s *validateGadgetTestSuite) TestValidateConsistencyWithoutModelCharacteris
 		c.Logf("tc: %v %v %v", i, tc.role, tc.label)
 		b := &bytes.Buffer{}
 
-		fmt.Fprintf(b, `
+		fmt.Fprint(b, `
 volumes:
   pc:
     bootloader: grub
@@ -252,7 +252,7 @@ volumes:
     structure:`)
 
 		if tc.role == "system-seed" {
-			fmt.Fprintf(b, `
+			fmt.Fprint(b, `
       - name: Recovery
         size: 10M
         type: 83
@@ -328,16 +328,16 @@ volumes:
 		c.Logf("tc: %v %v %v %v", i, tc.addSeed, tc.dataLabel, tc.hasModes)
 		b := &bytes.Buffer{}
 
-		fmt.Fprintf(b, bloader)
+		fmt.Fprint(b, bloader)
 		if tc.addSeed {
-			fmt.Fprintf(b, `
+			fmt.Fprint(b, `
       - name: Recovery
         size: 10M
         type: 83
         role: system-seed`)
 		}
 		if tc.addBoot {
-			fmt.Fprintf(b, `
+			fmt.Fprint(b, `
       - name: Boot
         size: 10M
         type: 83
@@ -354,7 +354,7 @@ volumes:
 		}
 
 		if tc.addSave {
-			fmt.Fprintf(b, `
+			fmt.Fprint(b, `
       - name: Save
         size: 10M
         type: 83

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -76,7 +76,14 @@ func Panicf(format string, v ...interface{}) {
 // Noticef notifies the user of something
 func Noticef(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
+	lock.Lock()
+	defer lock.Unlock()
 
+	logger.Notice(msg)
+}
+
+// Notice notifies the user of something
+func Notice(msg string) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -86,7 +93,14 @@ func Noticef(format string, v ...interface{}) {
 // Debugf records something in the debug log
 func Debugf(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
+	lock.Lock()
+	defer lock.Unlock()
 
+	logger.Debug(msg)
+}
+
+// Debug records something in the debug log
+func Debug(msg string) {
 	lock.Lock()
 	defer lock.Unlock()
 

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -20,6 +20,7 @@
 package osutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -181,7 +182,7 @@ func EnsureSnapUserGroup(name string, id uint32, extraUsers bool) error {
 - %s
 - %s`, name, useraddErrStr, groupdelErrStr)
 		}
-		return fmt.Errorf(useraddErrStr)
+		return errors.New(useraddErrStr)
 	}
 
 	return nil

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -436,7 +436,7 @@ func (m *DeviceManager) importAssertionsFromSeed(isCoreBoot bool) (seed.Seed, er
 		} else {
 			msg = "cannot seed a classic system with an all-snaps model"
 		}
-		return nil, fmt.Errorf(msg)
+		return nil, errors.New(msg)
 	}
 
 	// set device,model from the model assertion

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -286,7 +286,7 @@ func buildAppendedKernelCommandLine(t *state.Task, gd *gadget.GadgetData, device
 	cmdlineAppend, forbidden := gadget.FilterKernelCmdline(rawCmdlineAppend, gd.Info.KernelCmdline.Allow)
 	if forbidden != "" {
 		warnMsg := fmt.Sprintf("%q is not allowed by the gadget and has been filtered out from the kernel command line", forbidden)
-		logger.Noticef(warnMsg)
+		logger.Notice(warnMsg)
 		t.Logf(warnMsg)
 	}
 

--- a/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -62,8 +62,12 @@ func (c *baseCommand) setStdout(w io.Writer) {
 }
 
 func (c *baseCommand) printf(format string, a ...interface{}) {
+	c.print(fmt.Sprintf(format, a...))
+}
+
+func (c *baseCommand) print(msg string) {
 	if c.stdout != nil {
-		fmt.Fprintf(c.stdout, format, a...)
+		fmt.Fprint(c.stdout, msg)
 	}
 }
 
@@ -71,9 +75,9 @@ func (c *baseCommand) setStderr(w io.Writer) {
 	c.stderr = w
 }
 
-func (c *baseCommand) errorf(format string, a ...interface{}) {
+func (c *baseCommand) error(msg string) {
 	if c.stderr != nil {
-		fmt.Fprintf(c.stderr, format, a...)
+		fmt.Fprint(c.stderr, msg)
 	}
 }
 

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -21,7 +21,7 @@ package ctlcmd
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os/user"
 
 	"github.com/snapcore/snapd/asserts"
@@ -129,15 +129,15 @@ func (c *MockCommand) Execute(args []string) error {
 	c.Args = args
 
 	if c.FakeStdout != "" {
-		c.printf(c.FakeStdout)
+		c.print(c.FakeStdout)
 	}
 
 	if c.FakeStderr != "" {
-		c.errorf(c.FakeStderr)
+		c.error(c.FakeStderr)
 	}
 
 	if c.ExecuteError {
-		return fmt.Errorf("failed at user request")
+		return errors.New("failed at user request")
 	}
 
 	return nil

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -146,7 +146,7 @@ func (c *getCommand) printPatch(patch interface{}) error {
 
 func (c *getCommand) Execute(args []string) error {
 	if len(c.Positional.Keys) == 0 && c.Positional.PlugOrSlotSpec == "" {
-		return fmt.Errorf(i18n.G("get which option?"))
+		return errors.New(i18n.G("get which option?"))
 	}
 
 	context, err := c.ensureContext()
@@ -169,7 +169,7 @@ func (c *getCommand) Execute(args []string) error {
 		}
 		// registry views can be read without fields
 		if !c.View && len(c.Positional.Keys) == 0 {
-			return fmt.Errorf(i18n.G("get which attribute?"))
+			return errors.New(i18n.G("get which attribute?"))
 		}
 
 		if c.View {
@@ -266,7 +266,7 @@ func validatePlugOrSlot(attrsTask *state.Task, plugSide bool, plugOrSlot string)
 		}
 	}
 	if err != nil {
-		return fmt.Errorf(i18n.G("internal error: cannot find plug or slot data in the appropriate task"))
+		return errors.New(i18n.G("internal error: cannot find plug or slot data in the appropriate task"))
 	}
 	if name != plugOrSlot {
 		return fmt.Errorf(i18n.G("unknown plug or slot %q"), plugOrSlot)
@@ -287,7 +287,7 @@ func attributesTask(context *hookstate.Context) (*state.Task, error) {
 
 	attrsTask := st.Task(attrsTaskID)
 	if attrsTask == nil {
-		return nil, fmt.Errorf(i18n.G("internal error: cannot find attrs task"))
+		return nil, errors.New(i18n.G("internal error: cannot find attrs task"))
 	}
 
 	return attrsTask, nil
@@ -297,7 +297,7 @@ func (c *getCommand) getInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	// Make sure get :<plug|slot> is only supported during the execution of interface hooks
 	hookType, err := interfaceHookType(context.HookName())
 	if err != nil {
-		return fmt.Errorf(i18n.G("interface attributes can only be read during the execution of interface hooks"))
+		return errors.New(i18n.G("interface attributes can only be read during the execution of interface hooks"))
 	}
 
 	attrsTask, err := attributesTask(context)
@@ -356,7 +356,7 @@ func (c *getCommand) getInterfaceSetting(context *hookstate.Context, plugOrSlot 
 
 func (c *getCommand) getRegistryView(ctx *hookstate.Context, plugName string) error {
 	if c.ForcePlugSide || c.ForceSlotSide {
-		return fmt.Errorf(i18n.G("cannot use --plug or --slot with --view"))
+		return errors.New(i18n.G("cannot use --plug or --slot with --view"))
 	}
 
 	ctx.Lock()

--- a/overlord/hookstate/ctlcmd/services.go
+++ b/overlord/hookstate/ctlcmd/services.go
@@ -21,6 +21,7 @@ package ctlcmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"text/tabwriter"
@@ -80,7 +81,7 @@ func (c *servicesCommand) showGlobalEnablement() bool {
 func (c *servicesCommand) validateArguments() error {
 	// can't use --global and --user together
 	if c.Global && c.User {
-		return fmt.Errorf(i18n.G("cannot combine --global and --user switches."))
+		return errors.New(i18n.G("cannot combine --global and --user switches."))
 	}
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -21,6 +21,7 @@ package ctlcmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -71,7 +72,7 @@ func init() {
 
 func (s *setCommand) Execute(args []string) error {
 	if s.Positional.PlugOrSlotSpec == "" && len(s.Positional.ConfValues) == 0 {
-		return fmt.Errorf(i18n.G("set which option?"))
+		return errors.New(i18n.G("set which option?"))
 	}
 
 	context, err := s.ensureContext()
@@ -175,7 +176,7 @@ func (s *setCommand) setInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	// Make sure set :<plug|slot> is only supported during the execution of prepare-[plug|slot] hooks
 	hookType, _ := interfaceHookType(context.HookName())
 	if hookType != preparePlugHook && hookType != prepareSlotHook {
-		return fmt.Errorf(i18n.G("interface attributes can only be set during the execution of prepare hooks"))
+		return errors.New(i18n.G("interface attributes can only be set during the execution of prepare hooks"))
 	}
 
 	attrsTask, err := attributesTask(context)

--- a/overlord/hookstate/ctlcmd/unset.go
+++ b/overlord/hookstate/ctlcmd/unset.go
@@ -20,7 +20,7 @@
 package ctlcmd
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -54,7 +54,7 @@ func init() {
 
 func (s *unsetCommand) Execute(args []string) error {
 	if len(s.Positional.ConfKeys) == 0 {
-		return fmt.Errorf(i18n.G("unset which option?"))
+		return errors.New(i18n.G("unset which option?"))
 	}
 
 	context, err := s.ensureContext()

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -235,7 +235,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 		if errors := interfaces.SetupMany(m.repo, backend, appSets, confinementOpts, tm); len(errors) > 0 {
 			logger.Noticef("cannot regenerate %s profiles", backend.Name())
 			for _, err := range errors {
-				logger.Noticef(err.Error())
+				logger.Notice(err.Error())
 			}
 			shouldWriteSystemKey = false
 		}

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -648,7 +648,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 
 	msg := autoRefreshSummary(updated)
 	if msg == "" {
-		logger.Noticef(i18n.G("auto-refresh: all snaps are up-to-date"))
+		logger.Notice(i18n.G("auto-refresh: all snaps are up-to-date"))
 		return nil
 	}
 

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -234,7 +234,7 @@ func (b Backend) UndoHideSnapData(snapName string) error {
 		if firstErr == nil {
 			firstErr = err
 		} else {
-			logger.Noticef(err.Error())
+			logger.Notice(err.Error())
 		}
 	}
 
@@ -399,7 +399,7 @@ func (b Backend) UndoInitExposedSnapHome(snapName string, undoInfo *UndoInfo) er
 		if firstErr == nil {
 			firstErr = err
 		} else {
-			logger.Noticef(err.Error())
+			logger.Notice(err.Error())
 		}
 	}
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1260,7 +1260,7 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 		msg := fmt.Sprintf("expected snap %q revision %v to be mounted but is not", snapsup.InstanceName(), snapsup.Revision())
 		readInfoErr = fmt.Errorf("cannot proceed, %s", msg)
 		if i == 0 {
-			logger.Noticef(msg)
+			logger.Notice(msg)
 		}
 		time.Sleep(mountPollInterval)
 	}

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -429,7 +429,7 @@ func (t *Task) addLog(kind, format string, args []interface{}) {
 	tstr := timeNow().Format(time.RFC3339)
 	msg := tstr + " " + kind + " " + fmt.Sprintf(format, args...)
 	t.log = append(t.log, msg)
-	logger.Debugf(msg)
+	logger.Debug(msg)
 }
 
 // Log returns the most recent messages logged into the task.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -121,14 +121,14 @@ func (e *BadRequestError) Is(err error) bool {
 	return ok
 }
 
-func badRequestErrorFrom(v *View, operation, request, errMsg string, args ...interface{}) *BadRequestError {
+func badRequestErrorFrom(v *View, operation, request, msg string) *BadRequestError {
 	return &BadRequestError{
 		Account:      v.registry.Account,
 		RegistryName: v.registry.Name,
 		View:         v.Name,
 		Operation:    operation,
 		Request:      request,
-		Cause:        fmt.Sprintf(errMsg, args...),
+		Cause:        msg,
 	}
 }
 

--- a/registry/schema.go
+++ b/registry/schema.go
@@ -356,7 +356,7 @@ func (v *alternativesSchema) Validate(raw []byte) error {
 		sb.WriteString(err.Error())
 	}
 
-	return validationErrorf(sb.String())
+	return validationErrorFrom(errors.New(sb.String()))
 }
 
 // SchemaAt returns the list of schemas at the end of the path or an error if

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -470,9 +470,7 @@ func (e *errPathsNotReadable) Error() string {
 
 	b.WriteString("cannot access the following locations in the snap source directory:\n")
 	for _, p := range e.paths {
-		fmt.Fprintf(&b, "- ")
-		fmt.Fprintf(&b, p)
-		fmt.Fprintf(&b, "\n")
+		fmt.Fprintf(&b, "- %s\n", p)
 	}
 	if len(e.paths) == maxErrPaths {
 		fmt.Fprintf(&b, "- too many errors, listing first %v entries\n", maxErrPaths)

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -154,7 +154,7 @@ func (c *userServiceClient) startServices(enable bool, disabledServices map[int]
 		// If we manage to not receive a comm error, but still receive an error for failing to start one of
 		// the services, then propagate the first one instead of ignoring any start errors.
 		if err == nil {
-			err = fmt.Errorf(fmt.Sprintf("could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error))
+			err = fmt.Errorf("could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error)
 		}
 		c.inter.Notify(fmt.Sprintf("could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}


### PR DESCRIPTION
Backport of #14363 to fde-manager-features branch.

With the go1.23 release `go vet` has started to complain about calls to functions with a formatting string and varargs that use a non-constant string and don't have anything to format. So this change replaces all the unnecessary calls to Printf and its cousins with the non-formatting equivalent. Also adds those functions where we didn't have them before (e.g., logger/).