### PR TITLE
daemon: hide old experimental flags

### DIFF
--- a/overlord/configstate/config/export_test.go
+++ b/overlord/configstate/config/export_test.go
@@ -33,10 +33,3 @@ var (
 	SortPatchKeysByDepth       = sortPatchKeysByDepth
 	OverlapsWithExternalConfig = overlapsWithExternalConfig
 )
-
-func ClearExternalConfigMap() {
-	externalConfigMu.Lock()
-	defer externalConfigMu.Unlock()
-
-	externalConfigMap = nil
-}

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 
 	"github.com/snapcore/snapd/jsonutil"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -565,4 +566,13 @@ func RegisterExternalConfig(snapName, key string, vf ExternalCfgFunc) error {
 	}
 	externalConfigMap[snapName][key] = vf
 	return nil
+}
+
+// ClearExternalConfigMap must only be used for testing.
+func ClearExternalConfigMap() {
+	osutil.MustBeTestBinary("ClearExternalConfigMap only can be used in tests")
+
+	externalConfigMu.Lock()
+	defer externalConfigMu.Unlock()
+	externalConfigMap = nil
 }

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sysconfig"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func init() {
@@ -86,4 +87,22 @@ func doExportExperimentalFlags(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyCo
 
 func ExportExperimentalFlags(tr ConfGetter) error {
 	return doExportExperimentalFlags(nil, tr, nil)
+}
+
+// IsSupportedExperimentalFlag checks if passed flag is a supported experimental feature.
+func IsSupportedExperimentalFlag(flag string) bool {
+	return supportedConfigurations["core.experimental."+flag]
+}
+
+// MockSupportedExperimentalFlags mocks list of supported experimental flags for use in testing.
+func MockSupportedExperimentalFlags(flags []string) (restore func()) {
+	osutil.MustBeTestBinary("MockSupportedExperimentalFlags only can be used in tests")
+
+	restore = testutil.Backup(&supportedConfigurations)
+	newConfs := make(map[string]bool, len(flags))
+	for _, flag := range flags {
+		newConfs["core.experimental."+flag] = true
+	}
+	supportedConfigurations = newConfs
+	return restore
 }

--- a/tests/main/old-experimental-flags/task.yaml
+++ b/tests/main/old-experimental-flags/task.yaml
@@ -1,0 +1,37 @@
+summary: Ensure that old experimental flag configs are hidden
+
+details: |
+    Check that experimental flag configs that used to exist but now
+    are out of experimental are hidden unless specifically referenced
+    and their values will be retained to ensure it works as before in
+    case of revert to previous snapd version.
+
+prepare: |
+    snap install --devmode jq
+
+restore: |
+    snap remove jq
+
+execute: |
+    echo "Check that users cannot set unsupported experimental features"
+    snap set core experimental.old-flag=true 2>&1 | MATCH "unsupported system option"
+    snap get core experimental.old-flag | NOMATCH "true"
+
+    # Stop snapd while editing state.json manually
+    systemctl stop snapd.service snapd.socket
+
+    echo "Force setting the unsupported experimental.old-flag"
+    # This simulates the situation where an experimental feature got out
+    # of experimental after a snapd refresh and now is an unsupported config
+    jq '.data.config.core.experimental += {"old-flag": true}' /var/lib/snapd/state.json > state.json
+    mv state.json /var/lib/snapd/state.json
+    echo "Check that experimental.old-flag is persisted in state.json"
+    jq '.data.config.core.experimental."old-flag"' /var/lib/snapd/state.json | MATCH "true"
+
+    systemctl start snapd.service snapd.socket
+    echo "Old experimental flags are hidden in generic queries"
+    snap get core experimental | NOMATCH "old-flag"
+    echo "But not removed for exact queries"
+    snap get core experimental.old-flag | MATCH "true"
+    echo "Also, old flag is not removed from state in case of a revert"
+    jq '.data.config.core.experimental."old-flag"' /var/lib/snapd/state.json | MATCH "true"


### PR DESCRIPTION
There is window between moving an experimental flag out of experimental and possibly having a snapd revert to a version where the experimental flag was used.

To avoid breaking devices that depend on those flags, instead of removing them completely from state, let's hide them instead.

This PR will unblock https://github.com/canonical/snapd/pull/14117 and other attempts to move features out of experimental.

This PR replaces https://github.com/canonical/snapd/pull/14258.
