### PR TITLE
docs: Fix snapcraft build instructions and explicitly install lxd

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -82,7 +82,7 @@ Install snapcraft:
 sudo snap install snapcraft --classic
 ```
 
-Install and setup lxd:
+Install and init lxd:
 
 ```
 sudo snap install lxd

--- a/HACKING.md
+++ b/HACKING.md
@@ -79,19 +79,26 @@ Snapcraft 8.x or later is expected.
 Install snapcraft:
 
 ```
-sudo snap install snapcraft
+sudo snap install snapcraft --classic
+```
+
+Install and setup lxd:
+
+```
+sudo snap install lxd
+sudo lxd init --minimal
 ```
 
 Then run snapcraft:
 
 ```
-snapcraft --channel=latest/stable
+snapcraft
 ```
 
 Now the snapd snap that was just built can be installed with:
 
 ```
-snap install --dangerous snapd_*.snap
+sudo snap install --dangerous snapd_*.snap
 ```
 
 To go back to using snapd from the store instead of the custom version we 


### PR DESCRIPTION
I was running through a build using current documentation in HACKING.md for building snapd with snapcraft and it doesn't work in 24.04 (or 22.04). It also doesn't mention the lxd requirement, which leads to uncertainty about the build process when lxd asks many config questions and isn't mentioned in the build instructions. This documentation change:
- Adds --classic flag to snap install for snapcraft, as it is required
- Removes --channel option from snapcraft call as it no longer exists in 8.5.1
- Adds necessary and missing sudo to snap install
- Makes the lxd install and lxd init step explicit