### PR TITLE
overlord/fdestate: keep FDE state up to date

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&assetsSuite{})
 func (s *assetsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return nil
 	})
 	s.AddCleanup(restore)
@@ -788,7 +788,7 @@ func (s *assetsSuite) testUpdateObserverUpdateMockedWithReseal(c *C, seedRole st
 
 	// everything is set up, trigger a reseal
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -893,7 +893,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 
 	// everything is set up, trigger reseal
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -1649,7 +1649,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		"shim":  []string{shimHash},
 	})
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -1809,7 +1809,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -2561,7 +2561,7 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 
 	// everything is set up, trigger a reseal
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 1)
@@ -2713,7 +2713,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 
 	resealCalls := 0
 
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 1)
@@ -2846,7 +2846,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedNonEncryption(c *C) {
 
 	// make sure that no reseal is triggered
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -137,7 +137,7 @@ type baseBootenv20Suite struct {
 func (s *baseBootenv20Suite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return nil
 	})
 	s.AddCleanup(restore)
@@ -1121,7 +1121,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 2)
@@ -1241,7 +1241,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 2)
@@ -1362,7 +1362,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -1459,7 +1459,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -2058,7 +2058,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 1)
@@ -2292,7 +2292,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 1)
@@ -2453,7 +2453,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -2567,7 +2567,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -3156,7 +3156,7 @@ var _ = Suite(&bootConfigSuite{})
 func (s *bootConfigSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return nil
 	})
 	s.AddCleanup(restore)
@@ -3193,7 +3193,7 @@ func (s *bootConfigSuite) TestBootConfigUpdateHappyNoKeysNoReseal(c *C) {
 	c.Assert(m.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -3245,7 +3245,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyWithReseal(c *C, cmdlineAppen
 	newCmdline := strutil.JoinNonEmpty([]string{
 		"snapd_recovery_mode=run mocked candidate panic=-1", cmdlineAppend}, " ")
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 
@@ -3305,7 +3305,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyNoChange(c *C, cmdlineAppend 
 	c.Assert(m.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -3470,7 +3470,7 @@ volumes:
 	c.Assert(m.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		c.Assert(params, NotNil)
 
@@ -3536,7 +3536,7 @@ volumes:
 	// reseal does not happen, because the gadget overrides the static
 	// command line which is part of boot config, thus there's no resulting
 	// change in the command lines tracked in modeenv and no need to reseal
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return fmt.Errorf("unexpected call")
 	})
@@ -3573,7 +3573,7 @@ var _ = Suite(&bootKernelCommandLineSuite{})
 func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return nil
 	})
 	s.AddCleanup(restore)
@@ -3633,7 +3633,7 @@ func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 
 	s.resealCommandLines = nil
 	s.resealCalls = 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		s.resealCalls++
 		c.Assert(params, NotNil)
 		c.Assert(params.RunModeBootChains, HasLen, 0)
@@ -3909,7 +3909,7 @@ volumes:
 	c.Assert(s.modeenvWithEncryption.WriteTo(""), IsNil)
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return fmt.Errorf("reseal fails")
 	})
@@ -4053,7 +4053,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
 
 	resealPanic := false
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		s.resealCalls++
 		c.Logf("reseal call %v", s.resealCalls)
 		c.Assert(params, NotNil)
@@ -4636,7 +4636,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 1)
@@ -4747,7 +4747,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNew
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 
 		c.Assert(params.RunModeBootChains, HasLen, 1)
@@ -4859,7 +4859,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -4956,7 +4956,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSam
 	defer r()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})
@@ -5092,7 +5092,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 	model := coreDev.Model()
 
 	resealCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		return nil
 	})

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -226,7 +226,7 @@ func EnableTestingRebootFunction() (restore func()) {
 	return func() { testingRebootItself = false }
 }
 
-func MockResealKeyForBootChains(f func(method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
+func MockResealKeyForBootChains(f func(unlocker Unlocker, method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
 	old := ResealKeyForBootChains
 	ResealKeyForBootChains = f
 	return func() {

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -89,7 +89,7 @@ func makeEncodableModel(signingAccounts *assertstest.SigningAccounts, overrides 
 func (s *modelSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return nil
 	})
 	s.AddCleanup(restore)
@@ -204,7 +204,7 @@ func (s *modelSuite) TestDeviceChangeHappy(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -242,7 +242,7 @@ func (s *modelSuite) TestDeviceChangeHappy(c *C) {
 	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, u.unlocker)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 2)
-	c.Check(u.unlocked, Equals, 2)
+	c.Check(u.unlocked, Equals, 0)
 
 	c.Check(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"), testutil.FileContains,
 		"model: my-new-model-uc20\n")
@@ -267,7 +267,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstReseal(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -318,7 +318,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstSwapModelFile(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -371,7 +371,7 @@ func (s *modelSuite) TestDeviceChangeUnhappySecondReseal(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -467,7 +467,7 @@ func (s *modelSuite) TestDeviceChangeRebootBeforeNewModel(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")
@@ -586,7 +586,7 @@ func (s *modelSuite) TestDeviceChangeRebootAfterNewModelFileWrite(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		// timeline & calls:
 		// 1 - pre reboot, run & recovery keys, try model set
@@ -706,7 +706,7 @@ func (s *modelSuite) TestDeviceChangeRebootPostSameModel(c *C) {
 		"model: my-model-uc20\n")
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")
@@ -849,7 +849,7 @@ func (s *modelSuite) testDeviceChangeUnhappyMockedWriteModelToBoot(c *C, tc unha
 
 	writeModelToBootCalls := 0
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -972,7 +972,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFailReseaWithSwappedModelMockedWrite
 
 	writeModelToBootCalls := 0
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		if resealKeysCalls == 2 {
 			m, err := boot.ReadModeenv("")
@@ -1059,7 +1059,7 @@ func (s *modelSuite) TestDeviceChangeRebootRestoreModelKeyChangeMockedWriteModel
 	}))
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -251,11 +251,7 @@ func resealKeyToModeenvImpl(rootdir string, modeenv *Modeenv, expectReseal bool,
 		return err
 	}
 
-	if unlocker != nil {
-		// unlock/relock global state
-		defer unlocker()()
-	}
-	return resealKeyToModeenvForMethod(method, rootdir, modeenv, expectReseal)
+	return resealKeyToModeenvForMethod(unlocker, method, rootdir, modeenv, expectReseal)
 }
 
 type ResealKeyForBootChainsParams struct {
@@ -270,7 +266,7 @@ type ResealKeyForBootChainsParams struct {
 	RoleToBlName map[bootloader.Role]string
 }
 
-func resealKeyToModeenvForMethod(method device.SealingMethod, rootdir string, modeenv *Modeenv, expectReseal bool) error {
+func resealKeyToModeenvForMethod(unlocker Unlocker, method device.SealingMethod, rootdir string, modeenv *Modeenv, expectReseal bool) error {
 	// this is just optimization. If the backend does not need it, we should not calculate it.
 	requiresBootChains := true
 	switch method {
@@ -348,10 +344,10 @@ func resealKeyToModeenvForMethod(method device.SealingMethod, rootdir string, mo
 		}
 	}
 
-	return ResealKeyForBootChains(method, rootdir, params, expectReseal)
+	return ResealKeyForBootChains(unlocker, method, rootdir, params, expectReseal)
 }
 
-func resealKeyForBootChainsImpl(method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error {
+func resealKeyForBootChainsImpl(unlocker Unlocker, method device.SealingMethod, rootdir string, params *ResealKeyForBootChainsParams, expectReseal bool) error {
 	return fmt.Errorf("FDE manager was not started")
 }
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -560,7 +560,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 
 		// set mock key resealing
 		resealKeysCalls := 0
-		restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+		restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 			resealKeysCalls++
 
 			c.Check(method, Equals, device.SealingMethodTPM)
@@ -654,7 +654,7 @@ func (s *sealSuite) TestResealKeyToModeenvRecoveryKeysForGoodSystemsOnly(c *C) {
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealKeysCalls++
 
 		c.Check(method, Equals, device.SealingMethodTPM)
@@ -869,7 +869,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		c.Check(rootdirArg, Equals, rootdir)
 		c.Check(method, Equals, device.SealingMethodTPM)
 		c.Check(expectReseal, Equals, false)
@@ -1713,7 +1713,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	defer dirs.SetRootDir("")
 
 	mockResealKeyForBootChainsCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		c.Check(rootdirArg, Equals, rootdir)
 		c.Check(method, Equals, device.SealingMethodFDESetupHook)
 		c.Check(expectReseal, Equals, false)
@@ -1759,7 +1759,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookVerySad(c *C) {
 	defer dirs.SetRootDir("")
 
 	mockResealKeyForBootChainsCalls := 0
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		c.Check(rootdirArg, Equals, rootdir)
 		c.Check(method, Equals, device.SealingMethodFDESetupHook)
 		c.Check(expectReseal, Equals, false)
@@ -1871,7 +1871,7 @@ func (s *sealSuite) testResealKeyToModeenvWithTryModel(c *C, shimId, grubId stri
 
 	// set mock key resealing
 	resealKeysCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdirArg string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		c.Check(rootdirArg, Equals, rootdir)
 		c.Check(method, Equals, device.SealingMethodTPM)
 		c.Check(expectReseal, Equals, false)

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -83,7 +83,7 @@ func (s *systemsSuite) mockTrustedBootloaderWithAssetAndChains(c *C, runKernelBf
 func (s *systemsSuite) SetUpTest(c *C) {
 	s.baseBootenvSuite.SetUpTest(c)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return nil
 	})
 	s.AddCleanup(restore)
@@ -145,7 +145,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		// bootloader variables have already been modified
 		c.Check(mtbl.SetBootVarsCalls, Equals, 1)
@@ -270,7 +270,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemRemodelEncrypted(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		// bootloader variables have already been modified
 		c.Check(mtbl.SetBootVarsCalls, Equals, 1)
@@ -375,7 +375,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemSimple(c *C) {
 	}
 	c.Assert(modeenv.WriteTo(""), IsNil)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return fmt.Errorf("unexpected call")
 	})
 	s.AddCleanup(restore)
@@ -416,7 +416,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemSetBootVarsErr(c *C) {
 	}
 	c.Assert(modeenv.WriteTo(""), IsNil)
 
-	restore := boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return fmt.Errorf("unexpected call")
 	})
 	s.AddCleanup(restore)
@@ -527,7 +527,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorBeforeReseal(c *C) 
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		if cleanupTriggered {
 			return nil
@@ -636,7 +636,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:
@@ -737,7 +737,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupError(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:
@@ -784,7 +784,7 @@ func (s *systemsSuite) testInspectRecoverySystemOutcomeHappy(c *C, mtbl *bootloa
 	})
 	defer restore()
 
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		return fmt.Errorf("unexpected call")
 	})
 	defer restore()
@@ -980,7 +980,7 @@ func (s *systemsSuite) testClearRecoverySystem(c *C, mtbl *bootloadertest.MockTr
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:
@@ -1235,7 +1235,7 @@ func (s *systemsSuite) TestClearRecoverySystemReboot(c *C) {
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:
@@ -1365,7 +1365,7 @@ func (s *systemsSuite) testPromoteTriedRecoverySystem(c *C, systemLabel string, 
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:
@@ -1629,7 +1629,7 @@ func (s *systemsSuite) testDropRecoverySystem(c *C, systemLabel string, tc recov
 	defer restore()
 
 	resealCalls := 0
-	restore = boot.MockResealKeyForBootChains(func(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	restore = boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 		resealCalls++
 		switch resealCalls {
 		case 1:

--- a/osutil/disks/disks.go
+++ b/osutil/disks/disks.go
@@ -20,6 +20,7 @@
 package disks
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -236,4 +237,24 @@ func RegisterDeviceMapperBackResolver(name string, f func(dmUUID, dmName []byte)
 // mainly for tests to un-register and re-register handlers
 func unregisterDeviceMapperBackResolver(name string) {
 	delete(deviceMapperBackResolvers, name)
+}
+
+// ErrNoDmUUID is returned by DMCryptUUIDFromMountPoint when the device
+// at the mount point is not a device mapper device.
+var ErrNoDmUUID = errors.New("device has no DM_UUID")
+
+// ErrMountPointNotFound is returned by DMCryptUUIDFromMountPoint a path
+// is not a mount point.
+var ErrMountPointNotFound = errors.New("cannot find mount point")
+
+type errMountPointNotFoundImpl struct {
+	path string
+}
+
+func (e errMountPointNotFoundImpl) Error() string {
+	return fmt.Sprintf("cannot find mountpoint %q", e.path)
+}
+
+func (e errMountPointNotFoundImpl) Unwrap() error {
+	return ErrMountPointNotFound
 }

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -610,7 +610,7 @@ func partitionPropsFromMountPoint(mountpoint string) (source string, props map[s
 		}
 	}
 	if source == "" {
-		return "", nil, fmt.Errorf("cannot find mountpoint %q", mountpoint)
+		return "", nil, errMountPointNotFoundImpl{path: mountpoint}
 	}
 
 	// now we have the partition for this mountpoint, we need to tie that back
@@ -976,8 +976,9 @@ func DMCryptUUIDFromMountPoint(mountpoint string) (string, error) {
 
 	dmUUID, hasDmUUID := props["DM_UUID"]
 	if !hasDmUUID {
-		return "", fmt.Errorf("device has no DM_UUID")
+		return "", ErrNoDmUUID
 	}
+
 	match := dmUUIDRe.FindStringSubmatchIndex(dmUUID)
 	if match == nil {
 		return "", fmt.Errorf("value of DM_UUID is not recognized")

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -1854,7 +1854,8 @@ func (s *diskSuite) TestDMCryptUUIDFromMountPointErrs(c *C) {
 	defer restore()
 
 	_, err := disks.DMCryptUUIDFromMountPoint("/run/mnt/blah")
-	c.Assert(err, ErrorMatches, "cannot find mountpoint \"/run/mnt/blah\"")
+	c.Assert(err, ErrorMatches, `cannot find mountpoint "/run/mnt/blah"`)
+	c.Assert(errors.Is(err, disks.ErrMountPointNotFound), Equals, true)
 
 	restore = osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/vda4 rw
 `)
@@ -1872,6 +1873,7 @@ func (s *diskSuite) TestDMCryptUUIDFromMountPointErrs(c *C) {
 
 	_, err = disks.DMCryptUUIDFromMountPoint("/run/mnt/point")
 	c.Assert(err, ErrorMatches, "device has no DM_UUID")
+	c.Assert(err, Equals, disks.ErrNoDmUUID)
 
 	restore = disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
 		c.Assert(typeOpt, Equals, "--name")

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -19,4 +19,20 @@
 
 package fdestate
 
+import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/overlord/fdestate/backend"
+)
+
 var FdeMgr = fdeMgr
+
+var UpdateParameters = updateParameters
+
+func MockBackendResealKeyForBootChains(f func(updateState backend.StateUpdater, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
+	old := backendResealKeyForBootChains
+	backendResealKeyForBootChains = f
+	return func() {
+		backendResealKeyForBootChains = old
+	}
+}

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -64,7 +64,7 @@ func (s *fdeMgrSuite) TestGetManagerFromState(c *C) {
 
 	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		switch mountpoint {
-		case dirs.GlobalRootDir:
+		case dirs.SnapdStateDir(dirs.GlobalRootDir):
 			return "aaa", nil
 		case dirs.SnapSaveDir:
 			return "bbb", nil
@@ -136,7 +136,7 @@ func (s *fdeMgrSuite) TestUpdateState(c *C) {
 
 	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		switch mountpoint {
-		case dirs.GlobalRootDir:
+		case dirs.SnapdStateDir(dirs.GlobalRootDir):
 			return "aaa", nil
 		case dirs.SnapSaveDir:
 			return "bbb", nil
@@ -191,7 +191,7 @@ func (s *fdeMgrSuite) TestUpdateReseal(c *C) {
 
 	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		switch mountpoint {
-		case dirs.GlobalRootDir:
+		case dirs.SnapdStateDir(dirs.GlobalRootDir):
 			return "aaa", nil
 		case dirs.SnapSaveDir:
 			return "bbb", nil

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -20,12 +20,20 @@
 package fdestate_test
 
 import (
+	"crypto"
+	"fmt"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/secboot"
 )
 
 func TestFDE(t *testing.T) { TestingT(t) }
@@ -34,14 +42,217 @@ type fdeMgrSuite struct{}
 
 var _ = Suite(&fdeMgrSuite{})
 
+type instrumentedUnlocker struct {
+	state    *state.State
+	unlocked int
+	relocked int
+}
+
+func (u *instrumentedUnlocker) Unlock() (relock func()) {
+	u.state.Unlock()
+	u.unlocked += 1
+	return u.Relock
+}
+
+func (u *instrumentedUnlocker) Relock() {
+	u.state.Lock()
+	u.relocked += 1
+}
+
 func (s *fdeMgrSuite) TestGetManagerFromState(c *C) {
 	st := state.New(nil)
 
+	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+		switch mountpoint {
+		case dirs.GlobalRootDir:
+			return "aaa", nil
+		case dirs.SnapSaveDir:
+			return "bbb", nil
+		}
+		return "", fmt.Errorf("unknown mount point")
+	})()
+
+	defer fdestate.MockGetPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash) ([]byte, []byte, error) {
+		c.Check(devicePath, Equals, "/dev/disk/by-uuid/aaa")
+		c.Check(alg, Equals, crypto.Hash(crypto.SHA256))
+		return []byte{1, 2, 3, 4}, []byte{5, 6, 7, 8}, nil
+	})()
+
+	defer fdestate.MockVerifyPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash, salt, digest []byte) (bool, error) {
+		c.Check(devicePath, Equals, "/dev/disk/by-uuid/bbb")
+		c.Check(alg, Equals, crypto.Hash(crypto.SHA256))
+		c.Check(salt, DeepEquals, []byte{1, 2, 3, 4})
+		c.Check(digest, DeepEquals, []byte{5, 6, 7, 8})
+		return true, nil
+	})()
+
 	runner := state.NewTaskRunner(st)
 	manager := fdestate.Manager(st, runner)
-	c.Assert(manager.Ensure(), IsNil)
+	c.Assert(manager.StartUp(), IsNil)
 	st.Lock()
 	defer st.Unlock()
 	foundManager := fdestate.FdeMgr(st)
 	c.Check(foundManager, Equals, manager)
+
+	var fdeSt fdestate.FdeState
+	err := st.Get("fde", &fdeSt)
+	c.Assert(err, IsNil)
+	primaryKey, hasPrimaryKey := fdeSt.PrimaryKeys[0]
+	c.Assert(hasPrimaryKey, Equals, true)
+	c.Check(crypto.Hash(primaryKey.Digest.Algorithm), Equals, crypto.Hash(crypto.SHA256))
+	c.Check(primaryKey.Digest.Salt, DeepEquals, []byte{1, 2, 3, 4})
+	c.Check(primaryKey.Digest.Digest, DeepEquals, []byte{5, 6, 7, 8})
+}
+
+type mockModel struct {
+}
+
+func (m *mockModel) Series() string {
+	return "mock-series"
+}
+
+func (m *mockModel) BrandID() string {
+	return "mock-brand"
+}
+
+func (m *mockModel) Model() string {
+	return "mock-model"
+}
+
+func (m *mockModel) Classic() bool {
+	return false
+}
+
+func (m *mockModel) Grade() asserts.ModelGrade {
+	return asserts.ModelSigned
+}
+
+func (m *mockModel) SignKeyID() string {
+	return "mock-key"
+}
+
+func (s *fdeMgrSuite) TestUpdateState(c *C) {
+	st := state.New(nil)
+
+	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+		switch mountpoint {
+		case dirs.GlobalRootDir:
+			return "aaa", nil
+		case dirs.SnapSaveDir:
+			return "bbb", nil
+		}
+		return "", fmt.Errorf("unknown mount point")
+	})()
+
+	defer fdestate.MockGetPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash) ([]byte, []byte, error) {
+		c.Check(devicePath, Equals, "/dev/disk/by-uuid/aaa")
+		c.Check(alg, Equals, crypto.Hash(crypto.SHA256))
+		return []byte{1, 2, 3, 4}, []byte{5, 6, 7, 8}, nil
+	})()
+
+	defer fdestate.MockVerifyPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash, salt, digest []byte) (bool, error) {
+		c.Check(devicePath, Equals, "/dev/disk/by-uuid/bbb")
+		c.Check(alg, Equals, crypto.Hash(crypto.SHA256))
+		c.Check(salt, DeepEquals, []byte{1, 2, 3, 4})
+		c.Check(digest, DeepEquals, []byte{5, 6, 7, 8})
+		return true, nil
+	})()
+
+	runner := state.NewTaskRunner(st)
+	manager := fdestate.Manager(st, runner)
+	c.Assert(manager.StartUp(), IsNil)
+	st.Lock()
+	defer st.Unlock()
+	foundManager := fdestate.FdeMgr(st)
+	c.Check(foundManager, Equals, manager)
+
+	models := []secboot.ModelForSealing{
+		&mockModel{},
+	}
+
+	fdestate.UpdateParameters(st, "run+recover", "container-role", []string{"run"}, models, secboot.SerializedPCRProfile(`"serialized-profile"`))
+
+	var fdeSt fdestate.FdeState
+	err := st.Get("fde", &fdeSt)
+	c.Assert(err, IsNil)
+	runRecoverRole, hasRunRecoverRole := fdeSt.KeyslotRoles["run+recover"]
+	c.Assert(hasRunRecoverRole, Equals, true)
+	containerRole, hasContainerRole := runRecoverRole.Parameters["container-role"]
+	c.Assert(hasContainerRole, Equals, true)
+
+	c.Assert(containerRole.Models, HasLen, 1)
+	c.Check(containerRole.Models[0].Model(), Equals, "mock-model")
+	c.Check(containerRole.BootModes, DeepEquals, []string{"run"})
+	c.Check(containerRole.TPM2PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-profile"`))
+}
+
+func (s *fdeMgrSuite) TestUpdateReseal(c *C) {
+	st := state.New(nil)
+
+	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+		switch mountpoint {
+		case dirs.GlobalRootDir:
+			return "aaa", nil
+		case dirs.SnapSaveDir:
+			return "bbb", nil
+		}
+		return "", fmt.Errorf("unknown mount point")
+	})()
+
+	defer fdestate.MockGetPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash) ([]byte, []byte, error) {
+		c.Check(devicePath, Equals, "/dev/disk/by-uuid/aaa")
+		c.Check(alg, Equals, crypto.Hash(crypto.SHA256))
+		return []byte{1, 2, 3, 4}, []byte{5, 6, 7, 8}, nil
+	})()
+
+	defer fdestate.MockVerifyPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash, salt, digest []byte) (bool, error) {
+		c.Check(devicePath, Equals, "/dev/disk/by-uuid/bbb")
+		c.Check(alg, Equals, crypto.Hash(crypto.SHA256))
+		c.Check(salt, DeepEquals, []byte{1, 2, 3, 4})
+		c.Check(digest, DeepEquals, []byte{5, 6, 7, 8})
+		return true, nil
+	})()
+
+	runner := state.NewTaskRunner(st)
+	manager := fdestate.Manager(st, runner)
+	c.Assert(manager.StartUp(), IsNil)
+	st.Lock()
+	defer st.Unlock()
+	foundManager := fdestate.FdeMgr(st)
+	c.Check(foundManager, Equals, manager)
+
+	unlocker := &instrumentedUnlocker{state: st}
+	params := &boot.ResealKeyForBootChainsParams{}
+	resealed := 0
+
+	defer fdestate.MockBackendResealKeyForBootChains(func(updateState backend.StateUpdater, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+		c.Check(unlocker.unlocked, Equals, 1)
+		c.Check(unlocker.relocked, Equals, 0)
+		c.Check(method, Equals, device.SealingMethodFDESetupHook)
+		c.Check(rootdir, Equals, dirs.GlobalRootDir)
+		c.Check(params, Equals, params)
+		c.Check(expectReseal, Equals, expectReseal)
+		updateState("run+recover", "container-role", []string{"run"}, []secboot.ModelForSealing{&mockModel{}}, []byte(`"serialized-profile"`))
+		resealed += 1
+		return nil
+	})()
+
+	err := boot.ResealKeyForBootChains(unlocker.Unlock, device.SealingMethodFDESetupHook, dirs.GlobalRootDir, params, false)
+	c.Assert(err, IsNil)
+	c.Check(unlocker.unlocked, Equals, 1)
+	c.Check(unlocker.relocked, Equals, 1)
+	c.Check(resealed, Equals, 1)
+
+	var fdeSt fdestate.FdeState
+	err = st.Get("fde", &fdeSt)
+	c.Assert(err, IsNil)
+	runRecoverRole, hasRunRecoverRole := fdeSt.KeyslotRoles["run+recover"]
+	c.Assert(hasRunRecoverRole, Equals, true)
+	containerRole, hasContainerRole := runRecoverRole.Parameters["container-role"]
+	c.Assert(hasContainerRole, Equals, true)
+
+	c.Assert(containerRole.Models, HasLen, 1)
+	c.Check(containerRole.Models[0].Model(), Equals, "mock-model")
+	c.Check(containerRole.BootModes, DeepEquals, []string{"run"})
+	c.Check(containerRole.TPM2PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-profile"`))
 }

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/overlord/state"
@@ -263,15 +264,22 @@ func initializeState(st *state.State) error {
 		return saveErr
 	}
 
-	digest, err := getPrimaryKeyHMAC(fmt.Sprintf("/dev/disk/by-uuid/%s", dataUUID))
+	devpData := fmt.Sprintf("/dev/disk/by-uuid/%s", dataUUID)
+	devpSave := fmt.Sprintf("/dev/disk/by-uuid/%s", saveUUID)
+	digest, err := getPrimaryKeyHMAC(devpData)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot obtain primary key digest for data device %s: %w", devpData, err)
 	}
-	sameDigest, err := digest.verifyPrimaryKeyHMAC(fmt.Sprintf("/dev/disk/by-uuid/%s", saveUUID))
+	// TODO: restore key verification once we know that it is always added to
+	// the keyring
+	sameDigest, err := digest.verifyPrimaryKeyHMAC(devpSave)
 	if err != nil {
-		return err
-	}
-	if !sameDigest {
+		if !errors.Is(err, secboot.ErrKernelKeyNotFound) {
+			return fmt.Errorf("cannot verify primary key digest for save device %s: %w", devpSave, err)
+		} else {
+			logger.Noticef("cannot verify primary key digest for save device %s: %v", devpSave, err)
+		}
+	} else if !sameDigest {
 		return fmt.Errorf("primary key for data and save partition are not the same")
 	}
 

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -244,7 +244,7 @@ func initializeState(st *state.State) error {
 		return err
 	}
 
-	dataUUID, dataErr := disksDMCryptUUIDFromMountPoint(dirs.GlobalRootDir)
+	dataUUID, dataErr := disksDMCryptUUIDFromMountPoint(dirs.SnapdStateDir(dirs.GlobalRootDir))
 	saveUUID, saveErr := disksDMCryptUUIDFromMountPoint(dirs.SnapSaveDir)
 	if errors.Is(saveErr, disks.ErrMountPointNotFound) {
 		// TODO: do we need to care about old cases where there is no save partition?

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -19,14 +19,27 @@
 package fdestate
 
 import (
+	"crypto"
+	"encoding/json"
 	"errors"
+	"fmt"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/secboot"
 )
 
 var errNotImplemented = errors.New("not implemented")
+
+var (
+	disksDMCryptUUIDFromMountPoint = disks.DMCryptUUIDFromMountPoint
+	secbootGetPrimaryKeyHMAC       = secboot.GetPrimaryKeyHMAC
+	secbootVerifyPrimaryKeyHMAC    = secboot.VerifyPrimaryKeyHMAC
+)
 
 // EFISecureBootDBManagerStartup indicates that the local EFI key database
 // manager has started.
@@ -65,4 +78,310 @@ func EFISecureBootDBUpdateCleanup(st *state.State) error {
 	}
 
 	return errNotImplemented
+}
+
+// Model is a json serializable secboot.ModelForSealing
+type Model struct {
+	SeriesValue    string             `json:"series"`
+	BrandIDValue   string             `json:"brand-id"`
+	ModelValue     string             `json:"model"`
+	ClassicValue   bool               `json:"classic"`
+	GradeValue     asserts.ModelGrade `json:"grade"`
+	SignKeyIDValue string             `json:"sign-key-id"`
+}
+
+// Series implements secboot.ModelForSealing.Series
+func (m *Model) Series() string {
+	return m.SeriesValue
+}
+
+// BrandID implements secboot.ModelForSealing.BrandID
+func (m *Model) BrandID() string {
+	return m.BrandIDValue
+}
+
+// Model implements secboot.ModelForSealing.Model
+func (m *Model) Model() string {
+	return m.ModelValue
+}
+
+// Classic implements secboot.ModelForSealing.Classic
+func (m *Model) Classic() bool {
+	return m.ClassicValue
+}
+
+// Grade implements secboot.ModelForSealing.Grade
+func (m *Model) Grade() asserts.ModelGrade {
+	return m.GradeValue
+}
+
+// SignKeyID implements secboot.ModelForSealing.SignKeyID
+func (m *Model) SignKeyID() string {
+	return m.SignKeyIDValue
+}
+
+func newModel(m secboot.ModelForSealing) Model {
+	return Model{
+		SeriesValue:    m.Series(),
+		BrandIDValue:   m.BrandID(),
+		ModelValue:     m.Model(),
+		ClassicValue:   m.Classic(),
+		GradeValue:     m.Grade(),
+		SignKeyIDValue: m.SignKeyID(),
+	}
+}
+
+var _ secboot.ModelForSealing = (*Model)(nil)
+
+// KeyslotRoleParameters stores upgradeable parameters for a keyslot role
+type KeyslotRoleParameters struct {
+	// Models are the optional list of approved models
+	Models []Model `json:"models,omitempty"`
+	// BootModes are the optional list of approved modes (run, recover, ...)
+	BootModes []string `json:"boot-modes,omitempty"`
+	// TPM2PCRProfile is an optional serialized PCR profile
+	TPM2PCRProfile secboot.SerializedPCRProfile `json:"tpm2-pcr-profile,omitempty"`
+}
+
+// KeyslotRoleInfo stores information about a key slot role
+type KeyslotRoleInfo struct {
+	// PrimaryKeyID is the ID for the primary key found in
+	// PrimaryKeys field of FdeState
+	PrimaryKeyID int `json:"primary-key-id"`
+	// Parameters is indexed by container role name
+	Parameters map[string]KeyslotRoleParameters `json:"params,omitempty"`
+	// TPM2PCRPolicyRevocationCounter is the handle for the TPM
+	// policy revocation counter.  A value of 0 means it is not
+	// set.
+	TPM2PCRPolicyRevocationCounter uint32 `json:"tpm2-pcr-policy-revocation-counter,omitempty"`
+}
+
+type hashAlg crypto.Hash
+
+// UnmarshalJSON implements json.Unmarshaler.UnmarshalJSON
+func (h *hashAlg) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "sha256":
+		*h = hashAlg(crypto.SHA256)
+	default:
+		return fmt.Errorf("unknown algorithm %s", s)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.MarshalJSON
+func (h hashAlg) MarshalJSON() ([]byte, error) {
+	switch crypto.Hash(h) {
+	case crypto.SHA256:
+		return json.Marshal("sha256")
+	default:
+		return nil, fmt.Errorf("unknown algorithm %v", h)
+	}
+}
+
+// KeyDigest stores a HMAC(key, salt) of a key
+// FIXME: take what is implemented in secboot
+type KeyDigest struct {
+	// Algorithm is the algorithm for
+	Algorithm hashAlg `json:"alg"`
+	// Salt is the salt for the HMAC digest
+	Salt []byte `json:"salt"`
+	// Digest is the result of `HMAC(key, salt)`
+	Digest []byte `json:"digest"`
+}
+
+const defaultHashAlg = crypto.SHA256
+
+func getPrimaryKeyHMAC(devicePath string) (KeyDigest, error) {
+	salt, digest, err := secbootGetPrimaryKeyHMAC(devicePath, crypto.Hash(defaultHashAlg))
+	if err != nil {
+		return KeyDigest{}, err
+	}
+
+	return KeyDigest{
+		Algorithm: hashAlg(defaultHashAlg),
+		Salt:      salt,
+		Digest:    digest,
+	}, nil
+}
+
+func (kd *KeyDigest) verifyPrimaryKeyHMAC(devicePath string) (bool, error) {
+	return secbootVerifyPrimaryKeyHMAC(devicePath, crypto.Hash(kd.Algorithm), kd.Salt, kd.Digest)
+}
+
+// PrimaryKeyInfo provides information about a primary key that is used to manage key slots
+type PrimaryKeyInfo struct {
+	Digest KeyDigest `json:"digest"`
+}
+
+// FdeState is the root persistent FDE state
+type FdeState struct {
+	// PrimaryKeys are the keys on the system. Key with ID 0 is
+	// reserved for snapd and is populated on first boot. Other
+	// IDs are for externally managed keys.
+	PrimaryKeys map[int]PrimaryKeyInfo `json:"primary-keys"`
+
+	// KeyslotRoles are all keyslot roles indexed by the role name
+	KeyslotRoles map[string]KeyslotRoleInfo `json:"keyslot-roles"`
+}
+
+const fdeStateKey = "fde"
+
+func initializeState(st *state.State) error {
+	var s FdeState
+	err := st.Get(fdeStateKey, &s)
+	if err == nil {
+		// TODO: Do we need to do something in recover?
+		return nil
+	}
+
+	if !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
+	dataUUID, dataErr := disksDMCryptUUIDFromMountPoint(dirs.GlobalRootDir)
+	saveUUID, saveErr := disksDMCryptUUIDFromMountPoint(dirs.SnapSaveDir)
+	if errors.Is(saveErr, disks.ErrMountPointNotFound) {
+		// TODO: do we need to care about old cases where there is no save partition?
+		return nil
+	}
+
+	if errors.Is(dataErr, disks.ErrNoDmUUID) && errors.Is(saveErr, disks.ErrNoDmUUID) {
+		// There is no encryption, so we ignore it.
+		// TODO: we should verify the device "sealed key method"
+		return nil
+	}
+	if dataErr != nil {
+		return dataErr
+	}
+	if saveErr != nil {
+		return saveErr
+	}
+
+	digest, err := getPrimaryKeyHMAC(fmt.Sprintf("/dev/disk/by-uuid/%s", dataUUID))
+	if err != nil {
+		return err
+	}
+	sameDigest, err := digest.verifyPrimaryKeyHMAC(fmt.Sprintf("/dev/disk/by-uuid/%s", saveUUID))
+	if err != nil {
+		return err
+	}
+	if !sameDigest {
+		return fmt.Errorf("primary key for data and save partition are not the same")
+	}
+
+	s.PrimaryKeys = map[int]PrimaryKeyInfo{
+		0: {
+			Digest: digest,
+		},
+	}
+
+	// Note that Parameters will be updated on first update
+	s.KeyslotRoles = map[string]KeyslotRoleInfo{
+		// TODO: use a constant
+		"run": {
+			PrimaryKeyID: 0,
+			// FIXME: from Chris: Rather than hardcoding
+			// an index value, I'd prefer us to adopt the
+			// approach of picking a random index from a
+			// small acceptable range. I could add an API
+			// in secboot for that, or we could do it
+			// here.
+			TPM2PCRPolicyRevocationCounter: secboot.RunObjectPCRPolicyCounterHandle,
+		},
+		// TODO: use a constant
+		"run+recover": {
+			PrimaryKeyID: 0,
+			// FIXME: from Chris: Rather than hardcoding
+			// an index value, I'd prefer us to adopt the
+			// approach of picking a random index from a
+			// small acceptable range. I could add an API
+			// in secboot for that, or we could do it
+			// here.
+			TPM2PCRPolicyRevocationCounter: secboot.RunObjectPCRPolicyCounterHandle,
+		},
+		// TODO: use a constant
+		"recover": {
+			PrimaryKeyID: 0,
+			// FIXME: from Chris: Rather than hardcoding
+			// an index value, I'd prefer us to adopt the
+			// approach of picking a random index from a
+			// small acceptable range. I could add an API
+			// in secboot for that, or we could do it
+			// here.
+			TPM2PCRPolicyRevocationCounter: secboot.FallbackObjectPCRPolicyCounterHandle,
+		},
+	}
+
+	st.Set(fdeStateKey, s)
+
+	return nil
+}
+
+func updateParameters(st *state.State, role string, containerRole string, bootModes []string, models []secboot.ModelForSealing, tpmPCRProfile []byte) error {
+	var s FdeState
+	err := st.Get(fdeStateKey, &s)
+	if err != nil {
+		return err
+	}
+
+	roleInfo, hasRole := s.KeyslotRoles[role]
+	if !hasRole {
+		return fmt.Errorf("cannot find keyslot role %s", role)
+	}
+
+	var convertedModels []Model
+	for _, model := range models {
+		convertedModels = append(convertedModels, newModel(model))
+	}
+
+	if roleInfo.Parameters == nil {
+		roleInfo.Parameters = make(map[string]KeyslotRoleParameters)
+	}
+	roleInfo.Parameters[containerRole] = KeyslotRoleParameters{
+		Models:         convertedModels,
+		BootModes:      bootModes,
+		TPM2PCRProfile: tpmPCRProfile,
+	}
+
+	s.KeyslotRoles[role] = roleInfo
+
+	st.Set(fdeStateKey, s)
+
+	return nil
+}
+
+func MockDMCryptUUIDFromMountPoint(f func(mountpoint string) (string, error)) (restore func()) {
+	osutil.MustBeTestBinary("mocking DMCryptUUIDFromMountPoint can be done only from tests")
+
+	old := disksDMCryptUUIDFromMountPoint
+	disksDMCryptUUIDFromMountPoint = f
+	return func() {
+		disksDMCryptUUIDFromMountPoint = old
+	}
+}
+
+func MockGetPrimaryKeyHMAC(f func(devicePath string, alg crypto.Hash) ([]byte, []byte, error)) (restore func()) {
+	osutil.MustBeTestBinary("mocking GetPrimaryKeyHMAC can be done only from tests")
+
+	old := secbootGetPrimaryKeyHMAC
+	secbootGetPrimaryKeyHMAC = f
+	return func() {
+		secbootGetPrimaryKeyHMAC = old
+	}
+}
+
+func MockVerifyPrimaryKeyHMAC(f func(devicePath string, alg crypto.Hash, salt []byte, digest []byte) (bool, error)) (restore func()) {
+	osutil.MustBeTestBinary("mocking VerifyPrimaryKeyHMAC can be done only from tests")
+
+	old := secbootVerifyPrimaryKeyHMAC
+	secbootVerifyPrimaryKeyHMAC = f
+	return func() {
+		secbootVerifyPrimaryKeyHMAC = old
+	}
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -25,7 +25,6 @@ package secboot
 // Debian does run "go list" without any support for passing -tags.
 
 import (
-	"encoding/json"
 	"errors"
 
 	"github.com/snapcore/snapd/asserts"
@@ -137,15 +136,9 @@ type SealKeysWithFDESetupHookParams struct {
 	AuxKeyFile string
 }
 
-type SerializedPCRProfile json.RawMessage
-
-func (s SerializedPCRProfile) MarshalJSON() ([]byte, error) {
-	return json.RawMessage(s).MarshalJSON()
-}
-
-func (s *SerializedPCRProfile) UnmarshalJSON(data []byte) error {
-	return (*json.RawMessage)(s).UnmarshalJSON(data)
-}
+// SerializedPCRProfile wraps a serialized PCR profile which is treated as an
+// opaque binary blob outside of secboot package.
+type SerializedPCRProfile []byte
 
 type ResealKeysParams struct {
 	// The snap model parameters

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -26,6 +26,7 @@ package secboot
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
@@ -47,6 +48,8 @@ const (
 
 // WithSecbootSupport is true if this package was built with githbu.com/snapcore/secboot.
 var WithSecbootSupport = false
+
+var ErrKernelKeyNotFound = errors.New("kernel key not found")
 
 type LoadChain struct {
 	*bootloader.BootFile

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -25,6 +25,8 @@ package secboot
 // Debian does run "go list" without any support for passing -tags.
 
 import (
+	"encoding/json"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
@@ -132,9 +134,19 @@ type SealKeysWithFDESetupHookParams struct {
 	AuxKeyFile string
 }
 
+type SerializedPCRProfile json.RawMessage
+
+func (s SerializedPCRProfile) MarshalJSON() ([]byte, error) {
+	return json.RawMessage(s).MarshalJSON()
+}
+
+func (s *SerializedPCRProfile) UnmarshalJSON(data []byte) error {
+	return (*json.RawMessage)(s).UnmarshalJSON(data)
+}
+
 type ResealKeysParams struct {
 	// The snap model parameters
-	ModelParams []*SealKeyModelParams
+	PCRProfile SerializedPCRProfile
 	// The path to the sealed key files
 	KeyFiles []string
 	// The path to the authorization policy update key file (only relevant for TPM)

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -21,6 +21,7 @@
 package secboot
 
 import (
+	"crypto"
 	"errors"
 
 	"github.com/snapcore/snapd/kernel/fde"
@@ -84,4 +85,16 @@ func RenameOrDeleteKeys(node string, renames map[string]string) error {
 
 func DeleteKeys(node string, matches map[string]bool) error {
 	return errBuildWithoutSecboot
+}
+
+func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams) (SerializedPCRProfile, error) {
+	return nil, errBuildWithoutSecboot
+}
+
+func GetPrimaryKeyHMAC(devicePath string, alg crypto.Hash) ([]byte, []byte, error) {
+	return nil, nil, errBuildWithoutSecboot
+}
+
+func VerifyPrimaryKeyHMAC(devicePath string, alg crypto.Hash, salt []byte, digest []byte) (bool, error) {
+	return false, errBuildWithoutSecboot
 }

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -344,6 +344,9 @@ func GetPrimaryKeyHMAC(devicePath string, alg crypto.Hash) (salt []byte, digest 
 	const remove = false
 	p, err := sb.GetPrimaryKeyFromKernel(keyringPrefix, devicePath, remove)
 	if err != nil {
+		if errors.Is(err, sb.ErrKernelKeyNotFound) {
+			return nil, nil, ErrKernelKeyNotFound
+		}
 		return nil, nil, err
 	}
 
@@ -361,6 +364,9 @@ func VerifyPrimaryKeyHMAC(devicePath string, alg crypto.Hash, salt []byte, diges
 	const remove = false
 	p, err := sb.GetPrimaryKeyFromKernel(keyringPrefix, devicePath, remove)
 	if err != nil {
+		if errors.Is(err, sb.ErrKernelKeyNotFound) {
+			return false, ErrKernelKeyNotFound
+		}
 		return false, err
 	}
 

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -21,6 +21,9 @@
 package secboot
 
 import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -335,4 +338,33 @@ func DeleteKeys(node string, matches map[string]bool) error {
 	}
 
 	return nil
+}
+
+func GetPrimaryKeyHMAC(devicePath string, alg crypto.Hash) (salt []byte, digest []byte, err error) {
+	const remove = false
+	p, err := sb.GetPrimaryKeyFromKernel(keyringPrefix, devicePath, remove)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var saltArray [32]byte
+	if _, err := rand.Read(saltArray[:]); err != nil {
+		return nil, nil, err
+	}
+
+	h := hmac.New(alg.New, salt[:])
+	h.Write(p)
+	return saltArray[:], h.Sum(nil), nil
+}
+
+func VerifyPrimaryKeyHMAC(devicePath string, alg crypto.Hash, salt []byte, digest []byte) (bool, error) {
+	const remove = false
+	p, err := sb.GetPrimaryKeyFromKernel(keyringPrefix, devicePath, remove)
+	if err != nil {
+		return false, err
+	}
+
+	h := hmac.New(alg.New, salt[:])
+	h.Write(p)
+	return hmac.Equal(h.Sum(nil), digest), nil
 }

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1085,6 +1085,7 @@ func (s *secbootSuite) TestResealKey(c *C) {
 		revokeCalls            int
 		expectedErr            string
 		oldKeyFiles            bool
+		buildProfileErr        string
 	}{
 		// happy case
 		{tpmEnabled: true, resealCalls: 1, expectedErr: ""},
@@ -1094,10 +1095,10 @@ func (s *secbootSuite) TestResealKey(c *C) {
 		// unhappy cases
 		{tpmErr: mockErr, expectedErr: "cannot connect to TPM: some error"},
 		{tpmEnabled: false, expectedErr: "TPM device is not enabled"},
-		{tpmEnabled: true, missingFile: true, expectedErr: "cannot build new PCR protection profile: cannot build EFI image load sequences: file .*\\/file.efi does not exist"},
-		{tpmEnabled: true, addPCRProfileErr: mockErr, expectedErr: "cannot build new PCR protection profile: cannot add EFI secure boot and boot manager policy profiles: some error"},
-		{tpmEnabled: true, addSystemdEFIStubErr: mockErr, expectedErr: "cannot build new PCR protection profile: cannot add systemd EFI stub profile: some error"},
-		{tpmEnabled: true, addSnapModelErr: mockErr, expectedErr: "cannot build new PCR protection profile: cannot add snap model profile: some error"},
+		{tpmEnabled: true, missingFile: true, buildProfileErr: `cannot build EFI image load sequences: file .*\/file.efi does not exist`},
+		{tpmEnabled: true, addPCRProfileErr: mockErr, buildProfileErr: `cannot add EFI secure boot and boot manager policy profiles: some error`},
+		{tpmEnabled: true, addSystemdEFIStubErr: mockErr, buildProfileErr: `cannot add systemd EFI stub profile: some error`},
+		{tpmEnabled: true, addSnapModelErr: mockErr, buildProfileErr: `cannot add snap model profile: some error`},
 		{tpmEnabled: true, readSealedKeyObjectErr: mockErr, expectedErr: "cannot read key file .*: some error"},
 		{tpmEnabled: true, resealErr: mockErr, resealCalls: 1, expectedErr: "cannot update legacy PCR protection policy: some error", oldKeyFiles: true},
 		{tpmEnabled: true, resealErr: mockErr, resealCalls: 1, expectedErr: "cannot update PCR protection policy: some error"},
@@ -1115,17 +1116,66 @@ func (s *secbootSuite) TestResealKey(c *C) {
 			c.Assert(err, IsNil)
 		}
 
+		modelParams := []*secboot.SealKeyModelParams{
+			{
+				EFILoadChains:  []*secboot.LoadChain{secboot.NewLoadChain(mockEFI)},
+				KernelCmdlines: []string{"cmdline"},
+				Model:          &asserts.Model{},
+			},
+		}
+
+		sequences := sb_efi.NewImageLoadSequences().Append(
+			sb_efi.NewImageLoadActivity(
+				sb_efi.NewFileImage(mockEFI.Path),
+			),
+		)
+
+		addPCRProfileCalls := 0
+		restore := secboot.MockSbEfiAddPCRProfile(func(pcrAlg tpm2.HashAlgorithmId, branch *sb_tpm2.PCRProtectionProfileBranch, loadSequences *sb_efi.ImageLoadSequences, options ...sb_efi.PCRProfileOption) error {
+			addPCRProfileCalls++
+			c.Assert(pcrAlg, Equals, tpm2.HashAlgorithmSHA256)
+			c.Assert(loadSequences, DeepEquals, sequences)
+			return tc.addPCRProfileErr
+		})
+		defer restore()
+
+		// mock adding snap model profile
+		addSnapModelCalls := 0
+		restore = secboot.MockSbAddSnapModelProfile(func(profile *sb_tpm2.PCRProtectionProfileBranch, params *sb_tpm2.SnapModelProfileParams) error {
+			addSnapModelCalls++
+			//c.Assert(profile, Equals, pcrProfile)
+			c.Assert(params.PCRAlgorithm, Equals, tpm2.HashAlgorithmSHA256)
+			c.Assert(params.PCRIndex, Equals, 12)
+			c.Assert(params.Models[0], DeepEquals, modelParams[0].Model)
+			return tc.addSnapModelErr
+		})
+		defer restore()
+
+		// mock adding systemd EFI stub profile
+		addSystemdEfiStubCalls := 0
+		restore = secboot.MockSbEfiAddSystemdStubProfile(func(profile *sb_tpm2.PCRProtectionProfileBranch, params *sb_efi.SystemdStubProfileParams) error {
+			addSystemdEfiStubCalls++
+			//c.Assert(profile, Equals, pcrProfile)
+			c.Assert(params.PCRAlgorithm, Equals, tpm2.HashAlgorithmSHA256)
+			c.Assert(params.PCRIndex, Equals, 12)
+			c.Assert(params.KernelCmdlines, DeepEquals, modelParams[0].KernelCmdlines)
+			return tc.addSystemdEFIStubErr
+		})
+		defer restore()
+
+		pcrProfile, err := secboot.BuildPCRProtectionProfile(modelParams)
+		if len(tc.buildProfileErr) > 0 {
+			c.Assert(err, ErrorMatches, tc.buildProfileErr)
+			continue
+		} else {
+			c.Assert(err, IsNil)
+		}
+
 		tmpdir := c.MkDir()
 		keyFile := filepath.Join(tmpdir, "keyfile")
 		keyFile2 := filepath.Join(tmpdir, "keyfile2")
 		myParams := &secboot.ResealKeysParams{
-			ModelParams: []*secboot.SealKeyModelParams{
-				{
-					EFILoadChains:  []*secboot.LoadChain{secboot.NewLoadChain(mockEFI)},
-					KernelCmdlines: []string{"cmdline"},
-					Model:          &asserts.Model{},
-				},
-			},
+			PCRProfile:           pcrProfile,
 			KeyFiles:             []string{keyFile, keyFile2},
 			TPMPolicyAuthKeyFile: mockTPMPolicyAuthKeyFile,
 		}
@@ -1154,12 +1204,6 @@ func (s *secbootSuite) TestResealKey(c *C) {
 			}
 		}
 
-		sequences := sb_efi.NewImageLoadSequences().Append(
-			sb_efi.NewImageLoadActivity(
-				sb_efi.NewFileImage(mockEFI.Path),
-			),
-		)
-
 		// mock TPM connection
 		tpm, restore := mockSbTPMConnection(c, tc.tpmErr)
 		defer restore()
@@ -1167,39 +1211,6 @@ func (s *secbootSuite) TestResealKey(c *C) {
 		// mock TPM enabled check
 		restore = secboot.MockIsTPMEnabled(func(t *sb_tpm2.Connection) bool {
 			return tc.tpmEnabled
-		})
-		defer restore()
-
-		addPCRProfileCalls := 0
-		restore = secboot.MockSbEfiAddPCRProfile(func(pcrAlg tpm2.HashAlgorithmId, branch *sb_tpm2.PCRProtectionProfileBranch, loadSequences *sb_efi.ImageLoadSequences, options ...sb_efi.PCRProfileOption) error {
-			addPCRProfileCalls++
-			c.Assert(pcrAlg, Equals, tpm2.HashAlgorithmSHA256)
-			c.Assert(loadSequences, DeepEquals, sequences)
-			return tc.addPCRProfileErr
-		})
-		defer restore()
-
-		// mock adding systemd EFI stub profile
-		addSystemdEfiStubCalls := 0
-		restore = secboot.MockSbEfiAddSystemdStubProfile(func(profile *sb_tpm2.PCRProtectionProfileBranch, params *sb_efi.SystemdStubProfileParams) error {
-			addSystemdEfiStubCalls++
-			//c.Assert(profile, Equals, pcrProfile)
-			c.Assert(params.PCRAlgorithm, Equals, tpm2.HashAlgorithmSHA256)
-			c.Assert(params.PCRIndex, Equals, 12)
-			c.Assert(params.KernelCmdlines, DeepEquals, myParams.ModelParams[0].KernelCmdlines)
-			return tc.addSystemdEFIStubErr
-		})
-		defer restore()
-
-		// mock adding snap model profile
-		addSnapModelCalls := 0
-		restore = secboot.MockSbAddSnapModelProfile(func(profile *sb_tpm2.PCRProtectionProfileBranch, params *sb_tpm2.SnapModelProfileParams) error {
-			addSnapModelCalls++
-			//c.Assert(profile, Equals, pcrProfile)
-			c.Assert(params.PCRAlgorithm, Equals, tpm2.HashAlgorithmSHA256)
-			c.Assert(params.PCRIndex, Equals, 12)
-			c.Assert(params.Models[0], DeepEquals, myParams.ModelParams[0].Model)
-			return tc.addSnapModelErr
 		})
 		defer restore()
 
@@ -2533,4 +2544,23 @@ func (s *secbootSuite) TestDeleteKeysErrorDelete(c *C) {
 
 	err := secboot.DeleteKeys("/dev/foo", toRemove)
 	c.Assert(err, ErrorMatches, `cannot remove old container key: some error`)
+}
+
+type SomeStructure struct {
+	TPM2PCRProfile secboot.SerializedPCRProfile `json:"tpm2-pcr-profile"`
+}
+
+func (s *secbootSuite) TestSerializedProfile(c *C) {
+	krp := SomeStructure{
+		TPM2PCRProfile: secboot.SerializedPCRProfile(`"serialized-profile"`),
+	}
+
+	data, err := json.Marshal(krp)
+	c.Assert(err, IsNil)
+	var raw map[string]any
+	err = json.Unmarshal(data, &raw)
+	c.Assert(err, IsNil)
+	c.Check(raw, DeepEquals, map[string]any{
+		"tpm2-pcr-profile": "serialized-profile",
+	})
 }

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -2552,7 +2552,7 @@ type SomeStructure struct {
 
 func (s *secbootSuite) TestSerializedProfile(c *C) {
 	krp := SomeStructure{
-		TPM2PCRProfile: secboot.SerializedPCRProfile(`"serialized-profile"`),
+		TPM2PCRProfile: secboot.SerializedPCRProfile("serialized-profile"),
 	}
 
 	data, err := json.Marshal(krp)
@@ -2561,6 +2561,7 @@ func (s *secbootSuite) TestSerializedProfile(c *C) {
 	err = json.Unmarshal(data, &raw)
 	c.Assert(err, IsNil)
 	c.Check(raw, DeepEquals, map[string]any{
-		"tpm2-pcr-profile": "serialized-profile",
+		// binary blobk is serialized to base64 by default
+		"tpm2-pcr-profile": base64.StdEncoding.EncodeToString([]byte("serialized-profile")),
 	})
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -23,6 +23,7 @@ package secboot
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -443,10 +444,6 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) ([]byte, error) {
 // ResealKeys updates the PCR protection policy for the sealed encryption keys
 // according to the specified parameters.
 func ResealKeys(params *ResealKeysParams) error {
-	numModels := len(params.ModelParams)
-	if numModels < 1 {
-		return fmt.Errorf("at least one set of model-specific parameters is required")
-	}
 	numSealedKeyObjects := len(params.KeyFiles)
 	if numSealedKeyObjects < 1 {
 		return fmt.Errorf("at least one key file is required")
@@ -461,9 +458,9 @@ func ResealKeys(params *ResealKeysParams) error {
 		return fmt.Errorf("TPM device is not enabled")
 	}
 
-	pcrProfile, err := buildPCRProtectionProfile(params.ModelParams)
-	if err != nil {
-		return fmt.Errorf("cannot build new PCR protection profile: %w", err)
+	var pcrProfile sb_tpm2.PCRProtectionProfile
+	if err := json.Unmarshal(params.PCRProfile, &pcrProfile); err != nil {
+		return err
 	}
 
 	authKey, err := os.ReadFile(params.TPMPolicyAuthKeyFile)
@@ -495,7 +492,7 @@ func ResealKeys(params *ResealKeysParams) error {
 	}
 
 	if hasOldObject {
-		if err := sbUpdateKeyPCRProtectionPolicyMultiple(tpm, sealedKeyObjects, authKey, pcrProfile); err != nil {
+		if err := sbUpdateKeyPCRProtectionPolicyMultiple(tpm, sealedKeyObjects, authKey, &pcrProfile); err != nil {
 			return fmt.Errorf("cannot update legacy PCR protection policy: %w", err)
 		}
 
@@ -513,7 +510,7 @@ func ResealKeys(params *ResealKeysParams) error {
 		}
 	} else {
 		// TODO: find out which context when revocation should happen
-		if err := sbUpdateKeyDataPCRProtectionPolicy(tpm, authKey, pcrProfile, sb_tpm2.NoNewPCRPolicyVersion, keyDatas...); err != nil {
+		if err := sbUpdateKeyDataPCRProtectionPolicy(tpm, authKey, &pcrProfile, sb_tpm2.NoNewPCRPolicyVersion, keyDatas...); err != nil {
 			return fmt.Errorf("cannot update PCR protection policy: %w", err)
 		}
 
@@ -584,6 +581,16 @@ func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb_tpm2.PCRP
 	logger.Debugf("PCR protection profile:\n%s", pcrProfile.String())
 
 	return pcrProfile, nil
+}
+
+// BuildPCRProtectionProfile builds and serializes a PCR profile from
+// a list of SealKeyModelParams.
+func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams) (SerializedPCRProfile, error) {
+	pcrProfile, err := buildPCRProtectionProfile(modelParams)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(pcrProfile)
 }
 
 func tpmProvision(tpm *sb_tpm2.Connection, mode TPMProvisionMode, lockoutAuthFile string) error {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -23,7 +23,6 @@ package secboot
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -459,7 +458,7 @@ func ResealKeys(params *ResealKeysParams) error {
 	}
 
 	var pcrProfile sb_tpm2.PCRProtectionProfile
-	if err := json.Unmarshal(params.PCRProfile, &pcrProfile); err != nil {
+	if _, err := mu.UnmarshalFromBytes(params.PCRProfile, &pcrProfile); err != nil {
 		return err
 	}
 
@@ -590,7 +589,7 @@ func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams) (SerializedPCR
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(pcrProfile)
+	return mu.MarshalToBytes(pcrProfile)
 }
 
 func tpmProvision(tpm *sb_tpm2.Connection, mode TPMProvisionMode, lockoutAuthFile string) error {


### PR DESCRIPTION
Ensure() initializes the empty profiles, and reseal updates them.

This is on top of #14400