### PR TITLE
c/snap: add components subcommand to enable listing available and installed components for snaps

### DIFF
--- a/cmd/snap/cmd_components.go
+++ b/cmd/snap/cmd_components.go
@@ -1,0 +1,135 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/snap/naming"
+)
+
+var shortComponentsHelp = i18n.G("List available and installed components for installed snaps")
+var longComponentsHelp = i18n.G(`
+The components command displays a summary of the components that are installed
+and available for the set of currently installed snaps.
+
+Components for specific installed snaps can be queried by providing snap names
+as positional arguments.
+`)
+
+type cmdComponents struct {
+	clientMixin
+	Positional struct {
+		Snaps []installedSnapName `positional-arg-name:"<snap>"`
+	} `positional-args:"yes"`
+}
+
+func init() {
+	addCommand("components",
+		shortComponentsHelp,
+		longComponentsHelp,
+		func() flags.Commander { return &cmdComponents{} },
+		nil,
+		[]argDesc{{
+			name: i18n.G("<snap>"),
+			desc: i18n.G("Snaps to consider when listing available and installed components."),
+		}},
+	)
+}
+
+func (x *cmdComponents) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	names := installedSnapNames(x.Positional.Snaps)
+	snaps, err := x.client.List(names, nil)
+	if err != nil {
+		if err == client.ErrNoSnapsInstalled {
+			if len(names) == 0 {
+				fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try 'snap install hello-world'."))
+				return nil
+			} else {
+				return ErrNoMatchingSnaps
+			}
+		}
+		return err
+	}
+
+	anyComps := false
+	for _, snap := range snaps {
+		anyComps = anyComps || len(snap.Components) > 0
+	}
+
+	if !anyComps {
+		fmt.Fprintln(Stderr, i18n.G("No components are available for any installed snaps."))
+		return nil
+	}
+
+	sort.Sort(snapsByName(snaps))
+
+	w := tabWriter()
+	fmt.Fprintln(w, i18n.G("Component\tStatus\tType"))
+	for _, snap := range snaps {
+		for _, comp := range sortedComponents(snap.Components) {
+			// note that snap.Name is actually an instance name, and this isn't
+			// how we'd usually use a naming.ComponentRef. however, presenting
+			// users with a string that they can copy-paste into a "snap
+			// install" command seems useful
+			name := naming.NewComponentRef(snap.Name, comp.Name).String()
+			status := "available"
+			if comp.InstallDate != nil {
+				status = "installed"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", name, status, comp.Type)
+		}
+	}
+	w.Flush()
+
+	return nil
+}
+
+func sortedComponents(comps []client.Component) []client.Component {
+	copied := make([]client.Component, len(comps))
+	copy(copied, comps)
+
+	// installed components are put first, followed by available components.
+	// components within those groups are sorted lexicographically
+	sort.Slice(copied, func(i, j int) bool {
+		left, right := copied[i], copied[j]
+
+		if left.InstallDate == nil && right.InstallDate != nil {
+			return false
+		}
+
+		if left.InstallDate != nil && right.InstallDate == nil {
+			return true
+		}
+
+		return left.Name < right.Name
+	})
+
+	return copied
+}

--- a/cmd/snap/cmd_components.go
+++ b/cmd/snap/cmd_components.go
@@ -69,7 +69,7 @@ func (x *cmdComponents) Execute(args []string) error {
 	if err != nil {
 		if err == client.ErrNoSnapsInstalled {
 			if len(names) == 0 {
-				fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try 'snap install hello-world'."))
+				fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet."))
 				return nil
 			} else {
 				return ErrNoMatchingSnaps

--- a/cmd/snap/cmd_components_test.go
+++ b/cmd/snap/cmd_components_test.go
@@ -1,0 +1,226 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/client"
+	snapcli "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+	"gopkg.in/check.v1"
+)
+
+func (s *SnapSuite) TestComponentsHelp(c *check.C) {
+	msg := `Usage:
+  snap.test components [<snap>...]
+
+The components command displays a summary of the components that are installed
+and available for the set of currently installed snaps.
+
+Components for specific installed snaps can be queried by providing snap names
+as positional arguments.
+
+[components command arguments]
+  <snap>:         Snaps to consider when listing available and installed
+                  components.
+`
+	s.testSubCommandHelp(c, "components", msg)
+}
+
+type testComponentOpts struct {
+	err       error
+	stderr    string
+	stdout    string
+	provided  []string
+	installed []client.Snap
+}
+
+func (s *SnapSuite) TestComponents(c *check.C) {
+	s.testComponents(c, testComponentOpts{
+		stdout: `Component      Status     Type
+snap-1+comp-1  installed  standard
+snap-1+comp-3  installed  standard
+snap-1+comp-2  available  kernel-modules
+snap-2+comp-2  available  standard
+`,
+		installed: []client.Snap{
+			{
+				Name: "snap-2",
+				Components: []client.Component{
+					{
+						Name: "comp-2",
+						Type: snap.StandardComponent,
+					},
+				},
+			},
+			{
+				Name: "snap-1",
+				Components: []client.Component{
+					{
+						Name:        "comp-1",
+						Type:        snap.StandardComponent,
+						InstallDate: &time.Time{},
+					},
+					{
+						Name: "comp-2",
+						Type: snap.KernelModulesComponent,
+					},
+					{
+						Name:        "comp-3",
+						Type:        snap.StandardComponent,
+						InstallDate: &time.Time{},
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *SnapSuite) TestComponentsNoComponents(c *check.C) {
+	s.testComponents(c, testComponentOpts{
+		stderr: "No components are available for any installed snaps.\n",
+		installed: []client.Snap{
+			{
+				Name: "snap-2",
+			},
+			{
+				Name: "snap-1",
+			},
+		},
+	})
+}
+
+func (s *SnapSuite) TestComponentsInstanceName(c *check.C) {
+	s.testComponents(c, testComponentOpts{
+		stdout: `Component          Status     Type
+snap-1_one+comp-1  installed  standard
+snap-1_one+comp-2  available  kernel-modules
+snap-1_two+comp-2  installed  kernel-modules
+snap-1_two+comp-1  available  standard
+`,
+		installed: []client.Snap{
+			{
+				Name: "snap-1_one",
+				Components: []client.Component{
+					{
+						Name:        "comp-1",
+						Type:        snap.StandardComponent,
+						InstallDate: &time.Time{},
+					},
+					{
+						Name: "comp-2",
+						Type: snap.KernelModulesComponent,
+					},
+				},
+			},
+			{
+				Name: "snap-1_two",
+				Components: []client.Component{
+					{
+						Name: "comp-1",
+						Type: snap.StandardComponent,
+					},
+					{
+						Name:        "comp-2",
+						Type:        snap.KernelModulesComponent,
+						InstallDate: &time.Time{},
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *SnapSuite) TestComponentsNoSnaps(c *check.C) {
+	s.testComponents(c, testComponentOpts{
+		stderr: "No snaps are installed yet. Try 'snap install hello-world'.\n",
+	})
+}
+
+func (s *SnapSuite) TestComponentsFiltered(c *check.C) {
+	s.testComponents(c, testComponentOpts{
+		stdout: `Component      Status     Type
+snap-2+comp-2  available  standard
+`,
+		installed: []client.Snap{
+			{
+				Name: "snap-2",
+				Components: []client.Component{
+					{
+						Name: "comp-2",
+						Type: snap.StandardComponent,
+					},
+				},
+			},
+		},
+		provided: []string{"snap-2"},
+	})
+}
+
+func (s *SnapSuite) TestComponentsNoMatchingSnaps(c *check.C) {
+	s.testComponents(c, testComponentOpts{
+		err:      snapcli.ErrNoMatchingSnaps,
+		provided: []string{"snap-2"},
+	})
+}
+
+func (s *SnapSuite) testComponents(c *check.C, opts testComponentOpts) {
+	called := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if called > 0 {
+			c.Fatalf("expected to get 1 request, now on %d", called)
+		}
+		called++
+
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+		if len(opts.provided) == 0 {
+			c.Check(r.URL.RawQuery, check.Equals, "")
+		} else {
+			c.Check(r.URL.RawQuery, check.Equals, fmt.Sprintf("snaps=%s", strings.Join(opts.provided, ",")))
+		}
+
+		response := map[string]interface{}{
+			"type":   "sync",
+			"result": opts.installed,
+		}
+
+		err := json.NewEncoder(w).Encode(response)
+		c.Assert(err, check.IsNil)
+	})
+
+	args := append([]string{"components"}, opts.provided...)
+	rest, err := snapcli.Parser(snapcli.Client()).ParseArgs(args)
+	if opts.err != nil {
+		c.Assert(err, testutil.ErrorIs, opts.err)
+	} else {
+		c.Assert(err, check.IsNil)
+		c.Assert(rest, check.HasLen, 0)
+	}
+
+	c.Check(s.Stdout(), check.Equals, opts.stdout)
+	c.Check(s.Stderr(), check.Equals, opts.stderr)
+}

--- a/cmd/snap/cmd_components_test.go
+++ b/cmd/snap/cmd_components_test.go
@@ -156,7 +156,7 @@ snap-1_two+comp-1  available  standard
 
 func (s *SnapSuite) TestComponentsNoSnaps(c *check.C) {
 	s.testComponents(c, testComponentOpts{
-		stderr: "No snaps are installed yet. Try 'snap install hello-world'.\n",
+		stderr: "No snaps are installed yet.\n",
 	})
 }
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -204,7 +204,7 @@ var helpCategories = []helpCategory{
 	{
 		Label:       i18n.G("Basics"),
 		Description: i18n.G("basic snap management"),
-		Commands:    []string{"find", "info", "install", "remove", "list"},
+		Commands:    []string{"find", "info", "install", "remove", "list", "components"},
 	}, {
 		Label:       i18n.G("...more"),
 		Description: i18n.G("slightly more advanced snap management"),

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -76,7 +76,7 @@ type argDesc struct {
 
 var optionsData options
 
-// ErrExtraArgs is returned  if extra arguments to a command are found
+// ErrExtraArgs is returned if extra arguments to a command are found
 var ErrExtraArgs = errors.New(i18n.G("too many arguments for command"))
 
 // cmdInfo holds information needed to call parser.AddCommand(...).

--- a/tests/main/component-from-store/task.yaml
+++ b/tests/main/component-from-store/task.yaml
@@ -6,8 +6,12 @@ details: |
 
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 
+prepare: |
+  snap set system experimental.parallel-instances=true
+
 restore: |
   snap remove test-snap-with-components
+  snap unset system experimental.parallel-instances
 
 execute: |
   snap install test-snap-with-components+one+two
@@ -19,6 +23,10 @@ execute: |
   # while this component is defined in the snap, it should not be installed
   not snap run test-snap-with-components three
 
+  snap components test-snap-with-components | MATCH "test-snap-with-components\+one\s+installed\s+test"
+  snap components test-snap-with-components | MATCH "test-snap-with-components\+two\s+installed\s+test"
+  snap components test-snap-with-components | MATCH "test-snap-with-components\+three\s+available\s+test"
+
   # test installing a component for a snap that is already installed
   snap install test-snap-with-components+three
 
@@ -26,5 +34,8 @@ execute: |
       snap run test-snap-with-components ${comp}
   done
 
-  # TODO:COMPS: test variations of installing snap with components at specific
-  # revisions once PR to enable installing with revision and channel is merged
+  snap install test-snap-with-components_key+one+two
+  snap components test-snap-with-components_key | MATCH "test-snap-with-components_key\+one\s+installed\s+test"
+  snap components test-snap-with-components_key | MATCH "test-snap-with-components_key\+two\s+installed\s+test"
+  snap components test-snap-with-components_key | MATCH "test-snap-with-components_key\+three\s+available\s+test"
+  snap components test-snap-with-components_key | NOMATCH "test-snap-with-components\+one\s+installed\s+test"


### PR DESCRIPTION
Needs some spread tests, but this implements what we have in the components spec for the "snap components" subcommand.