### PR TITLE
tests: small improvements to mounts persist refresh content

### DIFF
--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -55,7 +55,7 @@ execute: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
 
   # Signal to kill the loop
-  rm ~test/snap/test-snapd-desktop-layout-with-content/common/keep-running
+  rm -f ~test/snap/test-snapd-desktop-layout-with-content/common/keep-running
   wait "$pid"
 
   # Ensure that /usr/share/fonts/foo-font was never missing.

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -40,6 +40,7 @@ execute: |
   # from background job of snap run with update with snap install of the
   # test-snapd-content-slot below.
   test-snapd-desktop-layout-with-content.sh -c 'true'
+  test-snapd-desktop-layout-with-content.sh -c 'stat /usr/share/fonts/foo-font' | tee before
   # Read a file continuously in the background until it fails. Note that we are
   # not using a service but a regular app running in the background since the
   # process must persist during the refresh.
@@ -60,4 +61,5 @@ execute: |
 
   # Ensure that /usr/share/fonts/foo-font was never missing.
   MATCH 'exited' <~test/snap/test-snapd-desktop-layout-with-content/common/status
+  test-snapd-desktop-layout-with-content.sh -c 'stat /usr/share/fonts/foo-font' | tee after
   NOMATCH 'foo-font missing' <~test/snap/test-snapd-desktop-layout-with-content/common/status

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -59,5 +59,5 @@ execute: |
   wait "$pid"
 
   # Ensure that /usr/share/fonts/foo-font was never missing.
-  MATCH 'exited' ~test/snap/test-snapd-desktop-layout-with-content/common/status
-  NOMATCH 'foo-font missing' ~test/snap/test-snapd-desktop-layout-with-content/common/status
+  MATCH 'exited' <~test/snap/test-snapd-desktop-layout-with-content/common/status
+  NOMATCH 'foo-font missing' <~test/snap/test-snapd-desktop-layout-with-content/common/status

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -35,6 +35,15 @@ prepare: |
   tests.session -u test prepare
   tests.cleanup defer tests.session -u test restore
 
+debug: |
+  set +e
+  echo "before file"
+  cat before
+  echo "after file"
+  cat after
+  echo "status file"
+  cat ~test/snap/test-snapd-desktop-layout-with-content/common/status
+
 execute: |
   # Construct the mount namespace once so that we are not racing construction
   # from background job of snap run with update with snap install of the

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
@@ -3,10 +3,13 @@ set -eu
 touch "$SNAP_USER_COMMON"/keep-running
 echo "started" > "$SNAP_USER_COMMON"/status
 while test -f "$SNAP_USER_COMMON"/keep-running; do
-    if ! [ -d /usr/share/fonts/foo-font ] ; then 
-        echo "foo-font missing" >> "$SNAP_USER_COMMON"/status
-        break
-    fi
+        set +e
+        if ! foo="$(stat /usr /usr/share /usr/share/fonts /usr/share/fonts/foo-font 2>&1)"; then
+                echo "$foo" >> "$SNAP_USER_COMMON"/status
+                echo "foo-font missing" >>"$SNAP_USER_COMMON"/status
+                break
+        fi
+        set -e
 done
 echo "exited" >> "$SNAP_USER_COMMON"/status
 

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin/crash-foo-font
@@ -5,7 +5,7 @@ echo "started" > "$SNAP_USER_COMMON"/status
 while test -f "$SNAP_USER_COMMON"/keep-running; do
     if ! [ -d /usr/share/fonts/foo-font ] ; then 
         echo "foo-font missing" >> "$SNAP_USER_COMMON"/status
-        exit 1
+        break
     fi
 done
 echo "exited" >> "$SNAP_USER_COMMON"/status


### PR DESCRIPTION
A few small improvements to the test I've been looking at for the past few days.