### PR TITLE
a/snapasserts: keep track of components in validation sets

### DIFF
--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -527,8 +527,7 @@ func (v *ValidationSets) Add(valset *asserts.ValidationSet) error {
 	return nil
 }
 
-// TODO: maybe a method on snapContraints?
-func addComponents(sc *snapConstraints, comps map[string]asserts.ValidationSetComponent, validationSetKey string) {
+func (sc *snapConstraints) addComponents(comps map[string]asserts.ValidationSetComponent, validationSetKey string) {
 	for name, comp := range comps {
 		sc.addComponent(name, comp, validationSetKey)
 	}
@@ -598,11 +597,11 @@ func (v *ValidationSets) addSnap(sn *asserts.ValidationSetSnap, validationSetKey
 			},
 			componentConstraints: make(map[string]*componentConstraints),
 		}
-		addComponents(v.snaps[sn.SnapID], sn.Components, validationSetKey)
+		v.snaps[sn.SnapID].addComponents(sn.Components, validationSetKey)
 		return
 	}
 
-	addComponents(sc, sn.Components, validationSetKey)
+	sc.addComponents(sn.Components, validationSetKey)
 
 	sc.revisions[rev] = append(sc.revisions[rev], rc)
 

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -376,12 +376,14 @@ func constraintsConflicts(c constraints) *conflictsError {
 	}
 
 	containerType := "snap"
+	name := c.name
 	if c.compRef != nil {
 		containerType = "component"
+		name = c.compRef.String()
 	}
 
 	return &conflictsError{
-		name:          c.name,
+		name:          name,
 		containerType: containerType,
 		revisions:     byRev,
 	}

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -191,7 +191,7 @@ type ValidationSets struct {
 	// sets maps sequence keys to validation-set in the combination
 	sets map[string]*asserts.ValidationSet
 	// snaps maps snap-ids to snap constraints
-	snaps map[string]*snapContraints
+	snaps map[string]*snapConstraints
 }
 
 const presConflict asserts.Presence = "conflict"
@@ -199,7 +199,7 @@ const presConflict asserts.Presence = "conflict"
 var unspecifiedRevision = snap.R(0)
 var invalidPresRevision = snap.R(-1)
 
-type snapContraints struct {
+type snapConstraints struct {
 	name     string
 	presence asserts.Presence
 	// revisions maps revisions to pairing of ValidationSetSnap
@@ -216,7 +216,7 @@ type revConstraint struct {
 	asserts.ValidationSetSnap
 }
 
-func (c *snapContraints) conflict() *snapConflictsError {
+func (c *snapConstraints) conflict() *snapConflictsError {
 	if c.presence != presConflict {
 		return nil
 	}
@@ -319,7 +319,7 @@ func (e *snapConflictsError) Error() string {
 func NewValidationSets() *ValidationSets {
 	return &ValidationSets{
 		sets:  map[string]*asserts.ValidationSet{},
-		snaps: map[string]*snapContraints{},
+		snaps: map[string]*snapConstraints{},
 	}
 }
 
@@ -396,7 +396,7 @@ func (v *ValidationSets) addSnap(sn *asserts.ValidationSetSnap, validationSetKey
 
 	cs := v.snaps[sn.SnapID]
 	if cs == nil {
-		v.snaps[sn.SnapID] = &snapContraints{
+		v.snaps[sn.SnapID] = &snapConstraints{
 			name:     sn.Name,
 			presence: sn.Presence,
 			revisions: map[snap.Revision][]*revConstraint{
@@ -584,7 +584,7 @@ func (e *PresenceConstraintError) Error() string {
 	return fmt.Sprintf("unexpected presence %q for snap %q", e.Presence, e.SnapName)
 }
 
-func (v *ValidationSets) constraintsForSnap(snapRef naming.SnapRef) *snapContraints {
+func (v *ValidationSets) constraintsForSnap(snapRef naming.SnapRef) *snapConstraints {
 	if snapRef.ID() != "" {
 		return v.snaps[snapRef.ID()]
 	}

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -46,10 +46,11 @@ type InstalledComponent struct {
 }
 
 // NewInstalledSnap creates InstalledSnap.
-func NewInstalledSnap(name, snapID string, revision snap.Revision) *InstalledSnap {
+func NewInstalledSnap(name, snapID string, revision snap.Revision, components []InstalledComponent) *InstalledSnap {
 	return &InstalledSnap{
-		SnapRef:  naming.NewSnapRef(name, snapID),
-		Revision: revision,
+		SnapRef:    naming.NewSnapRef(name, snapID),
+		Revision:   revision,
+		Components: components,
 	}
 }
 

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -528,12 +528,11 @@ func (v *ValidationSets) Add(valset *asserts.ValidationSet) error {
 // TODO: maybe a method on snapContraints?
 func addComponents(sc *snapConstraints, comps map[string]asserts.ValidationSetComponent, validationSetKey string) {
 	for name, comp := range comps {
-		addComponent(sc, name, comp, validationSetKey)
+		sc.addComponent(name, comp, validationSetKey)
 	}
 }
 
-// TODO: maybe a method on snapContraints?
-func addComponent(sc *snapConstraints, compName string, comp asserts.ValidationSetComponent, validationSetKey string) {
+func (sc *snapConstraints) addComponent(compName string, comp asserts.ValidationSetComponent, validationSetKey string) {
 	rev := snap.R(comp.Revision)
 	if comp.Presence == asserts.PresenceInvalid {
 		rev = invalidPresRevision

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -315,9 +315,9 @@ type componentConstraints struct {
 }
 
 type constraints struct {
-	// name is the name of the snap or component that is being constrained
+	// name of the snap or component that is being constrained
 	name string
-	// presence is the allowed presence of the snap or component, considering
+	// presence of the snap or component, considering
 	// all of the constraints that impact it. if any of the constraints are in
 	// conflict, the presence is set to presConflict.
 	presence asserts.Presence

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -739,6 +739,28 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsWithComponents(c *C) {
 				},
 			},
 		},
+		"four": {
+			map[string]interface{}{
+				"name":     "snap-a",
+				"id":       snaptest.AssertedSnapID("snap-a"),
+				"presence": "required",
+				"revision": "13",
+				"components": map[string]interface{}{
+					"comp-3": map[string]interface{}{
+						"presence": "required",
+						"revision": "1",
+					},
+					"comp-4": map[string]interface{}{
+						"presence": "required",
+						"revision": "2",
+					},
+					"comp-5": map[string]interface{}{
+						"presence": "optional",
+						"revision": "3",
+					},
+				},
+			},
+		},
 	}
 
 	assertions := make(map[string]*asserts.ValidationSet)
@@ -864,10 +886,36 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsWithComponents(c *C) {
 					"snap-a": {
 						MissingComponents: map[string]map[snap.Revision][]string{
 							"comp-2": {
-								{}:        {"acme/three"},
+								snap.R(0): {"acme/three"},
 								snap.R(3): {"acme/one"},
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			summary:    "missing required snap and required component",
+			assertions: []string{"four"},
+			verr: &snapasserts.ValidationSetsValidationError{
+				Sets: map[string]*asserts.ValidationSet{
+					"acme/four": assertions["four"],
+				},
+				ComponentErrors: map[string]*snapasserts.ValidationSetsComponentValidationError{
+					"snap-a": {
+						MissingComponents: map[string]map[snap.Revision][]string{
+							"comp-3": {
+								snap.R(1): {"acme/four"},
+							},
+							"comp-4": {
+								snap.R(2): {"acme/four"},
+							},
+						},
+					},
+				},
+				MissingSnaps: map[string]map[snap.Revision][]string{
+					"snap-a": {
+						snap.R(13): {"acme/four"},
 					},
 				},
 			},

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -275,7 +275,7 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 func (s *validationSetsSuite) TestCheckInstalledSnapsNoValidationSets(c *C) {
 	valsets := snapasserts.NewValidationSets()
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1)),
+		snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1), nil),
 	}
 	err := valsets.CheckInstalledSnaps(snaps, nil)
 	c.Assert(err, IsNil)
@@ -430,20 +430,20 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 	c.Assert(valsets.Add(vs6), IsNil)
 	c.Assert(valsets.Add(vs7), IsNil)
 
-	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1))
-	snapAlocal := snapasserts.NewInstalledSnap("snap-a", "", snap.R("x2"))
-	snapB := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(3))
-	snapBinvRev := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(8))
-	snapBlocal := snapasserts.NewInstalledSnap("snap-b", "", snap.R("x3"))
-	snapC := snapasserts.NewInstalledSnap("snap-c", "mysnapcccccccccccccccccccccccccc", snap.R(2))
-	snapCinvRev := snapasserts.NewInstalledSnap("snap-c", "mysnapcccccccccccccccccccccccccc", snap.R(99))
-	snapD := snapasserts.NewInstalledSnap("snap-d", "mysnapdddddddddddddddddddddddddd", snap.R(2))
-	snapDrev99 := snapasserts.NewInstalledSnap("snap-d", "mysnapdddddddddddddddddddddddddd", snap.R(99))
-	snapDlocal := snapasserts.NewInstalledSnap("snap-d", "", snap.R("x3"))
-	snapE := snapasserts.NewInstalledSnap("snap-e", "mysnapeeeeeeeeeeeeeeeeeeeeeeeeee", snap.R(2))
-	snapF := snapasserts.NewInstalledSnap("snap-f", "mysnapffffffffffffffffffffffffff", snap.R(4))
+	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1), nil)
+	snapAlocal := snapasserts.NewInstalledSnap("snap-a", "", snap.R("x2"), nil)
+	snapB := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(3), nil)
+	snapBinvRev := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(8), nil)
+	snapBlocal := snapasserts.NewInstalledSnap("snap-b", "", snap.R("x3"), nil)
+	snapC := snapasserts.NewInstalledSnap("snap-c", "mysnapcccccccccccccccccccccccccc", snap.R(2), nil)
+	snapCinvRev := snapasserts.NewInstalledSnap("snap-c", "mysnapcccccccccccccccccccccccccc", snap.R(99), nil)
+	snapD := snapasserts.NewInstalledSnap("snap-d", "mysnapdddddddddddddddddddddddddd", snap.R(2), nil)
+	snapDrev99 := snapasserts.NewInstalledSnap("snap-d", "mysnapdddddddddddddddddddddddddd", snap.R(99), nil)
+	snapDlocal := snapasserts.NewInstalledSnap("snap-d", "", snap.R("x3"), nil)
+	snapE := snapasserts.NewInstalledSnap("snap-e", "mysnapeeeeeeeeeeeeeeeeeeeeeeeeee", snap.R(2), nil)
+	snapF := snapasserts.NewInstalledSnap("snap-f", "mysnapffffffffffffffffffffffffff", snap.R(4), nil)
 	// extra snap, not referenced by any validation set
-	snapZ := snapasserts.NewInstalledSnap("snap-z", "mysnapzzzzzzzzzzzzzzzzzzzzzzzzzz", snap.R(1))
+	snapZ := snapasserts.NewInstalledSnap("snap-z", "mysnapzzzzzzzzzzzzzzzzzzzzzzzzzz", snap.R(1), nil)
 
 	tests := []struct {
 		snaps            []*snapasserts.InstalledSnap
@@ -727,9 +727,9 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsIgnoreValidation(c *C) {
 	valsets := snapasserts.NewValidationSets()
 	c.Assert(valsets.Add(vs), IsNil)
 
-	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1))
-	snapB := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(3))
-	snapBinvRev := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(8))
+	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1), nil)
+	snapB := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(3), nil)
+	snapBinvRev := snapasserts.NewInstalledSnap("snap-b", "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb", snap.R(8), nil)
 
 	// validity check
 	c.Check(valsets.CheckInstalledSnaps([]*snapasserts.InstalledSnap{snapA, snapB}, nil), ErrorMatches, "validation sets assertions are not met:\n"+
@@ -791,8 +791,8 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsErrorFormat(c *C) {
 	// not strictly important, but ensures test data makes sense and avoids confusing results
 	c.Assert(valsets.Conflict(), IsNil)
 
-	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1))
-	snapBlocal := snapasserts.NewInstalledSnap("snap-b", "", snap.R("x3"))
+	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1), nil)
+	snapBlocal := snapasserts.NewInstalledSnap("snap-b", "", snap.R("x3"), nil)
 
 	tests := []struct {
 		snaps    []*snapasserts.InstalledSnap

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -846,7 +846,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidati
 	restore := daemon.MockAssertstateFetchEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*assertstate.ValidationSetTracking, error) {
 		c.Check(ignoreValidation, check.DeepEquals, map[string]bool{"snap-b": true})
 		c.Check(snaps, testutil.DeepUnsortedMatches, []*snapasserts.InstalledSnap{
-			snapasserts.NewInstalledSnap("snap-b", "yOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.R("1"))})
+			snapasserts.NewInstalledSnap("snap-b", "yOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.R("1"), nil)})
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 0)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3351,8 +3351,8 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedHappy(c *C
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
-		snapasserts.NewInstalledSnap("other", "ididididid", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
+		snapasserts.NewInstalledSnap("other", "ididididid", snap.Revision{N: 1}, nil),
 	}
 
 	sequence := 0
@@ -3389,7 +3389,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforcePinnedHappy(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	sequence := 2
@@ -3518,7 +3518,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterForge
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	sequence := 0
@@ -3569,7 +3569,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterMonit
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	sequence := 0
@@ -3685,7 +3685,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertion(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	sequence := 2
@@ -3746,7 +3746,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionUpdate(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	sequence := 2
@@ -3823,7 +3823,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionPinToOlderSequence(c *
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	sequence := 2
@@ -3894,7 +3894,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionAfterMonitor(c *C) {
 	assertstate.UpdateValidationSet(st, &monitor)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	// add a newer sequence to the store
@@ -3946,7 +3946,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionIgnoreValidation(c *C)
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	snaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 3}),
+		snapasserts.NewInstalledSnap("foo", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 3}, nil),
 	}
 
 	sequence := 2
@@ -4038,8 +4038,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsValidationError(c
 	// try to enforce extra validation sets bar and baz. some-snap is present (and required by foo at any revision),
 	// but needs to be at revision 3 to satisfy bar. invalid-snap is present but is invalid for baz.
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
-		snapasserts.NewInstalledSnap("invalid-snap", "cccchntON3vR7kwEbVPsILm7bUViPDcc", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
+		snapasserts.NewInstalledSnap("invalid-snap", "cccchntON3vR7kwEbVPsILm7bUViPDcc", snap.Revision{N: 1}, nil),
 	}
 	err := assertstate.TryEnforcedValidationSets(st, []string{fmt.Sprintf("%s/bar", s.dev1Acct.AccountID()), fmt.Sprintf("%s/baz", s.dev1Acct.AccountID())}, 0, installedSnaps, nil)
 	verr, ok := err.(*snapasserts.ValidationSetsValidationError)
@@ -4122,7 +4122,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsOK(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 3}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 3}, nil),
 	}
 	err := assertstate.TryEnforcedValidationSets(st, []string{fmt.Sprintf("%s/bar", s.dev1Acct.AccountID()), fmt.Sprintf("%s/baz=1", s.dev1Acct.AccountID())}, 0, installedSnaps, nil)
 	c.Assert(err, IsNil)
@@ -4231,7 +4231,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsAlreadyTrackedUpd
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 3}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 3}, nil),
 	}
 	err := assertstate.TryEnforcedValidationSets(st, []string{fmt.Sprintf("%s/foo", s.dev1Acct.AccountID())}, 0, installedSnaps, nil)
 	c.Assert(err, IsNil)
@@ -4312,7 +4312,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsConflictError(c *
 	// try to enforce extra validation sets bar and baz. some-snap is present (and required by foo at any revision),
 	// but needs to be at revision 3 to satisfy bar. invalid-snap is present but is invalid for baz.
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 	err := assertstate.TryEnforcedValidationSets(st, []string{fmt.Sprintf("%s/bar", s.dev1Acct.AccountID())}, 0, installedSnaps, nil)
 	_, ok := err.(*snapasserts.ValidationSetsConflictError)
@@ -4523,7 +4523,7 @@ func (s *assertMgrSuite) testEnforceValidationSets(c *C, pinnedSeq int) {
 		requestedValSet: localVs,
 	}
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 	err := assertstate.ApplyEnforcedValidationSets(st, valSets, pinnedSeqs, installedSnaps, nil, 0)
 	c.Assert(err, IsNil)
@@ -4586,7 +4586,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetsWithNoLocalAssertions(c *C) {
 	}
 	pinnedSeqs := map[string]int{fmt.Sprintf("%s/foo", s.dev1Acct.AccountID()): 1}
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 
 	err := assertstate.ApplyEnforcedValidationSets(st, valSets, pinnedSeqs, installedSnaps, nil, 0)
@@ -4673,7 +4673,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetsWithUnmetConstraints(c *C) {
 	}
 
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 2}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 2}, nil),
 	}
 
 	err := assertstate.ApplyEnforcedValidationSets(st, valSets, nil, installedSnaps, nil, 0)
@@ -4723,7 +4723,7 @@ func (s *assertMgrSuite) testApplyLocalEnforcedValidationSets(c *C, pinnedSeq in
 		vsKey: {release.Series, s.dev1Acct.AccountID(), "foo", "1"},
 	}
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 1}, nil),
 	}
 	err := assertstate.ApplyLocalEnforcedValidationSets(st, valSets, pinnedSeqs, installedSnaps, nil)
 	c.Assert(err, IsNil)
@@ -4801,7 +4801,7 @@ func (s *assertMgrSuite) TestApplyLocalEnforcedValidationSetsWithUnmetConstraint
 	}
 
 	installedSnaps := []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 2}),
+		snapasserts.NewInstalledSnap("some-snap", "qOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.Revision{N: 2}, nil),
 	}
 
 	err := assertstate.ApplyLocalEnforcedValidationSets(st, valSets, nil, installedSnaps, nil)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -4127,8 +4127,9 @@ func InstalledSnaps(st *state.State) (snaps []*snapasserts.InstalledSnap, ignore
 		if err != nil {
 			return nil, nil, err
 		}
+		// TODO:COMPS: add components
 		snaps = append(snaps, snapasserts.NewInstalledSnap(snapState.InstanceName(),
-			snapState.CurrentSideInfo().SnapID, cur.Revision))
+			snapState.CurrentSideInfo().SnapID, cur.Revision, nil))
 		if snapState.IgnoreValidation {
 			ignoreValidation[snapState.InstanceName()] = true
 		}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8077,8 +8077,8 @@ version: 1`), &snap.SideInfo{Revision: snap.R("5")})
 	snaps, ignoreValidation, err = snapstate.InstalledSnaps(st)
 	c.Assert(err, IsNil)
 	c.Check(snaps, testutil.DeepUnsortedMatches, []*snapasserts.InstalledSnap{
-		snapasserts.NewInstalledSnap("foo", "foo-id", snap.R("23")),
-		snapasserts.NewInstalledSnap("bar", "bar-id", snap.R("5"))})
+		snapasserts.NewInstalledSnap("foo", "foo-id", snap.R("23"), nil),
+		snapasserts.NewInstalledSnap("bar", "bar-id", snap.R("5"), nil)})
 
 	c.Check(ignoreValidation, DeepEquals, map[string]bool{"bar": true})
 }

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1534,8 +1534,10 @@ func (w *Writer) validationSets() (*snapasserts.ValidationSets, error) {
 
 func (w *Writer) installedSnaps() []*snapasserts.InstalledSnap {
 	installedSnap := func(snap *SeedSnap) *snapasserts.InstalledSnap {
-		return snapasserts.NewInstalledSnap(snap.SnapName(), snap.ID(), snap.Info.Revision)
+		return snapasserts.NewInstalledSnap(snap.SnapName(), snap.ID(), snap.Info.Revision, nil)
 	}
+
+	// TODO:COMPS: add components
 
 	var installedSnaps []*snapasserts.InstalledSnap
 	for _, sn := range w.snapsFromModel {


### PR DESCRIPTION
This will enable us to track components alongside snaps with validation sets.