### PR TITLE
run-checks,.golangci.yml: move checks from run-checks to lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,6 +129,20 @@ linters-settings:
         deny:
           - pkg: "os/user"
             desc: "Please use osutil/user instead. See https://github.com/canonical/snapd/pull/13776"
+      mathrand:
+        files:
+          - "!**/randutil/*.go"
+          - "!**/vendor/**"
+          - "!$test"
+        deny:
+          - pkg: "math/rand"
+            desc: "Direct usage of math/rand, we prefer randutil"
+      ioioutil:
+        files:
+          - "!**/vendor/**"
+        deny:
+          - pkg: "io/ioutil"
+            desc: "Found usage of deprecated io/ioutil, please use \"io\" or \"os\" equivalents"
 
   misspell:
     # Correct spellings using locale preferences for US or UK.
@@ -140,8 +154,6 @@ linters-settings:
       - auther
       - PROCES
       - PROCESSS
-      - proces
-      - processs
       - exportfs
   lll:
     # max line length, lines longer will be reported. Default is 120.
@@ -183,8 +195,7 @@ linters:
     # gosimple may suggest patterns that work only with more recent Go versions
     # - gosimple
     - nakedret
-    # formatting is disabled until we move to Go 1.13
-    # - gofmt
+    - gofmt
     - ineffassign
     # disabling until https://github.com/daixiang0/gci/issues/54 is fixed
     # - gci

--- a/run-checks
+++ b/run-checks
@@ -209,38 +209,6 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
-    echo "Checking for direct usages of math/rand"
-    got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
-        # shellcheck disable=SC2063
-        s="$(grep -nP --exclude '*_test.go' --exclude 'randutil/*.go' math/rand "$dir"/*.go || true)"
-        if [ -n "$s" ]; then
-            got="$s\\n$got"
-        fi
-    done
-
-    if [ -n "$got" ]; then
-        echo 'Direct usages of math/rand, we prefer randutil:'
-        echo "$got"
-        exit 1
-    fi
-
-    echo "Checking for usages of deprecated io/ioutil"
-    got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
-        # shellcheck disable=SC2063
-        s="$(grep -nP io/ioutil "$dir"/*.go || true)"
-        if [ -n "$s" ]; then
-            got="$s\\n$got"
-        fi
-    done
-
-    if [ -n "$got" ]; then
-        echo 'Found usages of deprecated io/ioutil, please use "io" or "os" equivalents'
-        echo "$got"
-        exit 1
-    fi
-
     if command -v shellcheck >/dev/null; then
         exclude_tools_path=tests/lib/external/snapd-testing-tools
         echo "Checking shell scripts..."
@@ -304,7 +272,7 @@ if [ "$STATIC" = 1 ]; then
         # PROCES is used in the seccomp tests (PRIO_PROCES{,S,SS})
         # exportfs is used in the nfs-support test
         # becuase because of misspell in upstream steam rules (PR#12657)
-        MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs,becuase"
+        MISSPELL_IGNORE="auther,PROCES,PROCESSS,exportfs,becuase"
         git ls-files -z -- . ':!:./po' ':!:./vendor' ':!:./c-vendor' ':!:./cmd/libsnap-confine-private/bpf/vendor' ':!:./build-aux/snap/local/apparmor'|
             xargs -0 misspell -error -i "$MISSPELL_IGNORE"
     fi


### PR DESCRIPTION
Move the checks for `math/rand` and `io/ioutil` from run-checks to lints defined for golangci-lint.

Also, enable the gofmt lint, now that we're on go version 1.13+.