### PR TITLE
tests: install missing dependency to fix oracular building

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -622,8 +622,12 @@ pkg_dependencies_ubuntu_classic(){
                 lz4
                 qemu-kvm
                 qemu-utils
-                systemd-dev
                 "
+            if os.query is-ubuntu 24.10; then
+                echo "
+                    systemd-dev
+                    "
+            fi
             ;;
         ubuntu-*)
             echo "

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -622,6 +622,7 @@ pkg_dependencies_ubuntu_classic(){
                 lz4
                 qemu-kvm
                 qemu-utils
+                systemd-dev
                 "
             ;;
         ubuntu-*)


### PR DESCRIPTION
In oracular the packages systemd-cryptsetup and systemd-dev are not included anymore in the base image which is used in google and openstack.

This change adds this package as a tests dependency to avoid the following error when building snapd deb package.

To reproduce the error, run:
SPREAD_SNAPD_DEB_FROM_REPO=false spread -debug -no-debug-output google:ubuntu-24.10-64:tests/main/abort

Error:

configure: error: Package requirements (udev) were not met:

Package 'udev', required by 'virtual:world', not found
