### PR TITLE
tests: added nightly run from spread-cron

### DIFF
--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -20,49 +20,6 @@ jobs:
       rules: 'nightly'
       use-master-snap: true
 
-  spread-nested-core:
-    if: github.event.schedule == '0 2 * * *'
-    uses: ./.github/workflows/spread-tests.yaml
-    with:
-      runs-on: '["self-hosted", "spread-enabled"]'
-      group: ${{ matrix.group }}
-      backend: ${{ matrix.backend }}
-      systems: ${{ matrix.systems }}
-      tasks: 'tests/nested/core/... tests/nested/manual/...'
-      rules: 'nested'
-      use-master-snap: true
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - group: nested-ubuntu-16.04
-            backend: google-nested
-            systems: 'ubuntu-16.04-64'
-          - group: nested-ubuntu-18.04
-            backend: google-nested
-            systems: 'ubuntu-18.04-64'
-          - group: nested-ubuntu-20.04
-            backend: google-nested
-            systems: 'ubuntu-20.04-64'
-          - group: nested-ubuntu-22.04
-            backend: google-nested
-            systems: 'ubuntu-22.04-64'
-          - group: nested-ubuntu-24.04
-            backend: google-nested
-            systems: 'ubuntu-24.04-64'
-
-  spread-nested-classic:
-    if: github.event.schedule == '0 2 * * *'
-    uses: ./.github/workflows/spread-tests.yaml
-    with:
-      runs-on: '["self-hosted", "spread-enabled"]'
-      group: google
-      backend: google-nested
-      systems: '*'
-      tasks: 'tests/nested/classic/...'
-      rules: 'nested'
-      use-master-snap: true
-
   spread-test-build-from-current:
     if: github.event.schedule == '0 6 * * *'
     uses: ./.github/workflows/spread-tests.yaml

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -17,7 +17,7 @@ jobs:
       backend: google
       systems: 'ALL'
       tasks: 'tests/nightly/...'
-      rules: 'nightly'
+      rules: ''
       use-master-snap: true
 
   spread-test-build-from-current:
@@ -29,7 +29,7 @@ jobs:
       backend: ${{ matrix.backend }}
       systems: ${{ matrix.systems }}
       tasks: 'tests/...'
-      rules: 'main'
+      rules: ''
       use-master-snap: true
       spread-snapd-deb-from-repo: false
     strategy:
@@ -52,7 +52,7 @@ jobs:
       backend: 'google'
       systems: 'ubuntu-18.04-64 ubuntu-20.04-64 ubuntu-21.10-64 ubuntu-core-20-64'
       tasks: 'tests/...'
-      rules: 'main'
+      rules: ''
       use-master-snap: true
       spread-experimental-features: gate-auto-refresh-hook
 
@@ -65,5 +65,5 @@ jobs:
       backend: 'openstack'
       systems: 'ALL'
       tasks: 'tests/main/...'
-      rules: 'main'
+      rules: ''
       use-master-snap: true

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -15,7 +15,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: google
       backend: google
-      systems: '*'
+      systems: 'ALL'
       tasks: 'tests/nightly/...'
       rules: 'nightly'
       use-master-snap: true
@@ -63,7 +63,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: 'openstack'
       backend: 'openstack'
-      systems: '*'
+      systems: 'ALL'
       tasks: 'tests/main/...'
       rules: 'main'
       use-master-snap: true

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -31,6 +31,7 @@ jobs:
       tasks: 'tests/...'
       rules: 'main'
       use-master-snap: true
+      spread-snapd-deb-from-repo: false
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +54,7 @@ jobs:
       tasks: 'tests/...'
       rules: 'main'
       use-master-snap: true
+      spread-experimental-features: gate-auto-refresh-hook
 
   spread-test-openstack:
     if: github.event.schedule == '0 3 * * *'

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -1,0 +1,110 @@
+name: Nightly spread executions
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
+    - cron: '0 6 * * *'
+
+jobs:
+
+  spread-nightly:
+    if: github.event.schedule == '0 2 * * *'
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: google
+      backend: google
+      systems: '*'
+      tasks: 'tests/nightly/...'
+      rules: 'nightly'
+      use-master-snap: true
+
+  spread-nested-core:
+    if: github.event.schedule == '0 2 * * *'
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: 'tests/nested/core/... tests/nested/manual/...'
+      rules: 'nested'
+      use-master-snap: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: nested-ubuntu-16.04
+            backend: google-nested
+            systems: 'ubuntu-16.04-64'
+          - group: nested-ubuntu-18.04
+            backend: google-nested
+            systems: 'ubuntu-18.04-64'
+          - group: nested-ubuntu-20.04
+            backend: google-nested
+            systems: 'ubuntu-20.04-64'
+          - group: nested-ubuntu-22.04
+            backend: google-nested
+            systems: 'ubuntu-22.04-64'
+          - group: nested-ubuntu-24.04
+            backend: google-nested
+            systems: 'ubuntu-24.04-64'
+
+  spread-nested-classic:
+    if: github.event.schedule == '0 2 * * *'
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: google
+      backend: google-nested
+      systems: '*'
+      tasks: 'tests/nested/classic/...'
+      rules: 'nested'
+      use-master-snap: true
+
+  spread-test-build-from-current:
+    if: github.event.schedule == '0 6 * * *'
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: 'tests/...'
+      rules: 'main'
+      use-master-snap: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: google
+            backend: google
+            systems: 'ubuntu-18.04-64 ubuntu-20.04-64 ubuntu-22.04-64 ubuntu-24.04-64'
+          - group: debian-not-req
+            backend: google-distro-1
+            systems: 'debian-11-64 debian-12-64 debian-sid-64'
+
+  spread-test-experimental:
+    if: github.event.schedule == '0 3 * * *'
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: 'google'
+      backend: 'google'
+      systems: 'ubuntu-18.04-64 ubuntu-20.04-64 ubuntu-21.10-64 ubuntu-core-20-64'
+      tasks: 'tests/...'
+      rules: 'main'
+      use-master-snap: true
+
+  spread-test-openstack:
+    if: github.event.schedule == '0 3 * * *'
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: 'openstack'
+      backend: 'openstack'
+      systems: '*'
+      tasks: 'tests/main/...'
+      rules: 'main'
+      use-master-snap: true

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -3,14 +3,27 @@ name: Nightly spread executions
 # See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onschedule
 on:
   schedule:
+    # usual nitghtly run
     - cron: '0 2 * * *'
+    # from current
     - cron: '0 3 * * *'
+    # experimental features and openstack
     - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      job:
+        type: choice
+        description: Job to run
+        options:
+          - spread-nightly
+          - spread-test-build-from-current
+          - spread-test-experimental
+          - spread-test-openstack
 
 jobs:
 
   spread-nightly:
-    if: github.event.schedule == '0 2 * * *'
+    if: ${{ github.event.schedule == '0 2 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-nightly') }}
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'
@@ -22,7 +35,7 @@ jobs:
       use-snapd-snap-from-master: true
 
   spread-test-build-from-current:
-    if: github.event.schedule == '0 6 * * *'
+    if: ${{ github.event.schedule == '0 6 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-build-from-current') }}
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'
@@ -45,7 +58,7 @@ jobs:
             systems: 'debian-11-64 debian-12-64 debian-sid-64'
 
   spread-test-experimental:
-    if: github.event.schedule == '0 3 * * *'
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-experimental') }}
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'
@@ -58,7 +71,7 @@ jobs:
       spread-experimental-features: gate-auto-refresh-hook
 
   spread-test-openstack:
-    if: github.event.schedule == '0 3 * * *'
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-openstack') }}
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -1,5 +1,6 @@
 name: Nightly spread executions
 
+# See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onschedule
 on:
   schedule:
     - cron: '0 2 * * *'
@@ -18,7 +19,7 @@ jobs:
       systems: 'ALL'
       tasks: 'tests/nightly/...'
       rules: ''
-      use-master-snap: true
+      use-snapd-snap-from-master: true
 
   spread-test-build-from-current:
     if: github.event.schedule == '0 6 * * *'
@@ -30,7 +31,7 @@ jobs:
       systems: ${{ matrix.systems }}
       tasks: 'tests/...'
       rules: ''
-      use-master-snap: true
+      use-snapd-snap-from-master: true
       spread-snapd-deb-from-repo: false
     strategy:
       fail-fast: false
@@ -53,7 +54,7 @@ jobs:
       systems: 'ubuntu-18.04-64 ubuntu-20.04-64 ubuntu-21.10-64 ubuntu-core-20-64'
       tasks: 'tests/...'
       rules: ''
-      use-master-snap: true
+      use-snapd-snap-from-master: true
       spread-experimental-features: gate-auto-refresh-hook
 
   spread-test-openstack:
@@ -66,4 +67,4 @@ jobs:
       systems: 'ALL'
       tasks: 'tests/main/...'
       rules: ''
-      use-master-snap: true
+      use-snapd-snap-from-master: true

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -25,6 +25,10 @@ on:
         description: 'The rule .yaml file to use (found under tests/lib/spread/rules) for test discovery'
         required: true
         type: string
+      use-master-snap:
+        required: false
+        type: boolean
+        default: false
 
 
 jobs:
@@ -98,6 +102,16 @@ jobs:
               fi
           fi
 
+    - name: Populate systems
+      run: |
+        SYSTEMS=""
+        if [[ "${{ inputs.systems }}" == "*" ]]; then
+          SYSTEMS=$(spread -list ${{ inputs.backend }} | cut -d':' -f2 | sort -u | while read line; do echo -n "$line "; done)
+        else
+          SYSTEMS="${{ inputs.systems }}"
+        fi
+        echo "SYSTEMS=$SYSTEMS" >> $GITHUB_ENV
+
     - name: Setup run tests variable
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
@@ -111,7 +125,7 @@ jobs:
               for CHANGE in $CHANGED_FILES; do
                   CHANGES_PARAM="$CHANGES_PARAM -c $CHANGE"
               done
-              for SYSTEM in ${{ inputs.systems }}; do
+              for SYSTEM in $SYSTEMS; do
                   # Configure parameters to run tests based on current changes
                   # The tests are just filtered when the change is a PR
                   # When 'Run Nested' label is added in a PR, all the nested tests have to be executed
@@ -149,7 +163,7 @@ jobs:
 
     - name: Download built snap (amd64)
       uses: actions/download-artifact@v4
-      if: "!contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips')"
+      if: "${{ !inputs.use-master-snap && !contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-default-test
         # eg. snapd_1337.2.65.1+git97.gd35b459_amd64.snap
@@ -168,7 +182,7 @@ jobs:
     - name: Download built FIPS snap (amd64)
       uses: actions/download-artifact@v4
       # eg. ubuntu-fips
-      if: "!contains(inputs.group, '-arm64') && endsWith(inputs.group, '-fips')"
+      if: "${{ !inputs.use-master-snap && !contains(inputs.group, '-arm64') && endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-FIPS-test
         # eg. snapd_1337.2.65.1+git97.gd35b459-fips_amd64.snap
@@ -176,6 +190,7 @@ jobs:
         path: "${{ github.workspace }}/built-snap"
 
     - name: Rename imported snap
+      if: "${{ !inputs.use-master-snap }}"
       run: |
         for snap in built-snap/snapd_1337.*.snap; do
           mv -v "${snap}" "${snap}.keep"
@@ -196,8 +211,12 @@ jobs:
           fi
 
           export SPREAD_USE_PREBUILT_SNAPD_SNAP=true
+          
+          if [ "${{ inputs.use-master-snap }}" = true ]; then
+            export SPREAD_USE_SNAPD_SNAP_URL=https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
+          fi
 
-          if [[ "${{ inputs.systems }}" =~ amazon-linux-2023 ]]; then
+          if [[ "$SYSTEMS" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable
               # xdelta on a per-target basis as it's used in the repack section
               # of spread.yaml, which is shared by all targets, so all systems
@@ -234,7 +253,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: spread-logs-${{ inputs.systems }}
+        name: spread-logs-$SYSTEMS
         path: "spread-logs/*.log"
         if-no-files-found: ignore
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -131,19 +131,21 @@ jobs:
     - name: Setup run tests variable
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
-          get_new_tests() {
+          get_new_tasks() {
+            local prefix=$1
+            local changes_param=$2
             # The tests are just filtered when the change is a PR
             # When 'Run Nested' label is added in a PR, all the nested tests have to be executed
-            TESTS_TO_RUN=""
+            TASKS_TO_RUN=""
             if [ -z "${{ github.event.number }}" ] || [ "$RUN_NESTED" = 'true' ]; then
-                for TESTS in ${{ inputs.tasks }}; do
-                    TESTS_TO_RUN="$TESTS_TO_RUN ${{ inputs.backend }}$1:$TESTS"
+                for TASKS in ${{ inputs.tasks }}; do
+                    TASKS_TO_RUN="$TASKS_TO_RUN $prefix:$TASKS"
                 done
             else
-                NEW_TESTS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "${{ inputs.backend }}$1" $2)"
-                TESTS_TO_RUN="$NEW_TESTS"
+                NEW_TASKS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "$prefix" $changes_param)"
+                TASKS_TO_RUN="$NEW_TASKS"
             fi
-            echo "$TESTS_TO_RUN"
+            echo "$TASKS_TO_RUN"
           }
 
           CHANGES_PARAM=""
@@ -155,14 +157,14 @@ jobs:
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
           elif [ "${{ inputs.systems }}" == "ALL" ]; then
-              RUN_TESTS=$(get_new_tests "" "$CHANGES_PARAM")
+              RUN_TESTS=$(get_new_tasks "${{ inputs.backend }}" "$CHANGES_PARAM")
           elif [ "${{ inputs.systems }}" != "NONE" ]; then
               for SYSTEM in ${{ inputs.systems }}; do
-                NEW_TESTS="$(get_new_tests ":$SYSTEM" "$CHANGES_PARAM")"
+                NEW_TASKS="$(get_new_tasks "${{ inputs.backend }}:$SYSTEM" "$CHANGES_PARAM")"
                 if [ -z "$RUN_TESTS" ]; then
-                    RUN_TESTS="$NEW_TESTS"
+                    RUN_TESTS="$NEW_TASKS"
                 else
-                    RUN_TESTS="$RUN_TESTS $NEW_TESTS"
+                    RUN_TESTS="$RUN_TESTS $NEW_TASKS"
                 fi
               done
           fi

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -30,10 +30,23 @@ on:
         required: false
         type: boolean
         default: false
+      spread-snapd-deb-from-repo:
+        description: 'If true, will use the snapd package from the repository when possible'
+        required: false
+        type: boolean
+        default: true
+      spread-experimental-features:
+        description: 'Experimental snapd features to enable'
+        required: false
+        type: string
 
 
 jobs:
   run-spread:
+    env:
+      SPREAD_SNAPD_DEB_FROM_REPO: ${{ inputs.spread-snapd-deb-from-repo }}
+      SPREAD_EXPERIMENTAL_FEATURES: ${{ inputs.spread-experimental-features }}
+      
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
     - name: Cleanup job workspace

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -26,6 +26,7 @@ on:
         required: true
         type: string
       use-master-snap:
+        description: 'If true, will use the snapd snap built on master'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -253,7 +253,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: spread-logs-$SYSTEMS
+        name: "spread-logs-${{ env.SYSTEMS }}"
         path: "spread-logs/*.log"
         if-no-files-found: ignore
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       backend:
-        description: 'The spread backend to use (for possible values, check spread.yaml)'
+        description: 'The spread backend to use (for possible values, check spread.yaml). This cannot be empty'
         required: true
         type: string
       systems:
-        description: 'The spread system(s) to use (for possible values, check spread.yaml). If more than one, separate them with a space'
+        description: 'The spread system(s) to use (for possible values, check spread.yaml). If more than one, separate them with a space. To run all, write ALL. To run none, write NONE'
         required: true
         type: string
       tasks:
@@ -49,6 +49,18 @@ jobs:
       
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
+
+    - name: Verify inputs
+      run: |
+          if [ "${{ inputs.backend }}" == "" ]; then
+            echo "You must specify a backend."
+            exit 1
+          fi
+          if [ "${{ inputs.systems }}" == "" ]; then
+            echo "You must specify a value for systems. If you want to run all, specify ALL. If you want to run none, specify NONE."
+            exit 1
+          fi
+
     - name: Cleanup job workspace
       id: cleanup-job-workspace
       run: |
@@ -116,45 +128,42 @@ jobs:
               fi
           fi
 
-    - name: Populate systems
-      run: |
-        SYSTEMS=""
-        if [[ "${{ inputs.systems }}" == "*" ]]; then
-          SYSTEMS=$(spread -list ${{ inputs.backend }} | cut -d':' -f2 | sort -u | while read line; do echo -n "$line "; done)
-        else
-          SYSTEMS="${{ inputs.systems }}"
-        fi
-        echo "SYSTEMS=$SYSTEMS" >> $GITHUB_ENV
-
     - name: Setup run tests variable
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
       run: |
+          get_new_tests() {
+            # The tests are just filtered when the change is a PR
+            # When 'Run Nested' label is added in a PR, all the nested tests have to be executed
+            TESTS_TO_RUN=""
+            if [ -z "${{ github.event.number }}" ] || [ "$RUN_NESTED" = 'true' ]; then
+                for TESTS in ${{ inputs.tasks }}; do
+                    TESTS_TO_RUN="$TESTS_TO_RUN ${{ inputs.backend }}$1:$TESTS"
+                done
+            else
+                NEW_TESTS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "${{ inputs.backend }}$1" $2)"
+                TESTS_TO_RUN="$NEW_TESTS"
+            fi
+            echo "$TESTS_TO_RUN"
+          }
+
+          CHANGES_PARAM=""
+          for CHANGE in $CHANGED_FILES; do
+              CHANGES_PARAM="$CHANGES_PARAM -c $CHANGE"
+          done
           RUN_TESTS=""
-          SUGGESTED_TESTS=""
           # Save previous failed test results in FAILED_TESTS env var
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
-          else
-              CHANGES_PARAM=""
-              for CHANGE in $CHANGED_FILES; do
-                  CHANGES_PARAM="$CHANGES_PARAM -c $CHANGE"
-              done
-              for SYSTEM in $SYSTEMS; do
-                  # Configure parameters to run tests based on current changes
-                  # The tests are just filtered when the change is a PR
-                  # When 'Run Nested' label is added in a PR, all the nested tests have to be executed
-                  if [ -z "${{ github.event.number }}" ] || [ "$RUN_NESTED" = 'true' ]; then
-                      for TESTS in ${{ inputs.tasks }}; do
-                          RUN_TESTS="$RUN_TESTS ${{ inputs.backend }}:$SYSTEM:$TESTS"
-                      done
-                  else
-                      NEW_TESTS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "${{ inputs.backend }}:$SYSTEM" $CHANGES_PARAM)"
-                      if [ -z "$RUN_TESTS" ]; then
-                          RUN_TESTS="$NEW_TESTS"
-                      else
-                          RUN_TESTS="$RUN_TESTS $NEW_TESTS"
-                      fi
-                  fi
+          elif [ "${{ inputs.systems }}" == "ALL" ]; then
+              RUN_TESTS=$(get_new_tests "" "$CHANGES_PARAM")
+          elif [ "${{ inputs.systems }}" != "NONE" ]; then
+              for SYSTEM in ${{ inputs.systems }}; do
+                NEW_TESTS="$(get_new_tests ":$SYSTEM" "$CHANGES_PARAM")"
+                if [ -z "$RUN_TESTS" ]; then
+                    RUN_TESTS="$NEW_TESTS"
+                else
+                    RUN_TESTS="$RUN_TESTS $NEW_TESTS"
+                fi
               done
           fi
           echo RUN_TESTS="$RUN_TESTS"  >> $GITHUB_ENV
@@ -230,7 +239,21 @@ jobs:
             export SPREAD_USE_SNAPD_SNAP_URL=https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
           fi
 
-          if [[ "$SYSTEMS" =~ amazon-linux-2023 ]]; then
+          # This could be the case when either there are not systems for a group or
+          # the list of tests to run is empty
+          if [ -z "$RUN_TESTS" ]; then
+            echo "No tests to run, exiting..."
+            exit 0
+          fi
+
+          # Add openstack backend definition to spread.yaml
+          if [ "${{ inputs.backend }}" = openstack ]; then
+              ./tests/lib/spread/add-backend tests/lib/spread/backend.openstack.yaml spread.yaml
+          fi
+
+          spread_list=$($SPREAD -list $RUN_TESTS 2>&1)
+
+          if [[ "$spread_list" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable
               # xdelta on a per-target basis as it's used in the repack section
               # of spread.yaml, which is shared by all targets, so all systems
@@ -239,19 +262,7 @@ jobs:
               export NO_DELTA=1
           fi
 
-          # Add openstack backend definition to spread.yaml
-          if [ "${{ inputs.backend }}" = openstack ]; then
-              ./tests/lib/spread/add-backend tests/lib/spread/backend.openstack.yaml spread.yaml
-          fi
-
-          # This could be the case when either there are not systems for a group or
-          # the list of tests to run is empty
-          if [ -z "$RUN_TESTS" ]; then
-            echo "No tests to run, exiting..."
-            exit 0
-          fi
-
-          if "$SPREAD" -list $RUN_TESTS 2>&1 | grep -q "nothing matches provider filter"; then
+          if "$spread_list" | grep -q "nothing matches provider filter"; then
             echo "No tests to run, exiting..."
             exit 0
           fi
@@ -267,7 +278,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: "spread-logs-${{ env.SYSTEMS }}"
+        name: "spread-logs-${{ inputs.group }}-${{ inputs.systems }}"
         path: "spread-logs/*.log"
         if-no-files-found: ignore
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -25,8 +25,8 @@ on:
         description: 'The rule .yaml file to use (found under tests/lib/spread/rules) for test discovery'
         required: true
         type: string
-      use-master-snap:
-        description: 'If true, will use the snapd snap built on master'
+      use-snapd-snap-from-master:
+        description: 'If true, will use the snapd snap built on the master branch'
         required: false
         type: boolean
         default: false
@@ -137,7 +137,7 @@ jobs:
             # The tests are just filtered when the change is a PR
             # When 'Run Nested' label is added in a PR, all the nested tests have to be executed
             TASKS_TO_RUN=""
-            if [ -z "${{ github.event.number }}" ] || [ "$RUN_NESTED" = 'true' ]; then
+            if [ -z "${{ github.event.number }}" ] || [ "$RUN_NESTED" = 'true' ] || [ -z "${{ inputs.rules }}" ]; then
                 for TASKS in ${{ inputs.tasks }}; do
                     TASKS_TO_RUN="$TASKS_TO_RUN $prefix:$TASKS"
                 done
@@ -188,7 +188,7 @@ jobs:
 
     - name: Download built snap (amd64)
       uses: actions/download-artifact@v4
-      if: "${{ !inputs.use-master-snap && !contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips') }}"
+      if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-default-test
         # eg. snapd_1337.2.65.1+git97.gd35b459_amd64.snap
@@ -207,7 +207,7 @@ jobs:
     - name: Download built FIPS snap (amd64)
       uses: actions/download-artifact@v4
       # eg. ubuntu-fips
-      if: "${{ !inputs.use-master-snap && !contains(inputs.group, '-arm64') && endsWith(inputs.group, '-fips') }}"
+      if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-FIPS-test
         # eg. snapd_1337.2.65.1+git97.gd35b459-fips_amd64.snap
@@ -215,7 +215,7 @@ jobs:
         path: "${{ github.workspace }}/built-snap"
 
     - name: Rename imported snap
-      if: "${{ !inputs.use-master-snap }}"
+      if: "${{ !inputs.use-snapd-snap-from-master }}"
       run: |
         for snap in built-snap/snapd_1337.*.snap; do
           mv -v "${snap}" "${snap}.keep"
@@ -237,7 +237,7 @@ jobs:
 
           export SPREAD_USE_PREBUILT_SNAPD_SNAP=true
           
-          if [ "${{ inputs.use-master-snap }}" = true ]; then
+          if [ "${{ inputs.use-snapd-snap-from-master }}" = true ]; then
             export SPREAD_USE_SNAPD_SNAP_URL=https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
           fi
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -36,7 +36,7 @@ on:
         type: boolean
         default: true
       spread-experimental-features:
-        description: 'Experimental snapd features to enable'
+        description: 'Comma-separated list of experimental snapd features to enable with: snap set system "experimental.<feature-name>=true"'
         required: false
         type: string
 
@@ -52,11 +52,11 @@ jobs:
 
     - name: Verify inputs
       run: |
-          if [ "${{ inputs.backend }}" == "" ]; then
+          if [ -z "${{ inputs.backend }}" ]; then
             echo "You must specify a backend."
             exit 1
           fi
-          if [ "${{ inputs.systems }}" == "" ]; then
+          if [ -z "${{ inputs.systems }}" ]; then
             echo "You must specify a value for systems. If you want to run all, specify ALL. If you want to run none, specify NONE."
             exit 1
           fi
@@ -156,7 +156,7 @@ jobs:
           # Save previous failed test results in FAILED_TESTS env var
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
-          elif [ "${{ inputs.systems }}" == "ALL" ]; then
+          elif [ "${{ inputs.systems }}" = "ALL" ]; then
               RUN_TESTS=$(get_new_tasks "${{ inputs.backend }}" "$CHANGES_PARAM")
           elif [ "${{ inputs.systems }}" != "NONE" ]; then
               for SYSTEM in ${{ inputs.systems }}; do
@@ -253,7 +253,7 @@ jobs:
               ./tests/lib/spread/add-backend tests/lib/spread/backend.openstack.yaml spread.yaml
           fi
 
-          spread_list=$($SPREAD -list $RUN_TESTS 2>&1)
+          spread_list="$($SPREAD -list $RUN_TESTS 2>&1)"
 
           if [[ "$spread_list" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable
@@ -264,7 +264,7 @@ jobs:
               export NO_DELTA=1
           fi
 
-          if "$spread_list" | grep -q "nothing matches provider filter"; then
+          if grep -q "nothing matches provider filter" <<< "$spread_list"; then
             echo "No tests to run, exiting..."
             exit 0
           fi

--- a/tests/lib/spread/rules/nightly.yaml
+++ b/tests/lib/spread/rules/nightly.yaml
@@ -1,0 +1,9 @@
+rules:
+  tests:
+    from:
+      - tests/nightly/.*
+    to: [$SELF]
+  
+  rest:
+    from: [.*]
+    to: [tests/nightly/]

--- a/tests/lib/spread/rules/nightly.yaml
+++ b/tests/lib/spread/rules/nightly.yaml
@@ -1,9 +1,0 @@
-rules:
-  tests:
-    from:
-      - tests/nightly/.*
-    to: [$SELF]
-  
-  rest:
-    from: [.*]
-    to: [tests/nightly/]


### PR DESCRIPTION
This PR migrates all cron jobs from [spread-cron](https://github.com/canonical/spread-cron) to snapd that run spread tests on snapd. It makes a minor change in the spread-test.yaml to allow for use of the master snap along with two required environment variables.

It also adds the possibility of executing with (in addition to manually specifying the systems) "ALL" systems or "NONE." To help not create confusion, it will no longer be possible to leave the systems input blank.

To ensure the commands will run correctly, [I ran a job in snapd-ci with cron disabled to check the executed spread commands](https://github.com/snapcore/snapd-ci/actions/runs/11852303165). To ensure the scheduling mechanism works correctly, I pushed the changes to the master branch of snapd-ci and saw the three triggers [2 am UTC for nested and nightly](https://github.com/snapcore/snapd-ci/actions/runs/11849405571), [3 am UTC for experimental and openstack](https://github.com/snapcore/snapd-ci/actions/runs/11849767356), and [6 am UTC for build from current](https://github.com/snapcore/snapd-ci/actions/runs/11851435610).
## Cron jobs
### [spread-cron - snapd-nightly-suite](https://github.com/canonical/spread-cron/blob/master/branches/snapd-nightly-suite)
#### Command in spread-cron
```
spread -v google:tests/nightly/
```
#### Command in new nightly tests
```
spread -no-debug-output -logs spread-logs google:tests/nightly/...
```
### [spread-cron - snapd-test-build-from-current](https://github.com/canonical/spread-cron/blob/master/branches/snapd-test-build-from-current/run-checks)
#### Command in spread-cron
```
spread -v google:ubuntu-18.04-64:tests/... \
          google:ubuntu-20.04-64:tests/... \
          google:ubuntu-22.04-64:tests/... \
          google:ubuntu-24.04-64:tests/... \
          google-distro-1:debian-11-64:tests/... \
          google-distro-1:debian-12-64:tests/... \
          google-distro-1:debian-sid-64:tests/...
```
#### Command in new nightly tests
```
spread -no-debug-output -logs spread-logs google:ubuntu-18.04-64:tests/... google:ubuntu-20.04-64:tests/... google:ubuntu-22.04-64:tests/... google:ubuntu-24.04-64:tests/...
```
and
```
spread -no-debug-output -logs spread-logs google-distro-1:debian-11-64:tests/... google-distro-1:debian-12-64:tests/... google-distro-1:debian-sid-64:tests/...
```
### [spread-cron - snapd-test-experimental](https://github.com/canonical/spread-cron/blob/master/branches/snapd-test-experimental/run-checks)
#### Command in spread-cron
```
spread -v google:ubuntu-18.04-64:tests/ google:ubuntu-20.04-64:tests/ google:ubuntu-21.10-64:tests/ google:ubuntu-core-20-64:tests/ 
```
#### Command in new nightly tests
```
spread -no-debug-output -logs spread-logs google:ubuntu-18.04-64:tests/... google:ubuntu-20.04-64:tests/... google:ubuntu-21.10-64:tests/... google:ubuntu-core-20-64:tests/...
```
### [spread-cron - snapd-test-openstack](https://github.com/canonical/spread-cron/blob/master/branches/snapd-test-openstack/run-checks)
#### Command in spread-cron
```
spread -no-debug-output openstack:tests/main/
```
#### Command in new nightly tests
Currently not available because the testing environment doesn't have spread-plus. The output will be: `spread -no-debug-output -logs spread-logs openstack:tests/main/...`