### PR TITLE
confdb,asserts,daemon: add confdb-control api

### DIFF
--- a/confdb/confdb_control.go
+++ b/confdb/confdb_control.go
@@ -91,58 +91,255 @@ type ViewRef struct {
 	View    string
 }
 
-// AddControlGroup adds the group to an operator under the given authentication.
-func (op *Operator) AddControlGroup(views, auth []string) error {
-	if len(auth) == 0 {
-		return errors.New(`cannot add group: "auth" must be a non-empty list`)
+// newViewRef parses account/confdb/view into ViewRef.
+func newViewRef(view string) (*ViewRef, error) {
+	viewPath := strings.Split(view, "/")
+	if len(viewPath) != 3 {
+		return nil, fmt.Errorf(`view "%s" must be in the format account/confdb/view`, view)
 	}
 
-	authentication, err := convertToAuthenticationMethods(auth)
+	account := viewPath[0]
+	if !validAccountID.MatchString(account) {
+		return nil, fmt.Errorf("invalid Account ID %s", account)
+	}
+
+	confdb := viewPath[1]
+	if !ValidConfdbName.MatchString(confdb) {
+		return nil, fmt.Errorf("invalid confdb name %s", confdb)
+	}
+
+	viewName := viewPath[2]
+	if !ValidViewName.MatchString(viewName) {
+		return nil, fmt.Errorf("invalid view name %s", viewName)
+	}
+
+	return &ViewRef{Account: account, Confdb: confdb, View: viewName}, nil
+}
+
+// String returns the string representation of the ViewRef.
+func (v *ViewRef) String() string {
+	return fmt.Sprintf("%s/%s/%s", v.Account, v.Confdb, v.View)
+}
+
+// compare compares two ViewRefs lexicographically based on their fields.
+// returning -1 if v < b, 0 if v == b, 1 if v > b.
+func (v *ViewRef) compare(b *ViewRef) int {
+	fields := [][2]string{{v.Account, b.Account}, {v.Confdb, b.Confdb}, {v.View, b.View}}
+	for _, pair := range fields {
+		if pair[0] != pair[1] {
+			if pair[0] < pair[1] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// groupWithView returns the group that holds the given view.
+func (op *Operator) groupWithView(view *ViewRef) (*ControlGroup, int) {
+	for _, group := range op.Groups {
+		n := len(group.Views)
+		idx := sort.Search(n, func(i int) bool {
+			return group.Views[i].compare(view) >= 0
+		})
+
+		if idx < n && group.Views[idx].compare(view) == 0 {
+			return group, idx
+		}
+	}
+	return nil, 0
+}
+
+// groupWithAuthentication returns the group with the given auth (sorted).
+func (op *Operator) groupWithAuthentication(auth []AuthenticationMethod) *ControlGroup {
+	for _, group := range op.Groups {
+		if len(group.Authentication) == len(auth) {
+			equal := true
+			for i := range auth {
+				if auth[i] != group.Authentication[i] {
+					equal = false
+					break
+				}
+			}
+			if equal {
+				return group
+			}
+		}
+	}
+	return nil
+}
+
+// IsDelegated checks if the view is delegated to the operator with the given auth.
+func (op *Operator) IsDelegated(view string, rawAuth []string) (bool, error) {
+	parsedView, err := newViewRef(view)
 	if err != nil {
-		return fmt.Errorf("cannot add group: %w", err)
+		return false, err
+	}
+
+	auth, err := convertToAuthenticationMethods(rawAuth)
+	if err != nil {
+		return false, err
+	}
+
+	group, _ := op.groupWithView(parsedView)
+	if group == nil {
+		return false, nil
+	}
+
+	// compare the auth with the group's auth using a linear scan since they're both sorted.
+	// if the expected auth is not a subset of the group's auth, then the view is not delegated.
+	i, j := 0, 0
+	for i < len(auth) && j < len(group.Authentication) {
+		if auth[i] == group.Authentication[j] {
+			i++
+			j++
+		} else if auth[i] > group.Authentication[j] {
+			j++
+		} else {
+			return false, nil
+		}
+	}
+	return i == len(auth), nil
+}
+
+// AddControlGroup adds the group to an operator under the given authentication.
+func (op *Operator) Delegate(views, rawAuth []string) error {
+	if len(rawAuth) == 0 {
+		return errors.New(`cannot delegate: "auth" must be a non-empty list`)
+	}
+
+	auth, err := convertToAuthenticationMethods(rawAuth)
+	if err != nil {
+		return fmt.Errorf("cannot delegate: %w", err)
 	}
 
 	if len(views) == 0 {
-		return errors.New(`cannot add group: "views" must be a non-empty list`)
+		return errors.New(`cannot delegate: "views" must be a non-empty list`)
 	}
 
-	parsedViews := []*ViewRef{}
 	for _, view := range views {
-		viewPath := strings.Split(view, "/")
-		if len(viewPath) != 3 {
-			return fmt.Errorf(`view "%s" must be in the format account/confdb/view`, view)
+		parsedView, err := newViewRef(view)
+		if err != nil {
+			return fmt.Errorf("cannot delegate: %w", err)
 		}
-
-		account := viewPath[0]
-		if !validAccountID.MatchString(account) {
-			return fmt.Errorf("invalid Account ID %s", account)
-		}
-
-		confdb := viewPath[1]
-		if !ValidConfdbName.MatchString(confdb) {
-			return fmt.Errorf("invalid confdb name %s", confdb)
-		}
-
-		viewName := viewPath[2]
-		if !ValidViewName.MatchString(viewName) {
-			return fmt.Errorf("invalid view name %s", viewName)
-		}
-
-		parsedView := &ViewRef{
-			Account: account,
-			Confdb:  confdb,
-			View:    viewName,
-		}
-		parsedViews = append(parsedViews, parsedView)
+		op.delegateOne(parsedView, auth)
 	}
 
-	group := &ControlGroup{
-		Authentication: authentication,
-		Views:          parsedViews,
-	}
-	op.Groups = append(op.Groups, group)
-
+	op.compact()
 	return nil
+}
+
+// delegateOne grants remote control to the view.
+func (op *Operator) delegateOne(view *ViewRef, auth []AuthenticationMethod) {
+	newAuth := auth
+	existingGroup, idx := op.groupWithView(view)
+	if existingGroup != nil {
+		newAuth = append(newAuth, existingGroup.Authentication...)
+		sort.Slice(newAuth, func(i, j int) bool {
+			return newAuth[i] < newAuth[j]
+		})
+		newAuth = unique(newAuth)
+	}
+
+	newGroup := op.groupWithAuthentication(newAuth)
+	if existingGroup == newGroup && existingGroup != nil {
+		return // already delegated, nothing to do
+	}
+
+	if newGroup == nil {
+		newGroup = &ControlGroup{Authentication: newAuth, Views: []*ViewRef{view}}
+		op.Groups = append(op.Groups, newGroup)
+	} else {
+		newGroup.Views = append(newGroup.Views, view)
+		sort.Slice(newGroup.Views, func(i, j int) bool {
+			return newGroup.Views[i].compare(newGroup.Views[j]) < 0
+		})
+	}
+
+	if existingGroup != nil {
+		// remove the view from the group
+		existingGroup.Views = append(existingGroup.Views[:idx], existingGroup.Views[idx+1:]...)
+	}
+}
+
+// Revoke withdraws remote access to the views that have been delegated with the given auth.
+func (op *Operator) Revoke(views []string, rawAuth []string) error {
+	var err error
+	var auth []AuthenticationMethod
+	if len(rawAuth) == 0 {
+		// if no authentication is provided, revoke all auth methods
+		auth = []AuthenticationMethod{OperatorKey, Store}
+	} else {
+		auth, err = convertToAuthenticationMethods(rawAuth)
+		if err != nil {
+			return fmt.Errorf("cannot revoke: %w", err)
+		}
+	}
+
+	var parsedViews []*ViewRef
+	if len(views) == 0 {
+		// if no views are provided, revoke access to all views
+		for _, group := range op.Groups {
+			parsedViews = append(parsedViews, group.Views...)
+		}
+	} else {
+		for _, view := range views {
+			parsedView, err := newViewRef(view)
+			if err != nil {
+				return fmt.Errorf("cannot revoke: %w", err)
+			}
+			parsedViews = append(parsedViews, parsedView)
+		}
+	}
+
+	for _, view := range parsedViews {
+		op.revokeOne(view, auth)
+	}
+
+	op.compact()
+	return nil
+}
+
+// revokeOne revokes remote control over the view.
+func (op *Operator) revokeOne(view *ViewRef, revokedAuth []AuthenticationMethod) {
+	group, idx := op.groupWithView(view)
+	if group == nil {
+		return // not delegated, nothing to do
+	}
+
+	remaining := make([]AuthenticationMethod, 0, len(group.Authentication))
+	for _, existingAuth := range group.Authentication {
+		revoked := false
+		for _, a := range revokedAuth {
+			if a == existingAuth {
+				revoked = true
+				break
+			}
+		}
+		if !revoked {
+			remaining = append(remaining, existingAuth)
+		}
+	}
+
+	// remove the view from the group
+	group.Views = append(group.Views[:idx], group.Views[idx+1:]...)
+
+	if len(remaining) > 0 {
+		op.delegateOne(view, remaining) // delegate with remaining auth methods
+	}
+}
+
+// compact removes empty groups.
+func (op *Operator) compact() {
+	groups := make([]*ControlGroup, 0, len(op.Groups))
+	for _, group := range op.Groups {
+		if len(group.Views) != 0 {
+			groups = append(groups, group)
+		}
+	}
+
+	op.Groups = groups
 }
 
 // unique replaces consecutive runs of equal elements with a single copy.

--- a/confdb/confdb_control_test.go
+++ b/confdb/confdb_control_test.go
@@ -48,27 +48,102 @@ func (s *confdbCtrlSuite) TestConvertToAuthenticationMethods(c *C) {
 	c.Assert(converted, DeepEquals, expected)
 }
 
-func (s *confdbCtrlSuite) TestAddGroupOK(c *C) {
-	operator := confdb.Operator{ID: "canonical"}
+func (s *confdbCtrlSuite) TestCompareViewRef(c *C) {
+	observeDevice := confdb.ViewRef{Account: "canonical", Confdb: "device", View: "observe-device"}
+	controlDevice := confdb.ViewRef{Account: "canonical", Confdb: "device", View: "control-device"}
+	observeInterface := confdb.ViewRef{Account: "canonical", Confdb: "network", View: "observe-interface"}
+	controlConfig := confdb.ViewRef{Account: "system", Confdb: "telemetry", View: "control-config"}
 
-	views := []string{"canonical/network/control-device", "canonical/network/observe-device"}
-	auth := []string{"operator-key", "store"}
-	err := operator.AddControlGroup(views, auth)
-	c.Assert(err, IsNil)
-	c.Assert(len(operator.Groups), Equals, 1)
+	type testcase struct {
+		a      confdb.ViewRef
+		b      confdb.ViewRef
+		result int
+	}
+	tcs := []testcase{
+		{a: observeDevice, b: observeDevice, result: 0},
+		{a: observeDevice, b: controlDevice, result: 1},
+		{a: controlDevice, b: observeDevice, result: -1},
+		{a: observeInterface, b: controlDevice, result: 1},
+		{a: controlDevice, b: observeInterface, result: -1},
+		{a: controlConfig, b: controlDevice, result: 1},
+		{a: controlDevice, b: controlConfig, result: -1},
+	}
+	for i, tc := range tcs {
+		result := tc.a.Compare(&tc.b)
+		c.Assert(result, Equals, tc.result, Commentf("test number %d", i+1))
+	}
+}
 
-	g := operator.Groups[0]
+func (s *confdbCtrlSuite) TestGroupWithView(c *C) {
+	op := confdb.Operator{ID: "canonical"}
+	op.Delegate(
+		[]string{"canonical/network/control-interface", "canonical/network/observe-interface"},
+		[]string{"operator-key"},
+	)
+	op.Delegate(
+		[]string{"canonical/network/control-device", "canonical/network/observe-device"},
+		[]string{"store"},
+	)
+
+	group, idx := op.GroupWithView(&confdb.ViewRef{
+		Account: "canonical", Confdb: "network", View: "control-interface",
+	})
+	c.Assert(group, Equals, op.Groups[0])
+	c.Assert(idx, Equals, 0)
+
+	group, idx = op.GroupWithView(&confdb.ViewRef{
+		Account: "canonical", Confdb: "network", View: "observe-device",
+	})
+	c.Assert(group, Equals, op.Groups[1])
+	c.Assert(idx, Equals, 1)
+}
+
+func (s *confdbCtrlSuite) TestGroupWithAuthentication(c *C) {
+	op := confdb.Operator{ID: "canonical"}
+	op.Delegate([]string{"canonical/network/control-interface"}, []string{"operator-key"})
+	op.Delegate([]string{"canonical/network/observe-device"}, []string{"store"})
+	op.Delegate([]string{"canonical/network/observe-interface"}, []string{"store", "operator-key"})
+
+	group := op.GroupWithAuthentication([]confdb.AuthenticationMethod{confdb.OperatorKey})
+	c.Assert(group, Equals, op.Groups[0])
+
+	group = op.GroupWithAuthentication([]confdb.AuthenticationMethod{confdb.Store})
+	c.Assert(group, Equals, op.Groups[1])
+
+	group = op.GroupWithAuthentication([]confdb.AuthenticationMethod{confdb.OperatorKey, confdb.Store})
+	c.Assert(group, Equals, op.Groups[2])
+}
+
+func (s *confdbCtrlSuite) TestDelegateOK(c *C) {
+	op := confdb.Operator{ID: "canonical"}
+	op.Delegate(
+		[]string{"canonical/network/control-device", "canonical/network/observe-device"},
+		[]string{"operator-key"},
+	)
+	op.Delegate(
+		[]string{"canonical/network/control-device", "canonical/network/observe-device"},
+		[]string{"operator-key", "store"},
+	)
+
 	expectedViews := []*confdb.ViewRef{
 		{Account: "canonical", Confdb: "network", View: "control-device"},
 		{Account: "canonical", Confdb: "network", View: "observe-device"},
 	}
-	c.Assert(g.Views, DeepEquals, expectedViews)
+	c.Assert(op.Groups[0].Views, DeepEquals, expectedViews)
 	expectedAuth := []confdb.AuthenticationMethod{confdb.OperatorKey, confdb.Store}
-	c.Assert(g.Authentication, DeepEquals, expectedAuth)
+	c.Assert(op.Groups[0].Authentication, DeepEquals, expectedAuth)
+
+	// test idempotency
+	err := op.Delegate([]string{"canonical/network/control-device"}, []string{"operator-key", "store"})
+	c.Assert(err, IsNil)
+	c.Assert(len(op.Groups), Equals, 1)
+
+	delegated, _ := op.IsDelegated("canonical/network/control-device", []string{"store"})
+	c.Check(delegated, Equals, true)
 }
 
-func (s *confdbCtrlSuite) TestAddGroupFail(c *C) {
-	operator := confdb.Operator{ID: "canonical"}
+func (s *confdbCtrlSuite) TestDelegateFail(c *C) {
+	op := confdb.Operator{ID: "canonical"}
 
 	type testcase struct {
 		views []string
@@ -76,45 +151,141 @@ func (s *confdbCtrlSuite) TestAddGroupFail(c *C) {
 		err   string
 	}
 	tcs := []testcase{
-		{err: `cannot add group: "auth" must be a non-empty list`},
-		{auth: []string{"magic"}, err: "cannot add group: invalid authentication method: magic"},
-		{auth: []string{"store"}, err: `cannot add group: "views" must be a non-empty list`},
+		{err: `cannot delegate: "auth" must be a non-empty list`},
+		{auth: []string{"magic"}, err: "cannot delegate: invalid authentication method: magic"},
+		{auth: []string{"store"}, err: `cannot delegate: "views" must be a non-empty list`},
 		{
 			views: []string{"a/b/c/d"},
 			auth:  []string{"store"},
-			err:   `view "a/b/c/d" must be in the format account/confdb/view`,
+			err:   `cannot delegate: view "a/b/c/d" must be in the format account/confdb/view`,
 		},
 		{
 			views: []string{"a/b"},
 			auth:  []string{"store"},
-			err:   `view "a/b" must be in the format account/confdb/view`,
+			err:   `cannot delegate: view "a/b" must be in the format account/confdb/view`,
 		},
 		{
 			views: []string{"ab/"},
 			auth:  []string{"store"},
-			err:   `view "ab/" must be in the format account/confdb/view`,
+			err:   `cannot delegate: view "ab/" must be in the format account/confdb/view`,
 		},
 		{
 			views: []string{"@foo/network/control-device"},
 			auth:  []string{"store"},
-			err:   "invalid Account ID @foo",
+			err:   "cannot delegate: invalid Account ID @foo",
 		},
 		{
 			views: []string{"canonical/123/control-device"},
 			auth:  []string{"store"},
-			err:   "invalid confdb name 123",
+			err:   "cannot delegate: invalid confdb name 123",
 		},
 		{
 			views: []string{"canonical/network/_view"},
 			auth:  []string{"store"},
-			err:   "invalid view name _view",
+			err:   "cannot delegate: invalid view name _view",
 		},
 	}
 
 	for i, tc := range tcs {
 		cmt := Commentf("test number %d", i+1)
-		err := operator.AddControlGroup(tc.views, tc.auth)
-		c.Assert(err, NotNil)
+		err := op.Delegate(tc.views, tc.auth)
+		c.Assert(err, NotNil, cmt)
 		c.Assert(err, ErrorMatches, tc.err, cmt)
 	}
+}
+
+func (s *confdbCtrlSuite) TestRevokeOK(c *C) {
+	op := confdb.Operator{ID: "john"}
+	err := op.Delegate(
+		[]string{"canonical/network/control-interface", "canonical/network/observe-interface"},
+		[]string{"operator-key", "store"},
+	)
+	c.Assert(err, IsNil)
+
+	op.Revoke([]string{"canonical/network/control-interface"}, []string{"operator-key"})
+	delegated, err := op.IsDelegated("canonical/network/control-interface", []string{"operator-key"})
+	c.Check(err, IsNil)
+	c.Check(delegated, Equals, false)
+
+	// revoke non-existing view
+	err = op.Revoke([]string{"canonical/network/unknown"}, []string{"operator-key"})
+	c.Check(err, IsNil)
+
+	// revoke all auth
+	err = op.Delegate(
+		[]string{"canonical/network/observe-interface", "canonical/network/control-vpn"},
+		[]string{"store", "operator-key"},
+	)
+	c.Assert(err, IsNil)
+
+	err = op.Revoke(nil, nil)
+	c.Assert(err, IsNil)
+
+	delegated, err = op.IsDelegated("canonical/network/observe-interface", []string{"operator-key"})
+	c.Check(err, IsNil)
+	c.Check(delegated, Equals, false)
+
+	delegated, err = op.IsDelegated("canonical/network/observe-interface", []string{"store"})
+	c.Check(err, IsNil)
+	c.Check(delegated, Equals, false)
+}
+
+func (s *confdbCtrlSuite) TestRevokeFail(c *C) {
+	op := confdb.Operator{ID: "canonical"}
+
+	type testcase struct {
+		views []string
+		auth  []string
+		err   string
+	}
+	tcs := []testcase{
+		{auth: []string{"magic"}, err: "cannot revoke: invalid authentication method: magic"},
+		{
+			views: []string{"invalid"},
+			auth:  []string{"store"},
+			err:   `cannot revoke: view "invalid" must be in the format account/confdb/view`,
+		},
+	}
+
+	for i, tc := range tcs {
+		cmt := Commentf("test number %d", i+1)
+		err := op.Revoke(tc.views, tc.auth)
+		c.Assert(err, NotNil, cmt)
+		c.Assert(err, ErrorMatches, tc.err, cmt)
+	}
+}
+
+func (s *confdbCtrlSuite) TestIsDelegatedFail(c *C) {
+	op := confdb.Operator{ID: "canonical"}
+
+	type testcase struct {
+		view string
+		auth []string
+		err  string
+	}
+	tcs := []testcase{
+		{
+			view: "invalid",
+			auth: []string{"store"},
+			err:  `view "invalid" must be in the format account/confdb/view`,
+		},
+		{
+			view: "canonical/network/control-device",
+			auth: []string{"magic"},
+			err:  "invalid authentication method: magic",
+		},
+	}
+
+	for i, tc := range tcs {
+		cmt := Commentf("test number %d", i+1)
+		delegated, err := op.IsDelegated(tc.view, tc.auth)
+		c.Assert(err, NotNil, cmt)
+		c.Assert(err, ErrorMatches, tc.err, cmt)
+		c.Assert(delegated, Equals, false, cmt)
+	}
+}
+
+func (s *confdbCtrlSuite) TestViewRefString(c *C) {
+	view := confdb.ViewRef{Account: "canonical", Confdb: "network", View: "control-device"}
+	c.Assert(view.String(), Equals, "canonical/network/control-device")
 }

--- a/confdb/export_test.go
+++ b/confdb/export_test.go
@@ -34,3 +34,18 @@ var IsValidAuthenticationMethod = isValidAuthenticationMethod
 
 // convertToAuthenticationMethods exposed for tests
 var ConvertToAuthenticationMethods = convertToAuthenticationMethods
+
+// groupWithView exposed for tests
+func (o *Operator) GroupWithView(view *ViewRef) (*ControlGroup, int) {
+	return o.groupWithView(view)
+}
+
+// groupWithAuthentication exposed for tests
+func (o *Operator) GroupWithAuthentication(auth []AuthenticationMethod) *ControlGroup {
+	return o.groupWithAuthentication(auth)
+}
+
+// compare exposed for tests
+func (v *ViewRef) Compare(b *ViewRef) int {
+	return v.compare(b)
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/strutil"
@@ -83,6 +84,7 @@ var api = []*Command{
 	quotaGroupsCmd,
 	quotaGroupInfoCmd,
 	confdbCmd,
+	confdbControlCmd,
 	noticesCmd,
 	noticeCmd,
 	requestsPromptsCmd,
@@ -176,6 +178,8 @@ var (
 	confdbstateGetTransaction = confdbstate.GetTransactionToModify
 	confdbstateGet            = confdbstate.Get
 	confdbstateSetViaView     = confdbstate.SetViaView
+
+	devicestateSignConfdbControl = (*devicestate.DeviceManager).SignConfdbControl
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -24,10 +24,13 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -40,6 +43,11 @@ var (
 		ReadAccess:  authenticatedAccess{Polkit: polkitActionManage},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
+	confdbControlCmd = &Command{
+		Path:        "/v2/confdbs",
+		POST:        handleConfdbControlAction,
+		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
+	}
 )
 
 func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
@@ -47,7 +55,7 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	if err := validateConfdbFeatureFlag(st); err != nil {
+	if err := validateFeatureFlag(st, features.Confdbs); err != nil {
 		return err
 	}
 
@@ -73,7 +81,7 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	if err := validateConfdbFeatureFlag(st); err != nil {
+	if err := validateFeatureFlag(st, features.Confdbs); err != nil {
 		return err
 	}
 
@@ -122,16 +130,97 @@ func toAPIError(err error) *apiError {
 	}
 }
 
-func validateConfdbFeatureFlag(st *state.State) *apiError {
+func validateFeatureFlag(st *state.State, feature features.SnapdFeature) *apiError {
 	tr := config.NewTransaction(st)
-	enabled, err := features.Flag(tr, features.Confdbs)
+	enabled, err := features.Flag(tr, feature)
 	if err != nil && !config.IsNoOption(err) {
-		return InternalError(fmt.Sprintf("internal error: cannot check confdbs feature flag: %s", err))
+		return InternalError(
+			fmt.Sprintf("internal error: cannot check %s feature flag: %s", feature.String(), err),
+		)
 	}
 
 	if !enabled {
-		_, confName := features.Confdbs.ConfigOption()
-		return BadRequest(fmt.Sprintf(`"confdbs" feature flag is disabled: set '%s' to true`, confName))
+		_, confName := feature.ConfigOption()
+		return BadRequest(
+			fmt.Sprintf(`"%s" feature flag is disabled: set '%s' to true`, feature.String(), confName),
+		)
 	}
 	return nil
+}
+
+type confdbControlAction struct {
+	Action         string   `json:"action"`
+	OperatorID     string   `json:"operator-id"`
+	Authentication []string `json:"authentication"`
+	Views          []string `json:"views"`
+}
+
+func handleConfdbControlAction(c *Command, r *http.Request, user *auth.UserState) Response {
+	st := c.d.state
+	st.Lock()
+	defer st.Unlock()
+
+	if err := validateFeatureFlag(st, features.Confdbs); err != nil {
+		return err
+	}
+	if err := validateFeatureFlag(st, features.ConfdbControl); err != nil {
+		return err
+	}
+
+	devMgr := c.d.overlord.DeviceManager()
+	cc, err := getOrCreateConfdbControl(st, devMgr)
+	if err != nil {
+		return InternalError(err.Error())
+	}
+
+	var a confdbControlAction
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&a); err != nil {
+		return BadRequest("cannot decode request body: %v", err)
+	}
+
+	switch a.Action {
+	case "delegate":
+		err = cc.Delegate(a.OperatorID, a.Views, a.Authentication)
+	case "revoke":
+		err = cc.Revoke(a.OperatorID, a.Views, a.Authentication)
+	default:
+		return BadRequest("unknown action %q", a.Action)
+	}
+	if err != nil {
+		return BadRequest(err.Error())
+	}
+
+	cc, err = devicestateSignConfdbControl(devMgr, cc.Groups(), cc.Revision()+1)
+	if err != nil {
+		return InternalError(err.Error())
+	}
+
+	if err := assertstate.Add(st, cc); err != nil {
+		return InternalError(err.Error())
+	}
+
+	return SyncResponse(nil)
+}
+
+func getOrCreateConfdbControl(st *state.State, devMgr *devicestate.DeviceManager) (*asserts.ConfdbControl, error) {
+	serial, err := devMgr.Serial()
+	if err != nil {
+		return nil, errors.New("device has no serial assertion")
+	}
+
+	db := assertstate.DB(st)
+	a, err := db.Find(asserts.ConfdbControlType, map[string]string{
+		"brand-id": serial.BrandID(),
+		"model":    serial.Model(),
+		"serial":   serial.Serial(),
+	})
+	if errors.Is(err, &asserts.NotFoundError{}) {
+		return asserts.NewConfdbControl(serial), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return a.(*asserts.ConfdbControl), nil
 }

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -24,16 +24,24 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
+	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -620,4 +628,244 @@ func (s *confdbSuite) TestGetNoFields(c *C) {
 	rspe := s.syncReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 200)
 	c.Check(rspe.Result, DeepEquals, value)
+}
+
+type confdbControlSuite struct {
+	apiBaseSuite
+
+	st     *state.State
+	brands *assertstest.SigningAccounts
+	serial *asserts.Serial
+}
+
+var _ = Suite(&confdbControlSuite{})
+
+var (
+	deviceKey, _ = assertstest.GenerateKey(752)
+)
+
+func (s *confdbControlSuite) SetUpTest(c *C) {
+	s.apiBaseSuite.SetUpTest(c)
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
+
+	s.st = state.New(nil)
+	o := overlord.MockWithState(s.st)
+	s.d = daemon.NewWithOverlord(o)
+
+	hookMgr, err := hookstate.Manager(s.st, o.TaskRunner())
+	c.Assert(err, check.IsNil)
+
+	deviceMgr, err := devicestate.Manager(s.st, hookMgr, o.TaskRunner(), nil)
+	c.Assert(err, check.IsNil)
+	o.AddManager(deviceMgr)
+
+	assertMgr, err := assertstate.Manager(s.st, o.TaskRunner())
+	c.Assert(err, check.IsNil)
+	o.AddManager(assertMgr)
+
+	storeStack := assertstest.NewStoreStack("can0nical", nil)
+	s.brands = assertstest.NewSigningAccounts(storeStack)
+}
+
+func (s *confdbControlSuite) setFeatureFlag(c *C, confName string) {
+	s.st.Lock()
+	tr := config.NewTransaction(s.st)
+	err := tr.Set("core", confName, true)
+	c.Assert(err, IsNil)
+	tr.Commit()
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) prereqs(c *C) {
+	s.setFeatureFlag(c, "experimental.confdbs")
+	s.setFeatureFlag(c, "experimental.confdb-control")
+
+	s.st.Lock()
+	encDevKey, _ := asserts.EncodePublicKey(deviceKey.PublicKey())
+	a, err := s.brands.Signing("can0nical").Sign(asserts.SerialType, map[string]interface{}{
+		"brand-id":            "can0nical",
+		"model":               "generic-classic",
+		"serial":              "serial-serial",
+		"device-key":          string(encDevKey),
+		"device-key-sha3-384": deviceKey.PublicKey().ID(),
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	err = assertstate.Add(s.st, a)
+	c.Assert(err, IsNil)
+	s.serial = a.(*asserts.Serial)
+
+	devicestatetest.SetDevice(s.st, &auth.DeviceState{
+		Brand: "can0nical", Model: "generic-classic", Serial: "serial-serial",
+	})
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) TestConfdbFlagNotEnabled(c *C) {
+	req, err := http.NewRequest("POST", "/v2/confdbs", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 400)
+	c.Check(rspe.Message, Equals, `"confdbs" feature flag is disabled: set 'experimental.confdbs' to true`)
+}
+
+func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
+	s.setFeatureFlag(c, "experimental.confdbs")
+
+	req, err := http.NewRequest("POST", "/v2/confdbs", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 400)
+	c.Check(rspe.Message, Equals, `"confdb-control" feature flag is disabled: set 'experimental.confdb-control' to true`)
+}
+
+func (s *confdbSuite) TestValidateFeatureFlagErr(c *C) {
+	s.st.Lock()
+	tr := config.NewTransaction(s.st)
+	tr.Set("core", "experimental.confdb-control", "wut")
+	tr.Commit()
+
+	err := daemon.ValidateFeatureFlag(s.st, features.ConfdbControl)
+	c.Check(
+		err.Message, Equals,
+		`internal error: cannot check confdb-control feature flag: confdb-control can only be set to 'true' or 'false', got "wut"`,
+	)
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionNoSerial(c *C) {
+	s.setFeatureFlag(c, "experimental.confdbs")
+	s.setFeatureFlag(c, "experimental.confdb-control")
+
+	req, err := http.NewRequest("POST", "/v2/confdbs", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 500)
+	c.Check(rspe.Message, Equals, "device has no serial assertion")
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionOK(c *C) {
+	s.prereqs(c)
+	jane := map[string]interface{}{
+		"operator-id":    "jane",
+		"authentication": []interface{}{"store"},
+		"views":          []interface{}{"account/confdb/view"},
+	}
+	restore := daemon.MockDeviceStateSignConfdbControl(func(m *devicestate.DeviceManager, groups []interface{}, revision int) (*asserts.ConfdbControl, error) {
+		a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]interface{}{
+			"brand-id": "can0nical",
+			"model":    "generic-classic",
+			"serial":   "serial-serial",
+			"groups":   []interface{}{jane},
+		}, nil, deviceKey)
+		c.Assert(err, IsNil)
+		return a.(*asserts.ConfdbControl), nil
+	})
+	defer restore()
+
+	body := `{"action": "delegate", "operator-id": "jane", "authentication": ["store"], "views": ["account/confdb/view"]}`
+	req, err := http.NewRequest("POST", "/v2/confdbs", bytes.NewBufferString(body))
+	c.Assert(err, IsNil)
+	s.asUserAuth(c, req)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 200)
+	c.Check(rsp.Result, DeepEquals, nil)
+
+	s.st.Lock()
+	a, err := assertstate.DB(s.st).Find(
+		asserts.ConfdbControlType,
+		map[string]string{"brand-id": "can0nical", "model": "generic-classic", "serial": "serial-serial"},
+	)
+	c.Assert(err, IsNil)
+	cc := a.(*asserts.ConfdbControl)
+	c.Check(cc.Groups(), DeepEquals, []interface{}{jane})
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionSigningErr(c *C) {
+	s.prereqs(c)
+
+	body := `{"action": "delegate", "operator-id": "jane", "authentication": ["store"], "views": ["account/confdb/view"]}`
+	req, err := http.NewRequest("POST", "/v2/confdbs", bytes.NewBufferString(body))
+	c.Assert(err, IsNil)
+	s.asUserAuth(c, req)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 500)
+	c.Check(rspe.Message, Equals, "cannot sign confdb-control without device key")
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionAckErr(c *C) {
+	s.prereqs(c)
+	restore := daemon.MockDeviceStateSignConfdbControl(func(m *devicestate.DeviceManager, groups []interface{}, revision int) (*asserts.ConfdbControl, error) {
+		return asserts.NewConfdbControl(s.serial), nil //  return unsigned assertion
+	})
+	defer restore()
+
+	s.st.Lock()
+	jane := map[string]interface{}{
+		"operator-id":    "jane",
+		"authentication": []interface{}{"store"},
+		"views":          []interface{}{"account/confdb/view"},
+	}
+	a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]interface{}{
+		"brand-id": "can0nical",
+		"model":    "generic-classic",
+		"serial":   "serial-serial",
+		"groups":   []interface{}{jane},
+	}, nil, deviceKey)
+	c.Assert(err, IsNil)
+	assertstate.Add(s.st, a)
+	s.st.Unlock()
+
+	body := `{"action": "revoke", "operator-id": "jane", "authentication": ["store"]}`
+	req, err := http.NewRequest("POST", "/v2/confdbs", bytes.NewBufferString(body))
+	c.Assert(err, IsNil)
+	s.asUserAuth(c, req)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 500)
+	c.Check(
+		rspe.Message,
+		Equals,
+		`cannot check no-authority assertion type "confdb-control": confdb-control's signing key doesn't match the device key`,
+	)
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionInvalidRequest(c *C) {
+	s.prereqs(c)
+
+	type testcase struct {
+		body   string
+		errMsg string
+	}
+	tcs := []testcase{
+		{
+			body:   "}",
+			errMsg: "cannot decode request body: invalid character '}' looking for beginning of value",
+		},
+		{
+			body:   `{"action": "unknown", "operator-id": "jane"}`,
+			errMsg: `unknown action "unknown"`,
+		},
+		{
+			body:   `{"action": "delegate", "operator-id": "jane", "authentication": ["unknown"]}`,
+			errMsg: "cannot delegate: invalid authentication method: unknown",
+		},
+	}
+
+	for _, tc := range tcs {
+		req, err := http.NewRequest("POST", "/v2/confdbs", bytes.NewBufferString(tc.body))
+		c.Assert(err, IsNil)
+		s.asUserAuth(c, req)
+
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, Equals, 400)
+		c.Check(rspe.Message, Equals, tc.errMsg)
+	}
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -26,14 +26,17 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/confdb"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/confdbstate"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -431,4 +434,12 @@ func MockConfdbstateSetViaView(f func(confdb.DataBag, *confdb.View, map[string]i
 
 func MockAssertstateFetchAllValidationSets(f func(*state.State, int, *assertstate.RefreshAssertionsOptions) error) (restore func()) {
 	return testutil.Mock(&assertstateFetchAllValidationSets, f)
+}
+
+func MockDeviceStateSignConfdbControl(f func(m *devicestate.DeviceManager, groups []interface{}, revision int) (*asserts.ConfdbControl, error)) (restore func()) {
+	return testutil.Mock(&devicestateSignConfdbControl, f)
+}
+
+func ValidateFeatureFlag(st *state.State, feature features.SnapdFeature) *apiError {
+	return validateFeatureFlag(st, feature)
 }


### PR DESCRIPTION
This PR introduces the confdb-control API to snapd.

Please do not review just yet. Awaiting:

- [x] https://github.com/canonical/snapd/pull/14723
- [ ] Final approval on the spec _(I don't expect much to change given how the last design session went)_