### PR TITLE
tests: fix upload by changing from hidden directory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -914,7 +914,7 @@ jobs:
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
           echo "Running command: $SPREAD $RUN_TESTS"
-          (set -o pipefail; $SPREAD -no-debug-output -logs .logs $RUN_TESTS | PYTHONDONTWRITEBYTECODE=1 ./tests/lib/external/snapd-testing-tools/utils/log-filter $FILTER_PARAMS | tee spread.log)
+          (set -o pipefail; $SPREAD -no-debug-output -logs spread-logs $RUN_TESTS | PYTHONDONTWRITEBYTECODE=1 ./tests/lib/external/snapd-testing-tools/utils/log-filter $FILTER_PARAMS | tee spread.log)
 
 
     - name: Uploading spread logs
@@ -922,7 +922,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: spread-logs-${{ matrix.systems }}
-        path: ".logs/*.log"
+        path: "spread-logs/*.log"
 
     - name: Discard spread workers
       if: always()


### PR DESCRIPTION
Github actions changed their upload action to not include hidden files and directories by default. To ensure the logs get uploaded, I removed the hidden directory for the logs.
