### PR TITLE
o/snapstate: refuse to install snaps whose desktop-file-ids conflict with installed snaps

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -395,6 +395,17 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				URL:  "http://example.com",
 			},
 		}
+	case "channel-for-desktop-file-ids":
+		info.Plugs = map[string]*snap.PlugInfo{
+			"desktop": {
+				Snap:      info,
+				Interface: "desktop",
+				Name:      "desktop",
+				Attrs: map[string]interface{}{
+					"desktop-file-ids": []interface{}{"org.example.Foo"},
+				},
+			},
+		}
 	}
 
 	if spec.Name == "provenance-snap" {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -171,6 +171,11 @@ var (
 	CheckDBusServiceConflicts = checkDBusServiceConflicts
 )
 
+// desktop-file-ids
+var (
+	CheckDesktopFileIDsConflicts = checkDesktopFileIDsConflicts
+)
+
 // readme files
 var (
 	WriteSnapReadme = writeSnapReadme

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2164,6 +2164,11 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	if err := checkDBusServiceConflicts(st, newInfo); err != nil {
 		return err
 	}
+	// Check for desktop-file-ids conflicts a second time to detect
+	// conflicts within a transaction.
+	if err := checkDesktopFileIDsConflicts(st, newInfo); err != nil {
+		return err
+	}
 
 	opts, err := SnapServiceOptions(st, newInfo, nil)
 	if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1264,7 +1264,12 @@ func ensureInstallPreconditions(st *state.State, info *snap.Info, flags Flags, s
 	if err := validateFeatureFlags(st, info); err != nil {
 		return flags, err
 	}
+	// TODO: if we implement a --disabled flag for install we should skip the
+	// dbus and desktop-file-ids checks below.
 	if err := checkDBusServiceConflicts(st, info); err != nil {
+		return flags, err
+	}
+	if err := checkDesktopFileIDsConflicts(st, info); err != nil {
 		return flags, err
 	}
 	return flags, nil


### PR DESCRIPTION
This PR does desktop-file-ids conflict detection as they should be unique across the system. The checks are very similar to the [conflict checks for dbus activation](https://github.com/canonical/snapd/blob/718ba573a216859435eeaa10e73dcbd36d9c016e/overlord/snapstate/dbus.go#L51).

This simply checks if any other snap uses any of desktop-file-ids of the snap being installed and refuses to refresh/install when a conflict is detected. This is mostly target to prevent conflicts with parallel installs.