### PR TITLE
interfaces/builtin/opengl: enable parsing of nvidia driver information files

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -103,6 +103,8 @@ const openglConnectedPlugAppArmor = `
 # nvidia
 /etc/vdpau_wrapper.cfg r,
 @{PROC}/driver/nvidia/params r,
+@{PROC}/driver/nvidia/gpus/*/information r,
+@{PROC}/driver/nvidia/capabilities/mig/monitor r,
 @{PROC}/modules r,
 /dev/nvidia* rw,
 unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),


### PR DESCRIPTION
interfaces/opengl: Enable parsing of nvidia driver information files

Some nvidia hardware companion utilities required access to driver information in order to operate properly, for example nvidia-persistenced.  This enables read only access to those files.

Example file content:

`/proc/driver/nvidia/gpus/0000\:70\:00.0/information`
```
Model: 		 NVIDIA L4
IRQ:   		 16
GPU UUID: 	 GPU-3291dfa4-fcc4-0110-615b-c894a0d7c689
Video BIOS: 	 95.04.65.00.13
Bus Type: 	 PCIe
DMA Size: 	 47 bits
DMA Mask: 	 0x7fffffffffff
Bus Location: 	 0000:70:00.0
Device Minor: 	 0
GPU Excluded:	 No
```

`/proc/driver/nvidia/capabilities/mig/monitor`
```
DeviceFileMinor: 2
DeviceFileMode: 292
DeviceFileModify: 1
```