### PR TITLE
tests: don't use tmp directory for prepare files

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -84,10 +84,10 @@ environment:
     # Use the snapd package from the repository when possible
     SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-true}")'
     # Directory where the built snapd snaps and other assets are stored
-    SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/tmp/work-dir}")'
+    SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/opt/work-dir}")'
 
     # Directory where the nested images and test assets are stored
-    NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/tmp/work-dir}")'
+    NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/opt/work-dir}")'
     # Channel used to create the nested vm
     NESTED_CORE_CHANNEL: '$(HOST: echo "${NESTED_CORE_CHANNEL:-beta}")'
     # Kernel channel used to create the nested vm

--- a/spread.yaml
+++ b/spread.yaml
@@ -84,10 +84,10 @@ environment:
     # Use the snapd package from the repository when possible
     SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-true}")'
     # Directory where the built snapd snaps and other assets are stored
-    SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/opt/work-dir}")'
+    SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/var/tmp/work-dir}")'
 
     # Directory where the nested images and test assets are stored
-    NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/opt/work-dir}")'
+    NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/var/tmp/work-dir}")'
     # Channel used to create the nested vm
     NESTED_CORE_CHANNEL: '$(HOST: echo "${NESTED_CORE_CHANNEL:-beta}")'
     # Kernel channel used to create the nested vm

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: "${NESTED_WORK_DIR:=/tmp/work-dir}"
+: "${NESTED_WORK_DIR:=/var/tmp/work-dir}"
 : "${NESTED_IMAGES_DIR:=${NESTED_WORK_DIR}/images}"
 : "${NESTED_RUNTIME_DIR:=${NESTED_WORK_DIR}/runtime}"
 : "${NESTED_ASSETS_DIR:=${NESTED_WORK_DIR}/assets}"

--- a/tests/nested/core/core-revert/task.yaml
+++ b/tests/nested/core/core-revert/task.yaml
@@ -13,7 +13,7 @@ systems: [ubuntu-18.04-64]
 kill-timeout: 30m
 
 environment:
-    IMAGE_FILE: /tmp/work-dir/images/ubuntu-core-new.img
+    IMAGE_FILE: $SNAPD_WORK_DIR/images/ubuntu-core-new.img
 
 debug: |
     systemctl stop nested-vm || true

--- a/tests/nested/core/core20-fault-inject-on-install/task.yaml
+++ b/tests/nested/core/core20-fault-inject-on-install/task.yaml
@@ -31,7 +31,7 @@ prepare: |
     remote.exec "sudo systemctl daemon-reload"
     remote.exec "sudo systemctl restart snapd.service"
 
-    cp "$(ls /tmp/work-dir/snapd_snap/snapd_*.snap)" snapd.snap
+    cp "$(ls "$SNAPD_WORK_DIR"/snapd_snap/snapd_*.snap)" snapd.snap
 
 execute: |
     SNAP=snapd


### PR DESCRIPTION
Failures were noticed in snapd-update-services. It attempts to access the snapd.snap built during the prepare phase. If, before that test executes, another test triggers a reboot, the working directory gets removed and the test cannot find snapd.snap. This changes the working directory to `/var/tmp` to ensure the working files stick around. 