### PR TITLE
tests: replaced curl with snap debug api

### DIFF
--- a/tests/core/snapd-maintenance-msg/task.yaml
+++ b/tests/core/snapd-maintenance-msg/task.yaml
@@ -7,8 +7,6 @@ details: |
 systems: [ubuntu-core-20-64]
 
 prepare: |
-    # devmode as the snap does not have snapd-control
-    snap install test-snapd-curl --devmode --edge
     snap install jq
 
     # make sure that the snapd daemon gives us time for comms before
@@ -17,7 +15,7 @@ prepare: |
     systemctl restart snapd
 
 restore: |
-    snap remove test-snapd-curl jq
+    snap remove jq
 
     # remove SNAPD_SHUTDOWN_DELAY from /etc/environment again
     #shellcheck disable=SC2005
@@ -33,7 +31,7 @@ execute: |
         # closed so we need to catch it in that timeframe.
         echo "Testing maintenance message for daemon restarts"
         snap install --dangerous "$SNAPD_SNAP" &
-        retry -n 20 --wait 0.5 sh -c 'test-snapd-curl.curl -sS --unix-socket /run/snapd.socket http://localhost/v2/changes?select=all | jq ".maintenance" | MATCH "daemon is restarting"'
+        retry -n 20 --wait 0.5 sh -c 'snap debug api '/v2/changes?select=all' | jq ".maintenance" | MATCH "daemon is restarting"'
         wait
 
         echo "Restoring the snapd snap"
@@ -41,7 +39,7 @@ execute: |
 
         echo "Testing maintenance message for system reboots"
         snap refresh core20 --channel=stable --amend &
-        retry -n 20 --wait 0.5 sh -c 'test-snapd-curl.curl -sS --unix-socket /run/snapd.socket http://localhost/v2/changes?select=all | jq ".maintenance" | MATCH "system is restarting"'
+        retry -n 20 --wait 0.5 sh -c 'snap debug api '/v2/changes?select=all' | jq ".maintenance" | MATCH "system is restarting"'
         wait
 
         REBOOT

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -35,16 +35,14 @@ execute: |
         echo "In run mode"
 
         snap install --edge jq
-        # devmode as the snap does not have snapd-control
-        snap install test-snapd-curl --devmode --edge
 
         MATCH 'snapd_recovery_mode=run' < /proc/cmdline
         # verify we are in run mode via the API
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        snap debug api '/v2/system-info' > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
         echo "Obtain available systems"
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
+        snap debug api '/v2/systems' > systems.json
         # TODO:UC20: there is only one system for now
         jq .result.systems[0].current < systems.json | MATCH 'true'
         label="$(jq -r .result.systems[0].label < systems.json)"
@@ -67,7 +65,7 @@ execute: |
         # host data should be accessible
         test -e /host/ubuntu-data/systems.json.run
 
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems.json
+        snap debug api '/v2/systems' > systems.json
         jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install run'
 
         label="$(cat /host/ubuntu-data/systems.label)"
@@ -80,7 +78,7 @@ execute: |
         transition_to_run_mode "$label"
     elif [ "$SPREAD_REBOOT" == "2" ]; then
         echo "In run mode again"
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        snap debug api '/v2/system-info' > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
         # now go back to recover mode so we can test that a simple reboot 
@@ -108,6 +106,6 @@ execute: |
         REBOOT
     elif [ "$SPREAD_REBOOT" == "4" ]; then
         echo "In run mode again again"
-        test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+        snap debug api '/v2/system-info' > system-info
         jq -r '.result["system-mode"]' < system-info | MATCH 'run'
     fi

--- a/tests/lib/uc20-recovery.sh
+++ b/tests/lib/uc20-recovery.sh
@@ -130,10 +130,9 @@ prepare_recover_mode() {
 
     # we're running in an ephemeral system and thus have to re-install snaps
     snap install --edge jq
-    snap install test-snapd-curl --devmode --edge
 
     MATCH 'snapd_recovery_mode=recover' < /proc/cmdline
     # verify we are in recovery mode via the API
-    test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/system-info > system-info
+    snap debug api /v2/system-info > system-info
     jq -r '.result["system-mode"]' < system-info | MATCH 'recover'
 }

--- a/tests/main/api-get-systems-label/task.yaml
+++ b/tests/main/api-get-systems-label/task.yaml
@@ -9,15 +9,13 @@ systems:
 
 execute: |
   snap install --edge jq
-  # devmode as the snap does not have snapd-control
-  snap install test-snapd-curl --devmode --edge
 
   echo "Find what systems are available"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems > systems
+  snap debug api /v2/systems > systems
   current_label=$(jq -r '.result.systems[0]["label"]' < systems)
 
   echo "Get details for a specific system"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$current_label" > current-system
+  snap debug api /v2/systems/"$current_label" > current-system
   echo "Ensure the result contains a model assertion"
   jq -r '.result.model.type' < current-system | MATCH model
   jq -r '.result.model.series' < current-system | MATCH 16

--- a/tests/main/api-get-systems-label/task.yaml
+++ b/tests/main/api-get-systems-label/task.yaml
@@ -15,7 +15,7 @@ execute: |
   current_label=$(jq -r '.result.systems[0]["label"]' < systems)
 
   echo "Get details for a specific system"
-  snap debug api /v2/systems/"$current_label" > current-system
+  snap debug api "/v2/systems/$current_label" > current-system
   echo "Ensure the result contains a model assertion"
   jq -r '.result.model.type' < current-system | MATCH model
   jq -r '.result.model.series' < current-system | MATCH 16

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -15,10 +15,6 @@ systems:
 
 prepare: |
     snap install jq
-    if ! command -v curl; then
-        snap install --devmode --edge test-snapd-curl
-        snap alias test-snapd-curl.curl curl
-    fi
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
     "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
@@ -97,9 +93,9 @@ execute: |
         echo "Check that snap CLI reports prompting flag set correctly"
         snap get system experimental.apparmor-prompting | MATCH "$1"
         echo "Check that /v2/snaps/system/conf reports prompting flag set correctly"
-        curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
+        snap debug api /v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
         echo "Check that /v2/system-info reports prompting correctly"
-        curl -sS --unix-socket /run/snapd.socket http://localhost/v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
+        snap debug api /v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
     }
 
     echo "Precondition check that snapd is active"
@@ -143,16 +139,17 @@ execute: |
     check_prompting_setting "false"
 
     echo "Enable prompting via API request"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": true}' | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
-    echo "Check that snapd restarted after prompting set to true via curl"
+    echo '{"experimental.apparmor-prompting": true}' | snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | jq -r '.status' | MATCH "Accepted" || reset_start_limit
+
+    echo "Check that snapd restarted after prompting set to true via snap debug"
     check_snapd_restarted
     check_prompting_setting "true"
 
     echo "Disable prompting via API request"
-    curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps/system/conf -X PUT -d '{"experimental.apparmor-prompting": false}' | jq -r '.status' | MATCH "Accepted" || reset_start_limit
+    echo '{"experimental.apparmor-prompting": false}' | snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
-    echo "Check that snapd restarted after prompting set to false via curl"
+    echo "Check that snapd restarted after prompting set to false via snap debug"
     check_snapd_restarted
     check_prompting_setting "false"
 

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -142,14 +142,14 @@ execute: |
 
     echo '{"experimental.apparmor-prompting": true}' | snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
-    echo "Check that snapd restarted after prompting set to true via snap debug"
+    echo "Check that snapd restarted after prompting set to true via api"
     check_snapd_restarted
     check_prompting_setting "true"
 
     echo "Disable prompting via API request"
     echo '{"experimental.apparmor-prompting": false}' | snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | jq -r '.status' | MATCH "Accepted" || reset_start_limit
 
-    echo "Check that snapd restarted after prompting set to false via snap debug"
+    echo "Check that snapd restarted after prompting set to false via api"
     check_snapd_restarted
     check_prompting_setting "false"
 

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -4,9 +4,8 @@ details: |
     Verify the AppStream ID is included in the search API response and also validate
     that the AppStream ID is included in the installed snaps and apps API response.
 
-# ubuntu-core: no curl
-# ubuntu-14.04: curl too old, missing --unix-socket
-systems: [-ubuntu-14.04-*, -ubuntu-core*]
+# ubuntu-core: no jq
+systems: [-ubuntu-core*]
 
 prepare: |
     snap install --edge jq

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -4,10 +4,6 @@ details: |
     Verify the AppStream ID is included in the search API response and also validate
     that the AppStream ID is included in the installed snaps and apps API response.
 
-# ubuntu-core: no curl
-# ubuntu-14.04: curl too old, missing --unix-socket
-systems: [-ubuntu-14.04-*, -ubuntu-core*]
-
 prepare: |
     snap install --edge jq
 
@@ -16,7 +12,7 @@ debug: |
 
 execute: |
     echo "Verify that search results contain common-ids"
-    curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/find?name=test-snapd-appstreamid' > response
+    timeout 5 snap debug api /v2/find?name=test-snapd-appstreamid > response
     # shellcheck disable=SC2002
     cat response | jq -r ' .result[0]["common-ids"] | sort | join (",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
@@ -24,13 +20,13 @@ execute: |
     snap install --edge test-snapd-appstreamid
 
     echo "Verify that installed snap info contains common-ids"
-    curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/snaps/test-snapd-appstreamid' > response
+    timeout 5 snap debug api /v2/snaps/test-snapd-appstreamid > response
     # shellcheck disable=SC2002
     cat response | jq -r ' .result["common-ids"] | sort | join(",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
 
     echo "Verify that apps have their common-id set"
-    curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/apps?names=test-snapd-appstreamid' > response
+    timeout 5 snap debug api /v2/apps?names=test-snapd-appstreamid > response
     # shellcheck disable=SC2002
     cat response | jq -r ' .result | sort_by(.name) | [.[]."common-id"] | join(",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,,io.snapcraft.test-snapd-appstreamid.foo'

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -4,6 +4,10 @@ details: |
     Verify the AppStream ID is included in the search API response and also validate
     that the AppStream ID is included in the installed snaps and apps API response.
 
+# ubuntu-core: no curl
+# ubuntu-14.04: curl too old, missing --unix-socket
+systems: [-ubuntu-14.04-*, -ubuntu-core*]
+
 prepare: |
     snap install --edge jq
 

--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -10,7 +10,6 @@ systems: [ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 prepare: |
   snap install snap-store
   snap install jq
-  snap install --devmode --edge test-snapd-curl
 
 execute: |
   snap_id=$(snap info snap-store | grep snap-id | awk '{ print $2 }')
@@ -21,6 +20,6 @@ execute: |
   media_length=$(jq '. | length' < media.json)
   test "${media_length}" -gt 0
 
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 'http://localhost/v2/snaps/snap-store' | jq --sort-keys .result.media > snapd-media.json
+  timeout 5 snap debug api /v2/snaps/snap-store | jq --sort-keys .result.media > snapd-media.json
 
   diff media.json snapd-media.json

--- a/tests/main/debug-pprof/task.yaml
+++ b/tests/main/debug-pprof/task.yaml
@@ -6,7 +6,7 @@ details: |
     This test checks that the pprof profiles can be accessed through
     the http://localhost/v2/debug/pprof/ API
 
-# ubuntu-core: no jq and go
+# ubuntu-core: no jq and no go
 systems: [-ubuntu-core-*]
 
 execute: |

--- a/tests/main/debug-pprof/task.yaml
+++ b/tests/main/debug-pprof/task.yaml
@@ -6,24 +6,20 @@ details: |
     This test checks that the pprof profiles can be accessed through
     the http://localhost/v2/debug/pprof/ API
 
-# ubuntu-core: no curl
-# ubuntu-14.04: curl does not have --unix-socket option
-systems: [-ubuntu-core-*, -ubuntu-14.04-*]
-
 execute: |
     # endpoints are accessible only for the root user
-    su -c 'curl -s --unix-socket /run/snapd.socket http://localhost/v2/debug/pprof/cmdline' test > unauthorized
-    MATCH '"kind":"login-required"' < unauthorized
+    su -c 'snap debug api /v2/debug/pprof/cmdline' test > unauthorized
+    MATCH "login-required" <<<"$(jq '.result.kind' unauthorized)"
 
     # one of pprof endpoints exposes a cmdline of the process
-    curl -s --unix-socket /run/snapd.socket -o reported-cmdline http://localhost/v2/debug/pprof/cmdline
+    snap debug api /v2/debug/pprof/cmdline > reported-cmdline
     # should be the same as in /proc/<pid>/cmdline
     mainpid=$(systemctl show -p MainPID snapd.service | cut -f2 -d=)
     tr -d '\0' < "/proc/$mainpid/cmdline" > real-cmdline
     diff -up <(od -c real-cmdline) <(od -c reported-cmdline)
 
     # try to fetch a heap profile
-    curl -s --unix-socket /run/snapd.socket -o heap http://localhost/v2/debug/pprof/heap
+    snap debug api /v2/debug/pprof/heap > heap
 
     # go tool pprof fails if profile is corrupted
     go tool pprof -raw ./heap

--- a/tests/main/debug-pprof/task.yaml
+++ b/tests/main/debug-pprof/task.yaml
@@ -6,9 +6,8 @@ details: |
     This test checks that the pprof profiles can be accessed through
     the http://localhost/v2/debug/pprof/ API
 
-# ubuntu-core: no curl
-# ubuntu-14.04: curl does not have --unix-socket option
-systems: [-ubuntu-core-*, -ubuntu-14.04-*]
+# ubuntu-core: no jq and go
+systems: [-ubuntu-core-*]
 
 execute: |
     # endpoints are accessible only for the root user

--- a/tests/main/debug-pprof/task.yaml
+++ b/tests/main/debug-pprof/task.yaml
@@ -6,6 +6,10 @@ details: |
     This test checks that the pprof profiles can be accessed through
     the http://localhost/v2/debug/pprof/ API
 
+# ubuntu-core: no curl
+# ubuntu-14.04: curl does not have --unix-socket option
+systems: [-ubuntu-core-*, -ubuntu-14.04-*]
+
 execute: |
     # endpoints are accessible only for the root user
     su -c 'snap debug api /v2/debug/pprof/cmdline' test > unauthorized

--- a/tests/main/generic-unregister/task.yaml
+++ b/tests/main/generic-unregister/task.yaml
@@ -6,6 +6,9 @@ details: |
    the unregister to be performed immediately and after snapd is
    restarted.
 
+# ubuntu-14.04: curl does not have --unix-socket option
+systems: [-ubuntu-core-*, -ubuntu-14.04-*]
+
 environment:
   UNTIL_REBOOT/rereg: false
   UNTIL_REBOOT/until_reboot: true

--- a/tests/main/generic-unregister/task.yaml
+++ b/tests/main/generic-unregister/task.yaml
@@ -6,9 +6,6 @@ details: |
    the unregister to be performed immediately and after snapd is
    restarted.
 
-# ubuntu-14.04: curl does not have --unix-socket option
-systems: [-ubuntu-core-*, -ubuntu-14.04-*]
-
 environment:
   UNTIL_REBOOT/rereg: false
   UNTIL_REBOOT/until_reboot: true
@@ -44,7 +41,7 @@ execute: |
     keyfile=(/var/lib/snapd/device/private-keys-v1/*)
     test -f "${keyfile[0]}"
 
-    curl --data '{"action":"forget","no-registration-until-reboot":'${UNTIL_REBOOT}'}' --unix-socket /run/snapd.socket http://localhost/v2/model/serial
+    echo "{\"action\":\"forget\",\"no-registration-until-reboot\":${UNTIL_REBOOT}}" | snap debug api -X POST -H 'Content-Type: application/json' /v2/model/serial
 
     snap model --serial 2>&1|MATCH "error: device not registered yet"
     not test -e "${keyfile[0]}"

--- a/tests/main/generic-unregister/task.yaml
+++ b/tests/main/generic-unregister/task.yaml
@@ -6,8 +6,7 @@ details: |
    the unregister to be performed immediately and after snapd is
    restarted.
 
-# ubuntu-14.04: curl does not have --unix-socket option
-systems: [-ubuntu-core-*, -ubuntu-14.04-*]
+systems: [-ubuntu-core-*]
 
 environment:
   UNTIL_REBOOT/rereg: false

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -103,12 +103,9 @@ execute: |
     echo "Check snap can access rules via /v2/interfaces/requests/rules"
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
 
-    # XXX: creating rules requires polkit authentication, so for now, use curl
-    # XXX: should use `snap debug api` instead of curl, but should really just use api-client
     # echo "Check snap can create rule via /v2/interfaces/requests/rules"
     # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' "/v2/interfaces/requests/rules" > result.json
-    apt install -y curl
-    curl -sS --unix-socket /run/snapd.socket -d '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' "http://localhost/v2/interfaces/requests/rules" | tee result.json
+    echo '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' | snap debug api -X POST -H 'Content-Type: application/json' "/v2/interfaces/requests/rules" | tee result.json
     jq '."status-code"' < result.json | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
     RULE_ID=$(jq '."result"."id"' < result.json | tr -d '"')
     echo "Check snap can view a single rule via /v2/interfaces/requests/rules/<ID>"

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -103,6 +103,7 @@ execute: |
     echo "Check snap can access rules via /v2/interfaces/requests/rules"
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
 
+    # XXX: creating rules requires polkit authentication, so for now, use snap debug api instead of api-client
     # echo "Check snap can create rule via /v2/interfaces/requests/rules"
     # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' "/v2/interfaces/requests/rules" > result.json
     echo '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' | snap debug api -X POST -H 'Content-Type: application/json' "/v2/interfaces/requests/rules" | tee result.json

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -19,7 +19,6 @@ systems:
 
 prepare: |
   snap install go-example-webserver jq remarshal hello-world
-  snap install test-snapd-curl --edge --devmode
 
 execute: |
   echo "Create a group with a snap in it"
@@ -81,7 +80,7 @@ execute: |
       exit 1
   fi
 
-  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-one | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-one | jq -r '.result.current.memory')"
   kernelSaysMemUsage="$(cat "$cgroupMemFile")"
 
   pyCmd="import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))"
@@ -176,7 +175,7 @@ execute: |
   # in reporting it's memory usage on old systemd versions
   snap set-quota group-five --memory=10MB --parent=group-four hello-world
 
-  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-five | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-five | jq -r '.result.current.memory')"
   # both 0 and up to 12KiB values are expected here, 0 is for older systemd/kernels 
   # where an empty cgroup has exactly 0, but on newer systems there is some 
   # minimum amount of accounting memory for an empty cgroup, which is observed
@@ -190,7 +189,7 @@ execute: |
           exit 1
   esac
 
-  snapdSaysMemUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-four | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-four | jq -r '.result.current.memory')"
   case "$snapdSaysMemUsage" in
       null|0|4096|8192|12288)
           # expected

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -16,7 +16,6 @@ systems:
 
 prepare: |
   snap install test-snapd-stressd --edge --devmode
-  snap install test-snapd-curl --edge --devmode
 
 restore: |
   echo "Stop the service"

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -7,16 +7,6 @@ details: |
 prepare: |
     snap pack "$TESTSLIB"/snaps/snapctl-hooks
     snap install --dangerous snapctl-hooks_1.0_all.snap
-    # ensure curl is available (needed for e.g. core18)
-    if ! command -v curl; then
-        snap install --devmode --edge test-snapd-curl
-        snap alias test-snapd-curl.curl curl
-    fi
-
-restore: |
-    if snap list test-snapd-curl; then
-        snap remove --purge test-snapd-curl
-    fi
 
 execute: |
     echo "Verify that snapctl -h runs without a context"
@@ -47,7 +37,7 @@ execute: |
     echo "Verify that the snapd API is only available via the snapd socket"
     if ! printf 'GET /v2/snaps HTTP/1.0\r\n\r\n' | nc -U -w 1 /run/snapd.socket | grep '200 OK'; then
         echo "Expected snapd API to be available on the snapd socket"
-        echo "Got: $(curl -s --unix-socket /run/snapd.socket http:/v2/snaps)"
+        echo "Got: $(snap debug api /v2/snaps)"
         exit 1
     fi
 

--- a/tests/main/snapshot-exclusions-dynamic/task.yaml
+++ b/tests/main/snapshot-exclusions-dynamic/task.yaml
@@ -16,7 +16,6 @@ environment:
 
 prepare: | 
     "$TESTSTOOLS"/snaps-state install-local test-snap
-    snap install --devmode --edge test-snapd-curl
     snap install jq
 
 debug: |
@@ -48,11 +47,11 @@ execute: |
     # and is valid
     snap check-snapshot "$SET_ID"
     # and the snapshot metadata does not include an options entry
-    test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 http://localhost/v2/snapshots?set="$SET_ID" | NOMATCH '"options":'
+    timeout 5 snap debug api /v2/snapshots?set="$SET_ID" | NOMATCH '"options":'
 
     # Create snapshot that will apply dynamic exclusions, and grab the set ID
     #shellcheck disable=SC2016
-    RESPONSE=$( test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 http://localhost/v2/snaps -X POST -H 'Content-Type: application/json' -d '{"action": "snapshot", "snaps": ["test-snap"], "snapshot-options": {"test-snap":{"exclude":["$SNAP_DATA/dynamic-exclude.txt", "$SNAP_COMMON/dynamic-exclude.txt", "$SNAP_USER_COMMON/dynamic-exclude.txt", "$SNAP_USER_DATA/dynamic-exclude.txt"]}}}' )
+    RESPONSE=$( echo '{"action": "snapshot", "snaps": ["test-snap"], "snapshot-options": {"test-snap":{"exclude":["$SNAP_DATA/dynamic-exclude.txt", "$SNAP_COMMON/dynamic-exclude.txt", "$SNAP_USER_COMMON/dynamic-exclude.txt", "$SNAP_USER_DATA/dynamic-exclude.txt"]}}}' | timeout 5 snap debug api -X POST -H 'Content-Type: application/json' /v2/snaps )
     SET_ID=$( echo "$RESPONSE" | jq '.result."set-id"' )
     echo "$SET_ID" | MATCH "^[0-9]+$"
     CHANGE=$( echo "$RESPONSE" | jq ".change" | grep -o "[0-9]*" )
@@ -65,7 +64,7 @@ execute: |
     # and is valid
     snap check-snapshot "$SET_ID"
     # and the snapshot metadata includes options
-    test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 http://localhost/v2/snapshots?set="$SET_ID" | MATCH '"options":'
+    timeout 5 snap debug api /v2/snapshots?set="$SET_ID" | MATCH '"options":'
 
     # Check that shapshot is exportable
     snap export-snapshot "$SET_ID" "${SET_ID}_export.snapshot"
@@ -79,7 +78,7 @@ execute: |
     "\$SNAP_USER_COMMON/dynamic-exclude.txt"
     "\$SNAP_USER_DATA/dynamic-exclude.txt"
     EOF
-    test-snapd-curl.curl -s --unix-socket /run/snapd.socket --max-time 5 http://localhost/v2/snapshots?set="$SET_ID" | jq .result[0].snapshots[0].options.exclude[] > actual_options_entry
+    timeout 5 snap debug api /v2/snapshots?set="$SET_ID" | jq .result[0].snapshots[0].options.exclude[] > actual_options_entry
     diff -u expected_options_entry actual_options_entry
 
     # Remove the canaries to test restore

--- a/tests/nested/core/core20-basic/task.yaml
+++ b/tests/nested/core/core20-basic/task.yaml
@@ -69,8 +69,7 @@ execute: |
     fi
 
     # the remove API isn't exposed by snap recovery yet
-    remote.exec "sudo snap install --devmode --edge test-snapd-curl"
-    remote.exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
+    remote.exec "echo '{\"action\":\"remove\"}' | sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/system-recovery-keys"
 
     # keys were removed
     remote.exec "test ! -f /var/lib/snapd/device/fde/recovery.key"

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -29,8 +29,7 @@ execute: |
     remote.exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
 
     echo "verify that recovery key can be removed"
-    remote.exec "sudo snap install --devmode --edge test-snapd-curl"
-    remote.exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
+    remote.exec "echo '{\"action\":\"remove\"}' | sudo snap debug api -X POST -H 'Content-Type: application/json'  /v2/system-recovery-keys"
     echo "and the key is no longer available"
     remote.exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
 

--- a/tests/nested/manual/core20-create-recovery/task.yaml
+++ b/tests/nested/manual/core20-create-recovery/task.yaml
@@ -14,14 +14,13 @@ environment:
 
 prepare: |
     tests.nested build-image core
-    tests.nested create-vm core
-    remote.exec sudo snap install test-snapd-curl --edge --devmode    
+    tests.nested create-vm core    
 
 execute: |
     echo "Create a recovery system with a typical recovery system label"
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | \
-        remote.exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+        remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/debug" > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     remote.wait-for reboot "${boot_id}"
     remote.exec sudo snap watch "${REMOTE_CHG_ID}"
@@ -37,7 +36,7 @@ execute: |
     echo "Create a recovery system with an alternative recovery system label"
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | \
-        remote.exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+        remote.exec "sudo snap debug api -X POST  -H 'Content-Type: application/json' /v2/debug" > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     remote.wait-for reboot "${boot_id}"
     remote.exec sudo snap watch "${REMOTE_CHG_ID}"

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -212,8 +212,7 @@ execute: |
   fi
 
   # make sure that the system reports the expected available optional snaps
-  remote.exec "sudo snap install --edge test-snapd-curl"
-  remote.exec "sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/$LABEL" > available.json
+  remote.exec "sudo snap debug api /v2/systems/$LABEL" > available.json
   cat <<EOF > expected-available.json
   {
     "snaps": ["snap-with-comps"],

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -160,8 +160,7 @@ execute: |
       # check that on an already provisioned system the API will give a
       # sensible reason why the system cannot be installed without further
       # action.
-      remote.exec "sudo apt install -y curl"
-      remote.exec "sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/classic" > system
+      remote.exec "sudo snap debug api /v2/systems/classic" > system
       jq '.result."storage-encryption".support' < system | MATCH "unavailable"
       jq '.result."storage-encryption"."unavailable-reason"' < system | MATCH "not encrypting device storage as checking TPM gave: the TPM is in DA lockout mode"
   fi

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -28,7 +28,6 @@ prepare: |
       exit
   fi
   echo "Install used snaps"
-  snap install test-snapd-curl --devmode --edge
   snap install jq --devmode --edge
   if [ -d /var/lib/snapd/seed ]; then
       mv /var/lib/snapd/seed /var/lib/snapd/seed.orig
@@ -110,8 +109,8 @@ execute: |
   cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
   # do some light checking that the system is valid
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$LABEL" > system
+  snap debug api /v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
+  snap debug api /v2/systems/"$LABEL" > system
   jq '.result.model.distribution' system | MATCH "ubuntu"
 
   # build muinstaller and put in place

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -110,7 +110,7 @@ execute: |
 
   # do some light checking that the system is valid
   snap debug api /v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
-  snap debug api /v2/systems/"$LABEL" > system
+  snap debug api "/v2/systems/$LABEL" > system
   jq '.result.model.distribution' system | MATCH "ubuntu"
 
   # build muinstaller and put in place

--- a/tests/nested/manual/recovery-system-offline/task.yaml
+++ b/tests/nested/manual/recovery-system-offline/task.yaml
@@ -34,7 +34,7 @@ execute: |
     shift 2
 
     # shellcheck disable=SC2059
-    printf "${template}" "$@" | remote.exec "sudo test-snapd-curl.curl -X POST -H 'Content-Type: application/json' --unix-socket /run/snapd.socket -d @- http://localhost${route}" | jq .
+    printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}" | jq .
   }
 
   #shellcheck source=tests/lib/core-config.sh

--- a/tests/nested/manual/recovery-system-offline/task.yaml
+++ b/tests/nested/manual/recovery-system-offline/task.yaml
@@ -57,6 +57,7 @@ execute: |
     remote.exec "sudo ip r d default"
 
     if [ "${USE_FORM_API}" = 'true' ]; then
+      # Use curl to make the multipart/form-data HTML request since it is not supported by snap debug api
       response=$(remote.exec "sudo test-snapd-curl.curl -X POST --unix-socket /run/snapd.socket -F 'action=create' -F 'label=new-system' -F 'validation-sets=test-snapd/recovery-system-pinned' -F 'test-system=${TEST_SYSTEM}' -F 'mark-default=true' http://localhost/v2/systems")
     else
       response=$(post_json_data /v2/systems '{"action": "create", "label": "new-system", "validation-sets": ["test-snapd/recovery-system-pinned"], "mark-default": true, "offline": true, "test-system": %s}' "${TEST_SYSTEM}")
@@ -64,7 +65,7 @@ execute: |
   else
     remote.exec "sudo snap set system store.access=offline"
     remote.exec "sudo ip r d default"
-
+    # Use curl to make the multipart/form-data HTML request since it is not supported by snap debug api
     response=$(remote.exec "sudo test-snapd-curl.curl -X POST --unix-socket /run/snapd.socket -F 'action=create' -F 'label=new-system' -F 'validation-sets=test-snapd/recovery-system-pinned=1' -F 'assertion=<test-snapd-recovery-system-pinned.assert' -F 'assertion=<hello-world.assert' -F 'snap=@hello-world.snap' -F 'test-system=${TEST_SYSTEM}' -F 'mark-default=true' http://localhost/v2/systems")
   fi
 

--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -36,7 +36,7 @@ execute: |
     shift 2
 
     # shellcheck disable=SC2059
-    response=$(printf "${template}" "$@" | remote.exec "sudo test-snapd-curl.curl -X POST -H 'Content-Type: application/json' --unix-socket /run/snapd.socket -d @- http://localhost${route}")
+    response=$(printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}")
     if ! jq -e .change <<< "${response}"; then
       echo "could not get change id from response: ${response}"
       false
@@ -47,8 +47,6 @@ execute: |
   . "$TESTSLIB"/core-config.sh
 
   wait_for_first_boot_change
-
-  remote.exec sudo snap install --edge --devmode test-snapd-curl
 
   boot_id="$(tests.nested boot-id)"
 
@@ -105,8 +103,6 @@ execute: |
 
     # new system should be the default recovery system and the current system
     remote.exec 'sudo snap recovery' | awk '$1 == "new-system" { print $4 }' | MATCH 'current,default-recovery'
-
-    remote.exec sudo snap install --edge --devmode test-snapd-curl
 
     # since out new system is now the default and the current recovery system,
     # we should be able to remove the old one

--- a/tests/nested/manual/recovery-system/task.yaml
+++ b/tests/nested/manual/recovery-system/task.yaml
@@ -37,7 +37,7 @@ execute: |
     shift 2
 
     # shellcheck disable=SC2059
-    response=$(printf "${template}" "$@" | remote.exec "sudo test-snapd-curl.curl -X POST -H 'Content-Type: application/json' --unix-socket /run/snapd.socket -d @- http://localhost${route}")
+    response=$(printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}")
     if ! jq -e .change <<< "${response}"; then
       echo "could not get change id from response: ${response}"
       false
@@ -48,8 +48,6 @@ execute: |
   . "$TESTSLIB"/core-config.sh
 
   wait_for_first_boot_change
-
-  remote.exec sudo snap install --edge --devmode test-snapd-curl
 
   boot_id="$(tests.nested boot-id)"
 

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -25,7 +25,6 @@ prepare: |
       exit
   fi
   echo "Install used snaps"
-  snap install test-snapd-curl --devmode --edge
   snap install jq --devmode --edge
   if [ -d /var/lib/snapd/seed ]; then
     mv /var/lib/snapd/seed /var/lib/snapd/seed.orig
@@ -101,8 +100,8 @@ execute: |
   cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
   # do some light checking that the system is valid
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
-  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$LABEL" > system
+  snap debug api /v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
+  snap debug api /v2/systems/"$LABEL" > system
   jq '.result.model.distribution' system | MATCH "ubuntu"
   # build muinstaller and put in place
   go build -o muinstaller "$TESTSLIB"/muinstaller/main.go

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -101,7 +101,7 @@ execute: |
 
   # do some light checking that the system is valid
   snap debug api /v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
-  snap debug api /v2/systems/"$LABEL" > system
+  snap debug api "/v2/systems/$LABEL" > system
   jq '.result.model.distribution' system | MATCH "ubuntu"
   # build muinstaller and put in place
   go build -o muinstaller "$TESTSLIB"/muinstaller/main.go


### PR DESCRIPTION
Modifies spread tests to use, when possible, `snap debug api` instead of `curl`.