### PR TITLE
Ability to subscribe to  PropertiesChanged signal on systemd's dbus interface thru system-observe interface 

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -551,6 +551,7 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}bin/dbus-daemon ixr,
   /{,usr/}bin/dbus-run-session ixr,
   /{,usr/}bin/dbus-send ixr,
+  /{,usr/}bin/dbus-monitor ixr,
   /{,usr/}bin/dd ixr,
   /{,usr/}bin/diff{,3} ixr,
   /{,usr/}bin/dir ixr,

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -175,6 +175,14 @@ dbus (send)
     member={GetUnit,ListUnits}
     peer=(label=unconfined),
 
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/systemd1{,/**}
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+
 # Allow reading if protected hardlinks are enabled, but don't allow enabling or
 # disabling them
 @{PROC}/sys/fs/protected_hardlinks r,

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -89,6 +89,15 @@ func (s *SystemObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "ptrace")
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "@{PROC}/partitions r,")
+	// This will test whether PropertiesChange signal  on dbus path "/org/freedesktop/systemd1{,/**}
+	// and interface org.freedesktop.DBus.Properties  is allowed by apparmor profile or not.
+	expectedString := `dbus (receive)
+    bus=system
+    path=/org/freedesktop/systemd1{,/**}
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),`
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, expectedString)
 
 	updateNS := apparmorSpec.UpdateNS()
 	expectedUpdateNS := `  # Read-only access to /boot


### PR DESCRIPTION
The following changes are meant to include access to 'PropertiesChanged' signal on systemd's dbus interface.

This change enables snap applications with the 'system-observe' plug to subscribe to the 'PropertiesChanged' signal on systemd's DBus interface.
- **template.go**-: '/usr/bin/dbus-monitor' has been included in the list, as this executable allows monitoring signals on dbus.
- **system_observe.go**-: Adds the necessary DBus API string to the   'systemObserveConnectedPlugAppArmor' constant for the 'PropertiesChanged' signal.
- **system_observe_test.go**-: Adds corresponding test case for the new functionality.


