### PR TITLE
many: expose installing components while refreshing

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -162,12 +162,12 @@ func (client *Client) RemoveMany(names []string, components map[string][]string,
 
 // Refresh refreshes the snap with the given name (switching it to track
 // the given channel if given).
-func (client *Client) Refresh(name string, options *SnapOptions) (changeID string, err error) {
-	return client.doSnapAction("refresh", name, nil, options)
+func (client *Client) Refresh(name string, components []string, options *SnapOptions) (changeID string, err error) {
+	return client.doSnapAction("refresh", name, components, options)
 }
 
-func (client *Client) RefreshMany(names []string, options *SnapOptions) (changeID string, err error) {
-	return client.doMultiSnapAction("refresh", names, nil, options)
+func (client *Client) RefreshMany(names []string, components map[string][]string, options *SnapOptions) (changeID string, err error) {
+	return client.doMultiSnapAction("refresh", names, components, options)
 }
 
 func (client *Client) HoldRefreshes(name string, options *SnapOptions) (changeID string, err error) {

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -48,7 +48,12 @@ var ops = []struct {
 		},
 		action: "install",
 	},
-	{(*client.Client).Refresh, "refresh"},
+	{
+		op: func(c *client.Client, name string, options *client.SnapOptions) (string, error) {
+			return c.Refresh(name, nil, options)
+		},
+		action: "refresh",
+	},
 	{
 		op: func(c *client.Client, name string, options *client.SnapOptions) (string, error) {
 			return c.Remove(name, nil, options)
@@ -67,7 +72,12 @@ var multiOps = []struct {
 	op     func(*client.Client, []string, *client.SnapOptions) (string, error)
 	action string
 }{
-	{(*client.Client).RefreshMany, "refresh"},
+	{
+		op: func(c *client.Client, names []string, options *client.SnapOptions) (string, error) {
+			return c.RefreshMany(names, nil, options)
+		},
+		action: "refresh",
+	},
 	{
 		op: func(c *client.Client, names []string, options *client.SnapOptions) (string, error) {
 			return c.InstallMany(names, nil, options)
@@ -874,7 +884,7 @@ func (cs *clientSuite) TestClientRefreshWithValidationSets(c *check.C) {
 	}`
 
 	sets := []string{"foo/bar=2", "foo/baz"}
-	chgID, err := cs.cli.RefreshMany(nil, &client.SnapOptions{
+	chgID, err := cs.cli.RefreshMany(nil, nil, &client.SnapOptions{
 		ValidationSets: sets,
 	})
 	c.Assert(err, check.IsNil)
@@ -957,6 +967,10 @@ func (cs *clientSuite) TestClientOpInstallWithComponents(c *check.C) {
 	cs.testClientOpWithComponents(c, cs.cli.Install)
 }
 
+func (cs *clientSuite) TestClientOpRefreshWithComponents(c *check.C) {
+	cs.testClientOpWithComponents(c, cs.cli.Refresh)
+}
+
 func (cs *clientSuite) TestClientOpRemoveWithComponents(c *check.C) {
 	cs.testClientOpWithComponents(c, cs.cli.Remove)
 }
@@ -989,6 +1003,10 @@ func (cs *clientSuite) testClientOpManyWithComponents(c *check.C, action func(na
 
 func (cs *clientSuite) TestClientOpInstallManyWithComponents(c *check.C) {
 	cs.testClientOpManyWithComponents(c, cs.cli.InstallMany)
+}
+
+func (cs *clientSuite) TestClientOpRefreshManyWithComponents(c *check.C) {
+	cs.testClientOpManyWithComponents(c, cs.cli.RefreshMany)
 }
 
 func (cs *clientSuite) TestClientOpRemoveManyWithComponents(c *check.C) {

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -126,7 +126,7 @@ func (cmd *cmdValidate) Execute(args []string) error {
 		}
 
 		if cmd.Refresh {
-			changeID, err := cmd.client.RefreshMany(nil, &client.SnapOptions{
+			changeID, err := cmd.client.RefreshMany(nil, nil, &client.SnapOptions{
 				ValidationSets: []string{cmd.Positional.ValidationSet},
 			})
 			if err != nil {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -150,8 +150,9 @@ var (
 	snapstateInstallComponents              = snapstate.InstallComponents
 	snapstateRefreshCandidates              = snapstate.RefreshCandidates
 	snapstateTryPath                        = snapstate.TryPath
-	snapstateUpdate                         = snapstate.Update
-	snapstateUpdateMany                     = snapstate.UpdateMany
+	snapstateStoreUpdateGoal                = snapstate.StoreUpdateGoal
+	snapstateUpdateWithGoal                 = snapstate.UpdateWithGoal
+	snapstateUpdateOne                      = snapstate.UpdateOne
 	snapstateRemove                         = snapstate.Remove
 	snapstateRemoveMany                     = snapstate.RemoveMany
 	snapstateResolveValSetsEnforcementError = snapstate.ResolveValidationSetsEnforcementError

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -259,6 +259,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	}))
 
 	s.AddCleanup(daemon.MockSnapstateStoreInstallGoal(newStoreInstallGoalRecorder))
+	s.AddCleanup(daemon.MockSnapstateStoreUpdateGoal(newStoreUpdateGoalRecorder))
 }
 
 type storeInstallGoalRecorder struct {
@@ -270,6 +271,26 @@ func newStoreInstallGoalRecorder(snaps ...snapstate.StoreSnap) snapstate.Install
 	return &storeInstallGoalRecorder{
 		snaps:       snaps,
 		InstallGoal: snapstate.StoreInstallGoal(snaps...),
+	}
+}
+
+type storeUpdateGoalRecorder struct {
+	snapstate.UpdateGoal
+	snaps []snapstate.StoreUpdate
+}
+
+func (s *storeUpdateGoalRecorder) names() []string {
+	names := make([]string, 0, len(s.snaps))
+	for _, snap := range s.snaps {
+		names = append(names, snap.InstanceName)
+	}
+	return names
+}
+
+func newStoreUpdateGoalRecorder(snaps ...snapstate.StoreUpdate) snapstate.UpdateGoal {
+	return &storeUpdateGoalRecorder{
+		snaps:      snaps,
+		UpdateGoal: snapstate.StoreUpdateGoal(snaps...),
 	}
 }
 

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -423,6 +423,9 @@ func newFakeSnapManager(st *state.State, runner *state.TaskRunner) *fakeSnapMana
 	runner.AddHandler("fake-install-snap-error", func(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("fake-install-snap-error errored")
 	}, nil)
+	runner.AddHandler("fake-refresh-snap", func(t *state.Task, _ *tomb.Tomb) error {
+		return nil
+	}, nil)
 
 	return &fakeSnapManager{}
 }

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -533,7 +533,7 @@ func multiInstallMessage(inst *snapInstruction) string {
 	return b.String()
 }
 
-func snapUpdate(_ context.Context, inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
+func snapUpdate(ctx context.Context, inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
 	// TODO: bail if revision is given (and != current?), *or* behave as with install --revision?
 	flags, err := inst.modeFlags()
 	if err != nil {
@@ -554,7 +554,15 @@ func snapUpdate(_ context.Context, inst *snapInstruction, st *state.State) (*sna
 		return nil, err
 	}
 
-	ts, err := snapstateUpdate(st, inst.Snaps[0], inst.revnoOpts(), inst.userID, flags)
+	goal := snapstateStoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: inst.Snaps[0],
+		RevOpts:      *inst.revnoOpts(),
+	})
+
+	ts, err := snapstateUpdateOne(ctx, st, goal, nil, snapstate.Options{
+		Flags:  flags,
+		UserID: inst.userID,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -968,10 +976,19 @@ func snapUpdateMany(ctx context.Context, inst *snapInstruction, st *state.State)
 		return nil, err
 	}
 
-	transaction := inst.Transaction
-	updated, tasksets, err := snapstateUpdateMany(ctx, st, inst.Snaps, nil, inst.userID, &snapstate.Flags{
-		IgnoreRunning: inst.IgnoreRunning,
-		Transaction:   transaction,
+	updates := make([]snapstate.StoreUpdate, 0, len(inst.Snaps))
+	for _, name := range inst.Snaps {
+		updates = append(updates, snapstate.StoreUpdate{
+			InstanceName: name,
+		})
+	}
+
+	goal := snapstateStoreUpdateGoal(updates...)
+	updated, uts, err := snapstateUpdateWithGoal(ctx, st, goal, nil, snapstate.Options{
+		Flags: snapstate.Flags{
+			IgnoreRunning: inst.IgnoreRunning,
+			Transaction:   inst.Transaction,
+		},
 	})
 	if err != nil {
 		if opts.IsRefreshOfAllSnaps {
@@ -981,6 +998,7 @@ func snapUpdateMany(ctx context.Context, inst *snapInstruction, st *state.State)
 		}
 		return nil, err
 	}
+	tasksets := uts.Refresh
 
 	var msg string
 	switch len(updated) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -416,7 +416,7 @@ func (inst *snapInstruction) validate() error {
 
 	if len(inst.CompsRaw) > 0 {
 		switch inst.Action {
-		case "remove", "install":
+		case "remove", "install", "refresh":
 		default:
 			return fmt.Errorf("%q action is not supported for components", inst.Action)
 		}
@@ -463,12 +463,10 @@ func snapInstall(ctx context.Context, inst *snapInstruction, st *state.State) (*
 		return nil, errors.New(i18n.G("cannot install snap with empty name"))
 	}
 
-	var ckey string
 	if inst.CohortKey == "" {
 		logger.Noticef("Installing snap %q revision %s", inst.Snaps[0], inst.Revision)
 	} else {
-		ckey = strutil.ElliptLeft(inst.CohortKey, 10)
-		logger.Noticef("Installing snap %q from cohort %q", inst.Snaps[0], ckey)
+		logger.Noticef("Installing snap %q from cohort %q", inst.Snaps[0], strutil.ElliptLeft(inst.CohortKey, 10))
 	}
 
 	installedSnaps, installedComponents, tss, err := installationTaskSets(ctx, st, inst)
@@ -477,24 +475,29 @@ func snapInstall(ctx context.Context, inst *snapInstruction, st *state.State) (*
 	}
 
 	return &snapInstructionResult{
-		Summary:            installMessage(inst, ckey),
+		Summary:            installRefreshMessage(inst.Snaps[0], inst.CompsForSnaps[inst.Snaps[0]], inst.Action, inst.Channel, inst.CohortKey),
 		Tasksets:           tss,
 		Affected:           installedSnaps,
 		AffectedComponents: installedComponents,
 	}, nil
 }
 
-func installMessage(inst *snapInstruction, cohort string) string {
+func installRefreshMessage(snap string, comps []string, action, channel, cohort string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, i18n.G("Install %q snap"), inst.Snaps[0])
-	if inst.Channel != "stable" && inst.Channel != "" {
-		fmt.Fprintf(&b, i18n.G(" from %q channel"), inst.Channel)
-	}
-	if inst.CohortKey != "" {
-		fmt.Fprintf(&b, i18n.G(" from %q cohort"), cohort)
+	if action == "install" {
+		fmt.Fprintf(&b, i18n.G("Install %q snap"), snap)
+	} else {
+		fmt.Fprintf(&b, i18n.G("Refresh %q snap"), snap)
 	}
 
-	if comps := inst.CompsForSnaps[inst.Snaps[0]]; len(comps) > 0 {
+	if channel != "stable" && channel != "" {
+		fmt.Fprintf(&b, i18n.G(" from %q channel"), channel)
+	}
+	if cohort != "" {
+		fmt.Fprintf(&b, i18n.G(" from %q cohort"), strutil.ElliptLeft(cohort, 10))
+	}
+
+	if len(comps) > 0 {
 		if len(comps) > 1 {
 			fmt.Fprintf(&b, i18n.G(" with components %s"), strutil.Quoted(comps))
 		} else {
@@ -505,18 +508,22 @@ func installMessage(inst *snapInstruction, cohort string) string {
 	return b.String()
 }
 
-func multiInstallMessage(inst *snapInstruction) string {
-	if len(inst.Snaps) == 1 {
-		return installMessage(inst, "")
+func multiInstallRefreshMessage(action string, snaps []string, comps map[string][]string) string {
+	if len(snaps) == 1 {
+		return installRefreshMessage(snaps[0], comps[snaps[0]], action, "", "")
 	}
 
 	var b strings.Builder
-	fmt.Fprint(&b, i18n.G("Install snaps"))
+	if action == "install" {
+		fmt.Fprint(&b, i18n.G("Install snaps"))
+	} else {
+		fmt.Fprint(&b, i18n.G("Refresh snaps"))
+	}
 
-	for i, name := range inst.Snaps {
+	for i, name := range snaps {
 		fmt.Fprintf(&b, " %q", name)
 
-		if comps := inst.CompsForSnaps[name]; len(comps) > 0 {
+		if comps := comps[name]; len(comps) > 0 {
 			b.WriteString(" (")
 			if len(comps) > 1 {
 				fmt.Fprintf(&b, i18n.G("with components %s"), strutil.Quoted(comps))
@@ -526,7 +533,7 @@ func multiInstallMessage(inst *snapInstruction) string {
 			b.WriteRune(')')
 		}
 
-		if i < len(inst.Snaps)-1 {
+		if i < len(snaps)-1 {
 			b.WriteRune(',')
 		}
 	}
@@ -555,8 +562,9 @@ func snapUpdate(ctx context.Context, inst *snapInstruction, st *state.State) (*s
 	}
 
 	goal := snapstateStoreUpdateGoal(snapstate.StoreUpdate{
-		InstanceName: inst.Snaps[0],
-		RevOpts:      *inst.revnoOpts(),
+		InstanceName:         inst.Snaps[0],
+		RevOpts:              *inst.revnoOpts(),
+		AdditionalComponents: inst.CompsForSnaps[inst.Snaps[0]],
 	})
 
 	ts, err := snapstateUpdateOne(ctx, st, goal, nil, snapstate.Options{
@@ -567,13 +575,8 @@ func snapUpdate(ctx context.Context, inst *snapInstruction, st *state.State) (*s
 		return nil, err
 	}
 
-	msg := fmt.Sprintf(i18n.G("Refresh %q snap"), inst.Snaps[0])
-	if inst.Channel != "stable" && inst.Channel != "" {
-		msg = fmt.Sprintf(i18n.G("Refresh %q snap from %q channel"), inst.Snaps[0], inst.Channel)
-	}
-
 	return &snapInstructionResult{
-		Summary:            msg,
+		Summary:            installRefreshMessage(inst.Snaps[0], inst.CompsForSnaps[inst.Snaps[0]], inst.Action, inst.Channel, inst.CohortKey),
 		Tasksets:           []*state.TaskSet{ts},
 		Affected:           inst.Snaps,
 		AffectedComponents: inst.CompsForSnaps,
@@ -957,7 +960,7 @@ func snapInstallMany(ctx context.Context, inst *snapInstruction, st *state.State
 	}
 
 	return &snapInstructionResult{
-		Summary:            multiInstallMessage(inst),
+		Summary:            multiInstallRefreshMessage(inst.Action, inst.Snaps, inst.CompsForSnaps),
 		Affected:           installedSnaps,
 		AffectedComponents: installedComponents,
 		Tasksets:           tasksets,
@@ -979,7 +982,8 @@ func snapUpdateMany(ctx context.Context, inst *snapInstruction, st *state.State)
 	updates := make([]snapstate.StoreUpdate, 0, len(inst.Snaps))
 	for _, name := range inst.Snaps {
 		updates = append(updates, snapstate.StoreUpdate{
-			InstanceName: name,
+			InstanceName:         name,
+			AdditionalComponents: inst.CompsForSnaps[name],
 		})
 	}
 
@@ -1010,11 +1014,9 @@ func snapUpdateMany(ctx context.Context, inst *snapInstruction, st *state.State)
 			msg = i18n.G("Refresh all snaps: no updates")
 		}
 	case 1:
-		msg = fmt.Sprintf(i18n.G("Refresh snap %q"), updated[0])
+		msg = installRefreshMessage(updated[0], inst.CompsForSnaps[updated[0]], inst.Action, inst.Channel, inst.CohortKey)
 	default:
-		quoted := strutil.Quoted(updated)
-		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
-		msg = fmt.Sprintf(i18n.G("Refresh snaps %s"), quoted)
+		msg = multiInstallRefreshMessage(inst.Action, updated, inst.CompsForSnaps)
 	}
 
 	return &snapInstructionResult{

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -674,10 +674,11 @@ func (s *snapsSuite) TestPostSnapsOpSystemRestartImmediate(c *check.C) {
 
 func (s *snapsSuite) testPostSnapsOp(c *check.C, extraJSON, contentType string) (systemRestartImmediate bool) {
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(*state.State, int, *assertstate.RefreshAssertionsOptions) error { return nil })()
-	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, _ int, _ *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		c.Check(names, check.HasLen, 0)
+	defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Check(goal.snaps, check.HasLen, 0)
 		t := s.NewTask("fake-refresh-all", "Refreshing everything")
-		return []string{"fake1", "fake2"}, []*state.TaskSet{state.NewTaskSet(t)}, nil
+		return []string{"fake1", "fake2"}, &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(t)}}, nil
 	})()
 
 	d := s.daemonWithOverlordMockAndStore()
@@ -742,10 +743,11 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 		refreshSnapAssertions = false
 		refreshAssertionsOpts = nil
 
-		defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-			c.Check(names, check.HasLen, 0)
+		defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+			goal := g.(*storeUpdateGoalRecorder)
+			c.Check(goal.snaps, check.HasLen, 0)
 			t := s.NewTask("fake-refresh-all", "Refreshing everything")
-			return tst.snaps, []*state.TaskSet{state.NewTaskSet(t)}, nil
+			return tst.snaps, &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(t)}}, nil
 		})()
 
 		inst := &daemon.SnapInstruction{Action: "refresh"}
@@ -768,9 +770,10 @@ func (s *snapsSuite) TestRefreshAllNoChanges(c *check.C) {
 		return assertstate.RefreshSnapAssertions(s, userID, opts)
 	})()
 
-	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		c.Check(names, check.HasLen, 0)
-		return nil, nil, nil
+	defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Check(goal.snaps, check.HasLen, 0)
+		return nil, &snapstate.UpdateTaskSets{Refresh: nil}, nil
 	})()
 
 	d := s.daemon(c)
@@ -797,7 +800,7 @@ func (s *snapsSuite) TestRefreshAllRestoresValidationSets(c *check.C) {
 		return nil
 	})()
 
-	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+	defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
 		return nil, nil, fmt.Errorf("boom")
 	})()
 
@@ -824,12 +827,13 @@ func (s *snapsSuite) TestRefreshManyTransactionally(c *check.C) {
 		return nil
 	})()
 
-	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		calledFlags = flags
-
-		c.Check(names, check.HasLen, 2)
+	defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		calledFlags = &opts.Flags
+		c.Check(goal.snaps, check.HasLen, 2)
 		t := s.NewTask("fake-refresh-2", "Refreshing two")
-		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil
+
+		return goal.names(), &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(t)}}, nil
 	})()
 
 	d := s.daemon(c)
@@ -861,10 +865,11 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 		return nil
 	})()
 
-	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		c.Check(names, check.HasLen, 2)
+	defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Check(goal.snaps, check.HasLen, 2)
 		t := s.NewTask("fake-refresh-2", "Refreshing two")
-		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil
+		return goal.names(), &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(t)}}, nil
 	})()
 
 	d := s.daemon(c)
@@ -887,12 +892,13 @@ func (s *snapsSuite) TestRefreshManyIgnoreRunning(c *check.C) {
 	})()
 
 	var calledFlags *snapstate.Flags
-	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		calledFlags = flags
+	defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+		calledFlags = &opts.Flags
 
-		c.Check(names, check.HasLen, 2)
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Check(goal.snaps, check.HasLen, 2)
 		t := s.NewTask("fake-refresh-2", "Refreshing two")
-		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil
+		return goal.names(), &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(t)}}, nil
 	})()
 
 	d := s.daemon(c)
@@ -918,10 +924,11 @@ func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 		return nil
 	})()
 
-	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, _ []*snapstate.RevisionOptions, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		c.Check(names, check.HasLen, 1)
+	defer daemon.MockSnapstateUpdateWithGoal(func(_ context.Context, s *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Check(goal.snaps, check.HasLen, 1)
 		t := s.NewTask("fake-refresh-1", "Refreshing one")
-		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil
+		return goal.names(), &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(t)}}, nil
 	})()
 
 	d := s.daemon(c)
@@ -2586,12 +2593,13 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 	installQueue := []string{}
 	assertstateCalledUserID := 0
 
-	defer daemon.MockSnapstateUpdate(func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		calledFlags = flags
-		calledUserID = userID
-		installQueue = append(installQueue, name)
+	defer daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		calledFlags = opts.Flags
+		calledUserID = opts.UserID
+		installQueue = append(installQueue, goal.snaps[0].InstanceName)
 
-		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
+		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -2625,12 +2633,13 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 	calledUserID := 0
 	installQueue := []string{}
 
-	defer daemon.MockSnapstateUpdate(func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		calledFlags = flags
-		calledUserID = userID
-		installQueue = append(installQueue, name)
+	defer daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		calledFlags = opts.Flags
+		calledUserID = opts.UserID
+		installQueue = append(installQueue, goal.snaps[0].InstanceName)
 
-		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
+		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -2663,8 +2672,8 @@ func (s *snapsSuite) TestRefreshDevMode(c *check.C) {
 func (s *snapsSuite) TestRefreshClassic(c *check.C) {
 	var calledFlags snapstate.Flags
 
-	defer daemon.MockSnapstateUpdate(func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		calledFlags = flags
+	defer daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		calledFlags = opts.Flags
 		return nil, nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -2693,12 +2702,13 @@ func (s *snapsSuite) TestRefreshIgnoreValidation(c *check.C) {
 	calledUserID := 0
 	installQueue := []string{}
 
-	defer daemon.MockSnapstateUpdate(func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		calledFlags = flags
-		calledUserID = userID
-		installQueue = append(installQueue, name)
+	defer daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		calledFlags = opts.Flags
+		calledUserID = opts.UserID
+		installQueue = append(installQueue, goal.snaps[0].InstanceName)
 
-		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
+		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -2733,11 +2743,12 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 	var calledFlags snapstate.Flags
 	installQueue := []string{}
 
-	defer daemon.MockSnapstateUpdate(func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		calledFlags = flags
-		installQueue = append(installQueue, name)
+	defer daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		calledFlags = opts.Flags
+		installQueue = append(installQueue, goal.snaps[0].InstanceName)
 
-		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
+		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -2769,10 +2780,11 @@ func (s *snapsSuite) TestRefreshIgnoreRunning(c *check.C) {
 func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 	cohort := ""
 
-	defer daemon.MockSnapstateUpdate(func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		cohort = opts.CohortKey
+	defer daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		cohort = goal.snaps[0].RevOpts.CohortKey
 
-		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
+		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -2799,10 +2811,11 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
 	var leave *bool
 
-	defer daemon.MockSnapstateUpdate(func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		leave = &opts.LeaveCohort
+	defer daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		leave = &goal.snaps[0].RevOpts.LeaveCohort
 
-		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
+		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -737,7 +737,7 @@ func (s *snapsSuite) TestRefreshAll(c *check.C) {
 		msg   string
 	}{
 		{nil, "Refresh all snaps: no updates"},
-		{[]string{"fake"}, `Refresh snap "fake"`},
+		{[]string{"fake"}, `Refresh "fake" snap`},
 		{[]string{"fake1", "fake2"}, `Refresh snaps "fake1", "fake2"`},
 	} {
 		refreshSnapAssertions = false
@@ -938,7 +938,7 @@ func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 	res, err := inst.DispatchForMany()(context.Background(), inst, st)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
-	c.Check(res.Summary, check.Equals, `Refresh snap "foo"`)
+	c.Check(res.Summary, check.Equals, `Refresh "foo" snap`)
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
 	c.Check(refreshSnapAssertions, check.Equals, true)
 }
@@ -2599,7 +2599,7 @@ func (s *snapsSuite) TestRefresh(c *check.C) {
 		calledUserID = opts.UserID
 		installQueue = append(installQueue, goal.snaps[0].InstanceName)
 
-		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
+		t := st.NewTask("fake-refresh-snap", "Doing a fake refresh")
 		return state.NewTaskSet(t), nil
 	})()
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -2805,7 +2805,7 @@ func (s *snapsSuite) TestRefreshCohort(c *check.C) {
 	c.Check(err, check.IsNil)
 
 	c.Check(cohort, check.Equals, "xyzzy")
-	c.Check(res.Summary, check.Equals, `Refresh "some-snap" snap`)
+	c.Check(res.Summary, check.Equals, `Refresh "some-snap" snap from "xyzzy" cohort`)
 }
 
 func (s *snapsSuite) TestRefreshLeaveCohort(c *check.C) {
@@ -3745,7 +3745,7 @@ func (s *snapsSuite) TestPostRemoveComponents(c *check.C) {
 func (s *snapsSuite) TestPostComponentsWrongAction(c *check.C) {
 	s.daemonWithOverlordMockAndStore()
 
-	for _, action := range []string{"refresh", "revert", "enable", "disable"} {
+	for _, action := range []string{"revert", "enable", "disable"} {
 		buf := strings.NewReader(fmt.Sprintf(`{"action": %q,"components":["comp1","comp2"]}`,
 			action))
 		req, err := http.NewRequest("POST", "/v2/snaps/foo", buf)
@@ -3872,7 +3872,7 @@ func (s *snapsSuite) TestPostComponentsRemoveManyWithSnaps(c *check.C) {
 func (s *snapsSuite) TestPostComponentsManyWrongAction(c *check.C) {
 	s.daemonWithOverlordMockAndStore()
 
-	for _, action := range []string{"refresh", "revert", "enable", "disable"} {
+	for _, action := range []string{"revert", "enable", "disable"} {
 		buf := strings.NewReader(fmt.Sprintf(`{"action": %q, "snaps":["foo", "bar"], "components": { "snap1": ["comp1", "comp2"], "snap2": ["comp3", "comp4"] }}`, action))
 		req, err := http.NewRequest("POST", "/v2/snaps", buf)
 		c.Assert(err, check.IsNil)
@@ -3949,6 +3949,60 @@ func (s *snapsSuite) TestInstallWithComponents(c *check.C) {
 	c.Check(chg.Summary(), check.Equals, `Install "some-snap" snap with components "comp1", "comp2"`)
 }
 
+func (s *snapsSuite) TestUpdateWithAdditionalComponents(c *check.C) {
+	restore := daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+		return nil
+	})
+	defer restore()
+
+	restore = daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Check(goal.snaps, check.DeepEquals, []snapstate.StoreUpdate{{
+			InstanceName:         "some-snap",
+			AdditionalComponents: []string{"comp1", "comp2"},
+		}})
+		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
+		return state.NewTaskSet(t), nil
+	})
+	defer restore()
+
+	d := s.daemonWithFakeSnapManager(c)
+
+	r := strings.NewReader(`{"action": "refresh", "components": ["comp1", "comp2"]}`)
+	req, err := http.NewRequest("POST", "/v2/snaps/some-snap", r)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.asyncReq(c, req, nil)
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.Change(rsp.Change)
+	c.Assert(chg, check.NotNil)
+
+	c.Check(chg.Tasks(), check.HasLen, 1)
+
+	var data map[string]interface{}
+	err = chg.Get("api-data", &data)
+	c.Assert(err, check.IsNil)
+	c.Check(data, check.DeepEquals, map[string]interface{}{
+		"snap-names": []interface{}{"some-snap"},
+		"components": map[string]interface{}{
+			"some-snap": []interface{}{"comp1", "comp2"},
+		},
+	})
+
+	st.Unlock()
+	s.waitTrivialChange(c, chg)
+	st.Lock()
+
+	c.Check(chg.Status(), check.Equals, state.DoneStatus)
+	c.Check(err, check.IsNil)
+	c.Check(chg.Kind(), check.Equals, "refresh-snap")
+	c.Check(chg.Summary(), check.Equals, `Refresh "some-snap" snap with components "comp1", "comp2"`)
+}
+
 func (s *snapsSuite) TestInstallManyWithComponents(c *check.C) {
 	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
@@ -3996,6 +4050,60 @@ func (s *snapsSuite) TestInstallManyWithComponents(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(chg.Kind(), check.Equals, "install-snap")
 	c.Check(chg.Summary(), check.Equals, `Install snaps "some-snap" (with components "some-comp1", "some-comp2"), "other-snap" (with component "other-comp1")`)
+}
+
+func (s *snapsSuite) TestUpdateManyWithComponents(c *check.C) {
+	restore := daemon.MockAssertstateRefreshSnapAssertions(func(*state.State, int, *assertstate.RefreshAssertionsOptions) error {
+		return nil
+	})
+	defer restore()
+
+	restore = daemon.MockSnapstateUpdateWithGoal(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Assert(goal.snaps, check.HasLen, 2)
+
+		c.Check(goal.snaps, check.DeepEquals, []snapstate.StoreUpdate{
+			{
+				InstanceName:         "some-snap",
+				AdditionalComponents: []string{"some-comp1", "some-comp2"},
+			},
+			{
+				InstanceName:         "other-snap",
+				AdditionalComponents: []string{"other-comp1"},
+			},
+		})
+
+		t := st.NewTask("fake-refresh-snap", "Doing a fake refresh")
+		return []string{"some-snap", "other-snap"}, &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(t)}}, nil
+	})
+	defer restore()
+
+	d := s.daemonWithFakeSnapManager(c)
+
+	r := strings.NewReader(`{"action": "refresh", "snaps": ["some-snap", "other-snap"], "components": {"some-snap": ["some-comp1", "some-comp2"], "other-snap": ["other-comp1"]}}`)
+	req, err := http.NewRequest("POST", "/v2/snaps", r)
+	c.Assert(err, check.IsNil)
+	req.Header.Set("Content-Type", "application/json")
+
+	rsp := s.asyncReq(c, req, nil)
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.Change(rsp.Change)
+	c.Assert(chg, check.NotNil)
+
+	c.Check(chg.Tasks(), check.HasLen, 1)
+
+	st.Unlock()
+	s.waitTrivialChange(c, chg)
+	st.Lock()
+
+	c.Check(chg.Status(), check.Equals, state.DoneStatus)
+	c.Check(err, check.IsNil)
+	c.Check(chg.Kind(), check.Equals, "refresh-snap")
+	c.Check(chg.Summary(), check.Equals, `Refresh snaps "some-snap" (with components "some-comp1", "some-comp2"), "other-snap" (with component "other-comp1")`)
 }
 
 func (s *snapsSuite) TestInstallWithComponentsSnapAlreadyInstalled(c *check.C) {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -147,6 +147,14 @@ func MockSnapstateInstallWithGoal(mock func(ctx context.Context, st *state.State
 	}
 }
 
+func MockSnapstateUpdateOne(mock func(ctx context.Context, st *state.State, goal snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error)) (restore func()) {
+	old := snapstateUpdateOne
+	snapstateUpdateOne = mock
+	return func() {
+		snapstateUpdateOne = old
+	}
+}
+
 func MockSnapstateInstallComponents(mock func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
 	old := snapstateInstallComponents
 	snapstateInstallComponents = mock
@@ -163,19 +171,19 @@ func MockSnapstateStoreInstallGoal(mock func(snaps ...snapstate.StoreSnap) snaps
 	}
 }
 
+func MockSnapstateStoreUpdateGoal(mock func(snaps ...snapstate.StoreUpdate) snapstate.UpdateGoal) (restore func()) {
+	old := snapstateStoreUpdateGoal
+	snapstateStoreUpdateGoal = mock
+	return func() {
+		snapstateStoreUpdateGoal = old
+	}
+}
+
 func MockSnapstateInstallPath(mock func(*state.State, *snap.SideInfo, string, string, string, snapstate.Flags, snapstate.PrereqTracker) (*state.TaskSet, *snap.Info, error)) (restore func()) {
 	oldSnapstateInstallPath := snapstateInstallPath
 	snapstateInstallPath = mock
 	return func() {
 		snapstateInstallPath = oldSnapstateInstallPath
-	}
-}
-
-func MockSnapstateUpdate(mock func(*state.State, string, *snapstate.RevisionOptions, int, snapstate.Flags) (*state.TaskSet, error)) (restore func()) {
-	oldSnapstateUpdate := snapstateUpdate
-	snapstateUpdate = mock
-	return func() {
-		snapstateUpdate = oldSnapstateUpdate
 	}
 }
 
@@ -211,11 +219,11 @@ func MockSnapstateRevertToRevision(mock func(*state.State, string, snap.Revision
 	}
 }
 
-func MockSnapstateUpdateMany(mock func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, *snapstate.Flags) ([]string, []*state.TaskSet, error)) (restore func()) {
-	oldSnapstateUpdateMany := snapstateUpdateMany
-	snapstateUpdateMany = mock
+func MockSnapstateUpdateWithGoal(mock func(context.Context, *state.State, snapstate.UpdateGoal, func(*snap.Info, *snapstate.SnapState) bool, snapstate.Options) ([]string, *snapstate.UpdateTaskSets, error)) (restore func()) {
+	oldSnapstateUpdateWithGoal := snapstateUpdateWithGoal
+	snapstateUpdateWithGoal = mock
 	return func() {
-		snapstateUpdateMany = oldSnapstateUpdateMany
+		snapstateUpdateWithGoal = oldSnapstateUpdateWithGoal
 	}
 }
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1811,6 +1811,22 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	return tasksets, affected, nil
 }
 
+func keys[T comparable](m map[T]struct{}) []T {
+	keys := make([]T, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func unique[T comparable](s []T) []T {
+	m := make(map[T]struct{}, len(s))
+	for _, v := range s {
+		m[v] = struct{}{}
+	}
+	return keys(m)
+}
+
 // updateFilter is the type of function that can be passed to
 // updateManyFromChange so it filters the updates.
 //

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1833,7 +1833,7 @@ func unique[T comparable](s []T) []T {
 // If the filter returns true, the update for that snap proceeds. If
 // it returns false, the snap is removed from the list of updates to
 // consider.
-type updateFilter func(*snap.Info, *SnapState) bool
+type updateFilter = func(*snap.Info, *SnapState) bool
 
 func updateManyFiltered(ctx context.Context, st *state.State, names []string, revOpts []*RevisionOptions, userID int, filter updateFilter, flags *Flags, fromChange string) ([]string, *UpdateTaskSets, error) {
 	if flags == nil {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -14965,10 +14965,32 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughLoseComponentsUndo(
 	})
 }
 
+func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponents(c *C) {
+	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		instanceKey:           "key",
+		components:            []string{"standard-component"},
+		postRefreshComponents: []string{"standard-component", "kernel-modules-component"},
+		additionalComponents:  []string{"kernel-modules-component"},
+		refreshAppAwarenessUX: true,
+	})
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponentsUndo(c *C) {
+	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		instanceKey:           "key",
+		components:            []string{"standard-component"},
+		postRefreshComponents: []string{"standard-component", "kernel-modules-component"},
+		additionalComponents:  []string{"kernel-modules-component"},
+		refreshAppAwarenessUX: true,
+		undo:                  true,
+	})
+}
+
 type updateWithComponentsOpts struct {
 	instanceKey           string
 	components            []string
 	postRefreshComponents []string
+	additionalComponents  []string
 	refreshAppAwarenessUX bool
 	undo                  bool
 	useSameSnapRev        bool
@@ -15123,13 +15145,21 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		InstanceKey:     opts.instanceKey,
 	})
 
-	var revOpts *snapstate.RevisionOptions
+	var revOpts snapstate.RevisionOptions
 	if opts.useSameSnapRev {
-		revOpts = &snapstate.RevisionOptions{Revision: currentSnapRev}
+		revOpts.Revision = currentSnapRev
 	}
 
-	ts, err := snapstate.Update(s.state, instanceName, revOpts, s.user.ID, snapstate.Flags{
-		NoReRefresh: true,
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName:         instanceName,
+		RevOpts:              revOpts,
+		AdditionalComponents: opts.additionalComponents,
+	}), nil, snapstate.Options{
+		Flags: snapstate.Flags{
+			NoReRefresh: true,
+			Transaction: client.TransactionPerSnap,
+		},
+		UserID: s.user.ID,
 	})
 	c.Assert(err, IsNil)
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -532,7 +532,7 @@ func storeUpdatePlanCore(
 			return updatePlan{}, snap.NotInstalledError{Snap: update.InstanceName}
 		}
 
-		if snapst.HasActiveComponents() {
+		if snapst.HasActiveComponents() || len(update.AdditionalComponents) > 0 {
 			requestComponentsFromStore = true
 		}
 	}
@@ -568,7 +568,7 @@ func storeUpdatePlanCore(
 	}
 
 	for _, name := range localAmends {
-		hasLocalRevision[allSnaps[name]] = updates[name].RevOpts
+		hasLocalRevision[name] = allSnaps[name]
 	}
 
 	for id, actions := range amendActionsByUserID {
@@ -582,7 +582,7 @@ func storeUpdatePlanCore(
 	}
 
 	for _, name := range noStoreUpdates {
-		hasLocalRevision[allSnaps[name]] = updates[name].RevOpts
+		hasLocalRevision[name] = allSnaps[name]
 	}
 
 	for _, sar := range sars {
@@ -607,6 +607,10 @@ func storeUpdatePlanCore(
 		for _, comp := range currentComps {
 			compNames = append(compNames, comp.Component.ComponentName)
 		}
+
+		// add the additional components that the caller requested to be
+		// installed
+		compNames = unique(append(compNames, up.AdditionalComponents...))
 
 		// compTargets will be filtered down to only the components that appear
 		// in the action result, meaning that we might install fewer components
@@ -635,10 +639,15 @@ func storeUpdatePlanCore(
 
 	// consider snaps that already have a local copy of the revision that we are
 	// trying to install, skipping a trip to the store
-	for snapst, revOpts := range hasLocalRevision {
+	for name, snapst := range hasLocalRevision {
+		up, ok := updates[name]
+		if !ok {
+			return updatePlan{}, fmt.Errorf("internal error: unexpected update to local revision: %q", snapst.InstanceName())
+		}
+
 		var si *snap.SideInfo
-		if !revOpts.Revision.Unset() {
-			si = snapst.Sequence.Revisions[snapst.LastIndex(revOpts.Revision)].Snap
+		if !up.RevOpts.Revision.Unset() {
+			si = snapst.Sequence.Revisions[snapst.LastIndex(up.RevOpts.Revision)].Snap
 		} else {
 			si = snapst.CurrentSideInfo()
 		}
@@ -658,7 +667,11 @@ func storeUpdatePlanCore(
 			return updatePlan{}, err
 		}
 
-		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, si.Revision, revOpts.Channel, opts)
+		// add the additional components that the caller requested to be
+		// installed
+		compsToInstall = unique(append(compsToInstall, up.AdditionalComponents...))
+
+		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, si.Revision, up.RevOpts.Channel, opts)
 		if err != nil {
 			return updatePlan{}, err
 		}
@@ -666,25 +679,25 @@ func storeUpdatePlanCore(
 		// this must happen after the call to componentSetupsForInstall, since
 		// we can't set the channel to the tracking channel if we don't know
 		// that the requested revision is part of this channel
-		revOpts.setChannelIfUnset(snapst.TrackingChannel)
+		up.RevOpts.setChannelIfUnset(snapst.TrackingChannel)
 
 		// make sure that we switch the current channel of the snap that we're
 		// switching to
-		info.Channel = revOpts.Channel
+		info.Channel = up.RevOpts.Channel
 
 		plan.targets = append(plan.targets, target{
 			info:   info,
 			snapst: *snapst,
 			setup: SnapSetup{
-				Channel:   revOpts.Channel,
-				CohortKey: revOpts.CohortKey,
+				Channel:   up.RevOpts.Channel,
+				CohortKey: up.RevOpts.CohortKey,
 				SnapPath:  info.MountFile(),
 
 				// if the caller specified a revision, then we always run
 				// through the entire update process. this enables something
 				// like "snap refresh --revision=n", where revision n is already
 				// installed
-				AlwaysUpdate: !revOpts.Revision.Unset(),
+				AlwaysUpdate: !up.RevOpts.Revision.Unset(),
 			},
 			components: compsups,
 		})
@@ -720,8 +733,8 @@ func collectCurrentSnapsAndActions(
 	opts Options,
 	enforcedSets func() (*snapasserts.ValidationSets, error),
 	fallbackID int,
-) (actionsByUserID map[int][]*store.SnapAction, hasLocalRevision map[*SnapState]RevisionOptions, current []*store.CurrentSnap, err error) {
-	hasLocalRevision = make(map[*SnapState]RevisionOptions)
+) (actionsByUserID map[int][]*store.SnapAction, hasLocalRevision map[string]*SnapState, current []*store.CurrentSnap, err error) {
+	hasLocalRevision = make(map[string]*SnapState)
 	actionsByUserID = make(map[int][]*store.SnapAction)
 	refreshAll := len(requested) == 0
 
@@ -746,7 +759,7 @@ func collectCurrentSnapsAndActions(
 		}
 
 		if !req.RevOpts.Revision.Unset() && snapst.LastIndex(req.RevOpts.Revision) != -1 {
-			hasLocalRevision[snapst] = req.RevOpts
+			hasLocalRevision[snapst.InstanceName()] = snapst
 			return nil
 		}
 
@@ -780,7 +793,7 @@ func collectCurrentSnapsAndActions(
 		// consider this snap for a store update, but we still should return it
 		// as a target for potentially switching channels or cohort keys
 		if !action.Revision.Unset() && action.Revision == installed.Revision {
-			hasLocalRevision[snapst] = req.RevOpts
+			hasLocalRevision[installed.InstanceName] = snapst
 			return nil
 		}
 

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -1073,6 +1073,9 @@ type StoreUpdate struct {
 	InstanceName string
 	// RevOpts contains options that apply to the update of this snap.
 	RevOpts RevisionOptions
+	// AdditionalComponents is a list of additional components to install during
+	// the refresh.
+	AdditionalComponents []string
 }
 
 // StoreUpdateGoal creates a new UpdateGoal to update snaps from the store.
@@ -1133,6 +1136,13 @@ func validateAndInitStoreUpdates(allSnaps map[string]*SnapState, updates map[str
 
 		if err := sn.RevOpts.resolveChannel(sn.InstanceName, snapst.TrackingChannel, opts.DeviceCtx); err != nil {
 			return err
+		}
+
+		snapName, _ := snap.SplitInstanceName(sn.InstanceName)
+		for _, add := range sn.AdditionalComponents {
+			if snapst.CurrentComponentState(naming.NewComponentRef(snapName, add)) != nil {
+				return snap.AlreadyInstalledComponentError{Component: add}
+			}
 		}
 
 		updates[sn.InstanceName] = sn

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/testutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -380,6 +381,41 @@ func (s *targetTestSuite) TestUpdateSnapNotInstalled(c *C) {
 
 	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
 	c.Assert(err, ErrorMatches, `snap "some-snap" is not installed`)
+}
+
+func (s *targetTestSuite) TestUpdateAdditionalComponentAlreadyInstalled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+		RealName: "snap-1",
+		SnapID:   snaptest.AssertedSnapID("snap-1"),
+		Revision: snap.R(7),
+	}})
+
+	seq.AddComponentForRevision(snap.R(7), &sequence.ComponentState{
+		SideInfo: &snap.ComponentSideInfo{
+			Component: naming.NewComponentRef("snap-1", "comp-1"),
+			Revision:  snap.R(1),
+		},
+		CompType: snap.StandardComponent,
+	})
+
+	snapstate.Set(s.state, "snap-1", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence:        seq,
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName:         "snap-1",
+		AdditionalComponents: []string{"comp-1"},
+	})
+
+	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, testutil.ErrorIs, snap.AlreadyInstalledComponentError{Component: "comp-1"})
 }
 
 func (s *targetTestSuite) TestInvalidPathGoals(c *C) {

--- a/tests/main/component-refresh-and-revert/task.yaml
+++ b/tests/main/component-refresh-and-revert/task.yaml
@@ -70,3 +70,15 @@ execute: |
   snap revert test-snap-component-refreshes --revision=5
   test-snap-component-refreshes one | MATCH '.*revision 7$'
   test-snap-component-refreshes two | MATCH '.*revision 6$'
+
+  snap remove test-snap-component-refreshes
+
+  snap install test-snap-component-refreshes+one --revision=3 --edge
+  test-snap-component-refreshes one | MATCH '.*revision 3$'
+  not test-snap-component-refreshes two
+
+  # this should refresh the snap to the latest in the edge channel, update the
+  # "one" component, and install the "two" component
+  snap refresh test-snap-component-refreshes+two
+  test-snap-component-refreshes one | MATCH '.*revision 5$'
+  test-snap-component-refreshes two | MATCH '.*revision 5$'


### PR DESCRIPTION
This change allows the snapd HTTP API and CLI interfaces to install components while refreshing snaps.

The CLI looks like:
```
snap refresh <snapname>+<comp>+<comp>...
```

Requires functionality from https://github.com/canonical/snapd/pull/14621.