### PR TITLE
tests: show that snapctl can be used with bare base

### DIFF
--- a/tests/main/bare-snapctl/task.yaml
+++ b/tests/main/bare-snapctl/task.yaml
@@ -1,0 +1,13 @@
+summary: snapctl is usable in snaps with bare base
+
+details: |
+  The bare snap has no dynamic linker, no libraries and no programs. It's even
+  barren enough that there's no symbolic link that points to snapctl that is
+  found on PATH. Despite all of that, a snap can call snapctl with full path
+  and use its services.
+
+prepare: |
+  snap install test-snapd-busybox-static
+
+execute: |
+  test-snapd-busybox-static.busybox-static sh -c 'exec /usr/lib/snapd/snapctl --help' | MATCH 'snapctl \[OPTIONS\] <command>'


### PR DESCRIPTION
The bare base snap has no libraries and no dynamic linker. Show that even in such environment it is possible to use the snapctl program.

This test also helps in testing upcoming changes to the snapd-specific dynamic linker, namely in the fact that snapd linker is not affecting snapctl.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-32203
