### PR TITLE
tests: work around bug that is in snapcraft right now

### DIFF
--- a/tests/lib/muinstaller/snapcraft.yaml
+++ b/tests/lib/muinstaller/snapcraft.yaml
@@ -23,7 +23,7 @@ parts:
     build-environment:
       # Avoid libc deps to make muinstaller statically compiled
       # (desirable as this is a classic snap).
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: "0"
     override-build: |
       snapcraftctl build
       cp -a mk-classic-rootfs.sh $SNAPCRAFT_PART_INSTALL/bin


### PR DESCRIPTION
There is a bug in snapcraft right now (https://github.com/canonical/snapcraft/issues/4978) that causes building this snap to fail. This is the workaround, for now.