### PR TITLE
tests: fix time synchronization issues is ubuntu xenial

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -571,6 +571,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-16.04-64)
             echo "
+                chrony
                 dbus-user-session
                 evolution-data-server
                 fwupd


### PR DESCRIPTION
Some tests like auto-refresh-backoff fail in xenial. The issue is related to the following problem:

kernel reports TIME_ERROR: 0x41: Clock Unsynchronized

Other ubuntu varions have chrony installed, so this changes ensures chrony is installed in xenial too.
