### PR TITLE
asserts: do not require revision when setting component as invalid

### DIFF
--- a/asserts/validation_set.go
+++ b/asserts/validation_set.go
@@ -197,7 +197,7 @@ func checkValidationSetComponent(compName string, comp map[string]interface{}, s
 		return ValidationSetComponent{}, fmt.Errorf("cannot specify component revision %s at the same time as stating its presence is invalid", what)
 	}
 
-	if snapRevision != 0 && revision == 0 {
+	if snapRevision != 0 && revision == 0 && presence != PresenceInvalid {
 		return ValidationSetComponent{}, fmt.Errorf("must specify revision %s since its associated snap specifies a revision", what)
 	}
 

--- a/asserts/validation_set_test.go
+++ b/asserts/validation_set_test.go
@@ -183,6 +183,7 @@ func (vss *validationSetSuite) TestSnapComponents(c *C) {
       with-revision:
         revision: 10
         presence: required
+      invalid-without-revision: invalid
   -
     name: foo-linux
     id: foolinuxidididididididididididid
@@ -207,6 +208,9 @@ func (vss *validationSetSuite) TestSnapComponents(c *C) {
 		"with-revision": {
 			Presence: asserts.PresenceRequired,
 			Revision: 10,
+		},
+		"invalid-without-revision": {
+			Presence: asserts.PresenceInvalid,
 		},
 	})
 	c.Check(snaps[1].Components, DeepEquals, map[string]asserts.ValidationSetComponent{


### PR DESCRIPTION
This is a fix to a bug that was requiring that components have a revision, even if they are being marked as invalid.