### PR TITLE
o/registrystate: add -view-changed hook handler

### DIFF
--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -43,6 +43,8 @@ func init() {
 	snapstate.SetupGateAutoRefreshHook = SetupGateAutoRefreshHook
 }
 
+var ViewChangedHandlerGenerator func(context *Context) Handler
+
 func SetupInstallHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
 		Snap:     snapName,
@@ -333,20 +335,11 @@ func SetupGateAutoRefreshHook(st *state.State, snapName string) *state.Task {
 	return task
 }
 
-type snapHookHandler struct {
-}
+type SnapHookHandler struct{}
 
-func (h *snapHookHandler) Before() error {
-	return nil
-}
-
-func (h *snapHookHandler) Done() error {
-	return nil
-}
-
-func (h *snapHookHandler) Error(err error) (bool, error) {
-	return false, nil
-}
+func (h *SnapHookHandler) Before() error                 { return nil }
+func (h *SnapHookHandler) Done() error                   { return nil }
+func (h *SnapHookHandler) Error(err error) (bool, error) { return false, nil }
 
 func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
@@ -364,7 +357,7 @@ func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 
 func setupHooks(hookMgr *HookManager) {
 	handlerGenerator := func(context *Context) Handler {
-		return &snapHookHandler{}
+		return &SnapHookHandler{}
 	}
 	gateAutoRefreshHandlerGenerator := func(context *Context) Handler {
 		return NewGateAutoRefreshHookHandler(context)
@@ -375,4 +368,5 @@ func setupHooks(hookMgr *HookManager) {
 	hookMgr.Register(regexp.MustCompile("^pre-refresh$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^remove$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^gate-auto-refresh$"), gateAutoRefreshHandlerGenerator)
+	hookMgr.Register(regexp.MustCompile("^.+-view-changed$"), ViewChangedHandlerGenerator)
 }

--- a/overlord/registrystate/export_test.go
+++ b/overlord/registrystate/export_test.go
@@ -29,6 +29,10 @@ var (
 	GetPlugsAffectedByPaths = getPlugsAffectedByPaths
 )
 
+type (
+	ViewChangedHandler = viewChangedHandler
+)
+
 func MockReadDatabag(f func(st *state.State, account, registryName string) (registry.JSONDataBag, error)) func() {
 	old := readDatabag
 	readDatabag = f

--- a/overlord/registrystate/registrymgr.go
+++ b/overlord/registrystate/registrymgr.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package registrystate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+)
+
+func init() {
+	hookstate.ViewChangedHandlerGenerator = func(context *hookstate.Context) hookstate.Handler {
+		return &viewChangedHandler{ctx: context}
+	}
+}
+
+type viewChangedHandler struct {
+	hookstate.SnapHookHandler
+	ctx *hookstate.Context
+}
+
+func (h *viewChangedHandler) Precondition() (bool, error) {
+	h.ctx.Lock()
+	defer h.ctx.Unlock()
+
+	// check that the plug is still connected
+	plugName, _, ok := strings.Cut(h.ctx.HookName(), "-view-changed")
+	if !ok || plugName == "" {
+		return false, fmt.Errorf("cannot run registry hook handler for unknown hook: %s", h.ctx.HookName())
+	}
+
+	repo := ifacerepo.Get(h.ctx.State())
+	conns, err := repo.Connected(h.ctx.InstanceName(), plugName)
+	if err != nil {
+		var verr *interfaces.NoPlugOrSlotError
+		if errors.As(err, &verr) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("cannot determine precondition for hook %s: %w", h.ctx.HookName(), err)
+	}
+
+	return len(conns) > 0, nil
+}

--- a/overlord/registrystate/registrymgr_test.go
+++ b/overlord/registrystate/registrymgr_test.go
@@ -1,0 +1,129 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package registrystate_test
+
+import (
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/state"
+
+	. "gopkg.in/check.v1"
+)
+
+type hookHandlerSuite struct {
+	state *state.State
+
+	repo *interfaces.Repository
+}
+
+var _ = Suite(&hookHandlerSuite{})
+
+func (s *hookHandlerSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.state = overlord.Mock().State()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.repo = interfaces.NewRepository()
+	ifacerepo.Replace(s.state, s.repo)
+
+	regIface := &ifacetest.TestInterface{InterfaceName: "registry"}
+	err := s.repo.AddInterface(regIface)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1
+type: os
+slots:
+  registry-slot:
+    interface: registry
+`
+	info := mockInstalledSnap(c, s.state, coreYaml, "")
+	coreSet, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+
+	err = s.repo.AddAppSet(coreSet)
+	c.Assert(err, IsNil)
+
+	snapYaml := `name: test-snap
+version: 1
+type: app
+plugs:
+  setup:
+    interface: registry
+    account: my-acc
+    view: network/setup-wifi
+`
+
+	info = mockInstalledSnap(c, s.state, snapYaml, "")
+	appSet, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.repo.AddAppSet(appSet)
+	c.Assert(err, IsNil)
+
+	ref := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "test-snap", Name: "setup"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "registry-slot"},
+	}
+
+	_, err = s.repo.Connect(ref, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+}
+
+func (s *hookHandlerSuite) TestViewChangedHookPlugConnected(c *C) {
+	hooksup := &hookstate.HookSetup{
+		Snap: "test-snap",
+		Hook: "setup-view-changed",
+	}
+	ctx, err := hookstate.NewContext(nil, s.state, hooksup, nil, "")
+	c.Assert(err, IsNil)
+
+	handler, ok := hookstate.ViewChangedHandlerGenerator(ctx).(hookstate.Precondition)
+	c.Assert(ok, Equals, true)
+
+	condMet, err := handler.Precondition()
+	c.Assert(err, IsNil)
+	c.Assert(condMet, Equals, true)
+}
+
+func (s *hookHandlerSuite) TestViewChangedHookNoPlug(c *C) {
+	s.state.Lock()
+	s.repo = interfaces.NewRepository()
+	ifacerepo.Replace(s.state, s.repo)
+	s.state.Unlock()
+
+	hooksup := &hookstate.HookSetup{
+		Snap: "test-snap",
+		Hook: "setup-view-changed",
+	}
+	ctx, err := hookstate.NewContext(nil, s.state, hooksup, nil, "")
+	c.Assert(err, IsNil)
+
+	handler, ok := hookstate.ViewChangedHandlerGenerator(ctx).(hookstate.Precondition)
+	c.Assert(ok, Equals, true)
+
+	condMet, err := handler.Precondition()
+	c.Assert(err, IsNil)
+	c.Assert(condMet, Equals, false)
+}

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -39,6 +39,7 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^check-health$")),
 	NewHookType(regexp.MustCompile("^fde-setup$")),
 	NewHookType(regexp.MustCompile("^gate-auto-refresh$")),
+	NewHookType(regexp.MustCompile("^.+-view-changed$")),
 }
 
 var supportedComponentHooks = []*HookType{


### PR DESCRIPTION
Adds a hook handler that checks preconditions to calling <plug>-view-changed hooks, like checking that the plug that matching the hook is still connected (since this is performed asynchronously).