### PR TITLE
release: 2.67.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# New in snapd 2.67.1
+* Fix apparmor permissions to allow snaps access to kernel modules and firmware on UC24, which also fixes the kernel-modules-control interface on UC24
+* AppArmor prompting (experimental): disallow /./ and /../ in path patterns
+* Fix 'snap run' getent based user lookup in case of bad PATH
+* Fix snapd using the incorrect AppArmor version during undo of an refresh for regenerating snap profiles
+* Add new syscalls to base templates
+* hardware-observe interface: allow riscv_hwprobe syscall
+* mount-observe interface: allow listmount and statmount syscalls
+
 # New in snapd 2.67
 * AppArmor prompting (experimental): allow overlapping rules
 * Registry view (experimental): Changes to registry data (from both users and snaps) can be validated and saved by custodian snaps

--- a/cmd/snap-seccomp/syscalls/syscalls.go
+++ b/cmd/snap-seccomp/syscalls/syscalls.go
@@ -20,7 +20,7 @@
 package syscalls
 
 // Generated using arch-syscall-dump test tool from libseccomp tree, git
-// revision aa168d49243b95f63b9825a87351a1eb323dc792.
+// revision 42b596818635bf9d1cae54fa87e8c7b2e16869d3.
 var SeccompSyscalls = []string{
 	"_llseek",
 	"_newselect",
@@ -175,6 +175,7 @@ var SeccompSyscalls = []string{
 	"getuid",
 	"getuid32",
 	"getxattr",
+	"getxattrat",
 	"gtty",
 	"idle",
 	"init_module",
@@ -214,6 +215,7 @@ var SeccompSyscalls = []string{
 	"listen",
 	"listmount",
 	"listxattr",
+	"listxattrat",
 	"llistxattr",
 	"lock",
 	"lookup_dcookie",
@@ -336,6 +338,7 @@ var SeccompSyscalls = []string{
 	"recvmsg",
 	"remap_file_pages",
 	"removexattr",
+	"removexattrat",
 	"rename",
 	"renameat",
 	"renameat2",
@@ -422,6 +425,7 @@ var SeccompSyscalls = []string{
 	"setuid",
 	"setuid32",
 	"setxattr",
+	"setxattrat",
 	"sgetmask",
 	"shmat",
 	"shmctl",

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -700,6 +700,15 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	}
 	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch placeholder {
+		case "###KERNEL_MODULES_AND_FIRMWARE###":
+			if opts.KernelSnap != "" {
+				return fmt.Sprintf(`
+  # Allow access to kernel modules and firmware from the kernel snap
+  /snap/%[1]s/*/{modules,firmware}/{,**} r,
+  /snap/%[1]s/components/mnt/*/*/{modules,firmware}/{,**} r,
+  /var/snap/%[1]s/*/{modules,firmware}/{,**} r,`, opts.KernelSnap)
+			}
+			return ""
 		case "###DEVMODE_SNAP_CONFINE###":
 			if !opts.DevMode {
 				// nothing to add if we are not in devmode

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -85,6 +85,7 @@ var templateCommon = `
   #include <abstractions/base>
   #include <abstractions/consoles>
   #include <abstractions/openssl>
+  ###KERNEL_MODULES_AND_FIRMWARE###
 
   # While in later versions of the base abstraction, include this explicitly
   # for series 16 and cross-distro

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -72,6 +72,9 @@ type ConfinementOptions struct {
 	// AppArmorPrompting indicates whether the prompt prefix should be used in
 	// relevant rules when generating AppArmor security profiles.
 	AppArmorPrompting bool
+	// KernelSnap is the name of the kernel snap in the system
+	// (empty for classic systems).
+	KernelSnap string
 }
 
 // SecurityBackendOptions carries extra flags that affect initialization of the

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -145,6 +145,8 @@ const hardwareObserveConnectedPlugSecComp = `
 # used by 'lspci -A intel-conf1/intel-conf2'
 iopl
 
+riscv_hwprobe
+
 # multicast statistics
 socket AF_NETLINK - NETLINK_GENERIC
 

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -76,6 +76,9 @@ quotactl Q_GETINFO - - -
 quotactl Q_GETFMT - - -
 quotactl Q_XGETQUOTA - - -
 quotactl Q_XGETQSTAT - - -
+
+listmount
+statmount
 `
 
 func init() {

--- a/interfaces/prompting/patterns/patterns_test.go
+++ b/interfaces/prompting/patterns/patterns_test.go
@@ -133,6 +133,12 @@ func (s *patternsSuite) TestParsePathPatternHappy(c *C) {
 		"/foo/{a,b}{c,d}{e,f}{g,h,i,j,k}{l,m,n,o,p}{q,r,s,t,u},1,2,3", // expands to 1000, with commas outside groups
 		"/" + strings.Repeat("{a,", 999) + "a" + strings.Repeat("}", 999),
 		"/" + strings.Repeat("{", 999) + "a" + strings.Repeat(",a}", 999),
+		"/foo/.../bar",
+		"/foo/...",
+		"/foo/.{bar,baz}",
+		"/foo/..{bar,baz}",
+		"/foo/{bar,baz}.",
+		"/foo/{bar,baz}..",
 	} {
 		_, err := patterns.ParsePathPattern(pattern)
 		c.Check(err, IsNil, Commentf("valid path pattern %q was incorrectly not allowed", pattern))
@@ -151,6 +157,22 @@ func (s *patternsSuite) TestParsePathPatternUnhappy(c *C) {
 		{
 			`file.txt`,
 			`invalid path pattern: pattern must start with '/': "file.txt"`,
+		},
+		{
+			`/foo/./bar`,
+			`invalid path pattern: pattern cannot contain '/./' or '/../': .*`,
+		},
+		{
+			`/foo/../bar`,
+			`invalid path pattern: pattern cannot contain '/./' or '/../': .*`,
+		},
+		{
+			`/foo/.`,
+			`invalid path pattern: pattern cannot contain '/./' or '/../': .*`,
+		},
+		{
+			`/foo/..`,
+			`invalid path pattern: pattern cannot contain '/./' or '/../': .*`,
 		},
 		{
 			`{/,/foo}`,

--- a/interfaces/prompting/patterns/scan.go
+++ b/interfaces/prompting/patterns/scan.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -59,12 +60,18 @@ type token struct {
 	text  string
 }
 
+// relpathFinder matches `/./` and `/../` along with their trailing variants `/.` and `/..` in path patterns.
+var relpathFinder = regexp.MustCompile(`/\.(\.)?(/|$)`)
+
 func scan(text string) (tokens []token, err error) {
 	if len(text) == 0 {
 		return nil, errors.New("pattern has length 0")
 	}
 	if text[0] != '/' {
 		return nil, errors.New("pattern must start with '/'")
+	}
+	if relpathFinder.MatchString(text) {
+		return nil, errors.New("pattern cannot contain '/./' or '/../'")
 	}
 
 	var runes []rune

--- a/interfaces/prompting/patterns/scan_internal_test.go
+++ b/interfaces/prompting/patterns/scan_internal_test.go
@@ -124,6 +124,22 @@ func (s *scanSuite) TestScanUnhappy(c *C) {
 			`pattern must start with '/'`,
 		},
 		{
+			`/foo/./bar`,
+			`pattern cannot contain '/./' or '/../'`,
+		},
+		{
+			`/foo/../bar`,
+			`pattern cannot contain '/./' or '/../'`,
+		},
+		{
+			`/foo/.`,
+			`pattern cannot contain '/./' or '/../'`,
+		},
+		{
+			`/foo/..`,
+			`pattern cannot contain '/./' or '/../'`,
+		},
+		{
 			`/foo\`,
 			`trailing unescaped '\\' character`,
 		},

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -125,6 +125,7 @@ epoll_create1
 epoll_ctl
 epoll_ctl_old
 epoll_pwait
+epoll_pwait2
 epoll_wait
 epoll_wait_old
 eventfd

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -188,6 +188,7 @@ getuid32
 getxattr
 fgetxattr
 lgetxattr
+getxattrat
 
 inotify_add_watch
 inotify_init
@@ -234,6 +235,7 @@ linkat
 listxattr
 llistxattr
 flistxattr
+listxattrat
 
 lseek
 llseek
@@ -336,6 +338,7 @@ remap_file_pages
 removexattr
 fremovexattr
 lremovexattr
+removexattrat
 
 rename
 renameat
@@ -428,6 +431,7 @@ set_tid_address
 setxattr
 fsetxattr
 lsetxattr
+setxattrat
 
 shmat
 shmctl

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -55,6 +55,15 @@ set_tls
 usr26
 usr32
 
+# Requires input fd and so should not pose more security 
+# issues than access to the file in the first place
+# Flags are currently unused and should be 0
+cachestat - - - 0
+
+# Flags are currently unused and should be 0
+mseal - - 0
+map_shadow_stack
+
 capget
 # AppArmor mediates capabilities, so allow capset (useful for apps that for
 # example want to drop capabilities)
@@ -68,6 +77,7 @@ fchdir
 chmod
 fchmod
 fchmodat
+fchmodat2
 
 # Daemons typically run as 'root' so allow chown to 'root'. DAC will prevent
 # non-root from chowning to root.
@@ -147,8 +157,11 @@ flock
 fork
 ftime
 futex
+futex_requeue
 futex_time64
+futex_wait
 futex_waitv
+futex_wake
 get_mempolicy
 get_robust_list
 get_thread_area

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -53,6 +53,7 @@ func MockFindGid(f func(string) (uint64, error)) (restore func()) {
 
 // getent returns the identifier of the given UNIX user or group name as
 // determined by the specified database
+// TODO use a single implementation provided by osutil/user
 func getent(database, name string) (uint64, error) {
 	if database != "passwd" && database != "group" {
 		return 0, fmt.Errorf(`unsupported getent database "%q"`, database)

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -370,7 +370,7 @@ func UserMaybeSudoUser() (*user.User, error) {
 		return cur, nil
 	}
 
-	real, err := user.Lookup(realName)
+	real, err := userLookup(realName)
 	// This is a best effort, see the comment in findGidNoGetentFallback in
 	// group.go.
 	//

--- a/osutil/user/export_test.go
+++ b/osutil/user/export_test.go
@@ -19,6 +19,10 @@
 
 package user
 
+import (
+	"github.com/snapcore/snapd/testutil"
+)
+
 var (
 	LookupGroupFromGetent = lookupGroupFromGetent
 	LookupUserFromGetent  = lookupUserFromGetent
@@ -26,3 +30,7 @@ var (
 	UserMatchUsername     = userMatchUsername
 	GroupMatchGroupname   = groupMatchGroupname
 )
+
+func MockGetentSearchPath(p string) (restore func()) {
+	return testutil.Mock(&getentSearchPath, p)
+}

--- a/osutil/user/getent_test.go
+++ b/osutil/user/getent_test.go
@@ -54,6 +54,7 @@ if [ -f "${base}.exit" ]; then
   exit "$(cat "${base}.exit")"
 fi
 `, s.getentDir))
+	s.AddCleanup(user.MockGetentSearchPath(s.mockGetent.BinDir() + ":" + user.DefaultGetentSearchPath))
 	s.AddCleanup(s.mockGetent.Restore)
 }
 
@@ -176,4 +177,12 @@ func (s *getentSuite) TestLookupGroupByNameMissing(c *C) {
 	grp, err := user.LookupGroupFromGetent(user.GroupMatchGroupname("mygroup"))
 	c.Assert(err, IsNil)
 	c.Assert(grp, IsNil)
+}
+
+func (s *getentSuite) TestNoGetentBinary(c *C) {
+	defer user.MockGetentSearchPath("/foo:/bar")()
+
+	usr, err := user.LookupUserFromGetent(user.UserMatchUid(1000))
+	c.Assert(err, ErrorMatches, "cannot locate getent executable")
+	c.Assert(usr, IsNil)
 }

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -267,6 +267,29 @@ func (s *createUserSuite) TestUserMaybeSudoUser(c *check.C) {
 			}, nil
 		})
 		defer restore()
+		restore = osutil.MockUserLookup(func(username string) (*user.User, error) {
+			switch username {
+			case "guy":
+				return &user.User{
+					Uid:      "1000",
+					Gid:      "1000",
+					Username: username,
+					Name:     "guy",
+					HomeDir:  "~",
+				}, nil
+			case "root":
+				return &user.User{
+					Uid:      "0",
+					Gid:      "0",
+					Username: username,
+					Name:     "root",
+					HomeDir:  "/",
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected username in test: %s", username)
+			}
+		})
+		defer restore()
 
 		os.Setenv("SUDO_USER", t.SudoUsername)
 		cur, err := osutil.UserMaybeSudoUser()

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -74,8 +74,8 @@ func NewInterfaceManagerWithAppArmorPrompting(useAppArmorPrompting bool) *Interf
 	return m
 }
 
-func (m *InterfaceManager) BuildConfinementOptions(st *state.State, snapInfo *snap.Info, flags snapstate.Flags) (interfaces.ConfinementOptions, error) {
-	return m.buildConfinementOptions(st, snapInfo, flags)
+func (m *InterfaceManager) BuildConfinementOptions(st *state.State, task *state.Task, snapInfo *snap.Info, flags snapstate.Flags) (interfaces.ConfinementOptions, error) {
+	return m.buildConfinementOptions(st, task, snapInfo, flags)
 }
 
 type ConnectOpts = connectOpts

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -432,6 +432,20 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 	}
 	snapName := snapsup.InstanceName()
 
+	// The previous task's undo (link-snap) may have triggered a restart, if this
+	// is the case we can only proceed once the restart has happened or we
+	// may be invoking tools (like apparmor) from the wrong snapd. We set
+	// the default to true as we cannot set it otherwise since the change will
+	// always have been created by the old snapd (that may not have "finish-restart")
+	logger.Debugf("finish restart from undoLinkSnap")
+	finishOpts := snapstate.FinishRestartOptions{
+		// Only default to true for snapd snap
+		FinishRestartDefault: snapsup.Type == snap.TypeSnapd,
+	}
+	if err := snapstateFinishRestart(task, snapsup, finishOpts); err != nil {
+		return err
+	}
+
 	// Get the name from SnapSetup and use it to find the current SideInfo
 	// about the snap, if there is one.
 	var snapst snapstate.SnapState

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -20,12 +20,14 @@
 package ifacestate_test
 
 import (
+	"errors"
 	"path"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -34,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 const snapAyaml = `name: snap-a
@@ -42,14 +45,22 @@ base: base-snap-a
 `
 
 type handlersSuite struct {
+	testutil.BaseTest
 	st *state.State
 }
 
 var _ = Suite(&handlersSuite{})
 
+func (s *handlersSuite) mockModel() func() {
+	old := snapstate.DeviceCtx
+	snapstate.DeviceCtx = devicestate.DeviceCtx
+	return func() { snapstate.DeviceCtx = old }
+}
+
 func (s *handlersSuite) SetUpTest(c *C) {
 	s.st = state.New(nil)
 	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(s.mockModel())
 }
 
 func (s *handlersSuite) TearDownTest(c *C) {
@@ -136,7 +147,7 @@ func (s *handlersSuite) TestBuildConfinementOptions(c *C) {
 
 		snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
 		flags := snapstate.Flags{}
-		opts, err := m.BuildConfinementOptions(s.st, snapInfo, snapstate.Flags{})
+		opts, err := m.BuildConfinementOptions(s.st, nil, snapInfo, snapstate.Flags{})
 
 		c.Check(err, IsNil)
 		c.Check(len(opts.ExtraLayouts), Equals, 0)
@@ -144,6 +155,42 @@ func (s *handlersSuite) TestBuildConfinementOptions(c *C) {
 		c.Check(opts.DevMode, Equals, flags.DevMode)
 		c.Check(opts.JailMode, Equals, flags.JailMode)
 		c.Check(opts.AppArmorPrompting, Equals, testAppArmorPrompting)
+		c.Check(opts.KernelSnap, Equals, "")
+	}
+}
+
+func (s *handlersSuite) TestBuildConfinementOptionsWithTask(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// This test is to check that the task is actually passed down to snapstate.DeviceCtx(),
+	// and that errors there are handled fine.
+	t := s.st.NewTask("foo", "description")
+	s.AddCleanup(func() func() {
+		old := snapstate.DeviceCtx
+		snapstate.DeviceCtx = func(st *state.State, task *state.Task,
+			providedDeviceCtx snapstate.DeviceContext) (snapstate.DeviceContext, error) {
+			c.Check(task, DeepEquals, t)
+			return nil, errors.New("classic, no context")
+		}
+		return func() { snapstate.DeviceCtx = old }
+	}())
+
+	for _, testAppArmorPrompting := range []bool{true, false} {
+		// Create fake InterfaceManager to hold fake AppArmor Prompting value
+		m := ifacestate.NewInterfaceManagerWithAppArmorPrompting(testAppArmorPrompting)
+
+		snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
+		flags := snapstate.Flags{}
+		opts, err := m.BuildConfinementOptions(s.st, t, snapInfo, snapstate.Flags{})
+
+		c.Check(err, IsNil)
+		c.Check(len(opts.ExtraLayouts), Equals, 0)
+		c.Check(opts.Classic, Equals, flags.Classic)
+		c.Check(opts.DevMode, Equals, flags.DevMode)
+		c.Check(opts.JailMode, Equals, flags.JailMode)
+		c.Check(opts.AppArmorPrompting, Equals, testAppArmorPrompting)
+		c.Check(opts.KernelSnap, Equals, "")
 	}
 }
 
@@ -166,7 +213,7 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 	c.Assert(err, IsNil)
 
 	flags := snapstate.Flags{}
-	opts, err := m.BuildConfinementOptions(s.st, snapInfo, snapstate.Flags{})
+	opts, err := m.BuildConfinementOptions(s.st, nil, snapInfo, snapstate.Flags{})
 
 	c.Check(err, IsNil)
 	c.Assert(len(opts.ExtraLayouts), Equals, 1)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -219,7 +219,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 			logger.Noticef("cannot get current info for snap %q: %s", snapName, err)
 			return interfaces.ConfinementOptions{}
 		}
-		opts, err := m.buildConfinementOptions(m.state, snapInfo, snapst.Flags)
+		opts, err := m.buildConfinementOptions(m.state, nil, snapInfo, snapst.Flags)
 		if err != nil {
 			logger.Noticef("cannot get confinement options for snap %q: %s", snapName, err)
 		}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1796,8 +1796,8 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 
 	consumerAppSet := s.secBackend.SetupCalls[0].AppSet
 	c.Check(consumerAppSet.InstanceName(), Equals, "consumer")
@@ -4174,8 +4174,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "producer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInvokedOnSlotSide(c *C) {
@@ -4192,8 +4192,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "consumer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) testDoSetupSnapSecurityReloadsConnectionsWhenInvokedOn(c *C, snapName string, revision snap.Revision) {
@@ -4263,7 +4263,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "snap")
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true, KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) TestSetupProfilesSetupManyError(c *C) {
@@ -5305,8 +5305,8 @@ func (s *interfaceManagerSuite) TestConnectSetsUpSecurity(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "consumer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) TestConnectWithComponentsSetsUpSecurity(c *C) {
@@ -5345,8 +5345,8 @@ func (s *interfaceManagerSuite) TestConnectWithComponentsSetsUpSecurity(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 
 	producerAppSet := s.secBackend.SetupCalls[0].AppSet
 	consumerAppSet := s.secBackend.SetupCalls[1].AppSet
@@ -5444,8 +5444,8 @@ func (s *interfaceManagerSuite) TestDisconnectSetsUpSecurity(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "producer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) TestDisconnectTracksConnectionsInState(c *C) {
@@ -5875,13 +5875,13 @@ func (s *interfaceManagerSuite) TestSetupProfilesDevModeMultiple(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 4)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, siC.InstanceName())
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true, KernelSnap: "krnl"})
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, siP.InstanceName())
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 	c.Check(s.secBackend.SetupCalls[2].AppSet.InstanceName(), Equals, siC.InstanceName())
-	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true})
+	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true, KernelSnap: "krnl"})
 	c.Check(s.secBackend.SetupCalls[3].AppSet.InstanceName(), Equals, siP.InstanceName())
-	c.Check(s.secBackend.SetupCalls[3].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[3].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeny(c *C) {
@@ -6334,7 +6334,7 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, snapInfo.InstanceName())
 	c.Check(s.secBackend.SetupCalls[0].AppSet.Info().Revision, Equals, snapInfo.Revision)
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "snap", &snapst)
@@ -6723,16 +6723,16 @@ func (s *interfaceManagerSuite) TestUndoConnect(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 4)
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[1].AppSet.InstanceName(), Equals, "consumer")
-	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 	c.Check(s.secBackend.SetupCalls[0].AppSet.Runnables(), testutil.DeepUnsortedMatches, producerRunnablesFullSet)
 	c.Check(s.secBackend.SetupCalls[1].AppSet.Runnables(), testutil.DeepUnsortedMatches, consumerRunnablesFullSet)
 
 	// by undo
 	c.Check(s.secBackend.SetupCalls[2].AppSet.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[3].AppSet.InstanceName(), Equals, "consumer")
-	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[3].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
+	c.Check(s.secBackend.SetupCalls[3].Options, DeepEquals, interfaces.ConfinementOptions{KernelSnap: "krnl"})
 	c.Check(s.secBackend.SetupCalls[2].AppSet.Runnables(), testutil.DeepUnsortedMatches, producerRunnablesFullSet)
 	c.Check(s.secBackend.SetupCalls[3].AppSet.Runnables(), testutil.DeepUnsortedMatches, consumerRunnablesFullSet)
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1628,6 +1628,9 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// if we just put back a previous a core snap, request a restart
 	// so that we switch executing its snapd
+	// TODO: This needs changing, right now we restart snapd after undoing 'link-snap',
+	// inside 'undoSetupProfiles() and even though we request a restart here we are
+	// not actually waiting for the restart to occur in the task that comes before this.
 	return m.finishTaskWithMaybeRestart(t, state.UndoneStatus, restartPossibility{info: oldInfo, RebootInfo: reboot})
 }
 
@@ -2902,11 +2905,10 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// restart only when snapd was installed for the first time and the rest of
-	// the cleanup is performed by snapd from core;
-	// when reverting a subsequent snapd revision, the restart happens in
-	// undoLinkCurrentSnap() instead
-	if firstInstall && newInfo.Type() == snap.TypeSnapd {
+	// When undoing the snapd snap refresh/install we must ensure that
+	// we are restarting into the previous snapd, undoSetupProfiles() handles
+	// the actual waiting for restart.
+	if newInfo.Type() == snap.TypeSnapd {
 		restartPoss = &restartPossibility{info: newInfo, RebootInfo: boot.RebootInfo{RebootRequired: false}}
 	}
 

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -2447,11 +2447,19 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 	c.Check(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Check(s.fakeBackend.ops, DeepEquals, expected)
 
-	// 1 restart from link snap, the other restart happens
-	// in undoUnlinkCurrentSnap (not tested here)
-	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon})
-	c.Assert(t.Log(), HasLen, 1)
+	// 1 restart from link snap
+	// 1 restart from undo of 'setup-profiles'
+	// 1 in undoUnlinkCurrentSnap (not tested here)
+	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon, restart.RestartDaemon})
+	c.Assert(t.Log(), HasLen, 2)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
+	c.Check(t.Log()[1], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
+
+	// verify sequence file
+	// and check that the sequence file got updated
+	seqContent, err := os.ReadFile(filepath.Join(dirs.SnapSeqDir, "snapd.json"))
+	c.Assert(err, IsNil)
+	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"snapd","snap-id":"snapd-snap-id","revision":"20"}],"current":"20","migrated-hidden":false,"migrated-exposed-home":false}`)
 }
 
 func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheckOn(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1194,6 +1194,9 @@ func isChangeRequestingSnapdRestart(chg *state.Change) bool {
 	// have been set up in link-snap, daemon restart is requested, link-snap
 	// is marked as Done, and the auto-connect task is held off (in Do or
 	// Doing states) until the restart completes
+	// TODO: This may need additional handling for snapd restart along the
+	// Undo path. For instance, 'link-snap' can request a restart in the undo
+	// direction, making 'setup-profiles' wait for restart.
 	var haveSnapd, linkDone, autoConnectWaiting bool
 	for _, tsk := range chg.Tasks() {
 		kind := tsk.Kind()

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.67
+pkgver=2.67.1
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,20 @@
+snapd (2.67.1-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2089691
+    - Fix apparmor permissions to allow snaps access to kernel modules
+      and firmware on UC24, which also fixes the kernel-modules-control
+      interface on UC24
+    - AppArmor prompting (experimental): disallow /./ and /../ in path
+      patterns
+    - Fix 'snap run' getent based user lookup in case of bad PATH
+    - Fix snapd using the incorrect AppArmor version during undo of an
+      refresh for regenerating snap profiles
+    - Add new syscalls to base templates
+    - hardware-observe interface: allow riscv_hwprobe syscall
+    - mount-observe interface: allow listmount and statmount syscalls
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 15 Jan 2025 22:02:37 +0200
+
 snapd (2.67-1) unstable; urgency=medium
 
   * New upstream release, LP: #2089691

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.67
+Version:        2.67.1
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPL-3.0-only
@@ -1003,6 +1003,20 @@ fi
 
 
 %changelog
+* Wed Jan 15 2025 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.67.1
+ - Fix apparmor permissions to allow snaps access to kernel modules
+   and firmware on UC24, which also fixes the kernel-modules-control
+   interface on UC24
+ - AppArmor prompting (experimental): disallow /./ and /../ in path
+   patterns
+ - Fix 'snap run' getent based user lookup in case of bad PATH
+ - Fix snapd using the incorrect AppArmor version during undo of an
+   refresh for regenerating snap profiles
+ - Add new syscalls to base templates
+ - hardware-observe interface: allow riscv_hwprobe syscall
+ - mount-observe interface: allow listmount and statmount syscalls
+
 * Mon Dec 02 2024 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.67
  - AppArmor prompting (experimental): allow overlapping rules

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan 15 20:02:37 UTC 2025 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.67.1
+
+-------------------------------------------------------------------
 Mon Dec 02 21:14:24 UTC 2024 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.67

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.67
+Version:        2.67.1
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,20 @@
+snapd (2.67.1~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2089691
+    - Fix apparmor permissions to allow snaps access to kernel modules
+      and firmware on UC24, which also fixes the kernel-modules-control
+      interface on UC24
+    - AppArmor prompting (experimental): disallow /./ and /../ in path
+      patterns
+    - Fix 'snap run' getent based user lookup in case of bad PATH
+    - Fix snapd using the incorrect AppArmor version during undo of an
+      refresh for regenerating snap profiles
+    - Add new syscalls to base templates
+    - hardware-observe interface: allow riscv_hwprobe syscall
+    - mount-observe interface: allow listmount and statmount syscalls
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 15 Jan 2025 22:02:37 +0200
+
 snapd (2.67~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2089691

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,20 @@
+snapd (2.67.1) xenial; urgency=medium
+
+  * New upstream release, LP: #2089691
+    - Fix apparmor permissions to allow snaps access to kernel modules
+      and firmware on UC24, which also fixes the kernel-modules-control
+      interface on UC24
+    - AppArmor prompting (experimental): disallow /./ and /../ in path
+      patterns
+    - Fix 'snap run' getent based user lookup in case of bad PATH
+    - Fix snapd using the incorrect AppArmor version during undo of an
+      refresh for regenerating snap profiles
+    - Add new syscalls to base templates
+    - hardware-observe interface: allow riscv_hwprobe syscall
+    - mount-observe interface: allow listmount and statmount syscalls
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 15 Jan 2025 22:02:37 +0200
+
 snapd (2.67) xenial; urgency=medium
 
   * New upstream release, LP: #2089691

--- a/tests/core/snapd-refresh-undo/task.yaml
+++ b/tests/core/snapd-refresh-undo/task.yaml
@@ -1,0 +1,46 @@
+summary: Verify that snapd can undo the upgrade from non-snapd-snap to snapd-snap
+
+details: |
+  Verify that the snapd-snap can successfully undo after upgrading from a non snapd-snap
+  situation, and something causes a rollback even in spite of a successful snapd update.
+
+# UC16 still uses the core snap rather than the snapd snap, so disable this test
+# for UC16
+systems: [-ubuntu-core-16-*]
+
+environment:
+  SNAP_NAME_BAD: test-snapd-service-v2-bad
+
+restore: |
+  # Remove all inactive revisions of snapd.
+  current=$(readlink /snap/snapd/current)
+  for revno_path in /snap/snapd/*; do
+    revno=$(basename "$revno_path")
+    if [ "$revno" == current ] || [ "$revno" == "$current" ]; then
+      continue
+    fi
+    snap remove snapd --revision="$revno"
+  done
+
+execute: |
+  snap pack "$TESTSLIB/snaps/$SNAP_NAME_BAD"
+
+  # store a copy of the built snapd
+  cp /var/lib/snapd/snaps/snapd_x1.snap ./snapd.snap
+
+  # refresh to a snapd prior to snapd snap, this one is chosen from
+  # a customer case where they were seeing issues with snapd reverting
+  snap refresh snapd --amend --revision=18357
+  snap list | MATCH "snapd.*18357"
+
+  # perform a refresh to the current snapd, this will fail, do it in a way
+  # that will make snapd revert
+  CHG_ID=$(snap install --no-wait --dangerous --transaction=all-snaps ./snapd.snap ./test-snapd-service_2.0_all.snap)
+  snap watch "$CHG_ID" || true
+
+  # verify this has no undo failures for snapd related to security profiles
+  snap change "$CHG_ID" | MATCH "(Undone).*Setup snap \"snapd\" \(unset\) security profiles"
+  snap change "$CHG_ID" | grep -c "Error" | MATCH "1"
+
+  # restore original snapd
+  snap revert snapd

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -2751,7 +2751,7 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
 }
 
 var snapdYaml = `name: snapd
-version: 1.0
+version: 2.62
 type: snapd
 `
 


### PR DESCRIPTION
Generated changelogs with:
DEBEMAIL="Ernest Lotter [ernest.lotter@canonical.com](mailto:ernest.lotter@canonical.com)" release-tools/changelog.py 2.67 2089691 NEWS.md

Cherry-picks:
- [allow access to kernel snap in profiles](https://github.com/canonical/snapd/pull/14899)
- [look up getent executable in known host directories](https://github.com/canonical/snapd/pull/14792)
- [wait for snapd restart after requesting by undo of 'link-snap'](https://github.com/canonical/snapd/pull/14850)
- [allow epoll_pwait2 in the base template](https://github.com/canonical/snapd/pull/14885)
- [added new at-variant syscalls to base template](https://github.com/canonical/snapd/pull/14902)
- [added new syscalls](https://github.com/canonical/snapd/pull/14886)
- [update template with new syscalls](https://github.com/canonical/snapd/pull/14861)
- [disallow /./ and /../ in path patterns](https://github.com/canonical/snapd/pull/14774)

SRU Bug: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2089691
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34379

**Requires rebase merge**
