### PR TITLE
interfaces/modem-manager: add new format of WWAN ports

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1328,10 +1328,10 @@ KERNEL=="cdc-wdm[0-9]*", SUBSYSTEM=="usbmisc", ENV{ID_MM_CANDIDATE}="1"
 SUBSYSTEMS=="usb", GOTO="mm_candidate_end"
 SUBSYSTEM=="wwan", ENV{DEVTYPE}=="wwan_dev", GOTO="mm_candidate_end"
 SUBSYSTEM=="wwan", ENV{ID_MM_CANDIDATE}="1"
-SUBSYSTEM=="wwan", KERNEL=="*MBIM", ENV{ID_MM_PORT_TYPE_MBIM}="1"
-SUBSYSTEM=="wwan", KERNEL=="*QMI", ENV{ID_MM_PORT_TYPE_QMI}="1"
-SUBSYSTEM=="wwan", KERNEL=="*AT", ENV{ID_MM_PORT_TYPE_AT_PRIMARY}="1"
-SUBSYSTEM=="wwan", KERNEL=="*QCDM", ENV{ID_MM_PORT_TYPE_QCDM}="1"
+SUBSYSTEM=="wwan", KERNEL=="*MBIM|*mbim[0-9]*", ENV{ID_MM_PORT_TYPE_MBIM}="1"
+SUBSYSTEM=="wwan", KERNEL=="*QMI|*qmi[0-9]*", ENV{ID_MM_PORT_TYPE_QMI}="1"
+SUBSYSTEM=="wwan", KERNEL=="*AT|*at[0-9]*", ENV{ID_MM_PORT_TYPE_AT_PRIMARY}="1"
+SUBSYSTEM=="wwan", KERNEL=="*QCDM|*qcdm[0-9]*", ENV{ID_MM_PORT_TYPE_QCDM}="1"
 
 LABEL="mm_candidate_end"
 `
@@ -1373,7 +1373,7 @@ func (iface *modemManagerInterface) DBusPermanentSlot(spec *dbus.Specification, 
 
 func (iface *modemManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(modemManagerPermanentSlotUDev)
-	spec.TagDevice(`KERNEL=="rfcomm*|tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*|*MBIM|*QMI|*AT|*QCDM"`)
+	spec.TagDevice(`KERNEL=="rfcomm*|tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*|*MBIM|*QMI|*AT|*QCDM|*mbim[0-9]*|*qmi[0-9]*|*at[0-9]*|*qcdm[0-9]*"`)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -179,7 +179,7 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(udevSpec.Snippets(), HasLen, 3)
 	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `SUBSYSTEMS=="usb"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# modem-manager
-KERNEL=="rfcomm*|tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*|*MBIM|*QMI|*AT|*QCDM", TAG+="snap_modem-manager_mm"`)
+KERNEL=="rfcomm*|tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*|*MBIM|*QMI|*AT|*QCDM|*mbim[0-9]*|*qmi[0-9]*|*at[0-9]*|*qcdm[0-9]*", TAG+="snap_modem-manager_mm"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_modem-manager_mm", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_modem-manager_mm $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 


### PR DESCRIPTION
From Linux 5.14, the WWAN ports are using a different format. E.g:
* wwan0p1AT   -> wwan0at0
* wwan0p2MBIM -> wwan0mbim0
* wwan0p3AT   -> wwan0at1

See the following commits for the details:
[1] https://github.com/torvalds/linux/commit/392c26f7f133b9f09e5f58db1ce6ef4b3b4df49f
[2] https://github.com/torvalds/linux/commit/f458709ff40b0d992fec496952f79c7820dd3fde