### PR TITLE
tests: enable snap-builds for pushes to master

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,9 +33,6 @@ jobs:
           # are the build that should be installed by human users.
           - pristine
           - test
-    # only build the snap for pull requests, it's not needed on release branches
-    # or on master since we have launchpad build recipes which do this already
-    if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
To be able to run spread tests in master branch when changes are pushed it is required to run the snap-builds job first (spread jobs depends on snap-builds).

This change complements https://github.com/canonical/snapd/pull/14341