### PR TITLE
tests/main/snap-interface: added expected default doc url

### DIFF
--- a/tests/main/snap-interface/snap-interface-network-core.yaml
+++ b/tests/main/snap-interface/snap-interface-network-core.yaml
@@ -1,5 +1,6 @@
-name:    network
-summary: allows access to the network
+name:          network
+summary:       allows access to the network
+documentation: https://snapcraft.io/docs/network-interface
 plugs:
   - network-consumer
 slots:

--- a/tests/main/snap-interface/snap-interface-network-snapd.yaml
+++ b/tests/main/snap-interface/snap-interface-network-snapd.yaml
@@ -1,5 +1,6 @@
-name:    network
-summary: allows access to the network
+name:          network
+summary:       allows access to the network
+documentation: https://snapcraft.io/docs/network-interface
 plugs:
   - network-consumer
 slots:


### PR DESCRIPTION
After changes in this [PR](https://github.com/canonical/snapd/pull/14273) the default doc URL is expected.

