### PR TITLE
many: add coredump options

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -375,10 +375,16 @@ func SnapSystemdConfDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, "/etc/systemd/system.conf.d")
 }
 
-// SnapSystemdConfDirUnder returns the path to the systemd conf dir under
-// rootdir.
+// SnapServicesDirUnder returns the path to the systemd services
+// conf dir under rootdir.
 func SnapServicesDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, "/etc/systemd/system")
+}
+
+// SnapSystemdDirUnder returns the path to the systemd conf dir under
+// rootdir.
+func SnapSystemdDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, "/etc/systemd")
 }
 
 // SnapBootAssetsDirUnder returns the path to boot assets directory under a

--- a/overlord/configstate/configcore/coredump.go
+++ b/overlord/configstate/configcore/coredump.go
@@ -1,0 +1,121 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/sysconfig"
+)
+
+const (
+	optionCoredumpEnable     = "system.coredump.enable"
+	optionCoredumpMaxuse     = "system.coredump.maxuse"
+	coreOptionCoredumpEnable = "core." + optionCoredumpEnable
+	coreOptionCoredumpMaxuse = "core." + optionCoredumpMaxuse
+
+	coredumpCfgSubdir = "coredump.conf.d"
+	coredumpCfgFile   = "ubuntu-core.conf"
+)
+
+func init() {
+	// add supported configuration of this module
+	supportedConfigurations[coreOptionCoredumpEnable] = true
+	supportedConfigurations[coreOptionCoredumpMaxuse] = true
+}
+
+func validMaxUseSize(sizeStr string) error {
+	if sizeStr == "" {
+		return nil
+	}
+
+	_, err := quantity.ParseSize(sizeStr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateCoredumpSettings(tr ConfGetter) error {
+	if err := validateBoolFlag(tr, optionCoredumpEnable); err != nil {
+		return err
+	}
+
+	maxUse, err := coreCfg(tr, optionCoredumpMaxuse)
+	if err != nil {
+		return err
+	}
+
+	return validMaxUseSize(maxUse)
+}
+
+func handleCoredumpConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyContext) error {
+	coreEnabled, err := coreCfg(tr, optionCoredumpEnable)
+	if err != nil {
+		return err
+	}
+
+	cfgContent := "[Coredump]\n"
+	switch coreEnabled {
+	case "", "false":
+		cfgContent += "Storage=none\nProcessSizeMax=0\n"
+	case "true":
+		maxUse, err := coreCfg(tr, optionCoredumpMaxuse)
+		if err != nil {
+			return err
+		}
+		cfgContent += "Storage=external\n"
+		if maxUse != "" {
+			cfgContent += fmt.Sprintf("MaxUse=%s\n", maxUse)
+		}
+	}
+
+	var coredumpCfgDir string
+	if opts == nil {
+		// runtime system
+		coredumpCfgDir = dirs.SnapSystemdDir
+	} else {
+		coredumpCfgDir = dirs.SnapSystemdDirUnder(opts.RootDir)
+	}
+	coredumpCfgDir = filepath.Join(coredumpCfgDir, coredumpCfgSubdir)
+	if err := os.MkdirAll(coredumpCfgDir, 0755); err != nil {
+		return err
+	}
+
+	// Ensure content of configuration file (path is
+	// /etc/systemd/coredump.conf.d/ubuntu-core.conf)
+	dirContent := map[string]osutil.FileState{
+		coredumpCfgFile: &osutil.MemoryFileState{
+			Content: []byte(cfgContent),
+			Mode:    0644,
+		},
+	}
+	if _, _, err = osutil.EnsureDirState(coredumpCfgDir, coredumpCfgFile, dirContent); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/coredump.go
+++ b/overlord/configstate/configcore/coredump.go
@@ -72,7 +72,12 @@ func validateCoredumpSettings(tr ConfGetter) error {
 	return validMaxUseSize(maxUse)
 }
 
-func handleCoredumpConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyContext) error {
+func handleCoredumpConfiguration(dev sysconfig.Device, tr ConfGetter, opts *fsOnlyContext) error {
+	// Rule out UC16/18 as we will not backport systemd-coredump there
+	if !dev.HasModeenv() {
+		return nil
+	}
+
 	coreEnabled, err := coreCfg(tr, optionCoredumpEnable)
 	if err != nil {
 		return err

--- a/overlord/configstate/configcore/coredump_test.go
+++ b/overlord/configstate/configcore/coredump_test.go
@@ -1,0 +1,119 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type coredumpSuite struct {
+	configcoreSuite
+
+	coredumpCfgDir  string
+	coredumpCfgPath string
+}
+
+var _ = Suite(&coredumpSuite{})
+
+func (s *coredumpSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	s.coredumpCfgDir = filepath.Join(dirs.SnapSystemdDir, "coredump.conf.d")
+	s.coredumpCfgPath = filepath.Join(s.coredumpCfgDir, "ubuntu-core.conf")
+}
+
+func (s *coredumpSuite) TestConfigureCoredumpDefault(c *C) {
+	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+		state: s.state,
+		conf:  map[string]interface{}{},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(s.coredumpCfgPath, testutil.FileEquals,
+		fmt.Sprintf("[Coredump]\nStorage=none\nProcessSizeMax=0\n"))
+}
+
+func (s *coredumpSuite) TestConfigureCoredumpDisable(c *C) {
+	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.coredump.enable": false,
+			"system.coredump.maxuse": "100M",
+		},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(s.coredumpCfgPath, testutil.FileEquals,
+		fmt.Sprintf("[Coredump]\nStorage=none\nProcessSizeMax=0\n"))
+}
+
+func (s *coredumpSuite) TestConfigureCoredumpDefaultMaxUse(c *C) {
+	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.coredump.enable": true,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(s.coredumpCfgPath, testutil.FileEquals,
+		fmt.Sprintf("[Coredump]\nStorage=external\n"))
+}
+
+func (s *coredumpSuite) TestConfigureCoredumpWithMaxUse(c *C) {
+	// Configure with different MaxUse valid values
+	for _, size := range []string{"104857600", "16M", "2G", "0"} {
+		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				"system.coredump.enable": true,
+				"system.coredump.maxuse": size,
+			},
+		})
+		c.Assert(err, IsNil)
+
+		c.Check(s.coredumpCfgPath, testutil.FileEquals,
+			fmt.Sprintf("[Coredump]\nStorage=external\nMaxUse=%s\n", size))
+	}
+}
+
+func (s *coredumpSuite) TestConfigureCoredumpInvalidMaxUse(c *C) {
+	// Configure with different MaxUse invalid values
+	for _, size := range []string{"100p", "0x123", "10485f7600", "20%%",
+		"20%", "100m", "10k", "10K", "10g"} {
+
+		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				"system.coredump.enable": true,
+				"system.coredump.maxuse": size,
+			},
+		})
+		c.Assert(err, ErrorMatches, `invalid suffix .*`)
+
+		c.Assert(s.coredumpCfgPath, testutil.FileAbsent)
+	}
+}

--- a/overlord/configstate/configcore/coredump_test.go
+++ b/overlord/configstate/configcore/coredump_test.go
@@ -46,7 +46,7 @@ func (s *coredumpSuite) SetUpTest(c *C) {
 }
 
 func (s *coredumpSuite) TestConfigureCoredumpDefault(c *C) {
-	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
 		conf:  map[string]interface{}{},
 	})
@@ -57,7 +57,7 @@ func (s *coredumpSuite) TestConfigureCoredumpDefault(c *C) {
 }
 
 func (s *coredumpSuite) TestConfigureCoredumpDisable(c *C) {
-	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.coredump.enable": false,
@@ -71,7 +71,7 @@ func (s *coredumpSuite) TestConfigureCoredumpDisable(c *C) {
 }
 
 func (s *coredumpSuite) TestConfigureCoredumpDefaultMaxUse(c *C) {
-	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
 			"system.coredump.enable": true,
@@ -86,7 +86,7 @@ func (s *coredumpSuite) TestConfigureCoredumpDefaultMaxUse(c *C) {
 func (s *coredumpSuite) TestConfigureCoredumpWithMaxUse(c *C) {
 	// Configure with different MaxUse valid values
 	for _, size := range []string{"104857600", "16M", "2G", "0"} {
-		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+		err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				"system.coredump.enable": true,
@@ -105,7 +105,7 @@ func (s *coredumpSuite) TestConfigureCoredumpInvalidMaxUse(c *C) {
 	for _, size := range []string{"100p", "0x123", "10485f7600", "20%%",
 		"20%", "100m", "10k", "10K", "10g"} {
 
-		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+		err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 			state: s.state,
 			conf: map[string]interface{}{
 				"system.coredump.enable": true,
@@ -116,4 +116,16 @@ func (s *coredumpSuite) TestConfigureCoredumpInvalidMaxUse(c *C) {
 
 		c.Assert(s.coredumpCfgPath, testutil.FileAbsent)
 	}
+}
+
+func (s *coredumpSuite) TestConfigureCoredumpNoModeEnv(c *C) {
+	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"system.coredump.enable": true,
+		},
+	})
+	c.Assert(err, IsNil)
+	// No file is created for uc16/18
+	c.Check(s.coredumpCfgPath, testutil.FileAbsent)
 }

--- a/overlord/configstate/configcore/export_test.go
+++ b/overlord/configstate/configcore/export_test.go
@@ -101,3 +101,9 @@ func MockServicestateControl(f func(st *state.State, appInfos []*snap.AppInfo, i
 func MockServicestateChangeTimeout(v time.Duration) func() {
 	return testutil.Mock(&serviceStartChangeTimeout, v)
 }
+
+func MockEnvPath(newEnvPath string) func() {
+	oldEnvPath := envFilePath
+	envFilePath = newEnvPath
+	return func() { envFilePath = oldEnvPath }
+}

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -118,6 +118,9 @@ func init() {
 	// store.access
 	addFSOnlyHandler(validateStoreAccess, handleStoreAccess, coreOnly)
 
+	// system.coredump
+	addFSOnlyHandler(validateCoredumpSettings, handleCoredumpConfiguration, coreOnly)
+
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = filesystemOnlyApply
 }
 

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	devicestateResetSession = devicestate.ResetSession
+	envFilePath             = "/etc/environment"
 )
 
 var proxyConfigKeys = map[string]bool{
@@ -55,7 +56,7 @@ func init() {
 }
 
 func etcEnvironment() string {
-	return filepath.Join(dirs.GlobalRootDir, "/etc/environment")
+	return filepath.Join(dirs.GlobalRootDir, envFilePath)
 }
 
 func updateEtcEnvironmentConfig(path string, config map[string]string) error {

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -81,6 +81,8 @@ PATH="/usr/bin"
 
 func (s *proxySuite) TestConfigureProxyUnhappy(c *C) {
 	dirs.SetRootDir(c.MkDir())
+	r := configcore.MockEnvPath("/otherrootfs/etc/environment")
+	defer r()
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{

--- a/tests/core/coredump-options/task.yaml
+++ b/tests/core/coredump-options/task.yaml
@@ -1,0 +1,37 @@
+summary: Enable and use coredump options on UC
+
+details: |
+  Use coredump options and ensure that systemd-coredump can generate
+  core files when configured to do so.
+
+systems: [-ubuntu-core-1*, -ubuntu-core-20*, -ubuntu-core-22*]
+
+execute: |
+  cfg_path=/etc/systemd/coredump.conf.d/ubuntu-core.conf
+
+  # coredumps should be initially disabled
+  expect=$(printf "[Coredump]\nStorage=none\nProcessSizeMax=0\n")
+  test "$expect" = "$(cat $cfg_path)"
+
+  # TODO no coredumps are dropped, but we get a journal entry. Depends
+  # on https://github.com/snapcore/core-base/pull/227 being in the
+  # installed core24 channel already.
+
+  # enable coredump with a max use size
+  max_use=10M
+  snap set system system.coredump.enable=true
+  snap set system system.coredump.maxuse="$max_use"
+
+  expect=$(printf "[Coredump]\nStorage=external\nMaxUse=%s\n" "$max_use")
+  test "$expect" = "$(cat $cfg_path)"
+
+  # TODO Generate a core dump. Depends on
+  # https://github.com/snapcore/core-base/pull/227 too.
+
+  # Finally, disable again
+  snap set system system.coredump.enable=false
+  expect=$(printf "[Coredump]\nStorage=none\nProcessSizeMax=0\n")
+  test "$expect" = "$(cat $cfg_path)"
+
+  # TODO no coredumps are dropped, but we get a journal entry
+  # Depends on https://github.com/snapcore/core-base/pull/227 too.


### PR DESCRIPTION
Proposing https://github.com/canonical/snapd/pull/14202 again as it had to be reverted (https://github.com/canonical/snapd/pull/14374) due to failures on UC16 tests.

The problem was due to trying to create a folder in old UC where it was not possible, and due to the way system options work this code was being run even for any `snap set system ...` command. https://github.com/canonical/snapd/pull/14379/commits/133841500dd5e9748f8fa16d687357a70a0ebf85 is the code change to avoid this.