### PR TITLE
tests/main/listing: correct and clean up core and snapd version regex

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -42,7 +42,6 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
-    # TODO: Consider reverting to latest/candidate after Snapcraft compatibility with LXD 5.21 extended version string "5.21 LTS" is fixed
     LXD_SNAP_CHANNEL: "latest/candidate"
     OLD_UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/beta"

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -14,15 +14,15 @@ restore: |
 
 execute: |
     echo "List prints core snap version"
-    # most core versions should be like "16-2", so [0-9]{2}-[0-9.]+
-    # but edge will have a timestamp in there, "16.2+201701010932", so add an optional \+[0-9]+ to the end
-    # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
+    # all core versions will start with something like "16-2.61.4", so "[0-9]{2}-[0-9.]+"
+    # with core in security maintenance it has additional date like "16-2.61.4-20240607", so optional "(-[0-9]+)?"
+    # in edge it has additional git identifier like "16-2.63+git5348.e45449bd5", so optional "(\\+git[0-9]+\\.[0-9a-f]+)?"
 
     # Expressions for version and revision
     NUMERIC_VERSION="[0-9]+(\.[0-9]+)*"
-    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)?"
-    SNAPD_GIT_VERSION="+[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-z]+)?(-dirty)?"
-    FINAL_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+[0-9]+\\.[0-9a-f]+)?"
+    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)?" # core on  edge, beta, candidate, stable & sideload
+    CORE_STABLE_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?"                         # core on stable for SRU/PPA
+    SNAPD_GIT_VERSION="+[0-9.]+(\\+git[0-9]+\\.[0-9a-z]+)?(-dirty)?"         # snapd on edge, beta, candidate, stable, sideload & dirty
     SIDELOAD_REV="x[0-9]+"
     NUMBER_REV="[0-9]+"
 
@@ -50,7 +50,7 @@ execute: |
 
     elif [ "$SRU_VALIDATION" = "1" ] || [ -n "$PPA_VALIDATION_NAME" ]; then
         echo "When either sru or ppa validation is done the core snap is installed from the store"
-        VERSION=$FINAL_VERSION
+        VERSION=$CORE_STABLE_VERSION
         TRACKING="(latest/)?stable"
 
     elif [ "$SPREAD_BACKEND" = "external" ] && os.query is-core16; then


### PR DESCRIPTION
Correct and cleanup regex used to identify core & snapd `snap list` information.

This issue was discovered while testing with as part of snapd deb validation for Bionic:
`SPREAD_SNAPD_DEB_FROM_REPO=false SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable spread -no-debug-output google:ubuntu-18.04-64:tests/main/listing`.

It was confirmed relevant on master as well, if `SPREAD_CORE_CHANNEL=stable` as above. It does not typically show up because `SPREAD_CORE_CHANNEL=edge` by default

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34179