### PR TITLE
tests: remove NTP service on Xenial

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -795,16 +795,6 @@ restore_suite_each() {
         "$TESTSLIB"/reset.sh --reuse-core
     fi
 
-    # The ntp service randomly fails to create a socket on virbr0-nic,
-    # generating issues in actions like the auto-refresh (in Xenial).
-    # The errror lines are:
-    # ntpd: bind(23) AF_INET6 ... flags 0x11 failed: Cannot assign requested address
-    # ntpd: unable to create socket on virbr0-nic
-    # ntpd: kernel reports TIME_ERROR: 0x41: Clock Unsynchronized
-    if os.query is-xenial && systemctl status ntp | MATCH TIME_ERROR; then
-        systemctl restart ntp
-    fi
-
     # Check for invariants late, in order to detect any bugs in the code above.
     if [[ "$variant" = full ]]; then
         "$TESTSTOOLS"/cleanup-state pre-invariant

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -232,6 +232,16 @@ install_dependencies_gce_bucket(){
 ###
 
 prepare_project() {
+    # we install chrony on xenial (as its also used in later distros), so the
+    # ntp service was in conflict, degrading the systemd unit and sometimes breaking
+    # NTP syncs
+    if os.query is-xenial; then
+      systemctl stop ntp.service
+      systemctl disable ntp.service
+      apt-get remove --purge -y ntp
+      systemctl reset-failed
+    fi
+
     if os.query is-ubuntu && os.query is-classic; then
         apt-get remove --purge -y lxd lxcfs || true
         apt-get autoremove --purge -y


### PR DESCRIPTION
The auto-refresh tests and the degraded test were failing due to conflicts between chrony.service and ntp.service. The former happened because chrony sometimes failed to run and the latter because ntp.service conflicted with chrony and the unit would be marked as failed. Removing ntp and leaving chrony fixes both issues.
If merged this replaces https://github.com/canonical/snapd/pull/14888
Fixes:
```
- google:ubuntu-16.04-64:tests/main/auto-refresh-backoff
- google:ubuntu-16.04-64:tests/main/auto-refresh-gating-from-snap
- google:ubuntu-16.04-64:tests/main/auto-refresh-pre-download:close
- google:ubuntu-16.04-64:tests/main/auto-refresh-pre-download:close_mid_restart
- google:ubuntu-16.04-64:tests/main/auto-refresh-pre-download:ignore
- google:ubuntu-16.04-64:tests/main/auto-refresh-retry
- google:ubuntu-16.04-64:tests/main/auto-refresh:regular
- google:ubuntu-16.04-64:tests/main/snap-refresh-hold
- google:ubuntu-16.04-64:tests/main/snapd-state
- google:ubuntu-16.04-64:tests/main/degraded
```

