### PR TITLE
o/snapstate: do not restart again for snapd along the undo path inside undoUnlinkCurrentSnap

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1615,7 +1615,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 		return nil
 	}
 
-	// For all other snaps, including snapd that runs under the core snap,
+	// For all other snaps, including snapd bundled with the core snap,
 	// we must undo the unlinking of the old revision.
 	opts, err := SnapServiceOptions(st, oldInfo, nil)
 	if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3993,9 +3993,8 @@ func (m *SnapManager) undoRemoveAliases(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// The previous task's undo (unlink-current-snap) may have triggered a restart,
-	// Set the default to true as we cannot set it otherwise since the change will
-	// always have been created by the old snapd (that may not have "finish-restart")
+	// The previous task's undo (unlink-current-snap) may have triggered a restart
+	// so if that is the case ensure we wait for it to happen here.
 	logger.Debugf("finish restart from undoRemoveAliases")
 	if err := FinishRestart(t, snapsup, FinishRestartOptions{}); err != nil {
 		return err


### PR DESCRIPTION
Actually we skip the entire link code for snapd  as this has already been done in undoLinkSnap.

REF: SNAPDENG-34315