### PR TITLE
interfaces/builtin: add u2f trustkey t120 product id

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -188,9 +188,9 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "8055",
 	},
 	{
-		Name:             "TrustKey TrustKey G310H",
+		Name:             "TrustKeys FIDO2 U2F",
 		VendorIDPattern:  "311f",
-		ProductIDPattern: "4a2a",
+		ProductIDPattern: "4a2a|a6e9",
 	},
 	{
 		Name:             "OneSpan DIGIPASS FX Series",


### PR DESCRIPTION
Inspired by [pull/14429](https://github.com/canonical/snapd/pull/14429) that did not pass CLA check.

 https://github.com/Yubico/libfido2/blob/main/udev/70-u2f.rules

`# TrustKey Solutions FIDO2 T120 by eWBM Co., Ltd.
KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="311f", ATTRS{idProduct}=="a6e9", TAG+="uaccess", GROUP="plugdev", MODE="0660"`