### PR TITLE
cmd/snap: Revert "cmd/snap: add --terminate flag to remove command (#14192)"

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -56,7 +56,6 @@ type SnapOptions struct {
 	Unaliased        bool            `json:"unaliased,omitempty"`
 	Prefer           bool            `json:"prefer,omitempty"`
 	Purge            bool            `json:"purge,omitempty"`
-	Terminate        bool            `json:"terminate,omitempty"`
 	Amend            bool            `json:"amend,omitempty"`
 	Transaction      TransactionType `json:"transaction,omitempty"`
 	QuotaGroupName   string          `json:"quota-group,omitempty"`

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -134,7 +134,6 @@ type cmdRemove struct {
 
 	Revision   string `long:"revision"`
 	Purge      bool   `long:"purge"`
-	Terminate  bool   `long:"terminate"`
 	Positional struct {
 		Snaps []installedSnapName `positional-arg-name:"<snap>" required:"1"`
 	} `positional-args:"yes" required:"yes"`
@@ -310,7 +309,7 @@ func (x *cmdRemove) removeMany(opts *client.SnapOptions) error {
 }
 
 func (x *cmdRemove) Execute([]string) error {
-	opts := &client.SnapOptions{Revision: x.Revision, Purge: x.Purge, Terminate: x.Terminate}
+	opts := &client.SnapOptions{Revision: x.Revision, Purge: x.Purge}
 	if len(x.Positional.Snaps) == 1 {
 		return x.removeOne(opts)
 	}
@@ -1494,8 +1493,6 @@ func init() {
 			"revision": i18n.G("Remove only the given revision"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"purge": i18n.G("Remove the snap without saving a snapshot of its data"),
-			// TRANSLATORS: This should not start with a lowercase letter.
-			"terminate": i18n.G("Terminate running processes associated with a snap before removal"),
 		}), nil)
 	addCommand("install", shortInstallHelp, longInstallHelp, func() flags.Commander { return &cmdInstall{} },
 		colorDescs.also(waitDescs).also(channelDescs).also(modeDescs).also(map[string]string{

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -2874,26 +2874,6 @@ func (s *SnapOpSuite) TestRemoveWithPurge(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
-func (s *SnapOpSuite) TestRemoveWithTerminate(c *check.C) {
-	s.srv.total = 3
-	s.srv.checker = func(r *http.Request) {
-		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
-			"action":    "remove",
-			"terminate": true,
-		})
-	}
-
-	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"remove", "--terminate", "foo"})
-	c.Assert(err, check.IsNil)
-	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `(?sm).*foo removed`)
-	c.Check(s.Stderr(), check.Equals, "")
-	// ensure that the fake server api was actually hit
-	c.Check(s.srv.n, check.Equals, s.srv.total)
-}
-
 func (s *SnapOpSuite) TestRemoveInsufficientDiskSpace(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{

--- a/tests/main/snap-remove-terminate/api-client/bin/api-client.py
+++ b/tests/main/snap-remove-terminate/api-client/bin/api-client.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import argparse
+import http.client
+import sys
+import socket
+
+class UnixSocketHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, socket_path):
+        super().__init__('localhost')
+        self._socket_path = socket_path
+
+    def connect(self):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(self._socket_path)
+        self.sock = s
+
+
+def main(argv):
+    parser = argparse.ArgumentParser('Call the snapd REST API')
+    parser.add_argument('--socket', default='/run/snapd.socket',
+                        help='The socket path to connect to')
+    parser.add_argument('--method', default='GET',
+                        help='The HTTP method to use')
+    parser.add_argument('path', metavar='PATH',
+                        help='The HTTP path to request')
+    parser.add_argument('body', metavar='BODY', default=None, nargs='?',
+                        help='The HTTP request body')
+    args = parser.parse_args(argv[1:])
+
+    conn = UnixSocketHTTPConnection(args.socket)
+    conn.request(args.method, args.path, args.body)
+
+    response = conn.getresponse()
+    body = response.read()
+    print(body.decode('UTF-8'))
+    return response.status >= 300
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/main/snap-remove-terminate/api-client/meta/snap.yaml
+++ b/tests/main/snap-remove-terminate/api-client/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: api-client
+version: 1
+base: core18
+apps:
+  api-client:
+    command: bin/api-client.py
+    plugs:
+      - snapd-control

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -11,7 +11,13 @@ systems:
 prepare: |
     snap install test-snapd-sh
 
+    # TODO: Discard api-client when --terminate flag is added to remove command
+    "$TESTSTOOLS"/snaps-state install-local api-client
+    snap connect api-client:snapd-control
+
 restore: |
+    snap remove --purge api-client
+
     systemctl stop test-kill.service || true
     systemctl reset-failed test-kill.service || true
 
@@ -28,7 +34,9 @@ execute: |
     not flock --timeout 0 "$lockfile" --command "true"
 
     echo "Remove snap with --terminate flag"
-    snap remove --terminate test-snapd-sh
+    # TODO: Replace with "snap remove --terminate test-snapd-sh" when cli flag is added
+    api_client_bin="$(command -v api-client)"
+    sudo "$api_client_bin" --method=POST /v2/snaps/test-snapd-sh '{"action":"remove","terminate":true}'
 
     echo "Running process should be terminated after remove change is complete and lockfile should be unlocked"
     flock --timeout 60 "$lockfile" --command "true"


### PR DESCRIPTION
This reverts https://github.com/canonical/snapd/pull/14192, tests were passing on the PR (specifically `tests/main/snap-remove-terminate`) which is now failing on master.

I am suspecting interactions with other tests because it is passing locally when run standalone but until this is figured out let's revert in case it was a real issue.