### PR TITLE
overlord/fdestate: improve error handling when one of partitions isn't mounted, handle preseeding

### DIFF
--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -25,6 +25,7 @@ import (
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -139,8 +140,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if deviceCtx.HasModeenv() && deviceCtx.RunMode() {
-		// XXX make this a boot method
-		modeEnv, err := maybeReadModeenv()
+		modeEnv, err := boot.MaybeReadModeenv()
 		if err != nil {
 			return err
 		}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -232,7 +232,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 	kernelDir := kernelInfo.MountDir()
 
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := boot.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 	perfTimings := state.TimingsForTask(t)
 	defer perfTimings.Save(st)
 
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := boot.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 	}
 	kernelDir := kernelInfo.MountDir()
 
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := boot.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -55,7 +55,7 @@ func checkSystemRequestConflict(st *state.State, systemLabel string) error {
 	// holding the state lock so there is no race against mark-seeded
 	// clearing recovery system; recovery system is not cleared when seeding
 	// fails
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := boot.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func currentSeededSystem(st *state.State) (*seededSystem, error) {
 }
 
 func seededSystemFromModeenv() (*seededSystem, error) {
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := boot.MaybeReadModeenv()
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -35,3 +35,5 @@ func MockBackendResealKeyForBootChains(f func(updateState backend.StateUpdater, 
 	backendResealKeyForBootChains = f
 	return restore
 }
+
+func (m *FDEManager) IsFunctional() error { return m.isFunctional() }

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -24,6 +24,7 @@ package fdestate
 import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
@@ -63,7 +64,13 @@ func (m *FDEManager) Ensure() error {
 func (m *FDEManager) StartUp() error {
 	m.state.Lock()
 	defer m.state.Unlock()
-	return initializeState(m.state)
+
+	// FIXME should we try to initialize the state in
+	// install/recover/factory-reset modes?
+	if err := initializeState(m.state); err != nil {
+		logger.Noticef("cannot initialize FDE state: %v", err)
+	}
+	return nil
 }
 
 func (m *FDEManager) resealKeyForBootChains(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -92,7 +92,9 @@ func (m *FDEManager) Ensure() error {
 // StartUp implements StateStarterUp.Startup
 func (m *FDEManager) StartUp() error {
 	if m.preseed {
-		// nothing to do in preseeding mode
+		// nothing to do in preseeding mode, but set the init error so that
+		// attempts to use fdemgr will fail
+		m.initErr = fmt.Errorf("internal error: FDE manager cannot be used in preseeding mode")
 		return nil
 	}
 

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -23,7 +23,6 @@ package fdestate
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget/device"
@@ -51,13 +50,15 @@ type FDEManager struct {
 type fdeMgrKey struct{}
 
 func initModeFromModeenv(m *FDEManager) error {
-	modeenv, err := maybeReadModeenv()
+	mode, explicit, err := boot.SystemMode("")
 	if err != nil {
 		return err
 	}
 
-	if modeenv != nil {
-		m.mode = modeenv.Mode
+	if explicit {
+		// FDE manager is only relevant on systems where mode set explicitly,
+		// that is UC20
+		m.mode = mode
 	}
 	return nil
 }
@@ -86,14 +87,6 @@ func Manager(st *state.State, runner *state.TaskRunner) (*FDEManager, error) {
 // Ensure implements StateManager.Ensure
 func (m *FDEManager) Ensure() error {
 	return nil
-}
-
-func maybeReadModeenv() (*boot.Modeenv, error) {
-	modeenv, err := boot.ReadModeenv("")
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("cannot read modeenv: %v", err)
-	}
-	return modeenv, nil
 }
 
 // StartUp implements StateStarterUp.Startup

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -96,10 +96,12 @@ func (m *FDEManager) StartUp() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	// FIXME should we try to initialize the state in
-	// install/recover/factory-reset modes?
-	if err := initializeState(m.state); err != nil {
-		logger.Noticef("cannot initialize FDE state: %v", err)
+	if m.mode == "run" {
+		// TODO should we try to initialize the state in
+		// install/recover/factory-reset modes?
+		if err := initializeState(m.state); err != nil {
+			return fmt.Errorf("cannot initialize FDE state: %v", err)
+		}
 	}
 	return nil
 }

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/state"
@@ -248,6 +249,118 @@ func (s *fdeMgrSuite) TestUpdateReseal(c *C) {
 	c.Check(containerRole.Models[0].Model(), Equals, "mock-model")
 	c.Check(containerRole.BootModes, DeepEquals, []string{"run"})
 	c.Check(containerRole.TPM2PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-profile"`))
+}
+
+type mountResolveTestCase struct {
+	dataResolveErr error
+	saveResolveErr error
+	expectedError  string
+}
+
+func (s *fdeMgrSuite) testMountResolveError(c *C, tc mountResolveTestCase) {
+	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+		switch mountpoint {
+		case dirs.SnapdStateDir(dirs.GlobalRootDir):
+			// ubuntu-data
+			if tc.dataResolveErr != nil {
+				return "", tc.dataResolveErr
+			}
+			return "aaa", nil
+		case dirs.SnapSaveDir:
+			if tc.saveResolveErr != nil {
+				return "", tc.saveResolveErr
+			}
+			return "bbb", nil
+		}
+		panic(fmt.Sprintf("missing mocked mount point %q", mountpoint))
+	})()
+
+	defer fdestate.MockGetPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash) ([]byte, []byte, error) {
+		if tc.expectedError == "" {
+			return nil, nil, fmt.Errorf("unexpected call to get primary key")
+		}
+		return []byte{1, 2, 3, 4}, []byte{5, 6, 7, 8}, nil
+	})()
+
+	defer fdestate.MockVerifyPrimaryKeyHMAC(func(devicePath string, alg crypto.Hash, salt, digest []byte) (bool, error) {
+		if tc.expectedError == "" {
+			return false, fmt.Errorf("unexpected call to get primary key")
+		}
+		return true, nil
+	})()
+
+	manager, err := fdestate.Manager(s.st, s.runner)
+	c.Assert(err, IsNil)
+	err = manager.StartUp()
+	if tc.expectedError != "" {
+		c.Check(err, ErrorMatches, tc.expectedError)
+	} else {
+		c.Check(err, IsNil)
+	}
+}
+
+func (s *fdeMgrSuite) TestStateInitMountResolveError_StatePresentNoError(c *C) {
+	s.st.Lock()
+	s.st.Set("fde", fdestate.FdeState{})
+	s.st.Unlock()
+
+	// state initialization happens (and may fail) only when "fde" isn't yet set
+	// in the state
+
+	s.testMountResolveError(c, mountResolveTestCase{
+		dataResolveErr: fmt.Errorf("mock degraded mode"),
+	})
+}
+
+func (s *fdeMgrSuite) TestStateInitMountResolveError_NoDataNoSaveNoError(c *C) {
+	s.testMountResolveError(c, mountResolveTestCase{
+		dataResolveErr: disks.ErrNoDmUUID,
+		saveResolveErr: disks.ErrNoDmUUID,
+	})
+}
+
+func (s *fdeMgrSuite) TestStateInitMountResolveError_NoDataFails(c *C) {
+	s.testMountResolveError(c, mountResolveTestCase{
+		dataResolveErr: fmt.Errorf("mock error data"),
+		expectedError:  "cannot initialize FDE state: cannot resolve data partition mount: mock error data",
+	})
+}
+
+func (s *fdeMgrSuite) TestStatetInitMountResolveError_NoSaveFails(c *C) {
+	s.testMountResolveError(c, mountResolveTestCase{
+		saveResolveErr: fmt.Errorf("mock error save"),
+		expectedError:  "cannot initialize FDE state: cannot resolve save partition mount: mock error save",
+	})
+}
+
+func (s *fdeMgrSuite) TestStateInitMountResolveError_Recover(c *C) {
+	m := boot.Modeenv{
+		Mode:           boot.ModeRecover,
+		RecoverySystem: "1234",
+	}
+	err := m.WriteTo(dirs.GlobalRootDir)
+	c.Assert(err, IsNil)
+
+	// neither partition could be mounted
+	s.testMountResolveError(c, mountResolveTestCase{
+		dataResolveErr: disks.ErrNoDmUUID,
+		saveResolveErr: disks.ErrNoDmUUID,
+	})
+}
+
+func (s *fdeMgrSuite) TestMountResolveError_FactoryReset(c *C) {
+	m := boot.Modeenv{
+		Mode:           boot.ModeFactoryReset,
+		RecoverySystem: "1234",
+	}
+	err := m.WriteTo(dirs.GlobalRootDir)
+	c.Assert(err, IsNil)
+
+	// neither partition could be mounted
+	s.testMountResolveError(c, mountResolveTestCase{
+		dataResolveErr: disks.ErrNoDmUUID,
+		saveResolveErr: disks.ErrNoDmUUID,
+	})
 }
 
 func (s *fdeMgrSuite) TestManagerUC_16_18(c *C) {

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -292,10 +292,13 @@ func (s *fdeMgrSuite) testMountResolveError(c *C, tc mountResolveTestCase) {
 	manager, err := fdestate.Manager(s.st, s.runner)
 	c.Assert(err, IsNil)
 	err = manager.StartUp()
+	c.Check(err, IsNil)
+
+	functionalErr := manager.IsFunctional()
 	if tc.expectedError != "" {
-		c.Check(err, ErrorMatches, tc.expectedError)
+		c.Check(functionalErr, ErrorMatches, tc.expectedError)
 	} else {
-		c.Check(err, IsNil)
+		c.Check(functionalErr, IsNil)
 	}
 }
 

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -240,3 +240,13 @@ func (s *fdeMgrSuite) TestUpdateReseal(c *C) {
 	c.Check(containerRole.BootModes, DeepEquals, []string{"run"})
 	c.Check(containerRole.TPM2PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-profile"`))
 }
+
+func (s *fdeMgrSuite) TestManagerPreseeding(c *C) {
+	defer snapdenv.MockPreseeding(true)()
+
+	manager := fdestate.Manager(s.st, s.runner)
+
+	// neither startup nor ensure fails
+	c.Assert(manager.StartUp(), IsNil)
+	c.Assert(manager.Ensure(), IsNil)
+}

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -388,4 +388,6 @@ func (s *fdeMgrSuite) TestManagerPreseeding(c *C) {
 	// neither startup nor ensure fails
 	c.Assert(manager.StartUp(), IsNil)
 	c.Assert(manager.Ensure(), IsNil)
+	// but the manager is deemed non functional, so API calls will fail
+	c.Assert(manager.IsFunctional(), ErrorMatches, "internal error: FDE manager cannot be used in preseeding mode")
 }

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -245,6 +245,7 @@ func initializeState(st *state.State) error {
 		return err
 	}
 
+	// FIXME mount points will be different in recovery or factory-reset modes
 	dataUUID, dataErr := disksDMCryptUUIDFromMountPoint(dirs.SnapdStateDir(dirs.GlobalRootDir))
 	saveUUID, saveErr := disksDMCryptUUIDFromMountPoint(dirs.SnapSaveDir)
 	if errors.Is(saveErr, disks.ErrMountPointNotFound) {

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -246,6 +246,7 @@ func initializeState(st *state.State) error {
 	}
 
 	// FIXME mount points will be different in recovery or factory-reset modes
+	// either inspect degraded.json, or use boot.HostUbuntuDataForMode()
 	dataUUID, dataErr := disksDMCryptUUIDFromMountPoint(dirs.SnapdStateDir(dirs.GlobalRootDir))
 	saveUUID, saveErr := disksDMCryptUUIDFromMountPoint(dirs.SnapSaveDir)
 	if errors.Is(saveErr, disks.ErrMountPointNotFound) {
@@ -258,11 +259,12 @@ func initializeState(st *state.State) error {
 		// TODO: we should verify the device "sealed key method"
 		return nil
 	}
+
 	if dataErr != nil {
-		return dataErr
+		return fmt.Errorf("cannot resolve data partition mount: %w", dataErr)
 	}
 	if saveErr != nil {
-		return saveErr
+		return fmt.Errorf("cannot resolve save partition mount: %w", saveErr)
 	}
 
 	devpData := fmt.Sprintf("/dev/disk/by-uuid/%s", dataUUID)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -7460,11 +7460,13 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	defer restore()
 
 	restore = fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
-		if mountpoint == dirs.GlobalRootDir {
+		switch mountpoint {
+		case dirs.SnapdStateDir(dirs.GlobalRootDir):
 			return "root-uuid", nil
-		} else {
+		case dirs.SnapSaveDir:
 			return "save-uuid", nil
 		}
+		panic(fmt.Sprintf("unexpected mount point: %s", mountpoint))
 	})
 	defer restore()
 
@@ -7477,11 +7479,6 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 		return true, nil
 	})
 	defer restore()
-
-	fdemgr := s.o.FDEManager()
-	c.Assert(fdemgr, NotNil)
-	err := fdemgr.StartUp()
-	c.Assert(err, IsNil)
 
 	st := s.o.State()
 	st.Lock()
@@ -7499,7 +7496,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 		s.serveSnap(snapPath, "22")
 	}
 
-	err = assertstate.Add(st, s.devAcct)
+	err := assertstate.Add(st, s.devAcct)
 	c.Assert(err, IsNil)
 	// snaps in state
 	pcInfo := s.makeInstalledSnapInStateForRemodel(c, "pc", snap.R(1), "20/stable")
@@ -7629,6 +7626,24 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	})
 	defer restore()
 
+	// make sure FDE is initialized
+	fdemgr := s.o.FDEManager()
+	c.Assert(fdemgr, NotNil)
+	c.Assert(fdemgr.ReloadModeenv(), IsNil)
+	func() {
+		st.Unlock()
+		defer st.Lock()
+		err = fdemgr.StartUp()
+	}()
+	c.Assert(err, IsNil)
+
+	if encrypted {
+		// FDE state should have been initialized when the system uses encryption
+		var fdeState map[string]any
+		c.Assert(st.Get("fde", &fdeState), IsNil)
+		c.Check(fdeState, NotNil)
+	}
+
 	chg, err := devicestate.Remodel(st, newModel, nil, nil, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
@@ -7639,7 +7654,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	st.Lock()
 	c.Assert(err, IsNil, Commentf(s.logbuf.String()))
 
-	dumpTasks(c, "after setteling", chg.Tasks())
+	dumpTasks(c, "after settling", chg.Tasks())
 
 	c.Check(chg.Status(), Equals, state.WaitStatus, Commentf("remodel change failed: %v", chg.Err()))
 	c.Check(devicestate.RemodelingChange(st), NotNil)

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -175,7 +175,11 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	}
 	o.addManager(ifaceMgr)
 
-	o.addManager(fdestate.Manager(s, o.runner))
+	fdeMgr, err := fdestate.Manager(s, o.runner)
+	if err != nil {
+		return nil, err
+	}
+	o.addManager(fdeMgr)
 
 	deviceMgr, err := devicestate.Manager(s, hookMgr, o.runner, o.newStore)
 	if err != nil {


### PR DESCRIPTION
Attempt to improve the behavior when one of data or save partitions isn't mounted, thus only even consider failures when we are in run mode. There is a FIXME which we will need to address at some point to degrade this in a nicer way. Handle preseeding, by simply skipping all initialization there.

Supersedes https://github.com/canonical/snapd/pull/14644