### PR TITLE
o/devicestate, daemon: support creating recovery systems with components in offline context

### DIFF
--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/install"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
@@ -489,9 +490,9 @@ func postSystemActionCreateOffline(c *Command, form *Form) Response {
 	}
 
 	// TODO:COMPS: support adding components to a recovery system
-	localSnaps := make([]devicestate.LocalSnap, 0, len(slInfo.snaps))
+	localSnaps := make([]snapstate.PathSnap, 0, len(slInfo.snaps))
 	for _, sn := range slInfo.snaps {
-		localSnaps = append(localSnaps, devicestate.LocalSnap{
+		localSnaps = append(localSnaps, snapstate.PathSnap{
 			SideInfo: &sn.info.SideInfo,
 			Path:     sn.tmpPath,
 		})

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -489,20 +489,35 @@ func postSystemActionCreateOffline(c *Command, form *Form) Response {
 		return apiErr
 	}
 
-	// TODO:COMPS: support adding components to a recovery system
 	localSnaps := make([]snapstate.PathSnap, 0, len(slInfo.snaps))
+	localComponents := make([]snapstate.PathComponent, 0, len(slInfo.components))
 	for _, sn := range slInfo.snaps {
 		localSnaps = append(localSnaps, snapstate.PathSnap{
 			SideInfo: &sn.info.SideInfo,
 			Path:     sn.tmpPath,
 		})
+
+		for _, c := range sn.components {
+			localComponents = append(localComponents, snapstate.PathComponent{
+				SideInfo: c.sideInfo,
+				Path:     c.tmpPath,
+			})
+		}
+	}
+
+	for _, ci := range slInfo.components {
+		localComponents = append(localComponents, snapstate.PathComponent{
+			SideInfo: ci.sideInfo,
+			Path:     ci.tmpPath,
+		})
 	}
 
 	chg, err := devicestateCreateRecoverySystem(st, label, devicestate.CreateRecoverySystemOptions{
-		ValidationSets: validationSets.Sets(),
-		LocalSnaps:     localSnaps,
-		TestSystem:     testSystem,
-		MarkDefault:    markDefault,
+		ValidationSets:  validationSets.Sets(),
+		LocalSnaps:      localSnaps,
+		LocalComponents: localComponents,
+		TestSystem:      testSystem,
+		MarkDefault:     markDefault,
 		// using the form-based API implies that this should be an offline operation
 		Offline: true,
 	})

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1908,7 +1908,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionWithComponentsOffline(c *chec
 			"revision": "10",
 			"presence": "required",
 			"components": map[string]interface{}{
-				"pc-kernel": map[string]interface{}{
+				"kmod": map[string]interface{}{
 					"revision": "10",
 					"presence": "required",
 				},

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -54,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snapfile"
+	"github.com/snapcore/snapd/strutil"
 )
 
 var (
@@ -1459,11 +1460,14 @@ type recoverySystemSetup struct {
 	SnapSetupTasks []string `json:"snap-setup-tasks,omitempty"`
 	// LocalSnaps is a list of snaps that should be used to create the recovery
 	// system.
-	LocalSnaps []LocalSnap `json:"local-snaps,omitempty"`
+	LocalSnaps []snapstate.PathSnap `json:"local-snaps,omitempty"`
 	// ComponentSetupTasks is a list of task IDs that carry component setup
 	// information. Tasks could come from a remodel, or from downloading
 	// components that were required by a validation set.
 	ComponentSetupTasks []string `json:"component-setup-tasks,omitempty"`
+	// LocalComponents is a list of components that should be used to create the
+	// recovery system.
+	LocalComponents []snapstate.PathComponent `json:"local-components,omitempty"`
 	// TestSystem is set to true if the new recovery system should
 	// not be verified by rebooting into the new system. Once the system is
 	// created, it will immediately be considered a valid recovery system.
@@ -1535,6 +1539,7 @@ func createRecoverySystemTasks(st *state.State, label string, snapSetupTasks, co
 		SnapSetupTasks:      snapSetupTasks,
 		ComponentSetupTasks: compSetupTasks,
 		LocalSnaps:          opts.LocalSnaps,
+		LocalComponents:     opts.LocalComponents,
 		TestSystem:          opts.TestSystem,
 		MarkDefault:         opts.MarkDefault,
 	})
@@ -1582,7 +1587,13 @@ type CreateRecoverySystemOptions struct {
 	// the new recovery system. If provided, this list must contain any snap
 	// that is not already installed that will be needed by the new recovery
 	// system.
-	LocalSnaps []LocalSnap
+	LocalSnaps []snapstate.PathSnap
+
+	// LocalComponents is an optional list of components that will be used to
+	// create the new recovery system. If provided, this list must contain any
+	// component that is not already installed that will be needed by the new
+	// recovery system.
+	LocalComponents []snapstate.PathComponent
 
 	// TestSystem is set to true if the new recovery system should be verified
 	// by rebooting into the new system, prior to marking it as a valid recovery
@@ -1647,17 +1658,17 @@ func checkForRequiredSnapsNotPresentInModel(model *asserts.Model, vSets *snapass
 
 // CreateRecoverySystem creates a new recovery system with the given label. See
 // CreateRecoverySystemOptions for details on the options that can be provided.
-func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySystemOptions) (chg *state.Change, err error) {
+func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySystemOptions) (*state.Change, error) {
 	if err := snapstate.CheckChangeConflictRunExclusively(st, "create-recovery-system"); err != nil {
 		return nil, err
 	}
 
-	if !opts.Offline && len(opts.LocalSnaps) > 0 {
-		return nil, errors.New("locally provided snaps cannot be provided when creating a recovery system online")
+	if !opts.Offline && (len(opts.LocalSnaps) > 0 || len(opts.LocalComponents) > 0) {
+		return nil, errors.New("local snaps/components cannot be provided when creating a recovery system online")
 	}
 
 	var seeded bool
-	err = st.Get("seeded", &seeded)
+	err := st.Get("seeded", &seeded)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
@@ -1708,6 +1719,9 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 		return constraints.Revision.Unset() || current == constraints.Revision
 	}
 
+	usedLocalSnaps := make([]snapstate.PathSnap, 0, len(opts.LocalSnaps))
+	usedLocalComps := make([]snapstate.PathComponent, 0, len(opts.LocalComponents))
+
 	var downloadTSS []*state.TaskSet
 	for _, sn := range model.AllSnaps() {
 		constraints, err := valsets.Presence(sn)
@@ -1738,7 +1752,12 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 			continue
 		}
 
-		compsToDownload := make([]string, 0, len(sn.Components))
+		installedSnapValid := installed && validRevision(currentRevision, constraints.PresenceConstraint)
+
+		// keep track of the components that need to either be given to us or
+		// downloaded
+		requiredComponents := make([]string, 0, len(sn.Components))
+
 		for name, comp := range sn.Components {
 			compInstalled, currentCompRevision, err := installedComponentRevision(st, sn.Name, name)
 			if err != nil {
@@ -1757,41 +1776,97 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 			//
 			// TODO: consider making create-recovery-system aware of validation
 			// sets, allowing us to avoid requiring optional but installed components
-			required := comp.Presence == "required" || constraints.Component(name).Presence == asserts.PresenceRequired || compInstalled
+			required := comp.Presence == "required" || compConstraints.Presence == asserts.PresenceRequired || compInstalled
 			if !required {
 				continue
 			}
 
-			switch {
-			case compInstalled && validRevision(currentCompRevision, compConstraints):
-				// nothing to do!
-			case opts.Offline:
-				// TODO: verify that we have the offline component
-			default:
-				compsToDownload = append(compsToDownload, name)
+			// we must either download or have local components for all required
+			// components that are either not installed, installed at an invalid
+			// revision, or installed alongside a different snap revision. the
+			// last condition could be eliminated by creating a task that only
+			// downloads the missing snap-resource-pair assertion.
+			if compInstalled && validRevision(currentCompRevision, compConstraints) && installedSnapValid {
+				continue
 			}
+
+			requiredComponents = append(requiredComponents, name)
 		}
 
 		switch {
-		case installed && validRevision(currentRevision, constraints.PresenceConstraint):
+		case opts.Offline:
+			// offline case, everything must either already be installed or
+			// provided via the local snaps/components.
+
+			// even if the installed snap revision might be valid, we still
+			// should attempt to use the one that is provided by the caller.
+			//
+			// this matches what create-recovery-system does. it first checks
+			// for provided local snaps, and then falls back to the installed
+			// one.
+			info, localSnap, err := offlineSnapInfo(sn, constraints.Revision, opts)
+			if err != nil {
+				if !errors.Is(err, errMissingLocalSnap) || !installedSnapValid {
+					return nil, err
+				}
+
+				info, err = snapstate.CurrentInfo(st, sn.Name)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				usedLocalSnaps = append(usedLocalSnaps, localSnap)
+			}
+			tracker.Add(info)
+
+			for comp := range sn.Components {
+				cref := naming.NewComponentRef(sn.Name, comp)
+				rev := constraints.Component(comp).Revision
+
+				localComp, err := offlineComponentInfo(cref, rev, opts.LocalComponents)
+				if err != nil {
+					// we only care if the component is present if it needs to
+					// be provided.
+					//
+					// TODO: testme
+					if strutil.ListContains(requiredComponents, comp) {
+						return nil, err
+					}
+				} else {
+					usedLocalComps = append(usedLocalComps, localComp)
+				}
+			}
+		case installedSnapValid:
+			// online case, but the currently installed snap revision is valid
+			// in the given validation sets.
+
 			info, err := snapstate.CurrentInfo(st, sn.Name)
 			if err != nil {
 				return nil, err
 			}
 			tracker.Add(info)
-		case opts.Offline:
-			info, err := offlineSnapInfo(sn, constraints.Revision, opts)
-			if err != nil {
-				return nil, err
+
+			if len(requiredComponents) > 0 {
+				// TODO: download somewhere other than the default snap blob dir.
+				ts, err := snapstateDownloadComponents(context.TODO(), st, sn.Name, requiredComponents, dirs.SnapBlobDir, snapstate.RevisionOptions{
+					Channel:        sn.DefaultChannel,
+					ValidationSets: valsets,
+					Revision:       info.Revision,
+				}, snapstate.Options{
+					PrereqTracker: tracker,
+				})
+				if err != nil {
+					return nil, err
+				}
+				downloadTSS = append(downloadTSS, ts)
 			}
-			tracker.Add(info)
 		default:
 			// TODO: this respects the passed in validation sets, but does not
 			// currently respect refresh-control style of constraining snap
 			// revisions.
 			//
 			// TODO: download somewhere other than the default snap blob dir.
-			ts, _, err := snapstateDownload(context.TODO(), st, sn.Name, compsToDownload, dirs.SnapBlobDir, snapstate.RevisionOptions{
+			ts, _, err := snapstateDownload(context.TODO(), st, sn.Name, requiredComponents, dirs.SnapBlobDir, snapstate.RevisionOptions{
 				Channel:        sn.DefaultChannel,
 				ValidationSets: valsets,
 			}, snapstate.Options{
@@ -1805,20 +1880,6 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 			// if we go in this branch, then we'll handle downloading snaps and
 			// components at the same time.
 			continue
-		}
-
-		if len(compsToDownload) > 0 {
-			// TODO: download somewhere other than the default snap blob dir.
-			ts, err := snapstateDownloadComponents(context.TODO(), st, sn.Name, compsToDownload, dirs.SnapBlobDir, snapstate.RevisionOptions{
-				Channel:        sn.DefaultChannel,
-				ValidationSets: valsets,
-			}, snapstate.Options{
-				PrereqTracker: tracker,
-			})
-			if err != nil {
-				return nil, err
-			}
-			downloadTSS = append(downloadTSS, ts)
 		}
 	}
 
@@ -1844,7 +1905,12 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 		return nil, err
 	}
 
-	chg = st.NewChange("create-recovery-system", fmt.Sprintf("Create new recovery system with label %q", label))
+	// here we make sure that we only include the local snaps/components that
+	// are actually required.
+	opts.LocalComponents = usedLocalComps
+	opts.LocalSnaps = usedLocalSnaps
+
+	chg := st.NewChange("create-recovery-system", fmt.Sprintf("Create new recovery system with label %q", label))
 	createTS, err := createRecoverySystemTasks(st, label, snapsupTaskIDs, compsupTaskIDs, opts)
 	if err != nil {
 		return nil, err
@@ -1860,7 +1926,7 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 	return chg, nil
 }
 
-func checkForSnapIDs(model *asserts.Model, localSnaps []LocalSnap) error {
+func checkForSnapIDs(model *asserts.Model, localSnaps []snapstate.PathSnap) error {
 	for _, sn := range model.AllSnaps() {
 		if sn.ID() == "" {
 			return fmt.Errorf("cannot create recovery system from model with snap that has no snap id: %q", sn.Name)
@@ -1876,7 +1942,9 @@ func checkForSnapIDs(model *asserts.Model, localSnaps []LocalSnap) error {
 	return nil
 }
 
-func offlineSnapInfo(sn *asserts.ModelSnap, rev snap.Revision, opts CreateRecoverySystemOptions) (*snap.Info, error) {
+var errMissingLocalSnap = errors.New("missing snap from local snaps provided for offline creation of recovery system")
+
+func offlineSnapInfo(sn *asserts.ModelSnap, rev snap.Revision, opts CreateRecoverySystemOptions) (*snap.Info, snapstate.PathSnap, error) {
 	index := -1
 	for i, si := range opts.LocalSnaps {
 		if sn.ID() == si.SideInfo.SnapID {
@@ -1885,25 +1953,49 @@ func offlineSnapInfo(sn *asserts.ModelSnap, rev snap.Revision, opts CreateRecove
 		}
 	}
 	if index == -1 {
-		return nil, fmt.Errorf(
-			"missing snap from local snaps provided for offline creation of recovery system: %q, rev %v", sn.Name, rev,
-		)
+		return nil, snapstate.PathSnap{}, fmt.Errorf("%w: %q, rev %v", errMissingLocalSnap, sn.Name, rev)
 	}
 
 	localSnap := opts.LocalSnaps[index]
 
 	if !rev.Unset() && rev != localSnap.SideInfo.Revision {
-		return nil, fmt.Errorf(
+		return nil, snapstate.PathSnap{}, fmt.Errorf(
 			"snap %q does not match revision required by validation sets: %v != %v", localSnap.SideInfo.RealName, localSnap.SideInfo.Revision, rev,
 		)
 	}
 
 	s, err := snapfile.Open(localSnap.Path)
 	if err != nil {
-		return nil, err
+		return nil, snapstate.PathSnap{}, err
 	}
 
-	return snap.ReadInfoFromSnapFile(s, localSnap.SideInfo)
+	info, err := snap.ReadInfoFromSnapFile(s, localSnap.SideInfo)
+	return info, localSnap, err
+}
+
+func offlineComponentInfo(cref naming.ComponentRef, rev snap.Revision, comps []snapstate.PathComponent) (snapstate.PathComponent, error) {
+	index := -1
+	for i, si := range comps {
+		if si.SideInfo.Component == cref {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		return snapstate.PathComponent{}, fmt.Errorf(
+			"missing component from local components provided for offline creation of recovery system: %q, rev %v", cref, rev,
+		)
+	}
+
+	comp := comps[index]
+
+	if !rev.Unset() && rev != comp.SideInfo.Revision {
+		return snapstate.PathComponent{}, fmt.Errorf(
+			"component %q does not match revision required by validation sets: %v != %v", cref, comp.SideInfo.Revision, rev,
+		)
+	}
+
+	return comp, nil
 }
 
 func installedSnapRevision(st *state.State, name string) (bool, snap.Revision, error) {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1827,8 +1827,6 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 				if err != nil {
 					// we only care if the component is present if it needs to
 					// be provided.
-					//
-					// TODO: testme
 					if strutil.ListContains(requiredComponents, comp) {
 						return nil, err
 					}

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -242,6 +242,7 @@ func (ig *setupInfoGetter) ComponentInfo(st *state.State, cref naming.ComponentR
 	//   * have just been downloaded by a task in setup.ComponentSetupTasks
 	//   * already installed on the system
 
+	logger.Debugf("requested info for component %q being installed during remodel", cref)
 	for _, l := range ig.setup.LocalComponents {
 		if l.SideInfo.Component != cref {
 			continue
@@ -263,7 +264,6 @@ func (ig *setupInfoGetter) ComponentInfo(st *state.State, cref naming.ComponentR
 	// in a remodel scenario, the components may need to be fetched and thus
 	// their content can be different from what we have already installed, so we
 	// should first check the download tasks before consulting snapstate
-	logger.Debugf("requested info for component %q being installed during remodel", cref)
 	for _, tskID := range ig.setup.ComponentSetupTasks {
 		taskWithComponentSetup := st.Task(tskID)
 		compsup, snapsup, err := snapstate.TaskComponentSetup(taskWithComponentSetup)

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -237,11 +237,10 @@ type setupInfoGetter struct {
 
 func (ig *setupInfoGetter) ComponentInfo(st *state.State, cref naming.ComponentRef, snapInfo *snap.Info) (info *snap.ComponentInfo, path string, present bool, err error) {
 	// components will come from one of these places:
+	//   * passed into the task via a list of side infos (these would have
+	//     come from a user posting snaps via the API)
 	//   * have just been downloaded by a task in setup.ComponentSetupTasks
 	//   * already installed on the system
-	//
-	// TODO:COMPS: handle components passed into the task via a list of side
-	// infos (these would have come from a user posting components via the API)
 
 	for _, l := range ig.setup.LocalComponents {
 		if l.SideInfo.Component != cref {

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -243,6 +243,24 @@ func (ig *setupInfoGetter) ComponentInfo(st *state.State, cref naming.ComponentR
 	// TODO:COMPS: handle components passed into the task via a list of side
 	// infos (these would have come from a user posting components via the API)
 
+	for _, l := range ig.setup.LocalComponents {
+		if l.SideInfo.Component != cref {
+			continue
+		}
+
+		snapf, err := snapfile.Open(l.Path)
+		if err != nil {
+			return nil, "", false, err
+		}
+
+		info, err := snap.ReadComponentInfoFromContainer(snapf, snapInfo, l.SideInfo)
+		if err != nil {
+			return nil, "", false, err
+		}
+
+		return info, l.Path, true, nil
+	}
+
 	// in a remodel scenario, the components may need to be fetched and thus
 	// their content can be different from what we have already installed, so we
 	// should first check the download tasks before consulting snapstate
@@ -411,7 +429,6 @@ func createSystemForModelFromValidatedSnaps(
 		// RW mount of ubuntu-seed
 		SeedDir: boot.InitramfsUbuntuSeedDir,
 		Label:   label,
-
 		// due to the way that temp files are handled in daemon, they do not
 		// have .snap or .comp extensions. this flag lets us ignore that
 		// requirement.

--- a/tests/nested/manual/component-recovery-system-offline/task.yaml
+++ b/tests/nested/manual/component-recovery-system-offline/task.yaml
@@ -8,7 +8,7 @@ details: |
   is used, and we upload the snap and the component that are being used via an
   HTTP form.
 
-systems: [ubuntu-24.04-64]
+systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
 
 environment:
   MODEL_JSON: $TESTSLIB/assertions/test-snapd-component-recovery-system-pc-24.json

--- a/tests/nested/manual/component-recovery-system-offline/task.yaml
+++ b/tests/nested/manual/component-recovery-system-offline/task.yaml
@@ -1,0 +1,180 @@
+summary: |
+  create a recovery system with a kernel module component via the offline API
+  and reboot into it
+
+details: |
+  This test creates a recovery system with a kernel module component and
+  validates that the newly created system can be rebooted into. The offline API
+  is used, and we upload the snap and the component that are being used via an
+  HTTP form.
+
+systems: [ubuntu-24.04-64]
+
+environment:
+  MODEL_JSON: $TESTSLIB/assertions/test-snapd-component-recovery-system-pc-24.json
+  NESTED_ENABLE_TPM: true
+  NESTED_ENABLE_SECURE_BOOT: true
+  NESTED_BUILD_SNAPD_FROM_CURRENT: true
+  NESTED_REPACK_GADGET_SNAP: true
+  NESTED_REPACK_KERNEL_SNAP: true
+  NESTED_REPACK_BASE_SNAP: true
+  NESTED_REPACK_FOR_FAKESTORE: true
+  NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
+  NESTED_SIGN_SNAPS_FAKESTORE: true
+  NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+
+prepare: |
+    if [ "${TRUST_TEST_KEYS}" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    snap install test-snapd-swtpm --edge
+    snap download test-snapd-curl --edge --basename=test-snapd-curl
+    snap download core18 --basename=core18
+
+    "${TESTSTOOLS}/store-state" setup-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+    
+    gendeveloper1 sign-model < "${MODEL_JSON}" > model.assert
+
+    cp "${TESTSLIB}/assertions/testrootorg-store.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp "${TESTSLIB}/assertions/developer1.account" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp "${TESTSLIB}/assertions/developer1.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp model.assert "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+
+    tests.nested prepare-essential-snaps
+
+    "${TESTSTOOLS}"/store-state make-snap-installable --noack \
+      "${NESTED_FAKESTORE_BLOB_DIR}" \
+      ./test-snapd-curl.snap \
+      'A8JphBoJIkstBYyclynYlOonHoVzD1lm'
+
+    "${TESTSTOOLS}"/store-state make-snap-installable --noack \
+      "${NESTED_FAKESTORE_BLOB_DIR}" \
+      ./core18.snap \
+      'CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6'
+      
+    export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
+    ubuntu-image snap --channel edge --image-size 10G ./model.assert
+
+    image_dir=$(tests.nested get images-path)
+    image_name=$(tests.nested get image-name core)
+    cp ./pc.img "${image_dir}/${image_name}"
+    tests.nested configure-default-user
+
+    # run the fake device service too, so that the device can be initialised
+    systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
+
+    tests.nested build-image core
+    tests.nested create-vm core
+
+    #shellcheck source=tests/lib/core-config.sh
+    . "$TESTSLIB"/core-config.sh
+    wait_for_first_boot_change
+
+    remote.exec 'sudo systemctl stop snapd snapd.socket'
+    remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data.auth.device."session-macaroon"="fake-session"' > state.json
+    remote.push state.json
+    remote.exec 'sudo mv state.json /var/lib/snapd/state.json'
+    remote.exec 'sudo systemctl start snapd snapd.socket'
+
+restore: |
+    systemctl stop fakedevicesvc
+    "${TESTSTOOLS}/store-state" teardown-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+
+execute: |
+  function post_json_data() {
+    route=$1
+    template=$2
+    shift 2
+
+    # shellcheck disable=SC2059
+    response=$(printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}")
+    if ! gojq -e .change <<< "${response}"; then
+      echo "could not get change id from response: ${response}"
+      false
+    fi
+  }
+
+  unsquashfs "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel.snap"
+  sed -i -e '/^version/ s/$/-with-comps/' squashfs-root/meta/snap.yaml
+  snap pack --filename=pc-kernel-with-comps.snap ./squashfs-root
+  "${TESTSTOOLS}"/build_kernel_with_comps.sh mac80211_hwsim wifi-comp pc-kernel-with-comps.snap
+
+  kernel_id='pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza'
+
+  # bump the available kernel version in the fake store
+  "${TESTSTOOLS}"/store-state make-snap-installable --noack \
+    --revision 2 \
+    "${NESTED_FAKESTORE_BLOB_DIR}" \
+    ./pc-kernel-with-comps.snap \
+    "${kernel_id}"
+
+  "${TESTSTOOLS}"/store-state make-component-installable --noack \
+    --snap-revision 2 \
+    --component-revision 1 \
+    --snap-id "${kernel_id}" \
+    "${NESTED_FAKESTORE_BLOB_DIR}" \
+    ./pc-kernel+wifi-comp.comp
+
+  remote.exec 'sudo snap install test-snapd-curl --devmode'
+
+  snap_digest=$(openssl dgst -sha3-384 -binary < "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel-with-comps.snap" | basenc --base64url)
+  component_digest=$(openssl dgst -sha3-384 -binary < "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel+wifi-comp.comp" | basenc --base64url)
+
+  snap_revision="${NESTED_FAKESTORE_BLOB_DIR}/asserts/${snap_digest}.snap-revision"
+  snap_resource_pair="${NESTED_FAKESTORE_BLOB_DIR}/asserts/${kernel_id},wifi-comp,1,2.snap-resource-pair"
+  snap_resource_revision="${NESTED_FAKESTORE_BLOB_DIR}/asserts/${kernel_id},wifi-comp,${component_digest}.snap-resource-revision"
+  cat "${snap_resource_revision}" <(echo) "${snap_resource_pair}" <(echo) "${snap_revision}" > bundle.assert
+
+  remote.push bundle.assert
+  remote.push "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel-with-comps.snap"
+  remote.push "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel+wifi-comp.comp"
+
+  remote.exec 'sudo snap set system store.access=offline'
+  remote.exec 'sudo ip r d default'
+
+  boot_id="$(tests.nested boot-id)"
+  response=$(remote.exec "sudo test-snapd-curl.curl -X POST --unix-socket /run/snapd.socket -F 'action=create' -F 'label=new-system' -F 'assertion=<bundle.assert' -F 'snap=@pc-kernel-with-comps.snap' -F 'snap=@pc-kernel+wifi-comp.comp' -F 'test-system=true' -F 'mark-default=true' http://localhost/v2/systems")
+  change_id=$(gojq -r .change <<< "${response}")
+  remote.wait-for reboot "${boot_id}"
+
+  remote.wait-for snap-command
+  remote.exec snap watch "${change_id}"
+
+  remote.exec 'test -d /run/mnt/ubuntu-seed/systems/new-system'
+  remote.exec 'sudo cat /var/lib/snapd/modeenv' > modeenv
+  MATCH 'current_recovery_systems=.*,new-system$' < modeenv
+  MATCH 'good_recovery_systems=.*,new-system$' < modeenv
+
+  remote.exec 'sudo snap recovery' | awk '$1 == "new-system" { print $4 }' | MATCH 'default-recovery'
+
+  boot_id="$(tests.nested boot-id)"
+  remote.exec 'sudo snap reboot --recover' || true
+  remote.wait-for reboot "${boot_id}"
+
+  remote.wait-for snap-command
+
+  #shellcheck source=tests/lib/core-config.sh
+  . "$TESTSLIB"/core-config.sh
+  wait_for_first_boot_change
+
+  remote.exec 'sudo snap wait system seed.loaded'
+
+  boot_id="$(tests.nested boot-id)"
+
+  remote.exec 'cat /proc/cmdline' | MATCH 'snapd_recovery_mode=recover'
+  remote.exec 'sudo cat /var/lib/snapd/modeenv' > modeenv
+  MATCH 'mode=recover' < modeenv
+  MATCH 'recovery_system=new-system' < modeenv
+
+  # this at least indicates that we can have components in the recovery system,
+  # but kernel module components are not yet fully functional
+  remote.exec 'snap components pc-kernel' | sed 1d | MATCH 'pc-kernel\+wifi-comp\s+installed'
+  remote.exec 'readlink /snap/pc-kernel/components/2/wifi-comp' | MATCH '\.\./mnt/wifi-comp/1'
+
+  # TODO:COMPS: snap-bootstrap needs to be modified to mount the kernel modules
+  # from /var/lib/snapd/kernel, rather than from the kernel snap directly. once
+  # that is done, then the module should be able to be loaded while in recover
+  # mode
+  not remote.exec sudo modprobe mac80211_hwsim


### PR DESCRIPTION
This enables us to create recovery systems from local component files.