### PR TITLE
s/apparmor: expand apparmor prompting support checks

### DIFF
--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -69,6 +71,10 @@ func (s *promptingSuite) SetUpTest(c *C) {
 	))
 	// mock the presence of the notification socket
 	os.MkdirAll(notify.SysPath, 0o755)
+	// mock the presence of permstable32_version with supported version
+	s.AddCleanup(apparmor.MockFsRootPath(dirs.GlobalRootDir))
+	os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "sys/kernel/security/apparmor/features/policy"), 0o755)
+	os.WriteFile(filepath.Join(dirs.GlobalRootDir, "sys/kernel/security/apparmor/features/policy/permstable32_version"), []byte("0x000002"), 0o644)
 
 	s.overlord = overlord.MockWithState(nil)
 	// override state set up by configcoreSuite

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -22,6 +22,7 @@ package configcore_test
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/user"
 	"time"
 
@@ -45,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
@@ -65,6 +67,8 @@ func (s *promptingSuite) SetUpTest(c *C) {
 		[]string{"policy:permstable32:prompt"}, nil,
 		[]string{"prompt"}, nil,
 	))
+	// mock the presence of the notification socket
+	os.MkdirAll(notify.SysPath, 0o755)
 
 	s.overlord = overlord.MockWithState(nil)
 	// override state set up by configcoreSuite

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -469,10 +469,10 @@ func PromptingSupportedByFeatures(apparmorFeatures *FeaturesSupported) (bool, st
 	}
 	version, err := probeKernelFeaturesPermstable32Version()
 	if err != nil {
-		return false, "apparmor kernel permissions table version must be at least 2, but version could not be read"
+		return false, "apparmor kernel permissions table version must be at least 2 for prompting to be supported, but version could not be read"
 	}
 	if version < 2 {
-		return false, fmt.Sprintf("apparmor kernel permissions table version must be at least 2, but version is %d", version)
+		return false, fmt.Sprintf("apparmor kernel permissions table version must be at least 2 for prompting to be supported, but version is %d", version)
 	}
 	return true, ""
 }

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -704,7 +704,7 @@ func probeKernelFeaturesPermstable32Version() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.ParseInt(string(data), 0, 64)
+	return strconv.ParseInt(strings.TrimSpace(string(data)), 0, 64)
 }
 
 func probeParserFeatures() ([]string, error) {

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -460,12 +460,11 @@ func PromptingSupportedByFeatures(apparmorFeatures *FeaturesSupported) (bool, st
 	// for its presence among the kernel features.
 	if strutil.ListContains(apparmorFeatures.KernelFeatures, "policy:notify") {
 		if !strutil.ListContains(apparmorFeatures.KernelFeatures, "policy:notify:user:file") {
-			return false, "the kernel does not support prompting for file access"
-			// XXX: should this error message be "apparmor kernel features do not support prompting" as well?
+			return false, "apparmor kernel features do not support prompting for file access"
 		}
 	}
 	if !notify.SupportAvailable() {
-		return false, "kernel notification socket required by listener is not present"
+		return false, "apparmor kernel notification socket required by prompting listener is not present"
 	}
 	return true, ""
 }

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -516,7 +516,7 @@ var (
 
 	// Filesystem root defined locally to avoid dependency on the
 	// 'dirs' package
-	// XXX: is this still useful/relevant? The 'dirs' package is used here already.
+	// TODO: replace rootPath with dirs.GlobalRootDir, since dirs is used elsewhere
 	rootPath = "/"
 
 	// hostAbi30File is the path to the apparmor "3.0" ABI file and is typically

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -461,6 +461,7 @@ func PromptingSupportedByFeatures(apparmorFeatures *FeaturesSupported) (bool, st
 	if strutil.ListContains(apparmorFeatures.KernelFeatures, "policy:notify") {
 		if !strutil.ListContains(apparmorFeatures.KernelFeatures, "policy:notify:user:file") {
 			return false, "the kernel does not support prompting for file access"
+			// XXX: should this error message be "apparmor kernel features do not support prompting" as well?
 		}
 	}
 	if !notify.SupportAvailable() {

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -1049,3 +1049,11 @@ func MockParserSearchPath(new string) (restore func()) {
 		parserSearchPath = oldAppArmorParserSearchPath
 	}
 }
+
+func MockFsRootPath(path string) (restorer func()) {
+	old := rootPath
+	rootPath = path
+	return func() {
+		rootPath = old
+	}
+}

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -643,6 +643,13 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 			expectedReason: "the kernel does not support prompting for file access",
 		},
 		{
+			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt", "policy:notify", "policy:notify:user:foo"},
+			kernelError:    nil,
+			parserFeatures: []string{"mqueue", "prompt"},
+			parserError:    nil,
+			expectedReason: "the kernel does not support prompting for file access",
+		},
+		{
 			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt", "policy:notify", "policy:notify:user:file"},
 			kernelError:    nil,
 			parserFeatures: []string{"mqueue", "prompt"},

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -597,7 +597,7 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 
 func (s *apparmorSuite) TestPromptingSupported(c *C) {
 	goodKernelFeatures := []string{"policy:permstable32:prompt"}
-	goodKernelFeaturesWithNotify := []string{"policy:permstable32:prompt", "policy:notify:user:file"}
+	goodKernelFeaturesWithNotify := []string{"policy:permstable32:prompt", "policy:notify", "policy:notify:user:file"}
 	goodParserFeatures := []string{"prompt"}
 
 	for _, testCase := range []struct {

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -732,7 +732,7 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 
 	supported, reason := apparmor.PromptingSupported()
 	c.Check(supported, Equals, false)
-	c.Check(reason, Equals, "apparmor kernel permissions table version must be at least 2, but version could not be read")
+	c.Check(reason, Equals, "apparmor kernel permissions table version must be at least 2 for prompting to be supported, but version could not be read")
 
 	// Create permstable32_version file with a version too early
 	c.Assert(os.MkdirAll(filepath.Join(d, featuresSysPath, "policy"), 0o755), IsNil)
@@ -740,7 +740,7 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 
 	supported, reason = apparmor.PromptingSupported()
 	c.Check(supported, Equals, false)
-	c.Check(reason, Equals, "apparmor kernel permissions table version must be at least 2, but version is 1")
+	c.Check(reason, Equals, "apparmor kernel permissions table version must be at least 2 for prompting to be supported, but version is 1")
 
 	// Create permstable32_version file with a sufficient version
 	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32_version"), []byte("0x000002"), 0o644), IsNil)

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -640,28 +640,28 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 			kernelError:    nil,
 			parserFeatures: []string{"mqueue", "prompt"},
 			parserError:    nil,
-			expectedReason: "the kernel does not support prompting for file access",
+			expectedReason: "apparmor kernel features do not support prompting for file access",
 		},
 		{
 			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt", "policy:notify", "policy:notify:user:foo"},
 			kernelError:    nil,
 			parserFeatures: []string{"mqueue", "prompt"},
 			parserError:    nil,
-			expectedReason: "the kernel does not support prompting for file access",
+			expectedReason: "apparmor kernel features do not support prompting for file access",
 		},
 		{
 			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt", "policy:notify", "policy:notify:user:file"},
 			kernelError:    nil,
 			parserFeatures: []string{"mqueue", "prompt"},
 			parserError:    nil,
-			expectedReason: "kernel notification socket required by listener is not present",
+			expectedReason: "apparmor kernel notification socket required by prompting listener is not present",
 		},
 		{
 			kernelFeatures: []string{"policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt"},
 			kernelError:    nil,
 			parserFeatures: []string{"mqueue", "prompt"},
 			parserError:    nil,
-			expectedReason: "kernel notification socket required by listener is not present",
+			expectedReason: "apparmor kernel notification socket required by prompting listener is not present",
 		},
 	} {
 		restore := apparmor.MockFeatures(testCase.kernelFeatures, testCase.kernelError, testCase.parserFeatures, testCase.parserError)

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -375,7 +375,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeaturesPermstable32Version(c *C)
 		ver int64
 	}{
 		{
-			"0x000001",
+			"0x000001\n",
 			1,
 		},
 		{
@@ -383,7 +383,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeaturesPermstable32Version(c *C)
 			2,
 		},
 		{
-			"0x0000000000000003",
+			"0x0000000000000003\n",
 			3,
 		},
 		{

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -96,6 +96,8 @@ var (
 	ProbeKernelFeatures = probeKernelFeatures
 	ProbeParserFeatures = probeParserFeatures
 
+	ProbeKernelFeaturesPermstable32Version = probeKernelFeaturesPermstable32Version
+
 	RequiredKernelFeatures  = requiredKernelFeatures
 	RequiredParserFeatures  = requiredParserFeatures
 	PreferredKernelFeatures = preferredKernelFeatures

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -76,14 +76,6 @@ func MockProfilesPath(t *testutil.BaseTest, profiles string) {
 	t.AddCleanup(func() {
 		profilesPath = realProfilesPath
 	})
-}
-
-func MockFsRootPath(path string) (restorer func()) {
-	old := rootPath
-	rootPath = path
-	return func() {
-		rootPath = old
-	}
 }
 
 func MockSnapdAppArmorSupportsReexec(new func() bool) (restore func()) {

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -46,8 +46,17 @@ debug: |
     systemctl start snapd.service || systemctl status snapd.service || true
     retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
 
+    echo "Debug: Check kernel version"
+    uname -a
+    echo "Debug: Check kernel notification socket presence"
+    if ls /sys/kernel/security/apparmor/.notify ; then
+        echo "kernel notification socket exists"
+    else
+        echo "kernel notification socket does not exist"
+    fi
     echo "Debug: Report system info"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq
+    snap debug api /v2/system-info
+
 
 execute: |
     . /etc/os-release

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -114,8 +114,9 @@ execute: |
     fi
 
     echo "Enable prompting via snap client where possible"
-    if os.query is-core || os.query is-ubuntu-lt 24.04; then
-        # prompting is disabled on Ubuntu Core
+    # Prompting is unsupported everywhere but the Ubuntu non-core systems with
+    # kernels which support apparmor prompting
+    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -107,7 +107,6 @@ execute: |
     echo "Enable prompting via snap client where possible"
     if os.query is-core || os.query is-ubuntu-lt 24.04; then
         # prompting is disabled on Ubuntu Core
-        # TODO on releases < 24.04 we need the snapd snap for testing
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -105,9 +105,9 @@ execute: |
     fi
 
     echo "Enable prompting via snap client where possible"
-    if os.query is-core || os.query is-ubuntu-lt 22.04; then
+    if os.query is-core || os.query is-ubuntu-lt 24.04; then
         # prompting is disabled on Ubuntu Core
-        # on releases < 22.04 the kernel does not support prompting
+        # TODO on releases < 24.04 we need the snapd snap for testing
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -16,6 +16,18 @@ prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
     snap connect test-snapd-prompt-handler:snap-interfaces-requests-control
 
+debug: |
+    echo "Check kernel version"
+    uname -a
+    echo "Check kernel notification socket presence"
+    if ls /sys/kernel/security/apparmor/.notify ; then
+        echo "kernel notification socket exists"
+    else
+        echo "kernel notification socket does not exist"
+    fi
+    echo "Check system info"
+    snap debug api /v2/system-info
+
 execute: |
     RULES_PATH="/var/lib/snapd/interfaces-requests/request-rules.json"
 

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -35,8 +35,9 @@ execute: |
     mkdir -p "$(dirname $RULES_PATH)"
     echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"},{"id":"0000000000000003","timestamp":"2004-10-20T16:47:32.138415627-05:00","user":1000,"snap":"firefox","interface":"home","constraints":{"path-pattern":"/home/test/Downloads/**","permissions":["read","write"]},"outcome":"allow","lifespan":"timespan","expiration":"2005-04-08T00:00:00Z"}]}' | tee "$RULES_PATH"
 
-    # Prompting is unsupported everywhere but the Ubuntu non-core systems >= 24.04
-    if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
+    # Prompting is unsupported everywhere but the Ubuntu non-core systems with
+    # kernels which support apparmor prompting
+    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core; then
             # there is a more specific error on Ubuntu Core

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -24,8 +24,8 @@ execute: |
     echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"},{"id":"0000000000000003","timestamp":"2004-10-20T16:47:32.138415627-05:00","user":1000,"snap":"firefox","interface":"home","constraints":{"path-pattern":"/home/test/Downloads/**","permissions":["read","write"]},"outcome":"allow","lifespan":"timespan","expiration":"2005-04-08T00:00:00Z"}]}' | tee "$RULES_PATH"
 
     # Prompting is disabled everywhere but the Ubuntu systems
-    # on releases < 22.04 the kernel does not support prompting
-    if ! os.query is-ubuntu || os.query is-ubuntu-lt 22.04 || os.query is-core ; then
+    # TODO: on Ubuntu releases < 24.04 we need the snapd snap for testing
+    if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core; then
             # there is a more specific error on Ubuntu Core

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -23,8 +23,7 @@ execute: |
     mkdir -p "$(dirname $RULES_PATH)"
     echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"},{"id":"0000000000000003","timestamp":"2004-10-20T16:47:32.138415627-05:00","user":1000,"snap":"firefox","interface":"home","constraints":{"path-pattern":"/home/test/Downloads/**","permissions":["read","write"]},"outcome":"allow","lifespan":"timespan","expiration":"2005-04-08T00:00:00Z"}]}' | tee "$RULES_PATH"
 
-    # Prompting is disabled everywhere but the Ubuntu systems
-    # TODO: on Ubuntu releases < 24.04 we need the snapd snap for testing
+    # Prompting is unsupported everywhere but the Ubuntu non-core systems >= 24.04
     if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core; then

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -19,9 +19,9 @@ restore: |
 
 execute: |
     echo "Enable prompting via snap client where possible"
-    if os.query is-core || os.query is-ubuntu-lt 22.04; then
+    if os.query is-core || os.query is-ubuntu-lt 24.04; then
         # prompting is disabled on Ubuntu Core
-        # on releases < 22.04 we need the kernel does not support prompting
+        # TODO on releases < 24.04 we need the snapd snap for testing
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -21,7 +21,6 @@ execute: |
     echo "Enable prompting via snap client where possible"
     if os.query is-core || os.query is-ubuntu-lt 24.04; then
         # prompting is disabled on Ubuntu Core
-        # TODO on releases < 24.04 we need the snapd snap for testing
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -31,8 +31,9 @@ debug: |
 
 execute: |
     echo "Enable prompting via snap client where possible"
-    if os.query is-core || os.query is-ubuntu-lt 24.04; then
-        # prompting is disabled on Ubuntu Core
+    # Prompting is unsupported everywhere but the Ubuntu non-core systems with
+    # kernels which support apparmor prompting
+    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -17,6 +17,18 @@ prepare: |
 restore: |
     tests.session -u test restore
 
+debug: |
+    echo "Check kernel version"
+    uname -a
+    echo "Check kernel notification socket presence"
+    if ls /sys/kernel/security/apparmor/.notify ; then
+        echo "kernel notification socket exists"
+    else
+        echo "kernel notification socket does not exist"
+    fi
+    echo "Check system info"
+    snap debug api /v2/system-info
+
 execute: |
     echo "Enable prompting via snap client where possible"
     if os.query is-core || os.query is-ubuntu-lt 24.04; then

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -60,8 +60,9 @@ execute: |
     api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | jq '."status-code"' | MATCH '^200$'
 
     echo "Ensure AppArmor Prompting experimental feature can be enabled where possible"
-    # Prompting is unsupported everywhere but the Ubuntu non-core systems >= 24.04
-    if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
+    # Prompting is unsupported everywhere but the Ubuntu non-core systems with
+    # kernels which support apparmor prompting
+    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core; then
             # there is a more specific error on Ubuntu Core

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -22,6 +22,18 @@ prepare: |
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
 
+debug: |
+    echo "Check kernel version"
+    uname -a
+    echo "Check kernel notification socket presence"
+    if ls /sys/kernel/security/apparmor/.notify ; then
+        echo "kernel notification socket exists"
+    else
+        echo "kernel notification socket does not exist"
+    fi
+    echo "Check system info"
+    snap debug api /v2/system-info
+
 execute: |
     "$TESTSTOOLS"/snaps-state install-local api-client
     echo "The snap-interfaces-requests-control plug on the api-client snap is initially disconnected"

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -11,12 +11,6 @@ details: |
       # TODO: - /v2/interfaces/requests/prompts: to receive and reply to request prompts
       # TODO: - /v2/interfaces/requests/rules: to view and manage request rules
 
-systems:
-    # debian-sid: prompting is supposedly supported by the kernel, but doesn't work
-    # TODO: remove exclusion of debian-sid once we correctly detect that
-    # notifications are not running
-    - -debian-sid-*
-
 environment:
     # not all terminals support UTF-8, but Python tries to be smart and attempts
     # to guess the encoding as if the output would go to the terminal, but in

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -49,8 +49,8 @@ execute: |
 
     echo "Ensure AppArmor Prompting experimental feature can be enabled where possible"
     # prompting is disabled everywhere but the Ubuntu systems
-    # on Ubuntu releases < 22.04 the kernel does not support prompting
-    if ! os.query is-ubuntu || os.query is-ubuntu-lt 22.04 || os.query is-core ; then
+    # TODO on Ubuntu releases < 24.04 we need the snapd snap for testing
+    if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core; then
             # there is a more specific error on Ubuntu Core

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -5,11 +5,11 @@ details: |
     to view and manage request prompts and request rules.
 
     Specifically:
-      - /v2/notices: to read change-update and refresh-inhibit notices
+      - /v2/notices: to read interfaces-requests-prompt and interfaces-requests-rule-update notices
+      - /v2/interfaces/requests/prompts: to receive and reply to request prompts
+      - /v2/interfaces/requests/rules: to view and manage request rules
       - /v2/system-info: to check whether prompting is supported/enabled
       - /v2/snaps/{name}: to get details about installed snaps
-      # TODO: - /v2/interfaces/requests/prompts: to receive and reply to request prompts
-      # TODO: - /v2/interfaces/requests/rules: to view and manage request rules
 
 environment:
     # not all terminals support UTF-8, but Python tries to be smart and attempts
@@ -48,8 +48,7 @@ execute: |
     api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | jq '."status-code"' | MATCH '^200$'
 
     echo "Ensure AppArmor Prompting experimental feature can be enabled where possible"
-    # prompting is disabled everywhere but the Ubuntu systems
-    # TODO on Ubuntu releases < 24.04 we need the snapd snap for testing
+    # Prompting is unsupported everywhere but the Ubuntu non-core systems >= 24.04
     if ! os.query is-ubuntu || os.query is-ubuntu-lt 24.04 || os.query is-core ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core; then


### PR DESCRIPTION
This PR is based on #14294, only the final few commits are relevant to this PR. Should rebase this PR on master once that PR lands.

Prompting cannot be supported if the kernel notification socket does not exist. Thus, add a check for its presence to PromptingSupportedByFeatures.
    
However, this alone is not sufficient. The notification socket may be used for other purposes as well. When this becomes the case, a directory will be added at `/sys/kernel/security/apparmor/features/policy/notify`. If that directory exists, and it contains a file called `user`, which contains the list of prompting mediation classes, then prompting is supported on the system. If no file called `user` exists in that directory, but the directory itself exists, then we know prompting is not supported.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-31642