### PR TITLE
overlord/fdestate: add helper type for capturing externally running operations

### DIFF
--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -26,9 +26,18 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-var FdeMgr = fdeMgr
+var (
+	FdeMgr = fdeMgr
 
-var UpdateParameters = updateParameters
+	UpdateParameters = updateParameters
+
+	FindFirstPendingExternalOperationByKind = findFirstPendingExternalOperationByKind
+	FindFirstExternalOperationByChangeID    = findFirstExternalOperationByChangeID
+	AddExternalOperation                    = addExternalOperation
+	UpdateExternalOperation                 = updateExternalOperation
+)
+
+type ExternalOperation = externalOperation
 
 func MockBackendResealKeyForBootChains(f func(manager backend.FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error) (restore func()) {
 	restore = testutil.Backup(&backendResealKeyForBootChains)

--- a/overlord/fdestate/extop.go
+++ b/overlord/fdestate/extop.go
@@ -1,0 +1,207 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package fdestate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// ExternalOperationStatus captures the status of operations running externally.
+type ExternalOperationStatus int
+
+// Admitted status values for changes and tasks. The expected use of status is
+// shown in a diagram below:
+/*
+           Default
+              |
+              v
+          Preparing
+              | |
+              v +---------+
+            Doing         |
+              |           |
+       +------+-----+     |
+       v            v     |
+   Completing   Aborting  |
+      | |           |     |
+      | |           |     |
+      | +-----------+-----+
+      |             |
+      v             v
+    Done          Error
+*/
+// The Done and Error statuses are considered to be final. A newly created
+// operation should be assigned a Preparing status and then Doing after. Doing
+// is where the operation is running externally. Once notified about status
+// change, the status should be changed to Completing or Aborting, proceeded by
+// one of the final statues. The statuses Preparing, Completing, Aborting, are
+// useful when an intermediate step is needed for properly blocking conflicting
+// API calls, where a state is internally unlocked, eg. when resealing.
+const (
+	DefaultStatus ExternalOperationStatus = 0
+
+	// Preparing means that we are performing preparation steps, but the
+	// operation isn't yet running externally.
+	PreparingStatus ExternalOperationStatus = 1
+
+	// DoingStatus means the operation is running externally.
+	DoingStatus ExternalOperationStatus = 2
+
+	// DoneStatus means the operation has completed successfully. Done status is
+	// final.
+	DoneStatus ExternalOperationStatus = 3
+
+	// CompletingStatus means the operation is completing.
+	CompletingStatus ExternalOperationStatus = 4
+
+	// AbortingStatus means the operation is aborting.
+	AbortingStatus ExternalOperationStatus = 5
+
+	// ErrorStatus means the operation has failed. Error status is final.
+	ErrorStatus ExternalOperationStatus = 6
+)
+
+func (s ExternalOperationStatus) String() string {
+	switch s {
+	case DefaultStatus:
+		return "default"
+	case PreparingStatus:
+		return "preparing"
+	case DoingStatus:
+		return "doing"
+	case DoneStatus:
+		return "done"
+	case CompletingStatus:
+		return "completing"
+	case AbortingStatus:
+		return "aborting"
+	case ErrorStatus:
+		return "error"
+	}
+	panic(fmt.Sprintf("internal error: unexpected external operation status code: %d", s))
+}
+
+// externalOperation captures an externally running operation that is tracked in
+// the state.
+type externalOperation struct {
+	Kind string `json:"kind"`
+	// ChangeID is ID of a state.Change associated with the operation.
+	ChangeID string                  `json:"change-id"`
+	Status   ExternalOperationStatus `json:"status"`
+	// Err when not empty, carries the error message, usually associated with
+	// the operation having an ErrorStatus or AbortingStatus.
+	Err string `json:"err"`
+	// Context is an opaque piece of data associated with the operation.
+	Context json.RawMessage `json:"context"`
+}
+
+// SetFailed is a convenience helper, which essentially does
+// SetStatus(ErrorStatus), but also sets the error description.
+func (e *externalOperation) SetFailed(msg string) {
+	e.Status = ErrorStatus
+	e.Err = msg
+}
+
+func (e *externalOperation) SetStatus(status ExternalOperationStatus) {
+	e.Status = status
+}
+
+// Equal checks the operations for equality by comparing their kind and the
+// parent change ID.
+func (e *externalOperation) Equal(other *externalOperation) bool {
+	return e.ChangeID == other.ChangeID && e.Kind == other.Kind
+}
+
+// IsReady returns true when operation status is one of the final ones
+// (ErrorStatus or DoneStatus).
+func (e *externalOperation) IsReady() bool {
+	switch e.Status {
+	case DoneStatus, ErrorStatus:
+		return true
+	}
+
+	return false
+}
+
+// findFirstPendingExternalOperationByKind attempts to find a first instance of
+// an operation in the state with a given kind. If none is found, nil is
+// returned, without any errors.
+func findFirstPendingExternalOperationByKind(st *state.State, kind string) (foundOp *externalOperation, err error) {
+	err = withFdeState(st, func(fde *FdeState) (modified bool, err error) {
+		for _, op := range fde.PendingExternalOperations {
+			if op.Kind == kind && !op.IsReady() {
+				foundOp = &op
+				break
+			}
+		}
+		return false, nil
+	})
+	return foundOp, err
+}
+
+// findFirstExternalOperationByChangeID attempts to find a first instance of an
+// operation tracked in the state with a given change ID. If none is found, nil
+// is returned, without any errors.
+func findFirstExternalOperationByChangeID(st *state.State, changeID string) (foundOp *externalOperation, err error) {
+	err = withFdeState(st, func(fde *FdeState) (modified bool, err error) {
+		for _, op := range fde.PendingExternalOperations {
+			if op.ChangeID == changeID {
+				foundOp = &op
+				break
+			}
+		}
+		return false, nil
+	})
+	return foundOp, err
+}
+
+// addExternalOperation adds external operation to the state. Does not perform
+// any checks for duplicates.
+func addExternalOperation(st *state.State, op *externalOperation) error {
+	return withFdeState(st, func(fde *FdeState) (modified bool, err error) {
+		fde.PendingExternalOperations = append(fde.PendingExternalOperations, *op)
+		return true, nil
+	})
+}
+
+// updateExternalOperation updates an external operation tracked in the state,
+// replacing it with the new one. The operation uses externlOperation.Equal()
+// predicate. Returns an error if no matching operation was found in the state.
+func updateExternalOperation(st *state.State, upOp *externalOperation) error {
+	return withFdeState(st, func(fde *FdeState) (modified bool, err error) {
+		mod := false
+		for idx, op := range fde.PendingExternalOperations {
+			if op.Equal(upOp) {
+				// shallow copy
+				fde.PendingExternalOperations[idx] = *upOp
+				mod = true
+				break
+			}
+		}
+
+		if !mod {
+			return false, fmt.Errorf("no matching operation")
+		}
+
+		return true, nil
+	})
+}

--- a/overlord/fdestate/extop_test.go
+++ b/overlord/fdestate/extop_test.go
@@ -1,0 +1,211 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate_test
+
+import (
+	"encoding/json"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type extopSuite struct {
+	testutil.BaseTest
+
+	state *state.State
+}
+
+var _ = Suite(&extopSuite{})
+
+func (s *extopSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.state = state.New(nil)
+}
+
+func (s *extopSuite) TestExternalOperationInState(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+	s.state.Set("fde", fdestate.FdeState{})
+
+	opA := &fdestate.ExternalOperation{
+		Kind:     "fde-efi-secureboot-db-update",
+		ChangeID: "123",
+		Context:  json.RawMessage(`{"foo":"bar"}`),
+		Status:   fdestate.PreparingStatus,
+	}
+
+	opB := &fdestate.ExternalOperation{
+		Kind:     "other-op",
+		ChangeID: "999",
+		Context:  json.RawMessage(`{"no":"yes"}`),
+		Status:   fdestate.DoneStatus,
+	}
+
+	opC := &fdestate.ExternalOperation{
+		Kind:     "fde-efi-secureboot-db-update",
+		ChangeID: "444",
+		Context:  json.RawMessage(`{"data":"b"}`),
+		Status:   fdestate.DoingStatus,
+	}
+
+	c.Assert(fdestate.AddExternalOperation(st, opA), IsNil)
+	c.Assert(fdestate.AddExternalOperation(st, opB), IsNil)
+	c.Assert(fdestate.AddExternalOperation(st, opC), IsNil)
+
+	op, err := fdestate.FindFirstExternalOperationByChangeID(st, "111")
+	c.Assert(err, IsNil)
+	c.Check(op, IsNil)
+
+	op, err = fdestate.FindFirstExternalOperationByChangeID(st, "123")
+	c.Assert(err, IsNil)
+	c.Check(op, DeepEquals, opA)
+
+	op, err = fdestate.FindFirstExternalOperationByChangeID(st, "999")
+	c.Assert(err, IsNil)
+	c.Check(op, DeepEquals, opB)
+
+	// finds the first operation, which is opA
+	op, err = fdestate.FindFirstPendingExternalOperationByKind(st, "fde-efi-secureboot-db-update")
+	c.Assert(err, IsNil)
+	c.Check(op, DeepEquals, opA)
+
+	// opB has DoneStatus, no it's no longer 'pending'
+	op, err = fdestate.FindFirstPendingExternalOperationByKind(st, "other-op")
+	c.Assert(err, IsNil)
+	c.Check(op, IsNil)
+
+	opA_UpdateBad := &fdestate.ExternalOperation{
+		Kind: "fde-efi-secureboot-db-update",
+		// change ID which does not match opA
+		ChangeID: "111",
+		Context:  json.RawMessage(`{"no":"yes"}`),
+		Status:   fdestate.DoneStatus,
+	}
+	// accidental update when no matching operation exists raises an error
+	c.Assert(fdestate.UpdateExternalOperation(st, opA_UpdateBad), ErrorMatches, "no matching operation")
+
+	opA_UpdateGood := &fdestate.ExternalOperation{
+		Kind: "fde-efi-secureboot-db-update",
+		// change ID which does not match opA
+		ChangeID: "123",
+		Context:  json.RawMessage(`{"no":"yes"}`),
+		Status:   fdestate.DoneStatus,
+	}
+	c.Check(opA.Equal(opA_UpdateGood), Equals, true)
+	c.Assert(fdestate.UpdateExternalOperation(st, opA_UpdateGood), IsNil)
+
+	// finds the first pending operation, which at this point is opC, as opA has
+	// DoneStatus
+	op, err = fdestate.FindFirstPendingExternalOperationByKind(st, "fde-efi-secureboot-db-update")
+	c.Assert(err, IsNil)
+	c.Check(op, DeepEquals, opC)
+}
+
+func (s *extopSuite) TestStringifiedStatus(c *C) {
+	for _, tc := range []struct {
+		status fdestate.ExternalOperationStatus
+		desc   string
+	}{
+		{status: fdestate.DefaultStatus, desc: "default"},
+		{status: fdestate.DoingStatus, desc: "doing"},
+		{status: fdestate.PreparingStatus, desc: "preparing"},
+		{status: fdestate.CompletingStatus, desc: "completing"},
+		{status: fdestate.AbortingStatus, desc: "aborting"},
+		{status: fdestate.DoneStatus, desc: "done"},
+		{status: fdestate.ErrorStatus, desc: "error"},
+	} {
+		c.Check(tc.status.String(), Equals, tc.desc)
+	}
+}
+
+func (s *extopSuite) TestExternalOperationStatus(c *C) {
+	for _, tc := range []struct {
+		status fdestate.ExternalOperationStatus
+		ready  bool
+		desc   string
+	}{
+		{status: fdestate.DefaultStatus},
+		{status: fdestate.DoingStatus},
+		{status: fdestate.PreparingStatus},
+		{status: fdestate.CompletingStatus},
+		{status: fdestate.AbortingStatus},
+		{status: fdestate.DoneStatus, ready: true},
+		{status: fdestate.ErrorStatus, ready: true},
+	} {
+
+		op := fdestate.ExternalOperation{}
+		if tc.status != fdestate.DefaultStatus {
+			op.SetStatus(tc.status)
+		}
+		c.Check(op.Status, Equals, tc.status)
+		c.Check(op.IsReady(), Equals, tc.ready)
+	}
+
+	op := fdestate.ExternalOperation{
+		Status: fdestate.PreparingStatus,
+	}
+	op.SetFailed("this is an error")
+	c.Check(op.Status, Equals, fdestate.ErrorStatus)
+	c.Check(op.Err, Equals, "this is an error")
+	c.Check(op.IsReady(), Equals, true)
+}
+
+func (s *extopSuite) TestExternalOperationEqual(c *C) {
+	opA := fdestate.ExternalOperation{
+		Kind:     "fde-efi-secureboot-db-update",
+		ChangeID: "123",
+		Context:  json.RawMessage(`{"foo":"bar"}`),
+		Status:   fdestate.PreparingStatus,
+	}
+
+	opB := fdestate.ExternalOperation{
+		Kind:     "fde-efi-secureboot-db-update",
+		ChangeID: "123",
+		Context:  json.RawMessage(`{"different":"content"}`),
+		Status:   fdestate.DoneStatus,
+	}
+
+	opC_OtherKind := fdestate.ExternalOperation{
+		Kind:     "nope",
+		ChangeID: "123",
+		Context:  json.RawMessage(`{"different":"content"}`),
+		Status:   fdestate.PreparingStatus,
+	}
+
+	opC_OtherChange := fdestate.ExternalOperation{
+		Kind:     "fde-efi-secureboot-db-update",
+		ChangeID: "100",
+		Status:   fdestate.PreparingStatus,
+	}
+
+	c.Check(opA.Equal(&opB), Equals, true)
+	c.Check(opB.Equal(&opA), Equals, true)
+
+	c.Check(opA.Equal(&opC_OtherKind), Equals, false)
+	c.Check(opA.Equal(&opC_OtherChange), Equals, false)
+	c.Check(opB.Equal(&opC_OtherKind), Equals, false)
+	c.Check(opB.Equal(&opC_OtherChange), Equals, false)
+}


### PR DESCRIPTION
Add a helper type for capturing externally running operations

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Cherry picked from https://github.com/canonical/snapd/pull/14615

Related: [SNAPDENG-32509](https://warthogs.atlassian.net/browse/SNAPDENG-32509)

[SNAPDENG-32509]: https://warthogs.atlassian.net/browse/SNAPDENG-32509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ