### PR TITLE
tests: assorted fixes for mounts-persist-refresh-content-snap

### DIFF
--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -39,13 +39,13 @@ execute: |
   # Construct the mount namespace once so that we are not racing construction
   # from background job of snap run --shell with update with snap install of
   # the test-snapd-content-slot below.
-  snap run --shell test-snapd-desktop-layout-with-content.cmd -c 'true'
+  test-snapd-desktop-layout-with-content.sh -c 'true'
   touch /run/keep-running
   # Read a file continuously in the background until it fails - note that the
   # while loop here has to be inside the snap run shell, since the process must
   # persist during the refresh, if it is on the outside the mount namespace will
   # be rebuilt and the crash will not be reproduced.
-  tests.session -u test exec snap run --shell test-snapd-desktop-layout-with-content.cmd -c \
+  tests.session -u test exec test-snapd-desktop-layout-with-content.sh -c \
     'while test -f /run/keep-running && test -d /usr/share/fonts/foo-font; do true; done; ls -ld /usr/share/fonts/foo-font' &
   pid=$!
 

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -37,29 +37,27 @@ prepare: |
 
 execute: |
   # Construct the mount namespace once so that we are not racing construction
-  # from background job of snap run --shell with update with snap install of
-  # the test-snapd-content-slot below.
+  # from background job of snap run with update with snap install of the
+  # test-snapd-content-slot below.
   test-snapd-desktop-layout-with-content.sh -c 'true'
-  touch /run/keep-running
-  # Read a file continuously in the background until it fails - note that the
-  # while loop here has to be inside the snap run shell, since the process must
-  # persist during the refresh, if it is on the outside the mount namespace will
-  # be rebuilt and the crash will not be reproduced.
-  tests.session -u test exec test-snapd-desktop-layout-with-content.sh -c \
-    'while test -f /run/keep-running && test -d /usr/share/fonts/foo-font; do true; done; ls -ld /usr/share/fonts/foo-font' &
+  # Read a file continuously in the background until it fails. Note that we are
+  # not using a service but a regular app running in the background since the
+  # process must persist during the refresh.
+  tests.session -u test exec test-snapd-desktop-layout-with-content.crash-foo-font &
   pid=$!
+
+  # Wait for the script to start.
+  retry grep -xF 'started' ~test/snap/test-snapd-desktop-layout-with-content/common/status
 
   # Refresh the content slot snap.
   # TODO: when refresh app awareness is enabled, this will need to ignore running processes to
   # check the behavior
   "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
 
-  # Ensure the process is still running
-  if not ps -p "$pid"; then
-    echo "process died, test failed"
-    exit 1
-  fi
-
   # Signal to kill the loop
-  rm /run/keep-running
-  wait "$pid" || true
+  rm ~test/snap/test-snapd-desktop-layout-with-content/common/keep-running
+  wait "$pid"
+
+  # Ensure that /usr/share/fonts/foo-font was never missing.
+  MATCH 'exited' ~test/snap/test-snapd-desktop-layout-with-content/common/status
+  NOMATCH 'foo-font missing' ~test/snap/test-snapd-desktop-layout-with-content/common/status

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -45,7 +45,8 @@ execute: |
   # while loop here has to be inside the snap run shell, since the process must
   # persist during the refresh, if it is on the outside the mount namespace will
   # be rebuilt and the crash will not be reproduced
-  tests.session -u test exec snap run --shell test-snapd-desktop-layout-with-content.cmd -c 'while test -f /run/keep-running && test -d /usr/share/fonts/foo-font; do true; done' &
+  tests.session -u test exec snap run --shell test-snapd-desktop-layout-with-content.cmd -c \
+    'while test -f /run/keep-running && test -d /usr/share/fonts/foo-font; do true; done; ls -ld /usr/share/fonts/foo-font' &
   pid=$!
 
   # refresh the content slot snap

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -36,6 +36,10 @@ prepare: |
   tests.cleanup defer tests.session -u test restore
 
 execute: |
+  # Construct the mount namespace once so that we are not racing construction
+  # from background job of snap run --shell with update with snap install of
+  # the test-snapd-content-slot below.
+  snap run --shell test-snapd-desktop-layout-with-content.cmd -c 'true'
   touch /run/keep-running
   # read a file continuously in the background until it fails - note that the
   # while loop here has to be inside the snap run shell, since the process must

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -41,26 +41,25 @@ execute: |
   # the test-snapd-content-slot below.
   snap run --shell test-snapd-desktop-layout-with-content.cmd -c 'true'
   touch /run/keep-running
-  # read a file continuously in the background until it fails - note that the
+  # Read a file continuously in the background until it fails - note that the
   # while loop here has to be inside the snap run shell, since the process must
   # persist during the refresh, if it is on the outside the mount namespace will
-  # be rebuilt and the crash will not be reproduced
+  # be rebuilt and the crash will not be reproduced.
   tests.session -u test exec snap run --shell test-snapd-desktop-layout-with-content.cmd -c \
     'while test -f /run/keep-running && test -d /usr/share/fonts/foo-font; do true; done; ls -ld /usr/share/fonts/foo-font' &
   pid=$!
 
-  # refresh the content slot snap
+  # Refresh the content slot snap.
   # TODO: when refresh app awareness is enabled, this will need to ignore running processes to
   # check the behavior
   "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
 
-  # ensure the process is still running
+  # Ensure the process is still running
   if not ps -p "$pid"; then
     echo "process died, test failed"
     exit 1
   fi
 
-  # signal to kill the loop
+  # Signal to kill the loop
   rm /run/keep-running
-
   wait "$pid" || true

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -18,7 +18,8 @@ kill-timeout: 10m
 prepare: |
   # make a font directory and restart snapd so it will see it when it goes to
   # connect the desktop interface for the snap
-  mkdir /usr/share/fonts/foo-font
+  mkdir -p /usr/share/fonts/foo-font
+  tests.cleanup defer rmdir /usr/share/fonts/foo-font
   systemctl restart snapd
 
   # install a snap which exposes some files via a content slot

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin.sh
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-/bin/bash "$@"

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+touch "$SNAP_USER_COMMON"/keep-running
+echo "started" > "$SNAP_USER_COMMON"/status
+while test -f "$SNAP_USER_COMMON"/keep-running; do
+    if ! [ -d /usr/share/fonts/foo-font ] ; then 
+        echo "foo-font missing" >> "$SNAP_USER_COMMON"/status
+        exit 1
+    fi
+done
+echo "exited" >> "$SNAP_USER_COMMON"/status
+

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/sh
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/meta/snap.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/meta/snap.yaml
@@ -4,6 +4,8 @@ version: 0.1
 apps:
   sh:
     command: bin/sh
+  crash-foo-font:
+    command: bin/crash-foo-font
 
 plugs:
   desktop:

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/meta/snap.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/meta/snap.yaml
@@ -2,8 +2,8 @@ name: test-snapd-desktop-layout-with-content
 version: 0.1
 
 apps:
-  cmd:
-    cmd: bin.sh
+  sh:
+    command: bin/sh
 
 plugs:
   desktop:


### PR DESCRIPTION
There are three real bug fixes, broken out as separate patches:
- `meta/snap.yaml` is malformed
- `/usr/share/fonts/foo-font` directory was not cleaned up
- startup of `snap run --shell ... &` was racing with snap install

That last issue is the most serious, as the test checks what is going on to a process in a constructed mount namespace in face of updates but the race could have been lost and the invisible update may have masked a real bug in snapd.