### PR TITLE
interfaces/microstack-support: support cgroupv2 paths

### DIFF
--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -102,14 +102,23 @@ const microStackSupportConnectedPlugAppArmor = `
 # Used by libvirt (cgroup-related):
 /sys/fs/cgroup/unified/cgroup.controllers r,
 /sys/fs/cgroup/cpuset/cpuset.cpus r,
+# cgroups v2 used by libvirt and nova-compute:
+/sys/fs/cgroup/cgroup.controllers r,
+/sys/fs/cgroup/cgroup.subtree_control rw,
 
 # Non-systemd layout: https://libvirt.org/cgroups.html#currentLayoutGeneric
 /sys/fs/cgroup/*/ r,
 /sys/fs/cgroup/*/machine/ rw,
 /sys/fs/cgroup/*/machine/** rw,
+# Non-systemd layout cgroups v2:
+/sys/fs/cgroup/ r,
+/sys/fs/cgroup/machine/ rw,
+/sys/fs/cgroup/machine/** rw,
 
 # systemd-layout: https://libvirt.org/cgroups.html#systemdLayout
 /sys/fs/cgroup/*/machine.slice/machine-qemu*/{,**} rw,
+# systemd-layout cgroups v2:
+/sys/fs/cgroup/machine/qemu-*.libvirt-qemu/{,**} rw,
 
 @{PROC}/[0-9]*/cgroup r,
 @{PROC}/cgroups r,


### PR DESCRIPTION
MicroStack requires full access to cgroups to manage VMs resources. This was already granted, but these paths were not updated for CGroupsV2.

Here are sampled dmesg messages to see usage of the groups:
```
[Thu Oct 10 16:52:12 2024] audit: type=1400 audit(1728579133.147:675): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/cgroup.controllers" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:12 2024] audit: type=1400 audit(1728579133.147:676): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/cgroup.controllers" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:12 2024] audit: type=1400 audit(1728579133.147:677): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/cgroup.controllers" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:12 2024] audit: type=1400 audit(1728579133.147:678): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:12 2024] audit: type=1400 audit(1728579133.147:680): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/cgroup.controllers" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:12 2024] audit: type=1400 audit(1728579133.147:681): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/cgroup.controllers" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:12 2024] audit: type=1400 audit(1728579133.147:682): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:757): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:758): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/vcpu1/" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:759): apparmor="ALLOWED" operation="rmdir" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/vcpu1/" pid=41064 comm="rpc-libvirtd" requested_mask="d" denied_mask="d" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:760): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/vcpu0/" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:761): apparmor="ALLOWED" operation="rmdir" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/vcpu0/" pid=41064 comm="rpc-libvirtd" requested_mask="d" denied_mask="d" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:762): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/emulator/" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:763): apparmor="ALLOWED" operation="rmdir" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/emulator/" pid=41064 comm="rpc-libvirtd" requested_mask="d" denied_mask="d" fsuid=0 ouid=0
[Thu Oct 10 16:52:58 2024] audit: type=1400 audit(1728579178.652:764): apparmor="ALLOWED" operation="rmdir" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/qemu-3-instance-00000008.libvirt-qemu/" pid=41064 comm="rpc-libvirtd" requested_mask="d" denied_mask="d" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.916:1108): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.controllers" pid=41064 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.916:1109): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.subtree_control" pid=41064 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.916:1110): apparmor="ALLOWED" operation="truncate" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.subtree_control" pid=41064 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.916:1111): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.subtree_control" pid=41064 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.916:1112): apparmor="ALLOWED" operation="truncate" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.subtree_control" pid=41064 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.916:1113): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.subtree_control" pid=41064 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.920:1114): apparmor="ALLOWED" operation="truncate" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.subtree_control" pid=41064 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
[Thu Oct 10 17:10:54 2024] audit: type=1400 audit(1728580254.920:1115): apparmor="ALLOWED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/sys/fs/cgroup/machine/cgroup.subtree_control" pid=41064 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```

Examples of code paths making use of cgroups:
https://git.launchpad.net/ubuntu/+source/libvirt/tree/src/util/vircgroupv2.c?h=applied/ubuntu/noble-updates
https://review.opendev.org/c/openstack/nova/+/873127
