### PR TITLE
many: consume preseeded components when seeding system

### DIFF
--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -457,12 +457,12 @@ func comparePreseedAndSeedSnaps(seedSnap *seed.Snap, preseedSnap *asserts.Presee
 	for _, c := range seedSnap.Components {
 		preseedComp, ok := expectedComps[c.CompSideInfo.Component.ComponentName]
 		if !ok {
-			return fmt.Errorf("component %q not present in the preseed assertion", c.CompSideInfo.Component.ComponentName)
+			return fmt.Errorf("component %q not present in the preseed assertion", c.CompSideInfo.Component)
 		}
 
 		if preseedComp.Revision != c.CompSideInfo.Revision.N {
 			rev := snap.Revision{N: preseedComp.Revision}
-			return fmt.Errorf("component %q has wrong revision %s (expected: %s)", c.CompSideInfo.Component.ComponentName, c.CompSideInfo.Revision, rev)
+			return fmt.Errorf("component %q has wrong revision %s (expected: %s)", c.CompSideInfo.Component, c.CompSideInfo.Revision, rev)
 		}
 
 		// once we've seen the component, remove it from the expected

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/sysconfig"
@@ -473,7 +474,7 @@ func comparePreseedAndSeedSnaps(seedSnap *seed.Snap, preseedSnap *asserts.Presee
 	if len(expectedComps) != 0 {
 		missing := make([]string, 0, len(expectedComps))
 		for name := range expectedComps {
-			missing = append(missing, name)
+			missing = append(missing, naming.NewComponentRef(seedSnap.SnapName(), name).String())
 		}
 		return fmt.Errorf("seed is missing components expected by preseed assertion: %s", strutil.Quoted(missing))
 	}

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -1551,7 +1551,7 @@ func (s *installSuite) TestApplyPreseededDataComponentMismatchMissingComponent(c
 			},
 		},
 	}
-	const message = `seed is missing components expected by preseed assertion: "comp3"`
+	const message = `seed is missing components expected by preseed assertion: "essential-snap\+comp3"`
 	s.testApplyPreseededDataComponentMismatch(c, preseededDataComponentMismatchOpts{
 		preseed: preseed,
 		errMsg:  message,

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -1515,7 +1515,7 @@ func (s *installSuite) TestApplyPreseededDataComponentMismatchWrongRevision(c *C
 			},
 		},
 	}
-	const message = `component "comp1" has wrong revision 2 \(expected: 5\)`
+	const message = `component "essential-snap\+comp1" has wrong revision 2 \(expected: 5\)`
 	s.testApplyPreseededDataComponentMismatch(c, preseededDataComponentMismatchOpts{
 		preseed: preseed,
 		errMsg:  message,
@@ -1583,7 +1583,7 @@ func (s *installSuite) TestApplyPreseededDataComponentMismatchExtraComponent(c *
 			},
 		},
 	}
-	const message = `component \"comp3\" not present in the preseed assertion`
+	const message = `component "essential-snap\+comp3" not present in the preseed assertion`
 	s.testApplyPreseededDataComponentMismatch(c, preseededDataComponentMismatchOpts{
 		preseed: preseed,
 		errMsg:  message,

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/testutil"
@@ -1188,6 +1189,15 @@ func (s *installSuite) setupCore20Seed(c *C) *asserts.Model {
 	s.mountedGadget(c)
 	optSnapPath := snaptest.MakeTestSnapWithFiles(c, seedtest.SampleSnapYaml["optional20-a"], nil)
 
+	compRevs := map[string]snap.Revision{
+		"comp1": snap.R(2),
+		"comp2": snap.R(3),
+	}
+	s.MakeAssertedSnapWithComps(
+		c, seedtest.SampleSnapYaml["required20"], nil,
+		snap.R(1), compRevs, "canonical", s.StoreSigning.Database,
+	)
+
 	model := map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
@@ -1215,7 +1225,15 @@ func (s *installSuite) setupCore20Seed(c *C) *asserts.Model {
 				"name": "core20",
 				"id":   s.AssertedSnapID("core20"),
 				"type": "base",
-			}},
+			},
+			map[string]interface{}{
+				"name": "required20",
+				"id":   s.AssertedSnapID("required20"),
+				"components": map[string]interface{}{
+					"comp1": "required",
+				},
+			},
+		},
 	}
 
 	return s.MakeSeed(c, "20220401", "my-brand", "my-model", model, []*seedwriter.OptionsSnap{{Path: optSnapPath}})
@@ -1241,8 +1259,8 @@ func (s *installSuite) mockPreseedAssertion(c *C, brandID, modelName, series, pr
 	}
 
 	f, err := os.Create(preseedAsPath)
-	defer f.Close()
 	c.Assert(err, IsNil)
+	defer f.Close()
 	enc := asserts.NewEncoder(f)
 	c.Assert(enc.Encode(preseedAs), IsNil)
 }
@@ -1271,6 +1289,17 @@ func (s *installSuite) TestApplyPreseededData(c *C) {
 		map[string]interface{}{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
 		map[string]interface{}{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
 		map[string]interface{}{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
+		map[string]interface{}{
+			"name":     "required20",
+			"id":       s.AssertedSnapID("required20"),
+			"revision": "1",
+			"components": []interface{}{
+				map[string]interface{}{
+					"name":     "comp1",
+					"revision": "2",
+				},
+			},
+		},
 		map[string]interface{}{"name": "optional20-a"},
 	}
 	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
@@ -1311,6 +1340,8 @@ func (s *installSuite) TestApplyPreseededData(c *C) {
 		{"core20/1", "core20_1.snap"},
 		{"pc-kernel/1", "pc-kernel_1.snap"},
 		{"pc/1", "pc_1.snap"},
+		{"required20/1", "required20_1.snap"},
+		{"required20/components/mnt/comp1", "required20+comp1_2.comp"},
 		{"optional20-a/x1", "optional20-a_x1.snap"},
 	} {
 		c.Assert(osutil.FileExists(filepath.Join(writableDir, dirs.StripRootDir(dirs.SnapMountDir), seedSnap.name)), Equals, true, &dumpDirContents{c, writableDir})
@@ -1446,8 +1477,9 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 		c.Assert(err, ErrorMatches, tc.err)
 	}
 
-	// mode-snap is presend in the seed but missing in the preseed assertion; add other-snap to preseed assertion
-	// to satisfy the check for number of snaps.
+	// mode-snap is preseeded in the seed but missing in the preseed assertion;
+	// add other-snap to preseed assertion to satisfy the check for number of
+	// snaps.
 	preseedAsSnaps := []interface{}{
 		map[string]interface{}{"name": "essential-snap", "id": "id111111111111111111111111111111", "revision": "1"},
 		map[string]interface{}{"name": "other-snap", "id": "id333222222222222222222222222222", "revision": "2"},
@@ -1456,6 +1488,183 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 	s.mockPreseedAssertion(c, model.BrandID(), model.Model(), "16", preseedAsPath, sysLabel, digest, preseedAsSnaps)
 	err = install.ApplyPreseededData(sysSeed, writableDir)
 	c.Assert(err, ErrorMatches, `snap "mode-snap" not present in the preseed assertion`)
+}
+
+func (s *installSuite) TestApplyPreseededDataComponentMismatchWrongRevision(c *C) {
+	preseed := []interface{}{
+		map[string]interface{}{
+			"name":     "essential-snap",
+			"id":       snaptest.AssertedSnapID("essential-snap"),
+			"revision": "1",
+			"components": []interface{}{
+				map[string]interface{}{
+					"name":     "comp1",
+					"revision": "5",
+				},
+			},
+		},
+		map[string]interface{}{
+			"name":     "mode-snap",
+			"id":       snaptest.AssertedSnapID("mode-snap"),
+			"revision": "3",
+			"components": []interface{}{
+				map[string]interface{}{
+					"name":     "comp2",
+					"revision": "4",
+				},
+			},
+		},
+	}
+	const message = `component "comp1" has wrong revision 2 \(expected: 5\)`
+	s.testApplyPreseededDataComponentMismatch(c, preseededDataComponentMismatchOpts{
+		preseed: preseed,
+		errMsg:  message,
+	})
+}
+
+func (s *installSuite) TestApplyPreseededDataComponentMismatchMissingComponent(c *C) {
+	preseed := []interface{}{
+		map[string]interface{}{
+			"name":     "essential-snap",
+			"id":       snaptest.AssertedSnapID("essential-snap"),
+			"revision": "1",
+			"components": []interface{}{
+				map[string]interface{}{
+					"name":     "comp1",
+					"revision": "2",
+				},
+				map[string]interface{}{
+					"name":     "comp3",
+					"revision": "5",
+				},
+			},
+		},
+		map[string]interface{}{
+			"name":     "mode-snap",
+			"id":       snaptest.AssertedSnapID("mode-snap"),
+			"revision": "3",
+			"components": []interface{}{
+				map[string]interface{}{
+					"name":     "comp2",
+					"revision": "4",
+				},
+			},
+		},
+	}
+	const message = `seed is missing components expected by preseed assertion: "comp3"`
+	s.testApplyPreseededDataComponentMismatch(c, preseededDataComponentMismatchOpts{
+		preseed: preseed,
+		errMsg:  message,
+	})
+}
+
+func (s *installSuite) TestApplyPreseededDataComponentMismatchExtraComponent(c *C) {
+	preseed := []interface{}{
+		map[string]interface{}{
+			"name":     "essential-snap",
+			"id":       snaptest.AssertedSnapID("essential-snap"),
+			"revision": "1",
+			"components": []interface{}{
+				map[string]interface{}{
+					"name":     "comp1",
+					"revision": "2",
+				},
+			},
+		},
+		map[string]interface{}{
+			"name":     "mode-snap",
+			"id":       snaptest.AssertedSnapID("mode-snap"),
+			"revision": "3",
+			"components": []interface{}{
+				map[string]interface{}{
+					"name":     "comp2",
+					"revision": "4",
+				},
+			},
+		},
+	}
+	const message = `component \"comp3\" not present in the preseed assertion`
+	s.testApplyPreseededDataComponentMismatch(c, preseededDataComponentMismatchOpts{
+		preseed: preseed,
+		errMsg:  message,
+		extraSeedComponents: []seed.Component{{
+			CompSideInfo: snap.ComponentSideInfo{
+				Revision:  snap.R(5),
+				Component: naming.NewComponentRef("essential-snap", "comp3"),
+			},
+		}},
+	})
+}
+
+type preseededDataComponentMismatchOpts struct {
+	preseed             []interface{}
+	errMsg              string
+	extraSeedComponents []seed.Component
+}
+
+func (s *installSuite) testApplyPreseededDataComponentMismatch(c *C, opts preseededDataComponentMismatchOpts) {
+	mockTarCmd := testutil.MockCommand(c, "tar", "")
+	defer mockTarCmd.Restore()
+
+	snapPath1 := filepath.Join(dirs.GlobalRootDir, "essential-snap_1.snap")
+	snapPath2 := filepath.Join(dirs.GlobalRootDir, "mode-snap_3.snap")
+	c.Assert(os.WriteFile(snapPath1, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(snapPath2, nil, 0644), IsNil)
+
+	ubuntuSeedDir := filepath.Join(dirs.GlobalRootDir, "run/mnt/ubuntu-seed")
+	sysLabel := "20220105"
+	writableDir := filepath.Join(dirs.GlobalRootDir, "run/mnt/ubuntu-data/system-data")
+	preseedArtifact := filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed.tgz")
+	c.Assert(os.MkdirAll(filepath.Join(ubuntuSeedDir, "systems", sysLabel), 0755), IsNil)
+	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
+
+	model := s.mockModel(map[string]interface{}{
+		"grade": "dangerous",
+	})
+
+	sysSeed := &fakeSeed{
+		model:           model,
+		preseedArtifact: true,
+		sysDir:          filepath.Join(ubuntuSeedDir, "systems", sysLabel),
+		essentialSnaps: []*seed.Snap{{
+			Path: snapPath1,
+			SideInfo: &snap.SideInfo{RealName: "essential-snap",
+				Revision: snap.R(1),
+				SnapID:   snaptest.AssertedSnapID("essential-snap"),
+			},
+			Components: append([]seed.Component{{
+				CompSideInfo: snap.ComponentSideInfo{
+					Revision:  snap.R(2),
+					Component: naming.NewComponentRef("essential-snap", "comp1"),
+				},
+			}}, opts.extraSeedComponents...),
+		}},
+		modeSnaps: []*seed.Snap{{
+			Path: snapPath2,
+			SideInfo: &snap.SideInfo{RealName: "mode-snap",
+				Revision: snap.R(3),
+				SnapID:   snaptest.AssertedSnapID("mode-snap"),
+			},
+			Components: []seed.Component{{
+				CompSideInfo: snap.ComponentSideInfo{
+					Revision:  snap.R(4),
+					Component: naming.NewComponentRef("mode-snap", "comp2"),
+				},
+			}},
+		}},
+	}
+
+	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
+	c.Assert(err, IsNil)
+	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)
+	c.Assert(err, IsNil)
+
+	preseedAsPath := filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed")
+
+	s.mockPreseedAssertion(c, model.BrandID(), model.Model(), "16", preseedAsPath, sysLabel, digest, opts.preseed)
+	err = install.ApplyPreseededData(sysSeed, writableDir)
+	c.Assert(err, ErrorMatches, opts.errMsg)
 }
 
 func (s *installSuite) TestApplyPreseededDataWrongDigest(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -4427,6 +4427,8 @@ func MockOsutilCheckFreeSpace(mock func(path string, minSize uint64) error) (res
 }
 
 // UnmountAllSnaps unmounts all of the snaps and components in the system state.
+// The primary use case for this is to unmount all snaps that were installed in
+// the chroot environment that is used when creating a preseeded image.
 func UnmountAllSnaps(st *state.State) error {
 	all, err := All(st)
 	if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -4423,4 +4424,55 @@ func MockOsutilCheckFreeSpace(mock func(path string, minSize uint64) error) (res
 	old := osutilCheckFreeSpace
 	osutilCheckFreeSpace = mock
 	return func() { osutilCheckFreeSpace = old }
+}
+
+// UnmountAllSnaps unmounts all of the snaps and components in the system state.
+func UnmountAllSnaps(st *state.State) error {
+	all, err := All(st)
+	if err != nil {
+		return err
+	}
+
+	for _, snapst := range all {
+		if err := unmountSnap(snapst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unmountSnap(snapst *SnapState) error {
+	unmountedComps := make(map[string]bool)
+	for _, rev := range snapst.Sequence.Revisions {
+		for _, c := range rev.Components {
+			compName := c.SideInfo.Component.ComponentName
+			cpi := snap.MinimalComponentContainerPlaceInfo(
+				compName,
+				c.SideInfo.Revision,
+				snapst.InstanceName(),
+			)
+
+			mountDir := cpi.MountDir()
+
+			// components might be shared between snap revisions, so make sure
+			// we only unmount them once
+			if unmountedComps[mountDir] {
+				continue
+			}
+			unmountedComps[mountDir] = true
+
+			logger.Debugf("unmounting component %s at %s", compName, mountDir)
+			if _, err := exec.Command("umount", "-d", "-l", mountDir).CombinedOutput(); err != nil {
+				return err
+			}
+		}
+
+		mountDir := snap.MountDir(snapst.InstanceName(), rev.Snap.Revision)
+		logger.Debugf("unmounting snap %s at %s", snapst.InstanceName(), mountDir)
+		if _, err := exec.Command("umount", "-d", "-l", mountDir).CombinedOutput(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -878,7 +878,7 @@ func (s *seed20) lookupVerifiedComponent(cref naming.ComponentRef, snapRev snap.
 			compName, resPair.Provenance(), snapProvenance)
 	}
 
-	cpi := snap.MinimalComponentContainerPlaceInfo(compName, snap.R(resRev.Revision()), snapName)
+	cpi := snap.MinimalComponentContainerPlaceInfo(compName, snap.R(resRev.ResourceRevision()), snapName)
 	newPath, snapSHA3_384, resSize, err := handler.HandleAndDigestAssertedContainer(
 		cpi, compPath, tm)
 	if err != nil {

--- a/tests/lib/assertions/developer1-20-components-dangerous.json
+++ b/tests/lib/assertions/developer1-20-components-dangerous.json
@@ -1,0 +1,56 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "testkeys-snapd-dangerous-core-20-amd64",
+    "architecture": "amd64",
+    "timestamp": "2024-08-29T18:51:46+00:00",
+    "grade": "dangerous",
+    "base": "core20",
+    "serial-authority": [
+        "generic"
+    ],
+    "snaps": [
+        {
+            "default-channel": "20/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "20/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q",
+            "name": "core20",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK",
+            "name": "test-snap-with-components",
+            "type": "app",
+            "components": {
+                "one": "required",
+                "two": "required"
+            }
+        }
+    ]
+}

--- a/tests/lib/assertions/developer1-20-components-dangerous.model
+++ b/tests/lib/assertions/developer1-20-components-dangerous.model
@@ -1,0 +1,57 @@
+type: model
+authority-id: developer1
+series: 16
+brand-id: developer1
+model: testkeys-snapd-dangerous-core-20-amd64
+architecture: amd64
+base: core20
+grade: dangerous
+serial-authority:
+  - generic
+snaps:
+  -
+    default-channel: 20/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 20/edge
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
+    name: core20
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/stable
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    components:
+      one: required
+      two: required
+    default-channel: latest/stable
+    id: o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK
+    name: test-snap-with-components
+    type: app
+timestamp: 2024-08-29T18:51:46+00:00
+sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+
+AcLBUgQAAQoABgUCZtSz3gAA6LAQADF9qGlZoCvr2Gqw2OBwFlerlupGa29b73PnRIhSqGdGW0PS
+iwnLuSDM38+7XtSGpost9WiVH69hojNOa88/GK6z/wOECdH5pM5S5Hvtjt9UMiPaWhauO0HgjTD3
+NloseFTRzmCXLWU0sClAyFKNydlJx7yJUxfgMhXGVm5XsDrJ6jox6Ik/VDfj/xts4B1VTX4o4xQg
+OFgkxUTSIVhI6fkJy1XIvDX8afTNrqpyauYxc6zCWwou/qf+1UnWsenQnRkyt3HZA7O/4HYoLu+s
+pVxxZJxYDKY8BLg8JktBJ6OJIqpPqMyEiACtwV1VOAQCCq1i9jKUzpDIEUI3QexrN5f0D4NIcY5c
+43e2/nei6Vp+vFra8CWHktlWBhMoANG36aJ2GYb4PDWZovAezHg/E9uGpPDxtZxY5baIIwaYkGxE
+jQaMAgVFXXdnMbYFsMzb4vh70nTh1xztBjSvH3YU6BOGHlD/mCt7f8wLJmIak2Y75Q65H34VxMhW
+SmUwNUjRZzz10qmoLn0qKG2+792zOWgKkQdWypzRLfKy5HsnBE7Dvn/cbL3CV4RjCqNu9QXEg9DY
+dT/yrWcVnEHjmV1wzpxQIt/vL47CAcErTvre5BVwgiS6okpR/nviokduA2xVpnRV4IrcCDnDGXvC
+1Fv4VWhzyrTRZXo5X4d2vkdAsixc

--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -18,6 +18,10 @@ environment:
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
 
 prepare: |
+  wget https://github.com/andrewphelpsj/ubuntu-image/releases/download/testing/ubuntu-image
+  chmod +x ./ubuntu-image
+  cp ./ubuntu-image $(which ubuntu-image)
+
   "$TESTSTOOLS"/store-state setup-fake-store "$NESTED_FAKESTORE_BLOB_DIR"
 
   echo "Expose the needed assertions through the fakestore"

--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -18,10 +18,6 @@ environment:
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
 
 prepare: |
-  wget https://github.com/andrewphelpsj/ubuntu-image/releases/download/testing/ubuntu-image
-  chmod +x ./ubuntu-image
-  cp ./ubuntu-image $(which ubuntu-image)
-
   "$TESTSTOOLS"/store-state setup-fake-store "$NESTED_FAKESTORE_BLOB_DIR"
 
   echo "Expose the needed assertions through the fakestore"

--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -11,7 +11,7 @@ environment:
   NESTED_ENABLE_TPM: false
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
-  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-20-dangerous.model
+  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-20-components-dangerous.model
   # for the fake store
   STORE_ADDR: localhost:11028
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
@@ -60,5 +60,10 @@ execute: |
 
   echo "Check that no snaps are broken"
   remote.exec "snap list" | NOMATCH "broken"
-  remote.exec "snap list" | MATCH "core20"
-  remote.exec "snap list" | MATCH "snapd"
+  remote.exec "snap list core20"
+  remote.exec "snap list snapd"
+  remote.exec "snap list test-snap-with-components"
+
+  # both of these components should be installed, too
+  remote.exec "snap run test-snap-with-components one"
+  remote.exec "snap run test-snap-with-components two"


### PR DESCRIPTION
This should complete the changes to make preseeding work with components. `ubuntu-image` still needs to be updated (PR here: https://github.com/canonical/ubuntu-image/pull/243).