### PR TITLE
tests: added dependency system-dev for ubuntu24.10+

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -610,7 +610,7 @@ pkg_dependencies_ubuntu_classic(){
                 shellcheck
                 "
             ;;
-        ubuntu-22.*|ubuntu-23.*|ubuntu-24.*|ubuntu-25.*)
+        ubuntu-22.*|ubuntu-23.*|ubuntu-24.04*)
             # bpftool is part of linux-tools package
             echo "
                 dbus-user-session
@@ -623,11 +623,22 @@ pkg_dependencies_ubuntu_classic(){
                 qemu-kvm
                 qemu-utils
                 "
-            if os.query is-ubuntu 24.10; then
-                echo "
-                    systemd-dev
-                    "
-            fi
+            ;;
+	ubuntu-24.10*|ubuntu-25.*)
+            # bpftool is part of linux-tools package
+            # ubuntu-24.10+ systemd-dev is optional
+            echo "
+                dbus-user-session
+                fwupd
+                golang
+                gperf
+                libvirt-daemon-system
+                linux-tools-$(uname -r)
+                lz4
+                qemu-kvm
+                qemu-utils
+                systemd-dev
+                "
             ;;
         ubuntu-*)
             echo "


### PR DESCRIPTION
Fix  google:ubuntu-25.04-64:tests/unit/c-unit-tests-{clang,gcc} by installing package systemd-dev (provides /usr/share/pkgconfig/udev.pc) to resolve pkg-config dependency "udev".

**Failure looks like:**
___
checking for libapparmor... yes
checking for libudev... yes
checking for udev... no
configure: error: Package requirements (udev) were not met:
 
Package 'udev', required by 'virtual:world', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables UDEV_CFLAGS
and UDEV_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
___