### PR TITLE
tests: remove run from got setup

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,8 +44,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.18.10'
-      run: |
-          go version
 
     - name: Install the go snap
       run: |


### PR DESCRIPTION
Apparently the examples in go-setup action were not tested well.
