### PR TITLE
tests: migrate snap-seccomp-syscalls to noble

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -589,7 +589,6 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 dbus-user-session
                 gccgo-8
-                gperf
                 evolution-data-server
                 fwupd
                 packagekit
@@ -617,6 +616,7 @@ pkg_dependencies_ubuntu_classic(){
                 dbus-user-session
                 fwupd
                 golang
+                gperf
                 libvirt-daemon-system
                 linux-tools-$(uname -r)
                 lz4

--- a/tests/main/snap-seccomp-syscalls/task.yaml
+++ b/tests/main/snap-seccomp-syscalls/task.yaml
@@ -8,7 +8,7 @@ details: |
   more details.
 
 # one system is enough
-systems: [ubuntu-18.04-64]
+systems: [ubuntu-24.04-64]
 
 # Start early as it takes a long time.
 priority: 100


### PR DESCRIPTION
Migrate this test to noble as there is not new images for bionic anymore.

