### PR TITLE
overlord/fdestate/backend/reseal.go: factor FDE hook and TPM resealing

### DIFF
--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -60,7 +60,26 @@ func MockSecbootBuildPCRProtectionProfile(f func(modelParams []*secboot.SealKeyM
 	}
 }
 
-type StateUpdater func(role string, containerRole string, bootModes []string, models []secboot.ModelForSealing, tpmPCRProfile []byte) error
+// SealingParameters contains the parameters that may be used for
+// sealing.  It should be the same as
+// fdestate.KeyslotRoleParameters. However we cannot import it. See
+// documentation for that type.
+type SealingParameters struct {
+	BootModes     []string
+	Models        []secboot.ModelForSealing
+	TpmPCRProfile []byte
+}
+
+// FDEStateManager represents an interface for a manager that can
+// store a state for sealing parameters.
+type FDEStateManager interface {
+	// Update will update the sealing parameters for a give role.
+	Update(role string, containerRole string, parameters *SealingParameters) error
+	// Get returns the current parameters for a given role. If parameters exist for that role, it will return nil without error.
+	Get(role string, containerRole string) (parameters *SealingParameters, err error)
+	// Unlock notifies the manager that the state can be unlocked and returns a function to relock it.
+	Unlock() (relock func())
+}
 
 // comparableModel is just a representation of secboot.ModelForSealing
 // that is comparable so we can use it as an index of a map.
@@ -100,93 +119,96 @@ func getUniqueModels(bootChains []boot.BootChain) []secboot.ModelForSealing {
 	return models
 }
 
-func resealKeyForBootChainsFDEHook(method device.SealingMethod, rootdir string, inputs resealInputs, opts resealOptions) error {
-	params := inputs.bootChains
+func doReseal(manager FDEStateManager, method device.SealingMethod, rootdir string) error {
+	runParams, err := manager.Get("run+recover", "all")
+	if err != nil {
+		return err
+	}
+
+	recoveryParams, err := manager.Get("recover", "system-save")
+	if err != nil {
+		return err
+	}
+
 	runKeys := []string{
 		device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir),
 	}
-	runModels := getUniqueModels(append(params.RunModeBootChains, params.RecoveryBootChainsForRunKey...))
 
 	recoveryKeys := []string{
 		device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
 		device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
 	}
+
+	switch method {
+	case device.SealingMethodFDESetupHook:
+		primaryKeyFile := filepath.Join(boot.InstallHostFDESaveDir, "aux-key")
+		if runParams != nil {
+			if err := secbootResealKeysWithFDESetupHook(runKeys, primaryKeyFile, runParams.Models); err != nil {
+				return err
+			}
+		}
+		if recoveryParams != nil {
+			if err := secbootResealKeysWithFDESetupHook(recoveryKeys, primaryKeyFile, recoveryParams.Models); err != nil {
+				return err
+			}
+		}
+		return nil
+	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
+		saveFDEDir := dirs.SnapFDEDirUnderSave(dirs.SnapSaveDirUnder(rootdir))
+		authKeyFile := filepath.Join(saveFDEDir, "tpm-policy-auth-key")
+		if runParams != nil {
+			runResealKeyParams := &secboot.ResealKeysParams{
+				PCRProfile:           runParams.TpmPCRProfile,
+				KeyFiles:             runKeys,
+				TPMPolicyAuthKeyFile: authKeyFile,
+			}
+
+			if err := secbootResealKeys(runResealKeyParams); err != nil {
+				return fmt.Errorf("cannot reseal the encryption key: %v", err)
+			}
+		}
+		if recoveryParams != nil {
+			recoveryResealKeyParams := &secboot.ResealKeysParams{
+				PCRProfile:           recoveryParams.TpmPCRProfile,
+				KeyFiles:             recoveryKeys,
+				TPMPolicyAuthKeyFile: authKeyFile,
+			}
+			if err := secbootResealKeys(recoveryResealKeyParams); err != nil {
+				return fmt.Errorf("cannot reseal the fallback encryption keys: %v", err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown key sealing method: %q", method)
+	}
+}
+
+func recalculateParamatersFDEHook(manager FDEStateManager, method device.SealingMethod, rootdir string, inputs resealInputs, opts resealOptions) error {
+	params := inputs.bootChains
+	runModels := getUniqueModels(append(params.RunModeBootChains, params.RecoveryBootChainsForRunKey...))
 	recoveryModels := getUniqueModels(params.RecoveryBootChains)
 
-	primaryKeyFile := filepath.Join(boot.InstallHostFDESaveDir, "aux-key")
-
-	if err := secbootResealKeysWithFDESetupHook(runKeys, primaryKeyFile, runModels); err != nil {
+	runParams := &SealingParameters{
+		BootModes: []string{"run", "recover"},
+		Models:    runModels,
+	}
+	if err := manager.Update("run+recover", "all", runParams); err != nil {
 		return err
 	}
 
-	if err := secbootResealKeysWithFDESetupHook(recoveryKeys, primaryKeyFile, recoveryModels); err != nil {
+	recoveryParams := &SealingParameters{
+		BootModes: []string{"recover", "factory-reset"},
+		Models:    recoveryModels,
+	}
+	if err := manager.Update("recover", "system-save", recoveryParams); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// ResealKeyForBootChains reseals disk encryption keys with the given bootchains.
-func ResealKeyForBootChains(updateState StateUpdater, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
-	return resealKeys(updateState, method, rootdir,
-		resealInputs{
-			bootChains: params,
-		},
-		resealOptions{
-			ExpectReseal: expectReseal,
-		})
-}
-
-// ResealKeysForSignaturesDBUpdate reseals disk encryption keys for the provided
-// boot chains and an optional signature DB update
-func ResealKeysForSignaturesDBUpdate(
-	updateState StateUpdater, method device.SealingMethod, rootdir string,
-	params *boot.ResealKeyForBootChainsParams, dbUpdate []byte,
-) error {
-	return resealKeys(updateState, method, rootdir,
-		resealInputs{
-			bootChains:        params,
-			signatureDBUpdate: dbUpdate,
-		},
-		resealOptions{
-			ExpectReseal: true,
-			// the boot chains are unchanged, which normally would result in
-			// no-reseal being done, but the content of DBX is being changed,
-			// either being part of the request or it has already been written
-			// to the relevant EFI variables (in which case this is a
-			// post-update reseal)
-			Force: true,
-		})
-}
-
-type resealInputs struct {
-	bootChains        *boot.ResealKeyForBootChainsParams
-	signatureDBUpdate []byte
-}
-
-type resealOptions struct {
-	ExpectReseal bool
-	Force        bool
-}
-
-func resealKeys(
-	updateState StateUpdater, method device.SealingMethod, rootdir string,
-	inputs resealInputs,
-	opts resealOptions,
-) error {
+func recalculateParamatersTPM(manager FDEStateManager, method device.SealingMethod, rootdir string, inputs resealInputs, opts resealOptions) error {
 	params := inputs.bootChains
-
-	switch method {
-	case device.SealingMethodFDESetupHook:
-		return resealKeyForBootChainsFDEHook(method, rootdir, inputs, opts)
-	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
-	default:
-		return fmt.Errorf("unknown key sealing method: %q", method)
-	}
-
-	saveFDEDir := dirs.SnapFDEDirUnderSave(dirs.SnapSaveDirUnder(rootdir))
-	authKeyFile := filepath.Join(saveFDEDir, "tpm-policy-auth-key")
-
 	// reseal the run object
 	pbc := boot.ToPredictableBootChains(append(params.RunModeBootChains, params.RecoveryBootChainsForRunKey...))
 
@@ -200,7 +222,7 @@ func resealKeys(
 		pbcJSON, _ := json.Marshal(pbc)
 		logger.Debugf("resealing (%d) to boot chains: %s", nextCount, pbcJSON)
 
-		err := resealRunObjectKeys(updateState, runOnlyPbc, pbc, inputs.signatureDBUpdate, authKeyFile, params.RoleToBlName)
+		err := updateRunProtectionProfile(manager, runOnlyPbc, pbc, inputs.signatureDBUpdate, params.RoleToBlName)
 		if err != nil {
 			return err
 		}
@@ -227,7 +249,7 @@ func resealKeys(
 		rpbcJSON, _ := json.Marshal(rpbc)
 		logger.Debugf("resealing (%d) to recovery boot chains: %s", nextFallbackCount, rpbcJSON)
 
-		err := resealFallbackObjectKeys(updateState, rpbc, inputs.signatureDBUpdate, authKeyFile, params.RoleToBlName)
+		err := updateFallbackProtectionProfile(manager, rpbc, inputs.signatureDBUpdate, params.RoleToBlName)
 		if err != nil {
 			return err
 		}
@@ -244,10 +266,10 @@ func resealKeys(
 	return nil
 }
 
-func resealRunObjectKeys(
-	updateState StateUpdater, pbcRunOnly, pbcWithRecovery boot.PredictableBootChains,
+func updateRunProtectionProfile(
+	manager FDEStateManager,
+	pbcRunOnly, pbcWithRecovery boot.PredictableBootChains,
 	sigDbxUpdate []byte,
-	authKeyFile string,
 	roleToBlName map[bootloader.Role]string,
 ) error {
 	// get model parameters from bootchains
@@ -268,9 +290,30 @@ func resealRunObjectKeys(
 	if len(sigDbxUpdate) > 0 {
 		logger.Debug("attaching DB update payload")
 		attachSignatureDbxUpdate(modelParams, sigDbxUpdate)
+		attachSignatureDbxUpdate(modelParamsRunOnly, sigDbxUpdate)
 	}
 
-	pcrProfile, err := secbootBuildPCRProtectionProfile(modelParams)
+	var pcrProfile []byte
+	var pcrProfileRunOnly []byte
+
+	err = func() error {
+		relock := manager.Unlock()
+		defer relock()
+
+		var err error
+
+		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams)
+		if err != nil {
+			return err
+		}
+
+		pcrProfileRunOnly, err = secbootBuildPCRProtectionProfile(modelParamsRunOnly)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}()
 	if err != nil {
 		return err
 	}
@@ -280,20 +323,6 @@ func resealRunObjectKeys(
 	}
 
 	logger.Debugf("PCR profile length: %v", len(pcrProfile))
-
-	if len(sigDbxUpdate) > 0 {
-		logger.Debug("attaching DB update payload")
-		attachSignatureDbxUpdate(modelParamsRunOnly, sigDbxUpdate)
-	}
-
-	pcrProfileRunOnly, err := secbootBuildPCRProtectionProfile(modelParamsRunOnly)
-	if err != nil {
-		return err
-	}
-
-	if len(pcrProfileRunOnly) == 0 {
-		return fmt.Errorf("unexpected length of serialized PCR profile")
-	}
 
 	var models []secboot.ModelForSealing
 	for _, m := range modelParams {
@@ -305,35 +334,32 @@ func resealRunObjectKeys(
 		modelsRunOnly = append(modelsRunOnly, m.Model)
 	}
 
-	// list all the key files to reseal
-	keyFiles := []string{device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir)}
-
-	resealKeyParams := &secboot.ResealKeysParams{
-		PCRProfile:           pcrProfile,
-		KeyFiles:             keyFiles,
-		TPMPolicyAuthKeyFile: authKeyFile,
+	runParams := &SealingParameters{
+		BootModes:     []string{"run", "recover"},
+		Models:        models,
+		TpmPCRProfile: pcrProfile,
 	}
-	if err := secbootResealKeys(resealKeyParams); err != nil {
-		return fmt.Errorf("cannot reseal the encryption key: %v", err)
-	}
-
 	// TODO: use constants for "run+recover" and "all"
-	if err := updateState("run+recover", "all", []string{"run", "recover"}, models, pcrProfile); err != nil {
+	if err := manager.Update("run+recover", "all", runParams); err != nil {
 		return err
 	}
 
+	runOnlyParams := &SealingParameters{
+		BootModes:     []string{"run"},
+		Models:        modelsRunOnly,
+		TpmPCRProfile: pcrProfileRunOnly,
+	}
 	// TODO: use constants for "run+recover" and "all"
-	if err := updateState("run", "all", []string{"run"}, modelsRunOnly, pcrProfileRunOnly); err != nil {
+	if err := manager.Update("run", "all", runOnlyParams); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func resealFallbackObjectKeys(
-	updateState StateUpdater, pbc boot.PredictableBootChains,
+func updateFallbackProtectionProfile(
+	manager FDEStateManager, pbc boot.PredictableBootChains,
 	sigDbxUpdate []byte,
-	authKeyFile string,
 	roleToBlName map[bootloader.Role]string,
 ) error {
 	// get model parameters from bootchains
@@ -352,7 +378,19 @@ func resealFallbackObjectKeys(
 		attachSignatureDbxUpdate(modelParams, sigDbxUpdate)
 	}
 
-	pcrProfile, err := secbootBuildPCRProtectionProfile(modelParams)
+	var pcrProfile []byte
+	err = func() error {
+		relock := manager.Unlock()
+		defer relock()
+
+		var err error
+
+		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams)
+		if err != nil {
+			return err
+		}
+		return nil
+	}()
 	if err != nil {
 		return err
 	}
@@ -366,31 +404,86 @@ func resealFallbackObjectKeys(
 		models = append(models, m.Model)
 	}
 
-	// list all the key files to reseal
-	keyFiles := []string{
-		device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
-		device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir),
-	}
-
-	resealKeyParams := &secboot.ResealKeysParams{
-		PCRProfile:           pcrProfile,
-		KeyFiles:             keyFiles,
-		TPMPolicyAuthKeyFile: authKeyFile,
-	}
-	if err := secbootResealKeys(resealKeyParams); err != nil {
-		return fmt.Errorf("cannot reseal the fallback encryption keys: %v", err)
-	}
-
 	// FIXME: We are missing recover for system-data, for
 	// "recover" boot mode. It is different from the run+recover
 	// as this should only include working models.
 
+	params := &SealingParameters{
+		BootModes:     []string{"recover", "factory-reset"},
+		Models:        models,
+		TpmPCRProfile: pcrProfile,
+	}
 	// TODO: use constants for "recover" (the first parameter) and "system-save"
-	if err := updateState("recover", "system-save", []string{"recover", "factory-reset"}, models, pcrProfile); err != nil {
+	if err := manager.Update("recover", "system-save", params); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// ResealKeyForBootChains reseals disk encryption keys with the given bootchains.
+func ResealKeyForBootChains(manager FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
+	return resealKeys(manager, method, rootdir,
+		resealInputs{
+			bootChains: params,
+		},
+		resealOptions{
+			ExpectReseal: expectReseal,
+		})
+}
+
+// ResealKeysForSignaturesDBUpdate reseals disk encryption keys for the provided
+// boot chains and an optional signature DB update
+func ResealKeysForSignaturesDBUpdate(
+	manager FDEStateManager, method device.SealingMethod, rootdir string,
+	params *boot.ResealKeyForBootChainsParams, dbUpdate []byte,
+) error {
+	return resealKeys(manager, method, rootdir,
+		resealInputs{
+			bootChains:        params,
+			signatureDBUpdate: dbUpdate,
+		},
+		resealOptions{
+			ExpectReseal: true,
+			// the boot chains are unchanged, which normally would result in
+			// no-reseal being done, but the content of DBX is being changed,
+			// either being part of the request or it has already been written
+			// to the relevant EFI variables (in which case this is a
+			// post-update reseal)
+			Force: true,
+		})
+}
+
+type resealInputs struct {
+	bootChains        *boot.ResealKeyForBootChainsParams
+	signatureDBUpdate []byte
+}
+
+type resealOptions struct {
+	ExpectReseal bool
+	Force        bool
+}
+
+func resealKeys(
+	manager FDEStateManager, method device.SealingMethod, rootdir string,
+	inputs resealInputs,
+	opts resealOptions,
+) error {
+	switch method {
+	case device.SealingMethodFDESetupHook:
+		if err := recalculateParamatersFDEHook(manager, method, rootdir, inputs, opts); err != nil {
+			return err
+		}
+	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
+		if err := recalculateParamatersTPM(manager, method, rootdir, inputs, opts); err != nil {
+			// FIXME: remove the save boot chains.
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown key sealing method: %q", method)
+	}
+
+	return doReseal(manager, method, rootdir)
 }
 
 func attachSignatureDbxUpdate(params []*secboot.SealKeyModelParams, update []byte) {

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -30,7 +30,7 @@ var FdeMgr = fdeMgr
 
 var UpdateParameters = updateParameters
 
-func MockBackendResealKeyForBootChains(f func(updateState backend.StateUpdater, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
+func MockBackendResealKeyForBootChains(f func(manager backend.FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
 	restore = testutil.Backup(&backendResealKeyForBootChains)
 	backendResealKeyForBootChains = f
 	return restore


### PR DESCRIPTION
Instead of splitting completely FDE hook and TPM resealing, we split the calculation of role parameters, udpate the state, then do     the resealing based on that state.

This depends on https://github.com/canonical/snapd/pull/14305