### PR TITLE
tests: use images with 20G disk in openstack

### DIFF
--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -1,6 +1,6 @@
     openstack:
         key: '$(HOST: echo "$SPREAD_OPENSTACK_ENV")'
-        plan: staging-cpu2-ram4-disk50
+        plan: staging-cpu2-ram4-disk20
         halt-timeout: 2h
         groups: [default]        
         environment:


### PR DESCRIPTION
We need to update the plan used in openstack in order to save disk space which is not needed for testing.
