### PR TITLE
daemon,tests: grant /v2/snaps/{name} via snap-interfaces-requests-control

### DIFF
--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -51,7 +51,7 @@ var (
 		Path:        "/v2/snaps/{name}",
 		GET:         getSnapInfo,
 		POST:        postSnap,
-		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control", "snap-refresh-observe"}},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -75,6 +75,10 @@ func (s *snapsSuite) expectSnapsReadAccess() {
 	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
 }
 
+func (s *snapsSuite) expectSnapsNameReadAccess() {
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control", "snap-refresh-observe"}})
+}
+
 func (s *snapsSuite) TestSnapsInfoIntegration(c *check.C) {
 	s.checkSnapsInfoIntegration(c, false, nil)
 }
@@ -1050,7 +1054,7 @@ func (s *snapsSuite) TestRemoveManyWithPurge(c *check.C) {
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
 }
 func (s *snapsSuite) TestSnapInfoOneIntegration(c *check.C) {
-	s.expectSnapsReadAccess()
+	s.expectSnapsNameReadAccess()
 	d := s.daemon(c)
 
 	// we have v0 [r5] installed
@@ -1307,7 +1311,7 @@ UnitFileState=enabled
 }
 
 func (s *snapsSuite) TestSnapInfoNotFound(c *check.C) {
-	s.expectSnapsReadAccess()
+	s.expectSnapsNameReadAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/snaps/gfoo", nil)
@@ -1316,7 +1320,7 @@ func (s *snapsSuite) TestSnapInfoNotFound(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoNoneFound(c *check.C) {
-	s.expectSnapsReadAccess()
+	s.expectSnapsNameReadAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/snaps/gfoo", nil)
@@ -1325,7 +1329,7 @@ func (s *snapsSuite) TestSnapInfoNoneFound(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoIgnoresRemoteErrors(c *check.C) {
-	s.expectSnapsReadAccess()
+	s.expectSnapsNameReadAccess()
 	s.daemon(c)
 	s.err = errors.New("weird")
 
@@ -1337,7 +1341,7 @@ func (s *snapsSuite) TestSnapInfoIgnoresRemoteErrors(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoReturnsHolds(c *check.C) {
-	s.expectSnapsReadAccess()
+	s.expectSnapsNameReadAccess()
 	d := s.daemon(c)
 	s.mkInstalledInState(c, d, "foo", "bar", "v0", snap.R(5), true, "")
 
@@ -1416,7 +1420,7 @@ func (s *snapsSuite) TestSnapManyInfosReturnsHolds(c *check.C) {
 }
 
 func (s *snapsSuite) TestSnapInfoReturnsRefreshInhibitProceedTime(c *check.C) {
-	s.expectSnapsReadAccess()
+	s.expectSnapsNameReadAccess()
 	d := s.daemon(c)
 	s.mkInstalledInState(c, d, "foo", "bar", "v0", snap.R(5), true, "")
 

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -45,8 +45,13 @@ execute: |
     echo "Check snap can access system info via /v2/system-info"
     api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."status-code"' | MATCH '^200$'
 
+    SNAP_NAME="snapd"
+    if os.query is-core16; then
+        SNAP_NAME="core"
+    fi
+
     echo "Check snap can access snap info via /v2/snaps/{name}"
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/snapd" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | jq '."status-code"' | MATCH '^200$'
 
     echo "Ensure AppArmor Prompting experimental feature can be enabled where possible"
     # prompting is disabled everywhere but the Ubuntu systems
@@ -116,7 +121,7 @@ execute: |
     api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-prompt" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-rule-update" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/snapd" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts" | jq '."status-code"' | MATCH '^403$'
     # Try to access an arbitrary prompt ID, should fail with 403 rather than 404
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts/1234123412341234" | jq '."status-code"' | MATCH '^403$'

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -7,6 +7,7 @@ details: |
     Specifically:
       - /v2/notices: to read change-update and refresh-inhibit notices
       - /v2/system-info: to check whether prompting is supported/enabled
+      - /v2/snaps/{name}: to get details about installed snaps
       # TODO: - /v2/interfaces/requests/prompts: to receive and reply to request prompts
       # TODO: - /v2/interfaces/requests/rules: to view and manage request rules
 
@@ -43,6 +44,9 @@ execute: |
 
     echo "Check snap can access system info via /v2/system-info"
     api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."status-code"' | MATCH '^200$'
+
+    echo "Check snap can access snap info via /v2/snaps/{name}"
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/snapd" | jq '."status-code"' | MATCH '^200$'
 
     echo "Ensure AppArmor Prompting experimental feature can be enabled where possible"
     # prompting is disabled everywhere but the Ubuntu systems
@@ -112,6 +116,7 @@ execute: |
     api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-prompt" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-rule-update" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/snapd" | jq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts" | jq '."status-code"' | MATCH '^403$'
     # Try to access an arbitrary prompt ID, should fail with 403 rather than 404
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts/1234123412341234" | jq '."status-code"' | MATCH '^403$'


### PR DESCRIPTION
Previously on the prompting branch, `snap-interfaces-requests-control` granted access to `/v2/snaps/{name}` and a few other endpoints around snap metadata. When porting from the prompting branch to snapd master, I conservatively restricted the permissions granted by `snap-interfaces-requests-control` to the bare minimum. However, we still want to grant prompting clients access to information about the snap which triggered a request prompt.

CC @sminez

This task is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-31760