### PR TITLE
overlord: make sure to reference the snap-setup-task in kmod tasks

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -80,6 +80,7 @@ func InstallComponents(ctx context.Context, st *state.State, names []string, inf
 		kmodSetup = st.NewTask("prepare-kernel-modules-components", fmt.Sprintf(
 			i18n.G("Prepare kernel-modules components for %q%s"), info.InstanceName(), info.Revision,
 		))
+		kmodSetup.Set("snap-setup-task", setupSecurity.ID())
 	}
 
 	tss := make([]*state.TaskSet, 0, len(compsups))

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -917,10 +917,16 @@ func (s *snapmgrTestSuite) TestInstallComponents(c *C) {
 		chg.AddAll(ts)
 	}
 
+	snapsup, err := snapstate.TaskSnapSetup(prepareKmodComps)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, NotNil)
+
 	for _, ts := range tss[0 : len(tss)-1] {
 		task := ts.Tasks()[0]
-		compsup, _, err := snapstate.TaskComponentSetup(task)
+		compsup, snapsup, err := snapstate.TaskComponentSetup(task)
 		c.Assert(err, IsNil)
+		c.Assert(compsup, NotNil)
+		c.Assert(snapsup, NotNil)
 
 		opts := compOptMultiCompInstall
 		if compNameToType(compsup.ComponentName()) == snap.KernelModulesComponent {


### PR DESCRIPTION
The snap-setup-task was not being added to the prepare kernel-modules task in the case of installing from the store, which made the installation to fail.