### PR TITLE
o/i/apparmorprompting: record notices in goroutines

### DIFF
--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"gopkg.in/tomb.v2"
 
@@ -80,11 +79,12 @@ type InterfacesRequestsManager struct {
 
 func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 	notifyPrompt := func(userID uint32, promptID prompting.IDType, data map[string]string) error {
-		currTime := time.Now()
 		options := state.AddNoticeOptions{
 			Data: data,
-			// TODO: Make explicitly setting time guarantee order
-			Time: currTime,
+			// TODO: guarantee order by passing in the current time and ensuring
+			// that the notices backend keeps notice data from the AddNotice
+			// call with the most recent Time field.
+			// Time: time.Now(),
 		}
 		go func() {
 			s.Lock()
@@ -94,11 +94,12 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 		return nil
 	}
 	notifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
-		currTime := time.Now()
 		options := state.AddNoticeOptions{
 			Data: data,
-			// TODO: Make explicitly setting time guarantee order
-			Time: currTime,
+			// TODO: guarantee order by passing in the current time and ensuring
+			// that the notices backend keeps notice data from the AddNotice
+			// call with the most recent Time field.
+			// Time: time.Now(),
 		}
 		go func() {
 			s.Lock()

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -545,10 +545,15 @@ func (s *apparmorpromptingSuite) checkRecordedRuleUpdateNotices(c *C, since time
 }
 
 func (s *apparmorpromptingSuite) checkRecordedNotices(c *C, noticeType state.NoticeType, since time.Time, count int) {
+	timeout := time.Second
+	if count == 0 {
+		// Don't wait so long if we don't expect any notices
+		timeout = 100 * time.Millisecond
+	}
 	receivedCount := 0
 	for receivedCount < count {
 		s.st.Lock()
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
 			Types: []state.NoticeType{noticeType},

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -551,7 +551,7 @@ func (s *apparmorpromptingSuite) checkRecordedNotices(c *C, noticeType state.Not
 		timeout = 100 * time.Millisecond
 	}
 	receivedCount := 0
-	for receivedCount < count {
+	for count == 0 || receivedCount < count {
 		s.st.Lock()
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -1,0 +1,69 @@
+summary: Check that snapd successfully starts with AppArmor prompting enabled
+
+details: |
+    When snapd starts up with the AppArmor prompting flag enabled, it attempts
+    to load any existing rules from disk and records notices for them, expiring
+    any rules which have expiration timestamps in the past. This test checks
+    that snapd can successfully start with prompting enabled, and that it can
+    load and expire rules and record notices appropriately.
+
+systems:
+  - ubuntu-2*
+
+prepare: |
+    # prerequisite for having a prompt handler service
+    snap set system experimental.user-daemons=true
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
+    snap connect test-snapd-prompt-handler:snap-interfaces-requests-control
+
+execute: |
+    RULES_PATH="/var/lib/snapd/interfaces-requests/request-rules.json"
+
+    echo "Write two rules to disk, one of which is expired"
+    mkdir -p "$(dirname $RULES_PATH)"
+    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"},{"id":"0000000000000003","timestamp":"2004-10-20T16:47:32.138415627-05:00","user":1000,"snap":"firefox","interface":"home","constraints":{"path-pattern":"/home/test/Downloads/**","permissions":["read","write"]},"outcome":"allow","lifespan":"timespan","expiration":"2005-04-08T00:00:00Z"}]}' | tee "$RULES_PATH"
+
+    # Prompting is disabled everywhere but the Ubuntu systems
+    # TODO: on Ubuntu releases < 24.04 we need the snapd snap for testing
+    if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
+        not snap set system experimental.apparmor-prompting=true >& err.out
+        if os.query is-core; then
+            # there is a more specific error on Ubuntu Core
+            MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
+        else
+            MATCH "cannot enable prompting feature as it is not supported by the system" < err.out
+        fi
+        # even if unsupported setting it to false should succeed
+        snap set system experimental.apparmor-prompting=false
+        exit 0
+    fi
+
+    CURRTIME="$(date --rcf3339=ns | tr -s ' ' 'T')"
+
+    # Wait a second to make sure any notices are recorded after CURRTIME
+    sleep 1
+
+    echo "Enable AppArmor prompting experimental feature"
+    snap set system experimental.apparmor-prompting=true
+
+    # Wait for snapd to begin restart
+    sleep 5
+
+    echo "Check that snapd is able to start up"
+    retry --wait 1 -n 60 systemctl is-active snapd
+
+    # Write expected rules after the expired rule has been removed
+    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"}]}' | jq | tee expected.json
+    # Parse existing rules through jq so they can be compared
+    jq < "$RULES_PATH" > current.json
+
+    echo "Check that rules on disk match what is expected"
+    diff expected.json current.json
+
+    echo "Check that we received two notices"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 2
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result' | grep -c '"removed": "expired"' | MATCH 1
+
+    echo "Check that only the former rule is still valid (must be done with UID 1000)"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.[0].id' | MATCH "0000000000000002"


### PR DESCRIPTION
During snapd startup, the state lock is held while the prompting-related backends are created. However, the backends may try to record notices if, e.g., some rules on disk have expired before they are read by load.

Similarly, during snapd shutdown, the state lock may be held while the interfaces requests manager is being stopped.

If recording a notice happens synchronously during such situations, it results in a deadlock on the state lock. Thus, the notices must be recorded asynchronously.

Note: this means that the order of notices is no longer guaranteed in the prompt and rule backends, but this is okay, since clients should always be prepared to consult the actual prompting endpoints as a single source of truth, and notice data is just a convenient shortcut if it is known that a prompt or rule has already been removed.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-31228