### PR TITLE
t/m/snap-quota-thread: make the test more robust against delays

### DIFF
--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -32,7 +32,7 @@ execute: |
     local runs=$1
     local expected=$2
 
-    for _ in $(seq ${runs}); do
+    for _ in $(seq "${runs}"); do
         threadCount="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
         if [ "$threadCount" -eq "$expected" ]; then
             break

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -27,6 +27,21 @@ execute: |
   # count of threads expected is 33 including the main thread.
   SPAWNER_MAX_THREADS=33
 
+  function wait_for_thread_usage() {
+    local threadCount=0
+    local runs=$1
+    local expected=$2
+
+    for _ in $(seq ${runs}); do
+        threadCount="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
+        if [ "$threadCount" -eq "$expected" ]; then
+            break
+        fi
+        sleep 1
+    done
+    echo threadCount
+  }
+
   echo "Create a group with the spawner snap in it"
   snap set-quota group-one --threads=16 test-snapd-stressd
 
@@ -75,34 +90,25 @@ execute: |
 
   # verify that 'snap quota' is reporting the correct new usage
   echo "Verify the number of threads is correct (=16)"
-  threadUsage=0
-  for _ in $(seq 10); do
-      threadUsage="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
-      if [ "$threadUsage" -ge 16 ]; then
-          break
-      fi
-      sleep 1
-  done
+  threadUsage=$(wait_for_thread_usage 10 16)
   if ! [ "$threadUsage" -eq 16 ]; then
-    echo "thread usage reported does not equal the expected quota usage $threadUsage"
+    echo "thread usage reported does not equal the expected quota usage $threadUsage != 16"
     exit 1
   fi
 
-  echo "Increase the thread quota to 24"
+  echo "Increase the thread quota to 24 and restart the service"
   snap set-quota group-one --threads=24
+
+  # sometimes the cgroup change takes a while to kick in, avoid 
+  # waiting for the cgroup change to kick in and allow spawn
+  # to spawn additional threads
+  snap restart test-snapd-stressd.spawner
 
   # verify that 'snap quota' is reporting the correct new usage
   echo "Verify the number of threads is correct (=24)"
-  threadUsage=0
-  for _ in $(seq 10); do
-      threadUsage="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
-      if [ "$threadUsage" -ge 24 ]; then
-          break
-      fi
-      sleep 1
-  done
+  threadUsage=$(wait_for_thread_usage 10 24)
   if ! [ "$threadUsage" -eq 24 ]; then
-    echo "thread usage reported does not equal the expected quota usage $threadUsage"
+    echo "thread usage reported does not equal the expected quota usage $threadUsage != 24"
     exit 1
   fi
 

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -33,13 +33,13 @@ execute: |
     local expected=$2
 
     for _ in $(seq "${runs}"); do
-        threadCount="$(snap quota group-one | awk '/current:/,/threads:/{printf "%s",$2} END {print ""}')"
+        threadCount="$(snap quota group-one | awk '/current:/,/threads:/{if ($1 ~ "threads:") { print $2 }}')"
         if [ "$threadCount" -eq "$expected" ]; then
             break
         fi
         sleep 1
     done
-    echo threadCount
+    echo $threadCount
   }
 
   echo "Create a group with the spawner snap in it"

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -39,7 +39,7 @@ execute: |
         fi
         sleep 1
     done
-    echo $threadCount
+    echo "$threadCount"
   }
 
   echo "Create a group with the spawner snap in it"


### PR DESCRIPTION
The way the spawner snap works is by being a bit abusive and just trying to spawn X threads every delay - now this seems to be mostly fine, but from testing it more it seems that once in a while the delay it takes from changing the cgroup thread allowance for currently running processes to the moment when the spawner actually get to spawn additional thread can take a while, causing the test to timeout.

Avoid this instability all together by restarting the service, causing the change to go into immediate effect.
