### PR TITLE
secboot, o/fdestate/backend: reseal with DBX update payload

### DIFF
--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -100,7 +100,8 @@ func getUniqueModels(bootChains []boot.BootChain) []secboot.ModelForSealing {
 	return models
 }
 
-func resealKeyForBootChainsFDEHook(method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+func resealKeyForBootChainsFDEHook(method device.SealingMethod, rootdir string, inputs resealInputs, opts resealOptions) error {
+	params := inputs.bootChains
 	runKeys := []string{
 		device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir),
 	}
@@ -127,9 +128,52 @@ func resealKeyForBootChainsFDEHook(method device.SealingMethod, rootdir string, 
 
 // ResealKeyForBootChains reseals disk encryption keys with the given bootchains.
 func ResealKeyForBootChains(updateState StateUpdater, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	return resealKeys(updateState, method, rootdir,
+		resealInputs{
+			bootChains: params,
+		},
+		resealOptions{
+			ExpectReseal: expectReseal,
+		})
+}
+
+// ResealKeysForSignaturesDBUpdate reseals disk encryption keys for the provided
+// boot chains and an optional signature DB update
+func ResealKeysForSignaturesDBUpdate(
+	updateState StateUpdater, method device.SealingMethod, rootdir string,
+	params *boot.ResealKeyForBootChainsParams, dbUpdate []byte,
+) error {
+	return resealKeys(updateState, method, rootdir,
+		resealInputs{
+			bootChains:        params,
+			signatureDBUpdate: dbUpdate,
+		},
+		resealOptions{
+			ExpectReseal: true,
+			Force:        true,
+		})
+}
+
+type resealInputs struct {
+	bootChains        *boot.ResealKeyForBootChainsParams
+	signatureDBUpdate []byte
+}
+
+type resealOptions struct {
+	ExpectReseal bool
+	Force        bool
+}
+
+func resealKeys(
+	updateState StateUpdater, method device.SealingMethod, rootdir string,
+	inputs resealInputs,
+	opts resealOptions,
+) error {
+	params := inputs.bootChains
+
 	switch method {
 	case device.SealingMethodFDESetupHook:
-		return resealKeyForBootChainsFDEHook(method, rootdir, params, expectReseal)
+		return resealKeyForBootChainsFDEHook(method, rootdir, inputs, opts)
 	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
 	default:
 		return fmt.Errorf("unknown key sealing method: %q", method)
@@ -141,15 +185,16 @@ func ResealKeyForBootChains(updateState StateUpdater, method device.SealingMetho
 	// reseal the run object
 	pbc := boot.ToPredictableBootChains(append(params.RunModeBootChains, params.RecoveryBootChainsForRunKey...))
 
-	needed, nextCount, err := boot.IsResealNeeded(pbc, BootChainsFileUnder(rootdir), expectReseal)
+	needed, nextCount, err := boot.IsResealNeeded(pbc, BootChainsFileUnder(rootdir), opts.ExpectReseal)
 	if err != nil {
 		return err
 	}
-	if needed {
+	if needed || opts.Force {
 		pbcJSON, _ := json.Marshal(pbc)
 		logger.Debugf("resealing (%d) to boot chains: %s", nextCount, pbcJSON)
 
-		if err := resealRunObjectKeys(updateState, pbc, authKeyFile, params.RoleToBlName); err != nil {
+		err := resealRunObjectKeys(updateState, pbc, inputs.signatureDBUpdate, authKeyFile, params.RoleToBlName)
+		if err != nil {
 			return err
 		}
 
@@ -167,15 +212,16 @@ func ResealKeyForBootChains(updateState StateUpdater, method device.SealingMetho
 	rpbc := boot.ToPredictableBootChains(params.RecoveryBootChains)
 
 	var nextFallbackCount int
-	needed, nextFallbackCount, err = boot.IsResealNeeded(rpbc, RecoveryBootChainsFileUnder(rootdir), expectReseal)
+	needed, nextFallbackCount, err = boot.IsResealNeeded(rpbc, RecoveryBootChainsFileUnder(rootdir), opts.ExpectReseal)
 	if err != nil {
 		return err
 	}
-	if needed {
+	if needed || opts.Force {
 		rpbcJSON, _ := json.Marshal(rpbc)
 		logger.Debugf("resealing (%d) to recovery boot chains: %s", nextFallbackCount, rpbcJSON)
 
-		if err := resealFallbackObjectKeys(updateState, rpbc, authKeyFile, params.RoleToBlName); err != nil {
+		err := resealFallbackObjectKeys(updateState, rpbc, inputs.signatureDBUpdate, authKeyFile, params.RoleToBlName)
+		if err != nil {
 			return err
 		}
 		logger.Debugf("fallback resealing (%d) succeeded", nextFallbackCount)
@@ -191,7 +237,12 @@ func ResealKeyForBootChains(updateState StateUpdater, method device.SealingMetho
 	return nil
 }
 
-func resealRunObjectKeys(updateState StateUpdater, pbc boot.PredictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
+func resealRunObjectKeys(
+	updateState StateUpdater, pbc boot.PredictableBootChains,
+	sigDBUpdate []byte,
+	authKeyFile string,
+	roleToBlName map[bootloader.Role]string,
+) error {
 	// get model parameters from bootchains
 	modelParams, err := boot.SealKeyModelParams(pbc, roleToBlName)
 	if err != nil {
@@ -203,10 +254,21 @@ func resealRunObjectKeys(updateState StateUpdater, pbc boot.PredictableBootChain
 		return fmt.Errorf("at least one set of model-specific parameters is required")
 	}
 
+	if len(sigDBUpdate) > 0 {
+		logger.Debug("attaching DB update payload")
+		attachSignatureDBUPdate(modelParams, sigDBUpdate)
+	}
+
 	pcrProfile, err := secbootBuildPCRProtectionProfile(modelParams)
 	if err != nil {
 		return err
 	}
+
+	if len(pcrProfile) == 0 {
+		return fmt.Errorf("unexpected length of serialized PCR profile")
+	}
+
+	logger.Debugf("PCR profile length: %v", len(pcrProfile))
 
 	var models []secboot.ModelForSealing
 	for _, m := range modelParams {
@@ -235,7 +297,12 @@ func resealRunObjectKeys(updateState StateUpdater, pbc boot.PredictableBootChain
 	return nil
 }
 
-func resealFallbackObjectKeys(updateState StateUpdater, pbc boot.PredictableBootChains, authKeyFile string, roleToBlName map[bootloader.Role]string) error {
+func resealFallbackObjectKeys(
+	updateState StateUpdater, pbc boot.PredictableBootChains,
+	sigDBUpdate []byte,
+	authKeyFile string,
+	roleToBlName map[bootloader.Role]string,
+) error {
 	// get model parameters from bootchains
 	modelParams, err := boot.SealKeyModelParams(pbc, roleToBlName)
 	if err != nil {
@@ -247,9 +314,18 @@ func resealFallbackObjectKeys(updateState StateUpdater, pbc boot.PredictableBoot
 		return fmt.Errorf("at least one set of model-specific parameters is required")
 	}
 
+	if len(sigDBUpdate) > 0 {
+		logger.Debug("attaching DB update payload for fallback keys")
+		attachSignatureDBUPdate(modelParams, sigDBUpdate)
+	}
+
 	pcrProfile, err := secbootBuildPCRProtectionProfile(modelParams)
 	if err != nil {
 		return err
+	}
+
+	if len(pcrProfile) == 0 {
+		return fmt.Errorf("unexpected length of serialized PCR profile")
 	}
 
 	var models []secboot.ModelForSealing
@@ -282,4 +358,14 @@ func resealFallbackObjectKeys(updateState StateUpdater, pbc boot.PredictableBoot
 	}
 
 	return nil
+}
+
+func attachSignatureDBUPdate(params []*secboot.SealKeyModelParams, update []byte) {
+	if len(update) == 0 {
+		return
+	}
+
+	for _, p := range params {
+		p.EFIForbiddenKeySignatureDBUpdate = update
+	}
 }

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -244,7 +244,7 @@ func resealKeys(
 
 func resealRunObjectKeys(
 	updateState StateUpdater, pbc boot.PredictableBootChains,
-	sigDBUpdate []byte,
+	sigDbxUpdate []byte,
 	authKeyFile string,
 	roleToBlName map[bootloader.Role]string,
 ) error {
@@ -259,9 +259,9 @@ func resealRunObjectKeys(
 		return fmt.Errorf("at least one set of model-specific parameters is required")
 	}
 
-	if len(sigDBUpdate) > 0 {
+	if len(sigDbxUpdate) > 0 {
 		logger.Debug("attaching DB update payload")
-		attachSignatureDBUPdate(modelParams, sigDBUpdate)
+		attachSignatureDbxUpdate(modelParams, sigDbxUpdate)
 	}
 
 	pcrProfile, err := secbootBuildPCRProtectionProfile(modelParams)
@@ -304,7 +304,7 @@ func resealRunObjectKeys(
 
 func resealFallbackObjectKeys(
 	updateState StateUpdater, pbc boot.PredictableBootChains,
-	sigDBUpdate []byte,
+	sigDbxUpdate []byte,
 	authKeyFile string,
 	roleToBlName map[bootloader.Role]string,
 ) error {
@@ -319,9 +319,9 @@ func resealFallbackObjectKeys(
 		return fmt.Errorf("at least one set of model-specific parameters is required")
 	}
 
-	if len(sigDBUpdate) > 0 {
+	if len(sigDbxUpdate) > 0 {
 		logger.Debug("attaching DB update payload for fallback keys")
-		attachSignatureDBUPdate(modelParams, sigDBUpdate)
+		attachSignatureDbxUpdate(modelParams, sigDbxUpdate)
 	}
 
 	pcrProfile, err := secbootBuildPCRProtectionProfile(modelParams)
@@ -365,12 +365,12 @@ func resealFallbackObjectKeys(
 	return nil
 }
 
-func attachSignatureDBUPdate(params []*secboot.SealKeyModelParams, update []byte) {
+func attachSignatureDbxUpdate(params []*secboot.SealKeyModelParams, update []byte) {
 	if len(update) == 0 {
 		return
 	}
 
 	for _, p := range params {
-		p.EFIForbiddenKeySignatureDBUpdate = update
+		p.EFISignatureDbxUpdate = update
 	}
 }

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -150,7 +150,12 @@ func ResealKeysForSignaturesDBUpdate(
 		},
 		resealOptions{
 			ExpectReseal: true,
-			Force:        true,
+			// the boot chains are unchanged, which normally would result in
+			// no-reseal being done, but the content of DBX is being changed,
+			// either being part of the request or it has already been written
+			// to the relevant EFI variables (in which case this is a
+			// post-update reseal)
+			Force: true,
 		})
 }
 

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -1839,7 +1839,10 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 	defer restore()
 
 	updateCalls := 0
-	up := func(role string, containerRole string, bootModes []string, models []secboot.ModelForSealing, tpmPCRProfile []byte) error {
+	up := func(
+		role string, containerRole string, bootModes []string,
+		models []secboot.ModelForSealing, tpmPCRProfile []byte,
+	) error {
 		updateCalls++
 		return nil
 	}
@@ -1851,4 +1854,6 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 	// reseal was called
 	c.Check(buildProfileCalls, Equals, 2)
 	c.Check(resealKeysCalls, Equals, 2)
+	// and the state was updated
+	c.Check(updateCalls, Equals, 2)
 }

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -1820,7 +1820,7 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 
 		c.Assert(modelParams, HasLen, 1)
 		// same DBX update paylad is included for both run and recovery keys
-		c.Assert(modelParams[0].EFIForbiddenKeySignatureDBUpdate, DeepEquals, []byte("dbx-payload"))
+		c.Assert(modelParams[0].EFISignatureDbxUpdate, DeepEquals, []byte("dbx-payload"))
 
 		return []byte(`"serialized-pcr-profile-with-dbx"`), nil
 	})

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -89,6 +89,7 @@ type ModelForSealing interface {
 	SignKeyID() string
 }
 
+// TODO reame to SealKeyParams?
 type SealKeyModelParams struct {
 	// The snap model
 	Model ModelForSealing
@@ -97,6 +98,9 @@ type SealKeyModelParams struct {
 	EFILoadChains []*LoadChain
 	// The kernel command line
 	KernelCmdlines []string
+	// TODO move this somewhere else?
+	// The content of an update to EFI DBX
+	EFIForbiddenKeySignatureDBUpdate []byte
 }
 
 type TPMProvisionMode int

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -89,7 +89,7 @@ type ModelForSealing interface {
 	SignKeyID() string
 }
 
-// TODO reame to SealKeyParams?
+// TODO rename and drop Model from the name?
 type SealKeyModelParams struct {
 	// The snap model
 	Model ModelForSealing
@@ -100,7 +100,7 @@ type SealKeyModelParams struct {
 	KernelCmdlines []string
 	// TODO move this somewhere else?
 	// The content of an update to EFI DBX
-	EFIForbiddenKeySignatureDBUpdate []byte
+	EFISignatureDbxUpdate []byte
 }
 
 type TPMProvisionMode int

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -499,10 +499,10 @@ func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb_tpm2.PCRP
 	for _, mp := range modelParams {
 		var updateDB []*sb_efi.SignatureDBUpdate
 
-		if len(mp.EFIForbiddenKeySignatureDBUpdate) > 0 {
+		if len(mp.EFISignatureDbxUpdate) > 0 {
 			updateDB = append(updateDB, &sb_efi.SignatureDBUpdate{
 				Name: sb_efi.Dbx,
-				Data: mp.EFIForbiddenKeySignatureDBUpdate,
+				Data: mp.EFISignatureDbxUpdate,
 			})
 		}
 

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -497,6 +497,15 @@ func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb_tpm2.PCRP
 	modelPCRProfiles := make([]*sb_tpm2.PCRProtectionProfile, 0, numModels)
 
 	for _, mp := range modelParams {
+		var updateDB []*sb_efi.SignatureDBUpdate
+
+		if len(mp.EFIForbiddenKeySignatureDBUpdate) > 0 {
+			updateDB = append(updateDB, &sb_efi.SignatureDBUpdate{
+				Name: sb_efi.Dbx,
+				Data: mp.EFIForbiddenKeySignatureDBUpdate,
+			})
+		}
+
 		modelProfile := sb_tpm2.NewPCRProtectionProfile()
 
 		loadSequences, err := buildLoadSequences(mp.EFILoadChains)
@@ -510,6 +519,7 @@ func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb_tpm2.PCRP
 			loadSequences,
 			sb_efi.WithSecureBootPolicyProfile(),
 			sb_efi.WithBootManagerCodeProfile(),
+			sb_efi.WithSignatureDBUpdates(updateDB...),
 		); err != nil {
 			return nil, fmt.Errorf("cannot add EFI secure boot and boot manager policy profiles: %v", err)
 		}


### PR DESCRIPTION
A helper in fdestate backend to reseal with DBX update payload.

Cherry picked from #14615 

Related: SNAPDENG-32509 SNAPDENG-34135