### PR TITLE
i/builtin: make auditd-support grant seccomp setpriority

### DIFF
--- a/interfaces/builtin/auditd_support.go
+++ b/interfaces/builtin/auditd_support.go
@@ -39,6 +39,8 @@ const auditdSupportConnectedPlugSecComp = `
 # Description: Can use netlink to communicate with kernel audit system.
 bind
 socket AF_NETLINK - NETLINK_AUDIT
+
+setpriority
 `
 
 const auditdSupportConnectedPlugAppArmor = `

--- a/interfaces/builtin/auditd_support_test.go
+++ b/interfaces/builtin/auditd_support_test.go
@@ -91,7 +91,9 @@ func (s *AuditdSupportInterfaceSuite) TestSecCompSpec(c *C) {
 	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(spec.Snippets(), HasLen, 1)
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "bind")
 	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "socket AF_NETLINK")
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "setpriority")
 }
 
 func (s *AuditdSupportInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
The `auditd` program requires seccomp `setpriority` permission. This is mentioned under exit code 1 in the manpage: https://manpages.ubuntu.com/manpages/oracular/en/man8/auditd.8.html

This is a follow-up to the PR which added the auditd-support interface: #14811

This relates to ongoing work for the customer SF case 00399076.