### PR TITLE
tests: properly inject kernel failure for UC24

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -975,7 +975,7 @@ uc24_build_initramfs_kernel_snap() {
         chmod +x ./initrd/main/usr/lib/snapd/snap-bootstrap
         if [ "$injectKernelPanic" = "true" ]; then
             # add a kernel panic to the end of the-tool execution
-            echo "echo 'forcibly panicking'; echo c > /proc/sysrq-trigger" >> ./initrd/main/usr/lib/snapd/snap-bootstrap
+            echo "echo 'forcibly panicking'; echo c > /proc/sysrq-trigger" > ./initrd/main/usr/lib/snapd/snap-bootstrap
         fi
 
         (cd ./initrd/early; find . | cpio --create --quiet --format=newc --owner=0:0) >initrd.img


### PR DESCRIPTION
We were just appending to the snap-bootstrap binary instead of replacing it. Fixes
google-nested:ubuntu-24.04-64:tests/nested/core/core20-kernel-failover:crash.