### PR TITLE
o/ifacestate: fix generation of AppArmor profile w/ incorrect revision

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -43,7 +43,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
-	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -323,18 +322,13 @@ func (m *InterfaceManager) setupProfilesForAppSet(task *state.Task, appSet *inte
 			snapInfo.SideInfo = *snapst.PendingSecurity.SideInfo
 
 			var comps []*snap.ComponentInfo
-			for _, compSi := range snapst.PendingSecurity.Components {
-				compName := compSi.Component.ComponentName
-				compRev := compSi.Revision
-
-				cpi := snap.MinimalComponentContainerPlaceInfo(compName, compRev, snapInfo.InstanceName())
-				container := snapdir.New(cpi.MountDir())
-				comp, err := snap.ReadComponentInfoFromContainer(container, snapInfo, compSi)
+			for _, csi := range snapst.PendingSecurity.Components {
+				ci, err := snapstate.ReadComponentInfo(snapInfo, csi)
 				if err != nil {
 					return fmt.Errorf("cannot read component info when building app set %q: %v", name, err)
 				}
 
-				comps = append(comps, comp)
+				comps = append(comps, ci)
 			}
 
 			appSet, err = interfaces.NewSnapAppSet(snapInfo, comps)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -43,7 +43,6 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
 )
@@ -1104,17 +1103,12 @@ func snapsWithSecurityProfiles(st *state.State) ([]*interfaces.SnapAppSet, error
 
 			components := make([]*snap.ComponentInfo, 0, len(snapst.PendingSecurity.Components))
 			for _, csi := range snapst.PendingSecurity.Components {
-				cpi := snap.MinimalComponentContainerPlaceInfo(
-					csi.Component.ComponentName,
-					csi.Revision,
-					instanceName,
-				)
-				container := snapdir.New(cpi.MountDir())
-				ci, err := snap.ReadComponentInfoFromContainer(container, snapInfo, csi)
+				ci, err := snapstate.ReadComponentInfo(snapInfo, csi)
 				if err != nil {
 					logger.Noticef("cannot read component info for snap %q: %s", instanceName, err)
 					continue
 				}
+
 				components = append(components, ci)
 			}
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -73,9 +73,9 @@ func MockSnapReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, err
 }
 
 func MockReadComponentInfo(mock func(compMntDir string, snapInfo *snap.Info, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error)) (restore func()) {
-	old := readComponentInfo
-	readComponentInfo = mock
-	return func() { readComponentInfo = old }
+	old := readComponentInfoAt
+	readComponentInfoAt = mock
+	return func() { readComponentInfoAt = old }
 }
 
 func MockMountPollInterval(intv time.Duration) (restore func()) {

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -296,7 +296,7 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	var readInfoErr error
 	for i := 0; i < 10; i++ {
 		compMntDir := cpi.MountDir()
-		_, readInfoErr = readComponentInfo(compMntDir, nil, csi)
+		_, readInfoErr = readComponentInfoAt(compMntDir, nil, csi)
 		if readInfoErr == nil {
 			logger.Debugf("component %q (%v) available at %q",
 				csi.Component, compSetup.Revision(), compMntDir)
@@ -342,8 +342,15 @@ func (m *SnapManager) doMountComponent(t *state.Task, _ *tomb.Tomb) (err error) 
 	return nil
 }
 
+// ReadComponentInfo reads the snap's component and returns a ComponentInfo.
+func ReadComponentInfo(snapInfo *snap.Info, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
+	compName, compRev := csi.Component.ComponentName, csi.Revision
+	mountDir := snap.ComponentMountDir(compName, compRev, snapInfo.InstanceName())
+	return readComponentInfoAt(mountDir, snapInfo, csi)
+}
+
 // Maybe we will need flags as in readInfo
-var readComponentInfo = func(compMntDir string, snapInfo *snap.Info, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
+var readComponentInfoAt = func(compMntDir string, snapInfo *snap.Info, csi *snap.ComponentSideInfo) (*snap.ComponentInfo, error) {
 	cont := snapdir.New(compMntDir)
 	return snap.ReadComponentInfoFromContainer(cont, snapInfo, csi)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -665,10 +665,7 @@ func (snapst *SnapState) ComponentInfosForRevision(rev snap.Revision) ([]*snap.C
 
 	compInfos := make([]*snap.ComponentInfo, 0, len(revState.Components))
 	for _, comp := range revState.Components {
-		cpi := snap.MinimalComponentContainerPlaceInfo(comp.SideInfo.Component.ComponentName,
-			comp.SideInfo.Revision, si.InstanceName())
-
-		compInfo, err := readComponentInfo(cpi.MountDir(), si, comp.SideInfo)
+		compInfo, err := ReadComponentInfo(si, comp.SideInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -693,9 +690,7 @@ func (snapst *SnapState) CurrentComponentInfo(cref naming.ComponentRef) (*snap.C
 		return nil, err
 	}
 
-	cpi := snap.MinimalComponentContainerPlaceInfo(csi.Component.ComponentName,
-		csi.Revision, si.InstanceName())
-	return readComponentInfo(cpi.MountDir(), si, csi)
+	return ReadComponentInfo(si, csi)
 }
 
 func (snapst *SnapState) InstanceName() string {


### PR DESCRIPTION
In a scenario where two snaps with connected content plugs and slots were refreshed together, the first snap to be refreshed could get an AppArmor profile generated that used the previous revision (so revisioned paths like $SNAP_DATA and $SNAP_USER_DATA) would not be accessible. The issue is that we generate security profiles for connected snaps when generating the profile for the refreshed snap but don't take into account that the snap may have been refreshed in the same change (the new revision isn't reflected in state yet). So we'd generate an incorrect AppArmor profile with the previous revision. I couldn't add a spread test to tests/regression/ because it's not a deterministic failure.
