### PR TITLE
tests/lib: remove test file that breaks snapd go library

### DIFF
--- a/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/bad. ,?**[]{}^\$#.desktop
+++ b/tests/lib/snaps/test-snapd-desktop-file-ids/meta/gui/bad. ,?**[]{}^\$#.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Name=test-snapd-desktop.cmd
-Comment=A desktop file for test-snapd-desktop.cmd
-Exec=test-snapd-desktop.cmd
-Terminal=true
-Type=Application

--- a/tests/main/desktop-file-ids/task.yaml
+++ b/tests/main/desktop-file-ids/task.yaml
@@ -14,6 +14,15 @@ environment:
     DIR: /var/lib/snapd/desktop/applications
 
 prepare: |
+    cat > "$TESTSLIB/snaps/test-snapd-desktop-file-ids/meta/gui/bad. ,?**[]{}^\$#.desktop" << EOF
+    [Desktop Entry]
+    Name=test-snapd-desktop.cmd
+    Comment=A desktop file for test-snapd-desktop.cmd
+    Exec=test-snapd-desktop.cmd
+    Terminal=true
+    Type=Application
+    EOF
+
     "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop-file-ids
     touch "$DIR/test-confinement.desktop"
     tests.session -u test prepare

--- a/tests/main/desktop-file-ids/task.yaml
+++ b/tests/main/desktop-file-ids/task.yaml
@@ -14,7 +14,7 @@ environment:
     DIR: /var/lib/snapd/desktop/applications
 
 prepare: |
-    cat > "$TESTSLIB/snaps/test-snapd-desktop-file-ids/meta/gui/bad. ,?**[]{}^\$#.desktop" << EOF
+    cat > "$TESTSLIB"/snaps/test-snapd-desktop-file-ids/meta/gui/'bad. ,?**[]{}^\$#.desktop' << EOF
     [Desktop Entry]
     Name=test-snapd-desktop.cmd
     Comment=A desktop file for test-snapd-desktop.cmd


### PR DESCRIPTION
This test file name used to exercise desktop file name sanitization was causing trouble when packaging snapd go library.

This switches the test to generate the guilty test desktop file dynamically and removes the weird test file completely.
