### PR TITLE
many: use snap version in components when unspecified in them

### DIFF
--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -373,9 +373,9 @@ func (s *sideloadSuite) TestSideloadComponentForNotInstalledSnap(c *check.C) {
 	})()
 	defer daemon.MockReadComponentInfoFromCont(func(tempPath string, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
 		return &snap.ComponentInfo{
-			Component: naming.NewComponentRef("local", "comp"),
-			Type:      snap.StandardComponent,
-			Version:   "1.0",
+			Component:   naming.NewComponentRef("local", "comp"),
+			Type:        snap.StandardComponent,
+			CompVersion: "1.0",
 		}, nil
 	})()
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1808,7 +1808,6 @@ func (s *snapsSuite) TestMapLocalFieldsWithComponents(c *check.C) {
 	const comp1yaml = `
 component: some-snap+comp-1
 type: standard
-version: 1.0
 `
 	const comp2yaml = `
 component: some-snap+comp-2
@@ -1909,7 +1908,8 @@ components:
 			{Snap: "some-snap", Name: "foo"},
 		},
 		Components: []client.Component{
-			{Name: "comp-1", Type: "standard", Version: "1.0", Revision: snap.R(33),
+			// comp-1 has the snap version as it did not specify a version itself
+			{Name: "comp-1", Type: "standard", Version: "v1.0", Revision: snap.R(33),
 				InstallDate: snap.ComponentInstallDate(cpi, snap.R(7)), InstalledSize: 2},
 			{Name: "comp-2", Type: "standard", Version: "1.0", Revision: snap.R(34),
 				Summary: "summary 2", Description: "description 2",

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -311,7 +311,7 @@ func fillComponentInfo(about aboutSnap) []client.Component {
 		comps = append(comps, client.Component{
 			Name:          comp.Component.ComponentName,
 			Type:          comp.Type,
-			Version:       comp.Version,
+			Version:       comp.Version(about.info.Version),
 			Summary:       comp.Summary,
 			Description:   comp.Description,
 			Revision:      csi.Revision,

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -322,7 +322,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              snap.StandardComponent,
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	})

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -867,7 +867,7 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              componentNameToType(c, csi.Component.ComponentName),
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))
@@ -11187,7 +11187,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeRecordedOnPreDownl
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              "standard",
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))
@@ -14489,7 +14489,7 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              componentNameToType(c, csi.Component.ComponentName),
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))
@@ -14812,7 +14812,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              componentNameToType(c, csi.Component.ComponentName),
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))
@@ -15287,7 +15287,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              componentNameToType(c, csi.Component.ComponentName),
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))
@@ -15960,7 +15960,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, inst
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              componentNameToType(c, csi.Component.ComponentName),
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))
@@ -16419,7 +16419,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
 			Type:              compNameToType(csi.Component.ComponentName),
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))

--- a/overlord/snapstate/target_test.go
+++ b/overlord/snapstate/target_test.go
@@ -706,7 +706,7 @@ func (s *targetTestSuite) TestUpdateComponents(c *C) {
 		return &snap.ComponentInfo{
 			Component:         naming.NewComponentRef(info.SnapName(), compName),
 			Type:              snap.StandardComponent,
-			Version:           "1.0",
+			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
 	}))

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -215,7 +215,7 @@ func (tr *tree16) componentPath(sn *SeedSnap, sc *SeedComponent) (string, error)
 	return "", errors.New("components not supported on UC16")
 }
 
-func (tr *tree16) localComponentPath(sc *SeedComponent) (string, error) {
+func (tr *tree16) localComponentPath(*SeedComponent, string) (string, error) {
 	return "", errors.New("components not supported on UC16")
 }
 

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -258,13 +258,13 @@ func (tr *tree20) localSnapPath(sn *SeedSnap) (string, error) {
 	return filepath.Join(sysSnapsDir, fmt.Sprintf("%s_%s.snap", sn.SnapName(), sn.Info.Version)), nil
 }
 
-func (tr *tree20) localComponentPath(sc *SeedComponent) (string, error) {
+func (tr *tree20) localComponentPath(sc *SeedComponent, snapVersion string) (string, error) {
 	sysSnapsDir, err := tr.ensureSystemSnapsDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(sysSnapsDir, fmt.Sprintf("%s_%s.comp",
-		sc.ComponentRef.String(), sc.Info.Version)), nil
+		sc.ComponentRef.String(), sc.Info.Version(snapVersion))), nil
 }
 
 func (tr *tree20) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -290,7 +290,7 @@ type tree interface {
 	componentPath(*SeedSnap, *SeedComponent) (string, error)
 
 	localSnapPath(*SeedSnap) (string, error)
-	localComponentPath(*SeedComponent) (string, error)
+	localComponentPath(*SeedComponent, string) (string, error)
 
 	writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error
 
@@ -1606,11 +1606,11 @@ func (w *Writer) SeedSnaps(copySnap func(name, src, dst string) error) error {
 				}
 			} else {
 				var snapPath func(*SeedSnap) (string, error)
-				var compPath func(*SeedComponent) (string, error)
+				var compPath func(*SeedComponent, string) (string, error)
 				if sn.Info.ID() != "" {
 					// actually asserted
 					snapPath = w.tree.snapPath
-					compPath = func(sc *SeedComponent) (string, error) {
+					compPath = func(sc *SeedComponent, snapVersion string) (string, error) {
 						return w.tree.componentPath(sn, sc)
 					}
 				} else {
@@ -1627,7 +1627,7 @@ func (w *Writer) SeedSnaps(copySnap func(name, src, dst string) error) error {
 				}
 				// copy components
 				for i, comp := range sn.Components {
-					compDst, err := compPath(&comp)
+					compDst, err := compPath(&comp, sn.Info.Version)
 					if err != nil {
 						return err
 					}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -3033,10 +3033,10 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 		seedComps := map[string]*seedwriter.SeedComponent{}
 		if withComps {
 			cref1 := naming.NewComponentRef("required20", "comp1")
-			cinfo1 := snap.NewComponentInfo(cref1, snap.StandardComponent, "1.0", "", "", "", nil)
+			cinfo1 := snap.NewComponentInfo(cref1, snap.StandardComponent, "1.5", "", "", "", nil)
 			pathComp1 = s.makeLocalComponent(c, "required20+comp1")
 			cref2 := naming.NewComponentRef("required20", "comp2")
-			cinfo2 := snap.NewComponentInfo(cref2, snap.StandardComponent, "2.0", "", "", "", nil)
+			cinfo2 := snap.NewComponentInfo(cref2, snap.StandardComponent, "", "", "", "", nil)
 			pathComp2 = s.makeLocalComponent(c, "required20+comp2")
 			seedComps["comp1"] = &seedwriter.SeedComponent{
 				ComponentRef: cref1,
@@ -3097,8 +3097,10 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 	// local unasserted snap/component were put in system snaps dir
 	c.Check(filepath.Join(systemDir, "snaps", "required20_1.0.snap"), testutil.FilePresent)
 	if withComps {
-		c.Check(filepath.Join(systemDir, "snaps", "required20+comp1_1.0.comp"), testutil.FilePresent)
-		c.Check(filepath.Join(systemDir, "snaps", "required20+comp2_2.0.comp"), testutil.FilePresent)
+		c.Check(filepath.Join(systemDir, "snaps", "required20+comp1_1.5.comp"), testutil.FilePresent)
+		// Note that the component version is here the one for the snap
+		// as it was not specified in the component itself.
+		c.Check(filepath.Join(systemDir, "snaps", "required20+comp2_1.0.comp"), testutil.FilePresent)
 	}
 
 	options20, err := seedwriter.InternalReadOptions20(filepath.Join(systemDir, "options.yaml"))
@@ -3109,11 +3111,11 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 		compOpts = []internal.Component20{
 			{
 				Name:       "comp1",
-				Unasserted: "required20+comp1_1.0.comp",
+				Unasserted: "required20+comp1_1.5.comp",
 			},
 			{
 				Name:       "comp2",
-				Unasserted: "required20+comp2_2.0.comp",
+				Unasserted: "required20+comp2_1.0.comp",
 			},
 		}
 	}

--- a/snap/component.go
+++ b/snap/component.go
@@ -32,12 +32,13 @@ import (
 
 // ComponentInfo contains information about a snap component.
 type ComponentInfo struct {
-	Component           naming.ComponentRef `yaml:"component"`
-	Type                ComponentType       `yaml:"type"`
-	Version             string              `yaml:"version"`
-	Summary             string              `yaml:"summary"`
-	Description         string              `yaml:"description"`
-	ComponentProvenance string              `yaml:"provenance,omitempty"`
+	Component naming.ComponentRef `yaml:"component"`
+	Type      ComponentType       `yaml:"type"`
+	// CompVersion should be used only in tests
+	CompVersion         string `yaml:"version"`
+	Summary             string `yaml:"summary"`
+	Description         string `yaml:"description"`
+	ComponentProvenance string `yaml:"provenance,omitempty"`
 
 	// Hooks contains information about implicit and explicit hooks that this
 	// component has. This information is derived from a combination on the
@@ -61,6 +62,13 @@ func (ci *ComponentInfo) Provenance() string {
 	return ci.ComponentProvenance
 }
 
+func (ci *ComponentInfo) Version(snapVersion string) string {
+	if ci.CompVersion == "" {
+		return snapVersion
+	}
+	return ci.CompVersion
+}
+
 // NewComponentInfo creates a new ComponentInfo.
 func NewComponentInfo(cref naming.ComponentRef, ctype ComponentType, version, summary, description, provenance string, csi *ComponentSideInfo) *ComponentInfo {
 	if csi == nil {
@@ -70,7 +78,7 @@ func NewComponentInfo(cref naming.ComponentRef, ctype ComponentType, version, su
 	return &ComponentInfo{
 		Component:           cref,
 		Type:                ctype,
-		Version:             version,
+		CompVersion:         version,
 		Summary:             summary,
 		Description:         description,
 		ComponentProvenance: provenance,
@@ -340,8 +348,8 @@ func (ci *ComponentInfo) validate() error {
 		return fmt.Errorf("component type cannot be empty")
 	}
 	// version is optional
-	if ci.Version != "" {
-		if err := ValidateVersion(ci.Version); err != nil {
+	if ci.CompVersion != "" {
+		if err := ValidateVersion(ci.CompVersion); err != nil {
 			return err
 		}
 	}

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -89,6 +89,28 @@ provenance: prov
 func (s *componentSuite) TestReadComponentInfoMinimal(c *C) {
 	const componentYaml = `component: mysnap+test-info
 type: standard
+`
+	compName := "mysnap+test-info"
+	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(ci, DeepEquals, snap.NewComponentInfo(
+		naming.NewComponentRef("mysnap", "test-info"),
+		snap.ComponentType("standard"),
+		"", "", "", "", nil,
+	))
+	c.Assert(ci.FullName(), Equals, compName)
+	c.Check(ci.Version("2.0"), Equals, "2.0")
+	c.Assert(ci.Provenance(), Equals, naming.DefaultProvenance)
+}
+
+func (s *componentSuite) TestReadComponentInfoWithVersion(c *C) {
+	const componentYaml = `component: mysnap+test-info
+type: standard
 version: 1.0.2
 `
 	compName := "mysnap+test-info"
@@ -106,6 +128,7 @@ version: 1.0.2
 		"", "", "", nil,
 	))
 	c.Assert(ci.FullName(), Equals, compName)
+	c.Check(ci.Version("2.0"), Equals, "1.0.2")
 	c.Assert(ci.Provenance(), Equals, naming.DefaultProvenance)
 }
 
@@ -241,7 +264,7 @@ version: %s
 			c.Check(ci, IsNil)
 		} else {
 			c.Check(err, IsNil)
-			c.Check(ci.Version, Equals, tc.version)
+			c.Check(ci.Version(""), Equals, tc.version)
 		}
 	}
 }
@@ -400,7 +423,7 @@ plugs:
 	c.Check(ci.Component.ComponentName, Equals, "component")
 	c.Check(ci.Component.SnapName, Equals, "snap")
 	c.Check(ci.Type, Equals, ctype)
-	c.Check(ci.Version, Equals, "1.0")
+	c.Check(ci.Version(""), Equals, "1.0")
 	c.Check(ci.Summary, Equals, "short description")
 	c.Check(ci.Description, Equals, "long description")
 	c.Check(ci.FullName(), Equals, compName)
@@ -475,7 +498,7 @@ plugs:
 	c.Check(ci.Component.ComponentName, Equals, "component")
 	c.Check(ci.Component.SnapName, Equals, "snap")
 	c.Check(ci.Type, Equals, snap.StandardComponent)
-	c.Check(ci.Version, Equals, "1.0")
+	c.Check(ci.Version(""), Equals, "1.0")
 	c.Check(ci.Summary, Equals, "short description")
 	c.Check(ci.Description, Equals, "long description")
 	c.Check(ci.FullName(), Equals, compName)

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -295,8 +295,16 @@ func mksquashfs(sourceDir, fName, snapType string, opts *Options) error {
 
 func componentPath(ci *snap.ComponentInfo, targetDir, compName string) string {
 	if compName == "" {
+		// Note that here we do not know the version of the snap, so if
+		// there is no version in component.yaml we will get names like
+		// "<snap>+<comap>_.comp"
 		// TODO should we consider architecture as with snaps?
-		compName = fmt.Sprintf("%s_%s.comp", ci.FullName(), ci.Version)
+		compVersion := ci.Version("")
+		if compVersion == "" {
+			compName = fmt.Sprintf("%s.comp", ci.FullName())
+		} else {
+			compName = fmt.Sprintf("%s_%s.comp", ci.FullName(), compVersion)
+		}
 	}
 	if targetDir != "" && !filepath.IsAbs(compName) {
 		compName = filepath.Join(targetDir, compName)

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -423,6 +423,26 @@ provenance: prov
 	c.Assert(string(output), Matches, expr)
 }
 
+func (s *packSuite) TestPackComponentNoVersion(c *C) {
+	sourceDir := makeExampleComponentSourceDir(c, `component: hello+test
+type: standard
+`)
+
+	result, err := pack.Pack(sourceDir, nil)
+	c.Assert(err, IsNil)
+
+	// check that there is result
+	_, err = os.Stat(result)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, "hello+test.comp")
+
+	// check that the content looks sane
+	output, err := exec.Command("unsquashfs", "-ll", result).CombinedOutput()
+	c.Assert(err, IsNil)
+	expr := fmt.Sprintf(`(?ms).*%s.*`, regexp.QuoteMeta("meta/component.yaml"))
+	c.Assert(string(output), Matches, expr)
+}
+
 func (s *packSuite) TestPackSimple(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
 version: 1.0.1

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -88,7 +88,7 @@ func componentEnv(info *snap.Info, component *snap.ComponentInfo) osutil.Environ
 			component.Revision.String(),
 		),
 		"SNAP_COMPONENT_NAME":     component.FullName(),
-		"SNAP_COMPONENT_VERSION":  component.Version,
+		"SNAP_COMPONENT_VERSION":  component.Version(info.Version),
 		"SNAP_COMPONENT_REVISION": component.Revision.String(),
 	}
 

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -67,7 +67,16 @@ var mockComponentInfo = &snap.ComponentInfo{
 		SnapName:      "foo",
 		ComponentName: "comp",
 	},
-	Version: "1.0",
+	CompVersion: "1.1",
+	ComponentSideInfo: snap.ComponentSideInfo{
+		Revision: snap.R(5),
+	},
+}
+var mockComponentInfoNoVersion = &snap.ComponentInfo{
+	Component: naming.ComponentRef{
+		SnapName:      "foo",
+		ComponentName: "comp",
+	},
 	ComponentSideInfo: snap.ComponentSideInfo{
 		Revision: snap.R(5),
 	},
@@ -325,11 +334,7 @@ func (s *HTestSuite) TestExtendEnvForRunForClassic(c *C) {
 	c.Assert(env["TMPDIR"], Equals, "/var/tmp")
 }
 
-func (s *HTestSuite) TestExtendEnvForRunWithComponent(c *C) {
-	env := osutil.Environment{"TMPDIR": "/var/tmp"}
-
-	ExtendEnvForRun(env, mockSnapInfo, mockComponentInfo, nil)
-
+func checkEnvWithComp(c *C, env osutil.Environment, compVersion string) {
 	c.Assert(env["SNAP_NAME"], Equals, "foo")
 	c.Assert(env["SNAP_COMMON"], Equals, "/var/snap/foo/common")
 	c.Assert(env["SNAP_DATA"], Equals, "/var/snap/foo/17")
@@ -338,8 +343,25 @@ func (s *HTestSuite) TestExtendEnvForRunWithComponent(c *C) {
 
 	c.Assert(env["SNAP_COMPONENT"], Equals, filepath.Join(dirs.CoreSnapMountDir, "foo/components/mnt/comp/5"))
 	c.Assert(env["SNAP_COMPONENT_REVISION"], Equals, "5")
-	c.Assert(env["SNAP_COMPONENT_VERSION"], Equals, "1.0")
+	c.Assert(env["SNAP_COMPONENT_VERSION"], Equals, compVersion)
 	c.Assert(env["SNAP_COMPONENT_NAME"], Equals, "foo+comp")
+}
+
+func (s *HTestSuite) TestExtendEnvForRunWithComponent(c *C) {
+	env := osutil.Environment{"TMPDIR": "/var/tmp"}
+
+	ExtendEnvForRun(env, mockSnapInfo, mockComponentInfo, nil)
+	compVersion := "1.1"
+	checkEnvWithComp(c, env, compVersion)
+}
+
+func (s *HTestSuite) TestExtendEnvForRunWithComponentNoVersion(c *C) {
+	env := osutil.Environment{"TMPDIR": "/var/tmp"}
+
+	ExtendEnvForRun(env, mockSnapInfo, mockComponentInfoNoVersion, nil)
+	// Same as snap in this case
+	compVersion := "1.0"
+	checkEnvWithComp(c, env, compVersion)
 }
 
 func (s *HTestSuite) TestHiddenDirEnv(c *C) {

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -583,14 +583,7 @@ func (tsto *ToolingStore) componentDownload(targetFn string, snapName string, sr
 
 	return &DownloadedComponent{
 		Path: targetFn,
-		Info: &snap.ComponentInfo{
-			Component: cref,
-			Type:      ctyp,
-			Version:   srr.Version,
-			ComponentSideInfo: snap.ComponentSideInfo{
-				Component: cref,
-				Revision:  snap.R(srr.Revision),
-			},
-		},
+		Info: snap.NewComponentInfo(cref, ctyp, srr.Version,
+			"", "", "", snap.NewComponentSideInfo(cref, snap.R(srr.Revision))),
 	}, nil
 }


### PR DESCRIPTION
If there is no version filed in the component metadata, use the snap version as component version too.