### PR TITLE
snapcraft: support for FIPS build on LP

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -215,11 +215,18 @@ parts:
       craftctl default
       # set version, this needs dpkg-parsechangelog (from dpkg-dev) and git
       VERSION="$(./mkversion.sh --output-only)"
+
+      if [ -f fips-build ]; then
+          # CI can set a build stamp for enabling the FIPS build mode
+          echo "-- detected FIPS build from CI build stamp"
+          touch "${CRAFT_STAGE}"/fips-build
+      fi
+
       if [ "${VERSION/+fips/}" != "$VERSION" ] ; then
           # we have a '+fips' element in the version, which may be coming from
           # debian/changelog or git tag
           echo "-- detected FIPS build from version $VERSION"
-          touch "${CRAFT_PROJECT_DIR}/fips-build"
+          touch "${CRAFT_STAGE}/fips-build"
       fi
 
       # check for triggers that indicate a build on LP of the snapd-fips snap
@@ -227,11 +234,11 @@ parts:
       is_lp_fips_build="$(./release-tools/is-lp-fips-build.sh)"
       if [ "$is_lp_fips_build" = "true" ]; then
           echo "-- detected FIPS build from LP location"
-          touch "${CRAFT_PROJECT_DIR}/fips-build"
-          touch "${CRAFT_PROJECT_DIR}/fips-build-lp"
+          touch "${CRAFT_STAGE}/fips-build"
+          touch "${CRAFT_STAGE}/fips-build-lp"
       fi
 
-      if [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
+      if [ -f "${CRAFT_STAGE}/fips-build" ]; then
           if [ "${VERSION/+fips/}" = "$VERSION" ] ; then
               # we have a fips-build marker, but fips tag isn't yet part of the
               # snap version, let's add it
@@ -253,7 +260,7 @@ parts:
       GO_TOOLCHAIN_FIPS_CHANNEL="1.21-fips/stable"
 
       VERSION="$(craftctl get version)"
-      if [ -f "${CRAFT_PROJECT_DIR}/fips-build" ] ; then
+      if [ -f "${CRAFT_STAGE}/fips-build" ] ; then
           # use the fips channel of Go
           snap refresh --channel "$GO_TOOLCHAIN_FIPS_CHANNEL" go
           # make sure it is really the Go FIPS toolchain
@@ -364,7 +371,7 @@ parts:
         esac
 
         # FIPS specific build tags
-        if [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
+        if [ -f "${CRAFT_STAGE}/fips-build" ]; then
           case "${cmd}" in
             # per snapd FIPS spec, FIPS build tags are only relevant for snapd,
             # snap, snap-repair and snap-bootstrap, tags:
@@ -433,7 +440,7 @@ parts:
     override-pull: |
       craftctl default
       # FIPS stamp files were created in the 'snap' part build
-      if [ -f "${CRAFT_PROJECT_DIR}/fips-build-lp" ]; then
+      if [ -f "${CRAFT_STAGE}/fips-build-lp" ]; then
         mkdir -p etc/apt/preferences.d/
         # need to up the priority of the repository
         # TODO what if we need to choose between FIPS and FIPS preview?
@@ -449,7 +456,7 @@ parts:
           cd fips-debs
           apt download openssl libssl3 openssl-fips-module-3
         )
-      elif [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
+      elif [ -f "${CRAFT_STAGE}/fips-build" ]; then
         # grab the core22 from fips-updates channel
         snap download --channel fips-updates/stable --basename core22-fips core22
       fi
@@ -458,7 +465,7 @@ parts:
       # snap should include the information about a particular openssl version
       # which was included in the build but the core22 FIPS variant snap has
       # been stripped off of the manifest.
-      if [ -f "${CRAFT_PROJECT_DIR}/fips-build-lp" ]; then
+      if [ -f "${CRAFT_STAGE}/fips-build-lp" ]; then
         mkdir fips-libs-from-debs
         mkdir fips-libs-from-debs-stage
 
@@ -482,7 +489,7 @@ parts:
               xargs -0 -- cp -av --parents --target ../fips-libs-from-debs-stage/
         )
         cp -av fips-libs-from-debs-stage/* "${CRAFT_PART_INSTALL}"
-      elif [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
+      elif [ -f "${CRAFT_STAGE}/fips-build" ]; then
         unsquashfs -d core22-fips-squashfs-root core22-fips.snap \
           'usr/lib/*-linux-gnu*/engines-3' \
           'usr/lib/*-linux-gnu*/ossl-modules-3' \

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -436,8 +436,10 @@ parts:
     source: .
     after:
       - snapd
-    override-pull: |
-      craftctl default
+    override-build: |
+      # XXX this should be done in pull, but apparently ordering is not honored
+      # for 'pull' step of parts
+
       # FIPS stamp files were created in the 'snap' part build
       if [ -f "${CRAFT_STAGE}/fips-build-lp" ]; then
         mkdir -p etc/apt/preferences.d/
@@ -459,7 +461,7 @@ parts:
         # grab the core22 from fips-updates channel
         snap download --channel fips-updates/stable --basename core22-fips core22
       fi
-    override-build: |
+
       # TODO this is really a hack as we should likely be using on LP; The snapd
       # snap should include the information about a particular openssl version
       # which was included in the build but the core22 FIPS variant snap has

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -30,6 +30,18 @@ confinement: strict
 # See the comments from jdstrand in
 # https://forum.snapcraft.io/t/5547/10
 
+# There is no explicit mechanism for passing parameters/configuration through
+# snapcraft at snap build time, so instead the build process looks for (or
+# creates) the following stamp files, which influence the build process:
+#
+# - test-build - created by the CI (or the in-repo test build script), indicates
+#   a test build with version override to 1337.*
+# - fips-build - created by the CI or snapd part 'pull' stage to indicate a
+#   build with FIPS support
+# - fips-build-lp - only created by snapd part 'pull' stage, when the build
+#   environment has been identified to be LP within the FIPS-CC-STIG project,
+#   where the snapd snap recipe is named snapd-fips
+#
 parts:
   dynamic-linker:
     plugin: nil
@@ -206,12 +218,20 @@ parts:
       if [ "${VERSION/+fips/}" != "$VERSION" ] ; then
           # we have a '+fips' element in the version, which may be coming from
           # debian/changelog or git tag
-          echo "-- detected FIPS build"
-          touch fips-build
+          echo "-- detected FIPS build from version $VERSION"
+          touch "${CRAFT_PROJECT_DIR}/fips-build"
       fi
-      # TODO detect when doing a FIPS snap build on LP
 
-      if [ -f fips-build ]; then
+      # check for triggers that indicate a build on LP of the snapd-fips snap
+      # recipe https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips
+      is_lp_fips_build="$(./release-tools/is-lp-fips-build.sh)"
+      if [ "$is_lp_fips_build" = "true" ]; then
+          echo "-- detected FIPS build from LP location"
+          touch "${CRAFT_PROJECT_DIR}/fips-build"
+          touch "${CRAFT_PROJECT_DIR}/fips-build-lp"
+      fi
+
+      if [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
           if [ "${VERSION/+fips/}" = "$VERSION" ] ; then
               # we have a fips-build marker, but fips tag isn't yet part of the
               # snap version, let's add it
@@ -220,6 +240,7 @@ parts:
           fi
       fi
 
+      # TODO use $CRAFT_PROJECT_DIR
       if [ -f test-build ]; then
           VERSION="1337.${VERSION}"
       fi
@@ -232,7 +253,7 @@ parts:
       GO_TOOLCHAIN_FIPS_CHANNEL="1.21-fips/stable"
 
       VERSION="$(craftctl get version)"
-      if [ -f fips-build ] ; then
+      if [ -f "${CRAFT_PROJECT_DIR}/fips-build" ] ; then
           # use the fips channel of Go
           snap refresh --channel "$GO_TOOLCHAIN_FIPS_CHANNEL" go
           # make sure it is really the Go FIPS toolchain
@@ -343,7 +364,7 @@ parts:
         esac
 
         # FIPS specific build tags
-        if [ -f fips-build ]; then
+        if [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
           case "${cmd}" in
             # per snapd FIPS spec, FIPS build tags are only relevant for snapd,
             # snap, snap-repair and snap-bootstrap, tags:
@@ -411,7 +432,24 @@ parts:
       - snapd
     override-pull: |
       craftctl default
-      if [ -f fips-build ]; then
+      # FIPS stamp files were created in the 'snap' part build
+      if [ -f "${CRAFT_PROJECT_DIR}/fips-build-lp" ]; then
+        mkdir -p etc/apt/preferences.d/
+        # need to up the priority of the repository
+        # TODO what if we need to choose between FIPS and FIPS preview?
+        cat <<-'EOF' > /etc/apt/preferences.d/fips.pref
+      Package: *
+      Pin: release o=LP-PPA-fips-cc-stig-fips-under-certification
+      Pin-Priority: 1010
+      EOF
+        apt update
+        # FIPS libraries required by snapd
+        mkdir fips-debs
+        (
+          cd fips-debs
+          apt download openssl libssl3 openssl-fips-module-3
+        )
+      elif [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
         # grab the core22 from fips-updates channel
         snap download --channel fips-updates/stable --basename core22-fips core22
       fi
@@ -420,7 +458,31 @@ parts:
       # snap should include the information about a particular openssl version
       # which was included in the build but the core22 FIPS variant snap has
       # been stripped off of the manifest.
-      if [ -f fips-build ]; then
+      if [ -f "${CRAFT_PROJECT_DIR}/fips-build-lp" ]; then
+        mkdir fips-libs-from-debs
+        mkdir fips-libs-from-debs-stage
+
+        # extract
+        for f in fips-debs/*.deb; do
+          dpkg -x "$f" fips-libs-from-debs
+        done
+
+        # and cherry pick the files we want
+        (
+          cd fips-libs-from-debs
+
+          # XXX note with -print0 only the last match is printed
+          find . \
+            \( \
+              -wholename './usr/lib/*-linux-gnu*/engines-3' \
+              -o -wholename  './usr/lib/*-linux-gnu*/ossl-modules-3' \
+              -o -wholename './usr/lib/*-linux-gnu*/libssl.so.3' \
+              -o -wholename './usr/lib/*-linux-gnu*/libcrypto.so.3' \
+            \) -print0 | \
+              xargs -0 -- cp -av --parents --target ../fips-libs-from-debs-stage/
+        )
+        cp -av fips-libs-from-debs-stage/* "${CRAFT_PART_INSTALL}"
+      elif [ -f "${CRAFT_PROJECT_DIR}/fips-build" ]; then
         unsquashfs -d core22-fips-squashfs-root core22-fips.snap \
           'usr/lib/*-linux-gnu*/engines-3' \
           'usr/lib/*-linux-gnu*/ossl-modules-3' \
@@ -428,6 +490,7 @@ parts:
           'usr/lib/*-linux-gnu*/libcrypto.so.3'
         cp -av core22-fips-squashfs-root/* "${CRAFT_PART_INSTALL}"
       fi
+      find "${CRAFT_PART_INSTALL}/" -ls
 
   check-linker:
     plugin: nil

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -247,7 +247,6 @@ parts:
           fi
       fi
 
-      # TODO use $CRAFT_PROJECT_DIR
       if [ -f test-build ]; then
           VERSION="1337.${VERSION}"
       fi

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -444,7 +444,6 @@ parts:
 
   libcrypto-fips:
     plugin: nil
-    source: .
     after:
       - snapd
     override-build: |

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -219,14 +219,13 @@ parts:
       if [ -f fips-build ]; then
           # CI can set a build stamp for enabling the FIPS build mode
           echo "-- detected FIPS build from CI build stamp"
-          touch "${CRAFT_STAGE}"/fips-build
       fi
 
       if [ "${VERSION/+fips/}" != "$VERSION" ] ; then
           # we have a '+fips' element in the version, which may be coming from
           # debian/changelog or git tag
           echo "-- detected FIPS build from version $VERSION"
-          touch "${CRAFT_STAGE}/fips-build"
+          touch fips-build
       fi
 
       # check for triggers that indicate a build on LP of the snapd-fips snap
@@ -234,11 +233,11 @@ parts:
       is_lp_fips_build="$(./release-tools/is-lp-fips-build.sh)"
       if [ "$is_lp_fips_build" = "true" ]; then
           echo "-- detected FIPS build from LP location"
-          touch "${CRAFT_STAGE}/fips-build"
-          touch "${CRAFT_STAGE}/fips-build-lp"
+          touch fips-build
+          touch fips-build-lp
       fi
 
-      if [ -f "${CRAFT_STAGE}/fips-build" ]; then
+      if [ -f fips-build ]; then
           if [ "${VERSION/+fips/}" = "$VERSION" ] ; then
               # we have a fips-build marker, but fips tag isn't yet part of the
               # snap version, let's add it
@@ -259,7 +258,7 @@ parts:
       GO_TOOLCHAIN_FIPS_CHANNEL="1.21-fips/stable"
 
       VERSION="$(craftctl get version)"
-      if [ -f "${CRAFT_STAGE}/fips-build" ] ; then
+      if [ -f fips-build ] ; then
           # use the fips channel of Go
           snap refresh --channel "$GO_TOOLCHAIN_FIPS_CHANNEL" go
           # make sure it is really the Go FIPS toolchain
@@ -370,7 +369,7 @@ parts:
         esac
 
         # FIPS specific build tags
-        if [ -f "${CRAFT_STAGE}/fips-build" ]; then
+        if [ -f fips-build ]; then
           case "${cmd}" in
             # per snapd FIPS spec, FIPS build tags are only relevant for snapd,
             # snap, snap-repair and snap-bootstrap, tags:
@@ -425,8 +424,20 @@ parts:
       fi
 
       find "${CRAFT_PART_INSTALL}/usr/lib/snapd" "${CRAFT_PART_INSTALL}/usr/bin" -type f -exec strip {} ";"
+
+      if [ -f fips-build ]; then
+        touch "${CRAFT_PART_INSTALL}/fips-build"
+      fi
+      if [ -f fips-build-lp ]; then
+        touch "${CRAFT_PART_INSTALL}/fips-build-lp"
+      fi
+
     <<:
       - *dynamic-linker
+    prime:
+      # drop FIPS build stamps
+      - -fips-build
+      - -fips-build-lp
     override-prime: |
       craftctl default
       python3 "${CRAFT_PROJECT_DIR}/build-aux/snap/local/patch-dl.py" "/snap/snapd/current/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${DYNAMIC_LINKER}"

--- a/release-tools/is-lp-fips-build.sh
+++ b/release-tools/is-lp-fips-build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -x
+set -e
+
+# check for triggers that indicate a build on LP of the snapd-fips snap
+# recipe https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips
+#
+# - git origin https://git.launchpad.net/~snappy-dev/snapd/+git/snapd
+# - build path: /build/snapd-fips
+
+if ! git remote get-url origin | grep "git.launchpad.net" >&2 ; then
+    echo "false"
+    exit 0
+fi
+
+# when building from https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips
+# recipe, the code is cloned at /build/snapd-fips/
+if ! echo "$PWD" | grep '^/build/snapd-fips/' >&2 ; then
+    echo "false"
+    exit 0
+fi
+
+# TODO check if a FIPS PPA is enabled?
+
+echo "true"


### PR DESCRIPTION
Add support for building a FIPS variant of snapd snap in Launchpad using https://launchpad.net/~fips-cc-stig/fips-cc-stig/+snap/snapd-fips recipe.

Based on #14476 

Related: SNAPDENG-23124
