### PR TITLE
i/p/requestprompts: add timeout for prompts

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -100,6 +100,13 @@ func getUserID(r *http.Request) (uint32, Response) {
 	return uint32(userIDInt), nil
 }
 
+// isClientActivity returns true if the request comes a prompting handler
+// service.
+func isClientActivity(c *Command, r *http.Request) bool {
+	// TODO: check that it's a handler service client making the API request
+	return true
+}
+
 type invalidReason string
 
 const (
@@ -331,8 +338,7 @@ func getPrompts(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	// TODO: check that it's a handler service client making the API request
-	clientActivity := true
+	clientActivity := isClientActivity(c, r)
 
 	prompts, err := getInterfaceManager(c).InterfacesRequestsManager().Prompts(userID, clientActivity)
 	if err != nil {
@@ -363,8 +369,7 @@ func getPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	// TODO: check that it's a handler service client making the API request
-	clientActivity := true
+	clientActivity := isClientActivity(c, r)
 
 	prompt, err := getInterfaceManager(c).InterfacesRequestsManager().PromptWithID(userID, promptID, clientActivity)
 	if err != nil {
@@ -398,8 +403,7 @@ func postPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingError(fmt.Errorf("cannot decode request body into prompt reply: %w", err))
 	}
 
-	// TODO: check that it's a handler service client making the API request
-	clientActivity := true
+	clientActivity := isClientActivity(c, r)
 
 	satisfiedPromptIDs, err := getInterfaceManager(c).InterfacesRequestsManager().HandleReply(userID, promptID, reply.Constraints, reply.Outcome, reply.Lifespan, reply.Duration, clientActivity)
 	if err != nil {
@@ -450,7 +454,7 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	// TODO: check if it's a handler service client making the API request
+	// Do not treat activity on the rules endpoints as prompt client activity.
 	clientActivity := false
 
 	var postBody postRulesRequestBody
@@ -530,7 +534,7 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	// TODO: check if it's a handler service client making the API request
+	// Do not treat activity on the rules endpoints as prompt client activity.
 	clientActivity := false
 
 	var postBody postRuleRequestBody

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -331,7 +331,10 @@ func getPrompts(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	prompts, err := getInterfaceManager(c).InterfacesRequestsManager().Prompts(userID)
+	// TODO: check that it's a handler service client making the API request
+	clientActivity := true
+
+	prompts, err := getInterfaceManager(c).InterfacesRequestsManager().Prompts(userID, clientActivity)
 	if err != nil {
 		return promptingError(err)
 	}
@@ -360,7 +363,10 @@ func getPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	prompt, err := getInterfaceManager(c).InterfacesRequestsManager().PromptWithID(userID, promptID)
+	// TODO: check that it's a handler service client making the API request
+	clientActivity := true
+
+	prompt, err := getInterfaceManager(c).InterfacesRequestsManager().PromptWithID(userID, promptID, clientActivity)
 	if err != nil {
 		return promptingError(err)
 	}
@@ -392,7 +398,10 @@ func postPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingError(fmt.Errorf("cannot decode request body into prompt reply: %w", err))
 	}
 
-	satisfiedPromptIDs, err := getInterfaceManager(c).InterfacesRequestsManager().HandleReply(userID, promptID, reply.Constraints, reply.Outcome, reply.Lifespan, reply.Duration)
+	// TODO: check that it's a handler service client making the API request
+	clientActivity := true
+
+	satisfiedPromptIDs, err := getInterfaceManager(c).InterfacesRequestsManager().HandleReply(userID, promptID, reply.Constraints, reply.Outcome, reply.Lifespan, reply.Duration, clientActivity)
 	if err != nil {
 		return promptingError(err)
 	}

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -450,6 +450,9 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
+	// TODO: check if it's a handler service client making the API request
+	clientActivity := false
+
 	var postBody postRulesRequestBody
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&postBody); err != nil {
@@ -461,7 +464,7 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.AddRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "add"`)
 		}
-		newRule, err := getInterfaceManager(c).InterfacesRequestsManager().AddRule(userID, postBody.AddRule.Snap, postBody.AddRule.Interface, postBody.AddRule.Constraints, postBody.AddRule.Outcome, postBody.AddRule.Lifespan, postBody.AddRule.Duration)
+		newRule, err := getInterfaceManager(c).InterfacesRequestsManager().AddRule(userID, postBody.AddRule.Snap, postBody.AddRule.Interface, postBody.AddRule.Constraints, postBody.AddRule.Outcome, postBody.AddRule.Lifespan, postBody.AddRule.Duration, clientActivity)
 		if err != nil {
 			return promptingError(err)
 		}
@@ -527,6 +530,9 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
+	// TODO: check if it's a handler service client making the API request
+	clientActivity := false
+
 	var postBody postRuleRequestBody
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&postBody); err != nil {
@@ -538,7 +544,7 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.PatchRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "patch"`)
 		}
-		patchedRule, err := getInterfaceManager(c).InterfacesRequestsManager().PatchRule(userID, ruleID, postBody.PatchRule.Constraints, postBody.PatchRule.Outcome, postBody.PatchRule.Lifespan, postBody.PatchRule.Duration)
+		patchedRule, err := getInterfaceManager(c).InterfacesRequestsManager().PatchRule(userID, ruleID, postBody.PatchRule.Constraints, postBody.PatchRule.Outcome, postBody.PatchRule.Lifespan, postBody.PatchRule.Duration, clientActivity)
 		if err != nil {
 			return promptingError(err)
 		}

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -454,9 +454,6 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	// Do not treat activity on the rules endpoints as prompt client activity.
-	clientActivity := false
-
 	var postBody postRulesRequestBody
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&postBody); err != nil {
@@ -468,7 +465,7 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.AddRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "add"`)
 		}
-		newRule, err := getInterfaceManager(c).InterfacesRequestsManager().AddRule(userID, postBody.AddRule.Snap, postBody.AddRule.Interface, postBody.AddRule.Constraints, postBody.AddRule.Outcome, postBody.AddRule.Lifespan, postBody.AddRule.Duration, clientActivity)
+		newRule, err := getInterfaceManager(c).InterfacesRequestsManager().AddRule(userID, postBody.AddRule.Snap, postBody.AddRule.Interface, postBody.AddRule.Constraints, postBody.AddRule.Outcome, postBody.AddRule.Lifespan, postBody.AddRule.Duration)
 		if err != nil {
 			return promptingError(err)
 		}
@@ -534,9 +531,6 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		return promptingNotRunningError()
 	}
 
-	// Do not treat activity on the rules endpoints as prompt client activity.
-	clientActivity := false
-
 	var postBody postRuleRequestBody
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&postBody); err != nil {
@@ -548,7 +542,7 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.PatchRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "patch"`)
 		}
-		patchedRule, err := getInterfaceManager(c).InterfacesRequestsManager().PatchRule(userID, ruleID, postBody.PatchRule.Constraints, postBody.PatchRule.Outcome, postBody.PatchRule.Lifespan, postBody.PatchRule.Duration, clientActivity)
+		patchedRule, err := getInterfaceManager(c).InterfacesRequestsManager().PatchRule(userID, ruleID, postBody.PatchRule.Constraints, postBody.PatchRule.Outcome, postBody.PatchRule.Lifespan, postBody.PatchRule.Duration)
 		if err != nil {
 			return promptingError(err)
 		}

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -52,34 +52,38 @@ type fakeInterfacesRequestsManager struct {
 	err          error
 
 	// Store most recent received values
-	userID      uint32
-	snap        string
-	iface       string
-	id          prompting.IDType // used for prompt ID or rule ID
-	constraints *prompting.Constraints
-	outcome     prompting.OutcomeType
-	lifespan    prompting.LifespanType
-	duration    string
+	userID         uint32
+	snap           string
+	iface          string
+	id             prompting.IDType // used for prompt ID or rule ID
+	constraints    *prompting.Constraints
+	outcome        prompting.OutcomeType
+	lifespan       prompting.LifespanType
+	duration       string
+	clientActivity bool
 }
 
-func (m *fakeInterfacesRequestsManager) Prompts(userID uint32) ([]*requestprompts.Prompt, error) {
+func (m *fakeInterfacesRequestsManager) Prompts(userID uint32, clientActivity bool) ([]*requestprompts.Prompt, error) {
 	m.userID = userID
+	m.clientActivity = clientActivity
 	return m.prompts, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) PromptWithID(userID uint32, promptID prompting.IDType) (*requestprompts.Prompt, error) {
+func (m *fakeInterfacesRequestsManager) PromptWithID(userID uint32, promptID prompting.IDType, clientActivity bool) (*requestprompts.Prompt, error) {
 	m.userID = userID
 	m.id = promptID
+	m.clientActivity = clientActivity
 	return m.prompt, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) HandleReply(userID uint32, promptID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) ([]prompting.IDType, error) {
+func (m *fakeInterfacesRequestsManager) HandleReply(userID uint32, promptID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) ([]prompting.IDType, error) {
 	m.userID = userID
 	m.id = promptID
 	m.constraints = constraints
 	m.outcome = outcome
 	m.lifespan = lifespan
 	m.duration = duration
+	m.clientActivity = clientActivity
 	return m.satisfiedIDs, m.err
 }
 
@@ -651,6 +655,7 @@ func (s *promptingSuite) TestGetPromptsHappy(c *C) {
 
 	// Check parameters
 	c.Check(s.manager.userID, Equals, uint32(1000))
+	c.Check(s.manager.clientActivity, Equals, true)
 
 	// Check return value
 	prompts, ok := rsp.Result.([]*requestprompts.Prompt)
@@ -681,6 +686,7 @@ func (s *promptingSuite) TestGetPromptHappy(c *C) {
 	// Check parameters
 	c.Check(s.manager.userID, Equals, uint32(1000))
 	c.Check(s.manager.id, Equals, prompting.IDType(0x0123456789abcdef))
+	c.Check(s.manager.clientActivity, Equals, true)
 
 	// Check return value
 	prompt, ok := rsp.Result.(*requestprompts.Prompt)
@@ -722,6 +728,7 @@ func (s *promptingSuite) TestPostPromptHappy(c *C) {
 	c.Check(s.manager.outcome, Equals, contents.Outcome)
 	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
 	c.Check(s.manager.duration, Equals, contents.Duration)
+	c.Check(s.manager.clientActivity, Equals, true)
 
 	// Check return value
 	satisfiedIDs, ok := rsp.Result.([]prompting.IDType)

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -94,7 +94,7 @@ func (m *fakeInterfacesRequestsManager) Rules(userID uint32, snap string, iface 
 	return m.rules, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error) {
+func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
 	m.userID = userID
 	m.snap = snap
 	m.iface = iface
@@ -102,7 +102,6 @@ func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, ifac
 	m.outcome = outcome
 	m.lifespan = lifespan
 	m.duration = duration
-	m.clientActivity = clientActivity
 	return m.rule, m.err
 }
 
@@ -119,14 +118,13 @@ func (m *fakeInterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompti
 	return m.rule, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error) {
+func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
 	m.userID = userID
 	m.id = ruleID
 	m.constraints = constraints
 	m.outcome = outcome
 	m.lifespan = lifespan
 	m.duration = duration
-	m.clientActivity = clientActivity
 	return m.rule, m.err
 }
 
@@ -857,7 +855,6 @@ func (s *promptingSuite) TestPostRulesAddHappy(c *C) {
 	c.Check(s.manager.outcome, Equals, contents.Outcome)
 	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
 	c.Check(s.manager.duration, Equals, contents.Duration)
-	c.Check(s.manager.clientActivity, Equals, false)
 
 	// Check return value
 	rule, ok := rsp.Result.(*requestrules.Rule)
@@ -1025,7 +1022,6 @@ func (s *promptingSuite) TestPostRulePatchHappy(c *C) {
 	c.Check(s.manager.outcome, Equals, contents.Outcome)
 	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
 	c.Check(s.manager.duration, Equals, contents.Duration)
-	c.Check(s.manager.clientActivity, Equals, false)
 
 	// Check return value
 	rule, ok := rsp.Result.(*requestrules.Rule)

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -94,7 +94,7 @@ func (m *fakeInterfacesRequestsManager) Rules(userID uint32, snap string, iface 
 	return m.rules, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
+func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error) {
 	m.userID = userID
 	m.snap = snap
 	m.iface = iface
@@ -102,6 +102,7 @@ func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, ifac
 	m.outcome = outcome
 	m.lifespan = lifespan
 	m.duration = duration
+	m.clientActivity = clientActivity
 	return m.rule, m.err
 }
 
@@ -118,13 +119,14 @@ func (m *fakeInterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompti
 	return m.rule, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
+func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error) {
 	m.userID = userID
 	m.id = ruleID
 	m.constraints = constraints
 	m.outcome = outcome
 	m.lifespan = lifespan
 	m.duration = duration
+	m.clientActivity = clientActivity
 	return m.rule, m.err
 }
 
@@ -855,6 +857,7 @@ func (s *promptingSuite) TestPostRulesAddHappy(c *C) {
 	c.Check(s.manager.outcome, Equals, contents.Outcome)
 	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
 	c.Check(s.manager.duration, Equals, contents.Duration)
+	c.Check(s.manager.clientActivity, Equals, false)
 
 	// Check return value
 	rule, ok := rsp.Result.(*requestrules.Rule)
@@ -1022,6 +1025,7 @@ func (s *promptingSuite) TestPostRulePatchHappy(c *C) {
 	c.Check(s.manager.outcome, Equals, contents.Outcome)
 	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
 	c.Check(s.manager.duration, Equals, contents.Duration)
+	c.Check(s.manager.clientActivity, Equals, false)
 
 	// Check return value
 	rule, ok := rsp.Result.(*requestrules.Rule)

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -54,13 +54,9 @@ func (pdb *PromptDB) NextID() (prompting.IDType, error) {
 }
 
 func MockInitialTimeout(timeout time.Duration) (restore func()) {
-	restore = testutil.Backup(&initialTimeout)
-	initialTimeout = timeout
-	return restore
+	return testutil.Mock(&initialTimeout, timeout)
 }
 
 func MockActivityTimeout(timeout time.Duration) (restore func()) {
-	restore = testutil.Backup(&activityTimeout)
-	activityTimeout = timeout
-	return restore
+	return testutil.Mock(&activityTimeout, timeout)
 }

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/testutil"
 )
 
 const MaxOutstandingPromptsPerUser = maxOutstandingPromptsPerUser
@@ -50,4 +51,16 @@ func (pdb *PromptDB) PerUser() map[uint32]*userPromptDB {
 
 func (pdb *PromptDB) NextID() (prompting.IDType, error) {
 	return pdb.maxIDMmap.NextID()
+}
+
+func MockInitialTimeout(timeout time.Duration) (restore func()) {
+	restore = testutil.Backup(&initialTimeout)
+	initialTimeout = timeout
+	return restore
+}
+
+func MockActivityTimeout(timeout time.Duration) (restore func()) {
+	restore = testutil.Backup(&activityTimeout)
+	activityTimeout = timeout
+	return restore
 }

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -24,9 +24,14 @@ import (
 
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timeutil"
 )
 
-const MaxOutstandingPromptsPerUser = maxOutstandingPromptsPerUser
+const (
+	InitialTimeout               = initialTimeout
+	ActivityTimeout              = activityTimeout
+	MaxOutstandingPromptsPerUser = maxOutstandingPromptsPerUser
+)
 
 func NewPrompt(id prompting.IDType, timestamp time.Time, snap string, iface string, path string, remainingPermissions []string, availablePermissions []string, originalPermissions []string) *Prompt {
 	constraints := &promptConstraints{
@@ -53,10 +58,6 @@ func (pdb *PromptDB) NextID() (prompting.IDType, error) {
 	return pdb.maxIDMmap.NextID()
 }
 
-func MockInitialTimeout(timeout time.Duration) (restore func()) {
-	return testutil.Mock(&initialTimeout, timeout)
-}
-
-func MockActivityTimeout(timeout time.Duration) (restore func()) {
-	return testutil.Mock(&activityTimeout, timeout)
+func MockTimeAfterFunc(f func(d time.Duration, callback func()) timeutil.Timer) (restore func()) {
+	return testutil.Mock(&timeAfterFunc, f)
 }

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -535,9 +535,12 @@ func (pdb *PromptDB) Reply(user uint32, id prompting.IDType, outcome prompting.O
 // remaining unsatisfied permissions of a partially-satisfied prompt must be
 // satisfied for the prompt as a whole to be satisfied.
 //
+// If clientActivity is true, reset the expiration timeout for prompts for
+// the given user.
+//
 // Returns the IDs of any prompts which were fully satisfied by the given rule
 // contents.
-func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *prompting.Constraints, outcome prompting.OutcomeType) ([]prompting.IDType, error) {
+func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *prompting.Constraints, outcome prompting.OutcomeType, clientActivity bool) ([]prompting.IDType, error) {
 	// Validate outcome before locking
 	allow, err := outcome.AsBool()
 	if err != nil {
@@ -553,6 +556,9 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 	userEntry, ok := pdb.perUser[metadata.User]
 	if !ok {
 		return nil, nil
+	}
+	if clientActivity {
+		userEntry.expirationTimer.Reset(activityTimeout)
 	}
 	var satisfiedPromptIDs []prompting.IDType
 	for _, prompt := range userEntry.prompts {

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -350,10 +350,10 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 
 	userEntry, ok := pdb.perUser[metadata.User]
 	if !ok {
-		pdb.perUser[metadata.User] = &userPromptDB{
+		// New user entry, so create it and set up the expiration timer
+		userEntry = &userPromptDB{
 			ids: make(map[prompting.IDType]int),
 		}
-		userEntry = pdb.perUser[metadata.User]
 		userEntry.expirationTimer = time.AfterFunc(initialTimeout, func() {
 			pdb.mutex.Lock()
 			if pdb.maxIDMmap.IsClosed() {
@@ -384,6 +384,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 				p.sendReply(prompting.OutcomeDeny) // ignore any error, should not occur
 			}
 		})
+		pdb.perUser[metadata.User] = userEntry
 	}
 
 	constraints := &promptConstraints{

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -110,7 +110,7 @@ func responseForInterfaceConstraintsOutcome(iface string, constraints *promptCon
 	if err != nil {
 		// This should not occur, but if so, default to deny
 		allow = false
-		logger.Debugf("%v", err)
+		logger.Noticef("internal error: failed to compute prompting outcome: %v", err)
 	}
 	allowedPerms := constraints.originalPermissions
 	if !allow {
@@ -128,7 +128,7 @@ func responseForInterfaceConstraintsOutcome(iface string, constraints *promptCon
 	if err != nil {
 		// This should not occur, but if so, permission should be set to the
 		// empty value for its corresponding permission type.
-		logger.Debugf("internal error: cannot convert abstract permissions to AppArmor permissions: %v", err)
+		logger.Noticef("internal error: cannot convert abstract permissions to AppArmor permissions: %v", err)
 	}
 	return allowedPermission
 }
@@ -146,9 +146,7 @@ func (p *Prompt) sendReplyWithPermission(allowedPermission any) error {
 	return nil
 }
 
-var sendReply = func(listenerReq *listener.Request, allowedPermission any) error {
-	return listenerReq.Reply(allowedPermission)
-}
+var sendReply = (*listener.Request).Reply
 
 // promptConstraints store the path which was requested, along with three
 // lists of permissions: the original permissions associated with the request,

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -311,7 +311,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	expiredPrompts := udb.prompts
 	// Clear all outstanding prompts for the user
 	udb.prompts = nil
-	udb.ids = make(map[prompting.IDType]int)
+	udb.ids = make(map[prompting.IDType]int) // TODO: clear() once we're on Go 1.21+
 	// Unlock now so we can record notices without holding the prompt DB lock
 	pdb.mutex.Unlock()
 	data := map[string]string{"resolved": "expired"}

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -280,6 +280,7 @@ func (udb *userPromptDB) remove(id prompting.IDType) (*Prompt, error) {
 func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	pdb.mutex.Lock()
 	if pdb.maxIDMmap.IsClosed() {
+		pdb.mutex.Unlock()
 		return
 	}
 	// Restart expiration timer while holding the lock, so we don't
@@ -293,6 +294,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 		// function. So reset the timer to activityTimeout, and do not
 		// purge prompts.
 		udb.resetExpiration(activityTimeout)
+		pdb.mutex.Unlock()
 		return
 	}
 	expiredPrompts := udb.prompts

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -45,7 +45,7 @@ const (
 	// user since the previous timeout, or if the user prompt DB was just
 	// created.
 	initialTimeout = 10 * time.Second
-	// initialTimeout is the duration before which prompts for a given user
+	// activityTimeout is the duration before which prompts for a given user
 	// will expire after the most recent retrieval of prompt details for that
 	// user.
 	activityTimeout = 10 * time.Minute

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -540,12 +540,9 @@ func (pdb *PromptDB) Reply(user uint32, id prompting.IDType, outcome prompting.O
 // remaining unsatisfied permissions of a partially-satisfied prompt must be
 // satisfied for the prompt as a whole to be satisfied.
 //
-// If clientActivity is true, reset the expiration timeout for prompts for
-// the given user.
-//
 // Returns the IDs of any prompts which were fully satisfied by the given rule
 // contents.
-func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *prompting.Constraints, outcome prompting.OutcomeType, clientActivity bool) ([]prompting.IDType, error) {
+func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *prompting.Constraints, outcome prompting.OutcomeType) ([]prompting.IDType, error) {
 	// Validate outcome before locking
 	allow, err := outcome.AsBool()
 	if err != nil {
@@ -561,9 +558,6 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 	userEntry, ok := pdb.perUser[metadata.User]
 	if !ok {
 		return nil, nil
-	}
-	if clientActivity {
-		userEntry.resetExpiration(activityTimeout)
 	}
 	var satisfiedPromptIDs []prompting.IDType
 	for _, prompt := range userEntry.prompts {

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -672,7 +672,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	}
 	outcome := prompting.OutcomeAllow
 
-	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome)
+	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 2)
 	c.Check(promptIDListContains(satisfied, prompt2.ID), Equals, true)
@@ -713,7 +713,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 		PathPattern: pathPattern,
 		Permissions: permissions,
 	}
-	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome)
+	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
 
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 1)
@@ -801,7 +801,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	outcome := prompting.OutcomeDeny
 
 	// If one or more permissions denied each for prompts 1-3, so each is denied
-	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome)
+	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 3)
 	c.Check(promptIDListContains(satisfied, prompt1.ID), Equals, true)
@@ -884,7 +884,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Assert(stored, HasLen, 1)
 	c.Assert(stored[0], Equals, prompt)
 
-	satisfied, err := pdb.HandleNewRule(metadata, constraints, badOutcome)
+	satisfied, err := pdb.HandleNewRule(metadata, constraints, badOutcome, clientActivity)
 	c.Check(err, ErrorMatches, `invalid outcome: "foo"`)
 	c.Check(satisfied, IsNil)
 
@@ -895,7 +895,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		Snap:      snap,
 		Interface: iface,
 	}
-	satisfied, err = pdb.HandleNewRule(otherUserMetadata, constraints, outcome)
+	satisfied, err = pdb.HandleNewRule(otherUserMetadata, constraints, outcome, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
@@ -906,7 +906,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		Snap:      otherSnap,
 		Interface: iface,
 	}
-	satisfied, err = pdb.HandleNewRule(otherSnapMetadata, constraints, outcome)
+	satisfied, err = pdb.HandleNewRule(otherSnapMetadata, constraints, outcome, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
@@ -917,19 +917,19 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		Snap:      snap,
 		Interface: otherInterface,
 	}
-	satisfied, err = pdb.HandleNewRule(otherInterfaceMetadata, constraints, outcome)
+	satisfied, err = pdb.HandleNewRule(otherInterfaceMetadata, constraints, outcome, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	satisfied, err = pdb.HandleNewRule(metadata, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(metadata, otherConstraints, outcome, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome)
+	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
 	c.Check(err, IsNil)
 	c.Assert(satisfied, HasLen, 1)
 
@@ -1035,7 +1035,7 @@ func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
 	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
 	c.Check(result, IsNil)
 
-	promptIDs, err := pdb.HandleNewRule(nil, nil, prompting.OutcomeDeny)
+	promptIDs, err := pdb.HandleNewRule(nil, nil, prompting.OutcomeDeny, clientActivity)
 	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
 	c.Check(promptIDs, IsNil)
 

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -672,7 +672,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	}
 	outcome := prompting.OutcomeAllow
 
-	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
+	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 2)
 	c.Check(promptIDListContains(satisfied, prompt2.ID), Equals, true)
@@ -713,7 +713,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 		PathPattern: pathPattern,
 		Permissions: permissions,
 	}
-	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
+	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome)
 
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 1)
@@ -801,7 +801,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	outcome := prompting.OutcomeDeny
 
 	// If one or more permissions denied each for prompts 1-3, so each is denied
-	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
+	satisfied, err := pdb.HandleNewRule(metadata, constraints, outcome)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 3)
 	c.Check(promptIDListContains(satisfied, prompt1.ID), Equals, true)
@@ -884,7 +884,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Assert(stored, HasLen, 1)
 	c.Assert(stored[0], Equals, prompt)
 
-	satisfied, err := pdb.HandleNewRule(metadata, constraints, badOutcome, clientActivity)
+	satisfied, err := pdb.HandleNewRule(metadata, constraints, badOutcome)
 	c.Check(err, ErrorMatches, `invalid outcome: "foo"`)
 	c.Check(satisfied, IsNil)
 
@@ -895,7 +895,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		Snap:      snap,
 		Interface: iface,
 	}
-	satisfied, err = pdb.HandleNewRule(otherUserMetadata, constraints, outcome, clientActivity)
+	satisfied, err = pdb.HandleNewRule(otherUserMetadata, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
@@ -906,7 +906,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		Snap:      otherSnap,
 		Interface: iface,
 	}
-	satisfied, err = pdb.HandleNewRule(otherSnapMetadata, constraints, outcome, clientActivity)
+	satisfied, err = pdb.HandleNewRule(otherSnapMetadata, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
@@ -917,19 +917,19 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		Snap:      snap,
 		Interface: otherInterface,
 	}
-	satisfied, err = pdb.HandleNewRule(otherInterfaceMetadata, constraints, outcome, clientActivity)
+	satisfied, err = pdb.HandleNewRule(otherInterfaceMetadata, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	satisfied, err = pdb.HandleNewRule(metadata, otherConstraints, outcome, clientActivity)
+	satisfied, err = pdb.HandleNewRule(metadata, otherConstraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, IsNil)
 
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome, clientActivity)
+	satisfied, err = pdb.HandleNewRule(metadata, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Assert(satisfied, HasLen, 1)
 
@@ -1035,7 +1035,7 @@ func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
 	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
 	c.Check(result, IsNil)
 
-	promptIDs, err := pdb.HandleNewRule(nil, nil, prompting.OutcomeDeny, clientActivity)
+	promptIDs, err := pdb.HandleNewRule(nil, nil, prompting.OutcomeDeny)
 	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
 	c.Check(promptIDs, IsNil)
 

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -1109,6 +1109,7 @@ func (s *requestpromptsSuite) TestPromptExpiration(c *C) {
 		return nil
 	})
 	c.Assert(err, IsNil)
+	defer pdb.Close()
 
 	// Add prompt
 	listenerReq := &listener.Request{}

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -53,10 +53,10 @@ type Manager interface {
 	PromptWithID(userID uint32, promptID prompting.IDType, clientActivity bool) (*requestprompts.Prompt, error)
 	HandleReply(userID uint32, promptID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) ([]prompting.IDType, error)
 	Rules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error)
-	AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error)
+	AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error)
 	RemoveRules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error)
 	RuleWithID(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error)
-	PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error)
+	PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error)
 	RemoveRule(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error)
 }
 
@@ -449,18 +449,18 @@ func (m *InterfacesRequestsManager) HandleReply(userID uint32, promptID promptin
 	}
 
 	// Apply new rule to outstanding prompts.
-	satisfiedPromptIDs = m.applyRuleToOutstandingPrompts(newRule)
+	satisfiedPromptIDs = m.applyRuleToOutstandingPrompts(newRule, clientActivity)
 
 	return satisfiedPromptIDs, nil
 }
 
-func (m *InterfacesRequestsManager) applyRuleToOutstandingPrompts(rule *requestrules.Rule) []prompting.IDType {
+func (m *InterfacesRequestsManager) applyRuleToOutstandingPrompts(rule *requestrules.Rule, clientActivity bool) []prompting.IDType {
 	metadata := &prompting.Metadata{
 		User:      rule.User,
 		Snap:      rule.Snap,
 		Interface: rule.Interface,
 	}
-	satisfiedPromptIDs, err := m.prompts.HandleNewRule(metadata, rule.Constraints, rule.Outcome)
+	satisfiedPromptIDs, err := m.prompts.HandleNewRule(metadata, rule.Constraints, rule.Outcome, clientActivity)
 	if err != nil {
 		// The rule's constraints and outcome were already validated, so an
 		// error should not occur here unless the prompt DB was already closed.
@@ -493,7 +493,10 @@ func (m *InterfacesRequestsManager) Rules(userID uint32, snap string, iface stri
 
 // AddRule creates a new rule with the given contents and then checks it against
 // outstanding prompts, resolving any prompts which it satisfies.
-func (m *InterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
+//
+// If clientActivity is true, reset the expiration timeout for prompts for
+// the given user.
+func (m *InterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -502,7 +505,7 @@ func (m *InterfacesRequestsManager) AddRule(userID uint32, snap string, iface st
 		return nil, err
 	}
 	// Apply new rule to outstanding prompts.
-	m.applyRuleToOutstandingPrompts(newRule)
+	m.applyRuleToOutstandingPrompts(newRule, clientActivity)
 	return newRule, nil
 }
 
@@ -540,7 +543,10 @@ func (m *InterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompting.I
 
 // PatchRule updates the rule with the given ID using the provided contents.
 // Any of the given fields which are empty/nil are not updated in the rule.
-func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
+//
+// If clientActivity is true, reset the expiration timeout for prompts for
+// the given user.
+func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (*requestrules.Rule, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -549,7 +555,7 @@ func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.ID
 		return nil, err
 	}
 	// Apply patched rule to outstanding prompts.
-	m.applyRuleToOutstandingPrompts(patchedRule)
+	m.applyRuleToOutstandingPrompts(patchedRule, clientActivity)
 	return patchedRule, nil
 }
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -451,7 +451,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 	// Conflicting rule
 	// For this, need to add another rule to the DB first, then try to reply
 	// with a rule which conflicts with it. Reuse badPatternConstraints.
-	newRule, err := mgr.AddRule(s.defaultUser, "firefox", "home", &badPatternConstraints, prompting.OutcomeAllow, prompting.LifespanTimespan, "10s", false)
+	newRule, err := mgr.AddRule(s.defaultUser, "firefox", "home", &badPatternConstraints, prompting.OutcomeAllow, prompting.LifespanTimespan, "10s")
 	c.Assert(err, IsNil)
 	c.Assert(newRule, NotNil)
 	conflictingOutcome := prompting.OutcomeDeny
@@ -482,8 +482,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Add allow rule to match write permission
@@ -491,7 +490,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"write"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Create request for read and write
@@ -504,6 +503,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Check that no prompts were created
+	clientActivity := false
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(prompts, HasLen, 0)
@@ -554,8 +554,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Do NOT add rule to match write permission
@@ -584,8 +583,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "", clientActivity)
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Add no rule for write permissions
@@ -600,6 +598,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	time.Sleep(10 * time.Millisecond)
 
 	// Check that no prompts were created
+	clientActivity := false
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(prompts, HasLen, 0)
@@ -628,8 +627,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "", clientActivity)
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Add allow rule for write permissions
@@ -637,7 +635,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"write"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Create request for read and write
@@ -650,6 +648,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	time.Sleep(10 * time.Millisecond)
 
 	// Check that no prompts were created
+	clientActivity := false
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(prompts, HasLen, 0)
@@ -704,8 +703,7 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Check that kernel received a reply
@@ -717,6 +715,7 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 	c.Check(resp.AllowedPermission, DeepEquals, expectedPermissions)
 
 	// Check that read request prompt was satisfied
+	clientActivity := false
 	_, err = mgr.PromptWithID(s.defaultUser, readPrompt.ID, clientActivity)
 	c.Check(err, NotNil)
 
@@ -778,8 +777,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "", clientActivity)
+	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Check that kernel received two replies
@@ -790,6 +788,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 	}
 
 	// Check that read and rw prompts were satisfied
+	clientActivity := false
 	_, err = mgr.PromptWithID(s.defaultUser, readPrompt.ID, clientActivity)
 	c.Check(err, NotNil)
 	_, err = mgr.PromptWithID(s.defaultUser, rwPrompt.ID, clientActivity)
@@ -1033,8 +1032,7 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	_, err = mgr.AddRule(s.defaultUser, prompt.Snap, prompt.Interface, constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	_, err = mgr.AddRule(s.defaultUser, prompt.Snap, prompt.Interface, constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 
 	// Create identical request again, it should merge even though some
@@ -1094,8 +1092,7 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/1"),
 		Permissions: []string{"read"},
 	}
-	clientActivity := false
-	rule1, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	rule1, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 	rules = append(rules, rule1)
 
@@ -1104,7 +1101,7 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/2"),
 		Permissions: []string{"read"},
 	}
-	rule2, err := mgr.AddRule(s.defaultUser, "thunderbird", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	rule2, err := mgr.AddRule(s.defaultUser, "thunderbird", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 	rules = append(rules, rule2)
 
@@ -1113,7 +1110,7 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/3"),
 		Permissions: []string{"read"},
 	}
-	rule3, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	rule3, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 	// Since camera interface isn't supported yet, must adjust the interface
 	// after the rule has been created. This abuses implementation details of
@@ -1126,7 +1123,7 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/4"),
 		Permissions: []string{"read"},
 	}
-	rule4, err := mgr.AddRule(s.defaultUser+1, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	rule4, err := mgr.AddRule(s.defaultUser+1, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 	rules = append(rules, rule4)
 
@@ -1224,8 +1221,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"write"},
 	}
-	clientActivity := false
-	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 	s.checkRecordedRuleUpdateNotices(c, whenAdded, 1)
 
@@ -1236,6 +1232,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 
 	// Check prompt still exists and no prompt notices recorded since before
 	// the rule was added
+	clientActivity := false
 	retrievedPrompt, err := mgr.PromptWithID(s.defaultUser, prompt.ID, clientActivity)
 	c.Assert(err, IsNil)
 	c.Assert(retrievedPrompt, Equals, prompt)
@@ -1247,7 +1244,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/{foo,bar,baz}"),
 		Permissions: []string{"read", "write"},
 	}
-	patched, err := mgr.PatchRule(s.defaultUser, rule.ID, newConstraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
+	patched, err := mgr.PatchRule(s.defaultUser, rule.ID, newConstraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
 	c.Assert(err, IsNil)
 	s.checkRecordedRuleUpdateNotices(c, whenPatched, 1)
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -451,7 +451,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 	// Conflicting rule
 	// For this, need to add another rule to the DB first, then try to reply
 	// with a rule which conflicts with it. Reuse badPatternConstraints.
-	newRule, err := mgr.AddRule(s.defaultUser, "firefox", "home", &badPatternConstraints, prompting.OutcomeAllow, prompting.LifespanTimespan, "10s")
+	newRule, err := mgr.AddRule(s.defaultUser, "firefox", "home", &badPatternConstraints, prompting.OutcomeAllow, prompting.LifespanTimespan, "10s", false)
 	c.Assert(err, IsNil)
 	c.Assert(newRule, NotNil)
 	conflictingOutcome := prompting.OutcomeDeny
@@ -482,7 +482,8 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	clientActivity := false
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Add allow rule to match write permission
@@ -490,7 +491,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"write"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Create request for read and write
@@ -503,7 +504,6 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Check that no prompts were created
-	clientActivity := false
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(prompts, HasLen, 0)
@@ -554,7 +554,8 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	clientActivity := false
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Do NOT add rule to match write permission
@@ -583,7 +584,8 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "")
+	clientActivity := false
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Add no rule for write permissions
@@ -598,7 +600,6 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	time.Sleep(10 * time.Millisecond)
 
 	// Check that no prompts were created
-	clientActivity := false
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(prompts, HasLen, 0)
@@ -627,7 +628,8 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "")
+	clientActivity := false
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Add allow rule for write permissions
@@ -635,7 +637,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"write"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	_, err = mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Create request for read and write
@@ -648,7 +650,6 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	time.Sleep(10 * time.Millisecond)
 
 	// Check that no prompts were created
-	clientActivity := false
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
 	c.Check(err, IsNil)
 	c.Check(prompts, HasLen, 0)
@@ -703,7 +704,8 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	clientActivity := false
+	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Check that kernel received a reply
@@ -715,7 +717,6 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 	c.Check(resp.AllowedPermission, DeepEquals, expectedPermissions)
 
 	// Check that read request prompt was satisfied
-	clientActivity := false
 	_, err = mgr.PromptWithID(s.defaultUser, readPrompt.ID, clientActivity)
 	c.Check(err, NotNil)
 
@@ -777,7 +778,8 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "")
+	clientActivity := false
+	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeDeny, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Check that kernel received two replies
@@ -788,7 +790,6 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 	}
 
 	// Check that read and rw prompts were satisfied
-	clientActivity := false
 	_, err = mgr.PromptWithID(s.defaultUser, readPrompt.ID, clientActivity)
 	c.Check(err, NotNil)
 	_, err = mgr.PromptWithID(s.defaultUser, rwPrompt.ID, clientActivity)
@@ -1032,7 +1033,8 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"read"},
 	}
-	_, err = mgr.AddRule(s.defaultUser, prompt.Snap, prompt.Interface, constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	clientActivity := false
+	_, err = mgr.AddRule(s.defaultUser, prompt.Snap, prompt.Interface, constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 
 	// Create identical request again, it should merge even though some
@@ -1092,7 +1094,8 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/1"),
 		Permissions: []string{"read"},
 	}
-	rule1, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	clientActivity := false
+	rule1, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 	rules = append(rules, rule1)
 
@@ -1101,7 +1104,7 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/2"),
 		Permissions: []string{"read"},
 	}
-	rule2, err := mgr.AddRule(s.defaultUser, "thunderbird", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	rule2, err := mgr.AddRule(s.defaultUser, "thunderbird", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 	rules = append(rules, rule2)
 
@@ -1110,7 +1113,7 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/3"),
 		Permissions: []string{"read"},
 	}
-	rule3, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	rule3, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 	// Since camera interface isn't supported yet, must adjust the interface
 	// after the rule has been created. This abuses implementation details of
@@ -1123,7 +1126,7 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 		PathPattern: mustParsePathPattern(c, "/home/test/4"),
 		Permissions: []string{"read"},
 	}
-	rule4, err := mgr.AddRule(s.defaultUser+1, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	rule4, err := mgr.AddRule(s.defaultUser+1, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 	rules = append(rules, rule4)
 
@@ -1221,7 +1224,8 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/**"),
 		Permissions: []string{"write"},
 	}
-	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	clientActivity := false
+	rule, err := mgr.AddRule(s.defaultUser, "firefox", "home", constraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 	s.checkRecordedRuleUpdateNotices(c, whenAdded, 1)
 
@@ -1232,7 +1236,6 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 
 	// Check prompt still exists and no prompt notices recorded since before
 	// the rule was added
-	clientActivity := false
 	retrievedPrompt, err := mgr.PromptWithID(s.defaultUser, prompt.ID, clientActivity)
 	c.Assert(err, IsNil)
 	c.Assert(retrievedPrompt, Equals, prompt)
@@ -1244,7 +1247,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 		PathPattern: mustParsePathPattern(c, "/home/test/{foo,bar,baz}"),
 		Permissions: []string{"read", "write"},
 	}
-	patched, err := mgr.PatchRule(s.defaultUser, rule.ID, newConstraints, prompting.OutcomeAllow, prompting.LifespanForever, "")
+	patched, err := mgr.PatchRule(s.defaultUser, rule.ID, newConstraints, prompting.OutcomeAllow, prompting.LifespanForever, "", clientActivity)
 	c.Assert(err, IsNil)
 	s.checkRecordedRuleUpdateNotices(c, whenPatched, 1)
 


### PR DESCRIPTION
This PR now depends on https://github.com/canonical/snapd/pull/14672, which introduces mockable timers used in tests.

When there has been no retrieval of prompt details for a given user after a particular duration, expire all outstanding prompts for that user, as this suggests that there is no prompt client running for that user.

If a user retrieves prompt details or interacts with prompts in some way, such as by retrieving all prompts, a prompt by ID, or attempting to reply to a prompt, bump the timeout to a much longer timeout, since this indicates that a prompt client is running for that user.

This is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-28665
