### PR TITLE
data/selinux: allow mounting on var_t

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -575,8 +575,9 @@ allow snappy_mount_t lib_t:dir mounton;
 # mount things labeled usr_t from the host
 allow snappy_mount_t usr_t:dir mounton;
 
-# allow mounting on top of /var/lib
+# allow mounting on top of /var and /var/lib
 allow snappy_mount_t var_lib_t:dir mounton;
+allow snappy_mount_t var_t:dir mounton;
 
 # mount and unmount on top of snaps
 allow snappy_mount_t snappy_snap_t:dir mounton;


### PR DESCRIPTION
This comes up when snap-update-ns called from snapd attempts to mount on files labeled with var_t, such as /var/cache/swcatalog.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-32055
