### PR TITLE
{snap,wrappers}: improve desktop file to snap app matching

### DIFF
--- a/desktop/desktopentry/desktopentry.go
+++ b/desktop/desktopentry/desktopentry.go
@@ -39,6 +39,9 @@ type DesktopEntry struct {
 	Icon     string
 	Exec     string
 
+	SnapInstanceName string
+	SnapAppName      string
+
 	Hidden                bool
 	OnlyShowIn            []string
 	NotShownIn            []string
@@ -52,6 +55,8 @@ type Action struct {
 	Name string
 	Icon string
 	Exec string
+
+	SnapAppName string
 }
 
 type groupState int
@@ -155,6 +160,10 @@ func parse(filename string, r io.Reader) (*DesktopEntry, error) {
 				de.GnomeAutostartEnabled = value == "true"
 			case "Actions":
 				actions = splitList(value)
+			case "X-SnapInstanceName":
+				de.SnapInstanceName = value
+			case "X-SnapAppName":
+				de.SnapAppName = value
 			default:
 				// Ignore all other keys
 			}
@@ -166,6 +175,8 @@ func parse(filename string, r io.Reader) (*DesktopEntry, error) {
 				currentAction.Icon = value
 			case "Exec":
 				currentAction.Exec = value
+			case "X-SnapAppName":
+				currentAction.SnapAppName = value
 			default:
 				// Ignore all other keys
 			}

--- a/desktop/desktopentry/desktopentry_test.go
+++ b/desktop/desktopentry/desktopentry_test.go
@@ -39,9 +39,11 @@ var _ = Suite(&desktopentrySuite{})
 
 const browserDesktopEntry = `
 [Desktop Entry]
+X-SnapInstanceName=browser
 Version=1.0
 Type=Application
 Name=Web Browser
+X-SnapAppName=browser-app
 Exec=browser %u
 Icon = ${SNAP}/default256.png
 Actions=NewWindow;NewPrivateWindow;
@@ -53,10 +55,12 @@ Exec=not-the-executable
 # A comment
 [Desktop Action NewWindow]
 Name = Open a New Window
+X-SnapAppName=browser-app
 Exec=browser -new-window
 
 [Desktop Action NewPrivateWindow]
 Name=Open a New Private Window
+X-SnapAppName=browser-app
 Exec=browser -private-window
 Icon=${SNAP}/private.png
 `
@@ -69,17 +73,21 @@ func (s *desktopentrySuite) TestParse(c *C) {
 	c.Check(de.Name, Equals, "Web Browser")
 	c.Check(de.Icon, Equals, "${SNAP}/default256.png")
 	c.Check(de.Exec, Equals, "browser %u")
+	c.Check(de.SnapInstanceName, Equals, "browser")
+	c.Check(de.SnapAppName, Equals, "browser-app")
 	c.Check(de.Actions, HasLen, 2)
 
 	c.Assert(de.Actions["NewWindow"], NotNil)
 	c.Check(de.Actions["NewWindow"].Name, Equals, "Open a New Window")
 	c.Check(de.Actions["NewWindow"].Icon, Equals, "")
 	c.Check(de.Actions["NewWindow"].Exec, Equals, "browser -new-window")
+	c.Check(de.Actions["NewWindow"].SnapAppName, Equals, "browser-app")
 
 	c.Assert(de.Actions["NewPrivateWindow"], NotNil)
 	c.Check(de.Actions["NewPrivateWindow"].Name, Equals, "Open a New Private Window")
 	c.Check(de.Actions["NewPrivateWindow"].Icon, Equals, "${SNAP}/private.png")
 	c.Check(de.Actions["NewPrivateWindow"].Exec, Equals, "browser -private-window")
+	c.Check(de.Actions["NewPrivateWindow"].SnapAppName, Equals, "browser-app")
 }
 
 func (s *desktopentrySuite) TestParseBad(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9144,6 +9144,7 @@ X-SnapInstanceName=test-snap`)
 [Desktop Entry]
 X-SnapInstanceName=test-snap
 Name=test
+X-SnapAppName=test-snap
 Exec=env BAMF_DESKTOP_FILE_HINT=%s/test-snap_test-snap.desktop %s/test-snap
 `[1:], dirs.SnapDesktopFilesDir, dirs.SnapBinariesDir)
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -20,7 +20,6 @@
 package snap
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -32,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/snapcore/snapd/desktop/desktopentry"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
@@ -1423,25 +1423,6 @@ func (app *AppInfo) SecurityTag() string {
 	return AppSecurityTag(app.Snap.InstanceName(), app.Name)
 }
 
-func snapAppNameFromDesktopFile(desktopFile string) (string, error) {
-	file, err := os.Open(desktopFile)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for i := 0; scanner.Scan(); i++ {
-		bline := scanner.Text()
-		if !strings.HasPrefix(bline, "X-SnapAppName=") {
-			continue
-		}
-		return strings.TrimPrefix(bline, "X-SnapAppName="), nil
-	}
-
-	return "", fmt.Errorf("cannot find X-SnapAppName entry in %q", desktopFile)
-}
-
 // DesktopFile returns the path to the installed optional desktop file for the
 // application.
 func (app *AppInfo) DesktopFile() string {
@@ -1459,8 +1440,8 @@ func (app *AppInfo) DesktopFile() string {
 		}
 		// No need to also check instance name because we already filter by the
 		// snap's desktop file ids
-		appName, err := snapAppNameFromDesktopFile(desktopFile)
-		if err == nil && appName == app.Name {
+		de, err := desktopentry.Read(desktopFile)
+		if err == nil && de.SnapAppName == app.Name {
 			return desktopFile
 		}
 	}

--- a/snap/info.go
+++ b/snap/info.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/snapcore/snapd/desktop/desktopentry"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
@@ -1441,7 +1442,15 @@ func (app *AppInfo) DesktopFile() string {
 		// No need to also check instance name because we already filter by the
 		// snap's desktop file ids
 		de, err := desktopentry.Read(desktopFile)
-		if err == nil && de.SnapAppName == app.Name {
+		if err != nil {
+			// Errors when reading indicates either an issue opening the desktop
+			// file or a malformed desktop file, both of which are internal
+			// errors caused somewhere else.
+			// Let's log for debugging and try the next desktop file id.
+			logger.Debugf("internal error: failed to read %q: %v", desktopFile, err)
+			continue
+		}
+		if de.SnapAppName == app.Name {
 			return desktopFile
 		}
 	}

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -64,6 +64,7 @@ execute: |
     	X-SnapInstanceName=basic-desktop
     	Name=Echo
     	Comment=It echos stuff
+        X-SnapAppName=echo
     	Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop.echo
     EOF
 

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -59,12 +59,12 @@ execute: |
     echo "Sideload desktop snap"
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     snap install --dangerous ./basic-desktop_1.0_all.snap
-    diff -u <(head -n5 /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop) - <<-EOF
+    diff -u <(head -n6 /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop) - <<-EOF
     	[Desktop Entry]
     	X-SnapInstanceName=basic-desktop
     	Name=Echo
     	Comment=It echos stuff
-        X-SnapAppName=echo
+    	X-SnapAppName=echo
     	Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop.echo
     EOF
 

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -32,7 +32,7 @@ execute: |
         expected="^basic-desktop_$instance 1.0 installed\$"
         "$TESTSTOOLS"/snaps-state install-local-as basic-desktop "basic-desktop_$instance" | MATCH "$expected"
 
-        diff -u <(head -n5 "/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop") - <<-EOF
+        diff -u <(head -n6 "/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop") - <<-EOF
     [Desktop Entry]
     X-SnapInstanceName=basic-desktop_${instance}
     Name=Echo

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -37,6 +37,7 @@ execute: |
     X-SnapInstanceName=basic-desktop_${instance}
     Name=Echo
     Comment=It echos stuff
+    X-SnapAppName=echo
     Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop_$instance.echo
     EOF
 

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -691,10 +691,9 @@ apps:
 `))
 	c.Assert(err, IsNil)
 
-	app, newl, err := wrappers.DetectAppAndRewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
+	appName, newl, err := wrappers.DetectAppAndRewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
 	c.Assert(err, IsNil)
-	c.Assert(app.Name, Equals, "app")
-	c.Assert(app.Command, Equals, "cmd")
+	c.Assert(appName, Equals, "app")
 	c.Assert(newl, Equals, fmt.Sprintf("Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app", dirs.SnapMountDir))
 }
 

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -33,10 +33,10 @@ var (
 	GenerateDBusActivationFile = generateDBusActivationFile
 
 	// desktop
-	SanitizeDesktopFile    = sanitizeDesktopFile
-	RewriteExecLine        = rewriteExecLine
-	RewriteIconLine        = rewriteIconLine
-	IsValidDesktopFileLine = isValidDesktopFileLine
+	SanitizeDesktopFile         = sanitizeDesktopFile
+	DetectAppAndRewriteExecLine = detectAppAndRewriteExecLine
+	RewriteIconLine             = rewriteIconLine
+	IsValidDesktopFileLine      = isValidDesktopFileLine
 
 	// daemons
 	UsersToUids               = usersToUids


### PR DESCRIPTION
Now that `desktop-file-ids` are supported, the simple `$PREFIX_$APP.desktop` heuristic when looking up snap app's desktop file won't cut it.

Instead, Loop through `desktop-file-ids` desktop interface plug attribute in order to have deterministic output and return the first matching desktop file found if (the newly added) `X-SnapAppName` entry matches the app name and fallback to the simple heuristic if no matches are found.

This follows the [SD170 - Custom desktop file IDs for snaps](https://docs.google.com/document/d/1j4flP303OJKrSxSCjkeZkh-9COuahVmo_EK_ye09RxQ/edit?pli=1#heading=h.lifosn8k7vke) spec.