### PR TITLE
s/a/notify: add proper version handling to the notification protocol

### DIFF
--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -38,3 +38,7 @@ func MockVersionSupportedCallbacks(pairs []VersionAndCallback) (restore func()) 
 	}
 	return restore
 }
+
+func MockIoctl(f func(fd uintptr, req IoctlRequest, buf IoctlRequestBuffer) ([]byte, error)) (restore func()) {
+	return testutil.Mock(&doIoctl, f)
+}

--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -2,11 +2,39 @@ package notify
 
 import (
 	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/testutil"
+)
+
+var (
+	Versions                  = versions
+	VersionSupportedCallbacks = versionSupportedCallbacks
+
+	Supported                = Version.supported
+	SupportedProtocolVersion = supportedProtocolVersion
 )
 
 func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err unix.Errno)) (restore func()) {
-	old := doSyscall
-	doSyscall = syscall
-	restore = func() { doSyscall = old }
+	return testutil.Mock(&doSyscall, syscall)
+}
+
+type VersionAndCallback struct {
+	Version  Version
+	Callback func() bool
+}
+
+func MockVersionSupportedCallbacks(pairs []VersionAndCallback) (restore func()) {
+	restoreVersions := testutil.Backup(&versions)
+	restoreCallbacks := testutil.Backup(&versionSupportedCallbacks)
+	restore = func() {
+		restoreCallbacks()
+		restoreVersions()
+	}
+	versions = make([]Version, 0, len(pairs))
+	versionSupportedCallbacks = make(map[Version]func() bool, len(pairs))
+	for _, pair := range pairs {
+		versions = append(versions, pair.Version)
+		versionSupportedCallbacks[pair.Version] = pair.Callback
+	}
 	return restore
 }

--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 var (
-	Versions                  = versions
-	VersionSupportedCallbacks = versionSupportedCallbacks
+	Versions                        = versions
+	VersionLikelySupportedCallbacks = versionLikelySupportedCallbacks
 
-	Supported                = ProtocolVersion.supported
-	SupportedProtocolVersion = supportedProtocolVersion
+	LikelySupported                = ProtocolVersion.likelySupported
+	LikelySupportedProtocolVersion = likelySupportedProtocolVersion
 )
 
 func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err unix.Errno)) (restore func()) {
@@ -20,27 +20,27 @@ func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err uni
 
 // VersionAndCallback couples protocol version with a callback function which
 // returns true if the version is supported. This type is used so that
-// `versions` and `versionSupportedCallbacks` can be mocked to avoid calling
-// the actual callback functions (which generally probe the host system), and
-// so that the logic around handling of unsupported and supported versions can
-// be tested.
+// `versions` and `versionLikelySupportedCallbacks` can be mocked to avoid
+// calling the actual callback functions (which generally probe the host
+// system), and so that the logic around handling of unsupported and supported
+// versions can be tested.
 type VersionAndCallback struct {
 	Version  ProtocolVersion
 	Callback func() bool
 }
 
-func MockVersionSupportedCallbacks(pairs []VersionAndCallback) (restore func()) {
+func MockVersionLikelySupportedCallbacks(pairs []VersionAndCallback) (restore func()) {
 	restoreVersions := testutil.Backup(&versions)
-	restoreCallbacks := testutil.Backup(&versionSupportedCallbacks)
+	restoreCallbacks := testutil.Backup(&versionLikelySupportedCallbacks)
 	restore = func() {
 		restoreCallbacks()
 		restoreVersions()
 	}
 	versions = make([]ProtocolVersion, 0, len(pairs))
-	versionSupportedCallbacks = make(map[ProtocolVersion]func() bool, len(pairs))
+	versionLikelySupportedCallbacks = make(map[ProtocolVersion]func() bool, len(pairs))
 	for _, pair := range pairs {
 		versions = append(versions, pair.Version)
-		versionSupportedCallbacks[pair.Version] = pair.Callback
+		versionLikelySupportedCallbacks[pair.Version] = pair.Callback
 	}
 	return restore
 }

--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	Versions                        = versions
-	VersionLikelySupportedCallbacks = versionLikelySupportedCallbacks
+	Versions                     = versions
+	VersionLikelySupportedChecks = versionLikelySupportedChecks
 
 	LikelySupported                = ProtocolVersion.likelySupported
 	LikelySupportedProtocolVersion = likelySupportedProtocolVersion
@@ -18,29 +18,29 @@ func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err uni
 	return testutil.Mock(&doSyscall, syscall)
 }
 
-// VersionAndCallback couples protocol version with a callback function which
+// VersionAndCheck couples protocol version with a support check function which
 // returns true if the version is supported. This type is used so that
-// `versions` and `versionLikelySupportedCallbacks` can be mocked to avoid
-// calling the actual callback functions (which generally probe the host
+// `versions` and `versionLikelySupportedChecks` can be mocked to avoid
+// calling the actual check functions (which generally probe the host
 // system), and so that the logic around handling of unsupported and supported
 // versions can be tested.
-type VersionAndCallback struct {
-	Version  ProtocolVersion
-	Callback func() bool
+type VersionAndCheck struct {
+	Version ProtocolVersion
+	Check   func() bool
 }
 
-func MockVersionLikelySupportedCallbacks(pairs []VersionAndCallback) (restore func()) {
+func MockVersionLikelySupportedChecks(pairs []VersionAndCheck) (restore func()) {
 	restoreVersions := testutil.Backup(&versions)
-	restoreCallbacks := testutil.Backup(&versionLikelySupportedCallbacks)
+	restoreChecks := testutil.Backup(&versionLikelySupportedChecks)
 	restore = func() {
-		restoreCallbacks()
+		restoreChecks()
 		restoreVersions()
 	}
 	versions = make([]ProtocolVersion, 0, len(pairs))
-	versionLikelySupportedCallbacks = make(map[ProtocolVersion]func() bool, len(pairs))
+	versionLikelySupportedChecks = make(map[ProtocolVersion]func() bool, len(pairs))
 	for _, pair := range pairs {
 		versions = append(versions, pair.Version)
-		versionLikelySupportedCallbacks[pair.Version] = pair.Callback
+		versionLikelySupportedChecks[pair.Version] = pair.Check
 	}
 	return restore
 }

--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -10,7 +10,7 @@ var (
 	Versions                  = versions
 	VersionSupportedCallbacks = versionSupportedCallbacks
 
-	Supported                = Version.supported
+	Supported                = ProtocolVersion.supported
 	SupportedProtocolVersion = supportedProtocolVersion
 )
 
@@ -18,13 +18,14 @@ func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err uni
 	return testutil.Mock(&doSyscall, syscall)
 }
 
-// VersionAndCallback couples version with a callback function which returns
-// true if the version is supported. This type is used so that `versions` and
-// `versionSupportedCallbacks` can be mocked to avoid calling the actual
-// callback functions (which generally probe the host system), and so that the
-// logic around handling of unsupported and supported versions can be tested.
+// VersionAndCallback couples protocol version with a callback function which
+// returns true if the version is supported. This type is used so that
+// `versions` and `versionSupportedCallbacks` can be mocked to avoid calling
+// the actual callback functions (which generally probe the host system), and
+// so that the logic around handling of unsupported and supported versions can
+// be tested.
 type VersionAndCallback struct {
-	Version  Version
+	Version  ProtocolVersion
 	Callback func() bool
 }
 
@@ -35,8 +36,8 @@ func MockVersionSupportedCallbacks(pairs []VersionAndCallback) (restore func()) 
 		restoreCallbacks()
 		restoreVersions()
 	}
-	versions = make([]Version, 0, len(pairs))
-	versionSupportedCallbacks = make(map[Version]func() bool, len(pairs))
+	versions = make([]ProtocolVersion, 0, len(pairs))
+	versionSupportedCallbacks = make(map[ProtocolVersion]func() bool, len(pairs))
 	for _, pair := range pairs {
 		versions = append(versions, pair.Version)
 		versionSupportedCallbacks[pair.Version] = pair.Callback

--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -18,6 +18,11 @@ func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err uni
 	return testutil.Mock(&doSyscall, syscall)
 }
 
+// VersionAndCallback couples version with a callback function which returns
+// true if the version is supported. This type is used so that `versions` and
+// `versionSupportedCallbacks` can be mocked to avoid calling the actual
+// callback functions (which generally probe the host system), and so that the
+// logic around handling of unsupported and supported versions can be tested.
 type VersionAndCallback struct {
 	Version  Version
 	Callback func() bool

--- a/sandbox/apparmor/notify/ioctl.go
+++ b/sandbox/apparmor/notify/ioctl.go
@@ -25,6 +25,10 @@ func (ie *IoctlError) Error() string {
 	return fmt.Sprintf("cannot perform IOCTL request %v: %s", ie.Request, unix.ErrnoName(ie.Errno))
 }
 
+func (ie *IoctlError) Unwrap() error {
+	return ie.Errno
+}
+
 var doSyscall = func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err unix.Errno) {
 	return unix.Syscall(trap, a1, a2, a3)
 }

--- a/sandbox/apparmor/notify/ioctl.go
+++ b/sandbox/apparmor/notify/ioctl.go
@@ -17,12 +17,12 @@ import (
 var ErrIoctlReturnInvalid = errors.New("IOCTL request returned invalid bufsize")
 
 type IoctlError struct {
-	request IoctlRequest
-	errno   unix.Errno
+	Request IoctlRequest
+	Errno   unix.Errno
 }
 
 func (ie *IoctlError) Error() string {
-	return fmt.Sprintf("cannot perform IOCTL request %v: %s", ie.request, unix.ErrnoName(ie.errno))
+	return fmt.Sprintf("cannot perform IOCTL request %v: %s", ie.Request, unix.ErrnoName(ie.Errno))
 }
 
 var doSyscall = func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err unix.Errno) {

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -69,7 +69,7 @@ func MockEpollWait(f func(l *Listener) ([]epoll.Event, error)) (restore func()) 
 	return restore
 }
 
-func MockNotifyRegisterFileDescriptor(f func(fd uintptr) (notify.Version, error)) (restore func()) {
+func MockNotifyRegisterFileDescriptor(f func(fd uintptr) (notify.ProtocolVersion, error)) (restore func()) {
 	restore = testutil.Backup(&notifyRegisterFileDescriptor)
 	notifyRegisterFileDescriptor = f
 	return restore
@@ -89,7 +89,7 @@ func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.Ioct
 // call), it triggers an epoll event with the listener's notify socket fd, and
 // then passes the data on to the next ioctl RECV call. When the listener makes
 // a SEND call via ioctl, the data is instead written to the send channel.
-func MockEpollWaitNotifyIoctl(version notify.Version) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
+func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
 	recvChanRW := make(chan []byte)
 	sendChanRW := make(chan []byte)
 	internalRecvChan := make(chan []byte, 1)
@@ -124,8 +124,8 @@ func MockEpollWaitNotifyIoctl(version notify.Version) (recvChan chan<- []byte, s
 		}
 		return buf, nil
 	}
-	rfdF := func(fd uintptr) (notify.Version, error) {
-		return version, nil
+	rfdF := func(fd uintptr) (notify.ProtocolVersion, error) {
+		return protoVersion, nil
 	}
 	restoreEpoll := testutil.Mock(&listenerEpollWait, epollF)
 	restoreIoctl := testutil.Mock(&notifyIoctl, ioctlF)

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -69,22 +69,31 @@ func MockEpollWait(f func(l *Listener) ([]epoll.Event, error)) (restore func()) 
 	return restore
 }
 
+func MockNotifyRegisterFileDescriptor(f func(fd uintptr) (notify.Version, error)) (restore func()) {
+	restore = testutil.Backup(&notifyRegisterFileDescriptor)
+	notifyRegisterFileDescriptor = f
+	return restore
+}
+
 func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error)) (restore func()) {
 	restore = testutil.Backup(&notifyIoctl)
 	notifyIoctl = f
 	return restore
 }
 
-// Mocks epoll.Wait and notify.Ioctl calls by sending data over channels.
+// Mocks epoll.Wait, notify.Ioctl, and notify.RegisterFileDescriptor calls by
+// sending data over channels, using the given version as the protocol version
+// for the listener.
+//
 // When data is sent over the recv channel (to be consumed by a mocked ioctl
 // call), it triggers an epoll event with the listener's notify socket fd, and
 // then passes the data on to the next ioctl RECV call. When the listener makes
 // a SEND call via ioctl, the data is instead written to the send channel.
-func MockEpollWaitNotifyIoctl() (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
+func MockEpollWaitNotifyIoctl(version notify.Version) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
 	recvChanRW := make(chan []byte)
 	sendChanRW := make(chan []byte)
 	internalRecvChan := make(chan []byte, 1)
-	ef := func(l *Listener) ([]epoll.Event, error) {
+	epollF := func(l *Listener) ([]epoll.Event, error) {
 		for {
 			select {
 			case request := <-recvChanRW:
@@ -103,7 +112,7 @@ func MockEpollWaitNotifyIoctl() (recvChan chan<- []byte, sendChan <-chan []byte,
 			}
 		}
 	}
-	nf := func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+	ioctlF := func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
 		switch req {
 		case notify.APPARMOR_NOTIF_RECV:
 			request := <-internalRecvChan
@@ -115,13 +124,17 @@ func MockEpollWaitNotifyIoctl() (recvChan chan<- []byte, sendChan <-chan []byte,
 		}
 		return buf, nil
 	}
-	restoreEpoll := testutil.Backup(&listenerEpollWait)
-	listenerEpollWait = ef
-	restoreIoctl := testutil.Backup(&notifyIoctl)
-	notifyIoctl = nf
+	rfdF := func(fd uintptr) (notify.Version, error) {
+		return version, nil
+	}
+	restoreEpoll := testutil.Mock(&listenerEpollWait, epollF)
+	restoreIoctl := testutil.Mock(&notifyIoctl, ioctlF)
+	restoreRegisterFileDescriptor := testutil.Mock(&notifyRegisterFileDescriptor, rfdF)
+
 	restore = func() {
 		restoreEpoll()
 		restoreIoctl()
+		restoreRegisterFileDescriptor()
 		close(recvChanRW)
 		close(sendChanRW)
 	}

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -158,7 +158,7 @@ type Listener struct {
 	// listener's notify socket. Once registered with a particular version,
 	// that version will be used for all messages sent or received over that
 	// socket.
-	protocolVersion notify.Version
+	protocolVersion notify.ProtocolVersion
 
 	notifyFile *os.File
 	poll       *epoll.Epoll
@@ -204,7 +204,7 @@ func Register() (listener *Listener, err error) {
 		}
 	}()
 
-	version, err := notifyRegisterFileDescriptor(notifyFile.Fd())
+	protoVersion, err := notifyRegisterFileDescriptor(notifyFile.Fd())
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func Register() (listener *Listener, err error) {
 	listener = &Listener{
 		reqs: make(chan *Request, 1),
 
-		protocolVersion: version,
+		protocolVersion: protoVersion,
 
 		notifyFile: notifyFile,
 		poll:       poll,

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -9,7 +9,7 @@ import (
 	"github.com/snapcore/snapd/arch"
 )
 
-var ErrVersionUnset = errors.New("cannot marshal message with version unset")
+var ErrVersionUnset = errors.New("cannot marshal message without protocol version")
 
 // Message fields are defined as raw sized integer types as the same type may be
 // packed as 16 bit or 32 bit integer, to accommodate other fields in the

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -35,7 +35,7 @@ type MsgHeader struct {
 	// Version is the version of the communication protocol.
 	// Currently version 3 is implemented in the kernel, but other versions may
 	// be used in the future.
-	Version Version
+	Version ProtocolVersion
 }
 
 const sizeofMsgHeader = 4

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -491,6 +491,9 @@ func (msg *MsgNotificationFile) UnmarshalBinary(data []byte) error {
 func (msg *MsgNotificationFile) MarshalBinary() ([]byte, error) {
 	var raw msgNotificationFileKernel
 	packer := newStringPacker(raw)
+	if msg.Version == 0 {
+		return nil, ErrVersionUnset
+	}
 	raw.Version = msg.Version
 	raw.NotificationType = msg.NotificationType
 	raw.Signalled = msg.Signalled

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -172,11 +172,11 @@ func (msg *MsgNotificationFilter) UnmarshalBinary(data []byte) error {
 
 // MarshalBinary marshals the message into binary form.
 func (msg *MsgNotificationFilter) MarshalBinary() (data []byte, err error) {
-	var raw msgNotificationFilterKernel
-	packer := newStringPacker(raw)
 	if msg.Version == 0 {
 		return nil, ErrVersionUnset
 	}
+	var raw msgNotificationFilterKernel
+	packer := newStringPacker(raw)
 	raw.Version = msg.Version
 	raw.ModeSet = uint32(msg.ModeSet)
 	raw.NS = packer.PackString(msg.NameSpace)
@@ -489,11 +489,11 @@ func (msg *MsgNotificationFile) UnmarshalBinary(data []byte) error {
 }
 
 func (msg *MsgNotificationFile) MarshalBinary() ([]byte, error) {
-	var raw msgNotificationFileKernel
-	packer := newStringPacker(raw)
 	if msg.Version == 0 {
 		return nil, ErrVersionUnset
 	}
+	var raw msgNotificationFileKernel
+	packer := newStringPacker(raw)
 	raw.Version = msg.Version
 	raw.NotificationType = msg.NotificationType
 	raw.Signalled = msg.Signalled

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -3,10 +3,13 @@ package notify
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/snapcore/snapd/arch"
 )
+
+var ErrVersionUnset = errors.New("cannot marshal message with version unset")
 
 // Message fields are defined as raw sized integer types as the same type may be
 // packed as 16 bit or 32 bit integer, to accommodate other fields in the
@@ -32,7 +35,7 @@ type MsgHeader struct {
 	// Version is the version of the communication protocol.
 	// Currently version 3 is implemented in the kernel, but other versions may
 	// be used in the future.
-	Version uint16
+	Version Version
 }
 
 const sizeofMsgHeader = 4
@@ -43,8 +46,10 @@ func (msg *MsgHeader) UnmarshalBinary(data []byte) error {
 	if err := msg.unmarshalBinaryImpl(data); err != nil {
 		return fmt.Errorf("%s: %s", prefix, err)
 	}
-	if msg.Version != 3 {
+	if !versionKnown(msg.Version) {
 		return fmt.Errorf("%s: unsupported version: %d", prefix, msg.Version)
+		// XXX: caller should also check that the version matches that of the
+		// listener which is receiving this message.
 	}
 	if int(msg.Length) != len(data) {
 		return fmt.Errorf("%s: length mismatch %d != %d",
@@ -169,7 +174,10 @@ func (msg *MsgNotificationFilter) UnmarshalBinary(data []byte) error {
 func (msg *MsgNotificationFilter) MarshalBinary() (data []byte, err error) {
 	var raw msgNotificationFilterKernel
 	packer := newStringPacker(raw)
-	raw.Version = 3
+	if msg.Version == 0 {
+		return nil, ErrVersionUnset
+	}
+	raw.Version = msg.Version
 	raw.ModeSet = uint32(msg.ModeSet)
 	raw.NS = packer.PackString(msg.NameSpace)
 	filter := msg.Filter
@@ -195,7 +203,7 @@ func (msg *MsgNotificationFilter) MarshalBinary() (data []byte, err error) {
 	return msgBuf.Bytes(), nil
 }
 
-// Validate returns an error if the mssage contains invalid data.
+// Validate returns an error if the message contains invalid data.
 func (msg *MsgNotificationFilter) Validate() error {
 	if !msg.ModeSet.IsValid() {
 		return fmt.Errorf("unsupported modeset: %d", msg.ModeSet)
@@ -255,7 +263,9 @@ func (msg *MsgNotification) UnmarshalBinary(data []byte) error {
 
 // MarshalBinary marshals the message into binary form.
 func (msg *MsgNotification) MarshalBinary() ([]byte, error) {
-	msg.Version = 3
+	if msg.Version == 0 {
+		return nil, ErrVersionUnset
+	}
 	msg.Length = uint16(binary.Size(*msg))
 	buf := bytes.NewBuffer(make([]byte, 0, msg.Length))
 	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
@@ -265,7 +275,7 @@ func (msg *MsgNotification) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Validate returns an error if the mssage contains invalid data.
+// Validate returns an error if the message contains invalid data.
 func (msg *MsgNotification) Validate() error {
 	if !msg.NotificationType.IsValid() {
 		return fmt.Errorf("unsupported notification type: %d", msg.NotificationType)
@@ -301,6 +311,9 @@ type MsgNotificationResponse struct {
 func ResponseForRequest(req *MsgNotification) MsgNotificationResponse {
 	return MsgNotificationResponse{
 		MsgNotification: MsgNotification{
+			MsgHeader: MsgHeader{
+				Version: req.Version,
+			},
 			NotificationType: APPARMOR_NOTIF_RESP,
 			NoCache:          1,
 			ID:               req.ID,
@@ -311,7 +324,9 @@ func ResponseForRequest(req *MsgNotification) MsgNotificationResponse {
 
 // MarshalBinary marshals the message into binary form.
 func (msg *MsgNotificationResponse) MarshalBinary() ([]byte, error) {
-	msg.Version = 3
+	if msg.Version == 0 {
+		return nil, ErrVersionUnset
+	}
 	msg.Length = uint16(binary.Size(*msg))
 	buf := bytes.NewBuffer(make([]byte, 0, msg.Length))
 	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
@@ -476,7 +491,7 @@ func (msg *MsgNotificationFile) UnmarshalBinary(data []byte) error {
 func (msg *MsgNotificationFile) MarshalBinary() ([]byte, error) {
 	var raw msgNotificationFileKernel
 	packer := newStringPacker(raw)
-	raw.Version = 3
+	raw.Version = msg.Version
 	raw.NotificationType = msg.NotificationType
 	raw.Signalled = msg.Signalled
 	raw.NoCache = msg.NoCache

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -418,7 +418,7 @@ func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
 		ID:               0x1234,
 		Error:            0xFF,
 	}
-	msg.Version = notify.Version(0xAA)
+	msg.Version = notify.ProtocolVersion(0xAA)
 	data, err := msg.MarshalBinary()
 	c.Assert(err, IsNil)
 	c.Check(data, HasLen, 20)

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -234,6 +234,31 @@ func (*messageSuite) TestExtractFirstMsgErrors(c *C) {
 	}
 }
 
+func (*messageSuite) TestMessageMarshalErrors(c *C) {
+	// Try to marshal message structs without setting Version, check that
+	// ErrVersionUnset is returned
+
+	filter := notify.MsgNotificationFilter{}
+	bytes, err := filter.MarshalBinary()
+	c.Check(err, Equals, notify.ErrVersionUnset)
+	c.Check(bytes, IsNil)
+
+	notif := notify.MsgNotification{}
+	bytes, err = notif.MarshalBinary()
+	c.Check(err, Equals, notify.ErrVersionUnset)
+	c.Check(bytes, IsNil)
+
+	resp := notify.MsgNotificationResponse{}
+	bytes, err = resp.MarshalBinary()
+	c.Check(err, Equals, notify.ErrVersionUnset)
+	c.Check(bytes, IsNil)
+
+	file := notify.MsgNotificationFile{}
+	bytes, err = file.MarshalBinary()
+	c.Check(err, Equals, notify.ErrVersionUnset)
+	c.Check(bytes, IsNil)
+}
+
 func (*messageSuite) TestMsgNotificationFilterMarshalUnmarshal(c *C) {
 	if arch.Endian() == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -31,14 +31,14 @@ func (*messageSuite) TestMsgLength(c *C) {
 		{
 			bytes: []byte{
 				0xff, 0x0, // Incorrect length, but no validation done here
-				0x3, 0x0, // Protocol
+				0x5, 0x0, // Protocol
 			},
 			length: 255,
 		},
 		{
 			bytes: []byte{
 				0x10, 0x0, // Length
-				0xff, 0xff, // Protocol (invalid, should still work)
+				0xff, 0xff, // Protocol
 				0x80, 0x0, 0x0, 0x0, // Mode Set
 				0x0, 0x0, 0x0, 0x0, // Namespace
 				0x0, 0x0, 0x0, 0x0, // Filter
@@ -48,7 +48,7 @@ func (*messageSuite) TestMsgLength(c *C) {
 		{
 			bytes: []byte{
 				0x4, 0x0, // Length
-				0x3, 0x0, // Protocol
+				0xAB, 0xCD, // Protocol
 				// Next 4 bytes should be next header, but no validation done here
 				0x80, 0x0, 0x0, 0x0, // Mode Set
 				0x0, 0x0, 0x0, 0x0, // Namespace
@@ -122,7 +122,7 @@ func (*messageSuite) TestExtractFirstMsg(c *C) {
 		0x0, 0x0, 0x0, 0x0, // Filter
 		// third
 		0x4, 0x0, // Length
-		0x3, 0x0, // Protocol
+		0x5, 0x0, // Protocol
 		// Next 4 bytes should be next header, but no validation done here
 		0x80, 0x0, 0x0, 0x0, // Mode Set
 		0x0, 0x0, 0x0, 0x0, // Namespace
@@ -146,7 +146,7 @@ func (*messageSuite) TestExtractFirstMsg(c *C) {
 				0x0, 0x0, 0x0, 0x0, // Filter
 				// third
 				0x4, 0x0, // Length
-				0x3, 0x0, // Protocol
+				0x5, 0x0, // Protocol
 				// Next 4 bytes should be next header, but no validation done here
 				0x80, 0x0, 0x0, 0x0, // Mode Set
 				0x0, 0x0, 0x0, 0x0, // Namespace
@@ -164,7 +164,7 @@ func (*messageSuite) TestExtractFirstMsg(c *C) {
 			rest: []byte{
 				// third
 				0x4, 0x0, // Length
-				0x3, 0x0, // Protocol
+				0x5, 0x0, // Protocol
 				// Next 4 bytes should be next header, but no validation done here
 				0x80, 0x0, 0x0, 0x0, // Mode Set
 				0x0, 0x0, 0x0, 0x0, // Namespace
@@ -174,7 +174,7 @@ func (*messageSuite) TestExtractFirstMsg(c *C) {
 		{
 			first: []byte{
 				0x4, 0x0, // Length
-				0x3, 0x0, // Protocol
+				0x5, 0x0, // Protocol
 			},
 			rest: []byte{
 				// Next 4 bytes should be next header, but no validation done here
@@ -278,10 +278,11 @@ func (*messageSuite) TestMsgNotificationFilterMarshalUnmarshal(c *C) {
 				Filter:    []byte("bar"),
 			},
 		},
+		// TODO: add test cases for other versions once they are supported
 	} {
 		bytes, err := t.msg.MarshalBinary()
-		c.Assert(err, IsNil)
-		c.Assert(bytes, DeepEquals, t.bytes)
+		c.Check(err, IsNil)
+		c.Check(bytes, DeepEquals, t.bytes)
 
 		var msg notify.MsgNotificationFilter
 		err = msg.UnmarshalBinary(t.bytes)
@@ -356,7 +357,7 @@ func (*messageSuite) TestMsgNotificationFilterUnmarshalErrors(c *C) {
 			errMsg: `cannot unmarshal apparmor notification filter message: cannot unpack namespace: address 255 points outside of message body`,
 		},
 		{
-			comment: "message with with namespace without proper termination",
+			comment: "message with namespace without proper termination",
 			bytes: []byte{
 				0x13, 0x0, // Length
 				0x3, 0x0, // Protocol
@@ -392,12 +393,13 @@ func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
 		ID:               0x1234,
 		Error:            0xFF,
 	}
+	msg.Version = notify.Version(0xAA)
 	data, err := msg.MarshalBinary()
 	c.Assert(err, IsNil)
 	c.Check(data, HasLen, 20)
 	c.Check(data, DeepEquals, []byte{
 		0x14, 0x0, // Length
-		0x3, 0x0, // Protocol
+		0xAA, 0x0, // Protocol
 		0x0, 0x0, // Notification Type
 		0x1,                                            // Signalled
 		0x0,                                            // Reserved
@@ -479,6 +481,9 @@ func (s *messageSuite) TestMsgNotificationValidate(c *C) {
 
 func (s *messageSuite) TestResponseForRequest(c *C) {
 	req := notify.MsgNotification{
+		MsgHeader: notify.MsgHeader{
+			Version: 0xabcd,
+		},
 		ID:    1234,
 		Error: 0xbad,
 	}
@@ -487,6 +492,8 @@ func (s *messageSuite) TestResponseForRequest(c *C) {
 	c.Assert(resp.NoCache, Equals, uint8(1))
 	c.Assert(resp.ID, Equals, req.ID)
 	c.Assert(resp.MsgNotification.Error, Equals, req.Error)
+	_, err := resp.MarshalBinary()
+	c.Assert(err, IsNil)
 }
 
 func (s *messageSuite) TestMsgNotificationResponseMarshalBinary(c *C) {
@@ -495,6 +502,9 @@ func (s *messageSuite) TestMsgNotificationResponseMarshalBinary(c *C) {
 	}
 	msg := notify.MsgNotificationResponse{
 		MsgNotification: notify.MsgNotification{
+			MsgHeader: notify.MsgHeader{
+				Version: 43,
+			},
 			NotificationType: 0x11,
 			Signalled:        0x22,
 			NoCache:          0x33,
@@ -509,7 +519,7 @@ func (s *messageSuite) TestMsgNotificationResponseMarshalBinary(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(bytes, DeepEquals, []byte{
 		0x20, 0x0, // Length
-		0x3, 0x0, // Version
+		43, 0x0, // Version
 		0x11, 0x0, // Notification Type
 		0x22,                                    // Signalled
 		0x33,                                    // Reserved

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -28,8 +28,8 @@ var doIoctl = Ioctl
 //
 // If no protocol version is mutually supported, or some other error occurs,
 // returns an error.
-func RegisterFileDescriptor(fd uintptr) (Version, error) {
-	unsupported := make(map[Version]bool)
+func RegisterFileDescriptor(fd uintptr) (ProtocolVersion, error) {
+	unsupported := make(map[ProtocolVersion]bool)
 	for {
 		protocolVersion, ok := supportedProtocolVersion(unsupported)
 		if !ok {

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -31,7 +31,7 @@ var doIoctl = Ioctl
 func RegisterFileDescriptor(fd uintptr) (ProtocolVersion, error) {
 	unsupported := make(map[ProtocolVersion]bool)
 	for {
-		protocolVersion, ok := supportedProtocolVersion(unsupported)
+		protocolVersion, ok := likelySupportedProtocolVersion(unsupported)
 		if !ok {
 			return 0, fmt.Errorf("cannot register notify socket: no mutually supported protocol versions")
 		}

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -47,14 +47,9 @@ func RegisterFileDescriptor(fd uintptr) (Version, error) {
 		}
 		ioctlBuf := IoctlRequestBuffer(data)
 		if _, err = doIoctl(fd, APPARMOR_NOTIF_SET_FILTER, ioctlBuf); err != nil {
-			var ioctlErr *IoctlError
-			if errors.As(err, &ioctlErr) {
-				if ioctlErr.Errno == unix.ENOTSUP || ioctlErr.Errno == unix.EPROTONOSUPPORT {
-					// TODO: only one of these errnos is correct, so limit to
-					// correct one once confirming with JJ.
-					unsupported[protocolVersion] = true
-					continue
-				}
+			if errors.Is(err, unix.EPROTONOSUPPORT) {
+				unsupported[protocolVersion] = true
+				continue
 			}
 			return 0, err
 		}

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -2,7 +2,11 @@
 package notify
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -14,6 +18,46 @@ var SysPath string
 // prompting messages may be received from SysPath.
 func SupportAvailable() bool {
 	return osutil.FileExists(SysPath)
+}
+
+// RegisterFileDescriptor registers a notification socket using the given file
+// descriptor. Attempts to use the latest notification protocol version which
+// both snapd and the kernel support, and returns that version.
+//
+// If no protocol version is mutually supported, or some other error occurs,
+// returns an error.
+func RegisterFileDescriptor(fd uintptr) (Version, error) {
+	unsupported := make(map[Version]bool)
+	for {
+		protocolVersion, ok := supportedProtocolVersion(unsupported)
+		if !ok {
+			return 0, fmt.Errorf("cannot register notify socket: no mutually supported protocol versions")
+		}
+		msg := MsgNotificationFilter{
+			MsgHeader: MsgHeader{
+				Version: protocolVersion,
+			},
+			ModeSet: APPARMOR_MODESET_USER,
+		}
+		data, err := msg.MarshalBinary()
+		if err != nil {
+			return 0, err
+		}
+		ioctlBuf := IoctlRequestBuffer(data)
+		if _, err = Ioctl(fd, APPARMOR_NOTIF_SET_FILTER, ioctlBuf); err != nil {
+			var ioctlErr *IoctlError
+			if errors.As(err, &ioctlErr) {
+				if ioctlErr.errno == unix.ENOTSUP || ioctlErr.errno == unix.EPROTONOSUPPORT {
+					// TODO: only one of these errnos is correct, so limit to
+					// correct one once confirming with JJ.
+					unsupported[protocolVersion] = true
+					continue
+				}
+			}
+			return 0, err
+		}
+		return protocolVersion, nil
+	}
 }
 
 func setupSysPath(newrootdir string) {

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -20,6 +20,8 @@ func SupportAvailable() bool {
 	return osutil.FileExists(SysPath)
 }
 
+var doIoctl = Ioctl
+
 // RegisterFileDescriptor registers a notification socket using the given file
 // descriptor. Attempts to use the latest notification protocol version which
 // both snapd and the kernel support, and returns that version.
@@ -44,10 +46,10 @@ func RegisterFileDescriptor(fd uintptr) (Version, error) {
 			return 0, err
 		}
 		ioctlBuf := IoctlRequestBuffer(data)
-		if _, err = Ioctl(fd, APPARMOR_NOTIF_SET_FILTER, ioctlBuf); err != nil {
+		if _, err = doIoctl(fd, APPARMOR_NOTIF_SET_FILTER, ioctlBuf); err != nil {
 			var ioctlErr *IoctlError
 			if errors.As(err, &ioctlErr) {
-				if ioctlErr.errno == unix.ENOTSUP || ioctlErr.errno == unix.EPROTONOSUPPORT {
+				if ioctlErr.Errno == unix.ENOTSUP || ioctlErr.Errno == unix.EPROTONOSUPPORT {
 					// TODO: only one of these errnos is correct, so limit to
 					// correct one once confirming with JJ.
 					unsupported[protocolVersion] = true

--- a/sandbox/apparmor/notify/notify_test.go
+++ b/sandbox/apparmor/notify/notify_test.go
@@ -73,7 +73,7 @@ var fakeNotifyVersions = []notify.VersionAndCallback{
 }
 
 func (s *notifySuite) TestRegisterFileDescriptor(c *C) {
-	restoreVersions := notify.MockVersionSupportedCallbacks(fakeNotifyVersions)
+	restoreVersions := notify.MockVersionLikelySupportedCallbacks(fakeNotifyVersions)
 	defer restoreVersions()
 
 	var fakeFD uintptr = 1234
@@ -120,7 +120,7 @@ func checkIoctlBuffer(c *C, receivedBuf notify.IoctlRequestBuffer, expectedVersi
 }
 
 func (s *notifySuite) TestRegisterFileDescriptorErrors(c *C) {
-	restoreVersions := notify.MockVersionSupportedCallbacks(fakeNotifyVersions)
+	restoreVersions := notify.MockVersionLikelySupportedCallbacks(fakeNotifyVersions)
 	defer restoreVersions()
 
 	var fakeFD uintptr = 1234

--- a/sandbox/apparmor/notify/notify_test.go
+++ b/sandbox/apparmor/notify/notify_test.go
@@ -49,31 +49,31 @@ func (*notifySuite) TestSupportAvailable(c *C) {
 	c.Assert(notify.SupportAvailable(), Equals, true)
 }
 
-var fakeNotifyVersions = []notify.VersionAndCallback{
+var fakeNotifyVersions = []notify.VersionAndCheck{
 	{
-		Version:  2,
-		Callback: func() bool { return false },
+		Version: 2,
+		Check:   func() bool { return false },
 	},
 	{
-		Version:  3,
-		Callback: func() bool { return true },
+		Version: 3,
+		Check:   func() bool { return true },
 	},
 	{
-		Version:  5,
-		Callback: func() bool { return false },
+		Version: 5,
+		Check:   func() bool { return false },
 	},
 	{
-		Version:  7,
-		Callback: func() bool { return true },
+		Version: 7,
+		Check:   func() bool { return true },
 	},
 	{
-		Version:  11,
-		Callback: func() bool { return false },
+		Version: 11,
+		Check:   func() bool { return false },
 	},
 }
 
 func (s *notifySuite) TestRegisterFileDescriptor(c *C) {
-	restoreVersions := notify.MockVersionLikelySupportedCallbacks(fakeNotifyVersions)
+	restoreVersions := notify.MockVersionLikelySupportedChecks(fakeNotifyVersions)
 	defer restoreVersions()
 
 	var fakeFD uintptr = 1234
@@ -120,7 +120,7 @@ func checkIoctlBuffer(c *C, receivedBuf notify.IoctlRequestBuffer, expectedVersi
 }
 
 func (s *notifySuite) TestRegisterFileDescriptorErrors(c *C) {
-	restoreVersions := notify.MockVersionLikelySupportedCallbacks(fakeNotifyVersions)
+	restoreVersions := notify.MockVersionLikelySupportedChecks(fakeNotifyVersions)
 	defer restoreVersions()
 
 	var fakeFD uintptr = 1234

--- a/sandbox/apparmor/notify/notify_test.go
+++ b/sandbox/apparmor/notify/notify_test.go
@@ -7,6 +7,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/testutil"
@@ -44,4 +46,131 @@ func (*notifySuite) TestSupportAvailable(c *C) {
 	_, err = os.Create(notify.SysPath)
 	c.Assert(err, IsNil)
 	c.Assert(notify.SupportAvailable(), Equals, true)
+}
+
+var fakeNotifyVersions = []notify.VersionAndCallback{
+	{
+		Version:  2,
+		Callback: func() bool { return false },
+	},
+	{
+		Version:  3,
+		Callback: func() bool { return true },
+	},
+	{
+		Version:  5,
+		Callback: func() bool { return false },
+	},
+	{
+		Version:  7,
+		Callback: func() bool { return true },
+	},
+	{
+		Version:  11,
+		Callback: func() bool { return false },
+	},
+}
+
+func (s *notifySuite) TestRegisterFileDescriptor(c *C) {
+	restoreVersions := notify.MockVersionSupportedCallbacks(fakeNotifyVersions)
+	defer restoreVersions()
+
+	var fd uintptr = 1234
+
+	ioctlCalls := 0
+	restoreSyscall := notify.MockSyscall(func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err unix.Errno) {
+		c.Assert(unix.Errno(trap), Equals, unix.Errno(unix.SYS_IOCTL))
+		c.Assert(a1, Equals, fd)
+		c.Assert(notify.IoctlRequest(a2), Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+
+		ioctlCalls++
+
+		// First expect check for version 3, then for version 7
+		switch ioctlCalls {
+		case 1:
+			checkIoctlBuffer(c, a3, notify.Version(3))
+			return 0, 0, unix.EPROTONOSUPPORT
+		case 2:
+			checkIoctlBuffer(c, a3, notify.Version(7))
+			return 0, 0, 0 // no error
+		default:
+			c.Fatal("called Ioctl more than twice")
+			return 0, 0, 0 // no error
+		}
+	})
+	defer restoreSyscall()
+
+	receivedVersion, err := notify.RegisterFileDescriptor(fd)
+	c.Check(err, IsNil)
+	c.Check(receivedVersion, Equals, notify.Version(7))
+}
+
+func checkIoctlBuffer(c *C, ptr uintptr, expectedVersion notify.Version) {
+	expectedMsg := notify.MsgNotificationFilter{
+		MsgHeader: notify.MsgHeader{
+			Version: expectedVersion,
+		},
+		ModeSet: notify.APPARMOR_MODESET_USER,
+	}
+	expectedBuf, err := expectedMsg.MarshalBinary()
+	c.Assert(err, IsNil)
+
+	// XXX: go vet thinks this is unsafe, since uintptr isn't known to point to
+	// valid allocated memory, even though we, the programmer, know it does
+	// (to the buffer passed into Ioctl()). And there doesn't seem to be a way
+	// to disable the vet error. Need some golang wizard advice here.
+	// The tests pass with this uncommented, but go vet fails.
+	//receivedBuf := unsafe.Slice((*byte)(unsafe.Pointer(ptr)), len(expectedBuf))
+	//c.Check(receivedBuf, DeepEquals, expectedBuf, Commentf("received incorrect buffer on Ioctl call, which expected version %d", expectedVersion))
+	c.Check(expectedBuf, NotNil)
+}
+
+func (s *notifySuite) TestRegisterFileDescriptorErrors(c *C) {
+	restoreVersions := notify.MockVersionSupportedCallbacks(fakeNotifyVersions)
+	defer restoreVersions()
+
+	var fd uintptr = 1234
+
+	ioctlCalls := 0
+	restoreSyscall := notify.MockSyscall(func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err unix.Errno) {
+		c.Assert(unix.Errno(trap), Equals, unix.Errno(unix.SYS_IOCTL))
+		c.Assert(a1, Equals, fd)
+		c.Assert(notify.IoctlRequest(a2), Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+
+		ioctlCalls++
+
+		// First expect check for version 3, then for version 7
+		switch ioctlCalls {
+		case 1:
+			checkIoctlBuffer(c, a3, notify.Version(3))
+		case 2:
+			checkIoctlBuffer(c, a3, notify.Version(7))
+		default:
+			c.Fatal("called Ioctl more than twice")
+		}
+		// Always return EPROTONOSUPPORT
+		return 0, 0, unix.EPROTONOSUPPORT
+	})
+	defer restoreSyscall()
+
+	receivedVersion, err := notify.RegisterFileDescriptor(fd)
+	c.Check(err, ErrorMatches, "cannot register notify socket: no mutually supported protocol versions")
+	c.Check(receivedVersion, Equals, notify.Version(0))
+
+	calledIoctl := false
+	restoreSyscallError := notify.MockSyscall(func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err unix.Errno) {
+		c.Assert(unix.Errno(trap), Equals, unix.Errno(unix.SYS_IOCTL))
+		c.Assert(a1, Equals, fd)
+		c.Assert(notify.IoctlRequest(a2), Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+
+		checkIoctlBuffer(c, a3, notify.Version(3))
+		c.Assert(calledIoctl, Equals, false, Commentf("called ioctl more than once after first returned error"))
+		calledIoctl = true
+		return 0, 0, unix.EINVAL // some non-recoverable error
+	})
+	defer restoreSyscallError()
+
+	receivedVersion, err = notify.RegisterFileDescriptor(fd)
+	c.Check(err, ErrorMatches, "cannot perform IOCTL request APPARMOR_NOTIF_SET_FILTER: EINVAL")
+	c.Check(receivedVersion, Equals, notify.Version(0))
 }

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -21,8 +21,6 @@ package notify
 
 import (
 	"fmt"
-
-	"github.com/snapcore/snapd/testutil"
 )
 
 // ProtocolVersion denotes a notification protocol version.
@@ -92,5 +90,10 @@ func likelySupportedProtocolVersion(unsupported map[ProtocolVersion]bool) (Proto
 }
 
 func MockVersionKnown(f func(v ProtocolVersion) bool) (restore func()) {
-	return testutil.Mock(&versionKnown, f)
+	orig := versionKnown
+	versionKnown = f
+	restore = func() {
+		versionKnown = orig
+	}
+	return restore
 }

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notify
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/testutil"
+)
+
+// Version denotes a notification protocol version.
+type Version uint16
+
+// versions holds the notification protocol snapd supports, in order of
+// preference. If the first version is supported, try to use it, else try the
+// next version, etc.
+var (
+	versions = []Version{3}
+
+	versionSupportedCallbacks = map[Version]func() bool{
+		3: SupportAvailable,
+	}
+
+	versionKnown = func(v Version) bool {
+		_, exists := versionSupportedCallbacks[v]
+		return exists
+	}
+)
+
+func (v Version) supported() (bool, error) {
+	callback, exists := versionSupportedCallbacks[v]
+	if !exists {
+		// Should not occur, as tests should validate that each version has a callback function.
+		return false, fmt.Errorf("no callback defined for version %d", v)
+	}
+	return callback(), nil
+}
+
+// supportedProtocolVersion returns the preferred protocol version which is
+// expected to be supported by both snapd and the kernel. Any versions included
+// in unsupported are not tried.
+//
+// Any versions which are found to be unsupported are added to the given
+// unsupported map so that, in case the returned version reports as being
+// unsupported by the kernel, subsequent calls to this function will not
+// require duplicate checks of callback functions.
+func supportedProtocolVersion(unsupported map[Version]bool) (Version, bool) {
+	for _, v := range versions {
+		if _, exists := unsupported[v]; exists {
+			continue
+		}
+		if supported, _ := v.supported(); !supported {
+			unsupported[v] = true
+			continue
+		}
+		return v, true
+	}
+	return Version(0), false
+}
+
+func MockVersionKnown(f func(v Version) bool) (restore func()) {
+	return testutil.Mock(&versionKnown, f)
+}

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -45,10 +45,12 @@ var (
 )
 
 func (v ProtocolVersion) supported() (bool, error) {
-	callback, exists := versionSupportedCallbacks[v]
-	if !exists {
-		// Should not occur, as tests should validate that each version has a callback function.
-		return false, fmt.Errorf("no callback defined for version %d", v)
+	callback, ok := versionSupportedCallbacks[v]
+	if !ok {
+		// Should not occur, since the caller should only call this method on
+		// known versions, and tests should validate that each known version
+		// has a callback function.
+		return false, fmt.Errorf("internal error: no callback defined for version %d", v)
 	}
 	return callback(), nil
 }

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -28,24 +28,38 @@ import (
 // ProtocolVersion denotes a notification protocol version.
 type ProtocolVersion uint16
 
-// versions holds the notification protocols snapd supports, in order of
-// preference. If the first version is supported, try to use it, else try the
-// next version, etc.
 var (
+	// versions holds the notification protocols snapd supports, in order of
+	// preference. If the first version is supported, try to use it, else try
+	// the next version, etc.
 	versions = []ProtocolVersion{3}
 
-	versionSupportedCallbacks = map[ProtocolVersion]func() bool{
+	// versionLikelySupportedCallbacks provides a function for each known
+	// protocol version which returns true if that version is supported by
+	// snapd and likely supported by the kernel. Kernel support may be guaged
+	// by checking kernel features or probing the filesystem for hints from the
+	// kernel about which versions it supports. Even if the callback returns
+	// true, the kernel may return EPROTONOSUPPORT when attempting to register
+	// on the notify socket with that version, in which case we'll need to try
+	// the next version in the list.
+	versionLikelySupportedCallbacks = map[ProtocolVersion]func() bool{
 		3: SupportAvailable,
 	}
 
+	// versionKnown returns true if the given protocol version is known by
+	// snapd. Even if true, the version may still be unsupported by snapd or
+	// the kernel.
 	versionKnown = func(v ProtocolVersion) bool {
-		_, exists := versionSupportedCallbacks[v]
+		_, exists := versionLikelySupportedCallbacks[v]
 		return exists
 	}
 )
 
-func (v ProtocolVersion) supported() (bool, error) {
-	callback, ok := versionSupportedCallbacks[v]
+// likelySupported returns true if the receiving version is supported by snapd
+// and likely supported by the kernel, as reported by the likely supported
+// callback for that version.
+func (v ProtocolVersion) likelySupported() (bool, error) {
+	callback, ok := versionLikelySupportedCallbacks[v]
 	if !ok {
 		// Should not occur, since the caller should only call this method on
 		// known versions, and tests should validate that each known version
@@ -55,20 +69,20 @@ func (v ProtocolVersion) supported() (bool, error) {
 	return callback(), nil
 }
 
-// supportedProtocolVersion returns the preferred protocol version which is
-// expected to be supported by both snapd and the kernel. Any versions included
-// in unsupported are not tried.
+// likelySupportedProtocolVersion returns the preferred protocol version which
+// is expected to be supported by both snapd and the kernel. Any versions
+// included in the given unsupported map are not tried.
 //
 // Any versions which are found to be unsupported are added to the given
 // unsupported map so that, in case the returned version reports as being
 // unsupported by the kernel, subsequent calls to this function will not
 // require duplicate checks of callback functions.
-func supportedProtocolVersion(unsupported map[ProtocolVersion]bool) (ProtocolVersion, bool) {
+func likelySupportedProtocolVersion(unsupported map[ProtocolVersion]bool) (ProtocolVersion, bool) {
 	for _, v := range versions {
 		if _, exists := unsupported[v]; exists {
 			continue
 		}
-		if supported, _ := v.supported(); !supported {
+		if supported, _ := v.likelySupported(); !supported {
 			unsupported[v] = true
 			continue
 		}

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -25,26 +25,26 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-// Version denotes a notification protocol version.
-type Version uint16
+// ProtocolVersion denotes a notification protocol version.
+type ProtocolVersion uint16
 
-// versions holds the notification protocol snapd supports, in order of
+// versions holds the notification protocols snapd supports, in order of
 // preference. If the first version is supported, try to use it, else try the
 // next version, etc.
 var (
-	versions = []Version{3}
+	versions = []ProtocolVersion{3}
 
-	versionSupportedCallbacks = map[Version]func() bool{
+	versionSupportedCallbacks = map[ProtocolVersion]func() bool{
 		3: SupportAvailable,
 	}
 
-	versionKnown = func(v Version) bool {
+	versionKnown = func(v ProtocolVersion) bool {
 		_, exists := versionSupportedCallbacks[v]
 		return exists
 	}
 )
 
-func (v Version) supported() (bool, error) {
+func (v ProtocolVersion) supported() (bool, error) {
 	callback, exists := versionSupportedCallbacks[v]
 	if !exists {
 		// Should not occur, as tests should validate that each version has a callback function.
@@ -61,7 +61,7 @@ func (v Version) supported() (bool, error) {
 // unsupported map so that, in case the returned version reports as being
 // unsupported by the kernel, subsequent calls to this function will not
 // require duplicate checks of callback functions.
-func supportedProtocolVersion(unsupported map[Version]bool) (Version, bool) {
+func supportedProtocolVersion(unsupported map[ProtocolVersion]bool) (ProtocolVersion, bool) {
 	for _, v := range versions {
 		if _, exists := unsupported[v]; exists {
 			continue
@@ -72,9 +72,9 @@ func supportedProtocolVersion(unsupported map[Version]bool) (Version, bool) {
 		}
 		return v, true
 	}
-	return Version(0), false
+	return ProtocolVersion(0), false
 }
 
-func MockVersionKnown(f func(v Version) bool) (restore func()) {
+func MockVersionKnown(f func(v ProtocolVersion) bool) (restore func()) {
 	return testutil.Mock(&versionKnown, f)
 }

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -1,0 +1,168 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notify_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+)
+
+type versionSuite struct{}
+
+var _ = Suite(&versionSuite{})
+
+func (s *versionSuite) TestVersionsAndCallbacks(c *C) {
+	// Check both directions so we get pretty printing for the values on error
+	c.Check(notify.Versions, HasLen, len(notify.VersionSupportedCallbacks))
+	c.Check(notify.VersionSupportedCallbacks, HasLen, len(notify.Versions))
+
+	for _, version := range notify.Versions {
+		callback, exists := notify.VersionSupportedCallbacks[version]
+		c.Check(exists, Equals, true, Commentf("version in versions missing from versionSupportedCallbacks: %v", version))
+		c.Check(callback, NotNil, Commentf("version has nil callback: %v", version))
+	}
+
+	for version, callback := range notify.VersionSupportedCallbacks {
+		c.Check(callback, NotNil, Commentf("version has nil callback: %v", version))
+		found := false
+		for _, v := range notify.Versions {
+			if version == v {
+				found = true
+				break
+			}
+		}
+		c.Check(found, Equals, true, Commentf("version in versionSupportedCallbacks missing from versions: %v", version))
+	}
+}
+
+var fakeVersions = []notify.VersionAndCallback{
+	{
+		Version:  2,
+		Callback: func() bool { return false },
+	},
+	{
+		Version:  3,
+		Callback: func() bool { return true },
+	},
+	{
+		Version:  5,
+		Callback: func() bool { return false },
+	},
+	{
+		Version:  7,
+		Callback: func() bool { return true },
+	},
+	{
+		Version:  11,
+		Callback: func() bool { return false },
+	},
+}
+
+func (s *versionSuite) TestVersionSupported(c *C) {
+	restore := notify.MockVersionSupportedCallbacks(fakeVersions)
+	defer restore()
+
+	supported, err := notify.Supported(notify.Version(1))
+	c.Check(supported, Equals, false)
+	c.Check(err, ErrorMatches, "no callback defined for version .*")
+
+	supported, err = notify.Supported(notify.Version(2))
+	c.Check(supported, Equals, false)
+	c.Check(err, IsNil)
+
+	supported, err = notify.Supported(notify.Version(3))
+	c.Check(supported, Equals, true)
+	c.Check(err, IsNil)
+
+	supported, err = notify.Supported(notify.Version(4))
+	c.Check(supported, Equals, false)
+	c.Check(err, ErrorMatches, "no callback defined for version .*")
+}
+
+func (s *versionSuite) TestSupportedProtocolVersion(c *C) {
+	restore := notify.MockVersionSupportedCallbacks(fakeVersions)
+	defer restore()
+
+	for _, testCase := range []struct {
+		unsupported       map[notify.Version]bool
+		expectedVersion   notify.Version
+		expectedSupported bool
+		expectedMutated   map[notify.Version]bool
+	}{
+		{
+			unsupported:       map[notify.Version]bool{},
+			expectedVersion:   notify.Version(3),
+			expectedSupported: true,
+			expectedMutated:   map[notify.Version]bool{notify.Version(2): true},
+		},
+		{
+			unsupported: map[notify.Version]bool{
+				notify.Version(4): true,
+				notify.Version(5): true,
+			},
+			expectedVersion:   notify.Version(3),
+			expectedSupported: true,
+			expectedMutated: map[notify.Version]bool{
+				notify.Version(2): true,
+				notify.Version(4): true,
+				notify.Version(5): true,
+			},
+		},
+		{
+			unsupported: map[notify.Version]bool{
+				notify.Version(3): true,
+				notify.Version(4): true,
+				notify.Version(5): true,
+			},
+			expectedVersion:   notify.Version(7),
+			expectedSupported: true,
+			expectedMutated: map[notify.Version]bool{
+				notify.Version(2): true,
+				notify.Version(3): true,
+				notify.Version(4): true,
+				notify.Version(5): true,
+			},
+		},
+		{
+			unsupported: map[notify.Version]bool{
+				notify.Version(3): true,
+				notify.Version(4): true,
+				notify.Version(5): true,
+				notify.Version(7): true,
+			},
+			expectedVersion:   notify.Version(0),
+			expectedSupported: false,
+			expectedMutated: map[notify.Version]bool{
+				notify.Version(2):  true,
+				notify.Version(3):  true,
+				notify.Version(4):  true,
+				notify.Version(5):  true,
+				notify.Version(7):  true,
+				notify.Version(11): true,
+			},
+		},
+	} {
+		version, supported := notify.SupportedProtocolVersion(testCase.unsupported)
+		c.Check(version, Equals, testCase.expectedVersion, Commentf("testCase: %+v", testCase))
+		c.Check(supported, Equals, testCase.expectedSupported, Commentf("testCase: %+v", testCase))
+		c.Check(testCase.unsupported, DeepEquals, testCase.expectedMutated, Commentf("testCase: %+v"))
+	}
+}

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -32,18 +32,18 @@ var _ = Suite(&versionSuite{})
 
 func (s *versionSuite) TestVersionsAndCallbacks(c *C) {
 	// Check both directions so we get pretty printing for the values on error
-	c.Check(notify.Versions, HasLen, len(notify.VersionSupportedCallbacks))
-	c.Check(notify.VersionSupportedCallbacks, HasLen, len(notify.Versions))
+	c.Check(notify.Versions, HasLen, len(notify.VersionLikelySupportedCallbacks))
+	c.Check(notify.VersionLikelySupportedCallbacks, HasLen, len(notify.Versions))
 
 	for _, ver := range notify.Versions {
-		callback, exists := notify.VersionSupportedCallbacks[ver]
-		c.Check(exists, Equals, true, Commentf("version in versions missing from versionSupportedCallbacks: %v", ver))
+		callback, exists := notify.VersionLikelySupportedCallbacks[ver]
+		c.Check(exists, Equals, true, Commentf("version in versions missing from versionLikelySupportedCallbacks: %v", ver))
 		c.Check(callback, NotNil, Commentf("version has nil callback: %v", ver))
 	}
 
-	for ver, callback := range notify.VersionSupportedCallbacks {
+	for ver, callback := range notify.VersionLikelySupportedCallbacks {
 		c.Check(callback, NotNil, Commentf("version has nil callback: %v", ver))
-		c.Check(notify.Versions, testutil.Contains, ver, Commentf("version in versionSupportedCallbacks missing from versions: %v", ver))
+		c.Check(notify.Versions, testutil.Contains, ver, Commentf("version in versionLikelySupportedCallbacks missing from versions: %v", ver))
 	}
 }
 
@@ -70,29 +70,29 @@ var fakeVersions = []notify.VersionAndCallback{
 	},
 }
 
-func (s *versionSuite) TestVersionSupported(c *C) {
-	restore := notify.MockVersionSupportedCallbacks(fakeVersions)
+func (s *versionSuite) TestVersionLikelySupported(c *C) {
+	restore := notify.MockVersionLikelySupportedCallbacks(fakeVersions)
 	defer restore()
 
-	supported, err := notify.Supported(notify.ProtocolVersion(1))
+	supported, err := notify.LikelySupported(notify.ProtocolVersion(1))
 	c.Check(err, ErrorMatches, "internal error: no callback defined for version .*")
 	c.Check(supported, Equals, false)
 
-	supported, err = notify.Supported(notify.ProtocolVersion(2))
+	supported, err = notify.LikelySupported(notify.ProtocolVersion(2))
 	c.Check(err, IsNil)
 	c.Check(supported, Equals, false)
 
-	supported, err = notify.Supported(notify.ProtocolVersion(3))
+	supported, err = notify.LikelySupported(notify.ProtocolVersion(3))
 	c.Check(err, IsNil)
 	c.Check(supported, Equals, true)
 
-	supported, err = notify.Supported(notify.ProtocolVersion(4))
+	supported, err = notify.LikelySupported(notify.ProtocolVersion(4))
 	c.Check(err, ErrorMatches, "internal error: no callback defined for version .*")
 	c.Check(supported, Equals, false)
 }
 
-func (s *versionSuite) TestSupportedProtocolVersion(c *C) {
-	restore := notify.MockVersionSupportedCallbacks(fakeVersions)
+func (s *versionSuite) TestLikelySupportedProtocolVersion(c *C) {
+	restore := notify.MockVersionLikelySupportedCallbacks(fakeVersions)
 	defer restore()
 
 	for _, testCase := range []struct {
@@ -154,7 +154,7 @@ func (s *versionSuite) TestSupportedProtocolVersion(c *C) {
 			},
 		},
 	} {
-		protoVersion, supported := notify.SupportedProtocolVersion(testCase.unsupported)
+		protoVersion, supported := notify.LikelySupportedProtocolVersion(testCase.unsupported)
 		comment := Commentf("testCase: %+v", testCase)
 		c.Check(protoVersion, Equals, testCase.expectedVersion, comment)
 		c.Check(supported, Equals, testCase.expectedSupported, comment)

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -75,7 +75,7 @@ func (s *versionSuite) TestVersionSupported(c *C) {
 	defer restore()
 
 	supported, err := notify.Supported(notify.ProtocolVersion(1))
-	c.Check(err, ErrorMatches, "no callback defined for version .*")
+	c.Check(err, ErrorMatches, "internal error: no callback defined for version .*")
 	c.Check(supported, Equals, false)
 
 	supported, err = notify.Supported(notify.ProtocolVersion(2))
@@ -87,7 +87,7 @@ func (s *versionSuite) TestVersionSupported(c *C) {
 	c.Check(supported, Equals, true)
 
 	supported, err = notify.Supported(notify.ProtocolVersion(4))
-	c.Check(err, ErrorMatches, "no callback defined for version .*")
+	c.Check(err, ErrorMatches, "internal error: no callback defined for version .*")
 	c.Check(supported, Equals, false)
 }
 

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type versionSuite struct{}
@@ -42,14 +43,7 @@ func (s *versionSuite) TestVersionsAndCallbacks(c *C) {
 
 	for ver, callback := range notify.VersionSupportedCallbacks {
 		c.Check(callback, NotNil, Commentf("version has nil callback: %v", ver))
-		found := false
-		for _, v := range notify.Versions {
-			if ver == v {
-				found = true
-				break
-			}
-		}
-		c.Check(found, Equals, true, Commentf("version in versionSupportedCallbacks missing from versions: %v", ver))
+		c.Check(notify.Versions, testutil.Contains, ver, Commentf("version in versionSupportedCallbacks missing from versions: %v", ver))
 	}
 }
 
@@ -81,20 +75,20 @@ func (s *versionSuite) TestVersionSupported(c *C) {
 	defer restore()
 
 	supported, err := notify.Supported(notify.ProtocolVersion(1))
-	c.Check(supported, Equals, false)
 	c.Check(err, ErrorMatches, "no callback defined for version .*")
+	c.Check(supported, Equals, false)
 
 	supported, err = notify.Supported(notify.ProtocolVersion(2))
-	c.Check(supported, Equals, false)
 	c.Check(err, IsNil)
+	c.Check(supported, Equals, false)
 
 	supported, err = notify.Supported(notify.ProtocolVersion(3))
-	c.Check(supported, Equals, true)
 	c.Check(err, IsNil)
+	c.Check(supported, Equals, true)
 
 	supported, err = notify.Supported(notify.ProtocolVersion(4))
-	c.Check(supported, Equals, false)
 	c.Check(err, ErrorMatches, "no callback defined for version .*")
+	c.Check(supported, Equals, false)
 }
 
 func (s *versionSuite) TestSupportedProtocolVersion(c *C) {
@@ -161,8 +155,9 @@ func (s *versionSuite) TestSupportedProtocolVersion(c *C) {
 		},
 	} {
 		protoVersion, supported := notify.SupportedProtocolVersion(testCase.unsupported)
-		c.Check(protoVersion, Equals, testCase.expectedVersion, Commentf("testCase: %+v", testCase))
-		c.Check(supported, Equals, testCase.expectedSupported, Commentf("testCase: %+v", testCase))
-		c.Check(testCase.unsupported, DeepEquals, testCase.expectedMutated, Commentf("testCase: %+v"))
+		comment := Commentf("testCase: %+v", testCase)
+		c.Check(protoVersion, Equals, testCase.expectedVersion, comment)
+		c.Check(supported, Equals, testCase.expectedSupported, comment)
+		c.Check(testCase.unsupported, DeepEquals, testCase.expectedMutated, comment)
 	}
 }

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -34,22 +34,22 @@ func (s *versionSuite) TestVersionsAndCallbacks(c *C) {
 	c.Check(notify.Versions, HasLen, len(notify.VersionSupportedCallbacks))
 	c.Check(notify.VersionSupportedCallbacks, HasLen, len(notify.Versions))
 
-	for _, version := range notify.Versions {
-		callback, exists := notify.VersionSupportedCallbacks[version]
-		c.Check(exists, Equals, true, Commentf("version in versions missing from versionSupportedCallbacks: %v", version))
-		c.Check(callback, NotNil, Commentf("version has nil callback: %v", version))
+	for _, ver := range notify.Versions {
+		callback, exists := notify.VersionSupportedCallbacks[ver]
+		c.Check(exists, Equals, true, Commentf("version in versions missing from versionSupportedCallbacks: %v", ver))
+		c.Check(callback, NotNil, Commentf("version has nil callback: %v", ver))
 	}
 
-	for version, callback := range notify.VersionSupportedCallbacks {
-		c.Check(callback, NotNil, Commentf("version has nil callback: %v", version))
+	for ver, callback := range notify.VersionSupportedCallbacks {
+		c.Check(callback, NotNil, Commentf("version has nil callback: %v", ver))
 		found := false
 		for _, v := range notify.Versions {
-			if version == v {
+			if ver == v {
 				found = true
 				break
 			}
 		}
-		c.Check(found, Equals, true, Commentf("version in versionSupportedCallbacks missing from versions: %v", version))
+		c.Check(found, Equals, true, Commentf("version in versionSupportedCallbacks missing from versions: %v", ver))
 	}
 }
 
@@ -80,19 +80,19 @@ func (s *versionSuite) TestVersionSupported(c *C) {
 	restore := notify.MockVersionSupportedCallbacks(fakeVersions)
 	defer restore()
 
-	supported, err := notify.Supported(notify.Version(1))
+	supported, err := notify.Supported(notify.ProtocolVersion(1))
 	c.Check(supported, Equals, false)
 	c.Check(err, ErrorMatches, "no callback defined for version .*")
 
-	supported, err = notify.Supported(notify.Version(2))
+	supported, err = notify.Supported(notify.ProtocolVersion(2))
 	c.Check(supported, Equals, false)
 	c.Check(err, IsNil)
 
-	supported, err = notify.Supported(notify.Version(3))
+	supported, err = notify.Supported(notify.ProtocolVersion(3))
 	c.Check(supported, Equals, true)
 	c.Check(err, IsNil)
 
-	supported, err = notify.Supported(notify.Version(4))
+	supported, err = notify.Supported(notify.ProtocolVersion(4))
 	c.Check(supported, Equals, false)
 	c.Check(err, ErrorMatches, "no callback defined for version .*")
 }
@@ -102,66 +102,66 @@ func (s *versionSuite) TestSupportedProtocolVersion(c *C) {
 	defer restore()
 
 	for _, testCase := range []struct {
-		unsupported       map[notify.Version]bool
-		expectedVersion   notify.Version
+		unsupported       map[notify.ProtocolVersion]bool
+		expectedVersion   notify.ProtocolVersion
 		expectedSupported bool
-		expectedMutated   map[notify.Version]bool
+		expectedMutated   map[notify.ProtocolVersion]bool
 	}{
 		{
-			unsupported:       map[notify.Version]bool{},
-			expectedVersion:   notify.Version(3),
+			unsupported:       map[notify.ProtocolVersion]bool{},
+			expectedVersion:   notify.ProtocolVersion(3),
 			expectedSupported: true,
-			expectedMutated:   map[notify.Version]bool{notify.Version(2): true},
+			expectedMutated:   map[notify.ProtocolVersion]bool{notify.ProtocolVersion(2): true},
 		},
 		{
-			unsupported: map[notify.Version]bool{
-				notify.Version(4): true,
-				notify.Version(5): true,
+			unsupported: map[notify.ProtocolVersion]bool{
+				notify.ProtocolVersion(4): true,
+				notify.ProtocolVersion(5): true,
 			},
-			expectedVersion:   notify.Version(3),
+			expectedVersion:   notify.ProtocolVersion(3),
 			expectedSupported: true,
-			expectedMutated: map[notify.Version]bool{
-				notify.Version(2): true,
-				notify.Version(4): true,
-				notify.Version(5): true,
-			},
-		},
-		{
-			unsupported: map[notify.Version]bool{
-				notify.Version(3): true,
-				notify.Version(4): true,
-				notify.Version(5): true,
-			},
-			expectedVersion:   notify.Version(7),
-			expectedSupported: true,
-			expectedMutated: map[notify.Version]bool{
-				notify.Version(2): true,
-				notify.Version(3): true,
-				notify.Version(4): true,
-				notify.Version(5): true,
+			expectedMutated: map[notify.ProtocolVersion]bool{
+				notify.ProtocolVersion(2): true,
+				notify.ProtocolVersion(4): true,
+				notify.ProtocolVersion(5): true,
 			},
 		},
 		{
-			unsupported: map[notify.Version]bool{
-				notify.Version(3): true,
-				notify.Version(4): true,
-				notify.Version(5): true,
-				notify.Version(7): true,
+			unsupported: map[notify.ProtocolVersion]bool{
+				notify.ProtocolVersion(3): true,
+				notify.ProtocolVersion(4): true,
+				notify.ProtocolVersion(5): true,
 			},
-			expectedVersion:   notify.Version(0),
+			expectedVersion:   notify.ProtocolVersion(7),
+			expectedSupported: true,
+			expectedMutated: map[notify.ProtocolVersion]bool{
+				notify.ProtocolVersion(2): true,
+				notify.ProtocolVersion(3): true,
+				notify.ProtocolVersion(4): true,
+				notify.ProtocolVersion(5): true,
+			},
+		},
+		{
+			unsupported: map[notify.ProtocolVersion]bool{
+				notify.ProtocolVersion(3): true,
+				notify.ProtocolVersion(4): true,
+				notify.ProtocolVersion(5): true,
+				notify.ProtocolVersion(7): true,
+			},
+			expectedVersion:   notify.ProtocolVersion(0),
 			expectedSupported: false,
-			expectedMutated: map[notify.Version]bool{
-				notify.Version(2):  true,
-				notify.Version(3):  true,
-				notify.Version(4):  true,
-				notify.Version(5):  true,
-				notify.Version(7):  true,
-				notify.Version(11): true,
+			expectedMutated: map[notify.ProtocolVersion]bool{
+				notify.ProtocolVersion(2):  true,
+				notify.ProtocolVersion(3):  true,
+				notify.ProtocolVersion(4):  true,
+				notify.ProtocolVersion(5):  true,
+				notify.ProtocolVersion(7):  true,
+				notify.ProtocolVersion(11): true,
 			},
 		},
 	} {
-		version, supported := notify.SupportedProtocolVersion(testCase.unsupported)
-		c.Check(version, Equals, testCase.expectedVersion, Commentf("testCase: %+v", testCase))
+		protoVersion, supported := notify.SupportedProtocolVersion(testCase.unsupported)
+		c.Check(protoVersion, Equals, testCase.expectedVersion, Commentf("testCase: %+v", testCase))
 		c.Check(supported, Equals, testCase.expectedSupported, Commentf("testCase: %+v", testCase))
 		c.Check(testCase.unsupported, DeepEquals, testCase.expectedMutated, Commentf("testCase: %+v"))
 	}


### PR DESCRIPTION
Add versioning to the AppArmor notification protocol, do compatibility checks when registering a listener on the notify socket, and correctly validate incoming message versions against the listener version and set outgoing message versions correctly.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34337