### PR TITLE
cmd/snap-update-ns: add test explaining content-layout bugs

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -65,6 +65,10 @@ type Change struct {
 	Action Action
 }
 
+func (c *Change) GoString() string {
+	return fmt.Sprintf("%#+v", *c)
+}
+
 // String formats mount change to a human-readable line.
 func (c Change) String() string {
 	return fmt.Sprintf("%s (%s)", c.Action, c.Entry)

--- a/cmd/snap-update-ns/change_tricky_test.go
+++ b/cmd/snap-update-ns/change_tricky_test.go
@@ -1,0 +1,246 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/osutil"
+)
+
+func (s *changeSuite) TestContentLayout1InitiallyConnected(c *C) {
+	// NOTE: This doesn't measure what is going on during construction. It
+	// merely measures what is constructed is stable and that it does not cause
+	// further changes to be created.
+	current, err := osutil.LoadMountProfile("testdata/content-layout-1-initially-connected.current.fstab")
+	c.Assert(err, IsNil)
+	desired, err := osutil.LoadMountProfile("testdata/content-layout-1-initially-connected.desired.fstab")
+	c.Assert(err, IsNil)
+	changes := update.NeededChanges(current, desired)
+	showCurrentDesiredAndChanges(c, current, desired, changes)
+
+	// The change plan is to do nothing.
+	// Note that the order of entries is back to front.
+	//
+	// At this time, the mount namespace is correct:
+	// zyga@wyzima:/run/snapd/ns$ sudo nsenter -mtest-snapd-content-layout.mnt
+	// root@wyzima:/# ls -l /usr/share/secureboot/potato
+	// total 1
+	// -rw-rw-r-- 1 root root 22 Aug 30 09:36 canary.txt
+	// drwxrwxr-x 2 root root 32 Aug 30 09:36 meta
+	// root@wyzima:/# ls -l /snap/test-snapd-content-layout/
+	// current/ x1/      x2/
+	// root@wyzima:/# ls -l /snap/test-snapd-content-layout/x2/attached-content/
+	// total 1
+	// -rw-rw-r-- 1 root root 22 Aug 30 09:36 canary.txt
+	// drwxrwxr-x 2 root root 32 Aug 30 09:36 meta
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: "keep", Entry: current.Entries[4]},
+		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "keep", Entry: current.Entries[2]},
+		{Action: "keep", Entry: current.Entries[1]},
+		{Action: "keep", Entry: current.Entries[0]},
+	})
+}
+
+func (s *changeSuite) TestContentLayout2InitiallyConnectedThenDisconnected(c *C) {
+	current, err := osutil.LoadMountProfile("testdata/content-layout-1-initially-connected.current.fstab")
+	c.Assert(err, IsNil)
+	desired, err := osutil.LoadMountProfile("testdata/content-layout-2-after-disconnect.desired.fstab")
+	c.Assert(err, IsNil)
+	changes := update.NeededChanges(current, desired)
+	showCurrentDesiredAndChanges(c, current, desired, changes)
+
+	// The change plan is to do detach the content entry.
+	//
+	// Detached entries are first isolated from mount propagation. So the bug
+	// here is that the mount entry propagated to the layout during initial
+	// construction sticks around and is not updated. This is a bug.
+	// This is tracked as https://warthogs.atlassian.net/browse/SNAPDENG-31645
+	//
+	// zyga@wyzima:/run/snapd/ns$ sudo nsenter -mtest-snapd-content-layout.mnt
+	// root@wyzima:/# ls -l /snap/test-snapd-content-layout/x2/attached-content/
+	// total 1
+	// -rw-rw-r-- 1 root root 46 Aug 30 09:36 hidden
+	// root@wyzima:/# ls -l /usr/share/secureboot/potato
+	// total 1
+	// -rw-rw-r-- 1 root root 22 Aug 30 09:36 canary.txt
+	// drwxrwxr-x 2 root root 32 Aug 30 09:36 meta
+	//
+	// Note that the order of entries is back to front. There is another bug
+	// here, although it is not visible from the change plan alone. The reverse
+	// order of mount entries listed here is actually stored as the new current
+	// mount profile. This is tracked as
+	// https://warthogs.atlassian.net/browse/SNAPDENG-31644
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: "keep", Entry: current.Entries[4]},
+		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "keep", Entry: current.Entries[2]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[0]},
+	})
+
+	// The actual entry for clarity.
+	c.Assert(changes[3].Entry, DeepEquals, osutil.MountEntry{
+		Name:    "/snap/test-snapd-content/x1",
+		Dir:     "/snap/test-snapd-content-layout/x2/attached-content",
+		Type:    "none",
+		Options: []string{"bind", "ro", "x-snapd.detach"},
+	})
+}
+
+func (s *changeSuite) TestContentLayout3InitiallyConnectedThenDisconnectedAndReconnected(c *C) {
+	current, err := osutil.LoadMountProfile("testdata/content-layout-2-after-disconnect.current.fstab")
+	c.Assert(err, IsNil)
+	desired, err := osutil.LoadMountProfile("testdata/content-layout-3-after-reconnect.desired.fstab")
+	c.Assert(err, IsNil)
+	changes := update.NeededChanges(current, desired)
+	showCurrentDesiredAndChanges(c, current, desired, changes)
+
+	// In theory we should get back to the initial state but the reality is
+	// much more complicated. The change looks good on paper but the
+	// propagation that is not taken into account makes the actual mount
+	// namespace incorrect. The content connection is new and correct but the layout
+	// is still the same and was not propagated.
+	//
+	// zyga@wyzima:/run/snapd/ns$ sudo nsenter -mtest-snapd-content-layout.mnt
+	// root@wyzima:/# ls -l /usr/share/secureboot/potato
+	// total 1
+	// -rw-rw-r-- 1 root root 22 Aug 30 09:36 canary.txt
+	// drwxrwxr-x 2 root root 32 Aug 30 09:36 meta
+	// root@wyzima:/# ls -l /snap/test-snapd-content-layout/x2/attached-content/
+	// total 1
+	// -rw-rw-r-- 1 root root 22 Aug 30 09:36 canary.txt
+	// drwxrwxr-x 2 root root 32 Aug 30 09:36 meta
+	//
+	// Yes, but:
+	//
+	// root@wyzima:/# cat /proc/self/mountinfo  | grep attached
+	// 212 945 7:12 / /snap/test-snapd-content-layout/x2/attached-content ro,relatime master:34 - squashfs /dev/loop12 ro,errors=continue,threads=single
+	//
+	// root@wyzima:/# cat /proc/self/mountinfo  | grep potato
+	// 572 598 7:12 / /usr/share/secureboot/potato ro,relatime master:34 - squashfs /dev/loop12 ro,errors=continue,threads=single
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "keep", Entry: current.Entries[2]},
+		{Action: "keep", Entry: current.Entries[1]},
+		{Action: "keep", Entry: current.Entries[0]},
+		{Action: "mount", Entry: desired.Entries[1]},
+	})
+
+	// The actual entry for clarity.
+	c.Assert(changes[4].Entry, DeepEquals, osutil.MountEntry{
+		Name:    "/snap/test-snapd-content/x1",
+		Dir:     "/snap/test-snapd-content-layout/x2/attached-content",
+		Type:    "none",
+		Options: []string{"bind", "ro"},
+	})
+}
+
+func (s *changeSuite) TestContentLayout4InitiallyDisconnectedThenConnected(c *C) {
+	current, err := osutil.LoadMountProfile("testdata/content-layout-4-initially-disconnected-then-connected.before.current.fstab")
+	c.Assert(err, IsNil)
+	desired, err := osutil.LoadMountProfile("testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab")
+	c.Assert(err, IsNil)
+	changes := update.NeededChanges(current, desired)
+	showCurrentDesiredAndChanges(c, current, desired, changes)
+
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "keep", Entry: current.Entries[2]},
+		{Action: "keep", Entry: current.Entries[1]},
+		{Action: "keep", Entry: current.Entries[0]},
+		{Action: "mount", Entry: desired.Entries[1]},
+	})
+
+	// The actual entry for clarity.
+	c.Assert(changes[4].Entry, DeepEquals, osutil.MountEntry{
+		Name:    "/snap/test-snapd-content/x1",
+		Dir:     "/snap/test-snapd-content-layout/x2/attached-content",
+		Type:    "none",
+		Options: []string{"bind", "ro"},
+	})
+}
+
+func (s *changeSuite) TestContentLayout5InitiallyConnectedThenContentRefreshed(c *C) {
+	current, err := osutil.LoadMountProfile("testdata/content-layout-5-initially-connected-then-content-refreshed.before.current.fstab")
+	c.Assert(err, IsNil)
+	desired, err := osutil.LoadMountProfile("testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab")
+	c.Assert(err, IsNil)
+	changes := update.NeededChanges(current, desired)
+	showCurrentDesiredAndChanges(c, current, desired, changes)
+
+	// This test shows similar behavior to -2- test - the layout stays propagated.
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: "keep", Entry: current.Entries[4]},
+		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "keep", Entry: current.Entries[2]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[0]},
+		{Action: "mount", Entry: desired.Entries[1]},
+	})
+}
+
+func (s *changeSuite) TestContentLayout6InitiallyConnectedThenAppRefreshed(c *C) {
+	current, err := osutil.LoadMountProfile("testdata/content-layout-6-initially-connected-then-app-refreshed.before.current.fstab")
+	c.Assert(err, IsNil)
+	desired, err := osutil.LoadMountProfile("testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab")
+	c.Assert(err, IsNil)
+	changes := update.NeededChanges(current, desired)
+	showCurrentDesiredAndChanges(c, current, desired, changes)
+
+	// In this case, because the attached content is mounted to $SNAP (and not $SNAP_COMMON), the path changes
+	// and both the layout and content are re-made.
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: "unmount", Entry: withDetachOption(current.Entries[4])},
+		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "keep", Entry: current.Entries[2]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[0]},
+		// It is interesting to note that we first mount the content to $SNAP/attached-content
+		// and only then construct the layout from $SNAP/attached-content to /usr/share/secureboot/potato.
+		// This is correct but the ordering is fraigle.
+		{Action: "mount", Entry: desired.Entries[1]},
+		{Action: "mount", Entry: desired.Entries[0]},
+	})
+}
+
+// withDetachOption returns a copy of the given mount entry with the x-snapd.detach option.
+func withDetachOption(e osutil.MountEntry) osutil.MountEntry {
+	e.Options = append([]string{}, e.Options...)
+	e.Options = append(e.Options, "x-snapd.detach")
+	return e
+}
+
+func showCurrentDesiredAndChanges(c *C, current, desired *osutil.MountProfile, changes []*update.Change) {
+	c.Logf("Number of current entires: %d", len(current.Entries))
+	for _, entry := range current.Entries {
+		c.Logf("- current : %v", entry)
+	}
+	c.Logf("Number of desired entires: %d", len(desired.Entries))
+	for _, entry := range desired.Entries {
+		c.Logf("- desired: %v", entry)
+	}
+	c.Logf("Number of changes: %d", len(changes))
+	for _, change := range changes {
+		c.Logf("- change: %v", change)
+	}
+}

--- a/cmd/snap-update-ns/testdata/Makefile
+++ b/cmd/snap-update-ns/testdata/Makefile
@@ -1,0 +1,127 @@
+# This makefiles uses grouped-target feature and relies on it for correctness.
+ifeq (,$(findstring grouped-target,$(.FEATURES)))
+$(error You need make with the grouped-taget feature to build this dataset)
+endif
+
+fstab_files = content-layout-1-initially-connected.current.fstab \
+			  content-layout-1-initially-connected.desired.fstab \
+			  content-layout-2-after-disconnect.desired.fstab \
+			  content-layout-2-after-disconnect.current.fstab \
+			  content-layout-3-after-reconnect.desired.fstab \
+			  content-layout-3-after-reconnect.current.fstab \
+			  content-layout-4-initially-disconnected-then-connected.before.current.fstab \
+			  content-layout-4-initially-disconnected-then-connected.desired.fstab \
+			  content-layout-4-initially-disconnected-then-connected.current.fstab \
+			  content-layout-5-initially-connected-then-content-refreshed.before.current.fstab \
+			  content-layout-5-initially-connected-then-content-refreshed.desired.fstab \
+			  content-layout-5-initially-connected-then-content-refreshed.current.fstab \
+			  content-layout-6-initially-connected-then-app-refreshed.before.current.fstab \
+			  content-layout-6-initially-connected-then-app-refreshed.desired.fstab \
+			  content-layout-6-initially-connected-then-app-refreshed.current.fstab
+
+# None of the fstab files can be built in parallel as the depend on global system state.
+.NOTPARALLEL: $(fstab_files)
+.PHONY: all
+all: $(fstab_files)
+
+content-layout-1-initially-connected.desired.fstab content-layout-1-initially-connected.current.fstab &: test-snapd-content-layout_a_all.snap test-snapd-content_a_all.snap
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	sudo snap install --dangerous $(word 1,$^)
+	sudo snap install --dangerous $(word 1,$^) # Reinstall to get another revision for better clarity of the data.
+	sudo snap install --dangerous $(word 2,$^)
+	sudo snap connect test-snapd-content-layout:just-content test-snapd-content:just-content
+	snap run test-snapd-content-layout.sh -c true
+	cp /var/lib/snapd/mount/snap.test-snapd-content-layout.fstab content-layout-1-initially-connected.desired.fstab
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-1-initially-connected.current.fstab
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	patch <annotations-1.patch
+
+content-layout-2-after-disconnect.desired.fstab content-layout-2-after-disconnect.current.fstab &: test-snapd-content-layout_a_all.snap test-snapd-content_a_all.snap
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	sudo snap install --dangerous $(word 1,$^)
+	sudo snap install --dangerous $(word 1,$^) # Reinstall to get another revision for better clarity of the data.
+	sudo snap install --dangerous $(word 2,$^)
+	sudo snap connect test-snapd-content-layout:just-content test-snapd-content:just-content
+	snap run test-snapd-content-layout.sh -c true
+	sudo snap disconnect test-snapd-content-layout:just-content test-snapd-content:just-content
+	cp /var/lib/snapd/mount/snap.test-snapd-content-layout.fstab content-layout-2-after-disconnect.desired.fstab
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-2-after-disconnect.current.fstab
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	patch <annotations-2.patch
+
+content-layout-3-after-reconnect.desired.fstab content-layout-3-after-reconnect.current.fstab &: test-snapd-content-layout_a_all.snap test-snapd-content_a_all.snap
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	sudo snap install --dangerous $(word 1,$^)
+	sudo snap install --dangerous $(word 1,$^) # Reinstall to get another revision for better clarity of the data.
+	sudo snap install --dangerous $(word 2,$^)
+	sudo snap connect test-snapd-content-layout:just-content test-snapd-content:just-content
+	snap run test-snapd-content-layout.sh -c true
+	sudo snap disconnect test-snapd-content-layout:just-content test-snapd-content:just-content
+	sudo snap connect test-snapd-content-layout:just-content test-snapd-content:just-content
+	cp /var/lib/snapd/mount/snap.test-snapd-content-layout.fstab content-layout-3-after-reconnect.desired.fstab
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-3-after-reconnect.current.fstab
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	patch <annotations-3.patch
+
+content-layout-4-initially-disconnected-then-connected.before.current.fstab content-layout-4-initially-disconnected-then-connected.desired.fstab content-layout-4-initially-disconnected-then-connected.current.fstab &: test-snapd-content-layout_a_all.snap test-snapd-content_a_all.snap
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	sudo snap install --dangerous $(word 1,$^)
+	sudo snap install --dangerous $(word 1,$^) # Reinstall to get another revision for better clarity of the data.
+	sudo snap install --dangerous $(word 2,$^)
+	snap connections test-snapd-content-layout | grep -xF 'content    test-snapd-content-layout:just-content  -     -'
+	snap run test-snapd-content-layout.sh -c true
+	# This file is used by unit tests model the changes needed after the refresh below.
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-4-initially-disconnected-then-connected.before.current.fstab
+	sudo snap connect test-snapd-content-layout:just-content test-snapd-content:just-content
+	cp /var/lib/snapd/mount/snap.test-snapd-content-layout.fstab content-layout-4-initially-disconnected-then-connected.desired.fstab
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-4-initially-disconnected-then-connected.current.fstab
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	patch <annotations-4.patch
+
+content-layout-5-initially-connected-then-content-refreshed.before.current.fstab content-layout-5-initially-connected-then-content-refreshed.desired.fstab content-layout-5-initially-connected-then-content-refreshed.current.fstab &: test-snapd-content-layout_a_all.snap test-snapd-content_a_all.snap
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	sudo snap install --dangerous $(word 1,$^)
+	sudo snap install --dangerous $(word 1,$^) # Reinstall to get another revision for better clarity of the data.
+	sudo snap install --dangerous $(word 2,$^)
+	sudo snap connect test-snapd-content-layout:just-content test-snapd-content:just-content
+	snap run test-snapd-content-layout.sh -c true
+	# This file is used by unit tests model the changes needed after the refresh below.
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-5-initially-connected-then-content-refreshed.before.current.fstab
+	sudo snap install --dangerous $(word 2,$^) # Refresh the content.
+	cp /var/lib/snapd/mount/snap.test-snapd-content-layout.fstab content-layout-5-initially-connected-then-content-refreshed.desired.fstab
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-5-initially-connected-then-content-refreshed.current.fstab
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	patch <annotations-5.patch
+
+content-layout-6-initially-connected-then-app-refreshed.before.current.fstab content-layout-6-initially-connected-then-app-refreshed.desired.fstab content-layout-6-initially-connected-then-app-refreshed.current.fstab &: test-snapd-content-layout_a_all.snap test-snapd-content_a_all.snap
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	sudo snap install --dangerous $(word 1,$^)
+	sudo snap install --dangerous $(word 1,$^) # Reinstall to get another revision for better clarity of the data.
+	sudo snap install --dangerous $(word 2,$^)
+	sudo snap connect test-snapd-content-layout:just-content test-snapd-content:just-content
+	snap run test-snapd-content-layout.sh -c true
+	# This file is used by unit tests model the changes needed after the refresh below.
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-6-initially-connected-then-app-refreshed.before.current.fstab
+	sudo snap install --dangerous $(word 1,$^) # Refresh the app.
+	cp /var/lib/snapd/mount/snap.test-snapd-content-layout.fstab content-layout-6-initially-connected-then-app-refreshed.desired.fstab
+	cp /run/snapd/ns/snap.test-snapd-content-layout.fstab content-layout-6-initially-connected-then-app-refreshed.current.fstab
+	sudo snap remove --purge test-snapd-content-layout
+	sudo snap remove --purge test-snapd-content
+	patch <annotations-6.patch
+
+test-snapd-content-layout_a_all.snap: test-snapd-content-layout
+	snap pack $<
+
+test-snapd-content_a_all.snap: test-snapd-content
+	snap pack $<

--- a/cmd/snap-update-ns/testdata/annotations-1.patch
+++ b/cmd/snap-update-ns/testdata/annotations-1.patch
@@ -1,0 +1,42 @@
+diff --git b/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.current.fstab a/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.current.fstab
+index 54fbe65b9b..412f98e827 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.current.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.current.fstab
+@@ -1,5 +1,27 @@
++# This entry is injected by snap-confine. It represents the tmpfs
++# created at / during construction of the mount namespace, before
++# snap-update-ns is even invoked.
+ tmpfs / tmpfs x-snapd.origin=rootfs 0 0
++# This is the result of a content interface connection, all of
++# test-snapd-content at revision x1 is shared to test-snapd-content-layout at
++# revision x2, to directory $SNAP/attached-content.
+ /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0
++# This is a writable mimic created on /usr/share/secureboot, so that the
++# subdirectory "potato" can be created inside. There's nothing special about
++# the path. It was used as there are relatvely few elements that need to be
++# re-created inside, making the behavior of the algorithm easier to follow.
+ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
++# This is the only existing sub-directory of /usr/share/secureboot being
++# re-created by the writable mimic. Note that the name and directory are a lie
++# (or simplification) as this entry exists so that we know it needs to be
++# unmounted. The real source is somewhat more complicated and cannot be
++# expressed with the limited syntax of fstab mount entries.
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
++# This is the layout entry replicating the attached content. This is the root
++# of all evil, as the very popular behavior used by nearly all the snaps relies
++# on an implementation detail that was never envisioned to work this way.
++#
++# Notice that it uses the attached-content directory as source, it has no idea
++# or relation to the connected content and is happy to replicate an empty
++# unconnected directory.
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+diff --git b/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.desired.fstab
+index 7e92c4709a..6ffd2382a4 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.desired.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.desired.fstab
+@@ -1,2 +1,5 @@
++# This is the layout entry. Snapd orders layouts before any content entries.
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
++# This is the content entry. Notice that it is after the layout but the user
++# expectation is that the content shows up through the layout entry.
+ /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/annotations-2.patch
+++ b/cmd/snap-update-ns/testdata/annotations-2.patch
@@ -1,0 +1,18 @@
+diff --git b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
+index 701cbd04a3..55a955302a 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
+@@ -1,3 +1,5 @@
++# Note that the order of mount entries is entirely broken! They are now back to front.
++# This is tracked as https://warthogs.atlassian.net/browse/SNAPDENG-31644
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+diff --git b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab
+index 7df3de1c3b..0b004668dc 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab
+@@ -1 +1,3 @@
++# This is the layout entry. Snapd orders layouts before any content entries.
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
++# The content entry is now gone.

--- a/cmd/snap-update-ns/testdata/annotations-3.patch
+++ b/cmd/snap-update-ns/testdata/annotations-3.patch
@@ -1,0 +1,24 @@
+diff --git b/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.current.fstab a/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.current.fstab
+index 619722d4a8..4e37544570 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.current.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.current.fstab
+@@ -1,5 +1,11 @@
++# Note that the order is back to being correct because bug 
++# https://warthogs.atlassian.net/browse/SNAPDENG-31644 keeps flipping it back and forth!
+ tmpfs / tmpfs x-snapd.origin=rootfs 0 0
++# Unlike in the "initially connected" case. The mimic is ordered
++# differently from the content. Here we reuse the mimic so the content
++# is the last entry in the file.
+ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
++# The content is now here. The bind mount may or may not propagate though.
+ /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0
+diff --git b/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.desired.fstab
+index 7e92c4709a..5fea10444b 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.desired.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.desired.fstab
+@@ -1,2 +1,3 @@
++# This is exactly the same as content-layout-initially-connected.desired.fstab.
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+ /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/annotations-4.patch
+++ b/cmd/snap-update-ns/testdata/annotations-4.patch
@@ -1,0 +1,19 @@
+diff --git b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
+index f005f3ee63..e1c8e1bc91 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
+@@ -1,3 +1,6 @@
++# This file ought to be exactly the same as content-layout-1-initially-connected.current.fstab but is,
++# in fact, entirely different and wrong due to the ordering bug
++# https://warthogs.atlassian.net/browse/SNAPDENG-31644
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+diff --git b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
+index 7e92c4709a..9ea4953ad5 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
+@@ -1,2 +1,3 @@
++# This file is identical to content-layout-1-initially-connected.desired.fstab.
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+ /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/annotations-5.patch
+++ b/cmd/snap-update-ns/testdata/annotations-5.patch
@@ -1,0 +1,27 @@
+diff --git b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
+index fc78cff9ce..463b2181a9 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
+@@ -1,5 +1,10 @@
++# This file ought to be almost the same as
++# content-layout-1-initially-connected.current.fstab, but due to the ordering
++# bug it is more similar to the -3- file with the ordering being messed up,
++# again, as it flips back and forth.
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
++# This ought to be the initial entry.
+ tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+ /snap/test-snapd-content/x2 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0
+diff --git b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab
+index 98d9c0ef53..2de313d056 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab
+@@ -1,2 +1,7 @@
++# This file is almost the same as content-layout-1-initially-connected.desired.fstab, which is good.
++# The only difference, and one that we expect, is the revision of the attached content snap.
++# The revision changes from x1 to x2 as the content is refreshed.
+ /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
++# This is the content entry. Notice that it is after the layout but the user
++# expectation is that the content shows up through the layout entry.
+ /snap/test-snapd-content/x2 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/annotations-6.patch
+++ b/cmd/snap-update-ns/testdata/annotations-6.patch
@@ -1,0 +1,23 @@
+diff --git b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
+index 01a129094b..a9ae9cb91c 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
+@@ -1,5 +1,10 @@
++# This file ought to be almost the same as
++# content-layout-1-initially-connected.current.fstab, but due to the ordering
++# bug it is more similar to the -3- file with the ordering being messed up,
++# again, as it flips back and forth.
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
++# This ought to be the initial entry.
+ tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+ /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x3/attached-content none bind,ro 0 0
+ /snap/test-snapd-content-layout/x3/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+diff --git b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab
+index b49b4096d7..f4d4734242 100644
+--- b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab
++++ a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab
+@@ -1,2 +1,3 @@
++# The desired file is the same as -1-, apart from revision numbers, and correct.
+ /snap/test-snapd-content-layout/x3/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+ /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x3/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.current.fstab
@@ -1,0 +1,27 @@
+# This entry is injected by snap-confine. It represents the tmpfs
+# created at / during construction of the mount namespace, before
+# snap-update-ns is even invoked.
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+# This is the result of a content interface connection, all of
+# test-snapd-content at revision x1 is shared to test-snapd-content-layout at
+# revision x2, to directory $SNAP/attached-content.
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0
+# This is a writable mimic created on /usr/share/secureboot, so that the
+# subdirectory "potato" can be created inside. There's nothing special about
+# the path. It was used as there are relatvely few elements that need to be
+# re-created inside, making the behavior of the algorithm easier to follow.
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+# This is the only existing sub-directory of /usr/share/secureboot being
+# re-created by the writable mimic. Note that the name and directory are a lie
+# (or simplification) as this entry exists so that we know it needs to be
+# unmounted. The real source is somewhat more complicated and cannot be
+# expressed with the limited syntax of fstab mount entries.
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+# This is the layout entry replicating the attached content. This is the root
+# of all evil, as the very popular behavior used by nearly all the snaps relies
+# on an implementation detail that was never envisioned to work this way.
+#
+# Notice that it uses the attached-content directory as source, it has no idea
+# or relation to the connected content and is happy to replicate an empty
+# unconnected directory.
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.desired.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-1-initially-connected.desired.fstab
@@ -1,0 +1,5 @@
+# This is the layout entry. Snapd orders layouts before any content entries.
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+# This is the content entry. Notice that it is after the layout but the user
+# expectation is that the content shows up through the layout entry.
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
@@ -1,0 +1,6 @@
+# Note that the order of mount entries is entirely broken! They are now back to front.
+# This is tracked as https://warthogs.atlassian.net/browse/SNAPDENG-31644
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab
@@ -1,0 +1,3 @@
+# This is the layout entry. Snapd orders layouts before any content entries.
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+# The content entry is now gone.

--- a/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.current.fstab
@@ -1,0 +1,11 @@
+# Note that the order is back to being correct because bug 
+# https://warthogs.atlassian.net/browse/SNAPDENG-31644 keeps flipping it back and forth!
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+# Unlike in the "initially connected" case. The mimic is ordered
+# differently from the content. Here we reuse the mimic so the content
+# is the last entry in the file.
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+# The content is now here. The bind mount may or may not propagate though.
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.desired.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-3-after-reconnect.desired.fstab
@@ -1,0 +1,3 @@
+# This is exactly the same as content-layout-initially-connected.desired.fstab.
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.before.current.fstab
@@ -1,0 +1,4 @@
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
@@ -1,0 +1,8 @@
+# This file ought to be exactly the same as content-layout-1-initially-connected.current.fstab but is,
+# in fact, entirely different and wrong due to the ordering bug
+# https://warthogs.atlassian.net/browse/SNAPDENG-31644
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
@@ -1,0 +1,3 @@
+# This file is identical to content-layout-1-initially-connected.desired.fstab.
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.before.current.fstab
@@ -1,0 +1,5 @@
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
@@ -1,0 +1,10 @@
+# This file ought to be almost the same as
+# content-layout-1-initially-connected.current.fstab, but due to the ordering
+# bug it is more similar to the -3- file with the ordering being messed up,
+# again, as it flips back and forth.
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+# This ought to be the initial entry.
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x2 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab
@@ -1,0 +1,7 @@
+# This file is almost the same as content-layout-1-initially-connected.desired.fstab, which is good.
+# The only difference, and one that we expect, is the revision of the attached content snap.
+# The revision changes from x1 to x2 as the content is refreshed.
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+# This is the content entry. Notice that it is after the layout but the user
+# expectation is that the content shows up through the layout entry.
+/snap/test-snapd-content/x2 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.before.current.fstab
@@ -1,0 +1,5 @@
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
@@ -1,0 +1,10 @@
+# This file ought to be almost the same as
+# content-layout-1-initially-connected.current.fstab, but due to the ordering
+# bug it is more similar to the -3- file with the ordering being messed up,
+# again, as it flips back and forth.
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+# This ought to be the initial entry.
+tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x3/attached-content none bind,ro 0 0
+/snap/test-snapd-content-layout/x3/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab
@@ -1,0 +1,3 @@
+# The desired file is the same as -1-, apart from revision numbers, and correct.
+/snap/test-snapd-content-layout/x3/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x3/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/test-snapd-content-layout/attached-content/hidden
+++ b/cmd/snap-update-ns/testdata/test-snapd-content-layout/attached-content/hidden
@@ -1,0 +1,1 @@
+This file is hidden when content is connected

--- a/cmd/snap-update-ns/testdata/test-snapd-content-layout/bin/bash
+++ b/cmd/snap-update-ns/testdata/test-snapd-content-layout/bin/bash
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/bash "$@"

--- a/cmd/snap-update-ns/testdata/test-snapd-content-layout/bin/sh
+++ b/cmd/snap-update-ns/testdata/test-snapd-content-layout/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/cmd/snap-update-ns/testdata/test-snapd-content-layout/meta/snap.yaml
+++ b/cmd/snap-update-ns/testdata/test-snapd-content-layout/meta/snap.yaml
@@ -1,0 +1,22 @@
+name: test-snapd-content-layout
+version: a
+
+confinement: strict
+base: core24
+architecture: all
+
+apps:
+  sh:
+    command: bin/sh
+  bash:
+    command: bin/bash
+
+plugs:
+  just-content:
+    content: just-content
+    interface: content
+    target: $SNAP/attached-content
+
+layout:
+  /usr/share/secureboot/potato:
+    bind: $SNAP/attached-content

--- a/cmd/snap-update-ns/testdata/test-snapd-content/canary.txt
+++ b/cmd/snap-update-ns/testdata/test-snapd-content/canary.txt
@@ -1,0 +1,1 @@
+This is a canary file

--- a/cmd/snap-update-ns/testdata/test-snapd-content/meta/snap.yaml
+++ b/cmd/snap-update-ns/testdata/test-snapd-content/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: test-snapd-content
+version: a
+
+confinement: strict
+base: core24
+architecture: all
+
+slots:
+  just-content:
+    interface: content
+    read:
+    - /

--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -40,9 +40,9 @@ import (
 //	    int   mnt_passno;   /* pass number on parallel fsck */
 //	};
 type MountEntry struct {
-	Name    string
-	Dir     string
-	Type    string
+	Name    string // Device name, bind source, pseudo name
+	Dir     string // Directory name, bind target (including file)
+	Type    string // File system type
 	Options []string
 
 	DumpFrequency   int


### PR DESCRIPTION
Snapd is affected by several bugs related to content-layout interaction.
There's a very popular scheme where a snap has two interacting elements
that only work in one special edge case and break regularly:

- A content plug is used to receive content of another snap, typically
  under $SNAP/foo somewhere. Where foo exists and is not created with a
  mimic.
- A layout entry is used to "distribute" $SNAP/foo to /usr/share/foo or
  other locations.

This particular arrangement is used to share essential libraries from a
common "runtime" snap which is not a dedicated base. Several basic tests
explore the actual behavior in the following situations.

- The content is initially connected and a mount namespace is
  constructed. This is the only correct behavior show in this group of
  tests. This is known as test case 1.
- The content is initially connected and a mount namespace is
  constructed. The content is then disconnected. This shows several
  anomalies that are referenced in the code (ordering bug, propagation
  bug). This is known as test case 2.
- The content is initially connected and a mount namespace is
  constructed. The content is then disconnected and re-connected.
  This is known as test case 3.
- The content is initially disconnected and a mount namespace is
  constructed. The content is then connected.
  This is known as test case 4.
- The content interface is initially connected and a mount namespace is
  constructed. The content snap is then refreshed.
  This is known as test case 5.
- The content interface is initially connected and a mount namespace is
  constructed. The application snap is then refreshed.
  This is known as test case 6.

This is related to issues:
- https://warthogs.atlassian.net/browse/SNAPDENG-31644 (flip flop)
- https://warthogs.atlassian.net/browse/SNAPDENG-31645 (propagation)

A support makefile and a set of data files is provided to re-generate
the test data once snapd is improved.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
