### PR TITLE
snapdtool: update command line when re-executing

### DIFF
--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -235,6 +235,31 @@ func ExecInSnapdOrCoreSnap() {
 	}
 
 	logger.Debugf("restarting into %q", full)
+
+	// We want to make "ps", "top" and other tools show a
+	// command-line that is not misleading.
+	originalDir, originalBase := filepath.Split(os.Args[0])
+	// In the case of symlink, typically /snap/bin/myapp ->
+	// /usr/bin/snap, we want to keep the original path as the
+	// user will want to know what they originally intended to
+	// execute. More importantly, we will read os.Args[0] to
+	// decide what application to effectively run. So we must do
+	// nothing in that case.
+	if originalBase == filepath.Base(full) {
+		// Otherwise...
+		// If we did not have any / in the path, it was
+		// executed from PATH. So we do not have to change it.
+		// For instance "snap list" should stay "snap list".
+		if originalDir != "" {
+			// In the other case, we probably executed
+			// from a fork or from a service.  For example
+			// /usr/lib/snapd/snapd from snapd.service.
+			// In this case keeping the original path
+			// would be misleading. So let's change it.
+			os.Args[0] = full
+		}
+	}
+
 	panic(syscallExec(full, os.Args, os.Environ()))
 }
 

--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -384,6 +384,16 @@ func (s *toolSuite) TestExecInSnapdOrCoreSnap(c *C) {
 	c.Check(s.lastExecArgv, DeepEquals, os.Args)
 }
 
+func (s *toolSuite) TestExecInSnapdOrCoreSnapFixArg0(c *C) {
+	defer s.mockReExecFor(c, s.snapdPath, "snapdtool.test", dirs.DefaultDistroLibexecDir)()
+
+	c.Check(snapdtool.ExecInSnapdOrCoreSnap, PanicMatches, `>exec of "[^"]+/snapdtool.test" in tests<`)
+	c.Check(s.execCalled, Equals, 1)
+	c.Check(s.lastExecArgv0, Equals, filepath.Join(s.snapdPath, "/usr/lib/snapd/snapdtool.test"))
+	c.Check(s.lastExecArgv[0], Equals, filepath.Join(s.snapdPath, "/usr/lib/snapd/snapdtool.test"))
+	c.Check(s.lastExecArgv[1:], DeepEquals, os.Args[1:])
+}
+
 func (s *toolSuite) TestExecInOldCoreSnap(c *C) {
 	defer s.mockReExecFor(c, s.corePath, "potato", dirs.DefaultDistroLibexecDir)()
 


### PR DESCRIPTION
Snap re-execution looked confusing since it did not update `cmdline` in `/proc`. That means `ps`, `top`, `systemd-cgls` showed `/usr/lib/snapd/snapd` as running when the binary comes from the snap.
