### PR TITLE
run-checks: added golangci-lint to run-checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -188,7 +188,6 @@ jobs:
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd/c-vendor && ./vendor.sh
 
     - name: Install golangci-lint snap
-      if: ${{ matrix.gochannel == 'latest/stable' }}
       run: |
           sudo snap install --classic golangci-lint
 
@@ -211,10 +210,6 @@ jobs:
           if [ "${{ matrix.gochannel }}" != "1.18" ]; then
               export SKIP_GOFMT=1
               echo "Formatting checks will be skipped due to the use of Go version ${{ matrix.gochannel }}"
-          fi
-          if [ "${{ matrix.gochannel }}" != "latest/stable" ]; then
-              export SKIP_GOLANG_CI_LINT=1
-              echo "Will skip golangci_lint checks on all but the latest/stable version"
           fi
           sudo apt-get install -y python3-yamlordereddictloader
           ./run-checks --static

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,6 +131,7 @@ jobs:
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
       GITHUB_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+      GITHUB_BASE_REF: ${{ github.base_ref }}
 
     strategy:
       # we cache successful runs so it's fine to keep going
@@ -186,22 +187,10 @@ jobs:
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd/c-vendor && ./vendor.sh
 
-    - name: golangci-lint
+    - name: Install golangci-lint snap
       if: ${{ matrix.gochannel == 'latest/stable' }}
-      uses: golangci/golangci-lint-action@v3
-      with:
-        # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
-        # to use the latest version
-        version: v1.60.1
-        working-directory: ./src/github.com/snapcore/snapd
-        # show only new issues
-        # use empty path prefix to make annotations work
-        args: --new-from-rev=${{ github.base_ref }} --path-prefix=
-        # skip all additional steps
-        skip-pkg-cache: true
-        skip-build-cache: true
-        # XXX: does no work with working-directory
-        # only-new-issues: true
+      run: |
+          sudo snap install --classic golangci-lint
 
     - name: Get changed files
       id: changed-files
@@ -222,6 +211,10 @@ jobs:
           if [ "${{ matrix.gochannel }}" != "1.18" ]; then
               export SKIP_GOFMT=1
               echo "Formatting checks will be skipped due to the use of Go version ${{ matrix.gochannel }}"
+          fi
+          if [ "${{ matrix.gochannel }}" != "latest/stable" ]; then
+              export SKIP_GOLANG_CI_LINT=1
+              echo "Will skip golangci_lint checks on all but the latest/stable version"
           fi
           sudo apt-get install -y python3-yamlordereddictloader
           ./run-checks --static

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,7 +131,7 @@ jobs:
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
       GITHUB_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
-      GITHUB_BASE_REF: ${{ github.base_ref }}
+      BASE_REF: ${{ github.base_ref }}
 
     strategy:
       # we cache successful runs so it's fine to keep going

--- a/run-checks
+++ b/run-checks
@@ -407,9 +407,9 @@ if [ "$STATIC" = 1 ]; then
 
         echo "Running golangci-lint"
         if [ -n "${GITHUB_BASE_REF:-}" ]; then
-            golangci-lint --new-from-rev="$GITHUB_BASE_REF" --path-prefix= run || exit 1
+            golangci-lint --new-from-rev="$GITHUB_BASE_REF" --path-prefix= run
         else
-            golangci-lint --path-prefix= run || exit 1
+            golangci-lint --path-prefix= run
         fi
     fi
 fi

--- a/run-checks
+++ b/run-checks
@@ -397,24 +397,31 @@ if [ "$STATIC" = 1 ]; then
     if [ -z "${SKIP_GOLANGCI_LINT-}" ]; then
 
         echo "Checking installation of golangci-lint"
-        if ! command -v golangci-lint > /dev/null ; then
-            echo "ERROR: Cannot find golangci-lint. You need to first install the golangci-lint snap"
+        gcil="$(command -v golangci-lint || true)"
+        if [ -z "$gcil" ]; then 
+            echo "ERROR: Cannot find golangci-lint. You need to first install the golangci-lint"
             exit 1
         fi
-        if snap refresh --list | grep -q golangci-lint; then
-            echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours."
-        fi
-        if ! snap list golangci-lint | grep -q latest; then
-            echo "WARNING: your golangci-lint snap is not installed from the latest/* channel."
-        fi
-        goci_go_ver=$(golangci-lint --version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
-        go_ver=$(go version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
-        if [ "$(printf '%s\n' "$go_ver" "$goci_go_ver" | sort -V | head -n1)" != "$go_ver" ]; then
-           echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lint was built with ($goci_go_ver)."
+
+        if [ "${gcil/\/snap\/bin/}" != "$gcil" ]; then
+            # golangci-lint was installed from the snap
+            if snap refresh --list | grep -q golangci-lint; then
+                echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours."
+            fi
+            if ! snap list golangci-lint | grep -q latest; then
+                echo "WARNING: your golangci-lint snap is not installed from the latest/* channel."
+            fi
         fi
 
-        echo "Running golangci-lint"
+        # Check whether the version golangci-lint was built with is >= version of go installed
+        gcil_go_ver=$(golangci-lint --version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
+        go_ver=$(go version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
+        if [ "$(printf '%s\n' "$go_ver" "$gcil_go_ver" | sort -V | head -n1)" != "$go_ver" ]; then
+           echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lint was built with ($gcil_go_ver)."
+        fi
+
         if [ -n "${BASE_REF:-}" ]; then
+            echo "Running golangci-lint"
             golangci-lint --new-from-rev="$BASE_REF" --path-prefix= run
         else
             echo "Running golangci-lint without the --new-from-rev option. If you would rather use that option, specify the branch in the BASE_REF environment variable."

--- a/run-checks
+++ b/run-checks
@@ -401,14 +401,18 @@ if [ "$STATIC" = 1 ]; then
             echo "ERROR: Cannot find golangci-lint. You need to first install the golangci-lint snap"
             exit 1
         fi
-        if snap refresh --list | grep golangci-lint; then
+        if snap refresh --list | grep -q golangci-lint; then
             echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours."
+        fi
+        if ! snap list golangci-lint | grep -q latest; then
+            echo "WARNING: your golangci-lint snap is not installed from the latest/* channel."
         fi
 
         echo "Running golangci-lint"
-        if [ -n "${GITHUB_BASE_REF:-}" ]; then
-            golangci-lint --new-from-rev="$GITHUB_BASE_REF" --path-prefix= run
+        if [ -n "${BASE_REF:-}" ]; then
+            golangci-lint --new-from-rev="$BASE_REF" --path-prefix= run
         else
+            echo "Running golangci-lint without the --new-from-rev option. If you would rather use that option, specify the branch in the BASE_REF environment variable."
             golangci-lint --path-prefix= run
         fi
     fi

--- a/run-checks
+++ b/run-checks
@@ -393,6 +393,25 @@ if [ "$STATIC" = 1 ]; then
       echo "$got"
       exit 1
     fi
+
+    if [ -z "${SKIP_GOLANG_CI_LINT-}" ]; then
+
+        echo "Checking installation of golangci-lint"
+        if ! command -v golangci-lint > /dev/null ; then
+            echo "ERROR: Cannot find golangci-lint. You need to first install the golangci-lint snap"
+            exit 1
+        fi
+        if snap refresh --list | grep golangci-lint; then
+            echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours."
+        fi
+
+        echo "Running golangci-lint"
+        if [ -n "${GITHUB_BASE_REF:-}" ]; then
+            golangci-lint --new-from-rev="$GITHUB_BASE_REF" --path-prefix= run || exit 1
+        else
+            golangci-lint --path-prefix= run || exit 1
+        fi
+    fi
 fi
 
 if [ "$UNIT" = 1 ]; then

--- a/run-checks
+++ b/run-checks
@@ -407,6 +407,11 @@ if [ "$STATIC" = 1 ]; then
         if ! snap list golangci-lint | grep -q latest; then
             echo "WARNING: your golangci-lint snap is not installed from the latest/* channel."
         fi
+        goci_go_ver=$(golangci-lint --version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
+        go_ver=$(go version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
+        if [ "$(printf '%s\n' "$go_ver" "$goci_go_ver" | sort -V | head -n1)" != "$go_ver" ]; then
+           echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lang was built with ($goci_go_ver)."
+        fi
 
         echo "Running golangci-lint"
         if [ -n "${BASE_REF:-}" ]; then

--- a/run-checks
+++ b/run-checks
@@ -394,7 +394,7 @@ if [ "$STATIC" = 1 ]; then
       exit 1
     fi
 
-    if [ -z "${SKIP_GOLANG_CI_LINT-}" ]; then
+    if [ -z "${SKIP_GOLANGCI_LINT-}" ]; then
 
         echo "Checking installation of golangci-lint"
         if ! command -v golangci-lint > /dev/null ; then
@@ -410,7 +410,7 @@ if [ "$STATIC" = 1 ]; then
         goci_go_ver=$(golangci-lint --version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
         go_ver=$(go version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
         if [ "$(printf '%s\n' "$go_ver" "$goci_go_ver" | sort -V | head -n1)" != "$go_ver" ]; then
-           echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lang was built with ($goci_go_ver)."
+           echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lint was built with ($goci_go_ver)."
         fi
 
         echo "Running golangci-lint"

--- a/run-checks
+++ b/run-checks
@@ -403,7 +403,7 @@ if [ "$STATIC" = 1 ]; then
             exit 1
         fi
 
-        if [ "${gcil/\/snap\/bin/}" != "$gcil" ]; then
+        if echo "$gcil" | grep -q '/snap/bin/' ; then
             # golangci-lint was installed from the snap
             if snap refresh --list | grep -q golangci-lint; then
                 echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours."
@@ -413,7 +413,7 @@ if [ "$STATIC" = 1 ]; then
             fi
         fi
 
-        # Check whether the version golangci-lint was built with is >= version of go installed
+        # Check whether golangci-lint was built with go version >= the installed go version
         gcil_go_ver=$(golangci-lint --version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
         go_ver=$(go version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
         if [ "$(printf '%s\n' "$go_ver" "$gcil_go_ver" | sort -V | head -n1)" != "$go_ver" ]; then

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -56,8 +56,9 @@ execute: |
         skip="${skip:-} SKIP_NAKEDRET=1"
     fi
 
-    # To avoid checking old code, skip golangci-lint
-    skip="${skip:-} SKIP_GOLANG_CI_LINT=1"
+    # golangci-lint checks are system agnostic and were already checked in the github
+    # test workflow static checks. They can therefore be safely skipped here.
+    skip="${skip:-} SKIP_GOLANGCI_LINT=1"
 
     if not os.query is-trusty; then
         if [ "$VARIANT" = "static" ] ; then

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -56,6 +56,9 @@ execute: |
         skip="${skip:-} SKIP_NAKEDRET=1"
     fi
 
+    # To avoid checking old code, skip golangci-lint
+    skip="${skip:-} SKIP_GOLANG_CI_LINT=1"
+
     if not os.query is-trusty; then
         if [ "$VARIANT" = "static" ] ; then
             tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \


### PR DESCRIPTION
This adds the use of golangci-lint snap both in run-checks.sh and in the CI. The change in the CI's serves to align a local  run-checks.sh run with a CI run. By using the same snap and ensuring it's always up to date in both cases, developers should know what the CI is going to tell them before triggering a runner.