### PR TITLE
tests: fix cgroup-tracking-failure in ubuntu 25.04

### DIFF
--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -183,7 +183,7 @@ execute: |
     SNAPD_DEBUG=1 tests.session -u root exec snap run test-snapd-sh.sh -c 'exec cat /proc/self/cgroup' >cgroup.txt 2>debug.txt
     tests.session -u root restore
     case "$SPREAD_SYSTEM" in
-        ubuntu-24*)
+        ubuntu-24*|ubuntu-25*)
             # Ubuntu >= 24.04 uses systemd-run instead of busctl to run commands using tests.session
             MATCH '0::/user.slice/user-0.slice/user@0.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
@@ -240,7 +240,7 @@ execute: |
             MATCH 'DEBUG: transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
             MATCH '0::/user.slice/user-12345.slice/user@12345.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
-        ubuntu-24*)
+        ubuntu-24*|ubuntu-25*)
             # Ubuntu >= 24.04 uses systemd-run instead of busctl to run commands using tests.session
             MATCH '0::/user.slice/user-12345.slice/user@12345.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;


### PR DESCRIPTION
Simple fix for test cgroup-tracking-failure
