### PR TITLE
tests: set no-memory-limit for app armor tests

### DIFF
--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -37,6 +37,9 @@ environment:
 
     TIMEOUT: "30" # Define common timeout which can be modified as needed
 
+    # we unfortunately (frequently) run out of memory while setting up prompting-client
+    SNAPD_NO_MEMORY_LIMIT: 1
+
 prepare: |
     tests.session prepare -u test
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'


### PR DESCRIPTION
disable memory limit for app armor integration tests since they regularly exceed the 200MB limit