### PR TITLE
.github/workflows/coverity-scan.yaml: add github action for Coverity

### DIFF
--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -1,0 +1,65 @@
+name: Weekly Coverity scan of snap-confine
+on:
+  # Run this action on a schedule (we're allowed a maximum of two per day)
+  schedule:
+    - cron: '0 0 * * Mon' # Monday at 00:00 UTC
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  coverity:
+    runs-on: ubuntu-22.04
+    environment: normal
+    if: github.repository == 'canonical/snapd'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        # needed for git commit history
+        fetch-depth: 0
+
+    - name: Download Debian dependencies
+      run: |
+          sudo apt clean
+          sudo apt update
+          sudo apt build-dep -y .
+
+    - name: Get deps
+      run: |
+          ./get-deps.sh
+
+    - name: Configure snap-confine
+      run: |
+          cd cmd/
+          ./autogen.sh
+
+    - name: Download Coverity Build Tool
+      run: |
+          set -x
+          export TOKEN="${{ secrets.COVERITY_SCAN_TOKEN }}"
+          wget https://scan.coverity.com/download/cxx/linux64 --post-data "token=${TOKEN}&project=snap-confine" -O cov-analysis-linux64.tar.gz
+          mkdir cov-analysis-linux64
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+
+    - name: Build with cov-build
+      run: |
+          export PATH=$(pwd)/cov-analysis-linux64/bin:$PATH
+          cd cmd/
+          cov-build --dir cov-int make -j$(nproc)
+
+    - name: Submit to Coverity Scan
+      run: |
+          set -x
+          export TOKEN="${{ secrets.COVERITY_SCAN_TOKEN }}"
+          cd cmd/
+          version=$(cat VERSION)
+          tarball="snap-confine-$version.tar.gz"
+          tar czvf "$tarball" cov-int
+          curl \
+            --form project=snap-confine \
+            --form token="$TOKEN" \
+            --form email=alex.murray@canonical.com \
+            --form file=@"$tarball" \
+            --form version="$version" \
+            --form description="snap-confine `git rev-parse --abbrev-ref HEAD` `git rev-parse --short HEAD`" \
+            https://scan.coverity.com/builds?project=snap-confine


### PR DESCRIPTION
Since the scan.coverity.com API throttles submissions, run weekly for now.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
