### PR TITLE
many: fix behavior of deny rules created as a result of a prompt reply

### DIFF
--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -43,8 +43,8 @@ func MockListenerClose(f func(l *listener.Listener) error) (restore func()) {
 }
 
 type RequestResponse struct {
-	Request  *listener.Request
-	Response *listener.Response
+	Request           *listener.Request
+	AllowedPermission any
 }
 
 func MockListener() (reqChan chan *listener.Request, replyChan chan RequestResponse, restore func()) {
@@ -77,10 +77,10 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 		}
 		return nil
 	})
-	restoreReply := MockRequestReply(func(req *listener.Request, resp *listener.Response) error {
+	restoreReply := MockRequestReply(func(req *listener.Request, allowedPermission any) error {
 		reqResp := RequestResponse{
-			Request:  req,
-			Response: resp,
+			Request:           req,
+			AllowedPermission: allowedPermission,
 		}
 		replyChan <- reqResp
 		return nil
@@ -95,7 +95,7 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 	return reqChan, replyChan, restore
 }
 
-func MockRequestReply(f func(req *listener.Request, resp *listener.Response) error) (restore func()) {
+func MockRequestReply(f func(req *listener.Request, allowedPermission any) error) (restore func()) {
 	restoreRequestReply := testutil.Backup(&requestReply)
 	requestReply = f
 	restoreRequestpromptsSendReply := requestprompts.MockSendReply(f)

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -35,7 +35,7 @@ func ExitOnError() (restore func()) {
 	return restore
 }
 
-func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan *Response) *Request {
+func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan any) *Request {
 	return &Request{
 		Class:     class,
 		replyChan: replyChan,
@@ -128,6 +128,12 @@ func MockEpollWaitNotifyIoctl() (recvChan chan<- []byte, sendChan <-chan []byte,
 	return recvChanRW, sendChanRW, restore
 }
 
+func MockEncodeAndSendResponse(f func(l *Listener, resp *notify.MsgNotificationResponse) error) (restore func()) {
+	restore = testutil.Backup(&encodeAndSendResponse)
+	encodeAndSendResponse = f
+	return restore
+}
+
 func (l *Listener) Dead() <-chan struct{} {
 	return l.tomb.Dead()
 }
@@ -146,4 +152,8 @@ func (l *Listener) Kill(err error) {
 
 func (l *Listener) EpollIsClosed() bool {
 	return l.poll.IsClosed()
+}
+
+func (l *Listener) WaitAndRespondAaClassFile(req *Request, msg *notify.MsgNotificationFile) error {
+	return l.waitAndRespondAaClassFile(req, msg)
 }

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -58,41 +58,40 @@ func (s *listenerSuite) SetUpTest(c *C) {
 }
 
 func (*listenerSuite) TestReply(c *C) {
-	rc := make(chan *listener.Response, 1)
+	rc := make(chan any, 1)
 	req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, rc)
-	response := &listener.Response{
-		Allow:      true,
-		Permission: notify.FilePermission(1234),
-	}
+	response := notify.FilePermission(1234)
 	req.Reply(response)
 	resp := <-rc
 	c.Assert(resp, Equals, response)
 }
 
-func (*listenerSuite) TestBadReply(c *C) {
-	rc := make(chan *listener.Response, 1)
+func (*listenerSuite) TestReplyNil(c *C) {
+	rc := make(chan any, 1)
 	req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, rc)
-	response := &listener.Response{
-		Allow:      true,
-		Permission: "read",
-	}
+	req.Reply(nil)
+	resp := <-rc
+	var response any
+	c.Assert(resp, Equals, response)
+}
+
+func (*listenerSuite) TestBadReply(c *C) {
+	rc := make(chan any, 1)
+	req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, rc)
+	response := "read"
 	err := req.Reply(response)
 	c.Assert(err, ErrorMatches, "invalid reply: response permission must be of type notify.FilePermission")
 }
 
 func (*listenerSuite) TestReplyTwice(c *C) {
-	rc := make(chan *listener.Response, 1)
+	rc := make(chan any, 1)
 	req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, rc)
-	response := &listener.Response{
-		Allow:      false,
-		Permission: notify.FilePermission(1234),
-	}
+	response := notify.FilePermission(1234)
 	err := req.Reply(response)
 	c.Assert(err, IsNil)
 	resp := <-rc
 	c.Assert(resp, Equals, response)
 
-	response.Allow = true
 	err = req.Reply(response)
 	c.Assert(err, Equals, listener.ErrAlreadyReplied)
 }
@@ -301,24 +300,14 @@ func (*listenerSuite) TestRunSimple(c *C) {
 	}
 
 	for i, id := range ids {
-		response := &listener.Response{Permission: notify.FilePermission(respBits)}
+		response := notify.FilePermission(respBits)
+
 		var desiredBuf []byte
-		switch i % 2 {
-		case 0:
-			response.Allow = false
-			allow := aBits
-			deny := dBits
-			resp := newMsgNotificationResponse(id, allow, deny)
-			desiredBuf, err = resp.MarshalBinary()
-			c.Assert(err, IsNil)
-		case 1:
-			response.Allow = true
-			allow := aBits | (respBits & dBits)
-			deny := (^respBits) & dBits
-			resp := newMsgNotificationResponse(id, allow, deny)
-			desiredBuf, err = resp.MarshalBinary()
-			c.Assert(err, IsNil)
-		}
+		allow := aBits | (respBits & dBits)
+		deny := (^respBits) & dBits
+		resp := newMsgNotificationResponse(id, allow, deny)
+		desiredBuf, err = resp.MarshalBinary()
+		c.Assert(err, IsNil)
 		err = requests[i].Reply(response)
 		c.Assert(err, IsNil)
 
@@ -604,7 +593,7 @@ func (*listenerSuite) TestRunNoReply(c *C) {
 
 	c.Check(l.Close(), IsNil)
 
-	response := &listener.Response{} // doesn't matter if it's invalid
+	response := true // doesn't matter what the response is
 	req.Reply(response)
 
 	c.Check(t.Wait(), Equals, listener.ErrClosed)
@@ -848,10 +837,7 @@ func (*listenerSuite) TestRunConcurrency(c *C) {
 	replyCount := 0
 	go func() {
 		// reply to all requests as they are received, until l.Reqs() closes
-		response := &listener.Response{
-			Allow:      true,
-			Permission: notify.FilePermission(1234),
-		}
+		response := notify.FilePermission(1234)
 		for req := range l.Reqs() {
 			err := req.Reply(response)
 			c.Check(err, IsNil)
@@ -912,4 +898,139 @@ func (*listenerSuite) TestRunConcurrency(c *C) {
 	c.Check(requestsSent > 1, Equals, true, Commentf("should have sent more than one request"))
 	c.Check(replyCount > 1, Equals, true, Commentf("should have replied to more than one request"))
 	c.Check(responseCount > 1, Equals, true, Commentf("should have received more than one response"))
+}
+
+func (*listenerSuite) TestWaitAndRespondAaClassFile(c *C) {
+	respChan := make(chan *notify.MsgNotificationResponse, 1)
+	restore := listener.MockEncodeAndSendResponse(func(l *listener.Listener, resp *notify.MsgNotificationResponse) error {
+		respChan <- resp
+		return nil
+	})
+	defer restore()
+
+	fakeListener := &listener.Listener{}
+
+	// Define allow and deny permissions which explore all possibilities of
+	// omitted/included and disjoint/overlapping permissions.
+	msgAllow := uint32(0b0101)
+	msgDeny := uint32(0b0011)
+
+	for _, testCase := range []struct {
+		allowedPermission any
+		respAllow         uint32
+		respDeny          uint32
+	}{
+		{
+			nil,
+			0b0100,
+			0b0011,
+		},
+		{
+			notify.FilePermission(0b0000),
+			0b0100,
+			0b0011,
+		},
+		{
+			notify.FilePermission(0b0001),
+			0b0101,
+			0b0010,
+		},
+		{
+			notify.FilePermission(0b0010),
+			0b0110,
+			0b0001,
+		},
+		{
+			notify.FilePermission(0b0011),
+			0b0111,
+			0b0000,
+		},
+		{
+			notify.FilePermission(0b0100),
+			0b0100,
+			0b0011,
+		},
+		{
+			notify.FilePermission(0b0101),
+			0b0101,
+			0b0010,
+		},
+		{
+			notify.FilePermission(0b0110),
+			0b0110,
+			0b0001,
+		},
+		{
+			notify.FilePermission(0b0111),
+			0b0111,
+			0b0000,
+		},
+		{
+			notify.FilePermission(0b1000),
+			0b0100,
+			0b0011,
+		},
+		{
+			notify.FilePermission(0b1001),
+			0b0101,
+			0b0010,
+		},
+		{
+			notify.FilePermission(0b1010),
+			0b0110,
+			0b0001,
+		},
+		{
+			notify.FilePermission(0b1011),
+			0b0111,
+			0b0000,
+		},
+		{
+			notify.FilePermission(0b1100),
+			0b0100,
+			0b0011,
+		},
+		{
+			notify.FilePermission(0b1101),
+			0b0101,
+			0b0010,
+		},
+		{
+			notify.FilePermission(0b1110),
+			0b0110,
+			0b0001,
+		},
+		{
+			notify.FilePermission(0b1111),
+			0b0111,
+			0b0000,
+		},
+	} {
+		replyChan := make(chan any, 1)
+		req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, replyChan)
+
+		msg := &notify.MsgNotificationFile{
+			MsgNotificationOp: notify.MsgNotificationOp{
+				Allow: msgAllow,
+				Deny:  msgDeny,
+			},
+			SUID: 0,
+			OUID: 0,
+			Name: "/home/test/foo",
+		}
+
+		// Send reply
+		replyChan <- testCase.allowedPermission
+
+		// Wait for and respond to reply we just sent
+		fakeListener.WaitAndRespondAaClassFile(req, msg)
+
+		select {
+		case resp := <-respChan:
+			c.Check(resp.Allow, Equals, testCase.respAllow, Commentf("test case: %+v", testCase))
+			c.Check(resp.Deny, Equals, testCase.respDeny, Commentf("test case: %+v", testCase))
+		case <-time.NewTimer(10 * time.Millisecond).C:
+			c.Errorf("failed to receive response for test case: %+v", testCase)
+		}
+	}
 }


### PR DESCRIPTION
When an application tries to carry out an operation and AppArmor mediates the operation via prompting, it sends to snapd a struct with an `Allow` and `Deny` field, among others. The `Allow field contains the bits for the permissions which the application already possessed, while the `Deny` field contains the bits for the permissions which the application currently lacks.

The listener and related code was originally written with the assumption that a permission could not occur in both the `Allow` and `Deny` fields in the same request, and more generally, that any permission which occurred in the `Allow` field should be granted regardless of the prompt decision. The thought process was that this field was permissions which were matched by allow rules and were not in need of mediation.

However, in testing, requests from the kernel usually, if not always, receive the same permissions in both the `Allow` and `Deny` fields. This may be a bug, or it may be that the AppArmor profile happens to have both allow rules and prompt rules, with the prompt rules causing the permissions to be placed in the `Deny` field and passed to snapd.

Regardless, the solution to the immediate bug is relatively simple: if a permission occurs in both the `Allow` and `Deny` fields, ignore the fact that it was originally allowed, and treat it just like any other permission in the `Deny` field. When constructing the response message to send back to the kernel, the allowed permissions should be those from the request `Allow` field and *not* the request `Deny` field, along with any permissions from `Deny` which were explicitly allowed by the user. The denied permissions in the response should be any permissions from the message `Deny` field which were *not* explicitly allowed by the user. Thus, all permissions from the original request are included in the response, and we never allow previously denied permissions without explicit user consent.

This new design relies on the idea that replies always contain the set of permissions which were explicitly granted by the user. However, the existing mechanism for sending a reply to the listener is via a `Response` struct which has fields for outcome and permissions. Even when the user replies with a denial, we want to allow any permissions which were allowed by request rules prior to the eventual denial which resulted in the response to the kernel. Using an allow outcome in order to send the subset of allowed permissions even when the reply was a denial is confusing at best, and certainly superfluous, as the existing implementation ignored the replied permissions whenever the outcome was deny.

A cleaner implementation of the response mechanism forgoes the outcome field entirely, and instead simply takes the set of permissions that the user explicitly allowed and passes that to the listener, which then sorts out denying any permissions which were not explicitly allowed. This requires more than the minimum set of changes to fix the bug, but should simplify and clarify the code and its handling of allowed and denied permissions.

This is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-30187