### PR TITLE
i/builtin: allow accessing real-time clock device nodes via symlinks

### DIFF
--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -93,6 +93,9 @@ capability sys_time,
 /sys/class/rtc/*/ rw,
 /sys/class/rtc/*/** rw,
 
+# Nodes in /sys/class/rtc could be symlinks under /sys/devices
+/sys/devices/**/rtc/*/** rw,
+
 # Allow access to pps
 # https://www.kernel.org/doc/html/latest/driver-api/pps.html
 /dev/pps[0-9]* rw,

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer/bin/sh
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer/meta/snap.yaml
@@ -19,3 +19,6 @@ apps:
     date:
         command: bin/date
         plugs: [time-control]
+    sh:
+        command: bin/sh
+        plugs: [time-control]

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -67,6 +67,9 @@ execute: |
         exit 0
     fi
 
+    # make sure that we can access the files in /sys/class/rtc
+    test-snapd-timedate-control-consumer.sh -c "cat /sys/class/rtc/rtc0/wakealarm"
+
     echo "When the plug is disconnected"
     snap disconnect test-snapd-timedate-control-consumer:time-control
 
@@ -81,3 +84,5 @@ execute: |
     not test-snapd-timedate-control-consumer.date "$now" 2> call.error
     # EPERM because date gets blocked by the seccomp profile
     MATCH "cannot set date: Operation not permitted" < call.error
+
+    not test-snapd-timedate-control-consumer.sh -c "cat /sys/class/rtc/rtc0/wakealarm"


### PR DESCRIPTION
We already allow access to the symlinks themselves, but we weren't allowing access to their destinations.