### PR TITLE
core-initrd: fix some issues with ubuntu-core-initramfs package builds

### DIFF
--- a/core-initrd/24.04/debian/changelog
+++ b/core-initrd/24.04/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (69+2.67+git124.g98d9ab6+24.04) noble; urgency=medium
+
+  * Update to snapd version 2.67+git124.g98d9ab6
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Wed, 08 Jan 2025 13:51:11 -0500
+
 ubuntu-core-initramfs (68) noble; urgency=medium
 
   [ Valentin David ]

--- a/core-initrd/24.04/debian/control
+++ b/core-initrd/24.04/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper-compat (= 13), dh-python,
                cpio,
                fakeroot,
                fonts-ubuntu,
+               golang-go (>=2:1.18~) [!powerpc] | golang-1.18 [!powerpc] | golang-1.21,
                intel-microcode [amd64]
 Standards-Version: 4.4.1
 Homepage: https://launchpad.net/ubuntu-core-initramfs
@@ -15,7 +16,6 @@ Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf riscv64
 Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1),
          python3:any,
-         golang-go (>=2:1.18~) [!powerpc] | golang-1.18 [!powerpc] | golang-1.21,
          dracut-core,
          busybox-initramfs,
          zstd,

--- a/core-initrd/24.04/debian/rules
+++ b/core-initrd/24.04/debian/rules
@@ -44,7 +44,7 @@ ifeq (${FIPSBUILD},1)
 	fi
 endif
 # dh-golang sets GO111MODULE=off if present, fix that
-	GO111MODULE=on go build -mod=vendor $(BUILDFLAGS) $(SNAP_TAGS) ./cmd/snap-bootstrap
+	GOCACHE=/tmp/cache GO111MODULE=on go build -mod=vendor $(BUILDFLAGS) $(SNAP_TAGS) ./cmd/snap-bootstrap
 
 override_dh_auto_install:
 	rm -rf debian/tmp

--- a/core-initrd/latest/debian/changelog
+++ b/core-initrd/latest/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (70+2.67+git124.g98d9ab6+24.10) oracular; urgency=medium
+
+  * Update to snapd version 2.67+git124.g98d9ab6
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Wed, 08 Jan 2025 13:52:06 -0500
+
 ubuntu-core-initramfs (69) oracular; urgency=medium
 
   * Add systemd-cryptsetup, which is now a separate package, and libkmod2.

--- a/core-initrd/latest/debian/control
+++ b/core-initrd/latest/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper-compat (= 13), dh-python,
                cpio,
                fakeroot,
                fonts-ubuntu,
+               golang-go (>=2:1.18~) [!powerpc] | golang-1.18 [!powerpc] | golang-1.21,
                intel-microcode [amd64]
 Standards-Version: 4.4.1
 Homepage: https://launchpad.net/ubuntu-core-initramfs
@@ -15,7 +16,6 @@ Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf riscv64
 Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1),
          python3:any,
-         golang-go (>=2:1.18~) [!powerpc] | golang-1.18 [!powerpc] | golang-1.21,
          dracut-core,
          busybox-initramfs,
          zstd,

--- a/core-initrd/latest/debian/rules
+++ b/core-initrd/latest/debian/rules
@@ -44,7 +44,7 @@ ifeq (${FIPSBUILD},1)
 	fi
 endif
 # dh-golang sets GO111MODULE=off if present, fix that
-	GO111MODULE=on go build -mod=vendor $(BUILDFLAGS) $(SNAP_TAGS) ./cmd/snap-bootstrap
+	GOCACHE=/tmp/cache GO111MODULE=on go build -mod=vendor $(BUILDFLAGS) $(SNAP_TAGS) ./cmd/snap-bootstrap
 
 override_dh_auto_install:
 	rm -rf debian/tmp


### PR DESCRIPTION
- Fix builds in launchpad
- Add changelog entries automatically
- Fix golang dependency
- Include snapd version and Ubuntu series in package version