### PR TITLE
many: extract desktop-ids helpers from wrappers package into snap package

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -22,6 +22,7 @@ package snap
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -948,6 +949,109 @@ func (s *Info) DesktopPrefix() string {
 	// we cannot use the usual "_" separator because that is also used
 	// to separate "$snap_$desktopfile"
 	return fmt.Sprintf("%s+%s", s.SnapName(), s.InstanceKey)
+}
+
+// DesktopFileIDs returns desktop-file-ids desktop plug attribute entries.
+// The desktop-file-ids attribute is optional so an empty list is returned if
+// the it is not found.
+//
+// Note: DesktopFileIDs doesn't check if the desktop plug is connected because
+// the desktop-file-ids attribute is controlled by an allow-installation rule.
+func (s *Info) DesktopFileIDs() ([]string, error) {
+	var desktopPlug *PlugInfo
+	for _, plug := range s.Plugs {
+		if plug.Interface == "desktop" {
+			desktopPlug = plug
+			break
+		}
+	}
+	if desktopPlug == nil {
+		return nil, nil
+	}
+
+	attrVal, exists := desktopPlug.Lookup("desktop-file-ids")
+	if !exists {
+		// desktop-file-ids attribute is optional
+		return nil, nil
+	}
+
+	// TODO: The internal errors below should never happen due to validation
+	// in the desktop interface. It would be a good candidate for telemetry
+	// error reporting.
+
+	// desktop-file-ids must be a list of strings
+	attrList, ok := attrVal.([]interface{})
+	if !ok {
+		return nil, errors.New(`internal error: "desktop-file-ids" must be a list of strings`)
+	}
+
+	desktopFileIDs := make([]string, 0, len(attrList))
+	for _, val := range attrList {
+		desktopFileID, ok := val.(string)
+		if !ok {
+			return nil, errors.New(`internal error: "desktop-file-ids" must be a list of strings`)
+		}
+		desktopFileIDs = append(desktopFileIDs, desktopFileID)
+	}
+	return desktopFileIDs, nil
+}
+
+// MangleDesktopFileName returns the file name prefixed with Info.DesktopPrefix()
+// unless its name (without the .desktop extension) is listed under the
+// desktop-file-ids desktop interface attribute.
+func (s *Info) MangleDesktopFileName(desktopFile string) (string, error) {
+	desktopFileIDs, err := s.DesktopFileIDs()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(desktopFile)
+	base := filepath.Base(desktopFile)
+	// Don't mangle desktop files if listed under desktop-file-ids attribute
+	// XXX: Do we want to fail if a desktop-file-ids entry doesn't
+	// have a corresponding file?
+	for _, desktopFileID := range desktopFileIDs {
+		if strings.TrimSuffix(base, ".desktop") == desktopFileID {
+			return filepath.Join(dir, base), nil
+		}
+	}
+	// FIXME: don't blindly use the snap desktop filename, mangle it
+	// but we can't just use the app name because a desktop file
+	// may call the same app with multiple parameters, e.g.
+	// --create-new, --open-existing etc
+	return filepath.Join(dir, fmt.Sprintf("%s_%s", s.DesktopPrefix(), base)), nil
+}
+
+type DesktopFilesFromMountOptions struct {
+	// Mangles found desktop files using Info.MangleDesktopFileName()
+	MangleFileNames bool
+}
+
+// DesktopFilesFromMount returns the desktop files found under <snap-mount>/meta/gui.
+func (s *Info) DesktopFilesFromMount(opts *DesktopFilesFromMountOptions) ([]string, error) {
+	if opts == nil {
+		opts = &DesktopFilesFromMountOptions{}
+	}
+
+	rootDir := filepath.Join(s.MountDir(), "meta", "gui")
+	if !osutil.IsDirectory(rootDir) {
+		return nil, nil
+	}
+	desktopFiles, err := filepath.Glob(filepath.Join(rootDir, "*.desktop"))
+	if err != nil {
+		return nil, fmt.Errorf("cannot get desktop files from %v: %s", rootDir, err)
+	}
+
+	if !opts.MangleFileNames {
+		return desktopFiles, nil
+	}
+
+	for i, df := range desktopFiles {
+		desktopFiles[i], err = s.MangleDesktopFileName(df)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return desktopFiles, nil
 }
 
 // DownloadInfo contains the information to download a snap.

--- a/snap/info.go
+++ b/snap/info.go
@@ -951,13 +951,13 @@ func (s *Info) DesktopPrefix() string {
 	return fmt.Sprintf("%s+%s", s.SnapName(), s.InstanceKey)
 }
 
-// DesktopFileIDs returns desktop-file-ids desktop plug attribute entries.
+// DesktopPlugFileIDs returns desktop-file-ids desktop plug attribute entries.
 // The desktop-file-ids attribute is optional so an empty list is returned if
 // the it is not found.
 //
-// Note: DesktopFileIDs doesn't check if the desktop plug is connected because
+// Note: DesktopPlugFileIDs doesn't check if the desktop plug is connected because
 // the desktop-file-ids attribute is controlled by an allow-installation rule.
-func (s *Info) DesktopFileIDs() ([]string, error) {
+func (s *Info) DesktopPlugFileIDs() ([]string, error) {
 	var desktopPlug *PlugInfo
 	for _, plug := range s.Plugs {
 		if plug.Interface == "desktop" {
@@ -1000,7 +1000,7 @@ func (s *Info) DesktopFileIDs() ([]string, error) {
 // unless its name (without the .desktop extension) is listed under the
 // desktop-file-ids desktop interface attribute.
 func (s *Info) MangleDesktopFileName(desktopFile string) (string, error) {
-	desktopFileIDs, err := s.DesktopFileIDs()
+	desktopFileIDs, err := s.DesktopPlugFileIDs()
 	if err != nil {
 		return "", err
 	}
@@ -1027,11 +1027,7 @@ type DesktopFilesFromMountOptions struct {
 }
 
 // DesktopFilesFromMount returns the desktop files found under <snap-mount>/meta/gui.
-func (s *Info) DesktopFilesFromMount(opts *DesktopFilesFromMountOptions) ([]string, error) {
-	if opts == nil {
-		opts = &DesktopFilesFromMountOptions{}
-	}
-
+func (s *Info) DesktopFilesFromMount(opts DesktopFilesFromMountOptions) ([]string, error) {
 	rootDir := filepath.Join(s.MountDir(), "meta", "gui")
 	if !osutil.IsDirectory(rootDir) {
 		return nil, nil

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -2524,3 +2524,196 @@ func (s *infoSuite) TestSplitSnapInstanceAndComponents(c *C) {
 		c.Check(comps, DeepEquals, tc.comps, Commentf("%v", tc.input))
 	}
 }
+
+func (s *infoSuite) testDesktopFileIDs(c *C, hasDesktopPlug, hasDesktopFileIDs bool) {
+	if hasDesktopFileIDs && !hasDesktopPlug {
+		c.Error("cannot set hasDesktopFileIDs without hasDesktopPlug")
+	}
+
+	var desktopAppYaml = `
+name: foo
+version: 1.0
+`
+	if hasDesktopPlug {
+		desktopAppYaml += "\nplugs:\n  desktop:"
+	}
+	if hasDesktopFileIDs {
+		desktopAppYaml += "\n    desktop-file-ids: [org.example, org.example.Foo]"
+	}
+	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
+	c.Assert(err, IsNil)
+	if hasDesktopPlug {
+		c.Assert(info.Plugs["desktop"], NotNil)
+	}
+
+	desktopFileIDs, err := info.DesktopFileIDs()
+	c.Assert(err, IsNil)
+
+	if hasDesktopFileIDs {
+		c.Assert(desktopFileIDs, DeepEquals, []string{"org.example", "org.example.Foo"})
+	} else {
+		c.Assert(desktopFileIDs, IsNil)
+	}
+}
+
+func (s *infoSuite) TestDesktopFileIDs(c *C) {
+	const hasDesktopPlug = true
+	const hasDesktopFileIDs = true
+	s.testDesktopFileIDs(c, hasDesktopPlug, hasDesktopFileIDs)
+}
+
+func (s *infoSuite) TestDesktopFileIDsWithoutDesktopInterface(c *C) {
+	const hasDesktopPlug = false
+	const hasDesktopFileIDs = false
+	s.testDesktopFileIDs(c, hasDesktopPlug, hasDesktopFileIDs)
+}
+
+func (s *infoSuite) TestDesktopFileIDsWithoutDesktopFileIDs(c *C) {
+	const hasDesktopPlug = true
+	const hasDesktopFileIDs = false
+	s.testDesktopFileIDs(c, hasDesktopPlug, hasDesktopFileIDs)
+}
+
+func (s *infoSuite) TestDesktopFileIDsError(c *C) {
+	const desktopAppYamlTemplate = `
+name: foo
+version: 1.0
+plugs:
+  desktop:
+    desktop-file-ids: %s
+`
+
+	for _, tc := range []string{
+		"not-a-list-of-strings",
+		"1",
+		"true",
+		"[[string],1]",
+	} {
+		desktopAppYaml := fmt.Sprintf(desktopAppYamlTemplate, tc)
+		info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
+		c.Assert(err, IsNil)
+		c.Assert(info.Plugs["desktop"], NotNil)
+
+		_, err = info.DesktopFileIDs()
+		c.Assert(err, ErrorMatches, `internal error: "desktop-file-ids" must be a list of strings`)
+	}
+}
+
+func (s *infoSuite) TestMangleDesktopFileName(c *C) {
+	const desktopAppYaml = `
+name: foo
+version: 1.0
+plugs:
+  desktop:
+    desktop-file-ids: [org.example]
+`
+
+	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
+	c.Assert(err, IsNil)
+
+	type testcase struct {
+		fname, target string
+	}
+
+	for _, tc := range []testcase{
+		{"/some/dir/org.example.desktop", "/some/dir/org.example.desktop"},
+		{"/some/dir/org.example.Foo.desktop", "/some/dir/foo_org.example.Foo.desktop"},
+		{"/some/dir/org.desktop", "/some/dir/foo_org.desktop"},
+		{"/some/dir/test.desktop", "/some/dir/foo_test.desktop"},
+
+		{"org.example.desktop", "org.example.desktop"},
+		{"org.example.Foo.desktop", "foo_org.example.Foo.desktop"},
+		{"org.desktop", "foo_org.desktop"},
+		{"test.desktop", "foo_test.desktop"},
+	} {
+		mangled, err := info.MangleDesktopFileName(tc.fname)
+		c.Assert(err, IsNil, Commentf(tc.fname))
+		c.Assert(mangled, Equals, tc.target, Commentf(tc.fname))
+	}
+}
+
+func (s *infoSuite) TestMangleDesktopFileNameError(c *C) {
+	const desktopAppYaml = `
+name: foo
+version: 1.0
+plugs:
+  desktop:
+    desktop-file-ids: 1
+`
+
+	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
+	c.Assert(err, IsNil)
+
+	_, err = info.MangleDesktopFileName("test.desktop")
+	c.Assert(err, NotNil)
+}
+
+func (s *infoSuite) TestDesktopFilesFromMountNoFiles(c *C) {
+	const desktopAppYaml = `
+name: foo
+version: 1.0
+`
+
+	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
+	c.Assert(err, IsNil)
+
+	desktopFiles, err := info.DesktopFilesFromMount(nil)
+	c.Assert(err, IsNil)
+	c.Assert(desktopFiles, IsNil)
+}
+
+func (s *infoSuite) testDesktopFilesFromMount(c *C, mangle bool) {
+	const desktopAppYaml = `
+name: foo
+version: 1.0
+plugs:
+  desktop:
+    desktop-file-ids: [org.example]
+`
+
+	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
+	c.Assert(err, IsNil)
+
+	guiDir := filepath.Join(info.MountDir(), "meta", "gui")
+	err = os.MkdirAll(guiDir, 0755)
+	c.Assert(err, IsNil)
+
+	testDesktopFiles := []string{"org.example.desktop", "org.example.Foo.desktop", "test.desktop"}
+	for _, df := range testDesktopFiles {
+		err = os.WriteFile(filepath.Join(guiDir, df), nil, 0644)
+		c.Assert(err, IsNil)
+	}
+
+	opts := &snap.DesktopFilesFromMountOptions{MangleFileNames: mangle}
+	desktopFilesFound, err := info.DesktopFilesFromMount(opts)
+	c.Assert(err, IsNil)
+	c.Assert(desktopFilesFound, HasLen, len(testDesktopFiles))
+
+	for _, target := range desktopFilesFound {
+		ok := false
+		for _, src := range testDesktopFiles {
+			src := filepath.Join(guiDir, src)
+			if mangle {
+				src, err = info.MangleDesktopFileName(src)
+				c.Assert(err, IsNil)
+			}
+			if src == target {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			c.Error(Commentf(target))
+		}
+	}
+}
+
+func (s *infoSuite) TestDesktopFilesFromMount(c *C) {
+	const mangle = false
+	s.testDesktopFilesFromMount(c, mangle)
+}
+
+func (s *infoSuite) TestDesktopFilesFromMountMangled(c *C) {
+	const mangle = true
+	s.testDesktopFilesFromMount(c, mangle)
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -2546,7 +2546,7 @@ version: 1.0
 		c.Assert(info.Plugs["desktop"], NotNil)
 	}
 
-	desktopFileIDs, err := info.DesktopFileIDs()
+	desktopFileIDs, err := info.DesktopPlugFileIDs()
 	c.Assert(err, IsNil)
 
 	if hasDesktopFileIDs {
@@ -2594,7 +2594,7 @@ plugs:
 		c.Assert(err, IsNil)
 		c.Assert(info.Plugs["desktop"], NotNil)
 
-		_, err = info.DesktopFileIDs()
+		_, err = info.DesktopPlugFileIDs()
 		c.Assert(err, ErrorMatches, `internal error: "desktop-file-ids" must be a list of strings`)
 	}
 }
@@ -2657,7 +2657,7 @@ version: 1.0
 	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
 	c.Assert(err, IsNil)
 
-	desktopFiles, err := info.DesktopFilesFromMount(nil)
+	desktopFiles, err := info.DesktopFilesFromMount(snap.DesktopFilesFromMountOptions{})
 	c.Assert(err, IsNil)
 	c.Assert(desktopFiles, IsNil)
 }
@@ -2684,7 +2684,7 @@ plugs:
 		c.Assert(err, IsNil)
 	}
 
-	opts := &snap.DesktopFilesFromMountOptions{MangleFileNames: mangle}
+	opts := snap.DesktopFilesFromMountOptions{MangleFileNames: mangle}
 	desktopFilesFound, err := info.DesktopFilesFromMount(opts)
 	c.Assert(err, IsNil)
 	c.Assert(desktopFilesFound, HasLen, len(testDesktopFiles))

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -248,7 +248,7 @@ func findDesktopFiles(rootDir string) ([]string, error) {
 }
 
 func deriveDesktopFilesContent(s *snap.Info) (map[string]osutil.FileState, error) {
-	desktopFiles, err := s.DesktopFilesFromMount(nil)
+	desktopFiles, err := s.DesktopFilesFromMount(snap.DesktopFilesFromMountOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func EnsureSnapDesktopFiles(snaps []*snap.Info) error {
 			return fmt.Errorf("internal error: snap info cannot be nil")
 		}
 
-		desktopFileIDs, err := info.DesktopFileIDs()
+		desktopFileIDs, err := info.DesktopPlugFileIDs()
 		if err != nil {
 			return err
 		}

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -22,7 +22,6 @@ package wrappers
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -248,67 +247,22 @@ func findDesktopFiles(rootDir string) ([]string, error) {
 	return desktopFiles, nil
 }
 
-// Note: explicitSnapDesktopFileIDs doesn't check if the desktop plug
-// is connected because the desktop-file-ids attribute is controlled
-// by an allow-installation rule.
-func explicitSnapDesktopFileIDs(s *snap.Info) (map[string]bool, error) {
-	var desktopPlug *snap.PlugInfo
-	for _, plug := range s.Plugs {
-		if plug.Interface == "desktop" {
-			desktopPlug = plug
-			break
-		}
-	}
-	if desktopPlug == nil {
-		return nil, nil
-	}
-
-	attrVal, exists := desktopPlug.Lookup("desktop-file-ids")
-	if !exists {
-		// desktop-file-ids attribute is optional
-		return nil, nil
-	}
-
-	// desktop-file-ids must be a list of strings
-	desktopFileIDs, ok := attrVal.([]interface{})
-	if !ok {
-		return nil, errors.New(`internal error: "desktop-file-ids" must be a list of strings`)
-	}
-
-	desktopFileIDsMap := make(map[string]bool, len(desktopFileIDs))
-	for _, val := range desktopFileIDs {
-		desktopFileID, ok := val.(string)
-		if !ok {
-			return nil, errors.New(`internal error: "desktop-file-ids" must be a list of strings`)
-		}
-		desktopFileIDsMap[desktopFileID] = true
-	}
-	return desktopFileIDsMap, nil
-}
-
-func deriveDesktopFilesContent(s *snap.Info, desktopFileIDs map[string]bool) (map[string]osutil.FileState, error) {
-	rootDir := filepath.Join(s.MountDir(), "meta", "gui")
-	desktopFiles, err := findDesktopFiles(rootDir)
+func deriveDesktopFilesContent(s *snap.Info) (map[string]osutil.FileState, error) {
+	desktopFiles, err := s.DesktopFilesFromMount(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	content := make(map[string]osutil.FileState)
+	content := make(map[string]osutil.FileState, len(desktopFiles))
 	for _, df := range desktopFiles {
 		base := filepath.Base(df)
-		fileContent, err := os.ReadFile(df)
+		base, err := s.MangleDesktopFileName(base)
 		if err != nil {
 			return nil, err
 		}
-		// Don't mangle desktop files if listed under desktop-file-ids attribute
-		// XXX: Do we want to fail if a desktop-file-ids entry doesn't
-		// have a corresponding file?
-		if !desktopFileIDs[strings.TrimSuffix(base, ".desktop")] {
-			// FIXME: don't blindly use the snap desktop filename, mangle it
-			// but we can't just use the app name because a desktop file
-			// may call the same app with multiple parameters, e.g.
-			// --create-new, --open-existing etc
-			base = fmt.Sprintf("%s_%s", s.DesktopPrefix(), base)
+		fileContent, err := os.ReadFile(df)
+		if err != nil {
+			return nil, err
 		}
 		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, base)
 		fileContent = sanitizeDesktopFile(s, installedDesktopFileName, fileContent)
@@ -389,15 +343,15 @@ func EnsureSnapDesktopFiles(snaps []*snap.Info) error {
 			return fmt.Errorf("internal error: snap info cannot be nil")
 		}
 
-		desktopFileIDs, err := explicitSnapDesktopFileIDs(info)
+		desktopFileIDs, err := info.DesktopFileIDs()
 		if err != nil {
 			return err
 		}
 		desktopFilesGlobs := []string{fmt.Sprintf("%s_*.desktop", info.DesktopPrefix())}
-		for desktopFileID := range desktopFileIDs {
+		for _, desktopFileID := range desktopFileIDs {
 			desktopFilesGlobs = append(desktopFilesGlobs, desktopFileID+".desktop")
 		}
-		content, err := deriveDesktopFilesContent(info, desktopFileIDs)
+		content, err := deriveDesktopFilesContent(info)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Those helpers are extracted to be reused in a later PR when generating apparmor rules specific to desktop-file-ids.

Those helpers are needed by https://github.com/canonical/snapd/pull/14444.