### PR TITLE
tests: fixes and improvements to the document-interfaces-url test

### DIFF
--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -16,7 +16,7 @@ execute: |
 
         for _ in $(seq $num_retries); do
             # Make a HEAD request to the URL and capture the HTTP status code
-            status_code=$(curl -o /dev/null -s -w "%{http_code}\n" --connect-timeout 10 "$url")
+            status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" --connect-timeout 10 "$url")
 
             # If the status code is 2xx the url is ok
             if [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ]; then

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -47,13 +47,6 @@ execute: |
     declare -A exclusion_map
     # confdb are still in the experimental phase so its page is not exposed yet
     exclusion_map["confdb"]="2025/03"
-    # we have documentation pages for these interfaces but they have underscores
-    # in the URL instead of dashes. Due to issues w/ Discourse we can't fix it
-    # at the moment, so we need to skip these checks for a bit
-    exclusion_map["intel-qat"]="2025/01"
-    exclusion_map["microceph-support"]="2025/01"
-    exclusion_map["xilinx-dma"]="2025/01"
-    exclusion_map["snap-interfaces-requests-control"]="2025/01"
     # we're actually missing this page but can't add it yet due to the same Discourse issues
     exclusion_map["nomad-support"]="2024/12"
 

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -27,6 +27,13 @@ execute: |
             if [ "$status_code" == 500 ]; then
                 return 0
             fi
+
+            # we've sent too many requests. A manual check showed that the server
+            # doesn't include a Retry-After header so for now just wait a few seconds
+            # so just wait a couple of seconds before retrying
+            if [ "$status_code" == 429 ]; then
+              sleep 5
+            fi
         done
         # If status code 4xx is returned then the page is not found, return error
         return 1


### PR DESCRIPTION
A couple of improvements to the document-interfaces-url test:
* 59ed590b7ccca3f1151d4fa2f8f921a5fc84f796 adds a delay before retrying if we get a 429 (seen here: https://github.com/canonical/snapd/actions/runs/12232010759/job/34116725765?pr=14705). The server doesn't return a Retry-After so I just chose a fixed delay
* 21b600b544279c4163d4a4acf0831f65b075df63 changes the curl command to do a HEAD request instead of a GET to avoid downloading 100Kb of HTML each time
* b51c35e14fc48d3fe44b1f6c324ca9b59082ba17 removes some of the exclusions which we no longer need since the docs urls have been fixed in the mapping