### PR TITLE
cmd/snap-bootstrap: change /run mount wants to initrd-switch-root.ser…

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1429,7 +1429,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeHappyRealSystemdMou
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd-fs.target",
+		"initrd-switch-root.service",
 		"local-fs.target",
 	} {
 		for _, mountUnit := range []string{
@@ -1460,7 +1460,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.snapd.Filename()),
@@ -1469,7 +1469,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1478,7 +1478,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1487,7 +1487,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.gadget.Filename()),
@@ -1496,7 +1496,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1506,7 +1506,7 @@ Wants=%[1]s
 			"--type=tmpfs",
 			"--fsck=no",
 			"--options=nosuid,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		},
 	})
 }
@@ -1609,7 +1609,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeNoSaveHappyRealSyst
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd-fs.target",
+		"initrd-switch-root.service",
 		"local-fs.target",
 	} {
 		for _, mountUnit := range []string{
@@ -1641,7 +1641,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.snapd.Filename()),
@@ -1650,7 +1650,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1659,7 +1659,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1668,7 +1668,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.gadget.Filename()),
@@ -1677,7 +1677,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1687,7 +1687,7 @@ Wants=%[1]s
 			"--type=tmpfs",
 			"--fsck=no",
 			"--options=nosuid,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-boot-partuuid",
@@ -1696,7 +1696,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -1705,7 +1705,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=nosuid,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		},
 	})
 
@@ -1775,7 +1775,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeWithSaveHappyRealSy
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd-fs.target",
+		"initrd-switch-root.service",
 		"local-fs.target",
 	} {
 
@@ -1807,7 +1807,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.snapd.Filename()),
@@ -1816,7 +1816,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1825,7 +1825,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1834,7 +1834,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.gadget.Filename()),
@@ -1843,7 +1843,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1853,7 +1853,7 @@ Wants=%[1]s
 			"--type=tmpfs",
 			"--fsck=no",
 			"--options=nosuid,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-boot-partuuid",
@@ -1862,7 +1862,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -1871,7 +1871,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=nosuid,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-save-partuuid",
@@ -1880,7 +1880,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		},
 	})
 
@@ -1967,7 +1967,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeHappyNoSaveRealSystemdM
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd-fs.target",
+		"initrd-switch-root.service",
 		"local-fs.target",
 	} {
 		for _, mountUnit := range []string{
@@ -1998,7 +1998,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-seed-partuuid",
@@ -2007,7 +2007,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -2016,7 +2016,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=nosuid,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data")), s.core20.Filename()),
@@ -2025,7 +2025,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data")), s.gadget.Filename()),
@@ -2034,7 +2034,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data")), s.kernel.Filename()),
@@ -2043,7 +2043,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		},
 	})
 }
@@ -2103,7 +2103,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithSaveHappyRealSystem
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd-fs.target",
+		"initrd-switch-root.service",
 		"local-fs.target",
 	} {
 
@@ -2133,7 +2133,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-seed-partuuid",
@@ -2142,7 +2142,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -2151,7 +2151,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=nosuid,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-save-partuuid",
@@ -2160,7 +2160,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data")), s.core20.Filename()),
@@ -2169,7 +2169,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data")), s.gadget.Filename()),
@@ -2178,7 +2178,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data")), s.kernel.Filename()),
@@ -2187,7 +2187,7 @@ Wants=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro,private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		},
 	})
 }
@@ -2518,7 +2518,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunCVMModeHappy(c *C) {
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=private",
-			"--property=Before=initrd-fs.target",
+			"--property=Before=initrd-switch-root.service",
 		},
 		{
 			"systemd-mount",

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -275,7 +275,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					foundFsckNo = true
 				case arg == "--no-block":
 					foundNoBlock = true
-				case arg == "--property=Before=initrd-fs.target":
+				case arg == "--property=Before=initrd-switch-root.service":
 					foundBeforeInitrdfsTarget = true
 				case strings.HasPrefix(arg, "--options="):
 					for _, opt := range strings.Split(strings.TrimPrefix(arg, "--options="), ",") {
@@ -311,7 +311,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			// check that the overrides are present if opts.Ephemeral is false,
 			// or check the overrides are not present if opts.Ephemeral is true
 			for _, initrdUnit := range []string{
-				"initrd-fs.target",
+				"initrd-switch-root.service",
 				"local-fs.target",
 			} {
 				mountUnit := systemd.EscapeUnitNamePath(t.where)


### PR DESCRIPTION
…vice

Add "wants" dependencies to initrd-switch-root.service instead of initrd-fs.target when creating mounts in /run. This fixes a race condition by which systemd stops the mount units before switching root. These units were later re-mounted by systemd from the rootfs, but there were a few seconds during which they were not mounted. This can lead to snapd-generator not creating the mounts for /lib/{firmware,modules} as it needs data from the /run/mnt/kernel mount.

When the issue happens traces showing units unmoiunted before switching root appear:

Aug 27 13:43:11 localhost systemd[1]: Stopped target initrd-fs.target - Initrd File Systems.
Aug 27 13:43:11 localhost systemd[1]: Reached target initrd-switch-root.target - Switch Root.
Aug 27 13:43:11 localhost snap-bootstrap[159]: triggerwatch.go:146: Switching root
Aug 27 13:43:11 localhost systemd[1]: Unmounting run-mnt-base.mount - /run/mnt/base...
Aug 27 13:43:11 localhost systemd[1]: Unmounting run-mnt-gadget.mount - /run/mnt/gadget...
Aug 27 13:43:11 localhost systemd[1]: Unmounting run-mnt-kernel.mount - /run/mnt/kernel...
Aug 27 13:43:11 localhost systemd[1]: Unmounting run-mnt-ubuntu\x2dboot.mount - /run/mnt/ubuntu-boot...
Aug 27 13:43:11 localhost systemd[1]: Unmounting run-mnt-ubuntu\x2dsave.mount - /run/mnt/ubuntu-save...
Aug 27 13:43:11 localhost systemd[1]: Unmounting run-mnt-ubuntu\x2dseed.mount - /run/mnt/ubuntu-seed...
Aug 27 13:43:11 localhost kernel: EXT4-fs (vda3): unmounting filesystem f39a01bb-a446-46c8-91e6-44f3434ab60b.
Aug 27 13:43:11 localhost systemd[1]: Unmounting sysroot-writable.mount - /sysroot/writable...
Aug 27 13:43:11 localhost kernel: EXT4-fs (vda4): unmounting filesystem 6b78c2d8-1204-4eec-b056-f34bb30e4a24.
Aug 27 13:43:11 localhost systemd[1]: Starting initrd-switch-root.service - Switch Root...
Aug 27 13:43:11 localhost systemd[1]: run-mnt-base.mount: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Unmounted run-mnt-base.mount - /run/mnt/base.
Aug 27 13:43:11 localhost systemd[1]: run-mnt-gadget.mount: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Unmounted run-mnt-gadget.mount - /run/mnt/gadget.
Aug 27 13:43:11 localhost systemd[1]: run-mnt-kernel.mount: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Unmounted run-mnt-kernel.mount - /run/mnt/kernel.
Aug 27 13:43:11 localhost systemd[1]: run-mnt-ubuntu\x2dboot.mount: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Unmounted run-mnt-ubuntu\x2dboot.mount - /run/mnt/ubuntu-boot.
Aug 27 13:43:11 localhost systemd[1]: run-mnt-ubuntu\x2dsave.mount: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Unmounted run-mnt-ubuntu\x2dsave.mount - /run/mnt/ubuntu-save.
Aug 27 13:43:11 localhost systemd[1]: run-mnt-ubuntu\x2dseed.mount: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Unmounted run-mnt-ubuntu\x2dseed.mount - /run/mnt/ubuntu-seed.
Aug 27 13:43:11 localhost systemd[1]: sysroot-writable.mount: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Unmounted sysroot-writable.mount - /sysroot/writable.
Aug 27 13:43:11 localhost systemd[1]: Unmounting run-mnt-data.mount - /run/mnt/data...
Aug 27 13:43:11 localhost systemd[1]: systemd-fsck@dev-vda2.service: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Stopped systemd-fsck@dev-vda2.service - File System Check on /dev/vda2.
Aug 27 13:43:11 localhost systemd[1]: systemd-fsck@dev-vda3.service: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Stopped systemd-fsck@dev-vda3.service - File System Check on /dev/vda3.
Aug 27 13:43:11 localhost umount[500]: umount: /run/mnt/data: target is busy.
Aug 27 13:43:11 localhost systemd[1]: systemd-fsck@dev-vda4.service: Deactivated successfully.
Aug 27 13:43:11 localhost systemd[1]: Stopped systemd-fsck@dev-vda4.service - File System Check on /dev/vda4.
Aug 27 13:43:11 localhost systemd[1]: run-mnt-data.mount: Mount process exited, code=exited, status=32/n/a
Aug 27 13:43:11 localhost systemd[1]: Failed unmounting run-mnt-data.mount - /run/mnt/data.
Aug 27 13:43:11 localhost systemd[1]: Switching root.
