### PR TITLE
seed, o/devicestate: allow picking which optional snaps and components to copy when using seed.Copier

### DIFF
--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -162,7 +162,7 @@ type finishStepOpts struct {
 	hasPartial     bool
 }
 
-func (s *deviceMgrInstallAPISuite) mockSystemSeedWithLabel(c *C, label string, isClassic, hasPartial bool, seedCopyFn func(string, timings.Measurer, seed.CopyOptions) error) (gadgetSnapPath, kernelSnapPath string, ginfo *gadget.Info, mountCmd *testutil.MockCmd) {
+func (s *deviceMgrInstallAPISuite) mockSystemSeedWithLabel(c *C, label string, isClassic, hasPartial bool, seedCopyFn func(string, seed.CopyOptions, timings.Measurer) error) (gadgetSnapPath, kernelSnapPath string, ginfo *gadget.Info, mountCmd *testutil.MockCmd) {
 	// Mock partitioned disk
 	gadgetYaml := gadgettest.SingleVolumeUC20GadgetYaml
 	if isClassic {
@@ -396,11 +396,11 @@ var mockFilledPartialDiskVolume = gadget.OnDiskVolume{
 
 type fakeSeedCopier struct {
 	fakeSeed
-	copyFn func(seedDir string, tm timings.Measurer, opts seed.CopyOptions) error
+	copyFn func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error
 }
 
-func (s *fakeSeedCopier) Copy(seedDir string, tm timings.Measurer, opts seed.CopyOptions) error {
-	return s.copyFn(seedDir, tm, opts)
+func (s *fakeSeedCopier) Copy(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
+	return s.copyFn(seedDir, opts, tm)
 }
 
 // TODO encryption case for the finish step is not tested yet, it needs more mocking
@@ -420,12 +420,12 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 		label = "classic"
 	}
 
-	seedCopyFn := func(seedDir string, tm timings.Measurer, opts seed.CopyOptions) error {
+	seedCopyFn := func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
 		return fmt.Errorf("unexpected copy call")
 	}
 	seedCopyCalled := false
 	if !opts.installClassic {
-		seedCopyFn = func(seedDir string, tm timings.Measurer, opts seed.CopyOptions) error {
+		seedCopyFn = func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
 			c.Check(seedDir, Equals, filepath.Join(dirs.RunDir, "mnt/ubuntu-seed"))
 			c.Check(opts.Label, Equals, label)
 			seedCopyCalled = true
@@ -696,7 +696,7 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 	// Mock label
 	label := "classic"
 	isClassic := true
-	seedCopyFn := func(seedDir string, tm timings.Measurer, opts seed.CopyOptions) error {
+	seedCopyFn := func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
 		return fmt.Errorf("unexpected copy call")
 	}
 	gadgetSnapPath, kernelSnapPath, ginfo, mountCmd := s.mockSystemSeedWithLabel(c, label, isClassic, false, seedCopyFn)

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1069,7 +1069,9 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		}
 
 		logger.Debugf("copying label %q to seed partition", systemAndSnaps.Label)
-		if err := copier.Copy(seedMntDir, systemAndSnaps.Label, perfTimings); err != nil {
+		if err := copier.Copy(seedMntDir, perfTimings, seed.CopyOptions{
+			Label: systemAndSnaps.Label,
+		}); err != nil {
 			return fmt.Errorf("cannot copy seed: %w", err)
 		}
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1069,9 +1069,9 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		}
 
 		logger.Debugf("copying label %q to seed partition", systemAndSnaps.Label)
-		if err := copier.Copy(seedMntDir, perfTimings, seed.CopyOptions{
+		if err := copier.Copy(seedMntDir, seed.CopyOptions{
 			Label: systemAndSnaps.Label,
-		}); err != nil {
+		}, perfTimings); err != nil {
 			return fmt.Errorf("cannot copy seed: %w", err)
 		}
 	}

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -213,8 +213,8 @@ type PreseedCapable interface {
 // CopyOptions is the set of options that can be passed to a Copier's Copy
 // method.
 type CopyOptions struct {
-	// Label is the label of the recovery system to be copied. If empty, the
-	// label of the seed that implements Copier is used.
+	// Label is the label that will be used for the new seed produced by the
+	// copy. If empty, the label of the seed that implements Copier is used.
 	Label string
 	// OptionalContainers is the set of optional containers that should be
 	// copied to the new seed. If nil, all optional containers are copied.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -210,18 +210,39 @@ type PreseedCapable interface {
 	LoadPreseedAssertion() (*asserts.Preseed, error)
 }
 
+// CopyOptions is the set of options that can be passed to a Copier's Copy
+// method.
+type CopyOptions struct {
+	// Label is the label of the recovery system to be copied. If empty, the
+	// label of the seed that implements Copier is used.
+	Label string
+	// OptionalContainers is the set of optional containers that should be
+	// copied to the new seed. If nil, all optional containers are copied.
+	OptionalContainers *OptionalContainers
+}
+
+// OptionalContainers contains information about which optional containers
+// should be copied to a new seed.
+type OptionalContainers struct {
+	// Snaps is a set of names of optional snaps that should be copied to the
+	// new seed.
+	Snaps []string
+	// Components is a mapping of snap names to optional component names that
+	// should be copied to the new seed.
+	Components map[string][]string
+}
+
 // Copier can be implemented by a seed that supports copying itself to a given
 // destination.
 type Copier interface {
 	Seed
-	// Copy copies the seed to the given seedDir with the label provided. If
-	// label is empty, then the label of the seed that implements Copier is
-	// used. This interface only makes sense to implement for UC20+ seeds. Copy
-	// requires you to call the LoadAssertions method first. Note that LoadMeta
-	// for all modes will be called by Copy. If LoadMeta was called previously
-	// on this Seed with a different mode, then that metadata will be
-	// overwritten by the metadata for all modes.
-	Copy(seedDir string, label string, tm timings.Measurer) error
+	// Copy copies the seed to the given seedDir. This interface only makes
+	// sense to implement for UC20+ seeds. Copy requires you to call the
+	// LoadAssertions method first. Note that LoadMeta for all modes will be
+	// called by Copy. If LoadMeta was called previously on this Seed with a
+	// different mode, then that metadata will be overwritten by the metadata
+	// for all modes.
+	Copy(seedDir string, tm timings.Measurer, opts CopyOptions) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -242,7 +242,7 @@ type Copier interface {
 	// called by Copy. If LoadMeta was called previously on this Seed with a
 	// different mode, then that metadata will be overwritten by the metadata
 	// for all modes.
-	Copy(seedDir string, tm timings.Measurer, opts CopyOptions) error
+	Copy(seedDir string, opts CopyOptions, tm timings.Measurer) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -236,7 +236,7 @@ type OptionalContainers struct {
 // destination.
 type Copier interface {
 	Seed
-	// Copy copies the seed to the given seedDir. This interface only makes
+	// Copy copies the seed under the given seedDir. This interface only makes
 	// sense to implement for UC20+ seeds. Copy requires you to call the
 	// LoadAssertions method first. Note that LoadMeta for all modes will be
 	// called by Copy. If LoadMeta was called previously on this Seed with a

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -257,12 +257,15 @@ func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (er
 	if err := writeAssertions(filepath.Join(destSystemDir, "assertions", "snaps"), assertions); err != nil {
 		return err
 	}
-	if err := osutil.CopyFile(
-		filepath.Join(srcSystemDir, "assertions", "model-etc"),
-		filepath.Join(destSystemDir, "assertions", "model-etc"),
-		osutil.CopyFlagDefault,
-	); err != nil {
-		return err
+
+	for _, name := range []string{"assertions/model-etc", "grubenv"} {
+		if err := osutil.CopyFile(
+			filepath.Join(srcSystemDir, name),
+			filepath.Join(destSystemDir, name),
+			osutil.CopyFlagDefault,
+		); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -249,7 +249,9 @@ func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (er
 		return err
 	}
 
-	// copy the assertions that the seed needs
+	// copy the assertions that the seed needs. since we don't make any
+	// distinction between the assertions in "extra-snaps" and "snaps" files, we
+	// just write them all to the same "snaps" file.
 	if err := writeAssertions(filepath.Join(destSystemDir, "assertions", "snaps"), assertions); err != nil {
 		return err
 	}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -289,7 +289,7 @@ func componentInModel(cref naming.ComponentRef, modelSnaps map[string]*asserts.M
 }
 
 func (s *seed20) copySnapAndComponents(sn *Snap, destSeedDir string, opts CopyOptions) ([]asserts.Assertion, *internal.Snap20, error) {
-	destination := func(asserted, inModel bool, filename string) string {
+	destination := func(filename string, asserted, inModel bool) string {
 		if asserted && inModel {
 			return filepath.Join(destSeedDir, "snaps", filename)
 		}
@@ -315,7 +315,7 @@ func (s *seed20) copySnapAndComponents(sn *Snap, destSeedDir string, opts CopyOp
 
 	snapInModel := snapInModel(sn, s.modelSnaps)
 
-	snapDest := destination(snapAsserted, snapInModel, filepath.Base(sn.Path))
+	snapDest := destination(filepath.Base(sn.Path), snapAsserted, snapInModel)
 	if err := osutil.CopyFile(sn.Path, snapDest, osutil.CopyFlagOverwrite); err != nil {
 		return nil, nil, fmt.Errorf("cannot copy snap: %w", err)
 	}
@@ -367,7 +367,7 @@ func (s *seed20) copySnapAndComponents(sn *Snap, destSeedDir string, opts CopyOp
 		}
 
 		compInModel := componentInModel(comp.CompSideInfo.Component, s.modelSnaps)
-		destCompPath := destination(snapAsserted, compInModel, filepath.Base(comp.Path))
+		destCompPath := destination(filepath.Base(comp.Path), snapAsserted, compInModel)
 		if err := osutil.CopyFile(comp.Path, destCompPath, osutil.CopyFlagOverwrite); err != nil {
 			return nil, nil, fmt.Errorf("cannot copy component: %w", err)
 		}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -220,6 +220,7 @@ func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (er
 			continue
 		}
 
+		// note that assertions should always be present if we have a snap ID
 		if a, ok := s.snapDeclsByID[sn.ID()]; ok {
 			snapAssertions = append(snapAssertions, a)
 		}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -252,7 +252,7 @@ func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (er
 		}
 
 		if err := osutil.CopyFile(sn.Path, destSnapPath, osutil.CopyFlagOverwrite); err != nil {
-			return fmt.Errorf("cannot copy asserted snap: %w", err)
+			return fmt.Errorf("cannot copy snap: %w", err)
 		}
 
 		for _, comp := range sn.Components {
@@ -276,7 +276,7 @@ func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (er
 			}
 
 			if err := osutil.CopyFile(comp.Path, destCompPath, osutil.CopyFlagOverwrite); err != nil {
-				return fmt.Errorf("cannot copy asserted component: %w", err)
+				return fmt.Errorf("cannot copy component: %w", err)
 			}
 		}
 	}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -139,7 +139,7 @@ func shouldCopyComponent(target Component, snapName string, model *asserts.Model
 }
 
 // Copy implements the Copier interface.
-func (s *seed20) Copy(seedDir string, tm timings.Measurer, opts CopyOptions) (err error) {
+func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (err error) {
 	srcSystemDir, err := filepath.Abs(s.systemDir)
 	if err != nil {
 		return err

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -192,12 +192,15 @@ func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (er
 		}
 	}
 
-	if err := osutil.CopyFile(
-		filepath.Join(srcSystemDir, "model"),
-		filepath.Join(destSystemDir, "model"),
-		osutil.CopyFlagDefault,
-	); err != nil {
-		return err
+	// these files are the files we can safely copy without an modifications
+	for _, name := range []string{"assertions/model-etc", "grubenv", "model"} {
+		if err := osutil.CopyFile(
+			filepath.Join(srcSystemDir, name),
+			filepath.Join(destSystemDir, name),
+			osutil.CopyFlagDefault,
+		); err != nil {
+			return err
+		}
 	}
 
 	destAssertedSnapDir := filepath.Join(destSeedDir, "snaps")
@@ -255,16 +258,6 @@ func (s *seed20) Copy(seedDir string, opts CopyOptions, tm timings.Measurer) (er
 	// just write them all to the same "snaps" file.
 	if err := resolveAndSaveAssertions(assertions, s.db, filepath.Join(destSystemDir, "assertions", "snaps")); err != nil {
 		return err
-	}
-
-	for _, name := range []string{"assertions/model-etc", "grubenv"} {
-		if err := osutil.CopyFile(
-			filepath.Join(srcSystemDir, name),
-			filepath.Join(destSystemDir, name),
-			osutil.CopyFlagDefault,
-		); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -128,8 +128,7 @@ func shouldCopyComponent(target Component, snapName string, model *asserts.Model
 	var componentInModel bool
 	modelSnap, ok := modelSnaps[snapName]
 	if ok {
-		modelComp, ok := modelSnap.Components[target.CompSideInfo.Component.ComponentName]
-		if ok {
+		if modelComp, ok := modelSnap.Components[target.CompSideInfo.Component.ComponentName]; ok {
 			componentInModel = true
 			if modelComp.Presence == "required" {
 				return true

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3505,164 +3505,202 @@ func (s *seed20Suite) TestPreseedCapableSeedAlternateAuthority(c *C) {
 }
 
 func (s *seed20Suite) TestCopy(c *C) {
-	s.testCopy(c, seed.CopyOptions{Label: "20240126"}, []string{
-		"core20_1.snap",
-		"pc_1.snap",
-		"pc-kernel_1.snap",
-		"snapd_1.snap",
-		"component-test+comp1_22.comp",
-		"component-test+comp2_33.comp",
-		"component-test_11.snap",
-		"optional20-a_1.snap",
-		"required20_1.snap",
-		"aux-info-test_1.snap",
-	}, []string{
-		"optional20-b_1.0.snap",
-		"local-component-test_1.0.snap",
-		"local-component-test+comp4_1.0.comp",
-		"component-test+comp3_44.comp",
-	}, map[string][]string{
-		s.AssertedSnapID("core20"):         nil,
-		s.AssertedSnapID("pc"):             nil,
-		s.AssertedSnapID("pc-kernel"):      nil,
-		s.AssertedSnapID("snapd"):          nil,
-		s.AssertedSnapID("optional20-a"):   nil,
-		s.AssertedSnapID("required20"):     nil,
-		s.AssertedSnapID("aux-info-test"):  nil,
-		s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
+	s.testCopy(c, testCopyOpts{
+		copyOpts: seed.CopyOptions{
+			Label: "20240126",
+		},
+		expectedAssertedContainers: []string{
+			"core20_1.snap",
+			"pc_1.snap",
+			"pc-kernel_1.snap",
+			"snapd_1.snap",
+			"component-test+comp1_22.comp",
+			"component-test+comp2_33.comp",
+			"component-test_11.snap",
+			"optional20-a_1.snap",
+			"required20_1.snap",
+			"aux-info-test_1.snap",
+		},
+		expectedUnassertedContainers: []string{
+			"optional20-b_1.0.snap",
+			"local-component-test_1.0.snap",
+			"local-component-test+comp4_1.0.comp",
+			"component-test+comp3_44.comp",
+		},
+		snapIDToComps: map[string][]string{
+			s.AssertedSnapID("core20"):         nil,
+			s.AssertedSnapID("pc"):             nil,
+			s.AssertedSnapID("pc-kernel"):      nil,
+			s.AssertedSnapID("snapd"):          nil,
+			s.AssertedSnapID("optional20-a"):   nil,
+			s.AssertedSnapID("required20"):     nil,
+			s.AssertedSnapID("aux-info-test"):  nil,
+			s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
+		},
+		expectOptionsYaml: true,
 	})
 }
 
 func (s *seed20Suite) TestCopyEmptyLabel(c *C) {
-	s.testCopy(c, seed.CopyOptions{}, []string{
-		"core20_1.snap",
-		"pc_1.snap",
-		"pc-kernel_1.snap",
-		"snapd_1.snap",
-		"component-test+comp1_22.comp",
-		"component-test+comp2_33.comp",
-		"component-test_11.snap",
-		"optional20-a_1.snap",
-		"required20_1.snap",
-		"aux-info-test_1.snap",
-	}, []string{
-		"optional20-b_1.0.snap",
-		"local-component-test_1.0.snap",
-		"local-component-test+comp4_1.0.comp",
-		"component-test+comp3_44.comp",
-	}, map[string][]string{
-		s.AssertedSnapID("core20"):         nil,
-		s.AssertedSnapID("pc"):             nil,
-		s.AssertedSnapID("pc-kernel"):      nil,
-		s.AssertedSnapID("snapd"):          nil,
-		s.AssertedSnapID("optional20-a"):   nil,
-		s.AssertedSnapID("required20"):     nil,
-		s.AssertedSnapID("aux-info-test"):  nil,
-		s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
+	s.testCopy(c, testCopyOpts{
+		copyOpts: seed.CopyOptions{},
+		expectedAssertedContainers: []string{
+			"core20_1.snap",
+			"pc_1.snap",
+			"pc-kernel_1.snap",
+			"snapd_1.snap",
+			"component-test+comp1_22.comp",
+			"component-test+comp2_33.comp",
+			"component-test_11.snap",
+			"optional20-a_1.snap",
+			"required20_1.snap",
+			"aux-info-test_1.snap",
+		},
+		expectedUnassertedContainers: []string{
+			"optional20-b_1.0.snap",
+			"local-component-test_1.0.snap",
+			"local-component-test+comp4_1.0.comp",
+			"component-test+comp3_44.comp",
+		},
+		snapIDToComps: map[string][]string{
+			s.AssertedSnapID("core20"):         nil,
+			s.AssertedSnapID("pc"):             nil,
+			s.AssertedSnapID("pc-kernel"):      nil,
+			s.AssertedSnapID("snapd"):          nil,
+			s.AssertedSnapID("optional20-a"):   nil,
+			s.AssertedSnapID("required20"):     nil,
+			s.AssertedSnapID("aux-info-test"):  nil,
+			s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
+		},
+		expectOptionsYaml: true,
 	})
 }
 
 func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
-	s.testCopy(c, seed.CopyOptions{
-		Label: "20240126",
-		OptionalContainers: &seed.OptionalContainers{
-			Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test", "local-component-test"},
-			Components: map[string][]string{
-				"component-test":       {"comp2", "comp3"},
-				"local-component-test": {"comp4"},
+	s.testCopy(c, testCopyOpts{
+		copyOpts: seed.CopyOptions{
+			Label: "20240126",
+			OptionalContainers: &seed.OptionalContainers{
+				Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test", "local-component-test"},
+				Components: map[string][]string{
+					"component-test":       {"comp2", "comp3"},
+					"local-component-test": {"comp4"},
+				},
 			},
 		},
-	}, []string{
-		"core20_1.snap",
-		"pc_1.snap",
-		"pc-kernel_1.snap",
-		"snapd_1.snap",
-		"component-test+comp1_22.comp",
-		"component-test+comp2_33.comp",
-		"component-test_11.snap",
-		"optional20-a_1.snap",
-		"required20_1.snap",
-		"aux-info-test_1.snap",
-	}, []string{
-		"optional20-b_1.0.snap",
-		"local-component-test_1.0.snap",
-		"local-component-test+comp4_1.0.comp",
-		"component-test+comp3_44.comp",
-	}, map[string][]string{
-		s.AssertedSnapID("core20"):         nil,
-		s.AssertedSnapID("pc"):             nil,
-		s.AssertedSnapID("pc-kernel"):      nil,
-		s.AssertedSnapID("snapd"):          nil,
-		s.AssertedSnapID("optional20-a"):   nil,
-		s.AssertedSnapID("required20"):     nil,
-		s.AssertedSnapID("aux-info-test"):  nil,
-		s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
+		expectedAssertedContainers: []string{
+			"core20_1.snap",
+			"pc_1.snap",
+			"pc-kernel_1.snap",
+			"snapd_1.snap",
+			"component-test+comp1_22.comp",
+			"component-test+comp2_33.comp",
+			"component-test_11.snap",
+			"optional20-a_1.snap",
+			"required20_1.snap",
+			"aux-info-test_1.snap",
+		},
+		expectedUnassertedContainers: []string{
+			"optional20-b_1.0.snap",
+			"local-component-test_1.0.snap",
+			"local-component-test+comp4_1.0.comp",
+			"component-test+comp3_44.comp",
+		},
+		snapIDToComps: map[string][]string{
+			s.AssertedSnapID("core20"):         nil,
+			s.AssertedSnapID("pc"):             nil,
+			s.AssertedSnapID("pc-kernel"):      nil,
+			s.AssertedSnapID("snapd"):          nil,
+			s.AssertedSnapID("optional20-a"):   nil,
+			s.AssertedSnapID("required20"):     nil,
+			s.AssertedSnapID("aux-info-test"):  nil,
+			s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
+		},
+		expectOptionsYaml: true,
 	})
 }
 
 func (s *seed20Suite) TestCopyWithOptionalContainersExclude(c *C) {
-	s.testCopy(c, seed.CopyOptions{
-		Label: "20240126",
-		OptionalContainers: &seed.OptionalContainers{
-			Snaps: []string{"component-test"},
-		},
-	}, []string{
-		"core20_1.snap",
-		"pc_1.snap",
-		"pc-kernel_1.snap",
-		"snapd_1.snap",
-		"component-test+comp1_22.comp",
-		"component-test_11.snap",
-		"required20_1.snap",
-	}, nil, map[string][]string{
-		// note that optional20-a, aux-info-test and component-test+comp2
-		// assertions are not copied over
-		s.AssertedSnapID("core20"):         nil,
-		s.AssertedSnapID("pc"):             nil,
-		s.AssertedSnapID("pc-kernel"):      nil,
-		s.AssertedSnapID("snapd"):          nil,
-		s.AssertedSnapID("component-test"): {"comp1"},
-		s.AssertedSnapID("required20"):     nil,
-	})
-}
-
-func (s *seed20Suite) TestCopyWithOptionalContainersExcludeSomeComponent(c *C) {
-	s.testCopy(c, seed.CopyOptions{
-		Label: "20240126",
-		OptionalContainers: &seed.OptionalContainers{
-			Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test", "local-component-test"},
-			Components: map[string][]string{
-				"component-test":       {"comp2"},
-				"local-component-test": nil,
+	s.testCopy(c, testCopyOpts{
+		copyOpts: seed.CopyOptions{
+			Label: "20240126",
+			OptionalContainers: &seed.OptionalContainers{
+				Snaps: []string{"component-test"},
 			},
 		},
-	}, []string{
-		"core20_1.snap",
-		"pc_1.snap",
-		"pc-kernel_1.snap",
-		"snapd_1.snap",
-		"component-test+comp1_22.comp",
-		"component-test+comp2_33.comp",
-		"component-test_11.snap",
-		"optional20-a_1.snap",
-		"required20_1.snap",
-		"aux-info-test_1.snap",
-	}, []string{
-		"optional20-b_1.0.snap",
-		"local-component-test_1.0.snap",
-	}, map[string][]string{
-		s.AssertedSnapID("core20"):         nil,
-		s.AssertedSnapID("pc"):             nil,
-		s.AssertedSnapID("pc-kernel"):      nil,
-		s.AssertedSnapID("snapd"):          nil,
-		s.AssertedSnapID("optional20-a"):   nil,
-		s.AssertedSnapID("required20"):     nil,
-		s.AssertedSnapID("aux-info-test"):  nil,
-		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
+		expectedAssertedContainers: []string{
+			"core20_1.snap",
+			"pc_1.snap",
+			"pc-kernel_1.snap",
+			"snapd_1.snap",
+			"component-test+comp1_22.comp",
+			"component-test_11.snap",
+			"required20_1.snap",
+		},
+		expectedUnassertedContainers: nil,
+		snapIDToComps: map[string][]string{
+			s.AssertedSnapID("core20"):         nil,
+			s.AssertedSnapID("pc"):             nil,
+			s.AssertedSnapID("pc-kernel"):      nil,
+			s.AssertedSnapID("snapd"):          nil,
+			s.AssertedSnapID("component-test"): {"comp1"},
+			s.AssertedSnapID("required20"):     nil,
+		},
+		expectOptionsYaml: false,
 	})
 }
 
-func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedContainers, expectedUnassertedContainers []string, snapIDToComps map[string][]string) {
+func (s *seed20Suite) TestCopyWithOptionalContainersExcludeSomeComponents(c *C) {
+	s.testCopy(c, testCopyOpts{
+		copyOpts: seed.CopyOptions{
+			Label: "20240126",
+			OptionalContainers: &seed.OptionalContainers{
+				Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test", "local-component-test"},
+				Components: map[string][]string{
+					"component-test":       {"comp2"},
+					"local-component-test": nil,
+				},
+			},
+		},
+		expectedAssertedContainers: []string{
+			"core20_1.snap",
+			"pc_1.snap",
+			"pc-kernel_1.snap",
+			"snapd_1.snap",
+			"component-test+comp1_22.comp",
+			"component-test+comp2_33.comp",
+			"component-test_11.snap",
+			"optional20-a_1.snap",
+			"required20_1.snap",
+			"aux-info-test_1.snap",
+		},
+		expectedUnassertedContainers: []string{
+			"optional20-b_1.0.snap",
+			"local-component-test_1.0.snap",
+		},
+		snapIDToComps: map[string][]string{
+			s.AssertedSnapID("core20"):         nil,
+			s.AssertedSnapID("pc"):             nil,
+			s.AssertedSnapID("pc-kernel"):      nil,
+			s.AssertedSnapID("snapd"):          nil,
+			s.AssertedSnapID("optional20-a"):   nil,
+			s.AssertedSnapID("required20"):     nil,
+			s.AssertedSnapID("aux-info-test"):  nil,
+			s.AssertedSnapID("component-test"): {"comp1", "comp2"},
+		},
+		expectOptionsYaml: true,
+	})
+}
+
+type testCopyOpts struct {
+	copyOpts                     seed.CopyOptions
+	expectedAssertedContainers   []string
+	expectedUnassertedContainers []string
+	snapIDToComps                map[string][]string
+	expectOptionsYaml            bool
+}
+
+func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
 	s.makeSnap(c, "optional20-a", "")
@@ -3766,24 +3804,23 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 
 	destSeedDir := c.MkDir()
 
-	err = copier.Copy(destSeedDir, opts, s.perfTimings)
+	err = copier.Copy(destSeedDir, opts.copyOpts, s.perfTimings)
 	c.Assert(err, IsNil)
 
-	checkDirContents(c, filepath.Join(destSeedDir, "snaps"), expectedAssertedContainers)
+	checkDirContents(c, filepath.Join(destSeedDir, "snaps"), opts.expectedAssertedContainers)
 
-	copiedLabel := opts.Label
+	copiedLabel := opts.copyOpts.Label
 	if copiedLabel == "" {
 		copiedLabel = srcLabel
 	}
 
 	destSystemDir := filepath.Join(destSeedDir, "systems", copiedLabel)
 
-	checkDirContents(c, destSystemDir, []string{
-		"assertions",
-		"model",
-		"options.yaml",
-		"snaps",
-	})
+	expectedSystemDirContents := []string{"assertions", "model", "snaps"}
+	if opts.expectOptionsYaml {
+		expectedSystemDirContents = append(expectedSystemDirContents, "options.yaml")
+	}
+	checkDirContents(c, destSystemDir, expectedSystemDirContents)
 
 	checkDirContents(c, filepath.Join(destSystemDir, "assertions"), []string{
 		"model-etc",
@@ -3791,11 +3828,11 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 	})
 
 	expectAuxInfo := false
-	if _, ok := snapIDToComps[s.AssertedSnapID("aux-info-test")]; ok {
+	if _, ok := opts.snapIDToComps[s.AssertedSnapID("aux-info-test")]; ok {
 		expectAuxInfo = true
 	}
 
-	expectedFilesInUnasserted := append([]string(nil), expectedUnassertedContainers...)
+	expectedFilesInUnasserted := append([]string(nil), opts.expectedUnassertedContainers...)
 	if expectAuxInfo {
 		expectedFilesInUnasserted = append(expectedFilesInUnasserted, "aux-info.json")
 	}
@@ -3803,13 +3840,13 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 
 	srcAssertedSnapsDir := filepath.Join(s.SeedDir, "snaps")
 	destAssertedSnapsDir := filepath.Join(destSeedDir, "snaps")
-	for _, cont := range expectedAssertedContainers {
+	for _, cont := range opts.expectedAssertedContainers {
 		c.Check(filepath.Join(destAssertedSnapsDir, cont), testutil.FileEquals, testutil.FileContentRef(filepath.Join(srcAssertedSnapsDir, cont)))
 	}
 
 	srcUnassertedSnapsDir := filepath.Join(s.SeedDir, "systems", srcLabel, "snaps")
 	destUnassertedSnapsDir := filepath.Join(destSystemDir, "snaps")
-	for _, cont := range expectedUnassertedContainers {
+	for _, cont := range opts.expectedUnassertedContainers {
 		c.Check(
 			filepath.Join(destUnassertedSnapsDir, cont),
 			testutil.FileEquals,
@@ -3817,7 +3854,7 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 		)
 	}
 
-	ensureAssertionsPresent(c, filepath.Join(destSystemDir, "assertions", "snaps"), snapIDToComps)
+	ensureAssertionsPresent(c, filepath.Join(destSystemDir, "assertions", "snaps"), opts.snapIDToComps)
 
 	if expectAuxInfo {
 		var auxInfo map[string]*internal.AuxInfo20
@@ -3842,6 +3879,32 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 		Label: copiedLabel,
 	}, s.perfTimings)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot create system: system %q already exists at %q`, copiedLabel, destSystemDir))
+
+	seed20, err = seed.Open(destSeedDir, copiedLabel)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadAssertions(s.db, s.commitTo)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadMeta(seed.AllModes, nil, s.perfTimings)
+	c.Assert(err, IsNil)
+
+	foundContainers := make([]string, 0)
+	err = seed20.Iter(func(sn *seed.Snap) error {
+		foundContainers = append(foundContainers, filepath.Base(sn.Path))
+		for _, comp := range sn.Components {
+			foundContainers = append(foundContainers, filepath.Base(comp.Path))
+		}
+		return nil
+	})
+	c.Assert(err, IsNil)
+
+	allExpectedContainers := append(append([]string(nil), opts.expectedAssertedContainers...), opts.expectedUnassertedContainers...)
+
+	sort.Strings(foundContainers)
+	sort.Strings(allExpectedContainers)
+
+	c.Check(foundContainers, DeepEquals, allExpectedContainers)
 }
 
 func ensureAssertionsPresent(c *C, path string, snapIDToComps map[string][]string) {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3521,7 +3521,7 @@ func (s *seed20Suite) TestCopy(c *C) {
 			"required20_1.snap",
 			"aux-info-test_1.snap",
 		},
-		expectedUnassertedContainers: []string{
+		expectedSystemLocalContainers: []string{
 			"optional20-b_1.0.snap",
 			"local-component-test_1.0.snap",
 			"local-component-test+comp4_1.0.comp",
@@ -3556,7 +3556,7 @@ func (s *seed20Suite) TestCopyEmptyLabel(c *C) {
 			"required20_1.snap",
 			"aux-info-test_1.snap",
 		},
-		expectedUnassertedContainers: []string{
+		expectedSystemLocalContainers: []string{
 			"optional20-b_1.0.snap",
 			"local-component-test_1.0.snap",
 			"local-component-test+comp4_1.0.comp",
@@ -3600,7 +3600,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 			"required20_1.snap",
 			"aux-info-test_1.snap",
 		},
-		expectedUnassertedContainers: []string{
+		expectedSystemLocalContainers: []string{
 			"optional20-b_1.0.snap",
 			"local-component-test_1.0.snap",
 			"local-component-test+comp4_1.0.comp",
@@ -3637,7 +3637,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersExclude(c *C) {
 			"component-test_11.snap",
 			"required20_1.snap",
 		},
-		expectedUnassertedContainers: nil,
+		expectedSystemLocalContainers: nil,
 		snapIDToComps: map[string][]string{
 			s.AssertedSnapID("core20"):         nil,
 			s.AssertedSnapID("pc"):             nil,
@@ -3674,7 +3674,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersExcludeSomeComponents(c *C) 
 			"required20_1.snap",
 			"aux-info-test_1.snap",
 		},
-		expectedUnassertedContainers: []string{
+		expectedSystemLocalContainers: []string{
 			"optional20-b_1.0.snap",
 			"local-component-test_1.0.snap",
 		},
@@ -3693,11 +3693,11 @@ func (s *seed20Suite) TestCopyWithOptionalContainersExcludeSomeComponents(c *C) 
 }
 
 type testCopyOpts struct {
-	copyOpts                     seed.CopyOptions
-	expectedAssertedContainers   []string
-	expectedUnassertedContainers []string
-	snapIDToComps                map[string][]string
-	expectOptionsYaml            bool
+	copyOpts                      seed.CopyOptions
+	expectedAssertedContainers    []string
+	expectedSystemLocalContainers []string
+	snapIDToComps                 map[string][]string
+	expectOptionsYaml             bool
 }
 
 func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
@@ -3832,11 +3832,11 @@ func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
 		expectAuxInfo = true
 	}
 
-	expectedFilesInUnasserted := append([]string(nil), opts.expectedUnassertedContainers...)
+	expectedFilesInSystemLocalSnapsDir := append([]string(nil), opts.expectedSystemLocalContainers...)
 	if expectAuxInfo {
-		expectedFilesInUnasserted = append(expectedFilesInUnasserted, "aux-info.json")
+		expectedFilesInSystemLocalSnapsDir = append(expectedFilesInSystemLocalSnapsDir, "aux-info.json")
 	}
-	checkDirContents(c, filepath.Join(destSystemDir, "snaps"), expectedFilesInUnasserted)
+	checkDirContents(c, filepath.Join(destSystemDir, "snaps"), expectedFilesInSystemLocalSnapsDir)
 
 	srcAssertedSnapsDir := filepath.Join(s.SeedDir, "snaps")
 	destAssertedSnapsDir := filepath.Join(destSeedDir, "snaps")
@@ -3846,7 +3846,7 @@ func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
 
 	srcUnassertedSnapsDir := filepath.Join(s.SeedDir, "systems", srcLabel, "snaps")
 	destUnassertedSnapsDir := filepath.Join(destSystemDir, "snaps")
-	for _, cont := range opts.expectedUnassertedContainers {
+	for _, cont := range opts.expectedSystemLocalContainers {
 		c.Check(
 			filepath.Join(destUnassertedSnapsDir, cont),
 			testutil.FileEquals,
@@ -3899,7 +3899,7 @@ func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
 	})
 	c.Assert(err, IsNil)
 
-	allExpectedContainers := append(append([]string(nil), opts.expectedAssertedContainers...), opts.expectedUnassertedContainers...)
+	allExpectedContainers := append(append([]string(nil), opts.expectedAssertedContainers...), opts.expectedSystemLocalContainers...)
 
 	sort.Strings(foundContainers)
 	sort.Strings(allExpectedContainers)

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3793,6 +3793,9 @@ func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
 		},
 	})
 
+	err := os.WriteFile(filepath.Join(s.SeedDir, "systems", srcLabel, "grubenv"), []byte("grubenv"), 0644)
+	c.Assert(err, IsNil)
+
 	seed20, err := seed.Open(s.SeedDir, srcLabel)
 	c.Assert(err, IsNil)
 
@@ -3816,7 +3819,7 @@ func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
 
 	destSystemDir := filepath.Join(destSeedDir, "systems", copiedLabel)
 
-	expectedSystemDirContents := []string{"assertions", "model", "snaps"}
+	expectedSystemDirContents := []string{"assertions", "model", "snaps", "grubenv"}
 	if opts.expectOptionsYaml {
 		expectedSystemDirContents = append(expectedSystemDirContents, "options.yaml")
 	}

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3518,6 +3518,8 @@ func (s *seed20Suite) TestCopy(c *C) {
 		"aux-info-test_1.snap",
 	}, []string{
 		"optional20-b_1.0.snap",
+		"local-component-test_1.0.snap",
+		"local-component-test+comp4_1.0.comp",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
@@ -3544,6 +3546,8 @@ func (s *seed20Suite) TestCopyEmptyLabel(c *C) {
 		"aux-info-test_1.snap",
 	}, []string{
 		"optional20-b_1.0.snap",
+		"local-component-test_1.0.snap",
+		"local-component-test+comp4_1.0.comp",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
@@ -3560,9 +3564,10 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 	s.testCopy(c, seed.CopyOptions{
 		Label: "20240126",
 		OptionalContainers: &seed.OptionalContainers{
-			Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test"},
+			Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test", "local-component-test"},
 			Components: map[string][]string{
-				"component-test": {"comp2"},
+				"component-test":       {"comp2"},
+				"local-component-test": {"comp4"},
 			},
 		},
 	}, []string{
@@ -3578,6 +3583,8 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 		"aux-info-test_1.snap",
 	}, []string{
 		"optional20-b_1.0.snap",
+		"local-component-test_1.0.snap",
+		"local-component-test+comp4_1.0.comp",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
@@ -3616,6 +3623,42 @@ func (s *seed20Suite) TestCopyWithOptionalContainersExclude(c *C) {
 	})
 }
 
+func (s *seed20Suite) TestCopyWithOptionalContainersExcludeUnassertedComponent(c *C) {
+	s.testCopy(c, seed.CopyOptions{
+		Label: "20240126",
+		OptionalContainers: &seed.OptionalContainers{
+			Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test", "local-component-test"},
+			Components: map[string][]string{
+				"component-test":       {"comp2"},
+				"local-component-test": nil,
+			},
+		},
+	}, []string{
+		"core20_1.snap",
+		"pc_1.snap",
+		"pc-kernel_1.snap",
+		"snapd_1.snap",
+		"component-test+comp1_22.comp",
+		"component-test+comp2_33.comp",
+		"component-test_11.snap",
+		"optional20-a_1.snap",
+		"required20_1.snap",
+		"aux-info-test_1.snap",
+	}, []string{
+		"optional20-b_1.0.snap",
+		"local-component-test_1.0.snap",
+	}, map[string][]string{
+		s.AssertedSnapID("core20"):         nil,
+		s.AssertedSnapID("pc"):             nil,
+		s.AssertedSnapID("pc-kernel"):      nil,
+		s.AssertedSnapID("snapd"):          nil,
+		s.AssertedSnapID("optional20-a"):   nil,
+		s.AssertedSnapID("required20"):     nil,
+		s.AssertedSnapID("aux-info-test"):  nil,
+		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
+	})
+}
+
 func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedContainers, expectedUnassertedContainers []string, snapIDToComps map[string][]string) {
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
@@ -3636,7 +3679,7 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 	)
 
 	const srcLabel = "20191030"
-	s.MakeSeed(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
@@ -3696,6 +3739,13 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 		},
 		{
 			Name: "aux-info-test",
+		},
+		{
+			Path: s.makeLocalSnap(c, "local-component-test"),
+		},
+	}, map[string][]string{
+		"local-component-test": {
+			snaptest.MakeTestComponent(c, seedtest.SampleSnapYaml["local-component-test+comp4"]),
 		},
 	})
 

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3701,7 +3701,7 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 
 	destSeedDir := c.MkDir()
 
-	err = copier.Copy(destSeedDir, s.perfTimings, opts)
+	err = copier.Copy(destSeedDir, opts, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	checkDirContents(c, filepath.Join(destSeedDir, "snaps"), expectedAssertedContainers)
@@ -3773,9 +3773,9 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 		})
 	}
 
-	err = copier.Copy(destSeedDir, s.perfTimings, seed.CopyOptions{
+	err = copier.Copy(destSeedDir, seed.CopyOptions{
 		Label: copiedLabel,
-	})
+	}, s.perfTimings)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot create system: system %q already exists at %q`, copiedLabel, destSystemDir))
 }
 
@@ -3879,9 +3879,9 @@ func (s *seed20Suite) TestCopyCleanup(c *C) {
 	c.Assert(err, IsNil)
 
 	destSeedDir := c.MkDir()
-	err = copier.Copy(destSeedDir, s.perfTimings, seed.CopyOptions{
+	err = copier.Copy(destSeedDir, seed.CopyOptions{
 		Label: label,
-	})
+	}, s.perfTimings)
 	c.Check(err, ErrorMatches, fmt.Sprintf("cannot stat snap: stat %s: no such file or directory", removedSnap))
 
 	// seed destination should have been cleaned up

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3514,15 +3514,17 @@ func (s *seed20Suite) TestCopy(c *C) {
 		"component-test+comp2_33.comp",
 		"component-test_11.snap",
 		"optional20-a_1.snap",
+		"required20_1.snap",
 		"aux-info-test_1.snap",
 	}, []string{
-		"required20_1.0.snap",
+		"optional20-b_1.0.snap",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
 		s.AssertedSnapID("pc-kernel"):      nil,
 		s.AssertedSnapID("snapd"):          nil,
 		s.AssertedSnapID("optional20-a"):   nil,
+		s.AssertedSnapID("required20"):     nil,
 		s.AssertedSnapID("aux-info-test"):  nil,
 		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
 	})
@@ -3538,15 +3540,17 @@ func (s *seed20Suite) TestCopyEmptyLabel(c *C) {
 		"component-test+comp2_33.comp",
 		"component-test_11.snap",
 		"optional20-a_1.snap",
+		"required20_1.snap",
 		"aux-info-test_1.snap",
 	}, []string{
-		"required20_1.0.snap",
+		"optional20-b_1.0.snap",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
 		s.AssertedSnapID("pc-kernel"):      nil,
 		s.AssertedSnapID("snapd"):          nil,
 		s.AssertedSnapID("optional20-a"):   nil,
+		s.AssertedSnapID("required20"):     nil,
 		s.AssertedSnapID("aux-info-test"):  nil,
 		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
 	})
@@ -3556,7 +3560,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 	s.testCopy(c, seed.CopyOptions{
 		Label: "20240126",
 		OptionalContainers: &seed.OptionalContainers{
-			Snaps: []string{"component-test", "required20", "optional20-a", "aux-info-test"},
+			Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test"},
 			Components: map[string][]string{
 				"component-test": {"comp2"},
 			},
@@ -3570,15 +3574,17 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 		"component-test+comp2_33.comp",
 		"component-test_11.snap",
 		"optional20-a_1.snap",
+		"required20_1.snap",
 		"aux-info-test_1.snap",
 	}, []string{
-		"required20_1.0.snap",
+		"optional20-b_1.0.snap",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
 		s.AssertedSnapID("pc-kernel"):      nil,
 		s.AssertedSnapID("snapd"):          nil,
 		s.AssertedSnapID("optional20-a"):   nil,
+		s.AssertedSnapID("required20"):     nil,
 		s.AssertedSnapID("aux-info-test"):  nil,
 		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
 	})
@@ -3597,6 +3603,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersExclude(c *C) {
 		"snapd_1.snap",
 		"component-test+comp1_22.comp",
 		"component-test_11.snap",
+		"required20_1.snap",
 	}, nil, map[string][]string{
 		// note that optional20-a, aux-info-test and component-test+comp2
 		// assertions are not copied over
@@ -3605,6 +3612,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersExclude(c *C) {
 		s.AssertedSnapID("pc-kernel"):      nil,
 		s.AssertedSnapID("snapd"):          nil,
 		s.AssertedSnapID("component-test"): {"comp1"},
+		s.AssertedSnapID("required20"):     nil,
 	})
 }
 
@@ -3612,6 +3620,7 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
 	s.makeSnap(c, "optional20-a", "")
+	s.makeSnap(c, "required20", "")
 	s.makeSnap(c, "aux-info-test", "")
 	s.makeSnap(c, "pc-kernel=20", "")
 	s.makeSnap(c, "pc=20", "")
@@ -3651,9 +3660,9 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 				"presence": "optional",
 			},
 			map[string]interface{}{
-				"name":     "optional20-b",
-				"id":       s.AssertedSnapID("optional20-b"),
-				"presence": "optional",
+				"name":     "required20",
+				"id":       s.AssertedSnapID("required20"),
+				"presence": "required",
 			},
 			map[string]interface{}{
 				"name":     "aux-info-test",
@@ -3672,7 +3681,7 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 		},
 	}, []*seedwriter.OptionsSnap{
 		{
-			Path: s.makeLocalSnap(c, "required20"),
+			Path: s.makeLocalSnap(c, "optional20-b"),
 		},
 		{
 			Name: "component-test",

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3520,6 +3520,7 @@ func (s *seed20Suite) TestCopy(c *C) {
 		"optional20-b_1.0.snap",
 		"local-component-test_1.0.snap",
 		"local-component-test+comp4_1.0.comp",
+		"component-test+comp3_44.comp",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
@@ -3528,7 +3529,7 @@ func (s *seed20Suite) TestCopy(c *C) {
 		s.AssertedSnapID("optional20-a"):   nil,
 		s.AssertedSnapID("required20"):     nil,
 		s.AssertedSnapID("aux-info-test"):  nil,
-		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
+		s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
 	})
 }
 
@@ -3548,6 +3549,7 @@ func (s *seed20Suite) TestCopyEmptyLabel(c *C) {
 		"optional20-b_1.0.snap",
 		"local-component-test_1.0.snap",
 		"local-component-test+comp4_1.0.comp",
+		"component-test+comp3_44.comp",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
@@ -3556,7 +3558,7 @@ func (s *seed20Suite) TestCopyEmptyLabel(c *C) {
 		s.AssertedSnapID("optional20-a"):   nil,
 		s.AssertedSnapID("required20"):     nil,
 		s.AssertedSnapID("aux-info-test"):  nil,
-		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
+		s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
 	})
 }
 
@@ -3566,7 +3568,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 		OptionalContainers: &seed.OptionalContainers{
 			Snaps: []string{"component-test", "optional20-a", "optional20-b", "aux-info-test", "local-component-test"},
 			Components: map[string][]string{
-				"component-test":       {"comp2"},
+				"component-test":       {"comp2", "comp3"},
 				"local-component-test": {"comp4"},
 			},
 		},
@@ -3585,6 +3587,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 		"optional20-b_1.0.snap",
 		"local-component-test_1.0.snap",
 		"local-component-test+comp4_1.0.comp",
+		"component-test+comp3_44.comp",
 	}, map[string][]string{
 		s.AssertedSnapID("core20"):         nil,
 		s.AssertedSnapID("pc"):             nil,
@@ -3593,7 +3596,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersIncludeEverything(c *C) {
 		s.AssertedSnapID("optional20-a"):   nil,
 		s.AssertedSnapID("required20"):     nil,
 		s.AssertedSnapID("aux-info-test"):  nil,
-		s.AssertedSnapID("component-test"): {"comp1", "comp2"},
+		s.AssertedSnapID("component-test"): {"comp1", "comp2", "comp3"},
 	})
 }
 
@@ -3623,7 +3626,7 @@ func (s *seed20Suite) TestCopyWithOptionalContainersExclude(c *C) {
 	})
 }
 
-func (s *seed20Suite) TestCopyWithOptionalContainersExcludeUnassertedComponent(c *C) {
+func (s *seed20Suite) TestCopyWithOptionalContainersExcludeSomeComponent(c *C) {
 	s.testCopy(c, seed.CopyOptions{
 		Label: "20240126",
 		OptionalContainers: &seed.OptionalContainers{
@@ -3731,6 +3734,9 @@ func (s *seed20Suite) testCopy(c *C, opts seed.CopyOptions, expectedAssertedCont
 			Components: []seedwriter.OptionsComponent{
 				{
 					Name: "comp2",
+				},
+				{
+					Name: "comp3",
 				},
 			},
 		},

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3920,6 +3920,8 @@ func ensureAssertionsPresent(c *C, path string, snapIDToComps map[string][]strin
 	resourcePairs := make(map[string]*asserts.SnapResourcePair)
 	resourceRevs := make(map[string]*asserts.SnapResourceRevision)
 
+	foundAccountKey := false
+
 	dec := asserts.NewDecoder(f)
 	for {
 		a, err := dec.Decode()
@@ -3937,10 +3939,14 @@ func ensureAssertionsPresent(c *C, path string, snapIDToComps map[string][]strin
 			resourcePairs[fmt.Sprintf("%s+%s", a.SnapID(), a.ResourceName())] = a
 		case *asserts.SnapResourceRevision:
 			resourceRevs[fmt.Sprintf("%s+%s", a.SnapID(), a.ResourceName())] = a
+		case *asserts.AccountKey:
+			foundAccountKey = true
 		default:
 			c.Fatalf("unexpected assertion type: %T", a)
 		}
 	}
+
+	c.Check(foundAccountKey, Equals, true, Commentf("no account key found seed's assertions"))
 
 	var compCount int
 	for snap, comps := range snapIDToComps {

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -143,6 +143,18 @@ version: 2.0
 type: test
 version: 2.0
 `,
+	"local-component-test": `name: local-component-test
+type: app
+base: core20
+version: 1.0
+components:
+  comp4:
+    type: test
+`,
+	"local-component-test+comp4": `component: local-component-test+comp4
+type: test
+version: 1.0
+`,
 	"optional20-a": `name: optional20-a
 type: app
 base: core20

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -111,6 +111,14 @@ version: 2.0
 type: test
 version: 2.0
 `,
+	"aux-info-test": `name: aux-info-test
+type: app
+base: core20
+version: 1.0
+links:
+  contact:
+    - mailto:author@example.com
+`,
 	"component-test": `name: component-test
 type: app
 base: core20

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -70,8 +70,6 @@ func (opts *Options) manifest() *Manifest {
 // E.g. a component passed to ubuntu-image via --comp <snap_name>+<comp_name>.
 type OptionsComponent struct {
 	Name string
-	// TODO:COMPS it doesn't look like using a path is supported right now
-	// Path is set when a file is passed around.
 	Path string
 }
 

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -70,6 +70,7 @@ func (opts *Options) manifest() *Manifest {
 // E.g. a component passed to ubuntu-image via --comp <snap_name>+<comp_name>.
 type OptionsComponent struct {
 	Name string
+	// TODO:COMPS it doesn't look like using a path is supported right now
 	// Path is set when a file is passed around.
 	Path string
 }

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -260,13 +260,15 @@ func MakeTestSnapWithFiles(c *check.C, snapYamlContent string, files [][]string)
 // the squashfs with files if required.
 func MakeTestComponentWithFiles(c *check.C, componentName, componentYaml string, files [][]string) (snapFilePath string) {
 	compSource := populateContainer(c, "component.yaml", componentYaml, files)
+
+	componentFileName := fmt.Sprintf("%s.comp", componentName)
 	err := osutil.ChDir(compSource, func() error {
-		d := squashfs.New(componentName)
+		d := squashfs.New(componentFileName)
 		err := d.Build(compSource, nil)
 		return err
 	})
 	c.Assert(err, check.IsNil)
-	return filepath.Join(compSource, componentName)
+	return filepath.Join(compSource, componentFileName)
 }
 
 func MakeTestComponent(c *check.C, compYaml string) string {


### PR DESCRIPTION
Based on https://github.com/canonical/snapd/pull/14378 for now.