### PR TITLE
sandbox/apparmor: run apparmor via systemd-run

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -879,7 +879,9 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 				"--policy-features", abiFile,
 			}
 
-			return exec.Command(path, args...), true, nil
+			cmd := exec.Command("systemd-run", "--slice-inherit", "--pipe", path)
+			cmd.Args = append(cmd.Args, args...)
+			return cmd, true, nil
 		}
 	}
 

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -98,9 +98,8 @@ func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi3(c *C) {
 
 	cmd, internal, err := apparmor.AppArmorParser()
 	c.Check(err, IsNil)
-	c.Check(cmd.Path, Equals, parser)
 	c.Check(cmd.Args, DeepEquals, []string{
-		parser,
+		"systemd-run", "--slice-inherit", "--pipe", parser,
 		"--config-file", filepath.Join(libSnapdDir, "/apparmor/parser.conf"),
 		"--base", filepath.Join(libSnapdDir, "/apparmor.d"),
 		"--policy-features", filepath.Join(libSnapdDir, "/apparmor.d/abi/3.0"),
@@ -130,9 +129,9 @@ func (*apparmorSuite) TestAppArmorInternalAppArmorParserAbi4(c *C) {
 
 	cmd, internal, err := apparmor.AppArmorParser()
 	c.Check(err, IsNil)
-	c.Check(cmd.Path, Equals, parser)
+	// The parser is not the first argument as we are calling it through systemd-run.
 	c.Check(cmd.Args, DeepEquals, []string{
-		parser,
+		"systemd-run", "--slice-inherit", "--pipe", parser,
 		"--config-file", filepath.Join(libSnapdDir, "/apparmor/parser.conf"),
 		"--base", filepath.Join(libSnapdDir, "/apparmor.d"),
 		// 4.0 was preferred.


### PR DESCRIPTION
AppArmor parser is a compiler that transforms a tree of regular expressions into one deterministic finite automaton. During the NFA to DFA transformation phase a large amount of memory is required to compute the value and then to minimize the resulting graph.

We are regularly hitting issues where, in continuous integration, snapd calls apparmor_parser while being bound by a tight memory limit imposed on the snapd.service unit. When the parser is asked to process a number of profiles it will internally perform such computation in parallel. With an unlucky set, snapd may get killed by the out-of-memory mechanism because the memory of the parser is accounted to the same control group where snapd is running.

While this does not change the actual memory used, it does make the original intent of catching runaway snapd memory usage, which may indicate a memory leak, more useful.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-8640

