### PR TITLE
wrappers: skip snapd desktop files in {Ensure,Remove}SnapDesktopFiles

### DIFF
--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -701,6 +701,15 @@ var snapdDesktopFileNames = []string{
 	"snap-handle-link.desktop",
 }
 
+func isSnapdDesktopFile(desktopFile string) bool {
+	for _, df := range snapdDesktopFileNames {
+		if desktopFile == df {
+			return true
+		}
+	}
+	return false
+}
+
 func writeSnapdDesktopFilesOnCore(s *snap.Info) error {
 	// Ensure /var/lib/snapd/desktop/applications exists
 	if err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755); err != nil {

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -35,6 +35,8 @@ var (
 	DetectAppAndRewriteExecLine = detectAppAndRewriteExecLine
 	RewriteIconLine             = rewriteIconLine
 	IsValidDesktopFileLine      = isValidDesktopFileLine
+	ForAllDesktopFiles          = forAllDesktopFiles
+	SnapdDesktopFileNames       = snapdDesktopFileNames
 
 	// daemons
 	NewUserServiceClientNames = newUserServiceClientNames


### PR DESCRIPTION
Snapd desktop files on core are installed under `SnapDesktopFilesDir` and since they don't have the usual `X-SnapInstanceName` for other snaps errors were showing in the logs.

This PR just skips those files when looking up installed desktop files.

Sample log: https://github.com/canonical/spread-cron/actions/runs/10693759238/job/29688990832#step:4:2445