### PR TITLE
tests: ignore error in provider filter

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -251,7 +251,7 @@ jobs:
               ./tests/lib/spread/add-backend tests/lib/spread/backend.openstack.yaml spread.yaml
           fi
 
-          spread_list="$($SPREAD -list $RUN_TESTS 2>&1)"
+          spread_list="$($SPREAD -list $RUN_TESTS 2>&1 || true)"
 
           if [[ "$spread_list" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable


### PR DESCRIPTION
Fixes issue where if a spread task excludes a system and that task is run by itself in the CI, then the `spread -list <backend>:<system-that-excludes-task>:<task>` command will error.