### PR TITLE
tests: changed combined-result check to failure instead of success

### DIFF
--- a/.github/actions/combine-results/action.yaml
+++ b/.github/actions/combine-results/action.yaml
@@ -16,6 +16,8 @@ runs:
   - name: Summarise and combine results
     shell: bash
     run: |
+      # From https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#jobs-context
+      # Possible results are success, failed, cancelled, and skipped
       needs_results=$(echo '${{ inputs.needs-json }}' | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
 
       echo "Summary:"

--- a/.github/actions/combine-results/action.yaml
+++ b/.github/actions/combine-results/action.yaml
@@ -21,11 +21,11 @@ runs:
       echo "Summary:"
       failed="false"
       while IFS=" " read -r job result; do
-        if [[ "$result" != "success" ]]; then
+        if [[ "$result" != "failure" ]]; then
+          echo "- ✅ Job \"$job\" returned result \"$result\""
+        else
           failed="true"
           echo "- ❌ Job \"$job\" returned result \"$result\""
-        else
-          echo "- ✅ Job \"$job\" returned result \"$result\""
         fi
       done <<< "$needs_results"
       

--- a/.github/actions/combine-results/action.yaml
+++ b/.github/actions/combine-results/action.yaml
@@ -21,7 +21,7 @@ runs:
       echo "Summary:"
       failed="false"
       while IFS=" " read -r job result; do
-        if [[ "$result" != "failure" ]]; then
+        if [[ "$result" == "success" ]] || [[ "$result" == "skipped" ]]; then
           echo "- ✅ Job \"$job\" returned result \"$result\""
         else
           failed="true"


### PR DESCRIPTION
If a job is "skipped" then the combined-result treats it as a failure. This switches the logic so that everything that is not a failure is a success.
