### PR TITLE
i/b/u2f_devices: add Nitrokey Passkey

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -113,6 +113,11 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "42b2",
 	},
 	{
+		Name:             "Nitrokey Passkey",
+		VendorIDPattern:  "20a0",
+		ProductIDPattern: "42f3",
+	},
+	{
 		Name:             "Google Titan U2F",
 		VendorIDPattern:  "18d1",
 		ProductIDPattern: "5026|9470",

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -93,7 +93,7 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 32)
+	c.Assert(spec.Snippets(), HasLen, 33)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
This adds the Nitrokey Passkey FIDO2/U2F device to the `u2f_devices.go` list. I hope, this is the right way. I made it work in Firefox on my system by editing `/etc/udev/rules.d/70-snap.firefox.rules` manually.

You can verify the VendorId and ProductID here:
https://github.com/Nitrokey/nitrokey-udev-rules/blob/48482a54e4c101dcac4991af4b4f006e75800d84/41-nitrokey.rules#L23

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

(I haven't signed the license agreement, because it wouldn't let me without providing a "Canonical Project Manager or contact" – which I don't have...)

Edit: Nevermind. I have signed the agreement now. I put the snapd project contact's name from [this list](https://canonical.com/projects/directory) in the form.