### PR TITLE
tests: update actions versions to avoid warnings in prs github summary

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -357,7 +357,7 @@ jobs:
       if: ${{ matrix.unit-scenario == 'normal' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
@@ -456,13 +456,13 @@ jobs:
       if: ${{ matrix.unit-scenario == 'snapd_debug' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
 
     - name: Test Go (withbootassetstesting)
       if: ${{ matrix.unit-scenario == 'withbootassetstesting' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
 
     - name: Test Go (nosecboot)
       if: ${{ matrix.unit-scenario == 'nosecboot' }}
@@ -473,19 +473,19 @@ jobs:
         # install secboot again
         # ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
         # ${{ github.workspace }}/bin/govendor remove +unused
-        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
 
     - name: Test Go (faultinject)
       if: ${{ matrix.unit-scenario == 'faultinject' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
 
     - name: Test Go (-race)
       if: ${{ matrix.unit-scenario == 'race' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -491,7 +491,7 @@ jobs:
         SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
-      if: ${{ matrix.gochannel != 'latest/stable' }} || ${{ matrix.unit-scenario != 'race' }}
+      if: ${{ matrix.gochannel != 'latest/stable' }} && ${{ matrix.unit-scenario != 'race' }}
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
           - test
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
         fi
 
     - name: Uploading snapd snap artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: snap-files-${{ matrix.toolchain }}-${{ matrix.version }}
         path: "*.snap"
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -114,7 +114,7 @@ jobs:
         sudo tar cvf cached-apt.tar /var/cache/apt
 
     - name: upload Debian dependencies
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: debian-dependencies
         path: ./cached-apt.tar
@@ -143,7 +143,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -158,7 +158,7 @@ jobs:
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
     - name: Download Debian dependencies
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: debian-dependencies
         path: ./debian-deps/
@@ -259,7 +259,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -296,7 +296,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -311,7 +311,7 @@ jobs:
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
     - name: Download Debian dependencies
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: debian-dependencies
         path: ./debian-deps/
@@ -361,7 +361,7 @@ jobs:
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true
         name: coverage-files
@@ -395,7 +395,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -410,7 +410,7 @@ jobs:
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
     - name: Download Debian dependencies
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: debian-dependencies
         path: ./debian-deps/
@@ -489,7 +489,7 @@ jobs:
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true
         name: coverage-files
@@ -572,7 +572,7 @@ jobs:
       GOROOT: ""
     steps:
     - name: Download the coverage files
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage-files
         path: .coverage/
@@ -745,7 +745,7 @@ jobs:
           mkdir "${{ github.workspace }}"
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # spread uses tags as delta reference
         fetch-depth: 0
@@ -842,7 +842,7 @@ jobs:
           echo "GRAFANA START: pr ${CHANGE_ID} attempt ${{ github.run_attempt }} run ${{ github.run_id }} group ${{ matrix.group }}" > "$FILTERED_LOG_FILE"
 
     - name: Download built snap
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       if: "!endsWith(matrix.group, '-fips')"
       with:
         name: snap-files-default-test
@@ -918,13 +918,13 @@ jobs:
           echo "Running command: $SPREAD $RUN_TESTS"
           (set -o pipefail; $SPREAD -no-debug-output -logs spread-logs $RUN_TESTS | PYTHONDONTWRITEBYTECODE=1 ./tests/lib/external/snapd-testing-tools/utils/log-filter $FILTER_PARAMS | tee spread.log)
 
-
     - name: Uploading spread logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: spread-logs-${{ matrix.systems }}
         path: "spread-logs/*.log"
+        if-no-files-found: ignore
 
     - name: Discard spread workers
       if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -359,6 +359,7 @@ jobs:
       if: ${{ matrix.unit-scenario == 'normal' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -365,7 +365,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true
-        name: coverage-files
+        name: "coverage-files-${{ matrix.unit-scenario }}"
         path: "${{ github.workspace }}/coverage/coverage*.cov"
 
   # TODO run unit tests of C code
@@ -495,7 +495,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true
-        name: coverage-files-${{ matrix.unit-scenario }}
+        name: "coverage-files-${{ matrix.unit-scenario }}"
         path: "${{ github.workspace }}/coverage/coverage*.cov"
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -583,7 +583,7 @@ jobs:
         merge-multiple: true
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       # uploading to codecov occasionally fails, so continue running the test
       # workflow regardless of the upload
       continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -495,7 +495,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true
-        name: coverage-files
+        name: coverage-files-${{ matrix.unit-scenario }}
         path: "${{ github.workspace }}/coverage/coverage*.cov"
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -578,8 +578,9 @@ jobs:
     - name: Download the coverage files
       uses: actions/download-artifact@v4
       with:
-        name: coverage-files
+        pattern: coverage-files-*
         path: .coverage/
+        merge-multiple: true
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -489,10 +489,10 @@ jobs:
       if: ${{ matrix.unit-scenario == 'race' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
-      if: ${{ matrix.gochannel != 'latest/stable' }}
+      if: ${{ matrix.gochannel != 'latest/stable' && matrix.unit-scenario != 'race' }}
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -488,10 +488,10 @@ jobs:
       if: ${{ matrix.unit-scenario == 'race' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 ./run-checks --unit
 
     - name: Upload the coverage results
-      if: ${{ matrix.gochannel != 'latest/stable' && matrix.unit-scenario != 'race' }}
+      if: ${{ matrix.gochannel != 'latest/stable' }}
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -216,7 +216,7 @@ jobs:
 
     - name: Cache prebuilt indent
       id: cache-indent-bin
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: indent-bin
         key: ${{ runner.os }}-indent-2.2.13
@@ -357,7 +357,7 @@ jobs:
       if: ${{ matrix.unit-scenario == 'normal' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        ./run-checks --unit
+        COVERAGE_OUT=./coverage ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
@@ -365,7 +365,7 @@ jobs:
       with:
         include-hidden-files: true
         name: coverage-files
-        path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
+        path: "${{ github.workspace }}/src/github.com/snapcore/snapd/coverage/coverage*.cov"
 
   # TODO run unit tests of C code
   unit-tests-special:
@@ -456,13 +456,13 @@ jobs:
       if: ${{ matrix.unit-scenario == 'snapd_debug' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
+        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
 
     - name: Test Go (withbootassetstesting)
       if: ${{ matrix.unit-scenario == 'withbootassetstesting' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
+        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
 
     - name: Test Go (nosecboot)
       if: ${{ matrix.unit-scenario == 'nosecboot' }}
@@ -473,19 +473,19 @@ jobs:
         # install secboot again
         # ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
         # ${{ github.workspace }}/bin/govendor remove +unused
-        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
+        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
 
     - name: Test Go (faultinject)
       if: ${{ matrix.unit-scenario == 'faultinject' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
+        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
 
     - name: Test Go (-race)
       if: ${{ matrix.unit-scenario == 'race' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
+        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
@@ -493,7 +493,7 @@ jobs:
       with:
         include-hidden-files: true
         name: coverage-files
-        path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
+        path: "${{ github.workspace }}/src/github.com/snapcore/snapd/coverage/coverage*.cov"
 
 
   unit-tests-cross-distro:
@@ -757,7 +757,7 @@ jobs:
       shell: bash
 
     - name: Get previous cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.job }}-results-${{ github.run_id }}-${{ matrix.group }}-${{ steps.get-previous-attempt.outputs.previous_attempt }}"
@@ -851,7 +851,7 @@ jobs:
         path: "${{ github.workspace }}/built-snap"
 
     - name: Download built FIPS snap
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       # eg. ubuntu-fips
       if: "endsWith(matrix.group, '-fips')"
       with:
@@ -975,7 +975,7 @@ jobs:
 
     - name: Save spread test results to cache
       if: always()
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.job }}-results-${{ github.run_id }}-${{ matrix.group }}-${{ github.run_attempt }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -357,7 +357,7 @@ jobs:
       if: ${{ matrix.unit-scenario == 'normal' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=./coverage ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
@@ -365,7 +365,7 @@ jobs:
       with:
         include-hidden-files: true
         name: coverage-files
-        path: "${{ github.workspace }}/src/github.com/snapcore/snapd/coverage/coverage*.cov"
+        path: "${{ github.workspace }}/coverage/coverage*.cov"
 
   # TODO run unit tests of C code
   unit-tests-special:
@@ -456,13 +456,13 @@ jobs:
       if: ${{ matrix.unit-scenario == 'snapd_debug' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
 
     - name: Test Go (withbootassetstesting)
       if: ${{ matrix.unit-scenario == 'withbootassetstesting' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
 
     - name: Test Go (nosecboot)
       if: ${{ matrix.unit-scenario == 'nosecboot' }}
@@ -473,19 +473,19 @@ jobs:
         # install secboot again
         # ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
         # ${{ github.workspace }}/bin/govendor remove +unused
-        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
 
     - name: Test Go (faultinject)
       if: ${{ matrix.unit-scenario == 'faultinject' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
 
     - name: Test Go (-race)
       if: ${{ matrix.unit-scenario == 'race' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=./coverage SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
+        COVERAGE_OUT=${{ github.workspace }}/coverage SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
@@ -493,7 +493,7 @@ jobs:
       with:
         include-hidden-files: true
         name: coverage-files
-        path: "${{ github.workspace }}/src/github.com/snapcore/snapd/coverage/coverage*.cov"
+        path: "${{ github.workspace }}/coverage/coverage*.cov"
 
 
   unit-tests-cross-distro:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -352,12 +352,13 @@ jobs:
     - name: Reset code coverage data
       run: |
           rm -rf ${{ github.workspace }}/.coverage/
+          COVERAGE_OUT="${{ github.workspace }}/coverage/coverage-${{ matrix.unit-scenario}}.cov"
+          echo "COVERAGE_OUT=$COVERAGE_OUT" >> $GITHUB_ENV
 
     - name: Test Go
       if: ${{ matrix.unit-scenario == 'normal' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov ./run-checks --unit
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
@@ -451,18 +452,20 @@ jobs:
     - name: Reset code coverage data
       run: |
           rm -rf ${{ github.workspace }}/.coverage/
+          COVERAGE_OUT="${{ github.workspace }}/coverage/coverage-${{ matrix.unit-scenario}}.cov"
+          echo "COVERAGE_OUT=$COVERAGE_OUT" >> $GITHUB_ENV
 
     - name: Test Go (SNAPD_DEBUG=1)
       if: ${{ matrix.unit-scenario == 'snapd_debug' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
 
     - name: Test Go (withbootassetstesting)
       if: ${{ matrix.unit-scenario == 'withbootassetstesting' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
 
     - name: Test Go (nosecboot)
       if: ${{ matrix.unit-scenario == 'nosecboot' }}
@@ -473,22 +476,22 @@ jobs:
         # install secboot again
         # ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
         # ${{ github.workspace }}/bin/govendor remove +unused
-        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
 
     - name: Test Go (faultinject)
       if: ${{ matrix.unit-scenario == 'faultinject' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
 
     - name: Test Go (-race)
       if: ${{ matrix.unit-scenario == 'race' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-        COVERAGE_OUT=${{ github.workspace }}/coverage/coverage.cov SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
+        SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
-      if: ${{ matrix.gochannel != 'latest/stable' }}
+      if: ${{ matrix.gochannel != 'latest/stable' }} || ${{ matrix.unit-scenario != 'race' }}
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -491,7 +491,7 @@ jobs:
         SKIP_DIRTY_CHECK=1 GO_TEST_RACE=1 SKIP_COVERAGE=1 ./run-checks --unit
 
     - name: Upload the coverage results
-      if: ${{ matrix.gochannel != 'latest/stable' }} && ${{ matrix.unit-scenario != 'race' }}
+      if: ${{ matrix.gochannel != 'latest/stable' && matrix.unit-scenario != 'race' }}
       uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true

--- a/run-checks
+++ b/run-checks
@@ -455,6 +455,7 @@ if [ "$UNIT" = 1 ]; then
     # tests
     echo Running tests from "$PWD"
     if [ "$short" = 1 ]; then
+            echo "Running without test coverage"
             # shellcheck disable=SC2046,SC2086
             GOTRACEBACK=1 $goctest $tags $race -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
     else
@@ -463,7 +464,7 @@ if [ "$UNIT" = 1 ]; then
             coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
             # Prepare the coverage output profile.
             mkdir -p "$(dirname "$COVERAGE_OUT")"
-            echo "mode: $COVERMODE" > "$COVERAGE_OUT"
+            echo "Running with coverage mode: $COVERMODE"
         else
             echo "Skipping test coverage"
         fi

--- a/run-checks
+++ b/run-checks
@@ -464,7 +464,7 @@ if [ "$UNIT" = 1 ]; then
             coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
             # Prepare the coverage output profile.
             mkdir -p "$(dirname "$COVERAGE_OUT")"
-            echo "Running with coverage mode: $COVERMODE"
+            echo "Using coverage params: $coverage"
         else
             echo "Skipping test coverage"
         fi

--- a/run-checks
+++ b/run-checks
@@ -295,7 +295,7 @@ if [ "$STATIC" = 1 ]; then
         ./tests/lib/external/snapd-testing-tools/utils/spread-shellcheck $FILTERED_FILES --exclude "$exclude_tools_path" --exclude "tests/nested/manual/core20-preseed"
     fi
 
-    if [ -z "${SKIP_MISSPELL-}" ]; then
+    if [ -z "${SKIP_MISSPELL:-}" ]; then
         echo "Checking spelling errors"
         if ! command -v misspell >/dev/null; then
             goinstall github.com/client9/misspell/cmd/misspell
@@ -309,7 +309,7 @@ if [ "$STATIC" = 1 ]; then
             xargs -0 misspell -error -i "$MISSPELL_IGNORE"
     fi
 
-    if [ -z "${SKIP_INEFFASSIGN-}" ]; then
+    if [ -z "${SKIP_INEFFASSIGN:-}" ]; then
         if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
             echo "Checking for ineffective assignments"
             if ! command -v ineffassign >/dev/null; then
@@ -357,7 +357,7 @@ if [ "$STATIC" = 1 ]; then
 
     # FIXME: re-add staticcheck with a matching version for the used go-version
 
-    if [ -z "${SKIP_TESTS_FORMAT_CHECK-}" ] || [ "$SKIP_TESTS_FORMAT_CHECK" = 0 ]; then
+    if [ -z "${SKIP_TESTS_FORMAT_CHECK:-}" ] || [ "$SKIP_TESTS_FORMAT_CHECK" = 0 ]; then
         CHANGED_TESTS=""
         FILTERED_TESTS=""
         EXCLUDE_PATH=tests/lib/external/snapd-testing-tools
@@ -394,7 +394,7 @@ if [ "$STATIC" = 1 ]; then
       exit 1
     fi
 
-    if [ -z "${SKIP_GOLANGCI_LINT-}" ]; then
+    if [ -z "${SKIP_GOLANGCI_LINT:-}" ]; then
 
         echo "Checking installation of golangci-lint"
         gcil="$(command -v golangci-lint || true)"
@@ -439,11 +439,11 @@ if [ "$UNIT" = 1 ]; then
 
     tags=
     race=
-    if [ -n "${GO_BUILD_TAGS-}" ]; then
+    if [ -n "${GO_BUILD_TAGS:-}" ]; then
         echo "Using build tags: $GO_BUILD_TAGS"
         tags="-tags $GO_BUILD_TAGS"
     fi
-    if [ -n "${GO_TEST_RACE-}" ]; then
+    if [ -n "${GO_TEST_RACE:-}" ]; then
         echo "Using go test -race"
         race="-race"
     fi
@@ -459,7 +459,7 @@ if [ "$UNIT" = 1 ]; then
             GOTRACEBACK=1 $goctest $tags $race -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
     else
         coverage=""
-        if [ -z "${SKIP_COVERAGE-}" ]; then
+        if [ -z "${SKIP_COVERAGE:-}" ]; then
             coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
             # Prepare the coverage output profile.
             mkdir -p "$(dirname "$COVERAGE_OUT")"
@@ -492,7 +492,7 @@ EOF
     exit 1
 fi
 
-if [ -n "${SKIP_DIRTY_CHECK-}" ]; then
+if [ -n "${SKIP_DIRTY_CHECK:-}" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
For each pr we have too many warnings, mostly caused because we are not using the latest actions.
