### PR TITLE
i/p/requestrules,o/i/apparmorprompting: move request matching logic into requestrules

### DIFF
--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -21,6 +21,8 @@ package requestrules
 
 import (
 	"time"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 var JoinInternalErrors = joinInternalErrors
@@ -29,4 +31,12 @@ type RulesDBJSON rulesDBJSON
 
 func (rule *Rule) Validate(currTime time.Time) (expired bool, err error) {
 	return rule.validate(currTime)
+}
+
+func (rdb *RuleDB) IsPathPermAllowed(user uint32, snap string, iface string, path string, permission string) (bool, error) {
+	return rdb.isPathPermAllowed(user, snap, iface, path, permission)
+}
+
+func MockIsPathPermAllowed(f func(rdb *RuleDB, user uint32, snap string, iface string, path string, permission string) (bool, error)) func() {
+	return testutil.Mock(&isPathPermAllowedByRuleDB, f)
 }


### PR DESCRIPTION
This PR builds on #14865, only the final commit is relevant to this PR.

Move the logic which iterates through requested permissions into the requestrules package, instead of the o/i/apparmorprompting package. 

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-31370