### PR TITLE
tests/main/auto-refresh-backoff: generate properly 'bad' configure hook

### DIFF
--- a/tests/main/auto-refresh-backoff/task.yaml
+++ b/tests/main/auto-refresh-backoff/task.yaml
@@ -61,7 +61,10 @@ execute: |
     # Make bad version of SNAP_ONE
     unsquashfs -d bad-snap "$SNAP_ONE_GOOD_PATH"
     mkdir -p ./bad-snap/meta/hooks
-    echo 'exit 1' > ./bad-snap/meta/hooks/configure
+    cat <<'EOF' > ./bad-snap/meta/hooks/configure
+    #!/bin/sh
+    exit 1
+    EOF
     chmod +x ./bad-snap/meta/hooks/configure
     snap pack --filename="$SNAP_ONE-bad.snap" bad-snap .
     SNAP_ONE_BAD_PATH="$(pwd)/$SNAP_ONE-bad.snap"


### PR DESCRIPTION
Make sure that the tests generates a configure hook which is 'bad' in a proper way.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
