### PR TITLE
many: refactor registry errors and add GetView function

### DIFF
--- a/daemon/api_registry_test.go
+++ b/daemon/api_registry_test.go
@@ -166,14 +166,7 @@ func (s *registrySuite) TestGetViewNoFieldsFound(c *C) {
 		calls++
 		switch calls {
 		case 1:
-			return nil, &registry.NotFoundError{
-				Account:      "system",
-				RegistryName: "network",
-				View:         "wifi-setup",
-				Operation:    "get",
-				Requests:     []string{"ssid", "password"},
-				Cause:        "mocked",
-			}
+			return nil, registry.NewNotFoundError("not found")
 		default:
 			err := fmt.Errorf("expected 1 call to Get, now on %d", calls)
 			c.Error(err)
@@ -187,14 +180,14 @@ func (s *registrySuite) TestGetViewNoFieldsFound(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 404)
-	c.Check(rspe.Error(), Equals, `cannot get "ssid", "password" in registry view system/network/wifi-setup: mocked (api 404)`)
+	c.Check(rspe.Error(), Equals, `not found (api 404)`)
 }
 
 func (s *registrySuite) TestViewGetDatabagNotFound(c *C) {
 	s.setFeatureFlag(c)
 
 	restore := daemon.MockRegistrystateGet(func(_ *state.State, _, _, _ string, _ []string) (interface{}, error) {
-		return nil, &registry.NotFoundError{Account: "foo", RegistryName: "network", View: "wifi-setup", Operation: "get", Requests: []string{"ssid"}, Cause: "mocked"}
+		return nil, registry.NewNotFoundError("not found")
 	})
 	defer restore()
 
@@ -203,7 +196,7 @@ func (s *registrySuite) TestViewGetDatabagNotFound(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 404)
-	c.Check(rspe.Message, Equals, `cannot get "ssid" in registry view foo/network/wifi-setup: mocked`)
+	c.Check(rspe.Message, Equals, `not found`)
 }
 
 func (s *registrySuite) TestViewSetManyWithExistingState(c *C) {

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -188,10 +188,26 @@ func MockRegistrystateGetTransaction(f func(*registrystate.Context, *state.State
 	}
 }
 
-func MockGetRegistryView(f func(ctx *hookstate.Context, account, registryName, viewName string) (*registry.View, error)) (restore func()) {
-	old := getRegistryView
-	getRegistryView = f
+func MockRegistrystateGetView(f func(st *state.State, account, registryName, viewName string) (*registry.View, error)) (restore func()) {
+	old := registrystateGetView
+	registrystateGetView = f
 	return func() {
-		getRegistryView = old
+		registrystateGetView = old
+	}
+}
+
+func MockRegistrystateNewTransaction(f func(*state.State, string, string) (*registrystate.Transaction, error)) (restore func()) {
+	old := registrystateNewTransaction
+	registrystateNewTransaction = f
+	return func() {
+		registrystateNewTransaction = old
+	}
+}
+
+func MockRegistrystateGetStoredTransaction(f func(*state.Task) (*registrystate.Transaction, func(), error)) (restore func()) {
+	old := registrystateGetStoredTransaction
+	registrystateGetStoredTransaction = f
+	return func() {
+		registrystateGetStoredTransaction = old
 	}
 }

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -762,12 +762,12 @@ func (s *registrySuite) TestRegistryGetAndSetAssertionNotFound(c *C) {
 	s.state.Unlock()
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"get", "--view", ":read-wifi"}, 0)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("registry assertion %s/network not found", s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot find registry %s/network: assertion not found", s.devAccID))
 	c.Check(stdout, IsNil)
 	c.Check(stderr, IsNil)
 
 	stdout, stderr, err = ctlcmd.Run(s.mockContext, []string{"set", "--view", ":write-wifi", "ssid=my-ssid"}, 0)
-	c.Assert(err, ErrorMatches, fmt.Sprintf("registry assertion %s/network not found", s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot find registry %s/network: assertion not found", s.devAccID))
 	c.Check(stdout, IsNil)
 	c.Check(stderr, IsNil)
 }
@@ -885,7 +885,7 @@ func (s *registrySuite) TestRegistryGetDifferentViewThanOngoingTx(c *C) {
 
 	stdout, stderr, err := ctlcmd.Run(ctx, []string{"get", "--view", ":other", "ssid"}, 0)
 	// error is for no stored value, meaning we read the right registry
-	c.Assert(err, ErrorMatches, `.* matching rules don't map to any values`)
+	c.Assert(err, ErrorMatches, `.*: no view data`)
 	c.Check(stdout, IsNil)
 	c.Check(stderr, IsNil)
 }

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -241,7 +241,7 @@ func setRegistryValues(ctx *hookstate.Context, plugName string, requests map[str
 		return err
 	}
 
-	view, err := getRegistryView(ctx, account, registryName, viewName)
+	view, err := registrystateGetView(ctx.State(), account, registryName, viewName)
 	if err != nil {
 		return err
 	}

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -190,7 +190,7 @@ func (s *registrySuite) TestRegistryUnsetManyViews(c *C) {
 	s.state.Lock()
 	_, err = registrystate.Get(s.state, s.devAccID, "network", "write-wifi", []string{"ssid", "password"})
 	s.state.Unlock()
-	c.Assert(err, ErrorMatches, `cannot get "ssid", "password" .*: matching rules don't map to any values`)
+	c.Assert(err, ErrorMatches, `cannot get "ssid", "password" .*: no view data`)
 }
 
 func (s *registrySuite) TestRegistryUnsetInvalid(c *C) {

--- a/overlord/registrystate/registrystate_test.go
+++ b/overlord/registrystate/registrystate_test.go
@@ -179,17 +179,22 @@ func (s *registryTestSuite) TestGetNotFound(c *C) {
 
 	res, err := registrystate.Get(s.state, s.devAccID, "network", "other-view", []string{"ssid"})
 	c.Assert(err, FitsTypeOf, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "ssid" in registry view %s/network/other-view: not found`, s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find view "other-view" in registry %s/network`, s.devAccID))
 	c.Check(res, IsNil)
 
 	res, err = registrystate.Get(s.state, s.devAccID, "network", "setup-wifi", []string{"ssid"})
 	c.Assert(err, FitsTypeOf, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "ssid" in registry view %s/network/setup-wifi: matching rules don't map to any values`, s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "ssid" through %s/network/setup-wifi: no view data`, s.devAccID))
+	c.Check(res, IsNil)
+
+	res, err = registrystate.Get(s.state, s.devAccID, "network", "setup-wifi", []string{"ssid", "ssids"})
+	c.Assert(err, FitsTypeOf, &registry.NotFoundError{})
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "ssid", "ssids" through %s/network/setup-wifi: no view data`, s.devAccID))
 	c.Check(res, IsNil)
 
 	res, err = registrystate.Get(s.state, s.devAccID, "network", "setup-wifi", []string{"other-field"})
 	c.Assert(err, FitsTypeOf, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "other-field" in registry view %s/network/setup-wifi: no matching read rule`, s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot get "other-field" through %s/network/setup-wifi: no matching rule`, s.devAccID))
 	c.Check(res, IsNil)
 }
 
@@ -215,11 +220,11 @@ func (s *registryTestSuite) TestSetNotFound(c *C) {
 
 	err := registrystate.Set(s.state, s.devAccID, "network", "setup-wifi", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, FitsTypeOf, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot set "foo" in registry view %s/network/setup-wifi: no matching write rule`, s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot set "foo" through %s/network/setup-wifi: no matching rule`, s.devAccID))
 
 	err = registrystate.Set(s.state, s.devAccID, "network", "other-view", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, FitsTypeOf, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot set "foo" in registry view %s/network/other-view: not found`, s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find view "other-view" in registry %s/network`, s.devAccID))
 }
 
 func (s *registryTestSuite) TestUnsetView(c *C) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -329,23 +329,23 @@ func (s *viewSuite) TestRegistryNotFound(c *C) {
 
 	_, err = view.Get(databag, "missing")
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "missing" in registry view acc/foo/bar: no matching read rule`)
+	c.Assert(err, ErrorMatches, `cannot get "missing" through acc/foo/bar: no matching rule`)
 
 	err = view.Set(databag, "missing", "thing")
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot set "missing" in registry view acc/foo/bar: no matching write rule`)
+	c.Assert(err, ErrorMatches, `cannot set "missing" through acc/foo/bar: no matching rule`)
 
 	err = view.Unset(databag, "missing")
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot unset "missing" in registry view acc/foo/bar: no matching write rule`)
+	c.Assert(err, ErrorMatches, `cannot unset "missing" through acc/foo/bar: no matching rule`)
 
 	_, err = view.Get(databag, "top-level")
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "top-level" in registry view acc/foo/bar: matching rules don't map to any values`)
+	c.Assert(err, ErrorMatches, `cannot get "top-level" through acc/foo/bar: no view data`)
 
 	_, err = view.Get(databag, "")
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get registry view acc/foo/bar: matching rules don't map to any values`)
+	c.Assert(err, ErrorMatches, `cannot get acc/foo/bar: no view data`)
 
 	err = view.Set(databag, "nested", "thing")
 	c.Assert(err, IsNil)
@@ -355,7 +355,7 @@ func (s *viewSuite) TestRegistryNotFound(c *C) {
 
 	_, err = view.Get(databag, "other-nested")
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "other-nested" in registry view acc/foo/bar: matching rules don't map to any values`)
+	c.Assert(err, ErrorMatches, `cannot get "other-nested" through acc/foo/bar: no view data`)
 }
 
 func (s *viewSuite) TestViewBadRead(c *C) {
@@ -394,12 +394,12 @@ func (s *viewSuite) TestViewAccessControl(c *C) {
 		{
 			access: "read",
 			// non-access control error, access ok
-			getErr: `cannot get "foo" in registry view acc/registry/foo: matching rules don't map to any values`,
-			setErr: `cannot set "foo" in registry view acc/registry/foo: no matching write rule`,
+			getErr: `cannot get "foo" through acc/registry/foo: no view data`,
+			setErr: `cannot set "foo" through acc/registry/foo: no matching rule`,
 		},
 		{
 			access: "write",
-			getErr: `cannot get "foo" in registry view acc/registry/foo: no matching read rule`,
+			getErr: `cannot get "foo" through acc/registry/foo: no matching rule`,
 		},
 	} {
 		cmt := Commentf("sub-test with %q access failed", t.access)
@@ -865,7 +865,7 @@ func (s *viewSuite) TestViewUnsetSkipsReadOnly(c *C) {
 
 	view := registry.View("test")
 	err = view.Unset(databag, "foo")
-	c.Assert(err, ErrorMatches, `cannot unset "foo" in registry view acc/registry/test: no matching write rule`)
+	c.Assert(err, ErrorMatches, `cannot unset "foo" through acc/registry/test: no matching rule`)
 }
 
 func (s *viewSuite) TestViewGetNoMatchRequestLongerThanPattern(c *C) {
@@ -1876,7 +1876,7 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderLast(c *C) {
 
 	_, err = view.Get(databag, "foo")
 	c.Assert(err, testutil.ErrorIs, &registry.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "foo" in registry view acc/registry/foo: matching rules don't map to any values`)
+	c.Assert(err, ErrorMatches, `cannot get "foo" through acc/registry/foo: no view data`)
 }
 
 func (s *viewSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {
@@ -2219,7 +2219,7 @@ func (*viewSuite) TestViewWriteContentRuleNestedInRead(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = view.Get(databag, "a.b")
-	c.Assert(err, ErrorMatches, `.*: no matching read rule`)
+	c.Assert(err, ErrorMatches, `.*: no matching rule`)
 
 	val, err := view.Get(databag, "a")
 	c.Assert(err, IsNil)

--- a/tests/main/registries-cross-config/task.yaml
+++ b/tests/main/registries-cross-config/task.yaml
@@ -4,6 +4,9 @@ details: |
   Check that we can configure registries across snaps and that the appropriate
   hooks are invoked.
 
+# the test snaps have a core24 base
+systems: [ -ubuntu-16.04 ]
+
 prepare: |
   snap set system experimental.registries=true
   snap install --edge jq

--- a/tests/main/registries/task.yaml
+++ b/tests/main/registries/task.yaml
@@ -16,45 +16,28 @@ execute: |
 
   snap ack "$TESTSLIB/assertions/developer1-network.registry"
 
-  # write a value
+  # check basic read, write and unset
   snap set developer1/network/wifi-setup ssid=canonical
-
-  # read the same value
   snap get developer1/network/wifi-setup ssid | MATCH "canonical"
-
-  # delete it
   snap set developer1/network/wifi-setup ssid!
+  snap get developer1/network/wifi-setup ssid 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "ssid" through developer1/network/wifi-setup: no view data'
 
-  # check it was deleted
-  snap get developer1/network/wifi-setup ssid 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "ssid" in registry view developer1/network/wifi-setup: matching rules don\'t map to any values'
-
-  # write values using a placeholder access
+  # check writing, reading and unsetting using placeholders
   snap set -t developer1/network/wifi-setup private.my-company=\"my-config\" private.your-company=\"your-config\"
-
-  # check values were set
   snap get developer1/network/wifi-setup private.my-company | MATCH "my-config"
   snap get developer1/network/wifi-setup private.your-company | MATCH "your-config"
 
-  # delete it
   snap set developer1/network/wifi-setup private.my-company!
+  snap get developer1/network/wifi-setup private.my-company 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "private.my-company" through developer1/network/wifi-setup: no view data'
 
-  # check it was deleted
-  snap get developer1/network/wifi-setup private.my-company 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "private.my-company" in registry view developer1/network/wifi-setup: matching rules don\'t map to any values'
-
-  # check second value remains
   snap get developer1/network/wifi-setup private.your-company | MATCH "your-config"
   snap set developer1/network/wifi-setup private.your-company!
 
-  # write a list
+  # check writing and reading different types
   snap set -t developer1/network/wifi-setup ssids='["one", 2]'
-
-  # read the same value
   snap get -d developer1/network/wifi-setup ssids | jq -c .ssids | MATCH '["one", 2]'
 
-  # check read-only access control works
-  snap set developer1/network/wifi-setup status=foo 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'cannot set "status" in registry view developer1/network/wifi-setup: no matching write rule'
-
-  # check write-only access control works
+  # check access control
+  snap set developer1/network/wifi-setup status=foo 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'cannot set "status" through developer1/network/wifi-setup: no matching rule'
   snap set developer1/network/wifi-setup password=foo
-
-  snap get developer1/network/wifi-setup password 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'cannot get "password" in registry view developer1/network/wifi-setup: no matching read rule'
+  snap get developer1/network/wifi-setup password 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'cannot get "password" through developer1/network/wifi-setup: no matching rule'


### PR DESCRIPTION
Refactor the not found errors as we now also have to use them in registrystate so the previous construction is not convenient. Also improves clarity and consistency in some of the errors messages. The second commit adds a GetView function to registrystate so it can be used in several places and removes some usages of Set from ctlcmd tests (so we can remove it in the next PR when we stop using it in the API). This became a bit of a ball of mud of refactorings but I'd like to do them before moving on to the next epics