### PR TITLE
cmd/snap-seccomp: add 'dump' command

### DIFF
--- a/cmd/snap-seccomp/export_test.go
+++ b/cmd/snap-seccomp/export_test.go
@@ -31,6 +31,7 @@ var (
 	VersionInfo       = versionInfo
 	GoSeccompFeatures = goSeccompFeatures
 	ExportBPF         = exportBPF
+	Dump              = dump
 )
 
 func MockArchDpkgArchitecture(f func() string) (restore func()) {

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -27,6 +27,11 @@ execute: |
         SNAP_SECCOMP="$MOUNT_DIR/snapd/current$SNAP_SECCOMP"
     fi
 
+    # we can dump existing profile
+    $SNAP_SECCOMP dump "${PROFILE}.bin2" "$PWD/bpf-dump"
+    test -s "$PWD/bpf-dump.allow"
+    test -s "$PWD/bpf-dump.deny"
+
     # from the old test_complain
     echo "Test that the @complain keyword works"
     rm -f "${PROFILE}.bin2"


### PR DESCRIPTION
I was tinkering with the profiles in the context of https://github.com/canonical/snapd/pull/14138 and noticed there is no obvious way to dump the profiles written in the new format.

Add a command to dump the filter rules from a compiled profile to
separate files.
