### PR TITLE
interfaces/udisks2: allow `Ping`ing the UDisks2 service

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -177,6 +177,12 @@ const udisks2ConnectedPlugAppArmor = `
 
 #include <abstractions/dbus-strict>
 
+dbus (send)
+    bus=system
+    path=/org/freedesktop/UDisks2
+    interface=org.freedesktop.DBus.Peer
+    member=Ping
+    peer=(label=###SLOT_SECURITY_TAGS###),
 dbus (receive, send)
     bus=system
     path=/org/freedesktop/UDisks2/**


### PR DESCRIPTION
Otherwise:
```
apparmor="DENIED" operation="dbus_method_call"  bus="system" path="/org/freedesktop/UDisks2" interface="org.freedesktop.DBus.Peer" member="Ping" mask="send" name="org.freedesktop.UDisks2" pid=4321 label="snap.<foo>.<bar>" peer_pid=1234 peer_label="unconfined"
```