### PR TITLE
wrappers: do not reload activation units

### DIFF
--- a/tests/main/services-socket-activation/task.yaml
+++ b/tests/main/services-socket-activation/task.yaml
@@ -13,56 +13,68 @@ restore: |
 execute: |
     [ -f /etc/systemd/system/snap.socket-activation.sleep-daemon.sock.socket ]
     [ -S /var/snap/socket-activation/common/socket ]
+
+    verify_status() {
+        local ENABLED="$1"
+        local MAIN_ACTIVE="$2"
+        local ACT_ACTIVE="$3"
+
+        echo "Checking that services are listed correctly"
+        snap services | cat -n > svcs.txt
+        MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
+        MATCH "     2\s+socket-activation.sleep-daemon\s+${ENABLED}\s+${MAIN_ACTIVE}\s+socket-activated$" < svcs.txt
+
+        echo "Check that systemctl for the main unit is as expected"
+        systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.service | grep "static"
+        systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.service | grep "ActiveState=${MAIN_ACTIVE}"
+
+        echo "Check that systemctl for the socket is looking correct too"
+        systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "${ENABLED}"
+        systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=${ACT_ACTIVE}"
+    }
+
+    # verify default behavior on install is that the main service
+    # is inactive but enabled, and socket is active
+    verify_status "enabled" "inactive" "active"
+
+    # this will fail, but still start the service
+    echo "Start the primary unit, emulate that the trigger has run"
+    curl -D- --verbose --max-time 1 --unix-socket /var/snap/socket-activation/common/socket http://localhost/foo || true
+
+    # verify that the main service is now active
+    verify_status "enabled" "active" "active"
+
+    # test normal restart
+    snap restart socket-activation
     
-    echo "Checking that services are listed correctly"
-    snap services | cat -n > svcs.txt
-    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
-    MATCH "     2\s+socket-activation.sleep-daemon\s+enabled\s+inactive\s+socket-activated$" < svcs.txt
+    verify_status "enabled" "active" "active"
 
-    echo "Checking that the service is reported as static"
-    systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.service | grep "static"
+    # test --reload restart, with --reload we expect different behavior 
+    # because of systemd. Verify that systemd is acting like we expect
+    # as well
+    snap restart --reload socket-activation
 
-    echo "Checking that service activation unit is reported as enabled and running"
-    systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "enabled"
-    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=active"
+    verify_status "enabled" "active" "active"
+
+    systemctl reload-or-restart snap.socket-activation.sleep-daemon.sock.socket 2>&1 | MATCH "Job failed"
 
     echo "Testing that we can stop will not disable the service"
     snap stop socket-activation.sleep-daemon
-    systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "enabled"
-    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=inactive"
+
+    verify_status "enabled" "inactive" "inactive"
 
     echo "Testing that we can correctly disable activations"
     snap stop --disable socket-activation.sleep-daemon
 
     echo "Verifying that service is now listed as disabled"
-    snap services | cat -n > svcs.txt
-    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
-    MATCH "     2\s+socket-activation.sleep-daemon\s+disabled\s+inactive\s+socket-activated$" < svcs.txt
-    
-    echo "Checking that service activation unit is reported as disabled and inactive"
-    systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "disabled"
-    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=inactive"
+    verify_status "disabled" "inactive" "inactive"
 
     echo "Starting the service will start the socket unit, but not enable"
     snap start socket-activation.sleep-daemon
-
-    echo "Checking that services are listed as expected"
-    snap services | cat -n > svcs.txt
-    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
-    MATCH "     2\s+socket-activation.sleep-daemon\s+disabled\s+inactive\s+socket-activated$" < svcs.txt
-
-    echo "Checking that service activation unit is reported as disabled and active"
-    systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "disabled"
-    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=active"
+    
+    verify_status "disabled" "inactive" "active"
 
     echo "Enable service and verify its listed as enabled"
     snap start --enable socket-activation.sleep-daemon
 
-    echo "Checking that services are listed correctly"
-    snap services | cat -n > svcs.txt
-    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
-    MATCH "     2\s+socket-activation.sleep-daemon\s+enabled\s+inactive\s+socket-activated$" < svcs.txt
-
-    echo "Checking that service activation unit is reported as enabled and active again"
-    systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "enabled"
-    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=active"
+    verify_status "enabled" "inactive" "active"

--- a/tests/main/services-socket-activation/task.yaml
+++ b/tests/main/services-socket-activation/task.yaml
@@ -39,7 +39,7 @@ execute: |
 
     # this will fail, but still start the service
     echo "Start the primary unit, emulate that the trigger has run"
-    curl -D- --verbose --max-time 1 --unix-socket /var/snap/socket-activation/common/socket http://localhost/foo || true
+    systemctl start snap.socket-activation.sleep-daemon.service
 
     # verify that the main service is now active
     verify_status "enabled" "active" "active"
@@ -56,7 +56,7 @@ execute: |
 
     verify_status "enabled" "active" "active"
 
-    systemctl reload-or-restart snap.socket-activation.sleep-daemon.sock.socket 2>&1 | MATCH "Job failed"
+    systemctl reload-or-restart snap.socket-activation.sleep-daemon.sock.socket 2>&1 | MATCH "failed"
 
     echo "Testing that we can stop will not disable the service"
     snap stop socket-activation.sleep-daemon

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1231,7 +1231,10 @@ func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices
 		var unitsToRestart []string
 
 		// If the service is activated, then we must also consider it's activators
-		if len(st.ActivatorUnitStatuses()) != 0 {
+		// as long as we are not requesting a reload. For activated units reload
+		// is not a supported action. In that case treat it like a non-activated
+		// service.
+		if len(st.ActivatorUnitStatuses()) != 0 && !opts.Reload {
 			// Restart any activators first and operate normally on these
 			for _, act := range st.ActivatorUnitStatuses() {
 				// Use the primary name here for shouldRestart, as the caller


### PR DESCRIPTION
Reported here: https://bugs.launchpad.net/snapd/+bug/2083961 it seems that we fail to restart services that have activation units when passing `--reload`.

### Difference of `snap restart` and `snap restart --reload`

When we do `snap restart` we actually do `systemctl stop ...` and then `systemctl start ...`. This works completely fine when doing this on activated service units, with their activation units, and thus we do not see an issue here.

When we do `snap restart --reload`, we directly call `systemctl reload-or-restart` on the service unit and its activation units, however this causes an error from systemd, for two different reasons:
* We cannot restart socket units while the main service is running (i.e main service must be stopped, which happens during normal restart path)
* Systemd does not support reloading of socket units (so --reload makes no sense for activation units)

To fix this, we revert to the default behavior when reloading for activated units. Meaning, instead of operating on the activation units as well as the activated unit, we just operate on the activated unit (which does support reload-or-restart).

REF: SNAPDENG-34173
