### PR TITLE
o/snapstate, o/hookstate: run component remove hooks

### DIFF
--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -101,10 +101,11 @@ func SetupPostRefreshComponentHook(st *state.State, snap, component string) *sta
 
 func SetupRemoveComponentHook(st *state.State, snap, component string) *state.Task {
 	hooksup := &HookSetup{
-		Snap:      snap,
-		Component: component,
-		Hook:      "remove",
-		Optional:  true,
+		Snap:        snap,
+		Component:   component,
+		Hook:        "remove",
+		Optional:    true,
+		IgnoreError: true,
 	}
 
 	summary := fmt.Sprintf(i18n.G(`Run remove hook of "%s+%s" component if present`), hooksup.Snap, hooksup.Component)

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -37,6 +37,7 @@ func init() {
 	snapstate.SetupInstallComponentHook = SetupInstallComponentHook
 	snapstate.SetupPreRefreshComponentHook = SetupPreRefreshComponentHook
 	snapstate.SetupPostRefreshComponentHook = SetupPostRefreshComponentHook
+	snapstate.SetupRemoveComponentHook = SetupRemoveComponentHook
 	snapstate.SetupPreRefreshHook = SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = SetupPostRefreshHook
 	snapstate.SetupRemoveHook = SetupRemoveHook
@@ -93,6 +94,20 @@ func SetupPostRefreshComponentHook(st *state.State, snap, component string) *sta
 	}
 
 	summary := fmt.Sprintf(i18n.G(`Run post-refresh hook of "%s+%s" component if present`), hooksup.Snap, hooksup.Component)
+	task := HookTask(st, summary, hooksup, nil)
+
+	return task
+}
+
+func SetupRemoveComponentHook(st *state.State, snap, component string) *state.Task {
+	hooksup := &HookSetup{
+		Snap:      snap,
+		Component: component,
+		Hook:      "remove",
+		Optional:  true,
+	}
+
+	summary := fmt.Sprintf(i18n.G(`Run remove hook of "%s+%s" component if present`), hooksup.Snap, hooksup.Component)
 	task := HookTask(st, summary, hooksup, nil)
 
 	return task

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -558,11 +558,11 @@ func removeComponentTasks(st *state.State, snapst *SnapState, compst *sequence.C
 	removeHook.Set("component-setup", compSetup)
 	removeHook.Set("snap-setup", snapSup)
 
-	prev := removeHook
+	setupTask, prev := removeHook, removeHook
 	tasks := []*state.Task{removeHook}
 	addTask := func(t *state.Task) {
-		t.Set("component-setup-task", removeHook.ID())
-		t.Set("snap-setup-task", removeHook.ID())
+		t.Set("component-setup-task", setupTask.ID())
+		t.Set("snap-setup-task", setupTask.ID())
 		t.WaitFor(prev)
 		tasks = append(tasks, t)
 		prev = t
@@ -590,7 +590,7 @@ func removeComponentTasks(st *state.State, snapst *SnapState, compst *sequence.C
 		// We will be overwriting this object if removing multiple
 		// components, but should be fine as the SnapSetup does not
 		// change (snap still the same).
-		setupSecurity.Set("snap-setup-task", unlink.ID())
+		setupSecurity.Set("snap-setup-task", setupTask.ID())
 		prev = setupSecurity
 	}
 

--- a/overlord/snapstate/component_remove_test.go
+++ b/overlord/snapstate/component_remove_test.go
@@ -32,8 +32,7 @@ import (
 )
 
 func expectedComponentRemoveTasks(opts int) []string {
-	var removeTasks []string
-	removeTasks = append(removeTasks, "unlink-current-component")
+	removeTasks := []string{"run-hook[remove]", "unlink-current-component"}
 	if opts&compTypeIsKernMods != 0 {
 		removeTasks = append(removeTasks, "prepare-kernel-modules-components")
 	}
@@ -292,9 +291,10 @@ func (s *snapmgrTestSuite) TestRemoveComponentsPathRunWithError(c *C) {
 	// component tasks are undone/hold
 	for i := 0; i < 2; i++ {
 		ts := tss[i].Tasks()
-		c.Check(ts[0].Status(), Equals, state.UndoneStatus)
 		c.Check(ts[1].Status(), Equals, state.UndoneStatus)
-		c.Check(ts[2].Status(), Equals, state.HoldStatus)
+		c.Check(ts[1].Status(), Equals, state.UndoneStatus)
+		c.Check(ts[2].Status(), Equals, state.UndoneStatus)
+		c.Check(ts[3].Status(), Equals, state.HoldStatus)
 	}
 	// update profile is hold
 	c.Check(updateProfTask.Status(), Equals, state.HoldStatus)

--- a/overlord/snapstate/component_remove_test.go
+++ b/overlord/snapstate/component_remove_test.go
@@ -79,14 +79,26 @@ func (s *snapmgrTestSuite) testRemoveComponent(c *C, opts snapstate.RemoveCompon
 	}
 	c.Assert(len(tss), Equals, numTaskSets)
 	totalTasks := 0
+
+	var setupProfilesSnapsupID, snapsupID string
 	for i, ts := range tss {
 		if i == len(tss)-1 && opts.RefreshProfile {
-			kinds := taskKinds(ts.Tasks())
-			c.Assert(kinds, DeepEquals, []string{"setup-profiles"})
+			tasks := ts.Tasks()
+			c.Assert(tasks, HasLen, 1)
+			setupProfiles := tasks[0]
+			c.Assert(setupProfiles.Kind(), Equals, "setup-profiles")
+			err := setupProfiles.Get("snap-setup-task", &setupProfilesSnapsupID)
+			c.Assert(err, IsNil)
+			c.Assert(setupProfilesSnapsupID, Not(HasLen), 0)
 		} else {
+			snapsupID = ts.Tasks()[0].ID()
 			verifyComponentRemoveTasks(c, compCurrentIsDiscarded, ts)
 		}
 		totalTasks += len(ts.Tasks())
+	}
+
+	if opts.RefreshProfile {
+		c.Assert(setupProfilesSnapsupID, Equals, snapsupID)
 	}
 
 	c.Assert(s.state.TaskCount(), Equals, totalTasks)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3621,7 +3621,11 @@ func removeTasks(st *state.State, name string, revision snap.Revision, flags *Re
 
 	// only run remove hook if uninstalling the snap completely
 	if removeAll {
-		// TODO:COMPS: Run component remove hooks
+		for _, comp := range snapst.Sequence.ComponentsForRevision(snapst.Current) {
+			removeCompHook := SetupRemoveComponentHook(st, snapsup.InstanceName(), comp.SideInfo.Component.ComponentName)
+			addNext(state.NewTaskSet(removeCompHook))
+			prev = removeCompHook
+		}
 
 		removeHook := SetupRemoveHook(st, snapsup.InstanceName())
 		addNext(state.NewTaskSet(removeHook))

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -945,6 +945,10 @@ var SetupPostRefreshComponentHook = func(st *state.State, snap, component string
 	panic("internal error: snapstate.SetupPostRefreshComponentHook is unset")
 }
 
+var SetupRemoveComponentHook = func(st *state.State, snap, component string) *state.Task {
+	panic("internal error: snapstate.SetupRemoveComponentHook is unset")
+}
+
 var SetupPreRefreshHook = func(st *state.State, snapName string) *state.Task {
 	panic("internal error: snapstate.SetupPreRefreshHook is unset")
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3629,6 +3629,9 @@ func removeTasks(st *state.State, name string, revision snap.Revision, flags *Re
 
 		removeHook := SetupRemoveHook(st, snapsup.InstanceName())
 		addNext(state.NewTaskSet(removeHook))
+		if prev != nil {
+			removeHook.WaitFor(prev)
+		}
 		prev = removeHook
 
 		// run disconnect hooks

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -2148,7 +2148,9 @@ func (s *snapmgrTestSuite) TestRemoveWithCompsTasks(c *C) {
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 		"stop-snap-services",
-		"run-hook[remove]",
+		"run-hook[remove]", // component remove hook
+		"run-hook[remove]", // component remove hook
+		"run-hook[remove]", // snap remove hook
 		"auto-disconnect",
 		"save-snapshot",
 		"remove-aliases",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -187,6 +187,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	oldSetupInstallComponentHook := snapstate.SetupInstallComponentHook
 	oldSetupPostRefreshComponentHook := snapstate.SetupPostRefreshComponentHook
 	oldSetupPreRefreshComponentHook := snapstate.SetupPreRefreshComponentHook
+	oldSetupRemoveComponentHook := snapstate.SetupRemoveComponentHook
 	oldSetupPreRefreshHook := snapstate.SetupPreRefreshHook
 	oldSetupPostRefreshHook := snapstate.SetupPostRefreshHook
 	oldSetupRemoveHook := snapstate.SetupRemoveHook
@@ -236,6 +237,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 		snapstate.SetupInstallComponentHook = oldSetupInstallComponentHook
 		snapstate.SetupPostRefreshComponentHook = oldSetupPostRefreshComponentHook
 		snapstate.SetupPreRefreshComponentHook = oldSetupPreRefreshComponentHook
+		snapstate.SetupRemoveComponentHook = oldSetupRemoveComponentHook
 		snapstate.SetupPreRefreshHook = oldSetupPreRefreshHook
 		snapstate.SetupPostRefreshHook = oldSetupPostRefreshHook
 		snapstate.SetupRemoveHook = oldSetupRemoveHook

--- a/tests/lib/snaps/test-snap-component-hooks/two-hooks/remove
+++ b/tests/lib/snaps/test-snap-component-hooks/two-hooks/remove
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -xe
+
+if nc -l 127.0.0.1 12345; then
+    echo "should not be able to bind to anything"
+fi
+
+nc -zv snapcraft.io 80
+
+echo "ran remove hook" > /tmp/two-remove-hook-executed

--- a/tests/main/component-refresh-hooks/task.yaml
+++ b/tests/main/component-refresh-hooks/task.yaml
@@ -16,7 +16,7 @@ systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*]
 
 restore: |
   if snap list test-snap-component-hooks; then
-    snap remove test-snap-component-hooks || true
+    snap remove test-snap-component-hooks
   fi
 
 execute: |

--- a/tests/main/component-refresh-hooks/task.yaml
+++ b/tests/main/component-refresh-hooks/task.yaml
@@ -1,4 +1,4 @@
-summary: Test running component install, pre-refresh, and post-refresh hooks
+summary: Test running component install, pre-refresh, post-refresh, and remove hooks.
 
 details: |
   Tests a snap operations on a snap with two components. Some arbitrary
@@ -15,7 +15,9 @@ details: |
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*]
 
 restore: |
-  snap remove test-snap-component-hooks
+  if snap list test-snap-component-hooks; then
+    snap remove test-snap-component-hooks || true
+  fi
 
 execute: |
   snap install test-snap-component-hooks+one+two --revision=6
@@ -34,9 +36,9 @@ execute: |
   not snap get test-snap-component-hooks one-postrefreshed
   not snap get test-snap-component-hooks two-postrefreshed
 
-  snap refresh test-snap-component-hooks --edge
+  snap refresh test-snap-component-hooks --channel=latest/candidate
 
-  snap list test-snap-component-hooks | awk 'NR != 1 { print $3 }' | MATCH 7
+  snap list test-snap-component-hooks | awk 'NR != 1 { print $3 }' | MATCH 8
 
   # these shouldn't run again
   snap get test-snap-component-hooks one-installed | MATCH 4
@@ -47,5 +49,15 @@ execute: |
   snap get test-snap-component-hooks two-prerefreshed | MATCH 4
 
   # these run as the new revision
-  snap get test-snap-component-hooks one-postrefreshed | MATCH 5
-  snap get test-snap-component-hooks two-postrefreshed | MATCH 5
+  snap get test-snap-component-hooks one-postrefreshed | MATCH 6
+  snap get test-snap-component-hooks two-postrefreshed | MATCH 6
+
+  # make sure component remove hooks are run on individual component removal
+  snap remove test-snap-component-hooks+two
+  test -e /tmp/snap-private-tmp/snap.test-snap-component-hooks/tmp/two-remove-hook-executed
+  rm /tmp/snap-private-tmp/snap.test-snap-component-hooks/tmp/two-remove-hook-executed
+
+  # make sure component remove hooks are run on total snap removal
+  snap install test-snap-component-hooks+two
+  snap remove test-snap-component-hooks
+  test -e /tmp/snap-private-tmp/snap.test-snap-component-hooks/tmp/two-remove-hook-executed


### PR DESCRIPTION
This change lets us run component remove hooks.