### PR TITLE
many: support mixed outcomes for permissions in prompting constraints

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -308,7 +308,7 @@ type removeRulesSelector struct {
 }
 
 type patchRuleContents struct {
-	Constraints *prompting.PatchConstraints `json:"constraints,omitempty"`
+	Constraints *prompting.RuleConstraintsPatch `json:"constraints,omitempty"`
 }
 
 type postRulesRequestBody struct {

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -290,19 +290,16 @@ var getInterfaceManager = func(c *Command) interfaceManager {
 }
 
 type postPromptBody struct {
-	Outcome     prompting.OutcomeType  `json:"action"`
-	Lifespan    prompting.LifespanType `json:"lifespan"`
-	Duration    string                 `json:"duration,omitempty"`
-	Constraints *prompting.Constraints `json:"constraints"`
+	Outcome     prompting.OutcomeType       `json:"action"`
+	Lifespan    prompting.LifespanType      `json:"lifespan"`
+	Duration    string                      `json:"duration,omitempty"`
+	Constraints *prompting.ReplyConstraints `json:"constraints"`
 }
 
 type addRuleContents struct {
 	Snap        string                 `json:"snap"`
 	Interface   string                 `json:"interface"`
 	Constraints *prompting.Constraints `json:"constraints"`
-	Outcome     prompting.OutcomeType  `json:"outcome"`
-	Lifespan    prompting.LifespanType `json:"lifespan"`
-	Duration    string                 `json:"duration,omitempty"`
 }
 
 type removeRulesSelector struct {
@@ -311,10 +308,7 @@ type removeRulesSelector struct {
 }
 
 type patchRuleContents struct {
-	Constraints *prompting.Constraints `json:"constraints,omitempty"`
-	Outcome     prompting.OutcomeType  `json:"outcome,omitempty"`
-	Lifespan    prompting.LifespanType `json:"lifespan,omitempty"`
-	Duration    string                 `json:"duration,omitempty"`
+	Constraints *prompting.PatchConstraints `json:"constraints,omitempty"`
 }
 
 type postRulesRequestBody struct {
@@ -465,7 +459,7 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.AddRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "add"`)
 		}
-		newRule, err := getInterfaceManager(c).InterfacesRequestsManager().AddRule(userID, postBody.AddRule.Snap, postBody.AddRule.Interface, postBody.AddRule.Constraints, postBody.AddRule.Outcome, postBody.AddRule.Lifespan, postBody.AddRule.Duration)
+		newRule, err := getInterfaceManager(c).InterfacesRequestsManager().AddRule(userID, postBody.AddRule.Snap, postBody.AddRule.Interface, postBody.AddRule.Constraints)
 		if err != nil {
 			return promptingError(err)
 		}
@@ -542,7 +536,7 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.PatchRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "patch"`)
 		}
-		patchedRule, err := getInterfaceManager(c).InterfacesRequestsManager().PatchRule(userID, ruleID, postBody.PatchRule.Constraints, postBody.PatchRule.Outcome, postBody.PatchRule.Lifespan, postBody.PatchRule.Duration)
+		patchedRule, err := getInterfaceManager(c).InterfacesRequestsManager().PatchRule(userID, ruleID, postBody.PatchRule.Constraints)
 		if err != nil {
 			return promptingError(err)
 		}

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -57,7 +57,7 @@ type fakeInterfacesRequestsManager struct {
 	iface            string
 	id               prompting.IDType // used for prompt ID or rule ID
 	ruleConstraints  *prompting.Constraints
-	patchConstraints *prompting.PatchConstraints
+	constraintsPatch *prompting.RuleConstraintsPatch
 	replyConstraints *prompting.ReplyConstraints
 	outcome          prompting.OutcomeType
 	lifespan         prompting.LifespanType
@@ -117,10 +117,10 @@ func (m *fakeInterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompti
 	return m.rule, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.PatchConstraints) (*requestrules.Rule, error) {
+func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraintsPatch *prompting.RuleConstraintsPatch) (*requestrules.Rule, error) {
 	m.userID = userID
 	m.id = ruleID
-	m.patchConstraints = constraints
+	m.constraintsPatch = constraintsPatch
 	return m.rule, m.err
 }
 
@@ -1015,7 +1015,7 @@ func (s *promptingSuite) TestPostRulePatchHappy(c *C) {
 		},
 	}
 
-	constraints := &prompting.PatchConstraints{
+	constraintsPatch := &prompting.RuleConstraintsPatch{
 		PathPattern: mustParsePathPattern(c, "/home/test/Pictures/**/*.{png,jpg}"),
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
@@ -1029,7 +1029,7 @@ func (s *promptingSuite) TestPostRulePatchHappy(c *C) {
 		},
 	}
 	contents := &daemon.PatchRuleContents{
-		Constraints: constraints,
+		Constraints: constraintsPatch,
 	}
 	postBody := &daemon.PostRuleRequestBody{
 		Action:    "patch",
@@ -1042,7 +1042,7 @@ func (s *promptingSuite) TestPostRulePatchHappy(c *C) {
 
 	// Check parameters
 	c.Check(s.manager.userID, Equals, uint32(999))
-	c.Check(s.manager.patchConstraints, DeepEquals, contents.Constraints)
+	c.Check(s.manager.constraintsPatch, DeepEquals, contents.Constraints)
 
 	// Check return value
 	rule, ok := rsp.Result.(*requestrules.Rule)

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -52,15 +52,17 @@ type fakeInterfacesRequestsManager struct {
 	err          error
 
 	// Store most recent received values
-	userID         uint32
-	snap           string
-	iface          string
-	id             prompting.IDType // used for prompt ID or rule ID
-	constraints    *prompting.Constraints
-	outcome        prompting.OutcomeType
-	lifespan       prompting.LifespanType
-	duration       string
-	clientActivity bool
+	userID           uint32
+	snap             string
+	iface            string
+	id               prompting.IDType // used for prompt ID or rule ID
+	ruleConstraints  *prompting.Constraints
+	patchConstraints *prompting.PatchConstraints
+	replyConstraints *prompting.ReplyConstraints
+	outcome          prompting.OutcomeType
+	lifespan         prompting.LifespanType
+	duration         string
+	clientActivity   bool
 }
 
 func (m *fakeInterfacesRequestsManager) Prompts(userID uint32, clientActivity bool) ([]*requestprompts.Prompt, error) {
@@ -76,10 +78,10 @@ func (m *fakeInterfacesRequestsManager) PromptWithID(userID uint32, promptID pro
 	return m.prompt, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) HandleReply(userID uint32, promptID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) ([]prompting.IDType, error) {
+func (m *fakeInterfacesRequestsManager) HandleReply(userID uint32, promptID prompting.IDType, constraints *prompting.ReplyConstraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) ([]prompting.IDType, error) {
 	m.userID = userID
 	m.id = promptID
-	m.constraints = constraints
+	m.replyConstraints = constraints
 	m.outcome = outcome
 	m.lifespan = lifespan
 	m.duration = duration
@@ -94,14 +96,11 @@ func (m *fakeInterfacesRequestsManager) Rules(userID uint32, snap string, iface 
 	return m.rules, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
+func (m *fakeInterfacesRequestsManager) AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints) (*requestrules.Rule, error) {
 	m.userID = userID
 	m.snap = snap
 	m.iface = iface
-	m.constraints = constraints
-	m.outcome = outcome
-	m.lifespan = lifespan
-	m.duration = duration
+	m.ruleConstraints = constraints
 	return m.rule, m.err
 }
 
@@ -118,13 +117,10 @@ func (m *fakeInterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompti
 	return m.rule, m.err
 }
 
-func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.Constraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string) (*requestrules.Rule, error) {
+func (m *fakeInterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.PatchConstraints) (*requestrules.Rule, error) {
 	m.userID = userID
 	m.id = ruleID
-	m.constraints = constraints
-	m.outcome = outcome
-	m.lifespan = lifespan
-	m.duration = duration
+	m.patchConstraints = constraints
 	return m.rule, m.err
 }
 
@@ -706,7 +702,7 @@ func (s *promptingSuite) TestPostPromptHappy(c *C) {
 		prompting.IDType(0xF00BA4),
 	}
 
-	constraints := &prompting.Constraints{
+	constraints := &prompting.ReplyConstraints{
 		PathPattern: mustParsePathPattern(c, "/home/test/Pictures/**/*.{png,svg}"),
 		Permissions: []string{"read", "execute"},
 	}
@@ -724,7 +720,7 @@ func (s *promptingSuite) TestPostPromptHappy(c *C) {
 	// Check parameters
 	c.Check(s.manager.userID, Equals, uint32(1000))
 	c.Check(s.manager.id, Equals, prompting.IDType(0x0123456789abcdef))
-	c.Check(s.manager.constraints, DeepEquals, contents.Constraints)
+	c.Check(s.manager.replyConstraints, DeepEquals, contents.Constraints)
 	c.Check(s.manager.outcome, Equals, contents.Outcome)
 	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
 	c.Check(s.manager.duration, Equals, contents.Duration)
@@ -782,13 +778,15 @@ func (s *promptingSuite) TestGetRulesHappy(c *C) {
 				User:      1234,
 				Snap:      "firefox",
 				Interface: "home",
-				Constraints: &prompting.Constraints{
+				Constraints: &prompting.RuleConstraints{
 					PathPattern: mustParsePathPattern(c, "/foo/bar"),
-					Permissions: []string{"write"},
+					Permissions: prompting.RulePermissionMap{
+						"write": &prompting.RulePermissionEntry{
+							Outcome:  prompting.OutcomeDeny,
+							Lifespan: prompting.LifespanForever,
+						},
+					},
 				},
-				Outcome:    prompting.OutcomeDeny,
-				Lifespan:   prompting.LifespanForever,
-				Expiration: time.Now(),
 			},
 		}
 
@@ -817,26 +815,34 @@ func (s *promptingSuite) TestPostRulesAddHappy(c *C) {
 		User:      11235,
 		Snap:      "firefox",
 		Interface: "home",
-		Constraints: &prompting.Constraints{
+		Constraints: &prompting.RuleConstraints{
 			PathPattern: mustParsePathPattern(c, "/foo/bar/baz"),
-			Permissions: []string{"write"},
+			Permissions: prompting.RulePermissionMap{
+				"write": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
 		},
-		Outcome:    prompting.OutcomeDeny,
-		Lifespan:   prompting.LifespanForever,
-		Expiration: time.Now(),
 	}
 
 	constraints := &prompting.Constraints{
 		PathPattern: mustParsePathPattern(c, "/home/test/{foo,bar,baz}/**/*.{png,svg}"),
-		Permissions: []string{"read", "write"},
+		Permissions: prompting.PermissionMap{
+			"read": &prompting.PermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+			"write": &prompting.PermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+		},
 	}
 	contents := &daemon.AddRuleContents{
 		Snap:        "thunderbird",
 		Interface:   "home",
 		Constraints: constraints,
-		Outcome:     prompting.OutcomeAllow,
-		Lifespan:    prompting.LifespanForever,
-		Duration:    "",
 	}
 	postBody := &daemon.PostRulesRequestBody{
 		Action:  "add",
@@ -851,10 +857,7 @@ func (s *promptingSuite) TestPostRulesAddHappy(c *C) {
 	c.Check(s.manager.userID, Equals, uint32(11235))
 	c.Check(s.manager.snap, Equals, contents.Snap)
 	c.Check(s.manager.iface, Equals, contents.Interface)
-	c.Check(s.manager.constraints, DeepEquals, contents.Constraints)
-	c.Check(s.manager.outcome, Equals, contents.Outcome)
-	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
-	c.Check(s.manager.duration, Equals, contents.Duration)
+	c.Check(s.manager.ruleConstraints, DeepEquals, contents.Constraints)
 
 	// Check return value
 	rule, ok := rsp.Result.(*requestrules.Rule)
@@ -888,7 +891,6 @@ func (s *promptingSuite) TestPostRulesRemoveHappy(c *C) {
 		s.manager = &fakeInterfacesRequestsManager{}
 
 		// Set the rules to return
-		var timeZero time.Time
 		s.manager.rules = []*requestrules.Rule{
 			{
 				ID:        prompting.IDType(1234),
@@ -896,13 +898,15 @@ func (s *promptingSuite) TestPostRulesRemoveHappy(c *C) {
 				User:      1001,
 				Snap:      "thunderird",
 				Interface: "home",
-				Constraints: &prompting.Constraints{
+				Constraints: &prompting.RuleConstraints{
 					PathPattern: mustParsePathPattern(c, "/foo/bar/baz/qux"),
-					Permissions: []string{"write"},
+					Permissions: prompting.RulePermissionMap{
+						"write": &prompting.RulePermissionEntry{
+							Outcome:  prompting.OutcomeDeny,
+							Lifespan: prompting.LifespanForever,
+						},
+					},
 				},
-				Outcome:    prompting.OutcomeDeny,
-				Lifespan:   prompting.LifespanForever,
-				Expiration: timeZero,
 			},
 			{
 				ID:        prompting.IDType(5678),
@@ -910,13 +914,19 @@ func (s *promptingSuite) TestPostRulesRemoveHappy(c *C) {
 				User:      1001,
 				Snap:      "thunderbird",
 				Interface: "home",
-				Constraints: &prompting.Constraints{
+				Constraints: &prompting.RuleConstraints{
 					PathPattern: mustParsePathPattern(c, "/fizz/buzz"),
-					Permissions: []string{"read", "execute"},
+					Permissions: prompting.RulePermissionMap{
+						"read": &prompting.RulePermissionEntry{
+							Outcome:  prompting.OutcomeAllow,
+							Lifespan: prompting.LifespanTimespan,
+						},
+						"execute": &prompting.RulePermissionEntry{
+							Outcome:  prompting.OutcomeAllow,
+							Lifespan: prompting.LifespanTimespan,
+						},
+					},
 				},
-				Outcome:    prompting.OutcomeAllow,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: time.Now(),
 			},
 		}
 
@@ -955,13 +965,16 @@ func (s *promptingSuite) TestGetRuleHappy(c *C) {
 		User:      1005,
 		Snap:      "thunderbird",
 		Interface: "home",
-		Constraints: &prompting.Constraints{
+		Constraints: &prompting.RuleConstraints{
 			PathPattern: mustParsePathPattern(c, "/home/test/Videos/**/*.{mkv,mp4,mov}"),
-			Permissions: []string{"read"},
+			Permissions: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeAllow,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: time.Now().Add(-24 * time.Hour),
+				},
+			},
 		},
-		Outcome:    prompting.OutcomeAllow,
-		Lifespan:   prompting.LifespanTimespan,
-		Expiration: time.Now().Add(-24 * time.Hour),
 	}
 
 	rsp := s.makeSyncReq(c, "GET", "/v2/interfaces/requests/rules/000000000000012B", 1005, nil)
@@ -981,31 +994,42 @@ func (s *promptingSuite) TestPostRulePatchHappy(c *C) {
 
 	s.daemon(c)
 
-	var timeZero time.Time
 	s.manager.rule = &requestrules.Rule{
 		ID:        prompting.IDType(0x01123581321),
 		Timestamp: time.Now(),
 		User:      999,
 		Snap:      "gimp",
 		Interface: "home",
-		Constraints: &prompting.Constraints{
+		Constraints: &prompting.RuleConstraints{
 			PathPattern: mustParsePathPattern(c, "/home/test/Pictures/**/*.{png,jpg}"),
-			Permissions: []string{"read", "write"},
+			Permissions: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
 		},
-		Outcome:    prompting.OutcomeAllow,
-		Lifespan:   prompting.LifespanForever,
-		Expiration: timeZero,
 	}
 
-	constraints := &prompting.Constraints{
+	constraints := &prompting.PatchConstraints{
 		PathPattern: mustParsePathPattern(c, "/home/test/Pictures/**/*.{png,jpg}"),
-		Permissions: []string{"read", "write"},
+		Permissions: prompting.PermissionMap{
+			"read": &prompting.PermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+			"write": &prompting.PermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+		},
 	}
 	contents := &daemon.PatchRuleContents{
 		Constraints: constraints,
-		Outcome:     prompting.OutcomeAllow,
-		Lifespan:    prompting.LifespanForever,
-		Duration:    "",
 	}
 	postBody := &daemon.PostRuleRequestBody{
 		Action:    "patch",
@@ -1018,10 +1042,7 @@ func (s *promptingSuite) TestPostRulePatchHappy(c *C) {
 
 	// Check parameters
 	c.Check(s.manager.userID, Equals, uint32(999))
-	c.Check(s.manager.constraints, DeepEquals, contents.Constraints)
-	c.Check(s.manager.outcome, Equals, contents.Outcome)
-	c.Check(s.manager.lifespan, Equals, contents.Lifespan)
-	c.Check(s.manager.duration, Equals, contents.Duration)
+	c.Check(s.manager.patchConstraints, DeepEquals, contents.Constraints)
 
 	// Check return value
 	rule, ok := rsp.Result.(*requestrules.Rule)
@@ -1034,20 +1055,25 @@ func (s *promptingSuite) TestPostRuleRemoveHappy(c *C) {
 
 	s.daemon(c)
 
-	var timeZero time.Time
 	s.manager.rule = &requestrules.Rule{
 		ID:        prompting.IDType(0x01123581321),
 		Timestamp: time.Now(),
 		User:      100,
 		Snap:      "gimp",
 		Interface: "home",
-		Constraints: &prompting.Constraints{
+		Constraints: &prompting.RuleConstraints{
 			PathPattern: mustParsePathPattern(c, "/home/test/Pictures/**/*.{png,jpg}"),
-			Permissions: []string{"read", "write"},
+			Permissions: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
 		},
-		Outcome:    prompting.OutcomeAllow,
-		Lifespan:   prompting.LifespanForever,
-		Expiration: timeZero,
 	}
 	postBody := &daemon.PostRuleRequestBody{
 		Action: "remove",

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -32,11 +32,8 @@ import (
 )
 
 // Constraints hold information about the applicability of a new rule to
-// particular paths or permissions. A request will be matched by the constraints
-// if the requested path is matched by the path pattern (according to bash's
-// globstar matching) and one or more requested permissions are denied in the
-// permission map, or all of the requested permissions are allowed in the map.
-// When snapd creates a new rule, it converts Constraints to RuleConstraints.
+// particular paths and permissions. When creating a new rule, snapd converts
+// Constraints to RuleConstraints.
 type Constraints struct {
 	PathPattern *patterns.PathPattern `json:"path-pattern"`
 	Permissions PermissionMap         `json:"permissions"`
@@ -93,7 +90,7 @@ func (c *Constraints) ToRuleConstraints(iface string, currTime time.Time) (*Rule
 }
 
 // RuleConstraints hold information about the applicability of an existing rule
-// to particular paths or permissions. A request will be matched by the rule
+// to particular paths and permissions. A request will be matched by the rule
 // constraints if the requested path is matched by the path pattern (according
 // to bash's globstar matching) and one or more requested permissions are denied
 // in the permission map, or all of the requested permissions are allowed in the
@@ -130,7 +127,7 @@ func (c *RuleConstraints) Match(path string) (bool, error) {
 }
 
 // ReplyConstraints hold information about the applicability of a reply to
-// particular paths or permissions. Upon receiving the reply, snapd converts
+// particular paths and permissions. Upon receiving the reply, snapd converts
 // ReplyConstraints to Constraints.
 type ReplyConstraints struct {
 	PathPattern *patterns.PathPattern `json:"path-pattern"`
@@ -181,14 +178,10 @@ func (c *ReplyConstraints) ToConstraints(iface string, outcome OutcomeType, life
 	return constraints, nil
 }
 
-// PatchConstraints hold information about the applicability of the modified
-// rule to particular paths or permissions. A request will be matched by the
-// constraints if the requested path is matched by the path pattern (according
-// to bash's globstar matching) and one or more requested permissions are
-// denied in the permission map, or all of the requested permissions are
-// allowed in the map. When snapd modifies the rule, it converts
-// PatchConstraints to RuleConstraints, using the rule's existing constraints
-// wherever a field is omitted.
+// PatchConstraints hold partial rule contents which will be used to modify an
+// existing rule. When snapd modifies the rule using PatchConstraints, it
+// converts the PatchConstraints to RuleConstraints, using the rule's existing
+// constraints wherever a field is omitted from the PatchConstraints.
 //
 // Any permissions which are omitted from the new permission map are left
 // unchanged from the existing rule. To remove an existing permission from the

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -178,31 +178,32 @@ func (c *ReplyConstraints) ToConstraints(iface string, outcome OutcomeType, life
 	return constraints, nil
 }
 
-// PatchConstraints hold partial rule contents which will be used to modify an
-// existing rule. When snapd modifies the rule using PatchConstraints, it
-// converts the PatchConstraints to RuleConstraints, using the rule's existing
-// constraints wherever a field is omitted from the PatchConstraints.
+// RuleConstraintsPatch hold partial rule contents which will be used to modify
+// an existing rule. When snapd modifies the rule using RuleConstraintsPatch,
+// it converts the RuleConstraintsPatch to RuleConstraints, using the rule's
+// existing constraints wherever a field is omitted from the
+// RuleConstraintsPatch.
 //
 // Any permissions which are omitted from the new permission map are left
 // unchanged from the existing rule. To remove an existing permission from the
 // rule, the permission should map to null.
-type PatchConstraints struct {
+type RuleConstraintsPatch struct {
 	PathPattern *patterns.PathPattern `json:"path-pattern,omitempty"`
 	Permissions PermissionMap         `json:"permissions,omitempty"`
 }
 
-// PatchRuleConstraints validates the receiving PatchConstraints and uses the
-// existing rule constraints to construct a new RuleConstraints.
+// PatchRuleConstraints validates the receiving RuleConstraintsPatch and uses
+// the given existing rule constraints to construct a new RuleConstraints.
 //
 // If the path pattern or permissions fields are omitted, they are left
 // unchanged from the existing rule. If the permissions field is present in
-// the patch constraints, then any permissions which are omitted from the
-// patch constrants' permission map are left unchanged from the existing rule.
-// To remove an an existing permission from the rule, the permission should map
-// to null in the permission map of the patch constraints.
+// the patch, then any permissions which are omitted from the patch's
+// permission map are left unchanged from the existing rule. To remove an
+// existing permission from the rule, the permission should map to null in the
+// permission map of the patch.
 //
 // The existing rule constraints should never be modified.
-func (c *PatchConstraints) PatchRuleConstraints(existing *RuleConstraints, iface string, currTime time.Time) (*RuleConstraints, error) {
+func (c *RuleConstraintsPatch) PatchRuleConstraints(existing *RuleConstraints, iface string, currTime time.Time) (*RuleConstraints, error) {
 	ruleConstraints := &RuleConstraints{
 		PathPattern: c.PathPattern,
 	}
@@ -213,7 +214,7 @@ func (c *PatchConstraints) PatchRuleConstraints(existing *RuleConstraints, iface
 		ruleConstraints.Permissions = existing.Permissions
 		return ruleConstraints, nil
 	}
-	// Permissions are specified in the patch constraints, need to merge them
+	// Permissions are specified in the patch, need to merge them
 	newPermissions := make(RulePermissionMap, len(c.Permissions)+len(existing.Permissions))
 	// Pre-populate newPermissions with all the non-expired existing permissions
 	for perm, entry := range existing.Permissions {

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -415,7 +415,7 @@ type RulePermissionEntry struct {
 func (e *RulePermissionEntry) Expired(currTime time.Time) bool {
 	switch e.Lifespan {
 	case LifespanTimespan:
-		if currTime.After(e.Expiration) {
+		if !currTime.Before(e.Expiration) {
 			return true
 		}
 		// TODO: add lifespan session

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -332,6 +332,7 @@ func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Tim
 		}
 		if err := entry.validate(); err != nil {
 			errs = append(errs, err)
+			continue
 		}
 		if entry.Expired(currTime) {
 			expiredPerms = append(expiredPerms, perm)

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -49,7 +49,7 @@ func (c *Constraints) ToRuleConstraints(iface string, currTime time.Time) (*Rule
 	if c.PathPattern == nil {
 		return nil, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
 	}
-	rulePermissions, err := c.Permissions.ToRulePermissionMap(iface, currTime)
+	rulePermissions, err := c.Permissions.toRulePermissionMap(iface, currTime)
 	if err != nil {
 		return nil, err
 	}
@@ -259,11 +259,11 @@ func (c *PatchConstraints) PatchRuleConstraints(existing *RuleConstraints, iface
 // permissions.
 type PermissionMap map[string]*PermissionEntry
 
-// ToRulePermissionMap validates the receiving PermissionMap and converts it
+// toRulePermissionMap validates the receiving PermissionMap and converts it
 // to a RulePermissionMap, using the given current time to convert any included
 // durations to expirations. If the permission map is not valid with respect to
 // the given interface, returns an error.
-func (pm PermissionMap) ToRulePermissionMap(iface string, currTime time.Time) (RulePermissionMap, error) {
+func (pm PermissionMap) toRulePermissionMap(iface string, currTime time.Time) (RulePermissionMap, error) {
 	availablePerms, ok := interfacePermissionsAvailable[iface]
 	if !ok {
 		return nil, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -22,6 +22,7 @@ package prompting
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	prompting_errors "github.com/snapcore/snapd/interfaces/prompting/errors"
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
@@ -30,62 +31,61 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-// Constraints hold information about the applicability of a rule to particular
-// paths or permissions. A request matches the constraints if the requested path
-// is matched by the path pattern (according to bash's globstar matching) and
-// the requested permissions are contained in the constraints' permissions.
+// Constraints hold information about the applicability of a new rule to
+// particular paths or permissions. A request will be matched by the constraints
+// if the requested path is matched by the path pattern (according to bash's
+// globstar matching) and one or more requested permissions are denied in the
+// permission map, or all of the requested permissions are allowed in the map.
+// When snapd creates a new rule, it converts Constraints to RuleConstraints.
 type Constraints struct {
-	PathPattern *patterns.PathPattern `json:"path-pattern,omitempty"`
-	Permissions []string              `json:"permissions,omitempty"`
+	PathPattern *patterns.PathPattern `json:"path-pattern"`
+	Permissions PermissionMap         `json:"permissions"`
 }
 
-// ValidateForInterface returns nil if the constraints are valid for the given
-// interface, otherwise returns an error.
-func (c *Constraints) ValidateForInterface(iface string) error {
+// ToRuleConstraints validates the receiving Constraints and converts it to
+// RuleConstraints. If the constraints are not valid with respect to the given
+// interface, returns an error.
+func (c *Constraints) ToRuleConstraints(iface string, currTime time.Time) (*RuleConstraints, error) {
 	if c.PathPattern == nil {
-		return prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+		return nil, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
 	}
-	return c.validatePermissions(iface)
+	rulePermissions, err := c.Permissions.ToRulePermissionMap(iface, currTime)
+	if err != nil {
+		return nil, err
+	}
+	ruleConstraints := &RuleConstraints{
+		PathPattern: c.PathPattern,
+		Permissions: rulePermissions,
+	}
+	return ruleConstraints, nil
 }
 
-// validatePermissions checks that the permissions for the given constraints
-// are valid for the given interface. If not, returns an error, otherwise
-// ensures that the permissions are in the order in which they occur in the
-// list of available permissions for that interface.
-func (c *Constraints) validatePermissions(iface string) error {
-	availablePerms, ok := interfacePermissionsAvailable[iface]
-	if !ok {
-		return prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
+// RuleConstraints hold information about the applicability of an existing rule
+// to particular paths or permissions. A request will be matched by the rule
+// constraints if the requested path is matched by the path pattern (according
+// to bash's globstar matching) and one or more requested permissions are denied
+// in the permission map, or all of the requested permissions are allowed in the
+// map.
+type RuleConstraints struct {
+	PathPattern *patterns.PathPattern `json:"path-pattern"`
+	Permissions RulePermissionMap     `json:"permissions"`
+}
+
+// ValidateForInterface checks that the rule constraints are valid for the given
+// interface. Any permissions which have expired relative to the given current
+// time are pruned. If all permissions have expired, then returns true. If the
+// rule is invalid, returns an error.
+func (c *RuleConstraints) ValidateForInterface(iface string, currTime time.Time) (expired bool, err error) {
+	if c.PathPattern == nil {
+		return false, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
 	}
-	permsSet := make(map[string]bool, len(c.Permissions))
-	var invalidPerms []string
-	for _, perm := range c.Permissions {
-		if !strutil.ListContains(availablePerms, perm) {
-			invalidPerms = append(invalidPerms, perm)
-			continue
-		}
-		permsSet[perm] = true
-	}
-	if len(invalidPerms) > 0 {
-		return prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms)
-	}
-	if len(permsSet) == 0 {
-		return prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
-	}
-	newPermissions := make([]string, 0, len(permsSet))
-	for _, perm := range availablePerms {
-		if exists := permsSet[perm]; exists {
-			newPermissions = append(newPermissions, perm)
-		}
-	}
-	c.Permissions = newPermissions
-	return nil
+	return c.Permissions.validateForInterface(iface, currTime)
 }
 
 // Match returns true if the constraints match the given path, otherwise false.
 //
 // If the constraints or path are invalid, returns an error.
-func (c *Constraints) Match(path string) (bool, error) {
+func (c *RuleConstraints) Match(path string) (bool, error) {
 	if c.PathPattern == nil {
 		return false, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
 	}
@@ -97,15 +97,353 @@ func (c *Constraints) Match(path string) (bool, error) {
 	return match, nil
 }
 
-// ContainPermissions returns true if the constraints include every one of the
-// given permissions.
-func (c *Constraints) ContainPermissions(permissions []string) bool {
+// ReplyConstraints hold information about the applicability of a reply to
+// particular paths or permissions. Upon receiving the reply, snapd converts
+// ReplyConstraints to Constraints.
+type ReplyConstraints struct {
+	PathPattern *patterns.PathPattern `json:"path-pattern"`
+	Permissions []string              `json:"permissions"`
+}
+
+// ToConstraints validates the receiving ReplyConstraints with respect to the
+// given interface, along with the given outcome, lifespan, and duration, and
+// constructs an equivalent Constraints from the ReplyConstraints.
+func (c *ReplyConstraints) ToConstraints(iface string, outcome OutcomeType, lifespan LifespanType, duration string) (*Constraints, error) {
+	if _, err := outcome.AsBool(); err != nil {
+		// Should not occur, as outcome is validated when unmarshalled
+		return nil, err
+	}
+	if _, err := lifespan.ParseDuration(duration, time.Now()); err != nil {
+		return nil, err
+	}
+	if c.PathPattern == nil {
+		return nil, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+	}
+	availablePerms, ok := interfacePermissionsAvailable[iface]
+	if !ok {
+		return nil, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
+	}
+	if len(c.Permissions) == 0 {
+		return nil, prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
+	}
+	var invalidPerms []string
+	permissionMap := make(PermissionMap, len(c.Permissions))
+	for _, perm := range c.Permissions {
+		if !strutil.ListContains(availablePerms, perm) {
+			invalidPerms = append(invalidPerms, perm)
+			continue
+		}
+		permissionMap[perm] = &PermissionEntry{
+			Outcome:  outcome,
+			Lifespan: lifespan,
+			Duration: duration,
+		}
+	}
+	if len(invalidPerms) > 0 {
+		return nil, prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms)
+	}
+	constraints := &Constraints{
+		PathPattern: c.PathPattern,
+		Permissions: permissionMap,
+	}
+	return constraints, nil
+}
+
+// Match returns true if the constraints match the given path, otherwise false.
+//
+// If the constraints or path are invalid, returns an error.
+func (c *ReplyConstraints) Match(path string) (bool, error) {
+	if c.PathPattern == nil {
+		return false, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+	}
+	match, err := c.PathPattern.Match(path)
+	if err != nil {
+		// Error should not occur, since it was parsed internally
+		return false, prompting_errors.NewInvalidPathPatternError(c.PathPattern.String(), err.Error())
+	}
+	return match, nil
+}
+
+// ContainPermissions returns true if the permission list in the constraints
+// includes every one of the given permissions.
+func (c *ReplyConstraints) ContainPermissions(permissions []string) bool {
 	for _, perm := range permissions {
 		if !strutil.ListContains(c.Permissions, perm) {
 			return false
 		}
 	}
 	return true
+}
+
+// PatchConstraints hold information about the applicability of the modified
+// rule to particular paths or permissions. A request will be matched by the
+// constraints if the requested path is matched by the path pattern (according
+// to bash's globstar matching) and one or more requested permissions are
+// denied in the permission map, or all of the requested permissions are
+// allowed in the map. When snapd modifies the rule, it converts
+// PatchConstraints to RuleConstraints, using the rule's existing constraints
+// wherever a field is omitted.
+//
+// Any permissions which are omitted from the new permission map are left
+// unchanged from the existing rule. To remove an existing permission from the
+// rule, the permission should map to null.
+type PatchConstraints struct {
+	PathPattern *patterns.PathPattern `json:"path-pattern,omitempty"`
+	Permissions PermissionMap         `json:"permissions,omitempty"`
+}
+
+// PatchRuleConstraints validates the receiving PatchConstraints and uses the
+// existing rule constraints to construct a new RuleConstraints.
+//
+// If the path pattern or permissions fields are omitted, they are left
+// unchanged from the existing rule. If the permissions field is present in
+// the patch constraints, then any permissions which are omitted from the
+// patch constrants' permission map are left unchanged from the existing rule.
+// To remove an an existing permission from the rule, the permission should map
+// to null in the permission map of the patch constraints.
+//
+// The existing rule constraints should never be modified.
+func (c *PatchConstraints) PatchRuleConstraints(existing *RuleConstraints, iface string, currTime time.Time) (*RuleConstraints, error) {
+	ruleConstraints := &RuleConstraints{
+		PathPattern: c.PathPattern,
+	}
+	if c.PathPattern == nil {
+		ruleConstraints.PathPattern = existing.PathPattern
+	}
+	if c.Permissions == nil {
+		ruleConstraints.Permissions = existing.Permissions
+		return ruleConstraints, nil
+	}
+	// Permissions are specified in the patch constraints, need to merge them
+	newPermissions := make(RulePermissionMap, len(c.Permissions)+len(existing.Permissions))
+	for perm, entry := range existing.Permissions {
+		if !entry.Expired(currTime) {
+			newPermissions[perm] = entry
+		}
+	}
+	availablePerms, ok := interfacePermissionsAvailable[iface]
+	if !ok {
+		// Should not occur, as we should use the interface from the existing rule
+		return nil, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
+	}
+	var errs []error
+	var invalidPerms []string
+	for perm, entry := range c.Permissions {
+		if entry == nil {
+			delete(newPermissions, perm)
+			continue
+		}
+		if !strutil.ListContains(availablePerms, perm) {
+			invalidPerms = append(invalidPerms, perm)
+			continue
+		}
+		ruleEntry, err := entry.toRulePermissionEntry(currTime)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		newPermissions[perm] = ruleEntry
+	}
+	if len(invalidPerms) > 0 {
+		errs = append(errs, prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms))
+	}
+	if len(errs) > 0 {
+		return nil, prompting_errors.Join(errs...)
+	}
+	ruleConstraints.Permissions = newPermissions
+	return ruleConstraints, nil
+}
+
+// PermissionMap is a map from permissions to their corresponding entries,
+// which contain information about the outcome and lifespan for those
+// permissions.
+type PermissionMap map[string]*PermissionEntry
+
+// ToRulePermissionMap validates the receiving PermissionMap and converts it
+// to a RulePermissionMap, using the given current time to convert any included
+// durations to expirations. If the permission map is not valid with respect to
+// the given interface, returns an error.
+func (pm PermissionMap) ToRulePermissionMap(iface string, currTime time.Time) (RulePermissionMap, error) {
+	availablePerms, ok := interfacePermissionsAvailable[iface]
+	if !ok {
+		return nil, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
+	}
+	if len(pm) == 0 {
+		return nil, prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
+	}
+	var errs []error
+	var invalidPerms []string
+	rulePermissionMap := make(RulePermissionMap, len(pm))
+	for perm, entry := range pm {
+		if !strutil.ListContains(availablePerms, perm) {
+			invalidPerms = append(invalidPerms, perm)
+			continue
+		}
+		rulePermissionEntry, err := entry.toRulePermissionEntry(currTime)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		rulePermissionMap[perm] = rulePermissionEntry
+	}
+	if len(invalidPerms) > 0 {
+		errs = append(errs, prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms))
+	}
+	if len(errs) > 0 {
+		return nil, prompting_errors.Join(errs...)
+	}
+	return rulePermissionMap, nil
+}
+
+// RulePermissionMap is a map from permissions to their corresponding entries,
+// which contain information about the outcome and lifespan for those
+// permissions.
+type RulePermissionMap map[string]*RulePermissionEntry
+
+// validateForInterface checks that the rule permission map is valid for the
+// given interface. Any permissions which have expired relative to the given
+// current time are pruned. If all permissions have expired, then returns true.
+// If the permission map is invalid, returns an error.
+func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Time) (expired bool, err error) {
+	availablePerms, ok := interfacePermissionsAvailable[iface]
+	if !ok {
+		return false, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
+	}
+	if len(pm) == 0 {
+		return false, prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
+	}
+	var errs []error
+	var invalidPerms []string
+	var expiredPerms []string
+	for perm, entry := range pm {
+		if !strutil.ListContains(availablePerms, perm) {
+			invalidPerms = append(invalidPerms, perm)
+			continue
+		}
+		if entry.Expired(currTime) {
+			expiredPerms = append(expiredPerms, perm)
+			continue
+		}
+		if err := entry.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(invalidPerms) > 0 {
+		errs = append(errs, prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms))
+	}
+	if len(errs) > 0 {
+		return false, prompting_errors.Join(errs...)
+	}
+	for _, perm := range expiredPerms {
+		delete(pm, perm)
+	}
+	if len(pm) == 0 {
+		// All permissions expired
+		return true, nil
+	}
+	return false, nil
+}
+
+// Expired returns true if all permissions in the map have expired.
+func (pm RulePermissionMap) Expired(currTime time.Time) bool {
+	for _, entry := range pm {
+		if !entry.Expired(currTime) {
+			return false
+		}
+	}
+	return true
+}
+
+// PermissionEntry holds the outcome associated with a particular permission
+// and the lifespan for which that outcome is applicable.
+//
+// PermissionEntry is used when replying to a prompt, creating a new rule, or
+// modifying an existing rule.
+type PermissionEntry struct {
+	Outcome  OutcomeType  `json:"outcome"`
+	Lifespan LifespanType `json:"lifespan"`
+	Duration string       `json:"duration,omitempty"`
+}
+
+// toRulePermissionEntry validates the receiving PermissionEntry and converts
+// it to a RulePermissionEntry.
+//
+// Checks that the entry has a valid outcome, and that its lifespan is valid
+// for a rule (i.e. not LifespanSingle), and that it has an appropriate
+// duration for that lifespan. The duration, combined with the given current
+// time, is used to compute an expiration time, and that is returned as part
+// of the corresponding RulePermissionEntry.
+func (e *PermissionEntry) toRulePermissionEntry(currTime time.Time) (*RulePermissionEntry, error) {
+	if _, err := e.Outcome.AsBool(); err != nil {
+		return nil, err
+	}
+	if e.Lifespan == LifespanSingle {
+		// We don't allow rules with lifespan "single"
+		return nil, prompting_errors.NewRuleLifespanSingleError(SupportedRuleLifespans)
+	}
+	expiration, err := e.Lifespan.ParseDuration(e.Duration, currTime)
+	if err != nil {
+		return nil, err
+	}
+	rulePermissionEntry := &RulePermissionEntry{
+		Outcome:    e.Outcome,
+		Lifespan:   e.Lifespan,
+		Expiration: expiration,
+	}
+	return rulePermissionEntry, nil
+}
+
+// RulePermissionEntry holds the outcome associated with a particular permission
+// and the lifespan for which that outcome is applicable.
+//
+// RulePermissionEntry is derived from a PermissionEntry after it has been used
+// along with the rule's timestamp to define the expiration timeouts for any
+// permissions which have a lifespan of "timespan". RulePermissionEntry is what
+// is returned when retrieving rule contents, but PermissionEntry is used when
+// replying to prompts, creating new rules, or modifying existing rules.
+type RulePermissionEntry struct {
+	Outcome    OutcomeType  `json:"outcome"`
+	Lifespan   LifespanType `json:"lifespan"`
+	Expiration time.Time    `json:"expiration,omitempty"`
+}
+
+// Expired returns true if the receiving permission entry has expired and
+// should no longer be considered when matching requests.
+//
+// This is the case if the permission has a lifespan of timespan and the
+// current time is after its expiration time.
+func (e *RulePermissionEntry) Expired(currTime time.Time) bool {
+	switch e.Lifespan {
+	case LifespanTimespan:
+		if currTime.After(e.Expiration) {
+			return true
+		}
+		// TODO: add lifespan session
+		//case LifespanSession:
+		// TODO: return true if the user session has changed
+	}
+	return false
+}
+
+// validate checks that the entry has a valid outcome, and that its lifespan
+// is valid for a rule (i.e. not LifespanSingle), and has an appropriate
+// expiration for that lifespan.
+func (e *RulePermissionEntry) validate() error {
+	if _, err := e.Outcome.AsBool(); err != nil {
+		return err
+	}
+	if e.Lifespan == LifespanSingle {
+		// We don't allow rules with lifespan "single"
+		return prompting_errors.NewRuleLifespanSingleError(SupportedRuleLifespans)
+	}
+	if err := e.Lifespan.ValidateExpiration(e.Expiration); err != nil {
+		// Should never error due to an API request, since rules are always
+		// added via the API using duration, rather than expiration.
+		// Error may occur when validating a rule loaded from disk.
+		// We don't check expiration as part of validation.
+		return err
+	}
+	return nil
 }
 
 var (

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -251,7 +251,7 @@ func (c *PatchConstraints) PatchRuleConstraints(existing *RuleConstraints, iface
 		errs = append(errs, prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms))
 	}
 	if len(errs) > 0 {
-		return nil, prompting_errors.Join(errs...)
+		return nil, strutil.JoinErrors(errs...)
 	}
 	ruleConstraints.Permissions = newPermissions
 	return ruleConstraints, nil
@@ -293,7 +293,7 @@ func (pm PermissionMap) toRulePermissionMap(iface string, currTime time.Time) (R
 		errs = append(errs, prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms))
 	}
 	if len(errs) > 0 {
-		return nil, prompting_errors.Join(errs...)
+		return nil, strutil.JoinErrors(errs...)
 	}
 	return rulePermissionMap, nil
 }
@@ -336,7 +336,7 @@ func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Tim
 		errs = append(errs, prompting_errors.NewInvalidPermissionsError(iface, invalidPerms, availablePerms))
 	}
 	if len(errs) > 0 {
-		return false, prompting_errors.Join(errs...)
+		return false, strutil.JoinErrors(errs...)
 	}
 	for _, perm := range expiredPerms {
 		delete(pm, perm)

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -669,7 +669,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 
 	for i, testCase := range []struct {
 		initial *prompting.RuleConstraints
-		patch   *prompting.PatchConstraints
+		patch   *prompting.RuleConstraintsPatch
 		final   *prompting.RuleConstraints
 	}{
 		{
@@ -688,7 +688,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 					},
 				},
 			},
-			patch: &prompting.PatchConstraints{},
+			patch: &prompting.RuleConstraintsPatch{},
 			final: &prompting.RuleConstraints{
 				PathPattern: pathPattern,
 				Permissions: prompting.RulePermissionMap{
@@ -721,7 +721,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 					},
 				},
 			},
-			patch: &prompting.PatchConstraints{
+			patch: &prompting.RuleConstraintsPatch{
 				Permissions: prompting.PermissionMap{
 					"write": nil,
 					"execute": &prompting.PermissionEntry{
@@ -767,7 +767,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 					},
 				},
 			},
-			patch: &prompting.PatchConstraints{
+			patch: &prompting.RuleConstraintsPatch{
 				Permissions: prompting.PermissionMap{
 					"execute": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeAllow,
@@ -819,7 +819,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
 			},
 		},
 	}
-	goodPatch := &prompting.PatchConstraints{
+	goodPatch := &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"write": nil,
 			"execute": &prompting.PermissionEntry{
@@ -834,7 +834,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
 	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
 	c.Check(result, IsNil)
 
-	badPatch := &prompting.PatchConstraints{
+	badPatch := &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeAllow,

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -357,6 +357,17 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
 			},
 			`cannot create rule with lifespan "single"`,
 		},
+		{
+			"home",
+			prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeType("bar"),
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: time.Now().Add(-time.Second),
+				},
+			},
+			`invalid outcome: "bar"`,
+		},
 	}
 	for _, testCase := range cases {
 		constraints := &prompting.RuleConstraints{
@@ -833,10 +844,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
 				Outcome:  prompting.OutcomeAllow,
 				Lifespan: prompting.LifespanForever,
 			},
-			"lock": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
-			},
+			"lock": nil, // even if invalid permission is meant to be removed, include it
 			"execute": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeAllow,
 				Lifespan: prompting.LifespanTimespan,

--- a/interfaces/prompting/errors/errors.go
+++ b/interfaces/prompting/errors/errors.go
@@ -231,28 +231,3 @@ func (e *RuleConflictError) Error() string {
 func (e *RuleConflictError) Unwrap() error {
 	return ErrRuleConflict
 }
-
-// Join returns an error that wraps the given errors.
-// Any nil error values are discarded.
-// Join returns nil if every value in errs is nil.
-//
-// TODO: replace with errors.Join() once we're on golang v1.20+
-//
-// This is a lossy implementation of errors.Join, where only the first non-nil
-// error is preserved in a state which can be unwrapped.
-func Join(errs ...error) error {
-	var nonNilErrs []error
-	for _, e := range errs {
-		if e != nil {
-			nonNilErrs = append(nonNilErrs, e)
-		}
-	}
-	if len(nonNilErrs) == 0 {
-		return nil
-	}
-	err := nonNilErrs[0]
-	for _, e := range nonNilErrs[1:] {
-		err = fmt.Errorf("%w\n%v", err, e)
-	}
-	return err
-}

--- a/interfaces/prompting/errors/errors_test.go
+++ b/interfaces/prompting/errors/errors_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package errors_test
+
+import (
+	"errors"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	prompting_errors "github.com/snapcore/snapd/interfaces/prompting/errors"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type errorsSuite struct{}
+
+var _ = Suite(&errorsSuite{})
+
+func (s *errorsSuite) TestJoin(c *C) {
+	errs := []error{
+		errors.New("foo"),
+		errors.New("bar"),
+		errors.New("baz"),
+	}
+	for _, testCase := range []struct {
+		errors  []error
+		wrapped error
+		errStr  string
+	}{
+		{
+			errs,
+			errs[0],
+			"foo\nbar\nbaz",
+		},
+		{
+			[]error{nil, errs[2], nil, errs[1], nil},
+			errs[2],
+			"baz\nbar",
+		},
+		{
+			[]error{nil, nil, nil},
+			nil,
+			"",
+		},
+	} {
+		joined := prompting_errors.Join(testCase.errors...)
+		c.Check(errors.Is(joined, testCase.wrapped), Equals, true, Commentf("testCase: %+v", testCase))
+		if testCase.errStr != "" {
+			c.Check(joined, ErrorMatches, testCase.errStr)
+		} else {
+			c.Check(joined, IsNil)
+		}
+	}
+}

--- a/interfaces/prompting/export_test.go
+++ b/interfaces/prompting/export_test.go
@@ -23,7 +23,3 @@ var (
 	InterfacePermissionsAvailable = interfacePermissionsAvailable
 	InterfaceFilePermissionsMaps  = interfaceFilePermissionsMaps
 )
-
-func (c *Constraints) ValidatePermissions(iface string) error {
-	return c.validatePermissions(iface)
-}

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -159,10 +159,9 @@ func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
 // ValidateExpiration checks that the given expiration is valid for the
 // receiver lifespan.
 //
-// If the lifespan is LifespanTimespan, then expiration must be non-zero and be
-// after the given currTime. Otherwise, it must be zero. Returns an error if
-// any of the above are invalid.
-func (lifespan LifespanType) ValidateExpiration(expiration time.Time, currTime time.Time) error {
+// If the lifespan is LifespanTimespan, then expiration must be non-zero.
+// Otherwise, it must be zero. Returns an error if any of the above are invalid.
+func (lifespan LifespanType) ValidateExpiration(expiration time.Time) error {
 	switch lifespan {
 	case LifespanForever, LifespanSingle:
 		if !expiration.IsZero() {
@@ -171,9 +170,6 @@ func (lifespan LifespanType) ValidateExpiration(expiration time.Time, currTime t
 	case LifespanTimespan:
 		if expiration.IsZero() {
 			return prompting_errors.NewInvalidExpirationError(expiration, fmt.Sprintf("cannot have unspecified expiration when lifespan is %q", lifespan))
-		}
-		if currTime.After(expiration) {
-			return fmt.Errorf("%w: %q", prompting_errors.ErrRuleExpirationInThePast, expiration)
 		}
 	default:
 		// Should not occur, since lifespan is validated when unmarshalled

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -169,21 +169,18 @@ func (s *promptingSuite) TestValidateExpiration(c *C) {
 		prompting.LifespanForever,
 		prompting.LifespanSingle,
 	} {
-		err := lifespan.ValidateExpiration(unsetExpiration, currTime)
+		err := lifespan.ValidateExpiration(unsetExpiration)
 		c.Check(err, IsNil)
 		for _, exp := range []time.Time{negativeExpiration, validExpiration} {
-			err = lifespan.ValidateExpiration(exp, currTime)
+			err = lifespan.ValidateExpiration(exp)
 			c.Check(err, ErrorMatches, `invalid expiration: cannot have specified expiration when lifespan is.*`)
 		}
 	}
 
-	err := prompting.LifespanTimespan.ValidateExpiration(unsetExpiration, currTime)
+	err := prompting.LifespanTimespan.ValidateExpiration(unsetExpiration)
 	c.Check(err, ErrorMatches, `invalid expiration: cannot have unspecified expiration when lifespan is.*`)
 
-	err = prompting.LifespanTimespan.ValidateExpiration(negativeExpiration, currTime)
-	c.Check(err, ErrorMatches, `cannot have expiration time in the past.*`)
-
-	err = prompting.LifespanTimespan.ValidateExpiration(validExpiration, currTime)
+	err = prompting.LifespanTimespan.ValidateExpiration(validExpiration)
 	c.Check(err, IsNil)
 }
 

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -27,6 +27,6 @@ var JoinInternalErrors = joinInternalErrors
 
 type RulesDBJSON rulesDBJSON
 
-func (rule *Rule) Validate(currTime time.Time) error {
+func (rule *Rule) Validate(currTime time.Time) (expired bool, err error) {
 	return rule.validate(currTime)
 }

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -1009,8 +1009,8 @@ func (rdb *RuleDB) RemoveRulesForSnapInterface(user uint32, snap string, iface s
 // the rule, the permission should map to an empty permission entry.
 //
 // Permission entries must be provided as complete units, containing both
-// outcome and lifespan (and duration, if lifespan is timespan).
-// XXX: does API unmarshalling ensures this, or do we need explicit checks?
+// outcome and lifespan (and duration, if lifespan is timespan). Since neither
+// outcome nor lifespan are omitempty, the unmarshaller enforces this for us.
 //
 // Even if the given new rule contents exactly match the existing rule contents,
 // the timestamp of the rule is updated to the current time. If there is any
@@ -1018,7 +1018,7 @@ func (rdb *RuleDB) RemoveRulesForSnapInterface(user uint32, snap string, iface s
 // unmodified state, leaving the database unchanged. If the database is changed,
 // it is saved to disk.
 //
-// XXX: should we just remove this method entirely?
+// XXX: Is there a client use-case for this API method?
 // Clients can always delete a rule and re-add it later, which is basically what
 // this method already does.
 func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, patchConstraints *prompting.PatchConstraints) (r *Rule, err error) {

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -497,10 +497,11 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 			// Error shouldn't occur. If it does, the rule was already removed
 			continue
 		}
-		// Already removed the rule's permission from the tree, let's remove
-		// it from the rule as well
-		delete(maybeExpired.Constraints.Permissions, permission)
 		if !maybeExpired.expired(rule.Timestamp) {
+			// Previously removed the rule's permission entry from the tree for
+			// this permission, now let's remove it from the rule as well.
+			delete(maybeExpired.Constraints.Permissions, permission)
+
 			// This should not occur during load since it calls rule.validate()
 			// which calls RuleConstraints.ValidateForInterface, which prunes
 			// any expired permissions. Thus, it should only occur when adding

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -501,6 +501,11 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 		// it from the rule as well
 		delete(maybeExpired.Constraints.Permissions, permission)
 		if !maybeExpired.expired(rule.Timestamp) {
+			// This should not occur during load since it calls rule.validate()
+			// which calls RuleConstraints.ValidateForInterface, which prunes
+			// any expired permissions. Thus, it should only occur when adding
+			// a new rule which overlaps with another rule which has partially
+			// expired.
 			continue
 		}
 		_, err = rdb.removeRuleByID(ruleID)

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // Rule stores the contents of a request rule.
@@ -201,7 +202,7 @@ func (rdb *RuleDB) load() (retErr error) {
 		loadErr := fmt.Errorf("cannot read stored request rules: %w", err)
 		// Save the empty rule DB to disk to overwrite the previous one which
 		// could not be decoded.
-		return prompting_errors.Join(loadErr, rdb.save())
+		return strutil.JoinErrors(loadErr, rdb.save())
 	}
 
 	currTime := time.Now()
@@ -239,7 +240,7 @@ func (rdb *RuleDB) load() (retErr error) {
 
 		// Save the empty rule DB to disk to overwrite the previous one which
 		// was invalid.
-		return prompting_errors.Join(errInvalid, rdb.save())
+		return strutil.JoinErrors(errInvalid, rdb.save())
 	}
 
 	expiredData := map[string]string{"removed": "expired"}
@@ -586,7 +587,7 @@ func (rdb *RuleDB) removeRulePermissionFromTree(rule *Rule, permission string) e
 //
 // If there are no non-nil errors in the given errs list, return nil.
 func joinInternalErrors(errs []error) error {
-	joinedErr := prompting_errors.Join(errs...)
+	joinedErr := strutil.JoinErrors(errs...)
 	if joinedErr == nil {
 		return nil
 	}
@@ -1069,7 +1070,7 @@ func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, patchConstraints 
 		// Try to re-add original rule so all is unchanged.
 		if origErr := rdb.addRule(origRule); origErr != nil {
 			// Error should not occur, but if it does, wrap it in the other error
-			err = prompting_errors.Join(err, fmt.Errorf("cannot re-add original rule: %w", origErr))
+			err = strutil.JoinErrors(err, fmt.Errorf("cannot re-add original rule: %w", origErr))
 		}
 		return nil, err
 	}

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -1675,7 +1675,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 	rule = patched
 
 	// Check that patching with identical content works fine, and updates timestamp
-	newConstraints := &prompting.PatchConstraints{
+	constraintsPatch := &prompting.RuleConstraintsPatch{
 		PathPattern: rule.Constraints.PathPattern,
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
@@ -1684,7 +1684,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 			},
 		},
 	}
-	patched, err = rdb.PatchRule(rule.User, rule.ID, newConstraints)
+	patched, err = rdb.PatchRule(rule.User, rule.ID, constraintsPatch)
 	c.Assert(err, IsNil)
 	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
 	s.checkNewNoticesSimple(c, nil, rule)
@@ -1696,7 +1696,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 
 	rule = patched
 
-	newConstraints = &prompting.PatchConstraints{
+	constraintsPatch = &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"execute": &prompting.PermissionEntry{
 				Outcome:  rule.Constraints.Permissions["read"].Outcome,
@@ -1704,7 +1704,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 			},
 		},
 	}
-	patched, err = rdb.PatchRule(rule.User, rule.ID, newConstraints)
+	patched, err = rdb.PatchRule(rule.User, rule.ID, constraintsPatch)
 	c.Assert(err, IsNil)
 	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
 	s.checkNewNoticesSimple(c, nil, rule)
@@ -1729,7 +1729,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 
 	rule = patched
 
-	newConstraints = &prompting.PatchConstraints{
+	constraintsPatch = &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
@@ -1741,7 +1741,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 			},
 		},
 	}
-	patched, err = rdb.PatchRule(rule.User, rule.ID, newConstraints)
+	patched, err = rdb.PatchRule(rule.User, rule.ID, constraintsPatch)
 	c.Assert(err, IsNil)
 	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
 	s.checkNewNoticesSimple(c, nil, rule)
@@ -1755,7 +1755,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 
 	rule = patched
 
-	newConstraints = &prompting.PatchConstraints{
+	constraintsPatch = &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
@@ -1769,7 +1769,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 			},
 		},
 	}
-	patched, err = rdb.PatchRule(rule.User, rule.ID, newConstraints)
+	patched, err = rdb.PatchRule(rule.User, rule.ID, constraintsPatch)
 	c.Assert(err, IsNil)
 	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
 	s.checkNewNoticesSimple(c, nil, rule)
@@ -1785,7 +1785,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 
 	rule = patched
 
-	newConstraints = &prompting.PatchConstraints{
+	constraintsPatch = &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  origRule.Constraints.Permissions["read"].Outcome,
@@ -1794,7 +1794,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 			"execute": nil,
 		},
 	}
-	patched, err = rdb.PatchRule(rule.User, rule.ID, newConstraints)
+	patched, err = rdb.PatchRule(rule.User, rule.ID, constraintsPatch)
 	c.Assert(err, IsNil)
 	s.checkWrittenRuleDB(c, append(rules[:len(rules)-1], patched))
 	s.checkNewNoticesSimple(c, nil, rule)
@@ -1852,7 +1852,7 @@ func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
 	s.checkNewNoticesSimple(c, nil)
 
 	// Invalid lifespan
-	badConstraints := &prompting.PatchConstraints{
+	badPatch := &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeAllow,
@@ -1860,14 +1860,14 @@ func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
 			},
 		},
 	}
-	result, err = rdb.PatchRule(rule.User, rule.ID, badConstraints)
+	result, err = rdb.PatchRule(rule.User, rule.ID, badPatch)
 	c.Check(err, ErrorMatches, prompting_errors.NewRuleLifespanSingleError(prompting.SupportedRuleLifespans).Error())
 	c.Check(result, IsNil)
 	s.checkWrittenRuleDB(c, rules)
 	s.checkNewNoticesSimple(c, nil)
 
 	// Conflicting rule
-	conflictingConstraints := &prompting.PatchConstraints{
+	conflictingPatch := &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
@@ -1883,7 +1883,7 @@ func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
 			},
 		},
 	}
-	result, err = rdb.PatchRule(rule.User, rule.ID, conflictingConstraints)
+	result, err = rdb.PatchRule(rule.User, rule.ID, conflictingPatch)
 	c.Check(err, ErrorMatches, fmt.Sprintf("cannot patch rule: %v", prompting_errors.ErrRuleConflict))
 	c.Check(result, IsNil)
 	s.checkWrittenRuleDB(c, rules)
@@ -1943,7 +1943,7 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 
 	// Patching doesn't conflict with already-expired rules
 	rule := rules[2]
-	newConstraints := &prompting.PatchConstraints{
+	constraintsPatch := &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
@@ -1959,7 +1959,7 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 			},
 		},
 	}
-	patched, err := rdb.PatchRule(rule.User, rule.ID, newConstraints)
+	patched, err := rdb.PatchRule(rule.User, rule.ID, constraintsPatch)
 	c.Assert(err, IsNil)
 	s.checkWrittenRuleDB(c, []*requestrules.Rule{patched})
 	expectedNotices := []*noticeInfo{

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -376,24 +376,24 @@ func (m *InterfacesRequestsManager) HandleReply(userID uint32, promptID promptin
 	// constraints, such as check that the path pattern does not match
 	// any paths not granted by the interface.
 	// TODO: Should this be reconsidered?
-	matches, err := replyConstraints.Match(prompt.Constraints.Path())
+	matches, err := constraints.Match(prompt.Constraints.Path())
 	if err != nil {
 		return nil, err
 	}
 	if !matches {
 		return nil, &prompting_errors.RequestedPathNotMatchedError{
 			Requested: prompt.Constraints.Path(),
-			Replied:   replyConstraints.PathPattern.String(),
+			Replied:   constraints.PathPattern.String(),
 		}
 	}
 
 	// XXX: do we want to allow only replying to a select subset of permissions, and
 	// auto-deny the rest?
-	contained := replyConstraints.ContainPermissions(prompt.Constraints.RemainingPermissions())
+	contained := constraints.ContainPermissions(prompt.Constraints.RemainingPermissions())
 	if !contained {
 		return nil, &prompting_errors.RequestedPermissionsNotMatchedError{
 			Requested: prompt.Constraints.RemainingPermissions(),
-			Replied:   replyConstraints.Permissions,
+			Replied:   replyConstraints.Permissions, // equivalent to keys of constraints.Permissions
 		}
 	}
 

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -57,7 +57,7 @@ type Manager interface {
 	AddRule(userID uint32, snap string, iface string, constraints *prompting.Constraints) (*requestrules.Rule, error)
 	RemoveRules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error)
 	RuleWithID(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error)
-	PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.PatchConstraints) (*requestrules.Rule, error)
+	PatchRule(userID uint32, ruleID prompting.IDType, constraintsPatch *prompting.RuleConstraintsPatch) (*requestrules.Rule, error)
 	RemoveRule(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error)
 }
 
@@ -522,11 +522,11 @@ func (m *InterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompting.I
 
 // PatchRule updates the rule with the given ID using the provided contents.
 // Any of the given fields which are empty/nil are not updated in the rule.
-func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraints *prompting.PatchConstraints) (*requestrules.Rule, error) {
+func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraintsPatch *prompting.RuleConstraintsPatch) (*requestrules.Rule, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	patchedRule, err := m.rules.PatchRule(userID, ruleID, constraints)
+	patchedRule, err := m.rules.PatchRule(userID, ruleID, constraintsPatch)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/strutil"
 )
 
 var (
@@ -312,7 +313,7 @@ func (m *InterfacesRequestsManager) disconnect() error {
 		m.rules = nil
 	}
 
-	return prompting_errors.Join(errs...)
+	return strutil.JoinErrors(errs...)
 }
 
 // Stop closes the listener, prompt DB, and rule DB. Stop is idempotent, and

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -1323,7 +1323,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 
 	// Patch rule to now cover the outstanding prompt
 	whenPatched := time.Now()
-	newConstraints := &prompting.PatchConstraints{
+	constraintsPatch := &prompting.RuleConstraintsPatch{
 		PathPattern: mustParsePathPattern(c, "/home/test/{foo,bar,baz}"),
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
@@ -1336,7 +1336,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 			},
 		},
 	}
-	patched, err := mgr.PatchRule(s.defaultUser, rule.ID, newConstraints)
+	patched, err := mgr.PatchRule(s.defaultUser, rule.ID, constraintsPatch)
 	c.Assert(err, IsNil)
 	s.checkRecordedRuleUpdateNotices(c, whenPatched, 1)
 

--- a/strutil/joinerrors.go
+++ b/strutil/joinerrors.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil
+
+import (
+	"fmt"
+)
+
+// JoinErrors returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if every value in errs is nil.
+//
+// TODO: replace with errors.Join() once we're on golang v1.20+
+//
+// This is a lossy implementation of errors.Join, where only the first non-nil
+// error is preserved in a state which can be unwrapped.
+func JoinErrors(errs ...error) error {
+	var nonNilErrs []error
+	for _, e := range errs {
+		if e != nil {
+			nonNilErrs = append(nonNilErrs, e)
+		}
+	}
+	if len(nonNilErrs) == 0 {
+		return nil
+	}
+	err := nonNilErrs[0]
+	for _, e := range nonNilErrs[1:] {
+		err = fmt.Errorf("%w\n%v", err, e)
+	}
+	return err
+}

--- a/strutil/joinerrors_test.go
+++ b/strutil/joinerrors_test.go
@@ -17,24 +17,21 @@
  *
  */
 
-package errors_test
+package strutil_test
 
 import (
 	"errors"
-	"testing"
 
 	. "gopkg.in/check.v1"
 
-	prompting_errors "github.com/snapcore/snapd/interfaces/prompting/errors"
+	"github.com/snapcore/snapd/strutil"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+type joinErrorsSuite struct{}
 
-type errorsSuite struct{}
+var _ = Suite(&joinErrorsSuite{})
 
-var _ = Suite(&errorsSuite{})
-
-func (s *errorsSuite) TestJoin(c *C) {
+func (s *joinErrorsSuite) TestJoin(c *C) {
 	errs := []error{
 		errors.New("foo"),
 		errors.New("bar"),
@@ -61,7 +58,7 @@ func (s *errorsSuite) TestJoin(c *C) {
 			"",
 		},
 	} {
-		joined := prompting_errors.Join(testCase.errors...)
+		joined := strutil.JoinErrors(testCase.errors...)
 		c.Check(errors.Is(joined, testCase.wrapped), Equals, true, Commentf("testCase: %+v", testCase))
 		if testCase.errStr != "" {
 			c.Check(joined, ErrorMatches, testCase.errStr)

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -31,10 +31,82 @@ debug: |
 execute: |
     RULES_PATH="/var/lib/snapd/interfaces-requests/request-rules.json"
 
-    echo "Write two rules to disk, one of which is expired"
+    echo "Write three rules to disk, one of which is partially expired,"
+    echo "another is fully expired, and the last is not expired whatsoever"
     mkdir -p "$(dirname $RULES_PATH)"
-    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"},{"id":"0000000000000003","timestamp":"2004-10-20T16:47:32.138415627-05:00","user":1000,"snap":"firefox","interface":"home","constraints":{"path-pattern":"/home/test/Downloads/**","permissions":["read","write"]},"outcome":"allow","lifespan":"timespan","expiration":"2005-04-08T00:00:00Z"}]}' | \
-        tee "$RULES_PATH"
+    echo '{
+      "rules": [
+        {
+          "id": "0000000000000002",
+          "timestamp": "2004-10-20T14:05:08.901174186-05:00",
+          "user": 1000,
+          "snap": "shellcheck",
+          "interface": "home",
+          "constraints": {
+            "path-pattern": "/home/test/Projects/**",
+            "permissions": {
+              "read": {
+                "outcome": "allow",
+                "lifespan": "forever"
+              },
+              "write": {
+                "outcome": "allow",
+                "lifespan": "timespan",
+                "expiration": "2005-04-08T00:00:00Z"
+              },
+              "execute": {
+                "outcome": "deny",
+                "lifespan": "timespan",
+                "expiration": "9999-01-01T00:00:00Z"
+              }
+            }
+          }
+        },
+        {
+          "id": "0000000000000003",
+          "timestamp": "2004-10-20T16:47:32.138415627-05:00",
+          "user": 1000,
+          "snap": "firefox",
+          "interface": "home",
+          "constraints": {
+            "path-pattern": "/home/test/Downloads/**",
+            "permissions": {
+              "read": {
+                "outcome": "deny",
+                "lifespan": "timespan",
+                "expiration":"2005-04-08T00:00:00Z"
+              },
+              "write": {
+                "outcome": "allow",
+                "lifespan": "timespan",
+                "expiration": "2005-04-08T00:00:00Z"
+              }
+            }
+          }
+        },
+        {
+          "id": "0000000000000005",
+          "timestamp": "2004-10-20T17:27:41.932269962-05:00",
+          "user": 1000,
+          "snap": "thunderbird",
+          "interface": "home",
+          "constraints": {
+            "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
+            "permissions": {
+              "read": {
+                "outcome": "allow",
+                "lifespan": "forever"
+              },
+              "write": {
+                "outcome": "allow",
+                "lifespan": "timespan",
+                "expiration": "9999-01-01T00:00:00Z"
+              }
+            }
+          }
+        }
+      ]
+    }' | tee "$RULES_PATH"
 
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
@@ -70,24 +142,72 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     # Write expected rules after the expired rule has been removed
-    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"}]}' | \
-        gojq | tee expected.json
+    echo '{
+      "rules": [
+        {
+          "id": "0000000000000002",
+          "timestamp": "2004-10-20T14:05:08.901174186-05:00",
+          "user": 1000,
+          "snap": "shellcheck",
+          "interface": "home",
+          "constraints": {
+            "path-pattern": "/home/test/Projects/**",
+            "permissions": {
+              "read": {
+                "outcome": "allow",
+                "lifespan": "forever",
+                "expiration": "0001-01-01T00:00:00Z"
+              },
+              "execute": {
+                "outcome": "deny",
+                "lifespan": "timespan",
+                "expiration": "9999-01-01T00:00:00Z"
+              }
+            }
+          }
+        },
+        {
+          "id": "0000000000000005",
+          "timestamp": "2004-10-20T17:27:41.932269962-05:00",
+          "user": 1000,
+          "snap": "thunderbird",
+          "interface": "home",
+          "constraints": {
+            "path-pattern": "/home/test/Downloads/thunderbird.tmp/**",
+            "permissions": {
+              "read": {
+                "outcome": "allow",
+                "lifespan": "forever",
+                "expiration": "0001-01-01T00:00:00Z"
+              },
+              "write": {
+                "outcome": "allow",
+                "lifespan": "timespan",
+                "expiration": "9999-01-01T00:00:00Z"
+              }
+            }
+          }
+        }
+      ]
+    }' | gojq | tee expected.json
     # Parse existing rules through (go)jq so they can be compared
-    gojq < "$RULES_PATH" > current.json
 
     echo "Check that rules on disk match what is expected"
+    gojq < "$RULES_PATH" > current.json
     diff expected.json current.json
 
-    echo "Check that we received two notices"
+    echo "Check that we received three notices, one of which marked a rule as expired"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
-        gojq '.result | length' | MATCH 2
+        gojq '.result | length' | MATCH 3
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
         gojq '.result' | grep -c '"removed": "expired"' | MATCH 1
 
-    echo "Check that only the former rule is still valid (must be done with UID 1000)"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result[0].id' | MATCH "0000000000000002"
+    echo "Check that only the first and last rules are still valid (must be done with UID 1000)"
+    snap debug api --fail "/v2/interfaces/requests/rules?user-id=1000" | gojq
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH 2
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"
 
     echo "Stop snapd and ensure it is not in failure mode"
     systemctl stop snapd.service snapd.socket
@@ -106,18 +226,22 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
+    gojq < "$RULES_PATH" > current.json
     diff expected.json current.json
 
-    echo "Check that we received one notices for the non-expired rule"
+    echo "Check that we received two notices for the non-expired rules"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
-        gojq '.result | length' | MATCH 1
+        gojq '.result | length' | MATCH 2
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
         gojq '.result[0].key' | MATCH "0000000000000002"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[1].key' | MATCH "0000000000000005"
 
-    echo "Check that only the non-expired rule is still valid (must be done with UID 1000)"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result[0].id' | MATCH "0000000000000002"
+    echo "Check that only the non-expired rules are still valid (must be done with UID 1000)"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH 2
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"
 
     echo '### Simulate failure to open interfaces requests manager ###'
 
@@ -144,12 +268,12 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
+    gojq < "$RULES_PATH" > current.json
     diff expected.json current.json
 
     echo "Check that accessing a prompting endpoint results in an expected error"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '."status-code"' | MATCH 500
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | \
-        gojq '.result.message' | MATCH -i "Apparmor Prompting is not running"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '."status-code"' | MATCH 500
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result.message' | MATCH -i "Apparmor Prompting is not running"
 
     echo '### Remove the corrupted max prompt ID file and check that prompting backends can start again ###'
 
@@ -173,15 +297,19 @@ execute: |
     snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
+    gojq < "$RULES_PATH" > current.json
     diff expected.json current.json
 
-    echo "Check that we received one notices for the non-expired rule"
+    echo "Check that we received one notice each for the non-expired rules"
     snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
-        gojq '.result | length' | MATCH 1
+        gojq '.result | length' | MATCH 2
     snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
         gojq '.result[0].key' | MATCH "0000000000000002"
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[1].key' | MATCH "0000000000000005"
 
-    echo "Check that the non-expired rule is still valid (must be done with UID 1000)"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result[0].id' | MATCH "0000000000000002"
+    echo "Check that the non-expired rules are still valid (must be done with UID 1000)"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result | length' | MATCH 2
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[0].id' | MATCH "0000000000000002"
+    snap debug api "/v2/interfaces/requests/rules?user-id=1000" | gojq '.result[1].id' | MATCH "0000000000000005"

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -114,8 +114,33 @@ execute: |
 
     # XXX: creating rules requires polkit authentication, so for now, use snap debug api instead of api-client
     # echo "Check snap can create rule via /v2/interfaces/requests/rules"
-    # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' "/v2/interfaces/requests/rules" > result.json
-    echo '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' | snap debug api -X POST -H 'Content-Type: application/json' "/v2/interfaces/requests/rules" | \
+    # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":{"read":{"outcome":"allow","lifespan":"forever"},"write":{"outcome":"deny","lifespan":"forever"},"execute":{"outcome":"allow","lifespan":"timespan","duration":"1h"}}}}}' "/v2/interfaces/requests/rules" > result.json
+    echo '{
+      "action": "add",
+      "rule": {
+        "snap": "api-client",
+        "interface": "home",
+        "constraints": {
+          "path-pattern": "/path/to/file",
+          "permissions": {
+            "read": {
+              "outcome": "allow",
+              "lifespan": "forever"
+            },
+            "write": {
+              "outcome": "deny",
+              "lifespan": "forever"
+            },
+            "execute": {
+              "outcome": "allow",
+              "lifespan": "timespan",
+              "duration": "1h"
+            }
+          }
+        }
+      }
+    }' | \
+        snap debug api -X POST -H 'Content-Type: application/json' "/v2/interfaces/requests/rules" | \
         tee result.json
     gojq '."status-code"' < result.json | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
     RULE_ID=$(gojq '."result"."id"' < result.json | tr -d '"')
@@ -137,13 +162,16 @@ execute: |
         gojq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-rule-update" | \
         gojq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/system-info" | gojq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/system-info" | \
+        gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | \
+        gojq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts" | \
         gojq '."status-code"' | MATCH '^403$'
     # Try to access an arbitrary prompt ID, should fail with 403 rather than 404
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts/1234123412341234" | \
         gojq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | \
+        gojq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules/$RULE_ID" | \
         gojq '."status-code"' | MATCH '^403$'


### PR DESCRIPTION
This PR is based on #14538, and is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-32594. It addresses some of the problems discussed in that PR (such as https://github.com/canonical/snapd/pull/14538#issuecomment-2383774515), and more broadly in https://github.com/canonical/desktop-security-center/issues/74. CC @sminez @juanruitina.


Let rule content constraints have heterogeneous outcomes and lifespans for different permissions in the constraints. As such, convert the list of permissions to a map from permission to permission entry, where the entry holds the outcome, lifespan, and duration/expiration for that particular permission, where previous those were global to the containing rule, rule contents, or patch contents.

However, the existing concept of replying "allow"/"deny" to a particular set of requested permissions is clear and simple. We want to keep outcome, lifespan, and duration as reply-scoped values, not permission-specific, when accepting prompt replies. So we need different types of constraints for prompt replies vs. rule contents.

The motivation behind this is so that we can have only a single rule for any given path pattern. We may have a situation where the user previously replied with "allow read `/path/to/foo`" and they're now prompted for write access, they need to be able to respond with "deny read `/path/to/foo`". If we only support a single outcome for any given rule, then we'd need two rules for the same path `/path/to/foo`. Thus, we need rules to support different outcomes for different permissions.

The same logic applies for lifetimes and expirations, though this adds additional complexity now that the concept of rule expiration is shifted to being permission-specific. We care about expired rules in two primary places: when loading rules from disk, we want to discard any expired rules, and when adding a new rule, we want to discard any expired permission entry for a rule which shares a pattern variant with the new rule. For cases where that expired permission entry had a conflicting outcome, we clearly can't have that, and we want to remove the expired permission entry from its containing rule as well, so as to avoid confusion for the user without them needing to check expiration timestamps. Even if the outcome of the expired entry matches that of the new rule's entry for the same permission, we still want to prune the expired permission from the old rule to avoid confusion. The complexity is around when a notice is recorded for a rule for which some permissions have expired. At the moment, the logic is that a notice is recorded in these cases:

- when a rule is loaded from disk
    - data may be `"removed": "expired"` if all permissions are expired
- when a rule is added
- when a rule is patched
- when a rule is removed (with data `"removed": "removed"`)
- when a rule is found to be expired when attempting to add a new rule

Notably, a notice is not recorded automatically when a permission entry expires. Nor is a notice recorded when a permission is found to be expired, so long as its associated rule still has at least one non-expired permission. Neither pruning an expired permission entry from the rule tree nor from the entry's containing rule results in a notice, even though technically the rule data has changed, since the expired permission has been erased. The rationale is that the semantics of the rule have not changed, since the expiration of that permission was part of the semantics of the rule.

Since durations are used when adding/patching a rule and expirations are used when retrieving a rule, in addition to the differences for prompt replies vs. rule contents, we now need several different variants of constraints:
- `promptConstraints`:
    - path, requested permissions list, available permissions list
    - internal to `requestprompts`, unchanged
- `ReplyConstraints`:
    - path pattern, list of permissions
    - containing `PromptReply` holds outcome/lifespan/expiration
    - unchanged from before, though under a new name
    - converted to a `Constraints` if reply warrants a new rule
- `Constraints`:
    - path pattern, map from permission to outcome, lifespan, duration
    - used when adding rule to the rule DB
    - converted to `RuleConstraints` when the new rule is created
- `RuleConstraints`:
    - path pattern, map from permisison to outcome, lifespan, expiration
    - used when retrieving rules from the rule DB
    - never used when POSTing to the API
- `PatchConstraints`:
    - identical to `Constraints`, but with omitempty fields
    - converted to `RuleConstraints` when the patched rule is created

To support this, we define some new types, including `{,Rule}PermissionMap` and `{,Rule}PermissionEntry`. The latter of these is used in the leaves of the rule DB tree in place of the previous set of rule IDs of rules whose patterns render to a given pattern variant.

Whenever possible, logic surrounding constraints, permissions, and expiration is pushed down to methods on these new types, thus simplifying the logic of their callers.