### PR TITLE
fix(logger): make MockLogger lock the buffer implicitly

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -67,7 +67,7 @@ type baseInitramfsMountsSuite struct {
 	*seedtest.TestingSeed20
 
 	Stdout *bytes.Buffer
-	logs   *bytes.Buffer
+	logs   logger.MockedLogger
 
 	seedDir    string
 	byLabelDir string

--- a/cmd/snap-failure/main_test.go
+++ b/cmd/snap-failure/main_test.go
@@ -42,7 +42,7 @@ type failureSuite struct {
 
 	stderr *bytes.Buffer
 	stdout *bytes.Buffer
-	log    *bytes.Buffer
+	log    logger.MockedLogger
 
 	systemctlCmd *testutil.MockCmd
 }

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,7 +41,7 @@ func Test(t *testing.T) { TestingT(t) }
 type mainSuite struct {
 	testutil.BaseTest
 	as  *update.Assumptions
-	log *bytes.Buffer
+	log logger.MockedLogger
 }
 
 var _ = Suite(&mainSuite{})

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"bytes"
 	"fmt"
 	"path/filepath"
 	"syscall"
@@ -36,7 +35,7 @@ import (
 
 type updateSuite struct {
 	testutil.BaseTest
-	log *bytes.Buffer
+	log logger.MockedLogger
 }
 
 var _ = Suite(&updateSuite{})

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -40,7 +39,7 @@ import (
 type utilsSuite struct {
 	testutil.BaseTest
 	sys *testutil.SyscallRecorder
-	log *bytes.Buffer
+	log logger.MockedLogger
 	as  *update.Assumptions
 }
 

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -235,7 +234,7 @@ func (s *mainSuite) TestValidateArgs(c *C) {
 type integrationSuite struct {
 	testutil.BaseTest
 
-	logBuf    *bytes.Buffer
+	logBuf    logger.MockedLogger
 	parserCmd *testutil.MockCmd
 }
 

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -20,7 +20,6 @@
 package httputil_test
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -151,7 +150,7 @@ type tlsSuite struct {
 
 	tmpdir            string
 	certpath, keypath string
-	logbuf            *bytes.Buffer
+	logbuf            logger.MockedLogger
 
 	srv *httptest.Server
 }

--- a/httputil/logger_test.go
+++ b/httputil/logger_test.go
@@ -39,7 +39,7 @@ import (
 func TestHTTPUtil(t *testing.T) { check.TestingT(t) }
 
 type loggerSuite struct {
-	logbuf        *bytes.Buffer
+	logbuf        logger.MockedLogger
 	restoreLogger func()
 }
 

--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -1,7 +1,6 @@
 package devicestate_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +21,7 @@ import (
 
 type cloudInitBaseSuite struct {
 	deviceMgrBaseSuite
-	logbuf *bytes.Buffer
+	logbuf logger.MockedLogger
 }
 
 type cloudInitSuite struct {

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -72,7 +72,7 @@ type mockedSystemSeed struct {
 type deviceMgrSystemsBaseSuite struct {
 	deviceMgrBaseSuite
 
-	logbuf            *bytes.Buffer
+	logbuf            logger.MockedLogger
 	mockedSystemSeeds []mockedSystemSeed
 	ss                *seedtest.SeedSnaps
 	model             *asserts.Model

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -20,7 +20,6 @@
 package devicestate_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,7 +46,7 @@ type createSystemSuite struct {
 
 	ss *seedtest.SeedSnaps
 
-	logbuf *bytes.Buffer
+	logbuf logger.MockedLogger
 }
 
 var _ = Suite(&createSystemSuite{})

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -214,10 +214,8 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	resp, err := waitForReply(replyChan)
 	c.Assert(err, IsNil)
 	c.Check(resp.Request, Equals, req)
-	logger.WithLoggerLock(func() {
-		c.Check(logbuf.String(), testutil.Contains,
-			` error while parsing AppArmor permissions: cannot get abstract permissions from empty AppArmor permissions: "none"`)
-	})
+	c.Check(logbuf.String(), testutil.Contains,
+		` error while parsing AppArmor permissions: cannot get abstract permissions from empty AppArmor permissions: "none"`)
 
 	// Fill the requestprompts backend until we hit its outstanding prompt
 	// count limit
@@ -238,9 +236,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	c.Assert(len(prompts), Equals, maxOutstandingPromptsPerUser)
 
 	// Now try to add one more request, it should fail
-	logger.WithLoggerLock(func() {
-		logbuf.Reset()
-	})
+	logbuf.Reset()
 
 	req = &listener.Request{
 		Label:      "snap.firefox.firefox",
@@ -251,10 +247,8 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	}
 	reqChan <- req
 	time.Sleep(10 * time.Millisecond)
-	logger.WithLoggerLock(func() {
-		c.Check(logbuf.String(), testutil.Contains,
-			" WARNING: too many outstanding prompts for user 1000; auto-denying new one\n")
-	})
+	c.Check(logbuf.String(), testutil.Contains,
+		" WARNING: too many outstanding prompts for user 1000; auto-denying new one\n")
 
 	c.Assert(mgr.Stop(), IsNil)
 }
@@ -308,7 +302,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *listener.Re
 
 	// Check that no error occurred
 	time.Sleep(10 * time.Millisecond)
-	logger.WithLoggerLock(func() { c.Assert(logbuf.String(), Equals, "") })
+	c.Assert(logbuf.String(), Equals, "")
 
 	// which should generate a notice
 	s.st.Lock()

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -20,7 +20,6 @@
 package ifacestate_test
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -180,7 +179,7 @@ type interfaceManagerSuite struct {
 	extraBackends  []interfaces.SecurityBackend
 	secBackend     *ifacetest.TestSecurityBackend
 	mockSnapCmd    *testutil.MockCmd
-	log            *bytes.Buffer
+	log            logger.MockedLogger
 	coreSnap       *interfaces.SnapAppSet
 	snapdSnap      *interfaces.SnapAppSet
 
@@ -7010,9 +7009,7 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	running := mgr.AppArmorPromptingRunning()
 	c.Check(running, Equals, false)
 
-	logger.WithLoggerLock(func() {
-		c.Check(logbuf.String(), testutil.Contains, fmt.Sprintf("%v", createError))
-	})
+	c.Check(logbuf.String(), testutil.Contains, fmt.Sprintf("%v", createError))
 }
 
 func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -148,7 +148,7 @@ type baseMgrsSuite struct {
 
 	automaticSnapshots []automaticSnapshotCall
 
-	logbuf *bytes.Buffer
+	logbuf logger.MockedLogger
 
 	storeObserver func(r *http.Request)
 }

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -20,7 +20,6 @@
 package restart_test
 
 import (
-	"bytes"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -1183,7 +1182,7 @@ type notifyRebootRequiredSuite struct {
 
 	st          *state.State
 	mockNrrPath string
-	mockLog     *bytes.Buffer
+	mockLog     logger.MockedLogger
 	chg         *state.Change
 	t1          *state.Task
 }

--- a/snapdtool/fips_linux_test.go
+++ b/snapdtool/fips_linux_test.go
@@ -1,7 +1,6 @@
 package snapdtool_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,7 +19,7 @@ import (
 type fipsSuite struct {
 	testutil.BaseTest
 
-	logbuf *bytes.Buffer
+	logbuf logger.MockedLogger
 }
 
 var _ = Suite(&fipsSuite{})

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -180,7 +180,7 @@ type baseStoreSuite struct {
 
 	ctx context.Context
 
-	logbuf *bytes.Buffer
+	logbuf logger.MockedLogger
 }
 
 const (

--- a/usersession/agent/session_agent_test.go
+++ b/usersession/agent/session_agent_test.go
@@ -258,9 +258,7 @@ func (s *sessionAgentSuite) TestConnectFromOtherUser(c *C) {
 	_, err = s.client.Get("http://localhost/v1/session-info")
 	// This could be an EOF error or a failed read, depending on timing
 	c.Assert(err, ErrorMatches, "Get \"?http://localhost/v1/session-info\"?: .*")
-	logger.WithLoggerLock(func() {
-		c.Check(logbuf.String(), testutil.Contains, "Blocking request from user ID")
-	})
+	c.Check(logbuf.String(), testutil.Contains, "Blocking request from user ID")
 }
 
 func (s *sessionAgentSuite) TestConnectFromRoot(c *C) {
@@ -280,9 +278,7 @@ func (s *sessionAgentSuite) TestConnectFromRoot(c *C) {
 	c.Assert(err, IsNil)
 	defer response.Body.Close()
 	c.Check(response.StatusCode, Equals, 200)
-	logger.WithLoggerLock(func() {
-		c.Check(logbuf.String(), Equals, "")
-	})
+	c.Check(logbuf.String(), Equals, "")
 }
 
 func (s *sessionAgentSuite) TestConnectWithFailedPeerCredentials(c *C) {
@@ -300,7 +296,5 @@ func (s *sessionAgentSuite) TestConnectWithFailedPeerCredentials(c *C) {
 
 	_, err = s.client.Get("http://localhost/v1/session-info")
 	c.Assert(err, ErrorMatches, "Get \"?http://localhost/v1/session-info\"?: .*")
-	logger.WithLoggerLock(func() {
-		c.Check(logbuf.String(), testutil.Contains, "Failed to retrieve peer credentials: SO_PEERCRED failed")
-	})
+	c.Check(logbuf.String(), testutil.Contains, "Failed to retrieve peer credentials: SO_PEERCRED failed")
 }


### PR DESCRIPTION
This has been ported from a similar change in Pebble:

* https://github.com/canonical/pebble/pull/441

The explicit logging feature was implemented in snapd in commit https://github.com/canonical/snapd/commit/16c3680b78d, but this requires a developer to know when another goroutine might be using the logger, and using `WithLoggerLock()` explicitly. In addition, as `WithLoggerLock()` acquires the global logger lock, trying to log from the callback of `WithLoggerLock()` might result in a deadlock (but the testing code right now isn't doing this, of course).

Instead of requiring explicit locking, this change makes it so that `Write()`, `String()` and `Reset()` access to the `bytes.Buffer` is mutex-protected.

As `logger.MockLogger()` is only used in unit test code, locking an otherwise uncontested mutex for `Write()` should hopefully not cause any noticeable slowdown, while making it impossible to accidentally use the mock logger in a thread-unsafe way.