### PR TITLE
overlord: wait for snapd restart after requesting by undo of 'link-snap'

### DIFF
--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -1359,14 +1359,16 @@ base: core20
 	st.Lock()
 	c.Assert(err, IsNil)
 
-	// at this point the system is "restarting", pretend the restart has
-	// happened
+	// at this point snapd needs to restart along the 'Do' path before
+	// "auto-connect"
 	c.Assert(chg.Status(), Equals, state.DoingStatus)
 	restart.MockPending(st, restart.RestartUnset)
+
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
+
 	return chg
 }
 
@@ -1493,8 +1495,21 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20ValidationSetTrackingFailsU
 
 	chg := s.testPopulateFromSeedCore20ValidationSetTracking(c, "run", []string{"canonical/base-set/2"})
 
-	s.overlord.State().Lock()
-	defer s.overlord.State().Unlock()
+	st := s.overlord.State()
+	st.Lock()
+
+	// at this point another restart is required, but it's snapd restarting
+	// because it's undoing
+	c.Assert(chg.Status(), Equals, state.UndoingStatus)
+	restart.MockPending(st, restart.RestartUnset)
+
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	st.Lock()
+	defer st.Unlock()
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err().Error(), testutil.Contains, "my-snap (required at revision 1 by sets canonical/base-set))")
 }

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -1506,10 +1506,8 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20ValidationSetTrackingFailsU
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
-	c.Assert(err, IsNil)
-
-	st.Lock()
 	defer st.Unlock()
+	c.Assert(err, IsNil)
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err().Error(), testutil.Contains, "my-snap (required at revision 1 by sets canonical/base-set))")
 }

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -1496,14 +1496,16 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20ValidationSetTrackingFailsU
 	chg := s.testPopulateFromSeedCore20ValidationSetTracking(c, "run", []string{"canonical/base-set/2"})
 
 	st := s.overlord.State()
-	st.Lock()
 
-	// at this point another restart is required, but it's snapd restarting
-	// because it's undoing
-	c.Assert(chg.Status(), Equals, state.UndoingStatus)
-	restart.MockPending(st, restart.RestartUnset)
+	func() {
+		st.Lock()
+		defer st.Unlock()
+		// at this point another restart is required, but it's snapd restarting
+		// because it's undoing
+		c.Assert(chg.Status(), Equals, state.UndoingStatus)
+		restart.MockPending(st, restart.RestartUnset)
+	}()
 
-	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -2514,10 +2514,8 @@ func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingUnmetC
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
-	c.Assert(err, IsNil)
-
-	st.Lock()
 	defer st.Unlock()
+	c.Assert(err, IsNil)
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err().Error(), testutil.Contains, "pc-kernel (required at revision 7 by sets canonical/base-set))")
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -2503,8 +2503,21 @@ func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingUnmetC
 	}
 	chg := s.testPopulateFromSeedCore18ValidationSetTracking(c, []asserts.Assertion{a}, []interface{}{headers})
 
-	s.overlord.State().Lock()
-	defer s.overlord.State().Unlock()
+	st := s.overlord.State()
+	st.Lock()
+
+	// at this point another restart is required, but it's snapd restarting
+	// because it's undoing
+	c.Assert(chg.Status(), Equals, state.UndoingStatus)
+	restart.MockPending(st, restart.RestartUnset)
+
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	st.Lock()
+	defer st.Unlock()
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err().Error(), testutil.Contains, "pc-kernel (required at revision 7 by sets canonical/base-set))")
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -2504,14 +2504,16 @@ func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingUnmetC
 	chg := s.testPopulateFromSeedCore18ValidationSetTracking(c, []asserts.Assertion{a}, []interface{}{headers})
 
 	st := s.overlord.State()
-	st.Lock()
 
-	// at this point another restart is required, but it's snapd restarting
-	// because it's undoing
-	c.Assert(chg.Status(), Equals, state.UndoingStatus)
-	restart.MockPending(st, restart.RestartUnset)
+	func() {
+		st.Lock()
+		defer st.Unlock()
+		// at this point another restart is required, but it's snapd restarting
+		// because it's undoing
+		c.Assert(chg.Status(), Equals, state.UndoingStatus)
+		restart.MockPending(st, restart.RestartUnset)
+	}()
 
-	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -427,7 +427,7 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 
 	// The previous task's undo (link-snap) may have triggered a restart, if this
 	// is the case we can only proceed once the restart has happened or we
-	// may not have all the interfaces of the new core/base snap. We set
+	// may be invoking tools (like apparmor) from the wrong snapd. We set
 	// the default to true as we cannot set it otherwise since the change will
 	// always have been created by the old snapd (that may not have "finish-restart")
 	logger.Debugf("finish restart from undoLinkSnap")

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2913,7 +2913,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// When undoing the snapd snap refresh/install we must ensure that
 	// we are restarting into the previous snapd, undoSetupProfiles() handles
-	// the actual waiting for reboot.
+	// the actual waiting for restart.
 	if newInfo.Type() == snap.TypeSnapd {
 		restartPoss = &restartPossibility{info: newInfo, RebootInfo: boot.RebootInfo{RebootRequired: false}}
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2912,7 +2912,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// the cleanup is performed by snapd from core;
 	// when reverting a subsequent snapd revision, the restart happens in
 	// undoLinkCurrentSnap() instead
-	if firstInstall && newInfo.Type() == snap.TypeSnapd {
+	if newInfo.Type() == snap.TypeSnapd {
 		restartPoss = &restartPossibility{info: newInfo, RebootInfo: boot.RebootInfo{RebootRequired: false}}
 	}
 

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -2454,6 +2454,12 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 	c.Assert(t.Log(), HasLen, 2)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 	c.Check(t.Log()[1], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
+
+	// verify sequence file
+	// and check that the sequence file got updated
+	seqContent, err := os.ReadFile(filepath.Join(dirs.SnapSeqDir, "snapd.json"))
+	c.Assert(err, IsNil)
+	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"snapd","snap-id":"snapd-snap-id","revision":"20"}],"current":"20","migrated-hidden":false,"migrated-exposed-home":false}`)
 }
 
 func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheckOn(c *C) {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -2447,11 +2447,13 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 	c.Check(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Check(s.fakeBackend.ops, DeepEquals, expected)
 
-	// 1 restart from link snap, the other restart happens
-	// in undoUnlinkCurrentSnap (not tested here)
-	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon})
-	c.Assert(t.Log(), HasLen, 1)
+	// 1 restart from link snap
+	// 1 restart from undo of 'setup-profiles'
+	// 1 in undoUnlinkCurrentSnap (not tested here)
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon, restart.RestartDaemon})
+	c.Assert(t.Log(), HasLen, 2)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
+	c.Check(t.Log()[1], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 }
 
 func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheckOn(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1202,6 +1202,9 @@ func isChangeRequestingSnapdRestart(chg *state.Change) bool {
 	// have been set up in link-snap, daemon restart is requested, link-snap
 	// is marked as Done, and the auto-connect task is held off (in Do or
 	// Doing states) until the restart completes
+	// TODO: This may need additional handling for snapd reboot along the
+	// Undo path. For instance, 'link-snap' can request a reboot in the undo
+	// direction, making 'setup-profiles' wait for reboot.
 	var haveSnapd, linkDone, autoConnectWaiting bool
 	for _, tsk := range chg.Tasks() {
 		kind := tsk.Kind()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1202,9 +1202,9 @@ func isChangeRequestingSnapdRestart(chg *state.Change) bool {
 	// have been set up in link-snap, daemon restart is requested, link-snap
 	// is marked as Done, and the auto-connect task is held off (in Do or
 	// Doing states) until the restart completes
-	// TODO: This may need additional handling for snapd reboot along the
-	// Undo path. For instance, 'link-snap' can request a reboot in the undo
-	// direction, making 'setup-profiles' wait for reboot.
+	// TODO: This may need additional handling for snapd restart along the
+	// Undo path. For instance, 'link-snap' can request a restart in the undo
+	// direction, making 'setup-profiles' wait for restart.
 	var haveSnapd, linkDone, autoConnectWaiting bool
 	for _, tsk := range chg.Tasks() {
 		kind := tsk.Kind()

--- a/tests/core/snapd-refresh-undo/task.yaml
+++ b/tests/core/snapd-refresh-undo/task.yaml
@@ -31,7 +31,7 @@ execute: |
   # refresh to a snapd prior to snapd snap, this one is chosen from
   # a customer case where they were seeing issues with snapd reverting
   snap refresh snapd --amend --revision=18357
-  snap list" | MATCH "snapd.*18357
+  snap list | MATCH "snapd.*18357"
 
   # perform a refresh to the current snapd, this will fail, do it in a way
   # that will make snapd revert

--- a/tests/core/snapd-refresh-undo/task.yaml
+++ b/tests/core/snapd-refresh-undo/task.yaml
@@ -9,10 +9,7 @@ details: |
 systems: [-ubuntu-core-16-*]
 
 environment:
-  # uploading large snap triggers OOM
-  SNAPD_NO_MEMORY_LIMIT: 1
-  SNAP_NAME: test-snapd-service
-  SNAP_NAME_BAD: ${SNAP_NAME}-v2-bad
+  SNAP_NAME_BAD: test-snapd-service-v2-bad
 
 restore: |
   # Remove all inactive revisions of snapd.
@@ -43,4 +40,4 @@ execute: |
 
   # verify this has no undo failures for snapd related to security profiles
   snap change "$CHG_ID" | MATCH "(Undone).*Setup snap \"snapd\" \(unset\) security profiles"
-  snap change "$CHG_ID" | grep "Error" | wc -l | MATCH "1"
+  snap change "$CHG_ID" | grep -c "Error" | MATCH "1"

--- a/tests/core/snapd-refresh-undo/task.yaml
+++ b/tests/core/snapd-refresh-undo/task.yaml
@@ -41,3 +41,6 @@ execute: |
   # verify this has no undo failures for snapd related to security profiles
   snap change "$CHG_ID" | MATCH "(Undone).*Setup snap \"snapd\" \(unset\) security profiles"
   snap change "$CHG_ID" | grep -c "Error" | MATCH "1"
+
+  # restore original snapd
+  snap revert snapd

--- a/tests/core/snapd-refresh-undo/task.yaml
+++ b/tests/core/snapd-refresh-undo/task.yaml
@@ -1,0 +1,46 @@
+summary: Test refreshing snapd and running new units
+
+details: |
+  Check that snapd can be installed and reverted many times in a row resulting in a
+  working snapd. Also ensure snapd is working after a reboot.
+
+# UC16 still uses the core snap rather than the snapd snap, so disable this test
+# for UC16
+systems: [-ubuntu-core-16-*]
+
+environment:
+  # uploading large snap triggers OOM
+  SNAPD_NO_MEMORY_LIMIT: 1
+  SNAP_NAME: test-snapd-service
+  SNAP_NAME_BAD: ${SNAP_NAME}-v2-bad
+
+restore: |
+  # Remove all inactive revisions of snapd.
+  current=$(readlink /snap/snapd/current)
+  for revno_path in /snap/snapd/*; do
+    revno=$(basename "$revno_path")
+    if [ "$revno" == current ] || [ "$revno" == "$current" ]; then
+      continue
+    fi
+    snap remove snapd --revision="$revno"
+  done
+
+execute: |
+  snap pack "$TESTSLIB/snaps/$SNAP_NAME_BAD"
+
+  # store a copy of the built snapd
+  cp /var/lib/snapd/snaps/snapd_x1.snap ./snapd.snap
+
+  # refresh to a snapd prior to snapd snap, this one is chosen from
+  # a customer case where they were seeing issues with snapd reverting
+  snap refresh snapd --amend --revision=18357
+  snap list" | MATCH "snapd.*18357
+
+  # perform a refresh to the current snapd, this will fail, do it in a way
+  # that will make snapd revert
+  CHG_ID=$(snap install --no-wait --dangerous --transaction=all-snaps ./snapd.snap ./test-snapd-service_2.0_all.snap)
+  snap watch "$CHG_ID" || true
+
+  # verify this has no undo failures for snapd related to security profiles
+  snap change "$CHG_ID" | MATCH "(Undone).*Setup snap \"snapd\" \(unset\) security profiles"
+  snap change "$CHG_ID" | grep "Error" | wc -l | MATCH "1"

--- a/tests/core/snapd-refresh-undo/task.yaml
+++ b/tests/core/snapd-refresh-undo/task.yaml
@@ -1,8 +1,8 @@
-summary: Test refreshing snapd and running new units
+summary: Verify that snapd can undo the upgrade from non-snapd-snap to snapd-snap
 
 details: |
-  Check that snapd can be installed and reverted many times in a row resulting in a
-  working snapd. Also ensure snapd is working after a reboot.
+  Verify that the snapd-snap can successfully undo after upgrading from a non snapd-snap
+  situation, and something causes a rollback even in spite of a successful snapd update.
 
 # UC16 still uses the core snap rather than the snapd snap, so disable this test
 # for UC16

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -266,6 +266,8 @@ func AddSnapdSnapServices(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter
 		return nil, nil
 	}
 
+	logger.Debugf("removed units: %v", removed)
+	logger.Debugf("changed units: %v", changed)
 	// stop all removed units first
 	for _, unit := range removed {
 		serviceUnits := []string{unit}
@@ -315,8 +317,10 @@ func AddSnapdSnapServices(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter
 			// be started. Others like "snapd.seeded.service" are started
 			// as dependencies of snapd.service.
 			if snapdSkipStart(snapdUnits[unit].(*osutil.MemoryFileState).Content) {
+				logger.Debugf("skipping unit %v, has do-not-start tag", unit)
 				continue
 			}
+			logger.Debugf("(re)starting snapd unit %v", unit)
 			// Ensure to only restart if the unit was previously
 			// active. This ensures we DTRT on firstboot and do
 			// not stop e.g. snapd.socket because doing that

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -40,6 +41,23 @@ var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(/usr/bin/snap\s+.*|/usr/li
 
 // snapdToolingMountUnit is the name of the mount unit that provides the snapd tooling
 const SnapdToolingMountUnit = "usr-lib-snapd.mount"
+
+func skipStartDueToQuirks(unit string, targetVersion string) bool {
+	switch unit {
+	case "snapd.apparmor.service":
+		// versions earlier than 2.62 did not have the do-not-start tag in
+		// snapd.apparmor.service, which was introduced in
+		// https://github.com/canonical/snapd/commit/d1cf336e7c584078dff3883c93f0581ae455811e
+		// due to which snapd may attempt to restart snapd.apparmor.service and
+		// in specific cases use apparmor_parser from the base
+		compare, err := strutil.VersionCompare(targetVersion, "2.62")
+
+		// we're downgrading to version earlier than 2.62
+		return err == nil && compare < 0
+	default:
+		return false
+	}
+}
 
 func snapdSkipStart(content []byte) bool {
 	return bytes.Contains(content, []byte("X-Snapd-Snap: do-not-start"))
@@ -320,6 +338,12 @@ func AddSnapdSnapServices(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter
 				logger.Debugf("skipping unit %v, has do-not-start tag", unit)
 				continue
 			}
+			// check for any version specific quirks
+			if skipStartDueToQuirks(unit, s.Version) {
+				logger.Debugf("skipping unit %v, due to version specific quirks for %v", unit, s.Version)
+				continue
+			}
+
 			logger.Debugf("(re)starting snapd unit %v", unit)
 			// Ensure to only restart if the unit was previously
 			// active. This ensures we DTRT on firstboot and do

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -2751,7 +2751,7 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
 }
 
 var snapdYaml = `name: snapd
-version: 1.0
+version: 2.62
 type: snapd
 `
 


### PR DESCRIPTION
When doing a snapd upgrade (specifically from pre snapd-snap to snapd-snap) either as transactional or as a part of a validation-set/remodel refresh, and a snap fails to update after snapd has succesfully upgraded, it seems the 'undo' path of snapd ends up causing an issue with how we utilize internal tools from the snapd snap.

After 'link-snap' undo's for the snapd, we technically should not be running as the new snapd, and we do actually do a 'LinkSnap' operation in undo because a snapd snap must always be available, and the task does request a restart of snapd to switch to the older snapd. However, the task prior to 'link-snap', which is 'setup-profiles', does not wait for this restart request and instead continues to try to load apparmor_parser from the new snap. This fails.

Make undo of 'setup-profiles' wait for snapd restart to fix this, this ensures we run as the old snapd for the rest of the change's undo, and use the correct set of tools to generate apparmor profiles.