### PR TITLE
i/b/network_manager_observe: add getDevices methods

### DIFF
--- a/interfaces/builtin/network_manager_observe.go
+++ b/interfaces/builtin/network_manager_observe.go
@@ -52,7 +52,7 @@ dbus (receive)
     bus=system
     path="/org/freedesktop/NetworkManager"
     interface="org.freedesktop.NetworkManager"
-    member="Get{,All}Devices"
+    member="Get{Devices,AllDevices,DeviceByIpIface}"
     peer=(label=###PLUG_SECURITY_TAGS###),
 dbus (receive)
     bus=system
@@ -113,7 +113,7 @@ dbus (send)
     bus=system
     path="/org/freedesktop/NetworkManager"
     interface="org.freedesktop.NetworkManager"
-    member="GetDevices"
+    member="Get{Devices,AllDevices,DeviceByIpIface}"
     peer=(label=###SLOT_SECURITY_TAGS###),
 dbus (send)
     bus=system


### PR DESCRIPTION
GetAllDevices and GetDeviceByIpIface dbus methods looks appropriate to be part of the network-manager-observe interface. See https://forum.snapcraft.io/t/mission-center-auto-connection-requests/43198/22
