### PR TITLE
i/apparmor: allow using `vim.tiny` (available in base snaps)

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -639,6 +639,7 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}bin/unzip ixr,
   /{,usr/}bin/uptime ixr,
   /{,usr/}bin/vdir ixr,
+  /{,usr/}bin/vim.tiny ixr,
   /{,usr/}bin/wc ixr,
   /{,usr/}bin/which{,.debianutils} ixr,
   /{,usr/}bin/xargs ixr,


### PR DESCRIPTION
With the `microcloud` snap, we need an editor and `vim.tiny` is conveniently shipped in the `coreXX` base snaps so let's make it possible to use it.