### PR TITLE
o/snapstate: move the reboot part of Backend.LinkSnap to a new method

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -79,11 +79,12 @@ type managerBackend interface {
 	SetupKernelModulesComponents(currentComps, finalComps []*snap.ComponentSideInfo, ksnapName string, ksnapRev snap.Revision, meter progress.Meter) (err error)
 	CopySnapData(newSnap, oldSnap *snap.Info, opts *dirs.SnapDirOptions, meter progress.Meter) error
 	SetupSnapSaveData(info *snap.Info, dev snap.Device, meter progress.Meter) error
-	LinkSnap(info *snap.Info, dev snap.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootInfo boot.RebootInfo, err error)
+	LinkSnap(info *snap.Info, dev snap.Device, linkCtx backend.LinkContext, tm timings.Measurer) error
 	LinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revision) error
 	StartServices(svcs []*snap.AppInfo, disabledSvcs *wrappers.DisabledServices, meter progress.Meter, tm timings.Measurer) error
 	StopServices(svcs []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error
 	QueryDisabledServices(info *snap.Info, pb progress.Meter) (*wrappers.DisabledServices, error)
+	MaybeSetNextBoot(info *snap.Info, dev snap.Device, isUndo bool) (boot.RebootInfo, error)
 
 	// the undoers for install
 	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -48,10 +48,6 @@ type LinkContext struct {
 	// installed
 	FirstInstall bool
 
-	// IsUndo is set when we are installing the previous snap while
-	// performing a revert of the latest one that was installed
-	IsUndo bool
-
 	// ServiceOptions is used to configure services.
 	ServiceOptions *wrappers.SnapServiceOptions
 
@@ -156,16 +152,28 @@ func updateCurrentSymlinks(info *snap.Info) (revert func(), e error) {
 	return revertFunc, nil
 }
 
+// MaybeSetNextBoot configures the system for a reboot if necesssary because
+// of a snap refresh. isUndo must be set when we are installing the previous
+// snap while performing a revert of the latest one that was installed
+func (b Backend) MaybeSetNextBoot(info *snap.Info, dev snap.Device, isUndo bool) (boot.RebootInfo, error) {
+	if b.preseed {
+		return boot.RebootInfo{}, nil
+	}
+
+	bootCtx := boot.NextBootContext{BootWithoutTry: isUndo}
+	return boot.Participant(info, info.Type(), dev).SetNextBoot(bootCtx)
+}
+
 // LinkSnap makes the snap available by generating wrappers and setting the current symlinks.
-func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext, tm timings.Measurer) (rebootRequired boot.RebootInfo, e error) {
+func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext, tm timings.Measurer) (e error) {
 	// explicitly prevent passing nil state unlocker to avoid internal errors of
 	// forgeting to pass the unlocker leading to deadlocks.
 	if linkCtx.StateUnlocker == nil {
-		return boot.RebootInfo{}, errors.New("internal error: LinkContext.StateUnlocker cannot be nil")
+		return errors.New("internal error: LinkContext.StateUnlocker cannot be nil")
 	}
 
 	if info.Revision.Unset() {
-		return boot.RebootInfo{}, fmt.Errorf("cannot link snap %q with unset revision", info.InstanceName())
+		return fmt.Errorf("cannot link snap %q with unset revision", info.InstanceName())
 	}
 
 	osutil.MaybeInjectFault("link-snap")
@@ -176,7 +184,7 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 		restart, err = b.generateWrappers(info, linkCtx)
 	})
 	if err != nil {
-		return boot.RebootInfo{}, err
+		return err
 	}
 	defer func() {
 		if e == nil {
@@ -187,21 +195,11 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 		})
 	}()
 
-	var rebootInfo boot.RebootInfo
-	if !b.preseed {
-		bootCtx := boot.NextBootContext{BootWithoutTry: linkCtx.IsUndo}
-		rebootInfo, err = boot.Participant(
-			info, info.Type(), dev).SetNextBoot(bootCtx)
-		if err != nil {
-			return boot.RebootInfo{}, err
-		}
-	}
-
 	// only after link snap it will be possible to execute snap
 	// applications, so ensure that the shared snap directory exists for
 	// parallel installed snaps
 	if err := createSharedSnapDirForParallelInstance(info); err != nil {
-		return boot.RebootInfo{}, err
+		return err
 	}
 	cleanupSharedParallelInstanceDir := func() {
 		if !linkCtx.HasOtherInstances {
@@ -212,7 +210,7 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 	revertSymlinks, err := updateCurrentSymlinks(info)
 	if err != nil {
 		cleanupSharedParallelInstanceDir()
-		return boot.RebootInfo{}, err
+		return err
 	}
 	// if anything below here could return error, you need to
 	// somehow clean up whatever updateCurrentSymlinks did
@@ -223,17 +221,17 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 			revertSymlinks()
 			cleanupSharedParallelInstanceDir()
 
-			return boot.RebootInfo{}, err
+			return err
 		}
 
 	}
 
 	// Stop inhibiting application startup by removing the inhibitor file.
 	if err := runinhibit.Unlock(info.InstanceName(), linkCtx.StateUnlocker); err != nil {
-		return boot.RebootInfo{}, err
+		return err
 	}
 
-	return rebootInfo, nil
+	return nil
 }
 
 func (b Backend) LinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revision) error {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -101,6 +101,7 @@ type fakeOp struct {
 	containerFileName string
 
 	snapLocked bool
+	isUndo     bool
 }
 
 type fakeOps []fakeOp
@@ -1266,7 +1267,25 @@ func (f *fakeSnappyBackend) SetupSnapSaveData(info *snap.Info, _ snap.Device, me
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootInfo boot.RebootInfo, err error) {
+func (f *fakeSnappyBackend) MaybeSetNextBoot(
+	info *snap.Info, dev snap.Device, isUndo bool) (boot.RebootInfo, error) {
+
+	op := &fakeOp{
+		op:     "maybe-set-next-boot",
+		isUndo: isUndo,
+	}
+	f.appendOp(op)
+
+	reboot := false
+	if f.linkSnapMaybeReboot {
+		reboot = info.InstanceName() == dev.Base() ||
+			(f.linkSnapRebootFor != nil && f.linkSnapRebootFor[info.InstanceName()])
+	}
+
+	return boot.RebootInfo{RebootRequired: reboot}, nil
+}
+
+func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx backend.LinkContext, tm timings.Measurer) (err error) {
 	if info.MountDir() == f.linkSnapWaitTrigger {
 		f.linkSnapWaitCh <- 1
 		<-f.linkSnapWaitCh
@@ -1290,18 +1309,12 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx b
 	if info.MountDir() == f.linkSnapFailTrigger {
 		op.op = "link-snap.failed"
 		f.appendOp(op)
-		return boot.RebootInfo{RebootRequired: false}, errors.New("fail")
+		return errors.New("fail")
 	}
 
 	f.appendOp(op)
 
-	reboot := false
-	if f.linkSnapMaybeReboot {
-		reboot = info.InstanceName() == dev.Base() ||
-			(f.linkSnapRebootFor != nil && f.linkSnapRebootFor[info.InstanceName()])
-	}
-
-	return boot.RebootInfo{RebootRequired: reboot}, nil
+	return nil
 }
 
 func (f *fakeSnappyBackend) LinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revision) error {

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1572,6 +1572,10 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoRestoresCurrent(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
 		},
 		{
+			op:     "maybe-set-next-boot",
+			isUndo: true,
+		},
+		{
 			op: "update-aliases",
 		},
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1640,6 +1640,9 @@ func (s *snapmgrTestSuite) testRevertRunThrough(c *C, refreshAppAwarenessUX bool
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/2"),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(2),
@@ -1872,6 +1875,9 @@ func (s *snapmgrTestSuite) TestRevertWithBaseRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap-with-base/2"),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap-with-base",
 			revno: snap.R(2),
@@ -1962,6 +1968,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 			otherInstances: true,
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap_instance",
 			revno: snap.R(2),
@@ -2030,7 +2039,7 @@ func (s *snapmgrTestSuite) TestRevertWithLocalRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 8)
+	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 9)
 
 	// verify that LocalRevision is still -7
 	var snapst snapstate.SnapState
@@ -2097,6 +2106,9 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -2190,6 +2202,9 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/1"),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(1),
@@ -2219,6 +2234,10 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+		},
+		{
+			op:     "maybe-set-next-boot",
+			isUndo: true,
 		},
 		{
 			op: "update-aliases",
@@ -2310,6 +2329,10 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+		},
+		{
+			op:     "maybe-set-next-boot",
+			isUndo: true,
 		},
 		{
 			op: "update-aliases",
@@ -2997,6 +3020,9 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(7),
@@ -3157,6 +3183,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceEnableRunThrough(c *C) {
 			op:             "link-snap",
 			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
 			otherInstances: true,
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -5628,6 +5657,9 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "core/11"),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -8132,6 +8164,9 @@ func (s *snapmgrTestSuite) TestSnapdRefreshTasks(c *C) {
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "snapd/11"),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:    "auto-connect:Doing",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -130,6 +130,9 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(11),
@@ -270,6 +273,7 @@ func (s *snapmgrTestSuite) testUpdateScenario(c *C, desc string, t switchScenari
 		"setup-profiles:Doing",
 		"candidate",
 		"link-snap",
+		"maybe-set-next-boot",
 		"auto-connect:Doing",
 		"update-aliases",
 		"cleanup-trash",
@@ -414,6 +418,9 @@ func (s *snapmgrTestSuite) testUpdateCanDoBackwards(c *C, refreshAppAwarenessUX 
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -932,6 +939,7 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		"setup-profiles:Doing",
 		"candidate",
 		"link-snap",
+		"maybe-set-next-boot",
 	}...)
 	for range components {
 		ops = append(ops, "link-component")
@@ -1189,6 +1197,9 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "services-snap/11"),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -1564,6 +1575,9 @@ func (s *snapmgrTestSuite) testParallelInstanceUpdateRunThrough(c *C, refreshApp
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "services-snap_instance/11"),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:    "auto-connect:Doing",
@@ -2501,6 +2515,10 @@ func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX 
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
+		{
+			op:     "maybe-set-next-boot",
+			isUndo: true,
+		},
 	}...)
 	// aliases removal undo is skipped when refresh-app-awareness-ux is enabled
 	if !refreshAppAwarenessUX {
@@ -2817,6 +2835,9 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "some-snap",
 			revno: snap.R(11),
@@ -2865,6 +2886,10 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
+		},
+		{
+			op:     "maybe-set-next-boot",
+			isUndo: true,
 		},
 	}...)
 	// aliases removal undo is skipped when refresh-app-awareness-ux is enabled
@@ -14383,6 +14408,9 @@ func (s *snapmgrTestSuite) TestUpdateBackToPrevRevision(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  instanceName,
 			revno: prevSnapRev,
@@ -14604,6 +14632,9 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
 		},
 		{
+			op: "maybe-set-next-boot",
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  instanceName,
 			revno: prevSnapRev,
@@ -14646,6 +14677,10 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 			{
 				op:   "link-snap",
 				path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+			},
+			{
+				op:     "maybe-set-next-boot",
+				isUndo: true,
 			},
 			{
 				op: "update-aliases",
@@ -14999,6 +15034,9 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
 		},
+		{
+			op: "maybe-set-next-boot",
+		},
 	}...)
 
 	for i, compName := range components {
@@ -15338,6 +15376,9 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 		{
 			op:   "link-component",
@@ -15885,6 +15926,9 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 	}...)
 
@@ -16531,6 +16575,9 @@ components:
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
 		},
+		{
+			op: "maybe-set-next-boot",
+		},
 	}...)
 
 	for _, cs := range expectedComponentStates {
@@ -16976,6 +17023,9 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		{
 			op:   "link-snap",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+		},
+		{
+			op: "maybe-set-next-boot",
 		},
 	}...)
 


### PR DESCRIPTION
Backend.LinkSnap prepares the system for a reboot, move that bit to a different backend method so we can use it from tasks different from link-snap, as we now plan to do reboots later that said task in some cases.