### PR TITLE
tests/lib/fakestore: add support for tracking channels

### DIFF
--- a/tests/lib/tools/store-state
+++ b/tests/lib/tools/store-state
@@ -11,6 +11,7 @@ show_help() {
     echo "       store-state teardown-staging-store"
     echo "       store-state make-snap-installable [--noack ] [--extra-decl-json FILE] <DIR> <SNAP_PATH> [SNAP_ID]"
     echo "       store-state init-fake-refreshes <DIR>"
+    echo "       store-state add-to-channel <DIR> <FILENAME> <CHANNEL>"
 }
 
 _configure_store_backends(){
@@ -180,6 +181,15 @@ teardown_fake_store(){
         systemctl daemon-reload
         systemctl start snapd.socket
     fi
+}
+
+add_to_channel() {
+    local BLOB_DIR=$1
+    local FILENAME=$2
+    local CHANNEL=$3
+    SUM="$(snap info --verbose "$(realpath "${FILENAME}")" | sed '/^sha3-384: */{;s///;q;};d')"
+    mkdir -p "${BLOB_DIR}/channels"
+    echo "${CHANNEL}" >>"${BLOB_DIR}/channels/${SUM}"
 }
 
 main() {


### PR DESCRIPTION
Cherry-pick of eb2a9560e989335f9d5cb5b010b0b330886155e8 from https://github.com/canonical/snapd/pull/14305 in `fde-manager-features` branch.