### PR TITLE
many: build and use ubuntu-core-initramfs package in spread tests

### DIFF
--- a/core-initrd/build-source-pkgs.sh
+++ b/core-initrd/build-source-pkgs.sh
@@ -1,15 +1,27 @@
 #!/bin/bash -exu
 
 # This scripts cleans-up the core-initrd subfolder and pulls all necessary bits
-# from snapd to create the ubuntu-core-initramfs source package for each
-# supported Ubuntu release. It is meant to be called inside the core-initrd
-# folder.
-
-git clean -ffdx
+# from snapd to create the ubuntu-core-initramfs source package for supported
+# Ubuntu releases. It is meant to be called inside the core-initrd folder.
+#
+# Usage:
+#
+# $ ./build-source-pkgs.sh <ubuntu_release1> ... <ubuntu_releaseN>
+# or
+# $ ./build-source-pkgs.sh
+#
+# to build all releases in the directory.
 
 # The current commit must be in the repo to be able to get the dependencies
 # of snap-bootstrap.
-commit=$(git rev-parse HEAD)
+if [ -n "${TEST_BUILD-}" ]; then
+    # code at this commit won't be actually used, but we need it to exist so go
+    # mod tidy runs properly
+    commit=master
+else
+    git clean -ffdx
+    commit=$(git rev-parse HEAD)
+fi
 
 # build info file
 pushd ..
@@ -24,10 +36,10 @@ contains_element() {
 }
 
 # Folder for snapd bits, that will be copied to all releases
-mkdir snapd-initramfs
+mkdir -p snapd-initramfs
 pushd snapd-initramfs
 ## snap-bootstrap
-mkdir cmd
+mkdir -p cmd
 # go commands do not follow symlinks, copy instead
 cp -a ../../cmd/snap-bootstrap/ cmd/
 cat << EOF > go.mod
@@ -37,13 +49,17 @@ go 1.18
 
 require	github.com/snapcore/snapd $commit
 EOF
+if [ -n "${TEST_BUILD-}" ]; then
+    # Use local code for test builds
+    printf "\nreplace github.com/snapcore/snapd => ../../\n" >> go.mod
+fi
 # solve dependencies
 go mod tidy
 # build vendor folder
 go mod vendor
 
 ## info and recovery trigger service
-mkdir snapd
+mkdir -p snapd
 cp ../../data/info snapd/
 sed 's#@libexecdir@#/usr/lib#' ../../data/systemd/snapd.recovery-chooser-trigger.service.in > \
     snapd/snapd.recovery-chooser-trigger.service
@@ -52,9 +68,12 @@ popd
 # Go through the different supported Ubuntu releases, creating source
 # packages for them.
 no_link=(debian go.mod go.sum cmd snapd vendor)
-for dir in */debian; do
-    rel=${dir%/debian}
-
+if [ "$#" -eq 0 ]; then
+    # If no explicit releases are given, build all releases in the directory
+    deb_dir=(*/debian)
+    set -- "${deb_dir[@]%/debian}"
+fi
+for rel; do
     if [ "$rel" != latest ]; then
         for p in latest/*; do
             file=${p#latest/}

--- a/spread.yaml
+++ b/spread.yaml
@@ -1231,6 +1231,8 @@ suites:
             . "$TESTSLIB"/pkgdb.sh
             #shellcheck source=tests/lib/image.sh
             . "$TESTSLIB"/image.sh
+            #shellcheck source=tests/lib/core-initrd.sh
+            . "$TESTSLIB"/core-initrd.sh
             distro_update_package_db
             distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1255,6 +1257,11 @@ suites:
 
             # Configure the ssh connection to the test vm
             remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
+
+            # Build and install initramfs package
+            if os.query is-ubuntu-ge 24.04; then
+                build_and_install_initramfs_deb
+            fi
         prepare-each: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
             tests.nested prepare
@@ -1357,6 +1364,8 @@ suites:
             . "$TESTSLIB"/pkgdb.sh
             #shellcheck source=tests/lib/image.sh
             . "$TESTSLIB"/image.sh
+            #shellcheck source=tests/lib/core-initrd.sh
+            . "$TESTSLIB"/core-initrd.sh
             distro_update_package_db
             distro_install_package snapd qemu-kvm qemu-utils genisoimage sshpass cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1375,6 +1384,11 @@ suites:
 
             # Configure the ssh connection to the test vm
             remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
+
+            # Build and install initramfs package
+            if os.query is-ubuntu-ge 24.04; then
+                build_and_install_initramfs_deb
+            fi
 
             tests.nested prepare
             tests.nested build-image core

--- a/tests/lib/core-initrd.sh
+++ b/tests/lib/core-initrd.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -ex
+
+# Builds and installs the ubuntu-core-initramfs package for the Ubuntu
+# release running in the system. Runs in subshell to prevent changes
+# of working directory on failures.
+build_and_install_initramfs_deb() (
+    pushd "$PROJECT_PATH"/core-initrd
+
+    # For dpkg-parsechangelog (used by mkversion.sh too) and to have
+    # the tools needed to build the source package.
+    quiet eatmydata apt-get install -y dpkg-dev debhelper
+    codename=$(lsb_release -c -s)
+    latest=$(dpkg-parsechangelog --file latest/debian/changelog --show-field Distribution)
+    if [ "$codename" = "$latest" ]; then
+        rel=latest
+    else
+        rel=$(lsb_release -r -s)
+    fi
+
+    # build source packages using local code
+    TEST_BUILD=1 ./build-source-pkgs.sh "$rel"
+
+    # build and install binary package
+
+    pushd "$rel"
+    quiet eatmydata apt-get build-dep -y ./
+    dpkg-buildpackage -tc -us -uc
+    popd
+
+    quiet eatmydata apt-get install -y ./ubuntu-core-initramfs_*.deb
+
+    popd
+)


### PR DESCRIPTION
Build and install the ubuntu-core-initramfs package from snapd repo
sources, and use it to build the initramfs on UC24+.