### PR TITLE
daemon: hide old experimental flags

### DIFF
--- a/daemon/api_snap_conf_test.go
+++ b/daemon/api_snap_conf_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -108,6 +109,72 @@ func (s *snapConfSuite) TestGetConfMissingKey(c *check.C) {
 		"message": `snap "test-snap" has no "test-key2" configuration option`,
 		"kind":    "option-not-found",
 	})
+}
+
+func (s *snapConfSuite) TestGetConfCoreUnsupportedExperimentalFlag(c *check.C) {
+	d := s.daemon(c)
+
+	// We are testing that experimental features that are no longer experimental
+	// are hidden
+
+	d.Overlord().State().Lock()
+	tr := config.NewTransaction(d.Overlord().State())
+	err := tr.Set("core", "experimental.old-flag", true)
+	c.Assert(err, check.IsNil)
+	err = tr.Set("core", "experimental.supported-flag", true)
+	c.Assert(err, check.IsNil)
+	tr.Commit()
+	d.Overlord().State().Unlock()
+
+	// Simulate that experimental.old-flag is now out of experimental
+	restore := configcore.MockSupportedExperimentalFlags([]string{"supported-flag"})
+	defer restore()
+
+	// Exact query to old experimental feature returns an error
+	result := s.runGetConf(c, "core", []string{"experimental.old-flag"}, 400)
+	c.Check(result, check.DeepEquals, map[string]interface{}{
+		"value": map[string]interface{}{
+			"SnapName": "core",
+			"Key":      "experimental.old-flag",
+		},
+		"message": `snap "core" has no "experimental.old-flag" configuration option`,
+		"kind":    "option-not-found",
+	})
+
+	// Generic experimental features query should hide old experimental
+	// features that are no longer supported
+	result = s.runGetConf(c, "core", []string{"experimental"}, 200)
+	c.Check(result, check.DeepEquals, map[string]interface{}{
+		"experimental": map[string]interface{}{
+			"supported-flag": true,
+		},
+	})
+	// Let's only check experimental config in root document
+	result = s.runGetConf(c, "core", nil, 200)
+	result = result["experimental"].(map[string]interface{})
+	c.Check(result, check.DeepEquals, map[string]interface{}{"supported-flag": true})
+
+	// Simulate the scenario where snapd is reverted to revision
+	// that supports a hidden experimental feature
+	restore = configcore.MockSupportedExperimentalFlags([]string{"supported-flag", "old-flag"})
+	defer restore()
+
+	// Exact queries should now work
+	result = s.runGetConf(c, "core", []string{"experimental.old-flag"}, 200)
+	c.Check(result, check.DeepEquals, map[string]interface{}{"experimental.old-flag": true})
+
+	// Generic queries should now show previously hidden experimental feature
+	result = s.runGetConf(c, "core", []string{"experimental"}, 200)
+	c.Check(result, check.DeepEquals, map[string]interface{}{
+		"experimental": map[string]interface{}{
+			"old-flag":       true,
+			"supported-flag": true,
+		},
+	})
+	result = s.runGetConf(c, "core", nil, 200)
+	result = result["experimental"].(map[string]interface{})
+	c.Check(result, check.DeepEquals, map[string]interface{}{"old-flag": true, "supported-flag": true})
+
 }
 
 func (s *snapConfSuite) TestGetRootDocument(c *check.C) {

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sysconfig"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func init() {
@@ -86,4 +87,25 @@ func doExportExperimentalFlags(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyCo
 
 func ExportExperimentalFlags(tr ConfGetter) error {
 	return doExportExperimentalFlags(nil, tr, nil)
+}
+
+// IsSupportedExperimentalFlag checks if passed flag is a supported experimental feature.
+func IsSupportedExperimentalFlag(flag string) bool {
+	return supportedConfigurations["core.experimental."+flag]
+}
+
+func MockSupportedExperimentalFlags(flags []string) (restore func()) {
+	restore = testutil.Backup(&supportedConfigurations)
+	// Remove all experimental flags
+	for k := range supportedConfigurations {
+		if !strings.HasPrefix(k, "core.experimental.") {
+			continue
+		}
+		delete(supportedConfigurations, k)
+	}
+	// Add supported flags
+	for _, flag := range flags {
+		supportedConfigurations["core.experimental."+flag] = true
+	}
+	return restore
 }

--- a/tests/main/old-experimental-flags/task.yaml
+++ b/tests/main/old-experimental-flags/task.yaml
@@ -1,0 +1,33 @@
+summary: Ensure that old experimental flag configs are hidden
+
+details: |
+    Check that experimental flag configs that used to exist but now
+    are out of experimental are hidden.
+
+prepare: |
+    snap install --devmode jq
+
+restore: |
+    snap remove jq
+
+execute: |
+    echo "Check that users cannot set unsupported experimental features"
+    snap set core experimental.old-flag=true 2>&1 | MATCH "unsupported system option"
+    snap get core experimental.old-flag | NOMATCH "true"
+
+    # Stop snapd while editing state.json manually
+    systemctl stop snapd.service snapd.socket
+
+    echo "Force setting the unsupported experimental.old-flag"
+    # This simulates the situation where an experimental feature got out
+    # of experimental after a snapd refresh and now is an unsupported config
+    jq '.data.config.core.experimental += {"old-flag": true}' /var/lib/snapd/state.json > state.json
+    mv state.json /var/lib/snapd/state.json
+    echo "Check that experimental.old-flag is persisted in state.json"
+    jq '.data.config.core.experimental."old-flag"' /var/lib/snapd/state.json | MATCH "true"
+
+    echo "Starting snapd should hide old experimental flags"
+    systemctl start snapd.service snapd.socket
+    snap get core experimental.old-flag | NOMATCH "true"
+    echo "But not removed from state in case of a revert"
+    jq '.data.config.core.experimental."old-flag"' /var/lib/snapd/state.json | MATCH "true"


### PR DESCRIPTION
There is window between moving an experimental flag out of experimental and possibly having a snapd revert to a version where the experimental flag was used.

To avoid breaking devices that depend on those flags, instead of removing them completely from state, let's hide them instead.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
