### PR TITLE
secboot: use uuid of luks2 instead of partition

### DIFF
--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -67,14 +67,6 @@ var diskFromPartitionDeviceNode = func(node string) (Disk, error) {
 	return nil, osutil.ErrDarwin
 }
 
-func PartitionUUIDFromMountPoint(mountpoint string, opts *Options) (string, error) {
-	return "", osutil.ErrDarwin
-}
-
-func PartitionUUID(node string) (string, error) {
-	return "", osutil.ErrDarwin
-}
-
 func SectorSize(devname string) (uint64, error) {
 	return 0, osutil.ErrDarwin
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -1643,7 +1643,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 	var chosenBootstrapKey []byte
 	defer devicestate.MockSecbootAddBootstrapKeyOnExistingDisk(func(node string, newKey keys.EncryptionKey) error {
 		if tc.encrypt {
-			c.Check(node, Equals, "/dev/disk/by-partuuid/fbbb94fb-46ea-4e00-b830-afc72d202449")
+			c.Check(node, Equals, "/dev/disk/by-uuid/570faa3d-e3bc-49db-979b-e7814b6bd390")
 			chosenBootstrapKey = newKey
 			return nil
 		}
@@ -1653,7 +1653,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 
 	defer devicestate.MockSecbootRenameOrDeleteKeys(func(node string, renames map[string]string) error {
 		if tc.encrypt {
-			c.Check(node, Equals, "/dev/disk/by-partuuid/fbbb94fb-46ea-4e00-b830-afc72d202449")
+			c.Check(node, Equals, "/dev/disk/by-uuid/570faa3d-e3bc-49db-979b-e7814b6bd390")
 			c.Check(renames, DeepEquals, map[string]string{
 				"default":          "factory-reset-old",
 				"default-fallback": "factory-reset-old-fallback",
@@ -1940,7 +1940,7 @@ echo "mock output of: $(basename "$0") $*"
 
 	defer disks.MockUdevPropertiesForDevice(func(string, string) (map[string]string, error) {
 		return map[string]string{
-			"ID_PART_ENTRY_UUID": "fbbb94fb-46ea-4e00-b830-afc72d202449",
+			"ID_FS_UUID": "570faa3d-e3bc-49db-979b-e7814b6bd390",
 		}, nil
 	})()
 
@@ -2010,7 +2010,7 @@ echo "mock output of: $(basename "$0") $*"
 
 	defer disks.MockUdevPropertiesForDevice(func(string, string) (map[string]string, error) {
 		return map[string]string{
-			"ID_PART_ENTRY_UUID": "fbbb94fb-46ea-4e00-b830-afc72d202449",
+			"ID_FS_UUID": "570faa3d-e3bc-49db-979b-e7814b6bd390",
 		}, nil
 	})()
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
@@ -2199,7 +2198,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetEncrypted(c *C) 
 	})
 	defer restore()
 
-	restore = devicestate.MockDisksPartitionUUIDFromMountPoint(func(mountpoint string, opts *disks.Options) (string, error) {
+	restore = devicestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		c.Check(mountpoint, Equals, boot.InitramfsUbuntuSaveDir)
 		return "FOOUUID", nil
 	})
@@ -2207,7 +2206,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetEncrypted(c *C) 
 
 	deleteOldSaveKey := 0
 	restore = devicestate.MockSecbootDeleteKeys(func(node string, matches map[string]bool) error {
-		c.Check(node, Equals, "/dev/disk/by-partuuid/FOOUUID")
+		c.Check(node, Equals, "/dev/disk/by-uuid/FOOUUID")
 		c.Check(matches, DeepEquals, map[string]bool{
 			"factory-reset-old":          true,
 			"factory-reset-old-fallback": true,

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
@@ -628,10 +627,10 @@ func MockSecbootDeleteKeys(f func(node string, matches map[string]bool) error) (
 	}
 }
 
-func MockDisksPartitionUUIDFromMountPoint(f func(mountpoint string, opts *disks.Options) (string, error)) (restore func()) {
-	old := disksPartitionUUIDFromMountPoint
-	disksPartitionUUIDFromMountPoint = f
+func MockDisksDMCryptUUIDFromMountPoint(f func(mountpoint string) (string, error)) (restore func()) {
+	old := disksDMCryptUUIDFromMountPoint
+	disksDMCryptUUIDFromMountPoint = f
 	return func() {
-		disksPartitionUUIDFromMountPoint = old
+		disksDMCryptUUIDFromMountPoint = old
 	}
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -65,6 +65,7 @@ var (
 	bootMakeRunnableStandalone           = boot.MakeRunnableStandaloneSystem
 	bootMakeRunnableAfterDataReset       = boot.MakeRunnableSystemAfterDataReset
 	bootEnsureNextBootToRunMode          = boot.EnsureNextBootToRunMode
+	disksDMCryptUUIDFromMountPoint       = disks.DMCryptUUIDFromMountPoint
 	installRun                           = install.Run
 	installFactoryReset                  = install.FactoryReset
 	installMountVolumes                  = install.MountVolumes
@@ -610,11 +611,11 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 			return fmt.Errorf("internal error: no system-save device")
 		}
 
-		uuid, err := disks.PartitionUUID(saveNode)
+		uuid, err := disks.FilesystemUUID(saveNode)
 		if err != nil {
 			return fmt.Errorf("cannot find uuid for partition %s: %v", saveNode, err)
 		}
-		saveNode = fmt.Sprintf("/dev/disk/by-partuuid/%s", uuid)
+		saveNode = fmt.Sprintf("/dev/disk/by-uuid/%s", uuid)
 
 		saveBoostrapContainer, err := createSaveBootstrappedContainer(saveNode)
 		if err != nil {
@@ -1191,7 +1192,6 @@ var (
 	secbootRenameOrDeleteKeys            = secboot.RenameOrDeleteKeys
 	secbootCreateBootstrappedContainer   = secboot.CreateBootstrappedContainer
 	secbootDeleteKeys                    = secboot.DeleteKeys
-	disksPartitionUUIDFromMountPoint     = disks.PartitionUUIDFromMountPoint
 )
 
 func createSaveBootstrappedContainer(saveNode string) (secboot.BootstrappedContainer, error) {
@@ -1242,14 +1242,12 @@ func deleteOldSaveKey(saveMntPnt string) error {
 	// keys.
 
 	// FIXME: maybe there is better if we had a function returning the devname instead.
-	partUUID, err := disksPartitionUUIDFromMountPoint(saveMntPnt, &disks.Options{
-		IsDecryptedDevice: true,
-	})
+	uuid, err := disksDMCryptUUIDFromMountPoint(saveMntPnt)
 	if err != nil {
-		return fmt.Errorf("cannot partition save partition: %v", err)
+		return fmt.Errorf("cannot find save partition: %v", err)
 	}
 
-	diskPath := filepath.Join("/dev/disk/by-partuuid", partUUID)
+	diskPath := filepath.Join("/dev/disk/by-uuid", uuid)
 
 	toDelete := map[string]bool{
 		"factory-reset-old":          true,


### PR DESCRIPTION
`by-partuuid` does not make much sense because it uselessly assumes that it is a partition. Conceptually we should not care about it.  It also makes the resolution more complex as we need to fetch information about the device which we do not really need at this point.
    
It is more common to resolve by filesystem UUID than part UUID. For instance cryptsetup accepts path as `UUID=deadbeef-dead-dead-dead-deaddeafbeef`. But it does not accept this kind of syntax for partitions.


We will also need to register the old paths with something like https://github.com/snapcore/secboot/pull/331