### PR TITLE
tests: move debian-12 and sid to openstack

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,7 +238,7 @@ jobs:
             tasks: 'tests/...'
             rules: 'main'
           - group: debian-not-req
-            backend: google-distro-1
+            backend: openstack
             systems: 'debian-12-64 debian-sid-64'
             tasks: 'tests/...'
             rules: 'main'

--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -49,4 +49,7 @@
             - debian-12-64:
                 image: snapd-spread/debian-12-64
                 workers: 6
+            - debian-sid-64:
+                image: snapd-spread/debian-sid-64
+                workers: 6
 

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -19,8 +19,6 @@ systems:
   - -arch-*
   - -amazon-*
   - -centos-*
-  # TODO: su -l -c test-snapd-kernel-module-consumer.lsmod fails on core 22
-  - -ubuntu-core-22-*
 
 environment:
     MODULE: minix
@@ -33,7 +31,13 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_generic_consumer kernel-module-control
 
+    # Prepare for using sessions as the given user
+    tests.session prepare -u test
+
 restore: |
+    # Restore after using sessions as the given user
+    tests.session restore -u test
+
     if lsmod | MATCH "$MODULE" && [ ! -f module_present ]; then
         rmmod "$MODULE"
     elif [ -f module_present ] && ! lsmod | MATCH "$MODULE" ; then
@@ -58,7 +62,7 @@ execute: |
     snap connect generic-consumer:kernel-module-control
 
     echo "Then the snap is able to list the existing modules"
-    test "$(su -l -c "test-snapd-kernel-module-consumer.lsmod" test | wc -l)" -gt 2
+    test "$(tests.session -u test exec test-snapd-kernel-module-consumer.lsmod | wc -l)" -gt 2
 
     echo "And the snap is able to insert a module"
     if lsmod | MATCH "$MODULE"; then
@@ -72,7 +76,7 @@ execute: |
     generic-consumer.cmd ls /sys/module | MATCH "$MODULE"
 
     echo "And the snap is not able to write to /sys/module"
-    if su -l -c "generic-consumer.cmd touch /sys/module/test" test 2> touch.error; then
+    if tests.session -u test exec generic-consumer.cmd touch /sys/module/test 2> touch.error; then
         echo "Expected permission error writing to /sys/module"
         exit 1
     fi
@@ -91,7 +95,7 @@ execute: |
     snap disconnect generic-consumer:kernel-module-control
 
     echo "Then the snap is not able to list modules"
-    if su -l -c "test-snapd-kernel-module-consumer.lsmod" test 2> list.error; then
+    if tests.session -u test exec test-snapd-kernel-module-consumer.lsmod 2> list.error; then
         echo "Expected permission error listing modules with disconnected plug"
         exit 1
     fi
@@ -115,14 +119,14 @@ execute: |
     MATCH "Permission denied" < remove.error
 
     echo "And the snap is not able to read /sys/module"
-    if su -l -c "generic-consumer.cmd ls /sys/module" test 2> read.error; then
+    if tests.session -u test exec generic-consumer.cmd ls /sys/module 2> read.error; then
         echo "Expected permission error reading /sys/module with disconnected plug"
         exit 1
     fi
     MATCH "Permission denied" < read.error
 
     echo "And the snap is not able to write to /sys/module"
-    if su -l -c "generic-consumer.cmd touch /sys/module/test" test 2> touch.error; then
+    if tests.session -u test exec generic-consumer.cmd touch /sys/module/test 2> touch.error; then
         echo "Expected permission error writing to /sys/module"
         exit 1
     fi

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -60,11 +60,20 @@ execute: |
     # test workflow static checks. They can therefore be safely skipped here.
     skip="${skip:-} SKIP_GOLANGCI_LINT=1"
 
+    PROXY_PARAM=""
+    if [ -n "${http_proxy:-}" ]; then
+        PROXY_PARAM="HTTP_PROXY=$http_proxy"
+    fi
+    if [ -n "${https_proxy:-}" ]; then
+        PROXY_PARAM="$PROXY_PARAM HTTPS_PROXY=$https_proxy"
+    fi
+
     if not os.query is-trusty; then
         if [ "$VARIANT" = "static" ] ; then
             tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
                 PATH=$PATH \
                 GOPATH=/tmp/static-unit-tests \
+                $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
                 ./run-checks --static"
@@ -72,6 +81,7 @@ execute: |
             tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
                 PATH=$PATH \
                 GOPATH=/tmp/static-unit-tests \
+                $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
                 ./run-checks --unit"
@@ -98,6 +108,7 @@ execute: |
             su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
                 PATH=$PATH \
                 GOPATH=/tmp/static-unit-tests \
+                $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
                 ./run-checks --static" test
@@ -105,6 +116,7 @@ execute: |
             su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
                 PATH=$PATH \
                 GOPATH=/tmp/static-unit-tests \
+                $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
                 ./run-checks --unit" test


### PR DESCRIPTION
This change moves the non-required debian system to openstack
