### PR TITLE
tests: mark ubuntu-20.04/535-server as broken-packaging

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1161,7 +1161,7 @@ suites:
             NESTED_SNAPD_DEBUG_TO_SERIAL:  '$(HOST: echo "${NESTED_SNAPD_DEBUG_TO_SERIAL:-false}")'
             # Add any extra cmd line parameter to the nested vm
             NESTED_EXTRA_CMDLINE:  '$(HOST: echo "${NESTED_EXTRA_CMDLINE:-}")'
-            # Generic imane name which has to be overwritten in the test
+            # Generic image name which has to be overwritten in the test
             NESTED_IMAGE_ID: "unset"
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"

--- a/spread.yaml
+++ b/spread.yaml
@@ -931,7 +931,7 @@ suites:
     # environment on each platform. On autopkgtest we cannot run all tests
     # as this is very slow and we run into timeouts.
     #
-    # These tests are executed on all other plattforms as they
+    # These tests are executed on all other platforms as they
     # are designed to run on pristine systems
     tests/smoke/:
         summary: Essential system level tests for snapd

--- a/tests/main/nvidia-files/task.yaml
+++ b/tests/main/nvidia-files/task.yaml
@@ -60,6 +60,9 @@ prepare: |
     skip["ubuntu-20.04-64/515-server"]="transitional-driver"
     skip["ubuntu-20.04-64/525"]="transitional-driver"
     skip["ubuntu-20.04-64/530"]="transitional-driver"
+    # The i386 side of the driver is not installable due to
+    # https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-535-server/+bug/2080351
+    skip["ubuntu-20.04-64/535-server"]="broken-packaging"
     skip["ubuntu-20.04-64/550"]="no-driver"
     skip["ubuntu-22.04-64/390"]="broken-driver"
     skip["ubuntu-22.04-64/510"]="transitional-driver"
@@ -124,12 +127,6 @@ prepare: |
         ;;
     esac
 
-    # At this step, we we expect this test to work, and no skip file to exist.
-    echo "Everything is good, expecting: skip[\"$combi_key\"] does not exist"
-    if [[ -v "skip[$combi_key]" ]]; then
-        exit 1
-    fi
-
     # We will need to install i386 libraries. This is specifically done on an
     # amd64 system as there are cases of 32bit programs running through
     # otherwise 64bit snap, running on 64bit host.
@@ -137,7 +134,7 @@ prepare: |
     apt-get update
 
     # Install Nvidia userspace libraries at the designated version.
-    apt-get install -y \
+    if ! apt-get install -y \
         libnvidia-common-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}" \
         libnvidia-compute-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}":amd64 \
         libnvidia-compute-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}":i386 \
@@ -148,7 +145,17 @@ prepare: |
         libnvidia-fbc1-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}":amd64 \
         libnvidia-fbc1-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}":i386 \
         libnvidia-gl-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}":amd64 \
-        libnvidia-gl-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}":i386
+        libnvidia-gl-"$PACKAGE_VERSION${PACKAGE_SUFFIX:-}":i386 >install.txt 2>&1; then
+      echo "Broken packaging, expecting: skip[\"$combi_key\"]=\"broken-packaging\""
+      test "${skip[$combi_key]}" = "broken-packaging"
+      exit 0
+    fi
+
+    # At this step, we we expect this test to work, and no skip condition to exist.
+    echo "Everything is good, expecting: skip[\"$combi_key\"] not to exist"
+    if [[ -v "skip[$combi_key]" ]]; then
+        exit 1
+    fi
 
     # Look at the canary file libnvidia-glcore.so.* to get the exact version of
     # the driver. This file is also used by snap-confine, as a pre-condition
@@ -184,6 +191,7 @@ restore: |
     tests.cleanup restore
 
 debug: |
+    if [ -f install.txt ]; then cat install.txt; fi
     if [ -f log-32.txt ]; then cat log-32.txt; fi
     if [ -f log-64.txt ]; then cat log-64.txt; fi
 


### PR DESCRIPTION
There's a now-known new bug in the packaging of nvidia drivers that is
tracked as https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-535-server/+bug/2080351

The result is that the libnvidia-egl-wayland1:i386 package is not
installable.

Adjust the test to allow expressing broken packaging.

--

Separately, I've talked to the maintainer and their preference is not to fix it as the -server packages are unlikely to be used for gaming. I will follow up with a refactor that only exercises 32bit versions on non-server packages.