### PR TITLE
i/builtin: allow @ in custom-device filepaths

### DIFF
--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2022 Canonical Ltd
+ * Copyright (C) 2022-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -51,8 +51,14 @@ var (
 	// A cryptic, uninformative error message that we use only on impossible code paths
 	customDeviceInternalError = errors.New(`custom-device interface internal error`)
 
-	// Validating regexp for filesystem paths
-	customDevicePathRegexp = regexp.MustCompile(`^/[^"]*$`)
+	// Validating regexp for filesystem paths. @ can appear in paths under
+	// /sys/devices for devices that are defined in the device tree (of the
+	// form device@address), so we need to support @ characters in paths.
+	// However, @{foo} is the format for variables in AppArmor, so we must
+	// disallow `@{`. For completeness, we allow paths with a trailing @ as
+	// well. This is not the case for common-files-derived interfaces, since
+	// these append {,/,/**} pattern to the end of filepath.
+	customDevicePathRegexp = regexp.MustCompile(`^/([^"@]|@[^{])*@?$`)
 
 	// Validating regexp for udev device names.
 	// We forbid:

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -52,7 +52,7 @@ var (
 	customDeviceInternalError = errors.New(`custom-device interface internal error`)
 
 	// Validating regexp for filesystem paths
-	customDevicePathRegexp = regexp.MustCompile(`^/[^"@]*$`)
+	customDevicePathRegexp = regexp.MustCompile(`^/[^"]*$`)
 
 	// Validating regexp for udev device names.
 	// We forbid:

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2022 Canonical Ltd
+ * Copyright (C) 2022-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -72,7 +72,7 @@ slots:
   read-devices:
     - /dev/js*
   files:
-    write: [ /bar, /baz@qux ]
+    write: [ /bar, /baz@qux, /trailing@ ]
     read:
       - /dev/input/by-id/*
       - /dev/dma_heap/qcom,qseecom
@@ -209,6 +209,14 @@ apps:
 		{
 			"devices: [/dev/foo**]",
 			`custom-device "devices" path contains invalid glob pattern "\*\*"`,
+		},
+		{
+			`devices: ["/dev/@{foo}"]`,
+			`custom-device "devices" path must start with /dev/ and cannot contain special characters.*`,
+		},
+		{
+			`devices: ["/dev/@{foo"]`,
+			`custom-device "devices" path must start with /dev/ and cannot contain special characters.*`,
 		},
 		{
 			"devices: [/dev/foo|bar]",
@@ -403,7 +411,11 @@ func (s *CustomDeviceInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Check(plugSnippet, testutil.Contains, `"/dev/input/mice" rwk,`)
 	c.Check(plugSnippet, testutil.Contains, `"/dev/js*" r,`)
 	c.Check(plugSnippet, testutil.Contains, `"/bar" rw,`)
+	c.Check(plugSnippet, testutil.Contains, `"/baz@qux" rw,`)
+	c.Check(plugSnippet, testutil.Contains, `"/trailing@" rw,`)
 	c.Check(plugSnippet, testutil.Contains, `"/dev/input/by-id/*" r,`)
+	c.Check(plugSnippet, testutil.Contains, `"/dev/dma_heap/qcom,qseecom" r,`)
+	c.Check(plugSnippet, testutil.Contains, `"/sys/devices/platform/soc@0/soc@0:bus@30000000/30350000.ocotp-ctrl/imx-ocotp0/nvmem" r,`)
 	c.Check(slotSnippet, HasLen, 0)
 }
 

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -72,9 +72,11 @@ slots:
   read-devices:
     - /dev/js*
   files:
-    write: [ /bar ]
+    write: [ /bar, /baz@qux ]
     read:
       - /dev/input/by-id/*
+      - /dev/dma_heap/qcom,qseecom
+      - /sys/devices/platform/soc@0/soc@0:bus@30000000/30350000.ocotp-ctrl/imx-ocotp0/nvmem
   udev-tagging:
     - kernel: input/mice
       subsystem: input
@@ -207,10 +209,6 @@ apps:
 		{
 			"devices: [/dev/foo**]",
 			`custom-device "devices" path contains invalid glob pattern "\*\*"`,
-		},
-		{
-			"devices: [/dev/@foo]",
-			`custom-device "devices" path must start with / and cannot contain special characters.*`,
 		},
 		{
 			"devices: [/dev/foo|bar]",


### PR DESCRIPTION
Allow the `@` symbol to occur in filepaths for the custom-device interface. This is common in paths under `/sys/`, such as `/sys/devices/platform/soc@0/soc@0:bus@30000000/30350000.ocotp-ctrl/imx-ocotp0/nvmem`.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-32542