### PR TITLE
many: complete various component cross-checks

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -138,7 +138,7 @@ func CrossCheck(instanceName, snapSHA3_384, provenance string, snapSize uint64, 
 // provenance, and metadata of a snap resource with the relevant assertions
 // (snap-resource-revision and snap-resource-pair) in a database that should be
 // pre-populated with them.
-func CrossCheckResource(name, hash, provenance string, size uint64, csi *snap.ComponentSideInfo, si *snap.SideInfo, model *asserts.Model, db Finder) error {
+func CrossCheckResource(name, hash, provenance string, size uint64, csi *snap.ComponentSideInfo, si *snap.SideInfo, model *asserts.Model, db Finder) (*asserts.SnapResourceRevision, error) {
 	headers := map[string]string{
 		"resource-sha3-384": hash,
 		"resource-name":     name,
@@ -154,20 +154,20 @@ func CrossCheckResource(name, hash, provenance string, size uint64, csi *snap.Co
 		if provenance != "" {
 			provInf = fmt.Sprintf(" provenance: %s", provenance)
 		}
-		return fmt.Errorf("internal error: cannot find pre-populated snap-resource-revision assertion for %q: %s%s", name, hash, provInf)
+		return nil, fmt.Errorf("internal error: cannot find pre-populated snap-resource-revision assertion for %q: %s%s", name, hash, provInf)
 	}
 
 	resrev := a.(*asserts.SnapResourceRevision)
 
 	if resrev.ResourceSize() != size {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"resource %q file does not have expected size according to signatures (download is broken or tampered): %d != %d",
 			name, size, resrev.ResourceSize(),
 		)
 	}
 
 	if resrev.ResourceRevision() != csi.Revision.N {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"resource %q does not have expected revision according to assertions (metadata is broken or tampered): %s != %d",
 			name, csi.Revision, resrev.ResourceRevision(),
 		)
@@ -178,21 +178,21 @@ func CrossCheckResource(name, hash, provenance string, size uint64, csi *snap.Co
 	// it exists
 	_, err = findResourcePair(name, si.SnapID, csi.Revision.N, si.Revision.N, provenance, db)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if provenance != "" {
 		snapDecl, err := findSnapDeclaration(si.SnapID, si.RealName, db)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := crossCheckResourceProvenance(resrev, snapDecl, model, db); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return resrev, nil
 }
 
 // crossCheckResourceProvenance tries to cross check the given

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -215,14 +215,10 @@ func doValidateComponent(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	db := DB(st)
-	err = snapasserts.CrossCheckResource(compsup.ComponentName(), sha3_384, expectedProv, compSize, compsup.CompSideInfo, snapsup.SideInfo, modelAs, db)
+	resRev, err := snapasserts.CrossCheckResource(compsup.ComponentName(), sha3_384, expectedProv, compSize, compsup.CompSideInfo, snapsup.SideInfo, modelAs, db)
 	if err != nil {
 		return err
 	}
 
-	// TODO:COMPS: check the provenance stored inside the component blob against
-	// what we expect from the assertion (similar to
-	// snapasserts.CheckProvenanceWithVerifiedRevision)
-
-	return nil
+	return snapasserts.CheckComponentProvenanceWithVerifiedRevision(compsup.CompPath, resRev)
 }

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -764,7 +764,7 @@ func (s *seed20Suite) TestLoadMetaCore20DelegatedSnap(c *C) {
 		"provenance": []interface{}{"delegated-prov"},
 		"on-store":   []interface{}{"my-brand-store"},
 	}
-	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", ra, s.StoreSigning.Database)
+	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
 	s.setSnapContact("required20", "mailto:author@example.com")
 
@@ -869,7 +869,7 @@ func (s *seed20Suite) TestLoadMetaCore20DelegatedSnapProvenanceMismatch(c *C) {
 		"provenance": []interface{}{"delegated-prov"},
 		"on-store":   []interface{}{"my-brand-store"},
 	}
-	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov-other\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", ra, s.StoreSigning.Database)
+	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov-other\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
 	sysLabel := "20220705"
 	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
@@ -918,7 +918,7 @@ func (s *seed20Suite) TestLoadMetaCore20DelegatedSnapDeviceMismatch(c *C) {
 		"provenance": []interface{}{"delegated-prov"},
 		"on-model":   []interface{}{"my-brand/my-other-model"},
 	}
-	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", ra, s.StoreSigning.Database)
+	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
 	sysLabel := "20220705"
 	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
@@ -4387,7 +4387,8 @@ func (s *seed20Suite) TestModeSnaps(c *C) {
 }
 
 type seedOpts struct {
-	delegated bool
+	delegated                  bool
+	defaultComponentProvenance bool
 }
 
 func (s *seed20Suite) makeCore20SeedWithComps(c *C, sysLabel string, opts seedOpts) string {
@@ -4404,10 +4405,16 @@ func (s *seed20Suite) makeCore20SeedWithComps(c *C, sysLabel string, opts seedOp
 			"account-id": "my-brand",
 			"provenance": []interface{}{"delegated-prov", "other-prov"},
 		}
+
+		resourceProv := "delegated-prov"
+		if opts.defaultComponentProvenance {
+			resourceProv = ""
+		}
+
 		s.MakeAssertedDelegatedSnapWithComps(c,
 			snapYaml["required20"]+"\nprovenance: delegated-prov\n",
 			nil, snap.R(1), compRevs, "developerid", "my-brand",
-			"delegated-prov", ra, s.StoreSigning.Database)
+			"delegated-prov", resourceProv, ra, s.StoreSigning.Database)
 	} else {
 		s.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["required20"], nil,
 			snap.R(11), compRevs, "canonical", s.StoreSigning.Database)
@@ -4798,7 +4805,10 @@ func (s *seed20Suite) TestLoadMetaWithComponentsUnmatchedProvenanceInMetadata(c 
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
 
 	sysLabel := "20240805"
-	s.makeCore20SeedWithComps(c, sysLabel, seedOpts{delegated: true})
+	s.makeCore20SeedWithComps(c, sysLabel, seedOpts{
+		delegated:                  true,
+		defaultComponentProvenance: true,
+	})
 
 	seed20, err := seed.Open(s.SeedDir, sysLabel)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This adds some cross-checks that were missing for components. Testing this was a bit messy unfortunately.