### PR TITLE
tests: ensure chrony syncs time before tests

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -491,6 +491,13 @@ prepare_classic() {
         mkdir -p /etc/dbus-1/system.d
         systemctl reload dbus.service
     fi
+
+    # on Xenial chrony wasn't always running which means there was no NTP sync
+    # which breaks auto-refresh tests (we wait for a sync before auto-refreshing)
+    if systemctl status chrony &>/dev/null && ! timeout 15s chronyc waitsync; then
+      systemctl restart chrony
+      timeout 3m chronyc waitsync
+    fi
 }
 
 ensure_snapcraft() {


### PR DESCRIPTION
This fixes tests running on 16.04 that rely on forcing auto-refreshes. These were failing because on Xenial chrony would sometimes exit without synchronizing time (unsure why at the moment). Since the auto-refresh manager waits for an NTP sync (times out after a while but too late for testing purposes), the auto-refreshes were never triggered and the tests failed.

```
- google:ubuntu-16.04-64:tests/main/auto-refresh-backoff
- google:ubuntu-16.04-64:tests/main/auto-refresh-gating-from-snap
- google:ubuntu-16.04-64:tests/main/auto-refresh-pre-download:close
- google:ubuntu-16.04-64:tests/main/auto-refresh-pre-download:close_mid_restart
- google:ubuntu-16.04-64:tests/main/auto-refresh-pre-download:ignore
- google:ubuntu-16.04-64:tests/main/auto-refresh-retry
- google:ubuntu-16.04-64:tests/main/auto-refresh:regular
- google:ubuntu-16.04-64:tests/main/snap-refresh-hold
- google:ubuntu-16.04-64:tests/main/snapd-state
```