### PR TITLE
interfaces/builtin/fwupd.go: allow access to nvmem for thunderbolt plugin

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -154,6 +154,10 @@ const fwupdPermanentSlotAppArmor = `
   /sys/devices/**/psp_vbflash rw,
   /sys/devices/**/psp_vbflash_status r,
 
+  # Required by plugin thunderbolt
+  /sys/devices/**/nvm_non_active*/nvmem a,
+  /sys/devices/**/nvm_active*/nvmem r,
+
   # DBus accesses
   #include <abstractions/dbus-strict>
   dbus (send)


### PR DESCRIPTION
Downstream issue: https://github.com/fwupd/fwupd/issues/8014