### PR TITLE
gadget: emmc gadget update support

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -107,7 +107,7 @@ func MockFindVolumesMatchingDeviceAssignment(f func(gi *Info) (map[string]*Volum
 	return r
 }
 
-func MockSetEMMCPartitionReadWrite(mock func(device string, part string, rw bool) error) (restore func()) {
+func MockSetEMMCPartitionReadWrite(mock func(device string, rw bool) error) (restore func()) {
 	r := testutil.Backup(&setEMMCPartitionReadWrite)
 	setEMMCPartitionReadWrite = mock
 	return r

--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -106,3 +106,9 @@ func MockFindVolumesMatchingDeviceAssignment(f func(gi *Info) (map[string]*Volum
 	VolumesForCurrentDeviceAssignment = f
 	return r
 }
+
+func MockSetEMMCPartitionReadWrite(mock func(device string, part string, rw bool) error) (restore func()) {
+	r := testutil.Backup(&setEMMCPartitionReadWrite)
+	setEMMCPartitionReadWrite = mock
+	return r
+}

--- a/gadget/gadgettest/examples.go
+++ b/gadget/gadgettest/examples.go
@@ -1379,6 +1379,22 @@ const MultiVolumeUC20GadgetYaml = SingleVolumeUC20GadgetYaml + `
         size: 1G
 `
 
+const MultiVolumeEmmcUC20GadgetYaml = SingleVolumeUC20GadgetYaml + `
+  my-emmc:
+    schema: emmc
+    structure:
+      - name: boot0
+        size: 1048576
+      - name: boot1
+        size: 1048576
+volume-assignments:
+  - assignment-name: my-emmc-device
+    assignment:
+      pc:
+        device: /dev/disk/by-path/pci-42:0
+      my-emmc:
+        device: /dev/disk/by-path/pci-43:0
+`
 const SingleVolumeClassicwithModesNoEncryptGadgetYaml = `
 volumes:
   pc:
@@ -1580,6 +1596,39 @@ var VMSystemVolumeDiskMapping = &disks.MockDiskMapping{
 	},
 }
 
+var VMEmmcVolumeDiskMapping = &disks.MockDiskMapping{
+	DevNode:             "/dev/mmcblk0",
+	DevPath:             "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/mmcblk0",
+	DevNum:              "525:1",
+	DiskUsableSectorEnd: 5120 * oneMeg / 512,
+	DiskSizeInBytes:     5120 * oneMeg,
+	SectorSizeBytes:     512,
+	DiskSchema:          "emmc",
+	ID:                  "86964016-3b5c-477e-9828-24ba9c552d39",
+	Structure: []disks.Partition{
+		{
+			PartitionLabel:   "boot0",
+			Major:            525,
+			Minor:            2,
+			KernelDeviceNode: "/dev/mmcblk0boot0",
+			KernelDevicePath: "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/mmcblk0boot0",
+			DiskIndex:        1,
+			StartInBytes:     0,
+			SizeInBytes:      oneMeg,
+		},
+		{
+			PartitionLabel:   "boot1",
+			Major:            525,
+			Minor:            3,
+			KernelDeviceNode: "/dev/mmcblk0boot1",
+			KernelDevicePath: "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/mmcblk0boot1",
+			DiskIndex:        2,
+			StartInBytes:     0,
+			SizeInBytes:      oneMeg,
+		},
+	},
+}
+
 var VMSystemVolumeDiskMappingSeedFsLabelCaps = &disks.MockDiskMapping{
 	DevNode: "/dev/vda",
 	DevPath: "/sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda",
@@ -1758,6 +1807,29 @@ var VMSystemVolumeDeviceTraits = gadget.DiskVolumeDeviceTraits{
 			Offset:             (1 + 1 + 1200 + 750 + 16) * quantity.OffsetMiB,
 			// including the last usable sector - the offset
 			Size: ((5120*quantity.SizeMiB - 33*512) - (1+1+1200+750+16)*quantity.SizeMiB),
+		},
+	},
+}
+
+var VMEmmcVolumeDeviceTraits = gadget.DiskVolumeDeviceTraits{
+	OriginalDevicePath: "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/mmcblk0",
+	OriginalKernelPath: "/dev/mmcblk0",
+	DiskID:             "86964016-3b5c-477e-9828-24ba9c552d39",
+	Size:               5120 * quantity.SizeMiB,
+	SectorSize:         quantity.Size(512),
+	Schema:             "emmc",
+	Structure: []gadget.DiskStructureDeviceTraits{
+		{
+			OriginalDevicePath: "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/mmcblk0boot0",
+			OriginalKernelPath: "/dev/mmcblk0boot0",
+			Offset:             0,
+			Size:               quantity.SizeMiB,
+		},
+		{
+			OriginalDevicePath: "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/mmcblk0boot1",
+			OriginalKernelPath: "/dev/mmcblk0boot1",
+			Offset:             0,
+			Size:               quantity.SizeMiB,
 		},
 	},
 }

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -258,6 +258,30 @@ var MockGadgetPartitionedOnDiskVolume = gadget.OnDiskVolume{
 	},
 }
 
+// This matches the disk mapping set by MockGadgetPartitionedDisk
+var MockGadgetEMMCOnDiskVolume = gadget.OnDiskVolume{
+	Device:           "/dev/mmcblk0",
+	Schema:           "emmc",
+	Size:             5120 * quantity.SizeMiB,
+	UsableSectorsEnd: 5120 * oneMeg / 512,
+	SectorSize:       512,
+	ID:               "86964016-3b5c-477e-9828-24ba9c552d39",
+	Structure: []gadget.OnDiskStructure{
+		{
+			Name:      "boot0",
+			Node:      "/dev/mmcblk0boot0",
+			Size:      quantity.SizeMiB,
+			DiskIndex: 1,
+		},
+		{
+			Name:      "boot1",
+			Node:      "/dev/mmcblk0boot1",
+			Size:      quantity.SizeMiB,
+			DiskIndex: 2,
+		},
+	},
+}
+
 func MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot string) (ginfo *gadget.Info, laidVols map[string]*gadget.LaidOutVolume, model *asserts.Model, restore func(), err error) {
 	// TODO test for UC systems too
 	model = boottest.MakeMockClassicWithModesModel()
@@ -277,86 +301,134 @@ func MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot string) (ginfo *gadget.Inf
 		return nil, nil, nil, nil, err
 	}
 
+	mappings := make(map[string]*disks.MockDiskMapping)
+
 	// "Real" disk data that will be read. Filesystem type and label are not
 	// filled as the filesystem is considered not created yet, which is
 	// expected by some tests (some option would have to be added to fill or
 	// not if this data is needed by some test in the future).
-	vdaSysPath := "/sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda"
-	disk := &disks.MockDiskMapping{
-		Structure: []disks.Partition{
-			{
-				PartitionLabel:   "BIOS\\x20Boot",
-				PartitionType:    "21686148-6449-6E6F-744E-656564454649",
-				KernelDeviceNode: "/dev/vda1",
-				DiskIndex:        1,
-				StartInBytes:     oneMeg,
-				SizeInBytes:      oneMeg,
-			},
-			{
-				PartitionLabel:   "EFI System partition",
-				PartitionUUID:    "4b436628-71ba-43f9-aa12-76b84fe32728",
-				PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-				FilesystemUUID:   "04D6-5AE2",
-				FilesystemType:   "vfat",
-				KernelDeviceNode: "/dev/vda2",
-				DiskIndex:        2,
-				StartInBytes:     2 * oneMeg,
-				SizeInBytes:      99 * oneMeg,
-			},
-			{
-				PartitionLabel:   "ubuntu-boot",
-				PartitionUUID:    "ade3ba65-7831-fd40-bbe2-e01c9774ed5b",
-				PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-				FilesystemUUID:   "5b3e775a-407d-4af7-aa16-b92a8b7507e6",
-				FilesystemLabel:  "ubuntu-boot",
-				FilesystemType:   "ext4",
-				KernelDeviceNode: "/dev/vda3",
-				DiskIndex:        3,
-				StartInBytes:     1202 * oneMeg,
-				SizeInBytes:      750 * oneMeg,
-			},
-			{
-				PartitionLabel:   "ubuntu-save",
-				PartitionUUID:    "f1d01870-194b-8a45-84c0-0d1c90e17d9d",
-				PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-				FilesystemUUID:   "6766b605-9cd5-47ae-bc48-807c778b9987",
-				FilesystemLabel:  "ubuntu-save",
-				FilesystemType:   "ext4",
-				KernelDeviceNode: "/dev/vda4",
-				DiskIndex:        4,
-				StartInBytes:     1952 * oneMeg,
-				SizeInBytes:      16 * oneMeg,
-			},
-			{
-				PartitionLabel:   "ubuntu-data",
-				PartitionUUID:    "4994f0e5-1ead-1a4d-b696-2d8cb1fa980d",
-				PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-				FilesystemUUID:   "4e29a1e9-526d-48fc-a5c2-4f97e7e011e2",
-				FilesystemLabel:  "ubuntu-data",
-				FilesystemType:   "ext4",
-				KernelDeviceNode: "/dev/vda5",
-				DiskIndex:        5,
-				StartInBytes:     1968 * oneMeg,
-				SizeInBytes:      4096 * oneMeg,
-			},
-		},
-		DiskHasPartitions: true,
-		DevNum:            "disk1",
-		DevNode:           "/dev/vda",
-		DevPath:           vdaSysPath,
-		// assume 34 sectors at end for GPT headers backup
-		DiskUsableSectorEnd: 7000*oneMeg/512 - 34,
-		DiskSizeInBytes:     7000 * oneMeg,
-		SectorSizeBytes:     512,
-		DiskSchema:          "gpt",
-		ID:                  "f0eef013-a777-4a27-aaf0-dbb5cf68c2b6",
+	for _, vol := range ginfo.Volumes {
+		switch vol.Name {
+		case "pc":
+			vdaSysPath := "/sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda"
+			disk := &disks.MockDiskMapping{
+				Structure: []disks.Partition{
+					{
+						PartitionLabel:   "BIOS\\x20Boot",
+						PartitionType:    "21686148-6449-6E6F-744E-656564454649",
+						KernelDeviceNode: "/dev/vda1",
+						DiskIndex:        1,
+						StartInBytes:     oneMeg,
+						SizeInBytes:      oneMeg,
+					},
+					{
+						PartitionLabel:   "EFI System partition",
+						PartitionUUID:    "4b436628-71ba-43f9-aa12-76b84fe32728",
+						PartitionType:    "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+						FilesystemUUID:   "04D6-5AE2",
+						FilesystemType:   "vfat",
+						KernelDeviceNode: "/dev/vda2",
+						DiskIndex:        2,
+						StartInBytes:     2 * oneMeg,
+						SizeInBytes:      99 * oneMeg,
+					},
+					{
+						PartitionLabel:   "ubuntu-boot",
+						PartitionUUID:    "ade3ba65-7831-fd40-bbe2-e01c9774ed5b",
+						PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+						FilesystemUUID:   "5b3e775a-407d-4af7-aa16-b92a8b7507e6",
+						FilesystemLabel:  "ubuntu-boot",
+						FilesystemType:   "ext4",
+						KernelDeviceNode: "/dev/vda3",
+						DiskIndex:        3,
+						StartInBytes:     1202 * oneMeg,
+						SizeInBytes:      750 * oneMeg,
+					},
+					{
+						PartitionLabel:   "ubuntu-save",
+						PartitionUUID:    "f1d01870-194b-8a45-84c0-0d1c90e17d9d",
+						PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+						FilesystemUUID:   "6766b605-9cd5-47ae-bc48-807c778b9987",
+						FilesystemLabel:  "ubuntu-save",
+						FilesystemType:   "ext4",
+						KernelDeviceNode: "/dev/vda4",
+						DiskIndex:        4,
+						StartInBytes:     1952 * oneMeg,
+						SizeInBytes:      16 * oneMeg,
+					},
+					{
+						PartitionLabel:   "ubuntu-data",
+						PartitionUUID:    "4994f0e5-1ead-1a4d-b696-2d8cb1fa980d",
+						PartitionType:    "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+						FilesystemUUID:   "4e29a1e9-526d-48fc-a5c2-4f97e7e011e2",
+						FilesystemLabel:  "ubuntu-data",
+						FilesystemType:   "ext4",
+						KernelDeviceNode: "/dev/vda5",
+						DiskIndex:        5,
+						StartInBytes:     1968 * oneMeg,
+						SizeInBytes:      4096 * oneMeg,
+					},
+				},
+				DiskHasPartitions: true,
+				DevNum:            "disk1",
+				DevNode:           "/dev/vda",
+				DevPath:           vdaSysPath,
+				// assume 34 sectors at end for GPT headers backup
+				DiskUsableSectorEnd: 7000*oneMeg/512 - 34,
+				DiskSizeInBytes:     7000 * oneMeg,
+				SectorSizeBytes:     512,
+				DiskSchema:          "gpt",
+				ID:                  "f0eef013-a777-4a27-aaf0-dbb5cf68c2b6",
+			}
+			mappings[vdaSysPath] = disk
+			// this simulates a symlink in /sys/block which points to the above path
+			mappings["/sys/block/vda"] = disk
+		case "my-emmc":
+			mmcSysPath := "/sys/devices/platform/emmc2bus/fe340000.emmc2/mmc_host/mmc0/mmc0:0001/block/mmcblk0"
+			disk := &disks.MockDiskMapping{
+				DevNode:             "/dev/mmcblk0",
+				DevPath:             mmcSysPath,
+				DevNum:              "525:1",
+				DiskUsableSectorEnd: 5120 * oneMeg / 512,
+				DiskSizeInBytes:     5120 * oneMeg,
+				SectorSizeBytes:     512,
+				DiskSchema:          "emmc",
+				ID:                  "86964016-3b5c-477e-9828-24ba9c552d39",
+				Structure: []disks.Partition{
+					{
+						PartitionLabel:   "boot0",
+						Major:            525,
+						Minor:            2,
+						KernelDeviceNode: "/dev/mmcblk0boot0",
+						KernelDevicePath: fmt.Sprintf("%sboot0", mmcSysPath),
+						DiskIndex:        1,
+						StartInBytes:     0,
+						SizeInBytes:      oneMeg,
+					},
+					{
+						PartitionLabel:   "boot1",
+						Major:            525,
+						Minor:            3,
+						KernelDeviceNode: "/dev/mmcblk0boot1",
+						KernelDevicePath: fmt.Sprintf("%sboot1", mmcSysPath),
+						DiskIndex:        2,
+						StartInBytes:     0,
+						SizeInBytes:      oneMeg,
+					},
+				},
+			}
+			mappings[mmcSysPath] = disk
+			// symlink to the disk in /dev
+			mappings["/dev/mmcblk0"] = disk
+		}
 	}
-	diskMapping := map[string]*disks.MockDiskMapping{
-		vdaSysPath: disk,
-		// this simulates a symlink in /sys/block which points to the above path
-		"/sys/block/vda": disk,
-	}
-	restore = disks.MockDevicePathToDiskMapping(diskMapping)
 
+	rsNamings := disks.MockDeviceNameToDiskMapping(mappings)
+	rsPaths := disks.MockDevicePathToDiskMapping(mappings)
+
+	restore = func() {
+		rsNamings()
+		rsPaths()
+	}
 	return ginfo, laidVols, model, restore, nil
 }

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -202,6 +202,13 @@ func OnDiskStructureFromPartition(p disks.Partition) (OnDiskStructure, error) {
 // returned it to snapd.
 func OnDiskVolumeFromGadgetVol(vol *Volume) (*OnDiskVolume, error) {
 	var diskVol *OnDiskVolume
+
+	// If the volume has been pre-assigned to a device, we must use that.
+	// This will happen when gadget use 'device-assignments' for volumes.
+	if vol.AssignedDevice != "" {
+		return OnDiskVolumeFromDevice(vol.AssignedDevice)
+	}
+
 	for _, vs := range vol.Structure {
 		if vs.Device == "" || vs.Role == "mbr" || vs.Type == "bare" {
 			continue

--- a/gadget/raw.go
+++ b/gadget/raw.go
@@ -292,7 +292,7 @@ func openDiskForWrite(device string, laidOutStruct *LaidOutStructure) (*os.File,
 		// get the emmc block name from the device path
 		mmcDevice = eMMCDeviceRegex.FindString(device)
 		if mmcDevice == "" {
-			return nil, nil, fmt.Errorf("cannot find valid mmc device from %s", device)
+			return nil, nil, fmt.Errorf("%s is not a valid emmc block device", device)
 		}
 	}
 

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -483,8 +483,9 @@ func (r *rawTestSuite) testRawUpdaterBackupUpdateRestoreDifferentEMMC(c *C, upda
 	ps := &gadget.LaidOutStructure{
 		OnDiskStructure: gadget.OnDiskStructure{},
 		VolumeStructure: &gadget.VolumeStructure{
-			Name: "boot0",
-			Size: 4096,
+			Name:   "boot0",
+			Device: "/dev/mmcblk0boot0",
+			Size:   4096,
 			EnclosingVolume: &gadget.Volume{
 				Schema: "emmc",
 			},
@@ -560,8 +561,8 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferentEMMCWithPaths(c
 
 func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferentEMMCCorrectCalls(c *C) {
 	var calls []string
-	restore := gadget.MockSetEMMCPartitionReadWrite(func(device, part string, rw bool) error {
-		calls = append(calls, fmt.Sprintf("%s %s %t", device, part, rw))
+	restore := gadget.MockSetEMMCPartitionReadWrite(func(device string, rw bool) error {
+		calls = append(calls, fmt.Sprintf("%s %t", device, rw))
 		return nil
 	})
 	defer restore()
@@ -571,27 +572,27 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferentEMMCCorrectCall
 
 	// one set for update, one set for rollback
 	c.Check(calls, DeepEquals, []string{
-		"mmcblk1 boot0 true",
-		"mmcblk1 boot0 false",
-		"mmcblk1 boot0 true",
-		"mmcblk1 boot0 false",
+		"mmcblk1boot0 true",
+		"mmcblk1boot0 false",
+		"mmcblk1boot0 true",
+		"mmcblk1boot0 false",
 	})
 }
 
 func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferentEMMCCorrectCallsFails(c *C) {
 	var calls []string
-	restore := gadget.MockSetEMMCPartitionReadWrite(func(device, part string, rw bool) error {
-		calls = append(calls, fmt.Sprintf("%s %s %t", device, part, rw))
+	restore := gadget.MockSetEMMCPartitionReadWrite(func(device string, rw bool) error {
+		calls = append(calls, fmt.Sprintf("%s %t", device, rw))
 		return fmt.Errorf("failed to mark rw")
 	})
 	defer restore()
 
 	// test with mock in place to detect correct calls
-	r.testRawUpdaterBackupUpdateRestoreDifferentEMMC(c, "failed to mark rw")
+	r.testRawUpdaterBackupUpdateRestoreDifferentEMMC(c, "cannot open device for writing: failed to mark rw")
 
 	// one enable for update, which fails
 	c.Check(calls, DeepEquals, []string{
-		"mmcblk1 boot0 true",
+		"mmcblk1boot0 true",
 	})
 }
 

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -21,12 +21,14 @@ package gadget_test
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
@@ -462,6 +464,137 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferent(c *C) {
 	c.Check(osutil.FilesAreEqual(diskPath, pristinePath), Equals, true)
 }
 
+func (r *rawTestSuite) testRawUpdaterBackupUpdateRestoreDifferentEMMC(c *C, updateErr string) {
+	diskPath := filepath.Join(r.dir, "mmcblk1boot0.img")
+	mutateFile(c, diskPath, 4096, []mutateWrite{
+		{[]byte("foo foo foo"), 0},
+	})
+
+	pristinePath := filepath.Join(r.dir, "pristine.img")
+	err := osutil.CopyFile(diskPath, pristinePath, 0)
+	c.Assert(err, IsNil)
+
+	expectedPath := filepath.Join(r.dir, "expected.img")
+	mutateFile(c, expectedPath, 4096, []mutateWrite{
+		{[]byte("zzz zzz zzz zzz"), 0},
+	})
+
+	makeSizedFile(c, filepath.Join(r.dir, "foo.img"), 4096, []byte("zzz zzz zzz zzz"))
+	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{},
+		VolumeStructure: &gadget.VolumeStructure{
+			Name: "boot0",
+			Size: 4096,
+			EnclosingVolume: &gadget.Volume{
+				Schema: "emmc",
+			},
+		},
+		LaidOutContent: []gadget.LaidOutContent{
+			{
+				VolumeContent: &gadget.VolumeContent{
+					Image: "foo.img",
+				},
+				Size: 4096,
+			},
+		},
+	}
+	ru, err := gadget.NewRawStructureUpdater(r.dir, ps, r.backup, func(to *gadget.LaidOutStructure) (string, quantity.Offset, error) {
+		c.Check(to, DeepEquals, ps)
+		// Structure has a partition, thus it starts at 0 offset.
+		return diskPath, 0, nil
+	})
+	c.Assert(err, IsNil)
+	c.Assert(ru, NotNil)
+
+	err = ru.Backup()
+	c.Assert(err, IsNil)
+
+	for _, e := range []struct {
+		path   string
+		size   int64
+		exists bool
+	}{
+		{gadget.RawContentBackupPath(r.backup, ps, &ps.LaidOutContent[0]) + ".backup", 4096, true},
+		{gadget.RawContentBackupPath(r.backup, ps, &ps.LaidOutContent[0]) + ".same", 0, false},
+	} {
+		if e.exists {
+			c.Check(e.path, testutil.FilePresent)
+			c.Check(getFileSize(c, e.path), Equals, e.size)
+		} else {
+			c.Check(e.path, testutil.FileAbsent)
+		}
+	}
+
+	err = ru.Update()
+	if updateErr != "" {
+		c.Assert(err, ErrorMatches, updateErr)
+
+		// the file should not have updated
+		c.Check(osutil.FilesAreEqual(diskPath, expectedPath), Equals, false)
+		c.Check(osutil.FilesAreEqual(diskPath, pristinePath), Equals, true)
+	} else {
+		c.Assert(err, IsNil)
+
+		// after update, files should be identical
+		c.Check(osutil.FilesAreEqual(diskPath, expectedPath), Equals, true)
+
+		// rollback restores the original contents
+		err = ru.Rollback()
+		c.Assert(err, IsNil)
+
+		// which should match the pristine copy now
+		c.Check(osutil.FilesAreEqual(diskPath, pristinePath), Equals, true)
+	}
+}
+
+func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferentEMMCWithPaths(c *C) {
+	dirs.SetRootDir(r.dir)
+
+	// create the force_ro path that should be available for emmc block devices
+	c.Assert(os.MkdirAll(filepath.Join(r.dir, "sys", "block", "mmcblk1boot0"), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(r.dir, "sys", "block", "mmcblk1boot0", "force_ro"), []byte(`1`), 0644), IsNil)
+
+	// test with paths in place
+	r.testRawUpdaterBackupUpdateRestoreDifferentEMMC(c, "")
+}
+
+func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferentEMMCCorrectCalls(c *C) {
+	var calls []string
+	restore := gadget.MockSetEMMCPartitionReadWrite(func(device, part string, rw bool) error {
+		calls = append(calls, fmt.Sprintf("%s %s %t", device, part, rw))
+		return nil
+	})
+	defer restore()
+
+	// test with mock in place to detect correct calls
+	r.testRawUpdaterBackupUpdateRestoreDifferentEMMC(c, "")
+
+	// one set for update, one set for rollback
+	c.Check(calls, DeepEquals, []string{
+		"mmcblk1 boot0 true",
+		"mmcblk1 boot0 false",
+		"mmcblk1 boot0 true",
+		"mmcblk1 boot0 false",
+	})
+}
+
+func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferentEMMCCorrectCallsFails(c *C) {
+	var calls []string
+	restore := gadget.MockSetEMMCPartitionReadWrite(func(device, part string, rw bool) error {
+		calls = append(calls, fmt.Sprintf("%s %s %t", device, part, rw))
+		return fmt.Errorf("failed to mark rw")
+	})
+	defer restore()
+
+	// test with mock in place to detect correct calls
+	r.testRawUpdaterBackupUpdateRestoreDifferentEMMC(c, "failed to mark rw")
+
+	// one enable for update, which fails
+	c.Check(calls, DeepEquals, []string{
+		"mmcblk1 boot0 true",
+	})
+}
+
 func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreNoPartition(c *C) {
 	diskPath := filepath.Join(r.dir, "disk.img")
 
@@ -488,8 +621,9 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreNoPartition(c *C) {
 		},
 		VolumeStructure: &gadget.VolumeStructure{
 			// No partition table entry, would trigger fallback lookup path.
-			Type: "bare",
-			Size: 2048,
+			Type:            "bare",
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -22,6 +22,7 @@ package gadget
 import (
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 
@@ -137,10 +138,10 @@ func searchVolumeWithTraitsAndMatchParts(vol *Volume, traits DiskVolumeDeviceTra
 	compatibleCandidate := func(candidate disks.Disk, method string, providedErr error) map[int]*OnDiskStructure {
 		if providedErr != nil {
 			if candidate != nil {
-				logger.Debugf("candidate disk %s not appropriate for volume %s because err: %v", candidate.KernelDeviceNode(), vol.Name, providedErr)
+				log.Printf("candidate disk %s not appropriate for volume %s because err: %v", candidate.KernelDeviceNode(), vol.Name, providedErr)
 				return nil
 			}
-			logger.Debugf("cannot locate disk for volume %s with method %s because err: %v", vol.Name, method, providedErr)
+			log.Printf("cannot locate disk for volume %s with method %s because err: %v", vol.Name, method, providedErr)
 
 			return nil
 		}
@@ -150,7 +151,7 @@ func searchVolumeWithTraitsAndMatchParts(vol *Volume, traits DiskVolumeDeviceTra
 			// DiskFromDeviceName or DiskFromDevicePath to get this reference,
 			// so it's unclear how those methods could return a disk that
 			// OnDiskVolumeFromDevice is unhappy about
-			logger.Debugf("cannot find on disk volume from candidate disk %s: %v", candidate.KernelDeviceNode(), onDiskErr)
+			log.Printf("cannot find on disk volume from candidate disk %s: %v", candidate.KernelDeviceNode(), onDiskErr)
 			return nil
 		}
 		// then try to validate it by laying out the volume
@@ -161,7 +162,7 @@ func searchVolumeWithTraitsAndMatchParts(vol *Volume, traits DiskVolumeDeviceTra
 		}
 		gadgetStructToDiskStruct, ensureErr := EnsureVolumeCompatibility(vol, diskLayout, opts)
 		if ensureErr != nil {
-			logger.Debugf("candidate disk %s not appropriate for volume %s due to incompatibility: %v", candidate.KernelDeviceNode(), vol.Name, ensureErr)
+			log.Printf("candidate disk %s not appropriate for volume %s due to incompatibility: %v", candidate.KernelDeviceNode(), vol.Name, ensureErr)
 			return nil
 		}
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -22,7 +22,6 @@ package gadget
 import (
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 
@@ -138,10 +137,10 @@ func searchVolumeWithTraitsAndMatchParts(vol *Volume, traits DiskVolumeDeviceTra
 	compatibleCandidate := func(candidate disks.Disk, method string, providedErr error) map[int]*OnDiskStructure {
 		if providedErr != nil {
 			if candidate != nil {
-				log.Printf("candidate disk %s not appropriate for volume %s because err: %v", candidate.KernelDeviceNode(), vol.Name, providedErr)
+				logger.Debugf("candidate disk %s not appropriate for volume %s because err: %v", candidate.KernelDeviceNode(), vol.Name, providedErr)
 				return nil
 			}
-			log.Printf("cannot locate disk for volume %s with method %s because err: %v", vol.Name, method, providedErr)
+			logger.Debugf("cannot locate disk for volume %s with method %s because err: %v", vol.Name, method, providedErr)
 
 			return nil
 		}
@@ -151,7 +150,7 @@ func searchVolumeWithTraitsAndMatchParts(vol *Volume, traits DiskVolumeDeviceTra
 			// DiskFromDeviceName or DiskFromDevicePath to get this reference,
 			// so it's unclear how those methods could return a disk that
 			// OnDiskVolumeFromDevice is unhappy about
-			log.Printf("cannot find on disk volume from candidate disk %s: %v", candidate.KernelDeviceNode(), onDiskErr)
+			logger.Debugf("cannot find on disk volume from candidate disk %s: %v", candidate.KernelDeviceNode(), onDiskErr)
 			return nil
 		}
 		// then try to validate it by laying out the volume
@@ -162,7 +161,7 @@ func searchVolumeWithTraitsAndMatchParts(vol *Volume, traits DiskVolumeDeviceTra
 		}
 		gadgetStructToDiskStruct, ensureErr := EnsureVolumeCompatibility(vol, diskLayout, opts)
 		if ensureErr != nil {
-			log.Printf("candidate disk %s not appropriate for volume %s due to incompatibility: %v", candidate.KernelDeviceNode(), vol.Name, ensureErr)
+			logger.Debugf("candidate disk %s not appropriate for volume %s due to incompatibility: %v", candidate.KernelDeviceNode(), vol.Name, ensureErr)
 			return nil
 		}
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -946,6 +946,100 @@ type StructureLocation struct {
 	RootMountPoint string
 }
 
+func buildLocationsForVolumeStructures(vol *Volume, disk disks.Disk, structs map[int]*OnDiskStructure, encryptionParams map[string]StructureEncryptionParameters) (map[int]StructureLocation, error) {
+	locations := make(map[int]StructureLocation)
+	// the index here is 0-based and is equal to VolumeStructure.YamlIndex
+	for volYamlIndex, volStruct := range vol.Structure {
+		structStartOffset := structs[volYamlIndex].StartOffset
+		loc := StructureLocation{}
+
+		if volStruct.HasFilesystem() {
+			// Here we know what disk is associated with this volume, so we
+			// just need to find what partition is associated with this
+			// structure to find it's root mount points. On GPT since
+			// partition labels/names are unique in the partition table, we
+			// could do a lookup by matching partition label, but this won't
+			// work on MBR which doesn't have such a concept, so instead we
+			// use the start offset to locate which disk partition this
+			// structure is equal to.
+			partitions, err := disk.Partitions()
+			if err != nil {
+				return nil, err
+			}
+
+			var foundP disks.Partition
+			found := false
+			for _, p := range partitions {
+				if p.StartInBytes == uint64(structStartOffset) {
+					foundP = p
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, fmt.Errorf("cannot locate structure %d on volume %s: no matching start offset", volYamlIndex, vol.Name)
+			}
+
+			// if this structure is an encrypted one, then we can't just
+			// get the root mount points for the device node, we would need
+			// to find the decrypted mapper device for the encrypted device
+			// node and then find the root mount point of the mapper device
+			if _, ok := encryptionParams[volStruct.Name]; ok {
+				logger.Noticef("gadget asset update for assets on encrypted partition %s unsupported", volStruct.Name)
+
+				// leaving this structure as an empty location will
+				// mean when an update to this structure is actually
+				// performed it will fail, but we won't fail updates to
+				// other structures - it is treated like an unmounted
+				// partition
+				locations[volYamlIndex] = loc
+				continue
+			}
+
+			// otherwise normal unencrypted filesystem, find the rw mount
+			// points
+			mountpts, err := disks.MountPointsForPartitionRoot(foundP, map[string]string{"rw": ""})
+			if err != nil {
+				return nil, fmt.Errorf("cannot locate structure %d on volume %s: error searching for root mount points: %v", volYamlIndex, vol.Name, err)
+			}
+			var mountpt string
+			if len(mountpts) == 0 {
+				// this filesystem is not already mounted, we probably
+				// should mount it in order to proceed with the update?
+
+				// TODO: do something better here?
+				logger.Noticef("structure %d on volume %s (%s) is not mounted read/write anywhere to be able to update it", volYamlIndex, vol.Name, foundP.KernelDeviceNode)
+			} else {
+				// use the first one, it doesn't really matter to us
+				// which one is used to update the contents
+				mountpt = mountpts[0]
+			}
+			loc.RootMountPoint = mountpt
+		} else {
+			// no filesystem, the device for this one is just the device
+			// for the disk itself
+			loc.Device = disk.KernelDeviceNode()
+			loc.Offset = structStartOffset
+
+			// Specifically for eMMC devices, the boot0 and boot1 partitions are not
+			// really partitions, but actually pseudo devices. So even though there
+			// is no filesystem, we still must address each sub-device like if the
+			// device had a filesystem
+			if vol.Schema == schemaEMMC {
+				switch volStruct.Name {
+				case "boot0", "boot1":
+					loc.Device += volStruct.Name
+				// rpmb also exists but we do not handle this
+				default:
+					return nil, fmt.Errorf("structure %s on volume %s is not a valid eMMC partition", volStruct.Name, vol.Name)
+				}
+			}
+		}
+		locations[volYamlIndex] = loc
+	}
+	return locations, nil
+}
+
 // buildVolumeStructureToLocation builds a map of gadget volumes to
 // locations and to matched disk structures.
 func buildVolumeStructureToLocation(mod Model,
@@ -978,7 +1072,6 @@ func buildVolumeStructureToLocation(mod Model,
 	// unsupported structure change is present in the new one, but we check that
 	// situation after we have built the mapping
 	for volName, diskDeviceTraits := range volToDeviceMapping {
-		volumeStructureToLocation[volName] = make(map[int]StructureLocation)
 		gadgetVolToPartMap[volName] = make(map[int]*OnDiskStructure)
 		oldVol, ok := oldVolumes[volName]
 		if !ok {
@@ -1005,86 +1098,11 @@ func buildVolumeStructureToLocation(mod Model,
 		}
 		gadgetVolToPartMap[volName] = gadgetToDiskStruct
 
-		// the index here is 0-based and is equal to VolumeStructure.YamlIndex
-		for volYamlIndex, volStruct := range oldVol.Structure {
-			structStartOffset := gadgetToDiskStruct[volYamlIndex].StartOffset
-
-			loc := StructureLocation{}
-
-			if volStruct.HasFilesystem() {
-				// Here we know what disk is associated with this volume, so we
-				// just need to find what partition is associated with this
-				// structure to find it's root mount points. On GPT since
-				// partition labels/names are unique in the partition table, we
-				// could do a lookup by matching partition label, but this won't
-				// work on MBR which doesn't have such a concept, so instead we
-				// use the start offset to locate which disk partition this
-				// structure is equal to.
-
-				partitions, err := disk.Partitions()
-				if err != nil {
-					return nil, nil, err
-				}
-
-				var foundP disks.Partition
-				found := false
-				for _, p := range partitions {
-					if p.StartInBytes == uint64(structStartOffset) {
-						foundP = p
-						found = true
-						break
-					}
-				}
-				if !found {
-					dieErr := fmt.Errorf("cannot locate structure %d on volume %s: no matching start offset", volYamlIndex, volName)
-					return nil, nil, maybeFatalError(dieErr)
-				}
-
-				// if this structure is an encrypted one, then we can't just
-				// get the root mount points for the device node, we would need
-				// to find the decrypted mapper device for the encrypted device
-				// node and then find the root mount point of the mapper device
-				if _, ok := diskDeviceTraits.StructureEncryption[volStruct.Name]; ok {
-					logger.Noticef("gadget asset update for assets on encrypted partition %s unsupported", volStruct.Name)
-
-					// leaving this structure as an empty location will
-					// mean when an update to this structure is actually
-					// performed it will fail, but we won't fail updates to
-					// other structures - it is treated like an unmounted
-					// partition
-					volumeStructureToLocation[volName][volYamlIndex] = loc
-					continue
-				}
-
-				// otherwise normal unencrypted filesystem, find the rw mount
-				// points
-				mountpts, err := disks.MountPointsForPartitionRoot(foundP, map[string]string{"rw": ""})
-				if err != nil {
-					dieErr := fmt.Errorf("cannot locate structure %d on volume %s: error searching for root mount points: %v", volYamlIndex, volName, err)
-					return nil, nil, maybeFatalError(dieErr)
-				}
-				var mountpt string
-				if len(mountpts) == 0 {
-					// this filesystem is not already mounted, we probably
-					// should mount it in order to proceed with the update?
-
-					// TODO: do something better here?
-					logger.Noticef("structure %d on volume %s (%s) is not mounted read/write anywhere to be able to update it", volYamlIndex, volName, foundP.KernelDeviceNode)
-				} else {
-					// use the first one, it doesn't really matter to us
-					// which one is used to update the contents
-					mountpt = mountpts[0]
-				}
-				loc.RootMountPoint = mountpt
-			} else {
-				// no filesystem, the device for this one is just the device
-				// for the disk itself
-				loc.Device = disk.KernelDeviceNode()
-				loc.Offset = structStartOffset
-			}
-
-			volumeStructureToLocation[volName][volYamlIndex] = loc
+		locations, err := buildLocationsForVolumeStructures(oldVol, disk, gadgetToDiskStruct, diskDeviceTraits.StructureEncryption)
+		if err != nil {
+			return nil, nil, maybeFatalError(err)
 		}
+		volumeStructureToLocation[volName] = locations
 	}
 
 	return volumeStructureToLocation, gadgetVolToPartMap, nil

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -244,6 +244,8 @@ func isCompatibleSchema(gadgetSchema, diskSchema string) bool {
 		return diskSchema == "gpt"
 	case "mbr":
 		return diskSchema == "dos"
+	case "emmc":
+		return diskSchema == "emmc"
 	default:
 		return false
 	}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -5669,6 +5669,63 @@ func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20MultiVolumeNonMo
 	c.Assert(mockLogBuf.String(), testutil.Contains, "structure 2 on volume foo (/dev/vdb2) is not mounted read/write anywhere to be able to update it")
 }
 
+func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20EMMC(c *C) {
+	traits := map[string]gadget.DiskVolumeDeviceTraits{
+		"pc":      gadgettest.VMSystemVolumeDeviceTraits,
+		"my-emmc": gadgettest.VMEmmcVolumeDeviceTraits,
+	}
+
+	volMappings := map[string]*disks.MockDiskMapping{
+		"pc":      gadgettest.VMSystemVolumeDiskMapping,
+		"my-emmc": gadgettest.VMEmmcVolumeDiskMapping,
+	}
+
+	expMap := map[string]map[int]gadget.StructureLocation{
+		"pc": {
+			// keys are the YamlIndex in the gadget.yaml
+
+			// raw devices have Device + Offset set
+			0: {Device: "/dev/vda", Offset: 0},                  // for mbr
+			1: {Device: "/dev/vda", Offset: quantity.OffsetMiB}, // for bios-boot
+
+			// partition devices have RootMountPoint set
+			2: {RootMountPoint: filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-seed")},
+			3: {RootMountPoint: ""}, // ubuntu-boot is not mounted for some reason
+			4: {RootMountPoint: filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-save")},
+			5: {RootMountPoint: filepath.Join(dirs.GlobalRootDir, "/run/mnt/data")},
+		},
+		"my-emmc": {
+			0: {Device: "/dev/mmcblk0boot0"},
+			1: {Device: "/dev/mmcblk0boot1"},
+		},
+	}
+
+	mockLogBuf, restore := logger.MockLogger()
+	defer restore()
+
+	// setup mountinfo for root mount points of the partitions with some of the filesystems mounted
+	restore = osutil.MockMountInfo(
+		fmt.Sprintf(
+			`
+27 27 600:3 / %[1]s/run/mnt/ubuntu-seed rw,relatime shared:7 - vfat %[1]s/dev/vda2 rw
+29 27 600:5 / %[1]s/run/mnt/ubuntu-save rw,relatime shared:7 - vfat %[1]s/dev/vda4 rw
+30 27 600:6 / %[1]s/run/mnt/data rw,relatime shared:7 - vfat %[1]s/dev/vda5 rw`[1:],
+			dirs.GlobalRootDir,
+		),
+	)
+	defer restore()
+
+	s.testBuildVolumeStructureToLocation(c,
+		uc20Model,
+		gadgettest.MultiVolumeEmmcUC20GadgetYaml,
+		traits,
+		volMappings,
+		expMap,
+	)
+
+	c.Check(mockLogBuf.String(), testutil.Contains, "structure 3 on volume pc (/dev/vda3) is not mounted read/write anywhere to be able to update it")
+}
+
 func (s *updateTestSuite) testBuildVolumeStructureToLocation(c *C,
 	model gadget.Model,
 	yaml string,
@@ -5714,22 +5771,34 @@ func (s *updateTestSuite) setupForVolumeStructureToLocation(c *C,
 	blockDir := filepath.Join(dirs.SysfsDir, "block")
 	err = os.MkdirAll(blockDir, 0755)
 	c.Assert(err, IsNil)
-	for volName := range allLaidOutVolumes {
-		blockDevSym := filepath.Join(blockDir, volName)
-		err := os.Symlink("something", blockDevSym)
-		c.Assert(err, IsNil)
+	for volName, vol := range allLaidOutVolumes {
+		switch vol.Schema {
+		case "emmc":
+			mmcBlk := filepath.Join(blockDir, "mmcblk0")
+			mmcBlkBoot0 := filepath.Join(blockDir, "mmcblk0boot0")
+			mmcBlkBoot1 := filepath.Join(blockDir, "mmcblk0boot1")
 
-		devicePathMapping[blockDevSym] = volMappings[volName]
+			c.Assert(os.Symlink("mmcblk0", mmcBlk), IsNil)
+			devicePathMapping[mmcBlk] = volMappings[volName]
+			c.Assert(os.Symlink("mmcblk0boot0", mmcBlkBoot0), IsNil)
+			devicePathMapping[mmcBlkBoot0] = volMappings[volName]
+			c.Assert(os.Symlink("mmcblk0boot1", mmcBlkBoot1), IsNil)
+			devicePathMapping[mmcBlkBoot1] = volMappings[volName]
+		default:
+			blockDevSym := filepath.Join(blockDir, volName)
+			err := os.Symlink("something", blockDevSym)
+			c.Assert(err, IsNil)
+			devicePathMapping[blockDevSym] = volMappings[volName]
+		}
 	}
 
 	restore := disks.MockDevicePathToDiskMapping(devicePathMapping)
 	s.AddCleanup(restore)
 
 	// setup symlinks in /dev
-	err = os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel"), 0755)
-	c.Assert(err, IsNil)
-	err = os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label"), 0755)
-	c.Assert(err, IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-path"), 0755), IsNil)
 
 	partDeviceNodeMappings := map[string]*disks.MockDiskMapping{}
 	diskDeviceNodeMappings := map[string]*disks.MockDiskMapping{}
@@ -5754,19 +5823,33 @@ func (s *updateTestSuite) setupForVolumeStructureToLocation(c *C,
 			c.Assert(err, IsNil)
 			err = os.WriteFile(fakedevicepart, nil, 0644)
 			c.Assert(err, IsNil)
+			partDeviceNodeMappings[filepath.Join(dirs.GlobalRootDir, firstPartDev)] = volMappings[volName]
+			diskDeviceNodeMappings[traits[volName].OriginalKernelPath] = volMappings[volName]
 		case "dos":
 			fakedevicepart := filepath.Join(dirs.GlobalRootDir, firstPartDev)
 			err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label", fslabel))
 			c.Assert(err, IsNil)
 			err = os.WriteFile(fakedevicepart, nil, 0644)
 			c.Assert(err, IsNil)
+			partDeviceNodeMappings[filepath.Join(dirs.GlobalRootDir, firstPartDev)] = volMappings[volName]
+			diskDeviceNodeMappings[traits[volName].OriginalKernelPath] = volMappings[volName]
+		case "emmc":
+			fakedevicepart := filepath.Join(dirs.GlobalRootDir, "mmcblk0boot0")
+			c.Assert(os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-path", "mmcblk0.mmc-boot0")), IsNil)
+			c.Assert(os.WriteFile(fakedevicepart, nil, 0644), IsNil)
+			fakedevicepart = filepath.Join(dirs.GlobalRootDir, "mmcblk0boot1")
+			c.Assert(os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-path", "mmcblk0.mmc-boot1")), IsNil)
+			c.Assert(os.WriteFile(fakedevicepart, nil, 0644), IsNil)
+
+			diskDeviceNodeMappings[traits[volName].OriginalKernelPath] = volMappings[volName]
+			diskDeviceNodeMappings[traits[volName].OriginalKernelPath+"boot0"] = volMappings[volName]
+			diskDeviceNodeMappings[traits[volName].OriginalKernelPath+"boot1"] = volMappings[volName]
+
+			partDeviceNodeMappings[filepath.Join(dirs.GlobalRootDir, "/dev/mmcblk0boot0")] = volMappings[volName]
+			partDeviceNodeMappings[filepath.Join(dirs.GlobalRootDir, "/dev/mmcblk0boot1")] = volMappings[volName]
 		default:
 			panic(fmt.Sprintf("unexpected schema %s", traits[volName].Schema))
 		}
-
-		partDeviceNodeMappings[filepath.Join(dirs.GlobalRootDir, firstPartDev)] = volMappings[volName]
-
-		diskDeviceNodeMappings[traits[volName].OriginalKernelPath] = volMappings[volName]
 	}
 
 	// mock the partition device node to mock disk

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -980,7 +980,7 @@ nested_create_core_vm() {
             BOOTVOLUME=pc
             if [ -e pc-gadget/meta/gadget.yaml ]; then
                 # shellcheck disable=SC2016
-                BOOTVOLUME="$(gojq --yaml-input '.volumes | to_entries[] | .key as $p | .value.structure[] | select(.name == "ubuntu-boot") | $p' pc-gadget/meta/gadget.yaml | tr -d '"')"
+                BOOTVOLUME="$(gojq --yaml-input --raw-output '.volumes | to_entries[] | .key as $p | .value.structure[] | select(.name == "ubuntu-boot") | $p' pc-gadget/meta/gadget.yaml)"
                 if [ -z "$BOOTVOLUME" ]; then
                     echo "was not able to deduce the ubuntu-boot partition from gadget.yaml in pc-gadget/meta/gadget.yaml"
                     echo "please inspect it and make sure it looks as expected"


### PR DESCRIPTION
Couple of final changes to support eMMC

* Teach RawStructureUpdater to handle eMMC schema before writing to the disk. Because of how we deal with updates (i.e as a list of abstract updates), it felt simpler to handle this in the RawStructureUpdater, as that is the code that deals with this. 
* Add a missing schema switch in the gadget update code.
* Select the correct sub-device when finding a device location for a volume structure.

REF: SNAPDENG-32503
