### PR TITLE
interfaces: disable udev backend when inside a container

### DIFF
--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -37,7 +37,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -47,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snapdtool"
+	"github.com/snapcore/snapd/systemd"
 )
 
 // Checks to see if the current container is capable of having internal AppArmor
@@ -149,7 +149,7 @@ func loadAppArmorProfiles() error {
 
 func isContainer() bool {
 	// systemd's implementation may fail on WSL2 with custom kernels
-	return release.OnWSL || (exec.Command("systemd-detect-virt", "--quiet", "--container").Run() == nil)
+	return release.OnWSL || systemd.IsContainer()
 }
 
 func validateArgs(args []string) error {

--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -31,21 +31,50 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/logger"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
+	systemd_tools "github.com/snapcore/snapd/systemd"
 )
 
 // All returns a set of all available security backends.
 func All() []interfaces.SecurityBackend {
+	// Backends have non-obvious ordering constraints. The order in which they
+	// are registered below is significant.  Please refrain from reordering
+	// them when refactoring this code. Because this list changes rarely it is
+	// most likely that interactions are implicit and not well-known. Having
+	// said that we know of one specific constraint that is documented:
+	//
+	// Because of how the GPIO interface is implemented the systemd backend
+	// must be earlier in the sequence than the apparmor backend.
 	all := []interfaces.SecurityBackend{
-		// Because of how the GPIO interface is implemented the systemd backend
-		// must be earlier in the sequence than the apparmor backend.
 		&systemd.Backend{},
 		&seccomp.Backend{},
 		&dbus.Backend{},
-		&udev.Backend{},
-		&mount.Backend{},
+	}
+
+	// Since snapd 2.68 the udev backend, responsible for writing udev rules to
+	// /etc/udev/rules.d and for calling udevadm control --reload-rules, as
+	// well as udevadm trigger (with a number of options), is no longer enabled
+	// in containers. System administrators retain ability to manage access to
+	// real devices at the container level.
+	//
+	// For context:
+	//
+	// In Linux, devices are _not_ namespace aware so if a device is accessible
+	// in the container (and the container manager has allowed such access)
+	// then allow snaps to freely poke the device subject to still-enforced
+	// apparmor rules. In "traditional" containers such as docker or podman,
+	// where using systemd is unusual and unsupported this doesn't change
+	// anything. In system containers such as lxd and incus users may, with or
+	// without understanding the consequences, switch the container to
+	// privileged mode. In this mode udev does start inside the container, but
+	// actively configures devices on the host with undesirable consequences.
+	if !systemd_tools.IsContainer() {
+		all = append(all, &udev.Backend{})
+	}
+
+	all = append(all, &mount.Backend{},
 		&kmod.Backend{},
 		&polkit.Backend{},
-	}
+	)
 
 	// TODO use something like:
 	// level, summary := apparmor.ProbeResults()

--- a/systemd/detect.go
+++ b/systemd/detect.go
@@ -1,0 +1,35 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd
+
+import (
+	"os/exec"
+)
+
+// IsContainer returns true if the system is running in a container.
+//
+// The implementation calls: systemd-detect-virt --quiet --container.  It can
+// be mocked with testutil.MockCommand. The zero exit code indicates that
+// system _is_ running a container. Ensuring that --container is passed is
+// important.
+func IsContainer() bool {
+	err := exec.Command("systemd-detect-virt", "--quiet", "--container").Run()
+	return err == nil
+}

--- a/systemd/detect_test.go
+++ b/systemd/detect_test.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type detectSuite struct{}
+
+var _ = Suite(&detectSuite{})
+
+func (*detectSuite) TestIsContainer_Yes(c *C) {
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", `exit 0`)
+	defer systemdCmd.Restore()
+
+	c.Check(systemd.IsContainer(), Equals, true)
+}
+
+func (*detectSuite) TestIsContainer_No(c *C) {
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", `exit 1`)
+	defer systemdCmd.Restore()
+
+	c.Check(systemd.IsContainer(), Equals, false)
+}

--- a/tests/regression/lp-1867193/task.yaml
+++ b/tests/regression/lp-1867193/task.yaml
@@ -35,7 +35,5 @@ restore: |
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
 execute: |
-    # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503
-    lxc exec bionic -- snap install maas --channel=2.7/edge
     lxc exec bionic -- snap install maas --channel=2.7/edge
     lxc exec bionic -- snap refresh maas --channel=edge


### PR DESCRIPTION
Devices are not namespace-aware in Linux, thus udev inside containers does not really do anything sensible and is set to not execute if /sys is not mounted as a writable file system.

This solves the issue where snapd is failing to install snaps in LXD, demanding workarounds like installing the snap twice, hoping that once-generated files are intact and not trigger a udev rule reload.



Fixes: https://bugs.launchpad.net/snapd/+bug/1712808
Fixes: https://bugs.launchpad.net/snapd/+bug/1865503
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-24757
