### PR TITLE
tests: change main rule so that changes in nested tests won't run main

### DIFF
--- a/tests/lib/spread/rules/main.yaml
+++ b/tests/lib/spread/rules/main.yaml
@@ -19,6 +19,11 @@ rules:
      - tests/unit/c-unit-tests-clang
      - tests/unit/c-unit-tests-gcc
 
+  nested:
+    from:
+      - tests/nested/.*
+    to: [$NONE]
+
   rest:
     from: [.*]
     to: [tests/]


### PR DESCRIPTION
This maps anything under `tests/nested` to nothing. With this change, in future PRs, if the PR's only change is a nested test, the non-nested systems will not run any tests.

Here's the change to the main.yaml rule file in action:
```
$ python3 tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/main.yaml -p google::ubuntu-24.04-64 -c tests/nested/manual/some-test/task.yaml

$
```