### PR TITLE
o/configstate/configcore: support SSH socket activation configurations

### DIFF
--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -133,7 +133,7 @@ type configcoreSuite struct {
 
 	state *state.State
 
-	systemctlOutput   func(args ...string) []byte
+	systemctlOutput   func(args ...string) ([]byte, error)
 	systemctlArgs     [][]string
 	systemdSysctlArgs [][]string
 }
@@ -148,7 +148,7 @@ func (s *configcoreSuite) SetUpTest(c *C) {
 
 	s.AddCleanup(osutil.MockMountInfo(""))
 
-	s.systemctlOutput = func(args ...string) []byte {
+	s.systemctlOutput = func(args ...string) ([]byte, error) {
 		if args[0] == "show" {
 			return []byte(fmt.Sprintf(`Type=notify
 Id=%[1]s
@@ -156,14 +156,14 @@ Names=%[1]s
 ActiveState=inactive
 UnitFileState=enabled
 NeedDaemonReload=no
-`, args[len(args)-1]))
+`, args[len(args)-1])), nil
 		}
-		return []byte("ActiveState=inactive")
+		return []byte("ActiveState=inactive"), nil
 	}
 
 	s.AddCleanup(systemd.MockSystemctl(func(args ...string) ([]byte, error) {
 		s.systemctlArgs = append(s.systemctlArgs, args[:])
-		return s.systemctlOutput(args...), nil
+		return s.systemctlOutput(args...)
 	}))
 	s.systemctlArgs = nil
 	s.AddCleanup(systemd.MockSystemdSysctl(func(args ...string) error {

--- a/overlord/configstate/configcore/ctrlaltdel_test.go
+++ b/overlord/configstate/configcore/ctrlaltdel_test.go
@@ -59,7 +59,7 @@ var _ = Suite(&ctrlaltdelSuite{})
 
 func (s *ctrlaltdelSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
-	s.systemctlOutput = func(args ...string) []byte {
+	s.systemctlOutput = func(args ...string) ([]byte, error) {
 		var output []byte
 		// 'args' represents the arguments passed in for the systemctl Status call.
 		// The test context is specific to the ctrlaltdel handler, which only uses
@@ -91,7 +91,7 @@ func (s *ctrlaltdelSuite) SetUpTest(c *C) {
 				// No output returned by systemctl
 			}
 		}
-		return output
+		return output, nil
 	}
 	s.unit = unitStateNone
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -372,8 +372,20 @@ func handleServiceConfigSSHListen(dev sysconfig.Device, tr ConfGetter, opts *fsO
 
 	if opts == nil {
 		sysd := systemd.New(systemd.SystemMode, &sysdLogger{})
-		if err := sysd.ReloadOrRestart([]string{"ssh.service"}); err != nil {
-			return err
+		// From 22.10 sshd now uses socket based activation. This changes how to reload
+		// ssh configuration
+		// Discussion here: https://discourse.ubuntu.com/t/sshd-now-uses-socket-based-activation-ubuntu-22-10-and-later/30189/9
+		if enabled, err := sysd.IsEnabled("ssh.socket"); err == nil && enabled {
+			if err := sysd.DaemonReload(); err != nil {
+				return err
+			}
+			if err := sysd.Restart([]string{"ssh.socket"}); err != nil {
+				return err
+			}
+		} else {
+			if err := sysd.ReloadOrRestart([]string{"ssh.service"}); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -372,8 +372,7 @@ func handleServiceConfigSSHListen(dev sysconfig.Device, tr ConfGetter, opts *fsO
 
 	if opts == nil {
 		sysd := systemd.New(systemd.SystemMode, &sysdLogger{})
-		// From 22.10 sshd now uses socket based activation. This changes how to reload
-		// ssh configuration
+		// From 22.10 sshd now uses socket based activation. This changes how to reload ssh configuration
 		// Discussion here: https://discourse.ubuntu.com/t/sshd-now-uses-socket-based-activation-ubuntu-22-10-and-later/30189/9
 		if enabled, err := sysd.IsEnabled("ssh.socket"); err == nil && enabled {
 			if err := sysd.DaemonReload(); err != nil {


### PR DESCRIPTION
On ubuntu 22.10+ sshd uses socket activation and that means we must reload SSH differently for the socket unit.

This should fix the nested test tests/nested/manual/core20-early-config

REF: SNAPDENG-34249