### PR TITLE
seed/seedwriter: more precise error message when overriding channels with grade > dangerous

### DIFF
--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -58,7 +58,10 @@ func (pol *policy20) checkDefaultChannel(channel.Channel) error {
 }
 
 func (pol *policy20) checkSnapChannel(ch channel.Channel, whichSnap string) error {
-	return pol.checkAllowedDangerous()
+	if pol.checkAllowedDangerous() != nil {
+		return fmt.Errorf("cannot override channels with a model of grade higher than dangerous but --snap=<snap-name> is allowed to select optional snaps to include")
+	}
+	return nil
 }
 
 func (pol *policy20) checkClassicSnap(sn *SeedSnap) error {

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -2873,11 +2873,15 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 	baseLabel := "20191107"
 
 	tests := []struct {
-		optSnap *seedwriter.OptionsSnap
+		optSnap            *seedwriter.OptionsSnap
+		expectedErrVariant string
 	}{
-		{&seedwriter.OptionsSnap{Name: "extra"}},
-		{&seedwriter.OptionsSnap{Path: pcFn}},
-		{&seedwriter.OptionsSnap{Name: "pc", Channel: "edge"}},
+		{optSnap: &seedwriter.OptionsSnap{Name: "extra"}},
+		{optSnap: &seedwriter.OptionsSnap{Path: pcFn}},
+		{
+			optSnap:            &seedwriter.OptionsSnap{Name: "pc", Channel: "edge"},
+			expectedErrVariant: "cannot override channels with a model of grade higher than dangerous but --snap=<snap-name> is allowed to select optional snaps to include",
+		},
 	}
 
 	const expectedErr = `cannot override channels, add devmode snaps, local snaps, or extra snaps/components with a model of grade higher than dangerous`
@@ -2889,7 +2893,11 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 
 		err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{t.optSnap})
 		if err != nil {
-			c.Check(err, ErrorMatches, expectedErr)
+			if t.expectedErrVariant != "" {
+				c.Check(err, ErrorMatches, t.expectedErrVariant)
+			} else {
+				c.Check(err, ErrorMatches, expectedErr)
+			}
 			continue
 		}
 


### PR DESCRIPTION
This tries to address the discussion that happened in #14071 
