### PR TITLE
tests: disable some tests that no longer work on core18

### DIFF
--- a/tests/core/snapd-refresh-vs-services-reboots/task.yaml
+++ b/tests/core/snapd-refresh-vs-services-reboots/task.yaml
@@ -11,7 +11,9 @@ details: |
 # TODO: move this test to tests/regression/lp-1924805 ?
 
 systems:
-  - ubuntu-core-18-*
+  # snapd 2.49.2 doesn't support snap-declaration format 5, which is used by the
+  # kernel on core18 systems
+  # - ubuntu-core-18-*
   - ubuntu-core-20-*
   # TODO: 2.49.2 does not work on UC22 because of ABI breakage and missing
   # libgcc_s.so.1

--- a/tests/core/snapd-refresh-vs-services/task.yaml
+++ b/tests/core/snapd-refresh-vs-services/task.yaml
@@ -15,7 +15,9 @@ details: |
 # TODO: we should also run it on classic later
 
 systems:
-  - ubuntu-core-18-*
+  # snapd 2.49.2 doesn't support snap-declaration format 5, which is used by the
+  # kernel on core18 systems
+  # - ubuntu-core-18-*
   - ubuntu-core-20-*
   # TODO: 2.49.2 does not work on UC22 because of ABI breakage and missing
   # libgcc_s.so.1


### PR DESCRIPTION
Tests snapd-refresh-vs-services-reboots and snapd-refresh-vs-services no longer work on core18 because the kernel on core18 uses snap-declaration assertion format 5. These tests use snapd version 2.29.2, which only supports format 4 of snap-declaration assertions.