### PR TITLE
interfaces/builtin/cpu-control: Add read access to /sys/kernel/irq/<IRQ>

### DIFF
--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -84,6 +84,7 @@ const cpuControlConnectedPlugAppArmor = `
 /dev/cpu_dma_latency rw,
 
 # Allow interrupt affinity settings, see https://www.kernel.org/doc/html/latest/core-api/irq/irq-affinity.html
+/sys/kernel/irq/[0-9]*/* r,
 /proc/interrupts r,
 /proc/irq/[0-9]+/smp_affinity rw,
 /proc/irq/[0-9]+/smp_affinity_list rw,


### PR DESCRIPTION
* The contents available on `/sys/kernel/irq/<IRQnum>` are the same as those available on `/proc/interrupts` the difference is that on the `sysfs` directory they are present in a more machine-readable form.

  On this directory, usually it's found:

  - `actions`: Which is the string name of the IRQ, found on the last column of `/proc/interrupts`;
  - `chip_name`: Found The first column right after the CPUs columns;
  - `hwirq`: The IRQ number itself;
  - `name`: A string that usually represents the `type` of IRQ;
  - `per_cpu_count`: This is the data for all CPUs columns of `/proc/interrupts`;
  - `type`: Differentiates between an IO-APIC-edge and IO-APIC-fasteoi interrupt handling modes. Found on the last but one column of `/proc/interrupts`;
  - `wakeup`: Informs if the given IRQ is capable of waking the system from certain low-power states.

* Complements: https://github.com/canonical/snapd/pull/14424


Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
