### PR TITLE
tests: add support for ubuntu plucky

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -268,12 +268,12 @@ jobs:
             rules: 'main'
           - group: ubuntu-no-lts
             backend: google
-            systems: ''
+            systems: 'ubuntu-24.10-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-daily
             backend: google
-            systems: 'ubuntu-24.10-64'
+            systems: 'ubuntu-25.04-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-core-16

--- a/spread.yaml
+++ b/spread.yaml
@@ -144,6 +144,10 @@ backends:
             - ubuntu-24.10-64:
                   storage: 15G
                   workers: 8
+            - ubuntu-25.04-64:
+                  image: ubuntu-os-cloud-devel/ubuntu-2504-amd64
+                  storage: 15G
+                  workers: 8
 
     google-core:
         type: google

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -610,7 +610,7 @@ pkg_dependencies_ubuntu_classic(){
                 shellcheck
                 "
             ;;
-        ubuntu-22.*|ubuntu-23.*|ubuntu-24.*)
+        ubuntu-22.*|ubuntu-23.*|ubuntu-24.*|ubuntu-25.*)
             # bpftool is part of linux-tools package
             echo "
                 dbus-user-session

--- a/tests/main/cgroup-devices-v1/task.yaml
+++ b/tests/main/cgroup-devices-v1/task.yaml
@@ -18,8 +18,8 @@ systems:
     - -centos-9-*
     - -amazon-linux-2023-*
     - -ubuntu-22.*
-    - -ubuntu-23.*
     - -ubuntu-24.*
+    - -ubuntu-25.*
     - -ubuntu-core-22-*
     - -ubuntu-core-24-*
 

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -14,8 +14,8 @@ systems:
     - -centos-9-*
     - -amazon-linux-2023-*
     - -ubuntu-22.*
-    - -ubuntu-23.*
     - -ubuntu-24.*
+    - -ubuntu-25.*
     - -ubuntu-core-22-*
     - -ubuntu-core-24-*    
 

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -111,7 +111,7 @@ execute: |
             MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
-        ubuntu-22*|ubuntu-23*|ubuntu-24*)
+        ubuntu-22*|ubuntu-24*|ubuntu-25*)
             # Ubuntu > 22 uses unified cgroup hierarchy, where we wait
             # for the systemd to complete the job that creates a transient scope
             MATCH 'DEBUG: using session bus' <debug.txt

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -23,8 +23,8 @@ execute: |
     fi
 
     REMOTE=ubuntu
-    # There isn't an official image for 24.10 yet, let's use the daily one
-    if os.query is-ubuntu 24.10; then
+    # There isn't an official image for 25.04 yet, let's use the daily one
+    if os.query is-ubuntu 25.04; then
         REMOTE=ubuntu-daily
     fi
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -26,8 +26,8 @@ prepare: |
     "$TESTSTOOLS"/lxd-state prepare-snap
 
     REMOTE=ubuntu
-    # There isn't an official image for 24.10 yet, let's use the daily one
-    if os.query is-ubuntu 24.10; then
+    # There isn't an official image for 25.04 yet, let's use the daily one
+    if os.query is-ubuntu 25.04; then
       REMOTE=ubuntu-daily
     fi
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -25,7 +25,7 @@ execute: |
 
     REMOTE=ubuntu
     # There isn't an official image for noble yet, let's use the daily one
-    if os.query is-ubuntu 24.04; then
+    if os.query is-ubuntu 25.04; then
         REMOTE=ubuntu-daily
     fi
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -10,8 +10,8 @@ prepare: |
   "$TESTSTOOLS"/lxd-state prepare-snap
 
   REMOTE=ubuntu
-  # There isn't an official image for 24.10 yet, let's use the daily one
-  if os.query is-ubuntu 24.10; then
+  # There isn't an official image for 25.04 yet, let's use the daily one
+  if os.query is-ubuntu 25.04; then
       REMOTE=ubuntu-daily
   fi
   VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -87,8 +87,8 @@ execute: |
 
     # There isn't an official image for noble yet, let's use the community one
     REMOTE=ubuntu
-    # There isn't an official image for 24.10 yet, let's use the daily one
-    if os.query is-ubuntu 24.10; then
+    # There isn't an official image for 25.04 yet, let's use the daily one
+    if os.query is-ubuntu 25.04; then
         REMOTE=ubuntu-daily
     fi
     VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"

--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -7,20 +7,25 @@ details: |
 systems: [ubuntu-1*-64, ubuntu-2*-64]
 
 prepare: |
+    if os.query is-arm; then
+        tests.exec skip-test "there is no content for arm64 in repo http://archive.ubuntu.com/ubuntu (just amd64)" && exit 0
+    else if os.query is-ubuntu 25.04; then
+        tests.exec skip-test "there is no updates content for daily images in repo http://archive.ubuntu.com/ubuntu" && exit 0
+    fi
+
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
     distro_purge_package snapd
 
 restore: |
+    tests.exec is-skipped && exit 0
+
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
     distro_install_build_snapd
 
 execute: |
-    if os.query is-arm; then
-        echo "there is no content for arm64 in repo http://archive.ubuntu.com/ubuntu (just amd64)"
-        exit
-    fi
+    tests.exec is-skipped && exit 0
 
     . /etc/os-release
     # trusty has no UBUNTU_CODENAME in /etc/os-release and we need to cheat

--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -9,7 +9,7 @@ systems: [ubuntu-1*-64, ubuntu-2*-64]
 prepare: |
     if os.query is-arm; then
         tests.exec skip-test "there is no content for arm64 in repo http://archive.ubuntu.com/ubuntu (just amd64)" && exit 0
-    else if os.query is-ubuntu 25.04; then
+    elif os.query is-ubuntu 25.04; then
         tests.exec skip-test "there is no updates content for daily images in repo http://archive.ubuntu.com/ubuntu" && exit 0
     fi
 


### PR DESCRIPTION
This branch adds support for ubuntu plucky. 
Also moves oracular to no-lts

Related: [SNAPDENG-34223](https://warthogs.atlassian.net/browse/SNAPDENG-34223)

[SNAPDENG-34223]: https://warthogs.atlassian.net/browse/SNAPDENG-34223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ