### PR TITLE
asserts: allow defining components in preseed assertions

### DIFF
--- a/asserts/preseed_test.go
+++ b/asserts/preseed_test.go
@@ -208,6 +208,8 @@ func (ps *preseedSuite) TestDecodeInvalid(c *C) {
 		{"OTHER", "    components:\n      -\n        name: comp1\n        revision: 10\n      -\n        revision: 10\n", `"name" of component is mandatory`},
 		{"OTHER", "    components:\n      -\n        name: comp1\n", `component "comp1" must have a revision since its snap has a revision`},
 		{"OTHER", "  -\n    name: bar-linux\n    components:\n      -\n        name: comp1\n        revision: 10\n", `component "comp1" cannot have a revision since its snap has no revision`},
+		{"OTHER", "    components:\n      -\n        name: -invalid\n        revision: 1\n", `invalid snap name: "-invalid"`},
+		{"OTHER", "    components:\n      -\n        name: comp1\n        revision: invalid\n", `"revision" of component "comp1" is not an integer: invalid`},
 	}
 
 	for _, test := range invalidTests {


### PR DESCRIPTION
This is the first step in preseeding systems with components.

Example of components in preseed assertion:
```
type: preseed
snaps:
  -
    name: snap-one
    id: snap-one-id
    revision: 1
    components:
      -
        name: comp1
        revision: 2
  -
    name: snap-two
    components:
      -
        name: comp2
```

If the snap has a revision, then the components must have revisions. If the snap doesn't have a revision, then the components cannot have revisions.