### PR TITLE
osutil: add mount/libmount package with option validator

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,13 +1,15 @@
 ignore_files:
-  - packaging/ubuntu-14.04/changelog
-  - packaging/ubuntu-16.04/changelog
-  - packaging/debian-sid/changelog
-  - packaging/fedora/snapd.spec
+  - build-aux/snap/local/apparmor/apparmor-parser-fix-protocol-error-on-older-kernels-caused-by.patch
+  - build-aux/snap/local/apparmor/parser-add-support-for-prompting.patch
+  - cmd/libsnap-confine-private/snap.c
+  - cmd/libsnap-confine-private/string-utils-test.c
+  - cmd/libsnap-confine-private/string-utils-test.c
+  - cmd/libsnap-confine-private/string-utils.c
   - cmd/snap-confine/snap-confine.apparmor.in
   - cmd/snap-confine/snap-confine.c
-  - cmd/libsnap-confine-private/string-utils.c
-  - cmd/libsnap-confine-private/string-utils-test.c
-  - cmd/libsnap-confine-private/string-utils-test.c
-  - cmd/libsnap-confine-private/snap.c
-  - build-aux/snap/local/apparmor/parser-add-support-for-prompting.patch
-  - build-aux/snap/local/apparmor/apparmor-parser-fix-protocol-error-on-older-kernels-caused-by.patch
+  - osutil/mount/libmount/libmount_linux.go
+  - osutil/mount/libmount/libmount_linux_test.go
+  - packaging/debian-sid/changelog
+  - packaging/fedora/snapd.spec
+  - packaging/ubuntu-14.04/changelog
+  - packaging/ubuntu-16.04/changelog

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -154,3 +154,7 @@ func MockApparmorGenerateAAREExclusionPatterns(fn func(excludePatterns []string,
 func MockDesktopFilesFromInstalledSnap(fn func(s *snap.Info) ([]string, error)) (restore func()) {
 	return testutil.Mock(&desktopFilesFromInstalledSnap, fn)
 }
+
+func AllowedKernelMountOptions() []string {
+	return allowedKernelMountOptions
+}

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/osutil/mount/libmount"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
@@ -456,4 +457,11 @@ func (s *MountControlInterfaceSuite) TestMountDevicePathWithCommas(c *C) {
 	plug, _ := MockConnectedPlug(c, snapYaml, nil, "mntctl")
 	err := interfaces.BeforeConnectPlug(s.iface, plug)
 	c.Check(err, IsNil)
+}
+
+func (s *MountControlInterfaceSuite) TestMountOptionsAreValid(c *C) {
+	// All the options we claim to support are also allowed by the validator.
+	for _, opt := range builtin.AllowedKernelMountOptions() {
+		c.Check(libmount.ValidateMountOptions(opt), IsNil)
+	}
 }

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -459,6 +459,20 @@ func (s *MountControlInterfaceSuite) TestMountDevicePathWithCommas(c *C) {
 	c.Check(err, IsNil)
 }
 
+func (s *MountControlInterfaceSuite) TestConflictingMountOptions(c *C) {
+	plugYaml := `
+  mount:
+  - persistent: true
+    what: /dev/foo
+    where: /mnt/foo
+    options: [rw, ro]
+`
+	snapYaml := fmt.Sprintf(mountControlYaml, plugYaml)
+	plug, _ := MockConnectedPlug(c, snapYaml, nil, "mntctl")
+	err := interfaces.BeforeConnectPlug(s.iface, plug)
+	c.Check(err, ErrorMatches, "mount-control options are inconsistent: option ro conflicts with rw")
+}
+
 func (s *MountControlInterfaceSuite) TestMountOptionsAreValid(c *C) {
 	// All the options we claim to support are also allowed by the validator.
 	for _, opt := range builtin.AllowedKernelMountOptions() {

--- a/osutil/mount/libmount/libmount.go
+++ b/osutil/mount/libmount/libmount.go
@@ -1,0 +1,23 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package libmount contains validation logic for user-level mount options
+// typically handled by libmount. This is in contrast with the parent mount
+// package which deals with the low-level kernel interface.
+package libmount

--- a/osutil/mount/libmount/libmount_darwin.go
+++ b/osutil/mount/libmount/libmount_darwin.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package libmount
+
+// ValidateMountOptions is a stub.
+func ValidateMountOptions(opts ...string) error {
+	// This is not implemented for Darwin. We could implement it by baking all
+	// the MS_FOO flags and not using the unix package but this is somewhat
+	// problematic as now we need to maintain that list.
+	return nil
+}

--- a/osutil/mount/libmount/libmount_linux.go
+++ b/osutil/mount/libmount/libmount_linux.go
@@ -1,0 +1,186 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package libmount
+
+import (
+	"fmt"
+	"sort"
+
+	// Syscall package does not have all the constants.
+	"golang.org/x/sys/unix"
+)
+
+// mountOption binds libmount mount option name to kernel mount flags.
+type mountOption struct {
+	name      string
+	setMask   uint32 // Mount bits set by this option
+	clearMask uint32 // Mount bits cleared by this option.
+	alias     bool   // This entry is an alias and is not the canonical name.
+}
+
+// mountOptions and the bits they set or clear.
+// This table comes from https://gitlab.com/apparmor/apparmor/-/blob/master/parser/mount.cc?ref_type=heads
+// but the ultimate authority is the kernel since those are all kernel flags with userspace names.
+var mountOptions = []mountOption{
+	// The read-only vs read-write flag is represented by one bit. Presence of
+	// the bit indicates that the read-only mode is in effect. This is why "rw"
+	// has zero as the set mask and read-only bit as the clear mask.
+	{name: "ro", setMask: unix.MS_RDONLY},
+	{name: "r", setMask: unix.MS_RDONLY, alias: true},
+	{name: "read-only", setMask: unix.MS_RDONLY, alias: true},
+	{name: "rw", clearMask: unix.MS_RDONLY},
+	{name: "w", clearMask: unix.MS_RDONLY, alias: true},
+	{name: "suid", clearMask: unix.MS_NOSUID},
+	{name: "nosuid", setMask: unix.MS_NOSUID},
+	{name: "dev", clearMask: unix.MS_NODEV},
+	{name: "nodev", setMask: unix.MS_NODEV},
+	{name: "exec", clearMask: unix.MS_NOEXEC},
+	{name: "noexec", setMask: unix.MS_NOEXEC},
+	{name: "sync", setMask: unix.MS_SYNCHRONOUS}, // NOTE: MS_SYNC is for msync(2), not mount(2).
+	{name: "async", clearMask: unix.MS_SYNCHRONOUS},
+	{name: "remount", setMask: unix.MS_REMOUNT},
+	{name: "mand", setMask: unix.MS_MANDLOCK},
+	{name: "nomand", clearMask: unix.MS_MANDLOCK},
+	{name: "dirsync", setMask: unix.MS_DIRSYNC},
+	{name: "symfollow", clearMask: unix.MS_NOSYMFOLLOW},
+	{name: "nosymfollow", setMask: unix.MS_NOSYMFOLLOW},
+	{name: "atime", clearMask: unix.MS_NOATIME},
+	{name: "noatime", setMask: unix.MS_NOATIME},
+	{name: "diratime", clearMask: unix.MS_NODIRATIME},
+	{name: "nodiratime", setMask: unix.MS_NODIRATIME},
+	{name: "bind", setMask: unix.MS_BIND},
+	{name: "B", setMask: unix.MS_BIND, alias: true},
+	{name: "move", setMask: unix.MS_MOVE},
+	{name: "M", setMask: unix.MS_MOVE, alias: true},
+	{name: "rbind", setMask: unix.MS_BIND | unix.MS_REC},
+	{name: "R", setMask: unix.MS_BIND | unix.MS_REC, alias: true},
+	{name: "verbose", setMask: unix.MS_VERBOSE},
+	{name: "silent", setMask: unix.MS_SILENT},
+	{name: "loud", clearMask: unix.MS_SILENT},
+	{name: "acl", setMask: unix.MS_POSIXACL},
+	{name: "noacl", clearMask: unix.MS_POSIXACL},
+	{name: "unbindable", setMask: unix.MS_UNBINDABLE},
+	{name: "make-unbindable", setMask: unix.MS_UNBINDABLE, alias: true},
+	{name: "runbindable", setMask: unix.MS_UNBINDABLE | unix.MS_REC},
+	{name: "make-runbindable", setMask: unix.MS_UNBINDABLE | unix.MS_REC, alias: true},
+	{name: "private", setMask: unix.MS_PRIVATE},
+	{name: "make-private", setMask: unix.MS_PRIVATE, alias: true},
+	{name: "rprivate", setMask: unix.MS_PRIVATE | unix.MS_REC},
+	{name: "make-rprivate", setMask: unix.MS_PRIVATE | unix.MS_REC, alias: true},
+	{name: "slave", setMask: unix.MS_SLAVE},
+	{name: "make-slave", setMask: unix.MS_SLAVE, alias: true},
+	{name: "rslave", setMask: unix.MS_SLAVE | unix.MS_REC},
+	{name: "make-rslave", setMask: unix.MS_SLAVE | unix.MS_REC},
+	{name: "shared", setMask: unix.MS_SHARED},
+	{name: "make-shared", setMask: unix.MS_SHARED},
+	{name: "rshared", setMask: unix.MS_SHARED | unix.MS_REC},
+	{name: "make-rshared", setMask: unix.MS_SHARED | unix.MS_REC},
+	{name: "relatime", setMask: unix.MS_RELATIME},
+	{name: "norelatime", clearMask: unix.MS_RELATIME},
+	{name: "iversion", setMask: unix.MS_I_VERSION},
+	{name: "noiversion", clearMask: unix.MS_I_VERSION},
+	{name: "strictatime", setMask: unix.MS_STRICTATIME},
+	{name: "nostrictatime", clearMask: unix.MS_STRICTATIME},
+	{name: "lazytime", setMask: unix.MS_LAZYTIME},
+	{name: "nolazytime", clearMask: unix.MS_LAZYTIME},
+	{name: "user", clearMask: xMS_NOUSER},
+	{name: "nouser", setMask: xMS_NOUSER},
+}
+
+// xMS_NOUSER unix.MS_NOUSER which is missing.
+const xMS_NOUSER = 1 << 31
+
+func init() {
+	// Sort the slice of mount options by name.
+	sort.Slice(mountOptions, func(i, j int) bool {
+		return mountOptions[i].name < mountOptions[j].name
+	})
+}
+
+// findMountOption finds a mount option with the given name.
+func findMountOption(name string) (mountOption, bool) {
+	i := sort.Search(len(mountOptions), func(i int) bool {
+		return mountOptions[i].name >= name
+	})
+	if i < len(mountOptions) && mountOptions[i].name == name {
+		return mountOptions[i], true
+	}
+
+	return mountOption{}, false
+}
+
+// findMountOptionConflict finds option conflicting with prior set and clear masks.
+//
+// The result is the first mount option with a canonical name, where the set
+// mask or clear mask of the given and returned option are in conflict.
+func findMountOptionConflict(opt mountOption, priorSetMask, priorClearMask uint32) (mountOption, bool) {
+	if opt.setMask&priorClearMask != 0 || opt.clearMask&priorSetMask != 0 {
+		// We now know that at least one option has a conflicting set or clear
+		// mask. Given that there are only a handful of mount options, an
+		// amount that should easily fit into the cache of even the smallest
+		// CPU, this is a simple linear scan without anything more fancy.
+		for _, other := range mountOptions {
+			// Do not use aliases when providing conflict details. This makes
+			// us talk about ro conflicting with rw instead of ro conflicting
+			// with read-write.
+			if other.alias {
+				continue
+			}
+
+			if opt.setMask&other.clearMask != 0 || opt.clearMask&other.setMask != 0 {
+				return other, true
+			}
+		}
+	}
+
+	return mountOption{}, false
+}
+
+// ValidateMountOptions looks for unknown or conflicting options for libmount-style APIs.
+//
+// The returned error describes all the problems in the given slice of mount
+// options, including:
+//
+// - unknown options
+// - options that conflict with other options given earlier.
+//
+// Note that only well-known options are recognized. This function should not
+// be called with file-system specific options. Only one error is returned at a
+// time. This limitation may be lifted later.
+func ValidateMountOptions(opts ...string) error {
+	var priorSetMask, priorClearMask uint32
+
+	for _, name := range opts {
+		opt, ok := findMountOption(name)
+		if !ok {
+			return fmt.Errorf("option %s is unknown", name)
+		}
+
+		if prior, ok := findMountOptionConflict(opt, priorSetMask, priorClearMask); ok {
+			return fmt.Errorf("option %s conflicts with %s", opt.name, prior.name)
+		}
+
+		priorSetMask |= opt.setMask
+		priorClearMask |= opt.clearMask
+	}
+
+	// TODO: use errors.Join when we update to go 1.20.
+	return nil
+}

--- a/osutil/mount/libmount/libmount_linux_test.go
+++ b/osutil/mount/libmount/libmount_linux_test.go
@@ -1,0 +1,151 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package libmount_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil/mount/libmount"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type suite struct{}
+
+var _ = Suite(&suite{})
+
+func (s *suite) TestValidateMountOptions(c *C) {
+	c.Check(libmount.ValidateMountOptions("rw"), IsNil)
+	c.Check(libmount.ValidateMountOptions("ro"), IsNil)
+	c.Check(libmount.ValidateMountOptions("ro", "rw"), ErrorMatches, "option rw conflicts with ro")
+	c.Check(libmount.ValidateMountOptions("rw", "ro"), ErrorMatches, "option ro conflicts with rw")
+
+	c.Check(libmount.ValidateMountOptions("suid"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nosuid"), IsNil)
+	c.Check(libmount.ValidateMountOptions("suid", "nosuid"), ErrorMatches, "option nosuid conflicts with suid")
+	c.Check(libmount.ValidateMountOptions("nosuid", "suid"), ErrorMatches, "option suid conflicts with nosuid")
+
+	c.Check(libmount.ValidateMountOptions("dev"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nodev"), IsNil)
+	c.Check(libmount.ValidateMountOptions("dev", "nodev"), ErrorMatches, "option nodev conflicts with dev")
+	c.Check(libmount.ValidateMountOptions("nodev", "dev"), ErrorMatches, "option dev conflicts with nodev")
+
+	c.Check(libmount.ValidateMountOptions("exec"), IsNil)
+	c.Check(libmount.ValidateMountOptions("noexec"), IsNil)
+	c.Check(libmount.ValidateMountOptions("exec", "noexec"), ErrorMatches, "option noexec conflicts with exec")
+	c.Check(libmount.ValidateMountOptions("noexec", "exec"), ErrorMatches, "option exec conflicts with noexec")
+
+	c.Check(libmount.ValidateMountOptions("sync"), IsNil)
+	c.Check(libmount.ValidateMountOptions("async"), IsNil)
+	c.Check(libmount.ValidateMountOptions("sync", "async"), ErrorMatches, "option async conflicts with sync")
+	c.Check(libmount.ValidateMountOptions("async", "sync"), ErrorMatches, "option sync conflicts with async")
+
+	c.Check(libmount.ValidateMountOptions("remount"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("mand"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nomand"), IsNil)
+	c.Check(libmount.ValidateMountOptions("mand", "nomand"), ErrorMatches, "option nomand conflicts with mand")
+	c.Check(libmount.ValidateMountOptions("nomand", "mand"), ErrorMatches, "option mand conflicts with nomand")
+
+	c.Check(libmount.ValidateMountOptions("dirsync"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("symfollow"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nosymfollow"), IsNil)
+	c.Check(libmount.ValidateMountOptions("symfollow", "nosymfollow"), ErrorMatches, "option nosymfollow conflicts with symfollow")
+	c.Check(libmount.ValidateMountOptions("nosymfollow", "symfollow"), ErrorMatches, "option symfollow conflicts with nosymfollow")
+
+	c.Check(libmount.ValidateMountOptions("atime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("noatime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("atime", "noatime"), ErrorMatches, "option noatime conflicts with atime")
+	c.Check(libmount.ValidateMountOptions("noatime", "atime"), ErrorMatches, "option atime conflicts with noatime")
+
+	c.Check(libmount.ValidateMountOptions("diratime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nodiratime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("diratime", "nodiratime"), ErrorMatches, "option nodiratime conflicts with diratime")
+	c.Check(libmount.ValidateMountOptions("nodiratime", "diratime"), ErrorMatches, "option diratime conflicts with nodiratime")
+
+	c.Check(libmount.ValidateMountOptions("bind"), IsNil)
+	c.Check(libmount.ValidateMountOptions("B"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("move"), IsNil)
+	c.Check(libmount.ValidateMountOptions("M"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("rbind"), IsNil)
+	c.Check(libmount.ValidateMountOptions("R"), IsNil)
+
+	// Silent and verbose are two flags that can be passed together.
+	c.Check(libmount.ValidateMountOptions("verbose"), IsNil)
+	c.Check(libmount.ValidateMountOptions("silent"), IsNil)
+	c.Check(libmount.ValidateMountOptions("loud"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("acl"), IsNil)
+	c.Check(libmount.ValidateMountOptions("noacl"), IsNil)
+	c.Check(libmount.ValidateMountOptions("acl", "noacl"), ErrorMatches, "option noacl conflicts with acl")
+	c.Check(libmount.ValidateMountOptions("noacl", "acl"), ErrorMatches, "option acl conflicts with noacl")
+
+	c.Check(libmount.ValidateMountOptions("unbindable"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-unbindable"), IsNil)
+	c.Check(libmount.ValidateMountOptions("runbindable"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-runbindable"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("rprivate"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-rprivate"), IsNil)
+	c.Check(libmount.ValidateMountOptions("rprivate"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-rprivate"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("rslave"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-rslave"), IsNil)
+	c.Check(libmount.ValidateMountOptions("rslave"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-rslave"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("rshared"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-rshared"), IsNil)
+	c.Check(libmount.ValidateMountOptions("rshared"), IsNil)
+	c.Check(libmount.ValidateMountOptions("make-rshared"), IsNil)
+
+	c.Check(libmount.ValidateMountOptions("relatime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("norelatime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("relatime", "norelatime"), ErrorMatches, "option norelatime conflicts with relatime")
+	c.Check(libmount.ValidateMountOptions("norelatime", "relatime"), ErrorMatches, "option relatime conflicts with norelatime")
+
+	c.Check(libmount.ValidateMountOptions("iversion"), IsNil)
+	c.Check(libmount.ValidateMountOptions("noiversion"), IsNil)
+	c.Check(libmount.ValidateMountOptions("iversion", "noiversion"), ErrorMatches, "option noiversion conflicts with iversion")
+	c.Check(libmount.ValidateMountOptions("noiversion", "iversion"), ErrorMatches, "option iversion conflicts with noiversion")
+
+	c.Check(libmount.ValidateMountOptions("strictatime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nostrictatime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("strictatime", "nostrictatime"), ErrorMatches, "option nostrictatime conflicts with strictatime")
+	c.Check(libmount.ValidateMountOptions("nostrictatime", "strictatime"), ErrorMatches, "option strictatime conflicts with nostrictatime")
+
+	c.Check(libmount.ValidateMountOptions("lazytime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nolazytime"), IsNil)
+	c.Check(libmount.ValidateMountOptions("lazytime", "nolazytime"), ErrorMatches, "option nolazytime conflicts with lazytime")
+	c.Check(libmount.ValidateMountOptions("nolazytime", "lazytime"), ErrorMatches, "option lazytime conflicts with nolazytime")
+
+	c.Check(libmount.ValidateMountOptions("user"), IsNil)
+	c.Check(libmount.ValidateMountOptions("nouser"), IsNil)
+	c.Check(libmount.ValidateMountOptions("user", "nouser"), ErrorMatches, "option nouser conflicts with user")
+	c.Check(libmount.ValidateMountOptions("nouser", "user"), ErrorMatches, "option user conflicts with nouser")
+
+	c.Check(libmount.ValidateMountOptions("potato"), ErrorMatches, "option potato is unknown")
+}


### PR DESCRIPTION
We need to recognize and validate libmount-style mount options, such as those that one can use with the mount(1) utility on command line for possible conflicts.  This is so that the apparmor parser, which does similar validation, does not fail "late" in the interface setup process, when given incorrect data by the mount-control interface.

This patch adds the skeleton of the validator, along with read-only and read-write mount options.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-32984

NOTE: this is a draft, I need to hook it up to interfaces logic as well.
I have considered asking apparmor for this information but given that we cannot even discover the full set of known mount options and the interrogation is inefficient (compile and see if it gets ignored), I chose to just bake in the table. There are only 32 bits possible so we are not up an unbound problem anyway.

I've only added one pair of conflicting options as this is a draft solicitng review