### PR TITLE
cmd/snap: expose debug validate-seed and debug seeding

### DIFF
--- a/cmd/snap/cmd_debug_api.go
+++ b/cmd/snap/cmd_debug_api.go
@@ -32,7 +32,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 )
 
-var longDebugAPIHelp = `
+const longDebugAPIHelp = `
 Execute a raw query to snapd API. Complex input can be read from stdin, while
 output is printed to stdout. See examples below:
 

--- a/cmd/snap/cmd_debug_seeding.go
+++ b/cmd/snap/cmd_debug_seeding.go
@@ -36,13 +36,12 @@ type cmdSeeding struct {
 }
 
 func init() {
-	cmd := addDebugCommand("seeding",
-		"(internal) obtain seeding and preseeding details",
-		"(internal) obtain seeding and preseeding details",
+	addDebugCommand("seeding",
+		"Obtain seeding and preseeding details",
+		"Obtain seeding and preseeding details",
 		func() flags.Commander {
 			return &cmdSeeding{}
 		}, nil, nil)
-	cmd.hidden = true
 }
 
 func (x *cmdSeeding) Execute(args []string) error {

--- a/cmd/snap/cmd_debug_validate_seed.go
+++ b/cmd/snap/cmd_debug_validate_seed.go
@@ -33,14 +33,18 @@ type cmdValidateSeed struct {
 	} `positional-args:"true" required:"true"`
 }
 
+const longDebugValidateSeedHelp = `
+Validate correctness of snap seed located in the directory
+containing seed.yaml file.
+`
+
 func init() {
-	cmd := addDebugCommand("validate-seed",
-		"(internal) validate seed.yaml",
-		"(internal) validate seed.yaml",
+	addDebugCommand("validate-seed",
+		"Validate snap seed",
+		longDebugValidateSeedHelp,
 		func() flags.Commander {
 			return &cmdValidateSeed{}
 		}, nil, nil)
-	cmd.hidden = true
 }
 
 func (x *cmdValidateSeed) Execute(args []string) error {


### PR DESCRIPTION
After reviewing all debug commands, the all that are hidden also use `(internal)` in the help message, and the ones that aren't have reasonable help messages.

For clarity, the `snap debug seeding` and `snap debug validate-seed` are exposed since folks already use them in various contexts, so there is no point in keeping them hidden.

Related: [SNAPDENG-26743](https://warthogs.atlassian.net/browse/SNAPDENG-26743)

[SNAPDENG-26743]: https://warthogs.atlassian.net/browse/SNAPDENG-26743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ