### PR TITLE
s/apparmor: fix check for prompting support for kernels with policy/notify/user

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -663,7 +663,7 @@ func probeKernelFeatures() ([]string, error) {
 			features = append(features, "policy:permstable32:"+feat)
 		}
 	}
-	if data, err := os.ReadFile(filepath.Join(rootPath, featuresSysPath, "policy", "notify", "user")); err != nil {
+	if data, err := os.ReadFile(filepath.Join(rootPath, featuresSysPath, "policy", "notify", "user")); err == nil {
 		// XXX: there's no feature added for policy:notify:user, since user is
 		// a file rather than a directory.
 		notifyUserFeatures := strings.Fields(string(data))

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -348,6 +348,43 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 		expected = append(expected, "xyz")
 		c.Check(features, DeepEquals, expected, Commentf("test case: %+v", testCase))
 	}
+
+	// Set permstable32 to good value
+	c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "permstable32"), []byte("allow deny prompt"), 0644), IsNil)
+	// Create notify directory
+	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "policy", "notify"), 0755), IsNil)
+	features, err = apparmor.ProbeKernelFeatures()
+	expected := []string{"bar", "foo", "foo:baz", "foo:qux", "policy", "policy:notify", "policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt", "xyz"}
+	c.Check(features, DeepEquals, expected)
+
+	// Also test that prompt feature is read from notify/user if it exists
+	for _, testCase := range []struct {
+		userContent      string
+		expectedSuffixes []string
+	}{
+		{
+			"file",
+			[]string{"file"},
+		},
+		{
+			"network file",
+			[]string{"file", "network"},
+		},
+		{
+			"file\ndbus \n  network",
+			[]string{"dbus", "file", "network"},
+		},
+	} {
+		c.Assert(os.WriteFile(filepath.Join(d, featuresSysPath, "policy", "notify", "user"), []byte(testCase.userContent), 0644), IsNil)
+		features, err = apparmor.ProbeKernelFeatures()
+		c.Assert(err, IsNil)
+		expected = []string{"bar", "foo", "foo:baz", "foo:qux", "policy", "policy:notify"}
+		for _, suffix := range testCase.expectedSuffixes {
+			expected = append(expected, fmt.Sprintf("policy:notify:user:%s", suffix))
+		}
+		expected = append(expected, "policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt", "xyz")
+		c.Check(features, DeepEquals, expected, Commentf("test case: %+v", testCase))
+	}
 }
 
 func (s *apparmorSuite) TestProbeAppArmorKernelFeaturesPermstable32Version(c *C) {

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -354,6 +354,7 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 	// Create notify directory
 	c.Assert(os.Mkdir(filepath.Join(d, featuresSysPath, "policy", "notify"), 0755), IsNil)
 	features, err = apparmor.ProbeKernelFeatures()
+	c.Assert(err, IsNil)
 	expected := []string{"bar", "foo", "foo:baz", "foo:qux", "policy", "policy:notify", "policy:permstable32:allow", "policy:permstable32:deny", "policy:permstable32:prompt", "xyz"}
 	c.Check(features, DeepEquals, expected)
 


### PR DESCRIPTION
While testing prompting behavior on a new oracular VM with the new kernel, prompting was reported as not supported due to lack of kernel features. This was unexpected, since oracular should support prompting, and has in recent testing.

`snap debug api /v2/system-info` reported the following in kernel features:
```
...
        "kernel:policy",
        "kernel:policy:notify",
        "kernel:policy:permstable32:allow",
...
```

So we have `kernel:policy:notify` but we're missing `kernel:policy:notify:user:file`. This is strange, since:
```
ubuntu@oracular:~$ cat /sys/kernel/security/apparmor/features/policy/notify/user 
file
```

The new apparmor/kernel for oracular now has the more robust checks for prompting support, given by the presence of `/sys/kernel/security/apparmor/features/policy/notify/user`, but this has revealed the bug in the snapd kernel feature probing, which this PR fixes.

It would be good to get this into a release as soon as possible, since this bug prevents prompting from working. @ernestl please advise on what course of action you'd prefer.