### PR TITLE
c/snap-failure: fix failing unit test that was missed when restarting snapd.service after recovery

### DIFF
--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -367,7 +367,7 @@ func (r *failureSuite) testCallPrevSnapdWhenDistroInfoDriven(c *C, tc distroVers
 		{"systemctl", "stop", "snapd.socket"},
 		{"systemctl", "is-failed", "snapd.socket", "snapd.service"},
 		{"systemctl", "reset-failed", "snapd.socket", "snapd.service"},
-		{"systemctl", "restart", "snapd.socket"},
+		{"systemctl", "restart", "snapd.socket", "snapd.service"},
 	})
 }
 


### PR DESCRIPTION
It looks like https://github.com/canonical/snapd/pull/14394 didn't contain these unit tests, so they weren't updated.