### PR TITLE
client: fix typo in json tags

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -66,7 +66,7 @@ type Snap struct {
 	MountedFrom      string        `json:"mounted-from,omitempty"`
 	CohortKey        string        `json:"cohort-key,omitempty"`
 
-	Links map[string][]string `json:"links,omitempy"`
+	Links map[string][]string `json:"links,omitempty"`
 
 	// legacy fields before we had links
 	Contact string `json:"contact"`


### PR DESCRIPTION
this PR just fixes a typo in the json tags,
from:
```
`json:"links,omitempy"`
```
to:
```
`json:"links,omitempty"`
```