### PR TITLE
many: allow systems installed via installer API to pick optional snaps and components

### DIFF
--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -325,7 +325,7 @@ func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRe
 		ensureStateSoon(st)
 		return AsyncResponse(nil, chg.ID())
 	case client.InstallStepFinish:
-		var optional *devicestate.OptionalInstall
+		var optional *devicestate.OptionalContainers
 		if req.OptionalInstall != nil {
 			// note that we provide a nil optional install here in the case that
 			// the request set the All field to true. the nil optional install
@@ -336,7 +336,7 @@ func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRe
 					return BadRequest("cannot specify both all and individual optional snaps and components to install")
 				}
 			} else {
-				optional = &devicestate.OptionalInstall{
+				optional = &devicestate.OptionalContainers{
 					Snaps:      req.OptionalInstall.Snaps,
 					Components: req.OptionalInstall.Components,
 				}

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -171,7 +171,11 @@ func getSystemDetails(c *Command, r *http.Request, user *auth.UserState) Respons
 			Validation:  sys.Brand.Validation(),
 		},
 		// no body: we expect models to have empty bodies
-		Model:             sys.Model.Headers(),
+		Model: sys.Model.Headers(),
+		AvailableOptional: client.AvailableForInstall{
+			Snaps:      sys.OptionalContainers.Snaps,
+			Components: sys.OptionalContainers.Components,
+		},
 		Volumes:           gadgetInfo.Volumes,
 		StorageEncryption: storageEncryption(encryptionInfo),
 	}

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1112,8 +1112,8 @@ func (s *systemsSuite) testSystemInstallActionFinishCallsDevicestate(c *check.C,
 	nCalls := 0
 	var gotOnVolumes map[string]*gadget.Volume
 	var gotLabel string
-	var gotOptionalInstall *devicestate.OptionalInstall
-	r := daemon.MockDevicestateInstallFinish(func(st *state.State, label string, onVolumes map[string]*gadget.Volume, optionalInstall *devicestate.OptionalInstall) (*state.Change, error) {
+	var gotOptionalInstall *devicestate.OptionalContainers
+	r := daemon.MockDevicestateInstallFinish(func(st *state.State, label string, onVolumes map[string]*gadget.Volume, optionalInstall *devicestate.OptionalContainers) (*state.Change, error) {
 		gotLabel = label
 		gotOnVolumes = onVolumes
 		gotOptionalInstall = optionalInstall
@@ -1160,7 +1160,7 @@ func (s *systemsSuite) testSystemInstallActionFinishCallsDevicestate(c *check.C,
 	if optionalInstall.All {
 		c.Check(gotOptionalInstall, check.IsNil)
 	} else {
-		c.Check(gotOptionalInstall, check.DeepEquals, &devicestate.OptionalInstall{
+		c.Check(gotOptionalInstall, check.DeepEquals, &devicestate.OptionalContainers{
 			Snaps:      optionalInstall.Snaps,
 			Components: optionalInstall.Components,
 		})

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -864,6 +864,10 @@ func (s *systemsSuite) TestSystemsGetSystemDetailsForLabel(c *check.C) {
 				Model: s.seedModelForLabel20191119,
 				Label: "20191119",
 				Brand: s.Brands.Account("my-brand"),
+				OptionalContainers: devicestate.OptionalContainers{
+					Snaps:      []string{"snap1", "snap2"},
+					Components: map[string][]string{"snap1": {"comp1"}, "snap2": {"comp2"}},
+				},
 			}
 			return sys, mockGadgetInfo, mockEncryptionSupportInfo, nil
 		})
@@ -890,6 +894,13 @@ func (s *systemsSuite) TestSystemsGetSystemDetailsForLabel(c *check.C) {
 				UnavailableReason: tc.expectedUnavailableReason,
 			},
 			Volumes: mockGadgetInfo.Volumes,
+			AvailableOptional: client.AvailableForInstall{
+				Snaps: []string{"snap1", "snap2"},
+				Components: map[string][]string{
+					"snap1": {"comp1"},
+					"snap2": {"comp2"},
+				},
+			},
 		}, check.Commentf("%v", tc))
 	}
 }

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -45,7 +45,7 @@ func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(*devicestate.Devic
 	return restore
 }
 
-func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*gadget.Volume, *devicestate.OptionalInstall) (*state.Change, error)) (restore func()) {
+func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*gadget.Volume, *devicestate.OptionalContainers) (*state.Change, error)) (restore func()) {
 	restore = testutil.Backup(&devicestateInstallFinish)
 	devicestateInstallFinish = f
 	return restore

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2104,6 +2104,10 @@ type System struct {
 	// DefaultRecoverySystem is true when the system is the default recovery
 	// system.
 	DefaultRecoverySystem bool
+	// OptionalContainers is a set of snaps and components that are optional in
+	// the system's model, but are available to be installed when installing this
+	// system.
+	OptionalContainers OptionalContainers
 }
 
 var defaultSystemActions = []SystemAction{

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1906,20 +1906,20 @@ func extractSnapSetupTaskIDs(tss []*state.TaskSet) ([]string, error) {
 	return taskIDs, nil
 }
 
-// OptionalInstall is used to define the snaps and components that are optional
-// in a system's model, but should be installed when installing the system.
-type OptionalInstall struct {
-	// Snaps is a list of optional snap names that should be installed.
+// OptionalContainers is used to define the snaps and components that are
+// optional in a system's model, but can be installed when installing a system.
+type OptionalContainers struct {
+	// Snaps is a list of optional snap names that can be installed.
 	Snaps []string `json:"snaps,omitempty"`
 	// Components is a mapping of snap names to lists of optional components
-	// names that should be installed.
+	// names that can be installed.
 	Components map[string][]string `json:"components,omitempty"`
 }
 
 // InstallFinish creates a change that will finish the install for the given
 // label and volumes. This includes writing missing volume content, seting
 // up the bootloader and installing the kernel.
-func InstallFinish(st *state.State, label string, onVolumes map[string]*gadget.Volume, optionalInstall *OptionalInstall) (*state.Change, error) {
+func InstallFinish(st *state.State, label string, onVolumes map[string]*gadget.Volume, optionalContainers *OptionalContainers) (*state.Change, error) {
 	if label == "" {
 		return nil, fmt.Errorf("cannot finish install with an empty system label")
 	}
@@ -1931,8 +1931,8 @@ func InstallFinish(st *state.State, label string, onVolumes map[string]*gadget.V
 	finishTask := st.NewTask("install-finish", fmt.Sprintf("Finish setup of run system for %q", label))
 	finishTask.Set("system-label", label)
 	finishTask.Set("on-volumes", onVolumes)
-	if optionalInstall != nil {
-		finishTask.Set("optional-install", *optionalInstall)
+	if optionalContainers != nil {
+		finishTask.Set("optional-install", *optionalContainers)
 	}
 	chg.AddTask(finishTask)
 

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -21,7 +21,6 @@
 package devicestate_test
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -397,7 +396,8 @@ var mockFilledPartialDiskVolume = gadget.OnDiskVolume{
 
 type fakeSeedCopier struct {
 	fakeSeed
-	copyFn func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error
+	optionalContainers seed.OptionalContainers
+	copyFn             func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error
 }
 
 func (s *fakeSeedCopier) Copy(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
@@ -405,7 +405,7 @@ func (s *fakeSeedCopier) Copy(seedDir string, opts seed.CopyOptions, tm timings.
 }
 
 func (s *fakeSeedCopier) OptionalContainers() (seed.OptionalContainers, error) {
-	return seed.OptionalContainers{}, errors.New("not implemented")
+	return s.optionalContainers, nil
 }
 
 // TODO encryption case for the finish step is not tested yet, it needs more mocking

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -2474,7 +2474,7 @@ func (s *installStepSuite) TestDeviceManagerInstallFinishNoVolumesError(c *C) {
 }
 
 func (s *installStepSuite) TestDeviceManagerInstallFinishTasksAndChange(c *C) {
-	s.testDeviceManagerInstallFinishTasksAndChange(c, &devicestate.OptionalInstall{
+	s.testDeviceManagerInstallFinishTasksAndChange(c, &devicestate.OptionalContainers{
 		Snaps: []string{"snap1", "snap2"},
 		Components: map[string][]string{
 			"snap1": {"component1"},
@@ -2487,7 +2487,7 @@ func (s *installStepSuite) TestDeviceManagerInstallFinishTasksAndChangeNilOption
 	s.testDeviceManagerInstallFinishTasksAndChange(c, nil)
 }
 
-func (s *installStepSuite) testDeviceManagerInstallFinishTasksAndChange(c *C, optionalInstall *devicestate.OptionalInstall) {
+func (s *installStepSuite) testDeviceManagerInstallFinishTasksAndChange(c *C, optionalInstall *devicestate.OptionalContainers) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2510,7 +2510,7 @@ func (s *installStepSuite) testDeviceManagerInstallFinishTasksAndChange(c *C, op
 	c.Assert(err, IsNil)
 	c.Assert(onVols, DeepEquals, mockOnVolumes)
 
-	var gotOptionalInstall devicestate.OptionalInstall
+	var gotOptionalInstall devicestate.OptionalContainers
 	err = tskInstallFinish.Get("optional-install", &gotOptionalInstall)
 	if optionalInstall == nil {
 		c.Assert(err, testutil.ErrorIs, &state.NoStateError{Key: "optional-install"})
@@ -2526,7 +2526,7 @@ func (s *installStepSuite) TestDeviceManagerInstallFinishRunthrough(c *C) {
 	defer st.Unlock()
 
 	s.state.Set("seeded", true)
-	chg, err := devicestate.InstallFinish(s.state, "1234", mockOnVolumes, &devicestate.OptionalInstall{})
+	chg, err := devicestate.InstallFinish(s.state, "1234", mockOnVolumes, &devicestate.OptionalContainers{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -96,12 +96,27 @@ func loadSeedAndSystem(label string, current *currentSystem, defaultRecoverySyst
 		return nil, nil, fmt.Errorf("cannot obtain brand: %v", err)
 	}
 
+	var optionalContainers OptionalContainers
+	if copier, ok := s.(seed.Copier); ok {
+		oc, err := copier.OptionalContainers()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot list optional containers: %v", err)
+		}
+		optionalContainers = OptionalContainers{
+			Snaps:      oc.Snaps,
+			Components: oc.Components,
+		}
+	} else {
+		logger.Debugf("seed %q does not support copying", label)
+	}
+
 	system := &System{
-		Current: false,
-		Label:   label,
-		Model:   model,
-		Brand:   brand,
-		Actions: defaultSystemActions,
+		Current:            false,
+		Label:              label,
+		Model:              model,
+		Brand:              brand,
+		Actions:            defaultSystemActions,
+		OptionalContainers: optionalContainers,
 	}
 	system.DefaultRecoverySystem = defaultRecoverySystem.sameAs(system)
 	if current.sameAs(system) {

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -192,6 +192,18 @@ type: gadget
 base: core22
 version: 1.0
 `,
+	"optional22": `name: optional22
+type: app
+base: core22
+version: 1.0
+components:
+  comp1:
+    type: test
+`,
+	"optional22+comp1": `component: optional22+comp1
+type: test
+version: 1.0
+`,
 }
 
 func MergeSampleSnapYaml(snapYaml ...map[string]string) map[string]string {

--- a/tests/lib/muinstaller/go.mod
+++ b/tests/lib/muinstaller/go.mod
@@ -2,10 +2,10 @@ module github.com/snapcore/snapd/tests/lib/muinstaller
 
 go 1.18
 
-require github.com/snapcore/snapd v0.0.0-20240528091028-dc3b51bb4c9e
+require github.com/snapcore/snapd v0.0.0-20240822132116-0bf8d83f4586
 
 require (
-	github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 // indirect
+	github.com/canonical/go-efilib v0.4.0 // indirect
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 // indirect
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 // indirect
 	github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61 // indirect

--- a/tests/lib/muinstaller/go.sum
+++ b/tests/lib/muinstaller/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 h1:F0bRDzPy/j2IX/iIWqCEA23S1nal+f7A+/vLyj6Ye+4=
-github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93/go.mod h1:9b2PNAuPcZsB76x75/uwH99D8CyH/A2y4rq1/+bvplg=
+github.com/canonical/go-efilib v0.4.0 h1:2ee5pvhIZ+g1EO4HxFE/owBgs5Up2g7dw1+Ls9/fiSs=
+github.com/canonical/go-efilib v0.4.0/go.mod h1:9b2PNAuPcZsB76x75/uwH99D8CyH/A2y4rq1/+bvplg=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 h1:USzKjrfWo/ESzozv2i3OMM7XDgxrZRvaHFrKkIKRtwU=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
@@ -32,8 +32,8 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3Ss
 github.com/snapcore/secboot v0.0.0-20240411101434-f3ad7c92552a h1:yzzVi0yUosDYkjSQqGZNVtaVi+6yNFLiF0erKHlBbdo=
 github.com/snapcore/secboot v0.0.0-20240411101434-f3ad7c92552a/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
-github.com/snapcore/snapd v0.0.0-20240528091028-dc3b51bb4c9e h1:y5tdsmeugpiJAhNeQnUW+BPlcSlOYf1vwoo53yzIh1s=
-github.com/snapcore/snapd v0.0.0-20240528091028-dc3b51bb4c9e/go.mod h1:QNsQNTz6P2yqZ22QTU5Jt1FUIGGLlcUuNURvo2tWYOo=
+github.com/snapcore/snapd v0.0.0-20240822132116-0bf8d83f4586 h1:ZdnBopkJlW0yERpbGMos1ZbFtf+W2MWMZ+RCy4B26rs=
+github.com/snapcore/snapd v0.0.0-20240822132116-0bf8d83f4586/go.mod h1:RfaJNlcyEP2RfVuyAX/3x+CJPECCAlZn+36Yily9FzY=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
@@ -54,6 +54,7 @@ golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.7.0 h1:BEvjmm5fURWqcfbSKTdpkDXYBrUS1c0m8agp14W48vQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=

--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -284,8 +285,9 @@ func postSystemsInstallFinish(cli *client.Client,
 
 	// Finish steps does the writing of assets
 	opts := &client.InstallSystemOptions{
-		Step:      client.InstallStepFinish,
-		OnVolumes: vols,
+		Step:            client.InstallStepFinish,
+		OnVolumes:       vols,
+		OptionalInstall: maybeGetOptionalInstall(),
 	}
 	chgId, err := cli.InstallSystem(details.Label, opts)
 	if err != nil {
@@ -293,6 +295,21 @@ func postSystemsInstallFinish(cli *client.Client,
 	}
 	fmt.Printf("Change %s created\n", chgId)
 	return waitChange(chgId)
+}
+
+func maybeGetOptionalInstall() *client.OptionalInstallRequest {
+	f, err := os.Open("./optional-install.json")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var req client.OptionalInstallRequest
+	if err := json.NewDecoder(f).Decode(&req); err != nil {
+		return nil
+	}
+
+	return &req
 }
 
 // createAndMountFilesystems creates and mounts filesystems. It returns

--- a/tests/lib/muinstaller/snapcraft.yaml
+++ b/tests/lib/muinstaller/snapcraft.yaml
@@ -9,7 +9,7 @@ base: core22
 
 apps:
   auto:
-    command: bin/muinstaller classic auto $SNAP/bin/mk-classic-rootfs.sh
+    command: bin/muinstaller -label classic -device auto -rootfs-creator $SNAP/bin/mk-classic-rootfs.sh
   muinstaller:
     command: bin/muinstaller
 

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -138,8 +138,10 @@ run_muinstaller() {
     # run installation
     local install_disk
     install_disk=$(remote.exec "readlink -f /dev/disk/by-id/virtio-target")
-    remote.exec "sudo muinstaller ${label} \
-        ${install_disk} /snap/muinstaller/current/bin/mk-classic-rootfs.sh"
+    remote.exec "sudo muinstaller \
+        -label ${label} \
+        -device ${install_disk} \
+        -rootfs-creator /snap/muinstaller/current/bin/mk-classic-rootfs.sh"
 
     remote.exec "sudo sync"
 

--- a/tests/nested/manual/muinstaller-core/comp1/meta/component.yaml
+++ b/tests/nested/manual/muinstaller-core/comp1/meta/component.yaml
@@ -1,0 +1,5 @@
+component: snap-with-comps+comp1
+type: test
+version: 1.0
+summary: Component 1
+description: First component for snap-with-comps

--- a/tests/nested/manual/muinstaller-core/snap-with-comps/meta/snap.yaml
+++ b/tests/nested/manual/muinstaller-core/snap-with-comps/meta/snap.yaml
@@ -1,0 +1,11 @@
+name: snap-with-comps
+version: 1.0
+summary: Snap with components
+description: A snap that defines components
+base: core22
+components:
+  comp1:
+    type: test
+apps:
+  test:
+    command: test

--- a/tests/nested/manual/muinstaller-core/snap-with-comps/meta/snap.yaml
+++ b/tests/nested/manual/muinstaller-core/snap-with-comps/meta/snap.yaml
@@ -2,7 +2,7 @@ name: snap-with-comps
 version: 1.0
 summary: Snap with components
 description: A snap that defines components
-base: core22
+base: $BASE
 components:
   comp1:
     type: test

--- a/tests/nested/manual/muinstaller-core/snap-with-comps/test
+++ b/tests/nested/manual/muinstaller-core/snap-with-comps/test
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+if [ $# -ne 1 ]; then
+    echo "pass in a component name to check if it is installed"
+    exit 1
+fi
+
+if [ ! -f "/snap/${SNAP_NAME}/components/${SNAP_REVISION}/${1}/meta/component.yaml" ]; then
+    echo "component ${1} is not installed!"
+    exit 1
+fi
+
+comp_rev=$(basename "$(readlink -f "/snap/${SNAP_NAME}/components/${SNAP_REVISION}/${1}")")
+
+echo "component ${1} is installed at revision ${comp_rev}"

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -17,12 +17,33 @@ environment:
   NESTED_ENABLE_TPM/plain: false
   NESTED_ENABLE_SECURE_BOOT/plain: false
 
+  # default (unencrypted) case
+  NESTED_ENABLE_TPM: false
+  NESTED_ENABLE_SECURE_BOOT: false
+
   # ensure we use our latest code
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
   NESTED_REPACK_KERNEL_SNAP: true
   NESTED_ENABLE_OVMF: true
   # image
   IMAGE_MOUNTPOINT: /mnt/cloudimg
+
+  # by default, we don't specify any optional installs. this means we should
+  # install all snaps and components
+  INSTALL_OPTIONAL_SNAP: false
+  INSTALL_OPTIONAL_COMPONENT: false
+  INSTALL_OPTIONAL_ALL: false
+  INSTALL_OPTIONAL_EXPECT_ALL: true
+
+  INSTALL_OPTIONAL_SNAP/install_optional_snap: true
+  INSTALL_OPTIONAL_EXPECT_ALL/install_optional_snap: false
+
+  INSTALL_OPTIONAL_SNAP/install_optional_snap_and_comp: true
+  INSTALL_OPTIONAL_COMPONENT/install_optional_snap_and_comp: true
+  INSTALL_OPTIONAL_EXPECT_ALL/install_optional_snap_and_comp: true
+
+  INSTALL_OPTIONAL_ALL/install_optional_all: true
+  INSTALL_OPTIONAL_EXPECT_ALL/install_optional_all: true
 
 prepare: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -82,6 +103,9 @@ execute: |
   fi
   mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
 
+  snap pack ./snap-with-comps --filename=snap-with-comps.snap
+  snap pack ./comp1 --filename=snap-with-comps+comp1.comp
+
   # prepare a core seed
   # TODO:
   # - repacked snapd snap
@@ -92,6 +116,8 @@ execute: |
       --channel=edge \
       --snap ./pc-kernel.snap \
       --snap ./pc.snap \
+      --snap ./snap-with-comps.snap \
+      --comp ./snap-with-comps+comp1.comp \
       my.model \
       ./"$SEED_DIR"
 
@@ -178,6 +204,32 @@ execute: |
   remote.exec "sudo snap install --classic --dangerous $(basename "$MUINSTALLER_SNAP")"
   # Run installation
   install_disk=$(remote.exec "readlink -f /dev/disk/by-id/virtio-target")
+
+  if [ "$INSTALL_OPTIONAL_ALL" = "true" ]; then
+    echo '{"all": true}' > optional-install.json
+  elif [ "$INSTALL_OPTIONAL_COMPONENT" = "true" ]; then
+    echo '{"snaps": ["snap-with-comps"], "components": {"snap-with-comps": ["comp1"]}}' > optional-install.json
+  elif [ "$INSTALL_OPTIONAL_SNAP" = "true" ]; then
+    echo '{"snaps": ["snap-with-comps"]}' > optional-install.json
+  fi
+
+  if [ -f optional-install.json ]; then
+    remote.push optional-install.json
+  fi
+
+  # make sure that the system reports the expected available optional snaps
+  remote.exec "sudo snap install --edge test-snapd-curl"
+  remote.exec "sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/$LABEL" > available.json
+  cat <<EOF > expected-available.json
+  {
+    "snaps": ["snap-with-comps"],
+    "components": {
+      "snap-with-comps": ["comp1"];
+    }
+  }
+  EOF
+  diff -u <(jq --sort-keys . available.json) <(jq --sort-keys . expected-available.json)
+
   remote.exec "sudo muinstaller $LABEL $install_disk"
 
   remote.exec "sudo sync"
@@ -231,6 +283,22 @@ execute: |
       sn_version=$(remote.exec "snap list ${sn}" | awk 'NR != 1 { print $2 }')
       remote.exec "test -f /run/mnt/ubuntu-seed/systems/${LABEL}/snaps/${sn}_${sn_version}.snap"
   done
+
+  if [ "$INSTALL_OPTIONAL_SNAP" = "true" ] || [ "$INSTALL_OPTIONAL_EXPECT_ALL" = "true" ]; then
+      sn_version=$(remote.exec "snap list snap-with-comps" | awk 'NR != 1 { print $2 }')
+
+      # snap isn't asserted, but it is not in the model so it should end up here
+      remote.exec "test -f /run/mnt/ubuntu-seed/systems/${LABEL}/snaps/snap-with-comps_${sn_version}.snap"
+
+      if [ "$INSTALL_OPTIONAL_EXPECT_ALL" = "true" ]; then
+          # make sure our component is there too
+          remote.exec "snap run snap-with-comps.test comp1"
+      else
+          not remote.exec "snap run snap-with-comps.test comp1"
+      fi
+  else
+      not remote.exec "snap list snap-with-comps"
+  fi
 
   # check for asserted snaps
   for sn in snapd core"$version"; do

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -213,10 +213,6 @@ execute: |
     echo '{"snaps": ["snap-with-comps"]}' > optional-install.json
   fi
 
-  if [ -f optional-install.json ]; then
-    remote.push optional-install.json
-  fi
-
   # make sure that the system reports the expected available optional snaps
   remote.exec "sudo snap install --edge test-snapd-curl"
   remote.exec "sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/$LABEL" > available.json
@@ -230,7 +226,13 @@ execute: |
   EOF
   diff -u <(jq --sort-keys . available.json) <(jq --sort-keys . expected-available.json)
 
-  remote.exec "sudo muinstaller $LABEL $install_disk"
+  muinstaller_args="-label $LABEL -device $install_disk"
+  if [ -f optional-install.json ]; then
+    remote.push optional-install.json
+    muinstaller_args="$muinstaller_args -optional ./optional-install.json"
+  fi
+
+  remote.exec "sudo muinstaller $muinstaller_args"
 
   remote.exec "sudo sync"
 

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -100,6 +100,7 @@ execute: |
   fi
   mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
 
+  sed -i "s/\$BASE/core${version}/" ./snap-with-comps/meta/snap.yaml
   snap pack ./snap-with-comps --filename=snap-with-comps.snap
   snap pack ./comp1 --filename=snap-with-comps+comp1.comp
 

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -9,17 +9,14 @@ details: |
 systems: [ubuntu-22.04-64, ubuntu-24.04-64]
 
 environment:
-  # Test both encrypted and unencrypted install using the muinstaller
-  NESTED_ENABLE_TPM/encrypted: true
-  NESTED_ENABLE_SECURE_BOOT/encrypted: true
+  # default (encrypted) case. all of the install_optional_* variants exercise
+  # the encrypted case
+  NESTED_ENABLE_TPM: true
+  NESTED_ENABLE_SECURE_BOOT: true
 
   # unencrypted case
   NESTED_ENABLE_TPM/plain: false
   NESTED_ENABLE_SECURE_BOOT/plain: false
-
-  # default (unencrypted) case
-  NESTED_ENABLE_TPM: false
-  NESTED_ENABLE_SECURE_BOOT: false
 
   # ensure we use our latest code
   NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -121,7 +121,7 @@ execute: |
   truncate --size=4G fake-disk.img
   loop_device=$(losetup --show -f ./fake-disk.img)
   # and "install" the current seed to the fake disk
-  ./muinstaller "$LABEL" "$loop_device" "$TESTSLIB"/muinstaller/mk-classic-rootfs.sh
+  ./muinstaller -label "$LABEL" -device "$loop_device" -rootfs-creator "$TESTSLIB"/muinstaller/mk-classic-rootfs.sh
   # validate that the fake installer created the expected partitions
   sfdisk -d "$loop_device" > fdisk_output
   MATCH "${loop_device}p1 .* name=\"BIOS Boot\""   < fdisk_output

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -111,7 +111,7 @@ execute: |
   truncate --size=5G fake-disk.img
   loop_device=$(losetup --show -f ./fake-disk.img)
   # and "install" the current seed to the fake disk
-  ./muinstaller "$LABEL" "$loop_device" "$TESTSLIB"/muinstaller/mk-classic-rootfs.sh
+  ./muinstaller -label "$LABEL" -device "$loop_device" -rootfs-creator "$TESTSLIB"/muinstaller/mk-classic-rootfs.sh
   # validate that the fake installer created the expected partitions
   sfdisk -d "$loop_device" > fdisk_output
   MATCH "${loop_device}p1 .* name=\"BIOS Boot\""   < fdisk_output


### PR DESCRIPTION
This PR ties together work that enables users to pick which snaps and components to install from a set of available containers.