### PR TITLE
tests: skip apparmor-prompting-integration-tests in armhf

### DIFF
--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -14,7 +14,7 @@ systems:
   - ubuntu-16*
   - ubuntu-18*
   - ubuntu-2*
-  - ubuntu-core-*
+  - ubuntu-core-*-64-*
 
 environment:
     VARIANT/read_single_allow: read_single_allow


### PR DESCRIPTION
The prompting-client snap is not available for armhf.
