### PR TITLE
tests: run nested tests using ubuntu noble as host

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -726,27 +726,27 @@ jobs:
             rules: 'main'
           - group: nested-ubuntu-16.04
             backend: google-nested
-            systems: 'ubuntu-16.04-64'
+            systems: 'ubuntu-16-64'
             tests: 'tests/nested/...'
             rules: 'nested'
           - group: nested-ubuntu-18.04
             backend: google-nested
-            systems: 'ubuntu-18.04-64'
+            systems: 'ubuntu-18-64'
             tests: 'tests/nested/...'
             rules: 'nested'
           - group: nested-ubuntu-20.04
             backend: google-nested
-            systems: 'ubuntu-20.04-64'
+            systems: 'ubuntu-20-64'
             tests: 'tests/nested/...'
             rules: 'nested'
           - group: nested-ubuntu-22.04
             backend: google-nested
-            systems: 'ubuntu-22.04-64'
+            systems: 'ubuntu-22-64'
             tests: 'tests/nested/...'
             rules: 'nested'
           - group: nested-ubuntu-24.04
             backend: google-nested
-            systems: 'ubuntu-24.04-64'
+            systems: 'ubuntu-24-64'
             tests: 'tests/nested/...'
             rules: 'nested'
     steps:

--- a/spread.yaml
+++ b/spread.yaml
@@ -1169,7 +1169,7 @@ suites:
         summary: Tests for nested images controlled manually from the tests
         backends: [google-nested, google-nested-dev, qemu-nested, google-nested-arm]
         environment:
-            NESTED_TYPE: "classic"
+            NESTED_TYPE: "core"
             # Enable kvm in the qemu command line
             NESTED_ENABLE_KVM: '$(HOST: echo "${NESTED_ENABLE_KVM:-true}")'
             # Enable tpm in the nested vm in case it is supported

--- a/spread.yaml
+++ b/spread.yaml
@@ -291,23 +291,23 @@ backends:
         halt-timeout: 2h
         cpu-family: "Intel Cascade Lake"
         systems:
-            - ubuntu-16.04-64:
-                  image: ubuntu-1604-64-virt-enabled
+            - ubuntu-16-64:
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 20G
                   workers: 4
-            - ubuntu-18.04-64:
-                  image: ubuntu-1804-64-virt-enabled
+            - ubuntu-18-64:
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 20G
                   workers: 4
-            - ubuntu-20.04-64:
-                  image: ubuntu-2004-64-virt-enabled
+            - ubuntu-20-64:
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 20G
                   workers: 12
-            - ubuntu-22.04-64:
-                  image: ubuntu-2204-64-virt-enabled
+            - ubuntu-22-64:
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 25G
                   workers: 14
-            - ubuntu-24.04-64:
+            - ubuntu-24-64:
                   image: ubuntu-2404-64-virt-enabled
                   storage: 25G
                   workers: 14
@@ -319,7 +319,7 @@ backends:
         plan: t2a-standard-2
         halt-timeout: 2h
         systems:
-            - ubuntu-22.04-arm-64:
+            - ubuntu-22-arm-64:
                   image: ubuntu-2204-arm-64-virt-enabled
                   storage: 25G
                   workers: 8
@@ -333,19 +333,19 @@ backends:
         cpu-family: "Intel Cascade Lake"
         systems:
             - ubuntu-16.04-64:
-                  image: ubuntu-1604-64-virt-enabled
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 20G
                   workers: 3
             - ubuntu-18.04-64:
-                  image: ubuntu-1804-64-virt-enabled
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 20G
                   workers: 3
             - ubuntu-20.04-64:
-                  image: ubuntu-2004-64-virt-enabled
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 20G
                   workers: 8
             - ubuntu-22.04-64:
-                  image: ubuntu-2204-64-virt-enabled
+                  image: ubuntu-2404-64-virt-enabled
                   storage: 20G
                   workers: 8
             - ubuntu-24.04-64:
@@ -1191,27 +1191,14 @@ suites:
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m
-        prepare: |
-            #shellcheck source=tests/lib/pkgdb.sh
-            . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/image.sh
-            . "$TESTSLIB"/image.sh
-            distro_update_package_db
-            distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial; then
-                # the new ubuntu-image expects mkfs to support -d option, which was not
-                # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
-                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-            elif os.query is-arm; then
-                snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-            else
-               get_ubuntu_image
-            fi
-
+        prepare: |            
             if os.query is-arm; then
+                snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
                 export NESTED_ARCHITECTURE=arm64
             else
+                #shellcheck source=tests/lib/image.sh
+                . "$TESTSLIB"/image.sh
+                get_ubuntu_image
                 export NESTED_ARCHITECTURE=amd64
             fi
 
@@ -1253,26 +1240,13 @@ suites:
             SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
         manual: true
         prepare: |
-            #shellcheck source=tests/lib/pkgdb.sh
-            . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/image.sh
-            . "$TESTSLIB"/image.sh
-            distro_update_package_db
-            distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial; then
-                # the new ubuntu-image expects mkfs to support -d option, which was not
-                # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
-                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-            elif os.query is-arm; then
-                snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-            else
-                get_ubuntu_image
-            fi
-
             if os.query is-arm; then
+                snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
                 export NESTED_ARCHITECTURE=arm64
             else
+                #shellcheck source=tests/lib/image.sh
+                . "$TESTSLIB"/image.sh
+                get_ubuntu_image
                 export NESTED_ARCHITECTURE=amd64
             fi
 
@@ -1318,21 +1292,14 @@ suites:
             SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
         manual: true
         prepare: |
-            #shellcheck source=tests/lib/pkgdb.sh
-            . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/image.sh
-            . "$TESTSLIB"/image.sh
-            distro_update_package_db
-            distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial; then
-                # the new ubuntu-image expects mkfs to support -d option, which was not
-                # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
-                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-            elif os.query is-arm; then
+            if os.query is-arm; then
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+                export NESTED_ARCHITECTURE=arm64
             else
+                #shellcheck source=tests/lib/image.sh
+                . "$TESTSLIB"/image.sh
                 get_ubuntu_image
+                export NESTED_ARCHITECTURE=amd64
             fi
 
             # Install the snapd built
@@ -1384,21 +1351,14 @@ suites:
         warn-timeout: 10m
         kill-timeout: 60m
         prepare: |
-            #shellcheck source=tests/lib/pkgdb.sh
-            . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/image.sh
-            . "$TESTSLIB"/image.sh
-            distro_update_package_db
-            distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            if os.query is-xenial; then
-                # the new ubuntu-image expects mkfs to support -d option, which was not
-                # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
-                snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-            elif os.query is-arm; then
+            if os.query is-arm; then
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+                export NESTED_ARCHITECTURE=arm64
             else
+                #shellcheck source=tests/lib/image.sh
+                . "$TESTSLIB"/image.sh
                 get_ubuntu_image
+                export NESTED_ARCHITECTURE=amd64
             fi
   
             # Install the snapd built

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -47,7 +47,20 @@ get_ubuntu_image() {
 
 # shellcheck disable=SC2120
 get_google_image_url_for_vm() {
-    case "${1:-$SPREAD_SYSTEM}" in
+    local SYSTEM=$1
+    local ARCH="${2:-amd64}"
+
+    if [ -z "$SYSTEM" ]; then
+        echo "missing system"
+        exit 1
+    fi
+
+    if [ "$ARCH" != amd64 ] && [ "$ARCH" != arm64 ]; then
+        echo "architecture not supported"
+        exit 1
+    fi
+
+    case "$SYSTEM" in
         ubuntu-16.04-64*)
             echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/xenial-server-cloudimg-amd64-disk1.img"
             ;;
@@ -55,22 +68,25 @@ get_google_image_url_for_vm() {
             echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/bionic-server-cloudimg-amd64.img"
             ;;
         ubuntu-20.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-20.04-arm-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-arm64.img"
+            if [ "$ARCH" = amd64 ]; then
+                echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-amd64.img"
+            elif [ "$ARCH" = arm64 ]; then
+                echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-arm64.img"
+            fi
             ;;
         ubuntu-22.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/jammy-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-22.04-arm-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/jammy-server-cloudimg-arm64.img"
-            ;;
-        ubuntu-23.10-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/mantic-server-cloudimg-amd64.img"
+            if [ "$ARCH" = amd64 ]; then
+                echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/jammy-server-cloudimg-amd64.img"
+            elif [ "$ARCH" = arm64 ]; then
+                echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/jammy-server-cloudimg-arm64.img"
+            fi
             ;;
         ubuntu-24.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/noble-server-cloudimg-amd64.img"
+            if [ "$ARCH" = amd64 ]; then
+                echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/noble-server-cloudimg-amd64.img"
+            elif [ "$ARCH" = arm64 ]; then
+                echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/noble-server-cloudimg-arm64.img"
+            fi
             ;;
         *)
             echo "unsupported system"
@@ -81,30 +97,46 @@ get_google_image_url_for_vm() {
 
 # shellcheck disable=SC2120
 get_ubuntu_image_url_for_vm() {
-    case "${1:-$SPREAD_SYSTEM}" in
-        ubuntu-16.04-64*)
+    local SYSTEM=$1
+    local ARCH="${2:-amd64}"
+
+    if [ -z "$SYSTEM" ]; then
+        echo "missing system"
+        exit 1
+    fi
+
+    if [ "$ARCH" != amd64 ] && [ "$ARCH" != arm64 ]; then
+        echo "architecture not supported"
+        exit 1
+    fi
+
+    case "$SYSTEM" in
+        ubuntu-16*)
             echo "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img"
             ;;
-        ubuntu-18.04-64*)
+        ubuntu-18*)
             echo "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img"
             ;;
-        ubuntu-20.04-64*)
-            echo "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+        ubuntu-20*)
+            if [ "$ARCH" = amd64 ]; then
+                echo "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+            elif [ "$ARCH" = arm64 ]; then
+                echo "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+            fi
             ;;
-        ubuntu-20.04-arm-64*)
-            echo "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img"
+        ubuntu-22*)
+            if [ "$ARCH" = amd64 ]; then
+                echo "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+            elif [ "$ARCH" = arm64 ]; then
+                echo "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img"
+            fi
             ;;
-        ubuntu-22.04-64*)
-            echo "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-22.04-arm-64*)
-            echo "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img"
-            ;;
-        ubuntu-23.10-64*)
-            echo "https://cloud-images.ubuntu.com/mantic/current/mantic-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-24.04-64*)
-            echo "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+        ubuntu-24*)
+            if [ "$ARCH" = amd64 ]; then
+                echo "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+            elif [ "$ARCH" = arm64 ]; then
+                echo "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
+            fi
             ;;
         *)
             echo "unsupported system"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -861,8 +861,7 @@ nested_create_core_vm() {
         else
             # create the ubuntu-core image
             local UBUNTU_IMAGE="$GOHOME"/bin/ubuntu-image
-            if os.query is-xenial || os.query is-arm; then
-                # ubuntu-image on 16.04 needs to be installed from a snap
+            if os.query is-arm; then
                 UBUNTU_IMAGE=/snap/bin/ubuntu-image
             fi
 
@@ -1437,7 +1436,7 @@ nested_create_classic_vm() {
 
         # Get the cloud image
         local IMAGE_URL
-        IMAGE_URL="$(get_image_url_for_vm)"
+        IMAGE_URL="$(get_image_url_for_vm "$SPREAD_SYSTEM")"
         wget -q -P "$NESTED_IMAGES_DIR" "$IMAGE_URL"
         nested_download_image "$IMAGE_URL" "$IMAGE_NAME"
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -330,42 +330,42 @@ nested_is_classic_system() {
 
 nested_is_core_ge() {
     local VERSION=$1
-    os.query is-ubuntu-ge "${VERSION}.04"
+    test "${VERSION}" -ge "$(nested_get_version)"
 }
 
 nested_is_core_gt() {
     local VERSION=$1
-    os.query is-ubuntu-gt "${VERSION}.04"
+    test "${VERSION}" -gt "$(nested_get_version)"
 }
 
 nested_is_core_le() {
     local VERSION=$1
-    os.query is-ubuntu-le "${VERSION}.04"
+    test "${VERSION}" -le "$(nested_get_version)"
 }
 
 nested_is_core_lt() {
     local VERSION=$1
-    os.query is-ubuntu-lt "${VERSION}.04"
+    test "${VERSION}" -lt "$(nested_get_version)"
 }
 
 nested_is_core_24_system() {
-    [[ "$SPREAD_SYSTEM" =~ ubuntu-24* ]]
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-24 ]]
 }
 
 nested_is_core_22_system() {
-    [[ "$SPREAD_SYSTEM" =~ ubuntu-22* ]]
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-22 ]]
 }
 
 nested_is_core_20_system() {
-    [[ "$SPREAD_SYSTEM" =~ ubuntu-20* ]]
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-20 ]]
 }
 
 nested_is_core_18_system() {
-    [[ "$SPREAD_SYSTEM" =~ ubuntu-18* ]]
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-18 ]]
 }
 
 nested_is_core_16_system() {
-    [[ "$SPREAD_SYSTEM" =~ ubuntu-16* ]]
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-16 ]]
 }
 
 nested_refresh_to_new_core() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -330,22 +330,22 @@ nested_is_classic_system() {
 
 nested_is_core_ge() {
     local VERSION=$1
-    test "${VERSION}" -ge "$(nested_get_version)"
+    test "$(nested_get_version)" -ge "${VERSION}"
 }
 
 nested_is_core_gt() {
     local VERSION=$1
-    test "${VERSION}" -gt "$(nested_get_version)"
+    test "$(nested_get_version)" -gt "${VERSION}"
 }
 
 nested_is_core_le() {
     local VERSION=$1
-    test "${VERSION}" -le "$(nested_get_version)"
+    test "$(nested_get_version)" -le "${VERSION}"
 }
 
 nested_is_core_lt() {
     local VERSION=$1
-    test "${VERSION}" -lt "$(nested_get_version)"
+    test "$(nested_get_version)" -lt "${VERSION}"
 }
 
 nested_is_core_24_system() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -349,23 +349,23 @@ nested_is_core_lt() {
 }
 
 nested_is_core_24_system() {
-    os.query is-noble
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-24* ]]
 }
 
 nested_is_core_22_system() {
-    os.query is-jammy
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-22* ]]
 }
 
 nested_is_core_20_system() {
-    os.query is-focal
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-20* ]]
 }
 
 nested_is_core_18_system() {
-    os.query is-bionic
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-18* ]]
 }
 
 nested_is_core_16_system() {
-    os.query is-xenial
+    [[ "$SPREAD_SYSTEM" =~ ubuntu-16* ]]
 }
 
 nested_refresh_to_new_core() {
@@ -547,22 +547,22 @@ nested_get_model() {
         return
     fi
     case "$SPREAD_SYSTEM" in
-        ubuntu-16.04-64)
+        ubuntu-16*)
             echo "$TESTSLIB/assertions/nested-amd64.model"
             ;;
-        ubuntu-18.04-64)
+        ubuntu-18*)
             echo "$TESTSLIB/assertions/nested-18-amd64.model"
             ;;
-        ubuntu-20.04-64)
+        ubuntu-20*)
             echo "$TESTSLIB/assertions/nested-20-amd64.model"
             ;;
-        ubuntu-22.04-64)
+        ubuntu-22*)
             echo "$TESTSLIB/assertions/nested-22-amd64.model"
             ;;
-        ubuntu-22.04-arm-64)
+        ubuntu-22*)
             echo "$TESTSLIB/assertions/nested-22-arm64.model"
             ;;
-         ubuntu-24.04-64)
+        ubuntu-24*)
             echo "$TESTSLIB/assertions/nested-24-amd64.model"
             ;;
         *)

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -547,22 +547,22 @@ nested_get_model() {
         return
     fi
     case "$SPREAD_SYSTEM" in
-        ubuntu-16*)
+        ubuntu-16-64)
             echo "$TESTSLIB/assertions/nested-amd64.model"
             ;;
-        ubuntu-18*)
+        ubuntu-18-64)
             echo "$TESTSLIB/assertions/nested-18-amd64.model"
             ;;
-        ubuntu-20*)
+        ubuntu-20-64)
             echo "$TESTSLIB/assertions/nested-20-amd64.model"
             ;;
-        ubuntu-22*)
+        ubuntu-22-64)
             echo "$TESTSLIB/assertions/nested-22-amd64.model"
             ;;
-        ubuntu-22*)
+        ubuntu-22-arm-64)
             echo "$TESTSLIB/assertions/nested-22-arm64.model"
             ;;
-        ubuntu-24*)
+        ubuntu-24-64)
             echo "$TESTSLIB/assertions/nested-24-amd64.model"
             ;;
         *)

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -667,6 +667,8 @@ pkg_dependencies_ubuntu_nested(){
         gdebi-core
         genisoimage
         kpartx
+        lz4
+        lzop
         mtools
         ovmf
         qemu-kvm

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -658,6 +658,26 @@ pkg_dependencies_ubuntu_classic(){
     esac
 }
 
+pkg_dependencies_ubuntu_nested(){
+    echo "
+        build-essential
+        ca-certificates
+        cloud-image-utils
+        devscripts
+        gdebi-core
+        genisoimage
+        kpartx
+        mtools
+        ovmf
+        qemu-kvm
+        qemu-utils
+        snapd
+        sshpass
+        xdelta3
+        xz-utils
+    "
+}
+
 pkg_linux_image_extra (){
     if apt-cache show "linux-image-extra-$(uname -r)" > /dev/null 2>&1; then
         echo "linux-image-extra-$(uname -r)";
@@ -853,6 +873,12 @@ pkg_dependencies_arch(){
 }
 
 pkg_dependencies(){
+    # Nested hosts need a different set of dependencies
+    if tests.nested is-nested; then
+        pkg_dependencies_ubuntu_nested
+        return
+    fi
+
     case "$SPREAD_SYSTEM" in
         ubuntu-core-16-*)
             pkg_dependencies_ubuntu_generic

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -873,20 +873,19 @@ pkg_dependencies_arch(){
 }
 
 pkg_dependencies(){
-    # Nested hosts need a different set of dependencies
-    if tests.nested is-nested >/dev/null 2>&1; then
-        pkg_dependencies_ubuntu_nested
-        return
-    fi
-
     case "$SPREAD_SYSTEM" in
         ubuntu-core-16-*)
             pkg_dependencies_ubuntu_generic
             pkg_dependencies_ubuntu_core
             ;;
         ubuntu-*|debian-*)
-            pkg_dependencies_ubuntu_generic
-            pkg_dependencies_ubuntu_classic
+            # Nested hosts need a different set of dependencies
+            if [ -n "$NESTED_TYPE" ]; then
+                pkg_dependencies_ubuntu_nested
+            else
+                pkg_dependencies_ubuntu_generic
+                pkg_dependencies_ubuntu_classic
+            fi
             ;;
         amazon-*)
             pkg_dependencies_amazon

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -874,7 +874,7 @@ pkg_dependencies_arch(){
 
 pkg_dependencies(){
     # Nested hosts need a different set of dependencies
-    if tests.nested is-nested; then
+    if tests.nested is-nested >/dev/null 2>&1; then
         pkg_dependencies_ubuntu_nested
         return
     fi

--- a/tests/main/preseed-reset/task.yaml
+++ b/tests/main/preseed-reset/task.yaml
@@ -18,7 +18,7 @@ prepare: |
 
   # the get_image_url_for_vm is a convenient helper that returns
   # a cloud image url matching current $SPREAD_SYSTEM.
-  wget --quiet "$(get_image_url_for_vm)" -O cloudimg.img
+  wget --quiet "$(get_image_url_for_vm "$SPREAD_SYSTEM")" -O cloudimg.img
   mkdir -p "$IMAGE_MOUNTPOINT"
 
   #shellcheck source=tests/lib/preseed.sh

--- a/tests/nested/core/core-revert/task.yaml
+++ b/tests/nested/core/core-revert/task.yaml
@@ -8,7 +8,7 @@ details: |
     test uses a virtual machine to ensure that the core snap can be safely
     reverted in case this is required for another reason.
 
-systems: [ubuntu-18.04-64]
+systems: [ubuntu-18-64]
 
 kill-timeout: 30m
 

--- a/tests/nested/core/core-snap-refresh-on-core/task.yaml
+++ b/tests/nested/core/core-snap-refresh-on-core/task.yaml
@@ -5,7 +5,7 @@ details: |
     revision to a new one. It expects to find a new snap revision in the
     channel pointed by the NESTED_CORE_REFRESH_CHANNEL env var.
 
-systems: [ubuntu-16.04-64]
+systems: [ubuntu-16-64]
     
 execute: |
     INITIAL_REV="$(tests.nested snap-rev core "${NESTED_CORE_CHANNEL}")"

--- a/tests/nested/core/core20-basic/task.yaml
+++ b/tests/nested/core/core20-basic/task.yaml
@@ -3,7 +3,7 @@ summary: Run a smoke test on UC20 with encryption enabled
 details: |
     This test checks basic snapd commands on UC20 with secure boot and encryption enabled
 
-systems: [ubuntu-20.04-64, ubuntu-20.04-arm-64]
+systems: [ubuntu-20-64, ubuntu-20-arm-64]
 
 execute: |
     echo "Wait for the system to be seeded first"

--- a/tests/nested/core/core20-set-efi-boot-variables/task.yaml
+++ b/tests/nested/core/core20-set-efi-boot-variables/task.yaml
@@ -1,11 +1,10 @@
 summary: Tests for the code that sets EFI boot variables, as if it were a library separate from snapd
 
-details: >
+details: |
     This test uses snapd as a library to set UEFI boot entries. This
     is useful for installers.
 
-systems:
-  - -ubuntu-1*
+systems: [ubuntu-2*]
 
 prepare: |
     "$(command -v go)" build -o setefivars setefivars.go

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -3,7 +3,7 @@ summary: Check that tpm works properly on UC20
 details: |
     This test check UC20 can boot with secure boot successfully
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 debug: |
     cat modeenv || true

--- a/tests/nested/core/core22-basic/task.yaml
+++ b/tests/nested/core/core22-basic/task.yaml
@@ -3,7 +3,7 @@ summary: Run a smoke test on UC22 with encryption enabled
 details: |
     This test checks basic snapd commands on UC22 with secure boot and encryption enabled
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 execute: |
     echo "Wait for the system to be seeded first"

--- a/tests/nested/core/coreconfig-services/task.yaml
+++ b/tests/nested/core/coreconfig-services/task.yaml
@@ -4,7 +4,7 @@ details: |
   Verifies it is possible to disable and re-enable systemd-resolved service
   via `snap set` with reboot.
 
-systems: [ubuntu-18.04-64, ubuntu-2*]
+systems: [ubuntu-18-64, ubuntu-2*]
 
 execute: |
   remote.exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -8,7 +8,7 @@ details: |
     elevated privileges. The test ensures that once snapd snap is refreshed to a
     version which contains the fix, cloud-init gets disabled.
 
-systems: [ubuntu-18.04-64, ubuntu-16.04-64]
+systems: [ubuntu-18-64, ubuntu-16-64]
 
 environment:
     # this test ensures that existing images without the fix are no longer

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -8,7 +8,7 @@ details: |
     elevated privileges. The test ensures that cloud-init only runs on the first
     boot.
 
-systems: [ubuntu-18.04-64, ubuntu-16.04-64]
+systems: [ubuntu-18-64, ubuntu-16-64]
 
 environment:
     # this is for how nested.sh sets up the initial user, we will control

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -6,7 +6,7 @@ details: |
     configuration settings to a system that is booted for the first time.
 
 # core18 specific test (and nested vm is derived from host system)
-systems: [ubuntu-18.04-64]
+systems: [ubuntu-18-64]
 
 prepare: |
     # modify and repack gadget snap (add defaults section and install hook)

--- a/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
+++ b/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
@@ -15,8 +15,8 @@ details: |
   the old snap-bootstrap/initrd in the stable kernel can still unlock the
   encrypted partitions
 
-# ubuntu-22.04-64: enable on uc22 once pc-kernel is on 22/candidate channel
-systems: [ubuntu-20.04-64]
+# ubuntu-22-64: enable on uc22 once pc-kernel is on 22/candidate channel
+systems: [ubuntu-20-64]
 
 
 environment:

--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -4,7 +4,7 @@ details: |
   This test checks that preseeding of UC20 image with ubuntu-image works
   and that the resulting image boots.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
   NESTED_UBUNTU_IMAGE_PRESEED_KEY: "\" (test)\""

--- a/tests/nested/manual/core20-save/task.yaml
+++ b/tests/nested/manual/core20-save/task.yaml
@@ -5,7 +5,7 @@ details: |
     device or that a device can boot when ubuntu-save is not required
 
 # this is a UC20 specific test
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
   # ubuntu-save, TPM, secure boot

--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -9,7 +9,7 @@ details: |
 # the model in question uses latest/edge of core22 and 22/edge of pc and
 # pc-kernel snaps
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/valid-for-testing-pc-{VERSION}.model

--- a/tests/nested/manual/core20-validation-sets/task.yaml
+++ b/tests/nested/manual/core20-validation-sets/task.yaml
@@ -6,7 +6,7 @@ details: |
     system is known as validation sets. The test verifies that a validation set
     is effective immediately after seeding.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
     # use snapd from the spread run so that we have testkeys trusted in the

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -4,8 +4,8 @@ details: |
   This test creates a classic image that looks like what the installer
   would create and we boot into it.
 
-# TODO: make this test work for ubuntu-24.04-64
-systems: [ubuntu-22.04-64]
+# TODO: make this test work for ubuntu-24-64
+systems: [ubuntu-22-64]
 
 environment:
   NESTED_ENABLE_SECURE_BOOT: false

--- a/tests/nested/manual/gadget-connections/task.yaml
+++ b/tests/nested/manual/gadget-connections/task.yaml
@@ -5,7 +5,7 @@ details: |
     snaps. The test verifies that a gadget snap can effectively connect
     interfaces on a system that is booted for the first time.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
   NESTED_SIGN_SNAPS_FAKESTORE: true

--- a/tests/nested/manual/hybrid-remodel/task.yaml
+++ b/tests/nested/manual/hybrid-remodel/task.yaml
@@ -4,7 +4,7 @@ details: |
   This test remodels on a hybrid system to install a new kernel snap and new
   application snaps.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
   NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -6,7 +6,7 @@ details: |
   We test both the encrypted and unencrypted cases. We also verify that the
   system has properly installed system seed post-installation.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
   # default (encrypted) case. all of the install_optional_* variants exercise

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -2,7 +2,7 @@ summary: End-to-end test for install via muinstaller
 
 details: End-to-end test for install via muinstaller
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
   # No partial gadget by default

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -5,8 +5,8 @@ details: |
   Verify the instance created is a classic ubuntu with the kernel snap installed
 
 # this is a UC20+ specific test
-# TODO this currently fails on ubuntu-20.04-64 timing out
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+# TODO this currently fails on ubuntu-20-64 timing out
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
     # nested test so that we can test encryted installs eventually

--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -4,7 +4,7 @@ details: |
   This test creates a recovery system and validates that the newly created
   system can be rebooted into.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/test-snapd-recovery-system-pc-{VERSION}.model

--- a/tests/nested/manual/remodel-cross-store/task.yaml
+++ b/tests/nested/manual/remodel-cross-store/task.yaml
@@ -6,8 +6,8 @@ details: |
     target model uses test-snapd-remodel store. The new model requires additional
     snaps that are present in the test-snapd-remodel store.
 
-# ubuntu-22.04-64: enable when test-snapd-remodel-pc is release on 22/stable
-systems: [ubuntu-18.04-64, ubuntu-20.04-64]
+# ubuntu-22-64: enable when test-snapd-remodel-pc is release on 22/stable
+systems: [ubuntu-18-64, ubuntu-20-64]
 
 environment:
     NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert

--- a/tests/nested/manual/remodel-min-size/task.yaml
+++ b/tests/nested/manual/remodel-min-size/task.yaml
@@ -7,7 +7,7 @@ details: |
   assertion that uses a different gadget to the one used when building
   the image.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
   NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert

--- a/tests/nested/manual/remodel-offline/task.yaml
+++ b/tests/nested/manual/remodel-offline/task.yaml
@@ -2,7 +2,7 @@ summary: verify UC20 to UC22 offline remodel
 details: |
   Execute transition from UC20 to UC22 remodel in an offline scenario.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
   NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert

--- a/tests/nested/manual/remodel-simple/task.yaml
+++ b/tests/nested/manual/remodel-simple/task.yaml
@@ -5,7 +5,7 @@ details: |
   requires additional snaps that are present in the test-snapd-from
   store.
 
-systems: [ubuntu-18.04-64, ubuntu-2*]
+systems: [ubuntu-18-64, ubuntu-2*]
 
 environment:
     NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert

--- a/tests/nested/manual/remodel-target-base-installed/task.yaml
+++ b/tests/nested/manual/remodel-target-base-installed/task.yaml
@@ -4,7 +4,7 @@ details: |
   test-snapd brand. Both models use the same device view store. The
   old model already has core22 snap installed.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
   NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert

--- a/tests/nested/manual/remodel-uc20-to-uc22/task.yaml
+++ b/tests/nested/manual/remodel-uc20-to-uc22/task.yaml
@@ -4,7 +4,7 @@ details: |
   test-snapd brand. Both models use the same test-snapd-from device
   view store. The new model has new gadget using min-size.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20-64]
 
 environment:
   # encrypted case

--- a/tests/nested/manual/remodel-validation-sets-downgrade/task.yaml
+++ b/tests/nested/manual/remodel-validation-sets-downgrade/task.yaml
@@ -5,7 +5,7 @@ details: |
   version that is lower than the version currently installed on the system.
   Make sure that the remodel downgrades the snap to the lower pinned revision.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/test-snapd-remodel-without-vset-pc-{VERSION}.model

--- a/tests/nested/manual/remodel-validation-sets-invalid/task.yaml
+++ b/tests/nested/manual/remodel-validation-sets-invalid/task.yaml
@@ -7,7 +7,7 @@ details: |
   the case that the model declares a snap that is marked as invalid in any of
   the validation sets that the model declares.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/test-snapd-remodel-without-vset-pc-{VERSION}.model

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -7,7 +7,7 @@ details: |
   base, it does wait for its refresh (and a reboot) because the base must be
   refreshed before the kernel and gadget since those depend on it.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
     NESTED_ENABLE_TPM: false

--- a/tests/nested/manual/uc-update-assets-secure-add-sbat/task.yaml
+++ b/tests/nested/manual/uc-update-assets-secure-add-sbat/task.yaml
@@ -8,7 +8,7 @@ details: |
 # have an sbat, and it is unlikely any UC24 will boot without one.
 # Also it becomes difficult to build an old version on shim on newer
 # GCC.
-systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+systems: [ubuntu-20-64, ubuntu-22-64]
 
 environment:
   NESTED_ENABLE_SECURE_BOOT: true

--- a/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
@@ -4,7 +4,7 @@ details: |
   Check that Ubuntu Core image boots properly and the system is encrypted
   when using fde-setup with feature "inline-cryto-engine"
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22-64, ubuntu-24-64]
 
 environment:
     NESTED_ENABLE_TPM: false

--- a/tests/nested/manual/uc20-install-in-initrd/task.yaml
+++ b/tests/nested/manual/uc20-install-in-initrd/task.yaml
@@ -4,7 +4,7 @@ details: |
   This test checks that we are able to perform a single-boot installation in
   various scenarios.
 
-systems: [ubuntu-20.04-64, ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-20-64, ubuntu-22-64, ubuntu-24-64]
 
 environment:
   # There are 4 modes:


### PR DESCRIPTION
This PR changes the image used in the hosts for nested tests.

So far we used xenial for uc16, bionic for uc18, etc, which is not convenient because we need to maintain several images and the code complexity also is higher.

The system were renamed from ubuntu-XX.04-64 to ubuntu-XX-64. This is because we run ubuntu core and classic systems in the nested vms. Also it is convenient because otherwise, we should change for example all the systems in the tests from ubuntu-2* to ubuntu-core-2* (or similar).

Also the dependency packages installed in the nestet host was reduced and the spread.yaml was simplified.
