### PR TITLE
tests: copy less things when creating the overlay tarball

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1509,7 +1509,8 @@ EOF
           --exclude /gopath/bin/govendor \
           --exclude /gopath/pkg/ \
           -f /mnt/run-mode-overlay-data.tar.gz \
-          /home/gopath /root/test-etc /var/lib/extrausers
+          /home/gopath/bin /home/gopath/src/github.com/snapcore/snapd/tests \
+          /root/test-etc /var/lib/extrausers
     fi
 
     # now modify the image writable partition - only possible on uc16 / uc18


### PR DESCRIPTION
We should only need some binaries from gopath, otherwise tarball gets too big, might not fit in the boot partition, and takes longer to be created.