### PR TITLE
tests/core/remodel-base: fix the test when store base has different revision

### DIFF
--- a/tests/core/remodel-base/task.yaml
+++ b/tests/core/remodel-base/task.yaml
@@ -51,6 +51,14 @@ restore: |
             REBOOT_NEEDED=true
         fi
 
+        # find out what is the revision of the base in seed and one that is
+        # currently installed, if different a reboot will be issued
+        seed_base_rev="$(basename /var/lib/snapd/seed/snaps/core18_*.snap | cut -f1 -d. | cut -f2 -d_)"
+        cur_base_rev="$(readlink /snap/core18/current)"
+        if [ "$seed_base_rev" != "$cur_base_rev" ]; then
+            REBOOT_NEEDED=true
+        fi
+
         systemctl stop snapd.service snapd.socket
 
         clean_snapd_lib
@@ -79,6 +87,11 @@ restore: |
         find /var/snap
         exit 1
     fi
+
+debug: |
+   snap changes || true
+   snap change 1 || true
+   journalctl -u snapd --no-pager || true
 
 execute: |
     #shellcheck source=tests/lib/core-config.sh


### PR DESCRIPTION
On 2024-08-29 a new revision of core18 was pushed latest/edge to the store, which caused the test to revert back to a revision different than in the seed which is older. In this scenario, the restore snippet would incorrectly identify no need to a reboot and so the test would break. Snapd when forced to reinitialize the system would issue reboot, since the installed core18 is different than one in the seed, but the test would not trigger a reboot through spread.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
