### PR TITLE
overlord/fdestate/fdestate.go: fix path to data mount point on hybrid

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -141,6 +141,11 @@ var (
 	SysfsDir string
 
 	FeaturesDir string
+
+	// WritableMountPath is a path where writable root data is
+	// mounted. For Classic it is /, but Ubuntu Core it is
+	// /writable.
+	WritableMountPath string
 )
 
 // User defined home directory variables
@@ -633,6 +638,14 @@ func SetRootDir(rootdir string) {
 	// global vars if they want, instead of using the new rootdir directly
 	for _, c := range callbacks {
 		c(rootdir)
+	}
+
+	if release.OnClassic {
+		// On Classic, the data disk is mounted as /
+		WritableMountPath = rootdir
+	} else {
+		// If on Core /writable is a bind mount from data dir
+		WritableMountPath = filepath.Join(rootdir, "writable")
 	}
 
 }

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -290,3 +290,17 @@ func (s *DirsTestSuite) TestLibexecdirOpenSUSEFlavors(c *C) {
 	dirs.SetRootDir("/")
 	c.Check(dirs.DistroLibExecDir, Equals, "/usr/libexec/snapd")
 }
+
+func (s *DirsTestSuite) TestWritableMountPath(c *C) {
+	release.MockOnClassic(true)
+	dirs.SetRootDir("/")
+
+	c.Check(dirs.WritableMountPath, Equals, "/")
+}
+
+func (s *DirsTestSuite) TestWritableMountPathCore(c *C) {
+	release.MockOnClassic(false)
+	dirs.SetRootDir("/")
+
+	c.Check(dirs.WritableMountPath, Equals, "/writable")
+}

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -218,7 +218,7 @@ func initializeState(st *state.State) error {
 
 	// FIXME mount points will be different in recovery or factory-reset modes
 	// either inspect degraded.json, or use boot.HostUbuntuDataForMode()
-	dataUUID, dataErr := disksDMCryptUUIDFromMountPoint(dirs.SnapdStateDir(dirs.GlobalRootDir))
+	dataUUID, dataErr := disksDMCryptUUIDFromMountPoint(dirs.WritableMountPath)
 	saveUUID, saveErr := disksDMCryptUUIDFromMountPoint(dirs.SnapSaveDir)
 	if errors.Is(saveErr, disks.ErrMountPointNotFound) {
 		// TODO: do we need to care about old cases where there is no save partition?

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -7461,7 +7461,9 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 
 	restore = fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		switch mountpoint {
-		case dirs.SnapdStateDir(dirs.GlobalRootDir):
+		case filepath.Join(dirs.GlobalRootDir, "writable"):
+			return "root-uuid", nil
+		case dirs.GlobalRootDir:
 			return "root-uuid", nil
 		case dirs.SnapSaveDir:
 			return "save-uuid", nil


### PR DESCRIPTION
We used a path that is not a mount point on hybrid to discover the data disk. Instead we now use / for hybrid, and /writable on core.

