### PR TITLE
o/snapstate, o/assertstate: always run validate-component when installing components from the store

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -373,7 +373,22 @@ func doInstallComponent(st *state.State, snapst *SnapState, compSetup ComponentS
 
 	componentTS.beforeLinkTasks = append(componentTS.beforeLinkTasks, prepare)
 
-	if fromStore {
+	// if we're installing a component from the store, then we need to validate
+	// it. note that we will still run this task even if we're reusing an
+	// already installed component, since we will most likely need to fetch a
+	// new snap-resource-pair assertion. we don't run this task for a revert,
+	// since a revert cannot reach out to the store. once the TODOs below are
+	// addressed, this task can run during reverts as well.
+	//
+	// TODO:COMPS: this task currently will re-hash a component that is already
+	// installed, which is not ideal. make validate-component have two code
+	// paths that will properly handle this case.
+	//
+	// TODO:COMPS: this task should run when installing any asserted component,
+	// even from a local file. once it is modified to be able to skip fetching
+	// assertions from the store, then we should start running this task for all
+	// asserted components.
+	if !snapsup.Revert && compSetup.CompPath == "" {
 		validate := st.NewTask("validate-component", fmt.Sprintf(
 			i18n.G("Fetch and check assertions for component %q%s"), compSetup.ComponentName(), revisionStr),
 		)

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -67,10 +67,16 @@ func expectedComponentInstallTasks(opts int) []string {
 }
 
 func expectedComponentInstallTasksSplit(opts int) (beforeLink, link, postOpHooksAndAfter, discard []string) {
-	if opts&compOptIsLocal != 0 {
+	if opts&compOptIsLocal != 0 || opts&compOptRevisionPresent != 0 {
 		beforeLink = []string{"prepare-component"}
 	} else {
-		beforeLink = []string{"download-component", "validate-component"}
+		beforeLink = []string{"download-component"}
+	}
+
+	// validate-component runs for all snaps that were not explicitly installed
+	// from file, unless the operation is part of a revert.
+	if opts&compOptIsLocal == 0 && opts&compOptDuringSnapRevert == 0 {
+		beforeLink = append(beforeLink, "validate-component")
 	}
 
 	// Revision is not the same as the current one installed

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8317,7 +8317,7 @@ func (s *snapmgrTestSuite) testRemodelLinkNewBaseOrKernelHappy(c *C, model *asse
 	ts, err := snapstate.LinkNewBaseOrKernel(s.state, "some-kernel", "")
 	c.Assert(err, IsNil)
 	tasks := ts.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
 	tPrepare := tasks[0]
 	var tLink, tUpdateGadgetAssets *state.Task
 	if opts&needsKernelSetup != 0 {
@@ -8345,7 +8345,7 @@ func (s *snapmgrTestSuite) testRemodelLinkNewBaseOrKernelHappy(c *C, model *asse
 	ts, err = snapstate.LinkNewBaseOrKernel(s.state, "some-base", "")
 	c.Assert(err, IsNil)
 	tasks = ts.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
 	c.Assert(tasks, HasLen, 2)
 	tPrepare = tasks[0]
 	tLink = tasks[1]
@@ -8439,7 +8439,7 @@ func (s *snapmgrTestSuite) testRemodelAddLinkNewBaseOrKernel(c *C, model *assert
 	c.Assert(err, IsNil)
 	c.Assert(tsNew, NotNil)
 	tasks := tsNew.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, []string{"prepare-snap", "test-task"}, nil, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, 0, []string{"prepare-snap", "test-task"}, nil, kindsToSet(nonReLinkKinds)))
 	// since this is the kernel, we have our task + test task + update-gadget-assets + link-snap
 	var tLink, tUpdateGadgetAssets *state.Task
 	if opts&needsKernelSetup != 0 {
@@ -8483,7 +8483,7 @@ func (s *snapmgrTestSuite) testRemodelAddLinkNewBaseOrKernel(c *C, model *assert
 	c.Assert(err, IsNil)
 	c.Assert(tsNew, NotNil)
 	tasks = tsNew.Tasks()
-	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeBase, 0, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
 	// since this is the base, we have our task + link-snap only
 	c.Assert(tasks, HasLen, 2)
 	tLink = tasks[1]
@@ -8513,7 +8513,7 @@ func (s *snapmgrTestSuite) TestRemodelSwitchNewGadget(c *C) {
 	c.Assert(err, IsNil)
 	tasks := ts.Tasks()
 	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(
-		snap.TypeGadget, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(append(nonReLinkKinds, "link-snap"))),
+		snap.TypeGadget, 0, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(append(nonReLinkKinds, "link-snap"))),
 	)
 	c.Assert(tasks, HasLen, 3)
 	tPrepare := tasks[0]
@@ -8650,7 +8650,7 @@ func (s *snapmgrTestSuite) TestRemodelAddGadgetAssetTasks(c *C) {
 	c.Assert(tsNew, NotNil)
 	tasks := tsNew.Tasks()
 	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(
-		snap.TypeGadget, 0, 0, []string{"prepare-snap", "test-task"}, nil, kindsToSet(append(nonReLinkKinds, "link-snap"))),
+		snap.TypeGadget, 0, 0, 0, []string{"prepare-snap", "test-task"}, nil, kindsToSet(append(nonReLinkKinds, "link-snap"))),
 	)
 	// since this is the gadget, we have our task + test task + update assets + update cmdline
 	c.Assert(tasks, HasLen, 4)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -16135,8 +16135,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 	s.enableRefreshAppAwarenessUX()
 
 	const (
-		snapName = "some-snap"
-		snapID   = "some-snap-id"
+		snapName = "kernel"
+		snapID   = "kernel-id"
 	)
 
 	channel := "channel-for-components"
@@ -16177,7 +16177,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 		SnapID:   snapID,
 		Channel:  channel,
 	}
-	snaptest.MockSnapInstance(c, snapName, fmt.Sprintf("name: %s", snapName), &si)
+	snaptest.MockSnapInstance(c, snapName, fmt.Sprintf("name: %s\ntype: kernel", snapName), &si)
 	fi, err := os.Stat(snap.MountFile(snapName, si.Revision))
 	c.Assert(err, IsNil)
 
@@ -16374,6 +16374,11 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 			unlinkSkipBinaries: true,
 		},
 		{
+			op:    "update-gadget-assets:Doing",
+			name:  snapName,
+			revno: newSnapRev,
+		},
+		{
 			op:   "copy-data",
 			path: filepath.Join(dirs.SnapMountDir, snapName, newSnapRev.String()),
 			old:  filepath.Join(dirs.SnapMountDir, snapName, currentSnapRev.String()),
@@ -16501,8 +16506,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", snapName, newSnapRev)),
 		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		Version:   "some-snapVer",
+		Type:      snap.TypeKernel,
+		Version:   "kernelVer",
 		PlugsOnly: true,
 		Flags: snapstate.Flags{
 			Transaction: client.TransactionPerSnap,


### PR DESCRIPTION
Since we might need to fetch new assertions when installing a component alongside an arbitrary snap revision, we should always run this task when installing a component from the store.

Even if the snap doesn't get downloaded from the store because it was installed alongside a previous snap revision, we still need to fetch the new assertions and make sure that it can be installed with the new snap revision.