### PR TITLE
c/snap-bootstrap: refactor systemd-mount dm-verity/overlayfs options API

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_cvm_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_cvm_test.go
@@ -329,8 +329,8 @@ func (s *initramfsCVMMountsSuite) TestInitramfsMountsRunCVMModeEphemeralOverlayH
 			boot.InitramfsDataDir,
 			"--no-pager",
 			"--no-ask-password",
-			"--type=overlay",
 			"--fsck=no",
+			"--type=overlay",
 			"--options=lowerdir=" +
 				filepath.Join(boot.InitramfsRunMntDir, "cloudimg-rootfs") +
 				",upperdir=" + filepath.Join(boot.InitramfsRunMntDir, "writable-tmp", "upper") +

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -50,6 +50,8 @@ var (
 	CreateOverlayDirs = createOverlayDirs
 )
 
+type OverlayFsOptions = overlayFsOptions
+type DmVerityOptions = dmVerityOptions
 type SystemdMountOptions = systemdMountOptions
 
 type RecoverDegradedState = recoverDegradedState

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -102,28 +102,28 @@ func (o *overlayFsOptions) ValidateLowerDirs() (string, error) {
 // dmVerityOptions groups the options to systemd-mount related to dm-verity.
 type dmVerityOptions struct {
 	// dm-verity hash device
-	VerityHashDevice string
+	HashDevice string
 	// dm-verity root hash
-	VerityRootHash string
+	RootHash string
 	// dm-verity hash offset. Need to be specified if only verity data are
 	// appended to the snap. Defaults to 0 in mount command
-	VerityHashOffset uint64
+	HashOffset uint64
 }
 
 // Validate is used to perform consistency checks on the options related to dm-verity mounts
 func (o *dmVerityOptions) Validate() error {
-	if o.VerityHashDevice != "" && o.VerityRootHash == "" {
+	if o.HashDevice != "" && o.RootHash == "" {
 		return errors.New("mount with dm-verity was requested but a root hash was not specified")
 	}
-	if o.VerityRootHash != "" && o.VerityHashDevice == "" {
+	if o.RootHash != "" && o.HashDevice == "" {
 		return errors.New("mount with dm-verity was requested but a hash device was not specified")
 	}
 
-	if strings.ContainsAny(o.VerityHashDevice, forbiddenChars) {
-		return fmt.Errorf("dm-verity hash device path contains forbidden characters. %q contains one of %q.", o.VerityHashDevice, forbiddenChars)
+	if strings.ContainsAny(o.HashDevice, forbiddenChars) {
+		return fmt.Errorf("dm-verity hash device path contains forbidden characters. %q contains one of %q.", o.HashDevice, forbiddenChars)
 	}
 
-	if o.VerityHashOffset != 0 && (o.VerityHashDevice == "" || o.VerityRootHash == "") {
+	if o.HashOffset != 0 && (o.HashDevice == "" || o.RootHash == "") {
 		return errors.New("mount with dm-verity was requested but a hash device and root hash were not specified")
 	}
 
@@ -281,12 +281,12 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 			return fmt.Errorf("cannot mount %q at %q: %w", what, where, err)
 		}
 
-		if o.VerityHashDevice != "" && o.VerityRootHash != "" {
-			options = append(options, fmt.Sprintf("verity.roothash=%s", o.VerityRootHash))
-			options = append(options, fmt.Sprintf("verity.hashdevice=%s", o.VerityHashDevice))
+		if o.HashDevice != "" && o.RootHash != "" {
+			options = append(options, fmt.Sprintf("verity.roothash=%s", o.RootHash))
+			options = append(options, fmt.Sprintf("verity.hashdevice=%s", o.HashDevice))
 
-			if o.VerityHashOffset != 0 {
-				options = append(options, fmt.Sprintf("verity.hashoffset=%d", o.VerityHashOffset))
+			if o.HashOffset != 0 {
+				options = append(options, fmt.Sprintf("verity.hashoffset=%d", o.HashOffset))
 			}
 		}
 	}

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -104,18 +104,12 @@ func (o *overlayFsOptions) AppendOptions(options []string) ([]string, error) {
 		return nil, err
 	}
 
-	var lowerDirs strings.Builder
-	for i, d := range o.LowerDirs {
-		// This is used for splitting multiple lowerdirs as done in
-		// https://elixir.bootlin.com/linux/v6.10.9/C/ident/ovl_parse_param_split_lowerdirs.
-		if i != 0 {
-			lowerDirs.WriteRune(':')
-		}
+	// This is used for splitting multiple lowerdirs as done in
+	// https://elixir.bootlin.com/linux/v6.10.9/C/ident/ovl_parse_param_split_lowerdirs.
+	lowerDirs := strings.Join(o.LowerDirs, ":")
 
-		lowerDirs.WriteString(d)
-	}
-
-	options = append(options, fmt.Sprintf("lowerdir=%s", lowerDirs.String()))
+	// options = append(options, fmt.Sprintf("lowerdir=%s", lowerDirs.String()))
+	options = append(options, fmt.Sprintf("lowerdir=%s", lowerDirs))
 	options = append(options, fmt.Sprintf("upperdir=%s", o.UpperDir))
 	options = append(options, fmt.Sprintf("workdir=%s", o.WorkDir))
 

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -219,10 +219,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/merged",
 			where: "/merged",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower"},
-				UpperDir:  "/upper",
-				WorkDir:   "/work",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower"},
+					UpperDir:  "/upper",
+					WorkDir:   "/work",
+				},
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
 			isMountedReturns: []bool{true},
@@ -234,10 +235,12 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		Overlayfs: true,
-		// 		LowerDirs: []string{"/lower,"},
-		// 		UpperDir:  "/upper",
-		// 		WorkDir:   "/work",
+		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 			Overlayfs: true,
+		// 			LowerDirs: []string{"/lower,"},
+		// 			UpperDir:  "/upper",
+		// 			WorkDir:   "/work",
+		// 		},
 		// 	},
 		// 	timeNowTimes:     []time.Time{testStart, testStart},
 		// 	isMountedReturns: []bool{true},
@@ -249,10 +252,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		Overlayfs: true,
-		// 		LowerDirs: []string{"/lower"},
-		// 		UpperDir:  "/upper,",
-		// 		WorkDir:   "/work",
+		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 			LowerDirs: []string{"/lower"},
+		// 			UpperDir:  "/upper,",
+		// 			WorkDir:   "/work",
+		// 		},
 		// 	},
 		// 	timeNowTimes:     []time.Time{testStart, testStart},
 		// 	isMountedReturns: []bool{true},
@@ -264,10 +268,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		Overlayfs: true,
-		// 		LowerDirs: []string{"/lower"},
-		// 		UpperDir:  "/upper",
-		// 		WorkDir:   "/work,",
+		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 			LowerDirs: []string{"/lower"},
+		// 			UpperDir:  "/upper",
+		// 			WorkDir:   "/work,",
+		// 		},
 		// 	},
 		// 	timeNowTimes:     []time.Time{testStart, testStart},
 		// 	isMountedReturns: []bool{true},
@@ -278,10 +283,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/merged",
 			where: "/merged",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower1", "/lower2"},
-				UpperDir:  "/upper",
-				WorkDir:   "/work",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower1", "/lower2"},
+					UpperDir:  "/upper",
+					WorkDir:   "/work",
+				},
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
 			isMountedReturns: []bool{true},
@@ -293,10 +299,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		Overlayfs: true,
-		// 		LowerDirs: []string{"/lower1:", "/lower2:"},
-		// 		UpperDir:  "/upper",
-		// 		WorkDir:   "/work",
+		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 			LowerDirs: []string{"/lower1:", "/lower2:"},
+		// 			UpperDir:  "/upper",
+		// 			WorkDir:   "/work",
+		// 		},
 		// 	},
 		// 	timeNowTimes:     []time.Time{testStart, testStart},
 		// 	isMountedReturns: []bool{true},
@@ -307,9 +314,10 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				UpperDir:  "/upper",
-				WorkDir:   "/work",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					UpperDir: "/upper",
+					WorkDir:  "/work",
+				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": missing arguments for overlayfs mount. lowerdir, upperdir, workdir are needed.",
 			comment: "overlayfs mount requested without specifying a lowerdir",
@@ -319,9 +327,10 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower1"},
-				WorkDir:   "/work",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower1"},
+					WorkDir:   "/work",
+				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": missing arguments for overlayfs mount. lowerdir, upperdir, workdir are needed.",
 			comment: "overlayfs mount requested without specifying an upperdir",
@@ -331,9 +340,10 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower1"},
-				UpperDir:  "/upper",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower1"},
+					UpperDir:  "/upper",
+				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": missing arguments for overlayfs mount. lowerdir, upperdir, workdir are needed.",
 			comment: "overlayfs mount requested without specifying a workdir",
@@ -342,10 +352,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower1\\,\" "},
-				UpperDir:  "/upper",
-				WorkDir:   "/work",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower1\\,\" "},
+					UpperDir:  "/upper",
+					WorkDir:   "/work",
+				},
 			},
 			expErr:  `cannot mount "what" at "where": lowerdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/lower1\\,\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
 			comment: "disallow use of \\,\" and space in the overlayfs lowerdir mount option",
@@ -354,10 +365,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower1:"},
-				UpperDir:  "/upper",
-				WorkDir:   "/work",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower1:"},
+					UpperDir:  "/upper",
+					WorkDir:   "/work",
+				},
 			},
 			expErr:  `cannot mount "what" at "where": lowerdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/lower1:`) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
 			comment: "disallow use of : in the overlayfs lowerdir mount option",
@@ -366,10 +378,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower1"},
-				UpperDir:  "/upper\\,:\" ",
-				WorkDir:   "/work",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower1"},
+					UpperDir:  "/upper\\,:\" ",
+					WorkDir:   "/work",
+				},
 			},
 			expErr:  `cannot mount "what" at "where": upperdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/upper\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
 			comment: "disallow use of \\,:\" and space in the overlayfs upperdir mount option",
@@ -378,10 +391,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				Overlayfs: true,
-				LowerDirs: []string{"/lower1"},
-				UpperDir:  "/upper",
-				WorkDir:   "/work\\,:\" ",
+				OverlayFsOpts: &main.OverlayFsOptions{
+					LowerDirs: []string{"/lower1"},
+					UpperDir:  "/upper",
+					WorkDir:   "/work\\,:\" ",
+				},
 			},
 			expErr:  `cannot mount "what" at "where": workdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/work\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
 			comment: "disallow use of \\,:\" and space in the overlayfs workdir mount option",
@@ -390,9 +404,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/run/mnt/data/some.snap",
 			where: "/run/mnt/base",
 			opts: &main.SystemdMountOptions{
-				VerityHashDevice: "test.verity",
-				VerityRootHash:   "00000000000000000000000000000000",
-				VerityHashOffset: 4096,
+				DmVerityOpts: &main.DmVerityOptions{
+					VerityHashDevice: "test.verity",
+					VerityRootHash:   "00000000000000000000000000000000",
+					VerityHashOffset: 4096,
+				},
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
 			isMountedReturns: []bool{true},
@@ -402,8 +418,10 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/run/mnt/data/some.snap",
 			where: "/run/mnt/base",
 			opts: &main.SystemdMountOptions{
-				VerityHashDevice: "test.verity",
-				VerityRootHash:   "00000000000000000000000000000000",
+				DmVerityOpts: &main.DmVerityOptions{
+					VerityHashDevice: "test.verity",
+					VerityRootHash:   "00000000000000000000000000000000",
+				},
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
 			isMountedReturns: []bool{true},
@@ -413,7 +431,9 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				VerityHashDevice: "test.verity",
+				DmVerityOpts: &main.DmVerityOptions{
+					VerityHashDevice: "test.verity",
+				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": mount with dm-verity was requested but a root hash was not specified",
 			comment: "verity hash device specified without specifying a verity root hash",
@@ -422,7 +442,9 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				VerityRootHash: "00000000000000000000000000000000",
+				DmVerityOpts: &main.DmVerityOptions{
+					VerityRootHash: "00000000000000000000000000000000",
+				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": mount with dm-verity was requested but a hash device was not specified",
 			comment: "verity root hash specified without specifying a verity hash device",
@@ -431,7 +453,9 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				VerityHashOffset: 4096,
+				DmVerityOpts: &main.DmVerityOptions{
+					VerityHashOffset: 4096,
+				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": mount with dm-verity was requested but a hash device and root hash were not specified",
 			comment: "verity hash offset specified without specifying a verity root hash and a verity hash device",
@@ -440,8 +464,10 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				VerityHashDevice: "test.verity\\,:\" ",
-				VerityRootHash:   "00000000000000000000000000000000",
+				DmVerityOpts: &main.DmVerityOptions{
+					VerityHashDevice: "test.verity\\,:\" ",
+					VerityRootHash:   "00000000000000000000000000000000",
+				},
 			},
 			expErr:  `cannot mount "what" at "where": dm-verity hash device path contains forbidden characters. "` + regexp.QuoteMeta(`test.verity\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
 			comment: "disallow use of \\,:\": and space in the dm-verity hash device option",
@@ -594,7 +620,6 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 				}
 			}
 			c.Assert(foundTypeTmpfs, Equals, opts.Tmpfs)
-			c.Assert(foundTypeOverlayfs, Equals, opts.Overlayfs)
 			c.Assert(foundFsckYes, Equals, opts.NeedsFsck)
 			c.Assert(foundFsckNo, Equals, !opts.NeedsFsck)
 			c.Assert(foundNoBlock, Equals, opts.NoWait)
@@ -605,12 +630,19 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			c.Assert(foundBind, Equals, opts.Bind)
 			c.Assert(foundReadOnly, Equals, opts.ReadOnly)
 			c.Assert(foundPrivate, Equals, opts.Private)
-			c.Assert(foundOverlayLowerDir, Equals, len(opts.LowerDirs) > 0)
-			c.Assert(foundOverlayUpperDir, Equals, len(opts.UpperDir) > 0)
-			c.Assert(foundOverlayWorkDir, Equals, len(opts.WorkDir) > 0)
-			c.Assert(foundVerityHashDevice, Equals, len(opts.VerityHashDevice) > 0)
-			c.Assert(foundVerityRootHash, Equals, len(opts.VerityRootHash) > 0)
-			c.Assert(foundVerityHashOffset, Equals, opts.VerityHashOffset > 0)
+			if foundTypeOverlayfs {
+				c.Assert(opts.OverlayFsOpts, Not(Equals), nil)
+				c.Assert(foundOverlayLowerDir, Equals, len(opts.OverlayFsOpts.LowerDirs) > 0)
+				c.Assert(foundOverlayUpperDir, Equals, len(opts.OverlayFsOpts.UpperDir) > 0)
+				c.Assert(foundOverlayWorkDir, Equals, len(opts.OverlayFsOpts.WorkDir) > 0)
+			} else {
+				c.Assert(opts.OverlayFsOpts, IsNil)
+			}
+			if opts.DmVerityOpts != nil {
+				c.Assert(foundVerityHashDevice, Equals, len(opts.DmVerityOpts.VerityHashDevice) > 0)
+				c.Assert(foundVerityRootHash, Equals, len(opts.DmVerityOpts.VerityRootHash) > 0)
+				c.Assert(foundVerityHashOffset, Equals, opts.DmVerityOpts.VerityHashOffset > 0)
+			}
 
 			// check that the overrides are present if opts.Ephemeral is false,
 			// or check the overrides are not present if opts.Ephemeral is true

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -671,16 +671,16 @@ Wants=%[1]s
 	}
 }
 
-type dummyOpts struct{}
+type testOpts struct{}
 
-func (d dummyOpts) AppendOptions(strings []string) ([]string, error) {
-	return []string{"dummy options"}, nil
+func (d testOpts) AppendOptions(strings []string) ([]string, error) {
+	return []string{"test options"}, nil
 }
 
 func (s *doSystemdMountSuite) TestDoSystemdMountWrongFsOpts(c *C) {
 
 	opts := &main.SystemdMountOptions{
-		FsOpts: dummyOpts{},
+		FsOpts: testOpts{},
 	}
 
 	err := main.DoSystemdMount("what", "where", opts)

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -670,3 +670,20 @@ Wants=%[1]s
 		}
 	}
 }
+
+type dummyOpts struct{}
+
+func (d dummyOpts) AppendOptions(strings []string) ([]string, error) {
+	return []string{"dummy options"}, nil
+}
+
+func (s *doSystemdMountSuite) TestDoSystemdMountWrongFsOpts(c *C) {
+
+	opts := &main.SystemdMountOptions{
+		FsOpts: dummyOpts{},
+	}
+
+	err := main.DoSystemdMount("what", "where", opts)
+	c.Check(err, ErrorMatches, "cannot mount \"what\" at \"where\": invalid options")
+
+}

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -219,7 +219,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/merged",
 			where: "/merged",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower"},
 					UpperDir:  "/upper",
 					WorkDir:   "/work",
@@ -235,7 +235,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 		FsOpts: &main.OverlayFsOptions{
 		// 			Overlayfs: true,
 		// 			LowerDirs: []string{"/lower,"},
 		// 			UpperDir:  "/upper",
@@ -252,7 +252,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 		FsOpts: &main.OverlayFsOptions{
 		// 			LowerDirs: []string{"/lower"},
 		// 			UpperDir:  "/upper,",
 		// 			WorkDir:   "/work",
@@ -268,7 +268,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 		FsOpts: &main.OverlayFsOptions{
 		// 			LowerDirs: []string{"/lower"},
 		// 			UpperDir:  "/upper",
 		// 			WorkDir:   "/work,",
@@ -283,7 +283,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/merged",
 			where: "/merged",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower1", "/lower2"},
 					UpperDir:  "/upper",
 					WorkDir:   "/work",
@@ -299,7 +299,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 		// 	what:  "/merged",
 		// 	where: "/merged",
 		// 	opts: &main.SystemdMountOptions{
-		// 		OverlayFsOpts: &main.OverlayFsOptions{
+		// 		FsOpts: &main.OverlayFsOptions{
 		// 			LowerDirs: []string{"/lower1:", "/lower2:"},
 		// 			UpperDir:  "/upper",
 		// 			WorkDir:   "/work",
@@ -314,7 +314,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					UpperDir: "/upper",
 					WorkDir:  "/work",
 				},
@@ -327,7 +327,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower1"},
 					WorkDir:   "/work",
 				},
@@ -340,7 +340,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower1"},
 					UpperDir:  "/upper",
 				},
@@ -352,7 +352,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower1\\,\" "},
 					UpperDir:  "/upper",
 					WorkDir:   "/work",
@@ -365,7 +365,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower1:"},
 					UpperDir:  "/upper",
 					WorkDir:   "/work",
@@ -378,7 +378,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower1"},
 					UpperDir:  "/upper\\,:\" ",
 					WorkDir:   "/work",
@@ -391,7 +391,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				OverlayFsOpts: &main.OverlayFsOptions{
+				FsOpts: &main.OverlayFsOptions{
 					LowerDirs: []string{"/lower1"},
 					UpperDir:  "/upper",
 					WorkDir:   "/work\\,:\" ",
@@ -404,7 +404,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/run/mnt/data/some.snap",
 			where: "/run/mnt/base",
 			opts: &main.SystemdMountOptions{
-				DmVerityOpts: &main.DmVerityOptions{
+				FsOpts: &main.DmVerityOptions{
 					HashDevice: "test.verity",
 					RootHash:   "00000000000000000000000000000000",
 					HashOffset: 4096,
@@ -418,7 +418,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "/run/mnt/data/some.snap",
 			where: "/run/mnt/base",
 			opts: &main.SystemdMountOptions{
-				DmVerityOpts: &main.DmVerityOptions{
+				FsOpts: &main.DmVerityOptions{
 					HashDevice: "test.verity",
 					RootHash:   "00000000000000000000000000000000",
 				},
@@ -431,7 +431,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				DmVerityOpts: &main.DmVerityOptions{
+				FsOpts: &main.DmVerityOptions{
 					HashDevice: "test.verity",
 				},
 			},
@@ -442,7 +442,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				DmVerityOpts: &main.DmVerityOptions{
+				FsOpts: &main.DmVerityOptions{
 					RootHash: "00000000000000000000000000000000",
 				},
 			},
@@ -453,7 +453,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				DmVerityOpts: &main.DmVerityOptions{
+				FsOpts: &main.DmVerityOptions{
 					HashOffset: 4096,
 				},
 			},
@@ -464,7 +464,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "what",
 			where: "where",
 			opts: &main.SystemdMountOptions{
-				DmVerityOpts: &main.DmVerityOptions{
+				FsOpts: &main.DmVerityOptions{
 					HashDevice: "test.verity\\,:\" ",
 					RootHash:   "00000000000000000000000000000000",
 				},
@@ -630,18 +630,20 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			c.Assert(foundBind, Equals, opts.Bind)
 			c.Assert(foundReadOnly, Equals, opts.ReadOnly)
 			c.Assert(foundPrivate, Equals, opts.Private)
-			if foundTypeOverlayfs {
-				c.Assert(opts.OverlayFsOpts, Not(Equals), nil)
-				c.Assert(foundOverlayLowerDir, Equals, len(opts.OverlayFsOpts.LowerDirs) > 0)
-				c.Assert(foundOverlayUpperDir, Equals, len(opts.OverlayFsOpts.UpperDir) > 0)
-				c.Assert(foundOverlayWorkDir, Equals, len(opts.OverlayFsOpts.WorkDir) > 0)
-			} else {
-				c.Assert(opts.OverlayFsOpts, IsNil)
-			}
-			if opts.DmVerityOpts != nil {
-				c.Assert(foundVerityHashDevice, Equals, len(opts.DmVerityOpts.HashDevice) > 0)
-				c.Assert(foundVerityRootHash, Equals, len(opts.DmVerityOpts.RootHash) > 0)
-				c.Assert(foundVerityHashOffset, Equals, opts.DmVerityOpts.HashOffset > 0)
+
+			if opts.FsOpts != nil {
+				switch o := opts.FsOpts.(type) {
+				case *main.OverlayFsOptions:
+					c.Assert(foundTypeOverlayfs, Equals, true)
+					c.Assert(foundOverlayLowerDir, Equals, len(o.LowerDirs) > 0)
+					c.Assert(foundOverlayUpperDir, Equals, len(o.UpperDir) > 0)
+					c.Assert(foundOverlayWorkDir, Equals, len(o.WorkDir) > 0)
+				case *main.DmVerityOptions:
+					c.Assert(foundVerityHashDevice, Equals, len(o.HashDevice) > 0)
+					c.Assert(foundVerityRootHash, Equals, len(o.RootHash) > 0)
+					c.Assert(foundVerityHashOffset, Equals, o.HashOffset > 0)
+				default:
+				}
 			}
 
 			// check that the overrides are present if opts.Ephemeral is false,

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -405,9 +405,9 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			where: "/run/mnt/base",
 			opts: &main.SystemdMountOptions{
 				DmVerityOpts: &main.DmVerityOptions{
-					VerityHashDevice: "test.verity",
-					VerityRootHash:   "00000000000000000000000000000000",
-					VerityHashOffset: 4096,
+					HashDevice: "test.verity",
+					RootHash:   "00000000000000000000000000000000",
+					HashOffset: 4096,
 				},
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
@@ -419,8 +419,8 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			where: "/run/mnt/base",
 			opts: &main.SystemdMountOptions{
 				DmVerityOpts: &main.DmVerityOptions{
-					VerityHashDevice: "test.verity",
-					VerityRootHash:   "00000000000000000000000000000000",
+					HashDevice: "test.verity",
+					RootHash:   "00000000000000000000000000000000",
 				},
 			},
 			timeNowTimes:     []time.Time{testStart, testStart},
@@ -432,7 +432,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			where: "where",
 			opts: &main.SystemdMountOptions{
 				DmVerityOpts: &main.DmVerityOptions{
-					VerityHashDevice: "test.verity",
+					HashDevice: "test.verity",
 				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": mount with dm-verity was requested but a root hash was not specified",
@@ -443,7 +443,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			where: "where",
 			opts: &main.SystemdMountOptions{
 				DmVerityOpts: &main.DmVerityOptions{
-					VerityRootHash: "00000000000000000000000000000000",
+					RootHash: "00000000000000000000000000000000",
 				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": mount with dm-verity was requested but a hash device was not specified",
@@ -454,7 +454,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			where: "where",
 			opts: &main.SystemdMountOptions{
 				DmVerityOpts: &main.DmVerityOptions{
-					VerityHashOffset: 4096,
+					HashOffset: 4096,
 				},
 			},
 			expErr:  "cannot mount \"what\" at \"where\": mount with dm-verity was requested but a hash device and root hash were not specified",
@@ -465,8 +465,8 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			where: "where",
 			opts: &main.SystemdMountOptions{
 				DmVerityOpts: &main.DmVerityOptions{
-					VerityHashDevice: "test.verity\\,:\" ",
-					VerityRootHash:   "00000000000000000000000000000000",
+					HashDevice: "test.verity\\,:\" ",
+					RootHash:   "00000000000000000000000000000000",
 				},
 			},
 			expErr:  `cannot mount "what" at "where": dm-verity hash device path contains forbidden characters. "` + regexp.QuoteMeta(`test.verity\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
@@ -639,9 +639,9 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 				c.Assert(opts.OverlayFsOpts, IsNil)
 			}
 			if opts.DmVerityOpts != nil {
-				c.Assert(foundVerityHashDevice, Equals, len(opts.DmVerityOpts.VerityHashDevice) > 0)
-				c.Assert(foundVerityRootHash, Equals, len(opts.DmVerityOpts.VerityRootHash) > 0)
-				c.Assert(foundVerityHashOffset, Equals, opts.DmVerityOpts.VerityHashOffset > 0)
+				c.Assert(foundVerityHashDevice, Equals, len(opts.DmVerityOpts.HashDevice) > 0)
+				c.Assert(foundVerityRootHash, Equals, len(opts.DmVerityOpts.RootHash) > 0)
+				c.Assert(foundVerityHashOffset, Equals, opts.DmVerityOpts.HashOffset > 0)
 			}
 
 			// check that the overrides are present if opts.Ephemeral is false,

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -319,7 +319,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					WorkDir:  "/work",
 				},
 			},
-			expErr:  "cannot mount \"what\" at \"where\": missing arguments for overlayfs mount. lowerdir, upperdir, workdir are needed.",
+			expErr:  "cannot mount \"what\" at \"where\": missing arguments for overlayfs mount. at least one lowerdir is required",
 			comment: "overlayfs mount requested without specifying a lowerdir",
 		},
 		{
@@ -332,7 +332,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					WorkDir:   "/work",
 				},
 			},
-			expErr:  "cannot mount \"what\" at \"where\": missing arguments for overlayfs mount. lowerdir, upperdir, workdir are needed.",
+			expErr:  "cannot mount \"what\" at \"where\": a workdir for an overlayfs mount was specified but upperdir is missing",
 			comment: "overlayfs mount requested without specifying an upperdir",
 		},
 		{
@@ -345,7 +345,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					UpperDir:  "/upper",
 				},
 			},
-			expErr:  "cannot mount \"what\" at \"where\": missing arguments for overlayfs mount. lowerdir, upperdir, workdir are needed.",
+			expErr:  "cannot mount \"what\" at \"where\": an upperdir for an overlayfs mount was specified but workdir is missing",
 			comment: "overlayfs mount requested without specifying a workdir",
 		},
 		{
@@ -358,7 +358,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					WorkDir:   "/work",
 				},
 			},
-			expErr:  `cannot mount "what" at "where": lowerdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/lower1\\,\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
+			expErr:  `cannot mount "what" at "where": lowerdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/lower1\\,\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `"`,
 			comment: "disallow use of \\,\" and space in the overlayfs lowerdir mount option",
 		},
 		{
@@ -371,7 +371,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					WorkDir:   "/work",
 				},
 			},
-			expErr:  `cannot mount "what" at "where": lowerdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/lower1:`) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
+			expErr:  `cannot mount "what" at "where": lowerdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/lower1:`) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `"`,
 			comment: "disallow use of : in the overlayfs lowerdir mount option",
 		},
 		{
@@ -384,7 +384,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					WorkDir:   "/work",
 				},
 			},
-			expErr:  `cannot mount "what" at "where": upperdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/upper\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
+			expErr:  `cannot mount "what" at "where": upperdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/upper\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `"`,
 			comment: "disallow use of \\,:\" and space in the overlayfs upperdir mount option",
 		},
 		{
@@ -397,7 +397,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					WorkDir:   "/work\\,:\" ",
 				},
 			},
-			expErr:  `cannot mount "what" at "where": workdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/work\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
+			expErr:  `cannot mount "what" at "where": workdir overlayfs mount option contains forbidden characters. "` + regexp.QuoteMeta(`/work\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `"`,
 			comment: "disallow use of \\,:\" and space in the overlayfs workdir mount option",
 		},
 		{
@@ -469,7 +469,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					RootHash:   "00000000000000000000000000000000",
 				},
 			},
-			expErr:  `cannot mount "what" at "where": dm-verity hash device path contains forbidden characters. "` + regexp.QuoteMeta(`test.verity\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `".`,
+			expErr:  `cannot mount "what" at "where": dm-verity hash device path contains forbidden characters. "` + regexp.QuoteMeta(`test.verity\\,:\" `) + `" contains one of "` + regexp.QuoteMeta(`\\,:\" `) + `"`,
 			comment: "disallow use of \\,:\": and space in the dm-verity hash device option",
 		},
 	}


### PR DESCRIPTION
This tidies up options to `doSystemdMountImpl` related to dm-verity or overlayfs.