### PR TITLE
tests: remove go snap refresh from nightly job

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -83,7 +83,6 @@ jobs:
 
     - name: Install TICS dependencies
       run: |
-          sudo snap refresh --channel=latest/stable go
           go install honnef.co/go/tools/cmd/staticcheck@latest
           sudo apt install -y pylint
 


### PR DESCRIPTION
This step fails as we are not installing the go snap anymore
