### PR TITLE
o/registrystate: add registry hook handlers

### DIFF
--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -43,11 +43,6 @@ func init() {
 	snapstate.SetupGateAutoRefreshHook = SetupGateAutoRefreshHook
 }
 
-var (
-	ChangeViewHandlerGenerator func(context *Context) Handler
-	SaveViewHandlerGenerator   func(context *Context) Handler
-)
-
 func SetupInstallHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
 		Snap:     snapName,
@@ -338,11 +333,11 @@ func SetupGateAutoRefreshHook(st *state.State, snapName string) *state.Task {
 	return task
 }
 
-type snapHookHandler struct{}
+type SnapHookHandler struct{}
 
-func (h *snapHookHandler) Before() error                 { return nil }
-func (h *snapHookHandler) Done() error                   { return nil }
-func (h *snapHookHandler) Error(err error) (bool, error) { return false, nil }
+func (h *SnapHookHandler) Before() error                 { return nil }
+func (h *SnapHookHandler) Done() error                   { return nil }
+func (h *SnapHookHandler) Error(err error) (bool, error) { return false, nil }
 
 func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
@@ -360,7 +355,7 @@ func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 
 func setupHooks(hookMgr *HookManager) {
 	handlerGenerator := func(context *Context) Handler {
-		return &snapHookHandler{}
+		return &SnapHookHandler{}
 	}
 	gateAutoRefreshHandlerGenerator := func(context *Context) Handler {
 		return NewGateAutoRefreshHookHandler(context)
@@ -371,7 +366,4 @@ func setupHooks(hookMgr *HookManager) {
 	hookMgr.Register(regexp.MustCompile("^pre-refresh$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^remove$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^gate-auto-refresh$"), gateAutoRefreshHandlerGenerator)
-	hookMgr.Register(regexp.MustCompile("^change-view-.+$"), ChangeViewHandlerGenerator)
-	hookMgr.Register(regexp.MustCompile("^save-view-.+$"), SaveViewHandlerGenerator)
-	hookMgr.Register(regexp.MustCompile("^.+-view-changed$"), handlerGenerator)
 }

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -43,6 +43,8 @@ func init() {
 	snapstate.SetupGateAutoRefreshHook = SetupGateAutoRefreshHook
 }
 
+var ChangeViewHandlerGenerator func(context *Context) Handler
+
 func SetupInstallHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
 		Snap:     snapName,
@@ -333,20 +335,11 @@ func SetupGateAutoRefreshHook(st *state.State, snapName string) *state.Task {
 	return task
 }
 
-type snapHookHandler struct {
-}
+type SnapHookHandler struct{}
 
-func (h *snapHookHandler) Before() error {
-	return nil
-}
-
-func (h *snapHookHandler) Done() error {
-	return nil
-}
-
-func (h *snapHookHandler) Error(err error) (bool, error) {
-	return false, nil
-}
+func (h *SnapHookHandler) Before() error                 { return nil }
+func (h *SnapHookHandler) Done() error                   { return nil }
+func (h *SnapHookHandler) Error(err error) (bool, error) { return false, nil }
 
 func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
@@ -364,7 +357,7 @@ func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 
 func setupHooks(hookMgr *HookManager) {
 	handlerGenerator := func(context *Context) Handler {
-		return &snapHookHandler{}
+		return &SnapHookHandler{}
 	}
 	gateAutoRefreshHandlerGenerator := func(context *Context) Handler {
 		return NewGateAutoRefreshHookHandler(context)
@@ -375,4 +368,5 @@ func setupHooks(hookMgr *HookManager) {
 	hookMgr.Register(regexp.MustCompile("^pre-refresh$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^remove$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^gate-auto-refresh$"), gateAutoRefreshHandlerGenerator)
+	hookMgr.Register(regexp.MustCompile("^change-view-.+$"), ChangeViewHandlerGenerator)
 }

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -338,11 +338,11 @@ func SetupGateAutoRefreshHook(st *state.State, snapName string) *state.Task {
 	return task
 }
 
-type SnapHookHandler struct{}
+type snapHookHandler struct{}
 
-func (h *SnapHookHandler) Before() error                 { return nil }
-func (h *SnapHookHandler) Done() error                   { return nil }
-func (h *SnapHookHandler) Error(err error) (bool, error) { return false, nil }
+func (h *snapHookHandler) Before() error                 { return nil }
+func (h *snapHookHandler) Done() error                   { return nil }
+func (h *snapHookHandler) Error(err error) (bool, error) { return false, nil }
 
 func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
@@ -360,7 +360,7 @@ func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 
 func setupHooks(hookMgr *HookManager) {
 	handlerGenerator := func(context *Context) Handler {
-		return &SnapHookHandler{}
+		return &snapHookHandler{}
 	}
 	gateAutoRefreshHandlerGenerator := func(context *Context) Handler {
 		return NewGateAutoRefreshHookHandler(context)

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -43,7 +43,10 @@ func init() {
 	snapstate.SetupGateAutoRefreshHook = SetupGateAutoRefreshHook
 }
 
-var ChangeViewHandlerGenerator func(context *Context) Handler
+var (
+	ChangeViewHandlerGenerator func(context *Context) Handler
+	SaveViewHandlerGenerator   func(context *Context) Handler
+)
 
 func SetupInstallHook(st *state.State, snapName string) *state.Task {
 	hooksup := &HookSetup{
@@ -369,4 +372,5 @@ func setupHooks(hookMgr *HookManager) {
 	hookMgr.Register(regexp.MustCompile("^remove$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^gate-auto-refresh$"), gateAutoRefreshHandlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^change-view-.+$"), ChangeViewHandlerGenerator)
+	hookMgr.Register(regexp.MustCompile("^save-view-.+$"), SaveViewHandlerGenerator)
 }

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -373,4 +373,5 @@ func setupHooks(hookMgr *HookManager) {
 	hookMgr.Register(regexp.MustCompile("^gate-auto-refresh$"), gateAutoRefreshHandlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^change-view-.+$"), ChangeViewHandlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^save-view-.+$"), SaveViewHandlerGenerator)
+	hookMgr.Register(regexp.MustCompile("^.+-view-changed$"), handlerGenerator)
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -351,6 +351,7 @@ func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 func (s *interfaceManagerSuite) hookManager(c *C) *hookstate.HookManager {
 	if s.privateHookMgr == nil {
 		mgr, err := hookstate.Manager(s.state, s.o.TaskRunner())
+
 		c.Assert(err, IsNil)
 		s.privateHookMgr = mgr
 		s.o.AddManager(mgr)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -351,7 +351,6 @@ func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 func (s *interfaceManagerSuite) hookManager(c *C) *hookstate.HookManager {
 	if s.privateHookMgr == nil {
 		mgr, err := hookstate.Manager(s.state, s.o.TaskRunner())
-
 		c.Assert(err, IsNil)
 		s.privateHookMgr = mgr
 		s.o.AddManager(mgr)

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -46,11 +46,13 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
+	"github.com/snapcore/snapd/overlord/registrystate"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	_ "github.com/snapcore/snapd/overlord/snapstate/policy"
+
 	// import to register linkNotify callback
 	_ "github.com/snapcore/snapd/overlord/snapstate/agentnotify"
 	"github.com/snapcore/snapd/overlord/state"
@@ -179,6 +181,7 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 
 	o.addManager(cmdstate.Manager(s, o.runner))
 	o.addManager(snapshotstate.Manager(s, o.runner))
+	o.addManager(registrystate.Manager(s, hookMgr, o.runner))
 
 	if err := configstateInit(s, hookMgr); err != nil {
 		return nil, err

--- a/overlord/registrystate/export_test.go
+++ b/overlord/registrystate/export_test.go
@@ -19,6 +19,7 @@
 package registrystate
 
 import (
+	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/registry"
 )
@@ -30,6 +31,14 @@ var (
 	CreateChangeRegistryTasks = createChangeRegistryTasks
 	SetTransaction            = setTransaction
 )
+
+func ChangeViewHandlerGenerator(ctx *hookstate.Context) hookstate.Handler {
+	return &changeViewHandler{ctx: ctx}
+}
+
+func SaveViewHandlerGenerator(ctx *hookstate.Context) hookstate.Handler {
+	return &saveViewHandler{ctx: ctx}
+}
 
 func MockReadDatabag(f func(st *state.State, account, registryName string) (registry.JSONDataBag, error)) func() {
 	old := readDatabag

--- a/overlord/registrystate/export_test.go
+++ b/overlord/registrystate/export_test.go
@@ -28,6 +28,7 @@ var (
 	WriteDatabag              = writeDatabag
 	GetPlugsAffectedByPaths   = getPlugsAffectedByPaths
 	CreateChangeRegistryTasks = createChangeRegistryTasks
+	SetTransaction            = setTransaction
 )
 
 func MockReadDatabag(f func(st *state.State, account, registryName string) (registry.JSONDataBag, error)) func() {

--- a/overlord/registrystate/registrymgr.go
+++ b/overlord/registrystate/registrymgr.go
@@ -26,6 +26,12 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
+func init() {
+	hookstate.ChangeViewHandlerGenerator = func(context *hookstate.Context) hookstate.Handler {
+		return &changeViewHandler{ctx: context}
+	}
+}
+
 func setupRegistryHook(st *state.State, snapName, hookName string, ignoreError bool) *state.Task {
 	hookSup := &hookstate.HookSetup{
 		Snap:        snapName,
@@ -36,4 +42,26 @@ func setupRegistryHook(st *state.State, snapName, hookName string, ignoreError b
 	summary := fmt.Sprintf(i18n.G("Run hook %s of snap %q"), hookName, snapName)
 	task := hookstate.HookTask(st, summary, hookSup, nil)
 	return task
+}
+
+type changeViewHandler struct {
+	hookstate.SnapHookHandler
+	ctx *hookstate.Context
+}
+
+func (h *changeViewHandler) Done() error {
+	h.ctx.Lock()
+	defer h.ctx.Unlock()
+
+	t, _ := h.ctx.Task()
+	tx, _, err := GetStoredTransaction(t)
+	if err != nil {
+		return fmt.Errorf("cannot get transaction in change-registry handler: %v", err)
+	}
+
+	if tx.aborted() {
+		return fmt.Errorf("cannot change registry %s/%s: %s rejected changes: %s", tx.RegistryAccount, tx.RegistryName, tx.abortingSnap, tx.abortReason)
+	}
+
+	return nil
 }

--- a/overlord/registrystate/registrymgr.go
+++ b/overlord/registrystate/registrymgr.go
@@ -51,9 +51,11 @@ func setupRegistryHook(st *state.State, snapName, hookName string, ignoreError b
 }
 
 type changeViewHandler struct {
-	hookstate.SnapHookHandler
 	ctx *hookstate.Context
 }
+
+func (h *changeViewHandler) Before() error                 { return nil }
+func (h *changeViewHandler) Error(err error) (bool, error) { return false, nil }
 
 func (h *changeViewHandler) Done() error {
 	h.ctx.Lock()
@@ -73,9 +75,10 @@ func (h *changeViewHandler) Done() error {
 }
 
 type saveViewHandler struct {
-	hookstate.SnapHookHandler
 	ctx *hookstate.Context
 }
+
+func (h *saveViewHandler) Before() error { return nil }
 
 func (h *saveViewHandler) Error(origErr error) (ignoreErr bool, err error) {
 	h.ctx.Lock()

--- a/overlord/registrystate/registrymgr.go
+++ b/overlord/registrystate/registrymgr.go
@@ -96,7 +96,9 @@ func (h *saveViewHandler) Error(origErr error) (ignoreErr bool, err error) {
 		}
 	}
 
-	// create roll back tasks for the previously done save-registry hooks
+	// create roll back tasks for the previously done save-registry hooks (starting
+	// with the hook that failed, so it tries to overwrite with a pristine databag
+	// just like any previous save-view hooks)
 	last := t
 	for curTask := t; curTask.Kind() == "run-hook"; curTask = curTask.WaitTasks()[0] {
 		var hooksup hookstate.HookSetup

--- a/overlord/registrystate/registrymgr.go
+++ b/overlord/registrystate/registrymgr.go
@@ -19,9 +19,12 @@
 package registrystate
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -29,6 +32,9 @@ import (
 func init() {
 	hookstate.ChangeViewHandlerGenerator = func(context *hookstate.Context) hookstate.Handler {
 		return &changeViewHandler{ctx: context}
+	}
+	hookstate.SaveViewHandlerGenerator = func(context *hookstate.Context) hookstate.Handler {
+		return &saveViewHandler{ctx: context}
 	}
 }
 
@@ -64,4 +70,93 @@ func (h *changeViewHandler) Done() error {
 	}
 
 	return nil
+}
+
+type saveViewHandler struct {
+	hookstate.SnapHookHandler
+	ctx *hookstate.Context
+}
+
+func (h *saveViewHandler) Error(origErr error) (ignoreErr bool, err error) {
+	h.ctx.Lock()
+	defer h.ctx.Unlock()
+
+	t, _ := h.ctx.Task()
+	st := h.ctx.State()
+
+	var commitTaskID string
+	if err := t.Get("commit-task", &commitTaskID); err != nil {
+		return false, err
+	}
+
+	// stop all tasks (we need to do this manually because we're not erroring yet)
+	for _, t := range t.Change().Tasks() {
+		if t.Status() == state.DoStatus {
+			t.SetStatus(state.HoldStatus)
+		}
+	}
+
+	// create roll back tasks for the previously done save-registry hooks
+	last := t
+	for curTask := t; curTask.Kind() == "run-hook"; curTask = curTask.WaitTasks()[0] {
+		var hooksup hookstate.HookSetup
+		if err := curTask.Get("hook-setup", &hooksup); err != nil {
+			return false, err
+		}
+
+		if !strings.HasPrefix(hooksup.Hook, "save-view-") {
+			break
+		}
+
+		// if we fail to rollback, there's nothing we can do
+		ignoreError := true
+		rollbackTask := setupRegistryHook(st, hooksup.Snap, hooksup.Hook, ignoreError)
+		rollbackTask.Set("commit-task", commitTaskID)
+		rollbackTask.WaitFor(last)
+		curTask.Change().AddTask(rollbackTask)
+		last = rollbackTask
+
+		// should never happen but let's be careful for now
+		if len(curTask.WaitTasks()) != 1 {
+			return false, fmt.Errorf("internal error: cannot rollback failed save-view: expected one prerequisite task")
+		}
+	}
+
+	// save the original error so we can return that once the rollback is done
+	last.Set("original-error", origErr.Error())
+
+	tx, commitTask, err := GetStoredTransaction(t)
+	if err != nil {
+		return false, fmt.Errorf("cannot rollback failed save-view: cannot get transaction: %v", err)
+	}
+
+	// clear the transaction changes
+	err = tx.Clear(st)
+	if err != nil {
+		return false, fmt.Errorf("cannot rollback failed save-view: cannot clear transaction changes: %v", err)
+	}
+	commitTask.Set("registry-transaction", tx)
+
+	// ignore error for now so we run again to try to undo any committed data
+	return true, nil
+}
+
+func (h *saveViewHandler) Done() error {
+	h.ctx.Lock()
+	defer h.ctx.Unlock()
+
+	t, _ := h.ctx.Task()
+
+	var origErr string
+	if err := t.Get("original-error", &origErr); err != nil {
+		if errors.Is(err, state.ErrNoState) {
+			// no original-error, this isn't the last hook in a rollback, nothing to do
+			return nil
+		}
+		return err
+	}
+
+	logger.Noticef("successfully rolled back failed save-view hooks")
+	// we're finished rolling back, so return the original error
+	return errors.New(origErr)
 }

--- a/overlord/registrystate/registrymgr.go
+++ b/overlord/registrystate/registrymgr.go
@@ -33,6 +33,7 @@ import (
 type RegistryManager struct{}
 
 func Manager(st *state.State, hookMgr *hookstate.HookManager, _ *state.TaskRunner) *RegistryManager {
+	m := &RegistryManager{}
 
 	// TODO: add task handlers (commit-transaction, clear-state, etc)
 
@@ -46,7 +47,7 @@ func Manager(st *state.State, hookMgr *hookstate.HookManager, _ *state.TaskRunne
 		return &hookstate.SnapHookHandler{}
 	})
 
-	return nil
+	return m
 }
 
 func (m *RegistryManager) Ensure() error { return nil }

--- a/overlord/registrystate/registrymgr_test.go
+++ b/overlord/registrystate/registrymgr_test.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package registrystate_test
+
+import (
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/registrystate"
+	"github.com/snapcore/snapd/overlord/state"
+
+	. "gopkg.in/check.v1"
+)
+
+type hookHandlerSuite struct {
+	state *state.State
+
+	repo *interfaces.Repository
+}
+
+var _ = Suite(&hookHandlerSuite{})
+
+func (s *hookHandlerSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.state = overlord.Mock().State()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.repo = interfaces.NewRepository()
+	ifacerepo.Replace(s.state, s.repo)
+
+	regIface := &ifacetest.TestInterface{InterfaceName: "registry"}
+	err := s.repo.AddInterface(regIface)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1
+type: os
+slots:
+  registry-slot:
+    interface: registry
+`
+	info := mockInstalledSnap(c, s.state, coreYaml, "")
+	coreSet, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+
+	err = s.repo.AddAppSet(coreSet)
+	c.Assert(err, IsNil)
+
+	snapYaml := `name: test-snap
+version: 1
+type: app
+plugs:
+  setup:
+    interface: registry
+    account: my-acc
+    view: network/setup-wifi
+`
+
+	info = mockInstalledSnap(c, s.state, snapYaml, "")
+	appSet, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.repo.AddAppSet(appSet)
+	c.Assert(err, IsNil)
+
+	ref := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "test-snap", Name: "setup"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "registry-slot"},
+	}
+
+	_, err = s.repo.Connect(ref, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+}
+
+func (s *hookHandlerSuite) TestViewChangeHookOk(c *C) {
+	s.state.Lock()
+	hooksup := &hookstate.HookSetup{
+		Snap: "test-snap",
+		Hook: "view-change-setup",
+	}
+
+	tx, err := registrystate.NewTransaction(s.state, "my-acc", "network")
+	c.Assert(err, IsNil)
+
+	t := s.state.NewTask("task", "")
+	registrystate.SetTransaction(t, tx)
+
+	ctx, err := hookstate.NewContext(t, s.state, hooksup, nil, "")
+	c.Assert(err, IsNil)
+
+	handler := hookstate.ChangeViewHandlerGenerator(ctx)
+	s.state.Unlock()
+
+	c.Assert(err, IsNil)
+	err = handler.Done()
+	c.Assert(err, IsNil)
+}
+
+func (s *hookHandlerSuite) TestViewChangeHookRejectsChanges(c *C) {
+	s.state.Lock()
+	hooksup := &hookstate.HookSetup{
+		Snap: "test-snap",
+		Hook: "view-change-setup",
+	}
+
+	tx, err := registrystate.NewTransaction(s.state, "my-acc", "network")
+	c.Assert(err, IsNil)
+	tx.Abort("my-snap", "don't like")
+
+	t := s.state.NewTask("task", "")
+	registrystate.SetTransaction(t, tx)
+
+	ctx, err := hookstate.NewContext(t, s.state, hooksup, nil, "")
+	c.Assert(err, IsNil)
+
+	handler := hookstate.ChangeViewHandlerGenerator(ctx)
+	s.state.Unlock()
+
+	err = handler.Done()
+	c.Assert(err, ErrorMatches, `cannot change registry my-acc/network: my-snap rejected changes: don't like`)
+}

--- a/overlord/registrystate/registrymgr_test.go
+++ b/overlord/registrystate/registrymgr_test.go
@@ -99,7 +99,7 @@ func (s *hookHandlerSuite) TestViewChangeHookOk(c *C) {
 	s.state.Lock()
 	hooksup := &hookstate.HookSetup{
 		Snap: "test-snap",
-		Hook: "view-change-setup",
+		Hook: "change-view-setup",
 	}
 
 	tx, err := registrystate.NewTransaction(s.state, "my-acc", "network")
@@ -111,7 +111,7 @@ func (s *hookHandlerSuite) TestViewChangeHookOk(c *C) {
 	ctx, err := hookstate.NewContext(t, s.state, hooksup, nil, "")
 	c.Assert(err, IsNil)
 
-	handler := hookstate.ChangeViewHandlerGenerator(ctx)
+	handler := registrystate.ChangeViewHandlerGenerator(ctx)
 	s.state.Unlock()
 
 	c.Assert(err, IsNil)
@@ -119,11 +119,11 @@ func (s *hookHandlerSuite) TestViewChangeHookOk(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *hookHandlerSuite) TestViewChangeHookRejectsChanges(c *C) {
+func (s *hookHandlerSuite) TestChangeViewHookRejectsChanges(c *C) {
 	s.state.Lock()
 	hooksup := &hookstate.HookSetup{
 		Snap: "test-snap",
-		Hook: "view-change-setup",
+		Hook: "change-view-setup",
 	}
 
 	tx, err := registrystate.NewTransaction(s.state, "my-acc", "network")
@@ -136,7 +136,7 @@ func (s *hookHandlerSuite) TestViewChangeHookRejectsChanges(c *C) {
 	ctx, err := hookstate.NewContext(t, s.state, hooksup, nil, "")
 	c.Assert(err, IsNil)
 
-	handler := hookstate.ChangeViewHandlerGenerator(ctx)
+	handler := registrystate.ChangeViewHandlerGenerator(ctx)
 	s.state.Unlock()
 
 	err = handler.Done()
@@ -147,7 +147,7 @@ func (s *hookHandlerSuite) TestSaveViewHookOk(c *C) {
 	s.state.Lock()
 	hooksup := &hookstate.HookSetup{
 		Snap: "test-snap",
-		Hook: "view-change-setup",
+		Hook: "save-view-setup",
 	}
 
 	tx, err := registrystate.NewTransaction(s.state, "my-acc", "network")
@@ -159,7 +159,7 @@ func (s *hookHandlerSuite) TestSaveViewHookOk(c *C) {
 	ctx, err := hookstate.NewContext(t, s.state, hooksup, nil, "")
 	c.Assert(err, IsNil)
 
-	handler := hookstate.SaveViewHandlerGenerator(ctx)
+	handler := registrystate.SaveViewHandlerGenerator(ctx)
 	s.state.Unlock()
 
 	err = handler.Done()
@@ -209,7 +209,7 @@ func (s *hookHandlerSuite) TestSaveViewHookErrorRollsBackSaves(c *C) {
 	ctx, err := hookstate.NewContext(secondTask, s.state, hooksup, nil, "")
 	c.Assert(err, IsNil)
 
-	handler := hookstate.SaveViewHandlerGenerator(ctx)
+	handler := registrystate.SaveViewHandlerGenerator(ctx)
 	s.state.Unlock()
 
 	savingErr := errors.New("failed to save")
@@ -265,7 +265,7 @@ func (s *hookHandlerSuite) TestSaveViewHookErrorRollsBackSaves(c *C) {
 	c.Assert(err, IsNil)
 	s.state.Unlock()
 
-	handler = hookstate.SaveViewHandlerGenerator(ctx)
+	handler = registrystate.SaveViewHandlerGenerator(ctx)
 	err = handler.Done()
 	c.Assert(err, ErrorMatches, savingErr.Error())
 }
@@ -312,7 +312,7 @@ func (s *hookHandlerSuite) TestSaveViewHookErrorHoldsTasks(c *C) {
 	ctx, err := hookstate.NewContext(firstTask, s.state, hooksup, nil, "")
 	c.Assert(err, IsNil)
 
-	handler := hookstate.SaveViewHandlerGenerator(ctx)
+	handler := registrystate.SaveViewHandlerGenerator(ctx)
 
 	s.state.Unlock()
 	ignore, err := handler.Error(errors.New("failed to save"))

--- a/overlord/registrystate/registrystate.go
+++ b/overlord/registrystate/registrystate.go
@@ -438,3 +438,7 @@ func GetStoredTransaction(t *state.Task) (*Transaction, *state.Task, error) {
 
 	return tx, ct, nil
 }
+
+func setTransaction(t *state.Task, tx *Transaction) {
+	t.Set("registry-transaction", tx)
+}

--- a/overlord/registrystate/registrystate_test.go
+++ b/overlord/registrystate/registrystate_test.go
@@ -47,6 +47,7 @@ import (
 
 type registryTestSuite struct {
 	state *state.State
+	o     *overlord.Overlord
 
 	registry *registry.Registry
 	devAccID string
@@ -60,7 +61,8 @@ func Test(t *testing.T) { TestingT(t) }
 
 func (s *registryTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
-	s.state = overlord.Mock().State()
+	s.o = overlord.Mock()
+	s.state = s.o.State()
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -40,6 +40,7 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^fde-setup$")),
 	NewHookType(regexp.MustCompile("^gate-auto-refresh$")),
 	NewHookType(regexp.MustCompile("^change-view-.+$")),
+	NewHookType(regexp.MustCompile("^save-view-.+$")),
 }
 
 var supportedComponentHooks = []*HookType{

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -39,6 +39,7 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^check-health$")),
 	NewHookType(regexp.MustCompile("^fde-setup$")),
 	NewHookType(regexp.MustCompile("^gate-auto-refresh$")),
+	NewHookType(regexp.MustCompile("^change-view-.+$")),
 }
 
 var supportedComponentHooks = []*HookType{

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -41,6 +41,7 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^gate-auto-refresh$")),
 	NewHookType(regexp.MustCompile("^change-view-.+$")),
 	NewHookType(regexp.MustCompile("^save-view-.+$")),
+	NewHookType(regexp.MustCompile("^.+-view-changed$")),
 }
 
 var supportedComponentHooks = []*HookType{


### PR DESCRIPTION
Adds registry hook handlers. The change-view-<plug> hook handler checks the transaction to see if the snap has rejected the changes (this will be done with a `snapctl fail <reason>` command) and outputs that information nicely if so. The save-view-<plug> hook handler attempts to roll back previous save-view hooks that have already run if the hook failed. It saves the error, schedules rollback tasks and then outputs the error once those are done. The <plug>-view-changed doesn't have any code to it.