### PR TITLE
o/ifacestate: record warning if prompting errors during startup

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -218,7 +218,13 @@ func (m *InterfaceManager) StartUp() error {
 				// This is done before profilesNeedRegeneration, so profiles
 				// will only be regenerated if prompting is newly enabled and
 				// the backends were successfully created.
-				// TODO: also set "apparmor-prompting" flag to false?
+
+				// Do not set "apparmor-prompting" flag to false, since the
+				// user intends for prompting to be enabled, but do record a
+				// warning so the user knows prompting is not current running.
+				m.state.Lock()
+				defer m.state.Unlock()
+				m.state.AddWarning(fmt.Sprintf("failed to start prompting backend: %v\nprompting will be inactive until snapd is restarted", err), nil)
 			}
 		}()
 	}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -224,7 +224,7 @@ func (m *InterfaceManager) StartUp() error {
 				// warning so the user knows prompting is not current running.
 				m.state.Lock()
 				defer m.state.Unlock()
-				m.state.AddWarning(fmt.Sprintf("failed to start prompting backend: %v\nprompting will be inactive until snapd is restarted", err), nil)
+				m.state.AddWarning(fmt.Sprintf("cannot start prompting backend: %v; prompting will be inactive until snapd is restarted", err), nil)
 			}
 		}()
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -7036,7 +7036,7 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	defer s.state.Unlock()
 	warns := s.state.AllWarnings()
 	c.Check(warns, HasLen, 1)
-	c.Check(warns[0].String(), Matches, fmt.Sprintf(`failed to start prompting backend: %v\nprompting will be inactive until snapd is restarted`, createError))
+	c.Check(warns[0].String(), Matches, fmt.Sprintf(`cannot start prompting backend: %v; prompting will be inactive until snapd is restarted`, createError))
 }
 
 func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {


### PR DESCRIPTION
If an error occurs during interfaces requests manager initialization, record a warning containing the error and indicating that prompting will remain inactive until snapd is restarted.

Even when an error occurs, the `"apparmor-prompting"` feature flag is left enabled, as the user deliberately turned this flag on, and we don't want to change feature flags without user interaction.

This work is tracked internally by: https://warthogs.atlassian.net/browse/SNAPDENG-32064
