### PR TITLE
snap/unsquashfs: pass -xattrs-include ^user.

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -202,7 +202,7 @@ func (s *Snap) Unpack(src, dstDir string) error {
 	usw := newUnsquashfsStderrWriter()
 
 	var output bytes.Buffer
-	cmd := exec.Command("unsquashfs", "-n", "-f", "-d", dstDir, s.path, src)
+	cmd := exec.Command("unsquashfs", "-xattrs-include", "^user.", "-n", "-f", "-d", dstDir, s.path, src)
 	cmd.Stderr = io.MultiWriter(&output, usw)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("cannot extract %q to %q: %v", src, dstDir, osutil.OutputErr(output.Bytes(), err))
@@ -234,7 +234,7 @@ func (s *Snap) withUnpackedFile(filePath string, f func(p string) error) error {
 	defer os.RemoveAll(tmpdir)
 
 	unpackDir := filepath.Join(tmpdir, "unpack")
-	if output, err := exec.Command("unsquashfs", "-n", "-i", "-d", unpackDir, s.path, filePath).CombinedOutput(); err != nil {
+	if output, err := exec.Command("unsquashfs", "-xattrs-include", "^user.", "-n", "-i", "-d", unpackDir, s.path, filePath).CombinedOutput(); err != nil {
 		return fmt.Errorf("cannot run unsquashfs: %v", osutil.OutputErr(output, err))
 	}
 
@@ -419,7 +419,7 @@ func (s *Snap) Walk(relative string, walkFn filepath.WalkFunc) error {
 // ListDir returns the content of a single directory inside a squashfs snap.
 func (s *Snap) ListDir(dirPath string) ([]string, error) {
 	output, stderr, err := osutil.RunSplitOutput(
-		"unsquashfs", "-no-progress", "-dest", "_", "-l", s.path, dirPath)
+		"unsquashfs", "-xattrs-include", "^user.", "-no-progress", "-dest", "_", "-l", s.path, dirPath)
 	if err != nil {
 		return nil, osutil.OutputErrCombine(output, stderr, err)
 	}
@@ -640,7 +640,7 @@ func BuildDate(path string) time.Time {
 		N:      1,
 	}
 
-	cmd := exec.Command("unsquashfs", "-n", "-s", path)
+	cmd := exec.Command("unsquashfs", "-xattrs-include", "^user.", "-n", "-s", path)
 	cmd.Env = []string{"TZ=UTC"}
 	cmd.Stdout = m
 	cmd.Stderr = m


### PR DESCRIPTION
Writing security.* attributes as non-root user is not allowed but on Fedora and other SELinux systems, unsquashfs will attempt to write to security.selinux, which fails.

This fixes running unit tests on Fedora, while running as a regular user.