### PR TITLE
tests: increase flock check timeout in tests/main/snap-remove-terminate

### DIFF
--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -25,7 +25,7 @@ execute: |
     retry -n 10 systemctl is-active test-kill.service
 
     echo "Lock is held"
-    not flock --timeout 0 "$lockfile" --command "true"
+    not flock --timeout 10 "$lockfile" --command "true"
 
     echo "Remove snap with --terminate flag"
     snap remove --terminate test-snapd-sh

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -23,12 +23,9 @@ execute: |
     lockfile="$(pwd)/lockfile"
     touch "$lockfile"
     sh_snap_bin="$(command -v test-snapd-sh.sh)"
-    # shellcheck disable=SC2016
-    alive_check="$($sh_snap_bin -c 'echo $SNAP_COMMON/alive')"
-    # shellcheck disable=SC2016
-    systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch $SNAP_COMMON/alive; sleep 100000'
+    systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch /var/snap/test-snapd-sh/common/alive; sleep 100000'
     # Wait for service to be up
-    retry -n 10 test -f "$alive_check"
+    retry -n 10 test -f /var/snap/test-snapd-sh/common/alive
 
     echo "Lock is held"
     not flock --timeout 0 "$lockfile" --command "true"

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -23,7 +23,9 @@ execute: |
     lockfile="$(pwd)/lockfile"
     touch "$lockfile"
     sh_snap_bin="$(command -v test-snapd-sh.sh)"
+    # shellcheck disable=SC2016
     alive_check="$($sh_snap_bin -c 'echo $SNAP_COMMON/alive')"
+    # shellcheck disable=SC2016
     systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch $SNAP_COMMON/alive; sleep 100000'
     # Wait for service to be up
     retry -n 10 test -f "$alive_check"

--- a/tests/main/snap-remove-terminate/task.yaml
+++ b/tests/main/snap-remove-terminate/task.yaml
@@ -15,17 +15,21 @@ restore: |
     systemctl stop test-kill.service || true
     systemctl reset-failed test-kill.service || true
 
+debug: |
+    journalctl -u test-kill.service
+
 execute: |
     echo "Start a long running process"
     lockfile="$(pwd)/lockfile"
     touch "$lockfile"
     sh_snap_bin="$(command -v test-snapd-sh.sh)"
-    systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c "sleep 100000"
+    alive_check="$($sh_snap_bin -c 'echo $SNAP_COMMON/alive')"
+    systemd-run --unit test-kill.service flock "$lockfile" "$sh_snap_bin" -c 'touch $SNAP_COMMON/alive; sleep 100000'
     # Wait for service to be up
-    retry -n 10 systemctl is-active test-kill.service
+    retry -n 10 test -f "$alive_check"
 
     echo "Lock is held"
-    not flock --timeout 10 "$lockfile" --command "true"
+    not flock --timeout 0 "$lockfile" --command "true"
 
     echo "Remove snap with --terminate flag"
     snap remove --terminate test-snapd-sh


### PR DESCRIPTION
The flock check was testing that the service just created has held the flock immediately. In some cases the test service wasn't able to hold the lock fast enough.

Instead, check that a file is created by the service to confirm the snap is run by the service.

Sample test run where this happend: https://github.com/canonical/snapd/actions/runs/10846480097/job/30100068155