### PR TITLE
interfaces: apparmor: Add read-access to debian_version to the template

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -196,6 +196,9 @@ var templateCommon = `
   /etc/os-release rk,
   /usr/lib/os-release k,
 
+  # Debian version of the host OS which might be required in AppArmor-secured Debian
+  /etc/debian_version r,
+
   # systemd native journal API (see sd_journal_print(4)). This should be in
   # AppArmor's base abstraction, but until it is, include here. We include
   # the base journal path as well as the journal namespace pattern path. Each


### PR DESCRIPTION
As discovered while running Slack on Debian, it seems required and sensible to allow read-access to /etc/debian_version in a similar manner to /etc/os-release.

Reference: https://forum.snapcraft.io/t/cant-start-slack-on-debian-bookworm/41630/2