### PR TITLE
tests: add ubuntu oracular to google-sru backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -283,6 +283,9 @@ backends:
             - ubuntu-24.04-64:
                   storage: 12G
                   workers: 8
+            - ubuntu-24.10-64:
+                  storage: 12G
+                  workers: 8
 
     google-nested:
         type: google


### PR DESCRIPTION
This is needed to run the next set of sru validations
