### PR TITLE
tests: fix reexec tests when SNAP_REEXEC=0

### DIFF
--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -12,6 +12,8 @@ environment:
     SNAPD_NO_MEMORY_LIMIT: 1
 
 restore: |
+    tests.exec is-skipped && exit 0
+
     # Remove the local revision of snapd, if we installed one.
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$(readlink "$SNAP_MOUNT_DIR/snapd/current")" = x1 ]; then
@@ -20,9 +22,8 @@ restore: |
     fi
 
 execute: |
-    if [ "$SNAP_REEXEC" = 0 ]; then
-        echo "Reexec is not enabled, exiting..."
-        exit 0
+    if [ "${SNAP_REEXEC:-}" = "0" ]; then
+        tests.exec skip-test "skipping test when SNAP_REEXEC is disabled" && exit 0
     fi
 
     snap list snapd | awk "/^snapd / {print(\$3)}" > prevBoot

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -19,6 +19,10 @@ environment:
     SNAPD_SRC/snapd: "snapd"
 
 prepare: |
+    if [ "${SNAP_REEXEC:-}" = "0" ]; then
+        tests.exec skip-test "skipping test when SNAP_REEXEC is disabled" && exit 0
+    fi
+
     #  when testing core remove snapd snap as option for re-exec
     if [ "$SNAPD_SRC" == "core" ]; then
         systemctl stop snapd.service snapd.socket
@@ -33,6 +37,8 @@ prepare: |
     fi
 
 restore: |
+    tests.exec is-skipped && exit 0
+
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     SNAPD_MOUNT_DIR="$SNAP_MOUNT_DIR/$SNAPD_SRC"
     # remove the locale revision of the snapd source snap, if we installed one
@@ -64,17 +70,16 @@ restore: |
     systemctl start snapd.service
 
 debug: |
+    tests.exec is-skipped && exit 0
+
     ls /etc/systemd/system/snapd.service.d
     cat /etc/systemd/system/snapd.service.d/*
 
 execute: |
+    tests.exec is-skipped && exit 0
+    
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     SNAPD_MOUNT_DIR="$SNAP_MOUNT_DIR/$SNAPD_SRC"
-
-    if [ "${SNAP_REEXEC:-}" = "0" ]; then
-        echo "skipping test when SNAP_REEXEC is disabled"
-        exit 0
-    fi
 
     echo "Ensure we re-exec by default"
     IS_REEXEC=true


### PR DESCRIPTION
Those tests are failing when we ran it for SRU validation, I used tests.exec to make sure prepare, execute and restore phases are properly skipped.
