### PR TITLE
tests: fix xdg-open in opensuse

### DIFF
--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -36,20 +36,22 @@ prepare: |
 
     # setup the handler
     tests.session -u test exec sh -c 'mkdir -p ~test/.local/share/applications'
-    tests.session -u test exec sh -c 'cat > ~test/.local/share/applications/test-handler.desktop' << EOF
+    cat <<EOF > ~test/.local/share/applications/test-handler.desktop
     [Desktop Entry]
     Type=Application
     Name=Test Web Browser
     Exec=/bin/true %u
     MimeType=x-scheme-handler/randomurl;
     EOF
+    chown test:test ~test/.local/share/applications/test-handler.desktop
 
     # setup xdg-mime
     tests.session -u test exec mkdir -p ~test/.config
-    tests.session -u test exec sh -c 'cat  > ~test/.config/mimeapps.list' << EOF
+    cat <<EOF > ~test/.config/mimeapps.list
     [Default Applications]
     x-scheme-handler/randomurl=test-handler.desktop
     EOF
+    chown test:test ~test/.config/mimeapps.list
 
     # double check that the handler is properly registered
     tests.session -u test exec sh -c 'xdg-mime query default x-scheme-handler/randomurl' | \


### PR DESCRIPTION
The xdg-open test is getting stuck during prepare stage in opensuse when running the following line:
`tests.session -u test exec sh -c 'cat > ~test/.local/share/applications/test-handler.desktop' << EOF`

In the machine I can see the process runuser process consuming 100% of the cpu. 

That code was changed by
`cat <<EOF > ~test/.local/share/applications/test-handler.desktop`
`chown test:test ~test/.local/share/applications/test-handler.desktop`
