### PR TITLE
snapcraft: pin Ubuntu Advantage Pro FIPS Updates PPA when building FIPS variant

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -458,7 +458,7 @@ parts:
         # TODO what if we need to choose between FIPS and FIPS preview?
         cat <<-'EOF' > /etc/apt/preferences.d/fips.pref
       Package: *
-      Pin: release o=LP-PPA-fips-cc-stig-fips-under-certification
+      Pin: release o=LP-PPA-ubuntu-advantage-pro-fips-updates
       Pin-Priority: 1010
       EOF
         apt update


### PR DESCRIPTION
Pin the Ubuntu Advantage Pro FIPS updates PPA during the build. The PPA should be enabled on the build host, typically LP.

Related: SNAPDENG-33324
