### PR TITLE
asserts: require components in validation sets to have revisions if their associated snap has one

### DIFF
--- a/asserts/validation_set.go
+++ b/asserts/validation_set.go
@@ -166,7 +166,7 @@ func checkValidationSetComponents(snap map[string]interface{}, snapRevision int,
 			return nil, errors.New(`each field in "components" map must be either a map or a string`)
 		}
 
-		component, err := checkValidationSetComponent(parsed, name, snapRevision, snapName)
+		component, err := checkValidationSetComponent(name, parsed, snapName, snapRevision)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func checkValidationSetComponents(snap map[string]interface{}, snapRevision int,
 	return components, nil
 }
 
-func checkValidationSetComponent(comp map[string]interface{}, compName string, snapRevision int, snapName string) (ValidationSetComponent, error) {
+func checkValidationSetComponent(compName string, comp map[string]interface{}, snapName string, snapRevision int) (ValidationSetComponent, error) {
 	if err := naming.ValidateSnap(compName); err != nil {
 		return ValidationSetComponent{}, fmt.Errorf("invalid component name %q", compName)
 	}

--- a/asserts/validation_set.go
+++ b/asserts/validation_set.go
@@ -130,7 +130,7 @@ func checkValidationSetSnap(snap map[string]interface{}) (*ValidationSetSnap, er
 		return nil, fmt.Errorf(`cannot specify revision %s at the same time as stating its presence is invalid`, what)
 	}
 
-	components, err := checkValidationSetComponents(snap, snapRevision, snapName, what)
+	components, err := checkValidationSetComponents(snapName, snap, snapRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +144,8 @@ func checkValidationSetSnap(snap map[string]interface{}) (*ValidationSetSnap, er
 	}, nil
 }
 
-func checkValidationSetComponents(snap map[string]interface{}, snapRevision int, snapName string, what string) (map[string]ValidationSetComponent, error) {
-	mapping, err := checkMapWhat(snap, "components", what)
+func checkValidationSetComponents(snapName string, snap map[string]interface{}, snapRevision int) (map[string]ValidationSetComponent, error) {
+	mapping, err := checkMapWhat(snap, "components", fmt.Sprintf("of snap %q", snapName))
 	if err != nil {
 		return nil, errors.New(`"components" field in "snaps" header must be a map`)
 	}

--- a/asserts/validation_set.go
+++ b/asserts/validation_set.go
@@ -98,15 +98,15 @@ func (s *ValidationSetSnap) ID() string {
 }
 
 func checkValidationSetSnap(snap map[string]interface{}) (*ValidationSetSnap, error) {
-	name, err := checkNotEmptyStringWhat(snap, "name", "of snap")
+	snapName, err := checkNotEmptyStringWhat(snap, "name", "of snap")
 	if err != nil {
 		return nil, err
 	}
-	if err := naming.ValidateSnap(name); err != nil {
-		return nil, fmt.Errorf("invalid snap name %q", name)
+	if err := naming.ValidateSnap(snapName); err != nil {
+		return nil, fmt.Errorf("invalid snap name %q", snapName)
 	}
 
-	what := fmt.Sprintf("of snap %q", name)
+	what := fmt.Sprintf("of snap %q", snapName)
 
 	snapID, err := checkStringMatchesWhat(snap, "id", what, naming.ValidSnapID)
 	if err != nil {
@@ -130,13 +130,13 @@ func checkValidationSetSnap(snap map[string]interface{}) (*ValidationSetSnap, er
 		return nil, fmt.Errorf(`cannot specify revision %s at the same time as stating its presence is invalid`, what)
 	}
 
-	components, err := checkValidationSetComponents(snap, snapRevision, what)
+	components, err := checkValidationSetComponents(snap, snapRevision, snapName, what)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ValidationSetSnap{
-		Name:       name,
+		Name:       snapName,
 		SnapID:     snapID,
 		Presence:   presence,
 		Revision:   snapRevision,
@@ -144,7 +144,7 @@ func checkValidationSetSnap(snap map[string]interface{}) (*ValidationSetSnap, er
 	}, nil
 }
 
-func checkValidationSetComponents(snap map[string]interface{}, snapRevision int, what string) (map[string]ValidationSetComponent, error) {
+func checkValidationSetComponents(snap map[string]interface{}, snapRevision int, snapName string, what string) (map[string]ValidationSetComponent, error) {
 	mapping, err := checkMapWhat(snap, "components", what)
 	if err != nil {
 		return nil, errors.New(`"components" field in "snaps" header must be a map`)
@@ -166,7 +166,7 @@ func checkValidationSetComponents(snap map[string]interface{}, snapRevision int,
 			return nil, errors.New(`each field in "components" map must be either a map or a string`)
 		}
 
-		component, err := checkValidationSetComponent(parsed, snapRevision, name)
+		component, err := checkValidationSetComponent(parsed, name, snapRevision, snapName)
 		if err != nil {
 			return nil, err
 		}
@@ -176,12 +176,12 @@ func checkValidationSetComponents(snap map[string]interface{}, snapRevision int,
 	return components, nil
 }
 
-func checkValidationSetComponent(comp map[string]interface{}, snapRevision int, name string) (ValidationSetComponent, error) {
-	if err := naming.ValidateSnap(name); err != nil {
-		return ValidationSetComponent{}, fmt.Errorf("invalid component name %q", name)
+func checkValidationSetComponent(comp map[string]interface{}, compName string, snapRevision int, snapName string) (ValidationSetComponent, error) {
+	if err := naming.ValidateSnap(compName); err != nil {
+		return ValidationSetComponent{}, fmt.Errorf("invalid component name %q", compName)
 	}
 
-	what := fmt.Sprintf("of component %q", name)
+	what := fmt.Sprintf("of component %q", naming.NewComponentRef(snapName, compName))
 
 	presence, err := checkPresence(comp, what, validValidationSetSnapPresences)
 	if err != nil {

--- a/asserts/validation_set_test.go
+++ b/asserts/validation_set_test.go
@@ -127,15 +127,15 @@ func (vss *validationSetSuite) TestDecodeInvalid(c *C) {
 		{"presence: optional\n", "presence: no\n", `presence of snap "baz-linux" must be one of required\|optional\|invalid`},
 		{"revision: 99\n", "revision: 0\n", `"revision" of snap "baz-linux" must be >=1: 0`},
 		{"presence: optional\n", "presence: invalid\n", `cannot specify revision of snap "baz-linux" at the same time as stating its presence is invalid`},
-		{"OTHER", "    components:\n      comp: no\n", `presence of component "comp" must be one of required\|optional\|invalid`},
-		{"OTHER", "    components:\n      comp:\n        revision: 1\n        presence: invalid\n", `cannot specify component revision of component "comp" at the same time as stating its presence is invalid`},
+		{"OTHER", "    components:\n      comp: no\n", `presence of component "baz-linux\+comp" must be one of required\|optional\|invalid`},
+		{"OTHER", "    components:\n      comp:\n        revision: 1\n        presence: invalid\n", `cannot specify component revision of component "baz-linux\+comp" at the same time as stating its presence is invalid`},
 		{"OTHER", "    components:\n      c: optional\n", `invalid component name "c"`},
-		{"OTHER", "    components:\n      comp:\n        revision: 1\n", `"presence" of component "comp" is mandatory`},
+		{"OTHER", "    components:\n      comp:\n        revision: 1\n", `"presence" of component "baz-linux\+comp" is mandatory`},
 		{"OTHER", "    components:\n      comp:\n        - test\n", `each field in "components" map must be either a map or a string`},
-		{"OTHER", "    components:\n      comp:\n        revision: -1\n        presence: optional\n", `"revision" of component "comp" must be >=1: -1`},
+		{"OTHER", "    components:\n      comp:\n        revision: -1\n        presence: optional\n", `"revision" of component "baz-linux\+comp" must be >=1: -1`},
 		{"OTHER", "    components: some-string", `"components" field in "snaps" header must be a map`},
-		{"OTHER", "    components:\n      comp:\n        presence: optional\n", `must specify revision of component "comp" since its associated snap specifies a revision`},
-		{"OTHER", "  -\n    name: foo-linux\n    id: foolinuxidididididididididididid\n    components:\n      comp:\n        revision: 1\n        presence: optional\n", `cannot specify revision of component "comp" if its associated snap does not specify a revision`},
+		{"OTHER", "    components:\n      comp:\n        presence: optional\n", `must specify revision of component "baz-linux\+comp" since its associated snap specifies a revision`},
+		{"OTHER", "  -\n    name: foo-linux\n    id: foolinuxidididididididididididid\n    components:\n      comp:\n        revision: 1\n        presence: optional\n", `cannot specify revision of component "foo-linux\+comp" if its associated snap does not specify a revision`},
 	}
 
 	for _, test := range invalidTests {


### PR DESCRIPTION
We're going to require this for now, might be lifted later. I also added some more context to error messages while in here.