### PR TITLE
o/snapstate: add some metadata to help with component remodeling

### DIFF
--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -144,6 +144,8 @@ func InstallComponents(
 	setupSecurity.Set("component-setup-tasks", compSetupIDs)
 
 	ts := state.NewTaskSet(setupSecurity)
+	ts.MarkEdge(setupSecurity, SnapSetupEdge)
+
 	if kmodSetup != nil {
 		ts.AddTask(kmodSetup)
 	}
@@ -302,6 +304,7 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 	}
 
 	begin.Set("component-setup-tasks", []string{componentTS.compSetupTaskID})
+	ts.MarkEdge(begin, SnapSetupEdge)
 
 	ts.JoinLane(generateLane(st, opts))
 

--- a/overlord/snapstate/component.go
+++ b/overlord/snapstate/component.go
@@ -92,15 +92,15 @@ func InstallComponents(
 	// TODO:COMPS: verify validation sets here
 
 	snapsup := SnapSetup{
-		Base:                    info.Base,
-		SideInfo:                &info.SideInfo,
-		Channel:                 info.Channel,
-		Flags:                   opts.Flags.ForSnapSetup(),
-		Type:                    info.Type(),
-		Version:                 info.Version,
-		PlugsOnly:               len(info.Slots) == 0,
-		InstanceKey:             info.InstanceKey,
-		ComponentExclusiveSetup: true,
+		Base:                        info.Base,
+		SideInfo:                    &info.SideInfo,
+		Channel:                     info.Channel,
+		Flags:                       opts.Flags.ForSnapSetup(),
+		Type:                        info.Type(),
+		Version:                     info.Version,
+		PlugsOnly:                   len(info.Slots) == 0,
+		InstanceKey:                 info.InstanceKey,
+		ComponentExclusiveOperation: true,
 	}
 
 	setupSecurity := st.NewTask("setup-profiles",
@@ -267,15 +267,15 @@ func InstallComponentPath(st *state.State, csi *snap.ComponentSideInfo, info *sn
 	}
 
 	snapsup := SnapSetup{
-		Base:                    info.Base,
-		SideInfo:                &info.SideInfo,
-		Channel:                 info.Channel,
-		Flags:                   opts.Flags.ForSnapSetup(),
-		Type:                    info.Type(),
-		Version:                 info.Version,
-		PlugsOnly:               len(info.Slots) == 0,
-		InstanceKey:             info.InstanceKey,
-		ComponentExclusiveSetup: true,
+		Base:                        info.Base,
+		SideInfo:                    &info.SideInfo,
+		Channel:                     info.Channel,
+		Flags:                       opts.Flags.ForSnapSetup(),
+		Type:                        info.Type(),
+		Version:                     info.Version,
+		PlugsOnly:                   len(info.Slots) == 0,
+		InstanceKey:                 info.InstanceKey,
+		ComponentExclusiveOperation: true,
 	}
 	compSetup := ComponentSetup{
 		CompSideInfo: csi,

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -187,9 +187,14 @@ func verifyComponentInstallTasks(c *C, opts int, ts *state.TaskSet) {
 		snapsupTask, err := ts.Edge(snapstate.SnapSetupEdge)
 		c.Assert(err, IsNil)
 
+		var compsupsIDs []string
+		err = snapsupTask.Get("component-setup-tasks", &compsupsIDs)
+		c.Assert(err, IsNil)
+
 		// for now, all non-multi-component installs are by path, so this will
 		// point to prepare-component
 		c.Assert(snapsupTask.Kind(), Equals, "prepare-component")
+		c.Assert(compsupsIDs, DeepEquals, []string{snapsupTask.ID()})
 	}
 }
 
@@ -1049,6 +1054,7 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	snapsupTask, err := setupTs.Edge(snapstate.SnapSetupEdge)
 	c.Assert(err, IsNil)
 	c.Assert(snapsupTask.Kind(), Equals, "setup-profiles")
+	c.Assert(snapsupTask.Has("component-setup-tasks"), Equals, true)
 
 	expectedLane := opts.lane
 	if opts.transaction != "" && opts.lane == 0 {

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -516,7 +516,7 @@ func (s *snapmgrTestSuite) TestInstallComponentPathForParallelInstall(c *C) {
 	var snapsup snapstate.SnapSetup
 	c.Assert(ts.Tasks()[0].Get("snap-setup", &snapsup), IsNil)
 	c.Assert(snapsup.InstanceKey, Equals, snapKey)
-	c.Assert(snapsup.ComponentExclusiveSetup, Equals, true)
+	c.Assert(snapsup.ComponentExclusiveOperation, Equals, true)
 }
 
 func (s *snapmgrTestSuite) TestInstallComponentPathWrongSnap(c *C) {
@@ -1074,7 +1074,7 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	snapsup, err := snapstate.TaskSnapSetup(prepareKmodComps)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, NotNil)
-	c.Assert(snapsup.ComponentExclusiveSetup, Equals, true)
+	c.Assert(snapsup.ComponentExclusiveOperation, Equals, true)
 
 	for _, ts := range tss[0 : len(tss)-1] {
 		task := ts.Tasks()[0]

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -502,6 +502,7 @@ func (s *snapmgrTestSuite) TestInstallComponentPathForParallelInstall(c *C) {
 	var snapsup snapstate.SnapSetup
 	c.Assert(ts.Tasks()[0].Get("snap-setup", &snapsup), IsNil)
 	c.Assert(snapsup.InstanceKey, Equals, snapKey)
+	c.Assert(snapsup.ComponentExclusiveSetup, Equals, true)
 }
 
 func (s *snapmgrTestSuite) TestInstallComponentPathWrongSnap(c *C) {
@@ -1052,6 +1053,7 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	snapsup, err := snapstate.TaskSnapSetup(prepareKmodComps)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, NotNil)
+	c.Assert(snapsup.ComponentExclusiveSetup, Equals, true)
 
 	for _, ts := range tss[0 : len(tss)-1] {
 		task := ts.Tasks()[0]

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -159,6 +159,10 @@ type SnapSetup struct {
 	// case of an undo. Note that this cannot be tagged as omitempty, since we
 	// need to distinguish between empty and nil.
 	PreUpdateKernelModuleComponents []*snap.ComponentSideInfo `json:"pre-update-kernel-module-components"`
+
+	// ComponentExclusiveSetup is set if this SnapSetup exists only to deal with
+	// components, and not the snap itself.
+	ComponentExclusiveSetup bool `json:"component-exclusive-setup,omitempty"`
 }
 
 // ConfdbID identifies a confdb.

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -160,9 +160,9 @@ type SnapSetup struct {
 	// need to distinguish between empty and nil.
 	PreUpdateKernelModuleComponents []*snap.ComponentSideInfo `json:"pre-update-kernel-module-components"`
 
-	// ComponentExclusiveSetup is set if this SnapSetup exists only to deal with
+	// ComponentExclusiveOperation is set if this SnapSetup exists only to deal with
 	// components, and not the snap itself.
-	ComponentExclusiveSetup bool `json:"component-exclusive-setup,omitempty"`
+	ComponentExclusiveOperation bool `json:"component-exclusive-operation,omitempty"`
 }
 
 // ConfdbID identifies a confdb.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1635,18 +1635,19 @@ func downloadTasks(
 	}
 
 	snapsup := &SnapSetup{
-		Channel:            revOpts.Channel,
-		Base:               info.Base,
-		UserID:             opts.UserID,
-		Flags:              opts.Flags.ForSnapSetup(),
-		DownloadInfo:       &info.DownloadInfo,
-		SideInfo:           &info.SideInfo,
-		Type:               info.Type(),
-		Version:            info.Version,
-		InstanceKey:        info.InstanceKey,
-		CohortKey:          revOpts.CohortKey,
-		ExpectedProvenance: info.SnapProvenance,
-		DownloadBlobDir:    downloadDir,
+		Channel:                 revOpts.Channel,
+		Base:                    info.Base,
+		UserID:                  opts.UserID,
+		Flags:                   opts.Flags.ForSnapSetup(),
+		DownloadInfo:            &info.DownloadInfo,
+		SideInfo:                &info.SideInfo,
+		Type:                    info.Type(),
+		Version:                 info.Version,
+		InstanceKey:             info.InstanceKey,
+		CohortKey:               revOpts.CohortKey,
+		ExpectedProvenance:      info.SnapProvenance,
+		DownloadBlobDir:         downloadDir,
+		ComponentExclusiveSetup: skipSnapDownload,
 	}
 
 	if sar.RedirectChannel != "" {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1637,19 +1637,19 @@ func downloadTasks(
 	}
 
 	snapsup := &SnapSetup{
-		Channel:                 revOpts.Channel,
-		Base:                    info.Base,
-		UserID:                  opts.UserID,
-		Flags:                   opts.Flags.ForSnapSetup(),
-		DownloadInfo:            &info.DownloadInfo,
-		SideInfo:                &info.SideInfo,
-		Type:                    info.Type(),
-		Version:                 info.Version,
-		InstanceKey:             info.InstanceKey,
-		CohortKey:               revOpts.CohortKey,
-		ExpectedProvenance:      info.SnapProvenance,
-		DownloadBlobDir:         downloadDir,
-		ComponentExclusiveSetup: skipSnapDownload,
+		Channel:                     revOpts.Channel,
+		Base:                        info.Base,
+		UserID:                      opts.UserID,
+		Flags:                       opts.Flags.ForSnapSetup(),
+		DownloadInfo:                &info.DownloadInfo,
+		SideInfo:                    &info.SideInfo,
+		Type:                        info.Type(),
+		Version:                     info.Version,
+		InstanceKey:                 info.InstanceKey,
+		CohortKey:                   revOpts.CohortKey,
+		ExpectedProvenance:          info.SnapProvenance,
+		DownloadBlobDir:             downloadDir,
+		ComponentExclusiveOperation: skipSnapDownload,
 	}
 
 	if sar.RedirectChannel != "" {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -237,6 +237,8 @@ func verifyInstallTasksWithComponents(c *C, typ snap.Type, opts, discards int, c
 		}
 	}
 
+	c.Assert(ts.MaybeEdge(snapstate.SnapSetupEdge), NotNil)
+
 	var count int
 	for _, t := range ts.Tasks() {
 		switch t.Kind() {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -237,7 +237,9 @@ func verifyInstallTasksWithComponents(c *C, typ snap.Type, opts, discards int, c
 		}
 	}
 
-	c.Assert(ts.MaybeEdge(snapstate.SnapSetupEdge), NotNil)
+	te, err := ts.Edge(snapstate.SnapSetupEdge)
+	c.Assert(err, IsNil)
+	c.Assert(te.Has("component-setup-tasks"), Equals, true)
 
 	var count int
 	for _, t := range ts.Tasks() {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -251,6 +251,9 @@ func verifyInstallTasksWithComponents(c *C, typ snap.Type, opts, discards int, c
 			c.Assert(err, IsNil)
 			c.Check(compsup.CompSideInfo.Component.ComponentName, Equals, components[count])
 			count++
+		case "setup-profiles":
+			c.Assert(t.Has("component-setup-task"), Equals, false)
+			c.Assert(t.Has("component-setup"), Equals, false)
 		}
 	}
 	c.Check(count, Equals, len(components), Commentf("expected %d components, found %d", len(components), count))

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -872,6 +872,7 @@ func (s *snapmgrTestSuite) TestSwitchTasks(c *C) {
 
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{"switch-snap"})
+	c.Assert(ts.MaybeEdge(snapstate.SnapSetupEdge), NotNil)
 }
 
 func (s *snapmgrTestSuite) TestSwitchConflict(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10176,7 +10176,8 @@ func (s *snapmgrTestSuite) TestDownloadWithComponents(c *C) {
 	c.Assert(begin, NotNil)
 	c.Check(begin.Kind(), Equals, "download-snap")
 
-	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir)
+	const componentExclusive = false
+	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir, componentExclusive)
 }
 
 func (s *snapmgrTestSuite) TestDownloadWithComponentsWithMismatchValidationSets(c *C) {
@@ -10388,7 +10389,8 @@ func (s *snapmgrTestSuite) TestDownloadWithComponentsWithValidationSets(c *C) {
 	c.Assert(begin, NotNil)
 	c.Check(begin.Kind(), Equals, "download-snap")
 
-	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir)
+	const componentExclusive = false
+	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir, componentExclusive)
 }
 
 func (s *snapmgrTestSuite) TestDownloadComponents(c *C) {
@@ -10463,10 +10465,11 @@ func (s *snapmgrTestSuite) TestDownloadComponents(c *C) {
 	c.Assert(begin, NotNil)
 	c.Check(begin.Kind(), Equals, "download-component")
 
-	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir)
+	const componentExclusive = true
+	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir, componentExclusive)
 }
 
-func verifySnapAndComponentSetupsForDownload(c *C, begin *state.Task, ts *state.TaskSet, downloadDir string) {
+func verifySnapAndComponentSetupsForDownload(c *C, begin *state.Task, ts *state.TaskSet, downloadDir string, componentExclusive bool) {
 	var snapsup snapstate.SnapSetup
 	err := begin.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
@@ -10481,6 +10484,8 @@ func verifySnapAndComponentSetupsForDownload(c *C, begin *state.Task, ts *state.
 		expectedDownloadDir,
 		fmt.Sprintf("%s_%s.snap", snapsup.InstanceName(), snapsup.Revision()),
 	))
+
+	c.Assert(snapsup.ComponentExclusiveSetup, Equals, componentExclusive)
 
 	var compsupTaskIDs []string
 	err = begin.Get("component-setup-tasks", &compsupTaskIDs)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10486,7 +10486,7 @@ func verifySnapAndComponentSetupsForDownload(c *C, begin *state.Task, ts *state.
 		fmt.Sprintf("%s_%s.snap", snapsup.InstanceName(), snapsup.Revision()),
 	))
 
-	c.Assert(snapsup.ComponentExclusiveSetup, Equals, componentExclusive)
+	c.Assert(snapsup.ComponentExclusiveOperation, Equals, componentExclusive)
 
 	var compsupTaskIDs []string
 	err = begin.Get("component-setup-tasks", &compsupTaskIDs)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -3117,6 +3117,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchesChannel(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(ts.Tasks(), HasLen, 1)
 	c.Check(ts.Tasks()[0].Kind(), Equals, "switch-snap-channel")
+	c.Check(ts.MaybeEdge(snapstate.SnapSetupEdge).Kind(), Equals, "switch-snap-channel")
 }
 
 func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchesChannelConflict(c *C) {

--- a/overlord/snapstate/snapstatetest/snapstate.go
+++ b/overlord/snapstate/snapstatetest/snapstate.go
@@ -79,18 +79,21 @@ func InstallEssentialSnaps(c *check.C, st *state.State, base string, gadgetFiles
 		SnapID:   fakeSnapID("pc"),
 		Revision: snap.R(1),
 		RealName: "pc",
+		Channel:  "latest/stable",
 	}, InstallSnapOptions{Required: true})
 
 	InstallSnap(c, st, "name: pc-kernel\nversion: 1\ntype: kernel\n", nil, &snap.SideInfo{
 		SnapID:   fakeSnapID("pc-kernel"),
 		Revision: snap.R(1),
 		RealName: "pc-kernel",
+		Channel:  "latest/stable",
 	}, InstallSnapOptions{Required: true})
 
 	InstallSnap(c, st, fmt.Sprintf("name: %s\nversion: 1\ntype: base\n", base), nil, &snap.SideInfo{
 		SnapID:   fakeSnapID(base),
 		Revision: snap.R(1),
 		RealName: base,
+		Channel:  "latest/stable",
 	}, InstallSnapOptions{Required: true})
 
 	if bloader != nil {


### PR DESCRIPTION
This change adds a field to SnapSetup for tracking if a SnapSetup comes from a task set that only deals with components.

Additionally, this adds an edge that points to the snap setup task that is created by many of the functions in snapstate. Since a task set might contain many snap-setup tasks, but we really only want to find one (especially now that a snap-setup task needs to carry a `component-setup-tasks`), we use this edge to pick the one that will have all the fields needed to help with remodeling.