### PR TITLE
many: make snap pack --check-skeleton error logs consistent

### DIFF
--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -110,7 +110,7 @@ func (x *packCmd) Execute([]string) error {
 
 	if x.CheckSkeleton {
 		err := pack.CheckSkeleton(Stderr, x.Positional.SnapDir)
-		if err == snap.ErrMissingPaths {
+		if errors.Is(err, snap.ErrMissingPaths) {
 			return nil
 		}
 		return err

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -107,7 +107,7 @@ func (s *SnapSuite) TestPackPacksFailsForMissingPaths(c *check.C) {
 	snapDir := makeSnapDirForPack(c, packSnapYaml)
 
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", snapDir, snapDir})
-	c.Assert(err, check.ErrorMatches, ".* snap is unusable due to missing files")
+	c.Assert(err, check.ErrorMatches, `.* snap is unusable due to missing files: path "bin/hello" does not exist`)
 }
 
 func (s *SnapSuite) TestPackPacksASnap(c *check.C) {

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -107,7 +107,8 @@ func (s *SnapSuite) TestPackPacksFailsForMissingPaths(c *check.C) {
 	snapDir := makeSnapDirForPack(c, packSnapYaml)
 
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", snapDir, snapDir})
-	c.Assert(err, check.ErrorMatches, `.* snap is unusable due to missing files: path "bin/hello" does not exist`)
+	// needed files/dirs are tracked in map so order of first error is not guaranteed
+	c.Assert(err, check.ErrorMatches, `.* snap is unusable due to missing files: path "(bin/hello|bin)" does not exist`)
 }
 
 func (s *SnapSuite) TestPackPacksASnap(c *check.C) {

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -84,9 +84,11 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta" does not exist`)
 
 	err = snap.ValidateComponentContainer(container, "empty-snap+comp.comp", discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta" does not exist`)
 }
 
@@ -107,6 +109,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "." should be world-readable and executable, and isn't: drwx------`)
 }
 
@@ -121,6 +124,7 @@ func (s *validateSuite) TestValidateComponentContainerEmptyButBadPermFails(c *C)
 	// snapdir has /meta/component.yaml, but / is 0700
 
 	err = snap.ValidateComponentContainer(s.container(), "empty-snap+comp.comp", discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "." should be world-readable and executable, and isn't: drwx------`)
 }
 
@@ -138,11 +142,13 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta/snap.yaml" does not exist`)
 
 	// component's / and /meta are 0755 (i.e. OK), but no /meta/component.yaml
 
 	err = snap.ValidateComponentContainer(container, "empty-snap+comp.comp", discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta/component.yaml" does not exist`)
 }
 
@@ -161,6 +167,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/snap.yaml" should be world-readable, and isn't: ----------`)
 }
 
@@ -173,6 +180,7 @@ func (s *validateSuite) TestValidateComponentContainerSnapYamlBadPermsFails(c *C
 	// /meta/component.yaml exists, but isn't readable
 
 	err := snap.ValidateComponentContainer(s.container(), "empty-snap+comp.comp", discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/component.yaml" should be world-readable, and isn't: ----------`)
 }
 
@@ -191,6 +199,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/snap.yaml" should be a regular file \(or a symlink\) and isn't`)
 }
 
@@ -233,6 +242,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "foo" does not exist`)
 }
 
@@ -252,6 +262,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "foo" should be world-readable and executable, and isn't: -r--r--r--`)
 }
 
@@ -272,6 +283,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "apps" should be world-readable and executable, and isn't: drwx------`)
 }
 
@@ -293,6 +305,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "svcs/bar" should be executable, and isn't: ----------`)
 }
 
@@ -316,6 +329,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "comp/foo.sh" does not exist`)
 }
 
@@ -404,6 +418,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/symlink" should be world-readable, and isn't: -rwx--x--x`)
 }
 
@@ -429,6 +444,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/symlink" should be world-readable, and isn't: ----------`)
 }
 
@@ -450,6 +466,7 @@ version: 1
 	}
 
 	err = snap.ValidateSnapContainer(s.container(), info, mockLogf)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: external symlink found: meta/gui/icons/snap.empty-snap.png -> /etc/shadow`)
 }
 
@@ -472,6 +489,7 @@ version: 1
 	}
 
 	err = snap.ValidateSnapContainer(s.container(), info, mockLogf)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: external symlink found: meta/gui/icons/snap.empty-snap.png -> 1/../../2/../../3/4/../../../../..`)
 }
 
@@ -518,6 +536,7 @@ version: 1
 	c.Check(metaDirSymlinkErrFound, Equals, true)
 	// the check for missing files precedes check for permission errors, so we
 	// check for it instead.
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta/snap.yaml" does not exist`)
 }
 
@@ -599,6 +618,7 @@ version: 1
 	}
 
 	err = snap.ValidateSnapContainer(s.container(), info, mockLogf)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Check(err, ErrorMatches, "snap is unusable due to bad permissions: too many levels of symbolic links")
 	c.Check(loopFound, Equals, true)
 }

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -84,10 +84,10 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
-	c.Check(err, Equals, snap.ErrMissingPaths)
+	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta" does not exist`)
 
 	err = snap.ValidateComponentContainer(container, "empty-snap+comp.comp", discard)
-	c.Check(err, Equals, snap.ErrMissingPaths)
+	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta" does not exist`)
 }
 
 func (s *validateSuite) TestValidateContainerEmptyButBadPermFails(c *C) {
@@ -107,7 +107,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "." should be world-readable and executable, and isn't: drwx------`)
 }
 
 func (s *validateSuite) TestValidateComponentContainerEmptyButBadPermFails(c *C) {
@@ -121,16 +121,16 @@ func (s *validateSuite) TestValidateComponentContainerEmptyButBadPermFails(c *C)
 	// snapdir has /meta/component.yaml, but / is 0700
 
 	err = snap.ValidateComponentContainer(s.container(), "empty-snap+comp.comp", discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "." should be world-readable and executable, and isn't: drwx------`)
 }
 
 func (s *validateSuite) TestValidateContainerMissingSnapYamlFails(c *C) {
 	const yaml = `name: empty-snap
 version: 1
 `
-	container := s.container()
 	c.Assert(os.Chmod(s.snapDirPath, 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(s.snapDirPath, "meta"), 0755), IsNil)
+	container := s.container()
 
 	// snapdir's / and /meta are 0755 (i.e. OK), but no /meta/snap.yaml
 
@@ -138,12 +138,12 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
-	c.Check(err, Equals, snap.ErrMissingPaths)
+	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta/snap.yaml" does not exist`)
 
 	// component's / and /meta are 0755 (i.e. OK), but no /meta/component.yaml
 
 	err = snap.ValidateComponentContainer(container, "empty-snap+comp.comp", discard)
-	c.Check(err, Equals, snap.ErrMissingPaths)
+	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta/component.yaml" does not exist`)
 }
 
 func (s *validateSuite) TestValidateContainerSnapYamlBadPermsFails(c *C) {
@@ -161,7 +161,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/snap.yaml" should be world-readable, and isn't: ----------`)
 }
 
 func (s *validateSuite) TestValidateComponentContainerSnapYamlBadPermsFails(c *C) {
@@ -173,7 +173,7 @@ func (s *validateSuite) TestValidateComponentContainerSnapYamlBadPermsFails(c *C
 	// /meta/component.yaml exists, but isn't readable
 
 	err := snap.ValidateComponentContainer(s.container(), "empty-snap+comp.comp", discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/component.yaml" should be world-readable, and isn't: ----------`)
 }
 
 func (s *validateSuite) TestValidateContainerSnapYamlNonRegularFails(c *C) {
@@ -191,7 +191,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/snap.yaml" should be a regular file \(or a symlink\) and isn't`)
 }
 
 // bootstrapEmptyContainer creates a minimal container directory under
@@ -233,7 +233,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrMissingPaths)
+	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "foo" does not exist`)
 }
 
 func (s *validateSuite) TestValidateContainerBadAppPermsFails(c *C) {
@@ -252,7 +252,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "foo" should be world-readable and executable, and isn't: -r--r--r--`)
 }
 
 func (s *validateSuite) TestValidateContainerBadAppDirPermsFails(c *C) {
@@ -272,7 +272,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "apps" should be world-readable and executable, and isn't: drwx------`)
 }
 
 func (s *validateSuite) TestValidateContainerBadSvcPermsFails(c *C) {
@@ -293,7 +293,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "svcs/bar" should be executable, and isn't: ----------`)
 }
 
 func (s *validateSuite) TestValidateContainerCompleterFails(c *C) {
@@ -316,7 +316,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(s.container(), info, discard)
-	c.Check(err, Equals, snap.ErrMissingPaths)
+	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "comp/foo.sh" does not exist`)
 }
 
 func (s *validateSuite) TestValidateContainerBadAppPathOK(c *C) {
@@ -404,7 +404,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
-	c.Check(err, ErrorMatches, "snap is unusable due to bad permissions")
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/symlink" should be world-readable, and isn't: -rwx--x--x`)
 }
 
 func (s *validateSuite) TestValidateContainerSymlinksMetaBadTargetMode0000(c *C) {
@@ -429,7 +429,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	err = snap.ValidateSnapContainer(container, info, discard)
-	c.Check(err, ErrorMatches, "snap is unusable due to bad permissions")
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/symlink" should be world-readable, and isn't: ----------`)
 }
 
 func (s *validateSuite) TestValidateContainerMetaExternalAbsSymlinksFails(c *C) {
@@ -450,7 +450,7 @@ version: 1
 	}
 
 	err = snap.ValidateSnapContainer(s.container(), info, mockLogf)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: external symlink found: meta/gui/icons/snap.empty-snap.png -> /etc/shadow`)
 }
 
 func (s *validateSuite) TestValidateContainerMetaExternalRelativeSymlinksFails(c *C) {
@@ -472,7 +472,7 @@ version: 1
 	}
 
 	err = snap.ValidateSnapContainer(s.container(), info, mockLogf)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, `snap is unusable due to bad permissions: external symlink found: meta/gui/icons/snap.empty-snap.png -> 1/../../2/../../3/4/../../../../..`)
 }
 
 func (s *validateSuite) TestValidateContainerMetaExternalRelativeSymlinksOk(c *C) {
@@ -518,7 +518,7 @@ version: 1
 	c.Check(metaDirSymlinkErrFound, Equals, true)
 	// the check for missing files precedes check for permission errors, so we
 	// check for it instead.
-	c.Check(err, Equals, snap.ErrMissingPaths)
+	c.Check(err, ErrorMatches, `snap is unusable due to missing files: path "meta/snap.yaml" does not exist`)
 }
 
 func (s *validateSuite) TestValidateContainerAppsOK(c *C) {
@@ -599,7 +599,7 @@ version: 1
 	}
 
 	err = snap.ValidateSnapContainer(s.container(), info, mockLogf)
-	c.Check(err, Equals, snap.ErrBadModes)
+	c.Check(err, ErrorMatches, "snap is unusable due to bad permissions: too many levels of symbolic links")
 	c.Check(loopFound, Equals, true)
 }
 

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -122,7 +122,7 @@ func loadAndValidate(sourceDir string, yaml []byte) (*snap.Info, error) {
 		return nil, fmt.Errorf("cannot validate snap %q: %v", info.InstanceName(), err)
 	}
 
-	if err := snap.ValidateSnapContainer(container, info, logger.Debugf); err != nil {
+	if err := snap.ValidateSnapContainer(container, info, logger.Noticef); err != nil {
 		return nil, err
 	}
 	if _, err := snap.ReadSnapshotYamlFromSnapFile(container); err != nil {
@@ -256,7 +256,7 @@ func packComponent(sourceDir string, yaml []byte, opts *Options) (string, error)
 		return "", err
 	}
 	compPath := componentPath(ci, opts.TargetDir, opts.SnapName)
-	if err := snap.ValidateComponentContainer(cont, compPath, logger.Debugf); err != nil {
+	if err := snap.ValidateComponentContainer(cont, compPath, logger.Noticef); err != nil {
 		return "", err
 	}
 

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -122,7 +122,7 @@ func loadAndValidate(sourceDir string, yaml []byte) (*snap.Info, error) {
 		return nil, fmt.Errorf("cannot validate snap %q: %v", info.InstanceName(), err)
 	}
 
-	if err := snap.ValidateSnapContainer(container, info, logger.Noticef); err != nil {
+	if err := snap.ValidateSnapContainer(container, info, logger.Debugf); err != nil {
 		return nil, err
 	}
 	if _, err := snap.ReadSnapshotYamlFromSnapFile(container); err != nil {
@@ -256,7 +256,7 @@ func packComponent(sourceDir string, yaml []byte, opts *Options) (string, error)
 		return "", err
 	}
 	compPath := componentPath(ci, opts.TargetDir, opts.SnapName)
-	if err := snap.ValidateComponentContainer(cont, compPath, logger.Noticef); err != nil {
+	if err := snap.ValidateComponentContainer(cont, compPath, logger.Debugf); err != nil {
 		return "", err
 	}
 

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -167,6 +167,7 @@ apps:
 `)
 	c.Assert(os.Remove(filepath.Join(sourceDir, "bin", "hello-world")), IsNil)
 	_, err := pack.Pack(sourceDir, pack.Defaults)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Assert(err, ErrorMatches, `snap is unusable due to missing files: path "bin/hello-world" does not exist`)
 }
 
@@ -195,6 +196,7 @@ apps:
 	for _, hook := range configureHooks {
 		c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "hooks", hook), []byte("#!/bin/sh"), 0644), IsNil)
 		_, err := pack.Pack(sourceDir, pack.Defaults)
+		c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 		c.Check(err, ErrorMatches, fmt.Sprintf("snap is unusable due to bad permissions: \"meta/hooks/%s\" should be executable, and isn't: -rw-r--r--", hook))
 		// Fix hook error to catch next hook's error
 		c.Assert(os.Chmod(filepath.Join(sourceDir, "meta", "hooks", hook), 755), IsNil)
@@ -248,6 +250,7 @@ apps:
 `
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "snapshots.yaml"), []byte(invalidSnapshotYaml), 0411), IsNil)
 	_, err := pack.Pack(sourceDir, pack.Defaults)
+	c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 	c.Assert(err, ErrorMatches, `snap is unusable due to bad permissions: "meta/snapshots.yaml" should be world-readable, and isn't: -r----x--x`)
 }
 
@@ -285,6 +288,7 @@ apps:
 	c.Assert(os.Remove(filepath.Join(sourceDir, "bin", "hello-world")), IsNil)
 
 	err = pack.CheckSkeleton(&buf, sourceDir)
+	c.Check(err, testutil.ErrorIs, snap.ErrMissingPaths)
 	c.Assert(err, ErrorMatches, `snap is unusable due to missing files: path "bin/hello-world" does not exist`)
 	c.Check(buf.String(), Equals, "")
 }

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -193,9 +193,9 @@ apps:
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, "meta", "hooks"), 0755), IsNil)
 	configureHooks := []string{"configure", "default-configure"}
 	for _, hook := range configureHooks {
-		c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "hooks", hook), []byte("#!/bin/sh"), 0666), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "hooks", hook), []byte("#!/bin/sh"), 0644), IsNil)
 		_, err := pack.Pack(sourceDir, pack.Defaults)
-		c.Check(err, ErrorMatches, fmt.Sprintf("snap is unusable due to bad permissions: \"meta/hooks/%s\" should be executable, and isn't: -rw-rw-r--", hook))
+		c.Check(err, ErrorMatches, fmt.Sprintf("snap is unusable due to bad permissions: \"meta/hooks/%s\" should be executable, and isn't: -rw-r--r--", hook))
 		// Fix hook error to catch next hook's error
 		c.Assert(os.Chmod(filepath.Join(sourceDir, "meta", "hooks", hook), 755), IsNil)
 	}


### PR DESCRIPTION
This improves some inconsistencies in "snap pack --check-skeleton" error logs.

- Shows detailed logs only if SNAPD_DEBUG is set.
- Returns first error caught

It should be explored how to aggregate errors with consistency in mind as this is parsed by snapcraft.

For more context: https://warthogs.atlassian.net/browse/SNAPDENG-23795