### PR TITLE
o/snapstate: create shared snap directory during link-snap

### DIFF
--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -297,6 +298,57 @@ version: 1.0
 	c.Check(osutil.FileExists(currentActiveSymlink), Equals, false)
 	c.Check(osutil.FileExists(currentDataSymlink), Equals, false)
 
+}
+
+func (s *linkSuite) TestLinkDoUndoParallel(c *C) {
+	const yaml = `name: hello
+version: 1.0
+`
+	info := snaptest.MockSnapInstance(c, "hello_foo", yaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	reboot, err := s.be.LinkSnap(info, mockDev, backend.LinkContext{
+		HasOtherInstances: false,
+	}, s.perfTimings)
+	c.Assert(err, IsNil)
+
+	c.Check(reboot, Equals, boot.RebootInfo{RebootRequired: false})
+
+	mountDir := info.MountDir()
+	dataDir := info.DataDir()
+	currentActiveSymlink := filepath.Join(mountDir, "..", "current")
+	currentActiveDir, err := filepath.EvalSymlinks(currentActiveSymlink)
+	c.Assert(err, IsNil)
+	c.Assert(currentActiveDir, Equals, mountDir)
+
+	fi, err := os.Stat(snap.BaseDir("hello"))
+	c.Assert(err, IsNil)
+	c.Check(fi.IsDir(), Equals, true)
+
+	currentDataSymlink := filepath.Join(dataDir, "..", "current")
+	currentDataDir, err := filepath.EvalSymlinks(currentDataSymlink)
+	c.Assert(err, IsNil)
+	c.Assert(currentDataDir, Equals, dataDir)
+
+	// undo will remove the symlinks but leave the shared snap directory
+	// behind regardless of other instances presence
+	for _, other := range []bool{true, false} {
+		err = s.be.UnlinkSnap(info, backend.LinkContext{
+			HasOtherInstances: other,
+		}, progress.Null)
+		c.Assert(err, IsNil)
+
+		c.Check(osutil.FileExists(currentActiveSymlink), Equals, false)
+		c.Check(osutil.FileExists(currentDataSymlink), Equals, false)
+
+		fi, err = os.Stat(snap.BaseDir("hello"))
+		c.Assert(err, IsNil)
+		c.Check(fi.IsDir(), Equals, true)
+	}
+
+	// but the shared snap directory is left behind
+	fi, err = os.Stat(snap.BaseDir("hello"))
+	c.Assert(err, IsNil)
+	c.Check(fi.IsDir(), Equals, true)
 }
 
 func (s *linkSuite) TestLinkSetNextBoot(c *C) {
@@ -751,6 +803,48 @@ func (s *linkCleanupSuite) TestLinkCleanupFailedSnapdSnapNonFirstInstallOnCore(c
 	restore := release.MockOnClassic(false)
 	defer restore()
 	s.testLinkCleanupFailedSnapdSnapOnCorePastWrappers(c, false)
+}
+
+type testLinkCleanupParallelInstanceTestCase struct {
+	otherInstances bool
+}
+
+func (s *linkCleanupSuite) testLinkCleanupOnFailWithParallelInstance(c *C, tc testLinkCleanupParallelInstanceTestCase) {
+	const yaml = `name: instance-snap
+version: 1.0
+`
+
+	// break linking by creating a directory in place of 'current' symlink
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "instance-snap_foo/current"), 0755), IsNil)
+
+	snapinstance := snaptest.MockSnapInstance(c, "instance-snap_foo", yaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	_, err := s.be.LinkSnap(snapinstance, mockDev,
+		backend.LinkContext{
+			HasOtherInstances: tc.otherInstances,
+		},
+		s.perfTimings)
+	c.Assert(err, NotNil)
+	c.Assert(errors.Is(err, fs.ErrExist), Equals, true)
+
+	_, err = os.Stat(filepath.Join(dirs.SnapMountDir, "instance-snap"))
+	if !tc.otherInstances {
+		c.Assert(errors.Is(err, fs.ErrNotExist), Equals, true)
+	} else {
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *linkCleanupSuite) TestLinkCleanupOnFailWithParallelInstanceHasOther(c *C) {
+	s.testLinkCleanupOnFailWithParallelInstance(c, testLinkCleanupParallelInstanceTestCase{
+		otherInstances: true,
+	})
+}
+
+func (s *linkCleanupSuite) TestLinkCleanupOnFailWithParallelInstanceNoOther(c *C) {
+	s.testLinkCleanupOnFailWithParallelInstance(c, testLinkCleanupParallelInstanceTestCase{
+		otherInstances: false,
+	})
 }
 
 type snapdOnCoreUnlinkSuite struct {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1224,6 +1224,8 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx b
 
 		vitalityRank:        vitalityRank,
 		requireSnapdTooling: linkCtx.RequireMountedSnapdSnap,
+
+		otherInstances: linkCtx.HasOtherInstances,
 	}
 
 	if info.MountDir() == f.linkSnapFailTrigger {
@@ -1372,6 +1374,7 @@ func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, linkCtx backend.LinkCont
 
 		unlinkFirstInstallUndo: linkCtx.FirstInstall,
 		unlinkSkipBinaries:     linkCtx.SkipBinaries,
+		otherInstances:         linkCtx.HasOtherInstances,
 	})
 	return f.maybeErrForLastOp()
 }

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -419,8 +419,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 			name: "some-snap_instance",
 		},
 		{
-			op:   "unlink-snap",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			op:             "unlink-snap",
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			otherInstances: true,
 		},
 		{
 			op:    "remove-profiles:Doing",
@@ -573,8 +574,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 			name: "some-snap_instance",
 		},
 		{
-			op:   "unlink-snap",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			op:             "unlink-snap",
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			otherInstances: true,
 		},
 		{
 			op:    "remove-profiles:Doing",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1928,8 +1928,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 			inhibitHint: "refresh",
 		},
 		{
-			op:   "unlink-snap",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			op:             "unlink-snap",
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			otherInstances: true,
 		},
 		{
 			op:    "setup-profiles:Doing",
@@ -1944,8 +1945,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 			},
 		},
 		{
-			op:   "link-snap",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/2"),
+			op:             "link-snap",
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/2"),
+			otherInstances: true,
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -3140,8 +3142,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceEnableRunThrough(c *C) {
 			sinfo: si,
 		},
 		{
-			op:   "link-snap",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			op:             "link-snap",
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			otherInstances: true,
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -3213,8 +3216,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceDisableRunThrough(c *C) {
 			name: "some-snap_instance",
 		},
 		{
-			op:   "unlink-snap",
-			path: filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			op:             "unlink-snap",
+			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			otherInstances: true,
 		},
 		{
 			op:    "remove-profiles:Doing",


### PR DESCRIPTION
Fix a problem with parallel installs and handling of the shared snap directory, eg /snap/foo, for snap instances /snap/foo_bar. A bug was identified which was a race between a removal of the shared directory in the discard-snap handler of one instance, and creating of the same shared directory in setup-snap handler of another instances if both changes happened to be executing in parallel. The existing conflict resolution does not consider the instances of the same snap to be in conflict, since with exception of the shared snap directory and/or aliases, there should be no collision.

In detail, the shared directory was created in setup-snap handler, which runs before link-snap, and so before the instance-being-installed is effectively added to the state. At the same time, discard-snap handler would check the state for other snap instances, but since the new installation isn't there yet, there would be none, and so the shared directory would get removed.

Related: SNAPDENG-31335

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
