### PR TITLE
o/snapstate: bump timeout in test*ComponentsRunThrough variants

### DIFF
--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -15023,7 +15023,12 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		c.Assert(te.Kind(), Equals, "validate-snap")
 	}
 
-	s.settle(c)
+	// we manually settle here since this test can be slow when the host is
+	// under load
+	s.state.Unlock()
+	err = s.o.Settle(testutil.HostScaledTimeout(15 * time.Second))
+	s.state.Lock()
+	c.Assert(err, IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
 
 	if opts.undo {
 		c.Assert(chg.Err(), NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
@@ -15718,7 +15723,12 @@ components:
 	c.Assert(te, NotNil)
 	c.Assert(te.Kind(), Equals, "prepare-snap")
 
-	s.settle(c)
+	// we manually settle here since this test can be slow when the host is
+	// under load
+	s.state.Unlock()
+	err = s.o.Settle(testutil.HostScaledTimeout(15 * time.Second))
+	s.state.Lock()
+	c.Assert(err, IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
 
 	if undo {
 		c.Assert(chg.Err(), NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
@@ -16133,7 +16143,12 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 	c.Assert(te, NotNil)
 	c.Assert(te.Kind(), Equals, "prepare-snap")
 
-	s.settle(c)
+	// we manually settle here since this test can be slow when the host is
+	// under load
+	s.state.Unlock()
+	err = s.o.Settle(testutil.HostScaledTimeout(15 * time.Second))
+	s.state.Lock()
+	c.Assert(err, IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
 
 	if opts.undo {
 		c.Assert(chg.Err(), NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))


### PR DESCRIPTION
I spent a while trying to reproduce this issue by running the spread test manually, but I wasn't able to catch it in the act. I'm pretty confident the failures we're seeing are because of a timeout that is too low, since the state of the tasks when settle times out has been different in the cases where we have seen a failure. This indicates to me that we're not getting stuck on something specific.

Regardless, if we have a real issue where something is getting completely blocked, this won't solve anything. However, if the issue is that our timeout is just too low, then hopefully this will make things better.