### PR TITLE
boot, boottest: move helpers to boottest, allow mocking seed functions

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -91,18 +91,6 @@ func (s *baseBootenvSuite) mockCmdline(c *C, cmdline string) {
 	c.Assert(os.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
 }
 
-// mockAssetsCache mocks the listed assets in the boot assets cache by creating
-// an empty file for each.
-func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets []string) {
-	p := filepath.Join(dirs.SnapBootAssetsDirUnder(rootdir), bootloaderName)
-	err := os.MkdirAll(p, 0755)
-	c.Assert(err, IsNil)
-	for _, cachedAsset := range cachedAssets {
-		err = os.WriteFile(filepath.Join(p, cachedAsset), nil, 0644)
-		c.Assert(err, IsNil)
-	}
-}
-
 type bootenvSuite struct {
 	baseBootenvSuite
 
@@ -1080,7 +1068,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -1201,7 +1189,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -1320,7 +1308,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -1417,7 +1405,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -2016,7 +2004,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -2226,7 +2214,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"shim-recoveryshimhash",
 		"shim-" + shimHash,
 		"asset-assethash",
@@ -2392,7 +2380,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"shim-" + shimHash,
 		"asset-" + dataHash,
 	})
@@ -2414,7 +2402,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
+		return uc20Model, []*seed.Snap{boottest.MockNamedKernelSeedSnap(snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2505,7 +2493,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"shim-" + shimHash,
 		"asset-" + dataHash,
 	})
@@ -2527,7 +2515,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	uc20Model := boottest.MakeMockUC20Model()
 
 	restore := boot.MockSeedReadSystemEssential(func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error) {
-		return uc20Model, []*seed.Snap{mockNamedKernelSeedSnap(snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
+		return uc20Model, []*seed.Snap{boottest.MockNamedKernelSeedSnap(snap.R(1), "pc-kernel-recovery"), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
 
@@ -2609,7 +2597,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/asset"), data, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/asset"), data, 0644), IsNil)
 	// mock some state in the cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-one",
 		"asset-two",
 	})
@@ -2665,7 +2653,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 
 func (s *bootenv20Suite) setupMarkBootSuccessful20CommandLine(c *C, model *asserts.Model, mode string, cmdlines boot.BootCommandLines) *boot.Modeenv {
 	// mock some state in the cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-one",
 	})
 	// a pending kernel command line change
@@ -3214,7 +3202,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyWithReseal(c *C, cmdlineAppen
 
 	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-hash-1",
 	})
 
@@ -3439,7 +3427,7 @@ volumes:
 
 	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-hash-1",
 	})
 
@@ -3597,7 +3585,7 @@ func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 	s.uc20dev = boottest.MockUC20Device("", boottest.MakeMockUC20Model(nil))
 	s.runKernelBf = bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	s.recoveryKernelBf = bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -4596,7 +4584,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -4707,7 +4695,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNew
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -4817,7 +4805,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -4914,7 +4902,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSam
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 
@@ -5082,7 +5070,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 	// mock the files in cache
-	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+	boottest.MockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
 	})
 	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/secboot"
@@ -1067,13 +1068,13 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainWithAlternativeChains(c *C) {
 	}
 
 	// mock relevant files in cache
-	mockAssetsCache(c, s.rootDir, "recovery-bl", []string{
+	boottest.MockAssetsCache(c, s.rootDir, "recovery-bl", []string{
 		"shim-hash0",
 		"shim-hash1",
 		"loader-recovery-hash0",
 		"loader-recovery-hash1",
 	})
-	mockAssetsCache(c, s.rootDir, "run-bl", []string{
+	boottest.MockAssetsCache(c, s.rootDir, "run-bl", []string{
 		"loader-run-hash0",
 		"loader-run-hash1",
 	})

--- a/boot/boottest/fde.go
+++ b/boot/boottest/fde.go
@@ -1,0 +1,75 @@
+package boottest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+// MockAssetsCache mocks the listed assets in the boot assets cache by creating
+// an empty file for each.
+func MockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets []string) {
+	p := filepath.Join(dirs.SnapBootAssetsDirUnder(rootdir), bootloaderName)
+	err := os.MkdirAll(p, 0755)
+	c.Assert(err, IsNil)
+	for _, cachedAsset := range cachedAssets {
+		err = os.WriteFile(filepath.Join(p, cachedAsset), nil, 0644)
+		c.Assert(err, IsNil)
+	}
+}
+
+// MockNamedKernelSeedSnap creates a seed snap representation for a kernel snap
+// with a given name and revision.
+func MockNamedKernelSeedSnap(rev snap.Revision, name string) *seed.Snap {
+	revAsString := rev.String()
+	if rev.Unset() {
+		revAsString = "unset"
+	}
+	return &seed.Snap{
+		Path: fmt.Sprintf("/var/lib/snapd/seed/snaps/%v_%v.snap", name, revAsString),
+		SideInfo: &snap.SideInfo{
+			RealName: name,
+			Revision: rev,
+		},
+		EssentialType: snap.TypeKernel,
+	}
+}
+
+// MockGadgetSeedSnap creates a seed snap representation of a gadget snap with
+// given snap.yaml and a list of files. If gadget.yaml is not provided in the
+// file list, a mock one, referencing the grub bootloader, is added
+// automatically.
+func MockGadgetSeedSnap(c *C, snapYaml string, files [][]string) *seed.Snap {
+	mockGadgetYaml := `
+volumes:
+  volumename:
+    bootloader: grub
+`
+
+	hasGadgetYaml := false
+	for _, entry := range files {
+		if entry[0] == "meta/gadget.yaml" {
+			hasGadgetYaml = true
+		}
+	}
+	if !hasGadgetYaml {
+		files = append(files, []string{"meta/gadget.yaml", mockGadgetYaml})
+	}
+
+	gadgetSnapFile := snaptest.MakeTestSnapWithFiles(c, snapYaml, files)
+	return &seed.Snap{
+		Path: gadgetSnapFile,
+		SideInfo: &snap.SideInfo{
+			RealName: "gadget",
+			Revision: snap.R(1),
+		},
+		EssentialType: snap.TypeGadget,
+	}
+}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -27,10 +27,8 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
-	"github.com/snapcore/snapd/timings"
 )
 
 func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type, dev snap.Device) *coreBootParticipant {
@@ -108,14 +106,6 @@ func (o *trustedAssetsInstallObserverImpl) CurrentDataBootstrappedContainer() se
 
 func (o *trustedAssetsInstallObserverImpl) CurrentSaveBootstrappedContainer() secboot.BootstrappedContainer {
 	return o.saveBootstrappedContainer
-}
-
-func MockSeedReadSystemEssential(f func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error)) (restore func()) {
-	old := seedReadSystemEssential
-	seedReadSystemEssential = f
-	return func() {
-		seedReadSystemEssential = old
-	}
 }
 
 func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash string, recovery bool) {

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -131,7 +131,7 @@ func (s *modelSuite) SetUpTest(c *C) {
 	}
 	c.Assert(modeenv.WriteTo(""), IsNil)
 
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -45,6 +45,15 @@ var (
 	seedReadSystemEssential = seed.ReadSystemEssential
 )
 
+func MockSeedReadSystemEssential(f func(seedDir, label string, essentialTypes []snap.Type, tm timings.Measurer) (*asserts.Model, []*seed.Snap, error)) (restore func()) {
+	osutil.MustBeTestBinary("cannot mock seedReadSystemEssential in a non-test binary")
+	old := seedReadSystemEssential
+	seedReadSystemEssential = f
+	return func() {
+		seedReadSystemEssential = old
+	}
+}
+
 // Hook functions setup by devicestate to support device-specific full
 // disk encryption implementations. The state must be locked when these
 // functions are called.

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -67,50 +66,11 @@ func (s *sealSuite) SetUpTest(c *C) {
 }
 
 func mockKernelSeedSnap(rev snap.Revision) *seed.Snap {
-	return mockNamedKernelSeedSnap(rev, "pc-kernel")
-}
-
-func mockNamedKernelSeedSnap(rev snap.Revision, name string) *seed.Snap {
-	revAsString := rev.String()
-	if rev.Unset() {
-		revAsString = "unset"
-	}
-	return &seed.Snap{
-		Path: fmt.Sprintf("/var/lib/snapd/seed/snaps/%v_%v.snap", name, revAsString),
-		SideInfo: &snap.SideInfo{
-			RealName: name,
-			Revision: rev,
-		},
-		EssentialType: snap.TypeKernel,
-	}
+	return boottest.MockNamedKernelSeedSnap(rev, "pc-kernel")
 }
 
 func mockGadgetSeedSnap(c *C, files [][]string) *seed.Snap {
-	mockGadgetYaml := `
-volumes:
-  volumename:
-    bootloader: grub
-`
-
-	hasGadgetYaml := false
-	for _, entry := range files {
-		if entry[0] == "meta/gadget.yaml" {
-			hasGadgetYaml = true
-		}
-	}
-	if !hasGadgetYaml {
-		files = append(files, []string{"meta/gadget.yaml", mockGadgetYaml})
-	}
-
-	gadgetSnapFile := snaptest.MakeTestSnapWithFiles(c, gadgetSnapYaml, files)
-	return &seed.Snap{
-		Path: gadgetSnapFile,
-		SideInfo: &snap.SideInfo{
-			RealName: "gadget",
-			Revision: snap.R(1),
-		},
-		EssentialType: snap.TypeGadget,
-	}
+	return boottest.MockGadgetSeedSnap(c, gadgetSnapYaml, files)
 }
 
 func (s *sealSuite) TestSealKeyToModeenv(c *C) {
@@ -189,7 +149,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		}
 
 		// mock asset cache
-		mockAssetsCache(c, rootdir, "grub", []string{
+		boottest.MockAssetsCache(c, rootdir, "grub", []string{
 			fmt.Sprintf("%s-shim-hash-1", shimId),
 			fmt.Sprintf("%s-grub-hash-1", grubId),
 			fmt.Sprintf("%s-run-grub-hash-1", runGrubId),
@@ -1438,7 +1398,7 @@ func (s *sealSuite) TestSealKeyModelParams(c *C) {
 		bootloader.RoleRunMode:  "grub",
 	}
 	// mock asset cache
-	mockAssetsCache(c, rootdir, "grub", []string{
+	boottest.MockAssetsCache(c, rootdir, "grub", []string{
 		"shim-shim-hash",
 		"loader-loader-hash1",
 		"loader-loader-hash2",
@@ -2161,7 +2121,7 @@ func (s *sealSuite) TestWithBootChains(c *C) {
 	c.Assert(err, IsNil)
 
 	// mock asset cache
-	mockAssetsCache(c, rootdir, "grub", []string{
+	boottest.MockAssetsCache(c, rootdir, "grub", []string{
 		"run-grub-hash",
 		"grub-hash",
 		"shim-hash",

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -61,7 +61,7 @@ type systemsSuite struct {
 var _ = Suite(&systemsSuite{})
 
 func (s *systemsSuite) mockTrustedBootloaderWithAssetAndChains(c *C, runKernelBf, recoveryKernelBf bootloader.BootFile) *bootloadertest.MockTrustedAssetsBootloader {
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -102,7 +102,7 @@ func (s *systemsSuite) SetUpTest(c *C) {
 }
 
 func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -220,7 +220,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemEncrypted(c *C) {
 }
 
 func (s *systemsSuite) TestSetTryRecoverySystemRemodelEncrypted(c *C) {
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -455,7 +455,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemSetBootVarsErr(c *C) {
 }
 
 func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorBeforeReseal(c *C) {
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -558,7 +558,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorBeforeReseal(c *C) 
 }
 
 func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -673,7 +673,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemCleanupOnErrorAfterReseal(c *C) {
 }
 
 func (s *systemsSuite) TestSetTryRecoverySystemCleanupError(c *C) {
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -928,7 +928,7 @@ type clearRecoverySystemTestCase struct {
 }
 
 func (s *systemsSuite) testClearRecoverySystem(c *C, mtbl *bootloadertest.MockTrustedAssetsBootloader, tc clearRecoverySystemTestCase) {
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -1193,7 +1193,7 @@ func (s *systemsSuite) TestClearRecoverySystemReboot(c *C) {
 	err := mtbl.SetBootVars(setVars)
 	c.Assert(err, IsNil)
 
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -1315,7 +1315,7 @@ type recoverySystemGoodTestCase struct {
 
 func (s *systemsSuite) testPromoteTriedRecoverySystem(c *C, systemLabel string, tc recoverySystemGoodTestCase) {
 	mtbl := s.mockTrustedBootloaderWithAssetAndChains(c, s.runKernelBf, s.recoveryKernelBf)
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 
@@ -1579,7 +1579,7 @@ type recoverySystemDropTestCase struct {
 
 func (s *systemsSuite) testDropRecoverySystem(c *C, systemLabel string, tc recoverySystemDropTestCase) {
 	mtbl := s.mockTrustedBootloaderWithAssetAndChains(c, s.runKernelBf, s.recoveryKernelBf)
-	mockAssetsCache(c, s.rootdir, "trusted", []string{
+	boottest.MockAssetsCache(c, s.rootdir, "trusted", []string{
 		"asset-asset-hash-1",
 	})
 


### PR DESCRIPTION
Based on #14625. Move some test helpers into boot/boottest so that they can be reused in unit tests of other packages. Allow mocking seed.ReadSystemEssential in boot package in unit tests.

Related: SNAPDENG-32509