### PR TITLE
o/snapstate: reorder tasks such that snap and component downloads now happen consecutively

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -294,15 +294,17 @@ type ComponentInstallFlags struct {
 }
 
 type componentInstallTaskSet struct {
-	compSetupTaskID        string
-	beforeLinkTasks        []*state.Task
-	maybeLinkTask          *state.Task
-	postHookToDiscardTasks []*state.Task
-	maybeDiscardTask       *state.Task
+	compSetupTaskID               string
+	beforeLocalModificationsTasks []*state.Task
+	beforeLinkTasks               []*state.Task
+	maybeLinkTask                 *state.Task
+	postHookToDiscardTasks        []*state.Task
+	maybeDiscardTask              *state.Task
 }
 
 func (c *componentInstallTaskSet) taskSet() *state.TaskSet {
-	tasks := make([]*state.Task, 0, len(c.beforeLinkTasks)+1+len(c.postHookToDiscardTasks)+1)
+	tasks := make([]*state.Task, 0, len(c.beforeLocalModificationsTasks)+len(c.beforeLinkTasks)+1+len(c.postHookToDiscardTasks)+1)
+	tasks = append(tasks, c.beforeLocalModificationsTasks...)
 	tasks = append(tasks, c.beforeLinkTasks...)
 	if c.maybeLinkTask != nil {
 		tasks = append(tasks, c.maybeLinkTask)
@@ -403,7 +405,7 @@ func doInstallComponent(
 		compSetupTaskID: prepare.ID(),
 	}
 
-	componentTS.beforeLinkTasks = append(componentTS.beforeLinkTasks, prepare)
+	componentTS.beforeLocalModificationsTasks = append(componentTS.beforeLocalModificationsTasks, prepare)
 
 	// if the component we're installing has a revision from the store, then we
 	// need to validate it. note that we will still run this task even if we're
@@ -414,7 +416,7 @@ func doInstallComponent(
 		validate := st.NewTask("validate-component", fmt.Sprintf(
 			i18n.G("Fetch and check assertions for component %q%s"), compSetup.ComponentName(), revisionStr),
 		)
-		componentTS.beforeLinkTasks = append(componentTS.beforeLinkTasks, validate)
+		componentTS.beforeLocalModificationsTasks = append(componentTS.beforeLocalModificationsTasks, validate)
 		addTask(validate)
 	}
 

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -294,17 +294,17 @@ type ComponentInstallFlags struct {
 }
 
 type componentInstallTaskSet struct {
-	compSetupTaskID               string
-	beforeLocalModificationsTasks []*state.Task
-	beforeLinkTasks               []*state.Task
-	maybeLinkTask                 *state.Task
-	postHookToDiscardTasks        []*state.Task
-	maybeDiscardTask              *state.Task
+	compSetupTaskID                     string
+	beforeLocalSystemModificationsTasks []*state.Task
+	beforeLinkTasks                     []*state.Task
+	maybeLinkTask                       *state.Task
+	postHookToDiscardTasks              []*state.Task
+	maybeDiscardTask                    *state.Task
 }
 
 func (c *componentInstallTaskSet) taskSet() *state.TaskSet {
-	tasks := make([]*state.Task, 0, len(c.beforeLocalModificationsTasks)+len(c.beforeLinkTasks)+1+len(c.postHookToDiscardTasks)+1)
-	tasks = append(tasks, c.beforeLocalModificationsTasks...)
+	tasks := make([]*state.Task, 0, len(c.beforeLocalSystemModificationsTasks)+len(c.beforeLinkTasks)+1+len(c.postHookToDiscardTasks)+1)
+	tasks = append(tasks, c.beforeLocalSystemModificationsTasks...)
 	tasks = append(tasks, c.beforeLinkTasks...)
 	if c.maybeLinkTask != nil {
 		tasks = append(tasks, c.maybeLinkTask)
@@ -314,12 +314,12 @@ func (c *componentInstallTaskSet) taskSet() *state.TaskSet {
 		tasks = append(tasks, c.maybeDiscardTask)
 	}
 
-	if len(c.beforeLocalModificationsTasks) == 0 {
+	if len(c.beforeLocalSystemModificationsTasks) == 0 {
 		panic("component install task set should have at least one task before local modifications are done")
 	}
 
 	// get the id of the last task right before we do any local modifications
-	beforeLocalModsID := c.beforeLocalModificationsTasks[len(c.beforeLocalModificationsTasks)-1].ID()
+	beforeLocalModsID := c.beforeLocalSystemModificationsTasks[len(c.beforeLocalSystemModificationsTasks)-1].ID()
 
 	ts := state.NewTaskSet(tasks...)
 	for _, t := range ts.Tasks() {
@@ -417,7 +417,7 @@ func doInstallComponent(
 		compSetupTaskID: prepare.ID(),
 	}
 
-	componentTS.beforeLocalModificationsTasks = append(componentTS.beforeLocalModificationsTasks, prepare)
+	componentTS.beforeLocalSystemModificationsTasks = append(componentTS.beforeLocalSystemModificationsTasks, prepare)
 
 	// if the component we're installing has a revision from the store, then we
 	// need to validate it. note that we will still run this task even if we're
@@ -428,7 +428,7 @@ func doInstallComponent(
 		validate := st.NewTask("validate-component", fmt.Sprintf(
 			i18n.G("Fetch and check assertions for component %q%s"), compSetup.ComponentName(), revisionStr),
 		)
-		componentTS.beforeLocalModificationsTasks = append(componentTS.beforeLocalModificationsTasks, validate)
+		componentTS.beforeLocalSystemModificationsTasks = append(componentTS.beforeLocalSystemModificationsTasks, validate)
 		addTask(validate)
 	}
 

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -314,8 +314,20 @@ func (c *componentInstallTaskSet) taskSet() *state.TaskSet {
 		tasks = append(tasks, c.maybeDiscardTask)
 	}
 
+	if len(c.beforeLocalModificationsTasks) == 0 {
+		panic("component install task set should have at least one task before local modifications are done")
+	}
+
+	// get the id of the last task right before we do any local modifications
+	beforeLocalModsID := c.beforeLocalModificationsTasks[len(c.beforeLocalModificationsTasks)-1].ID()
+
 	ts := state.NewTaskSet(tasks...)
 	for _, t := range ts.Tasks() {
+		// note, this can't be a switch since one task might be multiple edges
+		if t.ID() == beforeLocalModsID {
+			ts.MarkEdge(t, LastBeforeLocalModificationsEdge)
+		}
+
 		if t.ID() == c.compSetupTaskID {
 			ts.MarkEdge(t, BeginEdge)
 		}

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -149,6 +149,7 @@ func checkSetupTasks(c *C, compOpts int, ts *state.TaskSet) {
 			c.Assert(t.Get("snap-setup-task", &storedTaskID), IsNil)
 			c.Assert(storedTaskID, Equals, snapSetupTaskID)
 		}
+
 		// ComponentSetup/SnapSetup found must match the ones from the first task
 		csup, ssup, err := snapstate.TaskComponentSetup(t)
 		c.Assert(err, IsNil)
@@ -172,6 +173,15 @@ func verifyComponentInstallTasks(c *C, opts int, ts *state.TaskSet) {
 	c.Assert(kinds, DeepEquals, expected)
 
 	checkSetupTasks(c, opts, ts)
+
+	t, err := ts.Edge(snapstate.LastBeforeLocalModificationsEdge)
+	c.Assert(err, IsNil)
+
+	if opts&compOptIsUnasserted == 0 {
+		c.Assert(t.Kind(), Equals, "validate-component")
+	} else {
+		c.Assert(t.Kind(), Equals, "prepare-component")
+	}
 }
 
 func createTestComponent(c *C, snapName, compName string, snapInfo *snap.Info) (*snap.ComponentInfo, string) {

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -64,19 +64,19 @@ const (
 
 // opts is a bitset with compOpt* as possible values.
 func expectedComponentInstallTasks(opts int) []string {
-	beforeLink, link, postOpHooksAndAfter, discard := expectedComponentInstallTasksSplit(opts)
-	return append(append(append(beforeLink, link...), postOpHooksAndAfter...), discard...)
+	beforeMount, beforeLink, link, postOpHooksAndAfter, discard := expectedComponentInstallTasksSplit(opts)
+	return append(append(append(append(beforeMount, beforeLink...), link...), postOpHooksAndAfter...), discard...)
 }
 
-func expectedComponentInstallTasksSplit(opts int) (beforeLink, link, postOpHooksAndAfter, discard []string) {
+func expectedComponentInstallTasksSplit(opts int) (beforeMount, beforeLink, link, postOpHooksAndAfter, discard []string) {
 	if opts&compOptIsLocal != 0 || opts&compOptRevisionPresent != 0 {
-		beforeLink = []string{"prepare-component"}
+		beforeMount = []string{"prepare-component"}
 	} else {
-		beforeLink = []string{"download-component"}
+		beforeMount = []string{"download-component"}
 	}
 
 	if opts&compOptIsUnasserted == 0 {
-		beforeLink = append(beforeLink, "validate-component")
+		beforeMount = append(beforeMount, "validate-component")
 	}
 
 	// Revision is not the same as the current one installed
@@ -116,7 +116,7 @@ func expectedComponentInstallTasksSplit(opts int) (beforeLink, link, postOpHooks
 		discard = append(discard, "discard-component")
 	}
 
-	return beforeLink, link, postOpHooksAndAfter, discard
+	return beforeMount, beforeLink, link, postOpHooksAndAfter, discard
 }
 
 func checkSetupTasks(c *C, compOpts int, ts *state.TaskSet) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -487,18 +487,18 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 		return nil, err
 	}
 
-	finalBeforeLocalMod := prepare
+	finalBeforeLocalSystemModifications := prepare
 
 	var checkAsserts *state.Task
 	if fromStore {
 		// fetch and check assertions
 		checkAsserts = st.NewTask("validate-snap", fmt.Sprintf(i18n.G("Fetch and check assertions for snap %q%s"), snapsup.InstanceName(), revisionStr))
 		addTask(checkAsserts)
-		finalBeforeLocalMod = checkAsserts
+		finalBeforeLocalSystemModifications = checkAsserts
 	}
 
 	for _, t := range componentsTSS.beforeLocalSystemModificationsTasks {
-		finalBeforeLocalMod = t
+		finalBeforeLocalSystemModifications = t
 		addTask(t)
 	}
 
@@ -817,7 +817,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 	if installHook != nil {
 		installSet.MarkEdge(installHook, HooksEdge)
 	}
-	installSet.MarkEdge(finalBeforeLocalMod, LastBeforeLocalModificationsEdge)
+	installSet.MarkEdge(finalBeforeLocalSystemModifications, LastBeforeLocalModificationsEdge)
 	if flags&noRestartBoundaries == 0 {
 		if err := SetEssentialSnapsRestartBoundaries(st, nil, []*state.TaskSet{installSet}); err != nil {
 			return nil, err


### PR DESCRIPTION
This change makes it so when installing (or refreshing) a snap and its components, we do all the downloads back-to-back. This will help make the code changes needed for remodeling simpler.

Example of the tasks created when installing a snap and two components from the store:
```
task prerequisites (1), Ensure prerequisites for "test-snap" are available
  waiting on:
task download-snap (2), Download snap "test-snap" (11) from channel "channel-for-components"
  waiting on:
  - prerequisites (1)
task validate-snap (13), Fetch and check assertions for snap "test-snap" (11)
  waiting on:
  - download-snap (2)
task download-component (3), Download component "kernel-modules-component" (1)
  waiting on:
  - validate-snap (13)
task validate-component (4), Fetch and check assertions for component "kernel-modules-component" (1)
  waiting on:
  - download-component (3)
task download-component (8), Download component "standard-component" (2)
  waiting on:
  - validate-component (4)
task validate-component (9), Fetch and check assertions for component "standard-component" (2)
  waiting on:
  - download-component (8)
task mount-snap (14), Mount snap "test-snap" (11)
  waiting on:
  - validate-component (9)
task mount-component (5), Mount component "test-snap+kernel-modules-component" (1)
  waiting on:
  - validate-component (4)
  - mount-snap (14)
task mount-component (10), Mount component "test-snap+standard-component" (2)
  waiting on:
  - validate-component (9)
  - mount-component (5)
task copy-snap-data (15), Copy snap "test-snap" data
  waiting on:
  - mount-component (10)
task setup-profiles (16), Setup snap "test-snap" (11) security profiles
  waiting on:
  - copy-snap-data (15)
task link-snap (17), Make snap "test-snap" (11) available to the system
  waiting on:
  - setup-profiles (16)
task link-component (6), Make component "test-snap+kernel-modules-component" (1) available to the system
  waiting on:
  - mount-component (5)
  - link-snap (17)
task link-component (11), Make component "test-snap+standard-component" (2) available to the system
  waiting on:
  - mount-component (10)
  - link-component (6)
task auto-connect (18), Automatically connect eligible plugs and slots of snap "test-snap"
  waiting on:
  - link-component (11)
task set-auto-aliases (19), Set automatic aliases for snap "test-snap"
  waiting on:
  - auto-connect (18)
task setup-aliases (20), Setup snap "test-snap" aliases
  waiting on:
  - set-auto-aliases (19)
task run-hook (21), Run install hook of "test-snap" snap if present
  waiting on:
  - setup-aliases (20)
task run-hook (7), Run install hook of "test-snap+kernel-modules-component" component if present
  waiting on:
  - link-component (6)
  - run-hook (21)
task run-hook (12), Run install hook of "test-snap+standard-component" component if present
  waiting on:
  - link-component (11)
  - run-hook (7)
task prepare-kernel-modules-components (22), Prepare kernel-modules components for "test-snap" (11)
  waiting on:
  - run-hook (12)
task run-hook (23), Run default-configure hook of "test-snap" snap if present
  waiting on:
  - prepare-kernel-modules-components (22)
task start-snap-services (24), Start snap "test-snap" (11) services
  waiting on:
  - run-hook (23)
task run-hook (25), Run configure hook of "test-snap" snap if present
  waiting on:
  - prerequisites (1)
  - download-snap (2)
  - validate-snap (13)
  - download-component (3)
  - validate-component (4)
  - download-component (8)
  - validate-component (9)
  - mount-snap (14)
  - mount-component (5)
  - mount-component (10)
  - copy-snap-data (15)
  - setup-profiles (16)
  - link-snap (17)
  - link-component (6)
  - link-component (11)
  - auto-connect (18)
  - set-auto-aliases (19)
  - setup-aliases (20)
  - run-hook (21)
  - run-hook (7)
  - run-hook (12)
  - prepare-kernel-modules-components (22)
  - run-hook (23)
  - start-snap-services (24)
task run-hook (26), Run health check of "test-snap" snap
  waiting on:
  - prerequisites (1)
  - download-snap (2)
  - validate-snap (13)
  - download-component (3)
  - validate-component (4)
  - download-component (8)
  - validate-component (9)
  - mount-snap (14)
  - mount-component (5)
  - mount-component (10)
  - copy-snap-data (15)
  - setup-profiles (16)
  - link-snap (17)
  - link-component (6)
  - link-component (11)
  - auto-connect (18)
  - set-auto-aliases (19)
  - setup-aliases (20)
  - run-hook (21)
  - run-hook (7)
  - run-hook (12)
  - prepare-kernel-modules-components (22)
  - run-hook (23)
  - start-snap-services (24)
  - run-hook (25)
```