### PR TITLE
tests: fixed coverage upload

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -375,6 +375,7 @@ jobs:
       if: ${{ matrix.gochannel != 'latest/stable' }}
       uses: actions/upload-artifact@v3
       with:
+        include-hidden-files: true
         name: coverage-files
         path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
 
@@ -502,6 +503,7 @@ jobs:
       if: ${{ matrix.gochannel != 'latest/stable' }}
       uses: actions/upload-artifact@v3
       with:
+        include-hidden-files: true
         name: coverage-files
         path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
 


### PR DESCRIPTION
I missed some other hidden folders. The coverage files are also in hidden folders, so I added the github directive to include those as well.