### PR TITLE
tests: fix typo: snapd vs snap

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -547,7 +547,7 @@ build_snapd_snap() {
                     *-arm-*)
                         ;;
                     *)
-                        echo "ERROR: system $SPREAD_SYSTEM should use a prebuilt snapd snapd"
+                        echo "ERROR: system $SPREAD_SYSTEM should use a prebuilt snapd snap"
                         echo "see HACKING.md and use tests/build-test-snapd-snap to build one locally"
                         exit 1
                         ;;


### PR DESCRIPTION
The error message talks about snapd snap.
