### PR TITLE
spread, tests: use prebuilt gojq, add simple tool for fetching files

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -939,9 +939,10 @@ prepare: |
         "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
             https://github.com/itchyny/gojq/releases/download/v0.12.16/gojq_v0.12.16_linux_arm64.tar.gz
     elif os.query is-arm; then
-        # build and provide gojq for armhf?
-        echo "no gojq for this platform?"
-        exit 1
+        # upstream does not provide prebuilt binaries for armhf
+        # built with: GOARCH=arm GOARM=7
+        "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
+            https://storage.googleapis.com/snapd-spread-tests/dependencies/gojq_v0.12.16_linux_armhf.tar.gz
     else
         # must be amd64
         "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \

--- a/spread.yaml
+++ b/spread.yaml
@@ -929,7 +929,33 @@ prepare: |
             exit 1
         fi
     fi
-    
+
+    # native jq replacement, but still with some incompatibilies, see
+    # https://github.com/itchyny/gojq
+    # major differences:
+    # - map keys are sorted by default
+    # - with --yaml-input, can parse YAML
+    if os.query is-arm64; then
+        "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
+            https://github.com/itchyny/gojq/releases/download/v0.12.16/gojq_v0.12.16_linux_arm64.tar.gz
+    elif os.query is-arm; then
+        # build and provide gojq for armhf?
+        echo "no gojq for this platform?"
+        exit 1
+    else
+        # must be amd64
+        "$TESTSTOOLS"/simpleget -o /tmp/gojq.tar.gz \
+            https://github.com/itchyny/gojq/releases/download/v0.12.16/gojq_v0.12.16_linux_amd64.tar.gz
+    fi
+
+    (
+        cd "$PROJECT_PATH/tests/bin"
+        # only extract gojq, typically under a path:
+        # -rwxr-xr-x runner/docker 4165784 2024-06-01 16:43 gojq_v0.12.16_linux_amd64/gojq
+        tar -xvf /tmp/gojq.tar.gz --strip-components=1 --wildcards "*/gojq"
+        test -x gojq
+    )
+
     # NOTE: At this stage the source tree is available and no more special
     # considerations apply.
     "$TESTSLIB"/prepare-restore.sh --prepare-project

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -608,15 +608,6 @@ prepare_project() {
         disable_journald_rate_limiting
         disable_journald_start_limiting
     fi
-
-    # native jq replacement, but still with some incompatibilies, see
-    # https://github.com/itchyny/gojq
-    # major differences:
-    # - map keys are sorted by default
-    # - with --yaml-input, can parse YAML
-    GOBIN=$PROJECT_PATH/tests/bin \
-    CGO_ENABLED=0 \
-        go install github.com/itchyny/gojq/cmd/gojq@v0.12.16
 }
 
 prepare_project_each() {

--- a/tests/lib/tools/simpleget
+++ b/tests/lib/tools/simpleget
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import os.path
+import argparse
+import logging
+import datetime
+from urllib import request
+from urllib.parse import urlparse
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="simple file getter")
+    parser.add_argument("-o", "--output", help="output file name")
+    parser.add_argument("URL", help="download URL")
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(message)s", level=logging.DEBUG
+    )
+    opts = parse_arguments()
+
+    fromurl = urlparse(opts.URL).path
+    output = os.path.basename(fromurl)
+    if opts.output:
+        output = opts.output
+
+    if os.path.exists(output):
+        raise RuntimeError(f"output path {output} already exists")
+
+    total = 0
+    now = datetime.datetime.now()
+    with request.urlopen(opts.URL) as f:
+        with open(output, "wb") as outf:
+            while True:
+                data = f.read(128 * 1024)
+                logging.debug("got %s bytes", len(data))
+                if len(data) == 0:
+                    logging.debug("done")
+                    break
+
+                total += len(data)
+                outf.write(data)
+
+    after = datetime.datetime.now()
+    speed = float(total) / (after - now).total_seconds() / 1024.0
+    logging.info("wrote %d bytes to %s, speed %.02f kB/s", total, output, speed)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lib/tools/simpleget
+++ b/tests/lib/tools/simpleget
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+# note this script needs to run on Python as old as 3.6
 import os.path
 import argparse
 import logging
@@ -28,7 +29,7 @@ def main() -> None:
         output = opts.output
 
     if os.path.exists(output):
-        raise RuntimeError(f"output path {output} already exists")
+        raise RuntimeError("output path {} already exists".format(output))
 
     total = 0
 

--- a/tests/lib/tools/simpleget
+++ b/tests/lib/tools/simpleget
@@ -4,6 +4,7 @@ import os.path
 import argparse
 import logging
 import datetime
+import tempfile
 from urllib import request
 from urllib.parse import urlparse
 
@@ -30,20 +31,22 @@ def main() -> None:
         raise RuntimeError(f"output path {output} already exists")
 
     total = 0
-    now = datetime.datetime.now()
-    with request.urlopen(opts.URL) as f:
-        with open(output, "wb") as outf:
-            while True:
-                data = f.read(128 * 1024)
-                logging.debug("got %s bytes", len(data))
-                if len(data) == 0:
-                    logging.debug("done")
-                    break
 
-                total += len(data)
-                outf.write(data)
+    def _report(blocks: int, bsize: int, tot: int):
+        nonlocal total
+        total = tot
+        logging.debug("got %d/%d kB", blocks * bsize / 1024.0, total / 1024.0)
 
-    after = datetime.datetime.now()
+    # create a temp in the same directory as output
+    outdir = os.path.dirname(output)
+
+    with tempfile.NamedTemporaryFile(mode="wb", dir=outdir) as outf:
+        now = datetime.datetime.now()
+        fn, _ = request.urlretrieve(opts.URL, filename=outf.name, reporthook=_report)
+        after = datetime.datetime.now()
+
+        os.rename(fn, output)
+
     speed = float(total) / (after - now).total_seconds() / 1024.0
     logging.info("wrote %d bytes to %s, speed %.02f kB/s", total, output, speed)
 

--- a/tests/lib/tools/simpleget
+++ b/tests/lib/tools/simpleget
@@ -40,12 +40,20 @@ def main() -> None:
     # create a temp in the same directory as output
     outdir = os.path.dirname(output)
 
-    with tempfile.NamedTemporaryFile(mode="wb", dir=outdir) as outf:
-        now = datetime.datetime.now()
-        fn, _ = request.urlretrieve(opts.URL, filename=outf.name, reporthook=_report)
-        after = datetime.datetime.now()
+    with tempfile.NamedTemporaryFile(mode="wb", dir=outdir, delete=False) as outf:
+        name = outf.name
+        outf.close()
+        try:
+            now = datetime.datetime.now()
+            fn, _ = request.urlretrieve(
+                opts.URL, filename=outf.name, reporthook=_report
+            )
+            after = datetime.datetime.now()
 
-        os.rename(fn, output)
+            os.rename(fn, output)
+        except:
+            os.unlink(name)
+            raise
 
     speed = float(total) / (after - now).total_seconds() / 1024.0
     logging.info("wrote %d bytes to %s, speed %.02f kB/s", total, output, speed)


### PR DESCRIPTION
It is not viable to build gojq in some of the test environments (eg. beta validation), so use a prebuilt binary from github.

Since we do not always have a wget or curl available on the host, add a simplistic replacement which is only capable of fetching files.

**NOTE** this doesn't solve the case for armhf yet, we do not have prebuilt binaries available there.

Related: [SNAPDENG-34224](https://warthogs.atlassian.net/browse/SNAPDENG-34224)


[SNAPDENG-34224]: https://warthogs.atlassian.net/browse/SNAPDENG-34224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ