### PR TITLE
daemon: fetch validation sets before checking refresh candidates

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -170,6 +170,7 @@ var (
 
 	assertstateRefreshSnapAssertions         = assertstate.RefreshSnapAssertions
 	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking
+	assertstateFetchAllValidationSets        = assertstate.FetchAllValidationSets
 
 	confdbstateGetView        = confdbstate.GetView
 	confdbstateGetTransaction = confdbstate.GetTransactionToModify

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -428,3 +428,7 @@ func MockConfdbstateGetView(f func(_ *state.State, _, _, _ string) (*confdb.View
 func MockConfdbstateSetViaView(f func(confdb.DataBag, *confdb.View, map[string]interface{}) error) (restore func()) {
 	return testutil.Mock(&confdbstateSetViaView, f)
 }
+
+func MockAssertstateFetchAllValidationSets(f func(*state.State, int, *assertstate.RefreshAssertionsOptions) error) (restore func()) {
+	return testutil.Mock(&assertstateFetchAllValidationSets, f)
+}

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -579,7 +579,8 @@ func FetchAllValidationSets(st *state.State, userID int, opts *RefreshAssertions
 	return nil
 }
 
-// RefreshValidationSetAssertions tries to refresh all validation set assertions.
+// RefreshValidationSetAssertions tries to refresh all validation set assertions,
+// updating the tracked validation sets accordingly.
 func RefreshValidationSetAssertions(s *state.State, userID int, opts *RefreshAssertionsOptions) error {
 	vsets, err := ValidationSets(s)
 	if err != nil {


### PR DESCRIPTION
`snap refresh --list` didn't report snaps that would be refreshed with a `snap refresh` because it, unlike the actual refresh, didn't refresh the validation sets which could make new snap revisions available. This change fetches new validation sets (without tracking them) before checking for refreshable snaps 