### PR TITLE
tests: upgrade Amazon Linux 2023 to the latest release during prepare

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -894,6 +894,16 @@ install_pkg_dependencies(){
 # to stdout
 distro_upgrade() {
     case "$SPREAD_SYSTEM" in
+        amazon-linux-2023-*)
+            # Amazon Linux 2023 uses versioned releases, see
+            # https://docs.aws.amazon.com/linux/al2023/ug/deterministic-upgrades-usage.html
+            if [ "$(dnf check-release-update 2>&1)" = "" ]; then
+                return
+            fi
+
+            dnf upgrade --releasever=latest -y
+            echo "reboot"
+            ;;
         arch-*)
             # Arch does not support partial upgrades. On top of this, the image
             # we are running in may have been built some time ago and we need to

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -312,6 +312,16 @@ prepare_project() {
     # remove any packages that are marked for auto removal before running any tests
     distro_auto_remove_packages
 
+    if os.query is-amazon-linux 2023; then
+        # perform system upgrade to the latest release
+        if [[ "$SPREAD_REBOOT" == 0 ]]; then
+            if distro_upgrade | MATCH "reboot"; then
+                echo "system upgraded, reboot required"
+                REBOOT
+            fi
+        fi
+    fi
+
     if os.query is-arch-linux; then
         # perform system upgrade on Arch so that we run with most recent kernel
         # and userspace


### PR DESCRIPTION
Aamazon Linux 2023 uses versioned releases. Make sure we are always working with the latest release.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
