### PR TITLE
o/h/ctlcmd: hide snapctl registry commands behind feature flag

### DIFF
--- a/overlord/hookstate/ctlcmd/fail.go
+++ b/overlord/hookstate/ctlcmd/fail.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/registrystate"
 )
@@ -52,13 +51,12 @@ func init() {
 }
 
 func (c *failCommand) Execute(args []string) error {
-	if !features.Registries.IsEnabled() {
-		_, confName := features.Registries.ConfigOption()
-		return fmt.Errorf(`cannot use "snapctl fail" without enabling the %q feature`, confName)
-	}
-
 	ctx, err := c.ensureContext()
 	if err != nil {
+		return err
+	}
+
+	if err := validateRegistriesFeatureFlag(ctx.State()); err != nil {
 		return err
 	}
 

--- a/overlord/hookstate/ctlcmd/fail_test.go
+++ b/overlord/hookstate/ctlcmd/fail_test.go
@@ -20,13 +20,8 @@
 package ctlcmd_test
 
 import (
-	"os"
-
-	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
@@ -34,23 +29,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-func (s *registrySuite) mockRegistriesFeature(c *C) (restore func()) {
-	oldDir := dirs.FeaturesDir
-	dirs.FeaturesDir = c.MkDir()
-
-	registryCtlFile := features.Registries.ControlFile()
-	c.Assert(os.WriteFile(registryCtlFile, []byte(nil), 0644), check.IsNil)
-
-	return func() {
-		c.Assert(os.Remove(registryCtlFile), IsNil)
-		dirs.FeaturesDir = oldDir
-	}
-}
-
 func (s *registrySuite) TestFailAbortsRegistryTransaction(c *C) {
-	restore := s.mockRegistriesFeature(c)
-	defer restore()
-
 	s.state.Lock()
 	chg := s.state.NewChange("test", "")
 	commitTask := s.state.NewTask("commit-registry-tx", "")
@@ -89,13 +68,18 @@ func (s *registrySuite) TestFailAbortsRegistryTransaction(c *C) {
 }
 
 func (s *registrySuite) TestFailErrors(c *C) {
+	s.state.Lock()
+	s.setRegistryFlag(false, c)
+	s.state.Unlock()
+
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"fail", "reason"}, 0)
-	c.Assert(err, ErrorMatches, i18n.G(`cannot use "snapctl fail" without enabling the "experimental.registries" feature`))
+	c.Assert(err, ErrorMatches, i18n.G(`"registries" feature flag is disabled: set 'experimental.registries' to true`))
 	c.Check(stdout, IsNil)
 	c.Check(stderr, IsNil)
 
-	restore := s.mockRegistriesFeature(c)
-	defer restore()
+	s.state.Lock()
+	s.setRegistryFlag(true, c)
+	s.state.Unlock()
 
 	stdout, stderr, err = ctlcmd.Run(s.mockContext, []string{"fail"}, 0)
 	c.Assert(err, ErrorMatches, i18n.G("the required argument `:<rejection-reason>` was not provided"))

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -108,6 +108,10 @@ func (s *setCommand) Execute(args []string) error {
 	}
 
 	if s.View {
+		if err := validateRegistriesFeatureFlag(context.State()); err != nil {
+			return err
+		}
+
 		opts := &clientutil.ParseConfigOptions{String: s.String, Typed: s.Typed}
 		requests, _, err := clientutil.ParseConfigValues(s.Positional.ConfValues, opts)
 		if err != nil {

--- a/overlord/hookstate/ctlcmd/unset.go
+++ b/overlord/hookstate/ctlcmd/unset.go
@@ -65,16 +65,20 @@ func (s *unsetCommand) Execute(args []string) error {
 		return err
 	}
 
-	context.Lock()
-	tr := configstate.ContextTransaction(context)
-	context.Unlock()
-
 	if !s.View {
+		context.Lock()
+		tr := configstate.ContextTransaction(context)
+		context.Unlock()
+
 		// unsetting options
 		for _, confKey := range s.Positional.ConfKeys {
 			tr.Set(context.InstanceName(), confKey, nil)
 		}
 		return nil
+	}
+
+	if err := validateRegistriesFeatureFlag(context.State()); err != nil {
+		return err
 	}
 
 	// unsetting registry data

--- a/overlord/registrystate/registrystate_test.go
+++ b/overlord/registrystate/registrystate_test.go
@@ -31,11 +31,13 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -149,6 +151,12 @@ func (s *registryTestSuite) SetUpTest(c *C) {
 
 	s.devAccID = devAccKey.AccountID()
 	s.registry = as.(*asserts.Registry).Registry()
+
+	tr := config.NewTransaction(s.state)
+	_, confOption := features.Registries.ConfigOption()
+	err = tr.Set("core", confOption, true)
+	c.Assert(err, IsNil)
+	tr.Commit()
 }
 
 func (s *registryTestSuite) TestGetView(c *C) {
@@ -1000,9 +1008,6 @@ func (s *registryTestSuite) checkModifyRegistryChange(c *C, chg *state.Change, h
 	val, err := tx.Get("wifi.ssid")
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "foo")
-}
-
-func (s *registryTestSuite) TestGetTransactionDifferentFromOngoingOnlyForRead(c *C) {
 }
 
 func (s *registryTestSuite) TestGetTransactionFromChangeViewHook(c *C) {


### PR DESCRIPTION
Hides the registry-related commands behind the feature flag.