### PR TITLE
i/builtin: add the checkbox-support interface

### DIFF
--- a/interfaces/builtin/checkbox_support.go
+++ b/interfaces/builtin/checkbox_support.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const checkboxSupportSummary = `allows checkbox to execute arbitrary system tests`
+
+const checkboxSupportBaseDeclarationPlugs = `
+  checkbox-support:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const checkboxSupportBaseDeclarationSlots = `
+  checkbox-support:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+type checkboxSupportInterface struct {
+	// The checkbox-support interface is exactly the steam-support interface
+	// with the exception that it is also allowed to run on core devices.
+	steamSupportInterface
+}
+
+func init() {
+	registerIface(&checkboxSupportInterface{steamSupportInterface{commonInterface{
+		name:                 "checkbox-support",
+		summary:              checkboxSupportSummary,
+		implicitOnCore:       true,
+		implicitOnClassic:    true,
+		baseDeclarationSlots: checkboxSupportBaseDeclarationSlots,
+		baseDeclarationPlugs: checkboxSupportBaseDeclarationPlugs,
+		connectedPlugSecComp: steamSupportConnectedPlugSecComp,
+	}}})
+}

--- a/interfaces/builtin/checkbox_support_test.go
+++ b/interfaces/builtin/checkbox_support_test.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type CheckboxSupportInterfaceSuite struct {
+	SteamSupportInterfaceSuite
+}
+
+const checkboxSupportCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  checkbox-support:
+`
+
+const checkboxSupportConsumerYaml = `name: consumer
+version: 0
+apps:
+  app:
+    plugs: [checkbox-support]
+`
+
+var _ = Suite(&CheckboxSupportInterfaceSuite{SteamSupportInterfaceSuite{
+	iface: builtin.MustInterface("checkbox-support"),
+}})
+
+func (s *CheckboxSupportInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, checkboxSupportConsumerYaml, nil, "checkbox-support")
+	s.slot, s.slotInfo = MockConnectedSlot(c, checkboxSupportCoreYaml, nil, "checkbox-support")
+}
+
+func (s *CheckboxSupportInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "checkbox-support")
+}
+
+func (s *CheckboxSupportInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, "allows checkbox to execute arbitrary system tests")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "checkbox-support")
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -808,6 +808,7 @@ var (
 		"bluez":                     {"app", "core"},
 		"bool-file":                 {"core", "gadget"},
 		"browser-support":           {"core"},
+		"checkbox-support":          {"core"},
 		"content":                   {"app", "gadget", "kernel"},
 		"core-support":              {"core"},
 		"cups":                      {"app"},
@@ -1011,6 +1012,7 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 
 	restricted := map[string]bool{
 		"block-devices":                    true,
+		"checkbox-support":                 true,
 		"classic-support":                  true,
 		"desktop-launch":                   true,
 		"dm-crypt":                         true,
@@ -1310,6 +1312,7 @@ func (s *baseDeclSuite) TestValidity(c *C) {
 		"block-devices":                    true,
 		"audio-playback":                   true,
 		"classic-support":                  true,
+		"checkbox-support":                 true,
 		"core-support":                     true,
 		"custom-device":                    true,
 		"desktop":                          true,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -239,6 +239,9 @@ apps:
   steam-support:
     command: bin/run
     plugs: [ steam-support ]
+  checkbox-support:
+    command: bin/run
+    plugs: [ checkbox-support ]
   storage-framework-service:
     command: bin/run
     plugs: [ storage-framework-service ]


### PR DESCRIPTION
The checkbox-support interface is a privileged interface designed for the Canonical checkbox test and certification system. The system is able to run a wide collection of system tests and is thus allowed to execute any command mostly bypassing the sandbox.

The interface is allowed to run on both core and classic systems, so that certification can use the same snap across the entire range of devices.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34252
