### PR TITLE
secboot: allow unlocking without key file

### DIFF
--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -26,6 +26,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	sb "github.com/snapcore/secboot"
@@ -127,14 +128,16 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, sealedE
 
 	res.PartDevice = partDevice
 
-	keyData, _, err := readKeyFile(sealedEncryptionKeyFile)
-	if err != nil {
-		return res, err
-	}
-
 	var keys []*sb.KeyData
-	if keyData != nil {
-		keys = append(keys, keyData)
+
+	if keyData, _, err := readKeyFile(sealedEncryptionKeyFile); err == nil {
+		if keyData != nil {
+			keys = append(keys, keyData)
+		}
+	} else {
+		if !os.IsNotExist(err) {
+			logger.Noticef("WARNING: there was an error loading key %s: %v", sealedEncryptionKeyFile, err)
+		}
 	}
 
 	if opts.WhichModel != nil {


### PR DESCRIPTION
Key datas may be in the tokens of the key slot. ActivateVolumeWithKeyData will read those. So in the case the key file does not exist, we should still try without keydata.