### PR TITLE
tests: udpate the go version used for nightly run

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         gochannel:
-          - 1.18
+          - 1.23
         unit-scenario:
           - normal
 


### PR DESCRIPTION
This is needed because staticcheck requires 1.23

go: honnef.co/go/tools/cmd/staticcheck@latest (in honnef.co/go/tools@v0.5.1): go.mod:3: invalid go version '1.22.1': must match format 1.23