### PR TITLE
spread, tests: drop openSUSE 15.5 (EOL)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -320,7 +320,7 @@ jobs:
             rules: 'main'
           - group: opensuse
             backend: openstack
-            systems: 'opensuse-15.5-64 opensuse-15.6-64 opensuse-tumbleweed-64'
+            systems: 'opensuse-15.6-64 opensuse-tumbleweed-64'
             tasks: 'tests/...'
             rules: 'main'
           - group: ubuntu-trusty

--- a/spread.yaml
+++ b/spread.yaml
@@ -242,8 +242,6 @@ backends:
                   storage: preserve-size
                   image: centos-9-64
 
-            - opensuse-15.5-64:
-                  workers: 6
             - opensuse-15.6-64:
                   workers: 6
             - opensuse-tumbleweed-64:

--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -30,10 +30,6 @@
                 image: snapd-spread/fedora-41-64
                 workers: 6
     
-            - opensuse-15.5-64:
-                image: snapd-spread/opensuse-15.5-64
-                workers: 6
-
             - opensuse-15.6-64:
                 image: snapd-spread/opensuse-15.6-64
                 workers: 6

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -27,7 +27,6 @@ systems:
     - -debian-*
     - -fedora-40-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-41-*  # test-snapd-eds is incompatible with eds version shipped with the distro
-    - -opensuse-15.5-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-15.6-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-tumbleweed-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -22,7 +22,6 @@ systems:
     - -debian-*
     - -fedora-40-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -fedora-41-*  # test-snapd-eds is incompatible with eds version shipped with the distro
-    - -opensuse-15.5-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-15.6-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -opensuse-tumbleweed-*  # test-snapd-eds is incompatible with eds version shipped with the distro
     - -ubuntu-14.04-*  # no tests.session support, eds is too old

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -12,8 +12,6 @@ systems:
     - -ubuntu-14.04-*
     # Arm64 is not supported
     - -ubuntu-*-arm-64
-    # Opensuse 15.5 PackageKit gets GDBus.Error setting proxy
-    - -opensuse-15.5-*
 
 restore: |
     snap remove --purge test-snapd-packagekit


### PR DESCRIPTION
OpenSUSE 15.5 is EOL now. Let's drop it from the CI.

Related: [SNAPDENG-34181](https://warthogs.atlassian.net/browse/SNAPDENG-34181)


[SNAPDENG-34181]: https://warthogs.atlassian.net/browse/SNAPDENG-34181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ