### PR TITLE
sandbox/cgroup: improve cgroup-based process termination algorithm

### DIFF
--- a/cmd/libsnap-confine-private/locking.h
+++ b/cmd/libsnap-confine-private/locking.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <sys/types.h>
+#include <stdbool.h>
 
 /**
  * Obtain a flock-based, exclusive, globally scoped, lock.
@@ -103,5 +104,15 @@ void sc_enable_sanity_timeout(void);
  * description for more details.
  **/
 void sc_disable_sanity_timeout(void);
+
+typedef enum sc_snap_inhibition_hint {
+	SC_SNAP_HINT_INHIBITED_FOR_REMOVE = 1 << 0,
+} sc_snap_inhibition_hint;
+
+/**
+ * sc_snap_is_inhibited returns true if a given inhibition hint is set for given snap.
+ * This is determined by testing the presence of a file in /var/lib/snapd/inhibit/<snap_name>.<hint>.
+**/
+bool sc_snap_is_inhibited(const char *snap_name, sc_snap_inhibition_hint hint);
 
 #endif				// SNAP_CONFINE_LOCKING_H

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -732,6 +732,19 @@ static void enter_non_classic_execution_environment(sc_invocation *inv,
 
 	// Do per-snap initialization.
 	int snap_lock_fd = sc_lock_snap(inv->snap_instance);
+
+	// This is a workaround for systemd v237 (used by Ubuntu 18.04) for non-root users
+	// where a transient scope cgroup is not created for a snap hence it cannot be tracked
+	// before the freezer cgroup is created (and joind) below.
+	if (sc_snap_is_inhibited
+	    (inv->snap_instance, SC_SNAP_HINT_INHIBITED_FOR_REMOVE)) {
+		// Prevent starting new snap processes when snap is being removed until
+		// the freezer cgroup is created below and the snap lock is released so
+		// that remove change can track running processes through pids under the
+		// freezer cgroup.
+		die("snap is currently being removed");
+	}
+
 	debug("initializing mount namespace: %s", inv->snap_instance);
 	struct sc_mount_ns *group = NULL;
 	group = sc_open_mount_ns(inv->snap_instance);

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -735,7 +735,7 @@ static void enter_non_classic_execution_environment(sc_invocation *inv,
 
 	// This is a workaround for systemd v237 (used by Ubuntu 18.04) for non-root users
 	// where a transient scope cgroup is not created for a snap hence it cannot be tracked
-	// before the freezer cgroup is created (and joind) below.
+	// before the freezer cgroup is created (and joined) below.
 	if (sc_snap_is_inhibited
 	    (inv->snap_instance, SC_SNAP_HINT_INHIBITED_FOR_REMOVE)) {
 		// Prevent starting new snap processes when snap is being removed until

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3378,6 +3378,7 @@ func (m *SnapManager) doKillSnapApps(t *state.Task, _ *tomb.Tomb) (err error) {
 	if err != nil {
 		return err
 	}
+	defer lock.Close()
 	lock.Lock()
 	defer lock.Unlock()
 

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	"github.com/snapcore/snapd/cmd/snaplock"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -2667,8 +2668,9 @@ func (s *linkSnapSuite) testDoKillSnapApps(c *C, svc bool) {
 
 	expected := fakeOps{
 		{
-			op:   "kill-snap-apps:remove",
-			name: "some-snap",
+			op:         "kill-snap-apps:remove",
+			name:       "some-snap",
+			snapLocked: true,
 		},
 	}
 	if svc {
@@ -2684,6 +2686,12 @@ func (s *linkSnapSuite) testDoKillSnapApps(c *C, svc bool) {
 	hint, _, err := runinhibit.IsLocked("some-snap")
 	c.Assert(err, IsNil)
 	c.Check(hint, Equals, runinhibit.HintInhibitedForRemove)
+
+	// Snap lock is unlocked after kill-snap-apps returns
+	testLock, err := snaplock.OpenLock("some-snap")
+	c.Assert(err, IsNil)
+	c.Check(testLock.TryLock(), IsNil)
+	testLock.Close()
 }
 
 func (s *linkSnapSuite) TestDoKillSnapApps(c *C) {
@@ -2736,6 +2744,11 @@ func (s *linkSnapSuite) TestDoKillSnapAppsUnlocksOnError(c *C) {
 	c.Assert(err, IsNil)
 	// On error hint inhibition file is unlocked
 	c.Check(hint, Equals, runinhibit.HintNotInhibited)
+	// And snap lock is also unlocked
+	testLock, err := snaplock.OpenLock("some-snap")
+	c.Assert(err, IsNil)
+	c.Check(testLock.TryLock(), IsNil)
+	testLock.Close()
 }
 
 func (s *linkSnapSuite) testDoUndoKillSnapApps(c *C, svc bool) {
@@ -2787,8 +2800,9 @@ func (s *linkSnapSuite) testDoUndoKillSnapApps(c *C, svc bool) {
 
 	expected := fakeOps{
 		{
-			op:   "kill-snap-apps:remove",
-			name: "some-snap",
+			op:         "kill-snap-apps:remove",
+			name:       "some-snap",
+			snapLocked: true,
 		},
 	}
 	if svc {
@@ -2805,6 +2819,11 @@ func (s *linkSnapSuite) testDoUndoKillSnapApps(c *C, svc bool) {
 	c.Assert(err, IsNil)
 	// On undo hint inhibition file is unlocked
 	c.Check(hint, Equals, runinhibit.HintNotInhibited)
+	// And snap lock is also unlocked
+	testLock, err := snaplock.OpenLock("some-snap")
+	c.Assert(err, IsNil)
+	c.Check(testLock.TryLock(), IsNil)
+	testLock.Close()
 }
 
 func (s *linkSnapSuite) TestDoUndoKillSnapApps(c *C) {

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -42,6 +42,8 @@ var (
 	SecurityTagFromCgroupPath = securityTagFromCgroupPath
 
 	ApplyToSnap = applyToSnap
+
+	KillProcessesInCgroup = killProcessesInCgroup
 )
 
 func MockFsTypeForPath(mock func(string) (int64, error)) (restore func()) {
@@ -137,28 +139,12 @@ func (iw *inotifyWatcher) MonitorDelete(folders []string, name string, channel c
 
 var NewInotifyWatcher = newInotifyWatcher
 
-func MockFreezeSnapProcessesImplV1(fn func(ctx context.Context, snapName string) error) (restore func()) {
-	return testutil.Mock(&freezeSnapProcessesImplV1, fn)
-}
-
-func MockThawSnapProcessesImplV1(fn func(snapName string) error) (restore func()) {
-	return testutil.Mock(&thawSnapProcessesImplV1, fn)
+func MockKillProcessesInCgroup(fn func(dir string) error) (restore func()) {
+	return testutil.Mock(&killProcessesInCgroup, fn)
 }
 
 func MockSyscallKill(fn func(pid int, sig syscall.Signal) error) (restore func()) {
 	return testutil.Mock(&syscallKill, fn)
-}
-
-func MockFreezeOneV2(fn func(ctx context.Context, dir string) error) (restore func()) {
-	return testutil.Mock(&freezeOneV2, fn)
-}
-
-func MockThawOneV2(fn func(dir string) error) (restore func()) {
-	return testutil.Mock(&thawOneV2, fn)
-}
-
-func MockFreezePulseDelay(t time.Duration) (restore func()) {
-	return testutil.Mock(&freezePulseDelay, t)
 }
 
 func MockOsReadFile(fn func(name string) ([]byte, error)) (restore func()) {

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -139,6 +139,14 @@ func (iw *inotifyWatcher) MonitorDelete(folders []string, name string, channel c
 
 var NewInotifyWatcher = newInotifyWatcher
 
+func MockFreezeSnapProcessesImplV1(fn func(ctx context.Context, snapName string) error) (restore func()) {
+	return testutil.Mock(&freezeSnapProcessesImplV1, fn)
+}
+
+func MockThawSnapProcessesImplV1(fn func(snapName string) error) (restore func()) {
+	return testutil.Mock(&thawSnapProcessesImplV1, fn)
+}
+
 func MockKillProcessesInCgroup(fn func(dir string) error) (restore func()) {
 	return testutil.Mock(&killProcessesInCgroup, fn)
 }

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -147,7 +147,7 @@ func MockThawSnapProcessesImplV1(fn func(snapName string) error) (restore func()
 	return testutil.Mock(&thawSnapProcessesImplV1, fn)
 }
 
-func MockKillProcessesInCgroup(fn func(dir string) error) (restore func()) {
+func MockKillProcessesInCgroup(fn func(ctx context.Context, dir string) error) (restore func()) {
 	return testutil.Mock(&killProcessesInCgroup, fn)
 }
 
@@ -157,4 +157,8 @@ func MockSyscallKill(fn func(pid int, sig syscall.Signal) error) (restore func()
 
 func MockOsReadFile(fn func(name string) ([]byte, error)) (restore func()) {
 	return testutil.Mock(&osReadFile, fn)
+}
+
+func MockMaxKillTimeout(t time.Duration) (restore func()) {
+	return testutil.Mock(&maxKillTimeout, t)
 }

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -147,7 +147,7 @@ func MockThawSnapProcessesImplV1(fn func(snapName string) error) (restore func()
 	return testutil.Mock(&thawSnapProcessesImplV1, fn)
 }
 
-func MockKillProcessesInCgroup(fn func(ctx context.Context, dir string) error) (restore func()) {
+func MockKillProcessesInCgroup(fn func(ctx context.Context, dir string, freeze func(ctx context.Context), thaw func()) error) (restore func()) {
 	return testutil.Mock(&killProcessesInCgroup, fn)
 }
 
@@ -161,4 +161,8 @@ func MockOsReadFile(fn func(name string) ([]byte, error)) (restore func()) {
 
 func MockMaxKillTimeout(t time.Duration) (restore func()) {
 	return testutil.Mock(&maxKillTimeout, t)
+}
+
+func MockKillThawCooldown(t time.Duration) (restore func()) {
+	return testutil.Mock(&killThawCooldown, t)
 }

--- a/sandbox/cgroup/freezer.go
+++ b/sandbox/cgroup/freezer.go
@@ -190,7 +190,7 @@ func writeExistingFile(where string, data []byte) error {
 	return errC
 }
 
-var freezeOneV2 = func(ctx context.Context, dir string) error {
+func freezeOneV2(ctx context.Context, dir string) error {
 	groupName := filepath.Base(dir)
 	fname := filepath.Join(dir, "cgroup.freeze")
 	if err := writeExistingFile(fname, []byte("1")); err != nil {
@@ -269,7 +269,7 @@ func freezeSnapProcessesImplV2(ctx context.Context, snapName string) error {
 	return fmt.Errorf("cannot finish freezing processes of snap %q: %w", snapName, err)
 }
 
-var thawOneV2 = func(dir string) error {
+func thawOneV2(dir string) error {
 	fname := filepath.Join(dir, "cgroup.freeze")
 	if err := writeExistingFile(fname, []byte("0")); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err

--- a/sandbox/cgroup/freezer.go
+++ b/sandbox/cgroup/freezer.go
@@ -37,9 +37,9 @@ import (
 
 const defaultFreezerCgroupV1Dir = "/sys/fs/cgroup/freezer"
 const maxFreezeTimeout = 3000 * time.Millisecond
+const freezePulseDelay = 100 * time.Millisecond
 
 var freezerCgroupV1Dir = defaultFreezerCgroupV1Dir
-var freezePulseDelay = 100 * time.Millisecond
 
 var osReadFile = os.ReadFile
 

--- a/sandbox/cgroup/kill.go
+++ b/sandbox/cgroup/kill.go
@@ -43,7 +43,7 @@ import (
 //     This is to address multiple edge cases:
 //     (1) Hybrid v1/v2 cgroups with pids controller mounted only on v1 or v2 (Ubuntu 20.04)
 //     so we cannot guarantee having pids.max so we use the freezer cgroup instead.
-//     (2) Address a known bug on systemd v327 for non-root users where transient scopes are
+//     (2) Address a known bug on systemd v237 for non-root users where transient scopes are
 //     not created (e.g. on Ubuntu 18.04) so we use the freezer cgroup for tracking. This is
 //     only useful for killing apps or processes which do not have their lifecycle managed by
 //     external entities like systemd.
@@ -89,7 +89,7 @@ var killProcessesInCgroup = func(ctx context.Context, dir string, freeze func(ct
 		}
 		var firstErr error
 		for _, pid := range pids {
-			// This prevents a rouge fork bomb from keeping this loop running forever
+			// This prevents a rogue fork bomb from keeping this loop running forever
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("cannot kill processes in cgroup %q: %w", dir, ctx.Err())

--- a/sandbox/cgroup/kill.go
+++ b/sandbox/cgroup/kill.go
@@ -59,6 +59,8 @@ var syscallKill = syscall.Kill
 var maxKillTimeout = 5 * time.Minute
 var killThawCooldown = 100 * time.Millisecond
 
+const killFreezeTimeout = 1 * time.Second
+
 // killProcessesInCgroup sends SIGKILL signal to all the processes belonging to
 // passed cgroup directory.
 //
@@ -129,7 +131,7 @@ func killSnapProcessesImplV1(ctx context.Context, snapName string) error {
 		//   - A bug in some kernel versions where sometimes a cgroup get stuck
 		//     in FREEZING state. Given that maxKillTimeout is bigger than timeout passed to freezer
 		//     This gives a chance to thaw the cgroup and trying again.
-		ctxWithTimeout, cancel := context.WithTimeout(ctx, 1*time.Second)
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, killFreezeTimeout)
 		defer cancel()
 		err := freezeSnapProcessesImplV1(ctxWithTimeout, snapName)
 		if err != nil && !isCgroupNotExistErr(err) {

--- a/sandbox/cgroup/kill.go
+++ b/sandbox/cgroup/kill.go
@@ -32,14 +32,17 @@ import (
 // a given snap.
 //
 // A correct implementation is picked depending on cgroup v1 or v2 use in the
-// system. For both cgroup v1 and v2, the call will act on all tracking groups
-// of a snap.
+// system. When cgroup v1 is detected, the call will directly act on the freezer
+// group created when a snap process was started, while with v2 the call will
+// act on all tracking groups of a snap.
 //
-// Note: When cgroup v1 is detected, the call will also act on the freezer
-// group created when a snap process was started to address a known bug on
-// systemd v327 for non-root users. This is only useful for killing apps or
-// processes which do not have their lifecycle managed by external entities
-// like systemd.
+// Note: Algorithms used for killing in cgroup v1 and v2 are different.
+//   - cgroup v1: freeze/kill/thaw.
+//     This is to address multiple edge cases:
+//     (1) Hybrid v1/v2 cgroups with pids controller mounted only on v1 or v2 (Ubuntu 20.04).
+//     (2) Address a known bug on systemd v327 for non-root users where transient scopes are not created (Ubuntu 18.04).
+//   - cgroup v2: stop forking, kill processes until cgroup is drained.
+//     This is to address kernel versions without v2 freezer support.
 var KillSnapProcesses = func(ctx context.Context, snapName string) error {
 	return errors.New("KillSnapProcesses not implemented")
 }
@@ -51,6 +54,8 @@ var syscallKill = syscall.Kill
 //
 // The caller is responsible for making sure that pids are not reused
 // after reading `cgroup.procs` to avoid TOCTOU.
+//
+// TODO: Pass context and add max timeout.
 var killProcessesInCgroup = func(dir string) error {
 	// Keep sending SIGKILL signals until no more pids are left in cgroup
 	// to cover the case where a process forks before we kill it.
@@ -79,46 +84,51 @@ var killProcessesInCgroup = func(dir string) error {
 	}
 }
 
-func killSnapProcessesImplV1(ctx context.Context, snapName string) error {
-	var firstErr error
-	skipError := func(err error) bool {
-		// fs.ErrNotExist and ENODEV are ignored in case the cgroup went away while we were
-		// processing the cgorup. ENODEV is returned by the kernel if the cgroup went
-		// away while a kernfs operation is ongoing.
-		if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, syscall.ENODEV) && firstErr == nil {
-			firstErr = err
-		}
-		return true
-	}
+func isCgroupNotExistErr(err error) bool {
+	// fs.ErrNotExist and ENODEV are ignored in case the cgroup went away while we were
+	// processing the cgroup. ENODEV is returned by the kernel if the cgroup went
+	// away while a kernfs operation is ongoing.
+	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENODEV)
+}
 
-	if err := applyToSnap(snapName, killProcessesInCgroup, skipError); err != nil {
+func killSnapProcessesImplV1(ctx context.Context, snapName string) error {
+	err := freezeSnapProcessesImplV1(ctx, snapName)
+	if err != nil && !isCgroupNotExistErr(err) {
+		return err
+	}
+	// For V1, SIGKILL on a frozen cgroup will not take effect
+	// until the cgroup is thawed
+	defer thawSnapProcessesImplV1(snapName)
+
+	err = killProcessesInCgroup(filepath.Join(freezerCgroupV1Dir, fmt.Sprintf("snap.%s", snapName)))
+	if err != nil && !isCgroupNotExistErr(err) {
 		return err
 	}
 
-	// This is a workaround for systemd v237 (used by Ubuntu 18.04) for non-root users
-	// where a transient scope cgroup is not created for a snap hence it cannot be tracked
-	// by the usual snap.<security-tag>-<uuid>.scope pattern.
-	// Here, We rely on the fact that snap-confine moves the snap pids into the freezer cgroup
-	// created for the snap.
-	// There is still a tiny race window between "snap run" unlocking the run inhibition lock
-	// and snap-confine moving pids to the freezer cgroup where we would miss those pids.
-	err := killProcessesInCgroup(filepath.Join(freezerCgroupV1Dir, fmt.Sprintf("snap.%s", snapName)))
-	if err != nil && !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, syscall.ENODEV) && firstErr == nil {
-		firstErr = err
-	}
-
-	return firstErr
+	return nil
 }
 
 func killSnapProcessesImplV2(ctx context.Context, snapName string) error {
 	killCgroupProcs := func(dir string) error {
 		// Use cgroup.kill if it exists (requires linux 5.14+)
 		err := writeExistingFile(filepath.Join(dir, "cgroup.kill"), []byte("1"))
-		if err == nil || !(errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENODEV)) {
+		if err == nil || !isCgroupNotExistErr(err) {
 			return err
 		}
 
 		// Fallback to killing each pid if cgroup.kill doesn't exist
+
+		// Set pids.max to 0 to prevent a fork bomb from racing with us.
+		err = writeExistingFile(filepath.Join(dir, "pids.max"), []byte("0"))
+		// Let's continue to killing pids if the pids.max doesn't exist because
+		// it could be the case on hybrid systems that the pids controller is
+		// mounted for v1 cgroups and not available in v2 so let's give snapd
+		// a chance to kill this process even if we can't limit its number of
+		// processes (hoping we win against a fork bomb).
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+
 		if err := killProcessesInCgroup(dir); err != nil {
 			return err
 		}
@@ -127,10 +137,7 @@ func killSnapProcessesImplV2(ctx context.Context, snapName string) error {
 
 	var firstErr error
 	skipError := func(err error) bool {
-		// fs.ErrNotExist and ENODEV are ignored in case the cgroup went away while we were
-		// processing the cgroup. ENODEV is returned by the kernel if the cgroup went
-		// away while a kernfs operation is ongoing.
-		if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, syscall.ENODEV) && firstErr == nil {
+		if !isCgroupNotExistErr(err) && firstErr == nil {
 			firstErr = err
 		}
 		return true

--- a/sandbox/cgroup/kill.go
+++ b/sandbox/cgroup/kill.go
@@ -37,7 +37,9 @@ import (
 //
 // Note: When cgroup v1 is detected, the call will also act on the freezer
 // group created when a snap process was started to address a known bug on
-// systemd v327 for non-root users.
+// systemd v327 for non-root users. This is only useful for killing apps or
+// processes which do not have their lifecycle managed by external entities
+// like systemd.
 var KillSnapProcesses = func(ctx context.Context, snapName string) error {
 	return errors.New("KillSnapProcesses not implemented")
 }
@@ -112,7 +114,7 @@ func killSnapProcessesImplV2(ctx context.Context, snapName string) error {
 	killCgroupProcs := func(dir string) error {
 		// Use cgroup.kill if it exists (requires linux 5.14+)
 		err := writeExistingFile(filepath.Join(dir, "cgroup.kill"), []byte("1"))
-		if err == nil || !errors.Is(err, fs.ErrNotExist) {
+		if err == nil || !(errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENODEV)) {
 			return err
 		}
 

--- a/sandbox/cgroup/kill.go
+++ b/sandbox/cgroup/kill.go
@@ -128,7 +128,7 @@ func killSnapProcessesImplV2(ctx context.Context, snapName string) error {
 	var firstErr error
 	skipError := func(err error) bool {
 		// fs.ErrNotExist and ENODEV are ignored in case the cgroup went away while we were
-		// processing the cgorup. ENODEV is returned by the kernel if the cgroup went
+		// processing the cgroup. ENODEV is returned by the kernel if the cgroup went
 		// away while a kernfs operation is ongoing.
 		if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, syscall.ENODEV) && firstErr == nil {
 			firstErr = err

--- a/sandbox/cgroup/kill_test.go
+++ b/sandbox/cgroup/kill_test.go
@@ -20,11 +20,14 @@ package cgroup_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
-	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -36,8 +39,6 @@ import (
 type killSuite struct {
 	testutil.BaseTest
 	rootDir string
-
-	ops []string
 }
 
 var _ = Suite(&killSuite{})
@@ -48,125 +49,117 @@ func (s *killSuite) SetUpTest(c *C) {
 	s.rootDir = c.MkDir()
 	dirs.SetRootDir(s.rootDir)
 	s.AddCleanup(func() { dirs.SetRootDir("") })
-
-	restore := cgroup.MockFreezePulseDelay(time.Nanosecond)
-	s.AddCleanup(restore)
-
-	restore = cgroup.MockFreezeSnapProcessesImplV1(func(ctx context.Context, snapName string) error {
-		s.ops = append(s.ops, "freeze-snap-processes-v1:"+snapName)
-		return nil
-	})
-	s.AddCleanup(restore)
-	restore = cgroup.MockFreezeOneV2(func(ctx context.Context, dir string) error {
-		s.ops = append(s.ops, "freeze-one-v2:"+filepath.Base(dir))
-		return nil
-	})
-	s.AddCleanup(restore)
-
-	restore = cgroup.MockThawSnapProcessesImplV1(func(snapName string) error {
-		s.ops = append(s.ops, "thaw-snap-processes-v1:"+snapName)
-		return nil
-	})
-	s.AddCleanup(restore)
-	restore = cgroup.MockThawOneV2(func(dir string) error {
-		s.ops = append(s.ops, "thaw-one-v2:"+filepath.Base(dir))
-		return nil
-	})
-	s.AddCleanup(restore)
-
-	restore = cgroup.MockSyscallKill(func(pid int, sig syscall.Signal) error {
-		s.ops = append(s.ops, fmt.Sprintf("kill-pid:%d, signal:%d", pid, sig))
-		return nil
-	})
-	s.AddCleanup(restore)
-
-	s.AddCleanup(s.clearOps)
 }
 
-func (s *killSuite) clearOps() {
-	s.ops = nil
+func mockCgroupsWithProcs(c *C, cgroupsToProcs map[string][]string) {
+	for cg, pids := range cgroupsToProcs {
+		procs := filepath.Join(dirs.GlobalRootDir, cg, "cgroup.procs")
+		c.Assert(os.MkdirAll(filepath.Dir(procs), 0755), IsNil)
+		c.Assert(os.WriteFile(procs, []byte(strings.Join(pids, "\n")), 0644), IsNil)
+	}
 }
 
 func (s *killSuite) TestKillSnapProcessesV1(c *C) {
 	restore := cgroup.MockVersion(cgroup.V1, nil)
 	defer restore()
 
+	cgroupsToProcs := map[string][]string{
+		// Transient cgroups for snap "foo"
+		"/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.1234-1234-1234.scope": {"1"},
+		"/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.9876.scope":           {"2", "3"},
+		"/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-2.some-scope.scope":     {"4"},
+		// Freezer cgroup for snap "foo"
+		"/sys/fs/cgroup/freezer/snap.foo": {"1", "2", "3", "4"},
+		// Transient cgroups for snap "bar"
+		"/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.bar.app-1.1234-1234-1234.scope": {"6", "7"},
+		// Freezer cgroup for snap "bar"
+		"/sys/fs/cgroup/freezer/snap.bar": {"6", "7"},
+	}
+	mockCgroupsWithProcs(c, cgroupsToProcs)
+
+	var ops []string
+	restore = cgroup.MockKillProcessesInCgroup(func(dir string) error {
+		// trim tmp root dir
+		dir = strings.TrimPrefix(dir, s.rootDir)
+		ops = append(ops, fmt.Sprintf("kill cgroup: %s", dir))
+		return nil
+	})
+	defer restore()
+
+	c.Assert(cgroup.KillSnapProcesses(context.TODO(), "foo"), IsNil)
+	c.Assert(ops, DeepEquals, []string{
+		"kill cgroup: /sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.1234-1234-1234.scope",
+		"kill cgroup: /sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.9876.scope",
+		"kill cgroup: /sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-2.some-scope.scope",
+		"kill cgroup: /sys/fs/cgroup/freezer/snap.foo",
+	})
+}
+
+func (s *killSuite) TestKillSnapProcessesV1NoCgroups(c *C) {
+	// Simulate the case of a snap that was never run so
+	// snap-confine never even created the freezer for it.
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
 	snapName := "foo"
 	cg := filepath.Join(cgroup.FreezerCgroupV1Dir(), fmt.Sprintf("snap.%s", snapName))
-	procs := filepath.Join(cg, "cgroup.procs")
+	c.Assert(cg, testutil.FileAbsent)
 
-	c.Assert(os.MkdirAll(cg, 0755), IsNil)
-	c.Assert(os.WriteFile(procs, nil, 0644), IsNil)
-
-	// When no pids exist in cgroup.procs, do nothing
 	c.Assert(cgroup.KillSnapProcesses(context.TODO(), snapName), IsNil)
-	c.Assert(s.ops, DeepEquals, []string{
-		"freeze-snap-processes-v1:foo",
-		"thaw-snap-processes-v1:foo",
-	})
-	// Clear logged ops for following checks
-	s.clearOps()
-
-	// Now mock running pids
-	c.Assert(os.WriteFile(procs, []byte("3\n1\n2"), 0644), IsNil)
-	c.Assert(cgroup.KillSnapProcesses(context.TODO(), snapName), IsNil)
-	c.Assert(s.ops, DeepEquals, []string{
-		"freeze-snap-processes-v1:foo",
-		"kill-pid:3, signal:9",
-		"kill-pid:1, signal:9",
-		"kill-pid:2, signal:9",
-		"thaw-snap-processes-v1:foo",
-	})
 }
 
 func (s *killSuite) testKillSnapProcessesV2(c *C, cgroupKillSupported bool) {
 	restore := cgroup.MockVersion(cgroup.V2, nil)
 	defer restore()
 
-	scopesToProcs := map[string]string{
-		"snap.foo.app-1.1234-1234-1234.scope": "1\n2\n3",
-		"snap.foo.app-1.no-pids.scope":        "",
-		"snap.foo.app-2.some-scope.scope":     "9\n8\n7",
+	cgroupsToProcs := map[string][]string{
+		// Transient cgroups for snap "foo"
+		"/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.1234-1234-1234.scope": {"1"},
+		"/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.9876.scope":           {"2", "3"},
+		"/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-2.some-scope.scope":     {"4"},
+		// Transient cgroups for snap "bar"
+		"/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.bar.app-1.1234-1234-1234.scope": {"5"},
 	}
+	mockCgroupsWithProcs(c, cgroupsToProcs)
 
-	for scope, pids := range scopesToProcs {
-		cg := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/system.slice", scope)
-		procs := filepath.Join(cg, "cgroup.procs")
-		c.Assert(os.MkdirAll(cg, 0755), IsNil)
-		c.Assert(os.WriteFile(procs, []byte(pids), 0644), IsNil)
-		if cgroupKillSupported {
-			c.Assert(os.WriteFile(filepath.Join(cg, "cgroup.kill"), []byte(""), 0644), IsNil)
+	if cgroupKillSupported {
+		for cg := range cgroupsToProcs {
+			c.Assert(os.WriteFile(filepath.Join(s.rootDir, cg, "cgroup.kill"), []byte(""), 0644), IsNil)
 		}
 	}
+
+	var ops []string
+	restore = cgroup.MockKillProcessesInCgroup(func(dir string) error {
+		// trim tmp root dir
+		dir = strings.TrimPrefix(dir, s.rootDir)
+		ops = append(ops, fmt.Sprintf("kill cgroup: %s", dir))
+		return nil
+	})
+	defer restore()
 
 	c.Assert(cgroup.KillSnapProcesses(context.TODO(), "foo"), IsNil)
 
 	if cgroupKillSupported {
-		for scope := range scopesToProcs {
-			cgKill := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/system.slice", scope, "cgroup.kill")
-			// "1" was written to cgroup.kill
-			c.Assert(cgKill, testutil.FileEquals, "1")
+		for cg := range cgroupsToProcs {
+			cgKill := filepath.Join(s.rootDir, cg, "cgroup.kill")
+			if strings.HasSuffix(cg, "snap.bar.app-1.1234-1234-1234.scope") {
+				c.Assert(cgKill, testutil.FileEquals, "")
+			} else {
+				// "1" was written to cgroup.kill
+				c.Assert(cgKill, testutil.FileEquals, "1")
+			}
 		}
 		// Didn't fallback to classic implementation
-		c.Assert(s.ops, IsNil)
+		c.Assert(ops, IsNil)
 	} else {
-		for scope := range scopesToProcs {
-			cgKill := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/system.slice", scope, "cgroup.kill")
+		for cg := range cgroupsToProcs {
+			cgKill := filepath.Join(s.rootDir, cg, "cgroup.kill")
 			c.Assert(cgKill, testutil.FileAbsent)
 		}
-		c.Assert(s.ops, DeepEquals, []string{
-			// Kill first cgroup
-			"freeze-one-v2:snap.foo.app-1.1234-1234-1234.scope",
-			"kill-pid:1, signal:9",
-			"kill-pid:2, signal:9",
-			"kill-pid:3, signal:9",
-			// No pids to kill in second cgroup
-			"freeze-one-v2:snap.foo.app-1.no-pids.scope",
-			// Kill third cgroup
-			"freeze-one-v2:snap.foo.app-2.some-scope.scope",
-			"kill-pid:9, signal:9",
-			"kill-pid:8, signal:9",
-			"kill-pid:7, signal:9",
+		c.Assert(ops, DeepEquals, []string{
+			"kill cgroup: /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.1234-1234-1234.scope",
+			"kill cgroup: /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.9876.scope",
+			"kill cgroup: /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-2.some-scope.scope",
 		})
 	}
 }
@@ -182,71 +175,180 @@ func (s *killSuite) TestKillSnapProcessesV2CgKillSupported(c *C) {
 	s.testKillSnapProcessesV2(c, cgroupKillSupported)
 }
 
-func (s *killSuite) testKillSnapProcessesError(c *C, cgVersion int) {
+func removePid(cgroupsToProcs map[string][]string, targetPid int) map[string][]string {
+	newCgroupsToProcs := make(map[string][]string, len(cgroupsToProcs))
+	for cg, pids := range cgroupsToProcs {
+		var newPids []string
+		for _, pid := range pids {
+			if strconv.Itoa(targetPid) == pid {
+				continue
+			}
+			newPids = append(newPids, pid)
+		}
+		newCgroupsToProcs[cg] = newPids
+	}
+
+	return newCgroupsToProcs
+}
+
+func (s *killSuite) testKillSnapProcessesError(c *C, cgVersion int, freezerOnly bool) {
 	restore := cgroup.MockVersion(cgVersion, nil)
 	defer restore()
 
+	var cgroupsToProcs map[string][]string
 	if cgVersion == cgroup.V1 {
-		procs := filepath.Join(cgroup.FreezerCgroupV1Dir(), "snap.foo", "cgroup.procs")
-		c.Assert(os.MkdirAll(filepath.Dir(procs), 0755), IsNil)
-		c.Assert(os.WriteFile(procs, []byte("1\n2\n3\n4"), 0644), IsNil)
-	} else {
-		scopesToProcs := map[string]string{
-			"snap.foo.app-1.1234-1234-1234.scope": "1",
-			"snap.foo.app-1.no-pids.scope":        "2\n3",
-			"snap.foo.app-2.some-scope.scope":     "4",
+		if freezerOnly {
+			// This tests the workaround implemented for systemd v237 (used by Ubuntu 18.04) for
+			// non-root users where a transient scope cgroup is not created for a snap hence it
+			// cannot be tracked by the usual snap.<security-tag>-<uuid>.scope pattern.
+			cgroupsToProcs = map[string][]string{
+				"/sys/fs/cgroup/freezer/snap.foo": {"1", "2", "3", "4"},
+			}
+		} else {
+			cgroupsToProcs = map[string][]string{
+				"/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.1234-1234-1234.scope": {"1"},
+				"/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.9876.scope":           {"2", "3"},
+				"/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-2.some-scope.scope":     {"4"},
+				"/sys/fs/cgroup/freezer/snap.foo": {"1", "2", "3", "4"},
+			}
 		}
-		for scope, pids := range scopesToProcs {
-			procs := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/system.slice", scope, "cgroup.procs")
-			c.Assert(os.MkdirAll(filepath.Dir(procs), 0755), IsNil)
-			c.Assert(os.WriteFile(procs, []byte(pids), 0644), IsNil)
+	} else {
+		cgroupsToProcs = map[string][]string{
+			"/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.1234-1234-1234.scope": {"1"},
+			"/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.9876.scope":           {"2", "3"},
+			"/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-2.some-scope.scope":     {"4"},
 		}
 	}
+	mockCgroupsWithProcs(c, cgroupsToProcs)
 
+	var ops []string
 	restore = cgroup.MockSyscallKill(func(pid int, sig syscall.Signal) error {
 		if pid == 1 || pid == 2 {
 			return fmt.Errorf("mock error for pid %d", pid)
 		}
-		s.ops = append(s.ops, fmt.Sprintf("kill-pid:%d, signal:%d", pid, sig))
+
+		// simulate killing pid
+		cgroupsToProcs = removePid(cgroupsToProcs, pid)
+		mockCgroupsWithProcs(c, cgroupsToProcs)
+
+		ops = append(ops, fmt.Sprintf("kill-pid:%d, signal:%d", pid, sig))
 		return nil
 	})
 	defer restore()
 
 	// Call failed and reported first error only
-	c.Assert(cgroup.KillSnapProcesses(context.TODO(), "foo"), ErrorMatches, "mock error for pid 1")
+	err := cgroup.KillSnapProcesses(context.TODO(), "foo")
+	c.Assert(err, ErrorMatches, "mock error for pid 1")
 
 	// But kept going
-	if cgVersion == cgroup.V1 {
-		c.Assert(s.ops, DeepEquals, []string{
-			"freeze-snap-processes-v1:foo",
-			"kill-pid:3, signal:9",
-			"kill-pid:4, signal:9",
-			"thaw-snap-processes-v1:foo",
-		})
-	} else {
-		c.Assert(s.ops, DeepEquals, []string{
-			// Kill first cgroup
-			"freeze-one-v2:snap.foo.app-1.1234-1234-1234.scope",
-			// Pid 1 not killed due to error
-			"thaw-one-v2:snap.foo.app-1.1234-1234-1234.scope", // Thaw on error
-			// Kill second cgroup
-			"freeze-one-v2:snap.foo.app-1.no-pids.scope",
-			// Pid 2 not killed due to error
-			"kill-pid:3, signal:9",
-			"thaw-one-v2:snap.foo.app-1.no-pids.scope", // Thaw on error
-			// Kill third cgroup
-			"freeze-one-v2:snap.foo.app-2.some-scope.scope",
-			"kill-pid:4, signal:9",
-		})
-	}
+	c.Assert(ops, DeepEquals, []string{
+		// Pid 1 not killed due to error
+		// Pid 2 not killed due to error
+		"kill-pid:3, signal:9",
+		"kill-pid:4, signal:9",
+	})
 }
 
 func (s *killSuite) TestKillSnapProcessesV1Error(c *C) {
 	const cgVersion = cgroup.V1
-	s.testKillSnapProcessesError(c, cgVersion)
+	const freezerOnly = false
+	s.testKillSnapProcessesError(c, cgVersion, freezerOnly)
+}
+
+func (s *killSuite) TestKillSnapProcessesV1ErrorSystemd237Regression(c *C) {
+	// This tests the workaround implemented for systemd v237 (used by Ubuntu 18.04) for
+	// non-root users where a transient scope cgroup is not created for a snap hence it
+	// cannot be tracked by the usual snap.<security-tag>-<uuid>.scope pattern.
+	const cgVersion = cgroup.V1
+	const freezerOnly = true
+	s.testKillSnapProcessesError(c, cgVersion, freezerOnly)
 }
 
 func (s *killSuite) TestKillSnapProcessesV2Error(c *C) {
 	const cgVersion = cgroup.V2
-	s.testKillSnapProcessesError(c, cgVersion)
+	const freezerOnly = false
+	s.testKillSnapProcessesError(c, cgVersion, freezerOnly)
+}
+
+func (s *killSuite) testKillSnapProcessesSkippedErrors(c *C, cgVersion int) {
+	restore := cgroup.MockVersion(cgVersion, nil)
+	defer restore()
+
+	cg := "/sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.1234-1234-1234.scope"
+	if cgVersion == cgroup.V2 {
+		cg = "/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.1234-1234-1234.scope"
+	}
+	mockCgroupsWithProcs(c, map[string][]string{cg: {"1"}})
+
+	var cgroupErr error
+	restore = cgroup.MockKillProcessesInCgroup(func(dir string) error {
+		return cgroupErr
+	})
+	defer restore()
+
+	// ENOENT should be ignored to account for a cgroup going away before processing
+	cgroupErr = fs.ErrNotExist
+	c.Assert(cgroup.KillSnapProcesses(context.TODO(), "foo"), IsNil)
+
+	// ENODEV should also be ignored to account to cgroup going away in the middle of
+	// kernel work (kernfs implementation return ENODEV)
+	cgroupErr = syscall.ENODEV
+	c.Assert(cgroup.KillSnapProcesses(context.TODO(), "foo"), IsNil)
+
+	// Other errors are propagated
+	cgroupErr = errors.New("cgroup error")
+	c.Assert(cgroup.KillSnapProcesses(context.TODO(), "foo"), ErrorMatches, "cgroup error")
+}
+
+func (s *killSuite) TestKillSnapProcessesSkippedErrorsV1(c *C) {
+	const cgVersion = cgroup.V1
+	s.testKillSnapProcessesSkippedErrors(c, cgVersion)
+}
+
+func (s *killSuite) TestKillSnapProcessesSkippedErrorsV2(c *C) {
+	const cgVersion = cgroup.V2
+	s.testKillSnapProcessesSkippedErrors(c, cgVersion)
+}
+
+func (s *killSuite) TestKillProcessesInCgroupForkingProcess(c *C) {
+	cg := filepath.Join(s.rootDir, "/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.1234-1234-1234.scope")
+	c.Assert(os.MkdirAll(cg, 0755), IsNil)
+
+	pid := 2
+	procs := filepath.Join(cg, "cgroup.procs")
+	c.Assert(os.WriteFile(procs, []byte(strconv.Itoa(pid)), 0644), IsNil)
+
+	restore := cgroup.MockSyscallKill(func(targetPid int, sig syscall.Signal) error {
+		c.Assert(targetPid, Equals, pid)
+		// Mock a new fork for next check
+		if pid < 10 {
+			pid++
+			c.Assert(os.WriteFile(procs, []byte(strconv.Itoa(pid)), 0644), IsNil)
+		} else {
+			c.Assert(os.WriteFile(procs, nil, 0644), IsNil)
+		}
+		return nil
+	})
+	defer restore()
+
+	c.Assert(cgroup.KillProcessesInCgroup(cg), IsNil)
+	c.Assert(pid, Equals, 10)
+}
+
+func (s *killSuite) TestKillProcessesInCgroupPidNotFound(c *C) {
+	cg := filepath.Join(s.rootDir, "/sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/app.slice/snap.foo.app-1.1234-1234-1234.scope")
+	c.Assert(os.MkdirAll(cg, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(cg, "cgroup.procs"), []byte("1"), 0644), IsNil)
+
+	var n int
+	restore := cgroup.MockSyscallKill(func(pid int, sig syscall.Signal) error {
+		n++
+		c.Assert(pid, Equals, 1)
+		c.Assert(os.WriteFile(filepath.Join(cg, "cgroup.procs"), nil, 0644), IsNil)
+		return syscall.ESRCH
+	})
+	defer restore()
+
+	c.Assert(cgroup.KillProcessesInCgroup(cg), IsNil)
+	c.Assert(n, Equals, 1)
 }

--- a/sandbox/cgroup/kill_test.go
+++ b/sandbox/cgroup/kill_test.go
@@ -100,6 +100,9 @@ func (s *killSuite) TestKillSnapProcessesV1(c *C) {
 	c.Assert(cgroup.KillSnapProcesses(context.TODO(), "foo"), IsNil)
 	c.Assert(ops, DeepEquals, []string{
 		"freeze-snap-processes-v1:foo",
+		"kill cgroup: /sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.1234-1234-1234.scope",
+		"kill cgroup: /sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-1.9876.scope",
+		"kill cgroup: /sys/fs/cgroup/pids/user.slice/user-0.slice/user@0.service/snap.foo.app-2.some-scope.scope",
 		"kill cgroup: /sys/fs/cgroup/freezer/snap.foo",
 		"thaw-snap-processes-v1:foo",
 	})
@@ -434,7 +437,7 @@ func (s *killSuite) TestKillProcessInCgroupTimeout(c *C) {
 	})
 	defer restore()
 
-	restore = cgroup.MockMaxKillTimeout(50 * time.Millisecond)
+	restore = cgroup.MockMaxKillTimeout(10 * time.Millisecond)
 	defer restore()
 
 	err := cgroup.KillProcessesInCgroup(context.TODO(), cg)

--- a/tests/lib/snaps/fork-bomb/bin/bomb
+++ b/tests/lib/snaps/fork-bomb/bin/bomb
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 bomb() { 
- bomb | bomb &
+  #shellcheck disable=SC2264
+  bomb | bomb &
 }; bomb

--- a/tests/lib/snaps/fork-bomb/bin/bomb
+++ b/tests/lib/snaps/fork-bomb/bin/bomb
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+bomb() { 
+ bomb | bomb &
+}; bomb

--- a/tests/lib/snaps/fork-bomb/bin/sh
+++ b/tests/lib/snaps/fork-bomb/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/fork-bomb/meta/snap.yaml
+++ b/tests/lib/snaps/fork-bomb/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: fork-bomb
+version: 1.0
+license: GPL-3.0
+apps:
+ fork-bomb:
+  command: bin/bomb
+description: |
+  A fork bomb as the name suggests

--- a/tests/lib/snaps/fork-bomb/meta/snap.yaml
+++ b/tests/lib/snaps/fork-bomb/meta/snap.yaml
@@ -1,8 +1,12 @@
 name: fork-bomb
 version: 1.0
+base: core24
 license: GPL-3.0
 apps:
- fork-bomb:
-  command: bin/bomb
+  fork-bomb:
+    command: bin/bomb
+  sh:
+    command: bin/sh
+
 description: |
   A fork bomb as the name suggests

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -44,6 +44,12 @@ execute: |
 
     sh_snap_bin="$(command -v fork-bomb.sh)"
     if [ "$BAD_SNAP" = "fork-bomb" ]; then
+        if [[ "$SPREAD_SYSTEM" = amazon-linux-2-* ]]; then
+            # Amazon Linux 2 does not support systemd --user (see tests/main/tests.session-support for details)
+            echo "Skipping because systemd --user is not supported"
+            exit 0
+        fi
+
         #shellcheck disable=SC2016,SC2086
         alive_check="$(tests.session -u test exec $sh_snap_bin -c 'echo $SNAP_USER_COMMON/alive')"
         #shellcheck disable=SC2016

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -8,8 +8,16 @@ systems:
     # Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
     - -ubuntu-14.04-*
 
+environment:
+    BAD_SNAP/fork_bomb: fork-bomb
+    BAD_SNAP/no_fork_bomb: no-fork-bomb
+
 prepare: |
-    snap install test-snapd-sh
+    if [ "$BAD_SNAP" = "fork-bomb" ]; then
+        "$TESTSTOOLS"/snaps-state install-local fork-bomb
+    else
+        snap install test-snapd-sh
+    fi
 
 restore: |
     systemctl stop test-kill.service || true
@@ -22,8 +30,14 @@ execute: |
     echo "Start a long running process"
     lockfile="$(pwd)/lockfile"
     touch "$lockfile"
-    sh_snap_bin="$(command -v test-snapd-sh.sh)"
-    systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/test-snapd-sh/common/alive; sleep 100000'
+
+    if [ "$BAD_SNAP" = "fork-bomb" ]; then
+        sh_snap_bin="$(command -v fork-bomb)"
+        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin"
+    else
+        sh_snap_bin="$(command -v test-snapd-sh.sh)"
+        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/test-snapd-sh/common/alive; sleep 100000'
+    fi
     # Wait for service to be up
     retry -n 10 test -f /var/snap/test-snapd-sh/common/alive
 
@@ -31,7 +45,11 @@ execute: |
     not flock --timeout 0 "$lockfile" --command "true"
 
     echo "Remove snap with --terminate flag"
-    snap remove --terminate test-snapd-sh
+    if [ "$BAD_SNAP" = "fork-bomb" ]; then
+        snap remove --terminate fork-bomb
+    else
+        snap remove --terminate test-snapd-sh
+    fi
 
     echo "Running process should be terminated after remove change is complete and lockfile should be unlocked"
     flock --timeout 60 "$lockfile" --command "true"

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -8,6 +8,8 @@ systems:
     # Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
     - -ubuntu-14.04-*
 
+kill-timeout: 10m
+
 environment:
     BAD_SNAP/fork_bomb: fork-bomb
     BAD_SNAP/no_fork_bomb: no-fork-bomb
@@ -15,9 +17,21 @@ environment:
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local fork-bomb
 
+    if [ "$BAD_SNAP" = "fork-bomb" ]; then
+        tests.session -u test prepare
+        uid="$(id -u test)"
+        systemctl set-property "user-$uid.slice" TasksMax=1000
+    fi
+
 restore: |
-    systemctl stop test-kill.service || true
-    systemctl reset-failed test-kill.service || true
+    if [ "$BAD_SNAP" = "fork-bomb" ]; then
+        tests.session -u test restore
+        tests.session -u test exec systemctl --user stop test-kill.service || true
+        tests.session -u test exec systemctl --user reset-failed test-kill.service || true
+    else
+        systemctl stop test-kill.service || true
+        systemctl reset-failed test-kill.service || true
+    fi
 
 debug: |
     journalctl -u test-kill.service
@@ -26,17 +40,19 @@ execute: |
     echo "Start a long running process"
     lockfile="$(pwd)/lockfile"
     touch "$lockfile"
+    alive_check="/var/snap/fork-bomb/common/alive"
 
     sh_snap_bin="$(command -v fork-bomb.sh)"
     if [ "$BAD_SNAP" = "fork-bomb" ]; then
+        #shellcheck disable=SC2016,SC2086
+        alive_check="$(tests.session -u test exec $sh_snap_bin -c 'echo $SNAP_USER_COMMON/alive')"
         #shellcheck disable=SC2016
-        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/fork-bomb/common/alive; $SNAP/bin/bomb'
+        tests.session -u test exec systemd-run --user --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch $SNAP_USER_COMMON/alive; sleep 100000'
     else
-        #shellcheck disable=SC2016
         systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/fork-bomb/common/alive; sleep 100000'
     fi
-    # Wait for service to be up
-    retry -n 10 test -f /var/snap/fork-bomb/common/alive
+    # Wait for snap to start
+    retry -n 10 test -f "$alive_check"
 
     echo "Lock is held"
     not flock --timeout 0 "$lockfile" --command "true"

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -30,13 +30,13 @@ execute: |
     sh_snap_bin="$(command -v fork-bomb.sh)"
     if [ "$BAD_SNAP" = "fork-bomb" ]; then
         #shellcheck disable=SC2016
-        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/test-snapd-sh/common/alive; $SNAP/bin/fork-bomb'
+        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/fork-bomb/common/alive; $SNAP/bin/fork-bomb'
     else
         #shellcheck disable=SC2016
-        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/test-snapd-sh/common/alive; sleep 100000'
+        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/fork-bomb/common/alive; sleep 100000'
     fi
     # Wait for service to be up
-    retry -n 10 test -f /var/snap/test-snapd-sh/common/alive
+    retry -n 10 test -f /var/snap/fork-bomb/common/alive
 
     echo "Lock is held"
     not flock --timeout 0 "$lockfile" --command "true"

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -30,7 +30,7 @@ execute: |
     sh_snap_bin="$(command -v fork-bomb.sh)"
     if [ "$BAD_SNAP" = "fork-bomb" ]; then
         #shellcheck disable=SC2016
-        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/fork-bomb/common/alive; $SNAP/bin/fork-bomb'
+        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/fork-bomb/common/alive; $SNAP/bin/bomb'
     else
         #shellcheck disable=SC2016
         systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/fork-bomb/common/alive; sleep 100000'

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -13,11 +13,7 @@ environment:
     BAD_SNAP/no_fork_bomb: no-fork-bomb
 
 prepare: |
-    if [ "$BAD_SNAP" = "fork-bomb" ]; then
-        "$TESTSTOOLS"/snaps-state install-local fork-bomb
-    else
-        snap install test-snapd-sh
-    fi
+    "$TESTSTOOLS"/snaps-state install-local fork-bomb
 
 restore: |
     systemctl stop test-kill.service || true
@@ -31,11 +27,12 @@ execute: |
     lockfile="$(pwd)/lockfile"
     touch "$lockfile"
 
+    sh_snap_bin="$(command -v fork-bomb.sh)"
     if [ "$BAD_SNAP" = "fork-bomb" ]; then
-        sh_snap_bin="$(command -v fork-bomb)"
-        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin"
+        #shellcheck disable=SC2016
+        systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/test-snapd-sh/common/alive; $SNAP/bin/fork-bomb'
     else
-        sh_snap_bin="$(command -v test-snapd-sh.sh)"
+        #shellcheck disable=SC2016
         systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/test-snapd-sh/common/alive; sleep 100000'
     fi
     # Wait for service to be up
@@ -45,11 +42,7 @@ execute: |
     not flock --timeout 0 "$lockfile" --command "true"
 
     echo "Remove snap with --terminate flag"
-    if [ "$BAD_SNAP" = "fork-bomb" ]; then
-        snap remove --terminate fork-bomb
-    else
-        snap remove --terminate test-snapd-sh
-    fi
+    snap remove --terminate fork-bomb
 
     echo "Running process should be terminated after remove change is complete and lockfile should be unlocked"
     flock --timeout 60 "$lockfile" --command "true"


### PR DESCRIPTION
unify termination algorithm for v1/v2
- for each snap cgroup:
  - while cgroup.procs is not empty:
    - SIGKILL each pid in cgroup.procs
- for v2 only
  - set pids.max to 0 to counter fork-bombs (this is an alternative to cgroup freezing which is not available on older kernels)
- for v1 only
  - kill pids found in freezer cgroup created by snap-confine (this is relevant for systemd v237 (used in ubuntu 18.04) for non-root users where the transient scope cgroups are not created)
  - freeze/thaw using freezer cgroup because we cannot guarantee having the pids controller on hybrid systems on the cgroup version we are using

**Note: Terminating classic snap apps is best effort and cannot be guaranteed because a snap app can use systemd-run to break out of the cgroups used for tracking snap pids.**

This PR should also fix flakey results seen in `tests/main/snap-remove-terminate`.
