### PR TITLE
i/b: allow ro when allowing rw for mount-control

### DIFF
--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -78,6 +78,10 @@ plugs:
     where: $SNAP_COMMON/mnt/**
     type: [aufs]
     options: [br:/mnt/a, add:0:/mnt/b, dirwh=1, rw]
+  - what: /dev/ctrlx-nvram/usr
+    where: $SNAP_COMMON/nvram
+    type: [nvram]
+    options: [rw,sync,nosuid]
 apps:
  app:
   plugs: [mntctl]
@@ -376,6 +380,15 @@ func (s *MountControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine7)
 	expectedUmountLine7 := `umount "/var/snap/consumer/common/mnt/**{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedUmountLine7)
+
+	expectedMountLine8 := `mount fstype=(nvram) options=(rw,sync,nosuid) ` +
+		`"/dev/ctrlx-nvram/usr" -> "/var/snap/consumer/common/nvram{,/}",`
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine8)
+	expectedMountLine9 := `mount fstype=(nvram) options=(ro,sync,nosuid) ` +
+		`"/dev/ctrlx-nvram/usr" -> "/var/snap/consumer/common/nvram{,/}",`
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine9)
+	expectedUmountLine8 := `umount "/var/snap/consumer/common/nvram{,/}",`
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedUmountLine8)
 }
 
 func (s *MountControlInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
AppArmor has fixed CVE-2016-1585 which made mount rules more strict. This has caused a regression where snaps relying on the old behavior stopped working.

One failure mode we are aware of is when the snap declares "rw" mounts in the mount-control plug but uses "ro" mount in practice. In this case we can reasonably emit an equivalent "ro" permission when "rw" permissions are already granted.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-32513
