### PR TITLE
tests: fix failure in snap-quota-cpu spread test

### DIFF
--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -36,7 +36,7 @@ execute: |
       # We use 'top' here to get the current CPU usage as top sorts by CPU usage, 
       # so we assume that 'stress' is going to lie in the top as the odds of another
       # process being in the top is close to 0.
-      usage=$(top -w256 -b -n 2 -d 0.2 | head | grep "$service_name" | awk '{print $9*100}')
+      usage=$(top -w256 -b -n 2 -d 0.2 | head | grep "$service_name" | awk '{print $9*100}' | xargs printf "%.0f\n")
       if [ "$usage" -gt "$expected_usage" ]; then
         return 0
       fi
@@ -102,7 +102,7 @@ execute: |
       # We use 'top' here to get the current CPU usage as top sorts by CPU usage, 
       # so we assume that 'stress' is going to lie in the top as the odds of another
       # process being in the top is close to 0.
-      usage=$(top -w256 -b -n 2 -d 0.2 | head | grep "$service_name" | awk '{print $9*100}')
+      usage=$(top -w256 -b -n 2 -d 0.2 | head | grep "$service_name" | awk '{print $9*100}' | xargs printf "%.0f\n")
       if [ "$usage" -lt "$expected_usage" ]; then
         return 0
       fi


### PR DESCRIPTION
Apparently, in some cases, the cpu usage can contain more than two decimal points as seen here in this failure: https://github.com/canonical/snapd/actions/runs/11165803126/job/31038865747. This fixes the issue by removing any decimal points.