### PR TITLE
tests: prepare memory limit before each test

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -696,10 +696,13 @@ prepare_suite_each() {
         return 0
     fi
 
+    # shellcheck source=tests/lib/prepare.sh
+    . "$TESTSLIB"/prepare.sh
+    # Each individual task may potentially set the SNAP_NO_MEMORY_LIMIT variable
+    prepare_memory_limit_override
+
     if [[ "$variant" = full ]]; then
         if os.query is-classic; then
-            # shellcheck source=tests/lib/prepare.sh
-            . "$TESTSLIB"/prepare.sh
             prepare_each_classic
         fi
     fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -696,15 +696,15 @@ prepare_suite_each() {
         return 0
     fi
 
-    # shellcheck source=tests/lib/prepare.sh
-    . "$TESTSLIB"/prepare.sh
-    # Each individual task may potentially set the SNAP_NO_MEMORY_LIMIT variable
-    prepare_memory_limit_override
-
     if [[ "$variant" = full ]]; then
+        # shellcheck source=tests/lib/prepare.sh
+        . "$TESTSLIB"/prepare.sh
         if os.query is-classic; then
             prepare_each_classic
+        else
+            prepare_each_core
         fi
+        
     fi
 
     case "$SPREAD_SYSTEM" in

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -342,6 +342,13 @@ prepare_each_classic() {
     fi
 
     prepare_reexec_override
+    # Each individual task may potentially set the SNAP_NO_MEMORY_LIMIT variable
+    prepare_memory_limit_override
+}
+
+prepare_each_core() {
+    # Each individual task may potentially set the SNAP_NO_MEMORY_LIMIT variable
+    prepare_memory_limit_override
 }
 
 prepare_classic() {


### PR DESCRIPTION
Occasionally, the mount order regression test would get the oom-killer called due to an imposed memory limit. That memory limit was incorrect applied due to the prepare_memory_limit_override not being called in the prepare-each.