### PR TITLE
tests: skip clean snapd snap when running run-spread script

### DIFF
--- a/run-spread
+++ b/run-spread
@@ -6,16 +6,21 @@ if ! snap list snapcraft &>/dev/null; then
     exit 1
 fi
 
-# Clean the snaps created in previous runs
-rm -rf built-snap test-build
-touch test-build
-mkdir built-snap
+if [ "$1" = "--no-clean" ]; then
+    shift
+else
+    # Clean the snaps created in previous runs
+    rm -rf built-snap test-build
+    touch test-build
+    mkdir built-snap
 
-rm -f snapd_1337.*.snap 
-rm -f snapd_1337.*.snap.keep
+    rm -f snapd_1337.*.snap 
+    rm -f snapd_1337.*.snap.keep
 
-# Build snapd snap
-snapcraft clean
+    # Build snapd snap
+    snapcraft clean
+fi
+
 snapcraft --use-lxd
 for snap in snapd_1337.*.snap; do
     mv "${snap}" built-snap/"${snap}.keep"


### PR DESCRIPTION
Add the parameter --no-clean to the run-spread script

This is used to avoid cleaning the snpad snap already built and reuse it when it is required.
