### PR TITLE
interfaces: generalize constant folding for patterns

### DIFF
--- a/interfaces/prompting/patterns/parse_internal_test.go
+++ b/interfaces/prompting/patterns/parse_internal_test.go
@@ -68,3 +68,19 @@ func (s *parseSuite) TestParse(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(tree, DeepEquals, handMadeTree)
 }
+
+func (s *parseSuite) TestParseWithLeadingLiteralOptimization(c *C) {
+	pattern := "/{foo,bar}"
+
+	handMadeTree := alt{
+		literal("/foo"),
+		literal("/bar"),
+	}
+
+	tokens, err := scan(pattern)
+	c.Assert(err, IsNil)
+	tree, err := parse(tokens)
+	c.Logf("Tree is: %v", tree)
+	c.Assert(err, IsNil)
+	c.Check(tree, DeepEquals, handMadeTree)
+}


### PR DESCRIPTION
The existing constant folding mechanism for sequences-of-literals is now generalized to inject the literal into the following item, possibly reducing the complexity of the tree at the cost of making the tree contain longer strings.

The tests are not fully adjusted, as the render test measures precise indices that were too tedious to fix on Friday.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
