### PR TITLE
data/completion: add tab completion for local component files

### DIFF
--- a/data/completion/bash/snap
+++ b/data/completion/bash/snap
@@ -58,7 +58,7 @@ _complete_snap() {
 
     case $command in
         install|info|sign-build)
-            _filedir "snap"
+            _filedir '@(snap|comp)'
             ;;
         ack)
             _filedir

--- a/data/completion/zsh/_snap
+++ b/data/completion/zsh/_snap
@@ -46,6 +46,7 @@ case "$command" in
     install)
         # include *.snap files
         _path_files -g "*.snap"
+        _path_files -g "*.comp"
         ;;
     try)
         # limit matches to directories

--- a/tests/main/completion/install.exp
+++ b/tests/main/completion/install.exp
@@ -1,7 +1,7 @@
 source lib.exp0
 
-# install completes directories and snaps
-chat "snap ins\t./\t\t" "bar.snap*testdir/"
+# install completes directories, snaps, and components
+chat "snap ins\t./\t\t" "bar.comp*bar.snap*testdir/"
 cancel
 
 # install also completes store stuff

--- a/tests/main/completion/install.exp
+++ b/tests/main/completion/install.exp
@@ -1,7 +1,7 @@
 source lib.exp0
 
 # install completes directories, snaps, and components
-chat "snap ins\t./\t\t" "bar.comp*bar.snap*testdir/"
+chat "snap ins\t./\t\t" "bar.snap*baz.comp*testdir/"
 cancel
 
 # install also completes store stuff

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -30,7 +30,9 @@ prepare: |
 
     mkdir -p testdir
     touch testdir/foo.snap
+    touch testdir/foo.comp
     touch bar.snap
+    touch bar.comp
 
     snap install core
     snap install test-snapd-tools

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -30,9 +30,8 @@ prepare: |
 
     mkdir -p testdir
     touch testdir/foo.snap
-    touch testdir/foo.comp
     touch bar.snap
-    touch bar.comp
+    touch baz.comp
 
     snap install core
     snap install test-snapd-tools


### PR DESCRIPTION
Allow tab completion in bash and zsh when `snap install`ing a local `.comp` file