### PR TITLE
tests/main/snapd-homedirs-vendored: skip when reexec is disabled

### DIFF
--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -17,7 +17,7 @@ environment:
 
 prepare: |
     if [ "$SNAP_REEXEC" = "0" ] && tests.info is-snapd-from-archive; then
-        tests.exec skip-test "No needed to test the snap pkg when it is coming from the repository" && exit 0
+        tests.exec skip-test "No need to test when the snapd pkg is from the repository and reexec is disabled" && exit 0
     fi
 
     echo "Build command chain snap"

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -15,7 +15,7 @@ environment:
 
 prepare: |
     if [ "$SNAP_REEXEC" = "0" ] && tests.info is-snapd-from-archive; then
-        tests.exec skip-test "No needed to test the snap pkg when it is coming from the repository" && exit 0
+        tests.exec skip-test "No need to test when the snapd pkg is from the repository and reexec is disabled" && exit 0
     fi
 
     echo "Given a snap with a failing command is installed"

--- a/tests/main/install-sideload-epochs/task.yaml
+++ b/tests/main/install-sideload-epochs/task.yaml
@@ -13,7 +13,7 @@ environment:
 
 prepare: |
     if [ "$SNAP_REEXEC" = "0" ] && tests.info is-snapd-from-archive; then
-        tests.exec skip-test "No needed to test the snap pkg when it is coming from the repository" && exit 0
+        tests.exec skip-test "No need to test when the snapd pkg is from the repository and reexec is disabled" && exit 0
     fi
     snap pack test-snapd-epoch-1
     snap pack test-snapd-epoch-2

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -15,7 +15,7 @@ environment:
 
 prepare: |
     if [ "$SNAP_REEXEC" = "0" ] && tests.info is-snapd-from-archive; then
-        tests.exec skip-test "No needed to test the snap pkg when it is coming from the repository" && exit 0
+        tests.exec skip-test "No need to test when the snapd pkg is from the repository and reexec is disabled" && exit 0
     fi
 
     for snap in basic test-snapd-tools basic-desktop test-snapd-devmode snap-hooks-bad-install; do

--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -13,7 +13,7 @@ environment:
 
 prepare: |
     if [ "$SNAP_REEXEC" = "0" ] && tests.info is-snapd-from-archive; then
-        tests.exec skip-test "No needed to test the snap pkg when it is coming from the repository" && exit 0
+        tests.exec skip-test "No need to test when the snapd pkg is from the repository and reexec is disabled" && exit 0
     fi
     "$TESTSTOOLS"/snaps-state install-local basic-hooks
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -13,8 +13,8 @@ environment:
     USERNAME: home-sweet-home
 
 prepare: |
-    if tests.info is-snapd-from-archive; then
-        tests.exec skip-test "No needed to test the snap pkg when it is coming from the repository" && exit 0
+    if [[ "$SNAP_REEXEC" = "0" ]]  || tests.info is-snapd-from-archive; then
+        tests.exec skip-test "No need to test when either the snapd pkg is from the repository or reexec is disabled" && exit 0
     fi
 
     # Create a new user in a non-standard location

--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -13,9 +13,8 @@ environment:
     SNAP_REEXEC/reexec1: 1
 
 prepare: |
-    # No needed to test the snap pkg when it is coming from the repository
     if [ "$SNAP_REEXEC" = "0" ] && tests.info is-snapd-from-archive; then
-        tests.exec skip-test "No needed to test the snap pkg when it is coming from the repository" && exit 0
+        tests.exec skip-test "No need to test when the snapd pkg is from the repository and reexec is disabled" && exit 0
     fi
     snap pack data-writer
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"


### PR DESCRIPTION
The test is not applicable when re-exec is not enabled. Also improved multiple copies of the same "No needed" message.

This issue was discovered while testing with as part of snapd deb validation for Bionic:
SPREAD_SNAPD_DEB_FROM_REPO=false SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable spread -no-debug-output google:ubuntu-18.04-64:tests/main/snapd-homedirs-vendored.

It was confirmed relevant on master as well, if SPREAD_SNAP_REEXEC=0 as above.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34179