### PR TITLE
many: add snap auto refresh backoff

### DIFF
--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -121,6 +121,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfo(c *C) {
 		"Hold",
 		"GatingHold",
 		"RefreshInhibit",
+		"RefreshFailures",
 		"Components",
 	}
 	var checker func(string, reflect.Value)

--- a/client/packages.go
+++ b/client/packages.go
@@ -91,6 +91,8 @@ type Snap struct {
 	GatingHold *time.Time `json:"gating-hold,omitempty"`
 	// if RefreshInhibit is nil, then there is no pending refresh.
 	RefreshInhibit *SnapRefreshInhibit `json:"refresh-inhibit,omitempty"`
+	// RefreshFailures tracks information about snap failed refreshes.
+	RefreshFailures *snap.RefreshFailuresInfo `json:"refresh-failures,omitempty"`
 
 	// Components is a list of the snap components
 	Components []Component `json:"components,omitempty"`

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -274,6 +274,11 @@ func (cs *clientSuite) testClientSnap(c *check.C, refreshInhibited bool) {
 			"private": true,
 			"devmode": true,
 			"trymode": true,
+			"refresh-failures": {
+				"revision": 43,
+				"failure-count": 5,
+				"last-failure-time": "2024-10-06T21:31:05Z"
+			},
                         "screenshots": [
                             {"url":"http://example.com/shot1.png", "width":640, "height":480},
                             {"url":"http://example.com/shot2.png"}
@@ -356,6 +361,11 @@ func (cs *clientSuite) testClientSnap(c *check.C, refreshInhibited bool) {
 		Website:        "http://example.com/funky",
 		StoreURL:       "https://snapcraft.io/chatroom",
 		RefreshInhibit: expectedSnapRefreshInhibit,
+		RefreshFailures: &snap.RefreshFailuresInfo{
+			Revision:        snap.R(43),
+			FailureCount:    5,
+			LastFailureTime: time.Date(2024, 10, 6, 21, 31, 5, 0, time.UTC),
+		},
 	})
 }
 

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -256,6 +256,7 @@ func mapLocal(about aboutSnap, sd clientutil.StatusDecorator) *client.Snap {
 	result.DevMode = snapst.DevMode
 	result.TryMode = snapst.TryMode
 	result.JailMode = snapst.JailMode
+	result.RefreshFailures = snapst.RefreshFailures
 	result.MountedFrom = localSnap.MountFile()
 	if result.TryMode {
 		// Readlink instead of EvalSymlinks because it's only expected

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -943,6 +943,9 @@ func (f *fakeSnappyBackend) maybeErrForLastOp() error {
 	if f.maybeInjectErr == nil {
 		return nil
 	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if len(f.ops) == 0 {
 		return nil
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2116,6 +2116,14 @@ func doUpdate(st *state.State, requested []string, updates []update, opts Option
 			continue
 		}
 
+		if err := checkSnapRefreshFailures(st, &up.SnapState, up.Setup.Revision(), opts); err != nil {
+			if errors.Is(err, errKnownBadRevision) {
+				// revision known to fail during refresh and backoff delay has not passed
+				continue
+			}
+			return nil, false, nil, err
+		}
+
 		// if any snaps actually get a revision change, we need to do a
 		// re-refresh check
 		needsRerefreshCheck = true

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -173,6 +173,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 		fakeBackend:         s.fakeBackend,
 		state:               s.state,
 		downloadError:       make(map[string]error),
+		refreshRevnos:       make(map[string]snap.Revision),
 	}
 
 	// make tests work consistently also in containers
@@ -9341,6 +9342,109 @@ func (s *snapmgrTestSuite) TestSaveRefreshCandidatesOnAutoRefresh(c *C) {
 	c.Assert(cands, HasLen, 2)
 	c.Check(cands["some-snap"], NotNil)
 	c.Check(cands["some-other-snap"], NotNil)
+}
+
+func (s *snapmgrTestSuite) TestBackoffOnAutoRefresh(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	badRevison := snap.R(12)
+	badSnapst := &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "app",
+		RefreshFailures: &snap.RefreshFailuresInfo{
+			Revision:        badRevison,
+			FailureCount:    1,
+			LastFailureTime: time.Now(),
+		},
+	}
+	snapstate.Set(s.state, "some-snap", badSnapst)
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	s.fakeStore.refreshRevnos["some-snap-id"] = badRevison
+	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
+	c.Assert(err, IsNil)
+	c.Assert(tss, NotNil)
+	// some-snap auto-refresh skipped
+	c.Check(names, DeepEquals, []string{"some-other-snap"})
+
+	// Failure delay is capped at 2 weeks
+	badSnapst.RefreshFailures.FailureCount = 100
+	badSnapst.RefreshFailures.LastFailureTime = time.Now().Add(-(2*7*24 - 1) * time.Hour)
+	snapstate.Set(s.state, "some-snap", badSnapst)
+	names, _, err = snapstate.AutoRefresh(context.Background(), s.state)
+	c.Assert(err, IsNil)
+	// some-snap auto-refresh skipped
+	c.Check(names, DeepEquals, []string{"some-other-snap"})
+	// But backoff delay is capped at two weeks
+	badSnapst.RefreshFailures.LastFailureTime = time.Now().Add(-(2 * 7 * 24) * time.Hour)
+	snapstate.Set(s.state, "some-snap", badSnapst)
+	names, _, err = snapstate.AutoRefresh(context.Background(), s.state)
+	c.Assert(err, IsNil)
+	c.Check(names, DeepEquals, []string{"some-other-snap", "some-snap"})
+}
+
+func (s *snapmgrTestSuite) TestBackoffOnAutoRefreshWithNewRevision(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	badRevison := snap.R(12)
+	badSnapst := &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "app",
+		RefreshFailures: &snap.RefreshFailuresInfo{
+			Revision:        badRevison,
+			FailureCount:    3,
+			LastFailureTime: time.Now(),
+		},
+	}
+	snapstate.Set(s.state, "some-snap", badSnapst)
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	s.fakeStore.refreshRevnos["some-snap-id"] = badRevison
+	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
+	c.Assert(err, IsNil)
+	c.Assert(tss, NotNil)
+	// some-snap auto-refresh skipped
+	c.Check(names, DeepEquals, []string{"some-other-snap"})
+
+	// Check that new revision resets RefreshFailures
+	s.fakeStore.refreshRevnos["some-snap-id"] = snap.R(13)
+	// First make sure RefreshFailures is not nil
+	var snapst snapstate.SnapState
+	snapstate.Get(s.state, "some-snap", &snapst)
+	c.Assert(snapst.RefreshFailures.FailureCount, Equals, 3)
+	// Trigger new auto-refresh (with new revision from fakestore)
+	names, tss, err = snapstate.AutoRefresh(context.Background(), s.state)
+	c.Assert(err, IsNil)
+	c.Assert(tss, NotNil)
+	// some-snap auto-refresh not skipped
+	c.Check(names, DeepEquals, []string{"some-other-snap", "some-snap"})
+	// And RefreshFailures is reset
+	snapstate.Get(s.state, "some-snap", &snapst)
+	c.Assert(snapst.RefreshFailures, IsNil)
 }
 
 type customStore struct {

--- a/snap/info.go
+++ b/snap/info.go
@@ -2099,3 +2099,16 @@ func RegistryPlugAttrs(plug *PlugInfo) (account, registry, view string, err erro
 
 	return account, registry, view, nil
 }
+
+// RefreshFailures holds information about snap failed refreshes.
+type RefreshFailuresInfo struct {
+	// Revision is the target revision that caused the refresh failure.
+	Revision Revision `json:"revision"`
+	// FailureCount is the number of failed attempts to refresh to the given revision.
+	FailureCount int `json:"failure-count"`
+	// LastFailureTime is the time of the last failed refresh attempt for the revision.
+	LastFailureTime time.Time `json:"last-failure-time"`
+
+	// TODO: add RefreshFailureSeverity to allow for more aggressive
+	// delays for snaps that fail after rebooting.
+}

--- a/tests/lib/tools/snapd-state
+++ b/tests/lib/tools/snapd-state
@@ -56,17 +56,17 @@ change_snap_channel() {
         echo "snapd-state: snap and channel are required parameters"
         exit 1
     fi
-    jq ".data.snaps[\"$SNAP\"].channel = \"$CHANNEL\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    jq ".data.snaps[\"$SNAP\"].channel = \"$CHANNEL\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 
 force_autorefresh() {
-    jq ".data[\"last-refresh\"] = \"2007-08-22T09:30:44.449455783+01:00\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    jq ".data[\"last-refresh\"] = \"2007-08-22T09:30:44.449455783+01:00\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 
 prevent_autorefresh() {
-    jq ".data[\"last-refresh\"] = \"$(date +%Y-%m-%dT%H:%M:%S%:z)\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    jq ".data[\"last-refresh\"] = \"$(date +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 

--- a/tests/lib/tools/store-state
+++ b/tests/lib/tools/store-state
@@ -72,9 +72,13 @@ make_snap_installable(){
 
     if [ -n "$snap_id" ]; then
         if ! command -v yaml2json; then
+            # FIXME: When fakestore is setup this snap cannot be installed
+            # TODO: Install remarshal in setup_fake_store
             snap install remarshal
         fi
         if ! command -v jq; then
+            # FIXME: When fakestore is setup this snap cannot be installed
+            # TODO: Install jq in setup_fake_store or don't use snapped jq
             SUFFIX="$(snaps.name snap-suffix)"
             snap install "jq$SUFFIX"
         fi

--- a/tests/main/auto-refresh-backoff/check_auto_refresh_count.sh
+++ b/tests/main/auto-refresh-backoff/check_auto_refresh_count.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+LAST_CHANGE_ID=$1
+CHANGES_COUNT=$2
+
+#shellcheck disable=SC2086,SC2046
+test $(snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | length") == $CHANGES_COUNT

--- a/tests/main/auto-refresh-backoff/task.yaml
+++ b/tests/main/auto-refresh-backoff/task.yaml
@@ -1,4 +1,4 @@
-summary: Ensures that a failed snap auto-refresh will be progressively in future refreshes.
+summary: Ensures that a failed snap auto-refresh will be will be exponentially delayed in future refreshes.
 
 details: |
     Test ensures that if a snap auto-refresh failed the next auto-refresh attempt for the

--- a/tests/main/auto-refresh-backoff/task.yaml
+++ b/tests/main/auto-refresh-backoff/task.yaml
@@ -1,0 +1,183 @@
+summary: Ensures that a failed snap auto-refresh will be progressively in future refreshes.
+
+details: |
+    Test ensures that if a snap auto-refresh failed the next auto-refresh attempt for the
+    same revision will be delayed. This checks that the auto-refresh backoff algorithm is
+    implemented properly.
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+    SNAP_ONE: test-snapd-tools
+    SNAP_ONE_ID: eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw
+    SNAP_TWO: test-snapd-sh
+    SNAP_TWO_ID: WOc8eDNKuk1POWZIfcCX08smZrUGY0QV
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # Needed by make-snap-installable, Install before switching to fakestore
+    snap install jq
+    snap install remarshal
+
+    # Install snaps as baseline since we want to test what happens in refreshes not installs
+    echo "Given installed snaps"
+    snap install "$SNAP_ONE" "$SNAP_TWO"
+
+    echo "And the daemon is configured to point to the fake store"
+    "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
+
+    echo "Expose the needed assertions through the fakestore"
+    cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account "$BLOB_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$BLOB_DIR/asserts"
+
+    # It is not enough to copy the assertions, we must also ack them otherwise we
+    # will get an error about not being able to resolve the account key
+    snap ack "$BLOB_DIR/asserts/testrootorg-store.account-key"
+    snap ack "$BLOB_DIR/asserts/developer1.account"
+    snap ack "$BLOB_DIR/asserts/developer1.account-key"
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
+    rm -rf "$BLOB_DIR"
+
+debug: |
+    snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\")] | sort_by(.id)"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+
+    SNAP_ONE_GOOD_PATH=$("$TESTSTOOLS"/snaps-state pack-local "$SNAP_ONE")
+    SNAP_TWO_GOOD_PATH=$("$TESTSTOOLS"/snaps-state pack-local "$SNAP_TWO")
+    # Make bad version of SNAP_ONE
+    unsquashfs -d bad-snap "$SNAP_ONE_GOOD_PATH"
+    mkdir -p ./bad-snap/meta/hooks
+    echo 'exit 1' > ./bad-snap/meta/hooks/configure
+    chmod +x ./bad-snap/meta/hooks/configure
+    snap pack --filename="$SNAP_ONE-bad.snap" bad-snap .
+    SNAP_ONE_BAD_PATH="$(pwd)/$SNAP_ONE-bad.snap"
+
+    # Prevent refreshes until we have right snap revisions
+    snap set system refresh.hold=forever
+
+    # Make snaps refreshable from fakestore
+    "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" "$SNAP_ONE" --snap-blob="$SNAP_ONE_GOOD_PATH"
+    "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" "$SNAP_TWO" --snap-blob="$SNAP_TWO_GOOD_PATH"
+
+    add_snap_to_fakestore() {
+        SNAP_FILE="$1"
+        SNAP_ID="$2"
+        SNAP_REV="$3"
+
+        # Rebuild snap with $SNAP_REV written into a file inside it to force a new snap-sha3-384
+        # hash in snap-revision assertion
+        unsquashfs -d /tmp/fake-snap "$SNAP_FILE"
+        # Force new snap-sha3-384 hash for snap
+        echo "$SNAP_REV" > /tmp/fake-snap/rev
+        snap pack --filename="$SNAP_ID-rev-$SNAP_REV.snap" /tmp/fake-snap .
+        rm -rf /tmp/fake-snap
+
+        "$TESTSTOOLS"/store-state make-snap-installable --revision "$SNAP_REV" "$BLOB_DIR" "$(pwd)/$SNAP_ID-rev-$SNAP_REV.snap" "$SNAP_ID"
+    }
+
+    # Record last change id before we start to avoid flakiness due to auto-refreshes in other tests
+    LAST_CHANGE_ID=$(snap debug api /v2/changes?select=all | jq '.result | sort_by(.id) | .[-1].id')
+
+    # -------- FIRST AUTO REFRESH --------
+
+    # Clean old snaps in fakestore directory because the fakestore can't distinguish
+    # multiple snaps files for the same snap
+    rm "$BLOB_DIR"/*.snap
+    echo "Make new revisions available to both snaps and break $SNAP_ONE"
+    add_snap_to_fakestore "$SNAP_ONE_BAD_PATH" "$SNAP_ONE_ID" 11
+    add_snap_to_fakestore "$SNAP_TWO_GOOD_PATH" "$SNAP_TWO_ID" 11
+
+    # Ensure there are no refresh holds, otherwise can't force auto-refresh
+    snap set system refresh.hold!
+
+    echo "Trigger auto-refresh"
+    systemctl stop snapd.{service,socket}
+    "$TESTSTOOLS"/snapd-state force-autorefresh
+    systemctl start snapd.{service,socket}
+    # Wait until auto-refresh is triggered and completed
+    retry -n 120 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 1
+
+    echo "Check we have expected revisions for both snaps"
+    readlink "$SNAP_MOUNT_DIR/$SNAP_ONE/current" | NOMATCH 11
+    readlink "$SNAP_MOUNT_DIR/$SNAP_TWO/current" | MATCH 11
+
+    # -------- SECOND AUTO REFRESH --------
+
+    # Clean old SNAP_TWO snap in fakestore directory and keep bad SNAP_ONE
+    rm "$BLOB_DIR/$SNAP_TWO_ID-rev-11.snap"
+    echo "Add new revision for $SNAP_TWO while keeping bad revision of $SNAP_ONE"
+    add_snap_to_fakestore "$SNAP_TWO_GOOD_PATH" "$SNAP_TWO_ID" 22
+
+    echo "Trigger auto-refresh a second time"
+    systemctl stop snapd.{service,socket}
+    "$TESTSTOOLS"/snapd-state force-autorefresh
+    systemctl start snapd.{service,socket}
+    # Wait until auto-refresh is triggered and completed
+    retry -n 120 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 2
+
+    echo "Check we have expected revisions for both snaps"
+    readlink "$SNAP_MOUNT_DIR/$SNAP_ONE/current" | NOMATCH 11
+    readlink "$SNAP_MOUNT_DIR/$SNAP_TWO/current" | MATCH 22
+
+    # -------- THIRD AUTO REFRESH --------
+
+    # Clean old snaps in fakestore directory because the fakestore can't distinguish
+    # multiple snaps files for the same snap
+    rm "$BLOB_DIR"/*.snap
+    echo "Fix $SNAP_ONE in new revision"
+    add_snap_to_fakestore "$SNAP_ONE_GOOD_PATH" "$SNAP_ONE_ID" 33
+    add_snap_to_fakestore "$SNAP_TWO_GOOD_PATH" "$SNAP_TWO_ID" 33
+
+    echo "Trigger auto-refresh a third time"
+    systemctl stop snapd.{service,socket}
+    "$TESTSTOOLS"/snapd-state force-autorefresh
+    systemctl start snapd.{service,socket}
+    # Wait until auto-refresh is triggered and completed
+    retry -n 120 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 3
+
+    echo "Check we have expected revisions for both snaps"
+    readlink "$SNAP_MOUNT_DIR/$SNAP_ONE/current" | MATCH 33
+    readlink "$SNAP_MOUNT_DIR/$SNAP_TWO/current" | MATCH 33
+
+    echo "Check auto-refresh behaviour matches expectations for backoff algorithm"
+    snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | sort_by(.id)" > changes.json
+
+    # 1st auto-refresh
+    jq '.[0].status' < changes.json | MATCH "Error"
+    jq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_ONE"
+    jq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
+    jq '.[0].data."refresh-failed"' < changes.json | MATCH "$SNAP_ONE"
+    jq '.[0].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"
+
+    # 2nd auto-refresh
+    jq '.[1].status' < changes.json | MATCH "Done"
+    # Broken SNAP_ONE should have been skipped this time
+    jq '.[1].data."snap-names"' < changes.json | NOMATCH "$SNAP_ONE"
+    jq '.[1].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
+    jq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_ONE"
+    jq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"
+
+    # 3rd auto-refresh
+    jq '.[2].status' < changes.json | MATCH "Done"
+    jq '.[2].data."snap-names"' < changes.json | MATCH "$SNAP_ONE"
+    jq '.[2].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
+    jq '.[2].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_ONE"
+    jq '.[2].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"


### PR DESCRIPTION
This PR implements a system to delay refreshing (auto-refreshing) a snap to the same revision in face of past failures as detailed in [SD183 - Avoiding failed upgrade loops](https://docs.google.com/document/d/1YmpZSvIoEeKeOGw-OA77j_PgCx0c7awCeee_9xlKIvU/edit) spec.

Since adding changes to the refresh logic is critical, I wrote the spread test first and went with TDD for this work. I faced some limitations and bugs in the fakestore because it wasn't designed with repeated auto-refreshes in mind.

The PR is split into multiple parts but closely related so I thought it would be inefficient to split into multiple PRs and ask for reviews on each. Those parts are:
- Update/Fix `fakestore` to handle multiple auto-refreshes properly
- Make `snapd-state` commands (specifically `force-autorefresh`) work on Ubuntu Core
- The `tests/main/auto-refresh-backoff` spread test (this was created before the actual algorithm implementation)
- Implement auto-refresh backoff algorthim
- Attach list of failed snaps to auto-refresh change api data `/v2/changes`
- Attach refresh failure information to snaps info api `/v2/snaps`

Future improvement work not included in this PR is to detect auto-refreshes that failed after a reboot and trigger a more aggressive delay.