### PR TITLE
seed: fix bugs pertaining to how components missing from the model are handled

### DIFF
--- a/seed/seed.go
+++ b/seed/seed.go
@@ -231,7 +231,7 @@ func Open(seedDir, label string) (Seed, error) {
 		if err := asserts.IsValidSystemLabel(label); err != nil {
 			return nil, err
 		}
-		return &seed20{systemDir: filepath.Join(seedDir, "systems", label)}, nil
+		return &seed20{seedDir: seedDir, systemDir: filepath.Join(seedDir, "systems", label)}, nil
 	}
 	return &seed16{seedDir: seedDir}, nil
 }

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -658,9 +658,16 @@ func (s *seed20) deriveSideInfo(snapRef naming.SnapRef, modelSnap *asserts.Model
 			return seedComps[i].CompSideInfo.Component.ComponentName <
 				seedComps[j].CompSideInfo.Component.ComponentName
 		})
-	} else {
-		// Asserted option snap
+	}
+
+	// if we have an options snap for this asserted snap, then it should only
+	// contain asserted components that are not present in the model
+	if optSnap != nil {
 		for _, comp := range optSnap.Components {
+			if comp.Unasserted != "" {
+				return "", nil, nil, fmt.Errorf("internal error: unasserted component in options.yaml for asserted snap: %s", comp.Unasserted)
+			}
+
 			seedComp, err := s.lookupVerifiedComponent(
 				naming.NewComponentRef(snapDecl.SnapName(), comp.Name),
 				snap.R(snapRev.SnapRevision()), snapDecl.SnapID(),

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -111,6 +111,30 @@ version: 2.0
 type: test
 version: 2.0
 `,
+	"component-test": `name: component-test
+type: app
+base: core20
+version: 1.0
+components:
+  comp1:
+    type: test
+  comp2:
+    type: test
+  comp3:
+    type: test
+`,
+	"component-test+comp1": `component: component-test+comp1
+type: test
+version: 1.0
+`,
+	"component-test+comp2": `component: component-test+comp2
+type: test
+version: 2.0
+`,
+	"component-test+comp3": `component: component-test+comp3
+type: test
+version: 2.0
+`,
 	"optional20-a": `name: optional20-a
 type: app
 base: core20

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -241,13 +241,13 @@ func (tr *tree20) snapPath(sn *SeedSnap) (string, error) {
 }
 
 func (tr *tree20) componentPath(sn *SeedSnap, sc *SeedComponent) (string, error) {
-	snapsDir, err := tr.componentDir(sn, sc)
+	componentsDir, err := tr.componentDir(sn, sc)
 	if err != nil {
 		return "", err
 	}
 
 	cpi := snap.MinimalComponentContainerPlaceInfo(sc.ComponentName, sc.Info.Revision, sc.SnapName)
-	return filepath.Join(snapsDir, cpi.Filename()), nil
+	return filepath.Join(componentsDir, cpi.Filename()), nil
 }
 
 func (tr *tree20) localSnapPath(sn *SeedSnap) (string, error) {

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -222,6 +222,16 @@ func (tr *tree20) snapDir(sn *SeedSnap) (string, error) {
 	return snapsDir, nil
 }
 
+func (tr *tree20) componentDir(sn *SeedSnap, sc *SeedComponent) (string, error) {
+	if ms := sn.modelSnap; ms != nil {
+		if _, ok := ms.Components[sc.ComponentName]; ok {
+			return tr.snapsDirPath, nil
+		}
+	}
+
+	return tr.ensureSystemSnapsDir()
+}
+
 func (tr *tree20) snapPath(sn *SeedSnap) (string, error) {
 	snapsDir, err := tr.snapDir(sn)
 	if err != nil {
@@ -231,7 +241,7 @@ func (tr *tree20) snapPath(sn *SeedSnap) (string, error) {
 }
 
 func (tr *tree20) componentPath(sn *SeedSnap, sc *SeedComponent) (string, error) {
-	snapsDir, err := tr.snapDir(sn)
+	snapsDir, err := tr.componentDir(sn, sc)
 	if err != nil {
 		return "", err
 	}
@@ -346,6 +356,9 @@ func (tr *tree20) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Re
 		}
 	}
 
+	// TODO: assertions for components that are not in the model (but their snap
+	// is in the model) still end up here, rather than extra-snaps. to be more
+	// consistent, they should go in extra-snaps
 	if err := writeByRefs("snaps", snapsRefGen(snapsFromModel)); err != nil {
 		return err
 	}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -3912,6 +3912,10 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C,
 			map[string]interface{}{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
+				"components": map[string]interface{}{
+					"comp1": "optional",
+					"comp2": "optional",
+				},
 			},
 		},
 	})

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -3518,7 +3518,12 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
-			}},
+			},
+			map[string]interface{}{
+				"name": "component-test",
+				"id":   s.AssertedSnapID("component-test"),
+			},
+		},
 	})
 
 	// validity
@@ -3535,17 +3540,26 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 		"comp1": snap.R(22),
 		"comp2": snap.R(33),
 	}
-	s.SeedSnaps.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["required20"], nil,
+	s.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["required20"], nil,
 		snap.R(21), comRevs, "canonical", s.StoreSigning.Database)
+
+	s.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["component-test"], nil,
+		snap.R(31), nil, "canonical", s.StoreSigning.Database)
 
 	s.opts.Label = "20191122"
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "cont-producer", Channel: "edge"},
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
+		{Name: "cont-producer", Channel: "edge"},
 		{Name: "core18"}, {Path: contConsumerFn},
 		{Name: "required20", Components: []seedwriter.OptionsComponent{
-			{Name: "comp1"}, {Name: "comp2"}}}})
+			{Name: "comp1"}, {Name: "comp2"},
+		}},
+		{Name: "component-test", Components: []seedwriter.OptionsComponent{
+			{Name: "comp1"},
+		}},
+	})
 	c.Assert(err, IsNil)
 
 	err = w.Start(s.db, s.rf)
@@ -3570,7 +3584,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 
 	snaps, err := w.SnapsToDownload()
 	c.Assert(err, IsNil)
-	c.Check(snaps, HasLen, 4)
+	c.Check(snaps, HasLen, 5)
 
 	for _, sn := range snaps {
 		channel := "latest/stable"
@@ -3632,7 +3646,10 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 
 	l, err := os.ReadDir(filepath.Join(s.opts.SeedDir, "snaps"))
 	c.Assert(err, IsNil)
-	c.Check(l, HasLen, 4)
+	c.Check(l, HasLen, 5)
+
+	// this snap is part of the model, so it should be in the seed's snap dir
+	c.Check(filepath.Join(s.opts.SeedDir, "snaps", "component-test_31.snap"), testutil.FilePresent)
 
 	// extra containers were put in system snaps dir
 	c.Check(filepath.Join(systemDir, "snaps", "core18_1.snap"), testutil.FilePresent)
@@ -3642,11 +3659,11 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 	c.Check(filepath.Join(systemDir, "snaps", "required20+comp1_22.comp"), testutil.FilePresent)
 	c.Check(filepath.Join(systemDir, "snaps", "required20+comp2_33.comp"), testutil.FilePresent)
 
-	// check extra-snaps in assertions
-	snapAsserts := seedtest.ReadAssertions(c, filepath.Join(systemDir, "assertions", "extra-snaps"))
-	seen := make(map[string]bool)
+	// although this component's snap is in the model, the component itself is
+	// not. that is why it ends up in this directory
+	c.Check(filepath.Join(systemDir, "snaps", "component-test+comp1_77.comp"), testutil.FilePresent)
 
-	for _, a := range snapAsserts {
+	uniqID := func(a asserts.Assertion) string {
 		uniq := a.Ref().Unique()
 		if a.Type() == asserts.SnapRevisionType {
 			rev := a.(*asserts.SnapRevision)
@@ -3656,7 +3673,20 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 			uniq = fmt.Sprintf("%s+%s@%d", rev.SnapID(),
 				rev.ResourceName(), rev.ResourceRevision())
 		}
-		seen[uniq] = true
+		return uniq
+	}
+
+	// check extra-snaps in assertions
+	extraAssertions := seedtest.ReadAssertions(c, filepath.Join(systemDir, "assertions", "extra-snaps"))
+	seenExtra := make(map[string]bool)
+	for _, a := range extraAssertions {
+		seenExtra[uniqID(a)] = true
+	}
+
+	assertions := seedtest.ReadAssertions(c, filepath.Join(systemDir, "assertions", "snaps"))
+	seen := make(map[string]bool)
+	for _, a := range assertions {
+		seen[uniqID(a)] = true
 	}
 
 	snapRevUniq := func(snapName string, revno int) string {
@@ -3668,25 +3698,41 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 	snapDeclUniq := func(snapName string) string {
 		return "snap-declaration/16/" + s.AssertedSnapID(snapName)
 	}
+	snapResPairUniq := func(snapName, compName string, resRev, snapRev int) string {
+		return fmt.Sprintf("snap-resource-pair/%s/%s/%d/%d", s.AssertedSnapID(snapName), compName, resRev, snapRev)
+	}
 
-	c.Check(seen, DeepEquals, map[string]bool{
-		"account/developerid":                                             true,
-		snapDeclUniq("core18"):                                            true,
-		snapDeclUniq("cont-producer"):                                     true,
-		snapDeclUniq("required20"):                                        true,
-		snapRevUniq("core18", 1):                                          true,
-		snapRevUniq("cont-producer", 1):                                   true,
-		snapRevUniq("required20", 21):                                     true,
-		resRevUniq("required20", "comp1", 22):                             true,
-		resRevUniq("required20", "comp2", 33):                             true,
-		"snap-resource-pair/required20ididididididididididid/comp1/22/21": true,
-		"snap-resource-pair/required20ididididididididididid/comp2/33/21": true,
+	c.Check(seenExtra, DeepEquals, map[string]bool{
+		"account/developerid":                          true,
+		snapDeclUniq("core18"):                         true,
+		snapDeclUniq("cont-producer"):                  true,
+		snapDeclUniq("required20"):                     true,
+		snapRevUniq("core18", 1):                       true,
+		snapRevUniq("cont-producer", 1):                true,
+		snapRevUniq("required20", 21):                  true,
+		resRevUniq("required20", "comp1", 22):          true,
+		resRevUniq("required20", "comp2", 33):          true,
+		snapResPairUniq("required20", "comp1", 22, 21): true,
+		snapResPairUniq("required20", "comp2", 33, 21): true,
 	})
+
+	// all of these end up in the main assertions file since the snap is
+	// asserted and in the model, despite the component not being in the model.
+	// this might be something we want to change
+	c.Check(seen[snapRevUniq("component-test", 31)], Equals, true)
+	c.Check(seen[resRevUniq("component-test", "comp1", 77)], Equals, true)
+	c.Check(seen[snapDeclUniq("component-test")], Equals, true)
+	c.Check(seen[snapResPairUniq("component-test", "comp1", 77, 31)], Equals, true)
 
 	options20, err := seedwriter.InternalReadOptions20(filepath.Join(systemDir, "options.yaml"))
 	c.Assert(err, IsNil)
 
 	c.Check(options20.Snaps, DeepEquals, []*seedwriter.InternalSnap20{
+		{
+			Name:       "component-test",
+			SnapID:     s.AssertedSnapID("component-test"),
+			Components: []internal.Component20{{Name: "comp1"}},
+		},
 		{
 			Name:    "cont-producer",
 			SnapID:  s.AssertedSnapID("cont-producer"),

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -516,7 +516,8 @@ func (s *toolingSuite) TestDownloadManySnapWithComps(c *C) {
 	}
 	dlDir := c.MkDir()
 	var numCore, numReq int
-	bdf := func(si *snap.Info, cinfos map[string]*snap.ComponentInfo) (targetPath string, err error) {
+	bdf := func(si *snap.Info, cinfos map[string]*snap.ComponentInfo) (targetPath string, compPaths map[string]string, err error) {
+		compPaths = make(map[string]string, len(cinfos))
 		switch si.SnapName() {
 		case "core":
 			c.Check(len(cinfos), Equals, 0)
@@ -539,10 +540,12 @@ func (s *toolingSuite) TestDownloadManySnapWithComps(c *C) {
 				},
 			})
 			numReq++
+			compPaths[cref1.ComponentName] = filepath.Join(dlDir, fmt.Sprintf("%s.comp", cref1.String()))
+			compPaths[cref2.ComponentName] = filepath.Join(dlDir, fmt.Sprintf("%s.comp", cref2.String()))
 		default:
 			c.Error("unexpected snap", si.SnapName())
 		}
-		return filepath.Join(dlDir, si.SnapName()), nil
+		return filepath.Join(dlDir, si.SnapName()), compPaths, nil
 	}
 	topts := tooling.DownloadManyOptions{
 		BeforeDownloadFunc: bdf,

--- a/tests/main/prepare-image-components/task.yaml
+++ b/tests/main/prepare-image-components/task.yaml
@@ -33,6 +33,15 @@ execute: |
       MATCH "type: snap-resource-pair" < "$LABEL_D"/assertions/snaps
   }
 
+  check_comps_local_to_system() {
+      LABEL_D=$(find $TARGET_D/system-seed/systems/ -maxdepth 1 -mindepth 1)
+      SYSTEM_SNAPS_D=$LABEL_D/snaps
+      for comp in "$@"; do
+          stat "$SYSTEM_SNAPS_D"/test-snap-with-components+"$comp"_*.comp
+          MATCH "resource-name: $comp" < "$LABEL_D"/assertions/snaps
+      done
+  }
+
   ## dangerous model
 
   # component one is mandatory in model
@@ -49,7 +58,8 @@ execute: |
   rm -rf "$TARGET_D"
   snap prepare-image "$TESTSLIB"/assertions/pc24-with-comps-dangerous.model \
        --comp test-snap-with-components+two --comp test-snap-with-components+three "$TARGET_D"
-  check_files_and_assertions one two three
+  check_files_and_assertions one two
+  check_comps_local_to_system three
 
   ## signed model
 


### PR DESCRIPTION
There were two related bugs here. First, we weren't writing anything to options.yaml when we added components to the seed that weren't in the model, but the snap was in the model.

On the other side of things, we weren't considering components from options.yaml when the snap itself was from the model.

There is the question of the currently failing `TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnapsWithComps`, which looks like it is adding extra components to a seed that doesn't have them defined in the model. I think maybe this shouldn't be allowed?