### PR TITLE
cmd/snap-update-ns: keep order of existing mount entries

### DIFF
--- a/cmd/snap-update-ns/testdata/annotations-2.patch
+++ b/cmd/snap-update-ns/testdata/annotations-2.patch
@@ -1,13 +1,12 @@
 diff --git b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
-index 701cbd04a3..55a955302a 100644
+index e6a6f386ab..161f422d67 100644
 --- b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
 +++ a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
-@@ -1,3 +1,5 @@
-+# Note that the order of mount entries is entirely broken! They are now back to front.
-+# This is tracked as https://warthogs.atlassian.net/browse/SNAPDENG-31644
- /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
- /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+@@ -1,3 +1,4 @@
++# The order is no longer broken.
+ tmpfs / tmpfs x-snapd.origin=rootfs 0 0
  tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
 diff --git b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab
 index 7df3de1c3b..0b004668dc 100644
 --- b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.desired.fstab

--- a/cmd/snap-update-ns/testdata/annotations-4.patch
+++ b/cmd/snap-update-ns/testdata/annotations-4.patch
@@ -1,19 +1,17 @@
 diff --git b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
-index f005f3ee63..e1c8e1bc91 100644
+index 619722d4a8..526d104f84 100644
 --- b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
 +++ a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
-@@ -1,3 +1,6 @@
-+# This file ought to be exactly the same as content-layout-1-initially-connected.current.fstab but is,
-+# in fact, entirely different and wrong due to the ordering bug
-+# https://warthogs.atlassian.net/browse/SNAPDENG-31644
- /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
- /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+@@ -1,3 +1,4 @@
++# This file is now similar to -1- except that re-made content/layout entries are last.
+ tmpfs / tmpfs x-snapd.origin=rootfs 0 0
  tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
 diff --git b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
-index 7e92c4709a..9ea4953ad5 100644
+index 7e92c4709a..4d0f5b97bd 100644
 --- b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
 +++ a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
 @@ -1,2 +1,3 @@
-+# This file is identical to content-layout-1-initially-connected.desired.fstab.
++# This file is identical to content-layout-1-initially-connected.desired.fstab, except for revision numbers.
  /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
  /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/annotations-5.patch
+++ b/cmd/snap-update-ns/testdata/annotations-5.patch
@@ -1,18 +1,12 @@
 diff --git b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
-index fc78cff9ce..463b2181a9 100644
+index aadd564c33..d55e3f9269 100644
 --- b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
 +++ a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
-@@ -1,5 +1,10 @@
-+# This file ought to be almost the same as
-+# content-layout-1-initially-connected.current.fstab, but due to the ordering
-+# bug it is more similar to the -3- file with the ordering being messed up,
-+# again, as it flips back and forth.
- /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
- /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
- tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
-+# This ought to be the initial entry.
+@@ -1,3 +1,4 @@
++# This file is similar to -1-, except that attached content has different revision.
  tmpfs / tmpfs x-snapd.origin=rootfs 0 0
- /snap/test-snapd-content/x2 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0
+ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+ /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
 diff --git b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab
 index 98d9c0ef53..2de313d056 100644
 --- b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.desired.fstab

--- a/cmd/snap-update-ns/testdata/annotations-6.patch
+++ b/cmd/snap-update-ns/testdata/annotations-6.patch
@@ -1,18 +1,3 @@
-diff --git b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
-index 01a129094b..a9ae9cb91c 100644
---- b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
-+++ a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
-@@ -1,5 +1,10 @@
-+# This file ought to be almost the same as
-+# content-layout-1-initially-connected.current.fstab, but due to the ordering
-+# bug it is more similar to the -3- file with the ordering being messed up,
-+# again, as it flips back and forth.
- /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
- tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
-+# This ought to be the initial entry.
- tmpfs / tmpfs x-snapd.origin=rootfs 0 0
- /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x3/attached-content none bind,ro 0 0
- /snap/test-snapd-content-layout/x3/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
 diff --git b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab
 index b49b4096d7..f4d4734242 100644
 --- b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.desired.fstab

--- a/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-2-after-disconnect.current.fstab
@@ -1,6 +1,5 @@
-# Note that the order of mount entries is entirely broken! They are now back to front.
-# This is tracked as https://warthogs.atlassian.net/browse/SNAPDENG-31644
-/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
-/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
-tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+# The order is no longer broken.
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.current.fstab
@@ -1,8 +1,6 @@
-# This file ought to be exactly the same as content-layout-1-initially-connected.current.fstab but is,
-# in fact, entirely different and wrong due to the ordering bug
-# https://warthogs.atlassian.net/browse/SNAPDENG-31644
-/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
-/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
-tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+# This file is now similar to -1- except that re-made content/layout entries are last.
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
 /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-4-initially-disconnected-then-connected.desired.fstab
@@ -1,3 +1,3 @@
-# This file is identical to content-layout-1-initially-connected.desired.fstab.
+# This file is identical to content-layout-1-initially-connected.desired.fstab, except for revision numbers.
 /snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
 /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-5-initially-connected-then-content-refreshed.current.fstab
@@ -1,10 +1,6 @@
-# This file ought to be almost the same as
-# content-layout-1-initially-connected.current.fstab, but due to the ordering
-# bug it is more similar to the -3- file with the ordering being messed up,
-# again, as it flips back and forth.
-/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
-/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
-tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
-# This ought to be the initial entry.
+# This file is similar to -1-, except that attached content has different revision.
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0
 /snap/test-snapd-content/x2 /snap/test-snapd-content-layout/x2/attached-content none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/content-layout-6-initially-connected-then-app-refreshed.current.fstab
@@ -1,10 +1,5 @@
-# This file ought to be almost the same as
-# content-layout-1-initially-connected.current.fstab, but due to the ordering
-# bug it is more similar to the -3- file with the ordering being messed up,
-# again, as it flips back and forth.
-/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
-tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
-# This ought to be the initial entry.
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
+/usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
 /snap/test-snapd-content/x1 /snap/test-snapd-content-layout/x3/attached-content none bind,ro 0 0
 /snap/test-snapd-content-layout/x3/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -93,8 +93,14 @@ func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
 	// Compute the new current profile so that it contains only changes that were made
 	// and save it back for next runs.
 	var currentAfter osutil.MountProfile
+	for i := len(changesMade) - 1; i >= 0; i-- {
+		change := changesMade[i]
+		if change.Action == Keep {
+			currentAfter.Entries = append(currentAfter.Entries, change.Entry)
+		}
+	}
 	for _, change := range changesMade {
-		if change.Action == Mount || change.Action == Keep {
+		if change.Action == Mount {
 			currentAfter.Entries = append(currentAfter.Entries, change.Entry)
 		}
 	}

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -363,14 +363,12 @@ func (s *updateSuite) TestKeepSyntheticMountsLP2043993(c *C) {
 
 	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Assert(saved.Entries, HasLen, 2)
-	// TODO: the change of order is a bit unexpected, but that is a larger issue
-	// synth mount kept because it is needed by a desired mount
-	c.Check(saved.Entries[1].Type, Equals, "tmpfs")
-	c.Check(saved.Entries[1].Name, Equals, "tmpfs")
-	c.Check(saved.Entries[1].Dir, Equals, filepath.Join(baseSourceDir, "rofs"))
-	c.Check(saved.Entries[1].XSnapdSynthetic(), Equals, true)
-	c.Check(saved.Entries[1].XSnapdNeededBy(), Equals, "test-id")
-	c.Check(saved.Entries[0], DeepEquals, desiredMountEntry)
+	c.Check(saved.Entries[0].Type, Equals, "tmpfs")
+	c.Check(saved.Entries[0].Name, Equals, "tmpfs")
+	c.Check(saved.Entries[0].Dir, Equals, filepath.Join(baseSourceDir, "rofs"))
+	c.Check(saved.Entries[0].XSnapdSynthetic(), Equals, true)
+	c.Check(saved.Entries[0].XSnapdNeededBy(), Equals, "test-id")
+	c.Check(saved.Entries[1], DeepEquals, desiredMountEntry)
 }
 
 // testProfileUpdateContext implements MountProfileUpdateContext and is suitable for testing.


### PR DESCRIPTION
This is stacked on top of https://github.com/canonical/snapd/pull/14491

We recently realized that the order of saved mount profile, after
performing mount namespace update, was subtly incorrect. The order was
seemingly swapped after each operation. In reality, the order reflected
the order of performed changes, including the special change type of
"keep", which means that an entry is kept intact.

Fix the problem by storing "kept" changes in the original order, which
is back-to-front compared to the order of changes computed by the
algorithm. At the same time, keep track of mount changes in the order of
their execution.

This probably fixes a hell lot of edge cases and weird behaviors that
went undiagnosed for many years. Interestingly a test case had a TODO
that hinted at the problem, but it was not clear what the problem was at
the time. The TODO is now gone and the test case is now up-to-date.

Test data for cmd/snap-update-ns/testdata was re-generated.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-31644

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
