### PR TITLE
tests: fix snap-run failure

### DIFF
--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -79,7 +79,8 @@ execute: |
     echo "Test snap run --strace with options works"
     snap run --strace="-V" test-snapd-sh.sh -c 'echo hello-world' >stdout 2>stderr
     MATCH "strace -- version" < stdout
-    # We don't want to test for an empty stderr should there be unrelated errors with strace. Instead we look for a keyword
+    # We don't want to test for an empty stderr should there be unrelated errors with
+    # strace. Instead we look for a keyword
     NOMATCH 'exec' < stderr
 
     snap run --trace-exec test-snapd-sh.sh -c 'echo hello' 2> stderr

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -79,7 +79,8 @@ execute: |
     echo "Test snap run --strace with options works"
     snap run --strace="-V" test-snapd-sh.sh -c 'echo hello-world' >stdout 2>stderr
     MATCH "strace -- version" < stdout
-    [ ! -s stderr ]
+    # We don't want to test for an empty stderr should there be unrelated errors with strace. Instead we look for a keyword
+    NOMATCH 'exec' < stderr
 
     snap run --trace-exec test-snapd-sh.sh -c 'echo hello' 2> stderr
     MATCH "Slowest [0-9]+ exec calls during snap run" < stderr


### PR DESCRIPTION
This fixes a problem in which strace and one of its dependent libraries (libunwind-ptrace) have an ABI disagreement. Instead of expecting a non-empty stderr, this searches instead for a keyword.