### PR TITLE
daemon: secureboot updates API endpoint

### DIFF
--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -329,16 +329,24 @@ func (s *accessSuite) TestInterfaceOpenAccess(c *C) {
 	s.daemon(c)
 	// interfaceOpenAccess allows access if requireInterfaceApiAccess() succeeds
 	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
+	restore := daemon.MockRequireInterfaceApiAccess(func(
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
+	) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
+		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
+			Interfaces: []string{"snap-themes-control"},
+			Plug:       true,
+		})
 		return nil
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, nil, ucred, nil), IsNil)
 
 	// Access is forbidden if requireInterfaceApiAccess() fails
-	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
+	restore = daemon.MockRequireInterfaceApiAccess(func(
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, req daemon.InterfaceAccessReqs,
+	) *daemon.APIError {
 		return errForbidden
 	})
 	defer restore()
@@ -361,9 +369,14 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 
 	// themesAuthenticatedAccess denies access if requireInterfaceApiAccess fails
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
-	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
+	restore = daemon.MockRequireInterfaceApiAccess(func(
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
+	) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
+		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
+			Plug: true,
+		})
 		return errForbidden
 	})
 	defer restore()
@@ -371,7 +384,9 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
 
 	// If requireInterfaceApiAccess succeeds, root is granted access
-	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
+	restore = daemon.MockRequireInterfaceApiAccess(func(
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
+	) *daemon.APIError {
 		return nil
 	})
 	defer restore()
@@ -393,9 +408,14 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
 
 	s.daemon(c)
-	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, interfaceNames []string) *daemon.APIError {
+	restore := daemon.MockRequireInterfaceApiAccess(func(
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
+	) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
+		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
+			Plug: true,
+		})
 		return nil
 	})
 	defer restore()
@@ -421,4 +441,196 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+}
+
+func (s *accessSuite) TestInterfaceProviderRootAccessCallsWithCorrectArgs(c *C) {
+	restore := daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) *daemon.APIError {
+		// Polkit is not consulted if no action is specified
+		c.Fail()
+		return errForbidden
+	})
+	defer restore()
+
+	var ac daemon.AccessChecker = daemon.InterfaceProviderRootAccess{
+		Interfaces: []string{"fwupd"},
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	s.daemon(c)
+
+	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
+
+	// mock and check whether correct arguments are passed
+	called := 0
+	restore = daemon.MockRequireInterfaceApiAccess(func(
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
+	) *daemon.APIError {
+		c.Check(d, Equals, s.d)
+		c.Check(u, Equals, ucred)
+		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
+			Interfaces: []string{"fwupd"},
+			Slot:       true,
+		})
+		called++
+		return errForbidden
+	})
+	defer restore()
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
+	c.Assert(called, Equals, 1)
+}
+
+func (s *accessSuite) TestInterfaceProviderRootAccessChecks(c *C) {
+	d := s.daemon(c)
+	s.mockSnap(c, `
+name: fwupd-app
+type: app
+version: 1
+slots:
+  fwupd-provider:
+    interface: fwupd
+plugs:
+  fwupd-consumer:
+    interface: fwupd
+  `)
+	s.mockSnap(c, `
+name: connected-fwupd-caller
+version: 1
+plugs:
+  fwupd-consumer:
+    interface: fwupd
+`)
+	s.mockSnap(c, `
+name: disconnected-fwupd-caller
+version: 1
+plugs:
+  fwupd-consumer:
+    interface: fwupd
+`)
+
+	restore := daemon.MockCgroupSnapNameFromPid(func(pid int) (string, error) {
+		switch pid {
+		case 42:
+			return "fwupd-app", nil
+		case 1042:
+			return "connected-fwupd-caller", nil
+		case 10042:
+			return "disconnected-fwupd-caller", nil
+		default:
+			return "", fmt.Errorf("not a snap")
+		}
+	})
+	defer restore()
+
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) *daemon.APIError {
+		// Polkit is not consulted if no action is specified
+		c.Fail()
+		return errForbidden
+	})
+	defer restore()
+
+	var ac daemon.AccessChecker = daemon.InterfaceProviderRootAccess{
+		Interfaces: []string{"fwupd"},
+	}
+
+	user := &auth.UserState{}
+
+	// fwupd-app, but unconnected and over snap socket
+	ucred := &daemon.Ucrednet{Uid: 0, Pid: 42, Socket: dirs.SnapSocket}
+	req := &http.Request{
+		RemoteAddr: ucred.String(),
+	}
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
+
+	// Now connect both interfaces
+	st := d.Overlord().State()
+	st.Lock()
+	st.Set("conns", map[string]interface{}{
+		"fwupd-app:fwupd-consumer fwupd-app:fwupd-provider": map[string]interface{}{
+			"interface": "fwupd",
+		},
+		"connected-fwupd-caller:fwupd fwupd-app:fwupd-provider": map[string]interface{}{
+			"interface": "fwupd",
+		},
+	})
+	st.Unlock()
+
+	// fwupd-app, connected on the slot side
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 42, Socket: dirs.SnapSocket}
+	req = &http.Request{
+		RemoteAddr: ucred.String(),
+	}
+	c.Check(ac.CheckAccess(s.d, req, ucred, user), IsNil)
+
+	// connected-fwupd-caller, but on the plug side
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 1042, Socket: dirs.SnapSocket}
+	req = &http.Request{
+		RemoteAddr: ucred.String(),
+	}
+	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
+
+	// disconnected-fwupd-caller
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 10042, Socket: dirs.SnapSocket}
+	req = &http.Request{
+		RemoteAddr: ucred.String(),
+	}
+	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
+
+	// normal user has no access even with a Macaroon auth
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 42, Socket: dirs.SnapSocket}
+	req = &http.Request{
+		RemoteAddr: ucred.String(),
+	}
+	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errUnauthorized)
+
+	// Without macaroon auth, normal users are unauthorized
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
+
+	// on snapd socket, non-root is unauthorized
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 123, Socket: dirs.SnapdSocket}
+	req = &http.Request{
+		RemoteAddr: ucred.String(),
+	}
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
+
+	// but root is
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 123, Socket: dirs.SnapdSocket}
+	req = &http.Request{
+		RemoteAddr: ucred.String(),
+	}
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+}
+
+func (s *accessSuite) TestRequireInterfaceApiAccessErrorChecks(c *C) {
+	d := s.daemon(c)
+	req := &http.Request{}
+
+	// no side of the connection is specified
+	c.Check(daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{}), DeepEquals,
+		daemon.InternalError("required connection side is unspecified"))
+
+	// check on both sides
+	c.Check(
+		daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
+			Plug:       true,
+			Slot:       true,
+			Interfaces: []string{"foo"},
+		}),
+		DeepEquals,
+		daemon.InternalError("snap cannot be specified on both sides of the connection"))
+
+	// no interfaces
+	c.Check(
+		daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
+			Plug: true,
+		}),
+		DeepEquals,
+		daemon.InternalError("interfaces access check, but interfaces list is empty"))
+
+	// this one actually reaches the credentials check
+	c.Check(
+		daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
+			Plug:       true,
+			Interfaces: []string{"foo"},
+		}),
+		DeepEquals, errForbidden)
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -85,6 +85,7 @@ var api = []*Command{
 	registryCmd,
 	noticesCmd,
 	noticeCmd,
+	systemSecurebootCmd,
 }
 
 const (

--- a/daemon/api_system_secureboot.go
+++ b/daemon/api_system_secureboot.go
@@ -1,0 +1,166 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/fdestate"
+)
+
+var systemSecurebootCmd = &Command{
+	// TODO GET returning whether secure boot is relevant for the system?
+
+	Path: "/v2/system-secureboot",
+	POST: postSystemSecurebootAction,
+	WriteAccess: interfaceProviderRootAccess{
+		// TODO find a specialized interface for this, but for now assume that
+		// requests will come only from snaps plugging fwupd interface on the
+		// slot side, which also allows manipulation of EFI variables
+		Interfaces: []string{"fwupd"},
+	},
+}
+
+func postSystemSecurebootAction(c *Command, r *http.Request, user *auth.UserState) Response {
+	contentType := r.Header.Get("Content-Type")
+
+	switch contentType {
+	case "application/json":
+		return postSystemSecurebootActionJSON(c, r)
+	default:
+		return BadRequest("unexpected content type: %q", contentType)
+	}
+}
+
+type securebootRequest struct {
+	Action string `json:"action,omitempty"`
+
+	// Payload is a base64 encoded binary blob, is used in
+	// efi-secureboot-db-prepare action, and carries the DBX update content. The
+	// blob is in the range from few kB to tens of kBs
+	Payload string `json:"payload,omitempty"`
+
+	// KeyDatabase is used with efi-secureboot-db-prepare action, and indicates the
+	// secureboot keys database which is a target of the action, possible values are
+	// PK, KEK, DB, DBX
+	KeyDatabase string `json:"key-database,omitempty"`
+}
+
+func (r *securebootRequest) Validate() error {
+	switch r.Action {
+	case "efi-secureboot-update-startup", "efi-secureboot-update-db-cleanup":
+		if r.KeyDatabase != "" {
+			return fmt.Errorf("unexpected key database for action %q", r.Action)
+		}
+
+		if len(r.Payload) > 0 {
+			return fmt.Errorf("unexpected payload for action %q", r.Action)
+		}
+	case "efi-secureboot-update-db-prepare":
+		switch r.KeyDatabase {
+		case "PK", "KEK", "DB", "DBX":
+		default:
+			return fmt.Errorf("invalid key database %q", r.KeyDatabase)
+		}
+
+		if len(r.Payload) == 0 {
+			return errors.New("update payload not provided")
+		}
+	default:
+		return fmt.Errorf("unsupported EFI secure boot action %q", r.Action)
+	}
+	return nil
+}
+
+func postSystemSecurebootActionJSON(c *Command, r *http.Request) Response {
+	var req securebootRequest
+
+	decoder := json.NewDecoder(r.Body)
+
+	if err := decoder.Decode(&req); err != nil {
+		return BadRequest("cannot decode request body: %v", err)
+	}
+
+	if decoder.More() {
+		return BadRequest("extra content found in request body")
+	}
+
+	if err := req.Validate(); err != nil {
+		return BadRequest(err.Error())
+	}
+
+	switch req.Action {
+	case "efi-secureboot-update-startup":
+		return postSystemActionEFISecurebootUpdateStartup(c)
+	case "efi-secureboot-update-db-cleanup":
+		return postSystemActionEFISecurebootUpdateDBCleanup(c)
+	case "efi-secureboot-update-db-prepare":
+		return postSystemActionEFISecurebootUpdateDBPrepare(c, &req)
+	default:
+		return InternalError("support for EFI secure boot action %q is not implemented", req.Action)
+	}
+}
+
+var fdestateEFISecureBootDBUpdatePrepare = fdestate.EFISecureBootDBUpdatePrepare
+
+func postSystemActionEFISecurebootUpdateDBPrepare(c *Command, req *securebootRequest) Response {
+	if req.KeyDatabase != "DBX" {
+		return InternalError("support for key database %q is not implemented", req.KeyDatabase)
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(req.Payload)
+	if err != nil {
+		return BadRequest("cannot decode payload: %v", err)
+	}
+
+	err = fdestateEFISecureBootDBUpdatePrepare(c.d.state,
+		fdestate.EFISecurebootDBX, // only DBX updates are supported
+		payload)
+	if err != nil {
+		return BadRequest("cannot notify of update prepare: %v", err)
+	}
+
+	return SyncResponse(nil)
+}
+
+var fdestateEFISecureBootDBUpdateCleanup = fdestate.EFISecureBootDBUpdateCleanup
+
+func postSystemActionEFISecurebootUpdateDBCleanup(c *Command) Response {
+	if err := fdestateEFISecureBootDBUpdateCleanup(c.d.state); err != nil {
+		return BadRequest("cannot notify of update cleanup: %v", err)
+	}
+
+	return SyncResponse(nil)
+}
+
+var fdestateEFISecureBootDBManagerStartup = fdestate.EFISecureBootDBManagerStartup
+
+func postSystemActionEFISecurebootUpdateStartup(c *Command) Response {
+	if err := fdestateEFISecureBootDBManagerStartup(c.d.state); err != nil {
+		return BadRequest("cannot notify of manager startup: %v", err)
+	}
+
+	return SyncResponse(nil)
+}

--- a/daemon/api_system_secureboot_test.go
+++ b/daemon/api_system_secureboot_test.go
@@ -1,0 +1,251 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var _ = Suite(&systemSecurebootSuite{})
+
+type systemSecurebootSuite struct {
+	apiBaseSuite
+}
+
+func (s *systemSecurebootSuite) SetUpTest(c *C) {
+	s.apiBaseSuite.SetUpTest(c)
+
+	s.expectRootAccess()
+	s.expectWriteAccess(daemon.InterfaceProviderRootAccess{
+		Interfaces: []string{"fwupd"},
+	})
+
+	s.AddCleanup(daemon.MockFdestateEFISecureBootDBUpdatePrepare(func(st *state.State, db fdestate.EFISecurebootKeyDatabase, payload []byte) error {
+		panic("unexpected call")
+	}))
+	s.AddCleanup(daemon.MockFdestateEFISecureBootDBUpdateCleanup(func(st *state.State) error {
+		panic("unexpected call")
+	}))
+	s.AddCleanup(daemon.MockFdestateEFISecureBootDBManagerStartup(func(st *state.State) error {
+		panic("unexpected call")
+	}))
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootContentType(c *C) {
+	s.daemon(c)
+
+	body := strings.NewReader(`{"action": "blah"}`)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", body)
+	c.Assert(err, IsNil)
+
+	rsp := s.errorReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Assert(rsp.Message, Equals, `unexpected content type: ""`)
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootBogusAction(c *C) {
+	s.daemon(c)
+
+	body := strings.NewReader(`{"action": "blah"}`)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", body)
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.errorReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Assert(rsp.Message, Equals, `unsupported EFI secure boot action "blah"`)
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootUpdateStartup(c *C) {
+	s.daemon(c)
+
+	startupCalls := 0
+	s.AddCleanup(daemon.MockFdestateEFISecureBootDBManagerStartup(func(st *state.State) error {
+		startupCalls++
+		return nil
+	}))
+
+	body := strings.NewReader(`{"action": "efi-secureboot-update-startup"}`)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", body)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 200)
+
+	c.Check(startupCalls, Equals, 1)
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootUpdateDBCleanup(c *C) {
+	s.daemon(c)
+
+	cleanupCalls := 0
+	s.AddCleanup(daemon.MockFdestateEFISecureBootDBUpdateCleanup(func(st *state.State) error {
+		cleanupCalls++
+		return nil
+	}))
+
+	body := strings.NewReader(`{"action": "efi-secureboot-update-db-cleanup"}`)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", body)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 200)
+
+	c.Check(cleanupCalls, Equals, 1)
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootUpdateDBPrepareNoData(c *C) {
+	s.daemon(c)
+
+	body := strings.NewReader(`{
+ "action": "efi-secureboot-update-db-prepare",
+ "key-database": "DBX"
+}`)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", body)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.errorReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Message, Matches, "update payload not provided")
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootUpdateDBPrepareBogusDB(c *C) {
+	s.daemon(c)
+
+	body := strings.NewReader(`{
+ "action": "efi-secureboot-update-db-prepare",
+ "key-database": "FOO"
+}`)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", body)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.errorReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Message, Equals, `invalid key database "FOO"`)
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootUpdateDBPrepareBadPayload(c *C) {
+	s.daemon(c)
+
+	body := strings.NewReader(`{
+ "action": "efi-secureboot-update-db-prepare",
+ "key-database": "DBX",
+ "payload": "123"
+}`)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", body)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.errorReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Message, Matches, `cannot decode payload: illegal base64 .*`)
+}
+
+func (s *systemSecurebootSuite) TestEFISecurebootUpdateDBPrepareHappy(c *C) {
+	s.daemon(c)
+
+	updatePrepareCalls := 0
+	s.AddCleanup(daemon.MockFdestateEFISecureBootDBUpdatePrepare(func(st *state.State, db fdestate.EFISecurebootKeyDatabase, payload []byte) error {
+		c.Check(db, Equals, fdestate.EFISecurebootDBX)
+		c.Check(payload, DeepEquals, []byte("payload"))
+		updatePrepareCalls++
+		return nil
+	}))
+
+	body, err := json.Marshal(map[string]any{
+		"action":       "efi-secureboot-update-db-prepare",
+		"key-database": "DBX",
+		"payload":      base64.StdEncoding.EncodeToString([]byte("payload")),
+	})
+	c.Assert(err, IsNil)
+	req, err := http.NewRequest("POST", "/v2/system-secureboot", bytes.NewReader(body))
+	c.Assert(err, IsNil)
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 200)
+
+	c.Check(updatePrepareCalls, Equals, 1)
+}
+
+func (s *systemSecurebootSuite) TestSecurebootRequestValidate(c *C) {
+	r := daemon.SecurebootRequest{
+		Action: "foo",
+	}
+	c.Check(r.Validate(), ErrorMatches, `unsupported EFI secure boot action "foo"`)
+
+	r = daemon.SecurebootRequest{
+		Action:      "efi-secureboot-update-startup",
+		KeyDatabase: "DBX",
+	}
+	c.Check(r.Validate(), ErrorMatches, `unexpected key database for action "efi-secureboot-update-startup"`)
+
+	r = daemon.SecurebootRequest{
+		Action:  "efi-secureboot-update-db-cleanup",
+		Payload: "123",
+	}
+	c.Check(r.Validate(), ErrorMatches, `unexpected payload for action "efi-secureboot-update-db-cleanup"`)
+
+	r = daemon.SecurebootRequest{
+		Action:      "efi-secureboot-update-db-prepare",
+		KeyDatabase: "FOO",
+	}
+	c.Check(r.Validate(), ErrorMatches, `invalid key database "FOO"`)
+
+	r = daemon.SecurebootRequest{
+		Action:      "efi-secureboot-update-db-prepare",
+		KeyDatabase: "DBX",
+	}
+	c.Check(r.Validate(), ErrorMatches, `update payload not provided`)
+
+	// valid
+	for _, r := range []daemon.SecurebootRequest{{
+		Action:      "efi-secureboot-update-db-prepare",
+		KeyDatabase: "DBX",
+		Payload:     "123",
+	}, {
+		Action: "efi-secureboot-update-db-cleanup",
+	}, {
+		Action: "efi-secureboot-update-startup",
+	}} {
+		c.Logf("testing valid request %+v", r)
+		c.Check(r.Validate(), IsNil)
+	}
+}

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -34,6 +34,9 @@ type (
 	SnapAccess                   = snapAccess
 	InterfaceOpenAccess          = interfaceOpenAccess
 	InterfaceAuthenticatedAccess = interfaceAuthenticatedAccess
+	InterfaceProviderRootAccess  = interfaceProviderRootAccess
+
+	InterfaceAccessReqs = interfaceAccessReqs
 )
 
 var CheckPolkitActionImpl = checkPolkitActionImpl
@@ -64,7 +67,7 @@ func MockCgroupSnapNameFromPid(new func(pid int) (string, error)) (restore func(
 
 var RequireInterfaceApiAccessImpl = requireInterfaceApiAccessImpl
 
-func MockRequireInterfaceApiAccess(new func(d *Daemon, r *http.Request, ucred *ucrednet, interfaceNames []string) *apiError) (restore func()) {
+func MockRequireInterfaceApiAccess(new func(d *Daemon, r *http.Request, ucred *ucrednet, reqs InterfaceAccessReqs) *apiError) (restore func()) {
 	old := requireInterfaceApiAccess
 	requireInterfaceApiAccess = new
 	return func() {

--- a/daemon/export_api_system_secureboot_test.go
+++ b/daemon/export_api_system_secureboot_test.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SecurebootRequest = securebootRequest
+
+func MockFdestateEFISecureBootDBUpdatePrepare(
+	f func(st *state.State, db fdestate.EFISecurebootKeyDatabase, payload []byte) error,
+) (restore func()) {
+	restore = testutil.Backup(&fdestateEFISecureBootDBUpdatePrepare)
+	fdestateEFISecureBootDBUpdatePrepare = f
+	return restore
+}
+
+func MockFdestateEFISecureBootDBUpdateCleanup(
+	f func(st *state.State) error,
+) (restore func()) {
+	restore = testutil.Backup(&fdestateEFISecureBootDBUpdateCleanup)
+	fdestateEFISecureBootDBUpdateCleanup = f
+	return restore
+}
+
+func MockFdestateEFISecureBootDBManagerStartup(
+	f func(st *state.State) error,
+) (restore func()) {
+	restore = testutil.Backup(&fdestateEFISecureBootDBManagerStartup)
+	fdestateEFISecureBootDBManagerStartup = f
+	return restore
+}

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -1,0 +1,68 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package fdestate
+
+import (
+	"errors"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// EFISecureBootDBManagerStartup indicates that the local EFI key database
+// manager has started.
+func EFISecureBootDBManagerStartup(st *state.State) error {
+	if _, err := device.SealedKeysMethod(dirs.GlobalRootDir); err == device.ErrNoSealedKeys {
+		return nil
+	}
+
+	return errNotImplemented
+}
+
+type EFISecurebootKeyDatabase int
+
+const (
+	EFISecurebootPK EFISecurebootKeyDatabase = iota
+	EFISecurebootKEK
+	EFISecurebootDB
+	EFISecurebootDBX
+)
+
+// EFISecureBootDBUpdatePrepare notifies notifies that the local EFI key
+// database manager is about to update the database.
+func EFISecureBootDBUpdatePrepare(st *state.State, db EFISecurebootKeyDatabase, payload []byte) error {
+	if _, err := device.SealedKeysMethod(dirs.GlobalRootDir); err == device.ErrNoSealedKeys {
+		return nil
+	}
+
+	return errNotImplemented
+}
+
+// EFISecureBootDBUpdateCleanup notifies that the local EFI key database manager
+// has reached a cleanup stage of the update process.
+func EFISecureBootDBUpdateCleanup(st *state.State) error {
+	if _, err := device.SealedKeysMethod(dirs.GlobalRootDir); err == device.ErrNoSealedKeys {
+		return nil
+	}
+
+	return errNotImplemented
+}


### PR DESCRIPTION
Add a dedicated integration API endpoint for controlling/notifying of secure boot keys databases updates.

This is a draft PR with no unit tests, with the purpose of validating the API endpoint and the policy around it.

Related: SNAPDENG-32364 SNAPDENG-31856
