### PR TITLE
tests: restart ntp in Xenial to prevent errors in auto-refresh

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -772,6 +772,16 @@ restore_suite_each() {
         "$TESTSLIB"/reset.sh --reuse-core
     fi
 
+    # The ntp service randomly fails to create a socket on virbr0-nic,
+    # generating issues in actions like the auto-refresh (in Xenial).
+    # The errror lines are:
+    # ntpd: bind(23) AF_INET6 ... flags 0x11 failed: Cannot assign requested address
+    # ntpd: unable to create socket on virbr0-nic
+    # ntpd: kernel reports TIME_ERROR: 0x41: Clock Unsynchronized
+    if os.query is-xenial && systemctl status ntp | MATCH TIME_ERROR; then
+        systemctl restart ntp
+    fi
+
     # Check for invariants late, in order to detect any bugs in the code above.
     if [[ "$variant" = full ]]; then
         "$TESTSTOOLS"/cleanup-state pre-invariant


### PR DESCRIPTION
The service in Xenial randomly fails to create a socket on virbr0-nic.

The problem is fixed when the ntp service is restarted. The test tests/main/auto-refresh is fixed with this change.

The errror lines are:
ntpd: bind(23) AF_INET6 ... flags 0x11 failed: Cannot assign requested address
ntpd: unable to create socket on virbr0-nic
ntpd: kernel reports TIME_ERROR: 0x41: Clock Unsynchronized
