### PR TITLE
tests/nested/core/core20-fault-inject-on-refresh: disable FDE

### DIFF
--- a/tests/nested/core/core20-fault-inject-on-refresh/task.yaml
+++ b/tests/nested/core/core20-fault-inject-on-refresh/task.yaml
@@ -44,7 +44,12 @@ environment:
     FAULT/kernel_reboot_refresh_gadget_assets: reboot
     TAG/gadget_reboot_refresh_gadget_assets: refresh-gadget-assets
     FAULT/gadget_reboot_refresh_gadget_assets: reboot
-    
+
+    # refresh from store might get some kernel that have an old
+    # initrd.
+    NESTED_ENABLE_SECURE_BOOT: false
+    NESTED_ENABLE_TPM: false
+
 prepare: |
     # automatically cleaned up in restore
     echo "Inject a $FAULT on $TAG"

--- a/tests/nested/core/core20-fault-inject-on-refresh/task.yaml
+++ b/tests/nested/core/core20-fault-inject-on-refresh/task.yaml
@@ -46,7 +46,8 @@ environment:
     FAULT/gadget_reboot_refresh_gadget_assets: reboot
 
     # refresh from store might get some kernel that have an old
-    # initrd.
+    # initrd. The problem is that a new snapd in seed may require a
+    # new initrd. For instance when adding a new format of key in FDE.
     # TODO: change it to use fakestore, so we can control all the
     # snaps we use.
     NESTED_ENABLE_SECURE_BOOT: false

--- a/tests/nested/core/core20-fault-inject-on-refresh/task.yaml
+++ b/tests/nested/core/core20-fault-inject-on-refresh/task.yaml
@@ -47,6 +47,8 @@ environment:
 
     # refresh from store might get some kernel that have an old
     # initrd.
+    # TODO: change it to use fakestore, so we can control all the
+    # snaps we use.
     NESTED_ENABLE_SECURE_BOOT: false
     NESTED_ENABLE_TPM: false
 


### PR DESCRIPTION
Refresh from store get some kernel that have an old initrd that do not support FDE installation from new snapd.
