### PR TITLE
tests: update document-interfaces-url exclusion dates

### DIFF
--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -38,15 +38,17 @@ execute: |
     # The expiry date is <expiration year>/<expiration month>      
     
     declare -A exclusion_map
-    exclusion_map["intel-qat"]="2024/10"
-    exclusion_map["microceph"]="2024/10"
-    exclusion_map["microceph-support"]="2024/10"
-    exclusion_map["pkcs11"]="2024/10"
-    exclusion_map["registry"]="2024/11"
-    exclusion_map["snap-interfaces-requests-control"]="2024/11"
-    exclusion_map["system-packages-doc"]="2024/10"
-    exclusion_map["xilinx-dma"]="2024/10"
-    exclusion_map["nomad-support"]="2024/10"
+    # confdb is still in the experimental phase so its page is not exposed yet
+    exclusion_map["confdb"]="2025/03"
+    # we have documentation pages for these interfaces but they have underscores
+    # in the URL instead of dashes. Due to issues w/ Discourse we can't fix it
+    # at the moment, so we need to skip these checks for a bit
+    exclusion_map["intel-qat"]="2025/01"
+    exclusion_map["microceph-support"]="2025/01"
+    exclusion_map["xilinx-dma"]="2025/01"
+    exclusion_map["snap-interfaces-requests-control"]="2025/01"
+    # we're actually missing this page but can't add it yet due to the same Discourse issues
+    exclusion_map["nomad-support"]="2024/12"
 
     # If the interface is in the exclusion_map and it is currently sooner
     # than its specified expiration date, then return true


### PR DESCRIPTION
Updates exclusion dates for URLs that we can't fix at the moment and removes some which are no longer necessary.