### PR TITLE
tests: minor fix for step used to setup go version

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -41,11 +41,11 @@ jobs:
           sudo apt build-dep -y "${{ github.workspace }}/src/github.com/snapcore/snapd"
 
     - name: Install the go version
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+      uses: actions/setup-go@v5
       with:
         go-version: '1.18.10'
-    - run: go version
+      run: |
+          go version
 
     - name: Install the go snap
       run: |


### PR DESCRIPTION
This fix is required to make the nightly job well.
