### PR TITLE
asserts: define registry-control assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -153,6 +153,7 @@ var (
 	DeviceSessionRequestType = &AssertionType{"device-session-request", []string{"brand-id", "model", "serial"}, nil, assembleDeviceSessionRequest, noAuthority}
 	SerialRequestType        = &AssertionType{"serial-request", nil, nil, assembleSerialRequest, noAuthority}
 	AccountKeyRequestType    = &AssertionType{"account-key-request", []string{"public-key-sha3-384"}, nil, assembleAccountKeyRequest, noAuthority}
+	RegistryControlType      = &AssertionType{"registry-control", []string{"brand-id", "model", "serial"}, nil, assembleRegistryControl, noAuthority}
 )
 
 var typeRegistry = map[string]*AssertionType{
@@ -178,6 +179,7 @@ var typeRegistry = map[string]*AssertionType{
 	DeviceSessionRequestType.Name: DeviceSessionRequestType,
 	SerialRequestType.Name:        SerialRequestType,
 	AccountKeyRequestType.Name:    AccountKeyRequestType,
+	RegistryControlType.Name:      RegistryControlType,
 }
 
 // Type returns the AssertionType with name or nil

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -56,6 +56,7 @@ func (as *assertsSuite) TestTypeNames(c *C) {
 		"model",
 		"preseed",
 		"registry",
+		"registry-control",
 		"repair",
 		"serial",
 		"serial-request",
@@ -1207,7 +1208,10 @@ func (as *assertsSuite) TestWithAuthority(c *C) {
 		"validation-set",
 		"repair",
 	}
-	c.Check(withAuthority, HasLen, asserts.NumAssertionType-3) // excluding device-session-request, serial-request, account-key-request
+
+	// excluding device-session-request, serial-request, account-key-request, registry-control
+	c.Check(withAuthority, HasLen, asserts.NumAssertionType-4)
+
 	for _, name := range withAuthority {
 		typ := asserts.Type(name)
 		_, err := asserts.AssembleAndSignInTest(typ, nil, []byte("{}"), testPrivKey1)

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -322,3 +322,20 @@ func checkMapWhat(m map[string]interface{}, name, what string) (map[string]inter
 	}
 	return mv, nil
 }
+
+func checkList(headers map[string]interface{}, name string) ([]interface{}, error) {
+	return checkListWhat(headers, name, "header")
+}
+
+func checkListWhat(m map[string]interface{}, name, what string) ([]interface{}, error) {
+	value, ok := m[name]
+	if !ok {
+		return nil, nil
+	}
+
+	list, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%q %s must be a list", name, what)
+	}
+	return list, nil
+}

--- a/asserts/registry.go
+++ b/asserts/registry.go
@@ -22,6 +22,7 @@ package asserts
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/snapcore/snapd/registry"
@@ -107,4 +108,220 @@ func assembleRegistry(assert assertionBase) (Assertion, error) {
 		registry:      registry,
 		timestamp:     timestamp,
 	}, nil
+}
+
+// RegistryControl holds a registry-control assertion, which holds a list of
+// registry views delegated by the device to an operator.
+type RegistryControl struct {
+	assertionBase
+
+	// the key is the operator ID
+	operators map[string]*registry.Operator
+}
+
+// BrandID returns the brand identifier of the device.
+func (rgCtrl *RegistryControl) BrandID() string {
+	return rgCtrl.HeaderString("brand-id")
+}
+
+// Model returns the model name identifier of the device.
+func (rgCtrl *RegistryControl) Model() string {
+	return rgCtrl.HeaderString("model")
+}
+
+// Serial returns the serial identifier of the device, together with
+// brand id and model they form the unique identifier of the device.
+func (rgCtrl *RegistryControl) Serial() string {
+	return rgCtrl.HeaderString("serial")
+}
+
+// IsDelegated checks if <accountID>/<registry>/<view> is delegated to
+// <operatorID> under the authentication method <auth>.
+func (rgCtrl *RegistryControl) IsDelegated(operatorID, view, auth string) bool {
+	operator, ok := rgCtrl.operators[operatorID]
+	if !ok {
+		// nothing is delegated to this operator
+		return false
+	}
+
+	authMethod, err := registry.StringToAuthenticationMethod(auth)
+	if err != nil {
+		// unknown authentication method
+		return false
+	}
+
+	return operator.IsDelegated(view, authMethod)
+}
+
+// Delegate delegates the given views under the provided authentication methods to the operator.
+func (rgCtrl *RegistryControl) Delegate(operatorID string, views []string, authentication []string) error {
+	operator, ok := rgCtrl.operators[operatorID]
+	if !ok {
+		operator = &registry.Operator{
+			OperatorID: operatorID,
+			Groups:     make([]*registry.Group, 0),
+		}
+	}
+
+	authMethods, err := stringListToAuthenticationMethods(authentication)
+	if err != nil {
+		return err
+	}
+
+	err = operator.Delegate(views, authMethods)
+	if err != nil {
+		return err
+	}
+
+	rgCtrl.operators[operatorID] = operator
+	return nil
+}
+
+// Revoke withdraws remote access to the views that have been delegated under
+// the authentication methods.
+func (rgCtrl *RegistryControl) Revoke(operatorID string, views []string, authentication []string) error {
+	operator, ok := rgCtrl.operators[operatorID]
+	if !ok {
+		// nothing is delegated to this operator
+		return nil
+	}
+
+	if len(views) == 0 && len(authentication) == 0 {
+		// completely revoke access from this operator
+		delete(rgCtrl.operators, operatorID)
+		return nil
+	}
+
+	authMethods, err := stringListToAuthenticationMethods(authentication)
+	if err != nil {
+		return err
+	}
+
+	return operator.Revoke(views, authMethods)
+}
+
+// assembleRegistryControl assembles the registry-control assertion.
+func assembleRegistryControl(assert assertionBase) (Assertion, error) {
+	_, err := checkStringMatches(assert.headers, "brand-id", validAccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = checkModel(assert.headers)
+	if err != nil {
+		return nil, err
+	}
+
+	groups, err := checkList(assert.headers, "groups")
+	if err != nil {
+		return nil, err
+	}
+	if groups == nil {
+		return nil, fmt.Errorf(`"groups" stanza is mandatory`)
+	}
+
+	rgCtrl := &RegistryControl{
+		assertionBase: assert,
+		operators:     make(map[string]*registry.Operator),
+	}
+
+	err = parseRegistryControlGroups(rgCtrl, groups)
+	if err != nil {
+		return nil, err
+	}
+
+	return rgCtrl, nil
+}
+
+func parseRegistryControlGroups(rgCtrl *RegistryControl, rawGroups []interface{}) error {
+	for i, rawGroup := range rawGroups {
+		errPrefix := fmt.Sprintf("group at position %d", i+1)
+
+		group, ok := rawGroup.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("%s: must be a map", errPrefix)
+		}
+
+		rawOperatorID, ok := group["operator-id"]
+		if !ok {
+			return fmt.Errorf(`%s: "operator-id" not provided`, errPrefix)
+		}
+
+		operatorID, ok := rawOperatorID.(string)
+		if !ok || len(operatorID) == 0 {
+			return fmt.Errorf(`%s: "operator-id" must be a non-empty string`, errPrefix)
+		}
+
+		// while in the future we'll accommodate other RBAC systems,
+		// for now operatorIDs must be snap store account IDs
+		if !IsValidAccountID(operatorID) {
+			return fmt.Errorf(`%s: invalid "operator-id" %s`, errPrefix, operatorID)
+		}
+
+		authentication, err := checkStringListInMap(group, "authentication", "field", nil)
+		if err != nil {
+			return fmt.Errorf(`%s: "authentication" %w`, errPrefix, err)
+		}
+		if authentication == nil {
+			return fmt.Errorf(`%s: "authentication" must be provided`, errPrefix)
+		}
+
+		views, err := checkStringListInMap(group, "views", "field", nil)
+		if err != nil {
+			return fmt.Errorf(`%s: "views" %w`, errPrefix, err)
+		}
+		if views == nil {
+			return fmt.Errorf(`%s: "views" must be provided`, errPrefix)
+		}
+
+		err = rgCtrl.Delegate(operatorID, views, authentication)
+		if err != nil {
+			return fmt.Errorf("%s: %w", errPrefix, err)
+		}
+	}
+
+	return nil
+}
+
+func stringListToAuthenticationMethods(authentication []string) ([]registry.AuthenticationMethod, error) {
+	authMethods := make([]registry.AuthenticationMethod, 0, len(authentication))
+	for _, auth := range authentication {
+		authMethod, err := registry.StringToAuthenticationMethod(auth)
+		if err != nil {
+			return nil, err
+		}
+
+		authMethods = append(authMethods, authMethod)
+	}
+	return authMethods, nil
+}
+
+// PrintGroups returns a string representation of the groups in the assertion
+// it's only used for testing
+func (rgCtrl RegistryControl) PrintGroups() string {
+	operatorIDs := make([]string, 0, len(rgCtrl.operators))
+	for key := range rgCtrl.operators {
+		operatorIDs = append(operatorIDs, key)
+	}
+	sort.Strings(operatorIDs)
+
+	result := "groups:\n"
+	for _, operatorID := range operatorIDs {
+		operator := rgCtrl.operators[operatorID]
+		for _, group := range operator.Groups {
+			result += fmt.Sprintf("  -\n    operator-id: %s\n", operatorID)
+
+			result += "    authentication:\n"
+			for _, auth := range group.Authentication {
+				result += fmt.Sprintf("      - %s\n", auth.String())
+			}
+
+			result += "    views:\n"
+			for _, view := range group.Views {
+				result += fmt.Sprintf("      - %s\n", view)
+			}
+		}
+	}
+
+	return result
 }

--- a/features/features.go
+++ b/features/features.go
@@ -75,6 +75,8 @@ const (
 	RefreshAppAwarenessUX
 	// Registries enables experimental configuration based on registries and views.
 	Registries
+	// RegistryControl enables experimental remote management of registries
+	RegistryControl
 	// AppArmorPrompting enables AppArmor to prompt the user for permission when apps perform certain operations.
 	AppArmorPrompting
 
@@ -123,7 +125,9 @@ var featureNames = map[SnapdFeature]string{
 	QuotaGroups: "quota-groups",
 
 	RefreshAppAwarenessUX: "refresh-app-awareness-ux",
-	Registries:            "registries",
+
+	Registries:      "registries",
+	RegistryControl: "registry-control",
 
 	AppArmorPrompting: "apparmor-prompting",
 }
@@ -150,6 +154,7 @@ var featuresExported = map[SnapdFeature]bool{
 
 	RefreshAppAwarenessUX: true,
 	Registries:            true,
+	RegistryControl:       true,
 	AppArmorPrompting:     true,
 }
 

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -64,6 +64,7 @@ func (*featureSuite) TestName(c *C) {
 	check(features.QuotaGroups, "quota-groups")
 	check(features.RefreshAppAwarenessUX, "refresh-app-awareness-ux")
 	check(features.Registries, "registries")
+	check(features.RegistryControl, "registry-control")
 	check(features.AppArmorPrompting, "apparmor-prompting")
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
@@ -106,6 +107,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.QuotaGroups, false)
 	check(features.RefreshAppAwarenessUX, true)
 	check(features.Registries, true)
+	check(features.RegistryControl, true)
 	check(features.AppArmorPrompting, true)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
@@ -232,6 +234,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.QuotaGroups, false)
 	check(features.RefreshAppAwarenessUX, false)
 	check(features.Registries, false)
+	check(features.RegistryControl, false)
 	check(features.AppArmorPrompting, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -476,7 +476,7 @@ func getPlaceholders(viewStr string) map[string]bool {
 	return placeholders
 }
 
-// View returns an view from the registry.
+// View returns a view from the registry.
 func (d *Registry) View(view string) *View {
 	return d.views[view]
 }

--- a/registry/registry_control.go
+++ b/registry/registry_control.go
@@ -1,0 +1,242 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package registry
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+var (
+	validAccountID = regexp.MustCompile("^(?:[a-z0-9A-Z]{32}|[-a-z0-9]{2,28})$")
+)
+
+type AuthenticationMethod int
+
+const (
+	OperatorKey AuthenticationMethod = iota
+	Store
+)
+
+var authMethodMap = map[string]AuthenticationMethod{
+	"operator-key": OperatorKey,
+	"store":        Store,
+}
+
+// StringToAuthenticationMethod converts a string to AuthenticationMethod.
+func StringToAuthenticationMethod(s string) (AuthenticationMethod, error) {
+	if method, ok := authMethodMap[s]; ok {
+		return method, nil
+	}
+	return -1, fmt.Errorf("unknown authentication method: %s", s)
+}
+
+var authMethodStringMap = map[AuthenticationMethod]string{
+	OperatorKey: "operator-key",
+	Store:       "store",
+}
+
+// String prints the string representation of AuthenticationMethod.
+func (auth AuthenticationMethod) String() string {
+	if s, ok := authMethodStringMap[auth]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+// Operator holds the delegations for a single operator.
+type Operator struct {
+	OperatorID string
+	Groups     []*Group
+}
+
+// Group holds a set of views delegated through the given authentication.
+type Group struct {
+	Authentication []AuthenticationMethod
+	Views          []string
+}
+
+// groupWithView returns the group that holds the given view.
+func (operator *Operator) groupWithView(view string) (*Group, int) {
+	for _, group := range operator.Groups {
+		index, ok := slices.BinarySearch(group.Views, view)
+		if ok {
+			return group, index
+		}
+	}
+
+	return nil, 0
+}
+
+// groupWithAuthentication returns the group with the given authentication.
+// The authentication should be sorted.
+func (operator *Operator) groupWithAuthentication(authentication []AuthenticationMethod) *Group {
+	for _, group := range operator.Groups {
+		if slices.Equal(group.Authentication, authentication) {
+			return group
+		}
+	}
+
+	return nil
+}
+
+// IsDelegated checks if <accountID>/<registry>/<view> is delegated to
+// the operator under the authentication method <auth>.
+func (operator *Operator) IsDelegated(view string, auth AuthenticationMethod) bool {
+	group, _ := operator.groupWithView(view)
+	if group == nil {
+		return false
+	}
+
+	return slices.Contains(group.Authentication, auth)
+}
+
+// Delegate delegates the given views under the provided authentication methods.
+func (operator *Operator) Delegate(views []string, authentication []AuthenticationMethod) error {
+	if len(views) == 0 {
+		return fmt.Errorf(`"views" must be a non-empty list`)
+	}
+
+	if len(authentication) == 0 {
+		return fmt.Errorf(`"authentication" must be a non-empty list`)
+	}
+	slices.Sort(authentication)
+
+	var err error
+	for _, view := range views {
+		viewPath := strings.Split(view, "/")
+		if len(viewPath) != 3 {
+			return fmt.Errorf(`"%s" must be in the format account/registry/view`, view)
+		}
+
+		if !validAccountID.MatchString(viewPath[0]) {
+			return fmt.Errorf("invalid Account ID %s", viewPath[0])
+		}
+
+		if !ValidRegistryName.MatchString(viewPath[1]) {
+			return fmt.Errorf("invalid registry name %s", viewPath[1])
+		}
+
+		if !ValidViewName.MatchString(viewPath[2]) {
+			return fmt.Errorf("invalid view name %s", viewPath[2])
+		}
+
+		err = operator.delegateOne(view, authentication)
+		if err != nil {
+			return err
+		}
+	}
+
+	operator.compact()
+	return nil
+}
+
+// delegateOne grants remote registry control to <account-id>/<registry>/<view>.
+func (operator *Operator) delegateOne(view string, authentication []AuthenticationMethod) error {
+	newAuth := authentication
+	existingGroup, viewIdx := operator.groupWithView(view)
+	if existingGroup != nil {
+		newAuth = append(newAuth, existingGroup.Authentication...)
+		slices.Sort(newAuth)
+		newAuth = slices.Compact(newAuth)
+	}
+
+	newGroup := operator.groupWithAuthentication(newAuth)
+	if existingGroup == newGroup && existingGroup != nil {
+		// already delegated, nothing to do
+		return nil
+	}
+
+	if newGroup == nil {
+		newGroup = &Group{Authentication: newAuth, Views: []string{view}}
+		operator.Groups = append(operator.Groups, newGroup)
+	} else {
+		newGroup.Views = append(newGroup.Views, view)
+		slices.Sort(newGroup.Views)
+	}
+
+	if existingGroup != nil {
+		// remove the view from the old group
+		existingGroup.Views = slices.Delete(existingGroup.Views, viewIdx, viewIdx+1)
+	}
+
+	return nil
+}
+
+// Revoke withdraws remote access to the views that have been delegated under
+// the authentication methods.
+func (operator *Operator) Revoke(views []string, authentication []AuthenticationMethod) error {
+	if len(authentication) == 0 {
+		// if no authentication is provided, revoke all auth methods
+		authentication = []AuthenticationMethod{OperatorKey, Store}
+	}
+	slices.Sort(authentication)
+
+	var err error
+	for _, view := range views {
+		err = operator.revokeOne(view, authentication)
+		if err != nil {
+			return err
+		}
+	}
+
+	operator.compact()
+	return nil
+}
+
+// revokeOne revokes remote registry control over <account-id>/<registry>/<view>.
+func (operator *Operator) revokeOne(view string, authentication []AuthenticationMethod) error {
+	group, viewIdx := operator.groupWithView(view)
+	if group == nil {
+		// not delegated, nothing to do
+		return nil
+	}
+
+	remaining := make([]AuthenticationMethod, 0, len(group.Authentication))
+	for _, existingAuth := range group.Authentication {
+		if !slices.Contains(authentication, existingAuth) {
+			remaining = append(remaining, existingAuth)
+		}
+	}
+
+	// remove the view from the group
+	group.Views = slices.Delete(group.Views, viewIdx, viewIdx+1)
+
+	if len(remaining) != 0 {
+		// delegate the view with the remaining authentication method(s)
+		return operator.delegateOne(view, remaining)
+	}
+
+	return nil
+}
+
+// compact removes empty groups.
+func (operator *Operator) compact() {
+	groups := make([]*Group, 0, len(operator.Groups))
+	for _, group := range operator.Groups {
+		if len(group.Views) != 0 {
+			groups = append(groups, group)
+		}
+	}
+
+	operator.Groups = groups
+}

--- a/registry/registry_control_test.go
+++ b/registry/registry_control_test.go
@@ -1,0 +1,164 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package registry_test
+
+import (
+	"github.com/snapcore/snapd/registry"
+	. "gopkg.in/check.v1"
+)
+
+type rgCtrlSuite struct{}
+
+var _ = Suite(&rgCtrlSuite{})
+
+func (s *rgCtrlSuite) TestAuthenticationMethods(c *C) {
+	authMethod, _ := registry.StringToAuthenticationMethod("operator-key")
+	c.Check(authMethod, Equals, registry.OperatorKey)
+	c.Check(authMethod.String(), Equals, "operator-key")
+
+	authMethod, err := registry.StringToAuthenticationMethod("foo-bar")
+	c.Check(err, ErrorMatches, "unknown authentication method: foo-bar")
+	c.Check(authMethod.String(), Equals, "unknown")
+}
+
+func (s *rgCtrlSuite) TestDelegateOK(c *C) {
+	operator := registry.Operator{
+		OperatorID: "jane",
+		Groups:     make([]*registry.Group, 0),
+	}
+
+	err := operator.Delegate(
+		[]string{"canonical/network/control-interface", "canonical/network/observe-interface"},
+		[]registry.AuthenticationMethod{registry.Store},
+	)
+	c.Assert(err, IsNil)
+
+	c.Check(operator.IsDelegated("canonical/network/control-vpn", registry.Store), Equals, false)
+
+	err = operator.Delegate(
+		[]string{"canonical/network/control-vpn"},
+		[]registry.AuthenticationMethod{registry.Store},
+	)
+	c.Assert(err, IsNil)
+	c.Check(operator.IsDelegated("canonical/network/control-vpn", registry.Store), Equals, true)
+	c.Check(operator.IsDelegated("canonical/network/control-vpn", registry.OperatorKey), Equals, false)
+
+	// test idempotency
+	err = operator.Delegate(
+		[]string{"canonical/network/control-vpn"},
+		[]registry.AuthenticationMethod{registry.Store},
+	)
+	c.Assert(err, IsNil)
+	c.Check(operator.IsDelegated("canonical/network/control-vpn", registry.Store), Equals, true)
+}
+
+func (s *rgCtrlSuite) TestDelegateFail(c *C) {
+	operator := registry.Operator{
+		OperatorID: "canonical",
+		Groups:     make([]*registry.Group, 0),
+	}
+
+	type testcase struct {
+		views          []string
+		authentication []registry.AuthenticationMethod
+		err            string
+	}
+
+	tcs := []testcase{
+		{err: `"views" must be a non-empty list`},
+		{
+			views:          []string{"a/b/c/d"},
+			authentication: []registry.AuthenticationMethod{registry.Store},
+			err:            `"a/b/c/d" must be in the format account/registry/view`,
+		},
+		{
+			views:          []string{"a/b"},
+			authentication: []registry.AuthenticationMethod{registry.Store},
+			err:            `"a/b" must be in the format account/registry/view`,
+		},
+		{
+			views:          []string{"ab/"},
+			authentication: []registry.AuthenticationMethod{registry.Store},
+			err:            `"ab/" must be in the format account/registry/view`,
+		},
+		{
+			views:          []string{"@foo/network/control-device"},
+			authentication: []registry.AuthenticationMethod{registry.Store},
+			err:            "invalid Account ID @foo",
+		},
+		{
+			views:          []string{"canonical/123/control-device"},
+			authentication: []registry.AuthenticationMethod{registry.Store},
+			err:            "invalid registry name 123",
+		},
+		{
+			views:          []string{"canonical/network/_view"},
+			authentication: []registry.AuthenticationMethod{registry.Store},
+			err:            "invalid view name _view",
+		},
+		{views: []string{"a/b/c"}, err: `"authentication" must be a non-empty list`},
+	}
+
+	for i, tc := range tcs {
+		cmt := Commentf("test number %d", i+1)
+		err := operator.Delegate(tc.views, tc.authentication)
+		c.Assert(err, NotNil)
+		c.Assert(err, ErrorMatches, tc.err, cmt)
+	}
+}
+
+func (s *rgCtrlSuite) TestRevoke(c *C) {
+	operator := registry.Operator{
+		OperatorID: "john",
+		Groups:     make([]*registry.Group, 0),
+	}
+
+	err := operator.Delegate(
+		[]string{"canonical/network/control-interface", "canonical/network/observe-interface"},
+		[]registry.AuthenticationMethod{registry.OperatorKey},
+	)
+	c.Assert(err, IsNil)
+
+	operator.Revoke(
+		[]string{"canonical/network/control-interface"},
+		[]registry.AuthenticationMethod{registry.OperatorKey},
+	)
+	c.Check(operator.IsDelegated("canonical/network/control-interface", registry.OperatorKey), Equals, false)
+
+	// test idempotency
+	operator.Revoke(
+		[]string{"canonical/network/control-interface"},
+		[]registry.AuthenticationMethod{registry.OperatorKey},
+	)
+	c.Check(operator.IsDelegated("canonical/network/control-interface", registry.OperatorKey), Equals, false)
+
+	// revoke all auth
+	err = operator.Delegate(
+		[]string{"canonical/network/observe-interface", "canonical/network/control-vpn"},
+		[]registry.AuthenticationMethod{registry.Store, registry.OperatorKey},
+	)
+	c.Assert(err, IsNil)
+
+	err = operator.Revoke([]string{"canonical/network/observe-interface"}, nil)
+	c.Assert(err, IsNil)
+
+	c.Check(operator.IsDelegated("canonical/network/observe-interface", registry.OperatorKey), Equals, false)
+	c.Check(operator.IsDelegated("canonical/network/observe-interface", registry.Store), Equals, false)
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -142,7 +142,7 @@ func (*viewSuite) TestNewRegistry(c *C) {
 			c.Assert(err.Error(), Equals, tc.err, cmt)
 		} else {
 			c.Assert(err, IsNil, cmt)
-			c.Check(registry, Not(IsNil), cmt)
+			c.Check(registry, NotNil, cmt)
 		}
 	}
 }
@@ -234,7 +234,7 @@ func (s *viewSuite) TestAccessTypes(c *C) {
 			c.Check(registry, IsNil, cmt)
 		} else {
 			c.Assert(err, IsNil, cmt)
-			c.Check(registry, Not(IsNil), cmt)
+			c.Check(registry, NotNil, cmt)
 		}
 	}
 }
@@ -605,7 +605,7 @@ func (s *viewSuite) TestViewRequestAndStorageValidation(c *C) {
 		}, registry.NewJSONSchema())
 
 		cmt := Commentf("sub-test %q failed", tc.testName)
-		c.Assert(err, Not(IsNil), cmt)
+		c.Assert(err, NotNil, cmt)
 		c.Assert(err.Error(), Equals, `cannot define view "foo": `+tc.err, cmt)
 	}
 }


### PR DESCRIPTION
This PR adds the registry-control assertion to snapd (SD172). This doesn't include signing or acknowledging of said assertion as we need a different approach since we're signing with the device key - that will be the next PR. Finally, the API changes will follow (SD186).

This also introduces a `registry-control` feature flag.