### PR TITLE
c/snap-bootstrap: import users from hybrid system into recovery system

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -550,6 +550,7 @@ func copyCoreUbuntuAuthData(srcUbuntuData, destUbuntuData string) error {
 // copied to <destUbuntuData>/system-data. User specific files are copied to
 // <destUbuntuData>/user-data.
 func copyHybridUbuntuDataAuth(srcUbuntuData, destUbuntuData string) error {
+	destSystemData := filepath.Join(destUbuntuData, "system-data")
 	for _, globEx := range []string{
 		"etc/ssh/*",
 		"etc/sudoers.d/*",
@@ -557,21 +558,23 @@ func copyHybridUbuntuDataAuth(srcUbuntuData, destUbuntuData string) error {
 	} {
 		if err := copyFromGlobHelper(
 			srcUbuntuData,
-			filepath.Join(destUbuntuData, "system-data"),
+			destSystemData,
 			globEx,
 		); err != nil {
 			return err
 		}
 	}
 
+	destHomeData := filepath.Join(srcUbuntuData, "home")
+	destUserData := filepath.Join(destUbuntuData, "user-data")
 	for _, globEx := range []string{
 		"*/.ssh/*",
 		"*/.snap/auth.json",
 		"*/.profile",
 	} {
 		if err := copyFromGlobHelper(
-			filepath.Join(srcUbuntuData, "home"),
-			filepath.Join(destUbuntuData, "user-data"),
+			destHomeData,
+			destUserData,
 			globEx,
 		); err != nil {
 			return err

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -455,7 +455,11 @@ func generateMountsModeInstall(mst *initramfsMountsState) error {
 // copyNetworkConfig copies the network configuration to the target
 // directory. This is used to copy the network configuration
 // data from a real uc20 ubuntu-data partition into a ephemeral one.
-func copyNetworkConfig(src, dst string) error {
+//
+// The given srcRoot should point to the directory that contains the writable
+// host system data. The given dstRoot should point to the directory that
+// contains the writable system data for the ephemeral recovery system.
+func copyNetworkConfig(srcRoot, dstRoot string) error {
 	for _, globEx := range []string{
 		// for network configuration setup by console-conf, etc.
 		// TODO:UC20: we want some way to "try" or "verify" the network
@@ -472,7 +476,7 @@ func copyNetworkConfig(src, dst string) error {
 		// also copy the machine-id across
 		"etc/machine-id",
 	} {
-		if err := copyFromGlobHelper(src, dst, globEx); err != nil {
+		if err := copyFromGlobHelper(srcRoot, dstRoot, globEx); err != nil {
 			return err
 		}
 	}
@@ -482,7 +486,11 @@ func copyNetworkConfig(src, dst string) error {
 // copyUbuntuDataMisc copies miscellaneous other files from the run mode system
 // to the recover system such as:
 //   - timesync clock to keep the same time setting in recover as in run mode
-func copyUbuntuDataMisc(src, dst string) error {
+//
+// The given srcRoot should point to the directory that contains the writable
+// host system data. The given dstRoot should point to the directory that
+// contains the writable system data for the ephemeral recovery system.
+func copyUbuntuDataMisc(srcRoot, dstRoot string) error {
 	for _, globEx := range []string{
 		// systemd's timesync clock file so that the time in recover mode moves
 		// forward to what it was in run mode
@@ -492,7 +500,7 @@ func copyUbuntuDataMisc(src, dst string) error {
 		// problem to "lose" the time spent in recover mode
 		"var/lib/systemd/timesync/clock",
 	} {
-		if err := copyFromGlobHelper(src, dst, globEx); err != nil {
+		if err := copyFromGlobHelper(srcRoot, dstRoot, globEx); err != nil {
 			return err
 		}
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -570,7 +570,6 @@ func copyHybridUbuntuDataAuth(srcUbuntuData, destUbuntuData string) error {
 	for _, globEx := range []string{
 		"*/.ssh/*",
 		"*/.snap/auth.json",
-		"*/.profile",
 	} {
 		if err := copyFromGlobHelper(
 			destHomeData,

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1467,9 +1467,13 @@ func generateMountsModeRecover(mst *initramfsMountsState) error {
 	// ubuntu-data, and as such we can proceed with copying files from there
 	// onto the tmpfs
 	// Proceed only if we trust ubuntu-data to be paired with ubuntu-save
-	hybrid := model.Classic() && model.KernelSnap() != nil
-
 	if machine.trustData() {
+		// on hybrid systems, we take special care to import the root user and
+		// users from the "admin" and "sudo" groups into the ephemeral system.
+		// this is our best-effort for allowing an owner of a hybrid system to
+		// login to the created recovery system.
+		hybrid := model.Classic() && model.KernelSnap() != nil
+
 		hostSystemData := boot.InitramfsHostWritableDir(model)
 		recoverySystemData := boot.InitramfsWritableDir(model, false)
 		if hybrid {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -537,6 +537,10 @@ func copyCoreUbuntuAuthData(srcUbuntuData, destUbuntuData string) error {
 	return nil
 }
 
+// copyHybridUbuntuDataAuth copies the authentication files that are relevant on
+// a hybrid system to the ubuntu data directory. Non-user specific files are
+// copied to <destUbuntuData>/system-data. User specific files are copied to
+// <destUbuntuData>/user-data.
 func copyHybridUbuntuDataAuth(srcUbuntuData, destUbuntuData string) error {
 	for _, globEx := range []string{
 		"etc/ssh/*",

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -500,14 +500,14 @@ func copyUbuntuDataMisc(src, dst string) error {
 	return nil
 }
 
-// copyUbuntuDataAuth copies the authentication files like
+// copyCoreUbuntuAuthData copies the authentication files like
 //   - extrausers passwd,shadow etc
 //   - sshd host configuration
 //   - user .ssh dir
 //
 // to the target directory. This is used to copy the authentication
 // data from a real uc20 ubuntu-data partition into a ephemeral one.
-func copyUbuntuDataAuth(srcUbuntuData, destUbuntuData string) error {
+func copyCoreUbuntuAuthData(srcUbuntuData, destUbuntuData string) error {
 	for _, globEx := range []string{
 		"system-data/var/lib/extrausers/*",
 		"system-data/etc/ssh/*",
@@ -1474,7 +1474,7 @@ func generateMountsModeRecover(mst *initramfsMountsState) error {
 		} else {
 			// TODO: erroring here should fallback to copySafeDefaultData and
 			// proceed on with degraded mode anyways
-			if err := copyUbuntuDataAuth(
+			if err := copyCoreUbuntuAuthData(
 				boot.InitramfsHostUbuntuDataDir,
 				boot.InitramfsDataDir,
 			); err != nil {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1480,6 +1480,8 @@ func generateMountsModeRecover(mst *initramfsMountsState) error {
 		hostSystemData := boot.InitramfsHostWritableDir(model)
 		recoverySystemData := boot.InitramfsWritableDir(model, false)
 		if hybrid {
+			// TODO: eventually, the base will be mounted directly on /sysroot.
+			// this will need to change once that happens.
 			if err := importHybridUserData(
 				hostSystemData,
 				filepath.Join(boot.InitramfsRunMntDir, "base"),

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -8672,8 +8672,8 @@ grade=signed
 const (
 	passwdHybrid = `root:x:0:0:root:/root:/bin/bash
 imported:x:1000:1001::/home/imported:/usr/bin/zsh
-system:x:10:10::/home/system:/bin/sh
-ignore:x:1002:1002::/home/ignore:/bin/sh
+system:x:10:10::/home/system:/bin/bash
+ignore:x:1002:1002::/home/ignore:/usr/bin/zsh
 shared:x:1003:1001::/home/shared:/bin/sh
 `
 	shadowHybrid = `root:$y$j9T$MWRKyDbOQcQR7X77eukIp0$SwBP/2CgMJ96ENp01Z2zDtbhp5ztYNXOmzov0J2iHUC:19836:0:99999:7:::
@@ -8714,9 +8714,9 @@ sudo:*::
 
 	passwdMerged = `dnsmasq:x:109:109:Reserved:/var/lib/misc:/bin/false
 daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
-root:x:0:0:root:/root:
-imported:x:1000:1001::/home/imported:
-shared:x:1003:1001::/home/shared:
+root:x:0:0:root:/root:/bin/bash
+imported:x:1000:1001::/home/imported:/bin/bash
+shared:x:1003:1001::/home/shared:/bin/bash
 `
 	shadowMerged = `daemon:*:16329:0:99999:7:::
 dnsmasq:*:16644:0:99999:7:::

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -8696,7 +8696,7 @@ sudo:*::imported
 `
 
 	passwdBase = `root:x:0:0:root:/root:/bin/bash
-dnsmasq:x:109:65534:Reserved:/var/lib/misc:/bin/false
+dnsmasq:x:109:109:Reserved:/var/lib/misc:/bin/false
 daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
 `
 	shadowBase = `root:*:16329:0:99999:7:::
@@ -8712,7 +8712,7 @@ daemon:*::
 sudo:*::
 `
 
-	passwdMerged = `dnsmasq:x:109:65534:Reserved:/var/lib/misc:/bin/false
+	passwdMerged = `dnsmasq:x:109:109:Reserved:/var/lib/misc:/bin/false
 daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
 root:x:0:0:root:/root:
 imported:x:1000:1001::/home/imported:

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -8572,6 +8572,13 @@ func (s *initramfsClassicMountsSuite) testRecoverModeHappy(c *C) {
 	c.Assert(err, IsNil)
 
 	writeLoginFiles(c, hostUbuntuData, passwdHybrid, shadowHybrid, groupHybrid, gshadowHybrid)
+	err = os.WriteFile(filepath.Join(hostUbuntuData, "etc/shells"), []byte(`
+/bin/sh
+/bin/bash
+/usr/bin/zsh
+`), 0640)
+	c.Assert(err, IsNil)
+
 	writeLoginFiles(c, filepath.Join(boot.InitramfsRunMntDir, "base"), passwdBase, shadowBase, groupBase, gshadowBase)
 
 	mockCopiedFiles := []string{

--- a/cmd/snap-bootstrap/hybrid_users_import.go
+++ b/cmd/snap-bootstrap/hybrid_users_import.go
@@ -1,0 +1,493 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
+)
+
+type user struct {
+	name   string
+	uid    int
+	gid    int
+	groups []string
+
+	// these are the original lines from their respective files
+	passwdEntry string
+	shadowEntry string
+}
+
+func importHybridUserData(rootToImport, referenceRoot string) error {
+	outputDir := filepath.Join(dirs.SnapRunDir, "hybrid-users")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return err
+	}
+
+	if err := mergeAndWriteUserFiles(rootToImport, referenceRoot, []string{"sudo", "admin"}, outputDir); err != nil {
+		return err
+	}
+
+	if !osutil.FileExists("/lib/core/extra-paths") {
+		return nil
+	}
+
+	// TODO: this is just a hack for now so that i don't have to repack this
+	// script for testing. will be removed once kernel snap is updated to
+	// include changes to extra-paths.
+	script, err := os.OpenFile("/lib/core/extra-paths", os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer script.Close()
+
+	mounts := []string{"passwd", "shadow", "group", "gshadow"}
+	for _, m := range mounts {
+		_, err := fmt.Fprintf(
+			script,
+			"echo '%s %s none bind,x-initrd.mount 0 0' >> /sysroot/etc/fstab\n",
+			filepath.Join(outputDir, m),
+			filepath.Join("/etc", m),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return script.Close()
+}
+
+func mergeAndWriteUserFiles(importRoot, referenceRoot string, targetGroups []string, outputDir string) error {
+	users, err := parseUsers(importRoot, func(u user) bool {
+		// we always want to import the root user
+		if u.uid == 0 {
+			return true
+		}
+
+		// don't consider any system users or users that have a system group as
+		// their primary group
+		if u.uid < 1000 || u.gid < 1000 {
+			return false
+		}
+
+		// only consider users that are in the groups that we're specifically
+		// importing
+		for _, tg := range targetGroups {
+			if strutil.ListContains(u.groups, tg) {
+				return true
+			}
+		}
+
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	// in addition to importing the users that are in the given groups, we also
+	// import the primary groups that those users are in. these will most likely
+	// all be unique, but there is a chance that users share a primary group.
+	groups, err := parseGroups(importRoot, func(g group) bool {
+		if g.gid == 0 {
+			return true
+		}
+
+		if g.gid < 1000 {
+			return false
+		}
+
+		for _, u := range users {
+			if u.gid == g.gid {
+				return true
+			}
+		}
+
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	// update the passwd and shadow files to contain the lines for the users
+	// that we're importing
+	err = addNamedEntriesToFile(
+		filepath.Join(referenceRoot, "etc/passwd"),
+		filepath.Join(outputDir, "passwd"),
+		users,
+		func(u user) string {
+			return u.passwdEntry
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = addNamedEntriesToFile(
+		filepath.Join(referenceRoot, "etc/shadow"),
+		filepath.Join(outputDir, "shadow"),
+		users,
+		func(u user) string {
+			return u.shadowEntry
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// update the group and gshadow files to add our users to any existing
+	// groups, and add any new primary groups that we're importing.
+	if err := mergeAndWriteGroupFiles(referenceRoot, outputDir, users, groups); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func mergeAndWriteGroupFiles(originalRoot string, outputDir string, users map[string]user, groups map[string]group) error {
+	groupsToNewUsers := make(map[string][]string)
+	for _, user := range users {
+		for _, group := range user.groups {
+			groupsToNewUsers[group] = append(groupsToNewUsers[group], user.name)
+		}
+	}
+
+	groupEntries, err := entriesByName(filepath.Join(originalRoot, "etc/group"))
+	if err != nil {
+		return err
+	}
+
+	gshadowEntries, err := entriesByName(filepath.Join(originalRoot, "etc/gshadow"))
+	if err != nil {
+		return err
+	}
+
+	var groupBuffer bytes.Buffer
+	var gshadowBuffer bytes.Buffer
+	for group, entry := range groupEntries {
+		parts := strings.Split(entry, ":")
+		if len(parts) != 4 {
+			continue
+		}
+
+		if group != parts[0] {
+			return errors.New("internal error: group entry inconsistent with parsed data")
+		}
+
+		// if we're importing a group that already exists, we take the imported
+		// group.
+		if _, ok := groups[group]; ok {
+			continue
+		}
+
+		var usersInGroup []string
+		if len(parts[3]) > 0 {
+			usersInGroup = strings.Split(parts[3], ",")
+		}
+
+		// we combine the users that are already in the group with the new users
+		// that we're importing
+		usersInGroup = unique(append(usersInGroup, groupsToNewUsers[group]...))
+		sort.Strings(usersInGroup)
+
+		usersPart := strings.Join(usersInGroup, ",")
+
+		fmt.Fprintf(&groupBuffer, "%s:%s:%s:%s\n", parts[0], parts[1], parts[2], usersPart)
+
+		// if this group has a gshadow entry, we need to update the list of
+		// users there as well. not having a gshadow entry is fine, though.
+		gshadowLine := gshadowEntries[group]
+		if gshadowLine == "" {
+			continue
+		}
+
+		gshadowParts := strings.Split(gshadowLine, ":")
+		if len(gshadowParts) != 4 {
+			continue
+		}
+
+		fmt.Fprintf(&gshadowBuffer, "%s:%s:%s:%s\n", gshadowParts[0], gshadowParts[1], gshadowParts[2], usersPart)
+	}
+
+	// add the group entries for the users that we're importing. note that we
+	// don't need to mess with the users in these groups, since they're coming
+	// directly from the system we're importing from.
+	for _, g := range groups {
+		groupBuffer.WriteString(g.groupEntry + "\n")
+		if g.gshadowEntry != "" {
+			gshadowBuffer.WriteString(g.gshadowEntry + "\n")
+		}
+	}
+
+	destinationGroup := filepath.Join(outputDir, "group")
+	if err := os.WriteFile(destinationGroup, groupBuffer.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	destinationGShadow := filepath.Join(outputDir, "gshadow")
+	return os.WriteFile(destinationGShadow, gshadowBuffer.Bytes(), 0644)
+}
+
+// unique returns a slice with unique entries; the provided slice is modified
+// and should not be re-used.
+func unique(slice []string) []string {
+	seen := make(map[string]bool)
+	current := 0
+	for _, entry := range slice {
+		if _, ok := seen[entry]; ok {
+			continue
+		}
+
+		seen[entry] = true
+		slice[current] = entry
+		current++
+	}
+	return slice[:current]
+}
+
+// addNamedEntriesToFile creates a new passwd or shadow file from the
+// combination of the original file and the given set of users. The given entry
+// function returns the line that should be added to the file. If an entry in
+// the original file shares the same login name as a given user's login name,
+// then the new entry is used.
+func addNamedEntriesToFile(original, destination string, users map[string]user, entry func(user) string) error {
+	f, err := os.Open(original)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+
+	var buffer bytes.Buffer
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		name, _, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+
+		// if there is a conflict in the existing file, we will use the new
+		// entry instead of the old one. this is consistent with how we handle
+		// groups, so any conflicting users will always be fully replaced.
+		if _, ok := users[name]; ok {
+			continue
+		}
+
+		buffer.WriteString(line + "\n")
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	for _, user := range users {
+		line := entry(user)
+		if line == "" {
+			continue
+		}
+
+		buffer.WriteString(line + "\n")
+	}
+
+	return os.WriteFile(destination, buffer.Bytes(), 0644)
+}
+
+func parseUsers(root string, filter func(user) bool) (map[string]user, error) {
+	passwdEntries, err := entriesByName(filepath.Join(root, "etc/passwd"))
+	if err != nil {
+		return nil, err
+	}
+
+	shadowEntries, err := entriesByName(filepath.Join(root, "etc/shadow"))
+	if err != nil {
+		return nil, err
+	}
+
+	userToGroups, err := parseGroupsForUser(filepath.Join(root, "etc/group"))
+	if err != nil {
+		return nil, err
+	}
+
+	users := make(map[string]user)
+	for name, entry := range passwdEntries {
+		parts := strings.Split(entry, ":")
+		if len(parts) != 7 {
+			continue
+		}
+
+		if name != parts[0] {
+			return nil, errors.New("internal error: passwd entry inconsistent with parsed data")
+		}
+
+		uid, err := strconv.Atoi(parts[2])
+		if err != nil {
+			continue
+		}
+
+		gid, err := strconv.Atoi(parts[3])
+		if err != nil {
+			continue
+		}
+
+		// we're going to ignore the user's shell, since it could be anything,
+		// and that shell might not be installed in the system that we're
+		// importing this user into. if empty, /bin/sh will be used.
+		parts[6] = ""
+
+		u := user{
+			name:   name,
+			uid:    uid,
+			gid:    gid,
+			groups: userToGroups[name],
+
+			passwdEntry: strings.Join(parts, ":"),
+			shadowEntry: shadowEntries[name],
+		}
+
+		if !filter(u) {
+			continue
+		}
+
+		users[name] = u
+	}
+
+	return users, nil
+}
+
+type group struct {
+	name  string
+	gid   int
+	users []string
+
+	groupEntry   string
+	gshadowEntry string
+}
+
+func parseGroups(root string, filter func(group) bool) (map[string]group, error) {
+	groupEntries, err := entriesByName(filepath.Join(root, "etc/group"))
+	if err != nil {
+		return nil, err
+	}
+
+	gshadowEntries, err := entriesByName(filepath.Join(root, "etc/gshadow"))
+	if err != nil {
+		return nil, err
+	}
+
+	groups := make(map[string]group)
+	for name, entry := range groupEntries {
+		parts := strings.Split(entry, ":")
+		if len(parts) != 4 {
+			continue
+		}
+
+		if name != parts[0] {
+			return nil, errors.New("internal error: group entry inconsistent with parsed data")
+		}
+
+		gid, err := strconv.Atoi(parts[2])
+		if err != nil {
+			continue
+		}
+
+		var users []string
+		if len(parts[3]) > 0 {
+			users = strings.Split(parts[3], ",")
+		}
+
+		g := group{
+			name:         name,
+			gid:          gid,
+			users:        users,
+			groupEntry:   entry,
+			gshadowEntry: gshadowEntries[name],
+		}
+
+		if !filter(g) {
+			continue
+		}
+
+		groups[name] = g
+	}
+
+	return groups, nil
+}
+
+func parseGroupsForUser(path string) (usersToGroups map[string][]string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	usersToGroups = make(map[string][]string)
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		parts := strings.Split(line, ":")
+		if len(parts) != 4 {
+			continue
+		}
+
+		group := parts[0]
+		users := strings.Split(parts[3], ",")
+		for _, user := range users {
+			usersToGroups[user] = append(usersToGroups[user], group)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return usersToGroups, nil
+}
+
+func entriesByName(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	entries := make(map[string]string)
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		name, _, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+
+		entries[name] = line
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}

--- a/cmd/snap-bootstrap/hybrid_users_import.go
+++ b/cmd/snap-bootstrap/hybrid_users_import.go
@@ -113,7 +113,7 @@ func mergeAndWriteUserFiles(originalRoot string, outputDir string, users map[str
 	// 1000. the base shouldn't contain anything that doesn't fit this criteria,
 	// but it is best to be safe.
 	sourceUsers, err := parseUsers(originalRoot, func(u user) bool {
-		return (u.gid == 0 && u.uid == 0) || (u.uid < 1000 && u.gid < 1000)
+		return u.uid < 1000 && u.gid < 1000
 	})
 	if err != nil {
 		return err

--- a/cmd/snap-bootstrap/hybrid_users_import.go
+++ b/cmd/snap-bootstrap/hybrid_users_import.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -286,6 +287,7 @@ func parseUsers(root string, filter func(user) bool) (map[string]user, error) {
 	for name, entry := range passwdEntries {
 		parts := strings.Split(entry, ":")
 		if len(parts) != 7 {
+			logger.Noticef("skipping importing user with invalid entry: %v", entry)
 			continue
 		}
 
@@ -295,11 +297,13 @@ func parseUsers(root string, filter func(user) bool) (map[string]user, error) {
 
 		uid, err := strconv.Atoi(parts[2])
 		if err != nil {
+			logger.Noticef("skipping importing user %q with invalid uid: %v", name, err)
 			continue
 		}
 
 		gid, err := strconv.Atoi(parts[3])
 		if err != nil {
+			logger.Noticef("skipping importing user %q with invalid gid: %v", name, err)
 			continue
 		}
 
@@ -347,6 +351,7 @@ func parseGroups(root string, filter func(group) bool) (map[string]group, error)
 	for name, entry := range groupEntries {
 		parts := strings.Split(entry, ":")
 		if len(parts) != 4 {
+			logger.Noticef("skipping importing group with invalid entry: %s", entry)
 			continue
 		}
 
@@ -356,6 +361,7 @@ func parseGroups(root string, filter func(group) bool) (map[string]group, error)
 
 		gid, err := strconv.Atoi(parts[2])
 		if err != nil {
+			logger.Noticef("skipping importing group %q with invalid gid: %v", name, err)
 			continue
 		}
 

--- a/cmd/snap-bootstrap/hybrid_users_import.go
+++ b/cmd/snap-bootstrap/hybrid_users_import.go
@@ -152,9 +152,9 @@ func mergeAndWriteUserFiles(originalRoot string, outputDir string, users map[str
 		}
 
 		// we're going to ignore the user's shell, since it could be anything,
-		// and that shell might not be installed in the system that we're
-		// importing this user into. if empty, /bin/sh will be used.
-		parts[6] = ""
+		// we replace it with /bin/bash, since this should give a good default
+		// experience and should always be available in the base.
+		parts[6] = "/bin/bash"
 
 		passwdBuffer.WriteString(strings.Join(parts, ":") + "\n")
 		if user.shadowEntry != "" {

--- a/cmd/snap-bootstrap/hybrid_users_import.go
+++ b/cmd/snap-bootstrap/hybrid_users_import.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -33,37 +32,7 @@ func importHybridUserData(rootToImport, referenceRoot string) error {
 		return err
 	}
 
-	if err := mergeAndWriteUserFiles(rootToImport, referenceRoot, []string{"sudo", "admin"}, outputDir); err != nil {
-		return err
-	}
-
-	if !osutil.FileExists("/lib/core/extra-paths") {
-		return nil
-	}
-
-	// TODO: this is just a hack for now so that i don't have to repack this
-	// script for testing. will be removed once kernel snap is updated to
-	// include changes to extra-paths.
-	script, err := os.OpenFile("/lib/core/extra-paths", os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer script.Close()
-
-	mounts := []string{"passwd", "shadow", "group", "gshadow"}
-	for _, m := range mounts {
-		_, err := fmt.Fprintf(
-			script,
-			"echo '%s %s none bind,x-initrd.mount 0 0' >> /sysroot/etc/fstab\n",
-			filepath.Join(outputDir, m),
-			filepath.Join("/etc", m),
-		)
-		if err != nil {
-			return err
-		}
-	}
-
-	return script.Close()
+	return mergeAndWriteUserFiles(rootToImport, referenceRoot, []string{"sudo", "admin"}, outputDir)
 }
 
 func mergeAndWriteUserFiles(importRoot, referenceRoot string, targetGroups []string, outputDir string) error {

--- a/cmd/snap-bootstrap/hybrid_users_import.go
+++ b/cmd/snap-bootstrap/hybrid_users_import.go
@@ -140,12 +140,6 @@ func mergeAndWriteUserFiles(originalRoot string, outputDir string, users map[str
 	}
 
 	for _, user := range users {
-		// only allow importing users that are either root or have a uid < 1000
-		// and gid < 1000
-		if (user.uid != 0 || user.gid != 0) && (user.uid < 1000 || user.gid < 1000) {
-			return fmt.Errorf("internal error: cannot import system users: %s has uid %d and gid %d", user.name, user.uid, user.gid)
-		}
-
 		parts := strings.Split(user.passwdEntry, ":")
 		if len(parts) != 7 {
 			return fmt.Errorf("internal error: passwd entry inconsistent with parsed data")
@@ -231,10 +225,6 @@ func mergeAndWriteGroupFiles(originalRoot string, outputDir string, users map[st
 	// don't need to mess with the users in these groups, since they're coming
 	// directly from the system we're importing from
 	for _, g := range groups {
-		if g.gid != 0 && g.gid < 1000 {
-			return fmt.Errorf("internal error: cannot import system groups: %s has gid %d", g.name, g.gid)
-		}
-
 		groupBuffer.WriteString(g.groupEntry + "\n")
 		if g.gshadowEntry != "" {
 			gshadowBuffer.WriteString(g.gshadowEntry + "\n")

--- a/cmd/snap-bootstrap/hybrid_users_import.go
+++ b/cmd/snap-bootstrap/hybrid_users_import.go
@@ -32,11 +32,11 @@ func importHybridUserData(rootToImport, referenceRoot string) error {
 		return err
 	}
 
-	return mergeAndWriteUserFiles(rootToImport, referenceRoot, []string{"sudo", "admin"}, outputDir)
+	return mergeAndWriteLoginFiles(rootToImport, referenceRoot, []string{"sudo", "admin"}, outputDir)
 }
 
-func mergeAndWriteUserFiles(importRoot, referenceRoot string, targetGroups []string, outputDir string) error {
-	users, err := parseUsers(importRoot, func(u user) bool {
+func userFilter(targetGroups []string) func(user) bool {
+	return func(u user) bool {
 		// we always want to import the root user
 		if u.uid == 0 {
 			return true
@@ -57,23 +57,19 @@ func mergeAndWriteUserFiles(importRoot, referenceRoot string, targetGroups []str
 		}
 
 		return false
-	})
-	if err != nil {
-		return err
 	}
+}
 
-	// in addition to importing the users that are in the given groups, we also
-	// import the primary groups that those users are in. these will most likely
-	// all be unique, but there is a chance that users share a primary group.
-	groups, err := parseGroups(importRoot, func(g group) bool {
+func groupFilter(users map[string]user) func(group) bool {
+	return func(g group) bool {
+		// always import the root group
 		if g.gid == 0 {
 			return true
 		}
 
-		if g.gid < 1000 {
-			return false
-		}
-
+		// in addition to importing the users that are in the given groups, we also
+		// import the primary groups that those users are in. these will most likely
+		// all be unique, but there is a chance that users share a primary group.
 		for _, u := range users {
 			if u.gid == g.gid {
 				return true
@@ -81,33 +77,23 @@ func mergeAndWriteUserFiles(importRoot, referenceRoot string, targetGroups []str
 		}
 
 		return false
-	})
+	}
+}
+
+func mergeAndWriteLoginFiles(importRoot, referenceRoot string, targetGroups []string, outputDir string) error {
+	users, err := parseUsers(importRoot, userFilter(targetGroups))
+	if err != nil {
+		return err
+	}
+
+	groups, err := parseGroups(importRoot, groupFilter(users))
 	if err != nil {
 		return err
 	}
 
 	// update the passwd and shadow files to contain the lines for the users
 	// that we're importing
-	err = addNamedEntriesToFile(
-		filepath.Join(referenceRoot, "etc/passwd"),
-		filepath.Join(outputDir, "passwd"),
-		users,
-		func(u user) string {
-			return u.passwdEntry
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	err = addNamedEntriesToFile(
-		filepath.Join(referenceRoot, "etc/shadow"),
-		filepath.Join(outputDir, "shadow"),
-		users,
-		func(u user) string {
-			return u.shadowEntry
-		},
-	)
+	err = mergeAndWriteUserFiles(referenceRoot, outputDir, users)
 	if err != nil {
 		return err
 	}
@@ -121,6 +107,69 @@ func mergeAndWriteUserFiles(importRoot, referenceRoot string, targetGroups []str
 	return nil
 }
 
+func mergeAndWriteUserFiles(originalRoot string, outputDir string, users map[string]user) error {
+	// only import users that are either root or have a uid < 1000 and gid <
+	// 1000. the base shouldn't contain anything that doesn't fit this criteria,
+	// but it is best to be safe.
+	sourceUsers, err := parseUsers(originalRoot, func(u user) bool {
+		return (u.gid == 0 && u.uid == 0) || (u.uid < 1000 && u.gid < 1000)
+	})
+	if err != nil {
+		return err
+	}
+
+	var passwdBuffer bytes.Buffer
+	var shadowBuffer bytes.Buffer
+	for name, user := range sourceUsers {
+		if name != user.name {
+			return fmt.Errorf("internal error: user entry inconsistent with parsed data")
+		}
+
+		// if there is a conflict in the existing file, we will use the new
+		// entry instead of the old one. this is consistent with how we handle
+		// groups, so any conflicting users will always be fully replaced.
+		if _, ok := users[name]; ok {
+			continue
+		}
+
+		passwdBuffer.WriteString(user.passwdEntry + "\n")
+		if user.shadowEntry != "" {
+			shadowBuffer.WriteString(user.shadowEntry + "\n")
+		}
+	}
+
+	for _, user := range users {
+		// only allow importing users that are either root or have a uid < 1000
+		// and gid < 1000
+		if (user.uid != 0 || user.gid != 0) && (user.uid < 1000 || user.gid < 1000) {
+			return fmt.Errorf("internal error: cannot import system users: %s has uid %d and gid %d", user.name, user.uid, user.gid)
+		}
+
+		parts := strings.Split(user.passwdEntry, ":")
+		if len(parts) != 7 {
+			return fmt.Errorf("internal error: passwd entry inconsistent with parsed data")
+		}
+
+		// we're going to ignore the user's shell, since it could be anything,
+		// and that shell might not be installed in the system that we're
+		// importing this user into. if empty, /bin/sh will be used.
+		parts[6] = ""
+
+		passwdBuffer.WriteString(strings.Join(parts, ":") + "\n")
+		if user.shadowEntry != "" {
+			shadowBuffer.WriteString(user.shadowEntry + "\n")
+		}
+	}
+
+	destinationPasswd := filepath.Join(outputDir, "passwd")
+	if err := os.WriteFile(destinationPasswd, passwdBuffer.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	destinationShadow := filepath.Join(outputDir, "shadow")
+	return os.WriteFile(destinationShadow, shadowBuffer.Bytes(), 0600)
+}
+
 func mergeAndWriteGroupFiles(originalRoot string, outputDir string, users map[string]user, groups map[string]group) error {
 	groupsToNewUsers := make(map[string][]string)
 	for _, user := range users {
@@ -129,56 +178,47 @@ func mergeAndWriteGroupFiles(originalRoot string, outputDir string, users map[st
 		}
 	}
 
-	groupEntries, err := entriesByName(filepath.Join(originalRoot, "etc/group"))
-	if err != nil {
-		return err
-	}
-
-	gshadowEntries, err := entriesByName(filepath.Join(originalRoot, "etc/gshadow"))
+	// we're not going to consider any of the source groups with a GID > 1000,
+	// since those have a chance of conflicting with users that we're importing.
+	// in practice, the base snap that we're importing from shouldn't have any
+	// users/groups with a GID > 1000.
+	sourceGroups, err := parseGroups(originalRoot, func(g group) bool {
+		return g.gid < 1000
+	})
 	if err != nil {
 		return err
 	}
 
 	var groupBuffer bytes.Buffer
 	var gshadowBuffer bytes.Buffer
-	for group, entry := range groupEntries {
-		parts := strings.Split(entry, ":")
-		if len(parts) != 4 {
-			continue
-		}
-
-		if group != parts[0] {
+	for name, group := range sourceGroups {
+		if name != group.name {
 			return errors.New("internal error: group entry inconsistent with parsed data")
 		}
 
 		// if we're importing a group that already exists, we take the imported
 		// group.
-		if _, ok := groups[group]; ok {
+		if _, ok := groups[name]; ok {
 			continue
-		}
-
-		var usersInGroup []string
-		if len(parts[3]) > 0 {
-			usersInGroup = strings.Split(parts[3], ",")
 		}
 
 		// we combine the users that are already in the group with the new users
 		// that we're importing
-		usersInGroup = unique(append(usersInGroup, groupsToNewUsers[group]...))
+		usersInGroup := unique(append(group.users, groupsToNewUsers[name]...))
 		sort.Strings(usersInGroup)
 
 		usersPart := strings.Join(usersInGroup, ",")
+		parts := strings.Split(group.groupEntry, ":")
 
 		fmt.Fprintf(&groupBuffer, "%s:%s:%s:%s\n", parts[0], parts[1], parts[2], usersPart)
 
 		// if this group has a gshadow entry, we need to update the list of
 		// users there as well. not having a gshadow entry is fine, though.
-		gshadowLine := gshadowEntries[group]
-		if gshadowLine == "" {
+		if group.gshadowEntry == "" {
 			continue
 		}
 
-		gshadowParts := strings.Split(gshadowLine, ":")
+		gshadowParts := strings.Split(group.gshadowEntry, ":")
 		if len(gshadowParts) != 4 {
 			continue
 		}
@@ -188,8 +228,12 @@ func mergeAndWriteGroupFiles(originalRoot string, outputDir string, users map[st
 
 	// add the group entries for the users that we're importing. note that we
 	// don't need to mess with the users in these groups, since they're coming
-	// directly from the system we're importing from.
+	// directly from the system we're importing from
 	for _, g := range groups {
+		if g.gid != 0 && g.gid < 1000 {
+			return fmt.Errorf("internal error: cannot import system groups: %s has gid %d", g.name, g.gid)
+		}
+
 		groupBuffer.WriteString(g.groupEntry + "\n")
 		if g.gshadowEntry != "" {
 			gshadowBuffer.WriteString(g.gshadowEntry + "\n")
@@ -202,7 +246,7 @@ func mergeAndWriteGroupFiles(originalRoot string, outputDir string, users map[st
 	}
 
 	destinationGShadow := filepath.Join(outputDir, "gshadow")
-	return os.WriteFile(destinationGShadow, gshadowBuffer.Bytes(), 0644)
+	return os.WriteFile(destinationGShadow, gshadowBuffer.Bytes(), 0600)
 }
 
 // unique returns a slice with unique entries; the provided slice is modified
@@ -220,58 +264,6 @@ func unique(slice []string) []string {
 		current++
 	}
 	return slice[:current]
-}
-
-// addNamedEntriesToFile creates a new passwd or shadow file from the
-// combination of the original file and the given set of users. The given entry
-// function returns the line that should be added to the file. If an entry in
-// the original file shares the same login name as a given user's login name,
-// then the new entry is used.
-func addNamedEntriesToFile(original, destination string, users map[string]user, entry func(user) string) error {
-	f, err := os.Open(original)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-
-	var buffer bytes.Buffer
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		name, _, ok := strings.Cut(line, ":")
-		if !ok {
-			continue
-		}
-
-		// if there is a conflict in the existing file, we will use the new
-		// entry instead of the old one. this is consistent with how we handle
-		// groups, so any conflicting users will always be fully replaced.
-		if _, ok := users[name]; ok {
-			continue
-		}
-
-		buffer.WriteString(line + "\n")
-	}
-
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-
-	for _, user := range users {
-		line := entry(user)
-		if line == "" {
-			continue
-		}
-
-		buffer.WriteString(line + "\n")
-	}
-
-	return os.WriteFile(destination, buffer.Bytes(), 0644)
 }
 
 func parseUsers(root string, filter func(user) bool) (map[string]user, error) {
@@ -311,18 +303,13 @@ func parseUsers(root string, filter func(user) bool) (map[string]user, error) {
 			continue
 		}
 
-		// we're going to ignore the user's shell, since it could be anything,
-		// and that shell might not be installed in the system that we're
-		// importing this user into. if empty, /bin/sh will be used.
-		parts[6] = ""
-
 		u := user{
 			name:   name,
 			uid:    uid,
 			gid:    gid,
 			groups: userToGroups[name],
 
-			passwdEntry: strings.Join(parts, ":"),
+			passwdEntry: entry,
 			shadowEntry: shadowEntries[name],
 		}
 
@@ -395,6 +382,9 @@ func parseGroups(root string, filter func(group) bool) (map[string]group, error)
 	return groups, nil
 }
 
+// parseGroupsForUser reads the contents of a file in the style of /etc/group
+// and returns a mapping of users in the file to the groups that each user is a
+// member of.
 func parseGroupsForUser(path string) (usersToGroups map[string][]string, err error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -417,6 +407,10 @@ func parseGroupsForUser(path string) (usersToGroups map[string][]string, err err
 		}
 
 		group := parts[0]
+		if parts[3] == "" {
+			continue
+		}
+
 		users := strings.Split(parts[3], ",")
 		for _, user := range users {
 			usersToGroups[user] = append(usersToGroups[user], group)
@@ -430,6 +424,12 @@ func parseGroupsForUser(path string) (usersToGroups map[string][]string, err err
 	return usersToGroups, nil
 }
 
+// entriesByName reads the contents of a file in the style of /etc/passwd and
+// returns a mapping of the value of the first column of each line in the file
+// to the entire line.
+//
+// Parsing "user:x:1000:1000::/home/user:/bin/bash" results in:
+// "user" -> "user:x:1000:1000::/home/user:/bin/bash"
 func entriesByName(path string) (map[string]string, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
+++ b/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
@@ -199,6 +199,7 @@ root:x:0:0:root:/root:/bin/bash
 user1:x:1000:1000:user1:/home/user1:/bin/bash
 user2:x:1001:1001:user2:/home/user2:/usr/bin/fish
 user3:x:1002:1002:user3:/home/user3:/usr/bin/zsh
+noshell:x:1003:1003:noshell:/home/noshell
 
 invalid-line:
 invalid-line
@@ -209,10 +210,12 @@ user5:x:1004:invalid-gid:user5:/home/user5:/usr/bin/zsh
 	writeTempFile(c, filepath.Join(dir, "etc/group"), `
 user1:x:1000:
 user2:x:1001:
+user3:x:1002:
+noshell:x:1003:
 wheel:x:998:user1,user2
 docker:x:968:user2
 lxd:x:964:user1,user3
-sudo:x:959:user1,user2
+sudo:x:959:user1,user2,noshell
 
 invalid-line:
 invalid-line
@@ -223,6 +226,7 @@ root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::
 user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::
 user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::
 user3:028deb5e54d669e73be35cb5a96eb35b:19839:0:99999:7:::
+noshell:1cc7b5ea6a765492910b611f5760929f:19840:0:99999:7:::
 
 invalid-line:
 invalid-line
@@ -265,6 +269,16 @@ invalid-line
 			groups:      []string{"lxd"},
 			passwdEntry: "user3:x:1002:1002:user3:/home/user3:/usr/bin/zsh",
 			shadowEntry: "user3:028deb5e54d669e73be35cb5a96eb35b:19839:0:99999:7:::",
+		},
+		// we handle importing users that omit the last colon in the passwd
+		// entry
+		"noshell": {
+			name:        "noshell",
+			uid:         1003,
+			gid:         1003,
+			groups:      []string{"sudo"},
+			passwdEntry: "noshell:x:1003:1003:noshell:/home/noshell",
+			shadowEntry: "noshell:1cc7b5ea6a765492910b611f5760929f:19840:0:99999:7:::",
 		},
 	})
 
@@ -623,6 +637,16 @@ user3:dc9b7b7b631aadd960231f4880923d0f:19839:0:99999:7:::
 			passwdEntry: "user2:x:1001:1001:user2:/home/user2:/usr/bin/fish",
 			shadowEntry: "user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
 		},
+		// we handle importing users that omit the last colon in the passwd
+		// entry
+		"noshell": {
+			name:        "noshell",
+			uid:         1002,
+			gid:         1002,
+			groups:      []string{"sudo"},
+			passwdEntry: "noshell:x:1002:1002:noshell:/home/noshell",
+			shadowEntry: "noshell:1cc7b5ea6a765492910b611f5760929f:19839:0:99999:7:::",
+		},
 	}
 
 	err = mergeAndWriteUserFiles(dir, dest, users)
@@ -636,6 +660,7 @@ user3:dc9b7b7b631aadd960231f4880923d0f:19839:0:99999:7:::
 		"lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false",
 		"user1:x:1000:1000:user1:/home/user1:/bin/bash",
 		"user2:x:1001:1001:user2:/home/user2:/bin/bash",
+		"noshell:x:1002:1002:noshell:/home/noshell:/bin/bash",
 	})
 	assertFileHasPermissions(c, filepath.Join(dest, "passwd"), 0644)
 
@@ -644,6 +669,7 @@ user3:dc9b7b7b631aadd960231f4880923d0f:19839:0:99999:7:::
 		"lxd:!:19838:0:99999:7:::",
 		"user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
 		"user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
+		"noshell:1cc7b5ea6a765492910b611f5760929f:19839:0:99999:7:::",
 	})
 	assertFileHasPermissions(c, filepath.Join(dest, "shadow"), 0600)
 }

--- a/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
+++ b/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
@@ -1,0 +1,872 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type hybridUserImportSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&hybridUserImportSuite{})
+
+func (s *hybridUserImportSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func assertFileHasPermissions(c *C, path string, perms os.FileMode) {
+	fi, err := os.Stat(path)
+	c.Assert(err, IsNil)
+	c.Check(fi.Mode(), Equals, perms)
+}
+
+func assertLinesInFile(c *C, path string, lines []string) {
+	contents, err := os.ReadFile(path)
+	c.Assert(err, IsNil)
+
+	split := strings.Split(string(contents), "\n")
+
+	// +1 for the trailing newline
+	c.Assert(split, HasLen, len(lines)+1)
+
+	c.Check(split[:len(lines)], testutil.DeepUnsortedMatches, lines)
+	c.Check(split[len(lines)], Equals, "")
+}
+
+func writeTempFile(c *C, path string, content string) string {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, IsNil)
+
+	f, err := os.Create(path)
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	_, err = f.WriteString(content)
+	c.Assert(err, IsNil)
+
+	return f.Name()
+}
+
+func (s *hybridUserImportSuite) TestEntriesByName(c *C) {
+	path := writeTempFile(c, filepath.Join(c.MkDir(), "passwd"), `
+root:x:0:0:root:/root:/bin/bash
+user1:x:1:1:user1:/home/user1:/bin/bash
+user2:x:2:2:user2:/home/user2:/bin/bash
+user3:x:3:3:user3:/home/user3:/bin/bash
+
+invalid-line
+`)
+
+	entries, err := entriesByName(path)
+	c.Assert(err, IsNil)
+
+	c.Assert(entries, DeepEquals, map[string]string{
+		"root":  "root:x:0:0:root:/root:/bin/bash",
+		"user1": "user1:x:1:1:user1:/home/user1:/bin/bash",
+		"user2": "user2:x:2:2:user2:/home/user2:/bin/bash",
+		"user3": "user3:x:3:3:user3:/home/user3:/bin/bash",
+	})
+}
+
+func (s *hybridUserImportSuite) TestParseUsersForGroup(c *C) {
+	path := writeTempFile(c, filepath.Join(c.MkDir(), "group"), `
+user1:x:1000:
+user2:x:1001:
+wheel:x:998:user1,user2
+docker:x:968:user2
+lxd:x:964:user1
+sudo:x:959:user1,user2
+
+invalid-line:
+invalid-line
+`)
+
+	usersToGroups, err := parseGroupsForUser(path)
+	c.Assert(err, IsNil)
+
+	c.Assert(usersToGroups, DeepEquals, map[string][]string{
+		"user1": {"wheel", "lxd", "sudo"},
+		"user2": {"wheel", "docker", "sudo"},
+	})
+}
+
+func (s *hybridUserImportSuite) TestParseGroups(c *C) {
+	dir := c.MkDir()
+	writeTempFile(c, filepath.Join(dir, "etc/group"), `
+user1:x:1000:
+user2:x:1001:
+wheel:x:998:user1,user2
+docker:x:968:user2
+lxd:x:964:user1
+sudo:x:959:user1,user2
+user0:x:invalid-gid:
+
+invalid-line:
+invalid-line
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/gshadow"), `
+user1:!::
+user2:!::
+wheel:!::user1,user2
+docker:!::user2
+lxd:!::user1
+sudo:!::user1,user2
+
+invalid-line:
+invalid-line
+`)
+
+	groups, err := parseGroups(dir, func(group) bool {
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	c.Assert(groups, DeepEquals, map[string]group{
+		"user1": {
+			name:         "user1",
+			gid:          1000,
+			users:        nil,
+			groupEntry:   "user1:x:1000:",
+			gshadowEntry: "user1:!::",
+		},
+		"user2": {
+			name:         "user2",
+			gid:          1001,
+			users:        nil,
+			groupEntry:   "user2:x:1001:",
+			gshadowEntry: "user2:!::",
+		},
+		"wheel": {
+			name:         "wheel",
+			gid:          998,
+			users:        []string{"user1", "user2"},
+			groupEntry:   "wheel:x:998:user1,user2",
+			gshadowEntry: "wheel:!::user1,user2",
+		},
+		"docker": {
+			name:         "docker",
+			gid:          968,
+			users:        []string{"user2"},
+			groupEntry:   "docker:x:968:user2",
+			gshadowEntry: "docker:!::user2",
+		},
+		"lxd": {
+			name:         "lxd",
+			gid:          964,
+			users:        []string{"user1"},
+			groupEntry:   "lxd:x:964:user1",
+			gshadowEntry: "lxd:!::user1",
+		},
+		"sudo": {
+			name:         "sudo",
+			gid:          959,
+			users:        []string{"user1", "user2"},
+			groupEntry:   "sudo:x:959:user1,user2",
+			gshadowEntry: "sudo:!::user1,user2",
+		},
+	})
+
+	groups, err = parseGroups(dir, func(g group) bool {
+		return g.name == "sudo"
+	})
+	c.Assert(err, IsNil)
+
+	c.Assert(groups, DeepEquals, map[string]group{
+		"sudo": {
+			name:         "sudo",
+			gid:          959,
+			users:        []string{"user1", "user2"},
+			groupEntry:   "sudo:x:959:user1,user2",
+			gshadowEntry: "sudo:!::user1,user2",
+		},
+	})
+}
+
+func (s *hybridUserImportSuite) TestParseUsers(c *C) {
+	dir := c.MkDir()
+	writeTempFile(c, filepath.Join(dir, "etc/passwd"), `
+root:x:0:0:root:/root:/bin/bash
+user1:x:1000:1000:user1:/home/user1:/bin/bash
+user2:x:1001:1001:user2:/home/user2:/usr/bin/fish
+user3:x:1002:1002:user3:/home/user3:/usr/bin/zsh
+
+invalid-line:
+invalid-line
+user4:x:invalid-uid:1003:user4:/home/user4:/usr/bin/zsh
+user5:x:1004:invalid-gid:user5:/home/user5:/usr/bin/zsh
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/group"), `
+user1:x:1000:
+user2:x:1001:
+wheel:x:998:user1,user2
+docker:x:968:user2
+lxd:x:964:user1,user3
+sudo:x:959:user1,user2
+
+invalid-line:
+invalid-line
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/shadow"), `
+root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::
+user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::
+user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::
+user3:028deb5e54d669e73be35cb5a96eb35b:19839:0:99999:7:::
+
+invalid-line:
+invalid-line
+`)
+
+	users, err := parseUsers(dir, func(user) bool {
+		return true
+	})
+	c.Assert(err, IsNil)
+
+	c.Assert(users, DeepEquals, map[string]user{
+		"root": {
+			name:        "root",
+			uid:         0,
+			gid:         0,
+			groups:      nil,
+			passwdEntry: "root:x:0:0:root:/root:/bin/bash",
+			shadowEntry: "root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		},
+		"user1": {
+			name:        "user1",
+			uid:         1000,
+			gid:         1000,
+			groups:      []string{"wheel", "lxd", "sudo"},
+			passwdEntry: "user1:x:1000:1000:user1:/home/user1:/bin/bash",
+			shadowEntry: "user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		},
+		"user2": {
+			name:        "user2",
+			uid:         1001,
+			gid:         1001,
+			groups:      []string{"wheel", "docker", "sudo"},
+			passwdEntry: "user2:x:1001:1001:user2:/home/user2:/usr/bin/fish",
+			shadowEntry: "user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
+		},
+		"user3": {
+			name:        "user3",
+			uid:         1002,
+			gid:         1002,
+			groups:      []string{"lxd"},
+			passwdEntry: "user3:x:1002:1002:user3:/home/user3:/usr/bin/zsh",
+			shadowEntry: "user3:028deb5e54d669e73be35cb5a96eb35b:19839:0:99999:7:::",
+		},
+	})
+
+	users, err = parseUsers(dir, func(u user) bool {
+		return u.name == "user1"
+	})
+	c.Assert(err, IsNil)
+
+	c.Assert(users, DeepEquals, map[string]user{
+		"user1": {
+			name:        "user1",
+			uid:         1000,
+			gid:         1000,
+			groups:      []string{"wheel", "lxd", "sudo"},
+			passwdEntry: "user1:x:1000:1000:user1:/home/user1:/bin/bash",
+			shadowEntry: "user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		},
+	})
+}
+
+func (s *hybridUserImportSuite) TestFilterUsers(c *C) {
+	users := map[string]user{
+		"root": {
+			name: "root",
+			uid:  0,
+			gid:  0,
+		},
+		"user1": {
+			name:   "user1",
+			uid:    1000,
+			gid:    1000,
+			groups: []string{"wheel", "lxd", "sudo"},
+		},
+		"user2": {
+			name:   "user2",
+			uid:    1001,
+			gid:    1001,
+			groups: []string{"wheel", "docker", "admin"},
+		},
+		"user3": {
+			name:   "user3",
+			uid:    1002,
+			gid:    1002,
+			groups: []string{"lxd"},
+		},
+		"system-gid": {
+			name: "system-gid",
+			uid:  1002,
+			gid:  998,
+		},
+		"lxd": {
+			name: "lxd",
+			uid:  999,
+			gid:  999,
+		},
+	}
+
+	targets := []string{"admin", "sudo"}
+	filter := userFilter(targets)
+	c.Assert(filter(users["root"]), Equals, true)
+	c.Assert(filter(users["user1"]), Equals, true)
+	c.Assert(filter(users["user2"]), Equals, true)
+	c.Assert(filter(users["user3"]), Equals, false)
+	c.Assert(filter(users["system-gid"]), Equals, false)
+	c.Assert(filter(users["lxd"]), Equals, false)
+}
+
+func (s *hybridUserImportSuite) TestFilterGroups(c *C) {
+	groups := map[string]group{
+		"root": {
+			name: "root",
+			gid:  0,
+		},
+		"user1": {
+			name: "user1",
+			gid:  1000,
+		},
+		"user2": {
+			name: "user2",
+			gid:  1001,
+		},
+		"user3": {
+			name: "user3",
+			gid:  1002,
+		},
+		"docker": {
+			name: "docker",
+			gid:  999,
+		},
+	}
+
+	users := map[string]user{
+		"root": {
+			name: "root",
+			uid:  0,
+			gid:  0,
+		},
+		"user1": {
+			name:   "user1",
+			uid:    1000,
+			gid:    1000,
+			groups: []string{"wheel", "lxd", "sudo"},
+		},
+		"user2": {
+			name:   "user2",
+			uid:    1001,
+			gid:    1001,
+			groups: []string{"wheel", "docker", "admin"},
+		},
+	}
+	filter := groupFilter(users)
+
+	c.Assert(filter(groups["root"]), Equals, true)
+	c.Assert(filter(groups["user1"]), Equals, true)
+	c.Assert(filter(groups["user2"]), Equals, true)
+	c.Assert(filter(groups["user3"]), Equals, false)
+	c.Assert(filter(groups["docker"]), Equals, false)
+}
+
+func (s *hybridUserImportSuite) TestMergeAndWriteGroupFiles(c *C) {
+	dir := c.MkDir()
+	writeTempFile(c, filepath.Join(dir, "etc/group"), `
+root:x:0:
+ignored:x:1000:
+wheel:x:998:user1
+docker:x:968:
+lxd:x:964:
+sudo:x:959:
+user1:x:999:
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/gshadow"), `
+root:::
+ignored:!::
+wheel:!::user1
+docker:!::
+sudo:!::
+user1:!::
+`)
+
+	dest := filepath.Join(dir, "etc-merged")
+	err := os.MkdirAll(dest, 0755)
+	c.Assert(err, IsNil)
+
+	users := map[string]user{
+		"root": {
+			name:        "root",
+			uid:         0,
+			gid:         0,
+			passwdEntry: "root:x:0:0:root:/root:",
+			shadowEntry: "root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		},
+		"user1": {
+			name:        "user1",
+			uid:         1000,
+			gid:         1000,
+			groups:      []string{"wheel", "lxd", "sudo"},
+			passwdEntry: "user1:x:1000:1000:user1:/home/user1:",
+			shadowEntry: "user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		},
+		"user2": {
+			name:        "user2",
+			uid:         1001,
+			gid:         1001,
+			groups:      []string{"wheel", "docker", "sudo"},
+			passwdEntry: "user2:x:1001:1001:user2:/home/user2:",
+			shadowEntry: "user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
+		},
+	}
+
+	groups := map[string]group{
+		"root": {
+			name:         "root",
+			gid:          0,
+			groupEntry:   "root:x:0:",
+			gshadowEntry: "root:!::",
+		},
+		"user1": {
+			name:         "user1",
+			gid:          1000,
+			groupEntry:   "user1:x:1000:",
+			gshadowEntry: "user1:!::",
+		},
+		"user2": {
+			name:         "user2",
+			gid:          1001,
+			groupEntry:   "user2:x:1001:",
+			gshadowEntry: "user2:!::",
+		},
+	}
+
+	err = mergeAndWriteGroupFiles(dir, dest, users, groups)
+	c.Assert(err, IsNil)
+
+	assertLinesInFile(c, filepath.Join(dest, "group"), []string{
+		"root:x:0:",
+		"wheel:x:998:user1,user2",
+		"docker:x:968:user2",
+		"lxd:x:964:user1",
+		"sudo:x:959:user1,user2",
+		"user1:x:1000:",
+		"user2:x:1001:",
+	})
+	assertFileHasPermissions(c, filepath.Join(dest, "group"), 0644)
+
+	assertLinesInFile(c, filepath.Join(dest, "gshadow"), []string{
+		"root:!::",
+		"wheel:!::user1,user2",
+		"docker:!::user2",
+		"sudo:!::user1,user2",
+		"user1:!::",
+		"user2:!::",
+	})
+	assertFileHasPermissions(c, filepath.Join(dest, "gshadow"), 0600)
+}
+
+func (s *hybridUserImportSuite) TestMergeAndWriteGroupFilesSharedPrimary(c *C) {
+	dir := c.MkDir()
+	writeTempFile(c, filepath.Join(dir, "etc/group"), `
+root:x:0:
+wheel:x:998:
+docker:x:968:
+lxd:x:964:
+sudo:x:959:
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/gshadow"), `
+root:::
+wheel:!::
+docker:!::
+sudo:!::
+`)
+
+	dest := filepath.Join(dir, "etc-merged")
+	err := os.MkdirAll(dest, 0755)
+	c.Assert(err, IsNil)
+
+	users := map[string]user{
+		"root": {
+			name:        "root",
+			uid:         0,
+			gid:         0,
+			passwdEntry: "root:x:0:0:root:/root:",
+			shadowEntry: "root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		},
+		"user1": {
+			name:        "user1",
+			uid:         1001,
+			gid:         1000,
+			groups:      []string{"wheel", "lxd", "sudo"},
+			passwdEntry: "user1:x:1001:1000:user1:/home/user1:",
+			shadowEntry: "user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		},
+		"user2": {
+			name:        "user2",
+			uid:         1002,
+			gid:         1000,
+			groups:      []string{"wheel", "docker", "sudo"},
+			passwdEntry: "user2:x:1002:1000:user2:/home/user2:",
+			shadowEntry: "user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
+		},
+	}
+
+	groups := map[string]group{
+		"root": {
+			name:         "root",
+			gid:          0,
+			groupEntry:   "root:x:0:",
+			gshadowEntry: "root:!::",
+		},
+		"primary": {
+			name:         "primary",
+			gid:          1000,
+			groupEntry:   "primary:x:1000:",
+			gshadowEntry: "primary:!::",
+		},
+	}
+
+	err = mergeAndWriteGroupFiles(dir, dest, users, groups)
+	c.Assert(err, IsNil)
+
+	assertLinesInFile(c, filepath.Join(dest, "group"), []string{
+		"root:x:0:",
+		"wheel:x:998:user1,user2",
+		"docker:x:968:user2",
+		"lxd:x:964:user1",
+		"sudo:x:959:user1,user2",
+		"primary:x:1000:",
+	})
+	assertFileHasPermissions(c, filepath.Join(dest, "group"), 0644)
+
+	assertLinesInFile(c, filepath.Join(dest, "gshadow"), []string{
+		"root:!::",
+		"wheel:!::user1,user2",
+		"docker:!::user2",
+		"sudo:!::user1,user2",
+		"primary:!::",
+	})
+	assertFileHasPermissions(c, filepath.Join(dest, "gshadow"), 0600)
+}
+
+func (s *hybridUserImportSuite) TestMergeAndWriteGroupFilesFailToImportSystemGroup(c *C) {
+	dir := c.MkDir()
+	writeTempFile(c, filepath.Join(dir, "etc/group"), `
+root:x:0:
+sudo:x:959:
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/gshadow"), `
+root:::
+sudo:!::
+`)
+
+	dest := filepath.Join(dir, "etc-merged")
+	err := os.MkdirAll(dest, 0755)
+	c.Assert(err, IsNil)
+
+	users := map[string]user{
+		"root": {
+			name:        "root",
+			uid:         0,
+			gid:         0,
+			passwdEntry: "root:x:0:0:root:/root:",
+			shadowEntry: "root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		},
+		"user1": {
+			name:        "user1",
+			uid:         1000,
+			gid:         999,
+			groups:      []string{"sudo"},
+			passwdEntry: "user1:x:1000:999:user1:/home/user1:",
+			shadowEntry: "user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		},
+	}
+
+	groups := map[string]group{
+		"root": {
+			name:         "root",
+			gid:          0,
+			groupEntry:   "root:x:0:",
+			gshadowEntry: "root:!::",
+		},
+		"user1": {
+			name:         "user1",
+			gid:          999,
+			groupEntry:   "user1:x:999:",
+			gshadowEntry: "user1:!::",
+		},
+	}
+
+	err = mergeAndWriteGroupFiles(dir, dest, users, groups)
+	c.Assert(err, ErrorMatches, "internal error: cannot import system groups: user1 has gid 999")
+}
+
+func (s *hybridUserImportSuite) TestMergeAndWriteUserFiles(c *C) {
+	dir := c.MkDir()
+	writeTempFile(c, filepath.Join(dir, "etc/passwd"), `
+root:x:0:0:root:/root:/bin/bash
+user1:x:1010:1010:user1:/home/user1:/bin/bash
+lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false
+user3:x:1011:1011:user3:/home/user3:/bin/bash
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/group"), `
+root:x:0:
+wheel:x:998:
+docker:x:968:
+lxd:x:964:
+sudo:x:959:
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/shadow"), `
+root:!:19836:0:99999:7:::
+user1:28n4517315osn7oqn8sqpso2s1s1q042:19837:0:99999:7:::
+lxd:!:19838:0:99999:7:::
+user3:dc9b7b7b631aadd960231f4880923d0f:19839:0:99999:7:::
+`)
+
+	dest := filepath.Join(dir, "etc-merged")
+	err := os.MkdirAll(dest, 0755)
+	c.Assert(err, IsNil)
+
+	// root will replace the original root, user1 will also replace the original
+	// user1. user2 will be directly imported. user3 will be dropped despite
+	// being in the original file, since we don't want to import non-system
+	// users.
+	users := map[string]user{
+		"root": {
+			name:        "root",
+			uid:         0,
+			gid:         0,
+			groups:      nil,
+			passwdEntry: "root:x:0:0:root:/root:/bin/bash",
+			shadowEntry: "root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		},
+		"user1": {
+			name:        "user1",
+			uid:         1000,
+			gid:         1000,
+			groups:      []string{"wheel", "lxd", "sudo"},
+			passwdEntry: "user1:x:1000:1000:user1:/home/user1:/bin/bash",
+			shadowEntry: "user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		},
+		"user2": {
+			name:        "user2",
+			uid:         1001,
+			gid:         1001,
+			groups:      []string{"wheel", "docker", "sudo"},
+			passwdEntry: "user2:x:1001:1001:user2:/home/user2:/usr/bin/fish",
+			shadowEntry: "user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
+		},
+	}
+
+	err = mergeAndWriteUserFiles(dir, dest, users)
+	c.Assert(err, IsNil)
+
+	// note that users lost their shells. we're not importing them since they
+	// might not be installed on the system that we're importing into.
+	assertLinesInFile(c, filepath.Join(dest, "passwd"), []string{
+		"root:x:0:0:root:/root:",
+		"lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false",
+		"user1:x:1000:1000:user1:/home/user1:",
+		"user2:x:1001:1001:user2:/home/user2:",
+	})
+	assertFileHasPermissions(c, filepath.Join(dest, "passwd"), 0644)
+
+	assertLinesInFile(c, filepath.Join(dest, "shadow"), []string{
+		"root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		"lxd:!:19838:0:99999:7:::",
+		"user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		"user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
+	})
+	assertFileHasPermissions(c, filepath.Join(dest, "shadow"), 0600)
+}
+
+func (s *hybridUserImportSuite) TestMergeAndWriteUserFilesFailToImportSystemUser(c *C) {
+	dir := c.MkDir()
+	writeTempFile(c, filepath.Join(dir, "etc/passwd"), `
+root:x:0:0:root:/root:/bin/bash
+lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/group"), `
+root:x:0:
+wheel:x:998:
+docker:x:968:
+lxd:x:964:
+sudo:x:959:
+`)
+
+	writeTempFile(c, filepath.Join(dir, "etc/shadow"), `
+root:!:19836:0:99999:7:::
+lxd:!:19838:0:99999:7:::
+`)
+
+	dest := filepath.Join(dir, "etc-merged")
+	err := os.MkdirAll(dest, 0755)
+	c.Assert(err, IsNil)
+
+	users := map[string]user{
+		"root": {
+			name:        "root",
+			uid:         0,
+			gid:         0,
+			groups:      nil,
+			passwdEntry: "root:x:0:0:root:/root:/bin/bash",
+			shadowEntry: "root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		},
+		"user1": {
+			name:        "user1",
+			uid:         999,
+			gid:         999,
+			groups:      []string{"wheel", "lxd", "sudo"},
+			passwdEntry: "user1:x:999:999:user1:/home/user1:/bin/bash",
+			shadowEntry: "user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		},
+	}
+
+	err = mergeAndWriteUserFiles(dir, dest, users)
+	c.Assert(err, ErrorMatches, "internal error: cannot import system users: user1 has uid 999 and gid 999")
+}
+
+func (s *hybridUserImportSuite) TestImportHybridUserData(c *C) {
+	base := c.MkDir()
+	writeTempFile(c, filepath.Join(base, "etc/passwd"), `
+root:x:0:0:root:/root:/bin/bash
+lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false
+`)
+
+	writeTempFile(c, filepath.Join(base, "etc/group"), `
+root:x:0:
+wheel:x:998:
+docker:x:968:
+lxd:x:964:
+sudo:x:959:
+admin:x:960:
+`)
+
+	writeTempFile(c, filepath.Join(base, "etc/shadow"), `
+root:!:19836:0:99999:7:::
+lxd:!:19838:0:99999:7:::
+`)
+
+	writeTempFile(c, filepath.Join(base, "etc/gshadow"), `
+wheel:!::
+root:::
+docker:!::
+lxd:!::
+sudo:!::
+admin:!::
+`)
+
+	hybrid := c.MkDir()
+	writeTempFile(c, filepath.Join(hybrid, "etc/passwd"), `
+root:x:0:0:root:/root:/bin/bash
+user1:x:1000:1000:user1:/home/user1:/bin/bash
+user2:x:1001:1001:user2:/home/user2:/usr/bin/fish
+user3:x:999:999:user3:/home/user3:/usr/bin/zsh
+`)
+
+	writeTempFile(c, filepath.Join(hybrid, "etc/group"), `
+root:x:0:
+wheel:x:898:user1,user2,user3
+docker:x:868:user2
+lxd:x:864:user1
+sudo:x:859:user1
+admin:x:860:user2
+user1:x:1000:
+user2:x:1001:
+user3:x:999:
+`)
+
+	writeTempFile(c, filepath.Join(hybrid, "etc/shadow"), `
+root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::
+user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::
+user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::
+user3:028deb5e54d669e73be35cb5a96eb35b:19839:0:99999:7:::
+`)
+
+	writeTempFile(c, filepath.Join(hybrid, "etc/gshadow"), `
+wheel:!::user1,user2,user3
+root:!::
+docker:!::user2
+lxd:!::user1
+sudo:!::user1
+admin:!::user2
+user1:!::
+user2:!::
+user3:!::
+`)
+
+	// user1 should be imported since it is in the sudo group. user1 should be
+	// added to the wheel, lxd, and sudo groups.
+	//
+	// user2 should be imported since it is in the admin group. user2 should be
+	// added to the wheel, admin and docker groups.
+	//
+	// user3 should not be imported, since it is not in either the sudo or admin
+	// groups.
+	err := importHybridUserData(hybrid, base)
+	c.Assert(err, IsNil)
+
+	output := filepath.Join(dirs.SnapRunDir, "hybrid-users")
+
+	assertLinesInFile(c, filepath.Join(output, "passwd"), []string{
+		"root:x:0:0:root:/root:",
+		"lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false",
+		"user1:x:1000:1000:user1:/home/user1:",
+		"user2:x:1001:1001:user2:/home/user2:",
+	})
+	assertFileHasPermissions(c, filepath.Join(output, "passwd"), 0644)
+
+	assertLinesInFile(c, filepath.Join(output, "group"), []string{
+		"root:x:0:",
+		"wheel:x:998:user1,user2",
+		"docker:x:968:user2",
+		"lxd:x:964:user1",
+		"sudo:x:959:user1",
+		"admin:x:960:user2",
+		"user1:x:1000:",
+		"user2:x:1001:",
+	})
+	assertFileHasPermissions(c, filepath.Join(output, "group"), 0644)
+
+	assertLinesInFile(c, filepath.Join(output, "shadow"), []string{
+		"root:d41d8cd98f00b204e9800998ecf8427e:19836:0:99999:7:::",
+		"lxd:!:19838:0:99999:7:::",
+		"user1:28a4517315bfa7bda8fdcfb2f1f1d042:19837:0:99999:7:::",
+		"user2:5177bcdd67b77a393852bb5ae47ee416:19838:0:99999:7:::",
+	})
+	assertFileHasPermissions(c, filepath.Join(output, "shadow"), 0600)
+
+	assertLinesInFile(c, filepath.Join(output, "gshadow"), []string{
+		"wheel:!::user1,user2",
+		"root:!::",
+		"docker:!::user2",
+		"lxd:!::user1",
+		"sudo:!::user1",
+		"admin:!::user2",
+		"user1:!::",
+		"user2:!::",
+	})
+	assertFileHasPermissions(c, filepath.Join(output, "gshadow"), 0600)
+
+}

--- a/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
+++ b/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
@@ -1009,3 +1009,9 @@ func (s *hybridUserImportSuite) TestParseShells(c *C) {
 		"/bin/ksh",
 	})
 }
+
+func (s *hybridUserImportSuite) TestParseShellsWithDefaults(c *C) {
+	defaults := []string{"/bin/dash", "/bin/bash"}
+	shells := parseShellsWithDefaults(c.MkDir(), defaults)
+	c.Assert(shells, DeepEquals, defaults)
+}

--- a/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
+++ b/cmd/snap-bootstrap/hybrid_users_import_internal_test.go
@@ -681,13 +681,14 @@ user3:dc9b7b7b631aadd960231f4880923d0f:19839:0:99999:7:::
 	err = mergeAndWriteUserFiles(dir, dest, users)
 	c.Assert(err, IsNil)
 
-	// note that users lost their shells. we're not importing them since they
-	// might not be installed on the system that we're importing into.
+	// note that the imported users had their default shells changed to
+	// /bin/bash, since we can't guarantee that the original shells are
+	// installed on the system that we're importing into.
 	assertLinesInFile(c, filepath.Join(dest, "passwd"), []string{
-		"root:x:0:0:root:/root:",
+		"root:x:0:0:root:/root:/bin/bash",
 		"lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false",
-		"user1:x:1000:1000:user1:/home/user1:",
-		"user2:x:1001:1001:user2:/home/user2:",
+		"user1:x:1000:1000:user1:/home/user1:/bin/bash",
+		"user2:x:1001:1001:user2:/home/user2:/bin/bash",
 	})
 	assertFileHasPermissions(c, filepath.Join(dest, "passwd"), 0644)
 
@@ -830,10 +831,10 @@ user3:!::
 	output := filepath.Join(dirs.SnapRunDir, "hybrid-users")
 
 	assertLinesInFile(c, filepath.Join(output, "passwd"), []string{
-		"root:x:0:0:root:/root:",
+		"root:x:0:0:root:/root:/bin/bash",
 		"lxd:x:964:984::/var/snap/lxd/common/lxd:/bin/false",
-		"user1:x:1000:1000:user1:/home/user1:",
-		"user2:x:1001:1001:user2:/home/user2:",
+		"user1:x:1000:1000:user1:/home/user1:/bin/bash",
+		"user2:x:1001:1001:user2:/home/user2:/bin/bash",
 	})
 	assertFileHasPermissions(c, filepath.Join(output, "passwd"), 0644)
 

--- a/tests/lib/muinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/muinstaller/mk-classic-rootfs.sh
@@ -64,8 +64,11 @@ EOF
 	fi
     fi
 
-    # ensure we can login
+    # ensure we can login. since when booting into recovery mode, we import
+    # users from the host system that are in the sudo and admin groups, we make
+    # sure to add our user to the sudo group.
     sudo chroot "$DESTDIR" /usr/sbin/adduser --disabled-password --gecos "" user1
+    sudo chroot "$DESTDIR" /usr/sbin/adduser user1 sudo
     printf "ubuntu\nubuntu\n" | sudo chroot "$DESTDIR" /usr/bin/passwd user1
     echo "user1 ALL=(ALL) NOPASSWD:ALL" | sudo tee -a "$DESTDIR"/etc/sudoers
 

--- a/tests/lib/muinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/muinstaller/mk-classic-rootfs.sh
@@ -64,10 +64,11 @@ EOF
 	fi
     fi
 
-    # ensure we can login. since when booting into recovery mode, we import
-    # users from the host system that are in the sudo and admin groups, we make
-    # sure to add our user to the sudo group.
+    # ensure we can login.
     sudo chroot "$DESTDIR" /usr/sbin/adduser --disabled-password --gecos "" user1
+    # since when booting into recovery mode, we import users from the host
+    # system that are in the sudo and admin groups, we make sure to add our user
+    # to the sudo group.
     sudo chroot "$DESTDIR" /usr/sbin/adduser user1 sudo
     printf "ubuntu\nubuntu\n" | sudo chroot "$DESTDIR" /usr/bin/passwd user1
     echo "user1 ALL=(ALL) NOPASSWD:ALL" | sudo tee -a "$DESTDIR"/etc/sudoers

--- a/tests/nested/manual/muinstaller-real/extra-paths
+++ b/tests/nested/manual/muinstaller-real/extra-paths
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -eu
+
+cat <<'EOF' >>/sysroot/etc/fstab
+/run/mnt/data /writable none bind,x-initrd.mount 0 0
+EOF
+
+# Find out kernel name / revision
+kernelPath=$(cat /sys/dev/block/"$(mountpoint --fs-devno /run/mnt/kernel)"/loop/backing_file)
+kernelFile=$(basename "$kernelPath")
+kernelName=${kernelFile%%_*}
+rev=${kernelFile#*_}
+rev=${rev%%.*}
+
+# Mount /lib/{firmware,modules} only if there is no drivers tree created by snapd
+if [ ! -d /run/mnt/data/system-data/var/lib/snapd/kernel/"$kernelName"/"$rev" ]; then
+    cat <<'EOF' >>/sysroot/etc/fstab
+/run/mnt/kernel/firmware /usr/lib/firmware none bind,x-initrd.mount 0 0
+/run/mnt/kernel/modules /usr/lib/modules none bind,x-initrd.mount 0 0
+EOF
+fi
+
+# in recovery mode on hybrid systems, snap-bootstrap generates passwd, shadow,
+# group, and gshadow files in /run/snapd/hybrid-users. these files contain users
+# imported from the host system mixed with the default users from the base snap
+# that is used for recovery mode.
+mode="$(/usr/libexec/core/get-mode mode)" || mode="$(/usr/libexec/core/get-arg snapd_recovery_mode)" || mode="unknown"
+if [ -f /run/snapd/hybrid-users/passwd ] && [ "${mode}" = "recover" ]; then
+    cat <<'EOF' >>/sysroot/etc/fstab
+/run/snapd/hybrid-users/passwd /etc/passwd none bind 0 0
+/run/snapd/hybrid-users/shadow /etc/shadow none bind 0 0
+/run/snapd/hybrid-users/group /etc/group none bind 0 0
+/run/snapd/hybrid-users/gshadow /etc/gshadow none bind 0 0
+EOF
+fi

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -307,3 +307,22 @@ execute: |
 
   # model in the seed should match the one that was installed on the system
   remote.exec "diff <(snap model --assertion) /run/mnt/ubuntu-seed/systems/classic/model"
+
+  boot_id=$(remote.exec "cat /proc/sys/kernel/random/boot_id")
+  remote.exec "sudo snap reboot --recover classic"
+  remote.wait-for reboot "${boot_id}"
+
+  # we explicitly provide a password since the sudo group is not configured to
+  # allow passwordless sudo
+  timeout -v 300 remote.exec "echo ubuntu | sudo -S snap wait system seed.loaded"
+
+  remote.exec "groups" | tr ' ' '\n' | sort | xargs | MATCH 'sudo user1'
+
+  remote.exec "snap list" > snap-list
+  for name in pc pc-kernel snapd core22; do
+    MATCH "${name}" < snap-list
+  done
+
+  for name in passwd shadow group gshadow; do
+    remote.exec "findmnt -n /etc/${name}" | awk '{ print $2 }' | MATCH "tmpfs\[/snapd/hybrid-users/${name}\]"
+  done

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -248,9 +248,9 @@ execute: |
 
   # Make sure we installed the new grub
   if os.query is-ubuntu-ge 24.04 && [ "$PARTIAL_GADGET" = false ]; then
-    remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-seed/EFI/ubuntu/grubx64.efi'
+      remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-seed/EFI/ubuntu/grubx64.efi'
   else
-    remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi'
+      remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi'
   fi
   remote.exec 'grep "This program cannot be run in XXX mode" /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi'
 
@@ -325,9 +325,9 @@ execute: |
 
   remote.exec "snap list" > snap-list
   for name in pc pc-kernel snapd core22; do
-    MATCH "${name}" < snap-list
+      MATCH "${name}" < snap-list
   done
 
   for name in passwd shadow group gshadow; do
-    remote.exec "findmnt -n /etc/${name}" | awk '{ print $2 }' | MATCH "tmpfs\[/snapd/hybrid-users/${name}\]"
+      remote.exec "findmnt -n /etc/${name}" | awk '{ print $2 }' | MATCH "tmpfs\[/snapd/hybrid-users/${name}\]"
   done

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -292,7 +292,7 @@ execute: |
 
   # check that seed is properly installed
   remote.exec test -d /run/mnt/ubuntu-seed/systems/classic
-  remote.exec "sudo snap recovery" | MATCH 'classic\s+developer1\s+developer1-22-classic-dangerous\s+current'
+  remote.exec "sudo snap recovery" | MATCH "classic\s+developer1\s+developer1-${version}-classic-dangerous\s+current"
 
   echo "unasserted snaps"
   remote.exec "ls /run/mnt/ubuntu-seed/systems/classic/snaps"
@@ -302,13 +302,13 @@ execute: |
 
   # check for unasserted snaps
   for sn in pc pc-kernel snapd; do
-      version=$(remote.exec "snap list ${sn}" | awk 'NR != 1 { print $2 }' | sed 's/+fake1//')
-      remote.exec "test -f /run/mnt/ubuntu-seed/systems/classic/snaps/${sn}_${version}.snap"
+      sn_version=$(remote.exec "snap list ${sn}" | awk 'NR != 1 { print $2 }' | sed 's/+fake1//')
+      remote.exec "test -f /run/mnt/ubuntu-seed/systems/classic/snaps/${sn}_${sn_version}.snap"
   done
 
   # check for asserted snaps
-  core22_rev=$(remote.exec "snap list core22" | awk 'NR != 1 { print $3 }')
-  remote.exec "test -f /run/mnt/ubuntu-seed/snaps/core22_${core22_rev}.snap"
+  core_rev=$(remote.exec "snap list core${version}" | awk 'NR != 1 { print $3 }')
+  remote.exec "test -f /run/mnt/ubuntu-seed/snaps/core${version}_${core_rev}.snap"
 
   # model in the seed should match the one that was installed on the system
   remote.exec "diff <(snap model --assertion) /run/mnt/ubuntu-seed/systems/classic/model"
@@ -324,7 +324,7 @@ execute: |
   remote.exec "groups" | tr ' ' '\n' | sort | xargs | MATCH 'sudo user1'
 
   remote.exec "snap list" > snap-list
-  for name in pc pc-kernel snapd core22; do
+  for name in "pc" "pc-kernel" "snapd" "core${version}"; do
       MATCH "${name}" < snap-list
   done
 

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -86,6 +86,11 @@ execute: |
   tests.nested secboot-sign gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
   snap pack --filename=pc.snap pc-gadget/
 
+  # TODO: remove this once this change to extra-paths has made it into a
+  # released kernel snap
+  mkdir -p ./extra-initrd/usr/lib/core
+  cp ./extra-paths ./extra-initrd/usr/lib/core/extra-paths
+
   # Retrieve kernel
   snap download --basename=pc-kernel --channel="$version/edge" pc-kernel
   # the fakestore needs this assertion


### PR DESCRIPTION
This PR changes snap-bootstrap so that we import users from the sudo and admin groups into the ephemeral system that is created when we boot into recovery mode.