### PR TITLE
osutil/user: look up getent executable in known host directories

### DIFF
--- a/osutil/group.go
+++ b/osutil/group.go
@@ -53,6 +53,7 @@ func MockFindGid(f func(string) (uint64, error)) (restore func()) {
 
 // getent returns the identifier of the given UNIX user or group name as
 // determined by the specified database
+// TODO use a single implementation provided by osutil/user
 func getent(database, name string) (uint64, error) {
 	if database != "passwd" && database != "group" {
 		return 0, fmt.Errorf(`unsupported getent database "%q"`, database)

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -370,7 +370,7 @@ func UserMaybeSudoUser() (*user.User, error) {
 		return cur, nil
 	}
 
-	real, err := user.Lookup(realName)
+	real, err := userLookup(realName)
 	// This is a best effort, see the comment in findGidNoGetentFallback in
 	// group.go.
 	//

--- a/osutil/user/export_test.go
+++ b/osutil/user/export_test.go
@@ -24,12 +24,11 @@ import (
 )
 
 var (
-	LookupGroupFromGetent   = lookupGroupFromGetent
-	LookupUserFromGetent    = lookupUserFromGetent
-	UserMatchUid            = userMatchUid
-	UserMatchUsername       = userMatchUsername
-	GroupMatchGroupname     = groupMatchGroupname
-	DefaultGetentSearchPath = defaultGetentSearchPath
+	LookupGroupFromGetent = lookupGroupFromGetent
+	LookupUserFromGetent  = lookupUserFromGetent
+	UserMatchUid          = userMatchUid
+	UserMatchUsername     = userMatchUsername
+	GroupMatchGroupname   = groupMatchGroupname
 )
 
 func MockGetentSearchPath(p string) (restore func()) {

--- a/osutil/user/export_test.go
+++ b/osutil/user/export_test.go
@@ -19,10 +19,19 @@
 
 package user
 
-var (
-	LookupGroupFromGetent = lookupGroupFromGetent
-	LookupUserFromGetent  = lookupUserFromGetent
-	UserMatchUid          = userMatchUid
-	UserMatchUsername     = userMatchUsername
-	GroupMatchGroupname   = groupMatchGroupname
+import (
+	"github.com/snapcore/snapd/testutil"
 )
+
+var (
+	LookupGroupFromGetent   = lookupGroupFromGetent
+	LookupUserFromGetent    = lookupUserFromGetent
+	UserMatchUid            = userMatchUid
+	UserMatchUsername       = userMatchUsername
+	GroupMatchGroupname     = groupMatchGroupname
+	DefaultGetentSearchPath = defaultGetentSearchPath
+)
+
+func MockGetentSearchPath(p string) (restore func()) {
+	return testutil.Mock(&getentSearchPath, p)
+}

--- a/osutil/user/getent.go
+++ b/osutil/user/getent.go
@@ -24,13 +24,42 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
 
+const (
+	defaultGetentSearchPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+)
+
+var (
+	getentSearchPath = defaultGetentSearchPath
+)
+
+func findGetent(searchPath string) (string, error) {
+	// try to look for getent in a couple of places, such that even when running
+	// with modified PATH we still can locate the executable
+	for _, dir := range filepath.SplitList(searchPath) {
+		p := filepath.Join(dir, "getent")
+		if fi, err := os.Stat(p); err == nil {
+			if !fi.IsDir() && fi.Mode().Perm()&0111 != 0 {
+				return p, nil
+			}
+		}
+	}
+	return "", errors.New("cannot locate getent executable")
+}
+
 func getEnt(params ...string) ([]byte, error) {
-	cmd := exec.Command("getent", params...)
+	getentCmd, err := findGetent(getentSearchPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(getentCmd, params...)
 	cmd.Stdin = nil
 
 	outBuf, err := cmd.Output()

--- a/osutil/user/getent.go
+++ b/osutil/user/getent.go
@@ -32,11 +32,11 @@ import (
 )
 
 const (
-	defaultGetentSearchPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	DefaultGetentSearchPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 
 var (
-	getentSearchPath = defaultGetentSearchPath
+	getentSearchPath = DefaultGetentSearchPath
 )
 
 func findGetent(searchPath string) (string, error) {
@@ -222,4 +222,12 @@ func lookupUserFromGetent(matcher userMatcher) (*User, error) {
 		Name:     components[4],
 		HomeDir:  components[5],
 	}, nil
+}
+
+// OverrideGetentSearchPath allows overriding getent search path. Its only
+// purpose is to be used in tests.
+func OverrideGetentSearchPath(p string) {
+	// TODO should use osutil.MustBeTestBinary() but we cannot import due to
+	// cyclic dependencies
+	getentSearchPath = p
 }

--- a/osutil/user/getent_test.go
+++ b/osutil/user/getent_test.go
@@ -54,6 +54,7 @@ if [ -f "${base}.exit" ]; then
   exit "$(cat "${base}.exit")"
 fi
 `, s.getentDir))
+	s.AddCleanup(user.MockGetentSearchPath(s.mockGetent.BinDir() + ":" + user.DefaultGetentSearchPath))
 	s.AddCleanup(s.mockGetent.Restore)
 }
 
@@ -176,4 +177,12 @@ func (s *getentSuite) TestLookupGroupByNameMissing(c *C) {
 	grp, err := user.LookupGroupFromGetent(user.GroupMatchGroupname("mygroup"))
 	c.Assert(err, IsNil)
 	c.Assert(grp, IsNil)
+}
+
+func (s *getentSuite) TestNoGetentBinary(c *C) {
+	defer user.MockGetentSearchPath("/foo:/bar")()
+
+	usr, err := user.LookupUserFromGetent(user.UserMatchUid(1000))
+	c.Assert(err, ErrorMatches, "cannot locate getent executable")
+	c.Assert(usr, IsNil)
 }

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -267,6 +267,29 @@ func (s *createUserSuite) TestUserMaybeSudoUser(c *check.C) {
 			}, nil
 		})
 		defer restore()
+		restore = osutil.MockUserLookup(func(username string) (*user.User, error) {
+			switch username {
+			case "guy":
+				return &user.User{
+					Uid:      "1000",
+					Gid:      "1000",
+					Username: username,
+					Name:     "guy",
+					HomeDir:  "~",
+				}, nil
+			case "root":
+				return &user.User{
+					Uid:      "0",
+					Gid:      "0",
+					Username: username,
+					Name:     "root",
+					HomeDir:  "/",
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected username in test: %s", username)
+			}
+		})
+		defer restore()
 
 		os.Setenv("SUDO_USER", t.SudoUsername)
 		cur, err := osutil.UserMaybeSudoUser()


### PR DESCRIPTION
It is possible that `snap run` may be called with a PATH set such that it does not include a directory containing getent. To workaround this, try to look up getent in a number of known locations on the host.

Fixes: https://bugs.launchpad.net/snapd/+bug/2090938


Ernest: this is the original scenario where the issue was first detected: https://github.com/canonical/operator-workflows/issues/496 