### PR TITLE
tests: import changes from snapd-testing-tools

### DIFF
--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -40,9 +40,9 @@ import (
 //	    int   mnt_passno;   /* pass number on parallel fsck */
 //	};
 type MountEntry struct {
-	Name    string
-	Dir     string
-	Type    string
+	Name    string // Device name, bind source, pseudo name
+	Dir     string // Directory name, bind target (including file)
+	Type    string // File system type
 	Options []string
 
 	DumpFrequency   int

--- a/tests/lib/external/snapd-testing-tools/spread.yaml
+++ b/tests/lib/external/snapd-testing-tools/spread.yaml
@@ -29,6 +29,7 @@ backends:
             - centos-9-64:
                 storage: preserve-size
             - opensuse-15.5-64:
+            - opensuse-15.6-64:
             - opensuse-tumbleweed-64:
 
     google-nested:
@@ -53,14 +54,18 @@ backends:
             HTTPS_PROXY: 'http://squid.internal:3128'
             NO_PROXY: 'canonical.com'
         systems:
-            - ubuntu-20.04-64:
-                image: ubuntu-focal-20.04-amd64
             - ubuntu-22.04-64:
-                image: ubuntu-jammy-22.04-amd64
-            - centos-9-64:
-            - debian-12-64:
+                image: snapd-spread/ubuntu-22.04-64
+            - ubuntu-24.04-64:
+                image: snapd-spread/ubuntu-24.04-64
             - fedora-40-64:
+                image: snapd-spread/fedora-40-64
             - opensuse-15.5-64:
+                image: snapd-spread/opensuse-15.5-64
+            - centos-9-64:
+                image: snapd-spread/centos-9-64
+            - debian-12-64:
+                image: snapd-spread/debian-12-64
 
 path: /root/snapd-testing-tools
 

--- a/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
@@ -105,7 +105,6 @@ execute: |
             ! os.query is-core
             ;;
         fedora-39-64)
-        fedora-39-64)
             os.query is-fedora
             os.query is-fedora 39
             ! os.query is-fedora rawhide
@@ -150,7 +149,11 @@ execute: |
             ! os.query is-core
             ;;
         opensuse-15.6-64)
+            os.query is-opensuse
             os.query is-opensuse 15.6
+            os.query is-classic
+            ! os.query is-core
+            ;;
         opensuse-tumbleweed-64)
             os.query is-opensuse
             os.query is-opensuse tumbleweed

--- a/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
@@ -104,7 +104,7 @@ execute: |
             os.query is-classic
             ! os.query is-core
             ;;
-
+        fedora-39-64)
         fedora-39-64)
             os.query is-fedora
             os.query is-fedora 39
@@ -149,6 +149,8 @@ execute: |
             os.query is-classic
             ! os.query is-core
             ;;
+        opensuse-15.6-64)
+            os.query is-opensuse 15.6
         opensuse-tumbleweed-64)
             os.query is-opensuse
             os.query is-opensuse tumbleweed

--- a/tests/lib/external/snapd-testing-tools/tests/tests.pkgs/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/tests.pkgs/task.yaml
@@ -47,6 +47,25 @@ execute: |
     not tests.pkgs is-installed test-snapd-pkg-1
     not tests.pkgs is-installed test-snapd-pkg-2
 
+    # Download 2 packages, trusty does not support apt download
+    PKG1="grep"
+    PKG2="curl"
+    MAXDEPTH=1
+    if os.query is-opensuse; then
+        MAXDEPTH=4
+    fi
+    if os.query is-arch-linux || os.query is-fedora || os.query is-opensuse; then
+        PKG2="vi"
+    fi
+
+    if not os.query is-trusty; then
+        tests.pkgs download "$PKG1" "$PKG2"
+        if os.query is-opensuse; then
+            find . -maxdepth "$MAXDEPTH" -name "$PKG1*"
+            find . -maxdepth "$MAXDEPTH" -name "$PKG2*"
+        fi
+    fi
+
     # Check the message when a command is not supported
     tests.pkgs noexist test-snapd-pkg-1 2>&1 | MATCH 'tests.pkgs: unknown command noexist'
     tests.pkgs -install test-snapd-pkg-1 2>&1 | MATCH 'tests.pkgs: unknown option -install'

--- a/tests/lib/external/snapd-testing-tools/tools/tests.pkgs
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.pkgs
@@ -3,6 +3,7 @@
 show_help() {
     echo "usage: tests.pkgs install [--no-install-recommends] [PACKAGE...]"
     echo "       tests.pkgs remove [PACKAGE...]"
+    echo "       tests.pkgs download [PACKAGE...]"
     echo "       tests.pkgs is-installed [PACKAGE]"
     echo "       tests.pkgs query [PACKAGE]"
     echo "       tests.pkgs list-installed"
@@ -23,6 +24,11 @@ cmd_install() {
 }
 
 cmd_install_local() {
+    # This is re-defined by the backend file.
+    unsupported
+}
+
+cmd_download() {
     # This is re-defined by the backend file.
     unsupported
 }
@@ -120,7 +126,7 @@ main() {
                 shift
                 break
                 ;;
-            install|remove|query|is-installed|list-installed)
+            install|remove|query|is-installed|list-installed|download)
                 action="$1"
                 shift
                 break  # consume remaining arguments
@@ -153,6 +159,9 @@ main() {
         remove)
             # shellcheck disable=SC2046
             cmd_remove $(remap_many "$@")
+            ;;
+        download)
+            cmd_download "$(remap_many "$@")"
             ;;
         *)
             echo "tests.pkgs: unknown action $action" >&2

--- a/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.apt.sh
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.apt.sh
@@ -79,3 +79,7 @@ cmd_remove() {
     # shellcheck disable=SC2086
     apt-get remove --yes $REMOVE_FLAGS "$@"
 }
+
+cmd_download() {
+    apt download -q $@ >/dev/null
+}

--- a/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.apt.sh
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.apt.sh
@@ -81,5 +81,6 @@ cmd_remove() {
 }
 
 cmd_download() {
+    # shellcheck disable=SC2068
     apt download -q $@ >/dev/null
 }

--- a/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.dnf-yum.sh
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.dnf-yum.sh
@@ -73,3 +73,12 @@ cmd_remove() {
         yum remove -y $@
     fi
 }
+
+cmd_download() {
+    # shellcheck disable=SC2068
+    if [ "$(command -v dnf)" != "" ]; then
+        dnf download -q $@
+    else
+        yum reinstall --downloadonly -q -y --downloaddir "${PWD:-.}" $@
+    fi
+}

--- a/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.pacman.sh
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.pacman.sh
@@ -69,3 +69,8 @@ cmd_remove() {
     # shellcheck disable=SC2068
     pacman -Rnsc --noconfirm $@
 }
+
+cmd_download() {
+    # shellcheck disable=SC2068
+    pacman -Sw --noconfirm --cachedir "${PWD:-.}" -q $@ >/dev/null
+}

--- a/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.zypper.sh
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.pkgs.zypper.sh
@@ -64,3 +64,8 @@ cmd_remove() {
     # shellcheck disable=SC2068
     zypper remove -y $@
 }
+
+cmd_download() {
+    # shellcheck disable=SC2068
+    zypper --pkg-cache-dir "${PWD:-.}" -q download $@
+}


### PR DESCRIPTION
The changes imported are:
 . Support downloading pkgs using tests.pkgs tool
 . New urls used for openstack
 . Support opensuse 15.6