### PR TITLE
tests: remove jq from PRE_CACHE_SNAPS to install

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -72,7 +72,7 @@ environment:
     PPA_SOURCE_LINE: '$(HOST: echo "${SPREAD_PPA_SOURCE_LINE:-}")'
     PPA_GPG_KEY: '$(HOST: echo "${SPREAD_PPA_GPG_KEY:-}")'
     # List the snaps which are cached
-    PRE_CACHE_SNAPS: test-snapd-tools test-snapd-sh jq
+    PRE_CACHE_SNAPS: test-snapd-tools test-snapd-sh
     # always skip removing the rsync snap
     SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18 test-snapd-rsync-core20 test-snapd-rsync-core22 test-snapd-rsync-core24'
     # Use the installed snapd and reset the systems without removing snapd


### PR DESCRIPTION
The jq snap should no longer be required after being replaced with gojq