### PR TITLE
cmd/snap-update-ns: remove incorrect optimization

### DIFF
--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -400,14 +400,15 @@ none $HOME/.local/share none x-snapd.kind=ensure-dir,x-snapd.must-exist-dir=$HOM
 	c.Assert(err, IsNil)
 	c.Assert(changes, HasLen, 2)
 
-	c.Assert(changes[0].Entry.Name, Equals, "none")
-	c.Assert(changes[0].Entry.Dir, Equals, tmpHomeDir+"/.local/share")
-	c.Assert(changes[0].Entry.XSnapdMustExistDir(), Equals, tmpHomeDir)
-
 	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, 1000)
-	c.Assert(changes[1].Action, Equals, update.Mount)
-	c.Assert(changes[1].Entry.Name, Equals, xdgRuntimeDir+"/doc/by-app/snap.foo")
-	c.Assert(changes[1].Entry.Dir, Matches, xdgRuntimeDir+"/doc")
+	c.Assert(changes[0].Action, Equals, update.Mount)
+	c.Assert(changes[0].Entry.Name, Equals, xdgRuntimeDir+"/doc/by-app/snap.foo")
+	c.Assert(changes[0].Entry.Dir, Matches, xdgRuntimeDir+"/doc")
+
+	c.Assert(changes[0].Action, Equals, update.Mount)
+	c.Assert(changes[1].Entry.Name, Equals, "none")
+	c.Assert(changes[1].Entry.Dir, Equals, tmpHomeDir+"/.local/share")
+	c.Assert(changes[1].Entry.XSnapdMustExistDir(), Equals, tmpHomeDir)
 }
 
 func (s *mainSuite) TestApplyUserFstabErrorHomeRequiredAndMissing(c *C) {

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/3-after-reconnect.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/3-after-reconnect.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/4-initially-disconnected-then-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/4-initially-disconnected-then-connected.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/5-initially-connected-then-content-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/5-initially-connected-then-content-refreshed.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x2/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x1/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0
-/snap/test-snapd-content/x2/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo-bar/6-initially-connected-then-app-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo-bar/6-initially-connected-then-app-refreshed.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x2/opt none bind,ro 0 0
+tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo/bar,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x2/opt/foo/bar /opt/foo/bar none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/3-after-reconnect.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/3-after-reconnect.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/4-initially-disconnected-then-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/4-initially-disconnected-then-connected.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0
-/snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/5-initially-connected-then-content-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/5-initially-connected-then-content-refreshed.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
+/snap/test-snapd-content/x2/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
 tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x1/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0
-/snap/test-snapd-content/x2/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0

--- a/cmd/snap-update-ns/testdata/opt-foo/6-initially-connected-then-app-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt-foo/6-initially-connected-then-app-refreshed.current.fstab
@@ -1,4 +1,4 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x2/opt none bind,ro 0 0
+tmpfs /opt tmpfs x-snapd.synthetic,x-snapd.needed-by=/opt/foo,mode=0755,uid=0,gid=0 0 0
 /snap/test-snapd-layout/x2/opt/foo /opt/foo none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt/3-after-reconnect.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt/3-after-reconnect.current.fstab
@@ -1,3 +1,3 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-layout/x1/opt /opt none rbind,rw,x-snapd.origin=layout 0 0
 /snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
+/snap/test-snapd-layout/x1/opt /opt none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt/4-initially-disconnected-then-connected.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt/4-initially-disconnected-then-connected.current.fstab
@@ -1,3 +1,3 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-layout/x1/opt /opt none rbind,rw,x-snapd.origin=layout 0 0
 /snap/test-snapd-content/x1/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
+/snap/test-snapd-layout/x1/opt /opt none rbind,rw,x-snapd.origin=layout 0 0

--- a/cmd/snap-update-ns/testdata/opt/5-initially-connected-then-content-refreshed.current.fstab
+++ b/cmd/snap-update-ns/testdata/opt/5-initially-connected-then-content-refreshed.current.fstab
@@ -1,3 +1,3 @@
 tmpfs / tmpfs x-snapd.origin=rootfs 0 0
-/snap/test-snapd-layout/x1/opt /opt none rbind,rw,x-snapd.origin=layout 0 0
 /snap/test-snapd-content/x2/opt /snap/test-snapd-layout/x1/opt none bind,ro 0 0
+/snap/test-snapd-layout/x1/opt /opt none rbind,rw,x-snapd.origin=layout 0 0

--- a/interfaces/mount/ns_test.go
+++ b/interfaces/mount/ns_test.go
@@ -63,7 +63,12 @@ func (s *nsSuite) TestDiscardNamespaceMnt(c *C) {
 		{
 			cmd:    "echo failure; exit 1;",
 			mnt:    true,
-			errStr: `cannot discard preserved namespace of snap "snap-name": failure`,
+			errStr: `cannot discard preserved namespace of snap "snap-name": exit status 1`,
+			res:    [][]string{{"snap-discard-ns", "snap-name"}}},
+		{
+			cmd:    "echo failure >&2; exit 1;",
+			mnt:    true,
+			errStr: `cannot discard preserved namespace of snap "snap-name": exit status 1: failure`,
 			res:    [][]string{{"snap-discard-ns", "snap-name"}}},
 		// The mnt file is present so we use snap-discard-ns;
 		// The command fails silently and we forward this fact using a generic message.
@@ -111,7 +116,7 @@ func (s *nsSuite) TestUpdateNamespaceMnt(c *C) {
 		{
 			cmd:    "echo failure; exit 1;",
 			mnt:    true,
-			errStr: `cannot update preserved namespace of snap "snap-name": failure`,
+			errStr: `cannot update preserved namespace of snap "snap-name": exit status 1`,
 			res:    [][]string{{"snap-update-ns", "snap-name"}}},
 		// The mnt file is present so we use snap-update-ns;
 		// The command fails silently and we forward this fact using a generic message.

--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -265,7 +265,7 @@ func (e *MountEntry) XSnapdSynthetic() bool {
 //
 // There are four kinds of mount entries today: one for directories, one for
 // files, one for symlinks and one for ensuring directories exist. The values are
-// "", "file", "symlink" and "ensure-dir respectively.
+// "", "file", "symlink" and "ensure-dir", respectively.
 //
 // Directories use the empty string (in fact they don't need the option at
 // all) as this was the default and is retained for backwards compatibility.
@@ -306,7 +306,7 @@ func (e *MountEntry) XSnapdIgnoreMissing() bool {
 	return e.OptBool("x-snapd.ignore-missing")
 }
 
-// XSnapdMustExistDir returns the path that must exist as prequisite
+// XSnapdMustExistDir returns the path that must exist as prerequisite
 // to a mount operation.
 func (e *MountEntry) XSnapdMustExistDir() string {
 	val, _ := e.OptStr("x-snapd.must-exist-dir")

--- a/tests/build-test-snapd-snap
+++ b/tests/build-test-snapd-snap
@@ -19,7 +19,7 @@ mkdir -p built-snap
 
 # Build snapd snap
 if [ -z "$SNAPCRAFT_NO_CLEAN" ]; then
-    snapcraft --verbose clean
+    snapcraft --verbose clean snapd
 fi
 
 snapcraft --verbose

--- a/tests/main/layout-change/task.yaml
+++ b/tests/main/layout-change/task.yaml
@@ -35,9 +35,7 @@ execute: |
     echo "Installing test snap with daemon"
     snap install --beta test-snapd-layout-change-with-daemon
 
+    # This used not to work, but the layout update algorithm has been updated
+    # to cope better with changes like this.
     echo "Refreshing test snap with daemon to newer version"
-    echo "(this one must fail because daemon snaps can't discard the namespace)"
-    if snap refresh --edge test-snapd-layout-change-with-daemon ; then
-        echo "ERROR: running snap refresh for test-snapd-layout-change-with-daemon did not fail as expected"
-        exit 1
-    fi
+    snap refresh --edge test-snapd-layout-change-with-daemon

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -55,7 +55,7 @@ execute: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
 
   # Signal to kill the loop
-  rm ~test/snap/test-snapd-desktop-layout-with-content/common/keep-running
+  rm -f ~test/snap/test-snapd-desktop-layout-with-content/common/keep-running
   wait "$pid"
 
   # Ensure that /usr/share/fonts/foo-font was never missing.

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -40,6 +40,7 @@ execute: |
   # from background job of snap run with update with snap install of the
   # test-snapd-content-slot below.
   test-snapd-desktop-layout-with-content.sh -c 'true'
+  test-snapd-desktop-layout-with-content.sh -c 'stat /usr/share/fonts/foo-font' | tee before
   # Read a file continuously in the background until it fails. Note that we are
   # not using a service but a regular app running in the background since the
   # process must persist during the refresh.
@@ -60,4 +61,5 @@ execute: |
 
   # Ensure that /usr/share/fonts/foo-font was never missing.
   MATCH 'exited' <~test/snap/test-snapd-desktop-layout-with-content/common/status
+  test-snapd-desktop-layout-with-content.sh -c 'stat /usr/share/fonts/foo-font' | tee after
   NOMATCH 'foo-font missing' <~test/snap/test-snapd-desktop-layout-with-content/common/status

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -59,5 +59,5 @@ execute: |
   wait "$pid"
 
   # Ensure that /usr/share/fonts/foo-font was never missing.
-  MATCH 'exited' ~test/snap/test-snapd-desktop-layout-with-content/common/status
-  NOMATCH 'foo-font missing' ~test/snap/test-snapd-desktop-layout-with-content/common/status
+  MATCH 'exited' <~test/snap/test-snapd-desktop-layout-with-content/common/status
+  NOMATCH 'foo-font missing' <~test/snap/test-snapd-desktop-layout-with-content/common/status

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
@@ -5,7 +5,7 @@ echo "started" > "$SNAP_USER_COMMON"/status
 while test -f "$SNAP_USER_COMMON"/keep-running; do
     if ! [ -d /usr/share/fonts/foo-font ] ; then 
         echo "foo-font missing" >> "$SNAP_USER_COMMON"/status
-        exit 1
+        break
     fi
 done
 echo "exited" >> "$SNAP_USER_COMMON"/status


### PR DESCRIPTION
Remove the complex logic to compute a delta to be applied by snap-update-ns and replace it with a unmount-all, mount-all approach. A number of tests are removed as they were testing some of the previous elaborate behavior. I saw no need to keep them in absence of said behavior. Some tests are skipped and need to be evaluated further. One integration test that used to fail now passes.

Since this is a rather big change, it warrants discussion of some of the history as well as some of the alternative approaches and the path forward.

** The problem **

Broadly speaking, computing a diff of two fstab-like mount profiles with the goal to know what to mount and what to unmount only works if we are mounting real file systems that are using unique device names as identifiers. It does *not work*, when the mount profile represents bind mounts, as then the source path is only a symbol and not a sufficient identifier of the source material. The actual source material depends on all prior mounts and the final shape of the mount namespace. Our long path towards realising this is littered with complex behavior of the optimizer pass, and bugs affecting applications.

In response to bugs in this area snapd has evolved a more and more elaborate algorithm that tries to tailor to specific cases in one way or another. I strongly believe all that logic is wrong. Instead of special cases, we should have not done the optimization or really come up with a full model of mount trees, bind mounting and propagation. At some point though, the cost exceeds any perceived benefit, in my opinion.

The recently added test files, present in cmd/snap-update-ns/testdata/ show how badly the current code fares in face of relatively simple operations performed on snaps that follow a common idiom present in nearly all snap packages with graphical applications.

I did my best to look for bugs that relate to this change. I'm sure I've missed some. The list I managed to complete is at the end of the commit message.

** Origin of persisted mount namespaces **

In the original 2.x release, snapd has shipped with a system of persistent mount namespace associated with each snap instance. The motivation back then was two-fold: on one hand side this allowed the per-snap private /tmp directory to keep its state from one invocation of a given snap to another. On the other hand side it allows avoiding the cost of mount namespace setup to be paid on each invocation. Instead, the first invocation of a given snap instance, subject to some limitations, sets up the mount namespace. First by running snap-confine to do the initial, mostly unconditional preparation which includes pivot-root.  Then followed by a call to snap-update-ns in inherited-namespace mode, to allow it to set up additional mount entries as dictated by the mount profile of the snap, lastly followed by an optional setup of per-snap, per-user mount namespace again unshared from the per-snap mount namespace - conditional on the presence of the per-user mount profile.

All of this leaves us with at between two and three mount namespaces. The mount namespace of the init process, the mount namespace of the given snap, initialled and persisted at /run/snapd/ns/$SNAP_INSTANCE_NAME.mnt and an optional per-user mount namespace which is not persisted by default, although this is supported with a conditional feature that has seen remarkably little testing in face of the history of bugs in this area.

** Updating in place **

Historically the approach to updating the persisted state was based on the assumption that we can look at two fstab-like mount profiles and compute a delta. The removed lines would get unmounted, added lines would get mounted and unchanged lines would stay as-is. This approach does work for the simples use cases, ideally those that show a content being mounted at an existing directory in $SNAP or even a dynamically created directory in $SNAP_COMMON or $SNAP_DATA. The list of cases where this behaves correctly is sadly remarkably short and without going into needless details, one can assume, ends at the examples just given.

Real world application authors have come up with a number of cases that behave less than ideally under typical conditions. There are dozens of bugs on Launchpad and elsewhere, describing mysterious failure modes. One can characterize those into two broad groups: one where content is unexpectedly missing and, a more subtle one, where content is unexpectedly stale. Since the second case is usually hard to notice and rarely results in application crashes, one can assume that the bulk of the reported failures are a result of the first-case. A connected content, typically holding shared libraries, is not available despite the relevant snap interface being connected, the mount profile looking just right.

** Alternatives **

During the work on this problem I've considered some alternatives. Those include:

- Stop persisting mount namespaces entirely. This would mostly work except for some important snaps that live on the edge of what normal snaps are allowed to do. The primary example is LXD and the way it uses the mount namespace to store further mount namespaces.  Not persisting anything would just break it entirely, or force a re-design.

- Attempting to model kernel mount namespaces, with perhaps, bug-for-bug behavior in order to model what would happen to understand if an optimization can be taken. I've deemed too complex to be practical.

- Alternative sorting schemes. I think this one still has merit but not in isolation.  As a follow-up to the mount story I would like to sort the desired mount profile with an algorithm that understands bind mounts better. I strongly believe building a graph or lattice and particular traversal of that graph would provide a generic solution to special-cases of how layouts/content interact. With this we might be able to entirely remove special cases that look at the type of mount entry.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2043993
Fixes: https://bugs.launchpad.net/snapd/+bug/1828354
Fixes: https://bugs.launchpad.net/snapd/+bug/1828357
Fixes: https://bugs.launchpad.net/snapd/+bug/2034056
Fixes: https://bugs.launchpad.net/snapd/+bug/1856093
Fixes: https://bugs.launchpad.net/snapd/+bug/2055273
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-31645
