### PR TITLE
tests: run once a week the nightly static checks

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,7 +3,7 @@ name: Nightly static code analysis
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 0 * * *'
+    - cron: '30 0 * * 0'
 
 jobs:
 


### PR DESCRIPTION
We received this communication:

"We are facing some infrastructure limitations due to the ramp up on CI integrations and we would like you to reduce the TIOBE runs to a single weekly run temporarily until we have this sorted out."
