### PR TITLE
wrappers/desktop: add more context to logs for malformed desktop files

### DIFF
--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -303,9 +303,13 @@ func forAllDesktopFiles(cb func(base, instanceName string) error) error {
 		}
 
 		de, err := desktopentry.Read(desktopFile)
-		if err != nil || de.SnapInstanceName == "" {
+		if err != nil {
 			// cannot read instance name from desktop file, ignore
-			logger.Noticef("cannot read instance name: %s", err)
+			logger.Noticef("cannot read instance name from %q: %v", desktopFile, err)
+			continue
+		}
+		if de.SnapInstanceName == "" {
+			logger.Noticef("cannot find X-SnapInstanceName entry in %q", desktopFile)
 			continue
 		}
 


### PR DESCRIPTION
Logs were cryptic when snapd found malformed desktop files, this PR improves the logs and make them actually usable.

```
Nov 25 15:21:35 snapd[31935]: desktop.go:308: cannot read instance name: %!s(<nil>)
Nov 25 15:21:35 snapd[31935]: desktop.go:308: cannot read instance name: %!s(<nil>)
Nov 25 15:21:35 snapd[31935]: desktop.go:308: cannot read instance name: %!s(<nil>)
```
