### PR TITLE
many: make kernel-modules components available on first boot

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -56,6 +56,18 @@ type BootableSet struct {
 
 	// Recovery is set when making the recovery partition bootable.
 	Recovery bool
+
+	// KernelMods contains kernel-modules components in the system.
+	KernelMods []BootableKModsComponents
+}
+
+// BootableComponent represents kernel-modules components, which are
+// needed as part of a BootableSet.
+type BootableKModsComponents struct {
+	// CompPlaceInfo is usde to build to file name with the right revision
+	CompPlaceInfo snap.ContainerPlaceInfo
+	// CompPath is the path where we will copy the file from
+	CompPath string
 }
 
 // MakeBootableImage sets up the given bootable set and target filesystem
@@ -334,7 +346,7 @@ type makeRunnableOptions struct {
 	StateUnlocker  Unlocker
 }
 
-func copyBootSnap(orig string, dstInfo *snap.Info, dstSnapBlobDir string) error {
+func copyBootSnap(orig string, filename string, dstSnapBlobDir string) error {
 	// if the source path is a symlink, don't copy the symlink, copy the
 	// target file instead of copying the symlink, as the initramfs won't
 	// follow the symlink when it goes to mount the base and kernel snaps by
@@ -347,10 +359,7 @@ func copyBootSnap(orig string, dstInfo *snap.Info, dstSnapBlobDir string) error 
 		}
 		orig = link
 	}
-	// note that we need to use the "Filename()" here because unasserted
-	// snaps will have names like pc-kernel_5.19.4.snap but snapd expects
-	// "pc-kernel_x1.snap"
-	dst := filepath.Join(dstSnapBlobDir, dstInfo.Filename())
+	dst := filepath.Join(dstSnapBlobDir, filename)
 	if err := osutil.CopyFile(orig, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync); err != nil {
 		return err
 	}
@@ -372,19 +381,27 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 	//   install the boot.sel onto ubuntu-boot directly, but the file should be
 	//   managed by snapd instead
 
-	// copy kernel/base/gadget into the ubuntu-data partition
+	// Copy kernel/base/gadget and kernel-modules components into the
+	// ubuntu-data partition. Note that we need to use the "Filename()"
+	// here because unasserted snaps/components will have names like
+	// pc-kernel_5.19.4.snap but snapd expects "pc-kernel_x1.snap"
 	snapBlobDir := dirs.SnapBlobDirUnder(InstallHostWritableDir(model))
 	if err := os.MkdirAll(snapBlobDir, 0755); err != nil {
 		return err
 	}
 	for _, origDest := range []struct {
 		orig     string
-		destInfo *snap.Info
+		fileName string
 	}{
-		{orig: bootWith.BasePath, destInfo: bootWith.Base},
-		{orig: bootWith.KernelPath, destInfo: bootWith.Kernel},
-		{orig: bootWith.GadgetPath, destInfo: bootWith.Gadget}} {
-		if err := copyBootSnap(origDest.orig, origDest.destInfo, snapBlobDir); err != nil {
+		{orig: bootWith.BasePath, fileName: bootWith.Base.Filename()},
+		{orig: bootWith.KernelPath, fileName: bootWith.Kernel.Filename()},
+		{orig: bootWith.GadgetPath, fileName: bootWith.Gadget.Filename()}} {
+		if err := copyBootSnap(origDest.orig, origDest.fileName, snapBlobDir); err != nil {
+			return err
+		}
+	}
+	for _, kmod := range bootWith.KernelMods {
+		if err := copyBootSnap(kmod.CompPath, kmod.CompPlaceInfo.Filename(), snapBlobDir); err != nil {
 			return err
 		}
 	}

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -64,9 +64,9 @@ type BootableSet struct {
 // BootableComponent represents kernel-modules components, which are
 // needed as part of a BootableSet.
 type BootableKModsComponents struct {
-	// CompPlaceInfo is usde to build to file name with the right revision
+	// CompPlaceInfo is used to build the file name with the right revision.
 	CompPlaceInfo snap.ContainerPlaceInfo
-	// CompPath is the path where we will copy the file from
+	// CompPath is the path where we will copy the file from.
 	CompPath string
 }
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -329,6 +329,10 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 		return fmt.Errorf("cannot use gadget: %v", err)
 	}
 
+	// TODO:COMPS take into account kernel-modules components, see
+	// DeviceManager,doSetupRunSystem and other parts of
+	// handlers_install.go.
+
 	bootDevice := ""
 	kernelSnapInfo := &gadgetInstall.KernelSnapInfo{
 		Name:       kernelSnap.SnapName(),

--- a/gadget/install/kernel.go
+++ b/gadget/install/kernel.go
@@ -31,8 +31,21 @@ type KernelSnapInfo struct {
 	// MountPoint is the root of the files from the kernel snap
 	MountPoint string
 	// NeedsDriversTree will be set if a drivers tree needs to be
-	// build on installation
+	// built on installation
 	NeedsDriversTree bool
 	// IsCore is set if this is UC
 	IsCore bool
+	// ModulesComps has the information for installed
+	// kernel-modules components from the snap
+	ModulesComps []KernelModulesComponentInfo
+}
+
+// KernelModulesComponentInfo includes information for kernel-modules
+// components that is needed to build a drivers tree.
+// TODO:COMPS support modules created by hooks in $SNAP_DATA.
+type KernelModulesComponentInfo struct {
+	Name     string
+	Revision snap.Revision
+	// MountPoint is the root of the files from the component
+	MountPoint string
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2253,7 +2253,7 @@ func (m *DeviceManager) defaultRecoverySystem() (*DefaultRecoverySystem, error) 
 // of the essential snaps for a given mode.
 // TODO: make this method optionally return the system seed, since it might not
 // always be needed, and it is quite large.
-func (m *DeviceManager) loadSystemAndEssentialSnaps(wantedSystemLabel string, types []snap.Type, mode string) (*systemAndEssentialSnaps, error) {
+func (m *DeviceManager) loadSystemAndEssentialSnaps(wantedSystemLabel string, types []snap.Type, modeForComps string) (*systemAndEssentialSnaps, error) {
 	// get current system as input for loadSeedAndSystem()
 	systemMode := m.SystemMode(SysAny)
 	var currentSys *currentSystem
@@ -2302,10 +2302,10 @@ func (m *DeviceManager) loadSystemAndEssentialSnaps(wantedSystemLabel string, ty
 			return nil, fmt.Errorf("cannot use snap info, expected %s but got %s", typ, snapInfo.SnapType)
 		}
 		// Read components in the seed too, for the mode we are interested in
-		snapForMode, err := s.ModeSnap(seedSnap.SnapName(), mode)
+		snapForMode, err := s.ModeSnap(seedSnap.SnapName(), modeForComps)
 		if err != nil {
 			return nil, fmt.Errorf("internal error while retrieving %s for %s mode: %v",
-				seedSnap.SnapName(), mode, err)
+				seedSnap.SnapName(), modeForComps, err)
 		}
 		var compInfosForType []compSeedInfo
 		if len(snapForMode.Components) > 0 {

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -205,6 +205,7 @@ type mockSystemSeedWithLabelOpts struct {
 	hasSystemSeed   bool
 	hasPartial      bool
 	preseedArtifact bool
+	testCompsMode   bool
 	kModsRevs       map[string]snap.Revision
 	types           []snap.Type
 }
@@ -250,15 +251,17 @@ func (s *deviceMgrInstallSuite) mockSystemSeedWithLabel(c *C, label string, seed
 				CompSideInfo: snap.ComponentSideInfo{
 					Component: naming.NewComponentRef("pc-kernel", "kcomp1"),
 					Revision:  opts.kModsRevs["kcomp1"]},
-			},
-			{
+			}}
+		kCompsPaths = []string{kernComps[0].Path}
+		if !opts.testCompsMode {
+			kernComps = append(kernComps, seed.Component{
 				Path: filepath.Join(s.SeedDir, "snaps", "pc-kernel+kcomp2_"+opts.kModsRevs["kcomp2"].String()+".comp"),
 				CompSideInfo: snap.ComponentSideInfo{
 					Component: naming.NewComponentRef("pc-kernel", "kcomp2"),
 					Revision:  opts.kModsRevs["kcomp2"]},
-			},
+			})
+			kCompsPaths = append(kCompsPaths, kernComps[1].Path)
 		}
-		kCompsPaths = []string{kernComps[0].Path, kernComps[1].Path}
 	}
 	essentialSnaps := make([]*seed.Snap, 0, len(opts.types))
 	for _, typ := range opts.types {

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
@@ -49,13 +48,23 @@ import (
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
 
-type deviceMgrInstallAPISuite struct {
+type deviceMgrInstallSuite struct {
 	deviceMgrBaseSuite
 	*seedtest.TestingSeed20
+}
+
+func (s *deviceMgrInstallSuite) SetUpTest(c *C) {
+	s.TestingSeed20 = &seedtest.TestingSeed20{}
+	s.SeedDir = dirs.SnapSeedDir
+}
+
+type deviceMgrInstallAPISuite struct {
+	deviceMgrInstallSuite
 }
 
 var _ = Suite(&deviceMgrInstallAPISuite{})
@@ -63,6 +72,7 @@ var _ = Suite(&deviceMgrInstallAPISuite{})
 func (s *deviceMgrInstallAPISuite) SetUpTest(c *C) {
 	classic := true
 	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
+	s.deviceMgrInstallSuite.SetUpTest(c)
 
 	// We uncompress a gadget with grub, and prefer not to mock in this case
 	bootloader.Force(nil)
@@ -71,9 +81,6 @@ func (s *deviceMgrInstallAPISuite) SetUpTest(c *C) {
 		return "fake system label", nil
 	})
 	s.AddCleanup(restore)
-
-	s.TestingSeed20 = &seedtest.TestingSeed20{}
-	s.SeedDir = dirs.SnapSeedDir
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -87,9 +94,8 @@ func unpackSnap(snapBlob, targetDir string) error {
 	return nil
 }
 
-func (s *deviceMgrInstallAPISuite) setupSystemSeed(c *C, sysLabel, gadgetYaml string, isClassic bool) *asserts.Model {
+func (s *deviceMgrInstallSuite) setupSystemSeed(c *C, sysLabel, gadgetYaml string, isClassic bool, kModsRevs map[string]snap.Revision) (*asserts.Model, map[string]interface{}) {
 	s.StoreSigning = assertstest.NewStoreStack("can0nical", nil)
-	s.AddCleanup(sysdb.InjectTrusted(s.StoreSigning.Trusted))
 
 	s.Brands = assertstest.NewSigningAccounts(s.StoreSigning)
 	s.Brands.Register("my-brand", brandPrivKey, nil)
@@ -109,35 +115,49 @@ func (s *deviceMgrInstallAPISuite) setupSystemSeed(c *C, sysLabel, gadgetYaml st
 	assertstest.AddMany(s.StoreSigning.Database, s.Brands.AccountsAndKeys("my-brand")...)
 
 	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["snapd"], nil, snap.R(1), "my-brand", s.StoreSigning.Database)
-	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["pc-kernel=22"],
-		[][]string{{"kernel.efi", ""}}, snap.R(1), "my-brand", s.StoreSigning.Database)
-	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["core22"], nil, snap.R(1), "my-brand", s.StoreSigning.Database)
-	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["pc=22"],
+	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["core24"], nil, snap.R(1), "my-brand", s.StoreSigning.Database)
+	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["pc=24"],
 		[][]string{
 			{"meta/gadget.yaml", gadgetYaml},
 			{"pc-boot.img", ""}, {"pc-core.img", ""}, {"grubx64.efi", ""},
 			{"shim.efi.signed", ""}, {"grub.conf", ""}},
 		snap.R(1), "my-brand", s.StoreSigning.Database)
+	if len(kModsRevs) > 0 {
+		s.MakeAssertedSnapWithComps(c,
+			seedtest.SampleSnapYaml["pc-kernel=24+kmods"],
+			[][]string{{"kernel.efi", ""}}, snap.R(1), kModsRevs, "my-brand", s.StoreSigning.Database)
+	} else {
+		s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["pc-kernel=24"],
+			[][]string{{"kernel.efi", ""}}, snap.R(1), "my-brand", s.StoreSigning.Database)
+	}
 
-	s.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["optional22"], nil, snap.R(1), nil, "my-brand", s.StoreSigning.Database)
+	s.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["optional24"], nil, snap.R(1), nil, "my-brand", s.StoreSigning.Database)
 
+	var kmods map[string]interface{}
+	if len(kModsRevs) > 0 {
+		kmods = map[string]interface{}{
+			"kcomp1": "required",
+			"kcomp2": "required",
+		}
+	}
 	model := map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
-		"base":         "core22",
+		"base":         "core24",
 		"grade":        "dangerous",
 		"snaps": []interface{}{
 			map[string]interface{}{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
-				"default-channel": "20",
+				"default-channel": "24",
+				"components":      kmods,
 			},
 			map[string]interface{}{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
-				"default-channel": "20",
+				"default-channel": "24",
 			},
 			map[string]interface{}{
 				"name": "snapd",
@@ -145,13 +165,13 @@ func (s *deviceMgrInstallAPISuite) setupSystemSeed(c *C, sysLabel, gadgetYaml st
 				"type": "snapd",
 			},
 			map[string]interface{}{
-				"name": "core22",
-				"id":   s.AssertedSnapID("core22"),
+				"name": "core24",
+				"id":   s.AssertedSnapID("core24"),
 				"type": "base",
 			},
 			map[string]interface{}{
-				"name": "optional22",
-				"id":   s.AssertedSnapID("optional22"),
+				"name": "optional24",
+				"id":   s.AssertedSnapID("optional24"),
 				"components": map[string]interface{}{
 					"comp1": "optional",
 				},
@@ -165,10 +185,10 @@ func (s *deviceMgrInstallAPISuite) setupSystemSeed(c *C, sysLabel, gadgetYaml st
 
 	return s.MakeSeed(c, sysLabel, "my-brand", "my-model", model, []*seedwriter.OptionsSnap{
 		{
-			Name:       "optional22",
+			Name:       "optional24",
 			Components: []seedwriter.OptionsComponent{{Name: "comp1"}},
 		},
-	})
+	}), model
 }
 
 type finishStepOpts struct {
@@ -176,21 +196,31 @@ type finishStepOpts struct {
 	installClassic     bool
 	hasPartial         bool
 	hasSystemSeed      bool
+	hasKernelModsComps bool
 	optionalContainers *seed.OptionalContainers
 }
 
-func (s *deviceMgrInstallAPISuite) mockSystemSeedWithLabel(c *C, label string, isClassic, hasSystemSeed, hasPartial bool, seedCopyFn func(string, seed.CopyOptions, timings.Measurer) error) (gadgetSnapPath, kernelSnapPath string, ginfo *gadget.Info, mountCmd *testutil.MockCmd) {
+type mockSystemSeedWithLabelOpts struct {
+	isClassic       bool
+	hasSystemSeed   bool
+	hasPartial      bool
+	preseedArtifact bool
+	kModsRevs       map[string]snap.Revision
+	types           []snap.Type
+}
+
+func (s *deviceMgrInstallSuite) mockSystemSeedWithLabel(c *C, label string, seedCopyFn func(string, seed.CopyOptions, timings.Measurer) error, opts mockSystemSeedWithLabelOpts) (gadgetSnapPath, kernelSnapPath string, kCompsPaths []string, ginfo *gadget.Info, mountCmd *testutil.MockCmd, rawModel map[string]interface{}) {
 	// Mock partitioned disk
 	gadgetYaml := gadgettest.SingleVolumeUC20GadgetYaml
-	if isClassic {
-		if hasSystemSeed {
+	if opts.isClassic {
+		if opts.hasSystemSeed {
 			gadgetYaml = gadgettest.SingleVolumeClassicWithModesAndSystemSeedGadgetYaml
 		} else {
 			gadgetYaml = gadgettest.SingleVolumeClassicWithModesGadgetYaml
 		}
 	}
 	seedGadget := gadgetYaml
-	if hasPartial {
+	if opts.hasPartial {
 		// This is the gadget provided by the installer, that must have
 		// filled the partial information.
 		gadgetYaml = gadgettest.SingleVolumeClassicWithModesFilledPartialGadgetYaml
@@ -203,41 +233,72 @@ func (s *deviceMgrInstallAPISuite) mockSystemSeedWithLabel(c *C, label string, i
 	s.AddCleanup(restore)
 
 	// now create a label with snaps/assertions
-	model := s.setupSystemSeed(c, label, seedGadget, isClassic)
+	model, rawModel := s.setupSystemSeed(c, label, seedGadget, opts.isClassic, opts.kModsRevs)
 	c.Check(model, NotNil)
 
 	// Create fake seed that will return information from the label we created
 	// (TODO: needs to be in sync with setupSystemSeed, fix that)
 	kernelSnapPath = filepath.Join(s.SeedDir, "snaps", "pc-kernel_1.snap")
-	baseSnapPath := filepath.Join(s.SeedDir, "snaps", "core22_1.snap")
+	baseSnapPath := filepath.Join(s.SeedDir, "snaps", "core24_1.snap")
 	gadgetSnapPath = filepath.Join(s.SeedDir, "snaps", "pc_1.snap")
+
+	var kernComps []seed.Component
+	if len(opts.kModsRevs) > 0 {
+		kernComps = []seed.Component{
+			{
+				Path: filepath.Join(s.SeedDir, "snaps", "pc-kernel+kcomp1_"+opts.kModsRevs["kcomp1"].String()+".comp"),
+				CompSideInfo: snap.ComponentSideInfo{
+					Component: naming.NewComponentRef("pc-kernel", "kcomp1"),
+					Revision:  opts.kModsRevs["kcomp1"]},
+			},
+			{
+				Path: filepath.Join(s.SeedDir, "snaps", "pc-kernel+kcomp2_"+opts.kModsRevs["kcomp2"].String()+".comp"),
+				CompSideInfo: snap.ComponentSideInfo{
+					Component: naming.NewComponentRef("pc-kernel", "kcomp2"),
+					Revision:  opts.kModsRevs["kcomp2"]},
+			},
+		}
+		kCompsPaths = []string{kernComps[0].Path, kernComps[1].Path}
+	}
+	essentialSnaps := make([]*seed.Snap, 0, len(opts.types))
+	for _, typ := range opts.types {
+		switch typ {
+		case snap.TypeKernel:
+			essentialSnaps = append(essentialSnaps, &seed.Snap{
+				Path: kernelSnapPath,
+				SideInfo: &snap.SideInfo{RealName: "pc-kernel",
+					Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("pc-kernel")},
+				EssentialType: snap.TypeKernel,
+				Components:    kernComps,
+			})
+		case snap.TypeBase:
+			essentialSnaps = append(essentialSnaps, &seed.Snap{
+				Path: baseSnapPath,
+				SideInfo: &snap.SideInfo{RealName: "core24",
+					Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("core24")},
+				EssentialType: snap.TypeBase,
+			})
+		case snap.TypeGadget:
+			essentialSnaps = append(essentialSnaps, &seed.Snap{
+				Path: gadgetSnapPath,
+				SideInfo: &snap.SideInfo{RealName: "pc",
+					Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("pc")},
+				EssentialType: snap.TypeGadget,
+			})
+		}
+	}
 
 	restore = devicestate.MockSeedOpen(func(seedDir, label string) (seed.Seed, error) {
 		return &fakeSeedCopier{
 			copyFn: seedCopyFn,
 			optionalContainers: seed.OptionalContainers{
-				Snaps:      []string{"optional22"},
-				Components: map[string][]string{"optional22": {"comp1"}},
+				Snaps:      []string{"optional24"},
+				Components: map[string][]string{"optional24": {"comp1"}},
 			},
 			fakeSeed: fakeSeed{
-				essentialSnaps: []*seed.Snap{
-					{
-						Path:          kernelSnapPath,
-						SideInfo:      &snap.SideInfo{RealName: "pc-kernel", Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("pc-kernel")},
-						EssentialType: snap.TypeKernel,
-					},
-					{
-						Path:          baseSnapPath,
-						SideInfo:      &snap.SideInfo{RealName: "core22", Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("core22")},
-						EssentialType: snap.TypeBase,
-					},
-					{
-						Path:          gadgetSnapPath,
-						SideInfo:      &snap.SideInfo{RealName: "pc", Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("pc")},
-						EssentialType: snap.TypeGadget,
-					},
-				},
-				model: model,
+				essentialSnaps:  essentialSnaps,
+				model:           model,
+				preseedArtifact: opts.preseedArtifact,
 			},
 		}, nil
 	})
@@ -247,7 +308,7 @@ func (s *deviceMgrInstallAPISuite) mockSystemSeedWithLabel(c *C, label string, i
 	mountCmd = testutil.MockCommand(c, "systemd-mount", "")
 	s.AddCleanup(func() { mountCmd.Restore() })
 
-	return gadgetSnapPath, kernelSnapPath, ginfo, mountCmd
+	return gadgetSnapPath, kernelSnapPath, kCompsPaths, ginfo, mountCmd, rawModel
 }
 
 func mockDiskVolume(opts finishStepOpts) *gadget.OnDiskVolume {
@@ -526,7 +587,19 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 		}
 	}
 
-	gadgetSnapPath, kernelSnapPath, ginfo, mountCmd := s.mockSystemSeedWithLabel(c, label, opts.installClassic, opts.hasSystemSeed, opts.hasPartial, seedCopyFn)
+	var kModsRevs map[string]snap.Revision
+	if opts.hasKernelModsComps {
+		kModsRevs = map[string]snap.Revision{"kcomp1": snap.R(77), "kcomp2": snap.R(77)}
+	}
+	seedOpts := mockSystemSeedWithLabelOpts{
+		isClassic:     opts.installClassic,
+		hasSystemSeed: opts.hasSystemSeed,
+		hasPartial:    opts.hasPartial,
+		kModsRevs:     kModsRevs,
+		types:         []snap.Type{snap.TypeKernel, snap.TypeBase, snap.TypeGadget},
+	}
+	gadgetSnapPath, kernelSnapPath, kCompsPaths, ginfo, mountCmd, _ := s.mockSystemSeedWithLabel(
+		c, label, seedCopyFn, seedOpts)
 
 	// Unpack gadget snap from seed where it would have been mounted
 	gadgetDir := filepath.Join(dirs.SnapRunDir, "snap-content/gadget")
@@ -534,6 +607,10 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	c.Assert(err, IsNil)
 	err = unpackSnap(filepath.Join(s.SeedDir, "snaps/pc_1.snap"), gadgetDir)
 	c.Assert(err, IsNil)
+
+	kernelMountDir := filepath.Join(dirs.SnapRunDir, "snap-content/kernel")
+	kcomp1MountDir := filepath.Join(dirs.SnapRunDir, "snap-content/pc-kernel+kcomp1")
+	kcomp2MountDir := filepath.Join(dirs.SnapRunDir, "snap-content/pc-kernel+kcomp2")
 
 	// Mock writing of contents
 	writeContentCalls := 0
@@ -561,6 +638,29 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 		} else {
 			c.Check(encSetupData, IsNil)
 		}
+		modulesComps := []install.KernelModulesComponentInfo{}
+		if opts.hasKernelModsComps {
+			modulesComps = []install.KernelModulesComponentInfo{
+				{
+					Name:       "kcomp1",
+					Revision:   snap.R(77),
+					MountPoint: kcomp1MountDir,
+				},
+				{
+					Name:       "kcomp2",
+					Revision:   snap.R(77),
+					MountPoint: kcomp2MountDir,
+				},
+			}
+		}
+		c.Check(kSnapInfo, DeepEquals, &install.KernelSnapInfo{
+			Name:             "pc-kernel",
+			Revision:         snap.R(1),
+			MountPoint:       kernelMountDir,
+			IsCore:           false,
+			ModulesComps:     modulesComps,
+			NeedsDriversTree: true,
+		})
 		return nil, nil
 	})
 	s.AddCleanup(restore)
@@ -606,7 +706,6 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 			gadgetToDiskMap, err := gadget.EnsureVolumeCompatibility(
 				vol, diskVolume, volCompatOpts)
 			if err != nil {
-				fmt.Println("HERE", err)
 				return nil, err
 			}
 			volToGadgetToDiskStruct[name] = gadgetToDiskMap
@@ -704,16 +803,30 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	c.Assert(chg.Err(), IsNil)
 
 	// Checks now
-	kernelDir := filepath.Join(dirs.SnapRunDir, "snap-content/kernel")
-	c.Check(mountCmd.Calls(), DeepEquals, [][]string{
-		{"systemd-mount", gadgetSnapPath, gadgetDir},
-		{"systemd-mount", kernelSnapPath, kernelDir},
-		{"systemd-mount", "--umount", gadgetDir},
-		{"systemd-mount", "--umount", kernelDir},
-	})
+	mountCalls := [][]string{
+		{"systemd-mount", kernelSnapPath, kernelMountDir},
+		{"systemd-mount", gadgetSnapPath, gadgetDir}}
+	if opts.hasKernelModsComps {
+		mountCalls = append(mountCalls,
+			[]string{"systemd-mount", kCompsPaths[0], kcomp1MountDir},
+			[]string{"systemd-mount", kCompsPaths[1], kcomp2MountDir})
+	}
+	mountCalls = append(mountCalls,
+		[]string{"systemd-mount", "--umount", kernelMountDir},
+		[]string{"systemd-mount", "--umount", gadgetDir})
+	if opts.hasKernelModsComps {
+		mountCalls = append(mountCalls,
+			[]string{"systemd-mount", "--umount", kcomp1MountDir},
+			[]string{"systemd-mount", "--umount", kcomp2MountDir})
+	}
+	c.Check(mountCmd.Calls(), DeepEquals, mountCalls)
 	c.Check(writeContentCalls, Equals, 1)
 	c.Check(mountVolsCalls, Equals, 1)
 	c.Check(saveStorageTraitsCalls, Equals, 1)
+
+	if !opts.installClassic {
+		c.Check(seedCopyCalled, Equals, true)
+	}
 
 	snapdVarDir := "mnt/ubuntu-data/system-data/var/lib/snapd"
 	if opts.installClassic {
@@ -728,18 +841,21 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 		filepath.Join(dirs.RunDir, "mnt/ubuntu-boot/EFI/ubuntu/kernel.efi"),
 		filepath.Join(dirs.RunDir, "mnt/ubuntu-boot/device/model"),
 		filepath.Join(dirs.RunDir, snapdVarDir, "modeenv"),
-		filepath.Join(dirs.RunDir, snapdVarDir, "snaps/core22_1.snap"),
+		filepath.Join(dirs.RunDir, snapdVarDir, "snaps/core24_1.snap"),
 		filepath.Join(dirs.RunDir, snapdVarDir, "snaps/pc_1.snap"),
 		filepath.Join(dirs.RunDir, snapdVarDir, "snaps/pc-kernel_1.snap"),
-	}
-	if !opts.installClassic {
-		c.Check(seedCopyCalled, Equals, true)
 	}
 	if opts.encrypted {
 		expectedFiles = append(expectedFiles, dirs.RunDir,
 			filepath.Join(dirs.RunDir, snapdVarDir, "device/fde/marker"),
 			filepath.Join(dirs.RunDir, snapdVarDir, "device/fde/ubuntu-save.key"),
 			filepath.Join(dirs.RunDir, "mnt/ubuntu-save/device/fde/marker"))
+	}
+	if opts.hasKernelModsComps {
+		expectedFiles = append(expectedFiles,
+			filepath.Join(dirs.RunDir, snapdVarDir, "snaps/pc-kernel+kcomp1_77.comp"),
+			filepath.Join(dirs.RunDir, snapdVarDir, "snaps/pc-kernel+kcomp2_77.comp"),
+		)
 	}
 	for _, f := range expectedFiles {
 		c.Check(f, testutil.FilePresent)
@@ -752,6 +868,11 @@ func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishNoEncryptionHappy(c *
 
 func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishEncryptionHappy(c *C) {
 	s.testInstallFinishStep(c, finishStepOpts{encrypted: true, installClassic: true})
+}
+
+func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishNoEncryptionWithKModsHappy(c *C) {
+	s.testInstallFinishStep(c, finishStepOpts{
+		encrypted: false, installClassic: true, hasKernelModsComps: true})
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallClassicFinishEncryptionAndSystemSeedHappy(c *C) {
@@ -779,8 +900,8 @@ func (s *deviceMgrInstallAPISuite) TestInstallCoreFinishWithOptionalContainers(c
 		encrypted:      true,
 		installClassic: false,
 		optionalContainers: &seed.OptionalContainers{
-			Snaps:      []string{"optional22"},
-			Components: map[string][]string{"optional22": {"comp1"}},
+			Snaps:      []string{"optional24"},
+			Components: map[string][]string{"optional24": {"comp1"}},
 		},
 	})
 }
@@ -826,7 +947,14 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 	seedCopyFn := func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
 		return fmt.Errorf("unexpected copy call")
 	}
-	gadgetSnapPath, kernelSnapPath, ginfo, mountCmd := s.mockSystemSeedWithLabel(c, label, isClassic, false, false, seedCopyFn)
+	seedOpts := mockSystemSeedWithLabelOpts{
+		isClassic:     isClassic,
+		hasSystemSeed: false,
+		hasPartial:    false,
+		types:         []snap.Type{snap.TypeKernel, snap.TypeBase, snap.TypeGadget},
+	}
+	gadgetSnapPath, kernelSnapPath, _, ginfo, mountCmd, _ := s.mockSystemSeedWithLabel(
+		c, label, seedCopyFn, seedOpts)
 
 	// Simulate system with TPM
 	if hasTPM {
@@ -895,10 +1023,10 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 	gadgetDir := filepath.Join(dirs.SnapRunDir, "snap-content/gadget")
 	kernelDir := filepath.Join(dirs.SnapRunDir, "snap-content/kernel")
 	c.Check(mountCmd.Calls(), DeepEquals, [][]string{
-		{"systemd-mount", gadgetSnapPath, gadgetDir},
 		{"systemd-mount", kernelSnapPath, kernelDir},
-		{"systemd-mount", "--umount", gadgetDir},
+		{"systemd-mount", gadgetSnapPath, gadgetDir},
 		{"systemd-mount", "--umount", kernelDir},
+		{"systemd-mount", "--umount", gadgetDir},
 	})
 	c.Check(encrytpPartCalls, Equals, 1)
 	// Check that some data has been stored in the change

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -56,6 +57,8 @@ import (
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/seed/seedtest"
+	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -63,6 +66,241 @@ import (
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
+
+type deviceMgrInstallSuite struct {
+	deviceMgrBaseSuite
+	*seedtest.TestingSeed20
+}
+
+func (s *deviceMgrInstallSuite) SetUpTest(c *C) {
+	s.TestingSeed20 = &seedtest.TestingSeed20{}
+	s.SeedDir = dirs.SnapSeedDir
+}
+
+func (s *deviceMgrInstallSuite) setupSystemSeed(c *C, sysLabel, gadgetYaml string, isClassic bool, kModsRevs map[string]snap.Revision) (*asserts.Model, map[string]interface{}) {
+	s.StoreSigning = assertstest.NewStoreStack("can0nical", nil)
+
+	s.Brands = assertstest.NewSigningAccounts(s.StoreSigning)
+	s.Brands.Register("my-brand", brandPrivKey, nil)
+
+	// now create a minimal seed dir with snaps/assertions
+	testSeed := &seedtest.TestingSeed20{
+		SeedSnaps: seedtest.SeedSnaps{
+			StoreSigning: s.StoreSigning,
+			Brands:       s.Brands,
+		},
+		SeedDir: dirs.SnapSeedDir,
+	}
+
+	restore := seed.MockTrusted(testSeed.StoreSigning.Trusted)
+	s.AddCleanup(restore)
+
+	assertstest.AddMany(s.StoreSigning.Database, s.Brands.AccountsAndKeys("my-brand")...)
+
+	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["snapd"], nil, snap.R(1), "my-brand", s.StoreSigning.Database)
+	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["core24"], nil, snap.R(1), "my-brand", s.StoreSigning.Database)
+	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["pc=24"],
+		[][]string{
+			{"meta/gadget.yaml", gadgetYaml},
+			{"pc-boot.img", ""}, {"pc-core.img", ""}, {"grubx64.efi", ""},
+			{"shim.efi.signed", ""}, {"grub.conf", ""}},
+		snap.R(1), "my-brand", s.StoreSigning.Database)
+	if len(kModsRevs) > 0 {
+		s.MakeAssertedSnapWithComps(c,
+			seedtest.SampleSnapYaml["pc-kernel=24+kmods"],
+			[][]string{{"kernel.efi", ""}}, snap.R(1), kModsRevs, "my-brand", s.StoreSigning.Database)
+	} else {
+		s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["pc-kernel=24"],
+			[][]string{{"kernel.efi", ""}}, snap.R(1), "my-brand", s.StoreSigning.Database)
+	}
+
+	s.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["optional24"], nil, snap.R(1), nil, "my-brand", s.StoreSigning.Database)
+
+	var kmods map[string]interface{}
+	if len(kModsRevs) > 0 {
+		kmods = map[string]interface{}{
+			"kcomp1": "required",
+			"kcomp2": "required",
+		}
+	}
+	model := map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core24",
+		"grade":        "dangerous",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "24",
+				"components":      kmods,
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "24",
+			},
+			map[string]interface{}{
+				"name": "snapd",
+				"id":   s.AssertedSnapID("snapd"),
+				"type": "snapd",
+			},
+			map[string]interface{}{
+				"name": "core24",
+				"id":   s.AssertedSnapID("core24"),
+				"type": "base",
+			},
+			map[string]interface{}{
+				"name": "optional24",
+				"id":   s.AssertedSnapID("optional24"),
+				"components": map[string]interface{}{
+					"comp1": "optional",
+				},
+			},
+		},
+	}
+	if isClassic {
+		model["classic"] = "true"
+		model["distribution"] = "ubuntu"
+	}
+
+	return s.MakeSeed(c, sysLabel, "my-brand", "my-model", model, []*seedwriter.OptionsSnap{
+		{
+			Name:       "optional24",
+			Components: []seedwriter.OptionsComponent{{Name: "comp1"}},
+		},
+	}), model
+}
+
+type fakeSeedCopier struct {
+	fakeSeed
+	optionalContainers seed.OptionalContainers
+	copyFn             func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error
+}
+
+func (s *fakeSeedCopier) Copy(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
+	return s.copyFn(seedDir, opts, tm)
+}
+
+func (s *fakeSeedCopier) OptionalContainers() (seed.OptionalContainers, error) {
+	return s.optionalContainers, nil
+}
+
+type mockSystemSeedWithLabelOpts struct {
+	isClassic       bool
+	hasSystemSeed   bool
+	hasPartial      bool
+	preseedArtifact bool
+	testCompsMode   bool
+	kModsRevs       map[string]snap.Revision
+	types           []snap.Type
+}
+
+func (s *deviceMgrInstallSuite) mockSystemSeedWithLabel(c *C, label string, seedCopyFn func(string, seed.CopyOptions, timings.Measurer) error, opts mockSystemSeedWithLabelOpts) (gadgetSnapPath, kernelSnapPath string, kCompsPaths []string, ginfo *gadget.Info, mountCmd *testutil.MockCmd, rawModel map[string]interface{}) {
+	// Mock partitioned disk
+	gadgetYaml := gadgettest.SingleVolumeUC20GadgetYaml
+	if opts.isClassic {
+		if opts.hasSystemSeed {
+			gadgetYaml = gadgettest.SingleVolumeClassicWithModesAndSystemSeedGadgetYaml
+		} else {
+			gadgetYaml = gadgettest.SingleVolumeClassicWithModesGadgetYaml
+		}
+	}
+	seedGadget := gadgetYaml
+	if opts.hasPartial {
+		// This is the gadget provided by the installer, that must have
+		// filled the partial information.
+		gadgetYaml = gadgettest.SingleVolumeClassicWithModesFilledPartialGadgetYaml
+		// This is the partial gadget, with parts not filled
+		seedGadget = gadgettest.SingleVolumeClassicWithModesPartialGadgetYaml
+	}
+	gadgetRoot := filepath.Join(c.MkDir(), "gadget")
+	ginfo, _, _, restore, err := gadgettest.MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot)
+	c.Assert(err, IsNil)
+	s.AddCleanup(restore)
+
+	// now create a label with snaps/assertions
+	model, rawModel := s.setupSystemSeed(c, label, seedGadget, opts.isClassic, opts.kModsRevs)
+	c.Check(model, NotNil)
+
+	// Create fake seed that will return information from the label we created
+	// (TODO: needs to be in sync with setupSystemSeed, fix that)
+	kernelSnapPath = filepath.Join(s.SeedDir, "snaps", "pc-kernel_1.snap")
+	baseSnapPath := filepath.Join(s.SeedDir, "snaps", "core24_1.snap")
+	gadgetSnapPath = filepath.Join(s.SeedDir, "snaps", "pc_1.snap")
+
+	var kernComps []seed.Component
+	if len(opts.kModsRevs) > 0 {
+		kernComps = []seed.Component{
+			{
+				Path: filepath.Join(s.SeedDir, "snaps", "pc-kernel+kcomp1_"+opts.kModsRevs["kcomp1"].String()+".comp"),
+				CompSideInfo: snap.ComponentSideInfo{
+					Component: naming.NewComponentRef("pc-kernel", "kcomp1"),
+					Revision:  opts.kModsRevs["kcomp1"]},
+			}}
+		kCompsPaths = []string{kernComps[0].Path}
+		if !opts.testCompsMode {
+			kernComps = append(kernComps, seed.Component{
+				Path: filepath.Join(s.SeedDir, "snaps", "pc-kernel+kcomp2_"+opts.kModsRevs["kcomp2"].String()+".comp"),
+				CompSideInfo: snap.ComponentSideInfo{
+					Component: naming.NewComponentRef("pc-kernel", "kcomp2"),
+					Revision:  opts.kModsRevs["kcomp2"]},
+			})
+			kCompsPaths = append(kCompsPaths, kernComps[1].Path)
+		}
+	}
+	essentialSnaps := make([]*seed.Snap, 0, len(opts.types))
+	for _, typ := range opts.types {
+		switch typ {
+		case snap.TypeKernel:
+			essentialSnaps = append(essentialSnaps, &seed.Snap{
+				Path: kernelSnapPath,
+				SideInfo: &snap.SideInfo{RealName: "pc-kernel",
+					Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("pc-kernel")},
+				EssentialType: snap.TypeKernel,
+				Components:    kernComps,
+			})
+		case snap.TypeBase:
+			essentialSnaps = append(essentialSnaps, &seed.Snap{
+				Path: baseSnapPath,
+				SideInfo: &snap.SideInfo{RealName: "core24",
+					Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("core24")},
+				EssentialType: snap.TypeBase,
+			})
+		case snap.TypeGadget:
+			essentialSnaps = append(essentialSnaps, &seed.Snap{
+				Path: gadgetSnapPath,
+				SideInfo: &snap.SideInfo{RealName: "pc",
+					Revision: snap.R(1), SnapID: s.SeedSnaps.AssertedSnapID("pc")},
+				EssentialType: snap.TypeGadget,
+			})
+		}
+	}
+
+	restore = devicestate.MockSeedOpen(func(seedDir, label string) (seed.Seed, error) {
+		return &fakeSeedCopier{
+			copyFn: seedCopyFn,
+			optionalContainers: seed.OptionalContainers{
+				Snaps:      []string{"optional24"},
+				Components: map[string][]string{"optional24": {"comp1"}},
+			},
+			fakeSeed: fakeSeed{
+				essentialSnaps:  essentialSnaps,
+				model:           model,
+				preseedArtifact: opts.preseedArtifact,
+			},
+		}, nil
+	})
+	s.AddCleanup(restore)
+
+	// Mock calls to systemd-mount, which is used to mount snaps from the system label
+	mountCmd = testutil.MockCommand(c, "systemd-mount", "")
+	s.AddCleanup(func() { mountCmd.Restore() })
+
+	return gadgetSnapPath, kernelSnapPath, kCompsPaths, ginfo, mountCmd, rawModel
+}
 
 type deviceMgrInstallModeSuite struct {
 	deviceMgrInstallSuite
@@ -1979,6 +2217,30 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 		s.state.Lock()
 		s.state.Unlock()
 
+		modulesComp := []install.KernelModulesComponentInfo{}
+		if len(model.KernelSnap().Components) > 0 {
+			modulesComp = []install.KernelModulesComponentInfo{
+				{
+					Name:       "kcomp1",
+					Revision:   snap.R(7),
+					MountPoint: filepath.Join(dirs.SnapRunDir, "snap-content/pc-kernel+kcomp1"),
+				},
+				{
+					Name:       "kcomp2",
+					Revision:   snap.R(14),
+					MountPoint: filepath.Join(dirs.SnapRunDir, "snap-content/pc-kernel+kcomp2"),
+				},
+			}
+		}
+		c.Check(kernelSnapInfo, DeepEquals, &install.KernelSnapInfo{
+			Name:             "pc-kernel",
+			Revision:         snap.R(1),
+			MountPoint:       filepath.Join(dirs.SnapRunDir, "snap-content/kernel"),
+			NeedsDriversTree: true,
+			IsCore:           true,
+			ModulesComps:     modulesComp,
+		})
+
 		c.Check(mod.Grade(), Equals, model.Grade())
 
 		brGadgetRoot = gadgetRoot
@@ -2070,6 +2332,18 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 		c.Check(bootWith.RecoverySystemLabel, Equals, "20191218")
 		c.Check(bootWith.RecoverySystemDir, Equals, "")
 		c.Check(bootWith.UnpackedGadgetDir, Equals, filepath.Join(dirs.SnapMountDir, "pc/1"))
+		if len(model.KernelSnap().Components) > 0 {
+			c.Check(bootWith.KernelMods, DeepEquals, []boot.BootableKModsComponents{
+				{
+					CompPlaceInfo: snap.MinimalComponentContainerPlaceInfo("kcomp1", snap.R(7), "pc-kernel"),
+					CompPath:      filepath.Join(dirs.SnapSeedDir, "snaps/pc-kernel+kcomp1_7.comp"),
+				},
+				{
+					CompPlaceInfo: snap.MinimalComponentContainerPlaceInfo("kcomp2", snap.R(14), "pc-kernel"),
+					CompPath:      filepath.Join(dirs.SnapSeedDir, "snaps/pc-kernel+kcomp2_14.comp"),
+				},
+			})
+		}
 		if tc.encrypt {
 			c.Check(obs, NotNil)
 		} else {
@@ -2220,8 +2494,22 @@ func makeDeviceSerialAssertionInDir(c *C, where string, storeStack *assertstest.
 }
 
 func (s *deviceMgrInstallModeSuite) TestFactoryResetNoEncryptionHappyFull(c *C) {
+	const withKMods = false
+	s.testFactoryResetNoEncryptionHappyFull(c, withKMods)
+}
+
+func (s *deviceMgrInstallModeSuite) TestFactoryResetNoEncryptionHappyFullWithComps(c *C) {
+	const withKMods = true
+	s.testFactoryResetNoEncryptionHappyFull(c, withKMods)
+}
+
+func (s *deviceMgrInstallModeSuite) testFactoryResetNoEncryptionHappyFull(c *C, withKMods bool) {
 	seedCopyFn := func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
 		return fmt.Errorf("unexpected copy call")
+	}
+	var kModsRevs map[string]snap.Revision
+	if withKMods {
+		kModsRevs = map[string]snap.Revision{"kcomp1": snap.R(7), "kcomp2": snap.R(14)}
 	}
 	seedOpts := mockSystemSeedWithLabelOpts{
 		isClassic:       false,
@@ -2229,6 +2517,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetNoEncryptionHappyFull(c *C) 
 		hasPartial:      false,
 		preseedArtifact: false,
 		types:           []snap.Type{snap.TypeKernel},
+		kModsRevs:       kModsRevs,
 	}
 	_, _, _, _, _, rawModel := s.mockSystemSeedWithLabel(c, "20191218", seedCopyFn, seedOpts)
 
@@ -2304,8 +2593,22 @@ echo "mock output of: $(basename "$0") $*"
 }
 
 func (s *deviceMgrInstallModeSuite) TestFactoryResetEncryptionHappyFull(c *C) {
+	const withKMods = false
+	s.testFactoryResetEncryptionHappyFull(c, withKMods)
+}
+
+func (s *deviceMgrInstallModeSuite) TestFactoryResetEncryptionHappyFullWithComps(c *C) {
+	const withKMods = true
+	s.testFactoryResetEncryptionHappyFull(c, withKMods)
+}
+
+func (s *deviceMgrInstallModeSuite) testFactoryResetEncryptionHappyFull(c *C, withKMods bool) {
 	seedCopyFn := func(seedDir string, opts seed.CopyOptions, tm timings.Measurer) error {
 		return fmt.Errorf("unexpected copy call")
+	}
+	var kModsRevs map[string]snap.Revision
+	if withKMods {
+		kModsRevs = map[string]snap.Revision{"kcomp1": snap.R(7), "kcomp2": snap.R(14)}
 	}
 	seedOpts := mockSystemSeedWithLabelOpts{
 		isClassic:       false,
@@ -2313,6 +2616,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetEncryptionHappyFull(c *C) {
 		hasPartial:      false,
 		preseedArtifact: false,
 		types:           []snap.Type{snap.TypeKernel},
+		kModsRevs:       kModsRevs,
 	}
 	_, _, _, _, _, rawModel := s.mockSystemSeedWithLabel(c, "20191218", seedCopyFn, seedOpts)
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -900,7 +900,7 @@ func mountSeedContainer(filePath, subdir string) (mountpoint string, unmount fun
 }
 
 func (m *DeviceManager) loadAndMountSystemLabelSnaps(systemLabel string, essentialTypes []snap.Type) (*systemAndEssentialSnaps, map[snap.Type]string, map[string]string, func(), error) {
-	systemAndSnaps, err := m.loadSystemAndEssentialSnaps(systemLabel, essentialTypes)
+	systemAndSnaps, err := m.loadSystemAndEssentialSnaps(systemLabel, essentialTypes, "run")
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -187,6 +187,23 @@ version: 1.0
 type: kernel
 version: 1.0
 `,
+	"pc-kernel=22+kmods": `name: pc-kernel
+type: kernel
+version: 1.0
+components:
+  kcomp1:
+    type: kernel-modules
+  kcomp2:
+    type: kernel-modules
+`,
+	"pc-kernel+kcomp1": `component: pc-kernel+kcomp1
+type: kernel-modules
+version: 1.0
+`,
+	"pc-kernel+kcomp2": `component: pc-kernel+kcomp2
+type: kernel-modules
+version: 1.0
+`,
 	"pc=22": `name: pc
 type: gadget
 base: core22

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -183,11 +183,28 @@ confinement: devmode
 type: base
 version: 1.0
 `,
+	"core24": `name: core24
+type: base
+version: 1.0
+`,
 	"pc-kernel=22": `name: pc-kernel
 type: kernel
 version: 1.0
 `,
+	"pc-kernel=24": `name: pc-kernel
+type: kernel
+version: 1.0
+`,
 	"pc-kernel=22+kmods": `name: pc-kernel
+type: kernel
+version: 1.0
+components:
+  kcomp1:
+    type: kernel-modules
+  kcomp2:
+    type: kernel-modules
+`,
+	"pc-kernel=24+kmods": `name: pc-kernel
 type: kernel
 version: 1.0
 components:
@@ -209,6 +226,11 @@ type: gadget
 base: core22
 version: 1.0
 `,
+	"pc=24": `name: pc
+type: gadget
+base: core24
+version: 1.0
+`,
 	"optional22": `name: optional22
 type: app
 base: core22
@@ -218,6 +240,18 @@ components:
     type: standard
 `,
 	"optional22+comp1": `component: optional22+comp1
+type: standard
+version: 1.0
+`,
+	"optional24": `name: optional24
+type: app
+base: core24
+version: 1.0
+components:
+  comp1:
+    type: standard
+`,
+	"optional24+comp1": `component: optional24+comp1
 type: standard
 version: 1.0
 `,

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -509,16 +509,24 @@ nested_get_images_path() {
     echo "$NESTED_IMAGES_DIR"
 }
 
-nested_get_extra_snaps() {
-    local EXTRA_SNAPS=""
+nested_get_extra_containers() {
+    local SUFFIX=$1
     local EXTRA_SNAPS_PATH
     EXTRA_SNAPS_PATH="$(nested_get_extra_snaps_path)"
 
     if [ -d "$EXTRA_SNAPS_PATH" ]; then
         while IFS= read -r mysnap; do
             echo "$mysnap"
-        done < <(find "$EXTRA_SNAPS_PATH" -name '*.snap')
+        done < <(find "$EXTRA_SNAPS_PATH" -name "*.$SUFFIX")
     fi
+}
+
+nested_get_extra_snaps() {
+    nested_get_extra_containers snap
+}
+
+nested_get_extra_comps() {
+    nested_get_extra_containers comp
 }
 
 nested_download_image() {
@@ -890,10 +898,13 @@ nested_create_core_vm() {
             # Invoke ubuntu image
             local NESTED_MODEL
             NESTED_MODEL="$(nested_get_model)"
-            
+
             local EXTRA_SNAPS=""
             for mysnap in $(nested_get_extra_snaps); do
                 EXTRA_SNAPS="$EXTRA_SNAPS --snap $mysnap"
+            done
+            for mycomp in $(nested_get_extra_comps); do
+                EXTRA_SNAPS="$EXTRA_SNAPS --comp $mycomp"
             done
 
             # only set SNAPPY_FORCE_SAS_URL because we don't need it defined 

--- a/tests/lib/tools/build_kernel_with_comps.sh
+++ b/tests/lib/tools/build_kernel_with_comps.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -uxe
+
+# Modify kernel and create a component
+build_kernel_with_comp() {
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB/prepare.sh"
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB"/nested.sh
+
+  VERSION="$(tests.nested show version)"
+  snap download --channel="$VERSION"/beta --basename=pc-kernel pc-kernel
+  unsquashfs -d kernel pc-kernel.snap
+  kern_ver=$(find kernel/modules/* -maxdepth 0 -printf "%f\n")
+  comp_ko_dir=wifi-comp/modules/"$kern_ver"/wireless/
+  mkdir -p "$comp_ko_dir"
+  mkdir -p wifi-comp/meta/
+  cat << 'EOF' > wifi-comp/meta/component.yaml
+component: pc-kernel+wifi-comp
+type: kernel-modules
+version: 1.0
+summary: wifi simulator
+description: wifi simulator for testing purposes
+EOF
+  hwsim_path=$(find kernel -name mac80211_hwsim.ko\*)
+  cp "$hwsim_path" "$comp_ko_dir"
+  snap pack --filename=pc-kernel+wifi-comp.comp wifi-comp
+
+  # Create kernel without the kernel module
+  rm "$hwsim_path"
+  # depmod wants a lib subdir, fake it and remove after invocation
+  mkdir kernel/lib
+  ln -s ../modules kernel/lib/modules
+  depmod -b kernel/ "$kern_ver"
+  rm -rf kernel/lib
+  rm pc-kernel.snap
+  # append component meta-information
+  printf 'components:\n  wifi-comp:\n    type: kernel-modules\n' >> kernel/meta/snap.yaml
+  snap pack --filename=pc-kernel.snap kernel
+}
+
+build_kernel_with_comp "$@"

--- a/tests/lib/tools/build_kernel_with_comps.sh
+++ b/tests/lib/tools/build_kernel_with_comps.sh
@@ -2,42 +2,47 @@
 
 set -uxe
 
+# shellcheck source=tests/lib/prepare.sh
+. "$TESTSLIB/prepare.sh"
+#shellcheck source=tests/lib/nested.sh
+. "$TESTSLIB"/nested.sh
+
 # Modify kernel and create a component
 build_kernel_with_comp() {
-  # shellcheck source=tests/lib/prepare.sh
-  . "$TESTSLIB/prepare.sh"
-  #shellcheck source=tests/lib/nested.sh
-  . "$TESTSLIB"/nested.sh
+    mod_name=$1
+    comp_name=$2
 
-  VERSION="$(tests.nested show version)"
-  snap download --channel="$VERSION"/beta --basename=pc-kernel pc-kernel
-  unsquashfs -d kernel pc-kernel.snap
-  kern_ver=$(find kernel/modules/* -maxdepth 0 -printf "%f\n")
-  comp_ko_dir=wifi-comp/modules/"$kern_ver"/wireless/
-  mkdir -p "$comp_ko_dir"
-  mkdir -p wifi-comp/meta/
-  cat << 'EOF' > wifi-comp/meta/component.yaml
-component: pc-kernel+wifi-comp
+    VERSION="$(tests.nested show version)"
+    snap download --channel="$VERSION"/beta --basename=pc-kernel pc-kernel
+    unsquashfs -d kernel pc-kernel.snap
+    kern_ver=$(find kernel/modules/* -maxdepth 0 -printf "%f\n")
+    comp_ko_dir=$comp_name/modules/"$kern_ver"/kmod/
+    mkdir -p "$comp_ko_dir"
+    mkdir -p "$comp_name"/meta/
+    cat << EOF > "$comp_name"/meta/component.yaml
+component: pc-kernel+$comp_name
 type: kernel-modules
 version: 1.0
-summary: wifi simulator
-description: wifi simulator for testing purposes
+summary: kernel component
+description: kernel component for testing purposes
 EOF
-  hwsim_path=$(find kernel -name mac80211_hwsim.ko\*)
-  cp "$hwsim_path" "$comp_ko_dir"
-  snap pack --filename=pc-kernel+wifi-comp.comp wifi-comp
+    # Replace _ or - with [_-], as it can be any of these
+    glob_mod_name=$(printf '%s' "$mod_name" | sed -r 's/[-_]/[-_]/g')
+    module_path=$(find kernel -name "${glob_mod_name}.ko*")
+    cp "$module_path" "$comp_ko_dir"
+    snap pack --filename=pc-kernel+"$comp_name".comp "$comp_name"
 
-  # Create kernel without the kernel module
-  rm "$hwsim_path"
-  # depmod wants a lib subdir, fake it and remove after invocation
-  mkdir kernel/lib
-  ln -s ../modules kernel/lib/modules
-  depmod -b kernel/ "$kern_ver"
-  rm -rf kernel/lib
-  rm pc-kernel.snap
-  # append component meta-information
-  printf 'components:\n  wifi-comp:\n    type: kernel-modules\n' >> kernel/meta/snap.yaml
-  snap pack --filename=pc-kernel.snap kernel
+    # Create kernel without the kernel module
+    rm "$module_path"
+    # depmod wants a lib subdir, fake it and remove after invocation
+    mkdir kernel/lib
+    ln -s ../modules kernel/lib/modules
+    depmod -b kernel/ "$kern_ver"
+    rm -rf kernel/lib
+    rm pc-kernel.snap
+    # append component meta-information
+    printf 'components:\n  %s:\n    type: kernel-modules\n' "$comp_name" >> kernel/meta/snap.yaml
+    snap pack --filename=pc-kernel.snap kernel
 }
 
 build_kernel_with_comp "$@"

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -19,6 +19,7 @@ run_muinstaller() {
     local kernel_assertion="${6}"
     local label="${7}"
     local disk="${8}"
+    local kern_mods_comp="${9:-}"
 
     # ack the needed assertions
     snap ack "${kernel_assertion}"
@@ -40,9 +41,15 @@ run_muinstaller() {
     mv snapd_*.snap snapd.snap
 
     # prepare a classic seed
+    kmodsarg=""
+    if [ -n "$kern_mods_comp" ]
+    then kmodsarg="--comp $kern_mods_comp"
+    fi
+    # shellcheck disable=SC2086
     snap prepare-image --classic \
         --channel=edge \
         --snap "${kernel_snap}" \
+        $kmodsarg \
         --snap pc.snap \
         --snap snapd.snap \
         "${model_assertion}" \
@@ -158,8 +165,26 @@ run_muinstaller() {
 
     # Change seed part label to capitals so we cover that use case
     image_path="${NESTED_IMAGES_DIR}/${image_name}"
-    kpartx -asv "${image_path}"
+    loop=$(kpartx -asv "$image_path" | head -n1 | cut -d' ' -f3)
     fatlabel /dev/disk/by-label/ubuntu-seed UBUNTU-SEED
+    # Also, introduce udev rule to force loading of kernel module in component
+    if [ -n "$kern_mods_comp" ]; then
+        loop=${loop%p*}
+        loop_data="$loop"p5
+        mkdir mnt
+        mount /dev/mapper/"$loop_data" mnt
+
+        # Rule to force module loading on system start (we randomly choose
+        # the rtc device add event for this)
+        rule='ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", RUN{builtin}+="kmod load mac80211_hwsim"'
+        printf '%s\n' "$rule" > mnt/etc/udev/rules.d/70-load-wifi.rules
+
+        if ! umount mnt; then
+            # just in case retry
+            sleep 1
+            umount mnt
+        fi
+    fi
     if ! kpartx -d "${image_path}"; then
         # Sometimes there are random failures, let's wait and re-try
         sleep 1
@@ -184,6 +209,7 @@ main() {
     local kernel_assertion=""
     local label="classic"
     local disk=""
+    local kern_mods_comp=""
     while [ $# -gt 0 ]; do
         case "$1" in
             --model)
@@ -216,6 +242,11 @@ main() {
                 ;;
             --disk)
                 disk="${2}"
+                shift 2
+                ;;
+            --kmods-comp)
+                # Only on kernel-modules component supported atm
+                kern_mods_comp="${2}"
                 shift 2
                 ;;
             --*|-*)
@@ -275,37 +306,40 @@ main() {
         kernel_assertion="$(realpath "${kernel_assertion}")"
     fi
 
+    if [ -n "${kern_mods_comp}" ]; then
+        kern_mods_comp="$(realpath "${kern_mods_comp}")"
+    fi
+
     # start a subshell and change directories so that we can change directories
     # to keep all of our generated files together
     (
-    cd "$(mktemp -d --tmpdir="${PWD}")"
+        cd "$(mktemp -d --tmpdir="${PWD}")"
 
-    # create new disk (if the caller didn't provide one) for the installer to
-    # work on and attach to the VM
-    if [ -z "${disk}" ]; then
-        disk="${PWD}/disk.img"
-        truncate --size=6G "${disk}"
-    fi
+        # create new disk (if the caller didn't provide one) for the installer to
+        # work on and attach to the VM
+        if [ -z "${disk}" ]; then
+            disk="${PWD}/disk.img"
+            truncate --size=6G "${disk}"
+        fi
 
-    # if a gadget wasn't provided, download one we know should work for hybrid
-    # systems
-    if [ -z "${gadget_snap}" ]; then
-        snap download --channel="classic-23.10/stable" --basename=pc pc
-        gadget_snap="${PWD}/pc.snap"
-        gadget_assertion="${PWD}/pc.assert"
-    fi
+        # if a gadget wasn't provided, download one we know should work for hybrid
+        # systems
+        if [ -z "${gadget_snap}" ]; then
+            snap download --channel="classic-23.10/stable" --basename=pc pc
+            gadget_snap="${PWD}/pc.snap"
+            gadget_assertion="${PWD}/pc.assert"
+        fi
 
-    # if a kernel wasn't provided, download one
-    if [ -z "${kernel_snap}" ]; then
-        snap download --channel="23.10/stable" --basename=pc-kernel pc-kernel
-        kernel_snap="${PWD}/pc-kernel.snap"
-        kernel_assertion="${PWD}/pc-kernel.assert"
-    fi
+        # if a kernel wasn't provided, download one
+        if [ -z "${kernel_snap}" ]; then
+            snap download --channel="23.10/stable" --basename=pc-kernel pc-kernel
+            kernel_snap="${PWD}/pc-kernel.snap"
+            kernel_assertion="${PWD}/pc-kernel.assert"
+        fi
 
-    run_muinstaller "${model_assertion}" "${store_dir}" "${gadget_snap}" \
-        "${gadget_assertion}" "${kernel_snap}" "${kernel_assertion}" "${label}" \
-        "${disk}"
-
+        run_muinstaller "${model_assertion}" "${store_dir}" "${gadget_snap}" \
+                        "${gadget_assertion}" "${kernel_snap}" "${kernel_assertion}" "${label}" \
+                        "${disk}" "${kern_mods_comp}"
     )
 }
 

--- a/tests/nested/manual/build-with-kernel-modules-components/task.yaml
+++ b/tests/nested/manual/build-with-kernel-modules-components/task.yaml
@@ -1,0 +1,73 @@
+summary: Verify kernel modules components work as expected
+details: |
+  Install a kernel-modules component and verify that the shipped
+  kernel module is installed.
+
+systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
+environment:
+  # Test both encrypted and unencrypted cases
+  NESTED_ENABLE_TPM/encrypted: true
+  NESTED_ENABLE_SECURE_BOOT/encrypted: true
+
+  # unencrypted case
+  NESTED_ENABLE_TPM/plain: false
+  NESTED_ENABLE_SECURE_BOOT/plain: false
+
+  NESTED_BUILD_SNAPD_FROM_CURRENT: true
+  NESTED_REPACK_KERNEL_SNAP: false
+  NESTED_ENABLE_OVMF: true
+
+  KMOD_COMP: efi-pstore
+
+prepare: |
+  # Modify kernel and create a component
+  "$TESTSTOOLS"/build_kernel_with_comps.sh efi_pstore "$KMOD_COMP"
+
+  cp pc-kernel.snap "$(tests.nested get extra-snaps-path)"
+  cp pc-kernel+"$KMOD_COMP".comp "$(tests.nested get extra-snaps-path)"
+  tests.nested build-image core
+  tests.nested create-vm core
+
+execute: |
+  check_efi_pstore() {
+      # Compare times to check that drivers tree was created on
+      # installation, not on seeding
+      # shellcheck disable=SC2016
+      tree_birth=$(remote.exec 'date -d"$(stat --printf="%w\n" /var/lib/snapd/kernel/pc-kernel)" +%s')
+      reboot_time=$(remote.exec 'last reboot --time-format full | sed -n "s/wtmp begins //p"')
+      reboot_time=$(date -d"$reboot_time" +%s)
+      test "$reboot_time" -gt "$tree_birth"
+
+      # check that the component is in place
+      kern_ver=$(remote.exec uname -r)
+      comp_install_dir=/var/lib/snapd/kernel/pc-kernel/x1/lib/modules/"$kern_ver"/updates/"$KMOD_COMP"
+      comp_dir=/snap/pc-kernel/components/mnt/"$KMOD_COMP"/x1/modules/"$kern_ver"
+      test "$(remote.exec readlink -f "$comp_install_dir")" = "$comp_dir"
+
+      # module comes from a component
+      remote.exec modinfo -F filename efi_pstore | MATCH updates/"$KMOD_COMP"/kmod/efi-pstore.ko
+      # module should have been loaded (pulled by systemd-pstore.service)
+      remote.exec lsmod | MATCH efi_pstore
+  }
+
+  # check component from store has been early-installed
+  check_efi_pstore
+
+  # remove kernel component
+  remote.exec sudo snap remove pc-kernel+"$KMOD_COMP"
+
+  # do a factory reset
+  printf "Request factory reset\n"
+  boot_id=$(tests.nested boot-id)
+  remote.exec "sudo snap reboot --factory-reset" || true
+  tests.nested wait-for reboot "$boot_id"
+
+  # check that we are back in run mode
+  remote.exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
+
+  # wait for the system to get setup and finish seeding
+  remote.wait-for snap-command
+  retry -n 10 --wait 2 remote.exec "sudo snap wait system seed.loaded"
+
+  # component was restored
+  check_efi_pstore

--- a/tests/nested/manual/kernel-modules-components/task.yaml
+++ b/tests/nested/manual/kernel-modules-components/task.yaml
@@ -65,9 +65,9 @@ execute: |
   remote.exec "sudo sh -c 'printf \"$rule\" > /etc/udev/rules.d/70-load-wifi.rules'"
 
   # Install jointly kernel with component
-  remote.push pc-kernel_*.snap
+  remote.push pc-kernel.snap
   boot_id=$(tests.nested boot-id)
-  remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel_*.snap "$comp_file")
+  remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel.snap "$comp_file")
   tests.nested wait-for reboot "$boot_id"
   remote.exec "snap change $remote_chg_id" | NOMATCH Error
   # Check that the module has been loaded by the udev rule
@@ -75,7 +75,7 @@ execute: |
 
   # Install again, but force a failure to check revert
   boot_id=$(tests.nested boot-id)
-  remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel_*.snap "$comp_file")
+  remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel.snap "$comp_file")
   remote.retry --wait 1 -n 100 'sudo rm /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi'
   tests.nested wait-for reboot "$boot_id"
   remote.retry --wait 5 -n 60 "snap change $remote_chg_id | MATCH Error"

--- a/tests/nested/manual/kernel-modules-components/task.yaml
+++ b/tests/nested/manual/kernel-modules-components/task.yaml
@@ -19,31 +19,9 @@ environment:
 
 prepare: |
   # Modify kernel and create a component
-  VERSION="$(tests.nested show version)"
-  snap download --channel="$VERSION"/beta pc-kernel
-  unsquashfs -d kernel pc-kernel_*.snap
-  kern_ver=$(find kernel/modules/* -maxdepth 0 -printf "%f\n")
-  comp_ko_dir=wifi-comp/modules/"$kern_ver"/wireless/
-  mkdir -p "$comp_ko_dir"
-  mkdir -p wifi-comp/meta/
-  cp component.yaml wifi-comp/meta/
-  hwsim_path=$(find kernel -name mac80211_hwsim.ko\*)
-  cp "$hwsim_path" "$comp_ko_dir"
-  snap pack wifi-comp
+  "$TESTSTOOLS"/build_kernel_with_comps.sh mac80211_hwsim wifi-comp
 
-  # Create kernel without the kernel module
-  rm "$hwsim_path"
-  # depmod wants a lib subdir, fake it and remove after invocation
-  mkdir kernel/lib
-  ln -s ../modules kernel/lib/modules
-  depmod -b kernel/ "$kern_ver"
-  rm -rf kernel/lib
-  rm pc-kernel_*.snap
-  # append component meta-information
-  printf 'components:\n  wifi-comp:\n    type: kernel-modules\n' >> kernel/meta/snap.yaml
-  snap pack kernel
-
-  cp pc-kernel_*.snap "$(tests.nested get extra-snaps-path)"
+  cp pc-kernel.snap "$(tests.nested get extra-snaps-path)"
   tests.nested build-image core
   tests.nested create-vm core
 
@@ -60,7 +38,7 @@ execute: |
   not remote.exec modprobe mac80211_hwsim
 
   # install the component
-  comp_file=pc-kernel+wifi-comp_1.0.comp
+  comp_file=pc-kernel+wifi-comp.comp
   remote.push "$comp_file"
   remote.exec sudo snap install --dangerous "$comp_file"
 

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -99,7 +99,7 @@ execute: |
   kmods_arg=""
   if os.query is-ubuntu-ge 24.04; then
       # split kernel into snap and kernel-modules component
-      "$TESTSTOOLS"/build_kernel_with_comps.sh
+      "$TESTSTOOLS"/build_kernel_with_comps.sh mac80211_hwsim wifi-comp
       kmods_arg="--kmods-comp pc-kernel+wifi-comp.comp"
       # build now uc24 initramfs
       uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
@@ -144,7 +144,7 @@ execute: |
       remote.exec test -d /var/lib/snapd/kernel/pc-kernel/x1
       # mac80211_hwsim has been loaded and comes from the "updates" subfolder
       remote.exec lsmod | MATCH mac80211_hwsim
-      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/wireless/mac80211_hwsim.ko
+      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/kmod/mac80211_hwsim.ko
       remote.exec ip link show wlan0
   fi
 
@@ -195,7 +195,7 @@ execute: |
       remote.exec "snap change $REMOTE_CHG_ID" | NOMATCH Error
       # mac80211_hwsim has been loaded and comes from the "updates" subfolder
       remote.exec lsmod | MATCH mac80211_hwsim
-      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/wireless/mac80211_hwsim.ko
+      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/kmod/mac80211_hwsim.ko
       remote.exec ip link show wlan0
   fi
 

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -146,7 +146,7 @@ execute: |
       # efi_pstore is loaded by systemd-pstore.service (pulled by sysinit.target) and must be available
       # early, otherwise it will not have been loaded
       remote.exec lsmod | MATCH efi_pstore
-      remote.exec modinfo -F filename efi_pstore | MATCH updates/kmod/efi-pstore.ko
+      remote.exec modinfo -F filename efi_pstore | MATCH updates/efi-pstore/kmod/efi-pstore.ko
   fi
 
   # check encryption
@@ -196,7 +196,7 @@ execute: |
       remote.exec "snap change $REMOTE_CHG_ID" | NOMATCH Error
       # efi_pstore has been loaded and comes from the "updates" subfolder
       remote.exec lsmod | MATCH efi_pstore
-      remote.exec modinfo -F filename efi_pstore | MATCH updates/kmod/efi-pstore.ko
+      remote.exec modinfo -F filename efi_pstore | MATCH updates/efi-pstore/kmod/efi-pstore.ko
   fi
 
   # test kernel/gadget refreshes via the fake-store

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -96,8 +96,13 @@ execute: |
   # keep original blob just so we can find the assertion later
   cp pc-kernel.snap pc-kernel.snap.orig
   # Build kernel with initramfs with the compiled snap-bootstrap
+  kmods_arg=""
   if os.query is-ubuntu-ge 24.04; then
-    uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+      # split kernel into snap and kernel-modules component
+      "$TESTSTOOLS"/build_kernel_with_comps.sh
+      kmods_arg="--kmods-comp pc-kernel+wifi-comp.comp"
+      # build now uc24 initramfs
+      uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   else
     uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   fi
@@ -118,6 +123,7 @@ execute: |
 
   # setup_nested_hybrid_system.sh runs the muinstaller to install a hybrid
   # system
+  # shellcheck disable=SC2086
   "${TESTSTOOLS}"/setup_nested_hybrid_system.sh \
      --model classic.model \
      --store-dir "${STORE_DIR}" \
@@ -125,6 +131,7 @@ execute: |
      --gadget-assertion pc.assert \
      --kernel pc-kernel.snap \
      --kernel-assertion pc-kernel.assert \
+     $kmods_arg \
      --disk disk.img
 
   # basic things look fine
@@ -132,10 +139,13 @@ execute: |
   remote.exec "snap changes" | MATCH "Done.* Initialize system state"
   remote.exec "snap list" | MATCH pc-kernel
   if os.query is-ubuntu-ge 24.04; then
+      remote.exec snap components pc-kernel | MATCH 'pc-kernel\+wifi-comp'
       # kernel drivers tree has been created
       remote.exec test -d /var/lib/snapd/kernel/pc-kernel/x1
-      # TODO check the drivers tree has been mounted (depends on
-      # https://github.com/snapcore/core-initrd/pull/238 being present in initramfs)
+      # mac80211_hwsim has been loaded and comes from the "updates" subfolder
+      remote.exec lsmod | MATCH mac80211_hwsim
+      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/wireless/mac80211_hwsim.ko
+      remote.exec ip link show wlan0
   fi
 
   # check encryption
@@ -170,6 +180,23 @@ execute: |
       remote.exec "sudo snap debug api /v2/systems/classic" > system
       gojq '.result."storage-encryption".support' < system | MATCH "unavailable"
       gojq '.result."storage-encryption"."unavailable-reason"' < system | MATCH "not encrypting device storage as checking TPM gave: the TPM is in DA lockout mode"
+  fi
+
+  if os.query is-ubuntu-ge 24.04; then
+      # test refresh of kernel with component
+      remote.push pc-kernel.snap
+      remote.push pc-kernel+wifi-comp.comp
+      REMOTE_CHG_ID=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel.snap pc-kernel+wifi-comp.comp)
+      retry --wait 1 -n 120 sh -c "remote.exec \"snap change $REMOTE_CHG_ID | grep -E 'Task set to wait until a system restart allows to continue'\""
+      boot_id=$(tests.nested boot-id)
+      remote.exec sudo reboot || true
+      tests.nested wait-for reboot "$boot_id"
+      remote.exec sudo snap watch "$REMOTE_CHG_ID"
+      remote.exec "snap change $REMOTE_CHG_ID" | NOMATCH Error
+      # mac80211_hwsim has been loaded and comes from the "updates" subfolder
+      remote.exec lsmod | MATCH mac80211_hwsim
+      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/wireless/mac80211_hwsim.ko
+      remote.exec ip link show wlan0
   fi
 
   # test kernel/gadget refreshes via the fake-store

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -100,7 +100,7 @@ execute: |
   if os.query is-ubuntu-ge 24.04; then
       # split kernel into snap and kernel-modules component
       "$TESTSTOOLS"/build_kernel_with_comps.sh efi_pstore efi-pstore
-      kmods_arg="--kmods-comp pc-kernel+efi-pstore.snap"
+      kmods_arg="--kmods-comp pc-kernel+efi-pstore.comp"
       # build now uc24 initramfs
       uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   else

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -99,8 +99,8 @@ execute: |
   kmods_arg=""
   if os.query is-ubuntu-ge 24.04; then
       # split kernel into snap and kernel-modules component
-      "$TESTSTOOLS"/build_kernel_with_comps.sh mac80211_hwsim wifi-comp
-      kmods_arg="--kmods-comp pc-kernel+wifi-comp.comp"
+      "$TESTSTOOLS"/build_kernel_with_comps.sh efi_pstore efi-pstore
+      kmods_arg="--kmods-comp pc-kernel+efi-pstore.snap"
       # build now uc24 initramfs
       uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   else
@@ -139,13 +139,14 @@ execute: |
   remote.exec "snap changes" | MATCH "Done.* Initialize system state"
   remote.exec "snap list" | MATCH pc-kernel
   if os.query is-ubuntu-ge 24.04; then
-      remote.exec snap components pc-kernel | MATCH 'pc-kernel\+wifi-comp'
+      remote.exec snap components pc-kernel | MATCH 'pc-kernel\+efi-pstore'
       # kernel drivers tree has been created
       remote.exec test -d /var/lib/snapd/kernel/pc-kernel/x1
-      # mac80211_hwsim has been loaded and comes from the "updates" subfolder
-      remote.exec lsmod | MATCH mac80211_hwsim
-      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/kmod/mac80211_hwsim.ko
-      remote.exec ip link show wlan0
+      # efi_pstore has been loaded and comes from the "updates" subfolder
+      # efi_pstore is loaded by systemd-pstore.service (pulled by sysinit.target) and must be available
+      # early, otherwise it will not have been loaded
+      remote.exec lsmod | MATCH efi_pstore
+      remote.exec modinfo -F filename efi_pstore | MATCH updates/kmod/efi-pstore.ko
   fi
 
   # check encryption
@@ -183,20 +184,19 @@ execute: |
   fi
 
   if os.query is-ubuntu-ge 24.04; then
-      # test refresh of kernel with component
+  # test refresh of kernel with component
       remote.push pc-kernel.snap
-      remote.push pc-kernel+wifi-comp.comp
-      REMOTE_CHG_ID=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel.snap pc-kernel+wifi-comp.comp)
+      remote.push pc-kernel+efi-pstore.comp
+      REMOTE_CHG_ID=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel.snap pc-kernel+efi-pstore.comp)
       retry --wait 1 -n 120 sh -c "remote.exec \"snap change $REMOTE_CHG_ID | grep -E 'Task set to wait until a system restart allows to continue'\""
       boot_id=$(tests.nested boot-id)
       remote.exec sudo reboot || true
       tests.nested wait-for reboot "$boot_id"
       remote.exec sudo snap watch "$REMOTE_CHG_ID"
       remote.exec "snap change $REMOTE_CHG_ID" | NOMATCH Error
-      # mac80211_hwsim has been loaded and comes from the "updates" subfolder
-      remote.exec lsmod | MATCH mac80211_hwsim
-      remote.exec modinfo -F filename mac80211_hwsim | MATCH updates/wifi-comp/kmod/mac80211_hwsim.ko
-      remote.exec ip link show wlan0
+      # efi_pstore has been loaded and comes from the "updates" subfolder
+      remote.exec lsmod | MATCH efi_pstore
+      remote.exec modinfo -F filename efi_pstore | MATCH updates/kmod/efi-pstore.ko
   fi
 
   # test kernel/gadget refreshes via the fake-store


### PR DESCRIPTION
Make sure that module shipped in kernel-modules components are available on first boot after auto-install. This does not consider yet installation using the snapd API.