### PR TITLE
cmd/snap-confine: pass uid/gid to initial tmpfs

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -542,7 +542,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		sc_initialize_ns_fstab(config->snap_instance);
 		// Create a tmpfs on scratch_dir; we'll them mount all the root
 		// directories of the base snap onto it.
-		sc_do_mount("none", scratch_dir, "tmpfs", 0, NULL);
+		sc_do_mount("none", scratch_dir, "tmpfs", 0, "uid=0,gid=0");
 		sc_replicate_base_rootfs(scratch_dir, config->rootfs_dir,
 					 config->mounts);
 	} else {


### PR DESCRIPTION
We mount the tmpfs which will be used as the rootfs of the mount namespace of the snap without any options. Since at the time were are running as root (user) but keep the original group of the calling user, this captures the gid of the user in the mount options.

Pass uid=0,gid=0 explicitly, so that it is not an issue.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-33380
