### PR TITLE
o/snapstate: make sure to put aux info from store on SnapSetup

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -382,6 +382,19 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				},
 			},
 		}
+	case "channel-for-media":
+		info.Media = snap.MediaInfos{
+			snap.MediaInfo{
+				Type:   "icon",
+				URL:    "http://example.com/icon.png",
+				Width:  100,
+				Height: 100,
+			},
+			snap.MediaInfo{
+				Type: "website",
+				URL:  "http://example.com",
+			},
+		}
 	}
 
 	if spec.Name == "provenance-snap" {

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -155,6 +155,11 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		InstanceKey:        t.info.InstanceKey,
 		ExpectedProvenance: t.info.SnapProvenance,
 		Registries:         registries,
+		auxStoreInfo: auxStoreInfo{
+			Media: t.info.Media,
+			// XXX we store this for the benefit of old snapd
+			Website: t.info.Website(),
+		},
 	}, compsups, nil
 }
 

--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -8,24 +8,19 @@ details: |
 systems: [ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 
 prepare: |
-  if ! snap list core24; then
-    snap install core24
-  fi
-
+  snap install snap-store
   snap install jq
   snap install --devmode --edge test-snapd-curl
 
 execute: |
-  snap_id=$(snap info core24 | grep snap-id | awk '{ print $2 }')
-  jq --sort-keys . < "/var/cache/snapd/aux/${snap_id}.json" > aux.json
+  snap_id=$(snap info snap-store | grep snap-id | awk '{ print $2 }')
+  jq --sort-keys .media < "/var/cache/snapd/aux/${snap_id}.json" > media.json
 
   # don't depend on the exact number of media files, but there should be
   # something here
-  media_length=$(jq '.media | length' < aux.json)
+  media_length=$(jq '. | length' < media.json)
   test "${media_length}" -gt 0
 
-  jq -r '.website' | MATCH "https://snapcraft.io"
+  test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/snaps/snap-store' | jq --sort-keys .result.media > snapd-media.json
 
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/snaps/core24' | jq --sort-keys .result.media > snapd-aux.json
-
-  diff aux.json snapd-aux.json
+  diff media.json snapd-media.json

--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -1,0 +1,29 @@
+summary: Test basic component tasks
+
+details: |
+  Verifies that basic snap component operations (install, refresh, remove) work.
+
+systems: [ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
+
+prepare: |
+  if ! snap list core24; then
+    snap install core24
+  fi
+
+  snap install jq
+  snap install --devmode --edge test-snapd-curl
+
+execute: |
+  snap_id=$(snap info core24 | grep snap-id | awk '{ print $2 }')
+  jq --sort-keys . < "/var/cache/snapd/aux/${snap_id}.json" > aux.json
+
+  # don't depend on the exact number of media files, but there should be
+  # something here
+  media_length=$(jq '.media | length' < aux.json)
+  test "${media_length}" -gt 0
+
+  jq -r '.website' | MATCH "https://snapcraft.io"
+
+  test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/snaps/core24' | jq --sort-keys .result.media > snapd-aux.json
+
+  diff aux.json snapd-aux.json

--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -1,7 +1,9 @@
-summary: Test basic component tasks
+summary: Test that snap aux info is correctly stored and returned by the snapd API
 
 details: |
-  Verifies that basic snap component operations (install, refresh, remove) work.
+  When installing a snap, we should store some auxiliary information about that
+  snap in /var/cache/snapd/aux. This test verifies that this is properly done,
+  and then verifies that the information is returned by the snapd API.
 
 systems: [ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 


### PR DESCRIPTION
This was dropped (by me) accidentally a while back when introducing components. This adds it back and adds some tests for it.