### PR TITLE
interfaces/builtin/cpu-control: Add IRQ affinity control to cpu_control

### DIFF
--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -82,6 +82,11 @@ const cpuControlConnectedPlugAppArmor = `
 
 # Allow control CPU C-states switching see: https://docs.kernel.org/power/pm_qos_interface.html#pm-qos-framework
 /dev/cpu_dma_latency rw,
+
+# Allow interrupt affinity settings
+/proc/interrupts r,
+/proc/irq/[0-9]+/smp_affinity rw,
+/proc/irq/[0-9]+/smp_affinity_list rw,
 `
 
 var cpuControlConnectedPlugUDev = []string{

--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -83,7 +83,7 @@ const cpuControlConnectedPlugAppArmor = `
 # Allow control CPU C-states switching see: https://docs.kernel.org/power/pm_qos_interface.html#pm-qos-framework
 /dev/cpu_dma_latency rw,
 
-# Allow interrupt affinity settings
+# Allow interrupt affinity settings, see https://www.kernel.org/doc/html/latest/core-api/irq/irq-affinity.html
 /proc/interrupts r,
 /proc/irq/[0-9]+/smp_affinity rw,
 /proc/irq/[0-9]+/smp_affinity_list rw,

--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -87,6 +87,7 @@ const cpuControlConnectedPlugAppArmor = `
 /proc/interrupts r,
 /proc/irq/[0-9]+/smp_affinity rw,
 /proc/irq/[0-9]+/smp_affinity_list rw,
+/proc/irq/default_smp_affinity rw,
 `
 
 var cpuControlConnectedPlugUDev = []string{


### PR DESCRIPTION
Many real-time system need to tune IRQ affinity by accessing the related `/proc` file system files. 

Adding this to CPU-control avoids the need to create a new interface for IRQ's or either for real-time applications.