### PR TITLE
seed: add ability to get optional snaps and components that are available from seeds

### DIFF
--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -21,6 +21,7 @@
 package devicestate_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -401,6 +402,10 @@ type fakeSeedCopier struct {
 
 func (s *fakeSeedCopier) Copy(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
 	return s.copyFn(seedDir, opts, tm)
+}
+
+func (s *fakeSeedCopier) OptionalContainers() (seed.OptionalContainers, error) {
+	return seed.OptionalContainers{}, errors.New("not implemented")
 }
 
 // TODO encryption case for the finish step is not tested yet, it needs more mocking

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -243,6 +243,11 @@ type Copier interface {
 	// different mode, then that metadata will be overwritten by the metadata
 	// for all modes.
 	Copy(seedDir string, opts CopyOptions, tm timings.Measurer) error
+	// OptionalContainers returns the set of snaps and components that are
+	// consider optional in the seed's model, but are available in the seed and
+	// can be copied to a new seed location. Use this in conjunction with
+	// Copier.Copy specific optional snaps and components.
+	OptionalContainers() (OptionalContainers, error)
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -244,9 +244,10 @@ type Copier interface {
 	// for all modes.
 	Copy(seedDir string, opts CopyOptions, tm timings.Measurer) error
 	// OptionalContainers returns the set of snaps and components that are
-	// consider optional in the seed's model, but are available in the seed and
-	// can be copied to a new seed location. Use this in conjunction with
-	// Copier.Copy specific optional snaps and components.
+	// considered optional in the seed's model, but are available in the seed
+	// and can be copied to a new seed location. Use this in conjunction with
+	// Copier.Copy to pick specific optional snaps and components that should be
+	// copied to the new seed.
 	OptionalContainers() (OptionalContainers, error)
 }
 

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -202,7 +202,7 @@ func (s *seed20) OptionalContainers() (OptionalContainers, error) {
 }
 
 func (s *seed20) availableContainers() (map[string]bool, map[string]map[string]bool, error) {
-	assertedSnapSet, assertedCompSets := s.availableAssertedContainers()
+	availableSnapSet, availableCompSets := s.availableAssertedContainers()
 
 	optsPath := filepath.Join(s.systemDir, "options.yaml")
 	if osutil.FileExists(optsPath) {
@@ -212,14 +212,14 @@ func (s *seed20) availableContainers() (map[string]bool, map[string]map[string]b
 		}
 
 		for _, sn := range opts.Snaps {
-			assertedSnapSet[sn.Name] = true
+			availableSnapSet[sn.Name] = true
 			for _, comp := range sn.Components {
-				assertedCompSets[sn.Name][comp.Name] = true
+				availableCompSets[sn.Name][comp.Name] = true
 			}
 		}
 	}
 
-	return assertedSnapSet, assertedCompSets, nil
+	return availableSnapSet, availableCompSets, nil
 }
 
 func (s *seed20) availableAssertedContainers() (map[string]bool, map[string]map[string]bool) {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -205,7 +205,7 @@ func (s *seed20) availableContainers() (map[string]bool, map[string]map[string]b
 	availableSnapSet, availableCompSets := s.availableAssertedContainers()
 
 	optsPath := filepath.Join(s.systemDir, "options.yaml")
-	if osutil.FileExists(optsPath) {
+	if s.model.Grade() == asserts.ModelDangerous && osutil.FileExists(optsPath) {
 		opts, err := internal.ReadOptions20(optsPath)
 		if err != nil {
 			return nil, nil, err

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -153,7 +153,7 @@ func (s *seed20) OptionalContainers() (OptionalContainers, error) {
 	requiredSnapsInModel := make(map[string]bool)
 	requiredComponentsInModel := make(map[string]map[string]bool)
 	for _, snap := range model.AllSnaps() {
-		if snap.Presence == "required" || snap.Presence == "" {
+		if snap.Presence == "required" {
 			requiredSnapsInModel[snap.Name] = true
 		}
 

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3984,7 +3984,7 @@ func (s *seed20Suite) TestOptionalContainers(c *C) {
 	)
 
 	const srcLabel = "20191030"
-	s.MakeSeed(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
@@ -4019,6 +4019,7 @@ func (s *seed20Suite) TestOptionalContainers(c *C) {
 				"components": map[string]interface{}{
 					"comp1": "required",
 					"comp2": "optional",
+					"comp3": "optional",
 				},
 			},
 		},
@@ -4037,6 +4038,13 @@ func (s *seed20Suite) TestOptionalContainers(c *C) {
 		{
 			Name: "optional20-a",
 		},
+		{
+			Path: s.makeLocalSnap(c, "local-component-test"),
+		},
+	}, map[string][]string{
+		"local-component-test": {
+			snaptest.MakeTestComponent(c, seedtest.SampleSnapYaml["local-component-test+comp4"]),
+		},
 	})
 
 	seed20, err := seed.Open(s.SeedDir, srcLabel)
@@ -4050,9 +4058,14 @@ func (s *seed20Suite) TestOptionalContainers(c *C) {
 	optional, err := copier.OptionalContainers()
 	c.Assert(err, IsNil)
 
-	c.Assert(optional.Snaps, testutil.DeepUnsortedMatches, []string{"optional20-a", "component-test"})
+	// note that the optional snap, optional20-b, is missing since it is not
+	// available in the seed
+	c.Assert(optional.Snaps, testutil.DeepUnsortedMatches, []string{"optional20-a", "component-test", "local-component-test", "required20"})
 	c.Assert(optional.Components, testutil.DeepUnsortedMatches, map[string][]string{
-		"component-test": {"comp2"},
+		// note that the optional components, comp3, is missing, since it is not
+		// available in the seed
+		"component-test":       {"comp2"},
+		"local-component-test": {"comp4"},
 	})
 }
 


### PR DESCRIPTION
This will enable us to return the set of optional snaps and components that are available in a seed. Will be used from the /v2/systems API eventually.
