### PR TITLE
spread, github: drop 18.04 i386 variant

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -650,7 +650,7 @@ jobs:
             tests: 'tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04'
           - group: ubuntu-xenial-bionic
             backend: google
-            systems: 'ubuntu-16.04-64 ubuntu-18.04-32 ubuntu-18.04-64'
+            systems: 'ubuntu-16.04-64 ubuntu-18.04-64'
             tests: 'tests/...'
           - group: ubuntu-focal-jammy
             backend: google

--- a/spread.yaml
+++ b/spread.yaml
@@ -124,8 +124,6 @@ backends:
             - ubuntu-16.04-64:
                   workers: 8
                   storage: 12G
-            - ubuntu-18.04-32:
-                  workers: 6
             - ubuntu-18.04-64:
                   storage: 15G
                   workers: 8


### PR DESCRIPTION
We stopped releasing core and snapd snaps for i386 with version 2.60.4. As such 18.04 i386 is no longer supported

Cherry picked from #14294 

Related: SNAPDENG-20098