### PR TITLE
o/ifacestate,tests: apparmor prompting not running if manager creation failed

### DIFF
--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -241,6 +242,9 @@ const (
 // for a substantial amount of time (such as to lock and modify snapd state).
 func New(notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error) (*PromptDB, error) {
 	maxIDFilepath := filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
+	if err := os.MkdirAll(dirs.SnapRunDir, 0o755); err != nil {
+		return nil, err
+	}
 	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(maxIDFilepath)
 	if err != nil {
 		return nil, err

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -74,7 +74,6 @@ func (s *requestpromptsSuite) SetUpTest(c *C) {
 	s.tmpdir = c.MkDir()
 	dirs.SetRootDir(s.tmpdir)
 	s.maxIDPath = filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
-	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0700), IsNil)
 }
 
 func (s *requestpromptsSuite) TestNew(c *C) {
@@ -195,6 +194,8 @@ func (s *requestpromptsSuite) TestNewNextIDUniqueIDs(c *C) {
 		return nil
 	})
 	defer restore()
+
+	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0o755), IsNil)
 
 	var initialMaxID uint64 = 42
 	var initialData [8]byte

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -211,12 +211,14 @@ func (m *InterfaceManager) StartUp() error {
 			m.state.Unlock()
 			defer m.state.Lock()
 			if err := m.initInterfacesRequestsManager(); err != nil {
-				// TODO: if this fails, set useAppArmorPromptingValue to false ?
-				// If this is done before profilesNeedRegeneration, then profiles will only
-				// be regenerated if prompting is newly supported and the backends were
-				// successfully created.
-				// TODO: also set "apparmor-prompting" flag to false?
 				logger.Noticef("failed to start interfaces requests manager: %v", err)
+				// Set m.useAppArmorPrompting to false so external callers
+				// don't try to access nil backends.
+				m.useAppArmorPrompting = false
+				// This is done before profilesNeedRegeneration, so profiles
+				// will only be regenerated if prompting is newly enabled and
+				// the backends were successfully created.
+				// TODO: also set "apparmor-prompting" flag to false?
 			}
 		}()
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -7006,6 +7006,10 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	err = mgr.StartUp()
 	c.Check(err, IsNil)
 
+	// Check that error caused AppArmorPromptingRunning() to now return false
+	running := mgr.AppArmorPromptingRunning()
+	c.Check(running, Equals, false)
+
 	logger.WithLoggerLock(func() {
 		c.Check(logbuf.String(), testutil.Contains, fmt.Sprintf("%v", createError))
 	})

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -71,13 +71,13 @@ execute: |
 
     echo "Check that only the former rule is still valid (must be done with UID 1000)"
     sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.[0].id' | MATCH "0000000000000002"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"
 
     echo "Stop snapd and ensure it is not in failure mode"
     systemctl stop snapd.service snapd.socket
     # Try for a while to make sure it's not in failure mode
     echo "Check that systemctl is-failed is never true after a while"
-    retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket && exit 1
+    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
 
     CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
 
@@ -95,8 +95,72 @@ execute: |
     echo "Check that we received one notices for the non-expired rule"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 1
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result.[0].key' | MATCH "0000000000000002"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result[0].key' | MATCH "0000000000000002"
 
     echo "Check that only the non-expired rule is still valid (must be done with UID 1000)"
     sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.[0].id' | MATCH "0000000000000002"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"
+
+    echo '### Simulate failure to open interfaces requests manager ###'
+
+    echo "Stop snapd and ensure it is not in failure mode"
+    systemctl stop snapd.service snapd.socket
+    # Try for a while to make sure it's not in failure mode
+    echo "Check that systemctl is-failed is never true after a while"
+    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+
+    echo "Corrupt the max prompt ID file (by making it a dir) so it will fail to start up next time"
+    # This simulates what would happen on system restart, if e.g. /run/snapd did not yet exist during StartUp
+    MAX_ID_FILEPATH="/run/snapd/request-prompt-max-id"
+    rm -f "$MAX_ID_FILEPATH"
+    mkdir -p "$MAX_ID_FILEPATH"
+
+    echo "Restart snapd and ensure it starts properly"
+    systemctl start snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that apparmor prompting is supported and enabled"
+    # XXX: in the future, we should set enabled to be false if m.AppArmorPromptingRunning() is false,
+    # such as because creating the interfaces requests manager failed.
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+
+    echo "Check that rules on disk still match what is expected"
+    diff expected.json current.json
+
+    echo "Check that accessing a prompting endpoint results in an expected error"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '."status-code"' | MATCH 500
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.message' | MATCH -i "Apparmor Prompting is not running"
+
+    echo '### Remove the corrupted max prompt ID file and check that prompting backends can start again ###'
+
+    echo "Stop snapd and ensure it is not in failure mode"
+    systemctl stop snapd.service snapd.socket
+    # Try for a while to make sure it's not in failure mode
+    echo "Check that systemctl is-failed is never true after a while"
+    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+
+    echo "Remove corrupted max prompt ID file"
+    rm -rf "$MAX_ID_FILEPATH"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Restart snapd and ensure it starts properly"
+    systemctl start snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that apparmor prompting is supported and enabled"
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+
+    echo "Check that rules on disk still match what is expected"
+    diff expected.json current.json
+
+    echo "Check that we received one notices for the non-expired rule"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 1
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result[0].key' | MATCH "0000000000000002"
+
+    echo "Check that the non-expired rule is still valid (must be done with UID 1000)"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"


### PR DESCRIPTION
If creation of the interfaces requests manager fails for some reason, we need to mark the manager's internal `useAppArmorPrompting` value to false so that calls to `AppArmorPromptingRunning()` will return false, and we don't try to access a nil-pointer manager backend.

Extend the apparmor-prompting-snapd-startup test to cover this scenario.

Further, we address one reason for this failure: lack of `/run/snapd/` during the interface manager startup. We should ensure that this directory exists as part of the requestprompts backend attempting to open the max prompt ID mmap.

This is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-31381