### PR TITLE
o/h/ctlcmd: allow snapctl set --view for non-root

### DIFF
--- a/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -148,7 +148,7 @@ func (f ForbiddenCommandError) Error() string {
 
 // nonRootAllowed lists the commands that can be performed even when snapctl
 // is invoked not by root.
-var nonRootAllowed = []string{"get", "services", "set-health", "is-connected", "system-mode", "model"}
+var nonRootAllowed = []string{"get", "set", "services", "set-health", "is-connected", "system-mode", "model"}
 
 // Run runs the requested command.
 func Run(context *hookstate.Context, args []string, uid uint32) (stdout, stderr []byte, err error) {

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -75,6 +75,10 @@ func init() {
 }
 
 func (s *setCommand) Execute(args []string) error {
+	if !s.View && s.uid != "0" {
+		return &ForbiddenCommandError{Message: fmt.Sprintf(`cannot use "set" with uid %s, try with sudo`, s.uid)}
+	}
+
 	if s.Positional.PlugOrSlotSpec == "" && len(s.Positional.ConfValues) == 0 {
 		return errors.New(i18n.G("set which option?"))
 	}

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -509,3 +509,10 @@ func (s *registrySuite) TestRegistrySetExclamationMark(c *C) {
 `)
 	c.Check(stderr, IsNil)
 }
+
+func (s *registrySuite) TestRegistrySetNonRoot(c *C) {
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "--view", ":write-wifi", "ssid=other-ssid", "password=other-secret"}, 1000)
+	c.Assert(err, IsNil)
+	c.Check(stdout, IsNil)
+	c.Check(stderr, IsNil)
+}


### PR DESCRIPTION
Access control for registry views is done through the interface plug so we need to move the root check for `snapctl set` into the handler. The other paths of `set` remain the same but views can be without being root.