### PR TITLE
release: 2.65.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# New in snapd 2.65.3:
+* Fix missing aux info from store on snap setup
+
 # New in snapd 2.65.2:
 * Bump squashfuse from version 0.5.0 to 0.5.2 (used in snapd deb only)
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -382,6 +382,19 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				},
 			},
 		}
+	case "channel-for-media":
+		info.Media = snap.MediaInfos{
+			snap.MediaInfo{
+				Type:   "icon",
+				URL:    "http://example.com/icon.png",
+				Width:  100,
+				Height: 100,
+			},
+			snap.MediaInfo{
+				Type: "website",
+				URL:  "http://example.com",
+			},
+		}
 	}
 
 	if spec.Name == "provenance-snap" {

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -155,6 +155,11 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		InstanceKey:        t.info.InstanceKey,
 		ExpectedProvenance: t.info.SnapProvenance,
 		Registries:         registries,
+		auxStoreInfo: auxStoreInfo{
+			Media: t.info.Media,
+			// XXX we store this for the benefit of old snapd
+			Website: t.info.Website(),
+		},
 	}, compsups, nil
 }
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.65.2
+pkgver=2.65.3
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,10 @@
+snapd (2.65.3-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Fix missing aux info from store on snap setup
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Thu, 12 Sep 2024 09:40:17 +0200
+
 snapd (2.65.2-1) unstable; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.65.2
+Version:        2.65.3
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -1003,6 +1003,10 @@ fi
 
 
 %changelog
+* Thu Sep 12 2024 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.65.3
+ - Fix missing aux info from store on snap setup
+
 * Fri Sep 06 2024 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.65.2
  - Bump squashfuse from version 0.5.0 to 0.5.2 (used in snapd deb

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Sep 12 07:40:17 UTC 2024 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.65.3
+
+-------------------------------------------------------------------
 Fri Sep 06 15:08:45 UTC 2024 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.65.2

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.65.2
+Version:        2.65.3
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.65.3~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Fix missing aux info from store on snap setup
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Thu, 12 Sep 2024 09:40:17 +0200
+
 snapd (2.65.2~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.65.3) xenial; urgency=medium
+
+  * New upstream release, LP: #2077473
+    - Fix missing aux info from store on snap setup
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Thu, 12 Sep 2024 09:40:17 +0200
+
 snapd (2.65.2) xenial; urgency=medium
 
   * New upstream release, LP: #2077473

--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -1,0 +1,26 @@
+summary: Test that snap aux info is correctly stored and returned by the snapd API
+
+details: |
+  When installing a snap, we should store some auxiliary information about that
+  snap in /var/cache/snapd/aux. This test verifies that this is properly done,
+  and then verifies that the information is returned by the snapd API.
+
+systems: [ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
+
+prepare: |
+  snap install snap-store
+  snap install jq
+  snap install --devmode --edge test-snapd-curl
+
+execute: |
+  snap_id=$(snap info snap-store | grep snap-id | awk '{ print $2 }')
+  jq --sort-keys .media < "/var/cache/snapd/aux/${snap_id}.json" > media.json
+
+  # don't depend on the exact number of media files, but there should be
+  # something here
+  media_length=$(jq '. | length' < media.json)
+  test "${media_length}" -gt 0
+
+  test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/snaps/snap-store' | jq --sort-keys .result.media > snapd-media.json
+
+  diff media.json snapd-media.json


### PR DESCRIPTION
Generated changelogs with:
DEBEMAIL="Ernest Lotter [ernest.lotter@canonical.com](mailto:ernest.lotter@canonical.com)" release-tools/changelog.py 2.65.3 2077473 NEWS.md

Cherry picked: https://github.com/canonical/snapd/pull/14482 (regression bug fix)

This change affects snapd debs and snap

**Requires rebase merge**


