### PR TITLE
many: registry API creates transaction commit change

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -169,8 +169,10 @@ var (
 	assertstateRefreshSnapAssertions         = assertstate.RefreshSnapAssertions
 	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking
 
-	registrystateGet = registrystate.Get
-	registrystateSet = registrystate.Set
+	registrystateGetView        = registrystate.GetView
+	registrystateGetTransaction = registrystate.GetTransactionToModify
+	registrystateGet            = registrystate.Get
+	registrystateSetViaView     = registrystate.SetViaView
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api_registry.go
+++ b/daemon/api_registry.go
@@ -78,7 +78,7 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	}
 
 	vars := muxVars(r)
-	account, registryName, view := vars["account"], vars["registry"], vars["view"]
+	account, registryName, viewName := vars["account"], vars["registry"], vars["view"]
 
 	decoder := json.NewDecoder(r.Body)
 	var values map[string]interface{}
@@ -86,19 +86,27 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 		return BadRequest("cannot decode registry request body: %v", err)
 	}
 
-	// TODO: replace w/ GetTransaction + call ctx.Done() then return changeID
-	err := registrystateSet(st, account, registryName, view, values)
+	view, err := registrystateGetView(st, account, registryName, viewName)
 	if err != nil {
 		return toAPIError(err)
 	}
 
-	// NOTE: could be sync but this is closer to the final version and the conf API
-	summary := fmt.Sprintf("Set registry view %s/%s/%s", account, registryName, view)
-	chg := newChange(st, "set-registry-view", summary, nil, nil)
-	chg.SetStatus(state.DoneStatus)
-	ensureStateSoon(st)
+	tx, commitTxFunc, err := registrystateGetTransaction(nil, st, view)
+	if err != nil {
+		return toAPIError(err)
+	}
 
-	return AsyncResponse(nil, chg.ID())
+	err = registrystateSetViaView(tx, view, values)
+	if err != nil {
+		return toAPIError(err)
+	}
+
+	changeID, _, err := commitTxFunc()
+	if err != nil {
+		return toAPIError(err)
+	}
+
+	return AsyncResponse(nil, changeID)
 }
 
 func toAPIError(err error) *apiError {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -32,9 +32,12 @@ import (
 	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/registrystate"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/registry"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -380,19 +383,11 @@ var (
 )
 
 func MockRegistrystateGet(f func(_ *state.State, _, _, _ string, _ []string) (interface{}, error)) (restore func()) {
-	old := registrystateGet
-	registrystateGet = f
-	return func() {
-		registrystateGet = old
-	}
+	return testutil.Mock(&registrystateGet, f)
 }
 
-func MockRegistrystateSet(f func(_ *state.State, _, _, _ string, _ map[string]interface{}) error) (restore func()) {
-	old := registrystateSet
-	registrystateSet = f
-	return func() {
-		registrystateSet = old
-	}
+func MockRegistrystateGetTransaction(f func(*hookstate.Context, *state.State, *registry.View) (*registrystate.Transaction, registrystate.CommitTxFunc, error)) (restore func()) {
+	return testutil.Mock(&registrystateGetTransaction, f)
 }
 
 func MockRebootNoticeWait(d time.Duration) (restore func()) {
@@ -419,4 +414,12 @@ func MockNewStatusDecorator(f func(ctx context.Context, isGlobal bool, uid strin
 	restore = testutil.Backup(&newStatusDecorator)
 	newStatusDecorator = f
 	return restore
+}
+
+func MockRegistrystateGetView(f func(_ *state.State, _, _, _ string) (*registry.View, error)) (restore func()) {
+	return testutil.Mock(&registrystateGetView, f)
+}
+
+func MockRegistrystateSetViaView(f func(registry.DataBag, *registry.View, map[string]interface{}) error) (restore func()) {
+	return testutil.Mock(&registrystateSetViaView, f)
 }

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -180,7 +180,7 @@ func MockNewStatusDecorator(f func(ctx context.Context, isGlobal bool, uid strin
 	return restore
 }
 
-func MockRegistrystateGetTransaction(f func(*registrystate.Context, *state.State, *registry.View) (*registrystate.Transaction, error)) (restore func()) {
+func MockRegistrystateGetTransaction(f func(*hookstate.Context, *state.State, *registry.View) (*registrystate.Transaction, registrystate.CommitTxFunc, error)) (restore func()) {
 	old := registrystateGetTransaction
 	registrystateGetTransaction = f
 	return func() {

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -175,8 +175,8 @@ func (s *registrySuite) TestRegistryUnsetManyViews(c *C) {
 	err = tx.Set("wifi.psk", "bar")
 	c.Assert(err, IsNil)
 
-	ctlcmd.MockRegistrystateGetTransaction(func(*registrystate.Context, *state.State, *registry.View) (*registrystate.Transaction, error) {
-		return tx, nil
+	ctlcmd.MockRegistrystateGetTransaction(func(*hookstate.Context, *state.State, *registry.View) (*registrystate.Transaction, registrystate.CommitTxFunc, error) {
+		return tx, nil, nil
 	})
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"unset", "--view", ":write-wifi", "ssid", "password"}, 0)

--- a/tests/main/registries/task.yaml
+++ b/tests/main/registries/task.yaml
@@ -4,6 +4,9 @@ details: |
   Verify the basic features of experimental configuration feature based on
   registries and views.
 
+# the test snaps have a core24 base
+systems: [ -ubuntu-16.04 ]
+
 prepare: |
   snap set system experimental.registries=true
   snap install --edge jq
@@ -15,10 +18,14 @@ execute: |
   fi
 
   snap ack "$TESTSLIB/assertions/developer1-network.registry"
+  "$TESTSTOOLS"/snaps-state install-local test-custodian-snap
+  snap connect test-custodian-snap:manage-wifi
 
   # check basic read, write and unset
   snap set developer1/network/wifi-setup ssid=canonical
   snap get developer1/network/wifi-setup ssid | MATCH "canonical"
+  # hook was called
+  MATCH "canonical" < /var/snap/test-custodian-snap/common/manage-wifi-view-changed-ran
   snap set developer1/network/wifi-setup ssid!
   snap get developer1/network/wifi-setup ssid 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "ssid" through developer1/network/wifi-setup: no view data'
 

--- a/tests/main/registries/test-custodian-snap/bin/sh
+++ b/tests/main/registries/test-custodian-snap/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/registries/test-custodian-snap/meta/hooks/manage-wifi-view-changed
+++ b/tests/main/registries/test-custodian-snap/meta/hooks/manage-wifi-view-changed
@@ -1,0 +1,4 @@
+#!/bin/sh -xe
+
+value=$(snapctl get --view :manage-wifi ssid)
+echo "$value" > "$SNAP_COMMON"/manage-wifi-view-changed-ran

--- a/tests/main/registries/test-custodian-snap/meta/snap.yaml
+++ b/tests/main/registries/test-custodian-snap/meta/snap.yaml
@@ -1,0 +1,13 @@
+name: test-custodian-snap
+version: 1.0
+apps:
+  sh:
+    command: /bin/sh
+base: core24
+
+plugs:
+  manage-wifi:
+    interface: registry
+    account: developer1
+    view: network/wifi-setup
+    role: custodian


### PR DESCRIPTION
29f4a008d5ccde85d5d68f658b11bb5fb9703506 allows TaskChanged handlers to signal that they should be removed after being called (this simplifies the removal of the handler since there's no need to track the ID, lock state, remove the handler, etc).
d2cccac161a264916f7222b90218dee5a8ba980b makes the API code (used in the `snap set --view` path) create a transaction and an associated change to commit it. It also removes the registrystate.Context in lieu of a simpler callback that is returned with the transaction to trigger the commit. That callback then returns the change ID or wait channel.