### PR TITLE
o/snapstate: fix TestUpdateWithComponentsRunThroughShareComponents tests now that reboot changes are merged

### DIFF
--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -6403,6 +6403,13 @@ func undoOps(instanceName string, snapType snap.Type, newSequence, prevSequence 
 	}
 
 	var ops fakeOps
+	if forRefresh && snapType == snap.TypeKernel {
+		// undo for "remove-kernel-snap-setup"
+		ops = append(ops, fakeOp{
+			op: "prepare-kernel-snap",
+		})
+	}
+
 	if len(installedKmods) > 0 || len(prevInstalledKmods) > 0 {
 		ops = append(ops, fakeOp{
 			op:           "prepare-kernel-modules-components",

--- a/run-checks
+++ b/run-checks
@@ -435,6 +435,7 @@ if [ "$UNIT" = 1 ]; then
 
     tags=
     race=
+    timeout="5m"
     if [ -n "${GO_BUILD_TAGS:-}" ]; then
         echo "Using build tags: $GO_BUILD_TAGS"
         tags="-tags $GO_BUILD_TAGS"
@@ -442,6 +443,7 @@ if [ "$UNIT" = 1 ]; then
     if [ -n "${GO_TEST_RACE:-}" ]; then
         echo "Using go test -race"
         race="-race"
+        timeout="10m"
     fi
 
     echo Building
@@ -453,7 +455,7 @@ if [ "$UNIT" = 1 ]; then
     if [ "$short" = 1 ]; then
             echo "Running without test coverage"
             # shellcheck disable=SC2046,SC2086
-            GOTRACEBACK=1 $goctest $tags $race -short -timeout 5m $(go list ./... | grep -v '/vendor/' )
+            GOTRACEBACK=1 $goctest $tags $race -short -timeout $timeout $(go list ./... | grep -v '/vendor/' )
     else
         coverage=""
         if [ -z "${SKIP_COVERAGE:-}" ]; then
@@ -466,7 +468,7 @@ if [ "$UNIT" = 1 ]; then
         fi
 
         # shellcheck disable=SC2046,SC2086
-        GOTRACEBACK=1 $goctest $tags $race -timeout 5m $coverage $(go list ./... | grep -v '/vendor/' )
+        GOTRACEBACK=1 $goctest $tags $race -timeout $timeout $coverage $(go list ./... | grep -v '/vendor/' )
     fi
 
     # python unit test for mountinfo.query and version-compare


### PR DESCRIPTION
Due to the ordering of some merges, TestUpdateWithComponentsRunThroughShareComponents were both not compiling and incorrect. This fixes those issues.