### PR TITLE
many: extract desktop-ids helpers from wrappers package into snap package

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -390,7 +390,7 @@ func (iface *desktopLegacyInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	// interfaces (like desktop-launch), so they are added here with the minimum
 	// priority, while those other, more privileged, interfaces will add an empty
 	// string with a bigger privilege value.
-	desktopSnippet := strings.Join(getDesktopFileRules(plug.Snap().DesktopPrefix()), "\n")
+	desktopSnippet := strings.Join(getDesktopFileRules(plug.Snap()), "\n")
 	spec.AddPrioritizedSnippet(desktopSnippet, prioritizedSnippetDesktopFileAccess, desktopLegacyAndUnity7Priority)
 
 	return nil

--- a/interfaces/builtin/desktop_legacy_test.go
+++ b/interfaces/builtin/desktop_legacy_test.go
@@ -87,10 +87,6 @@ func (s *DesktopLegacyInterfaceSuite) TestAppArmorSpec(c *C) {
 	// getDesktopFileRules() rules
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# This leaks the names of snaps with desktop files`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/var/lib/snapd/desktop/applications/ r,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_DESKTOP}_*.desktop r,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_DESKTOP}[^_.]*.desktop r,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/[^c]* r,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/consume[^r]* r,`)
 
 	// connected plug to core slot
 	appSet, err = interfaces.NewSnapAppSet(s.coreSlot.Snap(), nil)
@@ -111,3 +107,9 @@ func (s *DesktopLegacyInterfaceSuite) TestStaticInfo(c *C) {
 func (s *DesktopLegacyInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
+
+// Test how desktop-legacy interface interacts desktop-file-ids attribute in desktop interface.
+var _ = Suite(&desktopFileRulesBaseSuite{
+	iface:    "desktop-legacy",
+	slotYaml: desktopLegacyCoreYaml,
+})

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -25,8 +25,10 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -34,7 +36,6 @@ var (
 	ResolveSpecialVariable      = resolveSpecialVariable
 	ImplicitSystemPermanentSlot = implicitSystemPermanentSlot
 	ImplicitSystemConnectedSlot = implicitSystemConnectedSlot
-	AareExclusivePatterns       = aareExclusivePatterns
 	GetDesktopFileRules         = getDesktopFileRules
 	StringListAttribute         = stringListAttribute
 	PolkitPoliciesSupported     = polkitPoliciesSupported
@@ -145,4 +146,12 @@ func MockPolkitDaemonPaths(path1, path2 string) (restore func()) {
 		polkitDaemonPath1 = oldDaemonPath1
 		polkitDaemonPath2 = oldDaemonPath2
 	}
+}
+
+func MockApparmorGenerateAAREExclusionPatterns(fn func(excludePatterns []string, opts *apparmor.AAREExclusionPatternsOptions) (string, error)) (restore func()) {
+	return testutil.Mock(&apparmorGenerateAAREExclusionPatterns, fn)
+}
+
+func MockDesktopFilesFromMount(fn func(s *snap.Info) ([]string, error)) (restore func()) {
+	return testutil.Mock(&desktopFilesFromMount, fn)
 }

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -695,7 +695,7 @@ func (iface *unity7Interface) AppArmorConnectedPlug(spec *apparmor.Specification
 	// interfaces (like desktop-launch), so they are added here with the minimum
 	// priority, while those other, more privileged, interfaces will add an empty
 	// string with a bigger privilege value.
-	desktopSnippet := strings.Join(getDesktopFileRules(plug.Snap().DesktopPrefix()), "\n")
+	desktopSnippet := strings.Join(getDesktopFileRules(plug.Snap()), "\n")
 	spec.AddPrioritizedSnippet(desktopSnippet, prioritizedSnippetDesktopFileAccess, desktopLegacyAndUnity7Priority)
 	return nil
 }

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -92,10 +92,6 @@ func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// getDesktopFileRules() rules
 	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `# This leaks the names of snaps with desktop files`)
 	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `/var/lib/snapd/desktop/applications/ r,`)
-	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `/var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_DESKTOP}_*.desktop r,`)
-	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_DESKTOP}[^_.]*.desktop r,`)
-	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/[^o]* r,`)
-	c.Assert(apparmorSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, `deny /var/lib/snapd/desktop/applications/other-sna[^p]* r,`)
 
 	// connected plugs for instance name have a non-nil security snippet for apparmor
 	apparmorSpec = apparmor.NewSpecification(s.plugInst.AppSet())
@@ -124,3 +120,9 @@ func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 func (s *Unity7InterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
+
+// Test how unity7 interface interacts desktop-file-ids attribute in desktop interface.
+var _ = Suite(&desktopFileRulesBaseSuite{
+	iface:    "unity7",
+	slotYaml: unity7mockSlotSnapInfoYaml,
+})

--- a/tests/lib/snaps/test-snapd-desktop-file-ids/bin/check-dirs
+++ b/tests/lib/snaps/test-snapd-desktop-file-ids/bin/check-dirs
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for dir in "$@"; do
+    ls "$dir"
+done

--- a/tests/lib/snaps/test-snapd-desktop-file-ids/bin/check-files
+++ b/tests/lib/snaps/test-snapd-desktop-file-ids/bin/check-files
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for file in "$@"; do
+    cat "$file"
+done

--- a/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/foo.desktop
+++ b/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/foo.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=test-snapd-desktop.cmd
+Comment=A desktop file for test-snapd-desktop.cmd
+Exec=test-snapd-desktop.cmd
+Terminal=true
+Type=Application

--- a/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/org.example.Foo.desktop
+++ b/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/org.example.Foo.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=test-snapd-desktop.cmd
+Comment=A desktop file for test-snapd-desktop.cmd
+Exec=test-snapd-desktop.cmd
+Terminal=true
+Type=Application

--- a/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/org.example.desktop
+++ b/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/org.example.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=test-snapd-desktop.cmd
+Comment=A desktop file for test-snapd-desktop.cmd
+Exec=test-snapd-desktop.cmd
+Terminal=true
+Type=Application

--- a/tests/lib/snaps/test-snapd-desktop-file-ids/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-desktop-file-ids/meta/snap.yaml
@@ -1,0 +1,17 @@
+name: test-snapd-desktop-file-ids
+version: 1.0
+summary: Basic desktop interface test snap
+description: A basic snap with desktop-file-ids
+
+apps:
+    check-files:
+        command: bin/check-files
+        plugs: [desktop, desktop-legacy]
+    check-dirs:
+        command: bin/check-dirs
+        plugs: [desktop, desktop-legacy]
+
+plugs:
+  desktop:
+    desktop-file-ids:
+    - org.example

--- a/tests/main/desktop-file-ids/task.yaml
+++ b/tests/main/desktop-file-ids/task.yaml
@@ -1,0 +1,51 @@
+summary: Ensure that the desktop-file-ids desktop interface attribute works
+
+details: |
+    Check that when the desktop-file-ids desktop interface attribute
+    is set, the names of the desktop files matching the ids are not
+    mangled (with the snap's desktop prefix).
+
+# Disabled on Ubuntu Core because it doesn't provide the "desktop" slot.
+# TODO: Enable for Ubuntu Core Desktop when it is available.
+systems:
+    - -ubuntu-core-*
+
+environment:
+    DIR: /var/lib/snapd/desktop/applications/
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop-file-ids
+    touch "$DIR/test-confinement.desktop"
+    tests.session -u test prepare
+
+restore: |
+    rm -f "$DIR/test-confinement.desktop"
+    tests.session -u test restore
+
+execute: |
+    files="$DIR/org.example.desktop $DIR/test-snapd-desktop-file-ids_foo.desktop $DIR/test-snapd-desktop-file-ids_org.example.Foo.desktop"
+
+    # Connect desktop-legacy interface to test generated desktop allow/deny rules
+    # only allows access to the snap's desktop files
+    snap connect test-snapd-desktop-file-ids:desktop-legacy
+
+    # Check that desktop files are installed with expected names and implicitly check
+    # that for confined systems the snap can access its own desktop files when
+    # desktop-legacy interface plug is connected
+    echo "Check that desktop files are installed as expected"
+    tests.session -u test exec test-snapd-desktop-file-ids.check-dirs "$DIR"
+    tests.session -u test exec test-snapd-desktop-file-ids.check-files "$files"
+    if [ "$(snap debug confinement)" == strict ]; then
+        # Check that snap cannot access other desktop files
+        not tests.session -u test exec test-snapd-desktop-file-ids.check-files "$DIR/test-confinement.desktop"
+    fi
+
+    snap remove --purge test-snapd-desktop-file-ids
+    echo "Check desktop files are removed"
+    for file in $files; do
+        not test -f "$file"
+    done
+    echo "But not other snaps' desktop files"
+    test -f "$DIR/test-confinement.desktop"
+
+    # TODO: Add check for parallel installs


### PR DESCRIPTION
Those helpers are extracted to be reused in a later PR when generating apparmor rules specific to desktop-file-ids.

This PR builds on top of https://github.com/canonical/snapd/pull/14296 and should be rebased when it is merged.