### PR TITLE
o/devicestate,asserts: sign confdb-control assertions with the device key

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -351,8 +351,8 @@ func (akr *AccountKeyRequest) PublicKeyID() string {
 }
 
 // signKey returns the underlying public key of the requested account key.
-func (akr *AccountKeyRequest) signKey() PublicKey {
-	return akr.pubKey
+func (akr *AccountKeyRequest) signKey(db RODatabase) (PublicKey, error) {
+	return akr.pubKey, nil
 }
 
 // Implement further consistency checks.

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -569,7 +569,7 @@ type SequenceMember interface {
 // customSigner represents an assertion with special arrangements for its signing key (e.g. self-signed), rather than the usual case where an assertion is signed by its authority.
 type customSigner interface {
 	// signKey returns the public key material for the key that signed this assertion.  See also SignKeyID.
-	signKey() PublicKey
+	signKey(db RODatabase) (PublicKey, error)
 }
 
 // MediaType is the media type for encoded assertions on the wire.

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -121,15 +121,8 @@ type ConfdbControl struct {
 
 // expected interfaces are implemented
 var (
-	_ deviceSigner = (*ConfdbControl)(nil)
+	_ customSigner = (*ConfdbControl)(nil)
 )
-
-// deviceSigner represents an assertion that is signed by the device.
-// unlike a customSigner, the assertion doesn't carry the signing key in its body.
-type deviceSigner interface {
-	// signKey returns the public key material for the key that signed this assertion.
-	signKey(db RODatabase) (PublicKey, error)
-}
 
 // signKey returns the public key of the device that signed this assertion.
 func (cc *ConfdbControl) signKey(db RODatabase) (PublicKey, error) {

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -138,15 +138,11 @@ func (cc *ConfdbControl) signKey(db RODatabase) (PublicKey, error) {
 		"model":    cc.Model(),
 		"serial":   cc.Serial(),
 	})
-	if errors.Is(err, &NotFoundError{}) {
-		return nil, errors.New("no matching serial assertion found")
-	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot find matching serial: %w", err)
 	}
 
 	serial := a.(*Serial)
-
 	key := serial.DeviceKey()
 	if key.ID() != cc.SignKeyID() {
 		return nil, errors.New("confdb-control's signing key doesn't match the device's key")

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -132,13 +132,13 @@ func (cc *ConfdbControl) signKey(db RODatabase) (PublicKey, error) {
 		"serial":   cc.Serial(),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot find matching serial: %w", err)
+		return nil, fmt.Errorf("cannot find matching device serial assertion: %w", err)
 	}
 
 	serial := a.(*Serial)
 	key := serial.DeviceKey()
 	if key.ID() != cc.SignKeyID() {
-		return nil, errors.New("confdb-control's signing key doesn't match the device's key")
+		return nil, errors.New("confdb-control's signing key doesn't match the device key")
 	}
 
 	return key, nil

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -20,6 +20,7 @@
 package asserts_test
 
 import (
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -201,7 +202,9 @@ func (s *confdbSuite) TestAssembleAndSignChecksSchemaFormatFail(c *C) {
 	c.Assert(err, ErrorMatches, `assertion confdb: JSON in body must be indented with 2 spaces and sort object entries by key`)
 }
 
-type confdbCtrlSuite struct{}
+type confdbCtrlSuite struct {
+	db *asserts.Database
+}
 
 var _ = Suite(&confdbCtrlSuite{})
 
@@ -235,6 +238,42 @@ sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEH
 
 AXNpZw==`
 )
+
+func (s *confdbCtrlSuite) SetUpTest(c *C) {
+	topDir := filepath.Join(c.MkDir(), "asserts-db")
+	bs, err := asserts.OpenFSBackstore(topDir)
+	c.Assert(err, IsNil)
+	cfg := &asserts.DatabaseConfig{
+		Backstore: bs,
+		Trusted: []asserts.Assertion{
+			asserts.BootstrapAccountForTest("canonical"),
+			asserts.BootstrapAccountKeyForTest("canonical", testPrivKey0.PublicKey()),
+		},
+	}
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+	s.db = db
+}
+
+func (s *confdbCtrlSuite) addSerial(c *C) {
+	pubKey := testPrivKey0.PublicKey()
+	encodedPubKey, err := asserts.EncodePublicKey(pubKey)
+	c.Assert(err, IsNil)
+
+	serial, err := asserts.AssembleAndSignInTest(asserts.SerialType, map[string]interface{}{
+		"authority-id":        "canonical",
+		"brand-id":            "canonical",
+		"model":               "pc",
+		"serial":              "42",
+		"device-key":          string(encodedPubKey),
+		"device-key-sha3-384": pubKey.ID(),
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	err = s.db.Add(serial)
+	c.Assert(err, IsNil)
+}
 
 func (s *confdbCtrlSuite) TestDecodeOK(c *C) {
 	encoded := confdbControlExample
@@ -361,4 +400,45 @@ func (s *confdbCtrlSuite) TestPrerequisites(c *C) {
 		Type:       asserts.SerialType,
 		PrimaryKey: []string{"generic", "generic-classic", "03961d5d-26e5-443f-838d-6db046126bea"},
 	})
+}
+
+func (s *confdbCtrlSuite) TestAckAssertionNoSerial(c *C) {
+	headers := map[string]interface{}{
+		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []interface{}{},
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	err = s.db.Add(a)
+	c.Assert(
+		err,
+		ErrorMatches,
+		"cannot check signature: cannot find matching serial: .* not found",
+	)
+}
+
+func (s *confdbCtrlSuite) TestAckAssertionKeysMismatch(c *C) {
+	s.addSerial(c)
+
+	headers := map[string]interface{}{
+		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []interface{}{},
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey2)
+	c.Assert(err, IsNil)
+
+	err = s.db.Add(a)
+	c.Assert(err, ErrorMatches, "cannot check signature: confdb-control's signing key doesn't match the device's key")
+}
+
+func (s *confdbCtrlSuite) TestAckAssertionOK(c *C) {
+	s.addSerial(c)
+
+	headers := map[string]interface{}{
+		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []interface{}{},
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	err = s.db.Add(a)
+	c.Assert(err, IsNil)
 }

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -413,7 +413,7 @@ func (s *confdbCtrlSuite) TestAckAssertionNoSerial(c *C) {
 	c.Assert(
 		err,
 		ErrorMatches,
-		"cannot check signature: cannot find matching serial: .* not found",
+		`cannot check no-authority assertion type "confdb-control": cannot find matching device serial assertion: .* not found`,
 	)
 }
 
@@ -427,7 +427,11 @@ func (s *confdbCtrlSuite) TestAckAssertionKeysMismatch(c *C) {
 	c.Assert(err, IsNil)
 
 	err = s.db.Add(a)
-	c.Assert(err, ErrorMatches, "cannot check signature: confdb-control's signing key doesn't match the device's key")
+	c.Assert(
+		err,
+		ErrorMatches,
+		`cannot check no-authority assertion type "confdb-control": confdb-control's signing key doesn't match the device key`,
+	)
 }
 
 func (s *confdbCtrlSuite) TestAckAssertionOK(c *C) {

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -350,3 +350,15 @@ func (s *confdbCtrlSuite) TestDecodeInvalid(c *C) {
 		c.Assert(err, ErrorMatches, validationSetErrPrefix+test.expectedErr, Commentf("test %d/%d failed", i+1, len(invalidTests)))
 	}
 }
+
+func (s *confdbCtrlSuite) TestPrerequisites(c *C) {
+	a, err := asserts.Decode([]byte(confdbControlExample))
+	c.Assert(err, IsNil)
+
+	prereqs := a.Prerequisites()
+	c.Assert(prereqs, HasLen, 1)
+	c.Check(prereqs[0], DeepEquals, &asserts.Ref{
+		Type:       asserts.SerialType,
+		PrimaryKey: []string{"generic", "generic-classic", "03961d5d-26e5-443f-838d-6db046126bea"},
+	})
+}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -786,7 +786,7 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, c
 
 		pubKey, err = custom.signKey(roDB)
 		if err != nil {
-			return fmt.Errorf("cannot check signature: %w", err)
+			return fmt.Errorf("cannot check no-authority assertion type %q: %w", assert.Type().Name, err)
 		}
 	}
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -779,17 +779,14 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, c
 			return fmt.Errorf("assertion does not match signing constraints for public key %q from %q", assert.SignKeyID(), assert.AuthorityID())
 		}
 	} else {
-		switch signer := assert.(type) {
-		case customSigner:
-			pubKey = signer.signKey()
-		case deviceSigner:
-			var err error
-			pubKey, err = signer.signKey(roDB)
-			if err != nil {
-				return fmt.Errorf("cannot check signature: %w", err)
-			}
-		default:
+		custom, ok := assert.(customSigner)
+		if !ok {
 			return fmt.Errorf("cannot check no-authority assertion type %q", assert.Type().Name)
+		}
+
+		pubKey, err = custom.signKey(roDB)
+		if err != nil {
+			return fmt.Errorf("cannot check signature: %w", err)
 		}
 	}
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -786,7 +786,7 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, c
 			var err error
 			pubKey, err = signer.signKey(roDB)
 			if err != nil {
-				return err
+				return fmt.Errorf("cannot check signature: %w", err)
 			}
 		default:
 			return fmt.Errorf("cannot check no-authority assertion type %q", assert.Type().Name)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -1649,6 +1649,58 @@ func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
 	c.Check(err, ErrorMatches, `assertion does not match signing constraints for public key ".*" from "my-brand"`)
 }
 
+func (safs *signAddFindSuite) TestCheckSignatureDeviceKey(c *C) {
+	headers := map[string]interface{}{
+		"brand-id": "canonical",
+		"model":    "pc",
+		"serial":   "42",
+		"groups":   []interface{}{},
+	}
+
+	// No serial assertion
+	a, err := asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(a)
+	c.Assert(
+		err,
+		ErrorMatches,
+		"cannot check signature: cannot find matching serial: .* not found",
+	)
+
+	// Add serial
+	encodedPubKey, err := asserts.EncodePublicKey(testPrivKey0.PublicKey())
+	c.Assert(err, IsNil)
+
+	serial, err := asserts.AssembleAndSignInTest(asserts.SerialType, map[string]interface{}{
+		"authority-id":        "canonical",
+		"brand-id":            "canonical",
+		"model":               "pc",
+		"serial":              "42",
+		"device-key":          string(encodedPubKey),
+		"device-key-sha3-384": safs.signingKeyID,
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(serial)
+	c.Assert(err, IsNil)
+
+	// Keys don't match
+	a, err = asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey2)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(a)
+	c.Assert(err, ErrorMatches, "cannot check signature: confdb-control's signing key doesn't match the device's key")
+
+	// OK
+	a, err = asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(a)
+	c.Assert(err, IsNil)
+}
+
 type revisionErrorSuite struct{}
 
 func (res *revisionErrorSuite) TestErrorText(c *C) {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1964,7 +1965,7 @@ func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 }
 
 // SignConfdbControl signs a confdb-control assertion using the device's key as it needs to be attested by the device.
-func (m *DeviceManager) SignConfdbControl(groups []interface{}) (*asserts.ConfdbControl, error) {
+func (m *DeviceManager) SignConfdbControl(groups []interface{}, revision int) (*asserts.ConfdbControl, error) {
 	serial, err := m.Serial()
 	if err != nil {
 		return nil, fmt.Errorf("cannot sign confdb-control without a serial: %w", err)
@@ -1979,6 +1980,7 @@ func (m *DeviceManager) SignConfdbControl(groups []interface{}) (*asserts.Confdb
 		"brand-id": serial.BrandID(),
 		"model":    serial.Model(),
 		"serial":   serial.Serial(),
+		"revision": strconv.Itoa(revision),
 		"groups":   groups,
 	}, nil, privKey)
 	if err != nil {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1968,12 +1968,12 @@ func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 func (m *DeviceManager) SignConfdbControl(groups []interface{}, revision int) (*asserts.ConfdbControl, error) {
 	serial, err := m.Serial()
 	if err != nil {
-		return nil, fmt.Errorf("cannot sign confdb-control without a serial: %w", err)
+		return nil, fmt.Errorf("cannot sign confdb-control without a serial")
 	}
 
 	privKey, err := m.keyPair()
 	if err != nil {
-		return nil, fmt.Errorf("cannot sign confdb-control without device key: %w", err)
+		return nil, fmt.Errorf("cannot sign confdb-control without device key")
 	}
 
 	a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]interface{}{

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1967,15 +1967,12 @@ func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 func (m *DeviceManager) SignConfdbControl(groups []interface{}) (*asserts.ConfdbControl, error) {
 	serial, err := m.Serial()
 	if err != nil {
-		return nil, fmt.Errorf("internal error: cannot sign confdb-control without a serial: %w", err)
+		return nil, fmt.Errorf("cannot sign confdb-control without a serial: %w", err)
 	}
 
 	privKey, err := m.keyPair()
-	if errors.Is(err, state.ErrNoState) {
-		return nil, fmt.Errorf("internal error: inconsistent state with serial but no device key")
-	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot sign confdb-control without device key: %w", err)
 	}
 
 	a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]interface{}{

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2821,7 +2821,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlNoKey(c *C) {
 	c.Assert(err, ErrorMatches, "cannot sign confdb-control without device key: no state entry for key")
 }
 
-func (s *deviceMgrSuite) TestSignConfdbControlValidationFailure(c *C) {
+func (s *deviceMgrSuite) TestSignConfdbControlInvalid(c *C) {
 	s.setPCModelInState(c)
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2797,7 +2797,7 @@ func (s *deviceMgrSuite) TestSignConfdbControl(c *C) {
 	})
 
 	// No serial assertion exists yet
-	_, err := s.mgr.SignConfdbControl([]interface{}{})
+	_, err := s.mgr.SignConfdbControl([]interface{}{}, 2)
 	c.Assert(err, ErrorMatches, "cannot sign confdb-control without a serial: no state entry for key")
 
 	// Add serial assertion
@@ -2820,7 +2820,7 @@ func (s *deviceMgrSuite) TestSignConfdbControl(c *C) {
 		Serial: "42",
 	})
 
-	_, err = s.mgr.SignConfdbControl([]interface{}{})
+	_, err = s.mgr.SignConfdbControl([]interface{}{}, 3)
 	c.Assert(err, ErrorMatches, "cannot sign confdb-control without device key: no state entry for key")
 
 	// Add device key to manager
@@ -2835,7 +2835,7 @@ func (s *deviceMgrSuite) TestSignConfdbControl(c *C) {
 
 	// validation failure
 	groups := []interface{}{map[string]interface{}{"operator-id": "jane"}}
-	_, err = s.mgr.SignConfdbControl(groups)
+	_, err = s.mgr.SignConfdbControl(groups, 4)
 	c.Assert(
 		err,
 		ErrorMatches,
@@ -2853,8 +2853,9 @@ func (s *deviceMgrSuite) TestSignConfdbControl(c *C) {
 	}
 	groups = []interface{}{jane}
 
-	cc, err := s.mgr.SignConfdbControl(groups)
+	cc, err := s.mgr.SignConfdbControl(groups, 5)
 	c.Assert(err, IsNil)
+	c.Assert(cc.Revision(), Equals, 5)
 
 	// Confirm we can ack it
 	// AddMany panics on error, that's why we aren't c.Assert'ing anything

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2807,7 +2807,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlNoSerial(c *C) {
 	defer s.state.Unlock()
 
 	_, err := s.mgr.SignConfdbControl([]interface{}{}, 2)
-	c.Assert(err, ErrorMatches, "cannot sign confdb-control without a serial: no state entry for key")
+	c.Assert(err, ErrorMatches, "cannot sign confdb-control without a serial")
 }
 
 func (s *deviceMgrSuite) TestSignConfdbControlNoKey(c *C) {
@@ -2818,7 +2818,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlNoKey(c *C) {
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
 
 	_, err := s.mgr.SignConfdbControl([]interface{}{}, 3)
-	c.Assert(err, ErrorMatches, "cannot sign confdb-control without device key: no state entry for key")
+	c.Assert(err, ErrorMatches, "cannot sign confdb-control without device key")
 }
 
 func (s *deviceMgrSuite) TestSignConfdbControlInvalid(c *C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2858,6 +2858,5 @@ func (s *deviceMgrSuite) TestSignConfdbControl(c *C) {
 	c.Assert(cc.Revision(), Equals, 5)
 
 	// Confirm we can ack it
-	// AddMany panics on error, that's why we aren't c.Assert'ing anything
 	assertstatetest.AddMany(s.state, cc)
 }


### PR DESCRIPTION
The process to update a `confdb-control` assertion (see SD172 & SD186) looks like this:

1. Call `/v2/confdbs` with an action like `delegate` or `revoke`
2. The assertion is updated as required
3. The assertion is signed with the device key
4. The new revision of the assertion is acknowledged

This PR adds a method to `devicestate.DeviceManager` that can be used to sign `confdb-control` assertions.

Its usage would (roughly) look like:

`daemon/api_confdbs`:

```go
func doDelegateOrRevoke(c *Command, r *http.Request, _ *auth.UserState) Response {
	// request validation
	[...]

	// the existing assertion is updated
	[...]
        groups = existingAs.Groups()
	revision = existingAs.Revision() + 1

	// lock device state
	state := c.d.overlord.State()
	state.Lock()
	defer state.Unlock()

	// sign the assertion
	deviceMgr := c.d.overlord.DeviceManager()
	newAs, err = deviceMgr.SignConfdbControl(groups, revision)

	// acknowledge the new revision
	client.Ack(asserts.Encode(newAs))
}
```

CC @MiguelPires @pedronis 