### PR TITLE
spread:  update ubuntu pro image names, fix 22.04 image

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -180,12 +180,12 @@ backends:
         halt-timeout: 2h
         systems:
             - ubuntu-pro-20.04-64:
-                  image: ubuntu-os-pro-cloud/ubuntu-pro-2004-focal-v20240614
+                  image: ubuntu-os-pro-cloud/ubuntu-pro-2004-lts
                   workers: 1
                   attach-service-account: true
 
             - ubuntu-pro-22.04-64:
-                  image: ubuntu-os-pro-cloud/ubuntu-pro-2004-focal-v20240614
+                  image: ubuntu-os-pro-cloud/ubuntu-pro-2204-lts
                   workers: 1
                   attach-service-account: true
 


### PR DESCRIPTION
Update Ubuntu Pro image names to use the generic image family name. Fix the Ubuntu 22.04 Pro image name.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
