### PR TITLE
tests: create one PR for all github action dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+          
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
Have dependabot open only one PR for all github action updates.