### PR TITLE
c/libsnap-confine-private, interfaces: account for reexec on arch

### DIFF
--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -94,7 +94,8 @@ static void test_sc_is_expected_path(void)
 		{"/snap/core/1/usr/lib/snapd/snap-confine", true},
 		{"/snap/core/x1/usr/lib/snapd/snap-confine", true},
 		{"/snap/snapd/1/usr/lib/snapd/snap-confine", true},
-		{"/var/lib/snapd/snap/snapd/23374/usr/lib/snapd/snap-confine", true},
+		{"/var/lib/snapd/snap/snapd/23374/usr/lib/snapd/snap-confine",
+		 true},
 	};
 	size_t i;
 	for (i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -88,12 +88,13 @@ static void test_sc_is_expected_path(void)
 		{"/snap/cꓳre/1/usr/lib/snapd/snap-confine", false},
 		{"/snap/snapd1/1/usr/lib/snapd/snap-confine", false},
 		{"/snap/core/current/usr/lib/snapd/snap-confine", false},
+		{"/snap/snapd/1/usr/libexec/snapd/snap-confine", false},
 		{"/usr/lib/snapd/snap-confine", true},
 		{"/usr/libexec/snapd/snap-confine", true},
 		{"/snap/core/1/usr/lib/snapd/snap-confine", true},
 		{"/snap/core/x1/usr/lib/snapd/snap-confine", true},
 		{"/snap/snapd/1/usr/lib/snapd/snap-confine", true},
-		{"/snap/snapd/1/usr/libexec/snapd/snap-confine", false},
+		{"/var/lib/snapd/snap/snapd/23374/usr/lib/snapd/snap-confine", true},
 	};
 	size_t i;
 	for (i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -242,7 +242,7 @@ int sc_nonfatal_mkpath(const char *const path, mode_t mode)
 bool sc_is_expected_path(const char *path)
 {
 	const char *expected_path_re =
-	    "^(/snap/(snapd|core)/x?[0-9]+/usr/lib|/usr/lib(exec)?)/snapd/snap-confine$";
+	    "^((/var/lib/snapd)?/snap/(snapd|core)/x?[0-9]+/usr/lib|/usr/lib(exec)?)/snapd/snap-confine$";
 	regex_t re;
 	if (regcomp(&re, expected_path_re, REG_EXTENDED | REG_NOSUB) != 0)
 		die("can not compile regex %s", expected_path_re);

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -274,7 +274,7 @@ func SystemKeyMismatch(extraData SystemKeyExtraData) (bool, error) {
 	if mockedSystemKey == nil {
 		if exe, err := os.Readlink("/proc/self/exe"); err == nil {
 			// detect running local local builds
-			if !strings.HasPrefix(exe, "/usr") && !strings.HasPrefix(exe, "/snap") {
+			if !strings.HasPrefix(exe, "/usr") && !strings.HasPrefix(exe, dirs.SnapMountDir) {
 				logger.Noticef("running from non-installed location %s: ignoring system-key", exe)
 				return false, ErrSystemKeyVersion
 			}

--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -39,22 +39,6 @@ execute: |
     MATCH '^CHAIN_1_RAN=1$' < "$ENVDUMP"
     MATCH '^CHAIN_2_RAN=1$' < "$ENVDUMP"
 
-    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
-        # with snap mount dir different than /snap, internal s-c checks will fail
-        if command-chain.hello > err.out 2>&1 ; then
-            echo "unexpected success"
-            cat err.out || true
-            exit 1
-        fi
-
-        # with no AA support, we fail on a simple check for s-c being executed
-        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
-        # confinement
-        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
-        exit 0
-    fi
-
     echo "Test that command-chain runs for apps"
     [ "$(command-chain.hello)" = "chain1 chain2 hello" ]
 

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -43,22 +43,6 @@ execute: |
     echo "Sideloaded snap executes commands"
     snap install --dangerous ./test-snapd-tools_1.0_all.snap
 
-    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
-        # with snap mount dir different than /snap, internal s-c checks will fail
-        if test-snapd-tools.success > err.out 2>&1 ; then
-            echo "unexpected success"
-            cat err.out || true
-            exit 1
-        fi
-
-        # with no AA support, we fail on a simple check for s-c being executed
-        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
-        # confinement
-        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
-        exit 0
-    fi
-
     test-snapd-tools.success
     [ "$(test-snapd-tools.echo Hello World)" = "Hello World" ]
 

--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -32,22 +32,6 @@ execute: |
 
     echo "Test that snap run can call valid hooks"
 
-    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
-        # with snap mount dir different than /snap, internal s-c checks will fail
-        if snap run --hook=configure basic-hooks > err.out 2>&1 ; then
-            echo "unexpected success"
-            cat err.out || true
-            exit 1
-        fi
-
-        # with no AA support, we fail on a simple check for s-c being executed
-        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
-        # confinement
-        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
-        exit 0
-    fi
-
     if ! output="$(snap run --hook=configure basic-hooks)"; then
         echo "Failed to run configure hook"
         exit 1

--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -33,22 +33,6 @@ execute: |
 
     echo "Apps can write to writable areas"
 
-    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ]; then
-        # with snap mount dir different than /snap, internal s-c checks will fail
-        if data-writer.app > err.out 2>&1 ; then
-            echo "unexpected success"
-            cat err.out || true
-            exit 1
-        fi
-
-        # with no AA support, we fail on a simple check for s-c being executed
-        # from /snap/snapd/<rev>/, with AA we fail on an earlier check for AA
-        # confinement
-        MATCH "(running from unexpected location:|snap-confine has elevated permissions)" < err.out
-        exit 0
-    fi
-
     data-writer.app
     [ -f /var/snap/data-writer/x1/from-app ]
     [ -f /var/snap/data-writer/common/from-app ]


### PR DESCRIPTION
On arch, snap-confine's security tag will be prefixed with /var/lib/snapd. This change accounts for that, allowing us to use SNAP_REEXEC on arch systems.

Additionally, the fix in interfaces allows us to account for where snaps are installed on non-ubuntu systems.