### PR TITLE
github: only check formatting when using latest/stable Go

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,8 +202,8 @@ jobs:
     - name: Run static checks
       run: |
           cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
-          # run gofmt checks only with Go 1.18
-          if [ "${{ matrix.gochannel }}" != "1.18" ]; then
+          # run gofmt checks only with the latest stable Go
+          if [ "${{ matrix.gochannel }}" != "latest/stable" ]; then
               export SKIP_GOFMT=1
               echo "Formatting checks will be skipped due to the use of Go version ${{ matrix.gochannel }}"
           fi


### PR DESCRIPTION
Go formatting has been pretty stable after the 'breaking' changes introduced in 1.18. There is no clear reason to not simply use the latest/stable version, which is also most likely the version folks use for local development.

Cherry picked from https://github.com/canonical/snapd/pull/14676 

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
