### PR TITLE
o/snapstate: enable installing additional components during a refresh

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -125,7 +125,7 @@ func (ins installSnapInfo) SnapBase() string {
 }
 
 func (ins installSnapInfo) Prereq(st *state.State, prqt PrereqTracker) []string {
-	return getKeys(defaultProviderContentAttrs(st, ins.Info, prqt))
+	return keys(defaultProviderContentAttrs(st, ins.Info, prqt))
 }
 
 // InsufficientSpaceError represents an error where there is not enough disk
@@ -1243,16 +1243,6 @@ func defaultProviderContentAttrs(st *state.State, info *snap.Info, prqt PrereqTr
 	return prqt.MissingProviderContentTags(info, repo)
 }
 
-func getKeys(kv map[string][]string) []string {
-	keys := make([]string, 0, len(kv))
-
-	for key := range kv {
-		keys = append(keys, key)
-	}
-
-	return keys
-}
-
 // validateFeatureFlags validates the given snap only uses experimental
 // features that are enabled by the user.
 func validateFeatureFlags(st *state.State, info *snap.Info) error {
@@ -1809,6 +1799,22 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	tasksets = append(tasksets, ts)
 
 	return tasksets, affected, nil
+}
+
+func keys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func unique[T comparable](s []T) []T {
+	m := make(map[T]struct{}, len(s))
+	for _, v := range s {
+		m[v] = struct{}{}
+	}
+	return keys(m)
 }
 
 // updateFilter is the type of function that can be passed to

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1809,14 +1809,6 @@ func keys[K comparable, V any](m map[K]V) []K {
 	return keys
 }
 
-func unique[T comparable](s []T) []T {
-	m := make(map[T]struct{}, len(s))
-	for _, v := range s {
-		m[v] = struct{}{}
-	}
-	return keys(m)
-}
-
 // updateFilter is the type of function that can be passed to
 // updateManyFromChange so it filters the updates.
 //

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -15191,6 +15191,16 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponent
 	})
 }
 
+func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponentsAlreadyInstalled(c *C) {
+	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		instanceKey:           "key",
+		components:            []string{"standard-component"},
+		postRefreshComponents: []string{"standard-component"},
+		additionalComponents:  []string{"standard-component"},
+		refreshAppAwarenessUX: true,
+	})
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponentsUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
 		instanceKey:           "key",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -15112,6 +15112,328 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[0])
 }
 
+func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponents(c *C) {
+	const (
+		snapName    = "snap-with-components"
+		instanceKey = "key"
+		snapID      = "snap-with-components-id"
+		channel     = "channel-for-components-only-component-refresh"
+	)
+
+	currentSnapRev := snap.R(11)
+	prevSnapRev := snap.R(7)
+	instanceName := snap.InstanceName(snapName, instanceKey)
+
+	// we start without the auxiliary store info (or with an older one)
+	c.Check(snapstate.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
+
+	currentSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: currentSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &currentSI)
+
+	restore := snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	if instanceKey != "" {
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "experimental.parallel-instances", true)
+		tr.Commit()
+	}
+
+	prevSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: prevSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	otherSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: snap.R(99),
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&otherSI, &prevSI, &currentSI})
+
+	components := []string{"kernel-modules-component"}
+
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.InstanceName(), DeepEquals, instanceName)
+		var results []store.SnapResourceResult
+		for i, compName := range components {
+			results = append(results, store.SnapResourceResult{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: "http://example.com/" + compName,
+				},
+				Name:      compName,
+				Revision:  i + 2,
+				Type:      fmt.Sprintf("component/%s", componentNameToType(c, compName)),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			})
+		}
+		return results
+	}
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string, info *snap.Info, csi *snap.ComponentSideInfo,
+	) (*snap.ComponentInfo, error) {
+		return &snap.ComponentInfo{
+			Component:         csi.Component,
+			Type:              componentNameToType(c, csi.Component.ComponentName),
+			CompVersion:       "1.0",
+			ComponentSideInfo: *csi,
+		}, nil
+	}))
+
+	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
+		Active:          true,
+		Sequence:        seq,
+		Current:         currentSI.Revision,
+		SnapType:        "app",
+		TrackingChannel: channel,
+		InstanceKey:     instanceKey,
+	})
+
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName:         instanceName,
+		RevOpts:              snapstate.RevisionOptions{Revision: prevSnapRev},
+		AdditionalComponents: components,
+	}), nil, snapstate.Options{
+		UserID: s.user.ID,
+		Flags: snapstate.Flags{
+			Transaction: client.TransactionPerSnap,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("refresh", "refresh a snap")
+	chg.AddAll(ts)
+
+	// check unlink-reason
+	unlinkTask := findLastTask(chg, "unlink-current-snap")
+	c.Assert(unlinkTask, NotNil)
+	var unlinkReason string
+	unlinkTask.Get("unlink-reason", &unlinkReason)
+	c.Check(unlinkReason, Equals, "refresh")
+
+	// local modifications, edge must be set
+	te := ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(te, NotNil)
+	c.Assert(te.Kind(), Equals, "prepare-snap")
+
+	s.settle(c)
+
+	c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+
+	fi, err := os.Stat(snap.MountFile(instanceName, currentSnapRev))
+	c.Assert(err, IsNil)
+
+	expected := fakeOps{
+		{
+			op: "storesvc-snap-action",
+			curSnaps: []store.CurrentSnap{{
+				InstanceName:    instanceName,
+				SnapID:          snapID,
+				Revision:        currentSnapRev,
+				TrackingChannel: channel,
+				RefreshedDate:   fi.ModTime(),
+				Epoch:           snap.E("1*"),
+				Resources:       map[string]snap.Revision{},
+			}},
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:          "refresh",
+				InstanceName:    instanceName,
+				Revision:        prevSnapRev,
+				SnapID:          snapID,
+				ResourceInstall: true,
+				// note that channel is empty here since we can't provide a
+				// channel in this case, since we don't know if the revision is
+				// a part of the channel
+				Channel: "",
+			},
+			revno:  prevSnapRev,
+			userID: 1,
+		},
+	}
+
+	for i, compName := range components {
+		csi := snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, compName),
+			Revision:  snap.R(i + 2),
+		}
+
+		containerName := fmt.Sprintf("%s+%s", instanceName, compName)
+		filename := fmt.Sprintf("%s_%v.comp", containerName, csi.Revision)
+
+		expected = append(expected, []fakeOp{{
+			op:   "storesvc-download",
+			name: csi.Component.String(),
+		}, {
+			op:                "validate-component:Doing",
+			name:              instanceName,
+			revno:             prevSnapRev,
+			componentName:     compName,
+			componentPath:     filepath.Join(dirs.SnapBlobDir, filename),
+			componentRev:      csi.Revision,
+			componentSideInfo: csi,
+		}, {
+			op:                "setup-component",
+			containerName:     containerName,
+			containerFileName: filename,
+		}}...)
+	}
+
+	expected = append(expected, fakeOp{
+		op:   "remove-snap-aliases",
+		name: instanceName,
+	})
+
+	expected = append(expected, fakeOps{
+		{
+			op:          "run-inhibit-snap-for-unlink",
+			name:        instanceName,
+			inhibitHint: "refresh",
+		},
+		{
+			op:   "unlink-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:   "copy-data",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+			old:  filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op:   "setup-snap-save-data",
+			path: filepath.Join(dirs.SnapDataSaveDir, instanceName),
+		},
+		{
+			op:    "setup-profiles:Doing",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+		{
+			op: "candidate",
+			sinfo: snap.SideInfo{
+				RealName: snapName,
+				SnapID:   snapID,
+				Channel:  channel,
+				Revision: prevSnapRev,
+			},
+		},
+		{
+			op:   "link-snap",
+			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+		},
+		{
+			op:   "link-component",
+			path: snap.ComponentMountDir("kernel-modules-component", snap.R(2), instanceName),
+		},
+	}...)
+
+	newKmodComps := []*snap.ComponentSideInfo{{
+		Component: naming.NewComponentRef(snapName, "kernel-modules-component"),
+		Revision:  snap.R(2),
+	}}
+
+	expected = append(expected, fakeOps{
+		{
+			op:    "auto-connect:Doing",
+			name:  instanceName,
+			revno: prevSnapRev,
+		},
+		{
+			op: "update-aliases",
+		},
+		{
+			op:           "prepare-kernel-modules-components",
+			currentComps: []*snap.ComponentSideInfo{},
+			finalComps:   newKmodComps,
+		},
+	}...)
+
+	expected = append(expected, fakeOp{
+		op:    "cleanup-trash",
+		name:  instanceName,
+		revno: prevSnapRev,
+	})
+
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	task := ts.Tasks()[1]
+
+	// verify snapSetup info
+	var snapsup snapstate.SnapSetup
+	err = task.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
+		Channel: channel,
+		UserID:  s.user.ID,
+
+		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		Version:   "snap-with-componentsVer",
+		PlugsOnly: true,
+		Flags: snapstate.Flags{
+			Transaction: client.TransactionPerSnap,
+		},
+		InstanceKey:                     instanceKey,
+		PreUpdateKernelModuleComponents: []*snap.ComponentSideInfo{},
+	})
+	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
+		RealName: snapName,
+		Revision: prevSnapRev,
+		Channel:  channel,
+		SnapID:   snapID,
+	})
+
+	// verify snaps in the system state
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, instanceName, &snapst)
+	c.Assert(err, IsNil)
+
+	c.Assert(snapst.LastRefreshTime, NotNil)
+	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Sequence.Revisions, HasLen, 3)
+
+	// the original revision's components should be replaced with the new
+	// components
+	seq.Revisions[1].Components = nil
+	for i, comp := range components {
+		err := seq.AddComponentForRevision(prevSnapRev, &sequence.ComponentState{
+			SideInfo: &snap.ComponentSideInfo{
+				Component: naming.NewComponentRef(snapName, comp),
+				Revision:  snap.R(i + 2),
+			},
+			CompType: componentNameToType(c, comp),
+		})
+		c.Assert(err, IsNil)
+	}
+
+	// link-snap should put the revision we refreshed to at the end of the
+	// sequence
+	c.Assert(snapst.Sequence.Revisions[2], DeepEquals, seq.Revisions[1])
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, seq.Revisions[2])
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[0])
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThrough(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
 		components: []string{"standard-component", "kernel-modules-component"},

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -696,6 +696,14 @@ func storeUpdatePlanCore(
 	return plan, nil
 }
 
+func unique[T comparable](s []T) []T {
+	m := make(map[T]struct{}, len(s))
+	for _, v := range s {
+		m[v] = struct{}{}
+	}
+	return keys(m)
+}
+
 func currentComponentsAvailableInRevision(snapst *SnapState, info *snap.Info) ([]string, error) {
 	if len(info.Components) == 0 {
 		return nil, nil

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -522,7 +522,7 @@ func storeUpdatePlanCore(
 			return updatePlan{}, snap.NotInstalledError{Snap: update.InstanceName}
 		}
 
-		if snapst.HasActiveComponents() {
+		if snapst.HasActiveComponents() || len(update.AdditionalComponents) > 0 {
 			requestComponentsFromStore = true
 		}
 	}
@@ -558,7 +558,7 @@ func storeUpdatePlanCore(
 	}
 
 	for _, name := range localAmends {
-		hasLocalRevision[allSnaps[name]] = updates[name].RevOpts
+		hasLocalRevision[name] = allSnaps[name]
 	}
 
 	for id, actions := range amendActionsByUserID {
@@ -572,7 +572,7 @@ func storeUpdatePlanCore(
 	}
 
 	for _, name := range noStoreUpdates {
-		hasLocalRevision[allSnaps[name]] = updates[name].RevOpts
+		hasLocalRevision[name] = allSnaps[name]
 	}
 
 	for _, sar := range sars {
@@ -597,6 +597,10 @@ func storeUpdatePlanCore(
 		for _, comp := range currentComps {
 			compNames = append(compNames, comp.Component.ComponentName)
 		}
+
+		// add the additional components that the caller requested to be
+		// installed
+		compNames = unique(append(compNames, up.AdditionalComponents...))
 
 		// compTargets will be filtered down to only the components that appear
 		// in the action result, meaning that we might install fewer components
@@ -625,10 +629,15 @@ func storeUpdatePlanCore(
 
 	// consider snaps that already have a local copy of the revision that we are
 	// trying to install, skipping a trip to the store
-	for snapst, revOpts := range hasLocalRevision {
+	for name, snapst := range hasLocalRevision {
+		up, ok := updates[name]
+		if !ok {
+			return updatePlan{}, fmt.Errorf("internal error: unexpected update to local revision: %q", snapst.InstanceName())
+		}
+
 		var si *snap.SideInfo
-		if !revOpts.Revision.Unset() {
-			si = snapst.Sequence.Revisions[snapst.LastIndex(revOpts.Revision)].Snap
+		if !up.RevOpts.Revision.Unset() {
+			si = snapst.Sequence.Revisions[snapst.LastIndex(up.RevOpts.Revision)].Snap
 		} else {
 			si = snapst.CurrentSideInfo()
 		}
@@ -648,7 +657,11 @@ func storeUpdatePlanCore(
 			return updatePlan{}, err
 		}
 
-		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, si.Revision, revOpts.Channel, opts)
+		// add the additional components that the caller requested to be
+		// installed
+		compsToInstall = unique(append(compsToInstall, up.AdditionalComponents...))
+
+		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, si.Revision, up.RevOpts.Channel, opts)
 		if err != nil {
 			return updatePlan{}, err
 		}
@@ -656,25 +669,25 @@ func storeUpdatePlanCore(
 		// this must happen after the call to componentSetupsForInstall, since
 		// we can't set the channel to the tracking channel if we don't know
 		// that the requested revision is part of this channel
-		revOpts.setChannelIfUnset(snapst.TrackingChannel)
+		up.RevOpts.setChannelIfUnset(snapst.TrackingChannel)
 
 		// make sure that we switch the current channel of the snap that we're
 		// switching to
-		info.Channel = revOpts.Channel
+		info.Channel = up.RevOpts.Channel
 
 		plan.targets = append(plan.targets, target{
 			info:   info,
 			snapst: *snapst,
 			setup: SnapSetup{
-				Channel:   revOpts.Channel,
-				CohortKey: revOpts.CohortKey,
+				Channel:   up.RevOpts.Channel,
+				CohortKey: up.RevOpts.CohortKey,
 				SnapPath:  info.MountFile(),
 
 				// if the caller specified a revision, then we always run
 				// through the entire update process. this enables something
 				// like "snap refresh --revision=n", where revision n is already
 				// installed
-				AlwaysUpdate: !revOpts.Revision.Unset(),
+				AlwaysUpdate: !up.RevOpts.Revision.Unset(),
 			},
 			components: compsups,
 		})
@@ -710,8 +723,8 @@ func collectCurrentSnapsAndActions(
 	opts Options,
 	enforcedSets func() (*snapasserts.ValidationSets, error),
 	fallbackID int,
-) (actionsByUserID map[int][]*store.SnapAction, hasLocalRevision map[*SnapState]RevisionOptions, current []*store.CurrentSnap, err error) {
-	hasLocalRevision = make(map[*SnapState]RevisionOptions)
+) (actionsByUserID map[int][]*store.SnapAction, hasLocalRevision map[string]*SnapState, current []*store.CurrentSnap, err error) {
+	hasLocalRevision = make(map[string]*SnapState)
 	actionsByUserID = make(map[int][]*store.SnapAction)
 	refreshAll := len(requested) == 0
 
@@ -736,7 +749,7 @@ func collectCurrentSnapsAndActions(
 		}
 
 		if !req.RevOpts.Revision.Unset() && snapst.LastIndex(req.RevOpts.Revision) != -1 {
-			hasLocalRevision[snapst] = req.RevOpts
+			hasLocalRevision[snapst.InstanceName()] = snapst
 			return nil
 		}
 
@@ -770,7 +783,7 @@ func collectCurrentSnapsAndActions(
 		// consider this snap for a store update, but we still should return it
 		// as a target for potentially switching channels or cohort keys
 		if !action.Revision.Unset() && action.Revision == installed.Revision {
-			hasLocalRevision[snapst] = req.RevOpts
+			hasLocalRevision[installed.InstanceName] = snapst
 			return nil
 		}
 

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -1138,12 +1138,16 @@ func validateAndInitStoreUpdates(allSnaps map[string]*SnapState, updates map[str
 			return err
 		}
 
+		additional := make([]string, 0, len(sn.AdditionalComponents))
+
+		// filter out additional components that are already installed
 		snapName, _ := snap.SplitInstanceName(sn.InstanceName)
 		for _, add := range sn.AdditionalComponents {
-			if snapst.CurrentComponentState(naming.NewComponentRef(snapName, add)) != nil {
-				return snap.AlreadyInstalledComponentError{Component: add}
+			if snapst.CurrentComponentState(naming.NewComponentRef(snapName, add)) == nil {
+				additional = append(additional, add)
 			}
 		}
+		sn.AdditionalComponents = additional
 
 		updates[sn.InstanceName] = sn
 	}

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -144,7 +144,7 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		AlwaysUpdate: t.setup.AlwaysUpdate,
 
 		Base:               t.info.Base,
-		Prereq:             getKeys(providerContentAttrs),
+		Prereq:             keys(providerContentAttrs),
 		PrereqContentAttrs: providerContentAttrs,
 		UserID:             snapUserID,
 		Flags:              flags.ForSnapSetup(),
@@ -1073,6 +1073,9 @@ type StoreUpdate struct {
 	InstanceName string
 	// RevOpts contains options that apply to the update of this snap.
 	RevOpts RevisionOptions
+	// AdditionalComponents is a list of additional components to install during
+	// the refresh.
+	AdditionalComponents []string
 }
 
 // StoreUpdateGoal creates a new UpdateGoal to update snaps from the store.
@@ -1133,6 +1136,13 @@ func validateAndInitStoreUpdates(allSnaps map[string]*SnapState, updates map[str
 
 		if err := sn.RevOpts.resolveChannel(sn.InstanceName, snapst.TrackingChannel, opts.DeviceCtx); err != nil {
 			return err
+		}
+
+		snapName, _ := snap.SplitInstanceName(sn.InstanceName)
+		for _, add := range sn.AdditionalComponents {
+			if snapst.CurrentComponentState(naming.NewComponentRef(snapName, add)) != nil {
+				return snap.AlreadyInstalledComponentError{Component: add}
+			}
 		}
 
 		updates[sn.InstanceName] = sn

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
-	"github.com/snapcore/snapd/testutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -381,41 +380,6 @@ func (s *targetTestSuite) TestUpdateSnapNotInstalled(c *C) {
 
 	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
 	c.Assert(err, ErrorMatches, `snap "some-snap" is not installed`)
-}
-
-func (s *targetTestSuite) TestUpdateAdditionalComponentAlreadyInstalled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
-		RealName: "snap-1",
-		SnapID:   snaptest.AssertedSnapID("snap-1"),
-		Revision: snap.R(7),
-	}})
-
-	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
-		SideInfo: &snap.ComponentSideInfo{
-			Component: naming.NewComponentRef("snap-1", "comp-1"),
-			Revision:  snap.R(1),
-		},
-		CompType: snap.StandardComponent,
-	})
-
-	snapstate.Set(s.state, "snap-1", &snapstate.SnapState{
-		Active:          true,
-		TrackingChannel: "latest/stable",
-		Sequence:        seq,
-		Current:         snap.R(7),
-		SnapType:        "app",
-	})
-
-	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
-		InstanceName:         "snap-1",
-		AdditionalComponents: []string{"comp-1"},
-	})
-
-	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
-	c.Assert(err, testutil.ErrorIs, snap.AlreadyInstalledComponentError{Component: "comp-1"})
 }
 
 func (s *targetTestSuite) TestInvalidPathGoals(c *C) {

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/testutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -380,6 +381,41 @@ func (s *targetTestSuite) TestUpdateSnapNotInstalled(c *C) {
 
 	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
 	c.Assert(err, ErrorMatches, `snap "some-snap" is not installed`)
+}
+
+func (s *targetTestSuite) TestUpdateAdditionalComponentAlreadyInstalled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: "snap-1",
+		SnapID:   snaptest.AssertedSnapID("snap-1"),
+		Revision: snap.R(7),
+	}})
+
+	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef("snap-1", "comp-1"),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.StandardComponent,
+	})
+
+	snapstate.Set(s.state, "snap-1", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence:        seq,
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName:         "snap-1",
+		AdditionalComponents: []string{"comp-1"},
+	})
+
+	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, testutil.ErrorIs, snap.AlreadyInstalledComponentError{Component: "comp-1"})
 }
 
 func (s *targetTestSuite) TestInvalidPathGoals(c *C) {


### PR DESCRIPTION
This will eventually enable something like a `snap refresh <snapname>+<compname>`, where `<compname>` is a new component that will be installed during the refresh.