### PR TITLE
many: add passphrase authentication support

### DIFF
--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/kernel"
 )
@@ -84,7 +85,7 @@ func MockKernelEnsureKernelDriversTree(f func(kMntPts kernel.MountPoints, compsM
 	}
 }
 
-func CheckEncryptionSetupData(encryptSetup *EncryptionSetupData, labelToEncDevice map[string]string) error {
+func CheckEncryptionSetupData(encryptSetup *EncryptionSetupData, labelToEncDevice map[string]string, expectedVolumesAuth *device.VolumesAuthOptions) error {
 	for label, part := range encryptSetup.parts {
 		switch part.role {
 		case gadget.SystemData, gadget.SystemSave:
@@ -95,6 +96,10 @@ func CheckEncryptionSetupData(encryptSetup *EncryptionSetupData, labelToEncDevic
 		if part.encryptedDevice != labelToEncDevice[label] {
 			return fmt.Errorf("encrypted device in EncryptionSetupData (%q) different to expected (%q)",
 				encryptSetup.parts[label].encryptedDevice, labelToEncDevice[label])
+		}
+		if part.installKey.GetAuthOptions() != expectedVolumesAuth {
+			return fmt.Errorf("volume authentication for device %q in EncryptionSetupData (%v) different to expected (%v)",
+				labelToEncDevice[label], part.installKey.GetAuthOptions(), expectedVolumesAuth)
 		}
 	}
 

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -430,7 +430,7 @@ func Run(model gadget.Model, gadgetRoot string, kernelSnapInfo *KernelSnapInfo, 
 			if installKeyForRole == nil {
 				installKeyForRole = map[string]secboot.BootstrappedContainer{}
 			}
-			installKeyForRole[vs.Role] = secboot.CreateBootstrappedContainer(encryptionKey, diskPart.Node)
+			installKeyForRole[vs.Role] = secboot.CreateBootstrappedContainer(encryptionKey, diskPart.Node, nil)
 			partsEncrypted[vs.Name] = createEncryptionParams(options.EncryptionType)
 		}
 		if options.Mount && vs.Label != "" && vs.HasFilesystem() {
@@ -680,8 +680,6 @@ func EncryptPartitions(
 	encryptionType device.EncryptionType, model *asserts.Model,
 	gadgetRoot, kernelRoot string, perfTimings timings.Measurer,
 ) (*EncryptionSetupData, error) {
-	// TODO: Attach passed volumes auth options to encryption setup data.
-
 	setupData := &EncryptionSetupData{
 		parts: make(map[string]partEncryptionData),
 	}
@@ -721,7 +719,7 @@ func EncryptPartitions(
 				// EncryptedDevice will be /dev/mapper/ubuntu-data, etc.
 				encryptedDevice:     fsParams.Device,
 				volName:             volName,
-				installKey:          secboot.CreateBootstrappedContainer(encryptionKey, device),
+				installKey:          secboot.CreateBootstrappedContainer(encryptionKey, device, volumesAuth),
 				encryptedSectorSize: fsParams.SectorSize,
 				encryptionParams:    createEncryptionParams(encryptionType),
 			}
@@ -857,7 +855,7 @@ func FactoryReset(model gadget.Model, gadgetRoot string, kernelSnapInfo *KernelS
 			if installKeyForRole == nil {
 				installKeyForRole = map[string]secboot.BootstrappedContainer{}
 			}
-			installKeyForRole[vs.Role] = secboot.CreateBootstrappedContainer(encryptionKey, onDiskStruct.Node)
+			installKeyForRole[vs.Role] = secboot.CreateBootstrappedContainer(encryptionKey, onDiskStruct.Node, nil)
 		}
 		if options.Mount && vs.Label != "" && vs.HasFilesystem() {
 			// fs is taken from gadget, as on disk one might be displayed as

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1478,6 +1478,7 @@ func (s *installSuite) TestInstallWriteContentDeviceNotFound(c *C) {
 
 type encryptPartitionsOpts struct {
 	encryptType device.EncryptionType
+	volumesAuth *device.VolumesAuthOptions
 }
 
 func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
@@ -1518,19 +1519,26 @@ func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
 		return nil
 	})()
 
-	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, nil, opts.encryptType, model, gadgetRoot, "", timings.New(nil))
+	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, opts.volumesAuth, opts.encryptType, model, gadgetRoot, "", timings.New(nil))
 	c.Assert(err, IsNil)
 	c.Assert(encryptSetup, NotNil)
 	err = install.CheckEncryptionSetupData(encryptSetup, map[string]string{
 		"ubuntu-save": "/dev/mapper/ubuntu-save",
 		"ubuntu-data": "/dev/mapper/ubuntu-data",
-	})
+	}, opts.volumesAuth)
 	c.Assert(err, IsNil)
 }
 
 func (s *installSuite) TestInstallEncryptPartitionsLUKSHappy(c *C) {
 	s.testEncryptPartitions(c, encryptPartitionsOpts{
 		encryptType: device.EncryptionTypeLUKS,
+	})
+}
+
+func (s *installSuite) TestInstallEncryptPartitions(c *C) {
+	s.testEncryptPartitions(c, encryptPartitionsOpts{
+		encryptType: device.EncryptionTypeLUKS,
+		volumesAuth: &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"},
 	})
 }
 

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -78,6 +78,7 @@ func (esd *EncryptionSetupData) EncryptedDevices() map[string]string {
 type MockEncryptedDeviceAndRole struct {
 	Role            string
 	EncryptedDevice string
+	VolumesAuth     *device.VolumesAuthOptions
 }
 
 // MockEncryptionSetupData is meant to be used for unit tests from other
@@ -92,6 +93,7 @@ func MockEncryptionSetupData(labelToEncDevice map[string]*MockEncryptedDeviceAnd
 		//overlord/install/install.go. Once we have removed that call,
 		// we can use mock object instead.
 		bootstrapKey := secboot.CreateMockBootstrappedContainer()
+		bootstrapKey.AuthOptions = encryptData.VolumesAuth
 		esd.parts[label] = partEncryptionData{
 			role:                encryptData.Role,
 			encryptedDevice:     encryptData.EncryptedDevice,

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -39,8 +39,8 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
-	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -2347,7 +2347,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 	})()
 
 	var bootstrapContainer *secboot.MockBootstrappedContainer
-	defer devicestate.MockSecbootCreateBootstrappedContainer(func(key secboot.DiskUnlockKey, devicePath string) secboot.BootstrappedContainer {
+	defer devicestate.MockSecbootCreateBootstrappedContainer(func(key secboot.DiskUnlockKey, devicePath string, volumesAuth *device.VolumesAuthOptions) secboot.BootstrappedContainer {
 		if tc.encrypt {
 			c.Check([]byte(key), DeepEquals, chosenBootstrapKey)
 			c.Assert(bootstrapContainer, IsNil)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -563,7 +563,7 @@ func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, asser
 	return restore
 }
 
-func MockEncryptionSetupDataInCache(st *state.State, label string) (restore func()) {
+func MockEncryptionSetupDataInCache(st *state.State, label string, volumesAuth *device.VolumesAuthOptions) (restore func()) {
 	st.Lock()
 	defer st.Unlock()
 	var esd *install.EncryptionSetupData
@@ -571,10 +571,12 @@ func MockEncryptionSetupDataInCache(st *state.State, label string) (restore func
 		"ubuntu-save": {
 			Role:            "system-save",
 			EncryptedDevice: "/dev/mapper/ubuntu-save",
+			VolumesAuth:     volumesAuth,
 		},
 		"ubuntu-data": {
 			Role:            "system-data",
 			EncryptedDevice: "/dev/mapper/ubuntu-data",
+			VolumesAuth:     volumesAuth,
 		},
 	}
 	esd = install.MockEncryptionSetupData(labelToEncData)
@@ -618,7 +620,7 @@ func MockSecbootRenameOrDeleteKeys(f func(node string, renames map[string]string
 	}
 }
 
-func MockSecbootCreateBootstrappedContainer(f func(key secboot.DiskUnlockKey, devicePath string) secboot.BootstrappedContainer) (restore func()) {
+func MockSecbootCreateBootstrappedContainer(f func(key secboot.DiskUnlockKey, devicePath string, volumesAuth *device.VolumesAuthOptions) secboot.BootstrappedContainer) (restore func()) {
 	old := secbootCreateBootstrappedContainer
 	secbootCreateBootstrappedContainer = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1254,6 +1254,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		if cached == nil {
 			return errors.New("volumes authentication is required but cannot find corresponding cached options")
 		}
+		st.Cache(volumesAuthOptionsKey{systemLabel}, nil)
 		var ok bool
 		volumesAuth, ok = cached.(*device.VolumesAuthOptions)
 		if !ok {
@@ -1356,7 +1357,7 @@ func createSaveBootstrappedContainer(saveNode string) (secboot.BootstrappedConta
 		return nil, err
 	}
 
-	return secbootCreateBootstrappedContainer(secboot.DiskUnlockKey(saveEncryptionKey), saveNode), nil
+	return secbootCreateBootstrappedContainer(secboot.DiskUnlockKey(saveEncryptionKey), saveNode, nil), nil
 }
 
 func deleteOldSaveKey(saveMntPnt string) error {

--- a/secboot/bootstrap_container.go
+++ b/secboot/bootstrap_container.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -47,9 +48,11 @@ type BootstrappedContainer interface {
 	GetTokenWriter(slotName string) (KeyDataWriter, error)
 	// RemoveBootstrapKey removes the bootstrap key.
 	RemoveBootstrapKey() error
+	// GetAuthOptions returns attached authentication options.
+	GetAuthOptions() *device.VolumesAuthOptions
 }
 
-func createBootstrappedContainerMockImpl(key DiskUnlockKey, devicePath string) BootstrappedContainer {
+func createBootstrappedContainerMockImpl(key DiskUnlockKey, devicePath string, volumesAuth *device.VolumesAuthOptions) BootstrappedContainer {
 	panic("trying to create a bootstrapped container in a non-secboot build")
 }
 
@@ -59,6 +62,7 @@ type MockBootstrappedContainer struct {
 	BootstrapKeyRemoved bool
 	Slots               map[string][]byte
 	Tokens              map[string][]byte
+	AuthOptions         *device.VolumesAuthOptions
 }
 
 func CreateMockBootstrappedContainer() *MockBootstrappedContainer {
@@ -102,4 +106,8 @@ func (m *MockBootstrappedContainer) GetTokenWriter(slotName string) (KeyDataWrit
 func (l *MockBootstrappedContainer) RemoveBootstrapKey() error {
 	l.BootstrapKeyRemoved = true
 	return nil
+}
+
+func (l *MockBootstrappedContainer) GetAuthOptions() *device.VolumesAuthOptions {
+	return l.AuthOptions
 }

--- a/secboot/bootstrap_container_sb.go
+++ b/secboot/bootstrap_container_sb.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	sb "github.com/snapcore/secboot"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -31,6 +32,7 @@ type bootstrappedContainer struct {
 	tempContainerKeySlot string
 	devicePath           string
 	key                  DiskUnlockKey
+	authOptions          *device.VolumesAuthOptions
 	finished             bool
 }
 
@@ -76,11 +78,16 @@ func (bc *bootstrappedContainer) RemoveBootstrapKey() error {
 	return nil
 }
 
-func createBootstrappedContainerImpl(key DiskUnlockKey, devicePath string) BootstrappedContainer {
+func (bc *bootstrappedContainer) GetAuthOptions() *device.VolumesAuthOptions {
+	return bc.authOptions
+}
+
+func createBootstrappedContainerImpl(key DiskUnlockKey, devicePath string, volumesAuth *device.VolumesAuthOptions) BootstrappedContainer {
 	return &bootstrappedContainer{
 		tempContainerKeySlot: "bootstrap-key",
 		devicePath:           devicePath,
 		key:                  key,
+		authOptions:          volumesAuth,
 		finished:             false,
 	}
 }
@@ -89,7 +96,7 @@ func init() {
 	CreateBootstrappedContainer = createBootstrappedContainerImpl
 }
 
-func MockCreateBootstrappedContainer(f func(key DiskUnlockKey, devicePath string) BootstrappedContainer) func() {
+func MockCreateBootstrappedContainer(f func(key DiskUnlockKey, devicePath string, volumesAuth *device.VolumesAuthOptions) BootstrappedContainer) func() {
 	osutil.MustBeTestBinary("MockCreateBootstrappedContainer can be only called from tests")
 	old := CreateBootstrappedContainer
 	CreateBootstrappedContainer = f

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -230,6 +230,14 @@ func MockSbNewTPMProtectedKey(f func(tpm *sb_tpm2.Connection, params *sb_tpm2.Pr
 	}
 }
 
+func MockSbNewTPMPassphraseProtectedKey(f func(tpm *sb_tpm2.Connection, params *sb_tpm2.PassphraseProtectKeyParams, passphrase string) (protectedKey *sb.KeyData, primaryKey sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error)) (restore func()) {
+	old := sbNewTPMPassphraseProtectedKey
+	sbNewTPMPassphraseProtectedKey = f
+	return func() {
+		sbNewTPMPassphraseProtectedKey = old
+	}
+}
+
 func MockSbSetModel(f func(model sb.SnapModel)) (restore func()) {
 	old := sbSetModel
 	sbSetModel = f

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -504,7 +504,7 @@ func withTPMConnection(fn func(tpm *sb_tpm2.Connection)) error {
 	return nil
 }
 
-func kdfOptions(volumesAuth device.VolumesAuthOptions) (sb.KDFOptions, error) {
+func kdfOptions(volumesAuth *device.VolumesAuthOptions) (sb.KDFOptions, error) {
 	switch volumesAuth.KDFType {
 	case "":
 		return nil, nil
@@ -531,7 +531,7 @@ func newTPMProtectedKey(creationParams *sb_tpm2.ProtectKeyParams, volumesAuth *d
 	if volumesAuth != nil {
 		switch volumesAuth.Mode {
 		case device.AuthModePassphrase:
-			kdfOptions, kdferr := kdfOptions(*volumesAuth)
+			kdfOptions, kdferr := kdfOptions(volumesAuth)
 			if kdferr != nil {
 				return nil, nil, nil, kdferr
 			}


### PR DESCRIPTION
This PR implements passphrase authentication support during installation. Currently all volumes created during installation are passphrase encrypted, i.e. `ubuntu-data` and `ubuntu-save`.

The implications of having `ubuntu-save` optionally passphrase-protected is that a factory reset would require a passphrase to be entered to work. This is still an open question on what is optimal from a UX perspective.

Note: This is still not exposed through the API until target system and entropy checks are added. This is done by not including `passphrase-auth` in the list of supported encryption features (Check SD201).

I tested the implementation against the spread test from https://github.com/canonical/snapd/pull/14867.