### PR TITLE
tests: add apparmor prompting integration tests

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 show_help() {
-	echo "usage: tests.session exec [-u USER] [-p PID_FILE] [--] <CMD>"
+	echo "usage: tests.session [-u USER] [-p PID_FILE] exec <CMD>"
 	echo "       tests.session prepare | restore [-u USER | -u USER1,USER2,...]"
 	echo "       tests.session kill-leaked"
 	echo "       tests.session dump"
@@ -31,10 +31,6 @@ main() {
 				fi
 				pid_file="$2"
 				shift 2
-				;;
-			--)
-				shift
-				break
 				;;
 			kill-leaked)
 				action=kill-leaked

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.json
@@ -11,7 +11,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test1.txt",
+          "path": ".*/test1/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -20,7 +20,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test2.txt",
+          "path": ".*/test2/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -29,7 +29,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test3.txt",
+          "path": ".*/test3/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -38,7 +38,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test4.txt",
+          "path": ".*/test4/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -46,7 +46,7 @@
         "action": "allow",
         "lifespan": "forever",
         "constraints": {
-          "path-pattern": "${BASE_PATH}/test*.txt",
+          "path-pattern": "${BASE_PATH}/test?/file.txt",
           "permissions": [ "write" ]
         }
       }

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
@@ -4,9 +4,11 @@
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
-# Thus, we can't queue up multiple outstanding writes on files in the same
-# directory. Instead, we must write files in different directories in order
-# for this test to succeed.
+# Thus, we can't queue up multiple outstanding file creations in the same
+# directory. Instead, we must create files in different directories in order
+# for this test to succeed. Reads and writes to already-existing files in a
+# directory are not blocked by file creations pending replies in that same
+# directory.
 
 TEST_DIR="$1"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
@@ -11,6 +11,10 @@
 # directory.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
@@ -20,7 +24,7 @@ for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
 	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
-	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
 		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
@@ -40,7 +44,7 @@ mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
@@ -44,7 +44,7 @@ mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
@@ -1,23 +1,53 @@
 #!/usr/bin/sh
 
 # A test that replying with allow forever actions previous matching prompts.
+#
+# When creating a new file is blocked on a reply to a request prompt, the
+# directory in which the file will be created is locked from other writes.
+# Thus, we can't queue up multiple outstanding writes on files in the same
+# directory. Instead, we must write files in different directories in order
+# for this test to succeed.
 
 TEST_DIR="$1"
 
-WRITABLE="$(snap run --shell prompting-client.scripted -c "cd ~; pwd")/$(basename "$TEST_DIR")"
+WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 
-for name in test1.txt test2.txt test3.txt ; do
+for dir in test1 test2 test3 ; do
+	mkdir -p "${TEST_DIR}/${dir}"
+	name="${dir}/file.txt"
 	echo "Attempt to write $name in the background"
-	snap run --shell prompting-client.scripted -c "echo started > ${WRITABLE}/${name}; echo $name is written > ${TEST_DIR}/${name}" &
-	timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}' ] ; do sleep 0.1 ; done"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start write of $name within timeout period"
+		exit 1
+	fi
 done
 
-echo "Attempt to write test4.txt (for which client will reply)"
-snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has not yet finished"
+	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name finished before write for test4/file.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test4/file.txt (for which client will reply)"
+mkdir -p "${TEST_DIR}/test4"
+snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
 timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has finished"
+	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name did not finish after client replied"
+		exit 1
+	fi
+done
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
@@ -27,7 +57,8 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	exit 1
 fi
 
-for name in test1.txt test2.txt test3.txt test4.txt; do
+for dir in test1 test2 test3 test4; do
+	name="${dir}/file.txt"
 	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
 	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
 		echo "file creation failed for $name"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
@@ -44,7 +44,7 @@ mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_allow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sh
 
-# A test that replying with allow forever actions previous matching prompts.
+# A test that replying with allow forever actions previous matching creates.
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
@@ -18,24 +18,24 @@ snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 for dir in test1 test2 test3 ; do
 	mkdir -p "${TEST_DIR}/${dir}"
 	name="${dir}/file.txt"
-	echo "Attempt to write $name in the background"
+	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
 	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
-		echo "failed to start write of $name within timeout period"
+		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
 done
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has not yet finished"
+	echo "Check that create for $name has not yet finished"
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name finished before write for test4/file.txt started"
+		echo "create of $name finished before create for test4/file.txt started"
 		exit 1
 	fi
 done
 
-echo "Attempt to write test4/file.txt (for which client will reply)"
+echo "Attempt to create test4/file.txt (for which client will reply)"
 mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
@@ -44,9 +44,9 @@ timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do slee
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has finished"
+	echo "Check that create for $name has finished"
 	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name did not finish after client replied"
+		echo "create of $name did not finish after client replied"
 		exit 1
 	fi
 done

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.json
@@ -11,7 +11,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test1.txt",
+          "path": ".*/test1/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -20,7 +20,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test2.txt",
+          "path": ".*/test2/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -29,7 +29,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test3.txt",
+          "path": ".*/test3/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -38,7 +38,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test4.txt",
+          "path": ".*/test4/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -46,7 +46,7 @@
         "action": "deny",
         "lifespan": "forever",
         "constraints": {
-          "path-pattern": "${BASE_PATH}/test*.txt",
+          "path-pattern": "${BASE_PATH}/test?/file.txt",
           "permissions": [ "write" ]
         }
       }

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
@@ -4,9 +4,11 @@
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
-# Thus, we can't queue up multiple outstanding writes on files in the same
-# directory. Instead, we must write files in different directories in order
-# for this test to succeed.
+# Thus, we can't queue up multiple outstanding file creations in the same
+# directory. Instead, we must create files in different directories in order
+# for this test to succeed. Reads and writes to already-existing files in a
+# directory are not blocked by file creations pending replies in that same
+# directory.
 
 TEST_DIR="$1"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
@@ -1,23 +1,53 @@
 #!/usr/bin/sh
 
 # A test that replying with allow forever actions previous matching prompts.
+#
+# When creating a new file is blocked on a reply to a request prompt, the
+# directory in which the file will be created is locked from other writes.
+# Thus, we can't queue up multiple outstanding writes on files in the same
+# directory. Instead, we must write files in different directories in order
+# for this test to succeed.
 
 TEST_DIR="$1"
 
-WRITABLE="$(snap run --shell prompting-client.scripted -c "cd ~; pwd")/$(basename "$TEST_DIR")"
+WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 
-for name in test1.txt test2.txt test3.txt ; do
+for dir in test1 test2 test3 ; do
+	mkdir -p "${TEST_DIR}/${dir}"
+	name="${dir}/file.txt"
 	echo "Attempt to write $name in the background"
-	snap run --shell prompting-client.scripted -c "echo started > ${WRITABLE}/${name}; echo $name is written > ${TEST_DIR}/${name}" &
-	timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}' ] ; do sleep 0.1 ; done"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start write of $name within timeout period"
+		exit 1
+	fi
 done
 
-echo "Attempt to write test4.txt (for which client will reply)"
-snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has not yet finished"
+	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name finished before write for test4/file.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test4/file.txt (for which client will reply)"
+mkdir -p "${TEST_DIR}/test4"
+snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
 timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has finished"
+	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name did not finish after client replied"
+		exit 1
+	fi
+done
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
@@ -27,7 +57,8 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	exit 1
 fi
 
-for name in test1.txt test2.txt test3.txt test4.txt; do
+for dir in test1 test2 test3 test4; do
+	name="${dir}/file.txt"
 	if [ -f "${TEST_DIR}/${name}" ] ; then
 		echo "file creation unexpectedly succeeded for $name"
 		exit 1

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
@@ -11,6 +11,10 @@
 # directory.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
@@ -20,7 +24,7 @@ for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
 	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
-	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
 		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
@@ -40,7 +44,7 @@ mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/sh
+
+# A test that replying with allow forever actions previous matching prompts.
+
+TEST_DIR="$1"
+
+WRITABLE="$(snap run --shell prompting-client.scripted -c "cd ~; pwd")/$(basename "$TEST_DIR")"
+snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to write $name in the background"
+	snap run --shell prompting-client.scripted -c "echo started > ${WRITABLE}/${name}; echo $name is written > ${TEST_DIR}/${name}" &
+	timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}' ] ; do sleep 0.1 ; done"
+done
+
+echo "Attempt to write test4.txt (for which client will reply)"
+snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+for name in test1.txt test2.txt test3.txt test4.txt; do
+	if [ -f "${TEST_DIR}/${name}" ] ; then
+		echo "file creation unexpectedly succeeded for $name"
+		exit 1
+	fi
+done

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
@@ -44,7 +44,7 @@ mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
@@ -44,7 +44,7 @@ mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_actioned_by_other_pid_always_deny.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sh
 
-# A test that replying with allow forever actions previous matching prompts.
+# A test that replying with allow forever actions previous matching creates.
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
@@ -18,24 +18,24 @@ snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 for dir in test1 test2 test3 ; do
 	mkdir -p "${TEST_DIR}/${dir}"
 	name="${dir}/file.txt"
-	echo "Attempt to write $name in the background"
+	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
 	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
-		echo "failed to start write of $name within timeout period"
+		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
 done
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has not yet finished"
+	echo "Check that create for $name has not yet finished"
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name finished before write for test4/file.txt started"
+		echo "create of $name finished before create for test4/file.txt started"
 		exit 1
 	fi
 done
 
-echo "Attempt to write test4/file.txt (for which client will reply)"
+echo "Attempt to create test4/file.txt (for which client will reply)"
 mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
@@ -44,9 +44,9 @@ timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do slee
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has finished"
+	echo "Check that create for $name has finished"
 	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name did not finish after client replied"
+		echo "create of $name did not finish after client replied"
 		exit 1
 	fi
 done

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.json
@@ -33,7 +33,7 @@
       },
       "reply": {
         "action": "deny",
-        "lifespan": "once",
+        "lifespan": "single",
         "constraints": {
           "path-pattern": "${BASE_PATH}/*",
           "permissions": [ "write" ]

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/fail.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "once",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/*",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -15,7 +15,7 @@ for name in test1.txt test2.md fail.txt test3.pdf ; do
 done
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -4,6 +4,10 @@
 # path pattern to be created, but doesn't allow other file creation.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 for name in test1.txt test2.md fail.txt test3.pdf ; do
 	echo "Attempt to write $name"
@@ -11,7 +15,7 @@ for name in test1.txt test2.md fail.txt test3.pdf ; do
 done
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -15,7 +15,7 @@ for name in test1.txt test2.md fail.txt test3.pdf ; do
 done
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/sh
+
+# A test that replying with allow always allows multiple files which match the
+# path pattern to be created, but doesn't allow other file creation.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+for name in test1.txt test2.md fail.txt test3.pdf ; do
+	echo "Attempt to write $name"
+	$SNAP_DO "$name is written > ${TEST_DIR}/${name}"
+done
+
+sleep 1 # give the client a chance to write its result and exit
+
+CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_RESULT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+for name in test1.txt test2.md test3.pdf ; do
+	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
+	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
+		echo "file creation failed"
+		exit 1
+	fi
+done
+
+if [ -f "${TEST_DIR}/fail.txt" ] ; then
+	echo "file creation unexpectedly succeeded"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -20,9 +20,9 @@ done
 
 sleep 5 # give the client a chance to write its result and exit
 
-CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
-if [ "$CLIENT_RESULT" != "success" ] ; then
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	echo "test failed"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -24,12 +24,12 @@ fi
 for name in test1.txt test2.md test3.pdf ; do
 	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
 	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
-		echo "file creation failed"
+		echo "file creation failed for $name"
 		exit 1
 	fi
 done
 
 if [ -f "${TEST_DIR}/fail.txt" ] ; then
-	echo "file creation unexpectedly succeeded"
+	echo "file creation unexpectedly succeeded for fail.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -5,20 +5,13 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 for name in test1.txt test2.md fail.txt test3.pdf ; do
 	echo "Attempt to write $name"
 	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_allow.sh
@@ -8,16 +8,17 @@ TEST_DIR="$1"
 echo "Run the prompting client in scripted mode in the background"
 prompting-client.scripted \
 	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
 	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
 sleep 1 # give the client a chance to start listening
 
 for name in test1.txt test2.md fail.txt test3.pdf ; do
 	echo "Attempt to write $name"
-	$SNAP_DO "$name is written > ${TEST_DIR}/${name}"
+	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 1 # give the client a chance to write its result and exit
+sleep 5 # give the client a chance to write its result and exit
 
 CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/succeed.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "once",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/*",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.json
@@ -33,7 +33,23 @@
       },
       "reply": {
         "action": "allow",
-        "lifespan": "once",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/*",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/succeed.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
         "constraints": {
           "path-pattern": "${BASE_PATH}/*",
           "permissions": [ "write" ]

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -8,16 +8,17 @@ TEST_DIR="$1"
 echo "Run the prompting client in scripted mode in the background"
 prompting-client.scripted \
 	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
 	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
 sleep 1 # give the client a chance to start listening
 
 for name in test1.txt test2.md succeed.txt test3.pdf ; do
 	echo "Attempt to write $name"
-	$SNAP_DO "$name is written > ${TEST_DIR}/${name}"
+	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 1 # give the client a chance to write its result and exit
+sleep 5 # give the client a chance to write its result and exit
 
 CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -15,7 +15,7 @@ for name in test1.txt test2.md succeed.txt test3.pdf ; do
 done
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -5,20 +5,13 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 for name in test1.txt test2.md succeed.txt test3.pdf ; do
 	echo "Attempt to write $name"
 	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/sh
+
+# A test that replying with deny always denies multiple files which match the
+# path pattern to be created, but doesn't deny other file creation.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+for name in test1.txt test2.md succeed.txt test3.pdf ; do
+	echo "Attempt to write $name"
+	$SNAP_DO "$name is written > ${TEST_DIR}/${name}"
+done
+
+sleep 1 # give the client a chance to write its result and exit
+
+CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_RESULT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+for name in test1.txt test2.md test3.pdf ; do
+	if [ -f "${TEST_DIR}/${name}" ] ; then
+		echo "file creation unexpectedly succeeded"
+		exit 1
+	fi
+done
+
+TEST_OUTPUT="$(cat "${TEST_DIR}/succeed.txt")"
+if [ "$TEST_OUTPUT" != "succeed.txt is written" ] ; then
+	echo "file creation failed"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -15,7 +15,7 @@ for name in test1.txt test2.md succeed.txt test3.pdf ; do
 done
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -20,9 +20,9 @@ done
 
 sleep 5 # give the client a chance to write its result and exit
 
-CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
-if [ "$CLIENT_RESULT" != "success" ] ; then
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	echo "test failed"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -23,13 +23,13 @@ fi
 
 for name in test1.txt test2.md test3.pdf ; do
 	if [ -f "${TEST_DIR}/${name}" ] ; then
-		echo "file creation unexpectedly succeeded"
+		echo "file creation unexpectedly succeeded for $name"
 		exit 1
 	fi
 done
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/succeed.txt")"
 if [ "$TEST_OUTPUT" != "succeed.txt is written" ] ; then
-	echo "file creation failed"
+	echo "file creation failed for succeed.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_deny.sh
@@ -4,6 +4,10 @@
 # path pattern to be created, but doesn't deny other file creation.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 for name in test1.txt test2.md succeed.txt test3.pdf ; do
 	echo "Attempt to write $name"
@@ -11,7 +15,7 @@ for name in test1.txt test2.md succeed.txt test3.pdf ; do
 done
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.json
@@ -1,0 +1,87 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test5.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.json
@@ -11,7 +11,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test1.txt",
+          "path": ".*/test1/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -20,7 +20,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test2.txt",
+          "path": ".*/test2/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -29,7 +29,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test3.txt",
+          "path": ".*/test3/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -38,7 +38,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test4.txt",
+          "path": ".*/test4/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -46,7 +46,7 @@
         "action": "allow",
         "lifespan": "single",
         "constraints": {
-          "path-pattern": "${BASE_PATH}/test*.txt",
+          "path-pattern": "${BASE_PATH}/test?/file.txt",
           "permissions": [ "write" ]
         }
       }
@@ -54,7 +54,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test4.txt",
+          "path": ".*/test4/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -62,7 +62,7 @@
         "action": "allow",
         "lifespan": "single",
         "constraints": {
-          "path-pattern": "${BASE_PATH}/test*.txt",
+          "path-pattern": "${BASE_PATH}/test*/file.txt",
           "permissions": [ "write" ]
         }
       }
@@ -70,7 +70,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test5.txt",
+          "path": ".*/test5/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -78,7 +78,7 @@
         "action": "deny",
         "lifespan": "forever",
         "constraints": {
-          "path-pattern": "${BASE_PATH}/test*.txt",
+          "path-pattern": "${BASE_PATH}/test*/file.txt",
           "permissions": [ "write" ]
         }
       }

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -4,9 +4,11 @@
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
-# Thus, we can't queue up multiple outstanding writes on files in the same
-# directory. Instead, we must write files in different directories in order
-# for this test to succeed.
+# Thus, we can't queue up multiple outstanding file creations in the same
+# directory. Instead, we must create files in different directories in order
+# for this test to succeed. Reads and writes to already-existing files in a
+# directory are not blocked by file creations pending replies in that same
+# directory.
 
 TEST_DIR="$1"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sh
 
-# A test that replying with allow once does not action previous matching prompts.
+# A test that replying with allow once does not action previous matching creates.
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
@@ -18,37 +18,37 @@ snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 for dir in test1 test2 test3 ; do
 	mkdir -p "${TEST_DIR}/${dir}"
 	name="${dir}/file.txt"
-	echo "Attempt to write $name in the background"
+	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
 	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
-		echo "failed to start write of $name within timeout period"
+		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
 done
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has not yet finished"
+	echo "Check that create for $name has not yet finished"
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name finished before write for test4/file.txt started"
+		echo "create of $name finished before create for test4/file.txt started"
 		exit 1
 	fi
 done
 
-echo "Attempt to write test4/file.txt (for which client will reply allow single)"
+echo "Attempt to create test4/file.txt (for which client will reply allow single)"
 mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name was not actioned by reply for test4/file.txt"
+	echo "Check that create for $name was not actioned by reply for test4/file.txt"
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name finished before write for test5/file.txt started"
+		echo "create of $name finished before create for test5/file.txt started"
 		exit 1
 	fi
 done
 
-echo "Attempt to write test5/file.txt (for which client will reply deny forever)"
+echo "Attempt to create test5/file.txt (for which client will reply deny forever)"
 mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
@@ -57,9 +57,9 @@ timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do slee
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has finished"
+	echo "Check that create for $name has finished"
 	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name did not finish after client replied"
+		echo "create of $name did not finish after client replied"
 		exit 1
 	fi
 done

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -58,7 +58,7 @@ mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -42,6 +42,7 @@ snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
 	echo "Check that create for $name was not actioned by reply for test4/file.txt"
+	# NOTE: if one checks [ -f "${TEST_DIR}/${name}" ], it may kill the blocked create
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
 		echo "create of $name finished before create for test5/file.txt started"
 		exit 1

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -58,7 +58,7 @@ mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -11,6 +11,10 @@
 # directory.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
@@ -20,7 +24,7 @@ for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
 	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
-	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
 		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
@@ -54,7 +58,7 @@ mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -1,26 +1,66 @@
 #!/usr/bin/sh
 
-# A test that replying with allow forever actions previous matching prompts.
+# A test that replying with allow once does not action previous matching prompts.
+#
+# When creating a new file is blocked on a reply to a request prompt, the
+# directory in which the file will be created is locked from other writes.
+# Thus, we can't queue up multiple outstanding writes on files in the same
+# directory. Instead, we must write files in different directories in order
+# for this test to succeed.
 
 TEST_DIR="$1"
 
-WRITABLE="$(snap run --shell prompting-client.scripted -c "cd ~; pwd")/$(basename "$TEST_DIR")"
+WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 
-for name in test1.txt test2.txt test3.txt ; do
+for dir in test1 test2 test3 ; do
+	mkdir -p "${TEST_DIR}/${dir}"
+	name="${dir}/file.txt"
 	echo "Attempt to write $name in the background"
-	snap run --shell prompting-client.scripted -c "echo started > ${WRITABLE}/${name}; echo $name is written > ${TEST_DIR}/${name}" &
-	timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}' ] ; do sleep 0.1 ; done"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start write of $name within timeout period"
+		exit 1
+	fi
 done
 
-echo "Attempt to write test4.txt (for which client will reply allow single)"
-snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has not yet finished"
+	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name finished before write for test4/file.txt started"
+		exit 1
+	fi
+done
 
-echo "Attempt to write test5.txt (for which client will reply deny forever)"
-snap run --shell prompting-client.scripted -c "echo test5.txt is written > ${TEST_DIR}/test5.txt"
+echo "Attempt to write test4/file.txt (for which client will reply allow single)"
+mkdir -p "${TEST_DIR}/test4"
+snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
+
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name was not actioned by reply for test4/file.txt"
+	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name finished before write for test5/file.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test5/file.txt (for which client will reply deny forever)"
+mkdir -p "${TEST_DIR}/test5"
+snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
 timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has finished"
+	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name did not finish after client replied"
+		exit 1
+	fi
+done
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
@@ -30,13 +70,14 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	exit 1
 fi
 
-TEST_OUTPUT="$(cat "${TEST_DIR}/test4.txt")"
-if [ "$TEST_OUTPUT" != "test4.txt is written" ] ; then
-	echo "file creation failed for test4.txt"
+TEST_OUTPUT="$(cat "${TEST_DIR}/test4/file.txt")"
+if [ "$TEST_OUTPUT" != "test4/file.txt is written" ] ; then
+	echo "file creation failed for test4/file.txt"
 	exit 1
 fi
 
-for name in test1.txt test2.txt test3.txt test5.txt; do
+for dir in test1 test2 test3 test5; do
+	name="${dir}/file.txt"
 	if [ -f "${TEST_DIR}/${name}" ] ; then
 		echo "file creation unexpectedly succeeded for $name"
 		exit 1

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_allow.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/sh
+
+# A test that replying with allow forever actions previous matching prompts.
+
+TEST_DIR="$1"
+
+WRITABLE="$(snap run --shell prompting-client.scripted -c "cd ~; pwd")/$(basename "$TEST_DIR")"
+snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to write $name in the background"
+	snap run --shell prompting-client.scripted -c "echo started > ${WRITABLE}/${name}; echo $name is written > ${TEST_DIR}/${name}" &
+	timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}' ] ; do sleep 0.1 ; done"
+done
+
+echo "Attempt to write test4.txt (for which client will reply allow single)"
+snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+
+echo "Attempt to write test5.txt (for which client will reply deny forever)"
+snap run --shell prompting-client.scripted -c "echo test5.txt is written > ${TEST_DIR}/test5.txt"
+
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+TEST_OUTPUT="$(cat "${TEST_DIR}/test4.txt")"
+if [ "$TEST_OUTPUT" != "test4.txt is written" ] ; then
+	echo "file creation failed for test4.txt"
+	exit 1
+fi
+
+for name in test1.txt test2.txt test3.txt test5.txt; do
+	if [ -f "${TEST_DIR}/${name}" ] ; then
+		echo "file creation unexpectedly succeeded for $name"
+		exit 1
+	fi
+done

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.json
@@ -11,7 +11,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test1.txt",
+          "path": ".*/test1/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -20,7 +20,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test2.txt",
+          "path": ".*/test2/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -29,7 +29,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test3.txt",
+          "path": ".*/test3/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -38,7 +38,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test4.txt",
+          "path": ".*/test4/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -46,7 +46,7 @@
         "action": "deny",
         "lifespan": "single",
         "constraints": {
-          "path-pattern": "${BASE_PATH}/test*.txt",
+          "path-pattern": "${BASE_PATH}/test*/file.txt",
           "permissions": [ "write" ]
         }
       }
@@ -54,7 +54,7 @@
     {
       "prompt-filter": {
         "constraints": {
-          "path": ".*/test5.txt",
+          "path": ".*/test5/file.txt",
           "requested-permissions": [ "write" ]
         }
       },
@@ -62,7 +62,7 @@
         "action": "allow",
         "lifespan": "forever",
         "constraints": {
-          "path-pattern": "${BASE_PATH}/test*.txt",
+          "path-pattern": "${BASE_PATH}/test*/file.txt",
           "permissions": [ "write" ]
         }
       }

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test5.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -4,9 +4,11 @@
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
-# Thus, we can't queue up multiple outstanding writes on files in the same
-# directory. Instead, we must write files in different directories in order
-# for this test to succeed.
+# Thus, we can't queue up multiple outstanding file creations in the same
+# directory. Instead, we must create files in different directories in order
+# for this test to succeed. Reads and writes to already-existing files in a
+# directory are not blocked by file creations pending replies in that same
+# directory.
 
 TEST_DIR="$1"
 

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -39,14 +39,10 @@ echo "Attempt to create test4/file.txt (for which client will reply deny single)
 mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
-echo "Check that original files have not yet been created"
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	if [ -f "${TEST_DIR}/${name}" ] ; then
-		echo "file creation unexpectedly succeeded early for $name"
-		exit 1
-	fi
 	echo "Check that create for $name was not actioned by reply for test4/file.txt"
+	# NOTE: if one checks [ -f "${TEST_DIR}/${name}" ], it may kill the blocked create
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
 		echo "create of $name finished before create for test5/file.txt started"
 		exit 1

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -11,6 +11,10 @@
 # directory.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
@@ -20,7 +24,7 @@ for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
 	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
-	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
 		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
@@ -54,7 +58,7 @@ mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sh
 
-# A test that replying with deny once does not action previous matching prompts.
+# A test that replying with deny once does not action previous matching creates.
 #
 # When creating a new file is blocked on a reply to a request prompt, the
 # directory in which the file will be created is locked from other writes.
@@ -18,42 +18,42 @@ snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 for dir in test1 test2 test3 ; do
 	mkdir -p "${TEST_DIR}/${dir}"
 	name="${dir}/file.txt"
-	echo "Attempt to write $name in the background"
+	echo "Attempt to create $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
 	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
-		echo "failed to start write of $name within timeout period"
+		echo "failed to start create of $name within timeout period"
 		exit 1
 	fi
 done
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has not yet finished"
+	echo "Check that create for $name has not yet finished"
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name finished before write for test4/file.txt started"
+		echo "create of $name finished before create for test4/file.txt started"
 		exit 1
 	fi
 done
 
-echo "Attempt to write test4/file.txt (for which client will reply deny single)"
+echo "Attempt to create test4/file.txt (for which client will reply deny single)"
 mkdir -p "${TEST_DIR}/test4"
 snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
 
-echo "Check that original files have not yet been written"
+echo "Check that original files have not yet been created"
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
 	if [ -f "${TEST_DIR}/${name}" ] ; then
 		echo "file creation unexpectedly succeeded early for $name"
 		exit 1
 	fi
-	echo "Check that write for $name was not actioned by reply for test4/file.txt"
+	echo "Check that create for $name was not actioned by reply for test4/file.txt"
 	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name finished before write for test5/file.txt started"
+		echo "create of $name finished before create for test5/file.txt started"
 		exit 1
 	fi
 done
 
-echo "Attempt to write test5/file.txt (for which client will reply allow forever)"
+echo "Attempt to create test5/file.txt (for which client will reply allow forever)"
 mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
@@ -62,9 +62,9 @@ timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do slee
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"
-	echo "Check that write for $name has finished"
+	echo "Check that create for $name has finished"
 	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
-		echo "write of $name did not finish after client replied"
+		echo "create of $name did not finish after client replied"
 		exit 1
 	fi
 done

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/sh
+
+# A test that replying with allow forever actions previous matching prompts.
+
+TEST_DIR="$1"
+
+WRITABLE="$(snap run --shell prompting-client.scripted -c "cd ~; pwd")/$(basename "$TEST_DIR")"
+snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to write $name in the background"
+	snap run --shell prompting-client.scripted -c "echo started > ${WRITABLE}/${name}; echo $name is written > ${TEST_DIR}/${name}" &
+	timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}' ] ; do sleep 0.1 ; done"
+done
+
+echo "Attempt to write test4.txt (for which client will reply deny single)"
+snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+
+echo "Check that original files have not yet been written"
+for name in test1.txt test2.txt test3.txt; do
+	if [ -f "${TEST_DIR}/${name}" ] ; then
+		echo "file creation unexpectedly succeeded early for $name"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test5.txt (for which client will reply allow forever)"
+snap run --shell prompting-client.scripted -c "echo test5.txt is written > ${TEST_DIR}/test5.txt"
+
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+if [ -f "${TEST_DIR}/test4.txt" ] ; then
+	echo "file creation unexpectedly succeeded for test4.txt"
+	exit 1
+fi
+
+for name in test1.txt test2.txt test3.txt test5.txt; do
+	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
+	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
+		echo "file creation failed for $name"
+		exit 1
+	fi
+done

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -58,7 +58,7 @@ mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -1,34 +1,71 @@
 #!/usr/bin/sh
 
-# A test that replying with allow forever actions previous matching prompts.
+# A test that replying with deny once does not action previous matching prompts.
+#
+# When creating a new file is blocked on a reply to a request prompt, the
+# directory in which the file will be created is locked from other writes.
+# Thus, we can't queue up multiple outstanding writes on files in the same
+# directory. Instead, we must write files in different directories in order
+# for this test to succeed.
 
 TEST_DIR="$1"
 
-WRITABLE="$(snap run --shell prompting-client.scripted -c "cd ~; pwd")/$(basename "$TEST_DIR")"
+WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
 
-for name in test1.txt test2.txt test3.txt ; do
+for dir in test1 test2 test3 ; do
+	mkdir -p "${TEST_DIR}/${dir}"
+	name="${dir}/file.txt"
 	echo "Attempt to write $name in the background"
-	snap run --shell prompting-client.scripted -c "echo started > ${WRITABLE}/${name}; echo $name is written > ${TEST_DIR}/${name}" &
-	timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}' ] ; do sleep 0.1 ; done"
-done
-
-echo "Attempt to write test4.txt (for which client will reply deny single)"
-snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
-
-echo "Check that original files have not yet been written"
-for name in test1.txt test2.txt test3.txt; do
-	if [ -f "${TEST_DIR}/${name}" ] ; then
-		echo "file creation unexpectedly succeeded early for $name"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${dir}-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${dir}-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${dir}-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start write of $name within timeout period"
 		exit 1
 	fi
 done
 
-echo "Attempt to write test5.txt (for which client will reply allow forever)"
-snap run --shell prompting-client.scripted -c "echo test5.txt is written > ${TEST_DIR}/test5.txt"
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has not yet finished"
+	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name finished before write for test4/file.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test4/file.txt (for which client will reply deny single)"
+mkdir -p "${TEST_DIR}/test4"
+snap run --shell prompting-client.scripted -c "echo test4/file.txt is written > ${TEST_DIR}/test4/file.txt"
+
+echo "Check that original files have not yet been written"
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	if [ -f "${TEST_DIR}/${name}" ] ; then
+		echo "file creation unexpectedly succeeded early for $name"
+		exit 1
+	fi
+	echo "Check that write for $name was not actioned by reply for test4/file.txt"
+	if [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name finished before write for test5/file.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test5/file.txt (for which client will reply allow forever)"
+mkdir -p "${TEST_DIR}/test5"
+snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
 timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+for dir in test1 test2 test3 ; do
+	name="${dir}/file.txt"
+	echo "Check that write for $name has finished"
+	if ! [ -f "${WRITABLE}/${dir}-finished" ] ; then
+		echo "write of $name did not finish after client replied"
+		exit 1
+	fi
+done
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
@@ -38,12 +75,13 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	exit 1
 fi
 
-if [ -f "${TEST_DIR}/test4.txt" ] ; then
-	echo "file creation unexpectedly succeeded for test4.txt"
+if [ -f "${TEST_DIR}/test4/file.txt" ] ; then
+	echo "file creation unexpectedly succeeded for test4/file.txt"
 	exit 1
 fi
 
-for name in test1.txt test2.txt test3.txt test5.txt; do
+for dir in test1 test2 test3 test5; do
+	name="${dir}/file.txt"
 	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
 	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
 		echo "file creation failed for $name"

--- a/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/create_multiple_not_actioned_by_other_pid_single_deny.sh
@@ -58,7 +58,7 @@ mkdir -p "${TEST_DIR}/test5"
 snap run --shell prompting-client.scripted -c "echo test5/file.txt is written > ${TEST_DIR}/test5/file.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 for dir in test1 test2 test3 ; do
 	name="${dir}/file.txt"

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.json
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/Downloads/",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/Downloads/**",
+          "permissions": [ "read" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/Downloads/test.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/Downloads/**",
+          "permissions": [ "read", "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -42,7 +42,7 @@ if ! grep 'cannot add rule: a rule with conflicting path pattern and permission 
 fi
 
 if [ -f "$TEST_DIR/test.txt" ] ; then
-	echo "write unexpectedly succeeded"
+	echo "file creation unexpectedly succeeded for test.txt"
 	cat "${TEST_DIR}/test.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -6,14 +6,6 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 # Prep a "Downloads" directory with an existing file in it
 mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
@@ -30,7 +22,8 @@ snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/
 echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -27,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -5,6 +5,10 @@
 # the particular file in that directory.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 # Prep a "Downloads" directory with an existing file in it
 mkdir -p "${TEST_DIR}/Downloads"
@@ -23,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -27,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -20,11 +20,10 @@ if ! snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads" | 
 	exit 1
 fi
 
-echo "Attempt to write the file"
+echo "Attempt to write the file, to which the client should reply with a conflicting rule and exit with error"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/Downloads/test.txt"
 
-echo "Attempt to chmod the file after it has been written"
-snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
+echo "Don't attempt to chmod the file after it has been written, since the client should have exited"
 
 # Wait for the client to write its result and exit
 timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
@@ -34,7 +33,7 @@ CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 # We don't expect success, since there should be a rule conflict with the rule
 # we just added to grant read access forever
 if [ "$CLIENT_OUTPUT" = "success" ] ; then
-	echo "test unexpectedly succeeded, expected rule conflict error"
+	echo "client reply unexpectedly succeeded, expected rule conflict error"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -19,7 +19,7 @@ mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
 
 echo "Attempt to list the contents of the downloads directory"
-if ! snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads" | grep "existing.txt" ; then
+if ! snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads" ; then
 	echo "Failed to list contents of ${TEST_DIR}/Downloads"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_conflict.sh
@@ -15,7 +15,7 @@ mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
 
 echo "Attempt to list the contents of the downloads directory"
-if ! snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads" ; then
+if ! snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads" | grep "existing.txt" ; then
 	echo "Failed to list contents of ${TEST_DIR}/Downloads"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.json
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/Downloads/",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/Downloads/**",
+          "permissions": [ "read" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/Downloads/test.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/Downloads/**",
+          "permissions": [ "read", "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -42,7 +42,7 @@ if ! grep 'cannot add rule: a rule with conflicting path pattern and permission 
 fi
 
 if [ -f "$TEST_DIR/test.txt" ] ; then
-	echo "write unexpectedly succeeded"
+	echo "file creation unexpectedly succeeded for test.txt"
 	cat "${TEST_DIR}/test.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -6,14 +6,6 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 # Prep a "Downloads" directory with an existing file in it
 mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
@@ -30,7 +22,8 @@ snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/
 echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -27,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -5,6 +5,10 @@
 # the particular file in that directory.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 # Prep a "Downloads" directory with an existing file in it
 mkdir -p "${TEST_DIR}/Downloads"
@@ -23,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -27,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/sh
+
+# A simulation of what often happens when one attempts to download a file from
+# a web browser: read access on the parent directory, then write access to
+# the particular file in that directory.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+# Prep a "Downloads" directory with an existing file in it
+mkdir -p "${TEST_DIR}/Downloads"
+touch "${TEST_DIR}/Downloads/existing.txt"
+
+echo "Attempt to list the contents of the downloads directory"
+snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads"
+
+echo "Attempt to write the file"
+snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/Downloads/test.txt"
+
+echo "Attempt to chmod the file after it has been written"
+snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
+
+sleep 5 # give the client a chance to write its result and exit
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+# We don't expect success, since there should be a rule conflict with the rule
+# we just added to grant read access forever
+if [ "$CLIENT_OUTPUT" = "success" ] ; then
+	echo "test unexpectedly succeeded, expected rule conflict error"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+if ! grep 'cannot add rule: a rule with conflicting path pattern and permission already exists in the rule database' "${TEST_DIR}/result" ; then
+	echo "test failed, expected rule conflict error"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+if [ -f "$TEST_DIR/test.txt" ] ; then
+	echo "write unexpectedly succeeded"
+	cat "${TEST_DIR}/test.txt"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_defaults.sh
@@ -31,22 +31,17 @@ timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
-# We don't expect success, since there should be a rule conflict with the rule
-# we just added to grant read access forever
-if [ "$CLIENT_OUTPUT" = "success" ] ; then
-	echo "test unexpectedly succeeded, expected rule conflict error"
+# Now that two rules with the same pattern variant may coexist so long as their
+# outcomes do not conflict, we expect success.
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1
 fi
 
-if ! grep 'cannot add rule: a rule with conflicting path pattern and permission already exists in the rule database' "${TEST_DIR}/result" ; then
-	echo "test failed, expected rule conflict error"
-	echo "output='$CLIENT_OUTPUT'"
-	exit 1
-fi
+TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 
-if [ -f "$TEST_DIR/test.txt" ] ; then
-	echo "file creation unexpectedly succeeded for test.txt"
-	cat "${TEST_DIR}/test.txt"
+if [ "$TEST_OUTPUT" != "it is written" ] ; then
+	echo "write failed for test.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.json
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/Downloads/",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/Downloads/**",
+          "permissions": [ "read" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/Downloads/test.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/Downloads/**",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/sh
+
+# A simulation of what often happens when one attempts to download a file from
+# a web browser: read access on the parent directory, then write access to
+# the particular file in that directory.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+# Prep a "Downloads" directory with an existing file in it
+mkdir -p "${TEST_DIR}/Downloads"
+touch "${TEST_DIR}/Downloads/existing.txt"
+
+echo "Attempt to list the contents of the parent directory"
+snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads"
+
+echo "Attempt to write the file"
+snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/Downloads/test.txt"
+
+echo "Attempt to chmod the file after it has been written"
+snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
+
+sleep 5 # give the client a chance to write its result and exit
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
+
+if [ "$TEST_OUTPUT" != "it is written" ] ; then
+	echo "test script failed"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -6,14 +6,6 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 # Prep a "Downloads" directory with an existing file in it
 mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
@@ -30,7 +22,8 @@ snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/
 echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -27,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -5,6 +5,10 @@
 # the particular file in that directory.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 # Prep a "Downloads" directory with an existing file in it
 mkdir -p "${TEST_DIR}/Downloads"
@@ -23,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -27,7 +27,7 @@ echo "Attempt to chmod the file after it has been written"
 snap run --shell prompting-client.scripted -c "chmod 664 ${TEST_DIR}/Downloads/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -36,6 +36,6 @@ fi
 TEST_OUTPUT="$(cat "${TEST_DIR}/Downloads/test.txt")"
 
 if [ "$TEST_OUTPUT" != "it is written" ] ; then
-	echo "test script failed"
+	echo "write failed for test.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -14,7 +14,7 @@ fi
 mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
 
-echo "Attempt to list the contents of the parent directory"
+echo "Attempt to list the contents of the downloads directory"
 if ! snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads" | grep "existing.txt" ; then
 	echo "Failed to list contents of ${TEST_DIR}/Downloads"
 	exit 1

--- a/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
+++ b/tests/main/apparmor-prompting-integration-tests/download_file_safer.sh
@@ -19,7 +19,10 @@ mkdir -p "${TEST_DIR}/Downloads"
 touch "${TEST_DIR}/Downloads/existing.txt"
 
 echo "Attempt to list the contents of the parent directory"
-snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads"
+if ! snap run --shell prompting-client.scripted -c "ls ${TEST_DIR}/Downloads" | grep "existing.txt" ; then
+	echo "Failed to list contents of ${TEST_DIR}/Downloads"
+	exit 1
+fi
 
 echo "Attempt to write the file"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/Downloads/test.txt"

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test.txt",
+          "permissions": [ "read" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/sh
+
+# A simple allow once test of a read prompt.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+echo "Prepare the file to be read"
+echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
+
+echo "Attempt to read the file"
+TEST_OUTPUT="$($SNAP_DO cat "${TEST_DIR}/test.txt")"
+
+sleep 1 # give the client a chance to write its result and exit
+
+CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_RESULT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+if [ "$TEST_OUTPUT" != "testing testing 1 2 3" ] ; then
+	echo "test script failed"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
@@ -3,6 +3,10 @@
 # A simple allow once test of a read prompt.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 echo "Prepare the file to be read"
 echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
@@ -11,7 +15,7 @@ echo "Attempt to read the file"
 TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test.txt")"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
@@ -7,6 +7,7 @@ TEST_DIR="$1"
 echo "Run the prompting client in scripted mode in the background"
 prompting-client.scripted \
 	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
 	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
 sleep 1 # give the client a chance to start listening
@@ -15,9 +16,9 @@ echo "Prepare the file to be read"
 echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
 
 echo "Attempt to read the file"
-TEST_OUTPUT="$($SNAP_DO cat "${TEST_DIR}/test.txt")"
+TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test.txt")"
 
-sleep 1 # give the client a chance to write its result and exit
+sleep 5 # give the client a chance to write its result and exit
 
 CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
@@ -4,21 +4,14 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 echo "Prepare the file to be read"
 echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
 
 echo "Attempt to read the file"
 TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test.txt")"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
@@ -20,9 +20,9 @@ TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/te
 
 sleep 5 # give the client a chance to write its result and exit
 
-CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
-if [ "$CLIENT_RESULT" != "success" ] ; then
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	echo "test failed"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
@@ -15,7 +15,7 @@ echo "Attempt to read the file"
 TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test.txt")"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_allow.sh
@@ -15,7 +15,7 @@ echo "Attempt to read the file"
 TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test.txt")"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test.txt",
+          "permissions": [ "read" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/sh
+
+# A simple deny once test of a read prompt.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+echo "Prepare the file to be read"
+echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
+
+echo "Attempt to read the file (should fail)"
+TEST_OUTPUT="$($SNAP_DO cat "${TEST_DIR}/test.txt")"
+
+ECODE=$?
+
+sleep 1 # give the client a chance to write its result and exit
+
+CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_RESULT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+if [ "$TEST_OUTPUT" = "testing testing 1 2 3" ] ; then
+	echo "test script unexpectedly succeeded"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
@@ -4,14 +4,6 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 echo "Prepare the file to be read"
 echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
 
@@ -20,7 +12,8 @@ TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/te
 
 ECODE=$?
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
@@ -14,10 +14,8 @@ echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
 echo "Attempt to read the file (should fail)"
 TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test.txt")"
 
-ECODE=$?
-
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
@@ -7,6 +7,7 @@ TEST_DIR="$1"
 echo "Run the prompting client in scripted mode in the background"
 prompting-client.scripted \
 	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
 	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
 sleep 1 # give the client a chance to start listening
@@ -15,11 +16,11 @@ echo "Prepare the file to be read"
 echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
 
 echo "Attempt to read the file (should fail)"
-TEST_OUTPUT="$($SNAP_DO cat "${TEST_DIR}/test.txt")"
+TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test.txt")"
 
 ECODE=$?
 
-sleep 1 # give the client a chance to write its result and exit
+sleep 5 # give the client a chance to write its result and exit
 
 CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
@@ -3,6 +3,10 @@
 # A simple deny once test of a read prompt.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 echo "Prepare the file to be read"
 echo "testing testing 1 2 3" | tee "${TEST_DIR}/test.txt"
@@ -13,7 +17,7 @@ TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/te
 ECODE=$?
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
@@ -17,7 +17,7 @@ TEST_OUTPUT="$(snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/te
 ECODE=$?
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/read_single_deny.sh
@@ -22,9 +22,9 @@ ECODE=$?
 
 sleep 5 # give the client a chance to write its result and exit
 
-CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
-if [ "$CLIENT_RESULT" != "success" ] ; then
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	echo "test failed"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -77,7 +77,8 @@ execute: |
     snap set system experimental.apparmor-prompting=true
 
     echo "Wait for snapd to begin restart"
-    retry --wait 1 -n 300 test "$SNAPD_PID" != "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+    #shellcheck disable=SC2016
+    retry --wait 1 -n 300 sh -c 'test '"$SNAPD_PID"' != $(systemctl show --property MainPID snapd.service | cut -f2 -d=)'
 
     echo "Wait until snapd is active"
     retry --wait 1 -n 300 systemctl is-active snapd

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -28,10 +28,10 @@ environment:
     VARIANT/create_multiple_actioned_by_other_pid_always_deny: create_multiple_actioned_by_other_pid_always_deny
     VARIANT/create_multiple_not_actioned_by_other_pid_single_allow: create_multiple_not_actioned_by_other_pid_single_allow
     VARIANT/create_multiple_not_actioned_by_other_pid_single_deny: create_multiple_not_actioned_by_other_pid_single_deny
-    #VARIANT/overwrite_file: overwrite_file
+    VARIANT/write_read_multiple_actioned_by_other_pid_allow_deny: write_read_multiple_actioned_by_other_pid_allow_deny
+    VARIANT/write_read_multiple_actioned_by_other_pid_deny_allow: write_read_multiple_actioned_by_other_pid_deny_allow
 
 prepare: |
-    snap install jq
     tests.session prepare -u test
     #shellcheck disable=SC2016
     tests.session -u test exec sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
@@ -43,7 +43,11 @@ restore: |
     tests.session restore -u test
 
 debug: |
-    cat /var/lib/snapd/interfaces-requests/request-rules.json | jq
+    TEST_UID="$(id -u test)"
+    echo "outstanding prompts:"
+    snap debug api "/v2/interfaces/requests/prompts?user-id=$TEST_UID"
+    echo "rules:"
+    snap debug api "/v2/interfaces/requests/rules?user-id=$TEST_UID"
 
 execute: |
     echo "Enable prompting via snap client where possible"
@@ -99,4 +103,8 @@ execute: |
     sleep 1 # wait for scripted client to start listening, otherwise it may miss the first prompt
 
     echo "Run the test script as the test user"
-    tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR"
+    if ! tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR" ; then
+        # kill the prompting-client-scripted process for this test run
+        pkill -f "prompting-client-scripted.*${TEST_DIR}"
+        exit 1
+    fi

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -55,6 +55,10 @@ debug: |
     snap debug api "/v2/interfaces/requests/rules?user-id=$TEST_UID" || true
 
 execute: |
+    echo "Precondition check that snapd is active"
+    systemctl is-active snapd.service snapd.socket
+    SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
@@ -72,10 +76,10 @@ execute: |
     echo "Enable AppArmor prompting experimental feature"
     snap set system experimental.apparmor-prompting=true
 
-    # Wait for snapd to begin restart
-    sleep 1
+    echo "Wait for snapd to begin restart"
+    retry --wait 1 -n 60 test "$SNAPD_PID" != "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
 
-    echo "Wait until prompting is active"
+    echo "Wait until snapd is active"
     retry --wait 1 -n 60 systemctl is-active snapd
 
     echo "Check that shell script and scripted replies exist for $VARIANT"
@@ -110,7 +114,8 @@ execute: |
 
     echo "Run the test script as the test user"
     if ! tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR" "$TIMEOUT"; then
-        # kill the prompting-client-scripted process for this test run
+        # Test script exited early with error, so the prompting client may still
+        # be running, waiting for further requests, so it should be killed.
         pkill -f 'prompting-client-scripted.*'"${TEST_DIR}"
         exit 1
     fi

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -72,9 +72,9 @@ execute: |
     #shellcheck disable=SC2016
     TEST_DIR="$(tests.session -u test exec sh -c 'mktemp --directory --tmpdir="$HOME/integration-tests"')"
     cp "$VARIANT.sh" "${TEST_DIR}/${VARIANT}.sh"
-    chmod 664 "${TEST_DIR}/${VARIANT}.sh" # ensure it's readable by the test user
+    chown test "${TEST_DIR}/${VARIANT}.sh"
     cp "$VARIANT.json" "${TEST_DIR}/script.json"
-    chmod 664 "${TEST_DIR}/script.json" # ensure it's readable by the test user
+    chown test "${TEST_DIR}/script.json"
 
     # Test scripts can rely on the presence of "${TEST_DIR}/script.json",
     # which is the script of expected prompts and corresponding replies.

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -77,10 +77,10 @@ execute: |
     snap set system experimental.apparmor-prompting=true
 
     echo "Wait for snapd to begin restart"
-    retry --wait 1 -n 60 test "$SNAPD_PID" != "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+    retry --wait 1 -n 300 test "$SNAPD_PID" != "$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
 
     echo "Wait until snapd is active"
-    retry --wait 1 -n 60 systemctl is-active snapd
+    retry --wait 1 -n 300 systemctl is-active snapd
 
     echo "Check that shell script and scripted replies exist for $VARIANT"
     test -f "$VARIANT.sh"

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -24,11 +24,11 @@ environment:
 
 prepare: |
     tests.session prepare -u test
-    tests.session exec -u test -- sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
-    snap install prompting-client
+    tests.session -u test exec sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
+    snap install prompting-client --channel=latest/edge # TODO: use latest/stable once rev 28+ is stable
 
 restore: |
-    tests.session exec -u test -- sh -c 'rm -rf "$HOME/integration-tests"' # $HOME must be that of test user
+    tests.session -u test exec sh -c 'rm -rf "$HOME/integration-tests"' # $HOME must be that of test user
     tests.session restore -u test
 
 debug: |
@@ -65,15 +65,14 @@ execute: |
 
     # Create unique tmpdir and copy the script to it.
     # The tmpdir must be in the test user's home directory.
-    TEST_DIR="$(tests.session exec -u test -- sh -c 'mktemp --directory --tmpdir="$HOME/integration-tests"')"
+    TEST_DIR="$(tests.session -u test exec sh -c 'mktemp --directory --tmpdir="$HOME/integration-tests"')"
+    cp "$VARIANT.sh" "${TEST_DIR}/${VARIANT}.sh"
+    chmod 664 "${TEST_DIR}/${VARIANT}.sh" # ensure it's readable by the test user
     cp "$VARIANT.json" "${TEST_DIR}/script.json"
-    chmod 777 "${TEST_DIR}/script.json" # ensure it's readable by the test user
+    chmod 664 "${TEST_DIR}/script.json" # ensure it's readable by the test user
 
     # Test scripts can rely on the presence of "${TEST_DIR}/script.json",
     # which is the script of expected prompts and corresponding replies.
-    #
-    # Test scripts can use $SNAP_DO to execute a command as the prompting
-    # client snap, and thus trigger a prompt.
 
     echo "Run the test script as the test user"
-    tests.session exec -u test -- SNAP_DO='snap run --shell prompting-client -c "$*"' sh -ec "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR"
+    tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR"

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -40,7 +40,6 @@ environment:
 prepare: |
     tests.session prepare -u test
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
-    snap install prompting-client
 
 restore: |
     snap set system experimental.apparmor-prompting=false
@@ -57,7 +56,9 @@ debug: |
 execute: |
     echo "Precondition check that snapd is active"
     systemctl is-active snapd.service snapd.socket
-    SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
+
+    echo "Install the prompting client"
+    retry --wait 1 -n 100 snap install prompting-client
 
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
@@ -72,6 +73,8 @@ execute: |
 
         exit 0
     fi
+
+    SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
 
     echo "Enable AppArmor prompting experimental feature"
     snap set system experimental.apparmor-prompting=true

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -1,0 +1,79 @@
+summary: Check that AppArmor Prompting works end-to-end
+
+details: |
+    Test that the AppArmor Prompting subsystems work by simulating common usage
+    scenarios. Manually carry out operations which generate prompts and, using
+    the prompting-client snap in scripted mode, check that those prompts match
+    what is expected, and that the client suffessfully allows the operations.
+
+systems:
+  - ubuntu-16.04-*
+  - ubuntu-18.04-64
+  - ubuntu-2*
+  - ubuntu-core-*
+
+environment:
+    VARIANT/read_single_allow: read_single_allow
+    VARIANT/read_single_deny: read_single_deny
+    VARIANT/write_single_allow: write_single_allow
+    VARIANT/write_single_deny: write_single_deny
+    VARIANT/create_multiple_allow: create_multiple_allow
+    VARIANT/create_multiple_deny: create_multiple_deny
+    #VARIANT/create_multiple_actioned_by_other_pid: create_multiple_actioned_by_other_pid
+    #VARIANT/overwrite_file: overwrite_file
+
+prepare: |
+    tests.session prepare -u test
+    tests.session exec -u test -- sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
+    snap install prompting-client
+
+restore: |
+    tests.session exec -u test -- sh -c 'rm -rf "$HOME/integration-tests"' # $HOME must be that of test user
+    tests.session restore -u test
+
+debug: |
+
+execute: |
+    echo "Enable prompting via snap client where possible"
+    # Prompting is unsupported everywhere but the Ubuntu non-core systems with
+    # kernels which support apparmor prompting
+    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
+        not snap set system experimental.apparmor-prompting=true >& err.out
+        if os.query is-core ; then
+            MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
+        else
+            MATCH "cannot enable prompting feature as it is not supported by the system" < err.out
+        fi
+
+        # even if unsupported setting it to false should succeed
+        snap set system experimental.apparmor-prompting=false
+        exit 0
+    fi
+
+    echo "Enable AppArmor prompting experimental feature"
+    snap set system experimental.apparmor-prompting=true
+
+    # Wait for snapd to begin restart
+    sleep 1
+
+    echo "Wait until prompting is active"
+    retry --wait 1 -n 60 systemctl is-active snapd
+
+    echo "Check that shell script and scripted replies exist for $VARIANT"
+    test -f "$VARIANT.sh"
+    test -f "$VARIANT.json"
+
+    # Create unique tmpdir and copy the script to it.
+    # The tmpdir must be in the test user's home directory.
+    TEST_DIR="$(tests.session exec -u test -- sh -c 'mktemp --directory --tmpdir="$HOME/integration-tests"')"
+    cp "$VARIANT.json" "${TEST_DIR}/script.json"
+    chmod 777 "${TEST_DIR}/script.json" # ensure it's readable by the test user
+
+    # Test scripts can rely on the presence of "${TEST_DIR}/script.json",
+    # which is the script of expected prompts and corresponding replies.
+    #
+    # Test scripts can use $SNAP_DO to execute a command as the prompting
+    # client snap, and thus trigger a prompt.
+
+    echo "Run the test script as the test user"
+    tests.session exec -u test -- SNAP_DO='snap run --shell prompting-client -c "$*"' sh -ec "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR"

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -4,11 +4,15 @@ details: |
     Test that the AppArmor Prompting subsystems work by simulating common usage
     scenarios. Manually carry out operations which generate prompts and, using
     the prompting-client snap in scripted mode, check that those prompts match
-    what is expected, and that the client suffessfully allows the operations.
+    what is expected, and that the client carries out the operations as intended.
+
+    Details about the operation of the prompting client in scripted mode:
+    https://github.com/canonical/prompting-client/blob/main/docs/running-the-scripted-client.md
+
 
 systems:
-  - ubuntu-16.04-*
-  - ubuntu-18.04-64
+  - ubuntu-16*
+  - ubuntu-18*
   - ubuntu-2*
   - ubuntu-core-*
 
@@ -31,29 +35,30 @@ environment:
     VARIANT/write_read_multiple_actioned_by_other_pid_allow_deny: write_read_multiple_actioned_by_other_pid_allow_deny
     VARIANT/write_read_multiple_actioned_by_other_pid_deny_allow: write_read_multiple_actioned_by_other_pid_deny_allow
 
+    TIMEOUT: "30" # Define common timeout which can be modified as needed
+
 prepare: |
     tests.session prepare -u test
-    #shellcheck disable=SC2016
-    tests.session -u test exec sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
+    tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
     snap install prompting-client
 
 restore: |
-    #shellcheck disable=SC2016
-    tests.session -u test exec sh -c 'rm -rf "$HOME/integration-tests"' # $HOME must be that of test user
+    snap set system experimental.apparmor-prompting=false
+    tests.session -u test exec sh -c 'rm -rf "/home/test/integration-tests"'
     tests.session restore -u test
 
 debug: |
     TEST_UID="$(id -u test)"
     echo "outstanding prompts:"
-    snap debug api "/v2/interfaces/requests/prompts?user-id=$TEST_UID"
+    snap debug api "/v2/interfaces/requests/prompts?user-id=$TEST_UID" || true
     echo "rules:"
-    snap debug api "/v2/interfaces/requests/rules?user-id=$TEST_UID"
+    snap debug api "/v2/interfaces/requests/rules?user-id=$TEST_UID" || true
 
 execute: |
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
-    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
+    if ! os.query is-ubuntu || os.query is-core || NOMATCH 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
@@ -61,8 +66,6 @@ execute: |
             MATCH "cannot enable prompting feature as it is not supported by the system" < err.out
         fi
 
-        # even if unsupported setting it to false should succeed
-        snap set system experimental.apparmor-prompting=false
         exit 0
     fi
 
@@ -80,30 +83,33 @@ execute: |
     test -f "$VARIANT.json"
 
     # Create unique tmpdir and copy the script to it.
-    # The tmpdir must be in the test user's home directory.
-    #shellcheck disable=SC2016
-    TEST_DIR="$(tests.session -u test exec sh -c 'mktemp --directory --tmpdir="$HOME/integration-tests"')"
-    cp "$VARIANT.sh" "${TEST_DIR}/${VARIANT}.sh"
+    TEST_DIR="$(tests.session -u test exec sh -c 'mktemp --directory --tmpdir="/home/test/integration-tests"')"
+    cp "${VARIANT}.sh" "${TEST_DIR}/${VARIANT}.sh"
     chown test "${TEST_DIR}/${VARIANT}.sh"
-    cp "$VARIANT.json" "${TEST_DIR}/script.json"
+    cp "${VARIANT}.json" "${TEST_DIR}/script.json"
     chown test "${TEST_DIR}/script.json"
+
+    echo "Run the prompting client in scripted mode in the background as the test user"
+    # Grace period does not need to be as long as the timeout, and longer grace
+    # periods slow down every variant of every test run
+    tests.session -u test exec prompting-client.scripted \
+        --script="${TEST_DIR}/script.json" \
+        --grace-period=5 \
+        --var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
     # Test scripts can rely on the scripted client writing their result to
     # "${TEST_DIR}/result". Those results will be "success" if the scripted
     # client exits without error, or an error message if it encounters an
     # unexpected prompt or an error from snapd.
 
-    echo "Run the prompting client in scripted mode in the background as the test user"
-    tests.session -u test exec prompting-client.scripted \
-        --script="${TEST_DIR}/script.json" \
-        --grace-period=1 \
-        --var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-    timeout 5 sh -xc 'while ! pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
-    sleep 1 # wait for scripted client to start listening, otherwise it may miss the first prompt
+    echo "Wait for the scripted client to start"
+    timeout "$TIMEOUT" sh -xc "while ! pgrep -f 'prompting-client-scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
+    SCRIPTED_PID="$(pgrep -f "prompting-client-scripted.*${TEST_DIR}")"
+    echo "Wait for the scripted client to open a unix socket for streaming"
+    timeout "$TIMEOUT" sh -xc "while ! lsof -a -U -p '$SCRIPTED_PID' > /dev/null; do sleep 0.1; done"
 
     echo "Run the test script as the test user"
-    if ! tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR" ; then
+    if ! tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR" "$TIMEOUT"; then
         # kill the prompting-client-scripted process for this test run
         pkill -f "prompting-client-scripted.*${TEST_DIR}"
         exit 1

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -62,7 +62,7 @@ execute: |
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
-    if ! os.query is-ubuntu || os.query is-core || NOMATCH 'prompt' < /sys/kernel/security/apparmor/features/policy/permstable32 ; then
+    if ! os.query is-ubuntu || os.query is-core || [ ! -f /sys/kernel/security/apparmor/features/policy/permstable32 ] || NOMATCH 'prompt' < /sys/kernel/security/apparmor/features/policy/permstable32 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -21,6 +21,7 @@ environment:
     VARIANT/create_multiple_deny: create_multiple_deny
     VARIANT/download_file_defaults: download_file_defaults
     VARIANT/download_file_safer: download_file_safer
+    VARIANT/download_file_conflict: download_file_conflict
     VARIANT/timespan_allow: timespan_allow
     VARIANT/timespan_deny: timespan_deny
     #VARIANT/create_multiple_actioned_by_other_pid: create_multiple_actioned_by_other_pid

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -40,6 +40,7 @@ environment:
 prepare: |
     tests.session prepare -u test
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
+    snap install prompting-client
 
 restore: |
     snap set system experimental.apparmor-prompting=false
@@ -56,9 +57,6 @@ debug: |
 execute: |
     echo "Precondition check that snapd is active"
     systemctl is-active snapd.service snapd.socket
-
-    echo "Install the prompting client"
-    retry --wait 1 -n 100 snap install prompting-client
 
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -79,8 +79,18 @@ execute: |
     cp "$VARIANT.json" "${TEST_DIR}/script.json"
     chown test "${TEST_DIR}/script.json"
 
-    # Test scripts can rely on the presence of "${TEST_DIR}/script.json",
-    # which is the script of expected prompts and corresponding replies.
+    # Test scripts can rely on the scripted client writing their result to
+    # "${TEST_DIR}/result". Those results will be "success" if the scripted
+    # client exits without error, or an error message if it encounters an
+    # unexpected prompt or an error from snapd.
+
+    echo "Run the prompting client in scripted mode in the background as the test user"
+    tests.session -u test exec prompting-client.scripted \
+        --script="${TEST_DIR}/script.json" \
+        --grace-period=1 \
+        --var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+    timeout 5 sh -xc 'while ! pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
     echo "Run the test script as the test user"
     tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR"

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -31,6 +31,7 @@ environment:
     #VARIANT/overwrite_file: overwrite_file
 
 prepare: |
+    snap install jq
     tests.session prepare -u test
     #shellcheck disable=SC2016
     tests.session -u test exec sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
@@ -42,6 +43,7 @@ restore: |
     tests.session restore -u test
 
 debug: |
+    cat /var/lib/snapd/interfaces-requests/request-rules.json | jq
 
 execute: |
     echo "Enable prompting via snap client where possible"

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -104,13 +104,13 @@ execute: |
 
     echo "Wait for the scripted client to start"
     timeout "$TIMEOUT" sh -xc "while ! pgrep -f 'prompting-client-scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
-    SCRIPTED_PID="$(pgrep -f "prompting-client-scripted.*${TEST_DIR}")"
+    SCRIPTED_PID="$(pgrep -f 'prompting-client-scripted.*'"${TEST_DIR}")"
     echo "Wait for the scripted client to open a unix socket for streaming"
     timeout "$TIMEOUT" sh -xc "while ! lsof -a -U -p '$SCRIPTED_PID' > /dev/null; do sleep 0.1; done"
 
     echo "Run the test script as the test user"
     if ! tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR" "$TIMEOUT"; then
         # kill the prompting-client-scripted process for this test run
-        pkill -f "prompting-client-scripted.*${TEST_DIR}"
+        pkill -f 'prompting-client-scripted.*'"${TEST_DIR}"
         exit 1
     fi

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -24,7 +24,10 @@ environment:
     VARIANT/download_file_conflict: download_file_conflict
     VARIANT/timespan_allow: timespan_allow
     VARIANT/timespan_deny: timespan_deny
-    #VARIANT/create_multiple_actioned_by_other_pid: create_multiple_actioned_by_other_pid
+    VARIANT/create_multiple_actioned_by_other_pid_always_allow: create_multiple_actioned_by_other_pid_always_allow
+    VARIANT/create_multiple_actioned_by_other_pid_always_deny: create_multiple_actioned_by_other_pid_always_deny
+    VARIANT/create_multiple_not_actioned_by_other_pid_single_allow: create_multiple_not_actioned_by_other_pid_single_allow
+    VARIANT/create_multiple_not_actioned_by_other_pid_single_deny: create_multiple_not_actioned_by_other_pid_single_deny
     #VARIANT/overwrite_file: overwrite_file
 
 prepare: |
@@ -91,6 +94,7 @@ execute: |
         --var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
     timeout 5 sh -xc 'while ! pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+    sleep 1 # wait for scripted client to start listening, otherwise it may miss the first prompt
 
     echo "Run the test script as the test user"
     tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR"

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -62,7 +62,7 @@ execute: |
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
-    if ! os.query is-ubuntu || os.query is-core || NOMATCH 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 ; then
+    if ! os.query is-ubuntu || os.query is-core || cat /sys/kernel/security/apparmor/features/policy/permstable32 | NOMATCH 'prompt' ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
@@ -107,15 +107,22 @@ execute: |
     # unexpected prompt or an error from snapd.
 
     echo "Wait for the scripted client to start"
-    timeout "$TIMEOUT" sh -xc "while ! pgrep -f 'prompting-client-scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
-    SCRIPTED_PID="$(pgrep -f 'prompting-client-scripted.*'"${TEST_DIR}")"
+    if ! retry --wait 1 -n "$TIMEOUT" pgrep -af "^/snap/.*/prompting-client-scripted.*${TEST_DIR}" ; then
+        pgrep -af 'prompting-client' || true
+        pkill -f 'prompting-client' || true
+        exit 1
+    fi
+    SCRIPTED_PID="$(pgrep -f "^/snap/.*/prompting-client-scripted.*${TEST_DIR}")"
     echo "Wait for the scripted client to open a unix socket for streaming"
-    timeout "$TIMEOUT" sh -xc "while ! lsof -a -U -p '$SCRIPTED_PID' > /dev/null; do sleep 0.1; done"
+    if ! retry --wait 1 -n "$TIMEOUT" lsof -a -U -p "$SCRIPTED_PID" ; then
+        pkill -f "prompting-client-scripted.*${TEST_DIR}" || true
+        exit 1
+    fi
 
     echo "Run the test script as the test user"
     if ! tests.session -u test exec sh -x "${TEST_DIR}/${VARIANT}.sh" "$TEST_DIR" "$TIMEOUT"; then
         # Test script exited early with error, so the prompting client may still
         # be running, waiting for further requests, so it should be killed.
-        pkill -f 'prompting-client-scripted.*'"${TEST_DIR}"
+        pkill -f "prompting-client-scripted.*${TEST_DIR}"
         exit 1
     fi

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -62,7 +62,7 @@ execute: |
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
-    if ! os.query is-ubuntu || os.query is-core || cat /sys/kernel/security/apparmor/features/policy/permstable32 | NOMATCH 'prompt' ; then
+    if ! os.query is-ubuntu || os.query is-core || NOMATCH 'prompt' < /sys/kernel/security/apparmor/features/policy/permstable32 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -21,6 +21,8 @@ environment:
     VARIANT/create_multiple_deny: create_multiple_deny
     VARIANT/download_file_defaults: download_file_defaults
     VARIANT/download_file_safer: download_file_safer
+    VARIANT/timespan_allow: timespan_allow
+    VARIANT/timespan_deny: timespan_deny
     #VARIANT/create_multiple_actioned_by_other_pid: create_multiple_actioned_by_other_pid
     #VARIANT/overwrite_file: overwrite_file
 

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -24,10 +24,12 @@ environment:
 
 prepare: |
     tests.session prepare -u test
+    #shellcheck disable=SC2016
     tests.session -u test exec sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
     snap install prompting-client --channel=latest/edge # TODO: use latest/stable once rev 28+ is stable
 
 restore: |
+    #shellcheck disable=SC2016
     tests.session -u test exec sh -c 'rm -rf "$HOME/integration-tests"' # $HOME must be that of test user
     tests.session restore -u test
 
@@ -65,6 +67,7 @@ execute: |
 
     # Create unique tmpdir and copy the script to it.
     # The tmpdir must be in the test user's home directory.
+    #shellcheck disable=SC2016
     TEST_DIR="$(tests.session -u test exec sh -c 'mktemp --directory --tmpdir="$HOME/integration-tests"')"
     cp "$VARIANT.sh" "${TEST_DIR}/${VARIANT}.sh"
     chmod 664 "${TEST_DIR}/${VARIANT}.sh" # ensure it's readable by the test user

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -19,6 +19,8 @@ environment:
     VARIANT/write_single_deny: write_single_deny
     VARIANT/create_multiple_allow: create_multiple_allow
     VARIANT/create_multiple_deny: create_multiple_deny
+    VARIANT/download_file_defaults: download_file_defaults
+    VARIANT/download_file_safer: download_file_safer
     #VARIANT/create_multiple_actioned_by_other_pid: create_multiple_actioned_by_other_pid
     #VARIANT/overwrite_file: overwrite_file
 
@@ -26,7 +28,7 @@ prepare: |
     tests.session prepare -u test
     #shellcheck disable=SC2016
     tests.session -u test exec sh -c 'mkdir -p "$HOME/integration-tests"' # $HOME must be that of test user
-    snap install prompting-client --channel=latest/edge # TODO: use latest/stable once rev 28+ is stable
+    snap install prompting-client
 
 restore: |
     #shellcheck disable=SC2016

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "timespan",
+        "duration": "5s",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/*",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.json
@@ -18,7 +18,7 @@
       "reply": {
         "action": "allow",
         "lifespan": "timespan",
-        "duration": "1s",
+        "duration": "10s",
         "constraints": {
           "path-pattern": "${BASE_PATH}/test*",
           "permissions": [ "write" ]

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.json
@@ -18,7 +18,7 @@
       "reply": {
         "action": "allow",
         "lifespan": "timespan",
-        "duration": "5s",
+        "duration": "1s",
         "constraints": {
           "path-pattern": "${BASE_PATH}/test*",
           "permissions": [ "write" ]

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
@@ -4,19 +4,24 @@
 # path pattern to be created, but doesn't allow other file creation.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Attempt to write $name"
 	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 1 # wait for the rule to time out
+# The reply has a hard-coded duration of 10s
+sleep 10 # wait for the rule to expire
 
 echo "Attempt to write test4.txt (should fail)"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/sh
+
+# A test that replying with allow always allows multiple files which match the
+# path pattern to be created, but doesn't allow other file creation.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to write $name"
+	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
+done
+
+sleep 5 # wait for the rule to time out
+
+echo "Attempt to write test4.txt (should fail)"
+snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+
+sleep 5 # give the client a chance to write its result and exit
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+for name in test1.txt test2.txt test3.txt ; do
+	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
+	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
+		echo "file creation failed"
+		exit 1
+	fi
+done
+
+if [ -f "${TEST_DIR}/test4.txt" ] ; then
+	echo "file creation unexpectedly succeeded"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
@@ -21,7 +21,7 @@ echo "Attempt to write test4.txt (should fail)"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
@@ -21,7 +21,7 @@ echo "Attempt to write test4.txt (should fail)"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_allow.sh
@@ -5,25 +5,18 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Attempt to write $name"
 	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 5 # wait for the rule to time out
+sleep 1 # wait for the rule to time out
 
 echo "Attempt to write test4.txt (should fail)"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "timespan",
+        "duration": "10s",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/*",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/*",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
@@ -18,7 +18,7 @@
       "reply": {
         "action": "deny",
         "lifespan": "timespan",
-        "duration": "5s",
+        "duration": "1s",
         "constraints": {
           "path-pattern": "${BASE_PATH}/test*",
           "permissions": [ "write" ]

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
@@ -18,7 +18,7 @@
       "reply": {
         "action": "deny",
         "lifespan": "timespan",
-        "duration": "10s",
+        "duration": "5s",
         "constraints": {
           "path-pattern": "${BASE_PATH}/test*",
           "permissions": [ "write" ]

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.json
@@ -18,7 +18,7 @@
       "reply": {
         "action": "deny",
         "lifespan": "timespan",
-        "duration": "1s",
+        "duration": "10s",
         "constraints": {
           "path-pattern": "${BASE_PATH}/test*",
           "permissions": [ "write" ]

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
@@ -5,25 +5,18 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Attempt to write $name (should fail)"
 	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 5 # wait for the rule to time out
+sleep 1 # wait for the rule to time out
 
 echo "Attempt to write test4.txt"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
@@ -21,7 +21,7 @@ echo "Attempt to write test4.txt"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
@@ -4,19 +4,24 @@
 # path pattern to be created, but doesn't allow other file creation.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Attempt to write $name (should fail)"
 	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
 done
 
-sleep 1 # wait for the rule to time out
+# The reply has a hard-coded duration of 10s
+sleep 10 # wait for the rule to expire
 
 echo "Attempt to write test4.txt"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/sh
+
+# A test that replying with allow always allows multiple files which match the
+# path pattern to be created, but doesn't allow other file creation.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to write $name (should fail)"
+	snap run --shell prompting-client.scripted -c "echo $name is written > ${TEST_DIR}/${name}"
+done
+
+sleep 5 # wait for the rule to time out
+
+echo "Attempt to write test4.txt"
+snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+
+sleep 5 # give the client a chance to write its result and exit
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+for name in test1.txt test2.txt test3.txt ; do
+	if [ -f "${TEST_DIR}/${name}" ] ; then
+		echo "file creation unexpectedly succeeded"
+		exit 1
+	fi
+done
+
+TEST_OUTPUT="$(cat "${TEST_DIR}/test4.txt")"
+if [ "$TEST_OUTPUT" != "test4.txt is written" ] ; then
+	echo "file creation failed"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
@@ -21,7 +21,7 @@ echo "Attempt to write test4.txt"
 snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/timespan_deny.sh
@@ -28,13 +28,13 @@ fi
 
 for name in test1.txt test2.txt test3.txt ; do
 	if [ -f "${TEST_DIR}/${name}" ] ; then
-		echo "file creation unexpectedly succeeded"
+		echo "file creation unexpectedly succeeded for $name"
 		exit 1
 	fi
 done
 
 TEST_OUTPUT="$(cat "${TEST_DIR}/test4.txt")"
 if [ "$TEST_OUTPUT" != "test4.txt is written" ] ; then
-	echo "file creation failed"
+	echo "file creation failed for test4.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.json
@@ -1,0 +1,114 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*",
+          "permissions": [ "read", "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/other.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/other.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
@@ -137,7 +137,7 @@ if [ -f "${TEST_DIR}/other.txt" ] ; then
 fi
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
@@ -6,6 +6,10 @@
 # rule with the most specific path pattern has precedence.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
 snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
@@ -16,7 +20,7 @@ for name in test1.txt test2.txt test3.txt ; do
 	echo "Attempt to write $name in the background"
 	echo "not written" > "${TEST_DIR}/${name}"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${name}-write-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${name}-write-finished" &
-	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}-write-started' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${name}-write-started' ] ; do sleep 0.1 ; done" ; then
 		echo "failed to start write of $name within timeout period"
 		exit 1
 	fi
@@ -38,7 +42,7 @@ snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TES
 
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Check that write for $name has finished"
-	if ! timeout 5 sh -c "while ! [ -f '${WRITABLE}/${name}-write-finished' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${name}-write-finished' ] ; do sleep 0.1 ; done" ; then
 		echo "write of $name did not finish after client replied"
 		exit 1
 	fi
@@ -57,7 +61,7 @@ done
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Attempt to read $name in the background"
 	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${name}-read-started; cat ${TEST_DIR}/${name} > ${WRITABLE}/${name}; touch ${WRITABLE}/${name}-read-finished" &
-	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}-read-started' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${name}-read-started' ] ; do sleep 0.1 ; done" ; then
 		echo "failed to start read of $name within timeout period"
 		exit 1
 	fi
@@ -78,7 +82,7 @@ snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test4.txt > ${WRI
 
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Check that read for $name has finished"
-	if ! timeout 5 sh -c "while ! [ -f '${WRITABLE}/${name}-read-finished' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${name}-read-finished' ] ; do sleep 0.1 ; done" ; then
 		echo "read of $name did not finish after client replied"
 		exit 1
 	fi
@@ -133,7 +137,7 @@ if [ -f "${TEST_DIR}/other.txt" ] ; then
 fi
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/sh
+
+# A test that multiple writes and reads in the same directory can be queued up,
+# replies with lifespan forever action previous prompts, replying with broader
+# permissions requested handles future requests for other permissions, and the
+# rule with the most specific path pattern has precedence.
+
+TEST_DIR="$1"
+
+WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
+snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
+
+# First, queue up writes
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to write $name in the background"
+	echo "not written" > "${TEST_DIR}/${name}"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${name}-write-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${name}-write-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}-write-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start write of $name within timeout period"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that write for $name has not yet finished"
+	if [ -f "${WRITABLE}/${name}-write-finished" ] ; then
+		echo "write of $name finished before write for test4.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test4.txt (for which client will reply)"
+echo "not written" > "${TEST_DIR}/test4.txt"
+snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+
+# Reply for test4.txt will allow always write test*.txt
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that write for $name has finished"
+	if ! timeout 5 sh -c "while ! [ -f '${WRITABLE}/${name}-write-finished' ] ; do sleep 0.1 ; done" ; then
+		echo "write of $name did not finish after client replied"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt test4.txt ; do
+	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
+	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
+		echo "write failed for $name"
+		exit 1
+	fi
+done
+
+# Next queue up reads
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to read $name in the background"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${name}-read-started; cat ${TEST_DIR}/${name} > ${WRITABLE}/${name}; touch ${WRITABLE}/${name}-read-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}-read-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start read of $name within timeout period"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that read for $name has not yet finished"
+	if [ -f "${WRITABLE}/${name}-read-finished" ] ; then
+		echo "read of $name finished before read for test4/.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to read test4.txt (for which client will reply)"
+snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test4.txt > ${WRITABLE}/test4.txt"
+
+# Reply for test4.txt will deny always read|write test*
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that read for $name has finished"
+	if ! timeout 5 sh -c "while ! [ -f '${WRITABLE}/${name}-read-finished' ] ; do sleep 0.1 ; done" ; then
+		echo "read of $name did not finish after client replied"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt test4.txt ; do
+	TEST_OUTPUT="$(cat "${WRITABLE}/${name}")"
+	if [ "$TEST_OUTPUT" = "$name is written" ] ; then
+		echo "read unexpectedly succeeded for $name"
+		exit 1
+	fi
+done
+
+# Now check the following:
+# create test5.txt -> no prompt, allowed
+# create test5.md -> no prompt, denied
+# read test5.txt -> no prompt, denied
+# read test5.md -> no prompt, denied
+# create other.txt -> prompt, reply with deny (mostly to make sure the client lives long enough)
+
+echo "Attempt to create test5.txt (should be allowed by original rule)"
+snap run --shell prompting-client.scripted -c "echo test5.txt is written > ${TEST_DIR}/test5.txt"
+TEST_OUTPUT="$(cat "${TEST_DIR}/test5.txt")"
+if [ "$TEST_OUTPUT" != "test5.txt is written" ] ; then
+	echo "file creation failed for test5.txt"
+	exit 1
+fi
+
+echo "Attempt to create test5.md (should be denied by previous rule)"
+snap run --shell prompting-client.scripted -c "echo test5.md is written > ${TEST_DIR}/test5.md"
+if [ -f "${TEST_DIR}/test5.md" ] ; then
+	echo "file creation unexpectedly succeeded for test5.md"
+	exit 1
+fi
+
+for name in test5.txt test5.md ; do
+	echo "Attempt to read $name (should be denied by previous rule)"
+	echo "$name is written" > "${TEST_DIR}/${name}"
+	snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/${name} > ${WRITABLE}/${name}"
+	TEST_OUTPUT="$(cat "${WRITABLE}/${name}")"
+	if [ "$TEST_OUTPUT" = "$name is written" ] ; then
+		echo "read unexpectedly succeeded for $name"
+		exit 1
+	fi
+done
+
+echo "Attempt to create other.txt (should trigger prompt, which is then denied)"
+snap run --shell prompting-client.scripted -c "echo other.txt is written > ${TEST_DIR}/other.txt"
+if [ -f "${TEST_DIR}/other.txt" ] ; then
+	echo "file creation unexpectedly succeeded for other.txt"
+	exit 1
+fi
+
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_allow_deny.sh
@@ -137,7 +137,7 @@ if [ -f "${TEST_DIR}/other.txt" ] ; then
 fi
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.json
@@ -1,0 +1,114 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test1.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test2.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test3.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": null
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test4.txt",
+          "requested-permissions": [ "read" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "forever",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test*",
+          "permissions": [ "read", "write" ]
+        }
+      }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/other.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/other.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/sh
+
+# A test that multiple writes and reads in the same directory can be queued up,
+# replies with lifespan forever action previous prompts, replying with broader
+# permissions requested handles future requests for other permissions, and the
+# rule with the most specific path pattern has precedence.
+
+TEST_DIR="$1"
+
+WRITABLE="$(snap run --shell prompting-client.scripted -c 'cd ~; pwd')/$(basename "$TEST_DIR")"
+snap run --shell prompting-client.scripted -c "mkdir -p $WRITABLE"
+
+# First, queue up writes
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to write $name in the background"
+	echo "not written" > "${TEST_DIR}/${name}"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${name}-write-started; echo $name is written > ${TEST_DIR}/${name}; touch ${WRITABLE}/${name}-write-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}-write-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start write of $name within timeout period"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that write for $name has not yet finished"
+	if [ -f "${WRITABLE}/${name}-write-finished" ] ; then
+		echo "write of $name finished before write for test4.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to write test4.txt (for which client will reply)"
+echo "not written" > "${TEST_DIR}/test4.txt"
+snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TEST_DIR}/test4.txt"
+
+# Reply for test4.txt will deny always write test*.txt
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that write for $name has finished"
+	if ! timeout 5 sh -c "while ! [ -f '${WRITABLE}/${name}-write-finished' ] ; do sleep 0.1 ; done" ; then
+		echo "write of $name did not finish after client replied"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt test4.txt ; do
+	echo "Check that write failed as expected for $name"
+	TEST_OUTPUT="$(cat "${TEST_DIR}/${name}")"
+	if [ "$TEST_OUTPUT" = "$name is written" ] ; then
+		echo "write unexpectedly succeeded for $name"
+		exit 1
+	fi
+	echo "Prep $name for reading"
+	echo "$name is written" > "${TEST_DIR}/${name}"
+done
+
+# Next queue up reads
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Attempt to read $name in the background"
+	snap run --shell prompting-client.scripted -c "touch ${WRITABLE}/${name}-read-started; cat ${TEST_DIR}/${name} > ${WRITABLE}/${name}; touch ${WRITABLE}/${name}-read-finished" &
+	if ! timeout 10 sh -c "while ! [ -f '${WRITABLE}/${name}-read-started' ] ; do sleep 0.1 ; done" ; then
+		echo "failed to start read of $name within timeout period"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that read for $name has not yet finished"
+	if [ -f "${WRITABLE}/${name}-read-finished" ] ; then
+		echo "read of $name finished before read for test4/.txt started"
+		exit 1
+	fi
+done
+
+echo "Attempt to read test4.txt (for which client will reply)"
+snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test4.txt > ${WRITABLE}/test4.txt"
+
+# Reply for test4.txt will allow always read|write test*
+
+for name in test1.txt test2.txt test3.txt ; do
+	echo "Check that read for $name has finished"
+	if ! timeout 5 sh -c "while ! [ -f '${WRITABLE}/${name}-read-finished' ] ; do sleep 0.1 ; done" ; then
+		echo "read of $name did not finish after client replied"
+		exit 1
+	fi
+done
+
+for name in test1.txt test2.txt test3.txt test4.txt ; do
+	TEST_OUTPUT="$(cat "${WRITABLE}/${name}")"
+	if [ "$TEST_OUTPUT" != "$name is written" ] ; then
+		echo "read failed for $name"
+		exit 1
+	fi
+done
+
+# Now check the following:
+# create test5.txt -> no prompt, denied
+# create test5.md -> no prompt, allowed
+# read test5.txt -> no prompt, allowed
+# read test5.md -> no prompt, allowed
+# create other.txt -> prompt, reply with deny (mostly to make sure the client lives long enough)
+
+echo "Attempt to create test5.txt (should be denied by original rule)"
+snap run --shell prompting-client.scripted -c "echo test5.txt is written > ${TEST_DIR}/test5.txt"
+if [ -f "${TEST_DIR}/test5.txt" ] ; then
+	echo "file creation unexpectedly succeeded for test5.txt"
+	exit 1
+fi
+
+echo "Attempt to create test5.md (should be allowed by previous rule)"
+snap run --shell prompting-client.scripted -c "echo test5.md is written > ${TEST_DIR}/test5.md"
+TEST_OUTPUT="$(cat "${TEST_DIR}/test5.md")"
+if [ "$TEST_OUTPUT" != "test5.md is written" ] ; then
+	echo "file creation failed for test5.md"
+	exit 1
+fi
+
+for name in test5.txt test5.md ; do
+	echo "Attempt to read $name (should be allowed by previous rule)"
+	echo "$name is written" > "${TEST_DIR}/${name}"
+	snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/${name} > ${WRITABLE}/${name}"
+	TEST_OUTPUT="$(cat "${WRITABLE}/${name}")"
+	if [ "$TEST_OUTPUT" != "${name} is written" ] ; then
+		echo "read failed for ${name}"
+		exit 1
+	fi
+done
+
+echo "Attempt to create other.txt (should trigger prompt, which is then denied)"
+snap run --shell prompting-client.scripted -c "echo other.txt is written > ${TEST_DIR}/other.txt"
+if [ -f "${TEST_DIR}/other.txt" ] ; then
+	echo "file creation unexpectedly succeeded for other.txt"
+	exit 1
+fi
+
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.sh
@@ -140,7 +140,7 @@ if [ -f "${TEST_DIR}/other.txt" ] ; then
 fi
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_read_multiple_actioned_by_other_pid_deny_allow.sh
@@ -42,7 +42,7 @@ snap run --shell prompting-client.scripted -c "echo test4.txt is written > ${TES
 
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Check that write for $name has finished"
-	if ! timeout "$TIMEOUT" -c "while ! [ -f '${WRITABLE}/${name}-write-finished' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${name}-write-finished' ] ; do sleep 0.1 ; done" ; then
 		echo "write of $name did not finish after client replied"
 		exit 1
 	fi
@@ -85,7 +85,7 @@ snap run --shell prompting-client.scripted -c "cat ${TEST_DIR}/test4.txt > ${WRI
 
 for name in test1.txt test2.txt test3.txt ; do
 	echo "Check that read for $name has finished"
-	if ! timeout "$TIMEOUT" -c "while ! [ -f '${WRITABLE}/${name}-read-finished' ] ; do sleep 0.1 ; done" ; then
+	if ! timeout "$TIMEOUT" sh -c "while ! [ -f '${WRITABLE}/${name}-read-finished' ] ; do sleep 0.1 ; done" ; then
 		echo "read of $name did not finish after client replied"
 		exit 1
 	fi
@@ -140,7 +140,7 @@ if [ -f "${TEST_DIR}/other.txt" ] ; then
 fi
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.json
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.json
@@ -23,6 +23,22 @@
           "permissions": [ "write" ]
         }
       }
+    },
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "allow",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test.txt",
+          "permissions": [ "write" ]
+        }
+      }
     }
   ]
 }

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/sh
+
+# A simple allow once test of a write prompt.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+echo "Attempt to write the file"
+$SNAP_DO "echo it is written > ${TEST_DIR}/test.txt"
+
+sleep 1 # give the client a chance to write its result and exit
+
+CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_RESULT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+TEST_OUTPUT="$(cat "${TEST_DIR}/test.txt")"
+
+if [ "$TEST_OUTPUT" != "it is written" ] ; then
+	echo "test script failed"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -3,12 +3,16 @@
 # A simple allow once test of a write prompt.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 echo "Attempt to write the file"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -12,7 +12,7 @@ echo "Attempt to write the file"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -7,14 +7,15 @@ TEST_DIR="$1"
 echo "Run the prompting client in scripted mode in the background"
 prompting-client.scripted \
 	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
 	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
 sleep 1 # give the client a chance to start listening
 
 echo "Attempt to write the file"
-$SNAP_DO "echo it is written > ${TEST_DIR}/test.txt"
+snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
-sleep 1 # give the client a chance to write its result and exit
+sleep 5 # give the client a chance to write its result and exit
 
 CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -17,9 +17,9 @@ snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/
 
 sleep 5 # give the client a chance to write its result and exit
 
-CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
-if [ "$CLIENT_RESULT" != "success" ] ; then
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	echo "test failed"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -4,18 +4,11 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 echo "Attempt to write the file"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -12,7 +12,7 @@ echo "Attempt to write the file"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_allow.sh
@@ -21,6 +21,6 @@ fi
 TEST_OUTPUT="$(cat "${TEST_DIR}/test.txt")"
 
 if [ "$TEST_OUTPUT" != "it is written" ] ; then
-	echo "test script failed"
+	echo "write failed for test.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.json
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "prompt-filter": {
+    "snap": "prompting-client",
+    "interface": "home",
+    "constraints": {
+      "path": "$BASE_PATH/.*"
+    }
+  },
+  "prompts": [
+    {
+      "prompt-filter": {
+        "constraints": {
+          "path": ".*/test.txt",
+          "requested-permissions": [ "write" ]
+        }
+      },
+      "reply": {
+        "action": "deny",
+        "lifespan": "single",
+        "constraints": {
+          "path-pattern": "${BASE_PATH}/test.txt",
+          "permissions": [ "write" ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -12,7 +12,7 @@ echo "Attempt to write the file (should fail)"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -19,6 +19,6 @@ if [ "$CLIENT_OUTPUT" != "success" ] ; then
 fi
 
 if [ -f "${TEST_DIR}/test.txt" ] ; then
-	echo "test script unexpectedly succeeded"
+	echo "file creation unexpectedly succeeded for test.txt"
 	exit 1
 fi

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/sh
+
+# A simple deny once test of a write prompt.
+
+TEST_DIR="$1"
+
+echo "Run the prompting client in scripted mode in the background"
+prompting-client.scripted \
+	--script="${TEST_DIR}/script.json" \
+	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
+
+sleep 1 # give the client a chance to start listening
+
+echo "Attempt to write the file (should fail)"
+$SNAP_DO "echo it is written > ${TEST_DIR}/test.txt"
+
+sleep 1 # give the client a chance to write its result and exit
+
+CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+
+if [ "$CLIENT_RESULT" != "success" ] ; then
+	echo "test failed"
+	echo "output='$CLIENT_OUTPUT'"
+	exit 1
+fi
+
+if [ -f "${TEST_DIR}/test.txt" ] ; then
+	echo "test script unexpectedly succeeded"
+	exit 1
+fi

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -17,9 +17,9 @@ snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/
 
 sleep 5 # give the client a chance to write its result and exit
 
-CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
+CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 
-if [ "$CLIENT_RESULT" != "success" ] ; then
+if [ "$CLIENT_OUTPUT" != "success" ] ; then
 	echo "test failed"
 	echo "output='$CLIENT_OUTPUT'"
 	exit 1

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -7,14 +7,15 @@ TEST_DIR="$1"
 echo "Run the prompting client in scripted mode in the background"
 prompting-client.scripted \
 	--script="${TEST_DIR}/script.json" \
+	--grace-period=1 \
 	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
 
 sleep 1 # give the client a chance to start listening
 
 echo "Attempt to write the file (should fail)"
-$SNAP_DO "echo it is written > ${TEST_DIR}/test.txt"
+snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
-sleep 1 # give the client a chance to write its result and exit
+sleep 5 # give the client a chance to write its result and exit
 
 CLIENT_RESULT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -4,18 +4,11 @@
 
 TEST_DIR="$1"
 
-echo "Run the prompting client in scripted mode in the background"
-prompting-client.scripted \
-	--script="${TEST_DIR}/script.json" \
-	--grace-period=1 \
-	--var="BASE_PATH:${TEST_DIR}" | tee "${TEST_DIR}/result" &
-
-sleep 1 # give the client a chance to start listening
-
 echo "Attempt to write the file (should fail)"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
-sleep 5 # give the client a chance to write its result and exit
+# Wait for the client to write its result and exit
+timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -3,12 +3,16 @@
 # A simple deny once test of a write prompt.
 
 TEST_DIR="$1"
+TIMEOUT="$2"
+if [ -z "$TIMEOUT" ] ; then
+	TIMEOUT=10
+fi
 
 echo "Attempt to write the file (should fail)"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
 # Wait for the client to write its result and exit
-timeout 5 sh -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client-scripted" > /dev/null; do sleep 0.1; done'
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 

--- a/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
+++ b/tests/main/apparmor-prompting-integration-tests/write_single_deny.sh
@@ -12,7 +12,7 @@ echo "Attempt to write the file (should fail)"
 snap run --shell prompting-client.scripted -c "echo it is written > ${TEST_DIR}/test.txt"
 
 # Wait for the client to write its result and exit
-timeout "$TIMEOUT" -c 'while pgrep -f "prompting-client.scripted.*${TEST_DIR}" > /dev/null; do sleep 0.1; done'
+timeout "$TIMEOUT" sh -c "while pgrep -f 'prompting-client.scripted.*${TEST_DIR}' > /dev/null; do sleep 0.1; done"
 
 CLIENT_OUTPUT="$(cat "${TEST_DIR}/result")"
 


### PR DESCRIPTION
Port the prompting-client integration tests to snapd and extend them to cover common use cases for AppArmor Prompting.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-30450.