### PR TITLE
tests: migrate centos-9 from google to openstack

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -236,7 +236,7 @@ jobs:
             tasks: 'tests/...'
             rules: 'main'
           - group: centos
-            backend: google-distro-2
+            backend: openstack
             systems: 'centos-9-64'
             tasks: 'tests/...'
             rules: 'main'

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -692,6 +692,7 @@ pkg_dependencies_fedora_centos_common(){
         git
         golang
         jq
+        iptables
         iptables-services
         man
         net-tools


### PR DESCRIPTION
This is the first part of the migration to start using openstack to run spread tests in openstack located in PS6
