### PR TITLE
c/snap-mgmt: unmount components before unmounting snaps

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -41,6 +41,11 @@ systemctl_stop() {
     done
 }
 
+is_component_mount_unit() {
+    where=$(systemctl show "$1" -p Where | sed 's#Where=##')
+    echo "$where" | grep -q "${SNAP_MOUNT_DIR}/"'[^/]*/components/mnt/[^/]*/[^/]*'
+}
+
 purge() {
     # shellcheck disable=SC1091
     distribution=$(. /etc/os-release; echo "${ID}-${VERSION_ID}")
@@ -51,13 +56,28 @@ purge() {
     fi
 
     units=$(systemctl list-unit-files --no-legend --full | grep -vF snap.mount.service || true)
-    # *.snap mount points
     mounts=$(echo "$units" | grep "^${SNAP_UNIT_PREFIX}[-.].*\\.mount" | cut -f1 -d ' ')
+
+    # *.snap and *.comp mount points
+    snap_mounts=""
+    components_mounts=""
+
+    for mount in $mounts; do
+        if is_component_mount_unit "$mount"; then
+            components_mounts="$components_mounts $mount"
+        else
+            snap_mounts="$snap_mounts $mount"
+        fi
+    done
+
     # services from snaps
     services=$(echo "$units" | grep '^snap\..*\.service' | cut -f1 -d ' ')
     # slices from snaps
     slices=$(echo "$units" | grep '^snap\..*\.slice' | cut -f1 -d ' ')
-    for unit in $services $mounts $slices; do
+
+    # component mounts must come first so that they are unmounted before we
+    # unmount the snap mounts
+    for unit in $services $components_mounts $snap_mounts $slices; do
         # ensure its really a snap mount unit or systemd unit
         if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then
             echo "Skipping non-snapd systemd unit $unit"
@@ -67,7 +87,7 @@ purge() {
         echo "Stopping $unit"
         systemctl_stop "$unit"
 
-        if echo "$unit" | grep -q '.*\.mount' ; then
+        if echo "$unit" | grep -q '.*\.mount' && ! is_component_mount_unit "$unit"; then
             # Transform ${STATIC_SNAP_MOUNT_DIR}/core/3440 -> core/3440 removing any
             # extra / preceding snap name, eg:
             #  /var/lib/snapd/snap/core/3440  -> core/3440

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -42,8 +42,7 @@ systemctl_stop() {
 }
 
 is_component_mount_unit() {
-    where=$(systemctl show "$1" -p Where | sed 's#Where=##')
-    echo "$where" | grep -q "${SNAP_MOUNT_DIR}/"'[^/]*/components/mnt/[^/]*/[^/]*'
+    systemctl show "$1" -p Where | sed 's#Where=##' | grep -q "${SNAP_MOUNT_DIR}/"'[^/]*/components/mnt/[^/]*/[^/]*'
 }
 
 purge() {

--- a/packaging/debian-sid/snapd.postrm
+++ b/packaging/debian-sid/snapd.postrm
@@ -18,6 +18,10 @@ systemctl_stop() {
     done
 }
 
+is_component_mount_unit() {
+    systemctl show "$1" -p Where | sed 's#Where=##' | grep -q "${SNAP_MOUNT_DIR}/"'[^/]*/components/mnt/[^/]*/[^/]*'
+}
+
 if [ "$1" = "purge" ]; then
     # Undo any bind mounts to ${SNAP_MOUNT_DIR} or /var/snap done by parallel
     # installs or LP:#1668659
@@ -32,7 +36,21 @@ if [ "$1" = "purge" ]; then
     services=$(echo "$units" | grep '^snap[-.].*\.service$' || true)
     slices=$(echo "$units" | grep '^snap[-.].*\.slice$' || true)
 
-    for unit in $services $mounts $slices; do
+    # *.snap and *.comp mount points
+    snap_mounts=""
+    components_mounts=""
+
+    for mount in $mounts; do
+        if is_component_mount_unit "$mount"; then
+            components_mounts="$components_mounts $mount"
+        else
+            snap_mounts="$snap_mounts $mount"
+        fi
+    done
+
+    # component mounts must come first so that they are unmounted before we
+    # unmount the snap mounts
+    for unit in $services $components_mounts $snap_mounts $slices; do
         # ensure its really a snap mount unit or systemd unit
         if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then
             echo "Skipping non-snapd systemd unit $unit"
@@ -46,7 +64,7 @@ if [ "$1" = "purge" ]; then
         # unit (we just ignore unit files)
         snap=$(grep 'Where=/snap/' "/etc/systemd/system/$unit"|cut -f3 -d/)
         rev=$(grep 'Where=/snap/' "/etc/systemd/system/$unit"|cut -f4 -d/)
-        if [ -n "$snap" ]; then
+        if [ -n "$snap" ] && ! is_component_mount_unit "$unit"; then
             echo "Removing snap $snap and revision $rev"
             # aliases
             if [ -d /snap/bin ]; then

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -18,6 +18,10 @@ systemctl_stop() {
     done
 }
 
+is_component_mount_unit() {
+    systemctl show "$1" -p Where | sed 's#Where=##' | grep -q "${SNAP_MOUNT_DIR}/"'[^/]*/components/mnt/[^/]*/[^/]*'
+}
+
 if [ "$1" = "purge" ]; then
     # snap.mount.service is a trusty thing
     systemctl_stop snap.mount.service
@@ -32,7 +36,21 @@ if [ "$1" = "purge" ]; then
     services=$(echo "$units" | grep '^snap[-.].*\.service$' || true)
     slices=$(echo "$units" | grep '^snap[-.].*\.slice$' || true)
 
-    for unit in $services $mounts $slices; do
+    # *.snap and *.comp mount points
+    snap_mounts=""
+    components_mounts=""
+
+    for mount in $mounts; do
+        if is_component_mount_unit "$mount"; then
+            components_mounts="$components_mounts $mount"
+        else
+            snap_mounts="$snap_mounts $mount"
+        fi
+    done
+
+    # component mounts must come first so that they are unmounted before we
+    # unmount the snap mounts
+    for unit in $services $components_mounts $snap_mounts $slices; do
         # ensure its really a snap mount unit or systemd unit
         if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then
             echo "Skipping non-snapd systemd unit $unit"
@@ -46,7 +64,7 @@ if [ "$1" = "purge" ]; then
         # unit (we just ignore unit files)
         snap=$(grep 'Where=/snap/' "/etc/systemd/system/$unit"|cut -f3 -d/)
         rev=$(grep 'Where=/snap/' "/etc/systemd/system/$unit"|cut -f4 -d/)
-        if [ -n "$snap" ]; then
+        if [ -n "$snap" ] && ! is_component_mount_unit "$unit"; then
             echo "Removing snap $snap and revision $rev"
             # aliases
             if [ -d /snap/bin ]; then

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -23,6 +23,10 @@ systemctl_stop() {
     done
 }
 
+is_component_mount_unit() {
+    systemctl show "$1" -p Where | sed 's#Where=##' | grep -q "${SNAP_MOUNT_DIR}/"'[^/]*/components/mnt/[^/]*/[^/]*'
+}
+
 if [ "$1" = "purge" ]; then
     # Undo any bind mounts to /snap and /var/snap that resulted from parallel
     # installs for classic snaps or LP:#1668659 (for /snap only, that bug can't
@@ -38,7 +42,21 @@ if [ "$1" = "purge" ]; then
     services=$(echo "$units" | grep '^snap[-.].*\.service$' || true)
     slices=$(echo "$units" | grep '^snap[-.].*\.slice$' || true)
 
-    for unit in $services $mounts $slices; do
+    # *.snap and *.comp mount points
+    snap_mounts=""
+    components_mounts=""
+
+    for mount in $mounts; do
+        if is_component_mount_unit "$mount"; then
+            components_mounts="$components_mounts $mount"
+        else
+            snap_mounts="$snap_mounts $mount"
+        fi
+    done
+
+    # component mounts must come first so that they are unmounted before we
+    # unmount the snap mounts
+    for unit in $services $components_mounts $snap_mounts $slices; do
         # ensure its really a snap mount unit or systemd unit
         if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then
             echo "Skipping non-snapd systemd unit $unit"
@@ -52,7 +70,7 @@ if [ "$1" = "purge" ]; then
         # unit (we just ignore unit files)
         snap=$(grep 'Where=/snap/' "/etc/systemd/system/$unit"|cut -f3 -d/)
         rev=$(grep 'Where=/snap/' "/etc/systemd/system/$unit"|cut -f4 -d/)
-        if [ -n "$snap" ]; then
+        if [ -n "$snap" ] && ! is_component_mount_unit "$unit"; then
             echo "Removing snap $snap and revision $rev"
             # aliases
             if [ -d /snap/bin ]; then

--- a/tests/main/component-from-store/task.yaml
+++ b/tests/main/component-from-store/task.yaml
@@ -10,13 +10,6 @@ prepare: |
   snap set system experimental.parallel-instances=true
 
 restore: |
-  if snap list test-snap-with-components; then
-      snap remove test-snap-with-components
-  fi
-  if snap list test-snap-with-components_key; then
-      snap remove test-snap-with-components_key
-  fi
-  snap remove test-snap-with-components
   snap unset system experimental.parallel-instances
 
 execute: |

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -45,6 +45,10 @@ prepare: |
         snap set-quota group1 test-snapd-service --memory=100MB
     fi
 
+    # install a snap with some components to make sure that we properly clean
+    # those up too
+    snap install test-snap-with-components+one+two
+
     # expecting to find various files that snap installation produced
     test "$(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l)" -gt 0
     test "$(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l)" -gt 0

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -61,6 +61,10 @@ prepare: |
     echo "test service is known to systemd and enabled"
     systemctl list-unit-files --type service --no-legend | MATCH 'snap.test-snapd-service\..*\.service\s+enabled'
 
+    # install a snap with some components to make sure that we properly clean
+    # those up too
+    snap install test-snap-with-components+one+two
+
     # expecting to find various files that snap installation produced
     test "$(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l)" -gt 0
     test "$(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l)" -gt 0


### PR DESCRIPTION
This script was failing when ran on systems that have components installed because it was attempting to remove files that were part of the mounted components. Unmounting them first should solve that.