### PR TITLE
release: 2.65.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# New in snapd 2.65:
+# New in snapd 2.65.1:
 * Support building snapd using base Core22 (Snapcraft 8.x)
 * FIPS: support building FIPS complaint snapd variant that switches to FIPS mode when the system boots with FIPS enabled
 * AppArmor: update to latest 4.0.2 release
@@ -49,6 +49,7 @@
 * Support enabling snapd logging with snap set system debug.snapd.{log,log-level}
 * Add options system.coredump.enable and system.coredump.maxuse to support using systemd-coredump on Ubuntu Core
 * Provide documentation URL for 'snap interface <iface-name>'
+* Fix snapd riscv64 build
 * Fix restarting activated services instead of their activator units (i.e. sockets, timers)
 * Fix potential unexpected auto-refresh of snap on managed schedule
 * Fix potential segfault by guarding against kernel command-line changes on classic system

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -287,7 +287,16 @@ parts:
              ;;
            *)
              export CGO_ENABLED=1
-             GO_LD_FLAGS=()
+             case "${CRAFT_ARCH_BUILD_FOR}" in
+               armhf)
+                 # https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1822738
+                 BUILDMODE=()
+                 ;;
+               *)
+                 BUILDMODE=(-buildmode=pie)
+                 ;;
+             esac
+             GO_LD_FLAGS=("${BUILDMODE[@]}")
              unset CHECK_STATIC
              ;;
         esac

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -241,6 +242,9 @@ const (
 // for a substantial amount of time (such as to lock and modify snapd state).
 func New(notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error) (*PromptDB, error) {
 	maxIDFilepath := filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
+	if err := os.MkdirAll(dirs.SnapRunDir, 0o755); err != nil {
+		return nil, err
+	}
 	maxIDMmap, err := maxidmmap.OpenMaxIDMmap(maxIDFilepath)
 	if err != nil {
 		return nil, err

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -74,7 +74,6 @@ func (s *requestpromptsSuite) SetUpTest(c *C) {
 	s.tmpdir = c.MkDir()
 	dirs.SetRootDir(s.tmpdir)
 	s.maxIDPath = filepath.Join(dirs.SnapRunDir, "request-prompt-max-id")
-	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0700), IsNil)
 }
 
 func (s *requestpromptsSuite) TestNew(c *C) {
@@ -195,6 +194,8 @@ func (s *requestpromptsSuite) TestNewNextIDUniqueIDs(c *C) {
 		return nil
 	})
 	defer restore()
+
+	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0o755), IsNil)
 
 	var initialMaxID uint64 = 42
 	var initialData [8]byte

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -211,12 +211,14 @@ func (m *InterfaceManager) StartUp() error {
 			m.state.Unlock()
 			defer m.state.Lock()
 			if err := m.initInterfacesRequestsManager(); err != nil {
-				// TODO: if this fails, set useAppArmorPromptingValue to false ?
-				// If this is done before profilesNeedRegeneration, then profiles will only
-				// be regenerated if prompting is newly supported and the backends were
-				// successfully created.
-				// TODO: also set "apparmor-prompting" flag to false?
 				logger.Noticef("failed to start interfaces requests manager: %v", err)
+				// Set m.useAppArmorPrompting to false so external callers
+				// don't try to access nil backends.
+				m.useAppArmorPrompting = false
+				// This is done before profilesNeedRegeneration, so profiles
+				// will only be regenerated if prompting is newly enabled and
+				// the backends were successfully created.
+				// TODO: also set "apparmor-prompting" flag to false?
 			}
 		}()
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -7006,6 +7006,10 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	err = mgr.StartUp()
 	c.Check(err, IsNil)
 
+	// Check that error caused AppArmorPromptingRunning() to now return false
+	running := mgr.AppArmorPromptingRunning()
+	c.Check(running, Equals, false)
+
 	logger.WithLoggerLock(func() {
 		c.Check(logbuf.String(), testutil.Contains, fmt.Sprintf("%v", createError))
 	})

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.65
+pkgver=2.65.1
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,147 @@
+snapd (2.65.1-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Support building snapd using base Core22 (Snapcraft 8.x)
+    - FIPS: support building FIPS complaint snapd variant that switches
+      to FIPS mode when the system boots with FIPS enabled
+    - AppArmor: update to latest 4.0.2 release
+    - AppArmor: enable using ABI 4.0 from host parser
+    - AppArmor: fix parser lookup
+    - AppArmor: support AppArmor snippet priorities
+    - AppArmor: allow reading cgroup memory.max file
+    - AppArmor: allow using snap-exec coming from the snapd snap when
+      starting a confined process with jailmode
+    - AppArmor prompting (experimental): add checks for prompting
+      support, include prompting status in system key, and restart snapd
+      if prompting flag changes
+    - AppArmor prompting (experimental): include prompt prefix in
+      AppArmor rules if prompting is supported and enabled
+    - AppArmor prompting (experimental): add common types, constraints,
+      and mappings from AppArmor permissions to abstract permissions
+    - AppArmor prompting (experimental): add path pattern parsing and
+      matching
+    - AppArmor prompting (experimental): add path pattern precedence
+      based on specificity
+    - AppArmor prompting (experimental): add packages to manage
+      outstanding request prompts and rules
+    - AppArmor prompting (experimental): add prompting API and notice
+      types, which require snap-interfaces-requests-control interface
+    - AppArmor prompting (experimental): feature flag can only be
+      enabled if prompting is supported, handler service connected, and
+      the service can be started
+    - Registry views (experimental): rename from aspects to registries
+    - Registry views (experimental): support reading registry views and
+      setting/unsetting registry data using snapctl
+    - Registry views (experimental): fetch and refresh registry
+      assertions as needed
+    - Registry views (experimental): restrict view paths from using a
+      number as first character and view names to storage path style
+      patterns
+    - Snap components: support installing snaps and components from
+      files at the same time (no REST API/CLI)
+    - Snap components: support downloading components related assertions
+      from the store
+    - Snap components: support installing components from the store
+    - Snap components: support removing components individually and
+      during snap removal
+    - Snap components: support kernel modules as components
+    - Snap components: support for component install, pre-refresh and
+      post-refresh hooks
+    - Snap components: initial support for building systems that contain
+      components
+    - Refresh app awareness (experimental): add data field for
+      /v2/changes REST API to allow associating each task with affected
+      snaps
+    - Refresh app awareness (experimental): use the app name from
+      .desktop file in notifications
+    - Refresh app awareness (experimental): give snap-refresh-observe
+      interface access to /v2/snaps/{name} endpoint
+    - Improve snap-confine compatibility with nvidia drivers
+    - Allow re-exec when SNAP_REEXEC is set for unlisted distros to
+      simplify testing
+    - Allow mixing revision and channel on snap install
+    - Generate GNU build ID for Go binaries
+    - Add missing etelpmoc.sh for shell completion
+    - Do not attempt to run snapd on classic when re-exec is disabled
+    - Packaging/build maintenance for Debian sid, Fedora, Arch, openSuse
+    - Add snap debug API command to enable running raw queries
+    - Enable snap-confine snap mount directory detection
+    - Replace global seccomp filter with deny rules in standard seccomp
+      template
+    - Remove support for Ubuntu Core Launcher (superseded by snap-
+      confine)
+    - Support creating pending serial bound users after serial assertion
+      becomes available
+    - Support disabling cloud-init using kernel command-line
+    - In hybrid systems, apps can refresh without waiting for restarts
+      required by essential snaps
+    - Ship snap-debug-info.sh script used for system diagnostics
+    - Improve error messages when attempting to run non-existent snap
+    - Switch to -u UID:GID for strace-static
+    - Support enabling snapd logging with snap set system
+      debug.snapd.{log,log-level}
+    - Add options system.coredump.enable and system.coredump.maxuse to
+      support using systemd-coredump on Ubuntu Core
+    - Provide documentation URL for 'snap interface '
+    - Fix snapd riscv64 build
+    - Fix restarting activated services instead of their activator units
+      (i.e. sockets, timers)
+    - Fix potential unexpected auto-refresh of snap on managed schedule
+    - Fix potential segfault by guarding against kernel command-line
+      changes on classic system
+    - Fix proxy entries in /etc/environment with missing newline that
+      caused later manual entries to not be usable
+    - Fix offline remodelling by ignoring prerequisites that will
+      otherwise be downloaded from store
+    - Fix devmode seccomp deny regression that caused spamming the log
+      instead of actual denies
+    - Fix snap lock leak during refresh
+    - Fix not re-pinning validation sets that were already pinned when
+      enforcing new validation sets
+    - Fix handling of unexpected snapd runtime failure
+    - Fix /v2/notices REST API skipping notices with duplicate
+      timestamps
+    - Fix comparing systemd versions that may contain pre-release
+      suffixes
+    - Fix udev potentially starting before snap-device-helper is made
+      available
+    - Fix race in snap seed metadata loading
+    - Fix treating cloud-init exit status 2 as error
+    - Fix to prevent sending refresh complete notification if snap snap-
+      refresh-observe interface is connected
+    - Fix to queue snapctl service commands if run from the default-
+      configure hook to ensure they get up-to-date config values
+    - Fix stop service failure when the service is not actually running
+      anymore
+    - Fix parsing /proc/PID/mounts with spaces
+    - Add registry interface that provides snaps access to a particular
+      registry view
+    - Add snap-interfaces-requests-control interface to enable prompting
+      client snaps
+    - steam-support interface: remove all AppArmor and seccomp
+      restrictions to improve user experience
+    - opengl interface: improve compatibility with nvidia drivers
+    - home interface: autoconnect home on Ubuntu Core Desktop
+    - serial-port interface: support RPMsg tty
+    - display-control interface: allow changing LVDS backlight power and
+      brightness
+    - power-control interface: support for battery charging thesholds,
+      type/status and AC type/status
+    - cpu-control interface: allow CPU C-state control
+    - raw-usb interface: support RPi5 and Thinkpad x13s
+    - custom-device interface: allow device file locking
+    - lxd-support interface: allow LXD to self-manage its own cgroup
+    - network-manager interface: support MPTCP sockets
+    - network-control interface: allow plug/slot access to gnutls config
+      and systemd resolved cache flushing via D-Bus
+    - network-control interface: allow wpa_supplicant dbus api
+    - gpio-control interface: support gpiochip* devices
+    - polkit interface: fix "rw" mount option check
+    - u2f-devices interface: enable additional security keys
+    - desktop interface: enable kde theming support
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Sat, 24 Aug 2024 10:31:20 +0200
+
 snapd (2.65-1) unstable; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.65
+Version:        2.65.1
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -1003,6 +1003,147 @@ fi
 
 
 %changelog
+* Sat Aug 24 2024 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.65.1
+ - Support building snapd using base Core22 (Snapcraft 8.x)
+ - FIPS: support building FIPS complaint snapd variant that switches
+   to FIPS mode when the system boots with FIPS enabled
+ - AppArmor: update to latest 4.0.2 release
+ - AppArmor: enable using ABI 4.0 from host parser
+ - AppArmor: fix parser lookup
+ - AppArmor: support AppArmor snippet priorities
+ - AppArmor: allow reading cgroup memory.max file
+ - AppArmor: allow using snap-exec coming from the snapd snap when
+   starting a confined process with jailmode
+ - AppArmor prompting (experimental): add checks for prompting
+   support, include prompting status in system key, and restart snapd
+   if prompting flag changes
+ - AppArmor prompting (experimental): include prompt prefix in
+   AppArmor rules if prompting is supported and enabled
+ - AppArmor prompting (experimental): add common types, constraints,
+   and mappings from AppArmor permissions to abstract permissions
+ - AppArmor prompting (experimental): add path pattern parsing and
+   matching
+ - AppArmor prompting (experimental): add path pattern precedence
+   based on specificity
+ - AppArmor prompting (experimental): add packages to manage
+   outstanding request prompts and rules
+ - AppArmor prompting (experimental): add prompting API and notice
+   types, which require snap-interfaces-requests-control interface
+ - AppArmor prompting (experimental): feature flag can only be
+   enabled if prompting is supported, handler service connected, and
+   the service can be started
+ - Registry views (experimental): rename from aspects to registries
+ - Registry views (experimental): support reading registry views and
+   setting/unsetting registry data using snapctl
+ - Registry views (experimental): fetch and refresh registry
+   assertions as needed
+ - Registry views (experimental): restrict view paths from using a
+   number as first character and view names to storage path style
+   patterns
+ - Snap components: support installing snaps and components from
+   files at the same time (no REST API/CLI)
+ - Snap components: support downloading components related assertions
+   from the store
+ - Snap components: support installing components from the store
+ - Snap components: support removing components individually and
+   during snap removal
+ - Snap components: support kernel modules as components
+ - Snap components: support for component install, pre-refresh and
+   post-refresh hooks
+ - Snap components: initial support for building systems that contain
+   components
+ - Refresh app awareness (experimental): add data field for
+   /v2/changes REST API to allow associating each task with affected
+   snaps
+ - Refresh app awareness (experimental): use the app name from
+   .desktop file in notifications
+ - Refresh app awareness (experimental): give snap-refresh-observe
+   interface access to /v2/snaps/{name} endpoint
+ - Improve snap-confine compatibility with nvidia drivers
+ - Allow re-exec when SNAP_REEXEC is set for unlisted distros to
+   simplify testing
+ - Allow mixing revision and channel on snap install
+ - Generate GNU build ID for Go binaries
+ - Add missing etelpmoc.sh for shell completion
+ - Do not attempt to run snapd on classic when re-exec is disabled
+ - Packaging/build maintenance for Debian sid, Fedora, Arch, openSuse
+ - Add snap debug API command to enable running raw queries
+ - Enable snap-confine snap mount directory detection
+ - Replace global seccomp filter with deny rules in standard seccomp
+   template
+ - Remove support for Ubuntu Core Launcher (superseded by snap-
+   confine)
+ - Support creating pending serial bound users after serial assertion
+   becomes available
+ - Support disabling cloud-init using kernel command-line
+ - In hybrid systems, apps can refresh without waiting for restarts
+   required by essential snaps
+ - Ship snap-debug-info.sh script used for system diagnostics
+ - Improve error messages when attempting to run non-existent snap
+ - Switch to -u UID:GID for strace-static
+ - Support enabling snapd logging with snap set system
+   debug.snapd.{log,log-level}
+ - Add options system.coredump.enable and system.coredump.maxuse to
+   support using systemd-coredump on Ubuntu Core
+ - Provide documentation URL for 'snap interface '
+ - Fix snapd riscv64 build
+ - Fix restarting activated services instead of their activator units
+   (i.e. sockets, timers)
+ - Fix potential unexpected auto-refresh of snap on managed schedule
+ - Fix potential segfault by guarding against kernel command-line
+   changes on classic system
+ - Fix proxy entries in /etc/environment with missing newline that
+   caused later manual entries to not be usable
+ - Fix offline remodelling by ignoring prerequisites that will
+   otherwise be downloaded from store
+ - Fix devmode seccomp deny regression that caused spamming the log
+   instead of actual denies
+ - Fix snap lock leak during refresh
+ - Fix not re-pinning validation sets that were already pinned when
+   enforcing new validation sets
+ - Fix handling of unexpected snapd runtime failure
+ - Fix /v2/notices REST API skipping notices with duplicate
+   timestamps
+ - Fix comparing systemd versions that may contain pre-release
+   suffixes
+ - Fix udev potentially starting before snap-device-helper is made
+   available
+ - Fix race in snap seed metadata loading
+ - Fix treating cloud-init exit status 2 as error
+ - Fix to prevent sending refresh complete notification if snap snap-
+   refresh-observe interface is connected
+ - Fix to queue snapctl service commands if run from the default-
+   configure hook to ensure they get up-to-date config values
+ - Fix stop service failure when the service is not actually running
+   anymore
+ - Fix parsing /proc/PID/mounts with spaces
+ - Add registry interface that provides snaps access to a particular
+   registry view
+ - Add snap-interfaces-requests-control interface to enable prompting
+   client snaps
+ - steam-support interface: remove all AppArmor and seccomp
+   restrictions to improve user experience
+ - opengl interface: improve compatibility with nvidia drivers
+ - home interface: autoconnect home on Ubuntu Core Desktop
+ - serial-port interface: support RPMsg tty
+ - display-control interface: allow changing LVDS backlight power and
+   brightness
+ - power-control interface: support for battery charging thesholds,
+   type/status and AC type/status
+ - cpu-control interface: allow CPU C-state control
+ - raw-usb interface: support RPi5 and Thinkpad x13s
+ - custom-device interface: allow device file locking
+ - lxd-support interface: allow LXD to self-manage its own cgroup
+ - network-manager interface: support MPTCP sockets
+ - network-control interface: allow plug/slot access to gnutls config
+   and systemd resolved cache flushing via D-Bus
+ - network-control interface: allow wpa_supplicant dbus api
+ - gpio-control interface: support gpiochip* devices
+ - polkit interface: fix "rw" mount option check
+ - u2f-devices interface: enable additional security keys
+ - desktop interface: enable kde theming support
+
 * Fri Aug 23 2024 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.65
  - Support building snapd using base Core22 (Snapcraft 8.x)

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sat Aug 24 08:31:20 UTC 2024 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.65.1
+
+-------------------------------------------------------------------
 Fri Aug 23 06:49:28 UTC 2024 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.65

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.65
+Version:        2.65.1
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,147 @@
+snapd (2.65.1~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Support building snapd using base Core22 (Snapcraft 8.x)
+    - FIPS: support building FIPS complaint snapd variant that switches
+      to FIPS mode when the system boots with FIPS enabled
+    - AppArmor: update to latest 4.0.2 release
+    - AppArmor: enable using ABI 4.0 from host parser
+    - AppArmor: fix parser lookup
+    - AppArmor: support AppArmor snippet priorities
+    - AppArmor: allow reading cgroup memory.max file
+    - AppArmor: allow using snap-exec coming from the snapd snap when
+      starting a confined process with jailmode
+    - AppArmor prompting (experimental): add checks for prompting
+      support, include prompting status in system key, and restart snapd
+      if prompting flag changes
+    - AppArmor prompting (experimental): include prompt prefix in
+      AppArmor rules if prompting is supported and enabled
+    - AppArmor prompting (experimental): add common types, constraints,
+      and mappings from AppArmor permissions to abstract permissions
+    - AppArmor prompting (experimental): add path pattern parsing and
+      matching
+    - AppArmor prompting (experimental): add path pattern precedence
+      based on specificity
+    - AppArmor prompting (experimental): add packages to manage
+      outstanding request prompts and rules
+    - AppArmor prompting (experimental): add prompting API and notice
+      types, which require snap-interfaces-requests-control interface
+    - AppArmor prompting (experimental): feature flag can only be
+      enabled if prompting is supported, handler service connected, and
+      the service can be started
+    - Registry views (experimental): rename from aspects to registries
+    - Registry views (experimental): support reading registry views and
+      setting/unsetting registry data using snapctl
+    - Registry views (experimental): fetch and refresh registry
+      assertions as needed
+    - Registry views (experimental): restrict view paths from using a
+      number as first character and view names to storage path style
+      patterns
+    - Snap components: support installing snaps and components from
+      files at the same time (no REST API/CLI)
+    - Snap components: support downloading components related assertions
+      from the store
+    - Snap components: support installing components from the store
+    - Snap components: support removing components individually and
+      during snap removal
+    - Snap components: support kernel modules as components
+    - Snap components: support for component install, pre-refresh and
+      post-refresh hooks
+    - Snap components: initial support for building systems that contain
+      components
+    - Refresh app awareness (experimental): add data field for
+      /v2/changes REST API to allow associating each task with affected
+      snaps
+    - Refresh app awareness (experimental): use the app name from
+      .desktop file in notifications
+    - Refresh app awareness (experimental): give snap-refresh-observe
+      interface access to /v2/snaps/{name} endpoint
+    - Improve snap-confine compatibility with nvidia drivers
+    - Allow re-exec when SNAP_REEXEC is set for unlisted distros to
+      simplify testing
+    - Allow mixing revision and channel on snap install
+    - Generate GNU build ID for Go binaries
+    - Add missing etelpmoc.sh for shell completion
+    - Do not attempt to run snapd on classic when re-exec is disabled
+    - Packaging/build maintenance for Debian sid, Fedora, Arch, openSuse
+    - Add snap debug API command to enable running raw queries
+    - Enable snap-confine snap mount directory detection
+    - Replace global seccomp filter with deny rules in standard seccomp
+      template
+    - Remove support for Ubuntu Core Launcher (superseded by snap-
+      confine)
+    - Support creating pending serial bound users after serial assertion
+      becomes available
+    - Support disabling cloud-init using kernel command-line
+    - In hybrid systems, apps can refresh without waiting for restarts
+      required by essential snaps
+    - Ship snap-debug-info.sh script used for system diagnostics
+    - Improve error messages when attempting to run non-existent snap
+    - Switch to -u UID:GID for strace-static
+    - Support enabling snapd logging with snap set system
+      debug.snapd.{log,log-level}
+    - Add options system.coredump.enable and system.coredump.maxuse to
+      support using systemd-coredump on Ubuntu Core
+    - Provide documentation URL for 'snap interface '
+    - Fix snapd riscv64 build
+    - Fix restarting activated services instead of their activator units
+      (i.e. sockets, timers)
+    - Fix potential unexpected auto-refresh of snap on managed schedule
+    - Fix potential segfault by guarding against kernel command-line
+      changes on classic system
+    - Fix proxy entries in /etc/environment with missing newline that
+      caused later manual entries to not be usable
+    - Fix offline remodelling by ignoring prerequisites that will
+      otherwise be downloaded from store
+    - Fix devmode seccomp deny regression that caused spamming the log
+      instead of actual denies
+    - Fix snap lock leak during refresh
+    - Fix not re-pinning validation sets that were already pinned when
+      enforcing new validation sets
+    - Fix handling of unexpected snapd runtime failure
+    - Fix /v2/notices REST API skipping notices with duplicate
+      timestamps
+    - Fix comparing systemd versions that may contain pre-release
+      suffixes
+    - Fix udev potentially starting before snap-device-helper is made
+      available
+    - Fix race in snap seed metadata loading
+    - Fix treating cloud-init exit status 2 as error
+    - Fix to prevent sending refresh complete notification if snap snap-
+      refresh-observe interface is connected
+    - Fix to queue snapctl service commands if run from the default-
+      configure hook to ensure they get up-to-date config values
+    - Fix stop service failure when the service is not actually running
+      anymore
+    - Fix parsing /proc/PID/mounts with spaces
+    - Add registry interface that provides snaps access to a particular
+      registry view
+    - Add snap-interfaces-requests-control interface to enable prompting
+      client snaps
+    - steam-support interface: remove all AppArmor and seccomp
+      restrictions to improve user experience
+    - opengl interface: improve compatibility with nvidia drivers
+    - home interface: autoconnect home on Ubuntu Core Desktop
+    - serial-port interface: support RPMsg tty
+    - display-control interface: allow changing LVDS backlight power and
+      brightness
+    - power-control interface: support for battery charging thesholds,
+      type/status and AC type/status
+    - cpu-control interface: allow CPU C-state control
+    - raw-usb interface: support RPi5 and Thinkpad x13s
+    - custom-device interface: allow device file locking
+    - lxd-support interface: allow LXD to self-manage its own cgroup
+    - network-manager interface: support MPTCP sockets
+    - network-control interface: allow plug/slot access to gnutls config
+      and systemd resolved cache flushing via D-Bus
+    - network-control interface: allow wpa_supplicant dbus api
+    - gpio-control interface: support gpiochip* devices
+    - polkit interface: fix "rw" mount option check
+    - u2f-devices interface: enable additional security keys
+    - desktop interface: enable kde theming support
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Sat, 24 Aug 2024 10:31:20 +0200
+
 snapd (2.65~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,147 @@
+snapd (2.65.1) xenial; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Support building snapd using base Core22 (Snapcraft 8.x)
+    - FIPS: support building FIPS complaint snapd variant that switches
+      to FIPS mode when the system boots with FIPS enabled
+    - AppArmor: update to latest 4.0.2 release
+    - AppArmor: enable using ABI 4.0 from host parser
+    - AppArmor: fix parser lookup
+    - AppArmor: support AppArmor snippet priorities
+    - AppArmor: allow reading cgroup memory.max file
+    - AppArmor: allow using snap-exec coming from the snapd snap when
+      starting a confined process with jailmode
+    - AppArmor prompting (experimental): add checks for prompting
+      support, include prompting status in system key, and restart snapd
+      if prompting flag changes
+    - AppArmor prompting (experimental): include prompt prefix in
+      AppArmor rules if prompting is supported and enabled
+    - AppArmor prompting (experimental): add common types, constraints,
+      and mappings from AppArmor permissions to abstract permissions
+    - AppArmor prompting (experimental): add path pattern parsing and
+      matching
+    - AppArmor prompting (experimental): add path pattern precedence
+      based on specificity
+    - AppArmor prompting (experimental): add packages to manage
+      outstanding request prompts and rules
+    - AppArmor prompting (experimental): add prompting API and notice
+      types, which require snap-interfaces-requests-control interface
+    - AppArmor prompting (experimental): feature flag can only be
+      enabled if prompting is supported, handler service connected, and
+      the service can be started
+    - Registry views (experimental): rename from aspects to registries
+    - Registry views (experimental): support reading registry views and
+      setting/unsetting registry data using snapctl
+    - Registry views (experimental): fetch and refresh registry
+      assertions as needed
+    - Registry views (experimental): restrict view paths from using a
+      number as first character and view names to storage path style
+      patterns
+    - Snap components: support installing snaps and components from
+      files at the same time (no REST API/CLI)
+    - Snap components: support downloading components related assertions
+      from the store
+    - Snap components: support installing components from the store
+    - Snap components: support removing components individually and
+      during snap removal
+    - Snap components: support kernel modules as components
+    - Snap components: support for component install, pre-refresh and
+      post-refresh hooks
+    - Snap components: initial support for building systems that contain
+      components
+    - Refresh app awareness (experimental): add data field for
+      /v2/changes REST API to allow associating each task with affected
+      snaps
+    - Refresh app awareness (experimental): use the app name from
+      .desktop file in notifications
+    - Refresh app awareness (experimental): give snap-refresh-observe
+      interface access to /v2/snaps/{name} endpoint
+    - Improve snap-confine compatibility with nvidia drivers
+    - Allow re-exec when SNAP_REEXEC is set for unlisted distros to
+      simplify testing
+    - Allow mixing revision and channel on snap install
+    - Generate GNU build ID for Go binaries
+    - Add missing etelpmoc.sh for shell completion
+    - Do not attempt to run snapd on classic when re-exec is disabled
+    - Packaging/build maintenance for Debian sid, Fedora, Arch, openSuse
+    - Add snap debug API command to enable running raw queries
+    - Enable snap-confine snap mount directory detection
+    - Replace global seccomp filter with deny rules in standard seccomp
+      template
+    - Remove support for Ubuntu Core Launcher (superseded by snap-
+      confine)
+    - Support creating pending serial bound users after serial assertion
+      becomes available
+    - Support disabling cloud-init using kernel command-line
+    - In hybrid systems, apps can refresh without waiting for restarts
+      required by essential snaps
+    - Ship snap-debug-info.sh script used for system diagnostics
+    - Improve error messages when attempting to run non-existent snap
+    - Switch to -u UID:GID for strace-static
+    - Support enabling snapd logging with snap set system
+      debug.snapd.{log,log-level}
+    - Add options system.coredump.enable and system.coredump.maxuse to
+      support using systemd-coredump on Ubuntu Core
+    - Provide documentation URL for 'snap interface '
+    - Fix snapd riscv64 build
+    - Fix restarting activated services instead of their activator units
+      (i.e. sockets, timers)
+    - Fix potential unexpected auto-refresh of snap on managed schedule
+    - Fix potential segfault by guarding against kernel command-line
+      changes on classic system
+    - Fix proxy entries in /etc/environment with missing newline that
+      caused later manual entries to not be usable
+    - Fix offline remodelling by ignoring prerequisites that will
+      otherwise be downloaded from store
+    - Fix devmode seccomp deny regression that caused spamming the log
+      instead of actual denies
+    - Fix snap lock leak during refresh
+    - Fix not re-pinning validation sets that were already pinned when
+      enforcing new validation sets
+    - Fix handling of unexpected snapd runtime failure
+    - Fix /v2/notices REST API skipping notices with duplicate
+      timestamps
+    - Fix comparing systemd versions that may contain pre-release
+      suffixes
+    - Fix udev potentially starting before snap-device-helper is made
+      available
+    - Fix race in snap seed metadata loading
+    - Fix treating cloud-init exit status 2 as error
+    - Fix to prevent sending refresh complete notification if snap snap-
+      refresh-observe interface is connected
+    - Fix to queue snapctl service commands if run from the default-
+      configure hook to ensure they get up-to-date config values
+    - Fix stop service failure when the service is not actually running
+      anymore
+    - Fix parsing /proc/PID/mounts with spaces
+    - Add registry interface that provides snaps access to a particular
+      registry view
+    - Add snap-interfaces-requests-control interface to enable prompting
+      client snaps
+    - steam-support interface: remove all AppArmor and seccomp
+      restrictions to improve user experience
+    - opengl interface: improve compatibility with nvidia drivers
+    - home interface: autoconnect home on Ubuntu Core Desktop
+    - serial-port interface: support RPMsg tty
+    - display-control interface: allow changing LVDS backlight power and
+      brightness
+    - power-control interface: support for battery charging thesholds,
+      type/status and AC type/status
+    - cpu-control interface: allow CPU C-state control
+    - raw-usb interface: support RPi5 and Thinkpad x13s
+    - custom-device interface: allow device file locking
+    - lxd-support interface: allow LXD to self-manage its own cgroup
+    - network-manager interface: support MPTCP sockets
+    - network-control interface: allow plug/slot access to gnutls config
+      and systemd resolved cache flushing via D-Bus
+    - network-control interface: allow wpa_supplicant dbus api
+    - gpio-control interface: support gpiochip* devices
+    - polkit interface: fix "rw" mount option check
+    - u2f-devices interface: enable additional security keys
+    - desktop interface: enable kde theming support
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Sat, 24 Aug 2024 10:31:20 +0200
+
 snapd (2.65) xenial; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -71,13 +71,13 @@ execute: |
 
     echo "Check that only the former rule is still valid (must be done with UID 1000)"
     sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.[0].id' | MATCH "0000000000000002"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"
 
     echo "Stop snapd and ensure it is not in failure mode"
     systemctl stop snapd.service snapd.socket
     # Try for a while to make sure it's not in failure mode
     echo "Check that systemctl is-failed is never true after a while"
-    retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket && exit 1
+    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
 
     CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
 
@@ -95,8 +95,72 @@ execute: |
     echo "Check that we received one notices for the non-expired rule"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 1
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result.[0].key' | MATCH "0000000000000002"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result[0].key' | MATCH "0000000000000002"
 
     echo "Check that only the non-expired rule is still valid (must be done with UID 1000)"
     sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.[0].id' | MATCH "0000000000000002"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"
+
+    echo '### Simulate failure to open interfaces requests manager ###'
+
+    echo "Stop snapd and ensure it is not in failure mode"
+    systemctl stop snapd.service snapd.socket
+    # Try for a while to make sure it's not in failure mode
+    echo "Check that systemctl is-failed is never true after a while"
+    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+
+    echo "Corrupt the max prompt ID file (by making it a dir) so it will fail to start up next time"
+    # This simulates what would happen on system restart, if e.g. /run/snapd did not yet exist during StartUp
+    MAX_ID_FILEPATH="/run/snapd/request-prompt-max-id"
+    rm -f "$MAX_ID_FILEPATH"
+    mkdir -p "$MAX_ID_FILEPATH"
+
+    echo "Restart snapd and ensure it starts properly"
+    systemctl start snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that apparmor prompting is supported and enabled"
+    # XXX: in the future, we should set enabled to be false if m.AppArmorPromptingRunning() is false,
+    # such as because creating the interfaces requests manager failed.
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+
+    echo "Check that rules on disk still match what is expected"
+    diff expected.json current.json
+
+    echo "Check that accessing a prompting endpoint results in an expected error"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '."status-code"' | MATCH 500
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.message' | MATCH -i "Apparmor Prompting is not running"
+
+    echo '### Remove the corrupted max prompt ID file and check that prompting backends can start again ###'
+
+    echo "Stop snapd and ensure it is not in failure mode"
+    systemctl stop snapd.service snapd.socket
+    # Try for a while to make sure it's not in failure mode
+    echo "Check that systemctl is-failed is never true after a while"
+    not retry --wait 1 -n 30 systemctl is-failed snapd.service snapd.socket
+
+    echo "Remove corrupted max prompt ID file"
+    rm -rf "$MAX_ID_FILEPATH"
+
+    CURRTIME="$(date --rfc-3339=ns --utc | tr ' ' 'T' | sed 's/\+00:00/Z/')"
+
+    echo "Restart snapd and ensure it starts properly"
+    systemctl start snapd.service snapd.socket
+    retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
+
+    echo "Check that apparmor prompting is supported and enabled"
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+
+    echo "Check that rules on disk still match what is expected"
+    diff expected.json current.json
+
+    echo "Check that we received one notices for the non-expired rule"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 1
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result[0].key' | MATCH "0000000000000002"
+
+    echo "Check that the non-expired rule is still valid (must be done with UID 1000)"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"


### PR DESCRIPTION
Generated changelogs with:
DEBEMAIL="Ernest Lotter [ernest.lotter@canonical.com](mailto:ernest.lotter@canonical.com)" release-tools/changelog.py 2.65.1 2077473 NEWS.md

- This was required to fix AppArmor prompting bug preventing release of 2.65. 
- Additionally build fix for snapd riscv64.

Release notes for 2.65 (that will not become an actual release) was replaced with 2.65.1 in order to show the full set of changes relative to the last actual released snapd (2.63).

Cherry-picked:
- https://github.com/canonical/snapd/pull/14421
- https://github.com/canonical/snapd/pull/14411

**Requires rebase-merge**