### PR TITLE
snapcraft: build and use patchelf 0.18

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -191,6 +191,16 @@ parts:
       craftctl default
       python3 "${CRAFT_PROJECT_DIR}/build-aux/snap/local/patch-dl.py" "/snap/snapd/current/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${DYNAMIC_LINKER}"
 
+  patchelf:
+    plugin: autotools
+    build-packages:
+      - autoconf-archive
+    # as of 0.18.0-1.1build1 in Oracular, here are no relevant patches to apply
+    source: http://archive.ubuntu.com/ubuntu/pool/universe/p/patchelf/patchelf_0.18.0.orig.tar.gz
+    source-checksum: sha256/1451d01ee3a21100340aed867d0b799f46f0b1749680028d38c3f5d0128fb8a7
+    # nothing to prime
+    prime: [-*]
+
   snapd:
     plugin: nil
     source: .
@@ -198,6 +208,7 @@ parts:
       - go/1.23/stable # the default Go toolchain
     after:
       - apparmor
+      - patchelf
     build-packages:
       - git
       - dpkg-dev
@@ -441,8 +452,10 @@ parts:
       - -fips-build-lp
     override-prime: |
       craftctl default
-      "${CRAFT_PROJECT_DIR}/build-aux/snap/local/patch-dl.py" \
-          "/snap/snapd/current/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${DYNAMIC_LINKER}"
+      # use patchelf built in earlier step
+      PATH="${CRAFT_STAGE}"/usr/local/bin:$PATH \
+          "${CRAFT_PROJECT_DIR}/build-aux/snap/local/patch-dl.py" \
+              "/snap/snapd/current/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/${DYNAMIC_LINKER}"
 
   libcrypto-fips:
     plugin: nil


### PR DESCRIPTION
Patching with patchelf 0.14.3 available in 22.04 produces the result binaries get silently broken and break parsing with python-elfutils.

Inspectign a patched binary with readelf also shows a warning like so:

    snapcraft-snapd-on-amd64-for-amd64-1579591 ../project# readelf -h snapd.orig
    ELF Header:
      Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
      Class:                             ELF64
      Data:                              2's complement, little endian
      Version:                           1 (current)
      OS/ABI:                            UNIX - System V
      ABI Version:                       0
      Type:                              DYN (Position-Independent Executable file)
      Machine:                           Advanced Micro Devices X86-64
      Version:                           0x1
      Entry point address:               0x4800e0
      Start of program headers:          64 (bytes into file)
      Start of section headers:          680 (bytes into file)
      Flags:                             0x0
      Size of this header:               64 (bytes)
      Size of program headers:           56 (bytes)
      Number of program headers:         12
      Size of section headers:           64 (bytes)
      Number of section headers:         37
      Section header string table index: 35
    readelf: Warning: Section 0 has an out of range sh_link value of 72

The upstream patchelf 0.18 is fixed, so do a local build patchelf and use it instead of a distro package.

Related: [SNAPDENG-34352](https://warthogs.atlassian.net/browse/SNAPDENG-34352) 

Will need a rebase once #14901 lands

[SNAPDENG-34352]: https://warthogs.atlassian.net/browse/SNAPDENG-34352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ