### PR TITLE
tests: fix remodel-min-size test

### DIFF
--- a/tests/lib/assertions/test-snapd-remodel-bases-24.json
+++ b/tests/lib/assertions/test-snapd-remodel-bases-24.json
@@ -12,7 +12,7 @@
     "base": "core24",
     "snaps": [
         {
-            "default-channel": "latest/edge",
+            "default-channel": "24/edge",
             "id": "tTs9DVS01mt4L11PGqbrSiKcIxFHpUJq",
             "name": "test-snapd-remodel-pc-min-size",
             "type": "gadget"

--- a/tests/lib/assertions/test-snapd-remodel-bases-24.model
+++ b/tests/lib/assertions/test-snapd-remodel-bases-24.model
@@ -8,7 +8,7 @@ base: core24
 grade: dangerous
 snaps:
   -
-    default-channel: latest/edge
+    default-channel: 24/edge
     id: tTs9DVS01mt4L11PGqbrSiKcIxFHpUJq
     name: test-snapd-remodel-pc-min-size
     type: gadget
@@ -42,13 +42,13 @@ system-user-authority: *
 timestamp: 2024-04-24T00:00:00+00:00
 sign-key-sha3-384: z5UoZNBNRc6KXRIg96L6tZ723_CDbUu45bRC-wcINgigB2S9GGGe6DWJqlzI6p0S
 
-AcLBcwQAAQoAHRYhBJwYfdLgNpH0AbmOCVr7utGyRTi5BQJmKGN/AAoJEFr7utGyRTi57PMP/izp
-k6X8iSflQDc06niCh0L2dHb1rRDa4IAYFfLpw6jbevwqkEaL+9v/2aprt6EUDMG70Iukel29sbcA
-15x7k8GUEUNskHDG2cbDqBzQ8GJJ625g8KwBiKjxgsoB9sG3KeLKhTgb3DhgoLhT58NC8wg7NcGZ
-04NapWyeZ+BhI3kQ+kBUXlEQiwiimpweetG+wdWK4dqYQ91rtcLaYjvwM8Cfej3/OxCazKvKV0Cj
-Ppyjic0GdLN5l40tocwX4KqSpp9FBsflttquzxTpEbR/+vtc1pUcoIfY9Z+dg8mUIlKzatM6Tueo
-71ktVewr/naWsdlFz2u29P0OtbdIhClZCN30jlzAS2ExudKtNRTso1lnuxBpacddSQjKEaw8lmWE
-fMBQCZaIAG4Ygl5e30H/VK7Sqfot2TxCKVnwzVVVf9pynYaXgoAXrAH7AWlW8axB+xnu4WyAE3tx
-4DGq0rEQp01qF2n0PmWUPWW4uJ9U3c8ah0viwDX20muI6bQ0zhzLfm8YMC3h7/y6h7VCLOxruqRG
-LEyv29AJlSDlqaVD1HOsaP2x/Vsz9AvHTVJgmoukbQblW6vw3TqqXxNzLqHHm9HVLzRMSRrijOHN
-zD5BT+GnEHCZBcGKxiXftA/joQhc51PTpTgncY2O5ctJXkwh3bgoK0gXdC2q/qh0nG7WqmtU
+AcLBcwQAAQoAHRYhBJwYfdLgNpH0AbmOCVr7utGyRTi5BQJmvgsoAAoJEFr7utGyRTi5kYwP/juZ
+66qhb97JOhZ366m9FqDNgt3l4thGjZQS6WI8psd4gZHglflxTYTQW4Nse5xCgMElPhCNS1V/+JdW
+Z9mgFp4VYLFRW3juprP5wfoEMSxczIeQmNuMr0gsZHkNNHuiOUoBEEm1bV0Pyt+77nG5XxB5QwVO
+m+ZQZ/c1Eh684lnrhsDQZJpnQKJAmp35jIv2BS7jqWb2nE8i6FsEfWbCL2nhdLe/7487+BWi8SDk
+Sn+bewT54Nip83SOdJoJLOLWAq5ul4TNwlmkWXikT+EhQXKEphU+VKEEx1uoCjR9OWF3MhWZrvmQ
+rvx+PT0PCirGnQue47TenG5wiCNYQvuEvvWR5PTmq6mlezYFQc+aoXf0zY/cYBO8uViuDrshr8IB
+5mAwRJiUdG8/hNwx6Fh6rFsoW/Ry+W+VkvaQ7yAnOpPDUVGN0fzOuMkr15bo9XX4J98W3p6Pi6lb
+Y40awPbPdEAAyZPZ2gmDJmJmppyW/MuL1DGbhnTP606WF9gc4uP9apcXNp/2V6HmOfVEuLxNru4b
+g/wGeRB2kg3wkYIo9sn3eaWbESlUZAJPggMplQ1Q2bzKjLe1xhTJ6yg3hv3uTAL1y8GVvncjdfF3
+KFYl5anVN9jcmJRT4QdzAGFEdaO06A66C4c7C+1G1q3rURtns4HguHdiXZOSnQpLoB2ceKIN

--- a/tests/lib/assertions/test-snapd-remodel-pc-rev1-24.json
+++ b/tests/lib/assertions/test-snapd-remodel-pc-rev1-24.json
@@ -13,7 +13,7 @@
     "revision": "1",
     "snaps": [
         {
-            "default-channel": "latest/edge",
+            "default-channel": "24/stable",
             "id": "tTs9DVS01mt4L11PGqbrSiKcIxFHpUJq",
             "name": "test-snapd-remodel-pc-min-size",
             "type": "gadget"

--- a/tests/lib/assertions/test-snapd-remodel-pc-rev1-24.model
+++ b/tests/lib/assertions/test-snapd-remodel-pc-rev1-24.model
@@ -9,7 +9,7 @@ base: core24
 grade: dangerous
 snaps:
   -
-    default-channel: latest/edge
+    default-channel: 24/stable
     id: tTs9DVS01mt4L11PGqbrSiKcIxFHpUJq
     name: test-snapd-remodel-pc-min-size
     type: gadget
@@ -33,13 +33,13 @@ system-user-authority: *
 timestamp: 2024-05-14T10:05:00+00:00
 sign-key-sha3-384: z5UoZNBNRc6KXRIg96L6tZ723_CDbUu45bRC-wcINgigB2S9GGGe6DWJqlzI6p0S
 
-AcLBcwQAAQoAHRYhBJwYfdLgNpH0AbmOCVr7utGyRTi5BQJmdiPAAAoJEFr7utGyRTi5XigP/RW3
-NTnl9m4eog5DQMGptUEKrxhTqibFf7MMRI2GYJ10zPv+es/tTPjrxz6WTeYmBw/OoEwM2i72mPcK
-J0xzBMYS2VgWds4d8uMI8ENTPVjso1JwrHvy7vorYlrkjurAJJ25Wlc3NFoIaZpeo9EpShuQyALR
-47egAtjV5pMVbdfwSC07UkeL4OjtiwVe+snJ0WafAyp6A0K110ilvKmahhwhcOZs9d3hHjo5ir0S
-l+yAZQ9CvmDDtwP5RPWw/gtnqTQAUziDgZEFbn+II7yNyhJIei1Ua4zqVcGxjGXWWEXzmD641td4
-fcMh96wfFWdK5YTTVCPPPConYeaa5S+RbQqn9NNyjKSZL5FLW5IapGT4iz/Dt9YEQfYME8POT3Ph
-XRL2HsisGOxLWnBqh7Lm9aQ4heca67Hrjhno6e3/PpMn/cbgtBipEFY3+3EmtrLRc3xkfqUWvREs
-J4M0utRg9DI9NzhH1vDuSjAIfQh+xjML4T/gH7nL1iu3rl4G26vUzl5kpBMG49HbqEHO12vzUgRN
-zYluUK/iTe2tYOszJiwpW3bGVAaHxh+wY9UfhtQ90bvMzoslQQRS/wgiDH0uADfkiV89VyN+RvLx
-m2tgpc8OrvM4xid2QF1LeT4rVi+1somBM3jEmeoJ9yD/Q1JEOv1Qfa4etucmaJpm+cWsqDkh
+AcLBcwQAAQoAHRYhBJwYfdLgNpH0AbmOCVr7utGyRTi5BQJmvg8sAAoJEFr7utGyRTi5Y8UP/3jy
+8gUoexHw8zL6fDF1z8NXUSNbSPD0mvvzOqW0mlCnLM4KCYK3NUi9RZDmY6LkQjFlNi0PGjXwZVrV
+34OassXBMu1VkJoGn/CbL198RhB081s7s3KjjawAL+teGFnDa5CI4sVjd3u+Y0ZFG+0UaudACZEf
+twl3V+7ZQpEFof60FtwqKRIVC/05B16TdYHvovY9Vg+79Ca1mSoHsHfjNh5hbG2DStr022DORC6c
+H+JRXG3cUQb8Gd/VMHP5DJmqEj1a55K6gHSM8zzqGS/5PDQsE9bWb1NzAzdXZbYmQ4HI3fjSdmAQ
+Jvrii0c72vcj5UpdYAPSvBMfZ9bIlFT11XDDIiQvgrbcS8bt1gLryJ9/kxwgql0S+2dQJvSakvVK
+smjUIgOvLDXwC2rrosuaj65PZbQOeoc7eno7P74CRNfTzcmIqY2WuQt58Ou/4zlpk1o3wtEznvoD
+iqsKWsEnPSIiS+kWrFgjnzNb/6TKaxDiNm+J6gtFnMkINMRPytJ/UnC9zZ5Hn/PAOsKKCbo/SMlr
+8n+LyWXDo9e1XTjftOy7qDY+jF1nQTn1NW/7KxvsJ0HF1UmCflTRopVaT8LWxNagoXjcKQtIuQLo
+ikb8Peo34YD8+lacn0NACWPGruzZ6k6NEwLSHUBDsxRwxs0JPRlKy0bXQAAn6U+80Z+Pkoiu

--- a/tests/nested/manual/remodel-min-size/task.yaml
+++ b/tests/nested/manual/remodel-min-size/task.yaml
@@ -26,11 +26,11 @@ environment:
   NEW_GADGET_NAME: test-snapd-remodel-pc-min-size
 
 prepare: |
-  variant=$(tests.nested show version)
+  version=$(tests.nested show version)
 
   # Modify gadget so it sends the suggested serial
   GADGET_D=$GADGET_NAME
-  cp -av "$TESTSLIB/snaps/$GADGET_NAME-$variant" "$GADGET_D"
+  cp -av "$TESTSLIB/snaps/$GADGET_NAME-$version" "$GADGET_D"
   test -n "$SERIAL"
   echo "$SERIAL" > "$GADGET_D"/serial
   snap pack "$GADGET_D"
@@ -43,12 +43,12 @@ prepare: |
   # snapcraft 6.x and running the command 'snapcraft export-login <filename>'
   # Every 12 months (in January) the auth file needs to be regenerated.
   export UBUNTU_STORE_AUTH_DATA_FILENAME="$TESTSLIB/remodel-store-viewer.auth"
-  export NESTED_CUSTOM_MODEL="$TESTSLIB/assertions/test-snapd-remodel-pc-rev0-$variant.model"
+  export NESTED_CUSTOM_MODEL="$TESTSLIB/assertions/test-snapd-remodel-pc-rev0-$version.model"
   tests.nested build-image core
   tests.nested create-vm core
 
 execute: |
-  variant=$(tests.nested show version)
+  version=$(tests.nested show version)
   boot_id=$(tests.nested boot-id)
 
   # wait until device is initialized and has a serial
@@ -62,7 +62,7 @@ execute: |
   usaveSz=$(remote.exec "sudo blockdev --getsize64 /dev/disk/by-label/ubuntu-save")
   test "$usaveSz" -eq 16777216
 
-  new_model_rev=test-snapd-remodel-pc-rev1-$variant.model
+  new_model_rev=test-snapd-remodel-pc-rev1-$version.model
   remote.push "$TESTSLIB/assertions/$new_model_rev"
   CHANGE_ID=$(remote.exec "sudo snap remodel --no-wait $new_model_rev")
   test -n "$CHANGE_ID"


### PR DESCRIPTION
To fix this test it was required to have the track 24 for snap test-snapd-remodel-pc-min-size, otherwise the remodel failed because it was trying to remodel this snap from base 24 to base 22.
