### PR TITLE
cmd/snap-update-ns: switch to a three-pass process

### DIFF
--- a/cmd/snap-update-ns/change_tricky_test.go
+++ b/cmd/snap-update-ns/change_tricky_test.go
@@ -92,14 +92,14 @@ func (s *changeSuite) TestContentLayout2InitiallyConnectedThenDisconnected(c *C)
 	// https://warthogs.atlassian.net/browse/SNAPDENG-31644
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Action: "keep", Entry: current.Entries[4]},
-		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[3])},
 		{Action: "keep", Entry: current.Entries[2]},
-		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[1]},
 		{Action: "keep", Entry: current.Entries[0]},
 	})
 
 	// The actual entry for clarity.
-	c.Assert(changes[3].Entry, DeepEquals, osutil.MountEntry{
+	c.Assert(changes[1].Entry, DeepEquals, osutil.MountEntry{
 		Name:    "/snap/test-snapd-content/x1",
 		Dir:     "/snap/test-snapd-layout/x2/attached-content",
 		Type:    "none",
@@ -191,9 +191,9 @@ func (s *changeSuite) TestContentLayout5InitiallyConnectedThenContentRefreshed(c
 	// This test shows similar behavior to -2- test - the layout stays propagated.
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Action: "keep", Entry: current.Entries[4]},
-		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[3])},
 		{Action: "keep", Entry: current.Entries[2]},
-		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[1]},
 		{Action: "keep", Entry: current.Entries[0]},
 		{Action: "mount", Entry: desired.Entries[1]},
 	})
@@ -211,9 +211,9 @@ func (s *changeSuite) TestContentLayout6InitiallyConnectedThenAppRefreshed(c *C)
 	// and both the layout and content are re-made.
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Action: "unmount", Entry: withDetachOption(current.Entries[4])},
-		{Action: "keep", Entry: current.Entries[3]},
+		{Action: "unmount", Entry: withDetachOption(current.Entries[3])},
 		{Action: "keep", Entry: current.Entries[2]},
-		{Action: "unmount", Entry: withDetachOption(current.Entries[1])},
+		{Action: "keep", Entry: current.Entries[1]},
 		{Action: "keep", Entry: current.Entries[0]},
 		// It is interesting to note that we first mount the content to $SNAP/attached-content
 		// and only then construct the layout from $SNAP/attached-content to /usr/share/secureboot/potato.

--- a/cmd/snap-update-ns/change_tricky_test.go
+++ b/cmd/snap-update-ns/change_tricky_test.go
@@ -232,15 +232,15 @@ func withDetachOption(e osutil.MountEntry) osutil.MountEntry {
 
 func showCurrentDesiredAndChanges(c *C, current, desired *osutil.MountProfile, changes []*update.Change) {
 	c.Logf("Number of current entires: %d", len(current.Entries))
-	for _, entry := range current.Entries {
-		c.Logf("- current : %v", entry)
+	for i, entry := range current.Entries {
+		c.Logf("- current[%d] : %v", i, entry)
 	}
 	c.Logf("Number of desired entires: %d", len(desired.Entries))
-	for _, entry := range desired.Entries {
-		c.Logf("- desired: %v", entry)
+	for i, entry := range desired.Entries {
+		c.Logf("- desired[%d]: %v", i, entry)
 	}
 	c.Logf("Number of changes: %d", len(changes))
-	for _, change := range changes {
-		c.Logf("- change: %v", change)
+	for i, change := range changes {
+		c.Logf("- change[%d]: %v", i, change)
 	}
 }

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -163,11 +163,14 @@ func MockGetgid(fn func() sys.GroupID) (restore func()) {
 	}
 }
 
-func MockChangePerform(f func(chg *Change, as *Assumptions) ([]*Change, error)) func() {
-	origChangePerform := changePerform
-	changePerform = f
+func MockChangePerform(prepare func(chg *Change, as *Assumptions) ([]*Change, error), do func(chg *Change, as *Assumptions) error) func() {
+	origPrepareToPerformChange := prepareToPerformChangeOverride
+	origDoPerformChange := doPerformChangeOverride
+	prepareToPerformChangeOverride = prepare
+	doPerformChangeOverride = do
 	return func() {
-		changePerform = origChangePerform
+		prepareToPerformChangeOverride = origPrepareToPerformChange
+		doPerformChangeOverride = origDoPerformChange
 	}
 }
 

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -67,6 +67,8 @@ func (s *mainSuite) TestExecuteMountProfileUpdate(c *C) {
 
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return nil
 	})
 	defer restore()
 
@@ -151,6 +153,9 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 				Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
 		}
 		return synthetic, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -232,6 +237,9 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -274,6 +282,9 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 		default:
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -317,6 +328,9 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 		default:
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -345,6 +359,8 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 
 	n := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
 		n++
 		switch n {
 		case 0:
@@ -357,7 +373,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 					Options: []string{"bind", "x-snapd.ignore-missing"},
 				},
 			})
-			return nil, update.ErrIgnoredMissingMount
+			return update.ErrIgnoredMissingMount
 		default:
 			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
 		}
@@ -379,6 +395,9 @@ func (s *mainSuite) TestApplyUserFstabHomeRequiredAndValid(c *C) {
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		changes = append(changes, *chg)
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 
@@ -417,6 +436,9 @@ func (s *mainSuite) TestApplyUserFstabErrorHomeRequiredAndMissing(c *C) {
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		changes = append(changes, *chg)
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		// This is the doPerform side of the mock that is doing nothing in this test.
+		return nil
 	})
 	defer restore()
 

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/1-initially-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/1-initially-connected.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/5-initially-connected-then-content-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/5-initially-connected-then-content-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/6-initially-connected-then-app-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/6-initially-connected-then-app-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/1-initially-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/1-initially-connected.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/5-initially-connected-then-content-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/5-initially-connected-then-content-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/6-initially-connected-then-app-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/6-initially-connected-then-app-refreshed.before.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/1-initially-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/1-initially-connected.current.fstab
@@ -2,10 +2,6 @@
 # created at / during construction of the mount namespace, before
 # snap-update-ns is even invoked.
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-# This is the result of a content interface connection, all of
-# test-snapd-content at revision x1 is shared to test-snapd-layout at
-# revision x2, to directory $SNAP/attached-content.
-/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 # This is a writable mimic created on /usr/share/secureboot, so that the
 # subdirectory "potato" can be created inside. There's nothing special about
 # the path. It was used as there are relatvely few elements that need to be
@@ -17,6 +13,10 @@ tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share
 # unmounted. The real source is somewhat more complicated and cannot be
 # expressed with the limited syntax of fstab mount entries.
 /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+# This is the result of a content interface connection, all of
+# test-snapd-content at revision x1 is shared to test-snapd-layout at
+# revision x2, to directory $SNAP/attached-content.
+/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 # This is the layout entry replicating the attached content. This is the root
 # of all evil, as the very popular behavior used by nearly all the snaps relies
 # on an implementation detail that was never envisioned to work this way.

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/5-initially-connected-then-content-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/5-initially-connected-then-content-refreshed.before.current.fstab
@@ -1,5 +1,5 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
 /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 /snap/test-snapd-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/6-initially-connected-then-app-refreshed.before.current.fstab
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/6-initially-connected-then-app-refreshed.before.current.fstab
@@ -1,5 +1,5 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 tmpfs /usr/share/secureboot tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,mode=0755,uid=0,gid=0 0 0
 /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
+/snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 /snap/test-snapd-layout/x2/attached-content /usr/share/secureboot/potato none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/annotations-1.patch
+++ b/cmd/snap-update-ns/testdata/usr-share-secureboot-potato/annotations-1.patch
@@ -7,10 +7,6 @@ index 54fbe65b9b..412f98e827 100644
 +# created at / during construction of the mount namespace, before
 +# snap-update-ns is even invoked.
  tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-+# This is the result of a content interface connection, all of
-+# test-snapd-content at revision x1 is shared to test-snapd-layout at
-+# revision x2, to directory $SNAP/attached-content.
- /snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 +# This is a writable mimic created on /usr/share/secureboot, so that the
 +# subdirectory "potato" can be created inside. There's nothing special about
 +# the path. It was used as there are relatvely few elements that need to be
@@ -22,6 +18,10 @@ index 54fbe65b9b..412f98e827 100644
 +# unmounted. The real source is somewhat more complicated and cannot be
 +# expressed with the limited syntax of fstab mount entries.
  /usr/share/secureboot/updates /usr/share/secureboot/updates none rbind,x-snapd.synthetic,x-snapd.needed-by=/usr/share/secureboot/potato,x-snapd.detach 0 0
++# This is the result of a content interface connection, all of
++# test-snapd-content at revision x1 is shared to test-snapd-layout at
++# revision x2, to directory $SNAP/attached-content.
+ /snap/test-snapd-content/x1 /snap/test-snapd-layout/x2/attached-content none bind,ro 0 0
 +# This is the layout entry replicating the attached content. This is the root
 +# of all evil, as the very popular behavior used by nearly all the snaps relies
 +# on an implementation detail that was never envisioned to work this way.

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -768,6 +768,8 @@ func (s *utilsSuite) TestExecWirableMimicSuccess(c *C) {
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		c.Assert(plan, testutil.DeepContains, chg)
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return nil
 	})
 	defer restore()
 
@@ -811,6 +813,8 @@ func (s *utilsSuite) TestExecWirableMimicErrorWithRecovery(c *C) {
 			recoveryPlan = append(recoveryPlan, chg)
 		}
 		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return nil
 	})
 	defer restore()
 
@@ -840,7 +844,9 @@ func (s *utilsSuite) TestExecWirableMimicErrorNothingDone(c *C) {
 
 	// Mock the act of performing changes and just fail on any request.
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		return nil, errTesting
+		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
+		return errTesting
 	})
 	defer restore()
 
@@ -867,11 +873,13 @@ func (s *utilsSuite) TestExecWirableMimicErrorCannotUndo(c *C) {
 	// recovery path and will have to return a fatal error.
 	i := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+		return nil, nil
+	}, func(chg *update.Change, as *update.Assumptions) error {
 		i++
 		if i > 0 {
-			return nil, fmt.Errorf("failure-%d", i)
+			return fmt.Errorf("failure-%d", i)
 		}
-		return nil, nil
+		return nil
 	})
 	defer restore()
 


### PR DESCRIPTION

Historically Change.Perform was a two-step process, first it would ensure that
both the source and destination of the operation are ready and only then it
would call the lowLevelPerform function to actually mount or unmount.

This works for simple cases but has the problem that the desired changes are
interleaved with construction of writable mimics, especially in
ensure{Source,Target}. This is a problem because it may end up performing a
sequence of operations where a mount we perform is duplicated by the mimic,
like in the example given below:

High-level view:
- unmount /target
- mount --bind /source1 /target/dir
- mount --bind /source2 /target/dir/subdir

Low-level view:
- umount --lazy /target
- make writable mimic /target/dir
- mount --bind /source1/ /target/dir
- make writable mimic /target/dir/subdir
- mount --bind /source2 /target/dir/subdir

The bind mount /target/dir now has two instances, one performed directly and
then another that was created during the construction of a mimic at
/target/dir/ in order to create the sub-directory subdir.

The new three-pass approach breaks that to:
 - apply all keep and unmount actions
 - prepare to apply all mount actions by ensuring source/target is ready and
   constructing any writable mimics necessary.
 - actually apply all mount actions

The new order of operations, for the example given above, is now:

New low-level view:
- umount --lazy /target
- make writable mimic /target/dir
- make writable mimic /target/dir/subdir
- mount --bind /source1/ /target/dir
- mount --bind /source2 /target/dir/subdir

The functions related to preparation are now called PrepareToPerform and the
functions related to actually doing the change are called DoPerform. A helper
that calls one and then the other remains so that fewer overall changes are
necessary. The lowLevelPerform method is now gone and is now the actual
implementation of DoPerform.

Test mocking functions can now mock both sides individually. Mocking was also
redesigned from the classical function variable due to the cycle caused by
PrepareToPerform calling DoPerform internally.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-23293

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
