### PR TITLE
data/selinux: remove timedatex

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -345,11 +345,6 @@ optional_policy(`
 	allow snappy_t systemd_timedated_t:dbus send_msg;
 	allow systemd_timedated_t snappy_t:dbus send_msg;
 ')
-# or on some systems same dbus API may be provided by timedatex
-# RHEL7: there is no timedatex.if
-ifndef(`distro_rhel7',`
-  timedatex_dbus_chat(snappy_t)
-')
 
 # kernel-module-load interface may inspect or write files under /etc/modprobe.d
 optional_policy(`


### PR DESCRIPTION
The upstream selinux-policy has dropped timedatex in https://github.com/fedora-selinux/selinux-policy/commit/2246d17b3c63df73e3359161a9c4e9c07d1cd523 Even when referencing type that no longer exists, our SELinux module builds fine, but then cannot be loaded at runtime:

```
maciek@localhost:~/snapd/data/selinux$ sudo semodule -i snappy.pp.bz2
Failed to resolve typeattributeset statement at /var/lib/selinux/targeted/tmp/modules/400/snappy/cil:223
Failed to resolve AST
semodule:  Failed!
```

And the offending line is:

```
maciek@localhost:~/snapd/data/selinux$ /usr/libexec/selinux/hll/pp snappy.pp | tail -n +223 | head -1
(typeattributeset cil_gen_require timedatex_t)
```

Fixes: https://bugs.launchpad.net/snapd/+bug/2085535

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
