### PR TITLE
github: move oracular to ubuntu-no-lts, update ubuntu-daily

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -676,12 +676,12 @@ jobs:
             rules: 'main'
           - group: ubuntu-no-lts
             backend: google
-            systems: ''
+            systems: 'ubuntu-24.10-64'
             tests: 'tests/...'
             rules: 'main'
           - group: ubuntu-daily
             backend: google
-            systems: 'ubuntu-24.10-64'
+            systems: 'ubuntu-25.04-64'
             tests: 'tests/...'
             rules: 'main'
           - group: ubuntu-core-16

--- a/spread.yaml
+++ b/spread.yaml
@@ -144,6 +144,9 @@ backends:
             - ubuntu-24.10-64:
                   storage: 15G
                   workers: 8
+            - ubuntu-25.04-64:
+                  storage: 15G
+                  workers: 8
 
     google-core:
         type: google


### PR DESCRIPTION
Move 24.10 to ubuntu-no-lts group. Add 25.04 to ubuntu-daily.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
