### PR TITLE
tests: add run id to the file sent to grafana

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -794,7 +794,7 @@ jobs:
           if [ -z "$CHANGE_ID" ]; then
             CHANGE_ID="main"
           fi
-          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}_job${{ github.job_id }}_gh"
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}_gh"
           # The log-filter tool is used to filter the spread logs to be stored
           echo FILTER_PARAMS="-o spread_${CHANGE_ID}.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -794,9 +794,9 @@ jobs:
           if [ -z "$CHANGE_ID" ]; then
             CHANGE_ID="main"
           fi
-          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}"
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}_gh"
           # The log-filter tool is used to filter the spread logs to be stored
-          echo FILTER_PARAMS="-o spread_$CHANGE_ID.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
+          echo FILTER_PARAMS="-o spread_${CHANGE_ID}.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
 
     - name: Download built snap
       uses: actions/download-artifact@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -794,7 +794,7 @@ jobs:
           if [ -z "$CHANGE_ID" ]; then
             CHANGE_ID="main"
           fi
-          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}_job${{ github.job }}_gh"
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}_job${{ github.job_id }}_gh"
           # The log-filter tool is used to filter the spread logs to be stored
           echo FILTER_PARAMS="-o spread_${CHANGE_ID}.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -790,11 +790,11 @@ jobs:
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
           # Configure parameters to filter logs (these logs are sent read by grafana agent)
-          CHANGE_ID="${{ github.event.number }}"
+          CHANGE_ID="#${{ github.event.number }}"
           if [ -z "$CHANGE_ID" ]; then
             CHANGE_ID="main"
           fi
-          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}"
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}"
           # The log-filter tool is used to filter the spread logs to be stored
           echo FILTER_PARAMS="-o spread_$CHANGE_ID.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -790,11 +790,11 @@ jobs:
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
           # Configure parameters to filter logs (these logs are sent read by grafana agent)
-          CHANGE_ID="#${{ github.event.number }}"
+          CHANGE_ID="pr${{ github.event.number }}"
           if [ -z "$CHANGE_ID" ]; then
             CHANGE_ID="main"
           fi
-          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}_gh"
+          CHANGE_ID="${CHANGE_ID}_n${{ github.run_attempt }}_run${{ github.run_id }}_job${{ github.job }}_gh"
           # The log-filter tool is used to filter the spread logs to be stored
           echo FILTER_PARAMS="-o spread_${CHANGE_ID}.filtered.log -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
 


### PR DESCRIPTION
This is needed to be able to count different runs in grafana. 

Also will be needed to identify the source run for a failure
