### PR TITLE
interfaces/seccomp/template: allow epoll_pwait2 in the base template

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -135,6 +135,7 @@ epoll_create1
 epoll_ctl
 epoll_ctl_old
 epoll_pwait
+epoll_pwait2
 epoll_wait
 epoll_wait_old
 eventfd


### PR DESCRIPTION
Add epoll_pwait2 in the base template. The syscall has been available since 5.11 (early 2021).

Reported in the forum: https://forum.snapcraft.io/t/epoll-works-on-core20-but-fails-on-core22/44347

Some context: https://kernelnewbies.org/Linux_5.11#Add_epoll_pwait2.282.29_syscall_for_higher_resolution_waits

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
