### PR TITLE
cmd/s-b,g/install: mount ubuntu-seed as no{suid,exec,dev}

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_cvm.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_cvm.go
@@ -48,8 +48,16 @@ func (*genericCVMModel) Grade() asserts.ModelGrade {
 // mounts the rootfs from a partition on the disk rather than a base snap. It supports TPM-backed FDE
 // for the rootfs partition using a sealed key from the seed partition.
 func generateMountsModeRunCVM(mst *initramfsMountsState) error {
+	mountOpts := &systemdMountOptions{
+		// always fsck the partition when we are mounting it, as this is the
+		// first partition we will be mounting, we can't know if anything is
+		// corrupted yet
+		NeedsFsck: true,
+		Private:   true,
+	}
+
 	// Mount ESP as UbuntuSeedDir which has UEFI label
-	if err := mountNonDataPartitionMatchingKernelDisk(boot.InitramfsUbuntuSeedDir, "UEFI"); err != nil {
+	if err := mountNonDataPartitionMatchingKernelDisk(boot.InitramfsUbuntuSeedDir, "UEFI", mountOpts); err != nil {
 		return err
 	}
 

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -575,8 +575,7 @@ func WriteContent(onVolumes map[string]*gadget.Volume, allLaidOutVols map[string
 func mntParamsForPartRole(role string) (mntParams mntfsParams) {
 	var p mntfsParams
 	switch role {
-	// XXX: this might apply for SystemSeed as well
-	case gadget.SystemSave:
+	case gadget.SystemSeed, gadget.SystemSave:
 		p.NoDev = true
 		p.NoExec = true
 		p.NoSuid = true

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1579,7 +1579,7 @@ func (s *installSuite) testMountVolumes(c *C, opts mountVolumesOpts) {
 			c.Assert(source, Equals, "/dev/vda2")
 			c.Assert(target, Equals, seedMntPt)
 			c.Assert(fstype, Equals, "vfat")
-			c.Assert(flags, Equals, uintptr(0))
+			c.Assert(flags, Equals, uintptr(syscall.MS_NOEXEC|syscall.MS_NODEV|syscall.MS_NOSUID))
 			c.Assert(data, Equals, "")
 		case 2:
 			c.Assert(source, Equals, "/dev/vda3")
@@ -1709,8 +1709,15 @@ func (s *installSuite) TestMountVolumesManySeeds(c *C) {
 
 	mountCall := 0
 	restore := install.MockSysMount(func(source, target, fstype string, flags uintptr, data string) error {
+		switch mountCall {
+		case 0:
+			// is gadget.SystemSeed
+			c.Assert(flags, Equals, uintptr(syscall.MS_NOEXEC|syscall.MS_NODEV|syscall.MS_NOSUID))
+		case 1:
+			// is gadget.SystemSeedNull which should not have the flags
+			c.Assert(flags, Equals, uintptr(0))
+		}
 		mountCall++
-		c.Assert(flags, Equals, uintptr(0))
 		return nil
 	})
 	defer restore()
@@ -1744,7 +1751,7 @@ func (s *installSuite) TestMountVolumesLazyUnmount(c *C) {
 	mountCall := 0
 	restore := install.MockSysMount(func(source, target, fstype string, flags uintptr, data string) error {
 		mountCall++
-		c.Assert(flags, Equals, uintptr(0))
+		c.Assert(flags, Equals, uintptr(syscall.MS_NOEXEC|syscall.MS_NODEV|syscall.MS_NOSUID))
 		return nil
 	})
 	defer restore()
@@ -1792,7 +1799,7 @@ func (s *installSuite) TestMountVolumesLazyUnmountError(c *C) {
 	mountCall := 0
 	restore := install.MockSysMount(func(source, target, fstype string, flags uintptr, data string) error {
 		mountCall++
-		c.Assert(flags, Equals, uintptr(0))
+		c.Assert(flags, Equals, uintptr(syscall.MS_NOEXEC|syscall.MS_NODEV|syscall.MS_NOSUID))
 		return nil
 	})
 	defer restore()

--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -122,7 +122,7 @@ execute: |
 
     # make sure that ubuntu-{seed,save} is mounted with appropriate flags
     for mount in /run/mnt/ubuntu-seed /run/mnt/ubuntu-save; do
-        MNT_NAME="$(echo ${mount##*/})"
+        MNT_NAME="${mount##*/}"
         findmnt -T /run/mnt/ubuntu-save > "${MNT_NAME}.info"
 
         # print it for debug purposes before we match flags

--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -73,13 +73,9 @@ execute: |
 
     # ensure that our the-tool (and thus our snap-bootstrap ran)
     # for external backend the initramfs is not rebuilt
-    # On core24+ we repack the kernel snap differently, and thus do not
-    # touch the /writable/system-data/the-tool-ran
-    if os.query is-core20 || os.query is-core22; then
-        echo "Check that we booted with the rebuilt initramfs in the kernel snap"
-        if [ "$SPREAD_BACKEND" != "external" ] && [ "$SPREAD_BACKEND" != "testflinger" ]; then
-            test -e /writable/system-data/the-tool-ran
-        fi
+    echo "Check that we booted with the rebuilt initramfs in the kernel snap"
+    if [ "$SPREAD_BACKEND" != "external" ] && [ "$SPREAD_BACKEND" != "testflinger" ]; then
+        test -e /writable/system-data/the-tool-ran
     fi
 
     # ensure we handled cloud-init, either we have:
@@ -124,14 +120,17 @@ execute: |
         losetup -O ro -n --raw "${loop}" | MATCH "1"
     done
 
-    # make sure that ubuntu-save is mounted with appropriate flags
-    findmnt -T /run/mnt/ubuntu-save > save-mount.info
+    # make sure that ubuntu-{seed,save} is mounted with appropriate flags
+    for mount in /run/mnt/ubuntu-seed /run/mnt/ubuntu-save; do
+        MNT_NAME="$(echo ${mount##*/})"
+        findmnt -T /run/mnt/ubuntu-save > "${MNT_NAME}.info"
 
-    # print it for debug purposes before we match flags
-    cat save-mount.info
-    MATCH nosuid < save-mount.info
-    MATCH noexec < save-mount.info
-    MATCH nodev < save-mount.info
+        # print it for debug purposes before we match flags
+        cat "${MNT_NAME}.info"
+        MATCH nosuid < "${MNT_NAME}.info"
+        MATCH noexec < "${MNT_NAME}.info"
+        MATCH nodev < "${MNT_NAME}.info"
+    done
 
     # ensure apparmor works, see LP: 2024637
     systemctl status apparmor.service


### PR DESCRIPTION
Make ubuntu-seed mounted as no-{suid,exec,dev} as those mount permissions are strictly not required after booting. Important to note in this PR that I've not touched mount flags for ubuntu-seed in the CVM case.


REF: SNAPDENG-34221