### PR TITLE
o/snapstate: install/update component when resolving validation sets

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -72,22 +72,19 @@ func InstallComponents(
 				return nil, snap.AlreadyInstalledComponentError{Component: comp}
 			}
 		}
-
-		if opts.Flags.IgnoreValidation {
-			vsets = snapasserts.NewValidationSets()
-		} else {
-			vsets, err = EnforcedValidationSets(st)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
-	compsups, err := componentSetupsForInstall(ctx, st, names, snapst, RevisionOptions{
+	revOpts := RevisionOptions{
 		Revision:       snapst.Current,
 		Channel:        snapst.TrackingChannel,
 		ValidationSets: vsets,
-	}, opts)
+	}
+
+	if err := revOpts.initializeValidationSets(cachedEnforcedValidationSets(st), opts); err != nil {
+		return nil, err
+	}
+
+	compsups, err := componentSetupsForInstall(ctx, st, names, snapst, revOpts, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -4227,9 +4227,22 @@ func InstalledSnaps(st *state.State) (snaps []*snapasserts.InstalledSnap, ignore
 		if err != nil {
 			return nil, nil, err
 		}
-		// TODO:COMPS: add components
-		snaps = append(snaps, snapasserts.NewInstalledSnap(snapState.InstanceName(),
-			snapState.CurrentSideInfo().SnapID, cur.Revision, nil))
+
+		var comps []snapasserts.InstalledComponent
+		for _, comp := range snapState.Sequence.Revisions[snapState.LastIndex(cur.Revision)].Components {
+			comps = append(comps, snapasserts.InstalledComponent{
+				ComponentRef: comp.SideInfo.Component,
+				Revision:     comp.SideInfo.Revision,
+			})
+		}
+
+		snaps = append(snaps, snapasserts.NewInstalledSnap(
+			snapState.InstanceName(),
+			snapState.CurrentSideInfo().SnapID,
+			cur.Revision,
+			comps,
+		))
+
 		if snapState.IgnoreValidation {
 			ignoreValidation[snapState.InstanceName()] = true
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1801,8 +1801,9 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	// use the same lane for installing and refreshing so everything is reversed
 	lane := st.NewLane()
 
-	// keep track of snaps that are being fixed. we won't need to fix any of
-	// their components explicitly
+	// keep track of snaps that are being having their validation issues
+	// resolved. we won't need to resolve any of their component errors
+	// explicitly.
 	resolved := make(map[string]bool)
 
 	var wrongRevs []StoreUpdate

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1873,13 +1873,7 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 		comps = append(comps, keys(cerr.MissingComponents)...)
 		comps = append(comps, keys(cerr.WrongRevisionComponents)...)
 
-		var snapst SnapState
-		err := Get(st, snapName, &snapst)
-		if err != nil && !errors.Is(err, state.ErrNoState) {
-			return nil, nil, err
-		}
-
-		info, err := snapst.CurrentInfo()
+		info, err := CurrentInfo(st, snapName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1891,7 +1891,7 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	// updates should be done before the installs
 	for _, ts := range tss {
 		for _, prevTs := range tasksets {
-			ts.WaitAll(prevTs)
+			ts.WaitAll(prevTs) // TODO: make this not a WaitAll
 		}
 	}
 	tasksets = append(tasksets, tss...)
@@ -1910,7 +1910,7 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	enforceTask.Set("userID", userID)
 
 	for _, ts := range tasksets {
-		enforceTask.WaitAll(ts)
+		enforceTask.WaitAll(ts) // TODO: make this not a WaitAll
 	}
 	ts := state.NewTaskSet(enforceTask)
 	ts.JoinLane(lane)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8877,6 +8877,24 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementError(c *C) {
 	c.Assert(calledEnforce, Equals, true)
 }
 
+func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorInvalidComponents(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	verr := &snapasserts.ValidationSetsValidationError{
+		ComponentErrors: map[string]*snapasserts.ValidationSetsComponentValidationError{
+			"foo": {
+				InvalidComponents: map[string][]string{
+					"bar": {"vset/1"},
+				},
+			},
+		},
+	}
+
+	_, _, err := snapstate.ResolveValidationSetsEnforcementError(context.Background(), s.state, verr, nil, s.user.ID)
+	c.Assert(err, ErrorMatches, `cannot auto-resolve validation set constraints that require removing components: "foo\+bar"`)
+}
+
 func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorComponents(c *C) {
 	headers := map[string]interface{}{
 		"type":         "validation-set",


### PR DESCRIPTION
This change allows us to install/update components when resolving a validation set.