### PR TITLE
tests/lib: tweaks and fixes for running Ubuntu Core tests locally in a VM

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -540,6 +540,7 @@ pkg_dependencies_ubuntu_generic(){
         udisks2
         upower
         uuid-runtime
+        pigz
         "
 }
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -563,7 +563,7 @@ EOF
     # XXX: this duplicates a lot of setup_test_user_by_modify_writable()
     cat > "$UNPACK_DIR"/usr/lib/snapd/snapd.spread-tests-run-mode-tweaks.sh <<'EOF'
 #!/bin/sh
-set -e
+set -ex
 # ensure we don't enable ssh in install mode or spread will get confused
 if ! grep -E 'snapd_recovery_mode=(run|recover)' /proc/cmdline; then
     echo "not in run or recovery mode - script not running"
@@ -607,7 +607,9 @@ echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/99-ubuntu-user
 sed -i 's/\#\?\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
 echo "MaxAuthTries 120" >> /etc/ssh/sshd_config
 grep '^PermitRootLogin yes' /etc/ssh/sshd_config
-systemctl reload ssh
+if systemctl is-active ssh; then
+   systemctl reload ssh
+fi
 
 touch /root/spread-setup-done
 EOF

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1451,7 +1451,12 @@ EOF
     umount /mnt
     kpartx -d "$IMAGE_HOME/$IMAGE"
 
-    gzip "${IMAGE_HOME}/${IMAGE}"
+    if command -v pigz 2>/dev/null; then
+        pigz "${IMAGE_HOME}/${IMAGE}"
+    else
+        gzip "${IMAGE_HOME}/${IMAGE}"
+    fi
+
     if is_test_target_core 16; then
         "${TESTSLIB}/uc16-reflash.sh" "${IMAGE_HOME}/${IMAGE}.gz"
     else


### PR DESCRIPTION
Install and use pigz to speed up the image prepare time. 

Fix a possible race in snapd.run-mode-tweaks.service which was found when running in a VM with more than 1 CPU.