### PR TITLE
many: allow sideloading a single asserted component

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -342,20 +342,6 @@ func DeriveComponentSideInfo(name, path string, info *snap.Info, model *asserts.
 		return nil, err
 	}
 
-	// we don't need to return this, but we should make sure that the assertion
-	// exists in the db so that callers can fail early if the required
-	// assertions aren't present
-	if _, err := findResourcePair(
-		csi.Component.ComponentName,
-		info.ID(),
-		csi.Revision.N,
-		info.Revision.N,
-		info.Provenance(),
-		db,
-	); err != nil {
-		return nil, err
-	}
-
 	return csi, nil
 }
 

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -951,7 +951,7 @@ version: 1.0.2
 	err = s.localDB.Add(resPair)
 	c.Assert(err, IsNil)
 
-	// missing snap-resource-pair assertion
+	// missing snap-resource-revision assertion
 	csi, err := snapasserts.DeriveComponentSideInfo("comp1", compPath, &info, model, s.localDB)
 	c.Assert(err, IsNil)
 	c.Check(csi, DeepEquals, &snap.ComponentSideInfo{

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -912,7 +912,7 @@ version: 1.0.2
 		},
 	}
 
-	// missing resource-revision assertion
+	// missing snap-resource-revision assertion
 	_, err := snapasserts.DeriveComponentSideInfo("comp1", compPath, &info, model, s.localDB)
 	c.Assert(err, ErrorMatches, "snap-resource-revision assertion not found")
 
@@ -935,23 +935,6 @@ version: 1.0.2
 	err = s.localDB.Add(resRev)
 	c.Assert(err, IsNil)
 
-	// missing snap-resource-pair assertion
-	_, err = snapasserts.DeriveComponentSideInfo("comp1", compPath, &info, model, s.localDB)
-	c.Assert(err, ErrorMatches, "cannot find snap-resource-pair for comp1.*")
-
-	resPair, err := s.storeSigning.Sign(asserts.SnapResourcePairType, map[string]interface{}{
-		"snap-id":           "snap-id-1",
-		"resource-name":     "comp1",
-		"resource-revision": "22",
-		"snap-revision":     "1",
-		"developer-id":      s.dev1Acct.AccountID(),
-		"timestamp":         time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	err = s.localDB.Add(resPair)
-	c.Assert(err, IsNil)
-
-	// missing snap-resource-revision assertion
 	csi, err := snapasserts.DeriveComponentSideInfo("comp1", compPath, &info, model, s.localDB)
 	c.Assert(err, IsNil)
 	c.Check(csi, DeepEquals, &snap.ComponentSideInfo{

--- a/client/errors.go
+++ b/client/errors.go
@@ -160,6 +160,9 @@ const (
 
 	// ErrorKindInterfacesRequestsRuleConflict: a rule with conflicting path pattern and permissions already exists.
 	ErrorKindInterfacesRequestsRuleConflict ErrorKind = "interfaces-requests-rule-conflict"
+
+	// ErrorKindInterfacesRequestsRuleConflict: cannot find a snap-resource-pair when attempting to sideload a component
+	ErrorKindMissingSnapResourcePair ErrorKind = "missing-snap-resource-pair"
 )
 
 // Maintenance error kinds.

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -669,6 +669,11 @@ func readComponentInfo(st *state.State, upload *uploadedContainer, flags sideloa
 	} else {
 		snapName, _ := snap.SplitInstanceName(upload.instanceName)
 		compRef = naming.NewComponentRef(snapName, upload.componentName)
+	}
+
+	// we should still override the potentially derived snap name with the given
+	// instance name if we have one
+	if upload.instanceName != "" {
 		instanceName = upload.instanceName
 	}
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -680,7 +680,7 @@ func readComponentInfo(st *state.State, upload *uploadedContainer, flags sideloa
 	info, err := installedSnapInfo(st, instanceName)
 	if err != nil {
 		if errors.Is(err, state.ErrNoState) {
-			return nil, nil, SnapNotInstalled(instanceName, fmt.Errorf("snap owning %q not installed", compRef.ComponentName))
+			return nil, nil, SnapNotInstalled(instanceName, fmt.Errorf("snap owning %q not installed", compRef))
 		}
 		return nil, nil, BadRequest("cannot retrieve information for %q: %v", instanceName, err)
 	}

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -638,9 +638,15 @@ func readComponentInfoFromContImpl(tempPath string, csi *snap.ComponentSideInfo)
 }
 
 // readComponentInfo reads ComponentInfo from a snap component file and the
-// snap.Info of the matching installed snap. If instanceName is not empty, it is
-// used to find the right instance, otherwise the SnapName from the component is
-// used.
+// snap.Info of the matching installed snap.
+//
+// For dangerous installs, we use the component and snap name from the
+// component.yaml file inside the blob. If an upload.instanceName is provided,
+// then the component in installed for that snap instance.
+//
+// For non-dangerous installs, we use either the provided snap and component
+// names, or we attempt to derive the snap and component names from the provided
+// blob's filename.
 func readComponentInfo(st *state.State, upload *uploadedContainer, flags sideloadFlags, model *asserts.Model) (*snap.ComponentInfo, *snap.Info, *apiError) {
 	if flags.dangerousOK {
 		return readComponentInfoDangerous(st, upload)

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -23,12 +23,17 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/check.v1"
@@ -282,30 +287,227 @@ const sideLoadComponentBody = "" +
 	"\r\n" +
 	"xyzzy\r\n" +
 	"----hello--\r\n" +
+	"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
+	"\r\n" +
+	"a/b/local+comp_1.0.comp\r\n" +
+	"----hello--\r\n"
+
+const sideLoadComponentBodyDangerous = sideLoadComponentBody +
 	"Content-Disposition: form-data; name=\"dangerous\"\r\n" +
 	"\r\n" +
 	"true\r\n" +
-	"----hello--\r\n" +
-	"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
-	"\r\n" +
-	"a/b/local+localcomp.comp\r\n" +
 	"----hello--\r\n"
 
-func (s *sideloadSuite) TestSideloadComponent(c *check.C) {
-	// try a multipart/form-data upload
-	body := sideLoadComponentBody
+func makeFormData(c *check.C, paths []string, fields map[string]string) string {
+	var buffer bytes.Buffer
+	mw := multipart.NewWriter(&buffer)
+	mw.SetBoundary("--hello--")
+
+	for key, value := range fields {
+		err := mw.WriteField(key, value)
+		c.Assert(err, check.IsNil)
+	}
+
+	for _, p := range paths {
+		f, err := os.Open(p)
+		c.Assert(err, check.IsNil)
+		defer f.Close()
+
+		w, err := mw.CreateFormFile("snap", p)
+		c.Assert(err, check.IsNil)
+
+		_, err = io.Copy(w, f)
+		c.Assert(err, check.IsNil)
+	}
+
+	c.Assert(mw.Close(), check.IsNil)
+
+	return buffer.String()
+}
+
+func (s *sideloadSuite) TestSideloadComponentDangerous(c *check.C) {
+	body := sideLoadComponentBodyDangerous
 	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
 	flags := snapstate.Flags{RemoveSnapPath: true, Transaction: client.TransactionPerSnap}
 	csi := snap.NewComponentSideInfo(naming.NewComponentRef("local", "comp"), snap.Revision{})
 
-	chgSummary, systemRestartImmediate := s.sideloadComponentCheck(c, body, head, "local", flags, csi)
-	c.Check(chgSummary, check.Equals, `Install "comp" component for "local" snap from file "a/b/local+localcomp.comp"`)
+	d := s.daemonWithFakeSnapManager(c)
+	s.markSeeded(d)
+	st := s.d.Overlord().State()
+
+	chgSummary, systemRestartImmediate := s.sideloadComponentCheck(c, st, body, head, "local", flags, csi, strings.NewReader("xyzzy"))
+	c.Check(chgSummary, check.Equals, `Install "comp" component for "local" snap from file "a/b/local+comp_1.0.comp"`)
+	c.Check(systemRestartImmediate, check.Equals, false)
+}
+
+func (s *sideloadSuite) TestSideloadComponentAsserted(c *check.C) {
+	compPath := snaptest.MakeTestComponentWithFiles(c, "comp", `component: local+comp
+type: standard
+version: 1.0.2
+`, nil)
+
+	newPath := filepath.Join(filepath.Dir(compPath), "local+comp_1.0.comp")
+	err := os.Rename(compPath, newPath)
+	c.Assert(err, check.IsNil)
+	compPath = newPath
+
+	body := makeFormData(c, []string{compPath}, map[string]string{
+		"snap-path": compPath,
+	})
+
+	snapID := snaptest.AssertedSnapID("local")
+
+	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+		"series":       "16",
+		"snap-id":      snapID,
+		"snap-name":    "local",
+		"publisher-id": s.StoreSigning.AuthorityID,
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, check.IsNil)
+
+	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+		"snap-sha3-384": strings.Repeat("x", 64),
+		"snap-size":     "999",
+		"snap-id":       snapID,
+		"snap-revision": "1",
+		"developer-id":  s.StoreSigning.AuthorityID,
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, check.IsNil)
+
+	digest, size, err := asserts.SnapFileSHA3_384(compPath)
+	c.Assert(err, check.IsNil)
+
+	resRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+		"type":              "snap-resource-revision",
+		"snap-id":           snapID,
+		"resource-name":     "comp",
+		"resource-sha3-384": digest,
+		"developer-id":      s.StoreSigning.AuthorityID,
+		"provenance":        "global-upload",
+		"resource-revision": "22",
+		"resource-size":     strconv.Itoa(int(size)),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, check.IsNil)
+
+	resPair, err := s.StoreSigning.Sign(asserts.SnapResourcePairType, map[string]interface{}{
+		"snap-id":           snapID,
+		"resource-name":     "comp",
+		"resource-revision": "22",
+		"snap-revision":     "1",
+		"developer-id":      s.StoreSigning.AuthorityID,
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, check.IsNil)
+
+	d := s.daemonWithFakeSnapManager(c)
+	s.markSeeded(d)
+	st := s.d.Overlord().State()
+
+	st.Lock()
+	assertstatetest.AddMany(s.d.Overlord().State(), s.StoreSigning.StoreAccountKey(""), snapDecl, snapRev, resRev, resPair)
+	st.Unlock()
+
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef("local", "comp"), snap.R(22))
+	flags := snapstate.Flags{RemoveSnapPath: true, Transaction: client.TransactionPerSnap}
+	headers := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+
+	compFile, err := os.Open(compPath)
+	c.Assert(err, check.IsNil)
+	defer compFile.Close()
+
+	chgSummary, systemRestartImmediate := s.sideloadComponentCheck(c, st, body, headers, "local", flags, csi, compFile)
+	c.Check(chgSummary, check.Equals, fmt.Sprintf(`Install "comp" component for "local" snap from file %q`, compPath))
+	c.Check(systemRestartImmediate, check.Equals, false)
+}
+
+func (s *sideloadSuite) TestSideloadComponentDangerousProvideComponentRef(c *check.C) {
+	// try a multipart/form-data upload
+	body := "" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
+		"\r\n" +
+		"xyzzy\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
+		"\r\n" +
+		"a/b/comp\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"dangerous\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"component-ref\"\r\n" +
+		"\r\n" +
+		"local+comp\r\n" +
+		"----hello--\r\n"
+	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	flags := snapstate.Flags{RemoveSnapPath: true, Transaction: client.TransactionPerSnap}
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef("local", "comp"), snap.Revision{})
+
+	d := s.daemonWithFakeSnapManager(c)
+	s.markSeeded(d)
+	st := s.d.Overlord().State()
+
+	chgSummary, systemRestartImmediate := s.sideloadComponentCheck(c, st, body, head, "local", flags, csi, strings.NewReader("xyzzy"))
+	c.Check(chgSummary, check.Equals, `Install "comp" component for "local" snap from file "a/b/comp"`)
+	c.Check(systemRestartImmediate, check.Equals, false)
+}
+
+func (s *sideloadSuite) TestSideloadComponentDangerousProvideInvalidComponentRef(c *check.C) {
+	body := "" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
+		"\r\n" +
+		"xyzzy\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
+		"\r\n" +
+		"a/b/comp\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"dangerous\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"component-ref\"\r\n" +
+		"\r\n" +
+		"comp\r\n" +
+		"----hello--\r\n"
+	apiErr := s.sideloadComponentFailure(c, body, map[string]string{
+		"Content-Type": "multipart/thing; boundary=--hello--",
+	}, "local")
+	c.Check(apiErr.Message, check.Equals, `cannot parse given component name: incorrect component name "comp"`)
+}
+
+func (s *sideloadSuite) TestSideloadComponentDevModeNoAssertion(c *check.C) {
+	// try a multipart/form-data upload
+	body := sideLoadComponentBody +
+		"Content-Disposition: form-data; name=\"devmode\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n"
+	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	flags := snapstate.Flags{
+		RemoveSnapPath: true,
+		Transaction:    client.TransactionPerSnap,
+		DevMode:        true,
+	}
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef("local", "comp"), snap.Revision{})
+
+	d := s.daemonWithFakeSnapManager(c)
+	s.markSeeded(d)
+	st := s.d.Overlord().State()
+
+	chgSummary, systemRestartImmediate := s.sideloadComponentCheck(c, st, body, head, "local", flags, csi, strings.NewReader("xyzzy"))
+	c.Check(chgSummary, check.Equals, `Install "comp" component for "local" snap from file "a/b/local+comp_1.0.comp"`)
 	c.Check(systemRestartImmediate, check.Equals, false)
 }
 
 func (s *sideloadSuite) TestSideloadComponentInstanceName(c *check.C) {
 	// try a multipart/form-data upload
-	body := sideLoadComponentBody +
+	body := sideLoadComponentBodyDangerous +
 		"Content-Disposition: form-data; name=\"name\"\r\n" +
 		"\r\n" +
 		"local_instance\r\n" +
@@ -314,39 +516,13 @@ func (s *sideloadSuite) TestSideloadComponentInstanceName(c *check.C) {
 	flags := snapstate.Flags{RemoveSnapPath: true, Transaction: client.TransactionPerSnap}
 	csi := snap.NewComponentSideInfo(naming.NewComponentRef("local", "comp"), snap.Revision{})
 
-	chgSummary, systemRestartImmediate := s.sideloadComponentCheck(c, body, head, "local_instance", flags, csi)
-	c.Check(chgSummary, check.Equals, `Install "comp" component for "local_instance" snap from file "a/b/local+localcomp.comp"`)
-	c.Check(systemRestartImmediate, check.Equals, false)
-}
-
-func (s *sideloadSuite) TestSideloadComponentNoDangerousFlag(c *check.C) {
-	logbuf, r := logger.MockLogger()
-	defer r()
-	body := "----hello--\r\n" +
-		"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
-		"\r\n" +
-		"xyzzy\r\n" +
-		"----hello--\r\n" +
-		"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
-		"\r\n" +
-		"a/b/local+localcomp.comp\r\n" +
-		"----hello--\r\n"
 	d := s.daemonWithFakeSnapManager(c)
 	s.markSeeded(d)
+	st := s.d.Overlord().State()
 
-	defer daemon.MockUnsafeReadSnapInfo(func(path string) (*snap.Info, error) {
-		return nil, daemon.BadRequest("mocking error to force reading as component")
-	})()
-
-	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
-	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
-
-	rspe := s.errorReq(c, req, nil)
-	c.Check(logbuf.String(), testutil.Contains,
-		"cannot sideload as a component: only unasserted installation of local component with --dangerous is supported at the moment")
-	c.Check(rspe.Message, check.Equals,
-		`cannot find signatures with metadata for snap "a/b/local+localcomp.comp"`)
+	chgSummary, systemRestartImmediate := s.sideloadComponentCheck(c, st, body, head, "local_instance", flags, csi, strings.NewReader("xyzzy"))
+	c.Check(chgSummary, check.Equals, `Install "comp" component for "local_instance" snap from file "a/b/local+comp_1.0.comp"`)
+	c.Check(systemRestartImmediate, check.Equals, false)
 }
 
 func (s *sideloadSuite) TestSideloadComponentForNotInstalledSnap(c *check.C) {
@@ -363,7 +539,7 @@ func (s *sideloadSuite) TestSideloadComponentForNotInstalledSnap(c *check.C) {
 		"----hello--\r\n" +
 		"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
 		"\r\n" +
-		"a/b/local+localcomp.comp\r\n" +
+		"a/b/local+comp.comp\r\n" +
 		"----hello--\r\n"
 	d := s.daemonWithFakeSnapManager(c)
 	s.markSeeded(d)
@@ -405,20 +581,81 @@ func (s *sideloadSuite) TestSideloadComponentForNotInstalledSnap(c *check.C) {
 	c.Check(rspe.Kind, check.Equals, client.ErrorKindSnapNotInstalled)
 }
 
-func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
-	head map[string]string, expectedInstanceName string, expectedFlags snapstate.Flags,
-	expectedCompSideInfo *snap.ComponentSideInfo) (
-	summary string, systemRestartImmediate bool) {
+func (s *sideloadSuite) TestSideloadComponentMissingAssertions(c *check.C) {
+	apiErr := s.sideloadComponentFailure(c, sideLoadComponentBody, map[string]string{
+		"Content-Type": "multipart/thing; boundary=--hello--",
+	}, "local")
+	c.Check(apiErr.Message, check.Equals, `cannot find signatures with metadata for snap/component "a/b/local+comp_1.0.comp"`)
+}
+
+func (s *sideloadSuite) sideloadComponentFailure(
+	c *check.C,
+	content string,
+	headers map[string]string,
+	instanceName string,
+) *daemon.APIError {
 
 	d := s.daemonWithFakeSnapManager(c)
 	s.markSeeded(d)
 
-	st := s.d.Overlord().State()
+	ssi := &snap.SideInfo{
+		RealName: "local",
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+	}
 
+	st := s.d.Overlord().State()
 	st.Lock()
-	defer st.Unlock()
-	ssi := &snap.SideInfo{RealName: "local", Revision: snap.R(1),
-		SnapID: "some-snap-id"}
+	snapstate.Set(st, instanceName, &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{sequence.NewRevisionSideState(ssi, nil)},
+		),
+		Current: snap.R(1),
+	})
+	st.Unlock()
+
+	restore := daemon.MockUnsafeReadSnapInfo(func(path string) (*snap.Info, error) {
+		return nil, daemon.BadRequest("mocking error to force reading as component")
+	})
+	defer restore()
+
+	restore = daemon.MockReadComponentInfoFromCont(func(tempPath string, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
+		return nil, errors.New("should not be called")
+	})
+	defer restore()
+
+	buf := bytes.NewBufferString(content)
+	req, err := http.NewRequest("POST", "/v2/snaps", buf)
+	c.Assert(err, check.IsNil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	return s.errorReq(c, req, nil)
+}
+
+func (s *sideloadSuite) sideloadComponentCheck(
+	c *check.C,
+	st *state.State,
+	content string,
+	head map[string]string,
+	expectedInstanceName string,
+	expectedFlags snapstate.Flags,
+	expectedCompSideInfo *snap.ComponentSideInfo,
+	expectedFileContents io.Reader,
+) (
+	summary string,
+	systemRestartImmediate bool,
+) {
+	st.Lock()
+	// defer st.Unlock()
+
+	ssi := &snap.SideInfo{
+		RealName: "local",
+		Revision: snap.R(1),
+		SnapID:   snaptest.AssertedSnapID("local"),
+	}
 	snapstate.Set(st, expectedInstanceName, &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
@@ -448,7 +685,7 @@ func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
 		return snap.NewComponentInfo(
 			expectedCompSideInfo.Component,
 			snap.StandardComponent,
-			"1.0", "", "", "", nil,
+			"1.0", "", "", "", csi,
 		), nil
 	})()
 
@@ -456,7 +693,10 @@ func (s *sideloadSuite) sideloadComponentCheck(c *check.C, content string,
 		path string, opts snapstate.Options) (*state.TaskSet, error) {
 		c.Check(csi, check.DeepEquals, expectedCompSideInfo)
 		c.Check(opts.Flags, check.DeepEquals, expectedFlags)
-		c.Check(path, testutil.FileEquals, "xyzzy")
+
+		contents, err := io.ReadAll(expectedFileContents)
+		c.Assert(err, check.IsNil)
+		c.Check(path, testutil.FileEquals, contents)
 
 		installQueue = append(installQueue, csi.Component.String()+"::"+path)
 		t := st.NewTask("fake-install-component", "Doing a fake install")
@@ -654,7 +894,7 @@ func (s *sideloadSuite) TestSideloadSnapNoSignaturesDangerOff(c *check.C) {
 	glob := filepath.Join(os.TempDir(), "snapd-sideload-pkg-*")
 	glbBefore, _ := filepath.Glob(glob)
 	rspe := s.errorReq(c, req, nil)
-	c.Check(rspe.Message, check.Equals, `cannot find signatures with metadata for snap "x"`)
+	c.Check(rspe.Message, check.Equals, `cannot find signatures with metadata for snap/component "x"`)
 	glbAfter, _ := filepath.Glob(glob)
 	c.Check(len(glbBefore), check.Equals, len(glbAfter))
 }
@@ -1047,14 +1287,23 @@ func (s *sideloadSuite) testSideloadManySnapsAndComponents(c *check.C, opts side
 
 	st := d.Overlord().State()
 
-	if !opts.missingSnap {
-		ssi := &snap.SideInfo{
-			RealName: "three",
-			Revision: snap.R(1),
-			SnapID:   "three-snap-id",
+	st.Lock()
+	st.Set("snaps", make(map[string]*json.RawMessage))
+	st.Unlock()
+
+	for _, name := range []string{"one", "two", "three"} {
+		if opts.missingSnap && name == "three" {
+			continue
 		}
+
+		ssi := &snap.SideInfo{
+			RealName: name,
+			Revision: snap.R(1),
+			SnapID:   fmt.Sprintf("%s-snap-id", name),
+		}
+
 		st.Lock()
-		snapstate.Set(d.Overlord().State(), "three", &snapstate.SnapState{
+		snapstate.Set(d.Overlord().State(), name, &snapstate.SnapState{
 			Active: true,
 			Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{
 				sequence.NewRevisionSideState(ssi, nil),
@@ -1461,7 +1710,7 @@ version: 1`, nil)
 	rsp := s.errorReq(c, req, nil)
 
 	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Message, check.Matches, "cannot find signatures with metadata for snap \"file-two\"")
+	c.Check(rsp.Message, check.Matches, "cannot find signatures with metadata for snap/component \"file-two\"")
 }
 
 func (s *sideloadSuite) mockAssertions(c *check.C, st *state.State, snaps []string) (snapData [][]byte) {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -151,6 +151,16 @@ func SnapNotInstalled(snapName string, err error) *apiError {
 	}
 }
 
+// SnapNotInstalled is an error responder used when an operation is
+// requested on a snap that is not in the system but expected to be.
+func MissingSnapResourcePair(csi *snap.ComponentSideInfo, snapRev snap.Revision) *apiError {
+	return &apiError{
+		Status:  400,
+		Message: fmt.Sprintf("cannot find resource pair connecting component revision %q with snap revision %q for %q", csi.Revision, snapRev, csi.Component),
+		Kind:    client.ErrorKindMissingSnapResourcePair,
+	}
+}
+
 // SnapRevisionNotAvailable is an error responder used when an
 // operation is requested for which no revivision can be found
 // in the given context (e.g. request an install from a stable

--- a/snap/naming/componentref.go
+++ b/snap/naming/componentref.go
@@ -21,6 +21,7 @@ package naming
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -74,4 +75,17 @@ func (cid *ComponentRef) UnmarshalYAML(unmarshall func(interface{}) error) error
 	*cid = ComponentRef{SnapName: snap, ComponentName: comp}
 
 	return nil
+}
+
+// snapPackComponentFilename is a regular expression that matches what snap pack
+// creates when building a component. For example, "foo+bar_1.0.0.comp" matches
+// this expression.
+var snapPackComponentFilename = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)\+(%[1]s)(?:_.*)?\.comp$`, almostValidNameRegexString))
+
+func ComponentRefFromSnapPackFilename(filename string) (ComponentRef, error) {
+	matches := snapPackComponentFilename.FindStringSubmatch(filename)
+	if len(matches) != 3 {
+		return ComponentRef{}, fmt.Errorf("cannot parse snap pack component filename: %q", filename)
+	}
+	return NewComponentRef(matches[1], matches[2]), nil
 }

--- a/snap/naming/componentref.go
+++ b/snap/naming/componentref.go
@@ -82,6 +82,10 @@ func (cid *ComponentRef) UnmarshalYAML(unmarshall func(interface{}) error) error
 // this expression.
 var snapPackComponentFilename = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)\+(%[1]s)(?:_.*)?\.comp$`, almostValidNameRegexString))
 
+// ComponentRefFromSnapPackFilename parses a filename created when creating a
+// component with "snap pack". These are generally in one of two forms:
+//   - <snap>+<comp>.comp
+//   - <snap>+<comp>_<version>.comp
 func ComponentRefFromSnapPackFilename(filename string) (ComponentRef, error) {
 	matches := snapPackComponentFilename.FindStringSubmatch(filename)
 	if len(matches) != 3 {

--- a/snap/naming/componentref_test.go
+++ b/snap/naming/componentref_test.go
@@ -21,11 +21,14 @@ package naming_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/pack"
 )
 
 type componentRefSuite struct{}
@@ -84,4 +87,101 @@ func (s *componentRefSuite) TestSplitFullComponentNameErr(c *C) {
 		c.Check(snap, Equals, "")
 		c.Check(comp, Equals, "")
 	}
+}
+
+func (s *componentRefSuite) TestComponentRefFromSnapPackFilename(c *C) {
+	type test struct {
+		filename string
+		cr       naming.ComponentRef
+	}
+
+	cases := []test{
+		{
+			filename: "foo+bar_1.0.0.comp",
+			cr:       naming.NewComponentRef("foo", "bar"),
+		},
+		{
+			filename: "foo+bar.comp",
+			cr:       naming.NewComponentRef("foo", "bar"),
+		},
+		{
+			filename: "snap-1+comp-1_1.0.0.comp",
+			cr:       naming.NewComponentRef("snap-1", "comp-1"),
+		},
+		{
+			filename: "snap-1+comp-1_v1.comp",
+			cr:       naming.NewComponentRef("snap-1", "comp-1"),
+		},
+		{
+			filename: "foo+bar_1.0.0.snap",
+		},
+		{
+			filename: "+bar_1.0.0.comp",
+		},
+		{
+			filename: "foo+_1.0.0.comp",
+		},
+	}
+
+	for _, tc := range cases {
+		cref, err := naming.ComponentRefFromSnapPackFilename(tc.filename)
+		if tc.cr == (naming.ComponentRef{}) {
+			c.Check(err.Error(), Equals, fmt.Sprintf("cannot parse snap pack component filename: %q", tc.filename))
+			c.Check(cref, Equals, naming.ComponentRef{})
+		} else {
+			c.Check(err, IsNil)
+			if err == nil {
+				c.Check(cref, DeepEquals, tc.cr)
+			}
+		}
+	}
+}
+
+func (s *componentRefSuite) TestComponentRefFromSnapPack(c *C) {
+	root := c.MkDir()
+
+	packDir := filepath.Join(root, "component")
+	err := os.Mkdir(packDir, 0755)
+	c.Assert(err, IsNil)
+
+	err = os.Mkdir(filepath.Join(packDir, "meta"), 0755)
+	c.Assert(err, IsNil)
+
+	// check parsing a component with a version
+	err = os.WriteFile(filepath.Join(packDir, "meta", "component.yaml"), []byte(`
+component: snap+comp
+type: standard
+version: 1.0
+`), 0644)
+	c.Assert(err, IsNil)
+
+	target := c.MkDir()
+	path, err := pack.Pack(packDir, &pack.Options{TargetDir: target})
+	c.Assert(err, IsNil)
+
+	filename := filepath.Base(path)
+	c.Assert(filename, Equals, "snap+comp_1.0.comp")
+
+	cref, err := naming.ComponentRefFromSnapPackFilename(filename)
+	c.Assert(err, IsNil)
+
+	c.Check(cref, DeepEquals, naming.NewComponentRef("snap", "comp"))
+
+	// check parsing a component without a version
+	err = os.WriteFile(filepath.Join(packDir, "meta", "component.yaml"), []byte(`
+component: snap+comp
+type: standard
+`), 0644)
+	c.Assert(err, IsNil)
+
+	path, err = pack.Pack(packDir, &pack.Options{TargetDir: target})
+	c.Assert(err, IsNil)
+
+	filename = filepath.Base(path)
+	c.Assert(filename, Equals, "snap+comp.comp")
+
+	cref, err = naming.ComponentRefFromSnapPackFilename(filename)
+	c.Assert(err, IsNil)
+
+	c.Check(cref, DeepEquals, naming.NewComponentRef("snap", "comp"))
 }

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -26,18 +26,20 @@ import (
 	"strings"
 )
 
-// almostValidName is part of snap and socket name validation. The full regexp
-// we could use, "^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$", is O(2ⁿ) on the
-// length of the string in python. An equivalent regexp that doesn't have the
-// nested quantifiers that trip up Python's re would be
+// almostValidNameRegexString is part of snap and socket name validation. The
+// full regexp we could use, "^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$", is O(2ⁿ)
+// on the length of the string in python. An equivalent regexp that doesn't have
+// the nested quantifiers that trip up Python's re would be
 // "^(?:[a-z0-9]|(?<=[a-z0-9])-)*[a-z](?:[a-z0-9]|-(?=[a-z0-9]))*$", but Go's
 // regexp package doesn't support look-aheads nor look-behinds, so in order to
 // have a unified implementation in the Go and Python bits of the project we're
 // doing it this way instead. Check the length (if applicable), check this
-// regexp, then check the dashes. This still leaves sc_snap_name_validate
-// (in cmd/snap-confine/snap.c) and snap_validate
-// (cmd/snap-update-ns/bootstrap.c) with their own handcrafted validators.
-var almostValidName = regexp.MustCompile("^[a-z0-9-]*[a-z][a-z0-9-]*$")
+// regexp, then check the dashes. This still leaves sc_snap_name_validate (in
+// cmd/snap-confine/snap.c) and snap_validate (cmd/snap-update-ns/bootstrap.c)
+// with their own handcrafted validators.
+const almostValidNameRegexString = "[a-z0-9-]*[a-z][a-z0-9-]*"
+
+var almostValidName = regexp.MustCompile(fmt.Sprintf("^%s$", almostValidNameRegexString))
 
 // validInstanceKey is a regular expression describing a valid snap instance key
 var validInstanceKey = regexp.MustCompile("^[a-z0-9]{1,10}$")

--- a/tests/main/component-sideload/task.yaml
+++ b/tests/main/component-sideload/task.yaml
@@ -1,0 +1,37 @@
+summary: Test sideloading components
+
+details: |
+  Verifies that we can sideload asserted components, and that we cannot sideload
+  unasserted components without using the --dangerous flag.
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
+
+execute: |
+  snap install test-snap-with-components+one
+
+  cp /var/lib/snapd/snaps/test-snap-with-components*.comp test-snap-with-components+one.comp
+
+  # TODO:COMPS: make this test simpler once "snap download" for components is
+  # merged.
+
+  # TODO:COMPS: add usage of the --component-ref flag to this test once it is
+  # merged.
+
+  # remove the component, but the assertions will stay around. we should be able
+  # to sideload the component again.
+  snap remove test-snap-with-components+one
+
+  snap install ./test-snap-with-components+one.comp
+  snap components test-snap-with-components | MATCH "test-snap-with-components\+one\s+installed\s+test"
+
+  snap remove test-snap-with-components+one
+
+  # remove the assertions manually this time, we should not be able to sideload
+  # the component again.
+  rm -r /var/lib/snapd/assertions/asserts-v0/snap-resource-pair \
+        /var/lib/snapd/assertions/asserts-v0/snap-resource-revision
+
+  not snap install ./test-snap-with-components+one.comp 2>&1 | tr '\n' ' ' | MATCH 'cannot find signatures with metadata for snap/component\s+"\./test-snap-with-components\+one.comp"'
+
+  # and we also can't use the --dangerous flag, since the snap is asserted.
+  not snap install --dangerous ./test-snap-with-components+one.comp 2>&1  | tr '\n' ' ' | MATCH 'cannot install component file: cannot mix asserted snap and unasserted\s+components'

--- a/tests/main/local-install-w-metadata/task.yaml
+++ b/tests/main/local-install-w-metadata/task.yaml
@@ -16,7 +16,7 @@ execute: |
     snap download test-snapd-sh
 
     echo "Try to install the snap without assertions"
-    (snap install test-snapd-sh_*.snap 2>&1 || true) | MATCH 'cannot find signatures with metadata for snap "test-snapd-sh.*\.snap"'
+    (snap install test-snapd-sh_*.snap 2>&1 || true) | MATCH 'cannot find signatures with metadata for snap/component "test-snapd-sh.*\.snap"'
 
     echo "Add its assertions"
     snap ack test-snapd-sh_*.assert


### PR DESCRIPTION
This will enable `snap install ./local-comp.comp`.

To make sure that we don't open the component file before validating that it is asserted, we derive the component name from the filename. Right now we support patterns like `<snap>+<comp>_version.comp` and `<snap>+<comp>.comp`.

In a follow-up PR, I'll add a flag (`--component-ref=<snap>+<comp>`?) to allow the caller to provide this name.

SNAPDENG-34062