### PR TITLE
tests: added dependabot for updating dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      non-breaking:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "minor"
+        - "patch"
+      breaking:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "major"


### PR DESCRIPTION
When merged to master, dependabot will check for updates in go dependencies and github actions weekly. When it finds an out-of-date package, it will automatically open a pull request. Here's an example of the pull requests opened on my fork of snapd when I pushed this yaml file to master: https://github.com/maykathm/snapd/pulls