### PR TITLE
tests: remove not needed variables in spread.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -890,10 +890,6 @@ jobs:
           if [[ "${{ matrix.group }}" =~ nested- ]]; then
             export NESTED_BUILD_SNAPD_FROM_CURRENT=true
             export NESTED_ENABLE_KVM=true
-
-            if [[ "${{ matrix.systems }}" =~ ubuntu-16 ]]; then
-              export SPREAD_SNAPD_DEB_FROM_REPO=false
-            fi
           fi
 
           case "${{ matrix.systems }}" in

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -890,6 +890,10 @@ jobs:
           if [[ "${{ matrix.group }}" =~ nested- ]]; then
             export NESTED_BUILD_SNAPD_FROM_CURRENT=true
             export NESTED_ENABLE_KVM=true
+
+            if [[ "${{ matrix.systems }}" =~ ubuntu-16 ]]; then
+              export SPREAD_SNAPD_DEB_FROM_REPO=false
+            fi
           fi
 
           case "${{ matrix.systems }}" in

--- a/spread.yaml
+++ b/spread.yaml
@@ -1186,6 +1186,8 @@ suites:
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
             # Define which tests to run in the nested vm in run-spread test
             NESTED_SPREAD_TESTS:  '$(HOST: echo "${NESTED_SPREAD_TESTS:-}")'
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m
@@ -1247,6 +1249,8 @@ suites:
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-false}")'
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
         manual: true
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
@@ -1310,6 +1314,8 @@ suites:
             NESTED_EXTRA_CMDLINE:  '$(HOST: echo "${NESTED_EXTRA_CMDLINE:-}")'
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
         manual: true
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
@@ -1372,7 +1378,8 @@ suites:
             # Indicates the amount of memory in MB to use in the nested vm
             NESTED_MEM: '$(HOST: echo "${NESTED_MEM:-4096}")'
             SPREAD_URL: https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz
-
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m

--- a/spread.yaml
+++ b/spread.yaml
@@ -81,11 +81,8 @@ environment:
     # set to 1 when the snapd memory limit has to be removed
     SNAPD_NO_MEMORY_LIMIT: '$(HOST: echo "${SPREAD_SNAPD_NO_MEMORY_LIMIT:-}")'
 
-    SNAPD_PUBLISHED_VERSION: '$(HOST: echo "$SPREAD_SNAPD_PUBLISHED_VERSION")'
     # Use the snapd package from the repository when possible
     SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-true}")'
-    # Build and use snapd from current branch
-    BUILD_SNAPD_FROM_CURRENT: '$(HOST: echo "${SPREAD_BUILD_SNAPD_FROM_CURRENT:-true}")'
     # Directory where the built snapd snaps and other assets are stored
     SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/tmp/work-dir}")'
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -1214,7 +1214,7 @@ suites:
             fi
 
             # Install the snapd built
-            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+            dpkg -i "$GOHOME"/snapd_*.deb
 
             # Configure the ssh connection to the test vm
             remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
@@ -1273,7 +1273,7 @@ suites:
             fi
 
             # Install the snapd built
-            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+            dpkg -i "$GOHOME"/snapd_*.deb
 
             # Configure the ssh connection to the test vm
             remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
@@ -1330,7 +1330,7 @@ suites:
             fi
 
             # Install the snapd built
-            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+            dpkg -i "$GOHOME"/snapd_*.deb
 
             # Configure the ssh connection to the test vm
             remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
@@ -1395,7 +1395,7 @@ suites:
             fi
   
             # Install the snapd built
-            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+            dpkg -i "$GOHOME"/snapd_*.deb
 
             # Configure the ssh connection to the test vm
             remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -608,9 +608,6 @@ prepare_project() {
                 exit 1
                 ;;
         esac
-    elif [ -n "$SNAPD_PUBLISHED_VERSION" ]; then
-        download_from_published "$SNAPD_PUBLISHED_VERSION"
-        install_dependencies_from_published "$SNAPD_PUBLISHED_VERSION"
     else
         download_from_gce_bucket
         install_dependencies_gce_bucket


### PR DESCRIPTION
Remove the variables SNAPD_PUBLISHED_VERSION and
BUILD_SNAPD_FROM_CURRENT from the spread.yaml file

Those vars are not used in practice anymore
