### PR TITLE
build-aux: use <version?> golang

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -195,7 +195,7 @@ parts:
     plugin: nil
     source: .
     build-snaps:
-      - go/1.18/stable # the default Go toolchain
+      - go/latest/stable # the default Go toolchain
     after:
       - apparmor
     build-packages:


### PR DESCRIPTION
There's no need to stick to old go when building snapd snap. Upstream go maintains last three releases and this is mirrored in the go snap packages. By using latest stable go, we also get the latest stable standard library and corresponding CVE fixes.
