### PR TITLE
o/hookstate: allow hook handlers to set preconditions

### DIFF
--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -79,7 +79,7 @@ type Handler interface {
 // HandlerGenerator is the function signature required to register for hooks.
 type HandlerGenerator func(*Context) Handler
 
-type Preconditioner interface {
+type Precondition interface {
 	// Precondition is called prior to the Before method and should return true
 	// if the hook should run or false, if it should be skipped without erroring.
 	Precondition() (bool, error)
@@ -429,7 +429,7 @@ func (m *HookManager) runHook(context *Context, snapst *snapstate.SnapState, hoo
 		m.contextsMutex.Unlock()
 	}()
 
-	if ph, ok := context.Handler().(Preconditioner); ok {
+	if ph, ok := context.Handler().(Precondition); ok {
 		precond, err := ph.Precondition()
 		if err != nil {
 			return err

--- a/overlord/hookstate/hooktest/handler.go
+++ b/overlord/hookstate/hooktest/handler.go
@@ -23,6 +23,10 @@ import "fmt"
 
 // MockHandler is a mock hookstate.Handler.
 type MockHandler struct {
+	PreconditionCalled bool
+	PreconditionResult bool
+	PreconditionError  bool
+
 	BeforeCalled bool
 	BeforeError  bool
 
@@ -35,13 +39,14 @@ type MockHandler struct {
 	Err               error
 
 	// callbacks useful for testing
-	BeforeCallback func()
-	DoneCallback   func()
+	PreconditionCallback func()
+	BeforeCallback       func()
+	DoneCallback         func()
 }
 
 // NewMockHandler returns a new MockHandler.
 func NewMockHandler() *MockHandler {
-	return &MockHandler{}
+	return &MockHandler{PreconditionResult: true}
 }
 
 // Before satisfies hookstate.Handler.Before
@@ -76,4 +81,15 @@ func (h *MockHandler) Error(err error) (bool, error) {
 		return false, fmt.Errorf("Error failed at user request")
 	}
 	return h.IgnoreOriginalErr, nil
+}
+
+func (h *MockHandler) Precondition() (bool, error) {
+	if h.PreconditionCallback != nil {
+		h.PreconditionCallback()
+	}
+	h.PreconditionCalled = true
+	if h.PreconditionError {
+		return false, fmt.Errorf("Precondition failed at user request")
+	}
+	return h.PreconditionResult, nil
 }


### PR DESCRIPTION
Adds a Preconditioner interface that a hook handler can implement in order to set preconditions for a hook to run. This differs from the Handler's Before method in that, if the Precondition exists and returns false, the hook is skipped without any errors being outputted.
This will be used by registry hook handlers to check that the relevant plug is still connected and the hook should run.