### PR TITLE
interfaces/builtin: make checkbox-support exempt from device access mediation

### DIFF
--- a/interfaces/builtin/checkbox_support.go
+++ b/interfaces/builtin/checkbox_support.go
@@ -19,6 +19,11 @@
 
 package builtin
 
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/udev"
+)
+
 const checkboxSupportSummary = `allows checkbox to execute arbitrary system tests`
 
 const checkboxSupportBaseDeclarationPlugs = `
@@ -41,12 +46,20 @@ type checkboxSupportInterface struct {
 	steamSupportInterface
 }
 
+func (iface *checkboxSupportInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// we inherit one from steamSupportInterface, but none of the snippets are
+	// useful as the interface can manage device cgroup, giving it unrestricted
+	// access to devices
+	return iface.commonInterface.UDevConnectedPlug(spec, plug, slot)
+}
+
 func init() {
 	registerIface(&checkboxSupportInterface{steamSupportInterface{commonInterface{
 		name:                 "checkbox-support",
 		summary:              checkboxSupportSummary,
 		implicitOnCore:       true,
 		implicitOnClassic:    true,
+		controlsDeviceCgroup: true, // checkbox is exempt from device filtering
 		baseDeclarationSlots: checkboxSupportBaseDeclarationSlots,
 		baseDeclarationPlugs: checkboxSupportBaseDeclarationPlugs,
 		connectedPlugSecComp: steamSupportConnectedPlugSecComp,


### PR DESCRIPTION
Checkbox should have unrestricted access to all devices.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
