### PR TITLE
tests/lib/tools/tests.nested: change --tpm-no-restart to --keep-firmware-state

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1247,10 +1247,14 @@ nested_start_core_vm_unit() {
         if nested_is_secure_boot_enabled; then
             OVMF_CODE="secboot"
             if os.query is-arm; then
-                cp -f "/usr/share/AAVMF/AAVMF_VARS.fd" "$NESTED_ASSETS_DIR/AAVMF_VARS.fd"
+                if [ -z "$NESTED_KEEP_FIRMWARE_STATE" ] || ! [ -e "$NESTED_ASSETS_DIR/AAVMF_VARS.fd" ]; then
+                    cp -f "/usr/share/AAVMF/AAVMF_VARS.fd" "$NESTED_ASSETS_DIR/AAVMF_VARS.fd"
+                fi
                 PARAM_BIOS="-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$NESTED_ASSETS_DIR/AAVMF_VARS.fd,if=pflash,format=raw"
             else
-                cp -f "/usr/share/OVMF/OVMF_VARS.${OVMF_VARS}.fd" "$NESTED_ASSETS_DIR/OVMF_VARS.${OVMF_VARS}.fd"
+                if [ -z "$NESTED_KEEP_FIRMWARE_STATE" ] || ! [ -e "$NESTED_ASSETS_DIR/OVMF_VARS.${OVMF_VARS}.fd" ]; then
+                    cp -f "/usr/share/OVMF/OVMF_VARS.${OVMF_VARS}.fd" "$NESTED_ASSETS_DIR/OVMF_VARS.${OVMF_VARS}.fd"
+                fi
                 PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE.${OVMF_CODE}.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$NESTED_ASSETS_DIR/OVMF_VARS.${OVMF_VARS}.fd,if=pflash,format=raw"
                 PARAM_MACHINE="-machine q35${ATTR_KVM} -global ICH9-LPC.disable_s3=1"
             fi
@@ -1258,7 +1262,7 @@ nested_start_core_vm_unit() {
 
         if nested_is_tpm_enabled; then
             if snap list test-snapd-swtpm >/dev/null; then
-                if [ -z "$NESTED_TPM_NO_RESTART" ]; then
+                if [ -z "$NESTED_KEEP_FIRMWARE_STATE" ]; then
                     # reset the tpm state
                     snap stop test-snapd-swtpm > /dev/null
                     rm /var/snap/test-snapd-swtpm/current/tpm2-00.permall || true

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -172,7 +172,7 @@ run_muinstaller() {
     fi
 
     # Start installed image
-    tests.nested create-vm core --tpm-no-restart
+    tests.nested create-vm core --keep-firmware-state
 }
 
 main() {

--- a/tests/lib/tools/tests.nested
+++ b/tests/lib/tools/tests.nested
@@ -133,7 +133,7 @@ create_vm() {
             ;;
     esac
 
-    local NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
+    local NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_KEEP_FIRMWARE_STATE
     while [ $# -gt 0 ]; do
         case "$1" in
             --param-cdrom)
@@ -152,8 +152,8 @@ create_vm() {
                 NESTED_PARAM_EXTRA="$2"
                 shift 2
                 ;;
-            --tpm-no-restart)
-                NESTED_TPM_NO_RESTART=1
+            --keep-firmware-state)
+                NESTED_KEEP_FIRMWARE_STATE=1
                 shift
                 ;;
             *)
@@ -163,9 +163,9 @@ create_vm() {
         esac
     done
 
-    export NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
+    export NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_KEEP_FIRMWARE_STATE
     "$action"
-    unset NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
+    unset NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_KEEP_FIRMWARE_STATE
 }
 
 is_nested() {

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -246,7 +246,7 @@ execute: |
   mv fake-disk.img "$NESTED_IMAGES_DIR/$IMAGE_NAME"
 
   # Start installed image
-  tests.nested create-vm core --tpm-no-restart
+  tests.nested create-vm core --keep-firmware-state
 
   # things look fine
   remote.exec "cat /etc/os-release" | MATCH 'NAME="Ubuntu Core"'

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -222,7 +222,7 @@ execute: |
 
   # nested vm needs to restart for fake-store
   tests.nested vm stop
-  tests.nested create-vm core --tpm-no-restart
+  tests.nested create-vm core --keep-firmware-state
 
   # test gadget/kernel refresh
 


### PR DESCRIPTION


When restarting a nested VM, we reset the EFI variables and the TPM. It was possible to keep the state of the TPM, but it makes little sense to keep the TPM but not the EFI variables. With the new secboot, both resetting EFI and resetting the TPM will potentially cause recovery key to be needed.

This fixes the case where an installer image would create a sbatlevel revocation, and get a different one after reset and boot with the gadget snap.
