### PR TITLE
i/preseed, data: include components in preseed assertion during seed creation

### DIFF
--- a/data/preseed.json
+++ b/data/preseed.json
@@ -25,6 +25,7 @@
     ],
     "exclude": [
         "var/lib/snapd/snaps/*.snap",
+        "var/lib/snapd/snaps/*.comp",
         "var/lib/seed/*"
     ]
 }

--- a/image/preseed/preseed.go
+++ b/image/preseed/preseed.go
@@ -147,10 +147,28 @@ func writePreseedAssertion(artifactDigest []byte, opts *preseedCoreOptions) erro
 	addSnap := func(sn *seed.Snap) {
 		preseedSnap := map[string]interface{}{}
 		preseedSnap["name"] = sn.SnapName()
-		if sn.ID() != "" {
+
+		asserted := sn.ID() != ""
+		if asserted {
 			preseedSnap["id"] = sn.ID()
 			preseedSnap["revision"] = sn.PlaceInfo().SnapRevision().String()
 		}
+
+		components := make([]interface{}, 0, len(sn.Components))
+		for _, c := range sn.Components {
+			comp := map[string]interface{}{
+				"name": c.CompSideInfo.Component.ComponentName,
+			}
+			if asserted {
+				comp["revision"] = c.CompSideInfo.Revision.String()
+			}
+			components = append(components, comp)
+		}
+
+		if len(components) > 0 {
+			preseedSnap["components"] = components
+		}
+
 		snaps = append(snaps, preseedSnap)
 	}
 

--- a/image/preseed/preseed_linux.go
+++ b/image/preseed/preseed_linux.go
@@ -637,6 +637,7 @@ func createPreseedArtifact(opts *preseedCoreOptions) (digest []byte, err error) 
 	if err != nil {
 		return nil, err
 	}
+	defer pf.Close()
 
 	var patterns preseedFilePatterns
 	dec := json.NewDecoder(pf)

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/tooling"
 	"github.com/snapcore/snapd/testutil"
@@ -143,11 +145,39 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 					Revision: snap.R("1")}},
 			},
 			SnapsForMode: map[string][]*seed.Snap{
-				"run": {{
-					Path: "/some/path/foo.snap",
-					SideInfo: &snap.SideInfo{
-						RealName: "foo"},
-				}}},
+				"run": {
+					{
+						Path: "/some/path/bar.snap",
+						SideInfo: &snap.SideInfo{
+							RealName: "bar",
+							SnapID:   snaptest.AssertedSnapID("bar"),
+							Revision: snap.R(1),
+						},
+						Components: []seed.Component{
+							{
+								Path: "/some/path/bar+comp2.snap",
+								CompSideInfo: snap.ComponentSideInfo{
+									Component: naming.NewComponentRef("bar", "comp2"),
+									Revision:  snap.R(2),
+								},
+							},
+						},
+					},
+					{
+						Path: "/some/path/foo.snap",
+						SideInfo: &snap.SideInfo{
+							RealName: "foo",
+						},
+						Components: []seed.Component{
+							{
+								Path: "/some/path/foo+comp1.snap",
+								CompSideInfo: snap.ComponentSideInfo{
+									Component: naming.NewComponentRef("foo", "comp1"),
+								},
+							},
+						},
+					},
+				}},
 			loadAssertions: func(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
 				batch := asserts.NewBatch(nil)
 				c.Assert(batch.Add(ts.StoreSigning.StoreAccountKey("")), IsNil)
@@ -357,7 +387,18 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 				SnapID:   "snapdidididididididididididididd",
 				Revision: 1,
 			}, {
+				Name:     "bar",
+				SnapID:   snaptest.AssertedSnapID("bar"),
+				Revision: 1,
+				Components: []asserts.PreseedComponent{{
+					Name:     "comp2",
+					Revision: 2,
+				}},
+			}, {
 				Name: "foo",
+				Components: []asserts.PreseedComponent{{
+					Name: "comp1",
+				}},
 			}})
 		default:
 			c.Fatalf("unexpected assertion: %s", as.Type().Name)


### PR DESCRIPTION
Now that preseed assertions can contain components, we should include them in the one created with a seed.