### PR TITLE
github, tests: use separate spread rules for FIPS test suite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -316,7 +316,8 @@ jobs:
             backend: google-pro
             systems: 'ubuntu-fips-22.04-64'
             tasks: 'tests/fips/...'
-            rules: 'main'
+            # XXX fips test suite comes with separate ruless file
+            rules: 'fips'
           - group: nested-ubuntu-18.04
             backend: google-nested
             systems: 'ubuntu-18.04-64'

--- a/tests/lib/spread/rules/fips.yaml
+++ b/tests/lib/spread/rules/fips.yaml
@@ -1,0 +1,14 @@
+# rules for the tests/fips test suite, which runs a subset of tests from
+# tests/main and tests/smoke suites
+rules:
+  tests:
+    from:
+      # selected tests from the main and smoke test suites are symlinked to
+      # tests/fips test suite
+      - tests/main/.*
+      - tests/smoke/.*
+    to: [tests/fips/]
+
+  rest:
+    from: [.*]
+    to: [tests/fips/]


### PR DESCRIPTION
Use a separate rules file for matching the FIPS test suite tests.

Related: [SNAPDENG-34289](https://warthogs.atlassian.net/browse/SNAPDENG-34289)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-34289]: https://warthogs.atlassian.net/browse/SNAPDENG-34289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ