### PR TITLE
many: add method to seed to retrieve mode snap and components

### DIFF
--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -143,6 +143,10 @@ func (fs *FakeSeed) ModeSnaps(mode string) ([]*seed.Snap, error) {
 	return fs.SnapsForMode[mode], nil
 }
 
+func (s *FakeSeed) ModeSnap(snapName, mode string) (*seed.Snap, error) {
+	panic("ModeSnap not implemented")
+}
+
 func (fs *FakeSeed) NumSnaps() int {
 	return 0
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -733,6 +733,10 @@ func (fs *fakeSeed) ModeSnaps(mode string) ([]*seed.Snap, error) {
 	return nil, nil
 }
 
+func (s *fakeSeed) ModeSnap(snapName, mode string) (*seed.Snap, error) {
+	return nil, nil
+}
+
 func (*fakeSeed) NumSnaps() int {
 	return 0
 }

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -1773,6 +1773,10 @@ func (fs *fakeSeed) ModeSnaps(mode string) ([]*seed.Snap, error) {
 	return fs.modeSnaps, nil
 }
 
+func (s *fakeSeed) ModeSnap(snapName, mode string) (*seed.Snap, error) {
+	return nil, nil
+}
+
 func (*fakeSeed) NumSnaps() int {
 	return 0
 }

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -160,6 +160,11 @@ type Seed interface {
 	// mode here will result in error.
 	ModeSnaps(mode string) ([]*Snap, error)
 
+	// ModeSnap returns the snapName snap if available for the given mode
+	// and with the components available for mode. This method can be used
+	// for any snap type.
+	ModeSnap(snapName, mode string) (*Snap, error)
+
 	// NumSnaps returns the total number of snaps for which
 	// LoadMeta loaded their metadata.
 	NumSnaps() int

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -456,6 +456,18 @@ func (s *seed16) ModeSnaps(mode string) ([]*Snap, error) {
 	return s.snaps[s.essentialSnapsNum:], nil
 }
 
+func (s *seed16) ModeSnap(snapName, mode string) (*Snap, error) {
+	if mode != "run" {
+		return nil, fmt.Errorf("internal error: Core 16/18 have only run mode, got: %s", mode)
+	}
+	for _, sn := range s.snaps {
+		if sn.SnapName() == snapName {
+			return sn, nil
+		}
+	}
+	return nil, fmt.Errorf("snap %s not found in seed", snapName)
+}
+
 func (s *seed16) NumSnaps() int {
 	return len(s.snaps)
 }

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -487,14 +487,25 @@ func (s *seed16Suite) TestLoadMetaCore16(c *C) {
 	pi = essSnaps[2].PlaceInfo()
 	c.Check(pi.Filename(), Equals, "pc_1.snap")
 
-	c.Check(runSnaps, DeepEquals, []*seed.Snap{
-		{
-			Path:     s.expectedPath("required"),
-			SideInfo: &s.AssertedSnapInfo("required").SideInfo,
-			Required: true,
-			Channel:  "stable",
-		},
-	})
+	requiredExpect := &seed.Snap{
+		Path:     s.expectedPath("required"),
+		SideInfo: &s.AssertedSnapInfo("required").SideInfo,
+		Required: true,
+		Channel:  "stable",
+	}
+	c.Check(runSnaps, DeepEquals, []*seed.Snap{requiredExpect})
+
+	requiredSnap, err := s.seed16.ModeSnap("required", "run")
+	c.Assert(err, IsNil)
+	c.Check(requiredSnap, DeepEquals, requiredExpect)
+
+	notExistsSnap, err := s.seed16.ModeSnap("not-exists", "run")
+	c.Assert(notExistsSnap, IsNil)
+	c.Assert(err, ErrorMatches, "snap not-exists not found in seed")
+
+	requiredSnap, err = s.seed16.ModeSnap("required", "ephemeral")
+	c.Assert(requiredSnap, IsNil)
+	c.Assert(err, ErrorMatches, "internal error: Core 16/18 have only run mode, got: ephemeral")
 }
 
 func (s *seed16Suite) TestLoadMetaCore18Minimal(c *C) {


### PR DESCRIPTION
The new method returns snap if applicable to mode, and returns only the components that can be used in said mode.