### PR TITLE
gadget/install: create mount unit for the kernel on installation

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -381,6 +381,10 @@ func SnapServicesDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, "/etc/systemd/system")
 }
 
+func SnapRuntimeServicesDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, "/run/systemd/system")
+}
+
 // SnapSystemdDirUnder returns the path to the systemd conf dir under
 // rootdir.
 func SnapSystemdDirUnder(rootdir string) string {
@@ -522,8 +526,8 @@ func SetRootDir(rootdir string) {
 	SnapRollbackDir = filepath.Join(rootdir, snappyDir, "rollback")
 
 	SnapBinariesDir = filepath.Join(SnapMountDir, "bin")
-	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
-	SnapRuntimeServicesDir = filepath.Join(rootdir, "/run/systemd/system")
+	SnapServicesDir = SnapServicesDirUnder(rootdir)
+	SnapRuntimeServicesDir = SnapRuntimeServicesDirUnder(rootdir)
 	SnapUserServicesDir = filepath.Join(rootdir, "/etc/systemd/user")
 	SnapSystemdConfDir = SnapSystemdConfDirUnder(rootdir)
 	SnapSystemdDir = filepath.Join(rootdir, "/etc/systemd")

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -324,6 +324,7 @@ Description=Mount unit for pc-kernel, revision 111
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=systemd-udevd.service systemd-modules-load.service
+Before=usr-lib-modules.mount usr-lib-firmware.mount
 
 [Mount]
 What=/var/lib/snapd/snaps/pc-kernel_111.snap

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -36,7 +36,9 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/kernel"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -251,11 +253,13 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 func (s *contentTestSuite) testWriteFilesystemContentDriversTree(c *C, kMntPoint string, isCore bool) {
 	defer dirs.SetRootDir(dirs.GlobalRootDir)
 	dirs.SetRootDir(c.MkDir())
+	restore := osutil.MockMountInfo(``)
+	defer restore()
 
 	kMntPoint = filepath.Join(dirs.GlobalRootDir, kMntPoint)
 
 	dataMntPoint := filepath.Join(dirs.SnapRunDir, "gadget-install/dev-node2")
-	restore := install.MockSysMount(func(source, target, fstype string, flags uintptr, data string) error {
+	restore = install.MockSysMount(func(source, target, fstype string, flags uintptr, data string) error {
 		c.Check(source, Equals, "/dev/node2")
 		c.Check(fstype, Equals, "ext4")
 		c.Check(target, Equals, filepath.Join(dirs.SnapRunDir, "gadget-install/dev-node2"))
@@ -291,18 +295,17 @@ func (s *contentTestSuite) testWriteFilesystemContentDriversTree(c *C, kMntPoint
 		IsCore:           isCore,
 	}
 
+	dataDir := ""
+	if isCore {
+		dataDir = "system-data/_writable_defaults"
+	}
 	restore = install.MockKernelEnsureKernelDriversTree(func(kMntPts kernel.MountPoints, compsMntPts []kernel.ModulesCompMountPoints, destDir string, opts *kernel.KernelDriversTreeOptions) (err error) {
 		c.Check(kMntPts, Equals,
 			kernel.MountPoints{
 				Current: kMntPoint,
 				Target:  filepath.Join(dirs.SnapMountDir, "/pc-kernel/111")})
-		if isCore {
-			c.Check(destDir, Equals, filepath.Join(dataMntPoint,
-				"system-data/var/lib/snapd/kernel/pc-kernel/111"))
-		} else {
-			c.Check(destDir, Equals, filepath.Join(dataMntPoint,
-				"var/lib/snapd/kernel/pc-kernel/111"))
-		}
+		c.Check(destDir, Equals, filepath.Join(dataMntPoint, dataDir,
+			"var/lib/snapd/kernel/pc-kernel/111"))
 		return nil
 	})
 	defer restore()
@@ -310,6 +313,36 @@ func (s *contentTestSuite) testWriteFilesystemContentDriversTree(c *C, kMntPoint
 	err := install.WriteFilesystemContent(m, kInfo, "/dev/node2", obs)
 	c.Assert(err, IsNil)
 
+	// Check content of kernel mount unit / links
+	cpi := snap.MinimalSnapContainerPlaceInfo("pc-kernel", snap.R(111))
+	whereDir := dirs.StripRootDir(cpi.MountDir())
+	unitFileName := systemd.EscapeUnitNamePath(whereDir) + ".mount"
+	c.Check(filepath.Join(dataMntPoint, dataDir, "etc/systemd/system", unitFileName),
+		testutil.FileEquals, fmt.Sprintf(
+			`[Unit]
+Description=Mount unit for pc-kernel, revision 111
+After=snapd.mounts-pre.target
+Before=snapd.mounts.target
+Before=systemd-udevd.service systemd-modules-load.service
+
+[Mount]
+What=/var/lib/snapd/snaps/pc-kernel_111.snap
+Where=%s
+Type=squashfs
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide
+LazyUnmount=yes
+
+[Install]
+WantedBy=snapd.mounts.target
+WantedBy=multi-user.target
+`, whereDir))
+
+	for _, target := range []string{"multi-user.target.wants", "snapd.mounts.target.wants"} {
+		path, err := os.Readlink(filepath.Join(dataMntPoint, dataDir,
+			"etc/systemd/system", target, unitFileName))
+		c.Check(err, IsNil)
+		c.Check(path, Equals, filepath.Join(dirs.SnapServicesDir, unitFileName))
+	}
 }
 
 func (s *contentTestSuite) TestWriteFilesystemContentDriversTreeCore(c *C) {

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -150,12 +150,12 @@ func (s *emulation) EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions
 	// Pass directly options, note that passed options need to be correct
 	// for the final target that will use the preseeding tarball. See also
 	// comment in EnsureMountUnitFile.
-	mountUnitName, modified, err := ensureMountUnitFile(unitOptions)
+	mountUnitName, modified, err := EnsureMountUnitFileContent(unitOptions)
 	if err != nil {
 		return "", err
 	}
 
-	if modified == mountUnchanged {
+	if modified == MountUnchanged {
 		return mountUnitName, nil
 	}
 
@@ -169,8 +169,8 @@ func (s *emulation) EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions
 	// systemd.EnsureMountUnitFile. For instance, when preseeding in a lxd
 	// container, the snap will be mounted with fuse, but mount unit will
 	// use squashfs.
-	hostFsType, actualOptions := hostFsTypeAndMountOptions(unitOptions.Fstype)
-	if modified == mountUpdated {
+	hostFsType, actualOptions := HostFsTypeAndMountOptions(unitOptions.Fstype)
+	if modified == MountUpdated {
 		actualOptions = append(actualOptions, "remount")
 	}
 	cmd := exec.Command("mount", "-t", hostFsType, unitOptions.What, unitOptions.Where, "-o", strings.Join(actualOptions, ","))

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1422,7 +1422,8 @@ const snapMountUnitTmpl = `[Unit]
 Description={{.Description}}
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target{{if isBeforeDrivers .MountUnitType}}
-Before=systemd-udevd.service systemd-modules-load.service{{end}}
+Before=systemd-udevd.service systemd-modules-load.service
+Before=usr-lib-modules.mount usr-lib-firmware.mount{{end}}
 
 [Mount]
 What={{.What}}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -330,6 +330,8 @@ type MountUnitOptions struct {
 	Fstype      string
 	Options     []string
 	Origin      string
+	// RootDir is the root of the filesystem where the unit will be created
+	RootDir string
 	// PreventRestartIfModified is set if we do not want to restart the
 	// mount unit if modified
 	PreventRestartIfModified bool
@@ -347,12 +349,12 @@ const (
 	EmulationModeBackend
 )
 
-type mountUpdateStatus int
+type MountUpdateStatus int
 
 const (
-	mountUnchanged mountUpdateStatus = iota
-	mountUpdated
-	mountCreated
+	MountUnchanged MountUpdateStatus = iota
+	MountUpdated
+	MountCreated
 )
 
 // EnsureMountUnitFlags contains flags that modify behavior of EnsureMountUnitFile
@@ -1377,16 +1379,20 @@ func MountUnitPath(baseDir string) string {
 	return filepath.Join(dirs.SnapServicesDir, escapedPath+".mount")
 }
 
-// MountUnitPathWithLifetime returns the path of a {,auto}mount unit
-// created in the systemd directory suitable for the given unit lifetime
-func MountUnitPathWithLifetime(lifetime UnitLifetime, mountPointDir string) string {
+// mountUnitPathWithLifetime returns the path of a {,auto}mount unit created in
+// the systemd directory suitable for the given unit lifetime. rootDir is the
+// directory for the root filesystem.
+func mountUnitPathWithLifetime(lifetime UnitLifetime, mountPointDir, rootDir string) string {
+	if rootDir == "" {
+		rootDir = dirs.GlobalRootDir
+	}
 	escapedPath := EscapeUnitNamePath(mountPointDir)
 	var servicesPath string
 	switch lifetime {
 	case Persistent:
-		servicesPath = dirs.SnapServicesDir
+		servicesPath = dirs.SnapServicesDirUnder(rootDir)
 	case Transient:
-		servicesPath = dirs.SnapRuntimeServicesDir
+		servicesPath = dirs.SnapRuntimeServicesDirUnder(rootDir)
 	default:
 		panic(fmt.Sprintf("unknown systemd unit lifetime %q", lifetime))
 	}
@@ -1397,7 +1403,7 @@ func MountUnitPathWithLifetime(lifetime UnitLifetime, mountPointDir string) stri
 func ExistingMountUnitPath(mountPointDir string) string {
 	lifetimes := []UnitLifetime{Persistent, Transient}
 	for _, lifetime := range lifetimes {
-		unit := MountUnitPathWithLifetime(lifetime, mountPointDir)
+		unit := mountUnitPathWithLifetime(lifetime, mountPointDir, "")
 		if osutil.FileExists(unit) {
 			return unit
 		}
@@ -1445,25 +1451,26 @@ const (
 	snappyOriginModule = "X-SnapdOrigin"
 )
 
-func ensureMountUnitFile(u *MountUnitOptions) (mountUnitName string, modified mountUpdateStatus, err error) {
+// EnsureMountUnitFileContent creates a mount unit file.
+func EnsureMountUnitFileContent(u *MountUnitOptions) (mountUnitName string, modified MountUpdateStatus, err error) {
 	if u == nil {
-		return "", mountUnchanged, errors.New("ensureMountUnitFile() expects valid mount options")
+		return "", MountUnchanged, errors.New("ensureMountUnitFile() expects valid mount options")
 	}
 
-	mu := MountUnitPathWithLifetime(u.Lifetime, u.Where)
+	mu := mountUnitPathWithLifetime(u.Lifetime, u.Where, u.RootDir)
 	var unitContent bytes.Buffer
 	if err := parsedMountUnitTmpl.Execute(&unitContent, &u); err != nil {
-		return "", mountUnchanged, fmt.Errorf("cannot generate mount unit: %v", err)
+		return "", MountUnchanged, fmt.Errorf("cannot generate mount unit: %v", err)
 	}
 
 	if osutil.FileExists(mu) {
-		modified = mountUpdated
+		modified = MountUpdated
 	} else {
-		modified = mountCreated
+		modified = MountCreated
 	}
 
 	if err := os.MkdirAll(filepath.Dir(mu), 0755); err != nil {
-		return "", mountUnchanged, fmt.Errorf("cannot create directory %s: %v", filepath.Dir(mu), err)
+		return "", MountUnchanged, fmt.Errorf("cannot create directory %s: %v", filepath.Dir(mu), err)
 	}
 
 	stateErr := osutil.EnsureFileState(mu, &osutil.MemoryFileState{
@@ -1472,9 +1479,9 @@ func ensureMountUnitFile(u *MountUnitOptions) (mountUnitName string, modified mo
 	})
 
 	if stateErr == osutil.ErrSameState {
-		modified = mountUnchanged
+		modified = MountUnchanged
 	} else if stateErr != nil {
-		return "", mountUnchanged, stateErr
+		return "", MountUnchanged, stateErr
 	}
 
 	return filepath.Base(mu), modified, nil
@@ -1492,10 +1499,10 @@ func fsMountOptions(fstype string) []string {
 	return options
 }
 
-// hostFsTypeAndMountOptions returns filesystem type and options to actually
+// HostFsTypeAndMountOptions returns filesystem type and options to actually
 // mount the given fstype at runtime, i.e. it determines if fuse should be used
 // for squashfs.
-func hostFsTypeAndMountOptions(fstype string) (hostFsType string, options []string) {
+func HostFsTypeAndMountOptions(fstype string) (hostFsType string, options []string) {
 	options = fsMountOptions(fstype)
 	hostFsType = fstype
 	if fstype == "squashfs" {
@@ -1507,7 +1514,7 @@ func hostFsTypeAndMountOptions(fstype string) (hostFsType string, options []stri
 }
 
 func (s *systemd) EnsureMountUnitFile(description, what, where, fstype string, flags EnsureMountUnitFlags) (string, error) {
-	hostFsType, options := hostFsTypeAndMountOptions(fstype)
+	hostFsType, options := HostFsTypeAndMountOptions(fstype)
 	if osutil.IsDirectory(what) {
 		options = append(options, "bind")
 		hostFsType = "none"
@@ -1531,11 +1538,11 @@ func (s *systemd) EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions) 
 	daemonReloadLock.Lock()
 	defer daemonReloadLock.Unlock()
 
-	mountUnitName, modified, err := ensureMountUnitFile(unitOptions)
+	mountUnitName, modified, err := EnsureMountUnitFileContent(unitOptions)
 	if err != nil {
 		return "", err
 	}
-	if modified != mountUnchanged {
+	if modified != MountUnchanged {
 		// we need to do a daemon-reload here to ensure that systemd really
 		// knows about this new mount unit file
 		if err := s.daemonReloadNoLock(); err != nil {
@@ -1548,7 +1555,7 @@ func (s *systemd) EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions) 
 		}
 
 		// If just modified, some times it is not convenient to restart
-		if modified != mountUpdated || !unitOptions.PreventRestartIfModified {
+		if modified != MountUpdated || !unitOptions.PreventRestartIfModified {
 			// Start/restart the created or modified unit now
 			if err := s.RestartNoWaitForStop(units); err != nil {
 				return "", err

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1384,6 +1384,7 @@ Description=Mount unit for foo, revision x1
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=systemd-udevd.service systemd-modules-load.service
+Before=usr-lib-modules.mount usr-lib-firmware.mount
 
 [Mount]
 What=%s
@@ -1525,6 +1526,7 @@ Description=Mount unit for wifi kernel modules component
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=systemd-udevd.service systemd-modules-load.service
+Before=usr-lib-modules.mount usr-lib-firmware.mount
 
 [Mount]
 What=%s
@@ -1572,6 +1574,7 @@ Description=Mount unit for kernel modules in kernel tree
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=systemd-udevd.service systemd-modules-load.service
+Before=usr-lib-modules.mount usr-lib-firmware.mount
 
 [Mount]
 What=/run/mnt/kernel-modules/5.15.0-91-generic/mykmod/modules/5.15.0-91-generic
@@ -2143,6 +2146,7 @@ Description=Early mount unit for kernel snap
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=systemd-udevd.service systemd-modules-load.service
+Before=usr-lib-modules.mount usr-lib-firmware.mount
 
 [Mount]
 What=%s


### PR DESCRIPTION
We need to create a mount unit for the kernel snap as its content is
linked from the drivers tree. Otherwise the drivers tree is not
functional until the system is seeded.