### PR TITLE
o/{ifacestate,snapstate}: delay reboot when we have kernel-modules

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -202,14 +202,6 @@ func MockWriteSystemKey(fn func(extraData interfaces.SystemKeyExtraData) error) 
 	return func() { writeSystemKey = old }
 }
 
-func MockSnapstateFinishRestart(f func(task *state.Task, snapsup *snapstate.SnapSetup) error) (restore func()) {
-	old := snapstateFinishRestart
-	snapstateFinishRestart = f
-	return func() {
-		snapstateFinishRestart = old
-	}
-}
-
 func (m *InterfaceManager) TransitionConnectionsCoreMigration(st *state.State, oldName, newName string) error {
 	return m.transitionConnectionsCoreMigration(st, oldName, newName)
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1382,11 +1382,14 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// The previous task (link-snap) may have triggered a restart,
-	// if this is the case we can only proceed once the restart
-	// has happened or we may not have all the interfaces of the
-	// new core/base snap.
-	if err := snapstateFinishRestart(task, snapsup); err != nil {
+	// The previous task (link-snap) may have triggered a restart, if this
+	// is the case we can only proceed once the restart has happened or we
+	// may not have all the interfaces of the new core/base snap. We set
+	// the default to true as we always called FinishRestart in older
+	// snapd.
+	logger.Debugf("finish restart from doAutoConnect")
+	if err := snapstateFinishRestart(task, snapsup,
+		snapstate.FinishRestartOptions{FinishRestartDefault: true}); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -346,6 +346,10 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				Type: snap.StandardComponent,
 				Name: "standard-component",
 			},
+			"standard-component-extra": {
+				Type: snap.StandardComponent,
+				Name: "standard-component",
+			},
 			"kernel-modules-component": {
 				Type: snap.KernelModulesComponent,
 				Name: "kernel-modules-component",
@@ -522,8 +526,13 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		base = "some-base"
 	case "provenance-snap-id":
 		name = "provenance-snap"
-	case "snap-with-components-id":
-		name = "snap-with-components"
+		typ = snap.TypeKernel
+	case "app-snap-with-components-id":
+		name = "app-snap-with-components"
+		typ = snap.TypeApp
+	case "kernel-snap-with-components-id":
+		name = "kernel-snap-with-components"
+		typ = snap.TypeKernel
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}
@@ -1147,7 +1156,18 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		info.SnapType = snap.TypeOS
 	case "snapd":
 		info.SnapType = snap.TypeSnapd
-	case "snap-with-components":
+	case "app-snap-with-components":
+		info.Components = map[string]*snap.Component{
+			"standard-component": {
+				Type: snap.StandardComponent,
+				Name: "standard-component",
+			},
+			"standard-component-two": {
+				Type: snap.StandardComponent,
+				Name: "standard-component-two",
+			},
+		}
+	case "kernel-snap-with-components":
 		info.Components = map[string]*snap.Component{
 			"standard-component": {
 				Type: snap.StandardComponent,
@@ -1158,6 +1178,7 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 				Name: "kernel-modules-component",
 			},
 		}
+		info.SnapType = snap.TypeKernel
 	case "services-snap":
 		var err error
 		// fix services after/before so that there is only one solution
@@ -1278,7 +1299,7 @@ func (f *fakeSnappyBackend) MaybeSetNextBoot(
 
 	reboot := false
 	if f.linkSnapMaybeReboot {
-		reboot = info.InstanceName() == dev.Base() ||
+		reboot = info.Type() == snap.TypeKernel || info.InstanceName() == dev.Base() ||
 			(f.linkSnapRebootFor != nil && f.linkSnapRebootFor[info.InstanceName()])
 	}
 

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -318,7 +318,7 @@ func (bs *bootedSuite) TestFinishRestartCore(c *C) {
 	// not core snap
 	si := &snap.SideInfo{RealName: "some-app"}
 	snaptest.MockSnap(c, "name: some-app\nversion: 1", si)
-	err := snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si})
+	err := snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si}, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	si = &snap.SideInfo{RealName: "core"}
@@ -327,13 +327,13 @@ func (bs *bootedSuite) TestFinishRestartCore(c *C) {
 	// core snap, restarting ... wait
 	restart.MockPending(st, restart.RestartSystem)
 	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 1", si)
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, FitsTypeOf, &state.Retry{})
 
 	// core snap, restarted, waiting for current core revision
 	restart.MockPending(st, restart.RestartUnset)
 	bs.bootloader.BootVars["snap_mode"] = boot.TryingStatus
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, DeepEquals, &state.Retry{After: 5 * time.Second})
 
 	// core snap updated
@@ -342,12 +342,12 @@ func (bs *bootedSuite) TestFinishRestartCore(c *C) {
 
 	// core snap, restarted, right core revision, no rollback
 	bs.bootloader.BootVars["snap_mode"] = ""
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	// core snap, restarted, wrong core revision, rollback!
 	bs.bootloader.SetBootBase("core_1.snap")
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, ErrorMatches, `cannot finish core installation, there was a rollback across reboot`)
 }
 
@@ -364,13 +364,13 @@ func (bs *bootedSuite) TestFinishRestartBootableBase(c *C) {
 	// not core snap
 	si := &snap.SideInfo{RealName: "some-app", Revision: snap.R(1)}
 	snaptest.MockSnap(c, "name: some-app\nversion: 1", si)
-	err := snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si})
+	err := snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si}, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	// core snap but we are on a model with a different base
 	si = &snap.SideInfo{RealName: "core"}
 	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 1", si)
-	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si, Type: snap.TypeOS})
+	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si, Type: snap.TypeOS}, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	si = &snap.SideInfo{RealName: "core18"}
@@ -378,13 +378,13 @@ func (bs *bootedSuite) TestFinishRestartBootableBase(c *C) {
 	snaptest.MockSnap(c, "name: core18\ntype: base\nversion: 1", si)
 	// core snap, restarting ... wait
 	restart.MockPending(st, restart.RestartSystem)
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, FitsTypeOf, &state.Retry{})
 
 	// core snap, restarted, waiting for current core revision
 	restart.MockPending(st, restart.RestartUnset)
 	bs.bootloader.BootVars["snap_mode"] = boot.TryingStatus
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, DeepEquals, &state.Retry{After: 5 * time.Second})
 
 	// core18 snap updated
@@ -394,12 +394,12 @@ func (bs *bootedSuite) TestFinishRestartBootableBase(c *C) {
 	// core snap, restarted, right core revision, no rollback
 	bs.bootloader.BootVars["snap_mode"] = ""
 	bs.bootloader.SetBootBase("core18_2.snap")
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	// core snap, restarted, wrong core revision, rollback!
 	bs.bootloader.SetBootBase("core18_1.snap")
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, ErrorMatches, `cannot finish core18 installation, there was a rollback across reboot`)
 }
 
@@ -416,13 +416,13 @@ func (bs *bootedSuite) TestFinishRestartKernel(c *C) {
 	// not kernel snap
 	si := &snap.SideInfo{RealName: "some-app", Revision: snap.R(1)}
 	snaptest.MockSnap(c, "name: some-app\nversion: 1", si)
-	err := snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si})
+	err := snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si}, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	// different kernel (may happen with remodel)
 	si = &snap.SideInfo{RealName: "other-kernel"}
 	snaptest.MockSnap(c, "name: other-kernel\ntype: kernel\nversion: 1", si)
-	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si, Type: snap.TypeKernel})
+	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si, Type: snap.TypeKernel}, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	si = &snap.SideInfo{RealName: "kernel"}
@@ -430,13 +430,13 @@ func (bs *bootedSuite) TestFinishRestartKernel(c *C) {
 	snaptest.MockSnap(c, "name: kernel\ntype: kernel\nversion: 1", si)
 	// kernel snap, restarting ... wait
 	restart.MockPending(st, restart.RestartSystem)
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, FitsTypeOf, &state.Retry{})
 
 	// kernel snap, restarted, waiting for current core revision
 	restart.MockPending(st, restart.RestartUnset)
 	bs.bootloader.BootVars["snap_mode"] = boot.TryingStatus
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, DeepEquals, &state.Retry{After: 5 * time.Second})
 
 	// kernel snap updated
@@ -446,12 +446,12 @@ func (bs *bootedSuite) TestFinishRestartKernel(c *C) {
 	// kernel snap, restarted, right kernel revision, no rollback
 	bs.bootloader.BootVars["snap_mode"] = ""
 	bs.bootloader.SetBootKernel("kernel_2.snap")
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	// kernel snap, restarted, wrong core revision, rollback!
 	bs.bootloader.SetBootKernel("kernel_1.snap")
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, ErrorMatches, `cannot finish kernel installation, there was a rollback across reboot`)
 }
 
@@ -476,13 +476,13 @@ func (bs *bootedSuite) TestFinishRestartKernelClassicWithModes(c *C) {
 	// not kernel snap
 	si := &snap.SideInfo{RealName: "some-app", Revision: snap.R(1)}
 	snaptest.MockSnap(c, "name: some-app\nversion: 1", si)
-	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si})
+	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si}, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	// different kernel (may happen with remodel)
 	si = &snap.SideInfo{RealName: "other-kernel"}
 	snaptest.MockSnap(c, "name: other-kernel\ntype: kernel\nversion: 1", si)
-	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si, Type: snap.TypeKernel})
+	err = snapstate.FinishRestart(task, &snapstate.SnapSetup{SideInfo: si, Type: snap.TypeKernel}, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	si = &snap.SideInfo{RealName: "kernel"}
@@ -490,13 +490,13 @@ func (bs *bootedSuite) TestFinishRestartKernelClassicWithModes(c *C) {
 	snaptest.MockSnap(c, "name: kernel\ntype: kernel\nversion: 1", si)
 	// kernel snap, restarting ... wait
 	restart.MockPending(st, restart.RestartSystem)
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, FitsTypeOf, &state.Retry{})
 
 	// kernel snap, restarted, waiting for current core revision
 	restart.MockPending(st, restart.RestartUnset)
 	bl.BootVars["kernel_status"] = boot.TryingStatus
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, DeepEquals, &state.Retry{After: 5 * time.Second})
 
 	// kernel snap updated
@@ -508,14 +508,14 @@ func (bs *bootedSuite) TestFinishRestartKernelClassicWithModes(c *C) {
 	kernel, err = snap.ParsePlaceInfoFromSnapFileName("kernel_2.snap")
 	c.Assert(err, IsNil)
 	bl.SetEnabledKernel(kernel)
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 
 	// kernel snap, restarted, wrong core revision, rollback!
 	kernel, err = snap.ParsePlaceInfoFromSnapFileName("kernel_1.snap")
 	c.Assert(err, IsNil)
 	bl.SetEnabledKernel(kernel)
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, ErrorMatches, `cannot finish kernel installation, there was a rollback across reboot`)
 }
 
@@ -534,14 +534,14 @@ func (bs *bootedSuite) TestFinishRestartEphemeralModeSkipsRollbackDetection(c *C
 	snaptest.MockSnap(c, "name: kernel\ntype: kernel\nversion: 1", si)
 	// kernel snap, restarted, wrong core revision, rollback detected!
 	bs.bootloader.SetBootKernel("kernel_1.snap")
-	err := snapstate.FinishRestart(task, snapsup)
+	err := snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, ErrorMatches, `cannot finish kernel installation, there was a rollback across reboot`)
 
 	// but *not* in an ephemeral mode like "recover" - we skip the rollback
 	// detection here
 	r = snapstatetest.MockDeviceModelAndMode(DefaultModel(), "install")
 	defer r()
-	err = snapstate.FinishRestart(task, snapsup)
+	err = snapstate.FinishRestart(task, snapsup, snapstate.FinishRestartOptions{FinishRestartDefault: true})
 	c.Check(err, IsNil)
 }
 

--- a/overlord/snapstate/component_remove_test.go
+++ b/overlord/snapstate/component_remove_test.go
@@ -381,7 +381,7 @@ func (s *snapmgrTestSuite) TestRemoveComponentUpdateConflict(c *C) {
 	defer s.state.Unlock()
 
 	csi1 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName), snap.R(1))
-	cs1 := sequence.NewComponentState(csi1, snap.KernelModulesComponent)
+	cs1 := sequence.NewComponentState(csi1, snap.StandardComponent)
 	setStateWithComponents(s.state, snapName, snapRev, []*sequence.ComponentState{cs1})
 
 	tupd, err := snapstate.Update(s.state, snapName,
@@ -414,7 +414,7 @@ func (s *snapmgrTestSuite) TestRemoveComponentUpdateNoConflict(c *C) {
 	defer s.state.Unlock()
 
 	csi1 := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName), snap.R(1))
-	cs1 := sequence.NewComponentState(csi1, snap.KernelModulesComponent)
+	cs1 := sequence.NewComponentState(csi1, snap.StandardComponent)
 	setStateWithComponents(s.state, snapName, snapRev, []*sequence.ComponentState{cs1})
 
 	tupd, err := snapstate.Update(s.state, snapName,
@@ -430,5 +430,5 @@ func (s *snapmgrTestSuite) TestRemoveComponentUpdateNoConflict(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(len(tss), Equals, 1)
-	verifyComponentRemoveTasks(c, compTypeIsKernMods|compCurrentIsDiscarded, tss[0])
+	verifyComponentRemoveTasks(c, compCurrentIsDiscarded, tss[0])
 }

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -907,6 +907,7 @@ func (s *linkSnapSuite) TestDoLinkSnapWithVitalityScore(c *C) {
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: si,
 	})
+	t.Set("set-next-boot", true)
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(t)
 
@@ -1093,6 +1094,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBase(c *C) {
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: si,
 	})
+	t.Set("set-next-boot", true)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(t)
@@ -1143,6 +1145,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForKernelClassicWithModes(c *
 		SideInfo: si,
 		Type:     snap.TypeKernel,
 	})
+	t.Set("set-next-boot", true)
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(t)
 
@@ -1185,6 +1188,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBaseSystemRestartImmed
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: si,
 	})
+	t.Set("set-next-boot", true)
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(t)
 	chg.Set("system-restart-immediate", true)
@@ -1324,6 +1328,7 @@ func (s *linkSnapSuite) TestDoLinkSnapFailGadgetDoesRequestsRestart(c *C) {
 		SideInfo: si,
 		Type:     snap.TypeGadget,
 	})
+	t.Set("set-next-boot", true)
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(t)
 
@@ -1579,6 +1584,7 @@ func (s *linkSnapSuite) TestDoLinkSnapdDiscardsNsOnDowngrade(c *C) {
 		SideInfo: si,
 		Channel:  "beta",
 	})
+	t.Set("set-next-boot", true)
 
 	s.state.NewChange("sample", "...").AddTask(t)
 	s.state.Unlock()
@@ -1658,6 +1664,7 @@ func (s *linkSnapSuite) TestDoLinkSnapdRemovesAppArmorProfilesOnSnapdDowngrade(c
 		SideInfo: si,
 		Channel:  "beta",
 	})
+	t.Set("set-next-boot", true)
 
 	// set seeded so that AppArmor profile cleanup should occur - however
 	// since we now appear to be seeded this would trigger the mount units
@@ -2315,6 +2322,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdFirstInstall(c *C) {
 		SideInfo: si,
 		Type:     snap.TypeSnapd,
 	})
+	t.Set("set-next-boot", true)
 	chg.AddTask(t)
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
 	terr.WaitFor(t)
@@ -2395,6 +2403,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 		SideInfo: si,
 		Type:     snap.TypeSnapd,
 	})
+	t.Set("set-next-boot", true)
 	chg.AddTask(t)
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
 	terr.WaitFor(t)
@@ -2660,6 +2669,7 @@ func (s *linkSnapSuite) testDoLinkSnapWithToolingDependency(c *C, classicOrBase 
 		SideInfo: si,
 		Type:     snap.TypeApp,
 	})
+	t.Set("set-next-boot", true)
 	s.state.NewChange("sample", "...").AddTask(t)
 
 	s.state.Unlock()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -574,7 +574,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 		return nil, err
 	}
 
-	// This task is necessary only for UC20+ and hybrid
+	// This task is necessary only for UC24+ and hybrid 24.04+
 	if snapsup.Type == snap.TypeKernel && NeedsKernelSetup(deviceCtx.Model()) {
 		setupKernel := st.NewTask("prepare-kernel-snap", fmt.Sprintf(i18n.G("Prepare kernel driver tree for %q%s"), snapsup.InstanceName(), revisionStr))
 		addTask(setupKernel)
@@ -636,13 +636,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 	autoConnect := st.NewTask("auto-connect", fmt.Sprintf(i18n.G("Automatically connect eligible plugs and slots of snap %q"), snapsup.InstanceName()))
 	addTask(autoConnect)
 
-	if snapsup.Type == snap.TypeKernel && NeedsKernelSetup(deviceCtx.Model()) {
-		// This task needs to run after we're back and running the new
-		// kernel after a reboot was requested in link-snap handler.
-		setupKernel := st.NewTask("discard-old-kernel-snap-setup", fmt.Sprintf(i18n.G("Discard previous kernel driver tree for %q%s"), snapsup.InstanceName(), revisionStr))
-		addTask(setupKernel)
-	}
-
 	// setup aliases
 	setAutoAliases := st.NewTask("set-auto-aliases", fmt.Sprintf(i18n.G("Set automatic aliases for snap %q"), snapsup.InstanceName()))
 	addTask(setAutoAliases)
@@ -682,11 +675,26 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 		addTask(t)
 	}
 
-	// check if either the snap currently has kernel module components or any of
-	// the new components are kernel module components
+	// Check if either the snap currently has kernel-modules components or
+	// any of the new components are kernel-modules components (only will
+	// happen for kernel snaps).
+	var setupKmodComponents, afterSetupKmodComps *state.Task
 	if requiresKmodSetup(snapst, compsups) {
-		setupKmodComponents := st.NewTask("prepare-kernel-modules-components", fmt.Sprintf(i18n.G("Prepare kernel-modules components for %q%s"), snapsup.InstanceName(), revisionStr))
+		logger.Noticef("kernel-modules components present, delaying reboot after hooks are run")
+		// TODO move the setupKernel task here and make it configure
+		// kernel-modules components too so we can remove this task.
+		setupKmodComponents = st.NewTask("prepare-kernel-modules-components", fmt.Sprintf(i18n.G("Prepare kernel-modules components for %q%s"), snapsup.InstanceName(), revisionStr))
 		addTask(setupKmodComponents)
+	}
+
+	if snapsup.Type == snap.TypeKernel && NeedsKernelSetup(deviceCtx.Model()) {
+		// This task needs to run after we're back and running the new
+		// kernel after a reboot was requested in link-snap handler.
+		discardOldKernelSetup := st.NewTask("discard-old-kernel-snap-setup",
+			fmt.Sprintf(i18n.G("Discard previous kernel driver tree for %q%s"), snapsup.InstanceName(), revisionStr))
+		// Note that if requiresKmodSetup is true, NeedsKernelSetup must be too
+		afterSetupKmodComps = discardOldKernelSetup
+		addTask(discardOldKernelSetup)
 	}
 
 	if snapsup.QuotaGroupName != "" {
@@ -782,10 +790,31 @@ func doInstall(st *state.State, snapst *SnapState, snapsup SnapSetup, compsups [
 	installSet := state.NewTaskSet(tasks...)
 	installSet.MarkEdge(prereq, BeginEdge)
 	installSet.MarkEdge(setupAliases, BeforeHooksEdge)
-	installSet.MarkEdge(setupSecurity, BeforeMaybeRebootEdge)
-	installSet.MarkEdge(linkSnap, MaybeRebootEdge)
-	installSet.MarkEdge(autoConnect, MaybeRebootWaitEdge)
-	installSet.MarkEdge(setAutoAliases, AfterMaybeRebootWaitEdge)
+
+	// Let tasks know if they have to do something about restarts
+	// TODO fix tests so BeforeMaybeRebootEdge and AfterMaybeRebootWaitEdge
+	// are not needed.
+	installSet.MarkEdge(setupSecurity, BeforeMaybeRebootEdge) // this edge is just for tests
+	if setupKmodComponents == nil {
+		// No kernel modules, reboot after link snap
+		installSet.MarkEdge(linkSnap, MaybeRebootEdge)
+		installSet.MarkEdge(autoConnect, MaybeRebootWaitEdge)
+		linkSnap.Set("set-next-boot", true)
+		autoConnect.Set("finish-restart", true)
+		if afterSetupKmodComps != nil {
+			afterSetupKmodComps.Set("finish-restart", false)
+		}
+	} else {
+		logger.Noticef("reboot will happen after set-up of kernel-modules")
+		installSet.MarkEdge(setupKmodComponents, MaybeRebootEdge)
+		installSet.MarkEdge(afterSetupKmodComps, MaybeRebootWaitEdge)
+		linkSnap.Set("set-next-boot", false)
+		autoConnect.Set("finish-restart", false)
+		setupKmodComponents.Set("set-next-boot", true)
+		afterSetupKmodComps.Set("finish-restart", true)
+	}
+	installSet.MarkEdge(setAutoAliases, AfterMaybeRebootWaitEdge) // this edge is just for tests
+
 	if installHook != nil {
 		installSet.MarkEdge(installHook, HooksEdge)
 	}
@@ -873,7 +902,7 @@ func splitComponentTasksForInstall(
 }
 
 func NeedsKernelSetup(model *asserts.Model) bool {
-	// Checkinf if it has modeenv - it must be UC20+ or hybrid
+	// Checking if it has modeenv - it must be UC20+ or hybrid
 	if model.Grade() == asserts.ModelGradeUnset {
 		return false
 	}
@@ -985,16 +1014,36 @@ func isInvokedWithRevert() bool {
 	return os.Getenv("SNAPD_REVERT_TO_REV") != ""
 }
 
+// FinishRestartOptions are options for FinishRestart.
+type FinishRestartOptions struct {
+	// FinishRestartDefault sets the default behavior for FinishRestart in
+	// case the "finish-restart" task variable is not found, that is, this
+	// is the behavior for tasks created by older snapd. Tasks that call
+	// FinishRestart set this value to what would have been the expected
+	// behavior before the introduction of "finish-restart".
+	FinishRestartDefault bool
+}
+
 // FinishRestart will return a Retry error if there is a pending restart
 // and a real error if anything went wrong (like a rollback across
 // restarts).
 // For snapd snap updates this will also rerun wrappers generation to fully
 // catch up with any change.
-func FinishRestart(task *state.Task, snapsup *SnapSetup) (err error) {
+func FinishRestart(task *state.Task, snapsup *SnapSetup, opts FinishRestartOptions) (err error) {
 	if snapdenv.Preseeding() {
 		// nothing to do when preseeding
 		return nil
 	}
+	// Check if the task really needs to call this
+	needsFinishRestart := opts.FinishRestartDefault
+	if err := task.Get("finish-restart", &needsFinishRestart); err != nil &&
+		!errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if !needsFinishRestart {
+		return nil
+	}
+
 	if ok, _ := restart.Pending(task.State()); ok {
 		// don't continue until we are in the restarted snapd
 		task.Logf("Waiting for automatic snapd restart...")

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -37,6 +37,9 @@ import (
 	"github.com/snapcore/snapd/advisor"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/boot/boottest"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
@@ -786,10 +789,13 @@ func (s *snapmgrTestSuite) TestUpdateAmendWithComponentsRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, components []string) {
 	si := snap.SideInfo{
-		RealName: "some-snap",
+		RealName: "some-kernel",
 		Revision: snap.R(-42),
 	}
-	snaptest.MockSnap(c, `name: some-snap`, &si)
+	snaptest.MockSnap(c, `name: some-kernel`, &si)
+
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	defer r()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -879,7 +885,7 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		}, nil
 	}))
 
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+	snapstate.Set(s.state, "some-kernel", &snapstate.SnapState{
 		Active:          true,
 		Sequence:        currentSeq,
 		Current:         si.Revision,
@@ -889,7 +895,7 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 	})
 
 	chg := s.state.NewChange("refresh", "refresh a snap")
-	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{
+	ts, err := snapstate.Update(s.state, "some-kernel", &snapstate.RevisionOptions{
 		Channel: "channel-for-components",
 	}, s.user.ID, snapstate.Flags{Amend: true})
 	c.Assert(err, IsNil)
@@ -899,8 +905,8 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 
 	downloads := []fakeDownload{{
 		macaroon: s.user.StoreMacaroon,
-		name:     "some-snap",
-		target:   filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+		name:     "some-kernel",
+		target:   filepath.Join(dirs.SnapBlobDir, "some-kernel_11.snap"),
 	}}
 
 	for _, compName := range components {
@@ -934,13 +940,17 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		"remove-snap-aliases",
 		"run-inhibit-snap-for-unlink",
 		"unlink-snap",
+		"prepare-kernel-snap",
+		"update-gadget-assets:Doing",
 		"copy-data",
 		"setup-snap-save-data",
 		"setup-profiles:Doing",
 		"candidate",
 		"link-snap",
-		"maybe-set-next-boot",
 	}...)
+	if len(currentKmodComps) == 0 {
+		ops = append(ops, "maybe-set-next-boot")
+	}
 	for range components {
 		ops = append(ops, "link-component")
 	}
@@ -949,9 +959,10 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		"update-aliases",
 	}...)
 	if len(currentKmodComps) > 0 {
-		ops = append(ops, "prepare-kernel-modules-components")
+		ops = append(ops, "prepare-kernel-modules-components", "maybe-set-next-boot")
 	}
 	ops = append(ops, []string{
+		"remove-kernel-snap-setup",
 		"cleanup-trash",
 	}...)
 
@@ -962,7 +973,7 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
 			Action:       "install", // we asked for an Update, but an amend is actually an Install
-			InstanceName: "some-snap",
+			InstanceName: "some-kernel",
 			Channel:      "channel-for-components",
 			Epoch:        snap.E("1*"), // in amend, epoch in the action is not nil!
 		},
@@ -979,14 +990,14 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		Channel: "channel-for-components",
 		UserID:  s.user.ID,
 
-		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-kernel_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Size:        5,
 		},
 		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		Version:   "some-snapVer",
+		Type:      snap.TypeKernel,
+		Version:   "some-kernelVer",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
 			Amend:       true,
@@ -995,36 +1006,36 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		PreUpdateKernelModuleComponents: currentKmodComps,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
-		RealName: "some-snap",
+		RealName: "some-kernel",
 		Revision: snap.R(11),
 		Channel:  "channel-for-components",
-		SnapID:   "some-snap-id",
+		SnapID:   "some-kernel-id",
 	})
 
 	// verify services stop reason
 	verifyStopReason(c, ts, "refresh")
 
 	// check post-refresh hook
-	task = ts.Tasks()[14+(len(components)*5)]
+	task = ts.Tasks()[16+(len(components)*5)]
 	c.Assert(task.Kind(), Equals, "run-hook", Commentf(printTasks(ts.Tasks())))
-	c.Assert(task.Summary(), Matches, `Run post-refresh hook of "some-snap" snap if present`)
+	c.Assert(task.Summary(), Matches, `Run post-refresh hook of "some-kernel" snap if present`)
 
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	err = snapstate.Get(s.state, "some-kernel", &snapst)
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
 	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
-		RealName: "some-snap",
+		RealName: "some-kernel",
 		Channel:  "",
 		Revision: snap.R(-42),
 	}, currentComponentStates))
 	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, sequence.NewRevisionSideState(&snap.SideInfo{
-		RealName: "some-snap",
+		RealName: "some-kernel",
 		Channel:  "channel-for-components",
-		SnapID:   "some-snap-id",
+		SnapID:   "some-kernel-id",
 		Revision: snap.R(11),
 	}, expectedComponentStates))
 }
@@ -13334,7 +13345,8 @@ type: snapd
 			}
 			// fake restart
 			restart.MockPending(st, restart.RestartUnset)
-			if err := snapstate.FinishRestart(task, snapsup); err != nil {
+			if err := snapstate.FinishRestart(task, snapsup,
+				snapstate.FinishRestartOptions{FinishRestartDefault: true}); err != nil {
 				panic(err)
 			}
 		}
@@ -14490,7 +14502,7 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 		channel     = "channel-for-components"
 	)
 
-	components := []string{"standard-component", "kernel-modules-component"}
+	components := []string{"standard-component", "standard-component"}
 
 	currentSnapRev := snap.R(11)
 	prevSnapRev := snap.R(7)
@@ -14642,20 +14654,10 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 		{
 			op: "update-aliases",
 		},
-		{
-			op:           "prepare-kernel-modules-components",
-			currentComps: currentKmodComps,
-			finalComps:   prevKmodComps,
-		},
 	}
 
 	if undo {
 		expected = append(expected, []fakeOp{
-			{
-				op:           "prepare-kernel-modules-components",
-				currentComps: prevKmodComps,
-				finalComps:   currentKmodComps,
-			},
 			{
 				op:   "remove-snap-aliases",
 				name: instanceName,
@@ -14736,11 +14738,14 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	const (
-		snapName    = "snap-with-components"
-		instanceKey = "key"
-		snapID      = "snap-with-components-id"
+		snapName    = "kernel-snap-with-components"
+		instanceKey = ""
+		snapID      = "kernel-snap-with-components-id"
 		channel     = "channel-for-components-only-component-refresh"
 	)
+
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	defer r()
 
 	components := []string{"standard-component", "kernel-modules-component"}
 
@@ -14760,7 +14765,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		Channel:  channel,
 	}
 
-	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &currentSI)
+	snaptest.MockSnapInstance(c, instanceName,
+		fmt.Sprintf("name: %s\ntype: kernel\n", snapName), &currentSI)
 
 	restore := snapstate.MockRevisionDate(nil)
 	defer restore()
@@ -14894,7 +14900,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		Active:          true,
 		Sequence:        seq,
 		Current:         currentSI.Revision,
-		SnapType:        "app",
+		SnapType:        "kernel",
 		TrackingChannel: channel,
 		InstanceKey:     instanceKey,
 	})
@@ -15008,6 +15014,14 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
 		},
 		{
+			op: "prepare-kernel-snap",
+		},
+		{
+			op:    "update-gadget-assets:Doing",
+			name:  "kernel-snap-with-components",
+			revno: prevSnapRev,
+		},
+		{
 			op:   "copy-data",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
 			old:  filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
@@ -15031,11 +15045,9 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			},
 		},
 		{
-			op:   "link-snap",
-			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
-		},
-		{
-			op: "maybe-set-next-boot",
+			op:                  "link-snap",
+			path:                filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+			requireSnapdTooling: true,
 		},
 	}...)
 
@@ -15062,6 +15074,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			op:           "prepare-kernel-modules-components",
 			currentComps: currentKmodComps,
 			finalComps:   newKmodComps,
+		}, fakeOp{
+			op: "maybe-set-next-boot",
 		})
 	}
 
@@ -15070,6 +15084,9 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	discardedContainerName := fmt.Sprintf("%s+%s", instanceName, extraCsi.Component.ComponentName)
 	discardedFilename := fmt.Sprintf("%s_%v.comp", discardedContainerName, extraCsi.Revision)
 	expected = append(expected, []fakeOp{
+		{
+			op: "remove-kernel-snap-setup",
+		},
 		{
 			op:                "undo-setup-component",
 			containerName:     discardedContainerName,
@@ -15104,8 +15121,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		Version:   "snap-with-componentsVer",
+		Type:      snap.TypeKernel,
+		Version:   "kernel-snap-with-componentsVer",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
 			Transaction: client.TransactionPerSnap,
@@ -15152,11 +15169,14 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponents(c *C) {
 	const (
-		snapName    = "snap-with-components"
-		instanceKey = "key"
-		snapID      = "snap-with-components-id"
+		snapName    = "kernel-snap-with-components"
+		instanceKey = ""
+		snapID      = "kernel-snap-with-components-id"
 		channel     = "channel-for-components-only-component-refresh"
 	)
+
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	defer r()
 
 	currentSnapRev := snap.R(11)
 	prevSnapRev := snap.R(7)
@@ -15172,7 +15192,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 		Channel:  channel,
 	}
 
-	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &currentSI)
+	snaptest.MockSnapInstance(c, instanceName,
+		fmt.Sprintf("name: %s\ntype: kernel\n", snapName), &currentSI)
 
 	restore := snapstate.MockRevisionDate(nil)
 	defer restore()
@@ -15237,7 +15258,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 		Active:          true,
 		Sequence:        seq,
 		Current:         currentSI.Revision,
-		SnapType:        "app",
+		SnapType:        "kernel",
 		TrackingChannel: channel,
 		InstanceKey:     instanceKey,
 	})
@@ -15351,6 +15372,14 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
 		},
 		{
+			op: "prepare-kernel-snap",
+		},
+		{
+			op:    "update-gadget-assets:Doing",
+			name:  "kernel-snap-with-components",
+			revno: prevSnapRev,
+		},
+		{
 			op:   "copy-data",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
 			old:  filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
@@ -15374,11 +15403,9 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 			},
 		},
 		{
-			op:   "link-snap",
-			path: filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
-		},
-		{
-			op: "maybe-set-next-boot",
+			op:                  "link-snap",
+			path:                filepath.Join(dirs.SnapMountDir, instanceName, prevSnapRev.String()),
+			requireSnapdTooling: true,
 		},
 		{
 			op:   "link-component",
@@ -15405,6 +15432,12 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 			currentComps: []*snap.ComponentSideInfo{},
 			finalComps:   newKmodComps,
 		},
+		{
+			op: "maybe-set-next-boot",
+		},
+		{
+			op: "remove-kernel-snap-setup",
+		},
 	}...)
 
 	expected = append(expected, fakeOp{
@@ -15429,8 +15462,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		Version:   "snap-with-componentsVer",
+		Type:      snap.TypeKernel,
+		Version:   "kernel-snap-with-componentsVer",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
 			Transaction: client.TransactionPerSnap,
@@ -15477,16 +15510,18 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThrough(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		snapType:   snap.TypeKernel,
 		components: []string{"standard-component", "kernel-modules-component"},
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughNoComponents(c *C) {
-	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{})
+	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{snapType: snap.TypeKernel})
 }
 
 func (s *snapmgrTestSuite) TestUpdateExplicitlyToSameRevisionRunThrough(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		snapType:              snap.TypeKernel,
 		useSameSnapRev:        true,
 		refreshAppAwarenessUX: true,
 	})
@@ -15494,6 +15529,7 @@ func (s *snapmgrTestSuite) TestUpdateExplicitlyToSameRevisionRunThrough(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateExplicitlyToSameRevisionRunThroughUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		snapType:              snap.TypeKernel,
 		useSameSnapRev:        true,
 		undo:                  true,
 		refreshAppAwarenessUX: true,
@@ -15502,6 +15538,7 @@ func (s *snapmgrTestSuite) TestUpdateExplicitlyToSameRevisionRunThroughUndo(c *C
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component", "kernel-modules-component"},
 		refreshAppAwarenessUX: true,
 		undo:                  true,
@@ -15510,16 +15547,19 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughUndo(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughInstanceKey(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		snapType:              snap.TypeApp,
 		instanceKey:           "key",
-		components:            []string{"standard-component", "kernel-modules-component"},
+		components:            []string{"standard-component", "standard-component-extra"},
 		refreshAppAwarenessUX: true,
+		undo:                  false,
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughInstanceKeyUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
+		snapType:              snap.TypeApp,
 		instanceKey:           "key",
-		components:            []string{"standard-component", "kernel-modules-component"},
+		components:            []string{"standard-component", "standard-component-extra"},
 		refreshAppAwarenessUX: true,
 		undo:                  true,
 	})
@@ -15527,7 +15567,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughInstanceKeyUndo(c *
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughLoseComponents(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		instanceKey:           "key",
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component", "kernel-modules-component"},
 		postRefreshComponents: []string{"standard-component"},
 		refreshAppAwarenessUX: true,
@@ -15536,7 +15576,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughLoseComponents(c *C
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughLoseComponentsUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		instanceKey:           "key",
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component", "kernel-modules-component"},
 		postRefreshComponents: []string{"standard-component"},
 		refreshAppAwarenessUX: true,
@@ -15546,7 +15586,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughLoseComponentsUndo(
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponents(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		instanceKey:           "key",
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component"},
 		postRefreshComponents: []string{"standard-component", "kernel-modules-component"},
 		additionalComponents:  []string{"kernel-modules-component"},
@@ -15556,7 +15596,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponent
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponentsAlreadyInstalled(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		instanceKey:           "key",
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component"},
 		postRefreshComponents: []string{"standard-component"},
 		additionalComponents:  []string{"standard-component"},
@@ -15566,7 +15606,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponent
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponentsUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		instanceKey:           "key",
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component"},
 		postRefreshComponents: []string{"standard-component", "kernel-modules-component"},
 		additionalComponents:  []string{"kernel-modules-component"},
@@ -15577,12 +15617,22 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponent
 
 type updateWithComponentsOpts struct {
 	instanceKey           string
+	snapType              snap.Type
 	components            []string
 	postRefreshComponents []string
 	additionalComponents  []string
 	refreshAppAwarenessUX bool
 	undo                  bool
 	useSameSnapRev        bool
+}
+
+func findKindInTaskSet(ts *state.TaskSet, kind string) *state.Task {
+	for _, t := range ts.Tasks() {
+		if t.Kind() == kind {
+			return t
+		}
+	}
+	return nil
 }
 
 func componentNameToType(c *C, name string) snap.ComponentType {
@@ -15598,10 +15648,21 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		s.enableRefreshAppAwarenessUX()
 	}
 
-	const (
-		snapName = "some-snap"
-		snapID   = "some-snap-id"
-	)
+	var snapName, snapID string
+	switch opts.snapType {
+	case snap.TypeKernel:
+		s.fakeBackend.linkSnapMaybeReboot = true
+		snapName = "kernel-snap-with-components"
+		snapID = "kernel-snap-with-components-id"
+	case snap.TypeApp:
+		snapName = "app-snap-with-components"
+		snapID = "app-snap-with-components-id"
+	default:
+		c.Error("boo")
+	}
+
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	defer r()
 
 	channel := "channel-for-components"
 	currentSnapRev := snap.R(7)
@@ -15657,7 +15718,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		SnapID:   snapID,
 		Channel:  channel,
 	}
-	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &si)
+	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s\ntype: %s\n",
+		snapName, opts.snapType), &si)
 	fi, err := os.Stat(snap.MountFile(instanceName, si.Revision))
 	c.Assert(err, IsNil)
 
@@ -15714,6 +15776,22 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		})
 	}
 
+	newKmodComps := make([]*snap.ComponentSideInfo, 0, len(expectedComponentStates))
+	for _, cs := range expectedComponentStates {
+		if cs.CompType == snap.KernelModulesComponent {
+			newKmodComps = append(newKmodComps, cs.SideInfo)
+		}
+	}
+
+	currentKmodComps := make([]*snap.ComponentSideInfo, 0, len(currentComponentStates))
+	for _, cs := range currentComponentStates {
+		if cs.CompType == snap.KernelModulesComponent {
+			currentKmodComps = append(currentKmodComps, cs.SideInfo)
+		}
+	}
+
+	withKMods := len(currentKmodComps) > 0 || len(newKmodComps) > 0
+
 	s.AddCleanup(snapstate.MockReadComponentInfo(func(
 		compMntDir string, info *snap.Info, csi *snap.ComponentSideInfo,
 	) (*snap.ComponentInfo, error) {
@@ -15729,7 +15807,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		Active:          true,
 		Sequence:        currentSeq,
 		Current:         si.Revision,
-		SnapType:        "app",
+		SnapType:        string(opts.snapType),
 		TrackingChannel: channel,
 		InstanceKey:     opts.instanceKey,
 	})
@@ -15751,6 +15829,42 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		UserID: s.user.ID,
 	})
 	c.Assert(err, IsNil)
+
+	// Check boundaries are in the expected tasks
+	var setNextBoot, finishRestart bool
+	preRebootTask, err := ts.Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	postRebootTask, err := ts.Edge(snapstate.MaybeRebootWaitEdge)
+	c.Assert(err, IsNil)
+	if opts.snapType == snap.TypeKernel {
+		var restartBoundary restart.RestartBoundaryDirection
+		c.Check(preRebootTask.Get("restart-boundary", &restartBoundary), IsNil)
+		c.Check(restartBoundary, Equals, restart.RestartBoundaryDirectionDo)
+	}
+	if withKMods {
+		// Implies this is a kernel
+		c.Check(preRebootTask.Kind(), Equals, "prepare-kernel-modules-components")
+		c.Check(postRebootTask.Kind(), Equals, "discard-old-kernel-snap-setup")
+		lnTask := findKindInTaskSet(ts, "link-snap")
+		autoConnTask := findKindInTaskSet(ts, "auto-connect")
+		c.Check(lnTask.Get("set-next-boot", &setNextBoot), IsNil)
+		c.Check(setNextBoot, Equals, false)
+		c.Check(autoConnTask.Get("finish-restart", &finishRestart), IsNil)
+		c.Check(finishRestart, Equals, false)
+	} else {
+		c.Check(preRebootTask.Kind(), Equals, "link-snap")
+		c.Check(postRebootTask.Kind(), Equals, "auto-connect")
+		c.Check(findKindInTaskSet(ts, "prepare-kernel-modules-components"), IsNil)
+		if opts.snapType == snap.TypeKernel {
+			discardTask := findKindInTaskSet(ts, "discard-old-kernel-snap-setup")
+			c.Check(discardTask.Get("finish-restart", &setNextBoot), IsNil)
+			c.Check(setNextBoot, Equals, false)
+		}
+	}
+	c.Check(preRebootTask.Get("set-next-boot", &setNextBoot), IsNil)
+	c.Check(setNextBoot, Equals, true)
+	c.Check(postRebootTask.Get("finish-restart", &finishRestart), IsNil)
+	c.Check(finishRestart, Equals, true)
 
 	chg := s.state.NewChange("refresh", "refresh a snap")
 	chg.AddAll(ts)
@@ -15788,12 +15902,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 	err = s.o.Settle(testutil.HostScaledTimeout(15 * time.Second))
 	s.state.Lock()
 	c.Assert(err, IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
-
-	if opts.undo {
-		c.Assert(chg.Err(), NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
-	} else {
-		c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
-	}
 
 	var expected fakeOps
 	if !opts.useSameSnapRev {
@@ -15896,7 +16004,17 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
 			unlinkSkipBinaries: opts.refreshAppAwarenessUX,
-		},
+		}}...)
+	if opts.snapType == snap.TypeKernel {
+		expected = append(expected, fakeOp{
+			op: "prepare-kernel-snap",
+		}, fakeOp{
+			op:    "update-gadget-assets:Doing",
+			name:  instanceName,
+			revno: newSnapRev,
+		})
+	}
+	expected = append(expected, fakeOps{
 		{
 			op:   "copy-data",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
@@ -15924,13 +16042,25 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 			},
 		},
 		{
-			op:   "link-snap",
-			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
-		},
-		{
-			op: "maybe-set-next-boot",
+			op:                  "link-snap",
+			path:                filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
+			requireSnapdTooling: true,
 		},
 	}...)
+
+	if !withKMods {
+		expected = append(expected, fakeOp{
+			op: "maybe-set-next-boot",
+		})
+		if s.fakeBackend.linkSnapMaybeReboot {
+			// check for tasks up to rebooting
+			// start with an easier-to-read error if this fails:
+			c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+			c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+			// mock restart step and run change to completion.
+			s.mockRestartAndSettle(c, chg)
+		}
+	}
 
 	for _, cs := range expectedComponentStates {
 		compName := cs.SideInfo.Component.ComponentName
@@ -15952,25 +16082,32 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		},
 	}...)
 
-	currentKmodComps := make([]*snap.ComponentSideInfo, 0, len(currentComponentStates))
-	for _, cs := range currentComponentStates {
-		if cs.CompType == snap.KernelModulesComponent {
-			currentKmodComps = append(currentKmodComps, cs.SideInfo)
-		}
-	}
-
-	newKmodComps := make([]*snap.ComponentSideInfo, 0, len(expectedComponentStates))
-	for _, cs := range expectedComponentStates {
-		if cs.CompType == snap.KernelModulesComponent {
-			newKmodComps = append(newKmodComps, cs.SideInfo)
-		}
-	}
-
-	if len(currentKmodComps) > 0 || len(newKmodComps) > 0 {
+	if withKMods {
 		expected = append(expected, fakeOp{
 			op:           "prepare-kernel-modules-components",
 			currentComps: currentKmodComps,
 			finalComps:   newKmodComps,
+		}, fakeOp{
+			op: "maybe-set-next-boot",
+		})
+		// check for tasks up to rebooting
+		// start with an easier-to-read error if this fails:
+		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+		c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+		// mock restart step and run change to completion.
+		s.mockRestartAndSettle(c, chg)
+	}
+
+	// We've now run the task to completion also for reboot cases
+	if opts.undo {
+		c.Assert(chg.Err(), NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	} else {
+		c.Assert(chg.Err(), IsNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	}
+
+	if opts.snapType == snap.TypeKernel {
+		expected = append(expected, fakeOp{
+			op: "remove-kernel-snap-setup",
 		})
 	}
 
@@ -15984,7 +16121,14 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 	originalSideState := currentSeq.Revisions[0]
 
 	if opts.undo {
-		expected = append(expected, undoOps(instanceName, expectedSideState, originalSideState)...)
+		if opts.snapType == snap.TypeKernel {
+			// undo for "remove-kernel-snap-setup"
+			expected = append(expected, fakeOp{
+				op: "prepare-kernel-snap",
+			})
+		}
+		expected = append(expected,
+			undoOps(instanceName, opts.snapType, expectedSideState, originalSideState)...)
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",
@@ -16039,8 +16183,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, newSnapRev)),
 		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		Version:   "some-snapVer",
+		Type:      opts.snapType,
+		Version:   snapName + "Ver",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
 			Transaction: client.TransactionPerSnap,
@@ -16288,34 +16432,70 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithComponentsRemoved(c *C) {
 func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathRunThrough(c *C) {
 	const (
 		instanceKey           = ""
+		snapType              = snap.TypeKernel
 		refreshAppAwarenessUX = true
 		undo                  = false
 	)
-	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, []string{"standard-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
+	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
+		[]string{"standard-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathRunThroughUndo(c *C) {
 	const (
 		instanceKey           = ""
+		snapType              = snap.TypeKernel
 		refreshAppAwarenessUX = true
 		undo                  = true
 	)
-	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, []string{"standard-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
+	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
+		[]string{"standard-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
 }
 
-func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, instanceKey string, compNames []string, refreshAppAwarenessUX, undo bool) {
+func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsFromPathRunThrough(c *C) {
+	const (
+		instanceKey           = "key"
+		snapType              = snap.TypeApp
+		refreshAppAwarenessUX = true
+		undo                  = false
+	)
+	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
+		[]string{"standard-component", "standard-component-extra"}, refreshAppAwarenessUX, undo)
+}
+
+func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsFromPathRunThroughUndo(c *C) {
+	const (
+		instanceKey           = "key"
+		snapType              = snap.TypeApp
+		refreshAppAwarenessUX = true
+		undo                  = true
+	)
+	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
+		[]string{"standard-component", "standard-component-extra"}, refreshAppAwarenessUX, undo)
+}
+
+func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, instanceKey string, snapType snap.Type, compNames []string, refreshAppAwarenessUX, undo bool) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	const (
+		channel = "channel-for-components"
+	)
+	var snapName, snapID string
+	switch snapType {
+	case snap.TypeKernel:
+		snapName = "kernel"
+		snapID = "kernel-id"
+	case snap.TypeApp:
+		snapName = "some-snap"
+		snapID = "some-snap-id"
+	}
+
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	defer r()
 
 	if refreshAppAwarenessUX {
 		s.enableRefreshAppAwarenessUX()
 	}
-
-	const (
-		snapName = "some-snap"
-		snapID   = "some-snap-id"
-		channel  = "channel-for-components"
-	)
 
 	currentSnapRev := snap.R(7)
 	newSnapRev := snap.R(11)
@@ -16330,9 +16510,20 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, inst
 		Channel:  channel,
 	}
 
-	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &si)
+	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s\ntype: %s\n", snapName, snapType), &si)
 
-	restore := snapstate.MockRevisionDate(nil)
+	bl := boottest.MockUC20RunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bl.SetBootVars(map[string]string{"snap_kernel": snapName, "snap_core": "core24_2.snap"})
+	bootloader.Force(bl)
+	defer bootloader.Force(nil)
+
+	// This is the new revision as this information is accessed after the reboot
+	kPlaceInfo, err := snap.ParsePlaceInfoFromSnapFileName("kernel_" + newSnapRev.String() + ".snap")
+	c.Assert(err, IsNil)
+	restore := bl.SetEnabledKernel(kPlaceInfo)
+	defer restore()
+
+	restore = snapstate.MockRevisionDate(nil)
 	defer restore()
 
 	now, err := time.Parse(time.RFC3339, "2021-06-10T10:00:00Z")
@@ -16413,7 +16604,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, inst
 		Active:          true,
 		Sequence:        currentSeq,
 		Current:         si.Revision,
-		SnapType:        "app",
+		SnapType:        string(snapType),
 		TrackingChannel: channel,
 		InstanceKey:     instanceKey,
 	})
@@ -16431,7 +16622,10 @@ version: 1.0
 		components[cs.SideInfo] = path
 	}
 
-	snapPath := makeTestSnap(c, fmt.Sprintf(`name: %s
+	var snapPath string
+	switch snapType {
+	case snap.TypeKernel:
+		snapPath = makeTestSnap(c, `name: kernel
 version: some-snapVer
 type: kernel
 epoch: 1*
@@ -16440,7 +16634,19 @@ components:
     type: standard
   kernel-modules-component:
     type: kernel-modules
-    `, snapName))
+`)
+	case snap.TypeApp:
+		snapPath = makeTestSnap(c, `name: some-snap
+version: some-snapVer
+type: app
+epoch: 1*
+components:
+  standard-component:
+    type: standard
+  standard-component-extra:
+    type: standard
+`)
+	}
 
 	newSI := si
 	newSI.Revision = newSnapRev
@@ -16539,12 +16745,18 @@ components:
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
 			unlinkSkipBinaries: refreshAppAwarenessUX,
-		},
-		{
-			op:    "update-gadget-assets:Doing",
-			name:  instanceName,
-			revno: newSnapRev,
-		},
+		}}...)
+	if snapType == snap.TypeKernel {
+		expected = append(expected,
+			fakeOp{
+				op: "prepare-kernel-snap",
+			}, fakeOp{
+				op:    "update-gadget-assets:Doing",
+				name:  instanceName,
+				revno: newSnapRev,
+			})
+	}
+	expected = append(expected, fakeOps{
 		{
 			op:   "copy-data",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
@@ -16572,29 +16784,9 @@ components:
 			},
 		},
 		{
-			op:   "link-snap",
-			path: filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
-		},
-		{
-			op: "maybe-set-next-boot",
-		},
-	}...)
-
-	for _, cs := range expectedComponentStates {
-		expected = append(expected, fakeOp{
-			op:   "link-component",
-			path: snap.ComponentMountDir(cs.SideInfo.Component.ComponentName, cs.SideInfo.Revision, instanceName),
-		})
-	}
-
-	expected = append(expected, fakeOps{
-		{
-			op:    "auto-connect:Doing",
-			name:  instanceName,
-			revno: snap.R(11),
-		},
-		{
-			op: "update-aliases",
+			op:                  "link-snap",
+			path:                filepath.Join(dirs.SnapMountDir, instanceName, newSnapRev.String()),
+			requireSnapdTooling: true,
 		},
 	}...)
 
@@ -16614,6 +16806,30 @@ components:
 		}
 	}
 
+	if len(currentKmodComps) == 0 && len(newKmodComps) == 0 {
+		expected = append(expected, fakeOp{
+			op: "maybe-set-next-boot",
+		})
+	}
+
+	for _, cs := range expectedComponentStates {
+		expected = append(expected, fakeOp{
+			op:   "link-component",
+			path: snap.ComponentMountDir(cs.SideInfo.Component.ComponentName, cs.SideInfo.Revision, instanceName),
+		})
+	}
+
+	expected = append(expected, fakeOps{
+		{
+			op:    "auto-connect:Doing",
+			name:  instanceName,
+			revno: snap.R(11),
+		},
+		{
+			op: "update-aliases",
+		},
+	}...)
+
 	if len(currentKmodComps) > 0 || len(newKmodComps) > 0 {
 		expected = append(expected, fakeOp{
 			op:           "prepare-kernel-modules-components",
@@ -16622,8 +16838,22 @@ components:
 		})
 	}
 
+	if snapType == snap.TypeKernel {
+		expected = append(expected, fakeOp{
+			op: "maybe-set-next-boot",
+		}, fakeOp{
+			op: "remove-kernel-snap-setup",
+		})
+	}
+
 	if undo {
-		expected = append(expected, undoOps(instanceName, expectedSideState, originalSideState)...)
+		if snapType == snap.TypeKernel {
+			// undo for "remove-kernel-snap-setup"
+			expected = append(expected, fakeOp{
+				op: "prepare-kernel-snap",
+			})
+		}
+		expected = append(expected, undoOps(instanceName, snapType, expectedSideState, originalSideState)...)
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",
@@ -16646,7 +16876,7 @@ components:
 		Channel:   channel,
 		SnapPath:  snapPath,
 		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeKernel,
+		Type:      snapType,
 		Version:   "some-snapVer",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
@@ -16718,7 +16948,7 @@ components:
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughOnlyComponentUpdate(c *C) {
 	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
-		instanceKey:           "key",
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component", "kernel-modules-component"},
 		refreshAppAwarenessUX: true,
 	})
@@ -16726,14 +16956,37 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughOnlyComponentUpdate
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughOnlyComponentUpdateUndo(c *C) {
 	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
-		instanceKey:           "key",
+		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component", "kernel-modules-component"},
 		refreshAppAwarenessUX: true,
 		undo:                  true,
 	})
 }
 
+func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsRunThroughOnlyComponentUpdate(c *C) {
+	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
+		snapType:              snap.TypeApp,
+		instanceKey:           "key",
+		components:            []string{"standard-component", "standard-component-extra"},
+		refreshAppAwarenessUX: true,
+	})
+}
+
+func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsRunThroughOnlyComponentUpdateUndo(c *C) {
+	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
+		snapType:              snap.TypeApp,
+		instanceKey:           "key",
+		components:            []string{"standard-component", "standard-component-extra"},
+		refreshAppAwarenessUX: true,
+		undo:                  true,
+	})
+}
+
 func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate(c *C, opts updateWithComponentsOpts) {
+	model := MakeModel20("pc", map[string]interface{}{"base": "core24"})
+	r := snapstatetest.MockDeviceModel(model)
+	defer r()
+
 	if opts.postRefreshComponents != nil {
 		c.Fatalf("when refreshing a snap that results in only component revision changes, you cannot lose or gain components")
 	}
@@ -16742,13 +16995,28 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		s.enableRefreshAppAwarenessUX()
 	}
 
-	const (
+	var snapName, snapID string
+	switch opts.snapType {
+	case snap.TypeKernel:
+		snapName = "kernel"
+		snapID = "kernel-id"
+	case snap.TypeApp:
 		snapName = "some-snap"
-		snapID   = "some-snap-id"
-	)
+		snapID = "some-snap-id"
+	}
+
+	bl := boottest.MockUC20RunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bl.SetBootVars(map[string]string{"snap_kernel": snapName, "snap_core": "core24_2.snap"})
+	bootloader.Force(bl)
+	defer bootloader.Force(nil)
+
+	currentSnapRev := snap.R(7)
+	kPlaceInfo, err := snap.ParsePlaceInfoFromSnapFileName("kernel_" + currentSnapRev.String() + ".snap")
+	c.Assert(err, IsNil)
+	restore := bl.SetEnabledKernel(kPlaceInfo)
+	defer restore()
 
 	channel := "channel-for-components-only-component-refresh"
-	currentSnapRev := snap.R(7)
 	s.fakeStore.refreshRevnos = map[string]snap.Revision{
 		snapID: currentSnapRev,
 	}
@@ -16767,14 +17035,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		updatedCompRevisions[compName] = snap.R(i + 2)
 	}
 
-	compNameToType := func(name string) snap.ComponentType {
-		typ := strings.TrimSuffix(name, "-component")
-		if typ == name {
-			c.Fatalf("unexpected component name %q", name)
-		}
-		return snap.ComponentType(typ)
-	}
-
 	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
 		c.Assert(info.InstanceName(), DeepEquals, instanceName)
 		var results []store.SnapResourceResult
@@ -16785,7 +17045,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 				},
 				Name:      compName,
 				Revision:  updatedCompRevisions[compName].N,
-				Type:      fmt.Sprintf("component/%s", compNameToType(compName)),
+				Type:      fmt.Sprintf("component/%s", componentNameToType(c, compName)),
 				Version:   "1.0",
 				CreatedAt: "2024-01-01T00:00:00Z",
 			})
@@ -16803,13 +17063,14 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		Channel:  channel,
 	}
 
-	snaptest.MockSnapInstance(c, instanceName, fmt.Sprintf("name: %s", snapName), &si)
+	snaptest.MockSnapInstance(c, instanceName,
+		fmt.Sprintf("name: %s\ntype: %s\n", snapName, opts.snapType), &si)
 	fi, err := os.Stat(snap.MountFile(instanceName, si.Revision))
 	c.Assert(err, IsNil)
 
 	refreshedDate := fi.ModTime()
 
-	restore := snapstate.MockRevisionDate(nil)
+	restore = snapstate.MockRevisionDate(nil)
 	defer restore()
 
 	now, err := time.Parse(time.RFC3339, "2021-06-10T10:00:00Z")
@@ -16838,7 +17099,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 				Component: naming.NewComponentRef(snapName, comp),
 				Revision:  originalCompRevisions[comp],
 			},
-			CompType: compNameToType(comp),
+			CompType: componentNameToType(c, comp),
 		})
 		c.Assert(err, IsNil)
 
@@ -16856,7 +17117,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 				Component: naming.NewComponentRef(snapName, comp),
 				Revision:  updatedCompRevisions[comp],
 			},
-			CompType: compNameToType(comp),
+			CompType: componentNameToType(c, comp),
 		})
 	}
 
@@ -16865,7 +17126,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 	) (*snap.ComponentInfo, error) {
 		return &snap.ComponentInfo{
 			Component:         csi.Component,
-			Type:              compNameToType(csi.Component.ComponentName),
+			Type:              componentNameToType(c, csi.Component.ComponentName),
 			CompVersion:       "1.0",
 			ComponentSideInfo: *csi,
 		}, nil
@@ -16875,7 +17136,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		Active:          true,
 		Sequence:        currentSeq,
 		Current:         si.Revision,
-		SnapType:        "app",
+		SnapType:        string(opts.snapType),
 		TrackingChannel: channel,
 		InstanceKey:     opts.instanceKey,
 	})
@@ -16983,17 +17244,28 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		}}...)
 	}
 
-	expected = append(expected, fakeOps{
-		{
+	expected = append(expected,
+		fakeOp{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        instanceName,
 			inhibitHint: "refresh",
-		},
-		{
+		}, fakeOp{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
 			unlinkSkipBinaries: opts.refreshAppAwarenessUX,
-		},
+		})
+	if opts.snapType == snap.TypeKernel {
+		expected = append(expected,
+			fakeOp{
+				op: "prepare-kernel-snap",
+			},
+			fakeOp{
+				op:    "update-gadget-assets:Doing",
+				name:  "kernel",
+				revno: currentSnapRev,
+			})
+	}
+	expected = append(expected, fakeOps{
 		{
 			op:   "copy-data",
 			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
@@ -17021,13 +17293,31 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 			},
 		},
 		{
-			op:   "link-snap",
-			path: filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
-		},
-		{
-			op: "maybe-set-next-boot",
+			op:                  "link-snap",
+			path:                filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+			requireSnapdTooling: true,
 		},
 	}...)
+
+	var currentKmodComps = []*snap.ComponentSideInfo{}
+	for _, cs := range currentComponentStates {
+		if cs.CompType == snap.KernelModulesComponent {
+			currentKmodComps = append(currentKmodComps, cs.SideInfo)
+		}
+	}
+
+	var newKmodComps = []*snap.ComponentSideInfo{}
+	for _, cs := range expectedComponentStates {
+		if cs.CompType == snap.KernelModulesComponent {
+			newKmodComps = append(newKmodComps, cs.SideInfo)
+		}
+	}
+
+	if len(currentKmodComps) == 0 && len(newKmodComps) == 0 {
+		expected = append(expected, fakeOp{
+			op: "maybe-set-next-boot",
+		})
+	}
 
 	for _, cs := range expectedComponentStates {
 		compName := cs.SideInfo.Component.ComponentName
@@ -17051,26 +17341,18 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		},
 	}...)
 
-	var currentKmodComps []*snap.ComponentSideInfo
-	for _, cs := range currentComponentStates {
-		if cs.CompType == snap.KernelModulesComponent {
-			currentKmodComps = append(currentKmodComps, cs.SideInfo)
-		}
-	}
-
-	var newKmodComps []*snap.ComponentSideInfo
-	for _, cs := range expectedComponentStates {
-		if cs.CompType == snap.KernelModulesComponent {
-			newKmodComps = append(newKmodComps, cs.SideInfo)
-		}
-	}
-
 	if len(currentKmodComps) > 0 || len(newKmodComps) > 0 {
 		expected = append(expected, fakeOp{
 			op:           "prepare-kernel-modules-components",
 			currentComps: currentKmodComps,
 			finalComps:   newKmodComps,
+		}, fakeOp{
+			op: "maybe-set-next-boot",
 		})
+	}
+
+	if opts.snapType == snap.TypeKernel {
+		expected = append(expected, fakeOp{op: "remove-kernel-snap-setup"})
 	}
 
 	for _, cs := range currentComponentStates {
@@ -17096,7 +17378,13 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 	originalSideState := currentSeq.Revisions[0]
 
 	if opts.undo {
-		expected = append(expected, undoOps(instanceName, expectedSideState, originalSideState)...)
+		if opts.snapType == snap.TypeKernel {
+			// undo for "remove-kernel-snap-setup"
+			expected = append(expected, fakeOp{
+				op: "prepare-kernel-snap",
+			})
+		}
+		expected = append(expected, undoOps(instanceName, opts.snapType, expectedSideState, originalSideState)...)
 	} else {
 		expected = append(expected, fakeOp{
 			op:    "cleanup-trash",
@@ -17127,6 +17415,9 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 	var snapsup snapstate.SnapSetup
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
+	c.Assert(snapsup.DownloadInfo, DeepEquals, &snap.DownloadInfo{
+		DownloadURL: "https://some-server.com/some/path.snap",
+	})
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: channel,
 		UserID:  s.user.ID,
@@ -17134,8 +17425,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		Version:   "some-snapVer",
+		Type:      opts.snapType,
+		Version:   snapName + "Ver",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
 			Transaction: client.TransactionPerSnap,

--- a/tests/nested/manual/kernel-modules-components/task.yaml
+++ b/tests/nested/manual/kernel-modules-components/task.yaml
@@ -80,3 +80,26 @@ execute: |
   remote.exec sudo snap remove pc-kernel+wifi-comp
   not remote.exec grep mac80211_hwsim /lib/modules/*/modules.dep
   not remote.exec sudo modprobe mac80211_hwsim
+
+  # Rule to force module loading on system start (we randomly choose
+  # the rtc device add event for this)
+  rule='ACTION==\"add\", SUBSYSTEM==\"rtc\", KERNEL==\"rtc*\", RUN{builtin}+=\"kmod load mac80211_hwsim\"\n'
+  remote.exec "sudo sh -c 'printf \"$rule\" > /etc/udev/rules.d/70-load-wifi.rules'"
+
+  # Install jointly kernel with component
+  remote.push pc-kernel_*.snap
+  boot_id=$(tests.nested boot-id)
+  remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel_*.snap "$comp_file")
+  tests.nested wait-for reboot "$boot_id"
+  remote.exec "snap change $remote_chg_id" | NOMATCH Error
+  # Check that the module has been loaded by the udev rule
+  remote.exec ip link show wlan0
+
+  # Install again, but force a failure to check revert
+  boot_id=$(tests.nested boot-id)
+  remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel_*.snap "$comp_file")
+  remote.retry --wait 1 -n 100 'sudo rm /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi'
+  tests.nested wait-for reboot "$boot_id"
+  remote.retry --wait 5 -n 60 "snap change $remote_chg_id | MATCH Error"
+  # Module is still loaded
+  remote.exec ip link show wlan0


### PR DESCRIPTION
Delay reboot when we are installing/updating/removing kernel-modules
components jointly with a kernel refresh so it happens after the
refresh hooks have run. With this we ensure that the kernel modules
shipped in the component or built from the hooks is available at the
same time as the other modules after rebooting.
