### PR TITLE
tests/main/component-from-store: fix restore now that another snap is installed during test

### DIFF
--- a/tests/main/component-from-store/task.yaml
+++ b/tests/main/component-from-store/task.yaml
@@ -10,6 +10,12 @@ prepare: |
   snap set system experimental.parallel-instances=true
 
 restore: |
+  if snap list test-snap-with-components; then
+      snap remove test-snap-with-components
+  fi
+  if snap list test-snap-with-components_key; then
+      snap remove test-snap-with-components_key
+  fi
   snap remove test-snap-with-components
   snap unset system experimental.parallel-instances
 


### PR DESCRIPTION
Restore was failing on `google-distro-1:fedora-39-64:tests/main/component-from-store`:
```
...
postinst purge failed
+ ls -lR /var/lib/snapd/snap/ /var/snap/
/var/lib/snapd/snap/:
total 4
drwxr-xr-x. 1 root root 20 Oct 21 18:48 test-snap-with-components_key
...
```