### PR TITLE
i/apparmor/template:  allow writing to /run/systemd/journal/dev-log by default

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -203,6 +203,7 @@ var templateCommon = `
   /run/systemd/journal{,.snap-*}/socket w,
   /run/systemd/journal{,.snap-*}/stdout rw, # 'r' shouldn't be needed, but journald
                                             # doesn't leak anything so allow
+  /run/systemd/journal{,.snap-*}/dev-log w,
 
   # snapctl and its requirements
   /usr/bin/snapctl ixr,


### PR DESCRIPTION
When using `set-quota loggroup`, the journal only contains the log of service starting, but not the logs of run-time.
```
$ sudo journalctl -b --namespace snap-mmgroup
-- Logs begin at Wed 2024-09-04 06:29:18 UTC, end at Wed 2024-09-04 06:29:37 UTC. --
Sep 04 06:29:18 ubuntu systemd-journald[20109]: Journal started
Sep 04 06:29:18 ubuntu systemd-journald[20109]: Runtime Journal (/run/log/journal/1fd84e120be8440688196db3cca02d84.snap-mmgroup) is 7.6M, max 61.0M, 53.4M free.
Sep 04 06:29:18 ubuntu modem-manager.modemmanager[20108]: + export SNAP_APP_PATH=/snap/modem-manager/470
Sep 04 06:29:18 ubuntu modem-manager.modemmanager[20108]: + LOG_LEVEL=INFO
Sep 04 06:29:18 ubuntu modem-manager.modemmanager[20108]: + DEBUG=
Sep 04 06:29:18 ubuntu modem-manager.modemmanager[20108]: + [ -f /var/snap/modem-manager/470/.debug_enabled ]
Sep 04 06:29:18 ubuntu modem-manager.modemmanager[20108]: + exec /snap/modem-manager/470/usr/sbin/ModemManager --filter-policy=STRICT --log-level=INFO
```

In the journal, there are some access denials, such as:
```
Sep 05 01:34:08 ubuntu audit[23073]: AVC apparmor="DENIED" operation="sendmsg" profile="snap.modem-manager.modemmanager" name="/run/systemd/journal.snap-mmgroup/dev-log" pid=23073 comm="ModemManager" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```

Adding `dev-log` to the AppArmor profile will resolve the issue and make loggroup working.
```
$ sudo journalctl -b --namespace snap-mmgroup
  ...
Sep 05 06:15:43 ubuntu modem-manager.modemmanager[24082]: + export SNAP_APP_PATH=/snap/modem-manager/470
Sep 05 06:15:43 ubuntu modem-manager.modemmanager[24082]: + LOG_LEVEL=INFO
Sep 05 06:15:43 ubuntu modem-manager.modemmanager[24082]: + DEBUG=
Sep 05 06:15:43 ubuntu modem-manager.modemmanager[24082]: + [ -f /var/snap/modem-manager/470/.debug_enabled ]
Sep 05 06:15:43 ubuntu modem-manager.modemmanager[24082]: + exec /snap/modem-manager/470/usr/sbin/ModemManager --filter-policy=STRICT --log-level=INFO
Sep 05 06:15:43 ubuntu ModemManager[24082]: <info>  ModemManager (version 1.16.6) starting in system bus...
Sep 05 06:15:44 ubuntu ModemManager[24082]: <warn>  [wwan0qcdm0/qcdm] failed to open serial device
Sep 05 06:15:44 ubuntu ModemManager[24082]: <warn>  [plugin-manager] task 0,wwan0qcdm0: error when checking support with plugin 'foxconn': (wwan/wwan0qcdm0) Failed to open QCDM port: Failed to open QCDM >
Sep 05 06:15:44 ubuntu ModemManager[24082]: opening device...
Sep 05 06:15:44 ubuntu ModemManager[24082]: cannot connect to proxy: Could not connect: Connection refused
Sep 05 06:15:44 ubuntu ModemManager[24082]: spawning new mbim-proxy (try 1)...
Sep 05 06:15:44 ubuntu ModemManager[24082]: <warn>  [wwan0qcdm0/qcdm] failed to open serial device
Sep 05 06:15:44 ubuntu ModemManager[24082]: <warn>  [plugin-manager] task 0,wwan0qcdm0: error when checking support with plugin 'generic': (wwan/wwan0qcdm0) Failed to open QCDM port: Failed to open QCDM >
Sep 05 06:15:45 ubuntu ModemManager[24082]: [/dev/wwan0mbim0] Couldn't find udev device in usb/usbmisc subsystems
Sep 05 06:15:45 ubuntu ModemManager[24082]: [/dev/wwan0mbim0] Couldn't find descriptors file, possibly not using cdc_mbim
Sep 05 06:15:45 ubuntu ModemManager[24082]: [/dev/wwan0mbim0] Fallback to default max control message size: 4096
  ...
```