### PR TITLE
tests/main/interfaces-time-control: use "name" device node since it is also present on arm systems

### DIFF
--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -68,7 +68,7 @@ execute: |
     fi
 
     # make sure that we can access the files in /sys/class/rtc
-    test-snapd-timedate-control-consumer.sh -c "cat /sys/class/rtc/rtc0/wakealarm"
+    test-snapd-timedate-control-consumer.sh -c "cat /sys/class/rtc/rtc0/name"
 
     echo "When the plug is disconnected"
     snap disconnect test-snapd-timedate-control-consumer:time-control
@@ -85,4 +85,4 @@ execute: |
     # EPERM because date gets blocked by the seccomp profile
     MATCH "cannot set date: Operation not permitted" < call.error
 
-    not test-snapd-timedate-control-consumer.sh -c "cat /sys/class/rtc/rtc0/wakealarm"
+    not test-snapd-timedate-control-consumer.sh -c "cat /sys/class/rtc/rtc0/name"


### PR DESCRIPTION
`/sys/class/rtc/rtc0/wakealarm` seems to only be present on the amd64 machines. This will make this test work on arm as well, but still tests the same functionality.