### PR TITLE
interfaces/bulitin/opengl: add support for cuda workloads on Tegra iGPU in opengl interface

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -188,6 +188,11 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 # From https://bugs.launchpad.net/snapd/+bug/1862832
 /run/nvidia-xdriver-* rw,
 unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
+
+/dev/nvgpu/igpu[0-9]/power rw,
+/dev/nvgpu/igpu[0-9]/ctrl rw,
+/dev/nvgpu/igpu[0-9]/prof rw,
+/dev/host1x-fence rw,
 `
 
 type openglInterface struct {
@@ -211,6 +216,14 @@ var openglConnectedPlugUDev = []string{
 	`KERNEL=="mali[0-9]*"`,
 	`KERNEL=="dma_buf_te"`,
 	`KERNEL=="galcore"`,
+
+	//iGPU device nodes
+	`SUBSYSTEM=="nvidia-gpu-v2-power" KERNEL=="power"`,
+	`SUBSYSTEM=="nvidia-gpu-v2" KERNEL=="ctrl"`,
+	`SUBSYSTEM=="nvidia-gpu-v2" KERNEL=="prof"`,
+
+	// Nvidia dma barrier
+	`SUBSYSTEM=="host1x-fence"`,
 }
 
 // Those two are the same, but in theory they are separate and can move (or

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -189,9 +189,9 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 /run/nvidia-xdriver-* rw,
 unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 
-/dev/nvgpu/igpu[0-9]/power rw,
-/dev/nvgpu/igpu[0-9]/ctrl rw,
-/dev/nvgpu/igpu[0-9]/prof rw,
+/dev/nvgpu/igpu[0-9]*/power rw,
+/dev/nvgpu/igpu[0-9]*/ctrl rw,
+/dev/nvgpu/igpu[0-9]*/prof rw,
 /dev/host1x-fence rw,
 `
 

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -118,7 +118,7 @@ func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 15)
+	c.Assert(spec.Snippets(), HasLen, 19)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl


### PR DESCRIPTION
Add support for cuda workloads on Tegra iGPU in opengl interface

When run on a Tegra iGPU, cuda workloads require 4 more device nodes
than what is currently included in the opengl interface.

Notably, three device nodes are related to the GPU. On an integrated GPU on
tegra platforms, those correspond to `/dev/nvgpu/igpu0/power`,
`/dev/nvgpu/igpu0/ctrl` and `/dev/nvgpu/igpu0/prof`.

Additionally, we need read-write access to `/dev/host1x-fence`, which is a
tegra specific dma barrier.

In addition to granting write access in the apparmor profiles, we also
need to tag these device nodes in the udev rules.

This pull request is related to a previous one that created a new interface for this functionality: https://github.com/canonical/snapd/pull/14188

The device nodes listed are the ones needed to run cuda workloads without errors. On top of that, cuda workloads also try to access other iGPU device nodes like `as`, `channel` and `sched` but only using the `faccessat` system call therefore I don't think they are necessary to run the workloads.

I tested the change to this interface using 5 different snaps that are listed here:
* https://github.com/canonical/nvidia-tegra-drivers-36-snap/
* https://github.com/canonical/cuda-runtime-snap/
* https://github.com/canonical/cuda-samples-snap/
* https://github.com/canonical/tensorrt-libs-snap/
* https://github.com/canonical/tensorrt-samples-snap/

For testing I use the `opengl` branches when available. The cuda-runtime snap and tensorrt-libs snap only contain runtime libraries and nothing related to the opengl interface.

In order to test this on actual hardware we set up a Jenkins job that provisions our devices with an Ubuntu Core image, then fetches the modified snapd snap and the nvidia-tegra-drivers-36 snap from here: https://people.canonical.com/~sebwey/snaps/

For the cuda and tensorrt snaps, we don't have distribution rights, therefore I'm using a personal access token to download the build artifacts from their respective github actions.

The snaps are then installed and connected with the respective interfaces.

We then finally run the riverside-core-gpu tests defined in this checkbox provider: https://git.launchpad.net/~riverside-team/riverside/+git/checkbox-provider-riverside/tree/units/riverside/gpu.pxu

You can see one of the test runs on this Jenkins job (VPN necessary): http://10.102.156.15:8080/job/partner-engineering/job/riverside/job/riverside-core-jetson-orin-nano-daily-dangerous/22/

I look forward to hear your feedback on what's still missing. I'm happy to set up a meeting and provide access to hardware we have in the lab so you can have a look yourself.
