### PR TITLE
many: make snapstate.RevisionOpts carry snapasserts.ValidationSets

### DIFF
--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -495,10 +495,11 @@ func (v *ValidationSets) Revisions() (map[string]snap.Revision, error) {
 // Keys returns a slice of ValidationSetKey structs that represent each
 // validation set that this ValidationSets knows about.
 func (v *ValidationSets) Keys() []ValidationSetKey {
-	keys := make([]ValidationSetKey, 0, len(v.sets))
+	keys := make(ValidationSetKeySlice, 0, len(v.sets))
 	for _, vs := range v.sets {
 		keys = append(keys, NewValidationSetKey(vs))
 	}
+	sort.Sort(keys)
 	return keys
 }
 

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -502,6 +502,13 @@ func (v *ValidationSets) Keys() []ValidationSetKey {
 	return keys
 }
 
+// Empty returns true if this ValidationSets hasn't had any validation sets
+// added to it. An empty ValidationSets doesn't enforce any constraints on the
+// state of snaps.
+func (v *ValidationSets) Empty() bool {
+	return len(v.sets) == 0
+}
+
 // Sets returns a slice of all of the validation sets that this ValidationSets
 // knows about.
 func (v *ValidationSets) Sets() []*asserts.ValidationSet {

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -1593,6 +1593,23 @@ func (s *validationSetsSuite) TestKeys(c *C) {
 	})
 }
 
+func (s *validationSetsSuite) TestEmpty(c *C) {
+	a := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl",
+		"sequence":     "1",
+		"snaps":        []interface{}{},
+	}).(*asserts.ValidationSet)
+
+	vsets := snapasserts.NewValidationSets()
+	c.Assert(vsets.Empty(), Equals, true)
+	vsets.Add(a)
+	c.Assert(vsets.Empty(), Equals, false)
+}
+
 func (s *validationSetsSuite) TestRequiredSnapNames(c *C) {
 	valset1 := assertstest.FakeAssertion(map[string]interface{}{
 		"type":         "validation-set",

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -1587,9 +1587,9 @@ func (s *validationSetsSuite) TestKeys(c *C) {
 	c.Assert(valsets.Add(valset1), IsNil)
 	c.Assert(valsets.Add(valset2), IsNil)
 
-	c.Check(valsets.Keys(), testutil.DeepUnsortedMatches, []snapasserts.ValidationSetKey{
-		"16/account-id/my-snap-ctl2/2",
+	c.Check(valsets.Keys(), DeepEquals, []snapasserts.ValidationSetKey{
 		"16/account-id/my-snap-ctl/1",
+		"16/account-id/my-snap-ctl2/2",
 	})
 }
 

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -915,7 +915,7 @@ func installationTaskSets(ctx context.Context, st *state.State, inst *snapInstru
 				return nil, nil, nil, err
 			}
 
-			ts, err := snapstateInstallComponents(ctx, st, comps, info, opts)
+			ts, err := snapstateInstallComponents(ctx, st, comps, info, nil, opts)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -4151,7 +4151,7 @@ func (s *snapsSuite) TestUpdateManyWithComponents(c *check.C) {
 }
 
 func (s *snapsSuite) TestInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
-	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
 		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
 		c.Check(info.InstanceName(), check.Equals, "some-snap")
 		t := st.NewTask("fake-install-component", "Doing a fake components install")
@@ -4206,7 +4206,7 @@ func (s *snapsSuite) TestInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
 }
 
 func (s *snapsSuite) TestManyInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
-	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
 		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
 		c.Check(info.InstanceName(), check.Equals, "some-snap-with-components")
 		t := st.NewTask("fake-install-component", "Doing a fake components install")

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -4151,7 +4151,7 @@ func (s *snapsSuite) TestUpdateManyWithComponents(c *check.C) {
 }
 
 func (s *snapsSuite) TestInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
-	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets *snapasserts.ValidationSets, opts snapstate.Options) ([]*state.TaskSet, error) {
 		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
 		c.Check(info.InstanceName(), check.Equals, "some-snap")
 		t := st.NewTask("fake-install-component", "Doing a fake components install")
@@ -4206,7 +4206,7 @@ func (s *snapsSuite) TestInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
 }
 
 func (s *snapsSuite) TestManyInstallWithComponentsSnapAlreadyInstalled(c *check.C) {
-	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallComponents(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets *snapasserts.ValidationSets, opts snapstate.Options) ([]*state.TaskSet, error) {
 		c.Check(names, check.DeepEquals, []string{"comp1", "comp2"})
 		c.Check(info.InstanceName(), check.Equals, "some-snap-with-components")
 		t := st.NewTask("fake-install-component", "Doing a fake components install")

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -166,7 +166,7 @@ func MockSnapstateUpdateOne(mock func(ctx context.Context, st *state.State, goal
 	}
 }
 
-func MockSnapstateInstallComponents(mock func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
+func MockSnapstateInstallComponents(mock func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets *snapasserts.ValidationSets, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
 	old := snapstateInstallComponents
 	snapstateInstallComponents = mock
 	return func() {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -166,7 +166,7 @@ func MockSnapstateUpdateOne(mock func(ctx context.Context, st *state.State, goal
 	}
 }
 
-func MockSnapstateInstallComponents(mock func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
+func MockSnapstateInstallComponents(mock func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
 	old := snapstateInstallComponents
 	snapstateInstallComponents = mock
 	return func() {

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -75,7 +76,7 @@ func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *services
 	return func() { servicestateControl = old }
 }
 
-func MockSnapstateInstallComponentsFunc(f func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
+func MockSnapstateInstallComponentsFunc(f func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
 	old := snapstateInstallComponents
 	snapstateInstallComponents = f
 	return func() { snapstateInstallComponents = old }

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -76,7 +76,7 @@ func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *services
 	return func() { servicestateControl = old }
 }
 
-func MockSnapstateInstallComponentsFunc(f func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
+func MockSnapstateInstallComponentsFunc(f func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets *snapasserts.ValidationSets, opts snapstate.Options) ([]*state.TaskSet, error)) (restore func()) {
 	old := snapstateInstallComponents
 	snapstateInstallComponents = f
 	return func() { snapstateInstallComponents = old }

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -291,7 +291,7 @@ func createSnapctlInstallTasks(hctx *hookstate.Context, cmd managementCommand) (
 	if err != nil {
 		return nil, err
 	}
-	return snapstateInstallComponents(context.TODO(), st, cmd.components, info,
+	return snapstateInstallComponents(context.TODO(), st, cmd.components, info, nil,
 		snapstate.Options{ExpectOneSnap: true, FromChange: changeIDIfNotEphemeral(hctx)})
 }
 

--- a/overlord/hookstate/ctlcmd/snap_management_test.go
+++ b/overlord/hookstate/ctlcmd/snap_management_test.go
@@ -112,7 +112,7 @@ func (s *installSuite) testMngmtCommand(c *C, cmd string) {
 
 	switch cmd {
 	case "install":
-		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
+		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets *snapasserts.ValidationSets, opts snapstate.Options) ([]*state.TaskSet, error) {
 			c.Check(names, DeepEquals, []string{"comp1", "comp2"})
 			c.Check(opts, DeepEquals, snapstate.Options{ExpectOneSnap: true,
 				FromChange: s.mockContext.ChangeID()})
@@ -156,7 +156,7 @@ func (s *installSuite) testEphemeralMngmtCommand(c *C, cmd string) {
 
 	switch cmd {
 	case "install":
-		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
+		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets *snapasserts.ValidationSets, opts snapstate.Options) ([]*state.TaskSet, error) {
 			c.Check(names, DeepEquals,
 				[]string{"comp1", "comp2", "comp3", "comp4", "comp5", "comp6"})
 			c.Check(opts, DeepEquals, snapstate.Options{ExpectOneSnap: true})

--- a/overlord/hookstate/ctlcmd/snap_management_test.go
+++ b/overlord/hookstate/ctlcmd/snap_management_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -111,7 +112,7 @@ func (s *installSuite) testMngmtCommand(c *C, cmd string) {
 
 	switch cmd {
 	case "install":
-		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
+		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
 			c.Check(names, DeepEquals, []string{"comp1", "comp2"})
 			c.Check(opts, DeepEquals, snapstate.Options{ExpectOneSnap: true,
 				FromChange: s.mockContext.ChangeID()})
@@ -155,7 +156,7 @@ func (s *installSuite) testEphemeralMngmtCommand(c *C, cmd string) {
 
 	switch cmd {
 	case "install":
-		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, opts snapstate.Options) ([]*state.TaskSet, error) {
+		ctlcmd.MockSnapstateInstallComponentsFunc(func(ctx context.Context, st *state.State, names []string, info *snap.Info, vsets []snapasserts.ValidationSetKey, opts snapstate.Options) ([]*state.TaskSet, error) {
 			c.Check(names, DeepEquals,
 				[]string{"comp1", "comp2", "comp3", "comp4", "comp5", "comp6"})
 			c.Check(opts, DeepEquals, snapstate.Options{ExpectOneSnap: true})

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -70,6 +70,7 @@ func InstallComponents(
 	}
 
 	if vsets == nil {
+		// TODO:COMPS: use enforced validation sets as the default here
 		vsets = snapasserts.NewValidationSets()
 	}
 

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -82,7 +82,7 @@ func InstallComponents(
 		return nil, err
 	}
 
-	// TODO: verify validation sets here
+	// TODO:COMPS: verify validation sets here
 
 	snapsup := SnapSetup{
 		Base:        info.Base,

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
@@ -37,7 +38,14 @@ import (
 // InstallComponents installs all of the components in the given names list. The
 // snap represented by info must already be installed, and all of the components
 // in names should not be installed prior to calling this function.
-func InstallComponents(ctx context.Context, st *state.State, names []string, info *snap.Info, opts Options) ([]*state.TaskSet, error) {
+func InstallComponents(
+	ctx context.Context,
+	st *state.State,
+	names []string,
+	info *snap.Info,
+	vsets []snapasserts.ValidationSetKey,
+	opts Options,
+) ([]*state.TaskSet, error) {
 	if err := opts.setDefaultLane(st); err != nil {
 		return nil, err
 	}
@@ -61,7 +69,11 @@ func InstallComponents(ctx context.Context, st *state.State, names []string, inf
 		}
 	}
 
-	compsups, err := componentSetupsForInstall(ctx, st, names, snapst, snapst.Current, snapst.TrackingChannel, opts)
+	compsups, err := componentSetupsForInstall(ctx, st, names, snapst, RevisionOptions{
+		Revision:       snapst.Current,
+		Channel:        snapst.TrackingChannel,
+		ValidationSets: vsets,
+	}, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +140,7 @@ func InstallComponents(ctx context.Context, st *state.State, names []string, inf
 	return append(tss, ts), nil
 }
 
-func componentSetupsForInstall(ctx context.Context, st *state.State, names []string, snapst SnapState, snapRev snap.Revision, channel string, opts Options) ([]ComponentSetup, error) {
+func componentSetupsForInstall(ctx context.Context, st *state.State, names []string, snapst SnapState, revOpts RevisionOptions, opts Options) ([]ComponentSetup, error) {
 	if len(names) == 0 {
 		return nil, nil
 	}
@@ -144,7 +156,7 @@ func componentSetupsForInstall(ctx context.Context, st *state.State, names []str
 		return nil, err
 	}
 
-	action, err := installComponentAction(st, snapst, snapRev, channel, opts)
+	action, err := installComponentAction(st, snapst, revOpts, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -171,10 +183,16 @@ func componentSetupsForInstall(ctx context.Context, st *state.State, names []str
 	return componentTargetsFromActionResult("install", sars[0], names)
 }
 
-func installComponentAction(st *state.State, snapst SnapState, snapRev snap.Revision, channel string, opts Options) (*store.SnapAction, error) {
-	index := snapst.LastIndex(snapRev)
+// installComponentAction returns a store action that is used to get a list of
+// components that are available in the store.
+func installComponentAction(st *state.State, snapst SnapState, revOpts RevisionOptions, opts Options) (*store.SnapAction, error) {
+	if revOpts.Revision.Unset() {
+		return nil, errors.New("internal error: must specify snap revision when installing only components")
+	}
+
+	index := snapst.LastIndex(revOpts.Revision)
 	if index == -1 {
-		return nil, fmt.Errorf("internal error: cannot find snap revision %s in sequence", snapRev)
+		return nil, fmt.Errorf("internal error: cannot find snap revision %s in sequence", revOpts.Revision)
 	}
 	si := snapst.Sequence.SideInfos()[index]
 
@@ -193,15 +211,6 @@ func installComponentAction(st *state.State, snapst SnapState, snapRev snap.Revi
 		ResourceInstall: true,
 	}
 
-	// we send an action that contains the current channel and revision so
-	// that we make sure to get back components that are compatible with the
-	// currently installed snap
-	revOpts := RevisionOptions{
-		Revision: si.Revision,
-		Channel:  channel,
-	}
-
-	// TODO:COMPS: handle validation sets here
 	if err := completeStoreAction(action, revOpts, opts.Flags.IgnoreValidation, enforcedSetsFunc); err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -700,7 +700,7 @@ func (s *snapmgrTestSuite) TestInstallComponentUpdateConflict(c *C) {
 	chg := s.state.NewChange("update", "update a snap")
 	chg.AddAll(tupd)
 
-	_, err = snapstate.InstallComponents(context.TODO(), s.state, []string{compName}, info, snapstate.Options{})
+	_, err = snapstate.InstallComponents(context.TODO(), s.state, []string{compName}, info, nil, snapstate.Options{})
 	c.Assert(err.Error(), Equals, `snap "some-snap" has "update" change in progress`)
 }
 
@@ -740,14 +740,14 @@ func (s *snapmgrTestSuite) TestInstallComponentConflictsWithSelf(c *C) {
 		return results
 	}
 
-	tss, err := snapstate.InstallComponents(context.TODO(), s.state, []string{compName}, info, snapstate.Options{})
+	tss, err := snapstate.InstallComponents(context.TODO(), s.state, []string{compName}, info, nil, snapstate.Options{})
 	c.Assert(err, IsNil)
 	chg := s.state.NewChange("install-component", "install a component")
 	for _, ts := range tss {
 		chg.AddAll(ts)
 	}
 
-	_, err = snapstate.InstallComponents(context.TODO(), s.state, []string{conflictComponentName}, info, snapstate.Options{})
+	_, err = snapstate.InstallComponents(context.TODO(), s.state, []string{conflictComponentName}, info, nil, snapstate.Options{})
 	c.Assert(err.Error(), Equals, `snap "some-snap" has "install-component" change in progress`)
 }
 
@@ -778,7 +778,7 @@ func (s *snapmgrTestSuite) TestInstallComponentCausesConflict(c *C) {
 		}}
 	}
 
-	tss, err := snapstate.InstallComponents(context.TODO(), s.state, []string{compName}, info, snapstate.Options{})
+	tss, err := snapstate.InstallComponents(context.TODO(), s.state, []string{compName}, info, nil, snapstate.Options{})
 	c.Assert(err, IsNil)
 	chg := s.state.NewChange("install-component", "install a component")
 	for _, ts := range tss {
@@ -989,7 +989,7 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 		},
 	}
 
-	tss, err := snapstate.InstallComponents(context.Background(), s.state, components, info, installOpts)
+	tss, err := snapstate.InstallComponents(context.Background(), s.state, components, info, nil, installOpts)
 	c.Assert(err, IsNil)
 
 	setupProfiles := tss[len(tss)-1].Tasks()[0]
@@ -1083,7 +1083,7 @@ func (s *snapmgrTestSuite) TestInstallComponentsAlreadyInstalledError(c *C) {
 		TrackingChannel: "channel-for-components",
 	})
 
-	_, err := snapstate.InstallComponents(context.TODO(), s.state, []string{"one", "two"}, info, snapstate.Options{})
+	_, err := snapstate.InstallComponents(context.TODO(), s.state, []string{"one", "two"}, info, nil, snapstate.Options{})
 
 	c.Assert(err, testutil.ErrorIs, snap.AlreadyInstalledComponentError{Component: "one"})
 }
@@ -1101,7 +1101,7 @@ func (s *snapmgrTestSuite) TestInstallComponentsInvalidFlagAndTransaction(c *C) 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_, err := snapstate.InstallComponents(context.TODO(), s.state, []string{"one", "two"}, info, snapstate.Options{
+	_, err := snapstate.InstallComponents(context.TODO(), s.state, []string{"one", "two"}, info, nil, snapstate.Options{
 		Flags: snapstate.Flags{Lane: 1},
 	})
 	c.Assert(err, ErrorMatches, `cannot specify a lane without setting transaction to "all-snaps"`)
@@ -1149,7 +1149,7 @@ func (s *snapmgrTestSuite) TestInstallComponentsTooEarly(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_, err := snapstate.InstallComponents(context.TODO(), s.state, []string{"one", "two"}, info, snapstate.Options{
+	_, err := snapstate.InstallComponents(context.TODO(), s.state, []string{"one", "two"}, info, nil, snapstate.Options{
 		Seed: true,
 	})
 	c.Assert(err, ErrorMatches, `.*too early for operation, device model not yet acknowledged`)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -744,12 +744,9 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		result, err = sendOneInstallActionUnlocked(context.TODO(), st, StoreSnap{
 			InstanceName: snapsup.InstanceName(),
 			RevOpts: RevisionOptions{
-				Channel:   snapsup.Channel,
-				CohortKey: snapsup.CohortKey,
-				Revision:  snapsup.Revision(),
-				// TODO: do we actually want to use the enforced validation sets
-				// here? i personally think no, since we should have already
-				// validated this change before getting here.
+				Channel:        snapsup.Channel,
+				CohortKey:      snapsup.CohortKey,
+				Revision:       snapsup.Revision(),
 				ValidationSets: vsets,
 			},
 		}, Options{})

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -732,6 +732,11 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		RateLimit: rate,
 	}
 	if snapsup.DownloadInfo == nil {
+		vsets, err := EnforcedValidationSets(st)
+		if err != nil {
+			return err
+		}
+
 		var result store.SnapActionResult
 		// COMPATIBILITY - this task was created from an older version
 		// of snapd that did not store the DownloadInfo in the state
@@ -742,6 +747,10 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 				Channel:   snapsup.Channel,
 				CohortKey: snapsup.CohortKey,
 				Revision:  snapsup.Revision(),
+				// TODO: do we actually want to use the enforced validation sets
+				// here? i personally think no, since we should have already
+				// validated this change before getting here.
+				ValidationSets: vsets,
 			},
 		}, Options{})
 		if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1776,19 +1776,20 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	// use the same lane for installing and refreshing so everything is reversed
 	lane := st.NewLane()
 
+	vsets := snapasserts.NewValidationSets()
+	for _, vs := range valErr.Sets {
+		if err := vsets.Add(vs); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	collectRevOpts := func(snapToRevToVss map[string]map[snap.Revision][]string) ([]string, []*RevisionOptions) {
 		var names []string
 		var revOpts []*RevisionOptions
 
 		for snapName, revAndVs := range snapToRevToVss {
-			for rev, valsets := range revAndVs {
-				vsKeys := make([]snapasserts.ValidationSetKey, 0, len(valsets))
-				for _, vs := range valsets {
-					vsKey := snapasserts.NewValidationSetKey(valErr.Sets[vs])
-					vsKeys = append(vsKeys, vsKey)
-				}
-
-				revOpts = append(revOpts, &RevisionOptions{Revision: rev, ValidationSets: vsKeys})
+			for rev := range revAndVs {
+				revOpts = append(revOpts, &RevisionOptions{Revision: rev, ValidationSets: vsets})
 			}
 			names = append(names, snapName)
 		}
@@ -2639,7 +2640,7 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 type RevisionOptions struct {
 	Channel        string
 	Revision       snap.Revision
-	ValidationSets []snapasserts.ValidationSetKey
+	ValidationSets *snapasserts.ValidationSets
 	CohortKey      string
 	LeaveCohort    bool
 }
@@ -4029,10 +4030,16 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 		return nil, err
 	}
 	if !newSnapst.IsInstalled() {
+		enforced, err := EnforcedValidationSets(st)
+		if err != nil {
+			return nil, err
+		}
+
 		result, err := sendOneInstallAction(context.TODO(), st, StoreSnap{
 			InstanceName: newName,
 			RevOpts: RevisionOptions{
-				Channel: oldSnapst.TrackingChannel,
+				Channel:        oldSnapst.TrackingChannel,
+				ValidationSets: enforced,
 			},
 		}, Options{})
 		if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2674,6 +2674,27 @@ func (r *RevisionOptions) resolveChannel(instanceName string, fallback string, d
 	return nil
 }
 
+// initializeValidationSets ensures that r.ValidationSets is initialized with a
+// value. If the caller has provided a value, it is used. If validation sets are
+// explicitly ignored, we create a new empty validation set that has no rules.
+// Otherwise, we use the enforced validation sets.
+func (r *RevisionOptions) initializeValidationSets(vsets cachedValidationSets, opts Options) error {
+	if r.ValidationSets != nil {
+		return nil
+	}
+
+	if opts.Flags.IgnoreValidation {
+		r.ValidationSets = snapasserts.NewValidationSets()
+	} else {
+		enforced, err := vsets()
+		if err != nil {
+			return err
+		}
+		r.ValidationSets = enforced
+	}
+	return nil
+}
+
 // Update initiates a change updating a snap.
 // Note that the state must be locked by the caller.
 //

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/snapcore/snapd/advisor"
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
@@ -5906,18 +5907,20 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
 }
 
 func (s *validationSetsSuite) TestUpdateManyWithRevisionOpts(c *C) {
+	// current validation set forbids "some-snap"
+	vsets := snapasserts.NewValidationSets()
+	someSnapConstraint := map[string]interface{}{
+		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+		"name":     "some-snap",
+		"presence": "required",
+		"required": "1",
+	}
+	bar := s.mockValidationSetAssert(c, "bar", "1", someSnapConstraint)
+	err := vsets.Add(bar.(*asserts.ValidationSet))
+	c.Assert(err, IsNil)
+
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
-		// current validation set forbids "some-snap"
-		vs := snapasserts.NewValidationSets()
-		snapOne := map[string]interface{}{
-			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
-			"name":     "some-snap",
-			"presence": "required",
-			"required": "1",
-		}
-		vsa1 := s.mockValidationSetAssert(c, "bar", "1", snapOne)
-		vs.Add(vsa1.(*asserts.ValidationSet))
-		return vs, nil
+		return vsets, nil
 	})
 	defer restore()
 
@@ -5943,7 +5946,7 @@ func (s *validationSetsSuite) TestUpdateManyWithRevisionOpts(c *C) {
 
 	// updating "some-snap" with revision opts should succeed because current
 	// validation sets should be ignored
-	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
+	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSets: vsets}}
 	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap"}, revOpts, 0, nil)
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"some-snap"})
@@ -7924,7 +7927,20 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 
 	refreshedDate := fakeRevDateEpoch.AddDate(0, 0, 1)
 
-	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}, 0, snapstate.Flags{})
+	vsets := snapasserts.NewValidationSets()
+	vsets.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]interface{}{
+		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+		"name":     "some-snap",
+		"presence": "required",
+	}).(*asserts.ValidationSet))
+	vsets.Add(s.mockValidationSetAssert(c, "baz", "2", map[string]interface{}{
+		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+		"name":     "some-snap",
+		"presence": "required",
+		"revision": "11",
+	}).(*asserts.ValidationSet))
+
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSets: vsets}, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
 	var snapsup snapstate.SnapSetup
@@ -7951,7 +7967,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 			InstanceName:   "some-snap",
 			SnapID:         "some-snap-id",
 			Revision:       snap.R(11),
-			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"},
+			ValidationSets: vsets.Keys(),
 		},
 		revno: snap.R(11),
 	}}
@@ -13037,18 +13053,46 @@ func (s *snapmgrTestSuite) testUpdateManyRevOptsOrder(c *C, isThrottled map[stri
 	}
 	snapstate.ReplaceStore(s.state, &sto)
 
+	signer := assertstest.NewStoreStack("can0nical", nil)
+	valSetForSnap := func(snapName string) *snapasserts.ValidationSets {
+		headers := map[string]interface{}{
+			"authority-id": "foo",
+			"account-id":   "foo",
+			"name":         snapName,
+			"series":       "16",
+			"revision":     "5",
+			"sequence":     "1",
+			"timestamp":    "2030-11-06T09:16:26Z",
+			"snaps": []interface{}{
+				map[string]interface{}{
+					"id":       snaptest.AssertedSnapID(snapName),
+					"name":     snapName,
+					"presence": "required",
+				},
+			},
+		}
+
+		vs, err := signer.Sign(asserts.ValidationSetType, headers, nil, "")
+		c.Assert(err, IsNil)
+
+		vsets := snapasserts.NewValidationSets()
+		vsets.Add(vs.(*asserts.ValidationSet))
+
+		return vsets
+	}
+
 	nameToRevOpts := map[string]*snapstate.RevisionOptions{
 		"some-snap": {
 			Revision:       snap.R(111),
-			ValidationSets: []snapasserts.ValidationSetKey{"1", "1.1"},
+			ValidationSets: valSetForSnap("some-snap"),
 		},
 		"some-other-snap": {
 			Revision:       snap.R(222),
-			ValidationSets: []snapasserts.ValidationSetKey{"2", "2.2"},
+			ValidationSets: valSetForSnap("some-other-snap"),
 		},
 		"snap-c": {
 			Revision:       snap.R(333),
-			ValidationSets: []snapasserts.ValidationSetKey{"3", "3.3"},
+			ValidationSets: valSetForSnap("snap-c"),
 		},
 	}
 	getRevOpts := func(names []string) (revOpts []*snapstate.RevisionOptions) {
@@ -13067,7 +13111,7 @@ func (s *snapmgrTestSuite) testUpdateManyRevOptsOrder(c *C, isThrottled map[stri
 		c.Check(requestSnapToAction, NotNil)
 		for name, action := range requestSnapToAction {
 			c.Check(action.Revision, Equals, nameToRevOpts[name].Revision, Commentf("snap %q sent revision is incorrect", name))
-			c.Check(action.ValidationSets, DeepEquals, nameToRevOpts[name].ValidationSets, Commentf("snap %q sent validation sets are incorrect", name))
+			c.Check(action.ValidationSets, DeepEquals, nameToRevOpts[name].ValidationSets.Keys(), Commentf("snap %q sent validation sets are incorrect", name))
 		}
 	}
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -454,7 +454,7 @@ func storeUpdatePlan(ctx context.Context, st *state.State, allSnaps map[string]*
 	}
 
 	if len(missingRequests) > 0 {
-		if err := validateAndInitStoreUpdates(allSnaps, missingRequests, opts); err != nil {
+		if err := validateAndInitStoreUpdates(st, allSnaps, missingRequests, opts); err != nil {
 			return updatePlan{}, err
 		}
 
@@ -498,14 +498,26 @@ func storeUpdatePlanCore(
 
 	updates := requested
 	if plan.refreshAll() {
+		var vsets *snapasserts.ValidationSets
+		if !opts.Flags.IgnoreValidation {
+			enforced, err := EnforcedValidationSets(st)
+			if err != nil {
+				return updatePlan{}, err
+			}
+			vsets = enforced
+		} else {
+			vsets = snapasserts.NewValidationSets()
+		}
+
 		updates = make(map[string]StoreUpdate, len(allSnaps))
 		for _, snapst := range allSnaps {
 			updates[snapst.InstanceName()] = StoreUpdate{
 				InstanceName: snapst.InstanceName(),
 				// default the channel and cohort key to the existing values,
 				RevOpts: RevisionOptions{
-					Channel:   snapst.TrackingChannel,
-					CohortKey: snapst.CohortKey,
+					Channel:        snapst.TrackingChannel,
+					CohortKey:      snapst.CohortKey,
+					ValidationSets: vsets,
 				},
 			}
 		}
@@ -527,8 +539,6 @@ func storeUpdatePlanCore(
 		}
 	}
 
-	enforcedSetsFunc := cachedEnforcedValidationSets(st)
-
 	fallbackID := fallbackUserID(user)
 
 	// hasLocalRevision keeps track of snaps that already have a local revision
@@ -545,14 +555,14 @@ func storeUpdatePlanCore(
 	//
 	// in either case, we need to keep track of these, since we still might need
 	// to change the channel, cohort key, or validation set enforcement.
-	actionsByUserID, hasLocalRevision, current, err := collectCurrentSnapsAndActions(st, allSnaps, updates, plan.requested, opts, enforcedSetsFunc, fallbackID)
+	actionsByUserID, hasLocalRevision, current, err := collectCurrentSnapsAndActions(st, allSnaps, updates, plan.requested, opts, fallbackID)
 	if err != nil {
 		return updatePlan{}, err
 	}
 
 	// create actions to refresh (install, from the store's perspective) snaps
 	// that were installed locally
-	amendActionsByUserID, localAmends, err := installActionsForAmend(st, updates, opts, enforcedSetsFunc, fallbackID)
+	amendActionsByUserID, localAmends, err := installActionsForAmend(st, updates, opts, fallbackID)
 	if err != nil {
 		return updatePlan{}, err
 	}
@@ -662,8 +672,9 @@ func storeUpdatePlanCore(
 		compsToInstall = unique(append(compsToInstall, up.AdditionalComponents...))
 
 		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, RevisionOptions{
-			Channel:  up.RevOpts.Channel,
-			Revision: si.Revision,
+			Channel:        up.RevOpts.Channel,
+			Revision:       si.Revision,
+			ValidationSets: up.RevOpts.ValidationSets,
 		}, opts)
 		if err != nil {
 			return updatePlan{}, err
@@ -695,6 +706,8 @@ func storeUpdatePlanCore(
 			components: compsups,
 		})
 	}
+
+	// TODO: verify validation sets here to catch invalid component revisions
 
 	return plan, nil
 }
@@ -732,7 +745,6 @@ func collectCurrentSnapsAndActions(
 	updates map[string]StoreUpdate,
 	requested []string,
 	opts Options,
-	enforcedSets func() (*snapasserts.ValidationSets, error),
 	fallbackID int,
 ) (actionsByUserID map[int][]*store.SnapAction, hasLocalRevision map[string]*SnapState, current []*store.CurrentSnap, err error) {
 	hasLocalRevision = make(map[string]*SnapState)
@@ -786,7 +798,7 @@ func collectCurrentSnapsAndActions(
 			}
 		}
 
-		if err := completeStoreAction(action, req.RevOpts, ignoreValidation, enforcedSets); err != nil {
+		if err := completeStoreAction(action, req.RevOpts, ignoreValidation); err != nil {
 			return err
 		}
 
@@ -834,7 +846,7 @@ func collectCurrentSnapsAndActions(
 	return actionsByUserID, hasLocalRevision, current, nil
 }
 
-func installActionsForAmend(st *state.State, updates map[string]StoreUpdate, opts Options, enforcedSets func() (*snapasserts.ValidationSets, error), fallbackID int) (map[int][]*store.SnapAction, []string, error) {
+func installActionsForAmend(st *state.State, updates map[string]StoreUpdate, opts Options, fallbackID int) (map[int][]*store.SnapAction, []string, error) {
 	actionsByUserID := make(map[int][]*store.SnapAction)
 	var localAmends []string
 	for _, up := range updates {
@@ -879,7 +891,7 @@ func installActionsForAmend(st *state.State, updates map[string]StoreUpdate, opt
 			ignoreValidation = opts.Flags.IgnoreValidation
 		}
 
-		if err := completeStoreAction(action, up.RevOpts, ignoreValidation, enforcedSets); err != nil {
+		if err := completeStoreAction(action, up.RevOpts, ignoreValidation); err != nil {
 			return nil, nil, err
 		}
 
@@ -1015,9 +1027,12 @@ func sendOneInstallAction(ctx context.Context, st *state.State, snaps StoreSnap,
 	return results[0], nil
 }
 
-func sendInstallActions(ctx context.Context, st *state.State, snaps []StoreSnap, opts Options) ([]store.SnapActionResult, error) {
-	enforcedSetsFunc := cachedEnforcedValidationSets(st)
-
+func sendInstallActions(
+	ctx context.Context,
+	st *state.State,
+	snaps []StoreSnap,
+	opts Options,
+) ([]store.SnapActionResult, error) {
 	includeResources := false
 	actions := make([]*store.SnapAction, 0, len(snaps))
 	for _, sn := range snaps {
@@ -1026,7 +1041,7 @@ func sendInstallActions(ctx context.Context, st *state.State, snaps []StoreSnap,
 			InstanceName: sn.InstanceName,
 		}
 
-		if err := completeStoreAction(action, sn.RevOpts, opts.Flags.IgnoreValidation, enforcedSetsFunc); err != nil {
+		if err := completeStoreAction(action, sn.RevOpts, opts.Flags.IgnoreValidation); err != nil {
 			return nil, err
 		}
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -498,29 +498,11 @@ func storeUpdatePlanCore(
 
 	updates := requested
 	if plan.refreshAll() {
-		var vsets *snapasserts.ValidationSets
-		if !opts.Flags.IgnoreValidation {
-			enforced, err := EnforcedValidationSets(st)
-			if err != nil {
-				return updatePlan{}, err
-			}
-			vsets = enforced
-		} else {
-			vsets = snapasserts.NewValidationSets()
+		all, err := initRefreshAllStoreUpdates(st, opts, allSnaps)
+		if err != nil {
+			return updatePlan{}, err
 		}
-
-		updates = make(map[string]StoreUpdate, len(allSnaps))
-		for _, snapst := range allSnaps {
-			updates[snapst.InstanceName()] = StoreUpdate{
-				InstanceName: snapst.InstanceName(),
-				// default the channel and cohort key to the existing values,
-				RevOpts: RevisionOptions{
-					Channel:        snapst.TrackingChannel,
-					CohortKey:      snapst.CohortKey,
-					ValidationSets: vsets,
-				},
-			}
-		}
+		updates = all
 	}
 
 	// if any of the snaps that we are refreshing have components, we need to

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -661,7 +661,10 @@ func storeUpdatePlanCore(
 		// installed
 		compsToInstall = unique(append(compsToInstall, up.AdditionalComponents...))
 
-		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, si.Revision, up.RevOpts.Channel, opts)
+		compsups, err := componentSetupsForInstall(ctx, st, compsToInstall, *snapst, RevisionOptions{
+			Channel:  up.RevOpts.Channel,
+			Revision: si.Revision,
+		}, opts)
 		if err != nil {
 			return updatePlan{}, err
 		}


### PR DESCRIPTION
Using a `snapasserts.ValidationSets` rather than a slice of `snapasserts.ValidationSetKey` makes many operations more convenient.

This will help enable verifying that component revisions are correct inside of snapstate. Additionally, it alleviates the need of providing a revision in `snapstate.RevisionOpts` when installing with a specific set of validation sets.