### PR TITLE
o/snapstate: properly handle components when refreshing to revision that has been on the system before

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -506,6 +506,8 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		base = "some-base"
 	case "provenance-snap-id":
 		name = "provenance-snap"
+	case "snap-with-components-id":
+		name = "snap-with-components"
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}
@@ -1117,6 +1119,17 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		info.SnapType = snap.TypeOS
 	case "snapd":
 		info.SnapType = snap.TypeSnapd
+	case "snap-with-components":
+		info.Components = map[string]*snap.Component{
+			"test-component": {
+				Type: snap.TestComponent,
+				Name: "test-component",
+			},
+			"kernel-modules-component": {
+				Type: snap.KernelModulesComponent,
+				Name: "kernel-modules-component",
+			},
+		}
 	case "services-snap":
 		var err error
 		// fix services after/before so that there is only one solution

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -535,6 +535,14 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 				Type: snap.KernelModulesComponent,
 				Name: "kernel-modules-component",
 			},
+			"test-component-extra": {
+				Type: snap.TestComponent,
+				Name: "test-component-extra",
+			},
+			"test-component-present-in-sequence": {
+				Type: snap.TestComponent,
+				Name: "test-component-present-in-sequence",
+			},
 		}
 	}
 	if name == "some-snap-now-classic" {

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -155,16 +155,11 @@ func componentSetupsForInstall(ctx context.Context, st *state.State, names []str
 }
 
 func installComponentAction(st *state.State, snapst SnapState, snapRev snap.Revision, channel string, opts Options) (*store.SnapAction, error) {
-	var si *snap.SideInfo
-	if snapRev.Unset() {
-		si = snapst.CurrentSideInfo()
-	} else {
-		index := snapst.LastIndex(snapRev)
-		if index == -1 {
-			return nil, fmt.Errorf("internal error: cannot find snap revision %s in sequence", snapRev)
-		}
-		si = snapst.Sequence.SideInfos()[index]
+	index := snapst.LastIndex(snapRev)
+	if index == -1 {
+		return nil, fmt.Errorf("internal error: cannot find snap revision %s in sequence", snapRev)
 	}
+	si := snapst.Sequence.SideInfos()[index]
 
 	if si.SnapID == "" {
 		return nil, errors.New("internal error: cannot install components for a snap that is unknown to the store")

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -52,6 +52,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
@@ -273,6 +274,89 @@ func isCoreSnap(snapName string) bool {
 	return snapName == defaultCoreSnapName
 }
 
+// removeExtraComponentsTasks creates tasks that will remove unwanted components
+// that are currently installed alongside the snap revision that is about to be
+// installed. If the new snap revision is not in the sequence, then we don't
+// have anything to do. If the revision is in the sequence, then we generate
+// tasks that will unlink components that are not in compsups.
+//
+// This is mostly relevant when we're moving from one snap revision to another
+// snap revision that has already been installed on the system. The target snap
+// might have components that are installed that we don't want any more.
+func removeExtraComponentsTasks(st *state.State, snapst *SnapState, newRevision snap.Revision, compsups []ComponentSetup) (
+	unlinkTasks, discardTasks []*state.Task, err error,
+) {
+	idx := snapst.LastIndex(newRevision)
+	if idx < 0 {
+		return nil, nil, nil
+	}
+	si := snapst.Sequence.Revisions[idx].Snap
+
+	keep := make(map[naming.ComponentRef]bool, len(compsups))
+	for _, compsup := range compsups {
+		keep[compsup.CompSideInfo.Component] = true
+	}
+
+	snapst.CurrentComponentSideInfos()
+
+	linkedForRevision, err := snapst.ComponentInfosForRevision(newRevision)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// this is just a throwaway SnapSetup we create here so that
+	// unlink-component knows which snap revision we're unlinking the component
+	// from. note that we don't need to worry about kernel module components
+	// here, since the components that we are removing are not associated with
+	// the currently installed snap revision.
+	snapsup := SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: si.RealName,
+			SnapID:   si.SnapID,
+			Revision: si.Revision,
+		},
+		InstanceKey: snapst.InstanceKey,
+		Type:        snap.Type(snapst.SnapType),
+	}
+
+	for _, ci := range linkedForRevision {
+		if keep[ci.Component] {
+			continue
+		}
+
+		// note that we shouldn't ever be able to lose components during a
+		// refresh without a snap revision change. this might be able to happen
+		// once we introduce components and validation sets? if that is the
+		// case, we'll need to take care here to use "unlink-current-component"
+		// and point it to the correct snap setup task.
+		if snapst.Current == newRevision {
+			return nil, nil, errors.New("internal error: cannot lose a component during a refresh without a snap revision change")
+		}
+
+		unlink := st.NewTask("unlink-component", fmt.Sprintf(
+			i18n.G("Unlink component %q for snap revision %s"), ci.Component, snapsup.Revision(),
+		))
+
+		unlink.Set("snap-setup", snapsup)
+		unlink.Set("component-setup", ComponentSetup{
+			CompSideInfo: &ci.ComponentSideInfo,
+			CompType:     ci.Type,
+		})
+		unlinkTasks = append(unlinkTasks, unlink)
+
+		if !snapst.Sequence.IsComponentRevInRefSeqPtInAnyOtherSeqPt(ci.Component, idx) {
+			discard := st.NewTask("discard-component", fmt.Sprintf(
+				i18n.G("Discard previous revision for component %q"), ci.Component,
+			))
+			discard.Set("snap-setup-task", unlink.ID())
+			discard.Set("component-setup-task", unlink.ID())
+			discardTasks = append(discardTasks, discard)
+		}
+	}
+
+	return unlinkTasks, discardTasks, nil
+}
+
 func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups []ComponentSetup, flags int, fromChange string, inUseCheck func(snap.Type) (boot.InUseFunc, error)) (*state.TaskSet, error) {
 	tr := config.NewTransaction(st)
 	experimentalRefreshAppAwareness, err := features.Flag(tr, features.RefreshAppAwareness)
@@ -442,12 +526,23 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 		}
 	}
 
+	removeExtraComps, discardExtraComps, err := removeExtraComponentsTasks(st, snapst, snapsup.Revision(), compsups)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range removeExtraComps {
+		addTask(t)
+	}
+
 	tasksBeforePreRefreshHook, tasksAfterLinkSnap, tasksAfterPostOpHook, tasksBeforeDiscard, compSetupIDs, err := splitComponentTasksForInstall(
 		compsups, st, snapst, snapsup, prepare.ID(), fromChange,
 	)
 	if err != nil {
 		return nil, err
 	}
+
+	tasksBeforeDiscard = append(tasksBeforeDiscard, discardExtraComps...)
 
 	for _, t := range tasksBeforePreRefreshHook {
 		addTask(t)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -275,18 +275,18 @@ func isCoreSnap(snapName string) bool {
 }
 
 // removeExtraComponentsTasks creates tasks that will remove unwanted components
-// that are currently installed alongside the snap revision that is about to be
-// installed. If the new snap revision is not in the sequence, then we don't
-// have anything to do. If the revision is in the sequence, then we generate
-// tasks that will unlink components that are not in compsups.
+// that are currently installed alongside the target snap revision. If the new
+// snap revision is not in the sequence, then we don't have anything to do. If
+// the revision is in the sequence, then we generate tasks that will unlink
+// components that are not in compsups.
 //
 // This is mostly relevant when we're moving from one snap revision to another
 // snap revision that has already been installed on the system. The target snap
 // might have components that are installed that we don't want any more.
-func removeExtraComponentsTasks(st *state.State, snapst *SnapState, newRevision snap.Revision, compsups []ComponentSetup) (
+func removeExtraComponentsTasks(st *state.State, snapst *SnapState, targetRevision snap.Revision, compsups []ComponentSetup) (
 	unlinkTasks, discardTasks []*state.Task, err error,
 ) {
-	idx := snapst.LastIndex(newRevision)
+	idx := snapst.LastIndex(targetRevision)
 	if idx < 0 {
 		return nil, nil, nil
 	}
@@ -297,9 +297,7 @@ func removeExtraComponentsTasks(st *state.State, snapst *SnapState, newRevision 
 		keep[compsup.CompSideInfo.Component] = true
 	}
 
-	snapst.CurrentComponentSideInfos()
-
-	linkedForRevision, err := snapst.ComponentInfosForRevision(newRevision)
+	linkedForRevision, err := snapst.ComponentInfosForRevision(targetRevision)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -329,7 +327,7 @@ func removeExtraComponentsTasks(st *state.State, snapst *SnapState, newRevision 
 		// once we introduce components and validation sets? if that is the
 		// case, we'll need to take care here to use "unlink-current-component"
 		// and point it to the correct snap setup task.
-		if snapst.Current == newRevision {
+		if snapst.Current == targetRevision {
 			return nil, nil, errors.New("internal error: cannot lose a component during a refresh without a snap revision change")
 		}
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -281,8 +281,9 @@ func isCoreSnap(snapName string) bool {
 // components that are not in compsups.
 //
 // This is mostly relevant when we're moving from one snap revision to another
-// snap revision that has already been installed on the system. The target snap
-// might have components that are installed that we don't want any more.
+// snap revision that was installed in past and is still in the sequence. The
+// target snap might have had components that were installed alongside it in the
+// past, and they are not wanted anymore.
 func removeExtraComponentsTasks(st *state.State, snapst *SnapState, targetRevision snap.Revision, compsups []ComponentSetup) (
 	unlinkTasks, discardTasks []*state.Task, err error,
 ) {
@@ -317,7 +318,7 @@ func removeExtraComponentsTasks(st *state.State, snapst *SnapState, targetRevisi
 
 		// note that we don't need to worry about kernel module components here,
 		// since the components that we are removing are not associated with the
-		// currently installed snap revision. unlink-component differs from
+		// current snap revision. unlink-component differs from
 		// unlink-current-component in that it doesn't save the state of kernel
 		// module components on the the SnapSetup.
 		unlink := st.NewTask("unlink-component", fmt.Sprintf(

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -13794,6 +13794,195 @@ func (s *snapmgrTestSuite) TestUpdateStateConflictRemoved(c *C) {
 	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
 }
 
+func (s *snapmgrTestSuite) TestUpdateBackToPrevRevision(c *C) {
+	const (
+		snapName    = "some-snap"
+		instanceKey = "key"
+		snapID      = "some-snap-id"
+		channel     = "some-channel"
+	)
+
+	currentSnapRev := snap.R(11)
+	prevSnapRev := snap.R(7)
+	instanceName := snap.InstanceName(snapName, instanceKey)
+
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Fatalf("unexpected call to snapResourcesFn")
+		return nil
+	}
+
+	// we start without the auxiliary store info (or with an older one)
+	c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
+
+	currentSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: currentSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &currentSI)
+
+	restore := snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// since we don't have any components to check on, we shouldn't hit the
+	// store at all
+	snapstate.ReplaceStore(s.state, &storetest.Store{})
+
+	if instanceKey != "" {
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "experimental.parallel-instances", true)
+		tr.Commit()
+	}
+
+	prevSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: prevSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&prevSI, &currentSI})
+
+	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
+		Active:          true,
+		Sequence:        seq,
+		Current:         currentSI.Revision,
+		SnapType:        "app",
+		TrackingChannel: channel,
+		InstanceKey:     instanceKey,
+	})
+
+	ts, err := snapstate.Update(s.state, instanceName, &snapstate.RevisionOptions{
+		Revision: prevSnapRev,
+	}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("refresh", "refresh a snap")
+	chg.AddAll(ts)
+
+	// check unlink-reason
+	unlinkTask := findLastTask(chg, "unlink-current-snap")
+	c.Assert(unlinkTask, NotNil)
+	var unlinkReason string
+	unlinkTask.Get("unlink-reason", &unlinkReason)
+	c.Check(unlinkReason, Equals, "refresh")
+
+	// local modifications, edge must be set
+	te := ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(te, NotNil)
+	c.Assert(te.Kind(), Equals, "prepare-snap")
+
+	s.settle(c)
+
+	c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+
+	expected := fakeOps{
+		{
+			op:   "remove-snap-aliases",
+			name: instanceName,
+		},
+		{
+			op:          "run-inhibit-snap-for-unlink",
+			name:        instanceName,
+			inhibitHint: "refresh",
+		},
+		{
+			op:   "unlink-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:   "copy-data",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+			old:  filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:   "setup-snap-save-data",
+			path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+		},
+		{
+			op:    "setup-profiles:Doing",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+		{
+			op: "candidate",
+			sinfo: snap.SideInfo{
+				RealName: snapName,
+				SnapID:   snapID,
+				Channel:  channel,
+				Revision: prevSnapRev,
+			},
+		},
+		{
+			op:   "link-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+		},
+		{
+			op:    "auto-connect:Doing",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+		{
+			op: "update-aliases",
+		},
+		{
+			op:    "cleanup-trash",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+	}
+
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	task := ts.Tasks()[1]
+
+	// verify snapSetup info
+	var snapsup snapstate.SnapSetup
+	err = task.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
+		Channel: channel,
+		UserID:  s.user.ID,
+
+		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		Version:   "some-snapVer",
+		PlugsOnly: true,
+		Flags: snapstate.Flags{
+			Transaction: client.TransactionPerSnap,
+		},
+		InstanceKey:                     instanceKey,
+		PreUpdateKernelModuleComponents: []*snap.ComponentSideInfo{},
+	})
+	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
+		RealName: snapName,
+		Revision: prevSnapRev,
+		Channel:  channel,
+		SnapID:   snapID,
+	})
+
+	// verify snaps in the system state
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, instanceName, &snapst)
+	c.Assert(err, IsNil)
+
+	c.Assert(snapst.LastRefreshTime, NotNil)
+	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+
+	// link-snap should put the revision we refreshed to at the end of the
+	// sequence. in this case, swapping their positions.
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, seq.Revisions[0])
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[1])
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	const (
 		snapName    = "snap-with-components"

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -13810,14 +13810,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 	sort.Strings(components)
 
-	compNameToType := func(name string) snap.ComponentType {
-		typ := strings.TrimSuffix(name, "-component")
-		if typ == name {
-			c.Fatalf("unexpected component name %q", name)
-		}
-		return snap.ComponentType(typ)
-	}
-
 	// we start without the auxiliary store info (or with an older one)
 	c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
 
@@ -13849,7 +13841,14 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		Channel:  channel,
 	}
 
-	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&prevSI, &currentSI})
+	otherSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: snap.R(99),
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&otherSI, &prevSI, &currentSI})
 
 	currentKmodComps := make([]*snap.ComponentSideInfo, 0, len(components))
 	newKmodComps := make([]*snap.ComponentSideInfo, 0, len(components))
@@ -13889,21 +13888,50 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			})
 			currentKmodComps = append(currentKmodComps, &currentCsi)
 		}
-
 		currentResources[comp] = snap.R(i + 3)
+	}
+
+	availableComponents := make([]string, len(components))
+	copy(availableComponents, components)
+	availableComponents = append(availableComponents, "test-component-extra", "test-component-present-in-sequence")
+
+	// test-component-extra is installed for just the revision we're moving to,
+	// it should be unlinked and discarded
+	extraCsi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, "test-component-extra"),
+		Revision:  snap.R(len(availableComponents) + 1),
+	}
+	err := seq.AddComponentForRevision(prevSnapRev, &sequence.ComponentState{
+		SideInfo: &extraCsi,
+		CompType: componentNameToType(c, extraCsi.Component.ComponentName),
+	})
+	c.Assert(err, IsNil)
+
+	// test-component-present-in-sequence is installed for the revision we're
+	// moving to and another revision. it should be unlinked, but not discarded.
+	presentInSeqCsi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, "test-component-present-in-sequence"),
+		Revision:  snap.R(len(availableComponents) + 1),
+	}
+	for _, si := range []*snap.SideInfo{&prevSI, &otherSI} {
+		err := seq.AddComponentForRevision(si.Revision, &sequence.ComponentState{
+			SideInfo: &presentInSeqCsi,
+			CompType: componentNameToType(c, presentInSeqCsi.Component.ComponentName),
+		})
+		c.Assert(err, IsNil)
 	}
 
 	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
 		c.Assert(info.InstanceName(), DeepEquals, instanceName)
 		var results []store.SnapResourceResult
-		for i, compName := range components {
+		for i, compName := range availableComponents {
 			results = append(results, store.SnapResourceResult{
 				DownloadInfo: snap.DownloadInfo{
 					DownloadURL: "http://example.com/" + compName,
 				},
 				Name:      compName,
 				Revision:  i + 2,
-				Type:      fmt.Sprintf("component/%s", compNameToType(compName)),
+				Type:      fmt.Sprintf("component/%s", componentNameToType(c, compName)),
 				Version:   "1.0",
 				CreatedAt: "2024-01-01T00:00:00Z",
 			})
@@ -13985,6 +14013,13 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			revno:  prevSnapRev,
 			userID: 1,
 		},
+	}
+
+	for _, unlinked := range []snap.ComponentSideInfo{extraCsi, presentInSeqCsi} {
+		expected = append(expected, fakeOp{
+			op:   "unlink-component",
+			path: snap.ComponentMountDir(unlinked.Component.ComponentName, unlinked.Revision, instanceName),
+		})
 	}
 
 	for i, compName := range components {
@@ -14084,6 +14119,23 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		})
 	}
 
+	// note that test-present-in-both-component is not discarded since it is
+	// still referenced by the original snap revision
+	discardedContainerName := fmt.Sprintf("%s+%s", instanceName, extraCsi.Component.ComponentName)
+	discardedFilename := fmt.Sprintf("%s_%v.comp", discardedContainerName, extraCsi.Revision)
+	expected = append(expected, []fakeOp{
+		{
+			op:                "undo-setup-component",
+			containerName:     discardedContainerName,
+			containerFileName: discardedFilename,
+		},
+		{
+			op:                "remove-component-dir",
+			containerName:     discardedContainerName,
+			containerFileName: discardedFilename,
+		},
+	}...)
+
 	expected = append(expected, fakeOp{
 		op:    "cleanup-trash",
 		name:  instanceName,
@@ -14129,26 +14181,27 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 	c.Assert(snapst.LastRefreshTime, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions, HasLen, 3)
 
 	// the original revision's components should be replaced with the new
 	// components
-	seq.Revisions[0].Components = nil
+	seq.Revisions[1].Components = nil
 	for i, comp := range components {
 		err := seq.AddComponentForRevision(prevSnapRev, &sequence.ComponentState{
 			SideInfo: &snap.ComponentSideInfo{
 				Component: naming.NewComponentRef(snapName, comp),
 				Revision:  snap.R(i + 2),
 			},
-			CompType: compNameToType(comp),
+			CompType: componentNameToType(c, comp),
 		})
 		c.Assert(err, IsNil)
 	}
 
 	// link-snap should put the revision we refreshed to at the end of the
-	// sequence. in this case, swapping their positions.
-	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, seq.Revisions[0])
-	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[1])
+	// sequence
+	c.Assert(snapst.Sequence.Revisions[2], DeepEquals, seq.Revisions[1])
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, seq.Revisions[2])
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[0])
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThrough(c *C) {
@@ -14230,8 +14283,8 @@ type updateWithComponentsOpts struct {
 }
 
 func componentNameToType(c *C, name string) snap.ComponentType {
-	typ := strings.TrimSuffix(name, "-component")
-	if typ == name {
+	typ, _, ok := strings.Cut(name, "-component")
+	if !ok {
 		c.Fatalf("unexpected component name %q", name)
 	}
 	return snap.ComponentType(typ)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -14007,8 +14007,11 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 				InstanceName:    instanceName,
 				Revision:        prevSnapRev,
 				SnapID:          snapID,
-				Channel:         channel,
 				ResourceInstall: true,
+				// note that channel is empty here since we can't provide a
+				// channel in this case, since we don't know if the revision is
+				// a part of the channel
+				Channel: "",
 			},
 			revno:  prevSnapRev,
 			userID: 1,

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -13796,10 +13796,10 @@ func (s *snapmgrTestSuite) TestUpdateStateConflictRemoved(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	const (
-		snapName    = "some-snap"
+		snapName    = "snap-with-components"
 		instanceKey = "key"
-		snapID      = "some-snap-id"
-		channel     = "channel-for-components"
+		snapID      = "snap-with-components-id"
+		channel     = "channel-for-components-only-component-refresh"
 	)
 
 	components := []string{"test-component", "kernel-modules-component"}
@@ -13810,9 +13810,12 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 	sort.Strings(components)
 
-	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
-		c.Fatalf("unexpected call to snapResourcesFn")
-		return nil
+	compNameToType := func(name string) snap.ComponentType {
+		typ := strings.TrimSuffix(name, "-component")
+		if typ == name {
+			c.Fatalf("unexpected component name %q", name)
+		}
+		return snap.ComponentType(typ)
 	}
 
 	// we start without the auxiliary store info (or with an older one)
@@ -13824,6 +13827,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		SnapID:   snapID,
 		Channel:  channel,
 	}
+
 	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &currentSI)
 
 	restore := snapstate.MockRevisionDate(nil)
@@ -13831,11 +13835,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-
-	// right now, we don't expect to hit the store for this case. we might if we
-	// choose to start checking the store for an updated list of compatible
-	// components.
-	snapstate.ReplaceStore(s.state, &storetest.Store{})
 
 	if instanceKey != "" {
 		tr := config.NewTransaction(s.state)
@@ -13853,7 +13852,14 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&prevSI, &currentSI})
 
 	currentKmodComps := make([]*snap.ComponentSideInfo, 0, len(components))
-	prevKmodComps := make([]*snap.ComponentSideInfo, 0, len(components))
+	newKmodComps := make([]*snap.ComponentSideInfo, 0, len(components))
+	currentResources := make(map[string]snap.Revision, len(components))
+
+	// we have three sets of revisions we are working with:
+	// 1. current component revisions (+1 to index)
+	// 2. previous component revisions (+3 to index)
+	// 3. new component revisions (that is connected with the original snap
+	//    revision, via the store) (+2 to index)
 	for i, comp := range components {
 		prevCsi := snap.ComponentSideInfo{
 			Component: naming.NewComponentRef(snapName, comp),
@@ -13868,7 +13874,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 		currentCsi := snap.ComponentSideInfo{
 			Component: naming.NewComponentRef(snapName, comp),
-			Revision:  snap.R(i + 2),
+			Revision:  snap.R(i + 3),
 		}
 		err = seq.AddComponentForRevision(currentSnapRev, &sequence.ComponentState{
 			SideInfo: &currentCsi,
@@ -13877,9 +13883,32 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		c.Assert(err, IsNil)
 
 		if strings.HasPrefix(comp, string(snap.KernelModulesComponent)) {
-			prevKmodComps = append(prevKmodComps, &prevCsi)
+			newKmodComps = append(newKmodComps, &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, comp),
+				Revision:  snap.R(i + 2),
+			})
 			currentKmodComps = append(currentKmodComps, &currentCsi)
 		}
+
+		currentResources[comp] = snap.R(i + 3)
+	}
+
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.InstanceName(), DeepEquals, instanceName)
+		var results []store.SnapResourceResult
+		for i, compName := range components {
+			results = append(results, store.SnapResourceResult{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: "http://example.com/" + compName,
+				},
+				Name:      compName,
+				Revision:  i + 2,
+				Type:      fmt.Sprintf("component/%s", compNameToType(compName)),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			})
+		}
+		return results
 	}
 
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
@@ -13926,11 +13955,71 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 	c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
 
+	fi, err := os.Stat(snap.MountFile(instanceName, currentSnapRev))
+	c.Assert(err, IsNil)
+
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: instanceName,
+			op: "storesvc-snap-action",
+			curSnaps: []store.CurrentSnap{{
+				InstanceName:    instanceName,
+				SnapID:          snapID,
+				Revision:        currentSnapRev,
+				TrackingChannel: channel,
+				RefreshedDate:   fi.ModTime(),
+				Epoch:           snap.E("1*"),
+				Resources:       currentResources,
+			}},
+			userID: 1,
 		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:          "refresh",
+				InstanceName:    instanceName,
+				Revision:        prevSnapRev,
+				SnapID:          snapID,
+				Channel:         channel,
+				ResourceInstall: true,
+			},
+			revno:  prevSnapRev,
+			userID: 1,
+		},
+	}
+
+	for i, compName := range components {
+		csi := snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(i + 2),
+		}
+
+		containerName := fmt.Sprintf("%s+%s", instanceName, compName)
+		filename := fmt.Sprintf("%s_%v.comp", containerName, csi.Revision)
+
+		expected = append(expected, []fakeOp{{
+			op:   "storesvc-download",
+			name: csi.Component.String(),
+		}, {
+			op:                "validate-component:Doing",
+			name:              instanceName,
+			revno:             prevSnapRev,
+			componentName:     compName,
+			componentPath:     filepath.Join(dirs.SnapBlobDir, filename),
+			componentRev:      csi.Revision,
+			componentSideInfo: csi,
+		}, {
+			op:                "setup-component",
+			containerName:     containerName,
+			containerFileName: filename,
+		}}...)
+	}
+
+	expected = append(expected, fakeOp{
+		op:   "remove-snap-aliases",
+		name: instanceName,
+	})
+
+	expected = append(expected, fakeOps{
 		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        instanceName,
@@ -13967,12 +14056,12 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
 		},
-	}
+	}...)
 
 	for i, compName := range components {
 		expected = append(expected, fakeOp{
 			op:   "link-component",
-			path: snap.ComponentMountDir(compName, snap.R(i+1), instanceName),
+			path: snap.ComponentMountDir(compName, snap.R(i+2), instanceName),
 		})
 	}
 
@@ -13987,11 +14076,11 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		},
 	}...)
 
-	if len(prevKmodComps) > 0 || len(currentKmodComps) > 0 {
+	if len(newKmodComps) > 0 || len(currentKmodComps) > 0 {
 		expected = append(expected, fakeOp{
 			op:           "prepare-kernel-modules-components",
 			currentComps: currentKmodComps,
-			finalComps:   prevKmodComps,
+			finalComps:   newKmodComps,
 		})
 	}
 
@@ -14018,7 +14107,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeApp,
-		Version:   "some-snapVer",
+		Version:   "snap-with-componentsVer",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
 			Transaction: client.TransactionPerSnap,
@@ -14041,6 +14130,20 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	c.Assert(snapst.LastRefreshTime, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+
+	// the original revision's components should be replaced with the new
+	// components
+	seq.Revisions[0].Components = nil
+	for i, comp := range components {
+		err := seq.AddComponentForRevision(prevSnapRev, &sequence.ComponentState{
+			SideInfo: &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, comp),
+				Revision:  snap.R(i + 2),
+			},
+			CompType: compNameToType(comp),
+		})
+		c.Assert(err, IsNil)
+	}
 
 	// link-snap should put the revision we refreshed to at the end of the
 	// sequence. in this case, swapping their positions.

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -748,12 +748,15 @@ func storeUpdatePlanCore(
 			return updatePlan{}, err
 		}
 
-		revOpts.setChannelIfUnset(snapst.TrackingChannel)
-
 		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, si.Revision, revOpts.Channel, opts)
 		if err != nil {
 			return updatePlan{}, err
 		}
+
+		// this must happen after the call to componentSetupsForInstall, since
+		// we can't set the channel to the tracking channel if we don't know
+		// that the requested revision is part of this channel
+		revOpts.setChannelIfUnset(snapst.TrackingChannel)
 
 		// make sure that we switch the current channel of the snap that we're
 		// switching to


### PR DESCRIPTION
This change properly handles components when refreshing to a snap revision that has already been on the system.

When doing something like: `snap refresh --revision=n snapname`, where `n` has already been installed on the system, we were previously just switching back to the components that were installed with that revision. This is more of a revert than a refresh.

To properly handle this, we should consider which components are currently installed, and remove any that are not available for the revision `n`, and check with the store for the most up-to-date revisions of components.