### PR TITLE
tests: extend nvidia-files to check 24.10

### DIFF
--- a/tests/main/nvidia-files/task.yaml
+++ b/tests/main/nvidia-files/task.yaml
@@ -13,7 +13,10 @@ details: |
 
 systems:
     - ubuntu-18.04-64
-    - ubuntu-2*.04-64
+    - ubuntu-20.04-64
+    - ubuntu-22.04-64
+    - ubuntu-24.04-64
+    - ubuntu-24.10-64
 
 environment:
     # WARNING: Not all combinations of system and variant do something.
@@ -26,6 +29,7 @@ environment:
     PACKAGE_VERSION/530: 530
     PACKAGE_VERSION/535: 535
     PACKAGE_VERSION/550: 550
+    PACKAGE_VERSION/560: 560
     # All the -server versions.
     PACKAGE_SUFFIX/418_server: -server
     PACKAGE_SUFFIX/450_server: -server
@@ -54,6 +58,8 @@ prepare: |
     skip["ubuntu-18.04-64/535-server"]="no-driver"
     skip["ubuntu-18.04-64/550"]="no-driver"
     skip["ubuntu-18.04-64/550-server"]="no-driver"
+    skip["ubuntu-18.04-64/560"]="no-driver"
+
     skip["ubuntu-20.04-64/390"]="broken-driver"
     skip["ubuntu-20.04-64/510"]="transitional-driver"
     skip["ubuntu-20.04-64/515"]="transitional-driver"
@@ -65,12 +71,16 @@ prepare: |
     skip["ubuntu-20.04-64/535-server"]="broken-packaging"
     skip["ubuntu-20.04-64/550"]="no-driver"
     skip["ubuntu-20.04-64/550-server"]="broken-packaging"
+    skip["ubuntu-20.04-64/560"]="no-driver"
+
     skip["ubuntu-22.04-64/390"]="broken-driver"
     skip["ubuntu-22.04-64/510"]="transitional-driver"
     skip["ubuntu-22.04-64/515"]="transitional-driver"
     skip["ubuntu-22.04-64/515-server"]="transitional-driver"
     skip["ubuntu-22.04-64/525"]="transitional-driver"
     skip["ubuntu-22.04-64/530"]="transitional-driver"
+    skip["ubuntu-22.04-64/560"]="no-driver"
+
     skip["ubuntu-24.04-64/390"]="no-driver"
     skip["ubuntu-24.04-64/418-server"]="no-driver"
     skip["ubuntu-24.04-64/450-server"]="no-driver"
@@ -81,6 +91,22 @@ prepare: |
     skip["ubuntu-24.04-64/515-server"]="transitional-driver"
     skip["ubuntu-24.04-64/525"]="transitional-driver"
     skip["ubuntu-24.04-64/530"]="transitional-driver"
+    skip["ubuntu-24.04-64/560"]="no-driver"
+
+    skip["ubuntu-24.10-64/390"]="no-driver"
+    skip["ubuntu-24.10-64/418-server"]="no-driver"
+    skip["ubuntu-24.10-64/450-server"]="no-driver"
+    skip["ubuntu-24.10-64/470"]="no-driver"
+    skip["ubuntu-24.10-64/470-server"]="no-driver"
+    skip["ubuntu-24.10-64/510"]="no-driver"
+    skip["ubuntu-24.10-64/515"]="no-driver"
+    skip["ubuntu-24.10-64/515-server"]="no-driver"
+    skip["ubuntu-24.10-64/525"]="no-driver"
+    skip["ubuntu-24.10-64/530"]="transitional-driver"
+    skip["ubuntu-24.10-64/535"]="transitional-driver"
+    skip["ubuntu-24.10-64/550"]="transitional-driver"
+    # /bin/bash: line 109: 10426 Segmentation fault      (core dumped) test-snapd-nvidia.64 > log-64.txt
+    skip["ubuntu-24.10-64/560"]="broken-driver"
 
     driver_suffix=$PACKAGE_VERSION${PACKAGE_SUFFIX:-}
     combi_key=$SPREAD_SYSTEM/$driver_suffix
@@ -122,6 +148,12 @@ prepare: |
         # /var/lib/snapd/lib/gl/libEGL_nvidia.so.0
         # ...
         # /var/lib/snapd/lib/gl/libnvidia-vulkan-producer.so: undefined symbol: wlEglInitializeSurfaceExport: No such file or directory
+        echo "Broken driver is in use, expecting: skip[\"$combi_key\"]=\"broken-driver\""
+        test "${skip[$combi_key]}" = "broken-driver"
+        exit 0
+        ;;
+    ubuntu-24.10-64/560*)
+        # /bin/bash: line 109: 10426 Segmentation fault      (core dumped) test-snapd-nvidia.64 > log-64.txt
         echo "Broken driver is in use, expecting: skip[\"$combi_key\"]=\"broken-driver\""
         test "${skip[$combi_key]}" = "broken-driver"
         exit 0


### PR DESCRIPTION
Split exceptions table per system, for easier visual inspection. Add new entries to cover 24.10.

One notable problem is the 560 driver is not really working, causing a segvfault on startup.
```
  zyga@novigrad:~$ test-snapd-nvidia.64
  + shopt -s nullglob
  + export LD_LIBRARY_PATH=/snap/test-snapd-nvidia/2/usr/lib/x86_64-linux-gnu:/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void
  + LD_LIBRARY_PATH=/snap/test-snapd-nvidia/2/usr/lib/x86_64-linux-gnu:/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void ++ ls /var/lib/snapd/lib/gl/libEGL_nvidia.so.0 /var/lib/snapd/lib/gl/libEGL_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libGLESv1_CM_nvidia.so.1 /var/lib/snapd/lib/gl/libGLESv1_CM_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libGLESv2_nvidia.so.2 /var/lib/snapd/lib/gl/libGLESv2_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libGLX_nvidia.so.0 /var/lib/snapd/lib/gl/libGLX_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libcuda.so /var/lib/snapd/lib/gl/libcuda.so.1 /var/lib/snapd/lib/gl/libcuda.so.560.35.03 /var/lib/snapd/lib/gl/libnvcuvid.so /var/lib/snapd/lib/gl/libnvcuvid.so.1 /var/lib/snapd/lib/gl/libnvcuvid.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-allocator.so /var/lib/snapd/lib/gl/libnvidia-allocator.so.1 /var/lib/snapd/lib/gl/libnvidia-allocator.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-api.so.1 /var/lib/snapd/lib/gl/libnvidia-cfg.so /var/lib/snapd/lib/gl/libnvidia-cfg.so.1 /var/lib/snapd/lib/gl/libnvidia-cfg.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-egl-gbm.so.1 /var/lib/snapd/lib/gl/libnvidia-egl-gbm.so.1.1.1 /var/lib/snapd/lib/gl/libnvidia-egl-wayland.so.1 /var/lib/snapd/lib/gl/libnvidia-egl-wayland.so.1.1.15 /var/lib/snapd/lib/gl/libnvidia-eglcore.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-encode.so /var/lib/snapd/lib/gl/libnvidia-encode.so.1 /var/lib/snapd/lib/gl/libnvidia-encode.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-fbc.so /var/lib/snapd/lib/gl/libnvidia-fbc.so.1 /var/lib/snapd/lib/gl/libnvidia-fbc.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-glcore.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-glsi.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-glvkspirv.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-gpucomp.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-ml.so /var/lib/snapd/lib/gl/libnvidia-ml.so.1 /var/lib/snapd/lib/gl/libnvidia-ml.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-ngx.so.1 /var/lib/snapd/lib/gl/libnvidia-ngx.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-nvvm.so /var/lib/snapd/lib/gl/libnvidia-nvvm.so.4 /var/lib/snapd/lib/gl/libnvidia-nvvm.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-opencl.so.1 /var/lib/snapd/lib/gl/libnvidia-opencl.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-opticalflow.so /var/lib/snapd/lib/gl/libnvidia-opticalflow.so.1 /var/lib/snapd/lib/gl/libnvidia-opticalflow.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-pkcs11-openssl3.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-pkcs11.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so.1 /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-rtcore.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-tls.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.1 /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.560.35.03 /var/lib/snapd/lib/gl/libnvoptix.so.1 /var/lib/snapd/lib/gl/libnvoptix.so.560.35.03 ++ grep -v libnvidia-pkcs11.so
  + exec /snap/test-snapd-nvidia/2/bin/dlopen-tool.64 /var/lib/snapd/lib/gl/libEGL_nvidia.so.0 /var/lib/snapd/lib/gl/libEGL_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libGLESv1_CM_nvidia.so.1 /var/lib/snapd/lib/gl/libGLESv1_CM_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libGLESv2_nvidia.so.2 /var/lib/snapd/lib/gl/libGLESv2_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libGLX_nvidia.so.0 /var/lib/snapd/lib/gl/libGLX_nvidia.so.560.35.03 /var/lib/snapd/lib/gl/libcuda.so /var/lib/snapd/lib/gl/libcuda.so.1 /var/lib/snapd/lib/gl/libcuda.so.560.35.03 /var/lib/snapd/lib/gl/libnvcuvid.so /var/lib/snapd/lib/gl/libnvcuvid.so.1 /var/lib/snapd/lib/gl/libnvcuvid.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-allocator.so /var/lib/snapd/lib/gl/libnvidia-allocator.so.1 /var/lib/snapd/lib/gl/libnvidia-allocator.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-api.so.1 /var/lib/snapd/lib/gl/libnvidia-cfg.so /var/lib/snapd/lib/gl/libnvidia-cfg.so.1 /var/lib/snapd/lib/gl/libnvidia-cfg.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-egl-gbm.so.1 /var/lib/snapd/lib/gl/libnvidia-egl-gbm.so.1.1.1 /var/lib/snapd/lib/gl/libnvidia-egl-wayland.so.1 /var/lib/snapd/lib/gl/libnvidia-egl-wayland.so.1.1.15 /var/lib/snapd/lib/gl/libnvidia-eglcore.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-encode.so /var/lib/snapd/lib/gl/libnvidia-encode.so.1 /var/lib/snapd/lib/gl/libnvidia-encode.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-fbc.so /var/lib/snapd/lib/gl/libnvidia-fbc.so.1 /var/lib/snapd/lib/gl/libnvidia-fbc.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-glcore.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-glsi.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-glvkspirv.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-gpucomp.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-ml.so /var/lib/snapd/lib/gl/libnvidia-ml.so.1 /var/lib/snapd/lib/gl/libnvidia-ml.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-ngx.so.1 /var/lib/snapd/lib/gl/libnvidia-ngx.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-nvvm.so /var/lib/snapd/lib/gl/libnvidia-nvvm.so.4 /var/lib/snapd/lib/gl/libnvidia-nvvm.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-opencl.so.1 /var/lib/snapd/lib/gl/libnvidia-opencl.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-opticalflow.so /var/lib/snapd/lib/gl/libnvidia-opticalflow.so.1 /var/lib/snapd/lib/gl/libnvidia-opticalflow.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-pkcs11-openssl3.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so.1 /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-rtcore.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-tls.so.560.35.03 /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.1 /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.560.35.03 /var/lib/snapd/lib/gl/libnvoptix.so.1 /var/lib/snapd/lib/gl/libnvoptix.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libEGL_nvidia.so.0 dlopen /var/lib/snapd/lib/gl/libEGL_nvidia.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libGLESv1_CM_nvidia.so.1 dlopen /var/lib/snapd/lib/gl/libGLESv1_CM_nvidia.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libGLESv2_nvidia.so.2 dlopen /var/lib/snapd/lib/gl/libGLESv2_nvidia.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libGLX_nvidia.so.0 dlopen /var/lib/snapd/lib/gl/libGLX_nvidia.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libcuda.so dlopen /var/lib/snapd/lib/gl/libcuda.so.1 dlopen /var/lib/snapd/lib/gl/libcuda.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvcuvid.so dlopen /var/lib/snapd/lib/gl/libnvcuvid.so.1 dlopen /var/lib/snapd/lib/gl/libnvcuvid.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-allocator.so dlopen /var/lib/snapd/lib/gl/libnvidia-allocator.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-allocator.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-api.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-cfg.so dlopen /var/lib/snapd/lib/gl/libnvidia-cfg.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-cfg.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-egl-gbm.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-egl-gbm.so.1.1.1 dlopen /var/lib/snapd/lib/gl/libnvidia-egl-wayland.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-egl-wayland.so.1.1.15 dlopen /var/lib/snapd/lib/gl/libnvidia-eglcore.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-encode.so dlopen /var/lib/snapd/lib/gl/libnvidia-encode.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-encode.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-fbc.so dlopen /var/lib/snapd/lib/gl/libnvidia-fbc.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-fbc.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-glcore.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-glsi.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-glvkspirv.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-gpucomp.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-ml.so dlopen /var/lib/snapd/lib/gl/libnvidia-ml.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-ml.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-ngx.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-ngx.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-nvvm.so dlopen /var/lib/snapd/lib/gl/libnvidia-nvvm.so.4 dlopen /var/lib/snapd/lib/gl/libnvidia-nvvm.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-opencl.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-opencl.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-opticalflow.so dlopen /var/lib/snapd/lib/gl/libnvidia-opticalflow.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-opticalflow.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-pkcs11-openssl3.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so dlopen /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-ptxjitcompiler.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-rtcore.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-tls.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.1 dlopen /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.560.35.03 dlopen /var/lib/snapd/lib/gl/libnvoptix.so.1 dlopen /var/lib/snapd/lib/gl/libnvoptix.so.560.35.03 dlclose /var/lib/snapd/lib/gl/libnvoptix.so.560.35.03 dlclose /var/lib/snapd/lib/gl/libnvoptix.so.1 dlclose /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.560.35.03 dlclose /var/lib/snapd/lib/gl/libnvidia-vksc-core.so.1 Naruszenie ochrony pamięci (zrzut pamięci)
```

That last message is memory protection failure. System logs contain only this:

```
  lis 18 14:26:01 novigrad kernel: dlopen-tool.64[184619]: segfault at 0 ip 0000000000000000 sp 00007fffed2942c8 error 14 likely on CPU 13 (core 13, socket 0)
  lis 18 14:26:01 novigrad kernel: Code: Unable to access opcode bytes at 0xffffffffffffffd6.
```

I've witnessed this trying to debug a possibly related issue affecting X11 mode with Nvidia 560 driver, now reported as https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-560/+bug/2088456
