### PR TITLE
tests: skip microk8s test in tumbleweed

### DIFF
--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -10,14 +10,15 @@ backends:
   - -external
 
 systems:
-  - -amazon-linux-2-*    # fails to start service daemon-containerd
-  - -amazon-linux-2023-* # fails to start service daemon-containerd
-  - -centos-9-*          # fails to start service daemon-containerd
-  - -fedora-40-*         # fails to start service daemon-containerd
-  - -fedora-41-*         # fails to start service daemon-containerd
-  - -ubuntu-14.04-*      # doesn't have libseccomp >= 2.4
-  - -arch-linux-*        # XXX: no curl to the pod for unknown reasons
-  - -ubuntu-*-arm*       # not available on arm
+  - -amazon-linux-2-*       # fails to start service daemon-containerd
+  - -amazon-linux-2023-*    # fails to start service daemon-containerd
+  - -centos-9-*             # fails to start service daemon-containerd
+  - -fedora-40-*            # fails to start service daemon-containerd
+  - -fedora-41-*            # fails to start service daemon-containerd
+  - -ubuntu-14.04-*         # doesn't have libseccomp >= 2.4
+  - -arch-linux-*           # XXX: no curl to the pod for unknown reasons
+  - -ubuntu-*-arm*          # not available on arm
+  - -opensuse-tumbleweed-*  # fails to start nginx pod
 
 environment:
     CHANNEL/edge: 1.25-strict/edge


### PR DESCRIPTION
The nginx service fails to start in tumbleweed.

`microk8s kubectl get pods`
NAME     READY   STATUS                   RESTARTS   AGE
nginx    0/1     ContainerStatusUnknown   1          7m10s

Sometimes it starts (RUNNING status) but after few seconds it goes to COMPLETED.

`microk8s kubectl get pods`
NAME    READY   STATUS      RESTARTS   AGE
nginx   0/1     Completed   0          37s
