### PR TITLE
tests: increase disk-space-awareness default size to 200M

### DIFF
--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -11,12 +11,13 @@ environment:
   TMPFSMOUNT: /var/lib/snapd
   # filling tmpfs mounted under /var/lib/snapd triggers OOM
   SNAPD_NO_MEMORY_LIMIT: 1
+  SUFFICIENT_SIZE: 200M
 
 prepare: |
   systemctl stop snapd.{socket,service}
 
   # mount /var/lib/snapd on a tmpfs
-  mount -t tmpfs tmpfs -o size=150M,mode=0755 "$TMPFSMOUNT"
+  mount -t tmpfs tmpfs -o size="$SUFFICIENT_SIZE",mode=0755 "$TMPFSMOUNT"
 
   systemctl start snapd.{socket,service}
 
@@ -49,7 +50,7 @@ execute: |
 
   # note, installing hello-world also pulls core snap.
   echo "And succeeds with enough space"
-  resize 150M
+  resize "$SUFFICIENT_SIZE"
   snap install hello-world
 
   # run the snap once to have data dirs created
@@ -73,7 +74,7 @@ execute: |
   echo "Removing the snap with --purge works despite of low disk space"
   snap remove --purge hello-world
 
-  resize 150M
+  resize "$SUFFICIENT_SIZE"
   snap install hello-world test-snapd-sh
 
   # create 4M filler in common directory to inflate backup size
@@ -93,7 +94,7 @@ execute: |
   snap remove --purge hello-world
   snap remove --purge test-snapd-sh
 
-  resize 150M
+  resize "$SUFFICIENT_SIZE"
   snap install test-snapd-tools
 
   echo "Refresh fails due to low disk space"
@@ -107,5 +108,5 @@ execute: |
   MATCH "error: cannot refresh \"test-snapd-tools\" due to low disk space" < error.txt
 
   # succeeds with enough space
-  resize 150M
+  resize "$SUFFICIENT_SIZE"
   snap refresh --edge test-snapd-tools


### PR DESCRIPTION
It seems snap size has crept up over time, and now 150M is not sufficient to hold all the snaps and data needed for the `disk-space-awareness` test. This PR bumps the size to 200M and sets a variable, so the value can more easily be adjusted in the future.