### PR TITLE
daemon: Add Kernel Fusion Driver access to opengl

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -193,6 +193,9 @@ unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 /dev/nvgpu/igpu[0-9]*/ctrl rw,
 /dev/nvgpu/igpu[0-9]*/prof rw,
 /dev/host1x-fence rw,
+
+# Kernel Fusion Driver for AMD GPUs
+/dev/kfd rw,
 `
 
 type openglInterface struct {

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -227,6 +227,9 @@ var openglConnectedPlugUDev = []string{
 
 	// Nvidia dma barrier
 	`SUBSYSTEM=="host1x-fence"`,
+
+	// Kernel Fusion Driver
+	`SUBSYSTEM=="kfd", KERNEL=="kfd"`,
 }
 
 // Those two are the same, but in theory they are separate and can move (or

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -93,6 +93,7 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := apparmor.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/kfd rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/nvidia* rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/dri/renderD[0-9]* rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/mali[0-9]* rw,`)

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -119,7 +119,7 @@ func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 19)
+	c.Assert(spec.Snippets(), HasLen, 20)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
@@ -144,6 +144,8 @@ KERNEL=="mali[0-9]*", TAG+="snap_consumer_app"`)
 KERNEL=="dma_buf_te", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 KERNEL=="galcore", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
+SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 


### PR DESCRIPTION
This is used to control AMD GPUs, especially when using the [ROCm](https://www.amd.com/en/products/software/rocm.html) software stack.

This is my first time contributing to snapd, so please let me know if I missed something :smile: 