### PR TITLE
tests: use gojq - part 1

### DIFF
--- a/tests/core/auto-refresh-backoff-after-reboot/check_auto_refresh_count.sh
+++ b/tests/core/auto-refresh-backoff-after-reboot/check_auto_refresh_count.sh
@@ -4,4 +4,4 @@ LAST_CHANGE_ID=$1
 CHANGES_COUNT=$2
 
 #shellcheck disable=SC2086,SC2046
-test $(snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | length") == $CHANGES_COUNT
+test $(snap debug api /v2/changes?select=ready | gojq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | length") == $CHANGES_COUNT

--- a/tests/core/auto-refresh-backoff-after-reboot/task.yaml
+++ b/tests/core/auto-refresh-backoff-after-reboot/task.yaml
@@ -21,15 +21,11 @@ prepare: |
         exit
     fi
 
-    # Needed by make-snap-installable, Install before switching to fakestore
-    snap install jq
-    snap install remarshal
-
     # Prevent refreshes until we have right snap revisions
     snap set system refresh.hold=forever
 
     # Record last change id before we start to avoid flakiness due to auto-refreshes in other tests
-    snap debug api /v2/changes?select=all | jq '.result | sort_by(.id|tonumber) | .[-1].id' > last-change-id
+    snap debug api /v2/changes?select=all | gojq '.result | sort_by(.id|tonumber) | .[-1].id' > last-change-id
     # Record current snap revision for reference
     readlink "/snap/$SNAP_NAME/current" > snap.rev
 
@@ -58,7 +54,7 @@ restore: |
     snap set system refresh.hold!
 
 debug: |
-    snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\")] | sort_by(.id|tonumber)"
+    snap debug api /v2/changes?select=ready | gojq "[.result[] | select(.kind == \"auto-refresh\")] | sort_by(.id|tonumber)"
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -169,17 +165,18 @@ execute: |
         retry -n 50 --wait 1 "$(pwd)"/check_auto_refresh_count.sh "$LAST_CHANGE_ID" 2
 
         echo "Check auto-refresh behaviour matches expectations for backoff algorithm"
-        snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | sort_by(.id|tonumber)" > changes.json
+        snap debug api /v2/changes?select=ready | \
+            gojq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | sort_by(.id|tonumber)" > changes.json
 
         # 1st auto-refresh
-        jq '.[0].status' < changes.json | MATCH "Error"
-        jq '.[0].data."snap-names" | length' < changes.json | MATCH "1"
-        jq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_NAME"
-        jq '.[0].data."refresh-failed"' < changes.json | MATCH "$SNAP_NAME"
+        gojq '.[0].status' < changes.json | MATCH "Error"
+        gojq '.[0].data."snap-names" | length' < changes.json | MATCH "1"
+        gojq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_NAME"
+        gojq '.[0].data."refresh-failed"' < changes.json | MATCH "$SNAP_NAME"
 
         # 2nd auto-refresh
-        jq '.[1].status' < changes.json | MATCH "Done"
-        jq '.[1].data."snap-names" | length' < changes.json | MATCH "1"
-        jq '.[1].data."snap-names"' < changes.json | MATCH "$SNAP_NAME"
-        jq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_NAME"
+        gojq '.[1].status' < changes.json | MATCH "Done"
+        gojq '.[1].data."snap-names" | length' < changes.json | MATCH "1"
+        gojq '.[1].data."snap-names"' < changes.json | MATCH "$SNAP_NAME"
+        gojq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_NAME"
     fi

--- a/tests/core/snap-repair/task.yaml
+++ b/tests/core/snap-repair/task.yaml
@@ -8,10 +8,6 @@ environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
     STORE_ADDR: localhost:11028
 
-prepare: |
-    snap install jq
-    tests.cleanup defer snap remove jq
-
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
@@ -93,7 +89,7 @@ execute: |
 
         # note that the value "2" here _must_ be a string, otherwise we can't 
         # sign it as all values must be strings or lists of strings, etc. 
-        jq '."repair-id" = "2"' < "$PWD/$REPAIR_JSON" > "$PWD/$REPAIR_JSON.tmp"
+        gojq '."repair-id" = "2"' < "$PWD/$REPAIR_JSON" > "$PWD/$REPAIR_JSON.tmp"
         mv "$PWD/$REPAIR_JSON.tmp" "$PWD/2-$REPAIR_JSON"
 
         fakestore new-repair --dir "$BLOB_DIR" retry.sh --repair-json="$PWD/2-$REPAIR_JSON"
@@ -108,7 +104,7 @@ execute: |
 
         echo "Add a new repair ID 2 revision that completes successfully"
 
-        jq '."revision" = "1"' < "$PWD/2-$REPAIR_JSON" > "$PWD/2-$REPAIR_JSON.tmp"
+        gojq '."revision" = "1"' < "$PWD/2-$REPAIR_JSON" > "$PWD/2-$REPAIR_JSON.tmp"
         mv "$PWD/2-$REPAIR_JSON.tmp" "$PWD/2-$REPAIR_JSON"
 
         fakestore new-repair --dir "$BLOB_DIR" "$REPAIR_SCRIPT" --repair-json="$PWD/2-$REPAIR_JSON"

--- a/tests/core/snapd-maintenance-msg/task.yaml
+++ b/tests/core/snapd-maintenance-msg/task.yaml
@@ -7,16 +7,12 @@ details: |
 systems: [ubuntu-core-20-64]
 
 prepare: |
-    snap install jq
-
     # make sure that the snapd daemon gives us time for comms before
     # closing the socket
     echo "SNAPD_SHUTDOWN_DELAY=1" >> /etc/environment
     systemctl restart snapd
 
 restore: |
-    snap remove jq
-
     # remove SNAPD_SHUTDOWN_DELAY from /etc/environment again
     #shellcheck disable=SC2005
     echo "$(grep -v 'SNAPD_SHUTDOWN_DELAY=1' /etc/environment)" > /etc/environment
@@ -31,7 +27,7 @@ execute: |
         # closed so we need to catch it in that timeframe.
         echo "Testing maintenance message for daemon restarts"
         snap install --dangerous "$SNAPD_SNAP" &
-        retry -n 20 --wait 0.5 sh -c 'snap debug api '/v2/changes?select=all' | jq ".maintenance" | MATCH "daemon is restarting"'
+        retry -n 20 --wait 0.5 sh -c 'snap debug api '/v2/changes?select=all' | gojq ".maintenance" | MATCH "daemon is restarting"'
         wait
 
         echo "Restoring the snapd snap"
@@ -39,7 +35,7 @@ execute: |
 
         echo "Testing maintenance message for system reboots"
         snap refresh core20 --channel=stable --amend &
-        retry -n 20 --wait 0.5 sh -c 'snap debug api '/v2/changes?select=all' | jq ".maintenance" | MATCH "system is restarting"'
+        retry -n 20 --wait 0.5 sh -c 'snap debug api '/v2/changes?select=all' | gojq ".maintenance" | MATCH "system is restarting"'
         wait
 
         REBOOT

--- a/tests/core/snapd-refresh-vs-services/task.yaml
+++ b/tests/core/snapd-refresh-vs-services/task.yaml
@@ -42,11 +42,8 @@ environment:
   SNAPD_2_49_2_ARMHF: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.49.2_11586.snap
 
 prepare: |
-  # install http snap to download files, jq + remarshal to simplify the check if
-  # stable == 2.49.2 so we can skip that case automatically until a new version
-  # is released to stable
+  # install http snap to download files
   snap install test-snapd-curl --edge --devmode # devmode so it can save to any dir
-  snap install jq remarshal
   # save the current version of snapd for later
   INITIAL_REV=$(snap list snapd | tail -n +2 | awk '{print $3}')
   cp "/var/lib/snapd/snaps/snapd_$INITIAL_REV.snap" snapd-pr.snap
@@ -62,7 +59,7 @@ prepare: |
 execute: |
   # check if snapd 2.49.2 is the current latest/stable release as it simplifies
   # some of the logic below
-  if snap info snapd | yaml2json | jq -r '.channels."latest/stable"'  | grep -q -Po '2.49.2\s+'; then
+  if snap info snapd | gojq --yaml-input -r '.channels."latest/stable"'  | grep -q -Po '2.49.2\s+'; then
     # skip the stable variant of the test
     if [ "${SNAPD_VERSION_UNDER_TEST}" = "stable" ]; then
       echo "Skipping duplicated test case"

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -34,22 +34,20 @@ execute: |
     if [ "$SPREAD_REBOOT" == "0" ]; then
         echo "In run mode"
 
-        snap install --edge jq
-
         MATCH 'snapd_recovery_mode=run' < /proc/cmdline
         # verify we are in run mode via the API
         snap debug api '/v2/system-info' > system-info
-        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+        gojq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
         echo "Obtain available systems"
         snap debug api '/v2/systems' > systems.json
         # TODO:UC20: there is only one system for now
-        jq .result.systems[0].current < systems.json | MATCH 'true'
-        label="$(jq -r .result.systems[0].label < systems.json)"
+        gojq .result.systems[0].current < systems.json | MATCH 'true'
+        label="$(gojq -r .result.systems[0].label < systems.json)"
         test -n "$label"
         # make sure that the seed exists
         test -d "/var/lib/snapd/seed/systems/$label"
-        jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install recover run'
+        gojq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install recover run'
 
         # keep a copy of the systems dump for later reference
         cp systems.json /writable/systems.json.run
@@ -66,7 +64,7 @@ execute: |
         test -e /host/ubuntu-data/systems.json.run
 
         snap debug api '/v2/systems' > systems.json
-        jq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install run'
+        gojq -r .result.systems[0].actions[].mode < systems.json | sort | tr '\n' ' ' | MATCH 'install run'
 
         label="$(cat /host/ubuntu-data/systems.label)"
         test -n "$label"
@@ -79,11 +77,11 @@ execute: |
     elif [ "$SPREAD_REBOOT" == "2" ]; then
         echo "In run mode again"
         snap debug api '/v2/system-info' > system-info
-        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+        gojq -r '.result["system-mode"]' < system-info | MATCH 'run'
 
         # now go back to recover mode so we can test that a simple reboot 
         # works to transition us back to run mode
-        label="$(jq -r .result.systems[0].label < systems.json)"
+        label="$(gojq -r .result.systems[0].label < systems.json)"
         transition_to_recover_mode "$label"
     elif [ "$SPREAD_REBOOT" == "3" ]; then
         echo "In recover mode again"
@@ -107,5 +105,5 @@ execute: |
     elif [ "$SPREAD_REBOOT" == "4" ]; then
         echo "In run mode again again"
         snap debug api '/v2/system-info' > system-info
-        jq -r '.result["system-mode"]' < system-info | MATCH 'run'
+        gojq -r '.result["system-mode"]' < system-info | MATCH 'run'
     fi

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -299,7 +299,7 @@ nested_get_snap_rev_for_channel() {
          -H "Content-Type: application/json" \
          --data "{\"context\": [], \"actions\": [{\"action\": \"install\", \"name\": \"$SNAP\", \"channel\": \"$CHANNEL\", \"instance-key\": \"1\"}]}" \
          https://api.snapcraft.io/v2/snaps/refresh | \
-        jq '.results[0].snap.revision'
+        gojq '.results[0].snap.revision'
 }
 
 nested_is_nested_system() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -614,7 +614,9 @@ prepare_project() {
     # major differences:
     # - map keys are sorted by default
     # - with --yaml-input, can parse YAML
-    go install github.com/itchyny/gojq/cmd/gojq@v0.12.16
+    GOBIN=$PROJECT_PATH/tests/bin \
+    CGO_ENABLED=0 \
+        go install github.com/itchyny/gojq/cmd/gojq@v0.12.16
 }
 
 prepare_project_each() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -608,6 +608,13 @@ prepare_project() {
         disable_journald_rate_limiting
         disable_journald_start_limiting
     fi
+
+    # native jq replacement, but still with some incompatibilies, see
+    # https://github.com/itchyny/gojq
+    # major differences:
+    # - map keys are sorted by default
+    # - with --yaml-input, can parse YAML
+    go install github.com/itchyny/gojq/cmd/gojq@v0.12.16
 }
 
 prepare_project_each() {

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -97,9 +97,6 @@ ensure_jq() {
 }
 
 disable_refreshes() {
-    echo "Ensure jq is available"
-    ensure_jq
-
     echo "Modify state to make it look like the last refresh just happened"
     systemctl stop snapd.socket snapd.service
     "$TESTSTOOLS"/snapd-state prevent-autorefresh
@@ -108,13 +105,6 @@ disable_refreshes() {
     echo "Minimize risk of hitting refresh schedule"
     snap set core refresh.schedule=00:00-23:59
     snap refresh --time --abs-time | MATCH "last: 2[0-9]{3}"
-
-    echo "Ensure jq is gone"
-    snap remove --purge jq
-    snap remove --purge jq-core18
-    snap remove --purge jq-core20
-    snap remove --purge jq-core22
-    snap remove --purge test-snapd-jq-core24
 }
 
 setup_systemd_snapd_overrides() {

--- a/tests/lib/tools/snapd-state
+++ b/tests/lib/tools/snapd-state
@@ -19,7 +19,7 @@ print_state() {
         echo "snapd-state: jq-filter is a required parameter"
         exit 1
     fi
-    jq -r "$JQ_FILTER" < /var/lib/snapd/state.json
+    gojq -r "$JQ_FILTER" < /var/lib/snapd/state.json
 }
 
 check_state() {
@@ -56,17 +56,17 @@ change_snap_channel() {
         echo "snapd-state: snap and channel are required parameters"
         exit 1
     fi
-    jq ".data.snaps[\"$SNAP\"].channel = \"$CHANNEL\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq ".data.snaps[\"$SNAP\"].channel = \"$CHANNEL\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 
 force_autorefresh() {
-    jq ".data[\"last-refresh\"] = \"2007-08-22T09:30:44.449455783+01:00\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq ".data[\"last-refresh\"] = \"2007-08-22T09:30:44.449455783+01:00\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 
 prevent_autorefresh() {
-    jq ".data[\"last-refresh\"] = \"$(date +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq ".data[\"last-refresh\"] = \"$(date +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 

--- a/tests/lib/tools/store-state
+++ b/tests/lib/tools/store-state
@@ -73,21 +73,9 @@ make_snap_installable(){
     local snap_id="${3:-}"
 
     if [ -n "$snap_id" ]; then
-        if ! command -v yaml2json; then
-            # FIXME: When fakestore is setup this snap cannot be installed
-            # TODO: Install remarshal in setup_fake_store
-            snap install remarshal
-        fi
-        if ! command -v jq; then
-            # FIXME: When fakestore is setup this snap cannot be installed
-            # TODO: Install jq in setup_fake_store or don't use snapped jq
-            SUFFIX="$(snaps.name snap-suffix)"
-            snap install "jq$SUFFIX"
-        fi
-
         # unsquash the snap to get its name
         unsquashfs -d /tmp/snap-squashfs "$snap_path" meta/snap.yaml
-        snap_name=$(yaml2json < /tmp/snap-squashfs/meta/snap.yaml | jq -r .name)
+        snap_name=$(gojq --yaml-input -r '.name' < /tmp/snap-squashfs/meta/snap.yaml)
         rm -rf /tmp/snap-squashfs
 
         cat >> /tmp/snap-decl.json << EOF
@@ -102,7 +90,7 @@ EOF
         if [ -n "$extra_decl_json_file" ]; then
             # then we need to combine the extra snap declaration json with the one
             # we just wrote
-            jq -s '.[0] * .[1]' <(cat /tmp/snap-decl.json) <(cat "$extra_decl_json_file") > /tmp/snap-decl.json.tmp
+            gojq -s '.[0] * .[1]' <(cat /tmp/snap-decl.json) <(cat "$extra_decl_json_file") > /tmp/snap-decl.json.tmp
             mv /tmp/snap-decl.json.tmp /tmp/snap-decl.json
         fi
 

--- a/tests/main/api-get-systems-label/task.yaml
+++ b/tests/main/api-get-systems-label/task.yaml
@@ -8,27 +8,25 @@ systems:
   - ubuntu-core-2*
 
 execute: |
-  snap install --edge jq
-
   echo "Find what systems are available"
   snap debug api /v2/systems > systems
-  current_label=$(jq -r '.result.systems[0]["label"]' < systems)
+  current_label=$(gojq -r '.result.systems[0]["label"]' < systems)
 
   echo "Get details for a specific system"
   snap debug api "/v2/systems/$current_label" > current-system
   echo "Ensure the result contains a model assertion"
-  jq -r '.result.model.type' < current-system | MATCH model
-  jq -r '.result.model.series' < current-system | MATCH 16
-  jq -r '.result.model.base' < current-system | MATCH "core[0-9][0-9]"
+  gojq -r '.result.model.type' < current-system | MATCH model
+  gojq -r '.result.model.series' < current-system | MATCH 16
+  gojq -r '.result.model.base' < current-system | MATCH "core[0-9][0-9]"
   echo "Ensure the result looks like a systems reply"
-  jq -r '.result.brand.id' < current-system | MATCH "$(snap model --verbose|awk '/brand-id:/ {print $2}')"
-  jq -r '.result.brand.validation' < current-system | MATCH '(verified|unproven|starred)'
-  jq -r '.result.label' < current-system | MATCH "$current_label"
-  jq -r '.result.current' < current-system | MATCH '(true|false)'
+  gojq -r '.result.brand.id' < current-system | MATCH "$(snap model --verbose|awk '/brand-id:/ {print $2}')"
+  gojq -r '.result.brand.validation' < current-system | MATCH '(verified|unproven|starred)'
+  gojq -r '.result.label' < current-system | MATCH "$current_label"
+  gojq -r '.result.current' < current-system | MATCH '(true|false)'
   # we expect at least one current action to be available and
   # each action always has a mode
-  jq -r '.result.actions[0]' < current-system | MATCH 'mode'
+  gojq -r '.result.actions[0]' < current-system | MATCH 'mode'
   echo "Ensure the result contains the gadget volumes"
-  jq -r '.result.volumes' < current-system | MATCH bootloader
+  gojq -r '.result.volumes' < current-system | MATCH bootloader
   # internal fields are not exported
-  jq -r '.result.volumes' < current-system | NOMATCH VolumeName
+  gojq -r '.result.volumes' < current-system | NOMATCH VolumeName

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -14,7 +14,6 @@ systems:
   - ubuntu-core-*
 
 prepare: |
-    snap install jq
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
     "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
@@ -93,9 +92,9 @@ execute: |
         echo "Check that snap CLI reports prompting flag set correctly"
         snap get system experimental.apparmor-prompting | MATCH "$1"
         echo "Check that /v2/snaps/system/conf reports prompting flag set correctly"
-        snap debug api /v2/snaps/system/conf | jq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
+        snap debug api /v2/snaps/system/conf | gojq -r '.result.experimental."apparmor-prompting"' | MATCH "$1"
         echo "Check that /v2/system-info reports prompting correctly"
-        snap debug api /v2/system-info | jq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
+        snap debug api /v2/system-info | gojq -r '.result.features."apparmor-prompting".enabled' | MATCH "$1"
     }
 
     echo "Precondition check that snapd is active"
@@ -140,14 +139,18 @@ execute: |
 
     echo "Enable prompting via API request"
 
-    echo '{"experimental.apparmor-prompting": true}' | snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | jq -r '.status' | MATCH "Accepted" || reset_start_limit
+    echo '{"experimental.apparmor-prompting": true}' | \
+        snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | \
+        gojq -r '.status' | MATCH "Accepted" || reset_start_limit
 
     echo "Check that snapd restarted after prompting set to true via api"
     check_snapd_restarted
     check_prompting_setting "true"
 
     echo "Disable prompting via API request"
-    echo '{"experimental.apparmor-prompting": false}' | snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | jq -r '.status' | MATCH "Accepted" || reset_start_limit
+    echo '{"experimental.apparmor-prompting": false}' | \
+        snap debug api -X PUT -H 'Content-Type: application/json' /v2/snaps/system/conf | \
+        gojq -r '.status' | MATCH "Accepted" || reset_start_limit
 
     echo "Check that snapd restarted after prompting set to false via api"
     check_snapd_restarted

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -33,7 +33,8 @@ execute: |
 
     echo "Write two rules to disk, one of which is expired"
     mkdir -p "$(dirname $RULES_PATH)"
-    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"},{"id":"0000000000000003","timestamp":"2004-10-20T16:47:32.138415627-05:00","user":1000,"snap":"firefox","interface":"home","constraints":{"path-pattern":"/home/test/Downloads/**","permissions":["read","write"]},"outcome":"allow","lifespan":"timespan","expiration":"2005-04-08T00:00:00Z"}]}' | tee "$RULES_PATH"
+    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"},{"id":"0000000000000003","timestamp":"2004-10-20T16:47:32.138415627-05:00","user":1000,"snap":"firefox","interface":"home","constraints":{"path-pattern":"/home/test/Downloads/**","permissions":["read","write"]},"outcome":"allow","lifespan":"timespan","expiration":"2005-04-08T00:00:00Z"}]}' | \
+        tee "$RULES_PATH"
 
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
@@ -65,25 +66,28 @@ execute: |
     retry --wait 1 -n 60 systemctl is-active snapd
 
     echo "Check that apparmor prompting is supported and enabled"
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     # Write expected rules after the expired rule has been removed
-    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"}]}' | jq | tee expected.json
-    # Parse existing rules through jq so they can be compared
-    jq < "$RULES_PATH" > current.json
+    echo '{"rules":[{"id":"0000000000000002","timestamp":"2004-10-20T14:05:08.901174186-05:00","user":1000,"snap":"shellcheck","interface":"home","constraints":{"path-pattern":"/home/test/Projects/**","permissions":["read"]},"outcome":"allow","lifespan":"forever","expiration":"0001-01-01T00:00:00Z"}]}' | \
+        gojq | tee expected.json
+    # Parse existing rules through (go)jq so they can be compared
+    gojq < "$RULES_PATH" > current.json
 
     echo "Check that rules on disk match what is expected"
     diff expected.json current.json
 
     echo "Check that we received two notices"
-    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 2
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result' | grep -c '"removed": "expired"' | MATCH 1
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH 2
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result' | grep -c '"removed": "expired"' | MATCH 1
 
     echo "Check that only the former rule is still valid (must be done with UID 1000)"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result | length' | MATCH 1
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result[0].id' | MATCH "0000000000000002"
 
     echo "Stop snapd and ensure it is not in failure mode"
     systemctl stop snapd.service snapd.socket
@@ -98,20 +102,22 @@ execute: |
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
     diff expected.json current.json
 
     echo "Check that we received one notices for the non-expired rule"
-    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 1
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result[0].key' | MATCH "0000000000000002"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH 1
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "0000000000000002"
 
     echo "Check that only the non-expired rule is still valid (must be done with UID 1000)"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result | length' | MATCH 1
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result[0].id' | MATCH "0000000000000002"
 
     echo '### Simulate failure to open interfaces requests manager ###'
 
@@ -134,15 +140,16 @@ execute: |
     echo "Check that apparmor prompting is supported and enabled"
     # XXX: in the future, we should set enabled to be false if m.AppArmorPromptingRunning() is false,
     # such as because creating the interfaces requests manager failed.
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
     diff expected.json current.json
 
     echo "Check that accessing a prompting endpoint results in an expected error"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '."status-code"' | MATCH 500
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result.message' | MATCH -i "Apparmor Prompting is not running"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '."status-code"' | MATCH 500
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | \
+        gojq '.result.message' | MATCH -i "Apparmor Prompting is not running"
 
     echo '### Remove the corrupted max prompt ID file and check that prompting backends can start again ###'
 
@@ -162,17 +169,19 @@ execute: |
     retry --wait 1 -n 60 systemctl is-active snapd.service snapd.socket
 
     echo "Check that apparmor prompting is supported and enabled"
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".supported' | MATCH true
-    snap debug api "/v2/system-info" | jq '.result.features."apparmor-prompting".enabled' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".supported' | MATCH true
+    snap debug api "/v2/system-info" | gojq '.result.features."apparmor-prompting".enabled' | MATCH true
 
     echo "Check that rules on disk still match what is expected"
     diff expected.json current.json
 
     echo "Check that we received one notices for the non-expired rule"
-    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result | length' | MATCH 1
-    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | jq '.result[0].key' | MATCH "0000000000000002"
+    snap debug api --fail "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | gojq
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result | length' | MATCH 1
+    snap debug api "/v2/notices?after=$CURRTIME&types=interfaces-requests-rule-update&user-id=1000" | \
+        gojq '.result[0].key' | MATCH "0000000000000002"
 
     echo "Check that the non-expired rule is still valid (must be done with UID 1000)"
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result | length' | MATCH 1
-    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | jq '.result[0].id' | MATCH "0000000000000002"
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result | length' | MATCH 1
+    sudo -iu '#1000' snap debug api /v2/interfaces/requests/rules | gojq '.result[0].id' | MATCH "0000000000000002"

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -7,9 +7,6 @@ details: |
 # ubuntu-core: no jq
 systems: [-ubuntu-core*]
 
-prepare: |
-    snap install --edge jq
-
 debug: |
     cat response || true
 
@@ -17,7 +14,7 @@ execute: |
     echo "Verify that search results contain common-ids"
     timeout 5 snap debug api /v2/find?name=test-snapd-appstreamid > response
     # shellcheck disable=SC2002
-    cat response | jq -r ' .result[0]["common-ids"] | sort | join (",")' | \
+    cat response | gojq -r ' .result[0]["common-ids"] | sort | join (",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
 
     snap install --edge test-snapd-appstreamid
@@ -25,11 +22,11 @@ execute: |
     echo "Verify that installed snap info contains common-ids"
     timeout 5 snap debug api /v2/snaps/test-snapd-appstreamid > response
     # shellcheck disable=SC2002
-    cat response | jq -r ' .result["common-ids"] | sort | join(",")' | \
+    cat response | gojq -r ' .result["common-ids"] | sort | join(",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
 
     echo "Verify that apps have their common-id set"
     timeout 5 snap debug api /v2/apps?names=test-snapd-appstreamid > response
     # shellcheck disable=SC2002
-    cat response | jq -r ' .result | sort_by(.name) | [.[]."common-id"] | join(",")' | \
+    cat response | gojq -r ' .result | sort_by(.name) | [.[]."common-id"] | join(",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,,io.snapcraft.test-snapd-appstreamid.foo'

--- a/tests/main/auto-refresh-backoff/check_auto_refresh_count.sh
+++ b/tests/main/auto-refresh-backoff/check_auto_refresh_count.sh
@@ -4,4 +4,4 @@ LAST_CHANGE_ID=$1
 CHANGES_COUNT=$2
 
 #shellcheck disable=SC2086,SC2046
-test $(snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | length") == $CHANGES_COUNT
+test $(snap debug api /v2/changes?select=ready | gojq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | length") == $CHANGES_COUNT

--- a/tests/main/auto-refresh-backoff/task.yaml
+++ b/tests/main/auto-refresh-backoff/task.yaml
@@ -18,10 +18,6 @@ prepare: |
         exit
     fi
 
-    # Needed by make-snap-installable, Install before switching to fakestore
-    snap install jq
-    snap install remarshal
-
     # Install snaps as baseline since we want to test what happens in refreshes not installs
     echo "Given installed snaps"
     snap install "$SNAP_ONE" "$SNAP_TWO"
@@ -50,7 +46,7 @@ restore: |
     rm -rf "$BLOB_DIR"
 
 debug: |
-    snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\")] | sort_by(.id|tonumber)"
+    snap debug api /v2/changes?select=ready | gojq "[.result[] | select(.kind == \"auto-refresh\")] | sort_by(.id|tonumber)"
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -94,7 +90,7 @@ execute: |
     }
 
     # Record last change id before we start to avoid flakiness due to auto-refreshes in other tests
-    LAST_CHANGE_ID=$(snap debug api /v2/changes?select=all | jq '.result | sort_by(.id|tonumber) | .[-1].id')
+    LAST_CHANGE_ID=$(snap debug api /v2/changes?select=all | gojq '.result | sort_by(.id|tonumber) | .[-1].id')
 
     # -------- FIRST AUTO REFRESH --------
 
@@ -162,26 +158,26 @@ execute: |
     readlink "$SNAP_MOUNT_DIR/$SNAP_TWO/current" | MATCH 33
 
     echo "Check auto-refresh behaviour matches expectations for backoff algorithm"
-    snap debug api /v2/changes?select=ready | jq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | sort_by(.id|tonumber)" > changes.json
+    snap debug api /v2/changes?select=ready | gojq "[.result[] | select(.kind == \"auto-refresh\" and (.id|tonumber) > ($LAST_CHANGE_ID|tonumber))] | sort_by(.id|tonumber)" > changes.json
 
     # 1st auto-refresh
-    jq '.[0].status' < changes.json | MATCH "Error"
-    jq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_ONE"
-    jq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
-    jq '.[0].data."refresh-failed"' < changes.json | MATCH "$SNAP_ONE"
-    jq '.[0].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"
+    gojq '.[0].status' < changes.json | MATCH "Error"
+    gojq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_ONE"
+    gojq '.[0].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
+    gojq '.[0].data."refresh-failed"' < changes.json | MATCH "$SNAP_ONE"
+    gojq '.[0].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"
 
     # 2nd auto-refresh
-    jq '.[1].status' < changes.json | MATCH "Done"
+    gojq '.[1].status' < changes.json | MATCH "Done"
     # Broken SNAP_ONE should have been skipped this time
-    jq '.[1].data."snap-names"' < changes.json | NOMATCH "$SNAP_ONE"
-    jq '.[1].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
-    jq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_ONE"
-    jq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"
+    gojq '.[1].data."snap-names"' < changes.json | NOMATCH "$SNAP_ONE"
+    gojq '.[1].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
+    gojq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_ONE"
+    gojq '.[1].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"
 
     # 3rd auto-refresh
-    jq '.[2].status' < changes.json | MATCH "Done"
-    jq '.[2].data."snap-names"' < changes.json | MATCH "$SNAP_ONE"
-    jq '.[2].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
-    jq '.[2].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_ONE"
-    jq '.[2].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"
+    gojq '.[2].status' < changes.json | MATCH "Done"
+    gojq '.[2].data."snap-names"' < changes.json | MATCH "$SNAP_ONE"
+    gojq '.[2].data."snap-names"' < changes.json | MATCH "$SNAP_TWO"
+    gojq '.[2].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_ONE"
+    gojq '.[2].data."refresh-failed"' < changes.json | NOMATCH "$SNAP_TWO"

--- a/tests/main/auto-refresh-gating-from-snap/task.yaml
+++ b/tests/main/auto-refresh-gating-from-snap/task.yaml
@@ -16,7 +16,6 @@ environment:
   DEBUG_LOG_FILE: /var/snap/test-snapd-refresh-control/common/debug.log
 
 prepare: |
-  snap install --devmode jq
   snap set system experimental.gate-auto-refresh-hook=true
 
   echo "Install test snaps"
@@ -25,7 +24,7 @@ prepare: |
   "$TESTSTOOLS"/snaps-state install-local "$NOHOOK_SNAP"
 
 debug: |
-  jq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
+  gojq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
 
 execute: |
   LAST_REFRESH_CHANGE_ID=1

--- a/tests/main/auto-refresh-gating/task.yaml
+++ b/tests/main/auto-refresh-gating/task.yaml
@@ -14,11 +14,10 @@ environment:
   DEBUG_LOG_FILE: /var/snap/test-snapd-refresh-control/common/debug.log
 
 prepare: |
-  snap install --devmode jq
   snap set system experimental.gate-auto-refresh-hook=true
 
 debug: |
-  jq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
+  gojq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
   snap changes || true
   snap refresh --time || true
 

--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -22,11 +22,9 @@ environment:
 prepare: |
   # ensure no other refreshes interfere with the test
   snap refresh
-  snap install --devmode jq
   snap install test-snapd-sh
 
 restore: |
-  snap remove --purge jq || true
   snap remove --purge test-snapd-sh || true
 
 debug: |

--- a/tests/main/auto-refresh-private/task.yaml
+++ b/tests/main/auto-refresh-private/task.yaml
@@ -85,7 +85,8 @@ execute: |
 
     systemctl stop snapd.{service,socket}
 
-    jq ".data.auth.users[0][\"store-macaroon\"] = \"$M\"|.data.auth.users[0][\"store-discharges\"][0] = \"$D\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq ".data.auth.users[0][\"store-macaroon\"] = \"$M\"|.data.auth.users[0][\"store-discharges\"][0] = \"$D\"" \
+        /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
     "$TESTSTOOLS"/snapd-state force-autorefresh
     systemctl start snapd.{service,socket}

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -10,7 +10,6 @@ environment:
     SNAP_NAME/parallel: test-snapd-tools_instance
 
 prepare: |
-    snap install --devmode jq
     if [[ "$SPREAD_VARIANT" =~ parallel ]]; then
         snap set system experimental.parallel-instances=true
     fi
@@ -66,7 +65,7 @@ execute: |
     snap list|MATCH "$SNAP_NAME +[0-9]+\\.[0-9]+\\+fake1"
 
     echo "Ensure refresh.last is set"
-    jq ".data[\"last-refresh\"]" /var/lib/snapd/state.json | MATCH "$(date +%Y)"
+    gojq ".data[\"last-refresh\"]" /var/lib/snapd/state.json | MATCH "$(date +%Y)"
 
     echo "No refresh hold at this point"
     snap refresh --time | NOMATCH "^hold:"

--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -9,17 +9,16 @@ systems: [ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 
 prepare: |
   snap install snap-store
-  snap install jq
 
 execute: |
-  snap_id=$(snap info snap-store | grep snap-id | awk '{ print $2 }')
-  jq --sort-keys .media < "/var/cache/snapd/aux/${snap_id}.json" > media.json
+  snap_id=$(snap info snap-store | gojq -r --yaml-input '.["snap-id"]')
+  gojq .media < "/var/cache/snapd/aux/${snap_id}.json" > media.json
 
   # don't depend on the exact number of media files, but there should be
   # something here
-  media_length=$(jq '. | length' < media.json)
+  media_length=$(gojq '. | length' < media.json)
   test "${media_length}" -gt 0
 
-  timeout 5 snap debug api /v2/snaps/snap-store | jq --sort-keys .result.media > snapd-media.json
+  timeout 5 snap debug api /v2/snaps/snap-store | gojq .result.media > snapd-media.json
 
   diff media.json snapd-media.json

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -59,7 +59,7 @@ execute: |
     dump_cgroup_device_progs() {
         # dump all progs but those that are assigned to systemd, in which case
         # they have the pids list non empty
-        bpftool prog list -j | jq -r '.[] | select(.type == "cgroup_device") | select(.pids == null) | .id'
+        bpftool prog list -j | gojq -r '.[] | select(.type == "cgroup_device") | select(.pids == null) | .id'
     }
     echo "Dump BPF programs that are of type cgroup_device"
     dump_cgroup_device_progs > cgroup_device.progs-1

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -8,11 +8,6 @@ details: |
 # GCE backend sets instance data
 backends: [google]
 
-prepare: |
-    if ! command -v jq; then
-        snap install --devmode jq
-    fi
-
 execute: |
     if [[ ! -e /run/cloud-init/instance-data.json ]]; then
         echo "cloud-init instance data is required to execute the test"
@@ -35,7 +30,7 @@ execute: |
             kname=${kname/_/-}
         fi
 
-       jq -r ".[\"v1\"][\"$kname\"]" < /run/cloud-init/instance-data.json
+       gojq -r ".[\"v1\"][\"$kname\"]" < /run/cloud-init/instance-data.json
     }
     # GCE sets the following in Ubuntu images:
     # {

--- a/tests/main/interfaces-hooks/task.yaml
+++ b/tests/main/interfaces-hooks/task.yaml
@@ -11,8 +11,6 @@ environment:
     PRODUCER_DATA: /var/snap/basic-iface-hooks-producer/common
 
 prepare: |
-    snap install --devmode jq
-
     echo "Install test hooks snaps"
     "$TESTSTOOLS"/snaps-state install-local basic-iface-hooks-consumer
     "$TESTSTOOLS"/snaps-state install-local basic-iface-hooks-producer
@@ -36,13 +34,19 @@ execute: |
     }
     check_attributes(){
         # static values should have the values defined in snap's yaml
-        jq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["plug-static"]["consumer-attr-1"]' /var/lib/snapd/state.json | MATCH "consumer-value-1"
-        jq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["plug-static"]["consumer-attr-2"]' /var/lib/snapd/state.json | MATCH "consumer-value-2"
-        jq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["slot-static"]["producer-attr-1"]' /var/lib/snapd/state.json | MATCH "producer-value-1"
-        jq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["slot-static"]["producer-attr-2"]' /var/lib/snapd/state.json | MATCH "producer-value-2"
+        gojq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["plug-static"]["consumer-attr-1"]' \
+            /var/lib/snapd/state.json | MATCH "consumer-value-1"
+        gojq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["plug-static"]["consumer-attr-2"]' \
+            /var/lib/snapd/state.json | MATCH "consumer-value-2"
+        gojq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["slot-static"]["producer-attr-1"]' \
+            /var/lib/snapd/state.json | MATCH "producer-value-1"
+        gojq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["slot-static"]["producer-attr-2"]' \
+            /var/lib/snapd/state.json | MATCH "producer-value-2"
         # dynamic attributes have values created by the hooks, the "-validated" suffix is added by our test interface
-        jq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["plug-dynamic"]["before-connect"]' /var/lib/snapd/state.json | MATCH 'plug-changed\(consumer-value\)'
-        jq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["slot-dynamic"]["before-connect"]' /var/lib/snapd/state.json | MATCH 'slot-changed\(producer-value\)'
+        gojq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["plug-dynamic"]["before-connect"]' \
+            /var/lib/snapd/state.json | MATCH 'plug-changed\(consumer-value\)'
+        gojq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["slot-dynamic"]["before-connect"]' \
+            /var/lib/snapd/state.json | MATCH 'slot-changed\(producer-value\)'
     }
 
     check_hooks_were_run(){

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -14,11 +14,10 @@ details: |
 environment:
     # not all terminals support UTF-8, but Python tries to be smart and attempts
     # to guess the encoding as if the output would go to the terminal, but in
-    # fact all the test does is pipe the output to jq
+    # fact all the test does is pipe the output to (go)jq
     PYTHONIOENCODING: utf-8
 
 prepare: |
-    snap install --edge jq
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
 
@@ -42,14 +41,17 @@ execute: |
     snap connect api-client:snap-interfaces-requests-control
 
     echo "Check snap can access interfaces-requests-prompt and interfaces-requests-rule-update notices under /v2/notices"
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-prompt" | jq '."status-code"' | MATCH '^200$'
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-rule-update" | jq '."status-code"' | MATCH '^200$'
-    api-client --socket /run/snapd-snap.socket "/v2/notices" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-prompt" | \
+        gojq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-rule-update" | \
+        gojq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices" | gojq '."status-code"' | MATCH '^200$'
     echo "But not other notice types"
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update,warning" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update,warning" | \
+        gojq '."status-code"' | MATCH '^403$'
 
     echo "Check snap can access system info via /v2/system-info"
-    api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/system-info" | gojq '."status-code"' | MATCH '^200$'
 
     SNAP_NAME="snapd"
     if os.query is-core16; then
@@ -57,7 +59,7 @@ execute: |
     fi
 
     echo "Check snap can access snap info via /v2/snaps/{name}"
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | gojq '."status-code"' | MATCH '^200$'
 
     echo "Ensure AppArmor Prompting experimental feature can be enabled where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
@@ -79,10 +81,12 @@ execute: |
     snap set system experimental.apparmor-prompting=true
 
     echo 'Check "apparmor-prompting" is shown as enabled in /v2/system-info'
-    api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."result"."features"."apparmor-prompting"."enabled"' | MATCH '^true$'
+    api-client --socket /run/snapd-snap.socket "/v2/system-info" | \
+        gojq '."result"."features"."apparmor-prompting"."enabled"' | MATCH '^true$'
 
     EXPECTED_HTTP_CODE="200"
-    if api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."result"."features"."apparmor-prompting"."supported"' | MATCH '^false$' ; then
+    if api-client --socket /run/snapd-snap.socket "/v2/system-info" | \
+           gojq '."result"."features"."apparmor-prompting"."supported"' | MATCH '^false$' ; then
         # AppArmor prompting isn't supported, so rules and prompts backends are
         # not active, and will return InternalError (500). We can at least check
         # that we receive an InternalError instead of Forbidden (403).
@@ -91,29 +95,36 @@ execute: |
     fi
 
     echo "Check snap can access prompts via /v2/interfaces/requests/prompts"
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts" | \
+        gojq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
     # echo "Check snap can access a single prompt via /v2/interfaces/requests/prompts/<ID>"
     # TODO: include the "home" interface and create a request prompt by attempting to list contents of $HOME
     # PROMPT_ID=FIXME
-    # api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts/$PROMPT_ID" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
+    # api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts/$PROMPT_ID" | \
+    #     gojq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
     # echo "Check snap can reply to a prompt via /v2/interfaces/requests/prompts/<ID>
-    # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"allow","lifespan":"forever","constraints":{"path-pattern":"/**","permissions":["read"]}}' "/v2/interfaces/requests/prompts/$PROMPT_ID" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
+    # TODO: split this line more
+    # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"allow","lifespan":"forever","constraints":{"path-pattern":"/**","permissions":["read"]}}' "/v2/interfaces/requests/prompts/$PROMPT_ID" | \
+    #     gojq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
     # TODO: check that thread which triggered request completed successfully
 
     echo "Check snap can access rules via /v2/interfaces/requests/rules"
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | \
+        gojq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
 
     # XXX: creating rules requires polkit authentication, so for now, use snap debug api instead of api-client
     # echo "Check snap can create rule via /v2/interfaces/requests/rules"
     # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' "/v2/interfaces/requests/rules" > result.json
-    echo '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' | snap debug api -X POST -H 'Content-Type: application/json' "/v2/interfaces/requests/rules" | tee result.json
-    jq '."status-code"' < result.json | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
-    RULE_ID=$(jq '."result"."id"' < result.json | tr -d '"')
+    echo '{"action":"add","rule":{"snap":"api-client","interface":"home","constraints":{"path-pattern":"/path/to/file","permissions":["read","write","execute"]},"outcome":"allow","lifespan":"forever"}}' | snap debug api -X POST -H 'Content-Type: application/json' "/v2/interfaces/requests/rules" | \
+        tee result.json
+    gojq '."status-code"' < result.json | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
+    RULE_ID=$(gojq '."result"."id"' < result.json | tr -d '"')
     echo "Check snap can view a single rule via /v2/interfaces/requests/rules/<ID>"
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules/$RULE_ID" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules/$RULE_ID" | \
+        gojq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
     # XXX: modifying rules requires polkit authentication
     # echo "Check snap can modify a single rule via /v2/interfaces/requests/rules/<ID>"
-    # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"remove"}' "/v2/interfaces/requests/rules/$RULE_ID" | jq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
+    # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"remove"}' "/v2/interfaces/requests/rules/$RULE_ID" | gojq '."status-code"' | MATCH '^'"$EXPECTED_HTTP_CODE"'$'
 
     echo "Without snap-interfaces-requests-control the snap cannot access those API endpoints"
     snap disconnect api-client:snap-interfaces-requests-control
@@ -122,12 +133,17 @@ execute: |
     # the prerequisite of there being a snap with snap-interfaces-requests-control
     # connected and a handler service running is no longer true. Otherwise, the error
     # code would be 500 instead of 403.
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-prompt" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-rule-update" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/system-info" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-prompt" | \
+        gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=interfaces-requests-rule-update" | \
+        gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/system-info" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/$SNAP_NAME" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts" | \
+        gojq '."status-code"' | MATCH '^403$'
     # Try to access an arbitrary prompt ID, should fail with 403 rather than 404
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts/1234123412341234" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules/$RULE_ID" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/prompts/1234123412341234" | \
+        gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules/$RULE_ID" | \
+        gojq '."status-code"' | MATCH '^403$'

--- a/tests/main/interfaces-snap-refresh-observe/task.yaml
+++ b/tests/main/interfaces-snap-refresh-observe/task.yaml
@@ -12,11 +12,8 @@ details: |
 environment:
     # not all terminals support UTF-8, but Python tries to be smart and attempts
     # to guess the encoding as if the output would go to the terminal, but in
-    # fact all the test does is pipe the output to jq
+    # fact all the test does is pipe the output to (go)jq
     PYTHONIOENCODING: utf-8
-
-prepare: |
-    snap install --edge jq
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local api-client
@@ -26,29 +23,29 @@ execute: |
     snap connect api-client:snap-refresh-observe
 
     echo "Check snap can access change-update and refresh-inhibit notices under /v2/notices"
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update" | jq '."status-code"' | MATCH '^200$'
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=refresh-inhibit" | jq '."status-code"' | MATCH '^200$'
-    api-client --socket /run/snapd-snap.socket "/v2/notices" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update" | gojq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=refresh-inhibit" | gojq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices" | gojq '."status-code"' | MATCH '^200$'
     echo "But not other notice types"
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update,warning" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update,warning" | gojq '."status-code"' | MATCH '^403$'
 
     echo "Check snap can access changes /v2/changes"
-    api-client --socket /run/snapd-snap.socket "/v2/changes" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/changes" | gojq '."status-code"' | MATCH '^200$'
     echo "Check snap can access a single change /v2/changes/<ID>"
     CHANGE_ID=$(snap changes | tr -s '\n' | awk 'END{ print $1 }')
-    api-client --socket /run/snapd-snap.socket "/v2/changes/$CHANGE_ID" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/changes/$CHANGE_ID" | gojq '."status-code"' | MATCH '^200$'
 
     # TODO: Check it can only access /v2/snaps?select=refresh-inhibited
     echo "Check snap can access snaps /v2/snaps"
-    api-client --socket /run/snapd-snap.socket "/v2/snaps" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps" | gojq '."status-code"' | MATCH '^200$'
     echo "And also a specific snap /v2/snaps/<instance-name>"
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | jq '."status-code"' | MATCH '^200$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | gojq '."status-code"' | MATCH '^200$'
 
     echo "Without snap-refresh-observe the snap cannot access those API endpoints"
     snap disconnect api-client:snap-refresh-observe
 
-    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/changes" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/changes/$CHANGE_ID" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/snaps" | jq '."status-code"' | MATCH '^403$'
-    api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | jq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/notices?types=change-update" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/changes" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/changes/$CHANGE_ID" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | gojq '."status-code"' | MATCH '^403$'

--- a/tests/main/quota-groups-systemd-accounting/task.yaml
+++ b/tests/main/quota-groups-systemd-accounting/task.yaml
@@ -22,7 +22,7 @@ systems:
   - -ubuntu-core-*-arm-*
 
 prepare: |
-  snap install hello-world go-example-webserver remarshal jq
+  snap install hello-world go-example-webserver
 
 execute: |
   # the bug mainly happens when we create a quota group with nothing in it,
@@ -48,12 +48,12 @@ execute: |
   # that systemd returns
   # TODO: change this to use the no unit flag when that is a thing so we can
   # compare to actual value
-  snap quota sub | yaml2json | jq -r '.current.memory' | NOMATCH "18.4EB"
-  snap quota top | yaml2json | jq -r '.current.memory' | NOMATCH "18.4EB"
+  snap quota sub | gojq --yaml-input -r '.current.memory' | NOMATCH "18.4EB"
+  snap quota top | gojq --yaml-input -r '.current.memory' | NOMATCH "18.4EB"
 
   # now trigger the bug by removing the sub21 group
   snap remove-quota sub21
 
   # usage should still be sensible
-  snap quota sub | yaml2json | jq -r '.current.memory' | NOMATCH "18.4EB"
-  snap quota top | yaml2json | jq -r '.current.memory' | NOMATCH "18.4EB"
+  snap quota sub | gojq --yaml-input -r '.current.memory' | NOMATCH "18.4EB"
+  snap quota top | gojq --yaml-input -r '.current.memory' | NOMATCH "18.4EB"

--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -65,10 +65,10 @@ execute: |
 
     systemctl stop snapd snapd.socket
 
-    jq '.data.auth.device."session-macaroon"' /var/lib/snapd/state.json|MATCH null
+    gojq '.data.auth.device."session-macaroon"' /var/lib/snapd/state.json|MATCH null
 
     # XXX the fakestore currently does not support faking session creation
-    jq '.data.auth.device."session-macaroon"="fake-session"' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq '.data.auth.device."session-macaroon"="fake-session"' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
     systemctl start snapd.socket
 
@@ -81,14 +81,14 @@ execute: |
     snap refresh --list | not grep -Pzq "$expected"
 
     echo "Ensure changing the proxy.store will clear out the session-macaroon"
-    jq '.data.auth.device."session-macaroon"' /var/lib/snapd/state.json|NOMATCH  fake-session
+    gojq '.data.auth.device."session-macaroon"' /var/lib/snapd/state.json|NOMATCH  fake-session
 
     echo "Configure back to use fakestore"
     snap set core proxy.store=fake
 
     # XXX the fakestore currently does not support faking session creation
     systemctl stop snapd snapd.socket
-    jq '.data.auth.device."session-macaroon"="fake-session"' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq '.data.auth.device."session-macaroon"="fake-session"' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
     systemctl start snapd.socket
 

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -13,13 +13,12 @@ prepare: |
     echo "Install a test snap"
     snap pack "$TESTSLIB"/snaps/home-consumer
     snap install --dangerous "$SNAP_FILE"
-    snap install --edge jq
 
 execute: |
     inspect_connection() {
       CONN="$1"
-      # shellcheck disable=SC2002
-      cat /var/lib/snapd/state.json | jq --arg CONN "$CONN" -r '.data["conns"] | has($CONN)'
+      # shellcheck disable=SC2002,SC2016
+      cat /var/lib/snapd/state.json | gojq --arg CONN "$CONN" -r '.data["conns"] | has($CONN)'
     }
 
     DISCONNECTED_PATTERN='-\s+home-consumer:home'

--- a/tests/main/snap-get/task.yaml
+++ b/tests/main/snap-get/task.yaml
@@ -10,8 +10,6 @@ details: |
     the json output format and error scenarios.
 
 prepare: |
-    snap install --devmode jq
-
     echo "Build basic test package (without hooks)"
     snap pack "$TESTSLIB"/snaps/basic
     snap install --dangerous basic_1.0_all.snap
@@ -105,7 +103,7 @@ execute: |
     echo "$output" | MATCH ".*\"a\": 9876543210.*"
 
     echo "Ensure config value has correct format"
-    jq ".data[\"config\"][\"snapctl-hooks\"].intnumber" /var/lib/snapd/state.json | MATCH "1234567890"
+    gojq ".data[\"config\"][\"snapctl-hooks\"].intnumber" /var/lib/snapd/state.json | MATCH "1234567890"
 
     echo "Test unsetting of root.key2 with exclamation mark via snapctl"
     # precondition check

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -18,7 +18,7 @@ systems:
   - -ubuntu-core-*-arm-*
 
 prepare: |
-  snap install go-example-webserver jq remarshal hello-world
+  snap install go-example-webserver hello-world
 
 execute: |
   echo "Create a group with a snap in it"
@@ -80,7 +80,7 @@ execute: |
       exit 1
   fi
 
-  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-one | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-one | gojq -r '.result.current.memory')"
   kernelSaysMemUsage="$(cat "$cgroupMemFile")"
 
   pyCmd="import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))"
@@ -163,9 +163,9 @@ execute: |
 
   echo "Removing a snap ensures that the snap is not in the quota group anymore"
   snap set-quota group-three --memory=100MB go-example-webserver
-  snap quota group-three | yaml2json | jq -r '.snaps | .[]' | MATCH go-example-webserver
+  snap quota group-three | gojq --yaml-input -r '.snaps | .[]' | MATCH go-example-webserver
   snap remove go-example-webserver
-  snap quota group-three | yaml2json | jq -r '.snaps' | MATCH null
+  snap quota group-three | gojq --yaml-input -r '.snaps' | MATCH null
   snap remove-quota group-three
 
   echo "Creating a quota group with no actual services in it still has logical memory usage reported for it"
@@ -175,7 +175,7 @@ execute: |
   # in reporting it's memory usage on old systemd versions
   snap set-quota group-five --memory=10MB --parent=group-four hello-world
 
-  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-five | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-five | gojq -r '.result.current.memory')"
   # both 0 and up to 12KiB values are expected here, 0 is for older systemd/kernels 
   # where an empty cgroup has exactly 0, but on newer systems there is some 
   # minimum amount of accounting memory for an empty cgroup, which is observed
@@ -189,7 +189,7 @@ execute: |
           exit 1
   esac
 
-  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-four | jq -r '.result.current.memory')"
+  snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-four | gojq -r '.result.current.memory')"
   case "$snapdSaysMemUsage" in
       null|0|4096|8192|12288)
           # expected

--- a/tests/main/snapctl-from-snap/task.yaml
+++ b/tests/main/snapctl-from-snap/task.yaml
@@ -12,13 +12,12 @@ environment:
     SNAP/wcore18: snapctl-from-snap-core18
 
 prepare: |
-    snap install --devmode jq
     echo "Build basic test package"
     snap pack snapctl-from-snap
 
 execute: |
     check_single_cookie() {
-        cnt=$(jq -r '.data["snap-cookies"]' /var/lib/snapd/state.json | grep -c "$1" || true)
+        cnt=$(gojq -r '.data["snap-cookies"]' /var/lib/snapd/state.json | grep -c "$1" || true)
         if [ "$cnt" -ne 1 ]; then
             echo "Expected single cookie for snap $1, found $cnt"
             exit 1
@@ -61,7 +60,7 @@ execute: |
     echo "Simulate upgrade from old snapd with no cookie support"
     systemctl stop snapd.{service,socket}
     rm -f "$COOKIE_FILE"
-    jq -c 'del(.data["snap-cookies"])' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq -c 'del(.data["snap-cookies"])' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
     systemctl start snapd.{service,socket}
 

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -27,7 +27,7 @@ prepare: |
         # without .data.snaps.snapd.sequence and .data.snaps.snapd.current="unset"
         # snapd is not considered installed and core install will request restart
         cp -a /var/lib/snapd/state.json /tmp/backup_state.json
-        jq 'del(.data.snaps.snapd)' /tmp/backup_state.json > /tmp/modified_state.json
+        gojq 'del(.data.snaps.snapd)' /tmp/backup_state.json > /tmp/modified_state.json
         cp /tmp/modified_state.json /var/lib/snapd/state.json && rm /tmp/modified_state.json
         systemctl start snapd.service
     fi

--- a/tests/main/snapshot-exclusions-dynamic/task.yaml
+++ b/tests/main/snapshot-exclusions-dynamic/task.yaml
@@ -16,7 +16,6 @@ environment:
 
 prepare: | 
     "$TESTSTOOLS"/snaps-state install-local test-snap
-    snap install jq
 
 debug: |
     snap saved || true
@@ -52,9 +51,9 @@ execute: |
     # Create snapshot that will apply dynamic exclusions, and grab the set ID
     #shellcheck disable=SC2016
     RESPONSE=$( echo '{"action": "snapshot", "snaps": ["test-snap"], "snapshot-options": {"test-snap":{"exclude":["$SNAP_DATA/dynamic-exclude.txt", "$SNAP_COMMON/dynamic-exclude.txt", "$SNAP_USER_COMMON/dynamic-exclude.txt", "$SNAP_USER_DATA/dynamic-exclude.txt"]}}}' | timeout 5 snap debug api -X POST -H 'Content-Type: application/json' /v2/snaps )
-    SET_ID=$( echo "$RESPONSE" | jq '.result."set-id"' )
+    SET_ID=$( echo "$RESPONSE" | gojq '.result."set-id"' )
     echo "$SET_ID" | MATCH "^[0-9]+$"
-    CHANGE=$( echo "$RESPONSE" | jq ".change" | grep -o "[0-9]*" )
+    CHANGE=$( echo "$RESPONSE" | gojq ".change" | grep -o "[0-9]*" )
 
     # Wait for completion of async change
     retry -n 20 sh -c "snap change \"$CHANGE\" | tail -n2 | MATCH \"Done\".*"
@@ -78,7 +77,7 @@ execute: |
     "\$SNAP_USER_COMMON/dynamic-exclude.txt"
     "\$SNAP_USER_DATA/dynamic-exclude.txt"
     EOF
-    timeout 5 snap debug api /v2/snapshots?set="$SET_ID" | jq .result[0].snapshots[0].options.exclude[] > actual_options_entry
+    timeout 5 snap debug api /v2/snapshots?set="$SET_ID" | gojq .result[0].snapshots[0].options.exclude[] > actual_options_entry
     diff -u expected_options_entry actual_options_entry
 
     # Remove the canaries to test restore

--- a/tests/main/store-state/task.yaml
+++ b/tests/main/store-state/task.yaml
@@ -11,17 +11,6 @@ backends: [-external]
 # ubuntu-14.04: systemd-run not supported
 systems: [-ubuntu-14.04-64]
 
-prepare: |
-    echo "Ensure jq is installed"
-    if ! command -v jq; then
-        snap install --devmode jq
-    fi
-
-    echo "Ensure yaml2json is installed"
-    if ! command -v yaml2json; then
-        snap install --devmode remarshal
-    fi
-
 execute: |
     # Check help
     "$TESTSTOOLS"/store-state | MATCH "usage: store-state setup-fake-store <DIR>"
@@ -41,8 +30,8 @@ execute: |
     fi
 
     # install test snap dependency before switching to fake store
-    # TODO: extract base name when switching to gojq
-    snap install core22
+    base_dep="$(gojq -r --yaml-input '.base' < snap/meta/snap.yaml.in)"
+    snap install "$base_dep"
 
     # Setup fakestore
     STORE_DIR="$(pwd)/fake-store-blobdir"
@@ -54,8 +43,8 @@ execute: |
 
     # Check make-snap-installable command with snap-id
     create_snap() {
-        yaml2json -i snap/meta/snap.yaml.in > snap/meta/snap.json
-        jq ".name = \"$1\"" snap/meta/snap.json | json2yaml -o snap/meta/snap.yaml
+        gojq --yaml-input --yaml-output \
+            ".name = \"$1\"" snap/meta/snap.yaml.in > snap/meta/snap.yaml
         "$TESTSTOOLS"/snaps-state pack-local snap
     }
 

--- a/tests/main/store-state/task.yaml
+++ b/tests/main/store-state/task.yaml
@@ -11,6 +11,10 @@ backends: [-external]
 # ubuntu-14.04: systemd-run not supported
 systems: [-ubuntu-14.04-64]
 
+prepare: |
+    # acquire session macaroon
+    snap find core
+
 execute: |
     # Check help
     "$TESTSTOOLS"/store-state | MATCH "usage: store-state setup-fake-store <DIR>"

--- a/tests/main/system-usernames-snap-scoped/task.yaml
+++ b/tests/main/system-usernames-snap-scoped/task.yaml
@@ -34,21 +34,11 @@ prepare: |
         exit
     fi
 
-    echo "Ensure jq is installed"
-    if ! command -v jq; then
-        snap install --devmode jq
-    fi
-
-    echo "Ensure yaml2json is installed"
-    if ! command -v yaml2json; then
-        snap install --devmode remarshal
-    fi
-
     snap debug can-manage-refreshes | MATCH false
 
-    # install dependencies before switching to fake store
-    # TODO extract base from snap metadata when swithing to gojq
-    snap install core22
+    # install test snap dependencies before switching to fake store
+    base_dep="$(gojq -r --yaml-input '.base' < snap/meta/snap.yaml.in)"
+    snap install "$base_dep"
 
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
 
@@ -61,13 +51,14 @@ prepare: |
     snap ack "$TESTSLIB/assertions/developer1.account-key"
 
     create_snap() {
-        yaml2json -i  snap/meta/snap.yaml.in > snap/meta/snap.json
+        gojq --yaml-input --yaml-output ".name = \"$1\"" < snap/meta/snap.yaml.in > snap/meta/snap.yaml
         for user in $TESTED_USERS
         do
-            jq ".\"system-usernames\" += { \"$user\" : \"shared\"}" snap/meta/snap.json > snap/meta/snap.json.tmp
-            mv snap/meta/snap.json.tmp snap/meta/snap.json
+            gojq --yaml-input --yaml-output \
+                ".\"system-usernames\" += { \"$user\" : \"shared\"}" \
+                snap/meta/snap.yaml > snap/meta/snap.yaml.tmp
+            mv snap/meta/snap.yaml.tmp snap/meta/snap.yaml
         done
-        jq ".name = \"$1\"" snap/meta/snap.json | json2yaml -o snap/meta/snap.yaml
         "$TESTSTOOLS"/snaps-state pack-local snap
     }
 

--- a/tests/main/theme-install/task.yaml
+++ b/tests/main/theme-install/task.yaml
@@ -16,11 +16,8 @@ details: |
 environment:
     # not all terminals support UTF-8, but Python tries to be smart and attempts
     # to guess the encoding as if the output would go to the terminal, but in
-    # fact all the test does is pipe the output to jq
+    # fact all the test does is pipe the output to gojq
     PYTHONIOENCODING: utf-8
-
-prepare: |
-    snap install --edge jq
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local api-client
@@ -35,21 +32,21 @@ execute: |
 
     echo "Check for presence of a collection of themes"
     api-client '/v2/accessories/themes?gtk-theme=Yaru&gtk-theme=TraditionalHumanized&icon-theme=Yaru&icon-theme=Adwaita&sound-theme=Yaru&sound-theme=No-Such-Theme' > response.txt
-    jq . < response.txt
+    gojq . < response.txt
 
-    jq -r '.result."gtk-themes".Yaru' < response.txt | MATCH '^installed'
-    jq -r '.result."gtk-themes".TraditionalHumanized' < response.txt | MATCH '^available'
-    jq -r '.result."icon-themes".Yaru' < response.txt | MATCH '^installed'
-    jq -r '.result."icon-themes".Adwaita' < response.txt | MATCH '^installed'
-    jq -r '.result."sound-themes".Yaru' < response.txt | MATCH '^installed'
-    jq -r '.result."sound-themes"."No-Such-Theme"' < response.txt | MATCH '^unavailable'
+    gojq -r '.result."gtk-themes".Yaru' < response.txt | MATCH '^installed'
+    gojq -r '.result."gtk-themes".TraditionalHumanized' < response.txt | MATCH '^available'
+    gojq -r '.result."icon-themes".Yaru' < response.txt | MATCH '^installed'
+    gojq -r '.result."icon-themes".Adwaita' < response.txt | MATCH '^installed'
+    gojq -r '.result."sound-themes".Yaru' < response.txt | MATCH '^installed'
+    gojq -r '.result."sound-themes"."No-Such-Theme"' < response.txt | MATCH '^unavailable'
 
     echo "We can request installation of a snap to satisfy a theme"
     api-client --method=POST /v2/accessories/themes '{"gtk-themes":["TraditionalHumanized"]}' > response.txt
-    jq . < response.txt
+    gojq . < response.txt
 
     echo "Wait for change to complete"
-    change_id="$(jq -r .change < response.txt)"
+    change_id="$(gojq -r .change < response.txt)"
     snap watch "$change_id"
 
     echo "The snap providing the theme is now installed"
@@ -57,23 +54,23 @@ execute: |
 
     echo "The theme now reports as installed"
     api-client '/v2/accessories/themes?gtk-theme=TraditionalHumanized' > response.txt
-    jq -r '.result."gtk-themes".TraditionalHumanized' < response.txt | MATCH '^installed'
+    gojq -r '.result."gtk-themes".TraditionalHumanized' < response.txt | MATCH '^installed'
 
     echo "The API is also available to snaps via snapd-snap.socket, provided they have snap-themes-control plugged"
     snap disconnect api-client:snapd-control
 
     not api-client --socket /run/snapd-snap.socket '/v2/accessories/themes?gtk-theme=Yaru' > response.txt
-    jq -r '."status-code"' < response.txt | MATCH '^403$'
+    gojq -r '."status-code"' < response.txt | MATCH '^403$'
 
     snap connect api-client:snap-themes-control
     api-client --socket /run/snapd-snap.socket '/v2/accessories/themes?gtk-theme=Yaru' > response.txt
-    jq -r '.result."gtk-themes".Yaru' < response.txt | MATCH '^installed'
+    gojq -r '.result."gtk-themes".Yaru' < response.txt | MATCH '^installed'
 
     echo "POST requests are also accepted on snapd-snap.socket"
     not api-client --socket /run/snapd-snap.socket --method=POST /v2/accessories/themes '{"gtk-themes":["TraditionalHumanized"]}' > response.txt
-    jq -r '.result.message' < response.txt | MATCH '^no snaps to install'
+    gojq -r '.result.message' < response.txt | MATCH '^no snaps to install'
 
     echo "Information about install-themes changes can also be accessed"
     api-client --socket /run/snapd-snap.socket "/v2/accessories/changes/$change_id" > response.txt
-    jq -r .result.status < response.txt | MATCH '^Done$'
-    jq -r .result.kind < response.txt | MATCH '^install-themes$'
+    gojq -r .result.status < response.txt | MATCH '^Done$'
+    gojq -r .result.kind < response.txt | MATCH '^install-themes$'

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -306,75 +306,75 @@ execute: |
     LOOP_BASENAME="$(basename "$LOOP")"
 
     # disk things
-    jq -r '.pc.size'                                          < "$DISK_MAPPING_JSON" | MATCH 10000000000
-    jq -r '.pc."sector-size"'                                 < "$DISK_MAPPING_JSON" | MATCH 512
-    jq -r '.pc."device-path"'                                 < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME"
-    jq -r '.pc."kernel-path"'                                 < "$DISK_MAPPING_JSON" | MATCH "$LOOP"
-    jq -r '.pc.schema'                                        < "$DISK_MAPPING_JSON" | MATCH gpt
-    jq -r '.pc.structure | length'                            < "$DISK_MAPPING_JSON" | MATCH 5
-    jq -r '.pc."structure-encryption" | length'               < "$DISK_MAPPING_JSON" | MATCH 2
-    jq -r '.pc."structure-encryption"."ubuntu-data" | length' < "$DISK_MAPPING_JSON" | MATCH 1
-    jq -r '.pc."structure-encryption"."ubuntu-save" | length' < "$DISK_MAPPING_JSON" | MATCH 1
-    jq -r '.pc."structure-encryption"."ubuntu-data"."method"' < "$DISK_MAPPING_JSON" | MATCH LUKS
-    jq -r '.pc."structure-encryption"."ubuntu-save"."method"' < "$DISK_MAPPING_JSON" | MATCH LUKS
+    gojq -r '.pc.size'                                          < "$DISK_MAPPING_JSON" | MATCH 10000000000
+    gojq -r '.pc."sector-size"'                                 < "$DISK_MAPPING_JSON" | MATCH 512
+    gojq -r '.pc."device-path"'                                 < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME"
+    gojq -r '.pc."kernel-path"'                                 < "$DISK_MAPPING_JSON" | MATCH "$LOOP"
+    gojq -r '.pc.schema'                                        < "$DISK_MAPPING_JSON" | MATCH gpt
+    gojq -r '.pc.structure | length'                            < "$DISK_MAPPING_JSON" | MATCH 5
+    gojq -r '.pc."structure-encryption" | length'               < "$DISK_MAPPING_JSON" | MATCH 2
+    gojq -r '.pc."structure-encryption"."ubuntu-data" | length' < "$DISK_MAPPING_JSON" | MATCH 1
+    gojq -r '.pc."structure-encryption"."ubuntu-save" | length' < "$DISK_MAPPING_JSON" | MATCH 1
+    gojq -r '.pc."structure-encryption"."ubuntu-data"."method"' < "$DISK_MAPPING_JSON" | MATCH LUKS
+    gojq -r '.pc."structure-encryption"."ubuntu-save"."method"' < "$DISK_MAPPING_JSON" | MATCH LUKS
 
     # note: no partition "id" for gpt disks
 
     # first structure - "BIOS Boot"
     # note: no filesystem for the BIOS Boot structure
-    jq -r '.pc.structure[0]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p1"
-    jq -r '.pc.structure[0]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p1"
-    jq -r '.pc.structure[0]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[0]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH "BIOS\\\x20Boot"
-    jq -r '.pc.structure[0].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[0].offset'             < "$DISK_MAPPING_JSON" | MATCH 1048576
-    jq -r '.pc.structure[0].size'               < "$DISK_MAPPING_JSON" | MATCH 1048576
+    gojq -r '.pc.structure[0]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p1"
+    gojq -r '.pc.structure[0]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p1"
+    gojq -r '.pc.structure[0]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[0]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH "BIOS\\\x20Boot"
+    gojq -r '.pc.structure[0].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[0].offset'             < "$DISK_MAPPING_JSON" | MATCH 1048576
+    gojq -r '.pc.structure[0].size'               < "$DISK_MAPPING_JSON" | MATCH 1048576
 
     # second structure - ubuntu-seed
     # TODO: for some reason udev does not identify ubuntu-seed as having a
     # filesystem label, I think this has something to do with how we create it
     # artificially above
-    jq -r '.pc.structure[1]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p2"
-    jq -r '.pc.structure[1]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p2"
-    jq -r '.pc.structure[1]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[1]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-seed
-    jq -r '.pc.structure[1].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[1].offset'             < "$DISK_MAPPING_JSON" | MATCH 2097152
-    jq -r '.pc.structure[1].size'               < "$DISK_MAPPING_JSON" | MATCH 1258291200
+    gojq -r '.pc.structure[1]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p2"
+    gojq -r '.pc.structure[1]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p2"
+    gojq -r '.pc.structure[1]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[1]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-seed
+    gojq -r '.pc.structure[1].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[1].offset'             < "$DISK_MAPPING_JSON" | MATCH 2097152
+    gojq -r '.pc.structure[1].size'               < "$DISK_MAPPING_JSON" | MATCH 1258291200
 
     # third structure - ubuntu-boot
-    jq -r '.pc.structure[2]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p3"
-    jq -r '.pc.structure[2]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p3"
-    jq -r '.pc.structure[2]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
-    jq -r '.pc.structure[2]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
-    jq -r '.pc.structure[2].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[2].offset'             < "$DISK_MAPPING_JSON" | MATCH 1260388352
-    jq -r '.pc.structure[2].size'               < "$DISK_MAPPING_JSON" | MATCH 786432000
+    gojq -r '.pc.structure[2]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p3"
+    gojq -r '.pc.structure[2]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p3"
+    gojq -r '.pc.structure[2]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
+    gojq -r '.pc.structure[2]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
+    gojq -r '.pc.structure[2].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[2].offset'             < "$DISK_MAPPING_JSON" | MATCH 1260388352
+    gojq -r '.pc.structure[2].size'               < "$DISK_MAPPING_JSON" | MATCH 786432000
 
     # fourth structure - ubuntu-save-enc
-    jq -r '.pc.structure[3]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p4"
-    jq -r '.pc.structure[3]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p4"
-    jq -r '.pc.structure[3]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-save-enc
-    jq -r '.pc.structure[3]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
-    jq -r '.pc.structure[3].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[3]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p4"
+    gojq -r '.pc.structure[3]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p4"
+    gojq -r '.pc.structure[3]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-save-enc
+    gojq -r '.pc.structure[3]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
+    gojq -r '.pc.structure[3].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
     if [ "$channel" = "20" ]; then
-        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
-        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 16777216
+        gojq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        gojq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 16777216
     else
-        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
-        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 33554432
+        gojq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        gojq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 33554432
     fi
 
     # fifth structure - ubuntu-data-enc
-    jq -r '.pc.structure[4]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p5"
-    jq -r '.pc.structure[4]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p5"
-    jq -r '.pc.structure[4]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-data-enc
-    jq -r '.pc.structure[4]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
-    jq -r '.pc.structure[4].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[4]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p5"
+    gojq -r '.pc.structure[4]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p5"
+    gojq -r '.pc.structure[4]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-data-enc
+    gojq -r '.pc.structure[4]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
+    gojq -r '.pc.structure[4].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
     if [ "$channel" = "20" ]; then
-        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2063597568
-        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 7936385536
+        gojq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2063597568
+        gojq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 7936385536
     else
-        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2080374784
-        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 7919608320
+        gojq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2080374784
+        gojq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 7919608320
     fi

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -217,70 +217,70 @@ execute: |
     LOOP_BASENAME="$(basename "$LOOP")"
 
     # disk things
-    jq -r '.pc.size'               < "$DISK_MAPPING_JSON" | MATCH 20000000000
-    jq -r '.pc."sector-size"'      < "$DISK_MAPPING_JSON" | MATCH 512
-    jq -r '.pc."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME"
-    jq -r '.pc."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "$LOOP"
-    jq -r '.pc.schema'             < "$DISK_MAPPING_JSON" | MATCH gpt
-    jq -r '.pc.structure | length' < "$DISK_MAPPING_JSON" | MATCH 5
+    gojq -r '.pc.size'               < "$DISK_MAPPING_JSON" | MATCH 20000000000
+    gojq -r '.pc."sector-size"'      < "$DISK_MAPPING_JSON" | MATCH 512
+    gojq -r '.pc."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME"
+    gojq -r '.pc."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "$LOOP"
+    gojq -r '.pc.schema'             < "$DISK_MAPPING_JSON" | MATCH gpt
+    gojq -r '.pc.structure | length' < "$DISK_MAPPING_JSON" | MATCH 5
 
     # note: no partition "id" for gpt disks
 
     # first structure - "BIOS Boot"
     # note: no filesystem for the BIOS Boot structure
-    jq -r '.pc.structure[0]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p1"
-    jq -r '.pc.structure[0]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p1"
-    jq -r '.pc.structure[0]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[0]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH "BIOS\\\x20Boot"
-    jq -r '.pc.structure[0].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[0].offset'             < "$DISK_MAPPING_JSON" | MATCH 1048576
-    jq -r '.pc.structure[0].size'               < "$DISK_MAPPING_JSON" | MATCH 1048576
+    gojq -r '.pc.structure[0]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p1"
+    gojq -r '.pc.structure[0]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p1"
+    gojq -r '.pc.structure[0]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[0]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH "BIOS\\\x20Boot"
+    gojq -r '.pc.structure[0].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[0].offset'             < "$DISK_MAPPING_JSON" | MATCH 1048576
+    gojq -r '.pc.structure[0].size'               < "$DISK_MAPPING_JSON" | MATCH 1048576
 
     # second structure - ubuntu-seed
     # TODO: for some reason udev does not identify ubuntu-seed as having a
     # filesystem label, I think this has something to do with how we create it
     # artificially above
-    jq -r '.pc.structure[1]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p2"
-    jq -r '.pc.structure[1]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p2"
-    jq -r '.pc.structure[1]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[1]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-seed
-    jq -r '.pc.structure[1].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[1].offset'             < "$DISK_MAPPING_JSON" | MATCH 2097152
-    jq -r '.pc.structure[1].size'               < "$DISK_MAPPING_JSON" | MATCH 1258291200
+    gojq -r '.pc.structure[1]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p2"
+    gojq -r '.pc.structure[1]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p2"
+    gojq -r '.pc.structure[1]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[1]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-seed
+    gojq -r '.pc.structure[1].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[1].offset'             < "$DISK_MAPPING_JSON" | MATCH 2097152
+    gojq -r '.pc.structure[1].size'               < "$DISK_MAPPING_JSON" | MATCH 1258291200
 
     # third structure - ubuntu-boot
-    jq -r '.pc.structure[2]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p3"
-    jq -r '.pc.structure[2]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p3"
-    jq -r '.pc.structure[2]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
-    jq -r '.pc.structure[2]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
-    jq -r '.pc.structure[2].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[2].offset'             < "$DISK_MAPPING_JSON" | MATCH 1260388352
-    jq -r '.pc.structure[2].size'               < "$DISK_MAPPING_JSON" | MATCH 786432000
+    gojq -r '.pc.structure[2]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p3"
+    gojq -r '.pc.structure[2]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p3"
+    gojq -r '.pc.structure[2]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
+    gojq -r '.pc.structure[2]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-boot
+    gojq -r '.pc.structure[2].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[2].offset'             < "$DISK_MAPPING_JSON" | MATCH 1260388352
+    gojq -r '.pc.structure[2].size'               < "$DISK_MAPPING_JSON" | MATCH 786432000
 
     # fourth structure - ubuntu-save
-    jq -r '.pc.structure[3]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p4"
-    jq -r '.pc.structure[3]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p4"
-    jq -r '.pc.structure[3]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
-    jq -r '.pc.structure[3]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
-    jq -r '.pc.structure[3].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[3]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p4"
+    gojq -r '.pc.structure[3]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p4"
+    gojq -r '.pc.structure[3]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
+    gojq -r '.pc.structure[3]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
+    gojq -r '.pc.structure[3].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
     if [ "$channel" = "20" ]; then
-        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
-        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 16777216
+        gojq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        gojq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 16777216
     else
-        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
-        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 33554432
+        gojq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        gojq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 33554432
     fi
 
     # fifth structure - ubuntu-data
-    jq -r '.pc.structure[4]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p5"
-    jq -r '.pc.structure[4]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p5"
-    jq -r '.pc.structure[4]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
-    jq -r '.pc.structure[4]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
-    jq -r '.pc.structure[4].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
+    gojq -r '.pc.structure[4]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p5"
+    gojq -r '.pc.structure[4]."kernel-path"'      < "$DISK_MAPPING_JSON" | MATCH "${LOOP}p5"
+    gojq -r '.pc.structure[4]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
+    gojq -r '.pc.structure[4]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
+    gojq -r '.pc.structure[4].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
     if [ "$channel" = "20" ]; then
-        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2063597568
-        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 17936385536
+        gojq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2063597568
+        gojq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 17936385536
     else
-        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2080374784
-        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 17919608320
+        gojq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2080374784
+        gojq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 17919608320
     fi

--- a/tests/main/unhandled-task/task.yaml
+++ b/tests/main/unhandled-task/task.yaml
@@ -8,23 +8,20 @@ details: |
     unknown handler name in order to check that such tasks do not cause snapd to
     malfunction entirely, which would make rollback impossible.
 
-prepare: |
-    snap install --devmode jq
-
 execute: |
     echo "Stop snapd"
     systemctl stop snapd.{service,socket}
 
-    LAST_LANE_ID=$(jq ".[\"last-lane-id\"]" /var/lib/snapd/state.json)
+    LAST_LANE_ID=$(gojq ".[\"last-lane-id\"]" /var/lib/snapd/state.json)
 
     TASK_SNIPPET="{\"id\":\"90999\",\"kind\":\"alien-task\",\"summary\":\"alien task\",\"status\":0,\"data\":{},\"wait-tasks\":[],\"lanes\":[$LAST_LANE_ID],\"change\":\"80999\",\"spawn-time\":\"2010-11-09T22:04:10.320985653Z\"}"
 
     CHANGE_SNIPPET="{\"id\":\"80999\",\"kind\":\"some-change\",\"summary\":\"...\",\"status\":0,\"clean\":true,\"data\":{},\"task-ids\":[\"90999\"],\"spawn-time\":\"2010-11-09T22:04:10.320985653Z\"}"
 
     echo "Add unknown task to the state"
-    jq ".changes[\"80999\"]=$CHANGE_SNIPPET" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq ".changes[\"80999\"]=$CHANGE_SNIPPET" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
-    jq ".tasks[\"90999\"]=$TASK_SNIPPET" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    gojq ".tasks[\"90999\"]=$TASK_SNIPPET" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 
     systemctl start snapd.{service,socket}

--- a/tests/nested/manual/core20-create-recovery/task.yaml
+++ b/tests/nested/manual/core20-create-recovery/task.yaml
@@ -21,7 +21,7 @@ execute: |
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | \
         remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/debug" > change.out
-    REMOTE_CHG_ID=$(jq -r .change < change.out)
+    REMOTE_CHG_ID=$(gojq -r .change < change.out)
     remote.wait-for reboot "${boot_id}"
     remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
@@ -37,7 +37,7 @@ execute: |
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | \
         remote.exec "sudo snap debug api -X POST  -H 'Content-Type: application/json' /v2/debug" > change.out
-    REMOTE_CHG_ID=$(jq -r .change < change.out)
+    REMOTE_CHG_ID=$(gojq -r .change < change.out)
     remote.wait-for reboot "${boot_id}"
     remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 

--- a/tests/nested/manual/core20-install-device-file-install-ubuntu-save-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-ubuntu-save-via-hook/task.yaml
@@ -76,8 +76,8 @@ prepare: |
     # slurp our two yaml files together into one document, then convert write
     # out to the snap.yaml in the unpacked gadget snap
     gojq -s --yaml-input --yaml-output '.[0] * .[1]' <(cat snap-yaml-extras.yaml) <(cat pc-gadget/meta/snap.yaml) | \
-        tee pc-gadget/meta/snap.yaml.tmp
-    mv pc-gadget/meta/snap.yaml.tmp pc-gadget/meta/snap.yaml
+        tee snap.yaml.tmp
+    cp -v snap.yaml.tmp pc-gadget/meta/snap.yaml
 
     # delay all refreshes for a week from now, as otherwise refreshes for our 
     # snaps (which are asserted by the testrootorg authority-id) may happen, which

--- a/tests/nested/manual/core20-install-device-file-install-ubuntu-save-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-ubuntu-save-via-hook/task.yaml
@@ -41,11 +41,6 @@ prepare: |
         exit
     fi
 
-    # install pre-reqs which we need to adjust various bits
-    snap install jq remarshal
-    tests.cleanup defer snap remove remarshal
-    tests.cleanup defer snap remove jq
-
     # Setup the fake-store for ubuntu-image to use when creating our core image.
     # We immediately tear down the staging store, to make sure snapd is not pointed
     # towards this once we invoke ubuntu-image. 
@@ -78,12 +73,10 @@ prepare: |
     cp prepare-device pc-gadget/meta/hooks/prepare-device
 
     echo "Add the extra hooks definition to the snap.yaml"
-    # convert our yaml files to json (yaml is easier to write and maintain in VCS)
-    yaml2json < pc-gadget/meta/snap.yaml | tee pc-gadget/meta/snap.json > /dev/null
-    yaml2json < snap-yaml-extras.yaml | tee snap-yaml-extras.json > /dev/null
-    # slurp our two json files together into one json document, then convert 
-    # back to yaml and write out to the snap.yaml in the unpacked gadget snap
-    jq -s '.[0] * .[1]' <(cat snap-yaml-extras.json) <(cat pc-gadget/meta/snap.json) | json2yaml | tee pc-gadget/meta/snap.yaml
+    # slurp our two yaml files together into one document, then convert write
+    # out to the snap.yaml in the unpacked gadget snap
+    gojq -s --yaml-input --yaml-output '.[0] * .[1]' <(cat snap-yaml-extras.yaml) <(cat pc-gadget/meta/snap.yaml) | \
+        tee pc-gadget/meta/snap.yaml
 
     # delay all refreshes for a week from now, as otherwise refreshes for our 
     # snaps (which are asserted by the testrootorg authority-id) may happen, which

--- a/tests/nested/manual/core20-install-device-file-install-ubuntu-save-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-ubuntu-save-via-hook/task.yaml
@@ -76,7 +76,8 @@ prepare: |
     # slurp our two yaml files together into one document, then convert write
     # out to the snap.yaml in the unpacked gadget snap
     gojq -s --yaml-input --yaml-output '.[0] * .[1]' <(cat snap-yaml-extras.yaml) <(cat pc-gadget/meta/snap.yaml) | \
-        tee pc-gadget/meta/snap.yaml
+        tee pc-gadget/meta/snap.yaml.tmp
+    mv pc-gadget/meta/snap.yaml.tmp pc-gadget/meta/snap.yaml
 
     # delay all refreshes for a week from now, as otherwise refreshes for our 
     # snaps (which are asserted by the testrootorg authority-id) may happen, which

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -77,7 +77,8 @@ prepare: |
     # slurp our two yaml files together into one document, then convert write
     # out to the snap.yaml in the unpacked gadget snap
     gojq -s --yaml-output --yaml-input '.[0] * .[1]' <(cat snap-yaml-extras.yaml) <(cat pc-gadget/meta/snap.yaml) | \
-        tee pc-gadget/meta/snap.yaml
+        tee pc-gadget/meta/snap.yaml.tmp
+    mv pc-gadget/meta/snap.yaml.tmp pc-gadget/meta/snap.yaml
 
     # delay all refreshes for a week from now, as otherwise refreshes for our 
     # snaps (which are asserted by the testrootorg authority-id) may happen, which

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -42,11 +42,6 @@ prepare: |
         exit
     fi
 
-    # install pre-reqs which we need to adjust various bits
-    snap install jq remarshal
-    tests.cleanup defer snap remove remarshal
-    tests.cleanup defer snap remove jq
-
     # setup the fakestore, but don't use it for our snapd here on the host VM, so
     # tear down the staging_store immediately afterwards so that only the SAS is 
     # running and our snapd is not pointed at it, ubuntu-image is the only thing 
@@ -79,12 +74,10 @@ prepare: |
     cp prepare-device pc-gadget/meta/hooks/prepare-device
 
     echo "Add the extra hooks definition to the snap.yaml"
-    # convert our yaml files to json (yaml is easier to write and maintain in VCS)
-    yaml2json < pc-gadget/meta/snap.yaml | tee pc-gadget/meta/snap.json > /dev/null
-    yaml2json < snap-yaml-extras.yaml | tee snap-yaml-extras.json > /dev/null
-    # slurp our two json files together into one json document, then convert 
-    # back to yaml and write out to the snap.yaml in the unpacked gadget snap
-    jq -s '.[0] * .[1]' <(cat snap-yaml-extras.json) <(cat pc-gadget/meta/snap.json) | json2yaml | tee pc-gadget/meta/snap.yaml
+    # slurp our two yaml files together into one document, then convert write
+    # out to the snap.yaml in the unpacked gadget snap
+    gojq -s --yaml-output --yaml-input '.[0] * .[1]' <(cat snap-yaml-extras.yaml) <(cat pc-gadget/meta/snap.yaml) | \
+        tee pc-gadget/meta/snap.yaml
 
     # delay all refreshes for a week from now, as otherwise refreshes for our 
     # snaps (which are asserted by the testrootorg authority-id) may happen, which

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -77,8 +77,8 @@ prepare: |
     # slurp our two yaml files together into one document, then convert write
     # out to the snap.yaml in the unpacked gadget snap
     gojq -s --yaml-output --yaml-input '.[0] * .[1]' <(cat snap-yaml-extras.yaml) <(cat pc-gadget/meta/snap.yaml) | \
-        tee pc-gadget/meta/snap.yaml.tmp
-    mv pc-gadget/meta/snap.yaml.tmp pc-gadget/meta/snap.yaml
+        tee snap.yaml.tmp
+    cp -v snap.yaml.tmp pc-gadget/meta/snap.yaml
 
     # delay all refreshes for a week from now, as otherwise refreshes for our 
     # snaps (which are asserted by the testrootorg authority-id) may happen, which

--- a/tests/nested/manual/core20-validation-sets/task.yaml
+++ b/tests/nested/manual/core20-validation-sets/task.yaml
@@ -40,11 +40,8 @@ prepare: |
     }
 
     # install pre-reqs which we need to adjust various bits
-    snap install jq remarshal
     snap install test-snapd-swtpm --edge
     tests.cleanup defer snap remove test-snapd-swtpm
-    tests.cleanup defer snap remove remarshal
-    tests.cleanup defer snap remove jq
 
     # download snaps for the model
     snap download core

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -24,8 +24,6 @@ prepare: |
       echo "This test needs test keys to be trusted"
       exit
   fi
-  echo "Install used snaps"
-  snap install jq --devmode --edge
   if [ -d /var/lib/snapd/seed ]; then
     mv /var/lib/snapd/seed /var/lib/snapd/seed.orig
   fi
@@ -100,9 +98,9 @@ execute: |
   cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
   # do some light checking that the system is valid
-  snap debug api /v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
+  snap debug api /v2/systems | gojq '.result.systems[0].label' | MATCH "$LABEL"
   snap debug api "/v2/systems/$LABEL" > system
-  jq '.result.model.distribution' system | MATCH "ubuntu"
+  gojq '.result.model.distribution' system | MATCH "ubuntu"
   # build muinstaller and put in place
   go build -o muinstaller "$TESTSLIB"/muinstaller/main.go
 

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -173,7 +173,7 @@ execute: |
     snap aliases|MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +-"
 
     echo "Check migrating to types in state"
-    coreType=$(jq -r '.data.snaps["core"].type' /var/lib/snapd/state.json)
-    testSnapType=$(jq -r '.data.snaps["test-snapd-sh"].type' /var/lib/snapd/state.json)
+    coreType=$(gojq -r '.data.snaps["core"].type' /var/lib/snapd/state.json)
+    testSnapType=$(gojq -r '.data.snaps["test-snapd-sh"].type' /var/lib/snapd/state.json)
     [ "$coreType" = "os" ]
     [ "$testSnapType" = "app" ]


### PR DESCRIPTION
https://github.com/itchyny/gojq is almost-compatible replacement for jq, with additional features such as native support for YAML input and output. 

Attempt to switch the tests to use gojq instead of jq. Where appropriate drop use `remarshal`, since YAML support is built in.

Related: SNAPDENG-33306