### PR TITLE
i/p/patterns: clean path pattern variants before parsing

### DIFF
--- a/interfaces/prompting/patterns/patterns_test.go
+++ b/interfaces/prompting/patterns/patterns_test.go
@@ -232,6 +232,16 @@ func (s *patternsSuite) TestPathPatternMatch(c *C) {
 			true, // we override doublestar here
 		},
 		{
+			"/foo/",
+			"/foo",
+			false,
+		},
+		{
+			"/foo/",
+			"/foo/",
+			true,
+		},
+		{
 			"/foo/ba{r,z}/**",
 			"/foo/bar/baz/qux",
 			true,
@@ -335,6 +345,10 @@ func (s *patternsSuite) TestPathPatternRenderAllVariants(c *C) {
 		{
 			`/foo`,
 			[]string{`/foo`},
+		},
+		{
+			`/foo/`,
+			[]string{`/foo/`},
 		},
 		{
 			`/{foo,bar/}`,
@@ -470,6 +484,30 @@ func (s *patternsSuite) TestPathPatternRenderAllVariants(c *C) {
 		{
 			"/foo,bar,baz",
 			[]string{"/foo,bar,baz"},
+		},
+		{
+			"/foo/bar/../**",
+			[]string{"/foo/**"},
+		},
+		{
+			"/foo/bar/../baz",
+			[]string{"/foo/baz"},
+		},
+		{
+			"/foo/**/bar/./baz/../",
+			[]string{"/foo/**/bar/"},
+		},
+		{
+			"/foo/*/bar/./baz/**/../",
+			[]string{"/foo/*/bar/baz/"}, // this is uncharted territory
+		},
+		{
+			"/foo/bar/.{hidden,,.}/baz",
+			[]string{
+				"/foo/bar/.hidden/baz",
+				"/foo/bar/baz",
+				"/foo/baz",
+			},
 		},
 	} {
 		pathPattern, err := patterns.ParsePathPattern(testCase.pattern)

--- a/interfaces/prompting/patterns/variant.go
+++ b/interfaces/prompting/patterns/variant.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -393,7 +394,11 @@ func prepareVariantForParsing(variant string) string {
 		// Discard trailing "**", add "⁑" instead
 		return s[:len(s)-2] + "⁑"
 	})
-	return prepared
+	cleaned := filepath.Clean(prepared)
+	if strings.HasSuffix(prepared, "/") {
+		cleaned = cleaned + "/"
+	}
+	return cleaned
 }
 
 type componentReader struct {


### PR DESCRIPTION
Path patterns may contain `/./` or `/../` constructions, which we should handle similarly to how they should be in standard paths. That is:

- /foo/./bar is equal to /foo/bar
- /foo/../bar is equal to /bar

This allows us to treat identical path patterns (e.g. /foo/./bar and /foo/bar) as identical, rather than two distinct patterns.

This is useful for convenience so that the client may, for example, when requested /foo/bar/file.txt, reply with /foo/bar/file.txt/../* to grant access to all files in the parent directory of the requested path.

This is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-32063