### PR TITLE
tests: disable memory limit for aux-info

### DIFF
--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -7,6 +7,10 @@ details: |
 
 systems: [ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 
+environment:
+    # we unfortunately run out of memory while setting up the snap-store
+    SNAPD_NO_MEMORY_LIMIT: 1
+
 prepare: |
   snap install snap-store
 


### PR DESCRIPTION
The oom-killer gets somewhat regularly called during the snap-store setup. This disables the memory limit.