### PR TITLE
tests/lib/tools/store-state: exit on errors, update relevant tests

### DIFF
--- a/tests/lib/tools/store-state
+++ b/tests/lib/tools/store-state
@@ -143,8 +143,9 @@ setup_fake_store(){
         return 1
     fi
 
-    # before switching make sure we have a session macaroon
-    snap find test-snapd-tools
+    # before switching make sure we have a session macaroon, but keep it best
+    # effort
+    snap find test-snapd-tools || true
     mkdir -p "$top_dir/asserts"
 
     # debugging

--- a/tests/lib/tools/store-state
+++ b/tests/lib/tools/store-state
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 STORE_CONFIG=/etc/systemd/system/snapd.service.d/store.conf
 
 show_help() {

--- a/tests/main/interfaces-custom-device-app-slot/task.yaml
+++ b/tests/main/interfaces-custom-device-app-slot/task.yaml
@@ -25,9 +25,22 @@ prepare: |
       snap install core
     fi
 
+    # Install store-state dependencies
+    echo "Ensure jq is installed"
+    if ! command -v jq; then
+        snap install --devmode jq
+    fi
+
+    echo "Ensure yaml2json is installed"
+    if ! command -v yaml2json; then
+        snap install --devmode remarshal
+    fi
+
     snap debug can-manage-refreshes | MATCH false
 
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+    snap ack "$TESTSLIB/assertions/developer1.account"
+    snap ack "$TESTSLIB/assertions/developer1.account-key"
 
     "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
 

--- a/tests/main/store-state/snap/meta/snap.yaml.in
+++ b/tests/main/store-state/snap/meta/snap.yaml.in
@@ -1,6 +1,7 @@
 name: SNAPNAME
 summary: generic snap
 version: '1.0'
+base: core22
 
 apps:
   test-app:

--- a/tests/main/store-state/task.yaml
+++ b/tests/main/store-state/task.yaml
@@ -40,6 +40,10 @@ execute: |
         snap info core | MATCH "store-url:.*https://snapcraft.io"
     fi
 
+    # install test snap dependency before switching to fake store
+    # TODO: extract base name when switching to gojq
+    snap install core22
+
     # Setup fakestore
     STORE_DIR="$(pwd)/fake-store-blobdir"
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"

--- a/tests/main/system-usernames-snap-scoped/snap/meta/snap.yaml.in
+++ b/tests/main/system-usernames-snap-scoped/snap/meta/snap.yaml.in
@@ -1,6 +1,7 @@
 name: SNAPNAME
 summary: Snap requesting snap-scoped system users
 version: '1.0'
+base: core22
 
 apps:
   test-app:

--- a/tests/main/system-usernames-snap-scoped/task.yaml
+++ b/tests/main/system-usernames-snap-scoped/task.yaml
@@ -46,6 +46,10 @@ prepare: |
 
     snap debug can-manage-refreshes | MATCH false
 
+    # install dependencies before switching to fake store
+    # TODO extract base from snap metadata when swithing to gojq
+    snap install core22
+
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
 
     "$TESTSTOOLS"/store-state setup-fake-store "$STORE_DIR"


### PR DESCRIPTION
Use `set -e` in the store-state tool to catch errors. Fix failing tests. Update tests/main/store-state to use core22 instead of core for the test snap.

Cherry picked from #14686 