### PR TITLE
overlord,snap: order boot base before kernel when seeding

### DIFF
--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -380,7 +380,7 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(mgr, s.perfTimings)
 	c.Assert(err, IsNil)
 
-	snaps := []string{"snapd", "pc-kernel", "core20", "pc"}
+	snaps := []string{"snapd", "core20", "pc-kernel", "pc"}
 	allDevModeSnaps := stripSnapNamesWithChannels(opts.extraDevModeSnaps)
 	if len(opts.extraDevModeSnaps) != 0 {
 		snaps = append(snaps, allDevModeSnaps...)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1426,7 +1426,7 @@ snaps:
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), s.perfTimings)
 	c.Assert(err, IsNil)
 
-	checkOrder(c, tsAll, "snapd", "pc-kernel", "core18", "pc")
+	checkOrder(c, tsAll, "snapd", "core18", "pc-kernel", "pc")
 
 	// now run the change and check the result
 	// use the expected kind otherwise settle with start another one
@@ -1549,7 +1549,7 @@ snaps:
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), s.perfTimings)
 	c.Assert(err, IsNil)
 
-	checkOrder(c, tsAll, "snapd", "pc-kernel", "core18", "pc", "other-base", "snap-req-other-base")
+	checkOrder(c, tsAll, "snapd", "core18", "pc-kernel", "pc", "other-base", "snap-req-other-base")
 }
 
 func (s *firstBoot16Suite) TestFirstbootGadgetBaseModelBaseMismatch(c *C) {
@@ -2379,7 +2379,7 @@ snaps:
 	}
 	c.Assert(st.Changes(), HasLen, 1)
 
-	checkOrder(c, tsAll, "snapd", "pc-kernel", "core18", "pc")
+	checkOrder(c, tsAll, "snapd", "core18", "pc-kernel", "pc")
 
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)

--- a/snap/info.go
+++ b/snap/info.go
@@ -1890,16 +1890,6 @@ func InstanceName(snapName, instanceKey string) string {
 	return snapName
 }
 
-// ByType supports sorting the given slice of snap info by types. The most
-// important types will come first.
-type ByType []*Info
-
-func (r ByType) Len() int      { return len(r) }
-func (r ByType) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
-func (r ByType) Less(i, j int) bool {
-	return r[i].Type().SortsBefore(r[j].Type())
-}
-
 // SortServices sorts the apps based on their Before and After specs, such that
 // starting the services in the returned ordering will satisfy all specs.
 func SortServices(apps []*AppInfo) (sorted []*AppInfo, err error) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1965,21 +1965,27 @@ func (s *infoSuite) TestSortByType(c *C) {
 		{SuggestedName: "app1", SnapType: "app"},
 		{SuggestedName: "os1", SnapType: "os"},
 		{SuggestedName: "base1", SnapType: "base"},
+		{SuggestedName: "internal1", SnapType: "internal-boot-base"},
 		{SuggestedName: "gadget1", SnapType: "gadget"},
 		{SuggestedName: "kernel1", SnapType: "kernel"},
 		{SuggestedName: "app2", SnapType: "app"},
 		{SuggestedName: "os2", SnapType: "os"},
+		{SuggestedName: "internal2", SnapType: "internal-boot-base"},
 		{SuggestedName: "snapd", SnapType: "snapd"},
 		{SuggestedName: "base2", SnapType: "base"},
 		{SuggestedName: "gadget2", SnapType: "gadget"},
 		{SuggestedName: "kernel2", SnapType: "kernel"},
 	}
-	sort.Stable(snap.ByType(infos))
+	sort.SliceStable(infos, func(i, j int) bool {
+		return infos[i].Type().SortsBefore(infos[j].Type())
+	})
 
 	c.Check(infos, DeepEquals, []*snap.Info{
 		{SuggestedName: "snapd", SnapType: "snapd"},
 		{SuggestedName: "os1", SnapType: "os"},
 		{SuggestedName: "os2", SnapType: "os"},
+		{SuggestedName: "internal1", SnapType: "internal-boot-base"},
+		{SuggestedName: "internal2", SnapType: "internal-boot-base"},
 		{SuggestedName: "kernel1", SnapType: "kernel"},
 		{SuggestedName: "kernel2", SnapType: "kernel"},
 		{SuggestedName: "base1", SnapType: "base"},
@@ -1999,7 +2005,9 @@ func (s *infoSuite) TestSortByTypeAgain(c *C) {
 	snapd.SideInfo = snap.SideInfo{RealName: "snapd"}
 
 	byType := func(snaps ...*snap.Info) []*snap.Info {
-		sort.Stable(snap.ByType(snaps))
+		sort.SliceStable(snaps, func(i, j int) bool {
+			return snaps[i].Type().SortsBefore(snaps[j].Type())
+		})
 		return snaps
 	}
 

--- a/snap/types.go
+++ b/snap/types.go
@@ -34,6 +34,9 @@ const (
 	TypeKernel Type = "kernel"
 	TypeBase   Type = "base"
 	TypeSnapd  Type = "snapd"
+	// This is used internally so we can install the boot base for
+	// a system before the kernel.
+	InternalTypeBootBase Type = "internal-boot-base"
 
 	// FIXME: this really should be TypeCore
 	TypeOS Type = "os"
@@ -43,12 +46,13 @@ const (
 // types. On e.g. firstboot this will be used to order the snaps this
 // way.
 var typeOrder = map[Type]int{
-	TypeApp:    50,
-	TypeGadget: 40,
-	TypeBase:   30,
-	TypeKernel: 20,
-	TypeOS:     10,
-	TypeSnapd:  0,
+	TypeApp:              50,
+	TypeGadget:           40,
+	TypeBase:             30,
+	TypeKernel:           20,
+	InternalTypeBootBase: 11,
+	TypeOS:               10,
+	TypeSnapd:            0,
 }
 
 func (m Type) SortsBefore(other Type) bool {


### PR DESCRIPTION
We need to seed the boot base before the kernel so we can run the recently added kernel hooks on seeding. Otherwise, snap-confine is not able to find a usable base for the kernel.