### PR TITLE
interfaces/default: allow owner read on `@{PROC}/@{pid}/sessionid`

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -267,6 +267,7 @@ var templateCommon = `
   @{PROC}/@{pid}/io r,
   owner @{PROC}/@{pid}/limits r,
   owner @{PROC}/@{pid}/loginuid r,
+  owner @{PROC}/@{pid}/sessionid r,
   @{PROC}/@{pid}/smaps r,
   @{PROC}/@{pid}/stat r,
   @{PROC}/@{pid}/statm r,


### PR DESCRIPTION
This is used by auditd, and is generally safe to expose.