### PR TITLE
golangci: enable depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -189,6 +189,7 @@ linters:
     # disabling until https://github.com/daixiang0/gci/issues/54 is fixed
     # - gci
     - testpackage
+    - depguard
   # disable everything else
   disable-all: true
 


### PR DESCRIPTION
Enable the depguard linter. We alredy have some rules for it, but forgot to enable the linter itself.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
