### PR TITLE
tests/main/proxy-no-core: remove core snap from cache to ensure proxy download

### DIFF
--- a/tests/main/proxy-no-core/task.yaml
+++ b/tests/main/proxy-no-core/task.yaml
@@ -11,10 +11,26 @@ details: |
 systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 
 prepare: |
-    # Make sure there is not any .partial for the core snap to be resumed,
-    # otherwise it is not going to use the proxy to download it. The .partial
-    # file is being automatically restored with the snapd state.
+    # Ensure there is no .partial for the core snap to be resumed, otherwise
+    # it is not going to use the proxy to download it. The .partial file is
+    # being automatically restored with the snapd state.
     rm -f /var/lib/snapd/snaps/core_*.partial
+
+    # Ensure core snap is not available in cache, otherwise it is not 
+    # going to use the proxy to download it.
+    # remove cache entries in /var/lib/snapd/cache
+    core_inums="$(find /var/lib/snapd/snaps -name "core_*.snap" -printf "%i\n")"
+    if [[ -n "$core_inums" ]]; then
+        for inum in $core_inums; do
+            cache_entry="$(find /var/lib/snapd/cache -inum "$inum")"
+            if [[ -n "$cache_entry" ]]; then
+                echo "Removing cache entry: $cache_entry"
+                rm -f "$cache_entry"
+            fi
+        done
+    fi
+    # remove corresponding files in /var/lib/snapd/snaps
+    rm -f /var/lib/snapd/snaps/core_*.snap
 
 restore: |
     iptables -D OUTPUT -m owner --uid-owner "$(id -u test)" -j ACCEPT -p tcp


### PR DESCRIPTION
Remove core snap from cache to ensure proxy download.

This issue was discovered while testing with as part of snapd deb validation for Bionic:
`SPREAD_SNAPD_DEB_FROM_REPO=false SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable spread -no-debug-output google:ubuntu-18.04-64:tests/main/proxy-no-core`.

It was confirmed relevant on master as well, if `SPREAD_CORE_CHANNEL=stable` as above. It does not typically show up because `SPREAD_CORE_CHANNEL=edge` by default which means the cached core does not match stable.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34179