### PR TITLE
tests: divide spread into fundamental/non-fundamental

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -25,6 +25,11 @@ on:
         description: 'The rule .yaml file to use (found under tests/lib/spread/rules) for test discovery'
         required: true
         type: string
+      is-fundamental:
+        description: 'If true, then will mark results as from fundamental systems when uploading to Grafana'
+        required: false
+        type: boolean
+        default: false
       use-snapd-snap-from-master:
         description: 'If true, will use the snapd snap built on the master branch'
         required: false
@@ -300,12 +305,16 @@ jobs:
       run: |
         if [ -e spread.log ]; then
             echo "Running spread log analyzer"
+            fundamental=""
+            if [ "${{ inputs.is-fundamental }}" == 'true' ]; then
+              fundamental="#fundamental"
+            fi
             ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json --cut 1 >/dev/null
             while IFS= read -r line; do
                 if [ ! -z "$line" ]; then
                     echo "Adding failed test line to filtered log"
-                    echo "GRAFANA FAILED: $line $ACTIONS_URL" | tee -a "$FILTERED_LOG_FILE"
+                    echo "GRAFANA FAILED: $fundamental $line $ACTIONS_URL" | tee -a "$FILTERED_LOG_FILE"
                 fi
             done <<< $(jq -r '.[] | select( .type == "info" ) | select( .info_type == "Error" ) | "\(.verb) \(.task)"' spread-results.json)
         else

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -305,7 +305,7 @@ jobs:
       run: |
         if [ -e spread.log ]; then
             echo "Running spread log analyzer"
-            fundamental=""
+            fundamental="#notfundamental"
             if [ "${{ inputs.is-fundamental }}" == 'true' ]; then
               fundamental="#fundamental"
             fi
@@ -314,7 +314,7 @@ jobs:
             while IFS= read -r line; do
                 if [ ! -z "$line" ]; then
                     echo "Adding failed test line to filtered log"
-                    echo "GRAFANA FAILED: $fundamental $line $ACTIONS_URL" | tee -a "$FILTERED_LOG_FILE"
+                    echo "GRAFANA FAILED: $line $ACTIONS_URL" $fundamental | tee -a "$FILTERED_LOG_FILE"
                 fi
             done <<< $(jq -r '.[] | select( .type == "info" ) | select( .info_type == "Error" ) | "\(.verb) \(.task)"' spread-results.json)
         else

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -181,7 +181,11 @@ jobs:
           if [ -z "$CHANGE_ID" ]; then
             CHANGE_ID="main"
           fi
-          FILTERED_LOG_FILE="spread_${CHANGE_ID}_n${{ github.run_attempt }}.filtered.log"
+          fundamental=""
+          if [ "${{ inputs.is-fundamental }}" = 'true' ]; then
+            fundamental="fund"
+          fi
+          FILTERED_LOG_FILE="spread_${CHANGE_ID}_${fundamental}_n${{ github.run_attempt }}.filtered.log"
           # The log-filter tool is used to filter the spread logs to be stored
           echo FILTER_PARAMS="-o $FILTERED_LOG_FILE -e Debug -e WARNING: -f Failed=NO_LINES -f Error=NO_LINES"  >> $GITHUB_ENV
           echo FILTERED_LOG_FILE="$FILTERED_LOG_FILE"  >> $GITHUB_ENV
@@ -305,16 +309,12 @@ jobs:
       run: |
         if [ -e spread.log ]; then
             echo "Running spread log analyzer"
-            fundamental="#notfundamental"
-            if [ "${{ inputs.is-fundamental }}" == 'true' ]; then
-              fundamental="#fundamental"
-            fi
             ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json --cut 1 >/dev/null
             while IFS= read -r line; do
                 if [ ! -z "$line" ]; then
                     echo "Adding failed test line to filtered log"
-                    echo "GRAFANA FAILED: $line $ACTIONS_URL" $fundamental | tee -a "$FILTERED_LOG_FILE"
+                    echo "GRAFANA FAILED: $line $ACTIONS_URL" | tee -a "$FILTERED_LOG_FILE"
                 fi
             done <<< $(jq -r '.[] | select( .type == "info" ) | select( .info_type == "Error" ) | "\(.verb) \(.task)"' spread-results.json)
         else

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,17 +112,17 @@ jobs:
       run: |
         # Compare the daily system in master and in the current branch
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
-        get_daily_system() {
+        get_dev_current_system() {
           file=$1
-          system_daily="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
-          if [ -z "$system_daily" ]; then
-            system_daily="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
+          system_dev_current="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-dev-current") | .systems'  $file)" 
+          if [ -z "$system_dev_current" ]; then
+            system_dev_current="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-dev-current") | .systems'  $file)" 
           fi
-          echo $system_daily
+          echo $system_dev_current
         }
-        system_daily="$(get_daily_system  test_master.yaml)"
-        current_daily="$(get_daily_system  .github/workflows/test.yaml)"
-        test "$system_daily" == "$current_daily"
+        master_dev_current="$(get_dev_current_system  test_master.yaml)"
+        branch_dev_current="$(get_dev_current_system  .github/workflows/test.yaml)"
+        test "$system_dev_current" == "$branch_dev_current"
       shell: bash
 
   # The required-static-checks job was introduced to maintain a consistent
@@ -317,7 +317,7 @@ jobs:
             systems: 'ubuntu-24.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: 'ubuntu-no-lts (fundamental)'
+          - group: 'ubuntu-dev-previous (fundamental)'
             backend: google
             systems: 'ubuntu-24.10-64'
             tasks: 'tests/...'
@@ -407,7 +407,7 @@ jobs:
             systems: 'ubuntu-22.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: 'ubuntu-daily'
+          - group: 'ubuntu-dev-current'
             backend: google
             systems: 'ubuntu-25.04-64'
             tasks: 'tests/...'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,8 +112,16 @@ jobs:
       run: |
         # Compare the daily system in master and in the current branch
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
-        system_daily="$(yq '.jobs.spread-fundamental.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  test_master.yaml)"
-        current_daily="$(yq '.jobs.spread-fundamental.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  .github/workflows/test.yaml)"
+        get_daily_system() {
+          file=$1
+          system_daily="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
+          if [ -z "$system_daily" ]; then
+            system_daily="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
+          fi
+          echo $system_daily
+        }
+        system_daily="$(get_daily_system  test_master.yaml)"
+        current_daily="$(get_daily_system  .github/workflows/test.yaml)"
         test "$system_daily" == "$current_daily"
       shell: bash
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -314,6 +314,11 @@ jobs:
             systems: 'ubuntu-24.10-64'
             tasks: 'tests/...'
             rules: 'main'
+          - group: 'ubuntu-core-18 (fundamental)'
+            backend: google-core
+            systems: 'ubuntu-core-18-64'
+            tasks: 'tests/...'
+            rules: 'main'
           - group: 'ubuntu-core-20 (fundamental)'
             backend: google-core
             systems: 'ubuntu-core-20-64'
@@ -397,11 +402,6 @@ jobs:
           - group: 'ubuntu-daily'
             backend: google
             systems: 'ubuntu-25.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'ubuntu-core-18'
-            backend: google-core
-            systems: 'ubuntu-core-18-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-core-22

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,8 +112,8 @@ jobs:
       run: |
         # Compare the daily system in master and in the current branch
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
-        system_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  test_master.yaml)"
-        current_daily="$(yq '.jobs.spread.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  .github/workflows/test.yaml)"
+        system_daily="$(yq '.jobs.spread-fundamental.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  test_master.yaml)"
+        current_daily="$(yq '.jobs.spread-fundamental.strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  .github/workflows/test.yaml)"
         test "$system_daily" == "$current_daily"
       shell: bash
 
@@ -264,9 +264,70 @@ jobs:
         files: .coverage/coverage-*.cov
         verbose: true
 
-  spread:
+  spread-fundamental:
     uses: ./.github/workflows/spread-tests.yaml
     needs: [unit-tests, snap-builds]
+    name: "spread ${{ matrix.group }}"
+    with:
+      # Github doesn't support passing sequences as parameters.
+      # Instead here we create a json array and pass it as a string.
+      # Then in the spread workflow it turns it into a sequence 
+      # using the fromJSON expression.
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: ${{ matrix.tasks }}
+      rules: ${{ matrix.rules }}
+      is-fundamental: true
+    strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      # Disable fail-fast mode as it doesn't function with spread. It seems
+      # that cancelling tasks requires short, interruptible actions and
+      # interrupting spread, notably, does not work today. As such disable
+      # fail-fast while we tackle that problem upstream.
+      fail-fast: false
+      matrix:
+        include:
+          - group: 'debian-req (fundamental)'
+            backend: google-distro-1
+            systems: 'debian-11-64'
+            tasks: 'tests/...'
+            rules: 'main'
+          - group: 'fedora (fundamental)'
+            backend: openstack
+            systems: 'fedora-41-64'
+            tasks: 'tests/...'
+            rules: 'main'
+          - group: 'ubuntu-bionic (fundamental)'
+            backend: google
+            systems: 'ubuntu-18.04-64'
+            tasks: 'tests/...'
+            rules: 'main'
+          - group: 'ubuntu-noble (fundamental)'
+            backend: google
+            systems: 'ubuntu-24.04-64'
+            tasks: 'tests/...'
+            rules: 'main'
+          - group: 'ubuntu-daily (fundamental)'
+            backend: google
+            systems: 'ubuntu-25.04-64'
+            tasks: 'tests/...'
+            rules: 'main'
+          - group: 'ubuntu-core-18 (fundamental)'
+            backend: google-core
+            systems: 'ubuntu-core-18-64'
+            tasks: 'tests/...'
+            rules: 'main'
+          - group: 'ubuntu-core-24 (fundamental)'
+            backend: google-core
+            systems: 'ubuntu-core-24-64'
+            tasks: 'tests/...'
+            rules: 'main'
+
+  spread-not-fundamental:
+    uses: ./.github/workflows/spread-tests.yaml
+    needs: [unit-tests, snap-builds, spread-fundamental]
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.
@@ -303,11 +364,6 @@ jobs:
             systems: 'centos-9-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: debian-req
-            backend: google-distro-1
-            systems: 'debian-11-64'
-            tasks: 'tests/...'
-            rules: 'main'
           - group: debian-not-req
             backend: openstack
             systems: 'debian-12-64 debian-sid-64'
@@ -315,7 +371,7 @@ jobs:
             rules: 'main'
           - group: fedora
             backend: openstack
-            systems: 'fedora-40-64 fedora-41-64'
+            systems: 'fedora-40-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: opensuse
@@ -328,9 +384,9 @@ jobs:
             systems: 'ubuntu-14.04-64'
             tasks: 'tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04'
             rules: 'trusty'
-          - group: ubuntu-xenial-bionic
+          - group: ubuntu-xenial
             backend: google
-            systems: 'ubuntu-16.04-64 ubuntu-18.04-64'
+            systems: 'ubuntu-16.04-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-focal-jammy
@@ -338,24 +394,9 @@ jobs:
             systems: 'ubuntu-20.04-64 ubuntu-22.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: ubuntu-noble
-            backend: google
-            systems: 'ubuntu-24.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
           - group: ubuntu-no-lts
             backend: google
             systems: 'ubuntu-24.10-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-daily
-            backend: google
-            systems: 'ubuntu-25.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-core-18
-            backend: google-core
-            systems: 'ubuntu-core-18-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-core-20
@@ -366,11 +407,6 @@ jobs:
           - group: ubuntu-core-22
             backend: google-core
             systems: 'ubuntu-core-22-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-core-24
-            backend: google-core
-            systems: 'ubuntu-core-24-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-arm64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,14 +114,14 @@ jobs:
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
         get_daily_system() {
           file=$1
-          system_daily="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
+          system_daily="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems' $file)" 
           if [ -z "$system_daily" ]; then
-            system_daily="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
+            system_daily="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems' $file)" 
           fi
           echo $system_daily
         }
-        master_daily="$(get_daily_system  test_master.yaml)"
-        branch_daily="$(get_daily_system  .github/workflows/test.yaml)"
+        master_daily="$(get_daily_system test_master.yaml)"
+        branch_daily="$(get_daily_system .github/workflows/test.yaml)"
         test "$master_daily" == "$branch_daily"
       shell: bash
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -296,12 +296,12 @@ jobs:
             rules: 'main'
           - group: 'fedora (fundamental)'
             backend: openstack
-            systems: 'fedora-41-64'
+            systems: 'fedora-40-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: 'ubuntu-bionic (fundamental)'
+          - group: 'ubuntu-focal (fundamental)'
             backend: google
-            systems: 'ubuntu-18.04-64'
+            systems: 'ubuntu-20.04-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: 'ubuntu-noble (fundamental)'
@@ -309,14 +309,14 @@ jobs:
             systems: 'ubuntu-24.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: 'ubuntu-daily (fundamental)'
+          - group: 'ubuntu-no-lts (fundamental)'
             backend: google
-            systems: 'ubuntu-25.04-64'
+            systems: 'ubuntu-24.10-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: 'ubuntu-core-18 (fundamental)'
+          - group: 'ubuntu-core-20 (fundamental)'
             backend: google-core
-            systems: 'ubuntu-core-18-64'
+            systems: 'ubuntu-core-20-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: 'ubuntu-core-24 (fundamental)'
@@ -371,7 +371,7 @@ jobs:
             rules: 'main'
           - group: fedora
             backend: openstack
-            systems: 'fedora-40-64'
+            systems: 'fedora-41-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: opensuse
@@ -384,24 +384,24 @@ jobs:
             systems: 'ubuntu-14.04-64'
             tasks: 'tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04'
             rules: 'trusty'
-          - group: ubuntu-xenial
+          - group: ubuntu-xenial-bionic
             backend: google
-            systems: 'ubuntu-16.04-64'
+            systems: 'ubuntu-16.04-64 ubuntu-18.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: ubuntu-focal-jammy
+          - group: ubuntu-jammy
             backend: google
-            systems: 'ubuntu-20.04-64 ubuntu-22.04-64'
+            systems: 'ubuntu-22.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: ubuntu-no-lts
+          - group: 'ubuntu-daily'
             backend: google
-            systems: 'ubuntu-24.10-64'
+            systems: 'ubuntu-25.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: ubuntu-core-20
+          - group: 'ubuntu-core-18'
             backend: google-core
-            systems: 'ubuntu-core-20-64'
+            systems: 'ubuntu-core-18-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-core-22

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,17 +112,17 @@ jobs:
       run: |
         # Compare the daily system in master and in the current branch
         wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
-        get_dev_current_system() {
+        get_daily_system() {
           file=$1
-          system_dev_current="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-dev-current") | .systems'  $file)" 
-          if [ -z "$system_dev_current" ]; then
-            system_dev_current="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-dev-current") | .systems'  $file)" 
+          system_daily="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
+          if [ -z "$system_daily" ]; then
+            system_daily="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems'  $file)" 
           fi
-          echo $system_dev_current
+          echo $system_daily
         }
-        master_dev_current="$(get_dev_current_system  test_master.yaml)"
-        branch_dev_current="$(get_dev_current_system  .github/workflows/test.yaml)"
-        test "$system_dev_current" == "$branch_dev_current"
+        master_daily="$(get_daily_system  test_master.yaml)"
+        branch_daily="$(get_daily_system  .github/workflows/test.yaml)"
+        test "$master_daily" == "$branch_daily"
       shell: bash
 
   # The required-static-checks job was introduced to maintain a consistent
@@ -317,7 +317,7 @@ jobs:
             systems: 'ubuntu-24.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: 'ubuntu-dev-previous (fundamental)'
+          - group: 'ubuntu-interim (fundamental)'
             backend: google
             systems: 'ubuntu-24.10-64'
             tasks: 'tests/...'
@@ -407,7 +407,7 @@ jobs:
             systems: 'ubuntu-22.04-64'
             tasks: 'tests/...'
             rules: 'main'
-          - group: 'ubuntu-dev-current'
+          - group: ubuntu-daily
             backend: google
             systems: 'ubuntu-25.04-64'
             tasks: 'tests/...'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -304,7 +304,7 @@ jobs:
             rules: 'main'
           - group: 'fedora (fundamental)'
             backend: openstack
-            systems: 'fedora-40-64'
+            systems: 'fedora-41-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: 'ubuntu-focal (fundamental)'
@@ -384,7 +384,7 @@ jobs:
             rules: 'main'
           - group: fedora
             backend: openstack
-            systems: 'fedora-41-64'
+            systems: 'fedora-40-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: opensuse


### PR DESCRIPTION
Divides spread systems into fundamental and non-fundamental systems with the goal of running overall fewer tests. The fundamental set of systems are a representative group that hopefully will catch most problems without having to run spread across all systems. Once the tests pass across the fundamental systems, then the remaining systems will run. The systems required to pass for a PR merge remain unaltered.