### PR TITLE
tests: fix tests for beta validation

### DIFF
--- a/tests/core/uboot-unpacked-assets/task.yaml
+++ b/tests/core/uboot-unpacked-assets/task.yaml
@@ -20,15 +20,15 @@ execute: |
         exit
     fi
 
-    if os.query is-core20 || os.query is-core22; then
-        echo "Check that on UC20 and UC22, the kernel snap is extracted onto ubuntu-seed, not on ubuntu-boot"
+    if os.query is-core-ge 20; then
+        echo "Check that on UC20+, the kernel snap is extracted onto ubuntu-seed, not on ubuntu-boot"
         output=$(find /run/mnt/ubuntu-seed/systems/*/kernel/ -name "$NAME" )
         if [ -z "$output" ]; then
             echo "Not found expected file $NAME in /run/mnt/ubuntu-seed/systems/*/kernel/"
             exit 1
         fi
     else
-        echo "Check that on non UC20, the kernel snap is extracted onto /boot/uboot"
+        echo "Check that on non UC20+, the kernel snap is extracted onto /boot/uboot"
         output=$(find /boot/uboot/*-kernel_*.snap/ -name "$NAME" )
         if [ -z "$output" ]; then
             echo "Not found expected file $NAME in /boot/uboot/*-kernel_*.snap/"

--- a/tests/core/update-snapd-symlink/task.yaml
+++ b/tests/core/update-snapd-symlink/task.yaml
@@ -84,7 +84,7 @@ execute: |
   snap change "${broken_install_id}" | MATCH 'Error'
 
   # snapd.failure.service is not running
-  retry -n 10 --wait 1 sh -c "systemctl show -p ActiveState --value snapd.failure.service | MATCH inactive"
+  retry -n 10 --wait 3 sh -c "systemctl show -p ActiveState --value snapd.failure.service | MATCH inactive"
   # but it has run since last install
   last_activated="$(date --date="$(systemctl show -p InactiveEnterTimestamp --value snapd.failure.service)" +%s)"
   [ -n "${last_activated}" ]

--- a/tests/core/update-snapd-symlink/task.yaml
+++ b/tests/core/update-snapd-symlink/task.yaml
@@ -84,7 +84,7 @@ execute: |
   snap change "${broken_install_id}" | MATCH 'Error'
 
   # snapd.failure.service is not running
-  systemctl show -p ActiveState --value snapd.failure.service | MATCH inactive
+  retry -n 10 --wait 1 systemctl show -p ActiveState --value snapd.failure.service | MATCH inactive
   # but it has run since last install
   last_activated="$(date --date="$(systemctl show -p InactiveEnterTimestamp --value snapd.failure.service)" +%s)"
   [ -n "${last_activated}" ]

--- a/tests/core/update-snapd-symlink/task.yaml
+++ b/tests/core/update-snapd-symlink/task.yaml
@@ -84,7 +84,7 @@ execute: |
   snap change "${broken_install_id}" | MATCH 'Error'
 
   # snapd.failure.service is not running
-  retry -n 10 --wait 1 systemctl show -p ActiveState --value snapd.failure.service | MATCH inactive
+  retry -n 10 --wait 1 sh -c "systemctl show -p ActiveState --value snapd.failure.service | MATCH inactive"
   # but it has run since last install
   last_activated="$(date --date="$(systemctl show -p InactiveEnterTimestamp --value snapd.failure.service)" +%s)"
   [ -n "${last_activated}" ]

--- a/tests/lib/spread/backend.testflinger.beta.yaml
+++ b/tests/lib/spread/backend.testflinger.beta.yaml
@@ -62,19 +62,25 @@
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-20-arm-64-rpi4:
-                  queue: rpi4b8g
+                  queue: rpi4b
                   image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-20-stable-snapd_beta/pi.img.xz
                   workers: 1
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-22-arm-64-rpi4:
-                  queue: rpi4b8g
+                  queue: rpi4b
                   image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-22-stable-snapd_beta/pi.img.xz
                   workers: 1
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-24-arm-64-rpi4:
-                  queue: rpi4b8g
+                  queue: rpi4b
+                  image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-24-stable-snapd_beta/pi.img.xz
+                  workers: 1
+                  username: ubuntu
+                  password: ubuntu
+            - ubuntu-core-24-arm-64-rpi5:
+                  queue: rpi5b
                   image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-24-stable-snapd_beta/pi.img.xz
                   workers: 1
                   username: ubuntu

--- a/tests/lib/spread/backend.testflinger.edge.yaml
+++ b/tests/lib/spread/backend.testflinger.edge.yaml
@@ -26,21 +26,26 @@
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-20-arm-64-rpi4:
-                  queue: rpi4b8g
+                  queue: rpi4b
                   image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-20-stable-core20_edge/pi.img.xz
                   workers: 1
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-22-arm-64-rpi4:
-                  queue: rpi4b8g
+                  queue: rpi4b
                   image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-22-stable-core22_edge/pi.img.xz
                   workers: 1
                   username: ubuntu
                   password: ubuntu
             - ubuntu-core-24-arm-64-rpi4:
-                  queue: rpi4b8g
+                  queue: rpi4b
                   image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-24-stable-core24_edge/pi.img.xz
                   workers: 1
                   username: ubuntu
                   password: ubuntu
-
+            - ubuntu-core-24-arm-64-rpi5:
+                  queue: rpi5b
+                  image: https://storage.googleapis.com/snapd-spread-tests/images/pi4-24-stable-core24_edge/pi.img.xz
+                  workers: 1
+                  username: ubuntu
+                  password: ubuntu

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -53,16 +53,17 @@ execute: |
         VERSION=$CORE_STABLE_VERSION
         TRACKING="(latest/)?stable"
 
-    elif [ "$SPREAD_BACKEND" = "external" ] && os.query is-core16; then
-        echo "On the external device the core snap tested could be in any track"
-        TRACKING="(latest/)?(edge|beta|candidate|stable)"
-
-    elif [ "$SPREAD_BACKEND" = "external" ] && os.query is-core-ge 18; then
-        echo "On the external device the snapd snap tested could be in any track"
-        NAME=snapd
-        VERSION=$SNAPD_GIT_VERSION
-        TRACKING="(latest/)?(edge|beta|candidate|stable)"
-        NOTES=snapd
+    elif [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "testflinger" ]; then
+        if os.query is-core16; then
+            echo "On the external/testflinger device the core snap tested could be in any track"
+            TRACKING="(latest/)?(edge|beta|candidate|stable)"
+        else
+            echo "On the external/testflinger device the snapd snap tested could be in any track"
+            NAME=snapd
+            VERSION=$SNAPD_GIT_VERSION
+            TRACKING="(latest/)?(edge|beta|candidate|stable)"
+            NOTES=snapd
+        fi
 
     else
         TRACKING="(latest/)?$CORE_CHANNEL"


### PR DESCRIPTION
This change fixes 3 tests for beta validation:
. update-snapd-symlink: in this test the snapd.failure.service remains a bit activating and needs a retry to make sure it becomes inactive. . listing: needs support for testflinger backend
. uboot-unpacked-assets: support that uc24 does not use uboot.

Also it adds support for rpi5 in edge and beta validation
