### PR TITLE
tests/main/upgrade-from-release: workaround for older snapd deb version

### DIFF
--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -62,7 +62,15 @@ execute: |
     snap install go-example-webserver
     tests.systemd wait-for-service -n 30 --state active snap.go-example-webserver.webserver.service
     snap install test-snapd-tools
-    test-snapd-tools.echo hello | MATCH hello
+    # In case of known error on older snapd deb versions e.g. 2.32.5+18.04,
+    # rerun with SNAP_REEXEC=1 as workaround for this step
+    if result=$(test-snapd-tools.echo hello 2>&1); then
+        MATCH hello <<< "$result"
+    else
+        SNAPD_DEBUG=1 snap version 2>&1 | MATCH "re-exec disabled by user"
+        MATCH "cannot perform readlinkat\(\) on the mount namespace file descriptor of the init process" <<< "$result"
+        SNAP_REEXEC=1 test-snapd-tools.echo hello | MATCH hello
+    fi
 
     echo "upgrade to current snapd"
     if [ "${VERSION_ID}" = "14.04" ]; then


### PR DESCRIPTION
Provide workaround for older snapd debs that fail to run `test-snapd-tools.echo hello` with re-exec disabled.

This issue was discovered while testing with as part of snapd deb validation for Bionic:
SPREAD_SNAPD_DEB_FROM_REPO=false SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable spread -no-debug-output google:ubuntu-18.04-64:tests/main/proxy-no-core.

It was confirmed relevant on master as well, if SPREAD_SNAP_REEXEC=0 as above.
The specific snapd deb on Bionic to easily reproduce the failure:  2.32.5+18.04

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34179