### PR TITLE
tests: add wait for seeding to finish at the end of the prepare script

### DIFF
--- a/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
+++ b/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
@@ -73,6 +73,7 @@ prepare: |
   # unmount the image and start the VM
   umount_ubuntu_image "$IMAGE_MOUNTPOINT"
   tests.nested create-vm classic
+  remote.exec "sudo snap wait system seed.loaded"
 
 execute: |
   # check the current snapd snap is vulnerable


### PR DESCRIPTION
SNAPDENG-34146

fixes snapd-removes-vulnerable-snap-confine-revs intermittent failure