### PR TITLE
tests: update images used for core24 snap validation

### DIFF
--- a/tests/lib/spread/backend.testflinger.beta.yaml
+++ b/tests/lib/spread/backend.testflinger.beta.yaml
@@ -75,7 +75,7 @@
                   password: ubuntu
             - ubuntu-core-24-arm-64-rpi4:
                   queue: rpi4b8g
-                  image: https://cdimage.ubuntu.com/ubuntu-core/24/beta/pending/ubuntu-core-24-arm64+raspi.img.xz
+                  image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-24-stable-snapd_beta/pi.img.xz
                   workers: 1
                   username: ubuntu
                   password: ubuntu

--- a/tests/lib/spread/backend.testflinger.edge.yaml
+++ b/tests/lib/spread/backend.testflinger.edge.yaml
@@ -39,7 +39,7 @@
                   password: ubuntu
             - ubuntu-core-24-arm-64-rpi4:
                   queue: rpi4b8g
-                  image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-24-edge-core24_edge/pi.img.xz
+                  image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-24-stable-core24_edge/pi.img.xz
                   workers: 1
                   username: ubuntu
                   password: ubuntu


### PR DESCRIPTION
Replace the old images with the new ones in snapd project
