### PR TITLE
o/hookstate: remove precondition interface

### DIFF
--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -79,12 +79,6 @@ type Handler interface {
 // HandlerGenerator is the function signature required to register for hooks.
 type HandlerGenerator func(*Context) Handler
 
-type Precondition interface {
-	// Precondition is called prior to the Before method and should return true
-	// if the hook should run or false, if it should be skipped without erroring.
-	Precondition() (bool, error)
-}
-
 // HookSetup is a reference to a hook within a specific snap.
 type HookSetup struct {
 	Snap     string        `json:"snap"`
@@ -428,17 +422,6 @@ func (m *HookManager) runHook(context *Context, snapst *snapstate.SnapState, hoo
 		delete(m.contexts, contextID)
 		m.contextsMutex.Unlock()
 	}()
-
-	if ph, ok := context.Handler().(Precondition); ok {
-		precond, err := ph.Precondition()
-		if err != nil {
-			return err
-		}
-
-		if !precond {
-			return nil
-		}
-	}
 
 	if err := context.Handler().Before(); err != nil {
 		return err

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -1255,55 +1255,6 @@ func (s *hookManagerSuite) TestEphemeralRunHookContextCanCancel(c *C) {
 	c.Check(tombDying, Equals, 1)
 }
 
-func (s *hookManagerSuite) TestHookRunsIfPreconditionMet(c *C) {
-	s.mockHandler.PreconditionResult = true
-	s.se.Ensure()
-	s.se.Wait()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-	c.Check(s.mockHandler.PreconditionCalled, Equals, true)
-	c.Check(s.mockHandler.BeforeCalled, Equals, true)
-	c.Check(s.mockHandler.DoneCalled, Equals, true)
-	c.Check(s.mockHandler.ErrorCalled, Equals, false)
-
-	c.Check(s.task.Kind(), Equals, "run-hook")
-	c.Check(s.task.Status(), Equals, state.DoneStatus)
-}
-
-func (s *hookManagerSuite) TestHookSkippedIfPreconditionNotMet(c *C) {
-	s.mockHandler.PreconditionResult = false
-	s.se.Ensure()
-	s.se.Wait()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-	c.Check(s.mockHandler.PreconditionCalled, Equals, true)
-	c.Check(s.mockHandler.BeforeCalled, Equals, false)
-	c.Check(s.mockHandler.DoneCalled, Equals, false)
-	c.Check(s.mockHandler.ErrorCalled, Equals, false)
-
-	c.Check(s.task.Kind(), Equals, "run-hook")
-	c.Check(s.task.Status(), Equals, state.DoneStatus)
-}
-
-func (s *hookManagerSuite) TestPreconditionCallErrors(c *C) {
-	s.mockHandler.PreconditionResult = true
-	s.mockHandler.PreconditionError = true
-	s.se.Ensure()
-	s.se.Wait()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-	c.Check(s.mockHandler.PreconditionCalled, Equals, true)
-	c.Check(s.mockHandler.BeforeCalled, Equals, false)
-	c.Check(s.mockHandler.DoneCalled, Equals, false)
-	c.Check(s.mockHandler.ErrorCalled, Equals, false)
-
-	c.Check(s.task.Kind(), Equals, "run-hook")
-	c.Check(s.task.Status(), Equals, state.ErrorStatus)
-}
-
 type parallelInstancesHookManagerSuite struct {
 	baseHookManagerSuite
 }

--- a/overlord/hookstate/hooktest/handler.go
+++ b/overlord/hookstate/hooktest/handler.go
@@ -23,10 +23,6 @@ import "fmt"
 
 // MockHandler is a mock hookstate.Handler.
 type MockHandler struct {
-	PreconditionCalled bool
-	PreconditionResult bool
-	PreconditionError  bool
-
 	BeforeCalled bool
 	BeforeError  bool
 
@@ -39,14 +35,13 @@ type MockHandler struct {
 	Err               error
 
 	// callbacks useful for testing
-	PreconditionCallback func()
-	BeforeCallback       func()
-	DoneCallback         func()
+	BeforeCallback func()
+	DoneCallback   func()
 }
 
 // NewMockHandler returns a new MockHandler.
 func NewMockHandler() *MockHandler {
-	return &MockHandler{PreconditionResult: true}
+	return &MockHandler{}
 }
 
 // Before satisfies hookstate.Handler.Before
@@ -81,15 +76,4 @@ func (h *MockHandler) Error(err error) (bool, error) {
 		return false, fmt.Errorf("Error failed at user request")
 	}
 	return h.IgnoreOriginalErr, nil
-}
-
-func (h *MockHandler) Precondition() (bool, error) {
-	if h.PreconditionCallback != nil {
-		h.PreconditionCallback()
-	}
-	h.PreconditionCalled = true
-	if h.PreconditionError {
-		return false, fmt.Errorf("Precondition failed at user request")
-	}
-	return h.PreconditionResult, nil
 }


### PR DESCRIPTION
This reverts commit 8ffadb5d5b3304b9ce5c4801cdac78e4b7b55c1a. Due to changes in the way registry hooks are organised/named we no longer need this.