### PR TITLE
release: 2.65.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# New in snapd 2.65.2:
+* Bump squashfuse from version 0.5.0 to 0.5.2 (used in snapd deb only)
+
 # New in snapd 2.65.1:
 * Support building snapd using base Core22 (Snapcraft 8.x)
 * FIPS: support building FIPS complaint snapd variant that switches to FIPS mode when the system boots with FIPS enabled

--- a/c-vendor/vendor.sh
+++ b/c-vendor/vendor.sh
@@ -8,13 +8,13 @@ if [ ! -d ./squashfuse ]; then
     git clone https://github.com/vasi/squashfuse
 fi
 
-# This is the commit that was tagged as 0.5.0, released on September 2023:
-# https://github.com/vasi/squashfuse/releases/tag/v0.5.0
+# This is the commit that was tagged as 0.5.2, released on 22 February 2024:
+# https://github.com/vasi/squashfuse/releases/tag/0.5.2
 # It contains bug fixes and enables multithreading support to squashfuse_ll
 # by default.
 # It still should work with both "libfuse-dev" and "libfuse3-dev" which
 # is important as 16.04 only has libfuse-dev and 21.10 only has libfuse3-dev
-SQUASHFUSE_REF=3f4dd2928ab362f8b20eab2be864d8e622472df5
+SQUASHFUSE_REF=775b4cc72ab47641637897f11ce0da15d5c1f115
 
 if [ -d ./squashfuse/.git ]; then
 		cd squashfuse

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.65.1
+pkgver=2.65.2
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,11 @@
+snapd (2.65.2-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Bump squashfuse from version 0.5.0 to 0.5.2 (used in snapd deb
+      only)
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Fri, 06 Sep 2024 17:08:45 +0200
+
 snapd (2.65.1-1) unstable; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.65.1
+Version:        2.65.2
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -1003,6 +1003,11 @@ fi
 
 
 %changelog
+* Fri Sep 06 2024 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.65.2
+ - Bump squashfuse from version 0.5.0 to 0.5.2 (used in snapd deb
+   only)
+
 * Sat Aug 24 2024 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.65.1
  - Support building snapd using base Core22 (Snapcraft 8.x)

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 06 15:08:45 UTC 2024 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.65.2
+
+-------------------------------------------------------------------
 Sat Aug 24 08:31:20 UTC 2024 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.65.1

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.65.1
+Version:        2.65.2
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,11 @@
+snapd (2.65.2~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Bump squashfuse from version 0.5.0 to 0.5.2 (used in snapd deb
+      only)
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Fri, 06 Sep 2024 17:08:45 +0200
+
 snapd (2.65.1~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,11 @@
+snapd (2.65.2) xenial; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Bump squashfuse from version 0.5.0 to 0.5.2 (used in snapd deb
+      only)
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Fri, 06 Sep 2024 17:08:45 +0200
+
 snapd (2.65.1) xenial; urgency=medium
 
   * New upstream release, LP: #2077473


### PR DESCRIPTION
Generated changelogs with:
DEBEMAIL="Ernest Lotter [ernest.lotter@canonical.com](mailto:ernest.lotter@canonical.com)" release-tools/changelog.py 2.65.2 2077473 NEWS.md

Cherry picked: https://github.com/canonical/snapd/pull/14474

This addresses a build error caused by new version of GCC used in oracular that escalates warning that previously existed to and error when building snapd squashfuse for armhf (32bit). See:
- https://launchpadlibrarian.net/747597684/buildlog_ubuntu-oracular-armhf.snapd_2.65.1+24.10_BUILDING.txt.gz
- https://gcc.gnu.org/gcc-14/porting_to.html | `Type checking on pointer types`

This change only affects snapd deb

**Requires rebase-merge**