### PR TITLE
tests: pass machine parameter into systemctl --user to create a login session

### DIFF
--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -33,4 +33,4 @@ execute: |
     tests.session -u test prepare
 
     echo "We can see the service running"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.test-snapd-user-service
+    tests.session -u test exec systemctl --user --machine=test@.host is-active snap.test-snapd-user-service.test-snapd-user-service


### PR DESCRIPTION
The tests/main/snap-user-service test is failing on opensuse tumbleweed, as seen in these logs:

```
Aug 16 20:30:39 aug161946-854560 systemd[1]: Started tests.session running systemctl --user is-active snap.test-snapd-user-service.test-snapd-user-service as test.
Aug 16 20:30:39 aug161946-854560 runuser[21699]: pam_systemd(runuser-l:session): New sd-bus connection (system-bus-pam-systemd-21699) opened.
Aug 16 20:30:39 aug161946-854560 systemd-logind[764]: New session c5 of user test.
Aug 16 20:30:39 aug161946-854560 systemd[1]: Starting User Manager for UID 12345...
Aug 16 20:30:39 aug161946-854560 (systemd)[21700]: pam_systemd(systemd-user:session): Failed to create session: Invalid session class manager
Aug 16 20:30:39 aug161946-854560 (systemd)[21700]: pam_unix(systemd-user:session): session opened for user test(uid=12345) by test(uid=0)
Aug 16 20:30:39 aug161946-854560 systemd[21700]: Trying to run as user instance, but $XDG_RUNTIME_DIR is not set.
Aug 16 20:30:39 aug161946-854560 systemd[1]: user@12345.service: Main process exited, code=exited, status=1/FAILURE
Aug 16 20:30:39 aug161946-854560 (sd-pam)[21702]: pam_unix(systemd-user:session): session closed for user test
Aug 16 20:30:39 aug161946-854560 systemd[1]: user@12345.service: Failed with result 'exit-code'.
Aug 16 20:30:39 aug161946-854560 systemd[1]: Failed to start User Manager for UID 12345.
Aug 16 20:30:39 aug161946-854560 systemd[1]: Started Session c5 of User test.
Aug 16 20:30:39 aug161946-854560 runuser[21699]: pam_unix(runuser-l:session): session opened for user test(uid=12345) by (uid=0)
Aug 16 20:30:39 aug161946-854560 runuser[21699]: pam_systemd(runuser-l:session): New sd-bus connection (system-bus-pam-systemd-21699) opened.
Aug 16 20:30:39 aug161946-854560 runuser[21699]: pam_unix(runuser-l:session): session closed for user test
Aug 16 20:30:39 aug161946-854560 systemd-logind[764]: Session c5 logged out. Waiting for processes to exit.
Aug 16 20:30:39 aug161946-854560 systemd[1]: tests.session-67c2a14e-1ac3-4349-a309-dc262d29c7e8.service: Main process exited, code=exited, status=1/FAILURE
Aug 16 20:30:39 aug161946-854560 systemd[1]: tests.session-67c2a14e-1ac3-4349-a309-dc262d29c7e8.service: Failed with result 'exit-code'.
Aug 16 20:30:39 aug161946-854560 systemd[1]: session-c5.scope: Deactivated successfully.
Aug 16 20:30:39 aug161946-854560 systemd-logind[764]: Removed session c5.
Aug 16 20:30:42 aug161946-854560 test-snapd-user-service.test-snapd-user-service[21026]: running
```

This PR proposes a potential fix by setting the `--machine=test@.host` parameter, which should create a user login session. See man(1) systemctl.