### PR TITLE
snapdtool, snapcraft: enable FIPS compliant TLS configuration

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -328,9 +328,11 @@ parts:
         if [ -f fips-build ]; then
           case "${cmd}" in
             # per snapd FIPS spec, FIPS build tags are only relevant for snapd,
-            # snap, snap-repair and snap-bootstrap
+            # snap, snap-repair and snap-bootstrap, tags:
+            # - goexperiment.opensslcrypto - enable openssl crypto backend
+            # - snapdfips - enable additional FIPS support (enforce FIPS compliant TLS)
             bin/snap|lib/snapd/snapd|lib/snapd/snap-repair|lib/snapd/snap-bootstrap)
-              TAGS+=(goexperiment.opensslcrypto)
+              TAGS+=(goexperiment.opensslcrypto snapdfips)
               ;;
           esac
         fi

--- a/snapdtool/fips.go
+++ b/snapdtool/fips.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build snapdfips
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package snapdtool
+
+// The sole purpose of this file is to include the fipsonly package, so that the
+// set of supported TLS algorithms is limited to what is permitted by the FIPS
+// spec. Unfortunately Microsoft Go FIPS toolchain < 1.22 does not set up the
+// relevant runtime configuration dynamically, see
+// https://github.com/microsoft/go/blob/66dd0ab88969dff30f3180c41a1a77f592090d68/eng/doc/fips/README.md#configuration-overview.
+// Note that this will only build if the crypto/tls/fipsonly package itself is
+// enabled through relevant build tags.
+
+import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
Introduce a build that which sets up a FIPS compliant TLS configuration.  Unfortunately Microsoft Go FIPS toolchain < 1.22 does not set up the relevant runtime configuration dynamically, see     https://github.com/microsoft/go/blob/66dd0ab88969dff30f3180c41a1a77f592090d68/eng/doc/fips/README.md#configuration-overview In fact none of them does, so we need to have a workaround that isn't too invasive. 
Note that this will only build if the crypto/tls/fipsonly package itself is enabled through relevant build tags.

Related: SNAPDENG-23793
