### PR TITLE
testtime: add mockable timers for use in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,6 +129,14 @@ linters-settings:
         deny:
           - pkg: "os/user"
             desc: "Please use osutil/user instead. See https://github.com/canonical/snapd/pull/13776"
+      testtime:
+        files:
+          - "!$test"
+        deny:
+          - pkg: "github.com/snapcore/snapd/testtime"
+            desc: "Cannot use testtime outside of test code"
+          - pkg: "github.com/canonical/snapd/testtime"
+            desc: "Cannot use testtime outside of test code"
 
   misspell:
     # Correct spellings using locale preferences for US or UK.

--- a/randutil/rand.go
+++ b/randutil/rand.go
@@ -83,6 +83,7 @@ func RandomString(length int) string {
 var (
 	Intn   = rand.Intn
 	Int63n = rand.Int63n
+	Perm   = rand.Perm
 )
 
 // RandomDuration returns a random duration up to the given length.

--- a/run-checks
+++ b/run-checks
@@ -241,21 +241,6 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
-    echo "Checking for usages of testtime outside of test code"
-    got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
-        s="$(grep -nP --exclude '*_test.go' --exclude 'testtime/*.go' 'testtime' "$dir"/*.go || true)"
-        if [ -n "$s" ]; then
-            got="$s\\n$got"
-        fi
-    done
-
-    if [ -n "$got" ]; then
-        echo 'Found usages of testtime outside of test code:'
-        echo "$got"
-        exit 1
-    fi
-
     if command -v shellcheck >/dev/null; then
         exclude_tools_path=tests/lib/external/snapd-testing-tools
         echo "Checking shell scripts..."

--- a/run-checks
+++ b/run-checks
@@ -241,17 +241,17 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
-    echo "Checking for usages of testtime.MockTimers outside of test code"
+    echo "Checking for usages of testtime outside of test code"
     got=""
     for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
-        s="$(grep -nP --exclude '*_test.go' 'testtime\.MockTimers' "$dir"/*.go || true)"
+        s="$(grep -nP --exclude '*_test.go' --exclude 'testtime/*.go' 'testtime' "$dir"/*.go || true)"
         if [ -n "$s" ]; then
             got="$s\\n$got"
         fi
     done
 
     if [ -n "$got" ]; then
-        echo 'Found usages of testtime.MockTimers outside of test code:'
+        echo 'Found usages of testtime outside of test code:'
         echo "$got"
         exit 1
     fi

--- a/run-checks
+++ b/run-checks
@@ -241,6 +241,21 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
+    echo "Checking for usages of testtime.MockTimers outside of test code"
+    got=""
+    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
+        s="$(grep -nP --exclude '*_test.go' 'testtime\.MockTimers' "$dir"/*.go || true)"
+        if [ -n "$s" ]; then
+            got="$s\\n$got"
+        fi
+    done
+
+    if [ -n "$got" ]; then
+        echo 'Found usages of testtime.MockTimers outside of test code:'
+        echo "$got"
+        exit 1
+    fi
+
     if command -v shellcheck >/dev/null; then
         exclude_tools_path=tests/lib/external/snapd-testing-tools
         echo "Checking shell scripts..."

--- a/testtime/export_test.go
+++ b/testtime/export_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testtime
+
+import (
+	"time"
+)
+
+func (t *TestTimer) SetCChan(c chan time.Time) {
+	t.c = c
+}

--- a/testtime/testtime.go
+++ b/testtime/testtime.go
@@ -207,8 +207,7 @@ func (t *TestTimer) doFire(currTime time.Time) {
 	// Either t.callback or t.C should be non-nil, and the other should be nil.
 	if t.callback != nil {
 		go t.callback()
-	}
-	if t.c != nil {
+	} else if t.c != nil {
 		t.c <- currTime
 	}
 }

--- a/testtime/testtime_test.go
+++ b/testtime/testtime_test.go
@@ -97,8 +97,7 @@ func (s *testtimeSuite) TestAfterFunc(c *C) {
 	}
 
 	// Manually fire the timer with the current time, though the time doesn't matter here
-	err := timer.Fire(time.Now())
-	c.Check(err, IsNil)
+	timer.Fire(time.Now())
 
 	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 2)
@@ -147,8 +146,7 @@ func (s *testtimeSuite) TestNewTimer(c *C) {
 
 	// Manually fire the timer with the current time
 	currTime := time.Now()
-	err := timer.Fire(currTime)
-	c.Check(err, IsNil)
+	timer.Fire(currTime)
 
 	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 2)
@@ -171,8 +169,7 @@ func (s *testtimeSuite) TestReset(c *C) {
 	default:
 	}
 
-	err := timer.Fire(time.Now())
-	c.Check(err, IsNil)
+	timer.Fire(time.Now())
 
 	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 1)
@@ -320,9 +317,6 @@ func (s *testtimeSuite) TestFireErrors(c *C) {
 
 	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 0)
-	currTime := time.Now()
-	err := timer.Fire(currTime)
-	c.Check(err, ErrorMatches, "cannot fire timer which is not active")
 
 	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 0)
@@ -338,17 +332,10 @@ func (s *testtimeSuite) TestFireErrors(c *C) {
 	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 1)
 
-	err = timer.Fire(currTime)
-	c.Check(err, ErrorMatches, "cannot fire timer which is not active")
-
 	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 1)
 
 	active := timer.Stop()
 	c.Check(active, Equals, false)
-
-	err = timer.Fire(currTime)
-	c.Check(err, ErrorMatches, "cannot fire timer which is not active")
-	c.Check(timer.Active(), Equals, false)
 	c.Check(timer.FireCount(), Equals, 1)
 }

--- a/testtime/testtime_test.go
+++ b/testtime/testtime_test.go
@@ -17,27 +17,30 @@
  *
  */
 
-package timeutil_test
+package testtime_test
 
 import (
+	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/timeutil"
+	"github.com/snapcore/snapd/testtime"
 )
 
-type timerSuite struct{}
+func Test(t *testing.T) { TestingT(t) }
 
-var _ = Suite(&timerSuite{})
+type testtimeSuite struct{}
 
-func (s *timerSuite) TestFakeAfterFunc(c *C) {
+var _ = Suite(&testtimeSuite{})
+
+func (s *testtimeSuite) TestAfterFunc(c *C) {
 	// Create a non-buffered channel on which a message will be sent when the
 	// callback is called. Use a non-buffered channel so that we ensure that
 	// the callback runs in its own goroutine.
 	callbackChan := make(chan string)
 
-	timer := timeutil.FakeAfterFunc(time.Hour, func() {
+	timer := testtime.AfterFunc(time.Hour, func() {
 		callbackChan <- "called"
 	})
 
@@ -93,8 +96,8 @@ func (s *timerSuite) TestFakeAfterFunc(c *C) {
 	}
 }
 
-func (s *timerSuite) TestFakeNewTimer(c *C) {
-	timer := timeutil.FakeNewTimer(time.Second)
+func (s *testtimeSuite) TestNewTimer(c *C) {
+	timer := testtime.NewTimer(time.Second)
 
 	c.Check(timer.Active(), Equals, true)
 	c.Check(timer.FireCount(), Equals, 0)
@@ -142,8 +145,8 @@ func (s *timerSuite) TestFakeNewTimer(c *C) {
 	}
 }
 
-func (s *timerSuite) TestTimerInterfaceCompatibility(c *C) {
-	var t timeutil.Timer
+func (s *testtimeSuite) TestTimerInterfaceCompatibility(c *C) {
+	var t testtime.Timer
 
 	t = time.NewTimer(time.Second)
 	active := t.Reset(time.Second)
@@ -155,20 +158,20 @@ func (s *timerSuite) TestTimerInterfaceCompatibility(c *C) {
 	c.Check(active, Equals, true)
 	active = t.Stop()
 	c.Check(active, Equals, true)
-	t = timeutil.FakeNewTimer(time.Second)
+	t = testtime.NewTimer(time.Second)
 	active = t.Reset(time.Second)
 	c.Check(active, Equals, true)
 	active = t.Stop()
 	c.Check(active, Equals, true)
-	t = timeutil.FakeAfterFunc(time.Second, func() { return })
+	t = testtime.AfterFunc(time.Second, func() { return })
 	active = t.Reset(time.Second)
 	c.Check(active, Equals, true)
 	active = t.Stop()
 	c.Check(active, Equals, true)
 }
 
-func (s *timerSuite) TestFakeTimerReset(c *C) {
-	timer := timeutil.FakeNewTimer(time.Millisecond)
+func (s *testtimeSuite) TestReset(c *C) {
+	timer := testtime.NewTimer(time.Millisecond)
 
 	c.Check(timer.Active(), Equals, true)
 	c.Check(timer.FireCount(), Equals, 0)
@@ -260,8 +263,8 @@ func (s *timerSuite) TestFakeTimerReset(c *C) {
 	c.Check(timer.FireCount(), Equals, 2)
 }
 
-func (s *timerSuite) TestFakeTimerStop(c *C) {
-	timer := timeutil.FakeNewTimer(time.Millisecond)
+func (s *testtimeSuite) TestStop(c *C) {
+	timer := testtime.NewTimer(time.Millisecond)
 
 	c.Check(timer.Active(), Equals, true)
 	c.Check(timer.FireCount(), Equals, 0)
@@ -317,8 +320,8 @@ func (s *timerSuite) TestFakeTimerStop(c *C) {
 	}
 }
 
-func (s *timerSuite) TestFakeTimerFireErrors(c *C) {
-	timer := timeutil.FakeAfterFunc(time.Hour, func() { c.Fatal("should not have been called") })
+func (s *testtimeSuite) TestFireErrors(c *C) {
+	timer := testtime.AfterFunc(time.Hour, func() { c.Fatal("should not have been called") })
 	c.Check(timer.Active(), Equals, true)
 	c.Check(timer.FireCount(), Equals, 0)
 
@@ -334,7 +337,7 @@ func (s *timerSuite) TestFakeTimerFireErrors(c *C) {
 	c.Check(timer.FireCount(), Equals, 0)
 
 	// Re-declare timer with callback which doesn't cause error
-	timer = timeutil.FakeAfterFunc(time.Minute, func() {})
+	timer = testtime.AfterFunc(time.Minute, func() {})
 
 	c.Check(timer.Active(), Equals, true)
 	c.Check(timer.FireCount(), Equals, 0)

--- a/testtime/testtime_test.go
+++ b/testtime/testtime_test.go
@@ -108,6 +108,9 @@ func (s *testtimeSuite) TestAfterFunc(c *C) {
 		// Goroutine may not start immediately, so allow some grace period
 		c.Fatal("callback did not complete")
 	}
+
+	// Firing inactive timer panics
+	c.Check(func() { timer.Fire(time.Now()) }, PanicMatches, "cannot fire timer which is not active")
 }
 
 func (s *testtimeSuite) TestNewTimer(c *C) {
@@ -156,6 +159,9 @@ func (s *testtimeSuite) TestNewTimer(c *C) {
 	default:
 		c.Fatal("timer did not fire")
 	}
+
+	// Firing inactive timer panics
+	c.Check(func() { timer.Fire(currTime) }, PanicMatches, "cannot fire timer which is not active")
 }
 
 func (s *testtimeSuite) TestReset(c *C) {
@@ -305,37 +311,4 @@ func (s *testtimeSuite) TestStop(c *C) {
 		c.Fatal("received from timer chan after Stop called after firing")
 	default:
 	}
-}
-
-func (s *testtimeSuite) TestFireErrors(c *C) {
-	timer := testtime.AfterFunc(time.Hour, func() { c.Fatal("should not have been called") })
-
-	c.Check(timer.Active(), Equals, true)
-	c.Check(timer.FireCount(), Equals, 0)
-
-	timer.Stop()
-
-	c.Check(timer.Active(), Equals, false)
-	c.Check(timer.FireCount(), Equals, 0)
-
-	c.Check(timer.Active(), Equals, false)
-	c.Check(timer.FireCount(), Equals, 0)
-
-	// Re-declare timer with callback which doesn't cause error
-	timer = testtime.AfterFunc(time.Minute, func() {})
-
-	c.Check(timer.Active(), Equals, true)
-	c.Check(timer.FireCount(), Equals, 0)
-
-	timer.Elapse(time.Minute)
-
-	c.Check(timer.Active(), Equals, false)
-	c.Check(timer.FireCount(), Equals, 1)
-
-	c.Check(timer.Active(), Equals, false)
-	c.Check(timer.FireCount(), Equals, 1)
-
-	active := timer.Stop()
-	c.Check(active, Equals, false)
-	c.Check(timer.FireCount(), Equals, 1)
 }

--- a/testtime/testtime_test.go
+++ b/testtime/testtime_test.go
@@ -20,11 +20,15 @@
 package testtime_test
 
 import (
+	"errors"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/testtime"
 )
 
@@ -311,4 +315,465 @@ func (s *testtimeSuite) TestStop(c *C) {
 		c.Fatal("received from timer chan after Stop called after firing")
 	default:
 	}
+}
+
+// Tests from the Go standard library which relate to timers
+
+// Adapted from src/time/time_test.go as of go1.23.3.
+//
+// Issue 25686: hard crash on concurrent timer access.
+// Issue 37400: panic with "racy use of timers"
+// This test deliberately invokes a race condition.
+// We are testing that we don't crash with "fatal error: panic holding locks",
+// and that we also don't panic.
+func (s *testtimeSuite) TestStdlibConcurrentTimerReset(c *C) {
+	const goroutines = 8
+	const tries = 1000
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	timer := testtime.NewTimer(time.Hour)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < tries; j++ {
+				timer.Reset(time.Hour + time.Duration(i*j))
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// Adapted from src/time/time_test.go as of go1.23.3.
+//
+// Issue 37400: panic with "racy use of timers".
+func (s *testtimeSuite) TestStdlibConcurrentTimerResetStop(c *C) {
+	const goroutines = 8
+	const tries = 1000
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	timer := testtime.NewTimer(time.Hour)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < tries; j++ {
+				timer.Reset(time.Hour + time.Duration(i*j))
+			}
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			timer.Stop()
+		}(i)
+	}
+	wg.Wait()
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// newTimerFunc simulates NewTimer using AfterFunc,
+// but this version will not hit the special cases for channels
+// that are used when calling NewTimer.
+// This makes it easy to test both paths.
+func newTimerFunc(d time.Duration) *testtime.TestTimer {
+	c := make(chan time.Time, 1)
+	// XXX: Unlike stdlib test, don't send time over C channel in callback
+	// function, with one exception: if the given duration was <= 0, then the
+	// timer will fire during AfterFunc, which occurs before the C channel is
+	// set, so it needs to be sent over the channel.
+	// Any time the timer expires in the future, it will send current time over
+	// the C channel automatically. If the duration is > 0, then if the
+	// callback tries to send the current time as well, it will block trying
+	// to write to the buffer which has already been filled. This problem can
+	// only occur in this test file, where there is an exported helper to set
+	// the C channel even when the timer was created via AfterFunc.
+	var once sync.Once
+	t := testtime.AfterFunc(d, func() {
+		if d <= 0 {
+			// AfterFunc will expire for the first time before the C channel is
+			// set, so send the current time just this once. If it's reset,
+			// future expirations will send the time over c automatically.
+			once.Do(func() {
+				c <- time.Now()
+			})
+		}
+	})
+	t.SetCChan(c)
+	return t
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func (s *testtimeSuite) TestStdlibAfterStopNewTimer(c *C) {
+	testAfterStop(c, testtime.NewTimer)
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func (s *testtimeSuite) TestStdlibAfterStopAfterFunc(c *C) {
+	testAfterStop(c, newTimerFunc)
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func testAfterStop(c *C, newTimer func(time.Duration) *testtime.TestTimer) {
+	// We want to test that we stop a timer before it runs.
+	// We also want to test that it didn't run after a longer timer.
+	// Since we don't want the test to run for too long, we don't
+	// want to use lengthy times. That makes the test inherently flaky.
+	// So only report an error if it fails five times in a row.
+
+	var errs []string
+	logErrs := func() {
+		for _, e := range errs {
+			c.Log(e)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		tInitial := testtime.AfterFunc(100*time.Millisecond, func() {})
+		t0 := newTimer(50 * time.Millisecond)
+		c1 := make(chan bool, 1)
+		t1 := testtime.AfterFunc(150*time.Millisecond, func() { c1 <- true })
+		if !t0.Stop() {
+			errs = append(errs, "failed to stop event 0")
+			continue
+		}
+		if !t1.Stop() {
+			errs = append(errs, "failed to stop event 1")
+			continue
+		}
+		for _, timer := range []*testtime.TestTimer{tInitial, t0, t1} {
+			timer.Elapse(200 * time.Millisecond)
+		}
+		select {
+		case <-t0.ExpiredC():
+			errs = append(errs, "event 0 was not stopped")
+			continue
+		case <-c1:
+			errs = append(errs, "event 1 was not stopped")
+			continue
+		default:
+		}
+		if t1.Stop() {
+			errs = append(errs, "Stop returned true twice")
+			continue
+		}
+
+		// Test passed, so all done.
+		if len(errs) > 0 {
+			c.Logf("saw %d errors, ignoring to avoid flakiness", len(errs))
+			logErrs()
+		}
+
+		return
+	}
+
+	c.Errorf("saw %d errors", len(errs))
+	logErrs()
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func (s *testtimeSuite) TestStdlibTimerStopStress(c *C) {
+	for i := 0; i < 100; i++ {
+		go func(i int) {
+			timer := testtime.AfterFunc(2*time.Second, func() {
+				c.Errorf("timer %d was not stopped", i)
+			})
+			timer.Elapse(1 * time.Second)
+			timer.Stop()
+			timer.Elapse(1 * time.Second)
+		}(i)
+	}
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func testReset(d time.Duration) error {
+	t0 := testtime.NewTimer(2 * d)
+	t0.Elapse(d)
+	if !t0.Reset(3 * d) {
+		return errors.New("resetting unfired timer returned false")
+	}
+	t0.Elapse(2 * d)
+	select {
+	case <-t0.ExpiredC():
+		return errors.New("timer fired early")
+	default:
+	}
+	t0.Elapse(2 * d)
+	select {
+	case <-t0.ExpiredC():
+	default:
+		return errors.New("reset timer did not fire")
+	}
+
+	if t0.Reset(50 * time.Millisecond) {
+		return errors.New("resetting expired timer returned true")
+	}
+	return nil
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func (s *testtimeSuite) TestStdlibReset(c *C) {
+	// We try to run this test with increasingly larger multiples
+	// until one works so slow, loaded hardware isn't as flaky,
+	// but without slowing down fast machines unnecessarily.
+	//
+	// (maxDuration is several orders of magnitude longer than we
+	// expect this test to actually take on a fast, unloaded machine.)
+	d := 1 * time.Millisecond
+	const maxDuration = 10 * time.Second
+	for {
+		err := testReset(d)
+		if err == nil {
+			break
+		}
+		d *= 2
+		if d > maxDuration {
+			c.Error(err)
+		}
+		c.Logf("%v; trying duration %v", err, d)
+	}
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// Test that zero duration timers aren't missed by the scheduler. Regression test for issue 44868.
+func (s *testtimeSuite) TestStdlibZeroTimerNewTimer(c *C) {
+	testZeroTimer(c, testtime.NewTimer)
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// Test that zero duration timers aren't missed by the scheduler. Regression test for issue 44868.
+func (s *testtimeSuite) TestStdlibZeroTimerAfterFunc(c *C) {
+	testZeroTimer(c, newTimerFunc)
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// Test that zero duration timers aren't missed by the scheduler. Regression test for issue 44868.
+func (s *testtimeSuite) TestStdlibZeroTimerAfterFuncReset(c *C) {
+	timer := newTimerFunc(time.Hour)
+	testZeroTimer(c, func(d time.Duration) *testtime.TestTimer {
+		timer.Reset(d)
+		return timer
+	})
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func testZeroTimer(c *C, newTimer func(time.Duration) *testtime.TestTimer) {
+	// XXX: stdlib does 1000000, but that's really slow, so do 1/10 that
+	for i := 0; i < 100000; i++ {
+		s := time.Now()
+		ti := newTimer(0)
+		<-ti.ExpiredC()
+		if diff := time.Since(s); diff > 2*time.Second {
+			c.Errorf("Expected time to get value from Timer channel in less than 2 sec, took %v", diff)
+		}
+	}
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// Test that rapidly moving a timer earlier doesn't cause it to get dropped.
+// Issue 47329.
+func (s *testtimeSuite) TestStdlibTimerModifiedEarlier(c *C) {
+	past := time.Until(time.Unix(0, 0))
+	count := 1000
+	fail := 0
+	for i := 0; i < count; i++ {
+		timer := newTimerFunc(time.Hour)
+		for j := 0; j < 10; j++ {
+			if !timer.Stop() {
+				select {
+				case <-timer.ExpiredC():
+					// This shouldn't be necessary since we comply with 1.23
+					// behavior:
+					// "as of Go 1.23, any receive from t.C after Stop has
+					// returned is guaranteed to block rather than receive a
+					// stale time value from before the Stop"
+					//
+					// See: https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/time/sleep.go;l=105
+				default:
+				}
+			}
+			timer.Reset(past)
+		}
+
+		now := time.Now()
+		select {
+		case <-timer.ExpiredC():
+			if since := time.Since(now); since > 8*time.Second {
+				c.Errorf("timer took too long (%v)", since)
+				fail++
+			}
+		default:
+			c.Error("deadline expired")
+		}
+	}
+
+	if fail > 0 {
+		c.Errorf("%d failures", fail)
+	}
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// Test that rapidly moving timers earlier and later doesn't cause
+// some of the sleep times to be lost.
+// Issue 47762
+func (s *testtimeSuite) TestStdlibAdjustTimers(c *C) {
+	timers := make([]*testtime.TestTimer, 100)
+	states := make([]int, len(timers))
+	indices := randutil.Perm(len(timers))
+
+	for len(indices) != 0 {
+		var ii = randutil.Intn(len(indices))
+		var i = indices[ii]
+
+		var timer = timers[i]
+		var state = states[i]
+		states[i]++
+
+		switch state {
+		case 0:
+			timers[i] = newTimerFunc(0)
+
+		case 1:
+			<-timer.ExpiredC() // Timer is now idle.
+
+		// Reset to various long durations, which we'll cancel.
+		case 2:
+			if timer.Reset(1 * time.Minute) {
+				panic("shouldn't be active (1)")
+			}
+		case 4:
+			if timer.Reset(3 * time.Minute) {
+				panic("shouldn't be active (3)")
+			}
+		case 6:
+			if timer.Reset(2 * time.Minute) {
+				panic("shouldn't be active (2)")
+			}
+
+		// Stop and drain a long-duration timer.
+		case 3, 5, 7:
+			if !timer.Stop() {
+				c.Logf("timer %d state %d Stop returned false", i, state)
+				<-timer.ExpiredC()
+			}
+
+		// Start a short-duration timer we expect to select without blocking.
+		case 8:
+			if timer.Reset(0) {
+				c.Fatal("timer.Reset returned true")
+			}
+		case 9:
+			now := time.Now()
+			<-timer.ExpiredC()
+			dur := time.Since(now)
+			if dur > 750*time.Millisecond {
+				c.Errorf("timer %d took %v to complete", i, dur)
+			}
+
+		// Timer is done. Swap with tail and remove.
+		case 10:
+			indices[ii] = indices[len(indices)-1]
+			indices = indices[:len(indices)-1]
+		}
+	}
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func (s *testtimeSuite) TestStdlibStopResult(c *C) {
+	testStopResetResult(c, true)
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+func (s *testtimeSuite) TestStdlibResetResult(c *C) {
+	testStopResetResult(c, false)
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// Test that when racing between running a timer and stopping a timer Stop
+// consistently indicates whether a value can be read from the channel.
+// Issue #69312.
+func testStopResetResult(c *C, testStop bool) {
+	stopOrReset := func(timer *testtime.TestTimer) bool {
+		if testStop {
+			return timer.Stop()
+		} else {
+			return timer.Reset(1 * time.Hour)
+		}
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	const N = 1000
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				timer1 := testtime.NewTimer(1 * time.Millisecond)
+				timer2 := testtime.NewTimer(1 * time.Millisecond)
+				if randutil.Intn(2) == 0 {
+					timer1.Elapse(time.Millisecond)
+				} else {
+					timer2.Elapse(time.Millisecond)
+				}
+				select {
+				case <-timer1.ExpiredC():
+					if !stopOrReset(timer2) {
+						// The test fails if this
+						// channel read times out.
+						<-timer2.ExpiredC()
+					}
+				case <-timer2.ExpiredC():
+					if !stopOrReset(timer1) {
+						// The test fails if this
+						// channel read times out.
+						<-timer1.ExpiredC()
+					}
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+}
+
+// Adapted from src/time/sleep_test.go as of go1.23.3.
+//
+// Test having a large number of goroutines wake up a timer simultaneously.
+// This used to trigger a crash when run under x/tools/cmd/stress.
+func (s *testtimeSuite) TestStdlibMultiWakeupTimer(c *C) {
+	goroutines := runtime.GOMAXPROCS(0)
+	timer := testtime.NewTimer(time.Nanosecond)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10000; j++ {
+				select {
+				case <-timer.ExpiredC():
+				default:
+				}
+				timer.Reset(time.Nanosecond)
+			}
+		}()
+	}
+	doneChan := make(chan struct{})
+	go func() {
+		// Time won't elapse on its own, so we do it manually
+		for {
+			select {
+			case <-doneChan:
+				return
+			default:
+				timer.Elapse(time.Nanosecond)
+			}
+		}
+	}()
+	wg.Wait()
+	close(doneChan)
 }

--- a/timeutil/timer.go
+++ b/timeutil/timer.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil
+
+import (
+	"time"
+)
+
+// Timer is an interface which wraps time.Timer so that it may be mocked.
+//
+// Timer is fully compatible with time.Timer, except that since interfaces
+// cannot have instance variables, we must expose the C channel as a method.
+// Therefore, when replacing a time.Timer with timeutil.Timer, any accesses of C
+// must be replaced with ExpireC().
+//
+// For more information about time.Timer, see: https://pkg.go.dev/time#Timer
+type Timer interface {
+	Reset(d time.Duration) bool
+	Stop() bool
+	// ExpiredC is equivalent to t.C for StdlibTimer and time.Timer.
+	ExpiredC() <-chan time.Time
+}
+
+type StdlibTimer struct {
+	*time.Timer
+}
+
+// AfterFunc waits for the duration to elapse and then calls f in its own
+// goroutine. It returns a Timer that can be used to cancel the call using its
+// Stop method. The returned Timer's C field is not used and will be nil.
+//
+// See here for more information: https://pkg.go.dev/time#AfterFunc
+func AfterFunc(d time.Duration, f func()) StdlibTimer {
+	return StdlibTimer{time.AfterFunc(d, f)}
+}
+
+// NewTimer creates a new Timer that will send the current time on its channel
+// after at least duration d.
+//
+// See here for more information: https://pkg.go.dev/time#NewTimer
+func NewTimer(d time.Duration) StdlibTimer {
+	return StdlibTimer{time.NewTimer(d)}
+}
+
+// ExpiredC returns the channel t.C over which the current time will be sent
+// when the timer expires, assuming the timer was created via NewTimer.
+//
+// If the timer was created via AfterFunc, then t.C is nil, so this function
+// returns nil.
+func (t StdlibTimer) ExpiredC() <-chan time.Time {
+	return t.C
+}

--- a/timeutil/timer.go
+++ b/timeutil/timer.go
@@ -1,0 +1,178 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package timer provides a wrapper around time.Timer and its associated
+// functions so that timers can be mocked in tests.
+package timeutil
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Timer is an interface which wraps time.Timer so that it may be mocked.
+type Timer interface {
+	Reset(d time.Duration) bool
+	Stop() bool
+}
+
+// FakeAfterFunc creates a new fake timer which will call the given callback in
+// its own goroutine when the timer fires. The returned FakeTimer's C field is
+// not used and will be nil.
+//
+// This simulates the behavior of AfterFunc() from the time package.
+// See here for more details: https://pkg.go.dev/time#AfterFunc
+func FakeAfterFunc(d time.Duration, f func()) *FakeTimer {
+	currTime := time.Now()
+	return &FakeTimer{
+		currTime:   currTime,
+		expiration: currTime.Add(d),
+		callback:   f,
+	}
+}
+
+// FakeNewTimer creates a new fake timer which, when it fires, will send the
+// time that the timer fires over the C channel.
+//
+// This simulates the behavior of NewTimer() from the time package.
+// See here for more details: https://pkg.go.dev/time#NewTimer
+func FakeNewTimer(d time.Duration) *FakeTimer {
+	currTime := time.Now()
+	c := make(chan time.Time, 1)
+	return &FakeTimer{
+		currTime:   currTime,
+		expiration: currTime.Add(d),
+		c:          c,
+		C:          c,
+	}
+}
+
+// FakeTimer is a mocked version of time.Timer for which the passage of time or
+// the direct expiration of the timer is controlled manually.
+type FakeTimer struct {
+	lock       sync.Mutex
+	currTime   time.Time
+	expiration time.Time
+	fired      bool
+	stopped    bool
+	callback   func()
+	c          chan<- time.Time // internally, c is write-only
+	C          <-chan time.Time // export c as read-only
+}
+
+// Reset changes the timer to expire after duration d. It returns true if the
+// timer had been active, false if the timer had expired or been stopped.
+//
+// As the fake timer does not actually count down, Reset sets the timer's
+// expiration to be the given duration added to the timer's internal current
+// time. This internal time must be advanced manually using Elapse.
+//
+// This simulates the behavior of Timer.Reset() from the time package.
+// See here fore more details: https://pkg.go.dev/time#Timer.Reset
+func (t *FakeTimer) Reset(d time.Duration) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	notYetFired := !t.fired
+	t.fired = false
+	t.stopped = false
+	t.expiration = t.currTime.Add(d)
+	if t.C != nil {
+		// Drain the channel, guaranteeing that a receive after Reset will
+		// block until the timer fires again, and not receive a time value
+		// from the timer firing before the reset occurred.
+		// This complies with the new behavior of Reset as of Go 1.23.
+		// See: https://pkg.go.dev/time#Timer.Reset
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	return notYetFired
+}
+
+// Stop prevents the timer from firing. It returns true if the call stops the
+// timer, false if the timer has already expired or been stopped.
+//
+// This simulates the behavior of Timer.Stop() from the time package.
+// See here for more details: https://pkg.go.dev/time#Timer.Stop
+func (t *FakeTimer) Stop() bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	notYetFired := !t.fired
+	t.stopped = true
+	if t.C != nil {
+		// Drain the channel, guaranteeing that a receive after Stop will block
+		// and not receive a time value from the timer firing before the stop
+		// occurred. This complies with the new behavior of Stop as of Go 1.23.
+		// See: https://pkg.go.dev/time#Timer.Stop
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	return notYetFired
+}
+
+// Elapse simulates the current time advancing by the given duration, which
+// potentially causes the timer to fire.
+//
+// The timer will fire if the time after the elapsed duration is after the
+// expiration time and the timer has not yet fired.
+func (t *FakeTimer) Elapse(duration time.Duration) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.currTime = t.currTime.Add(duration)
+	if !t.currTime.Before(t.expiration) {
+		t.doFire(t.expiration)
+	}
+}
+
+// Fire causes the timer to fire. If the timer was created via NewTimer, then
+// sends the given current time over the C channel.
+//
+// To avoid accidental misuse, throw an error if the timer has already fired or
+// been stopped.
+func (t *FakeTimer) Fire(currTime time.Time) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.stopped {
+		return fmt.Errorf("cannot fire timer which has already been stopped")
+	}
+	if t.fired {
+		return fmt.Errorf("cannot fire timer which has already fired")
+	}
+	t.doFire(currTime)
+	return nil
+}
+
+// doFire carries out the timer firing. The caller must hold the timer lock.
+func (t *FakeTimer) doFire(currTime time.Time) {
+	if t.stopped || t.fired {
+		return
+	}
+	t.fired = true
+	// Either t.callback or t.C should be non-nil, and the other should be nil.
+	if t.callback != nil {
+		go t.callback()
+	}
+	if t.c != nil {
+		t.c <- currTime
+	}
+}

--- a/timeutil/timer_test.go
+++ b/timeutil/timer_test.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/timeutil"
+)
+
+type timerSuite struct{}
+
+var _ = Suite(&timerSuite{})
+
+var _ timeutil.Timer = timeutil.StdlibTimer{}
+
+func (s *timerSuite) TestAfterFuncExpiredC(c *C) {
+	var timer timeutil.Timer = timeutil.AfterFunc(time.Second, func() {})
+	c.Assert(timer, NotNil)
+	c.Assert(timer.ExpiredC(), IsNil)
+	active := timer.Stop()
+	c.Assert(active, Equals, true)
+}
+
+func (s *timerSuite) TestNewTimerExpiredC(c *C) {
+	before := time.Now()
+	var timer timeutil.Timer = timeutil.NewTimer(time.Nanosecond)
+	c.Assert(timer, NotNil)
+	c.Assert(timer.ExpiredC(), NotNil)
+	fired := <-timer.ExpiredC()
+	after := time.Now()
+	c.Check(before.Before(fired), Equals, true)
+	c.Check(after.After(fired), Equals, true)
+	active := timer.Reset(time.Second)
+	c.Check(active, Equals, false)
+	active = timer.Stop()
+	c.Check(active, Equals, true)
+}

--- a/timeutil/timer_test.go
+++ b/timeutil/timer_test.go
@@ -1,0 +1,289 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/timeutil"
+)
+
+type timerSuite struct{}
+
+var _ = Suite(&timerSuite{})
+
+func (s *timerSuite) TestFakeAfterFunc(c *C) {
+	// Create a non-buffered channel on which a message will be sent when the
+	// callback is called. Use a non-buffered channel so that we ensure that
+	// the callback runs in its own goroutine.
+	callbackChan := make(chan string)
+
+	timer := timeutil.FakeAfterFunc(time.Hour, func() {
+		callbackChan <- "called"
+	})
+
+	c.Check(timer.C, IsNil)
+
+	select {
+	case <-callbackChan:
+		c.Fatal("callback fired early")
+	default:
+	}
+
+	// Manually advance the timer so that it will fire
+	timer.Elapse(time.Hour)
+
+	select {
+	case msg := <-callbackChan:
+		c.Assert(msg, Equals, "called")
+	case <-time.NewTimer(time.Minute).C:
+		// Goroutine may not start immediately, so allow some grace period
+		c.Fatal("callback did not complete")
+	}
+
+	// Reset timer to check that if it fires again, the callback will be called again
+	timer.Reset(time.Nanosecond)
+
+	c.Check(timer.C, IsNil)
+
+	select {
+	case <-callbackChan:
+		c.Fatal("callback fired early")
+	default:
+	}
+
+	// Manually fire the timer with the current time, though the time doesn't matter here
+	err := timer.Fire(time.Now())
+	c.Check(err, IsNil)
+
+	select {
+	case msg := <-callbackChan:
+		c.Assert(msg, Equals, "called")
+	case <-time.NewTimer(time.Minute).C:
+		// Goroutine may not start immediately, so allow some grace period
+		c.Fatal("callback did not complete")
+	}
+}
+
+func (s *timerSuite) TestFakeNewTimer(c *C) {
+	timer := timeutil.FakeNewTimer(time.Second)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired early")
+	default:
+	}
+
+	// Manually advance the timer so that it will fire
+	timer.Elapse(time.Second)
+
+	select {
+	case <-timer.C:
+	default:
+		c.Fatal("timer did not fire")
+	}
+
+	// Reset timer to check that if it fires again, the callback will be called again
+	timer.Reset(time.Nanosecond)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired early")
+	default:
+	}
+
+	// Manually fire the timer with the current time
+	currTime := time.Now()
+	err := timer.Fire(currTime)
+	c.Check(err, IsNil)
+
+	select {
+	case t := <-timer.C:
+		c.Assert(t.Equal(currTime), Equals, true)
+	default:
+		c.Fatal("timer did not fire")
+	}
+}
+
+func (s *timerSuite) TestTimerInterfaceCompatibility(c *C) {
+	var t timeutil.Timer
+
+	t = time.NewTimer(time.Second)
+	t.Reset(time.Second)
+	t.Stop()
+	t = time.AfterFunc(time.Second, func() { return })
+	t.Reset(time.Second)
+	t.Stop()
+	t = timeutil.FakeNewTimer(time.Second)
+	t.Reset(time.Second)
+	t.Stop()
+	t = timeutil.FakeAfterFunc(time.Second, func() { return })
+	t.Reset(time.Second)
+	t.Stop()
+}
+
+func (s *timerSuite) TestFakeTimerReset(c *C) {
+	timer := timeutil.FakeNewTimer(time.Millisecond)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired early")
+	default:
+	}
+
+	err := timer.Fire(time.Now())
+	c.Check(err, IsNil)
+
+	notFired := timer.Reset(time.Millisecond)
+	c.Check(notFired, Equals, false)
+
+	// Check that receiving from the timer channel blocks after reset, even
+	// though the timer previously fired
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired after reset")
+	default:
+	}
+
+	// Reset the timer
+	notFired = timer.Reset(3 * time.Second)
+	c.Check(notFired, Equals, true)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired early")
+	default:
+	}
+
+	// Elapse more than half the time
+	timer.Elapse(2 * time.Second)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired early")
+	default:
+	}
+
+	// Reset the timer
+	notFired = timer.Reset(3 * time.Second)
+	c.Check(notFired, Equals, true)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired after reset")
+	default:
+	}
+
+	// Elapse more than half the time again
+	timer.Elapse(2 * time.Second)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired after time elapsed following reset")
+	default:
+	}
+
+	// Elapse the remaining time
+	timer.Elapse(time.Second)
+
+	select {
+	case <-timer.C:
+	default:
+		c.Fatal("timer did not fire")
+	}
+
+	notFired = timer.Reset(time.Second)
+	c.Check(notFired, Equals, false)
+}
+
+func (s *timerSuite) TestFakeTimerStop(c *C) {
+	timer := timeutil.FakeNewTimer(time.Millisecond)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired early")
+	default:
+	}
+
+	notFired := timer.Stop()
+	c.Check(notFired, Equals, true)
+
+	select {
+	case <-timer.C:
+		c.Fatal("timer fired after Stop")
+	default:
+	}
+
+	// Elapse time so the timer would have fired if it were not stopped
+	timer.Elapse(time.Millisecond)
+
+	select {
+	case <-timer.C:
+		c.Fatal("received from timer chan after Stop and Elapse")
+	default:
+	}
+
+	// Reset the timer, and check that the timer was not previously fired
+	notFired = timer.Reset(time.Second)
+	c.Check(notFired, Equals, true)
+
+	// Elapse time so that the timer fires
+	timer.Elapse(1500 * time.Millisecond)
+
+	// Stop the timer after it has fired
+	notFired = timer.Stop()
+	c.Check(notFired, Equals, false)
+
+	select {
+	case <-timer.C:
+		c.Fatal("received from timer chan after Stop called after firing")
+	default:
+	}
+}
+
+func (s *timerSuite) TestFakeTimerFireErrors(c *C) {
+	timer := timeutil.FakeAfterFunc(time.Hour, func() { c.Fatal("should not have been called") })
+
+	timer.Stop()
+
+	currTime := time.Now()
+	err := timer.Fire(currTime)
+	c.Check(err, ErrorMatches, "cannot fire timer which has already been stopped")
+
+	notFired := timer.Reset(time.Minute)
+	c.Check(notFired, Equals, true)
+
+	// Re-declare timer with callback which doesn't cause error
+	timer = timeutil.FakeAfterFunc(time.Minute, func() {})
+
+	timer.Elapse(time.Minute)
+	err = timer.Fire(currTime)
+	c.Check(err, ErrorMatches, "cannot fire timer which has already fired")
+
+	notFired = timer.Stop()
+	c.Check(notFired, Equals, false)
+
+	// Check that the error from calling Fire on a stopped timer preempts the
+	// error for calling Fire on a timer which has already fired.
+	err = timer.Fire(currTime)
+	c.Check(err, ErrorMatches, "cannot fire timer which has already been stopped")
+}


### PR DESCRIPTION
Introduce a `testtime` package with a `Timer` interface which can be used in place of `time.Timer` when we want direct control over timers in tests.

The `testtime.Timer` interface is fully compatible with `time.Timer`, except that the former has a `C()` method instead of instance variable, as interfaces cannot have instance variables. As such, `time.Timer` does not directly implement `testtime.Timer`, so we must define a minimal wrapper (`testtime.RealTimer`) which directly calls the functions/methods associated with `time.Timer`, and exposes the latter's `C` instance variable as `C()`.

The `testtime.TestTimer` struct simulates the behavior of `time.Timer`, except that control of the passage of time and the ability to fire the timer are provided directly to the user. This way, tests which depend on timer behavior can avoid race conditions and sleeps.