### PR TITLE
tests: install go version using the setup-go@v5 action

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -39,6 +39,13 @@ jobs:
           sudo apt clean
           sudo apt update
           sudo apt build-dep -y "${{ github.workspace }}/src/github.com/snapcore/snapd"
+
+    - name: Install the go version
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.18.10'
+    - run: go version
 
     - name: Install the go snap
       run: |


### PR DESCRIPTION
This is required to fix an issue that happens when Coverity tool is used with go snap.

Also update the version of the checkout action to avoid a warning
