### PR TITLE
image: added feature to inject proxy store assertions in build image

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -62,7 +62,7 @@ type cmdPrepareImage struct {
 	Validation               string   `long:"validation" choice:"ignore" choice:"enforce"`
 	AllowSnapdKernelMismatch bool     `long:"allow-snapd-kernel-mismatch"`
 
-	// Filenames for injected assertions
+	// Filenames for extra assertions
 	ExtraAssertionFiles []string `long:"assert" value-name:"<filename>"`
 }
 

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -61,6 +61,9 @@ type cmdPrepareImage struct {
 	WriteRevisionsFile       string   `long:"write-revisions" optional:"true" optional-value:"./seed.manifest"`
 	Validation               string   `long:"validation" choice:"ignore" choice:"enforce"`
 	AllowSnapdKernelMismatch bool     `long:"allow-snapd-kernel-mismatch"`
+
+	// Filenames for injected assertions
+	ExtraAssertionFiles []string `long:"assert" value-name:"<filename>"`
 }
 
 func init() {
@@ -106,6 +109,8 @@ For preparing classic images it supports a --classic mode`),
 			"validation": i18n.G("Control whether validations should be ignored or enforced. (default: ignore)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"allow-snapd-kernel-mismatch": i18n.G("Whether a mismatch between versions of the snapd snap and snapd in kernel is allowed"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"assert": i18n.G("Include the assertion from the local file"),
 		}, []argDesc{
 			{
 				// TRANSLATORS: This needs to begin with < and end with >
@@ -138,6 +143,7 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 		Architecture:             x.Architecture,
 		SeedManifestPath:         x.WriteRevisionsFile,
 		AllowSnapdKernelMismatch: x.AllowSnapdKernelMismatch,
+		ExtraAssertionsFiles:     x.ExtraAssertionFiles,
 	}
 
 	if x.RevisionsFile != "" {

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -336,3 +336,23 @@ func (s *SnapPrepareImageSuite) TestPrepareImageValidation(c *C) {
 		},
 	})
 }
+
+func (s *SnapPrepareImageSuite) TestPrepareImageCoreExtraAssertions(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := cmdsnap.MockImagePrepare(prep)
+	defer r()
+
+	rest, err := cmdsnap.Parser(cmdsnap.Client()).ParseArgs([]string{"prepare-image", "model", "prepare-dir", "--assert", "extra1", "--assert", "extra2"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		ModelFile:            "model",
+		PrepareDir:           "prepare-dir",
+		ExtraAssertionsFiles: []string{"extra1", "extra2"},
+	})
+}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -5604,7 +5604,7 @@ func (s *imageSuite) TestPrepareExtraAssertionsInvalidAssertion(c *C) {
 		PrepareDir:           preparedir,
 		ExtraAssertionsFiles: []string{proxyFilePath, accountFilePath},
 	})
-	c.Assert(err.Error(), testutil.Contains, "failed to decode extra assertion in "+proxyFilePath+": unexpected EOF")
+	c.Assert(err.Error(), testutil.Contains, "failed to decode extra assertion: unexpected EOF")
 }
 
 func (s *imageSuite) TestPrepareExtraAssertionsForbiddenType(c *C) {
@@ -5640,6 +5640,6 @@ func (s *imageSuite) TestPrepareExtraAssertionsForbiddenType(c *C) {
 		// Pass model assertion as extra assertion
 		ExtraAssertionsFiles: []string{modelFn},
 	})
-	c.Assert(err.Error(), testutil.Contains, "assertion in "+modelFn+" of type model is not of an allowed type")
+	c.Assert(err.Error(), testutil.Contains, "assertion type model is not allowed for extra assertions")
 
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -5495,11 +5495,8 @@ func (s *imageSuite) TestPrepareExtraAssertions(c *C) {
 	// check assertions
 	seedAssertsDir := filepath.Join(preparedir, "image/var/lib/snapd/seed/assertions")
 
-	_, err = os.Open(filepath.Join(seedAssertsDir, "my-proxy-store.store"))
-	c.Assert(err, IsNil)
-
-	_, err = os.Open(filepath.Join(seedAssertsDir, "other-brand.account"))
-	c.Assert(err, IsNil)
+	c.Assert(filepath.Join(seedAssertsDir, "my-proxy-store.store"), testutil.FilePresent)
+	c.Assert(filepath.Join(seedAssertsDir, "other-brand.account"), testutil.FilePresent)
 }
 
 func (s *imageSuite) TestPrepareExtraAssertionsFileNotFound(c *C) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -5429,7 +5429,7 @@ func (s *imageSuite) TestSetupSeedLocalComponentBadType(c *C) {
 	c.Assert(err, ErrorMatches, "component comp1 has type kernel-modules while snap required20 defines type standard for it")
 }
 
-func (s *imageSuite) TestPrepareAdditionalProxyStoreAssertions(c *C) {
+func (s *imageSuite) TestPrepareExtraAssertions(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
@@ -5515,4 +5515,149 @@ func (s *imageSuite) TestPrepareAdditionalProxyStoreAssertions(c *C) {
 
 	c.Assert(foundProxyAssertion, Equals, true)
 	c.Assert(foundAccountAssertion, Equals, true)
+}
+
+func (s *imageSuite) TestPrepareExtraAssertionsFileNotFound(c *C) {
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	restore = image.MockNewToolingStoreFromModel(func(model *asserts.Model, fallbackArchitecture string) (*tooling.ToolingStore, error) {
+		return s.tsto, nil
+	})
+	defer restore()
+
+	s.setupSnaps(c, map[string]string{
+		"pc-kernel": "canonical",
+		"pc":        "canonical",
+	}, "")
+
+	preparedir := c.MkDir()
+
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my display name",
+		"architecture": "amd64",
+		"gadget":       "pc",
+		"kernel":       "pc-kernel",
+	})
+
+	modelFn := filepath.Join(preparedir, "model.assertion")
+	err := os.WriteFile(modelFn, asserts.Encode(model), 0644)
+	c.Assert(err, IsNil)
+
+	proxyFn := "proxy.assertion"
+	proxyFilePath := filepath.Join(preparedir, proxyFn)
+
+	accountFn := "account.assertion"
+	accountFilePath := filepath.Join(preparedir, accountFn)
+
+	// Prepare image with non-existent files
+	err = image.Prepare(&image.Options{
+		ModelFile:            modelFn,
+		PrepareDir:           preparedir,
+		ExtraAssertionsFiles: []string{proxyFilePath, accountFilePath},
+	})
+	c.Assert(err.Error(), testutil.Contains, "cannot read extra assertion: open "+proxyFilePath+": no such file or directory")
+}
+
+func (s *imageSuite) TestPrepareExtraAssertionsInvalidAssertion(c *C) {
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	restore = image.MockNewToolingStoreFromModel(func(model *asserts.Model, fallbackArchitecture string) (*tooling.ToolingStore, error) {
+		return s.tsto, nil
+	})
+	defer restore()
+
+	s.setupSnaps(c, map[string]string{
+		"pc-kernel": "canonical",
+		"pc":        "canonical",
+	}, "")
+
+	preparedir := c.MkDir()
+
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my display name",
+		"architecture": "amd64",
+		"gadget":       "pc",
+		"kernel":       "pc-kernel",
+	})
+
+	modelFn := filepath.Join(preparedir, "model.assertion")
+	err := os.WriteFile(modelFn, asserts.Encode(model), 0644)
+	c.Assert(err, IsNil)
+
+	// Create assertions and write them to file
+	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":        "my-proxy-store",
+		"operator-id":  "other-brand",
+		"authority-id": "canonical",
+		"url":          "https://my-proxy-store.com",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	proxyFn := "proxy.assertion"
+	proxyFilePath := filepath.Join(preparedir, proxyFn)
+	// The store assertion is not valid, only the first 10 bytes are written
+	// Simulate when e.g. the yaml syntax is wrong or a field is missing
+	err = os.WriteFile(proxyFilePath, asserts.Encode(proxyStoreAssertion)[:10], 0644)
+	c.Assert(err, IsNil)
+
+	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
+		"type":         "account",
+		"authority-id": "canonical",
+		"account-id":   "other-brand",
+		"validation":   "verified",
+		"display-name": "Predef",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	accountFn := "account.assertion"
+	accountFilePath := filepath.Join(preparedir, accountFn)
+	err = os.WriteFile(accountFilePath, asserts.Encode(accountAssertion), 0644)
+	c.Assert(err, IsNil)
+
+	// Prepare image with the two additional filepaths
+	err = image.Prepare(&image.Options{
+		ModelFile:            modelFn,
+		PrepareDir:           preparedir,
+		ExtraAssertionsFiles: []string{proxyFilePath, accountFilePath},
+	})
+	c.Assert(err.Error(), testutil.Contains, "failed to decode extra assertion in "+proxyFilePath+": unexpected EOF")
+}
+
+func (s *imageSuite) TestPrepareExtraAssertionsForbiddenType(c *C) {
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	restore = image.MockNewToolingStoreFromModel(func(model *asserts.Model, fallbackArchitecture string) (*tooling.ToolingStore, error) {
+		return s.tsto, nil
+	})
+	defer restore()
+
+	s.setupSnaps(c, map[string]string{
+		"pc-kernel": "canonical",
+		"pc":        "canonical",
+	}, "")
+
+	preparedir := c.MkDir()
+
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my display name",
+		"architecture": "amd64",
+		"gadget":       "pc",
+		"kernel":       "pc-kernel",
+	})
+
+	modelFn := filepath.Join(preparedir, "model.assertion")
+	err := os.WriteFile(modelFn, asserts.Encode(model), 0644)
+	c.Assert(err, IsNil)
+
+	err = image.Prepare(&image.Options{
+		ModelFile:  modelFn,
+		PrepareDir: preparedir,
+		// Pass model assertion as extra assertion
+		ExtraAssertionsFiles: []string{modelFn},
+	})
+	c.Assert(err.Error(), testutil.Contains, "assertion in "+modelFn+" of type model is not of an allowed type")
+
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -5456,10 +5456,10 @@ func (s *imageSuite) TestPrepareExtraAssertions(c *C) {
 	err := os.WriteFile(modelFn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
-	// Create assertion for proxy1 and write to file
+	// Create assertion for proxy store and write to file
 	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
 		"store":        "my-proxy-store",
-		"operator-id":  "my-brand",
+		"operator-id":  "other-brand",
 		"authority-id": "canonical",
 		"url":          "https://my-proxy-store.com",
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
@@ -5473,7 +5473,7 @@ func (s *imageSuite) TestPrepareExtraAssertions(c *C) {
 	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
 		"type":         "account",
 		"authority-id": "canonical",
-		"account-id":   "my-brand",
+		"account-id":   "other-brand",
 		"validation":   "verified",
 		"display-name": "Predef",
 		"timestamp":    time.Now().Format(time.RFC3339),
@@ -5492,29 +5492,14 @@ func (s *imageSuite) TestPrepareExtraAssertions(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	// Check that the proxy assertions are written in the seed
+	// check assertions
+	seedAssertsDir := filepath.Join(preparedir, "image/var/lib/snapd/seed/assertions")
 
-	seedDir := filepath.Join(preparedir, "image/var/lib/snapd/seed/assertions")
-
-	l, err := os.ReadDir(seedDir)
+	_, err = os.Open(filepath.Join(seedAssertsDir, "my-proxy-store.store"))
 	c.Assert(err, IsNil)
-	c.Check(l, HasLen, 11)
 
-	foundProxyAssertion := false
-	foundAccountAssertion := false
-
-	for _, fn := range l {
-		if fn.Name() == "my-proxy-store.store" {
-			foundProxyAssertion = true
-		}
-
-		if fn.Name() == "my-brand.account" {
-			foundAccountAssertion = true
-		}
-	}
-
-	c.Assert(foundProxyAssertion, Equals, true)
-	c.Assert(foundAccountAssertion, Equals, true)
+	_, err = os.Open(filepath.Join(seedAssertsDir, "other-brand.account"))
+	c.Assert(err, IsNil)
 }
 
 func (s *imageSuite) TestPrepareExtraAssertionsFileNotFound(c *C) {

--- a/image/options.go
+++ b/image/options.go
@@ -19,7 +19,10 @@
 
 package image
 
-import "github.com/snapcore/snapd/seed/seedwriter"
+import (
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/seed/seedwriter"
+)
 
 type Options struct {
 	ModelFile string
@@ -74,6 +77,12 @@ type Options struct {
 	AllowSnapdKernelMismatch bool
 
 	Customizations Customizations
+
+	// Assertion files to inject into the built image
+	// The first field is for filenames passed as input, the second one
+	// for the validated assertions that the Writer and Fetcher will use
+	ExtraAssertionsFiles []string
+	ExtraAssertions      []asserts.Assertion
 }
 
 // Customizatons defines possible image customizations. Not all of

--- a/seed/seedwriter/fetcher.go
+++ b/seed/seedwriter/fetcher.go
@@ -61,8 +61,9 @@ func (af *assertionFetcher) FetchSequence(seq *asserts.AtSequence) error {
 }
 
 func (af *assertionFetcher) Save(a asserts.Assertion) error {
-
 	// Check prerequisites against extraAssertions only if there are any
+	// If a prerequisite is not found within the extra assertions, it will be searched through
+	// the usual means. If is not found, the error will be returned later rather than by this block
 	if len(af.extraAssertions) != 0 {
 		for _, prerequisite := range a.Prerequisites() {
 			for _, extraAssertion := range af.extraAssertions {

--- a/seed/seedwriter/fetcher.go
+++ b/seed/seedwriter/fetcher.go
@@ -90,7 +90,7 @@ func (af *assertionFetcher) ResetRefs() {
 }
 
 func (af *assertionFetcher) AddExtraAssertions(extraAssertions []asserts.Assertion) {
-	af.extraAssertions = extraAssertions
+	af.extraAssertions = append(af.extraAssertions, extraAssertions...)
 }
 
 // A NewFetcherFunc can build a Fetcher saving to an (implicit)

--- a/seed/seedwriter/fetcher.go
+++ b/seed/seedwriter/fetcher.go
@@ -68,7 +68,7 @@ func (af *assertionFetcher) Save(a asserts.Assertion) error {
 			for _, extraAssertion := range af.extraAssertions {
 				if prerequisite.Unique() == extraAssertion.Ref().Unique() {
 					if err := af.Save(extraAssertion); err != nil {
-						return err
+						return fmt.Errorf("prerequisite injected assertion: %s", err)
 					}
 
 					// This prerequisite has been matched to an extraAssertion, proceed with the next

--- a/seed/seedwriter/fetcher_test.go
+++ b/seed/seedwriter/fetcher_test.go
@@ -161,7 +161,6 @@ func (s *fetcherSuite) TestAssertFetcherInvalidSequenceFormingFetcher(c *C) {
 }
 
 func (s *fetcherSuite) TestAssertFetcherSaveExtraAssertions(c *C) {
-
 	as := s.setupTestAssertion(c)
 
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
@@ -181,7 +180,7 @@ func (s *fetcherSuite) TestAssertFetcherSaveExtraAssertions(c *C) {
 
 	proxyStoreAssertion, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
 		"store":        "my-proxy-store",
-		"operator-id":  "my-brand",
+		"operator-id":  "other-brand",
 		"authority-id": "canonical",
 		"url":          "https://my-proxy-store.com",
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
@@ -191,16 +190,18 @@ func (s *fetcherSuite) TestAssertFetcherSaveExtraAssertions(c *C) {
 	accountAssertion, err := s.storeSigning.Sign(asserts.AccountType, map[string]interface{}{
 		"type":         "account",
 		"authority-id": "canonical",
-		"account-id":   "my-brand",
+		"account-id":   "other-brand",
 		"validation":   "verified",
 		"display-name": "Predef",
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	af := seedwriter.MakeSeedAssertionFetcher(newFetcher, proxyStoreAssertion, accountAssertion)
+	af := seedwriter.MakeSeedAssertionFetcher(newFetcher)
 	c.Assert(af, NotNil)
 	c.Check(newFetcherCalled, Equals, 1)
+
+	af.AddExtraAssertions([]asserts.Assertion{proxyStoreAssertion, accountAssertion})
 
 	// Fetch the model assertion, then let's verify the refs was added.
 	err = af.Save(as)
@@ -217,6 +218,6 @@ func (s *fetcherSuite) TestAssertFetcherSaveExtraAssertions(c *C) {
 	c.Check(err, IsNil)
 
 	c.Assert(af.Refs(), HasLen, 4)
-	c.Check(af.Refs()[2].String(), Equals, "account (my-brand)")
+	c.Check(af.Refs()[2].String(), Equals, "account (other-brand)")
 	c.Check(af.Refs()[3].String(), Equals, "store (my-proxy-store)")
 }

--- a/seed/seedwriter/fetcher_test.go
+++ b/seed/seedwriter/fetcher_test.go
@@ -159,3 +159,64 @@ func (s *fetcherSuite) TestAssertFetcherInvalidSequenceFormingFetcher(c *C) {
 	err := af.FetchSequence(nil)
 	c.Check(err, ErrorMatches, `cannot fetch assertion sequence point, fetcher must be a SequenceFormingFetcher`)
 }
+
+func (s *fetcherSuite) TestAssertFetcherSaveExtraAssertions(c *C) {
+
+	as := s.setupTestAssertion(c)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+
+	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		return ref.Resolve(s.storeSigning.Find)
+	}
+	var newFetcherCalled int
+	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
+		newFetcherCalled++
+		return asserts.NewFetcher(db, retrieve, save)
+	}
+
+	proxyStoreAssertion, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":        "my-proxy-store",
+		"operator-id":  "my-brand",
+		"authority-id": "canonical",
+		"url":          "https://my-proxy-store.com",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	accountAssertion, err := s.storeSigning.Sign(asserts.AccountType, map[string]interface{}{
+		"type":         "account",
+		"authority-id": "canonical",
+		"account-id":   "my-brand",
+		"validation":   "verified",
+		"display-name": "Predef",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	af := seedwriter.MakeSeedAssertionFetcher(newFetcher, proxyStoreAssertion, accountAssertion)
+	c.Assert(af, NotNil)
+	c.Check(newFetcherCalled, Equals, 1)
+
+	// Fetch the model assertion, then let's verify the refs was added.
+	err = af.Save(as)
+	c.Check(err, IsNil)
+	c.Assert(af.Refs(), HasLen, 2)
+	c.Check(af.Refs()[0].Type, Equals, asserts.AccountKeyType)
+	c.Check(af.Refs()[1].String(), Equals, "model (my-model-2; series:16 brand-id:can0nical)")
+
+	// This order checks that prerequisites are correctly saved before the actual assertion
+	err = af.Save(proxyStoreAssertion)
+	c.Check(err, IsNil)
+
+	err = af.Save(accountAssertion)
+	c.Check(err, IsNil)
+
+	c.Assert(af.Refs(), HasLen, 4)
+	c.Check(af.Refs()[2].String(), Equals, "account (my-brand)")
+	c.Check(af.Refs()[3].String(), Equals, "store (my-proxy-store)")
+}

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -219,7 +219,7 @@ func (tr *tree16) localComponentPath(*SeedComponent, string) (string, error) {
 	return "", errors.New("components not supported on UC16")
 }
 
-func (tr *tree16) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
+func (tr *tree16) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, extraRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
 	seedAssertsDir := filepath.Join(tr.opts.SeedDir, "assertions")
 	if err := os.MkdirAll(seedAssertsDir, 0755); err != nil {
 		return err
@@ -246,6 +246,10 @@ func (tr *tree16) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Re
 	}
 
 	if err := writeByRefs(modelRefs); err != nil {
+		return err
+	}
+
+	if err := writeByRefs(extraRefs); err != nil {
 		return err
 	}
 

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -270,7 +270,7 @@ func (tr *tree20) localComponentPath(sc *SeedComponent, snapVersion string) (str
 		sc.ComponentRef.String(), sc.Info.Version(snapVersion))), nil
 }
 
-func (tr *tree20) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
+func (tr *tree20) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, extraRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
 	assertsDir := filepath.Join(tr.systemDir, "assertions")
 	if err := os.MkdirAll(assertsDir, 0755); err != nil {
 		return err

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -317,7 +317,7 @@ func (tr *tree20) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Re
 	modelOnly := func(aRef *asserts.Ref) bool { return aRef.Type == asserts.ModelType }
 	excludeModel := func(aRef *asserts.Ref) bool { return aRef.Type != asserts.ModelType }
 
-	modelRefsGen := func(writeRefs []*asserts.Ref, include func(*asserts.Ref) bool) func(stop <-chan struct{}) <-chan *asserts.Ref {
+	refsGen := func(writeRefs []*asserts.Ref, include func(*asserts.Ref) bool) func(stop <-chan struct{}) <-chan *asserts.Ref {
 		return func(stop <-chan struct{}) <-chan *asserts.Ref {
 			refs := make(chan *asserts.Ref)
 			go func() {
@@ -334,16 +334,16 @@ func (tr *tree20) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Re
 		}
 	}
 
-	if err := writeByRefs("../model", modelRefsGen(modelRefs, modelOnly)); err != nil {
+	if err := writeByRefs("../model", refsGen(modelRefs, modelOnly)); err != nil {
 		return err
 	}
 
-	if err := writeByRefs("model-etc", modelRefsGen(modelRefs, excludeModel)); err != nil {
+	if err := writeByRefs("model-etc", refsGen(modelRefs, excludeModel)); err != nil {
 		return err
 	}
 
 	if len(extraRefs) != 0 {
-		if err := writeByRefs("extra-assertions", modelRefsGen(extraRefs, excludeModel)); err != nil {
+		if err := writeByRefs("extra-assertions", refsGen(extraRefs, excludeModel)); err != nil {
 			return err
 		}
 	}

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -644,6 +644,8 @@ func (w *Writer) Start(db asserts.RODatabase, f SeedAssertionFetcher) error {
 		// but we skip extra cycles from the model and all the snaps in the second for loop
 		f.ResetRefs()
 
+		f.AddExtraAssertions(w.opts.ExtraAssertions)
+
 		for _, extraAssertion := range w.opts.ExtraAssertions {
 			if err := f.Save(extraAssertion); err != nil {
 				return fmt.Errorf(

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -639,9 +639,8 @@ func (w *Writer) Start(db asserts.RODatabase, f SeedAssertionFetcher) error {
 	w.modelRefs = f.Refs()
 
 	if len(w.opts.ExtraAssertions) != 0 {
-
 		// By resetting the fetcher's refs we might retrieve some of them a second time
-		// but we skip extra cycles from the model and all the snaps in the second for loop
+		// but we skip extra cycles of the second for loop cause by the model and all the snaps
 		f.ResetRefs()
 
 		f.AddExtraAssertions(w.opts.ExtraAssertions)

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -60,6 +60,9 @@ type Options struct {
 	// IgnoreOptionFileExtentions if set, snaps and components will not be
 	// required to end in .snap or .comp, respectively.
 	IgnoreOptionFileExtentions bool
+
+	// Assertions to inject into the built image
+	ExtraAssertions []asserts.Assertion
 }
 
 // manifest returns either the manifest already provided by the
@@ -629,6 +632,15 @@ func (w *Writer) Start(db asserts.RODatabase, f SeedAssertionFetcher) error {
 	// fetch model validation sets if any
 	if err := w.fetchValidationSets(f); err != nil {
 		return err
+	}
+
+	for _, extraAssertion := range w.opts.ExtraAssertions {
+		if err := f.Save(extraAssertion); err != nil {
+			return fmt.Errorf(
+				"cannot fetch and check prerequisites for an injected assertion: %v",
+				err,
+			)
+		}
 	}
 
 	w.modelRefs = f.Refs()

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -5291,7 +5291,7 @@ func (s *writerSuite) TestVerifySnapBootstrapCompatibility(c *C) {
 	c.Check(err, ErrorMatches, `snapd 2.68[+] is not compatible with a kernel containing snapd prior to 2.68`)
 }
 
-func (s *writerSuite) TestSeedWriterExtraAssertionsCore18(c *C) {
+func (s *writerSuite) testSeedWriterExtraAssertionsCore18(c *C, reverseOrder bool) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
@@ -5324,7 +5324,11 @@ func (s *writerSuite) TestSeedWriterExtraAssertionsCore18(c *C) {
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	s.opts.ExtraAssertions = []asserts.Assertion{proxyStoreAssertion, accountAssertion}
+	if reverseOrder {
+		s.opts.ExtraAssertions = []asserts.Assertion{proxyStoreAssertion, accountAssertion}
+	} else {
+		s.opts.ExtraAssertions = []asserts.Assertion{accountAssertion, proxyStoreAssertion}
+	}
 
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
@@ -5368,19 +5372,47 @@ func (s *writerSuite) TestSeedWriterExtraAssertionsCore18(c *C) {
 	c.Assert(filepath.Join(seedAssertsDir, "other-brand.account"), testutil.FilePresent)
 }
 
-func (s *writerSuite) TestSeedWriterExtraAssertionsAlternateOrderCore18(c *C) {
+func (s *writerSuite) TestSeedWriterExtraAssertionsCore18(c *C) {
+	const reverseOrder = false
+	s.testSeedWriterExtraAssertionsCore18(c, reverseOrder)
+}
+
+func (s *writerSuite) TestSeedWriterExtraAssertionsCore18ReverseOrder(c *C) {
+	const reverseOrder = true
+	s.testSeedWriterExtraAssertionsCore18(c, reverseOrder)
+}
+
+func (s *writerSuite) testSeedWriterExtraAssertionsCore20(c *C, reverseOrder bool) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
-		"gadget":       "pc=18",
-		"kernel":       "pc-kernel=18",
-		"base":         "core18",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "snapd",
+				"id":              s.AssertedSnapID("snapd"),
+				"type":            "snapd",
+				"default-channel": "20",
+			},
+		},
 	})
 
 	s.makeSnap(c, "snapd", "")
-	s.makeSnap(c, "core18", "")
-	s.makeSnap(c, "pc-kernel=18", "")
-	s.makeSnap(c, "pc=18", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
 
 	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
 		"store":        "my-proxy-store",
@@ -5401,8 +5433,13 @@ func (s *writerSuite) TestSeedWriterExtraAssertionsAlternateOrderCore18(c *C) {
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	s.opts.ExtraAssertions = []asserts.Assertion{accountAssertion, proxyStoreAssertion}
+	if reverseOrder {
+		s.opts.ExtraAssertions = []asserts.Assertion{proxyStoreAssertion, accountAssertion}
+	} else {
+		s.opts.ExtraAssertions = []asserts.Assertion{accountAssertion, proxyStoreAssertion}
+	}
 
+	s.opts.Label = "20250326"
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
@@ -5413,11 +5450,6 @@ func (s *writerSuite) TestSeedWriterExtraAssertionsAlternateOrderCore18(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(snaps, HasLen, 4)
 
-	c.Check(naming.SameSnap(snaps[0], naming.Snap("snapd")), Equals, true)
-	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc-kernel")), Equals, true)
-	c.Check(naming.SameSnap(snaps[2], naming.Snap("core18")), Equals, true)
-	c.Check(naming.SameSnap(snaps[3], naming.Snap("pc")), Equals, true)
-
 	for _, sn := range snaps {
 		s.fillDownloadedSnap(c, w, sn)
 	}
@@ -5426,267 +5458,64 @@ func (s *writerSuite) TestSeedWriterExtraAssertionsAlternateOrderCore18(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(complete, Equals, true)
 
-	essSnaps, err := w.BootSnaps()
-	c.Assert(err, IsNil)
-	c.Check(essSnaps, DeepEquals, snaps[:4])
-
-	c.Check(w.Warnings(), HasLen, 0)
-
 	err = w.SeedSnaps(nil)
 	c.Assert(err, IsNil)
 
 	err = w.WriteMeta()
 	c.Assert(err, IsNil)
 
-	// check assertions
-	seedAssertsDir := filepath.Join(s.opts.SeedDir, "assertions")
+	// check seed
+	systemDir := filepath.Join(s.opts.SeedDir, "systems", s.opts.Label)
 
-	c.Assert(filepath.Join(seedAssertsDir, "my-proxy-store.store"), testutil.FilePresent)
-	c.Assert(filepath.Join(seedAssertsDir, "other-brand.account"), testutil.FilePresent)
+	// check assertions
+	c.Check(filepath.Join(systemDir, "model"), testutil.FileEquals, asserts.Encode(model))
+
+	assertsDir := filepath.Join(systemDir, "assertions")
+	modelEtc := seedtest.ReadAssertions(c, filepath.Join(assertsDir, "model-etc"))
+	c.Check(modelEtc, HasLen, 3)
+
+	keyPKs := make(map[string]bool)
+	for _, a := range modelEtc {
+		switch a.Type() {
+		case asserts.AccountType:
+			c.Check(a.HeaderString("account-id"), Equals, "my-brand")
+		case asserts.StoreType:
+			c.Check(a.HeaderString("store"), Equals, "my-store")
+		case asserts.AccountKeyType:
+			keyPKs[a.HeaderString("public-key-sha3-384")] = true
+		default:
+			c.Fatalf("unexpected assertion %s", a.Type().Name)
+		}
+	}
+	c.Check(keyPKs, DeepEquals, map[string]bool{
+		s.StoreSigning.StoreAccountKey("").PublicKeyID(): true,
+		s.Brands.AccountKey("my-brand").PublicKeyID():    true,
+	})
+
+	// check extra assertions
+	extraAssertions := seedtest.ReadAssertions(c, filepath.Join(assertsDir, "extra-assertions"))
+	c.Check(extraAssertions, HasLen, 2)
+
+	for _, a := range extraAssertions {
+		switch a.Type() {
+		case asserts.AccountType:
+			c.Check(a.HeaderString("account-id"), Equals, "other-brand")
+		case asserts.StoreType:
+			c.Check(a.HeaderString("store"), Equals, "my-proxy-store")
+		default:
+			c.Fatalf("unexpected assertion %s", a.Type().Name)
+		}
+	}
 }
 
 func (s *writerSuite) TestSeedWriterExtraAssertionsCore20(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
-		"display-name": "my model",
-		"architecture": "amd64",
-		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
-				"name":            "pc-kernel",
-				"id":              s.AssertedSnapID("pc-kernel"),
-				"type":            "kernel",
-				"default-channel": "20",
-			},
-			map[string]interface{}{
-				"name":            "pc",
-				"id":              s.AssertedSnapID("pc"),
-				"type":            "gadget",
-				"default-channel": "20",
-			},
-			map[string]interface{}{
-				"name":            "snapd",
-				"id":              s.AssertedSnapID("snapd"),
-				"type":            "snapd",
-				"default-channel": "20",
-			},
-		},
-	})
-
-	s.makeSnap(c, "snapd", "")
-	s.makeSnap(c, "core20", "")
-	s.makeSnap(c, "pc-kernel=20", "")
-	s.makeSnap(c, "pc=20", "")
-
-	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
-		"store":        "my-proxy-store",
-		"operator-id":  "other-brand",
-		"authority-id": "canonical",
-		"url":          "https://my-proxy-store.com",
-		"timestamp":    time.Now().UTC().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-
-	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
-		"type":         "account",
-		"authority-id": "canonical",
-		"account-id":   "other-brand",
-		"validation":   "verified",
-		"display-name": "Predef",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-
-	s.opts.ExtraAssertions = []asserts.Assertion{proxyStoreAssertion, accountAssertion}
-
-	s.opts.Label = "20250326"
-	w, err := seedwriter.New(model, s.opts)
-	c.Assert(err, IsNil)
-
-	err = w.Start(s.db, s.rf)
-	c.Assert(err, IsNil)
-
-	snaps, err := w.SnapsToDownload()
-	c.Assert(err, IsNil)
-	c.Check(snaps, HasLen, 4)
-
-	for _, sn := range snaps {
-		s.fillDownloadedSnap(c, w, sn)
-	}
-
-	complete, err := w.Downloaded(s.fetchAsserts(c))
-	c.Assert(err, IsNil)
-	c.Check(complete, Equals, true)
-
-	err = w.SeedSnaps(nil)
-	c.Assert(err, IsNil)
-
-	err = w.WriteMeta()
-	c.Assert(err, IsNil)
-
-	// check seed
-	systemDir := filepath.Join(s.opts.SeedDir, "systems", s.opts.Label)
-
-	// check assertions
-	c.Check(filepath.Join(systemDir, "model"), testutil.FileEquals, asserts.Encode(model))
-
-	assertsDir := filepath.Join(systemDir, "assertions")
-	modelEtc := seedtest.ReadAssertions(c, filepath.Join(assertsDir, "model-etc"))
-	c.Check(modelEtc, HasLen, 3)
-
-	keyPKs := make(map[string]bool)
-	for _, a := range modelEtc {
-		switch a.Type() {
-		case asserts.AccountType:
-			c.Check(a.HeaderString("account-id"), Equals, "my-brand")
-		case asserts.StoreType:
-			c.Check(a.HeaderString("store"), Equals, "my-store")
-		case asserts.AccountKeyType:
-			keyPKs[a.HeaderString("public-key-sha3-384")] = true
-		default:
-			c.Fatalf("unexpected assertion %s", a.Type().Name)
-		}
-	}
-	c.Check(keyPKs, DeepEquals, map[string]bool{
-		s.StoreSigning.StoreAccountKey("").PublicKeyID(): true,
-		s.Brands.AccountKey("my-brand").PublicKeyID():    true,
-	})
-
-	// check extra assertions
-	extraAssertions := seedtest.ReadAssertions(c, filepath.Join(assertsDir, "extra-assertions"))
-	c.Check(extraAssertions, HasLen, 2)
-
-	for _, a := range extraAssertions {
-		switch a.Type() {
-		case asserts.AccountType:
-			c.Check(a.HeaderString("account-id"), Equals, "other-brand")
-		case asserts.StoreType:
-			c.Check(a.HeaderString("store"), Equals, "my-proxy-store")
-		default:
-			c.Fatalf("unexpected assertion %s", a.Type().Name)
-		}
-	}
+	const reverseOrder = false
+	s.testSeedWriterExtraAssertionsCore20(c, reverseOrder)
 }
 
-func (s *writerSuite) TestSeedWriterExtraAssertionsAlternateOrderCore20(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
-		"display-name": "my model",
-		"architecture": "amd64",
-		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
-				"name":            "pc-kernel",
-				"id":              s.AssertedSnapID("pc-kernel"),
-				"type":            "kernel",
-				"default-channel": "20",
-			},
-			map[string]interface{}{
-				"name":            "pc",
-				"id":              s.AssertedSnapID("pc"),
-				"type":            "gadget",
-				"default-channel": "20",
-			},
-			map[string]interface{}{
-				"name":            "snapd",
-				"id":              s.AssertedSnapID("snapd"),
-				"type":            "snapd",
-				"default-channel": "20",
-			},
-		},
-	})
-
-	s.makeSnap(c, "snapd", "")
-	s.makeSnap(c, "core20", "")
-	s.makeSnap(c, "pc-kernel=20", "")
-	s.makeSnap(c, "pc=20", "")
-
-	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
-		"store":        "my-proxy-store",
-		"operator-id":  "other-brand",
-		"authority-id": "canonical",
-		"url":          "https://my-proxy-store.com",
-		"timestamp":    time.Now().UTC().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-
-	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
-		"type":         "account",
-		"authority-id": "canonical",
-		"account-id":   "other-brand",
-		"validation":   "verified",
-		"display-name": "Predef",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-
-	s.opts.ExtraAssertions = []asserts.Assertion{accountAssertion, proxyStoreAssertion}
-
-	s.opts.Label = "20250326"
-	w, err := seedwriter.New(model, s.opts)
-	c.Assert(err, IsNil)
-
-	err = w.Start(s.db, s.rf)
-	c.Assert(err, IsNil)
-
-	snaps, err := w.SnapsToDownload()
-	c.Assert(err, IsNil)
-	c.Check(snaps, HasLen, 4)
-
-	for _, sn := range snaps {
-		s.fillDownloadedSnap(c, w, sn)
-	}
-
-	complete, err := w.Downloaded(s.fetchAsserts(c))
-	c.Assert(err, IsNil)
-	c.Check(complete, Equals, true)
-
-	err = w.SeedSnaps(nil)
-	c.Assert(err, IsNil)
-
-	err = w.WriteMeta()
-	c.Assert(err, IsNil)
-
-	// check seed
-	systemDir := filepath.Join(s.opts.SeedDir, "systems", s.opts.Label)
-
-	// check assertions
-	c.Check(filepath.Join(systemDir, "model"), testutil.FileEquals, asserts.Encode(model))
-
-	assertsDir := filepath.Join(systemDir, "assertions")
-	modelEtc := seedtest.ReadAssertions(c, filepath.Join(assertsDir, "model-etc"))
-	c.Check(modelEtc, HasLen, 3)
-
-	keyPKs := make(map[string]bool)
-	for _, a := range modelEtc {
-		switch a.Type() {
-		case asserts.AccountType:
-			c.Check(a.HeaderString("account-id"), Equals, "my-brand")
-		case asserts.StoreType:
-			c.Check(a.HeaderString("store"), Equals, "my-store")
-		case asserts.AccountKeyType:
-			keyPKs[a.HeaderString("public-key-sha3-384")] = true
-		default:
-			c.Fatalf("unexpected assertion %s", a.Type().Name)
-		}
-	}
-	c.Check(keyPKs, DeepEquals, map[string]bool{
-		s.StoreSigning.StoreAccountKey("").PublicKeyID(): true,
-		s.Brands.AccountKey("my-brand").PublicKeyID():    true,
-	})
-
-	// check extra assertions
-	extraAssertions := seedtest.ReadAssertions(c, filepath.Join(assertsDir, "extra-assertions"))
-	c.Check(extraAssertions, HasLen, 2)
-
-	for _, a := range extraAssertions {
-		switch a.Type() {
-		case asserts.AccountType:
-			c.Check(a.HeaderString("account-id"), Equals, "other-brand")
-		case asserts.StoreType:
-			c.Check(a.HeaderString("store"), Equals, "my-proxy-store")
-		default:
-			c.Fatalf("unexpected assertion %s", a.Type().Name)
-		}
-	}
+func (s *writerSuite) TestSeedWriterExtraAssertionsCore20ReverseOrder(c *C) {
+	const reverseOrder = true
+	s.testSeedWriterExtraAssertionsCore20(c, reverseOrder)
 }
 
 func (s *writerSuite) TestSeedWriterExtraAssertionsErrorPrerequisites(c *C) {

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -5291,26 +5291,23 @@ func (s *writerSuite) TestVerifySnapBootstrapCompatibility(c *C) {
 	c.Check(err, ErrorMatches, `snapd 2.68[+] is not compatible with a kernel containing snapd prior to 2.68`)
 }
 
-func (s *writerSuite) TestSeedWriteExtraAssertions(c *C) {
+func (s *writerSuite) TestSeedWriterExtraAssertionsCore18(c *C) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
 		"base":         "core18",
-		// "required-snaps": []interface{}{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core18", "")
 	s.makeSnap(c, "pc-kernel=18", "")
 	s.makeSnap(c, "pc=18", "")
-	// s.makeSnap(c, "cont-producer", "developerid")
-	// s.makeSnap(c, "cont-consumer", "developerid")
 
 	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
 		"store":        "my-proxy-store",
-		"operator-id":  "my-brand",
+		"operator-id":  "other-brand",
 		"authority-id": "canonical",
 		"url":          "https://my-proxy-store.com",
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
@@ -5320,7 +5317,7 @@ func (s *writerSuite) TestSeedWriteExtraAssertions(c *C) {
 	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
 		"type":         "account",
 		"authority-id": "canonical",
-		"account-id":   "my-brand",
+		"account-id":   "other-brand",
 		"validation":   "verified",
 		"display-name": "Predef",
 		"timestamp":    time.Now().Format(time.RFC3339),
@@ -5367,24 +5364,281 @@ func (s *writerSuite) TestSeedWriteExtraAssertions(c *C) {
 	// check assertions
 	seedAssertsDir := filepath.Join(s.opts.SeedDir, "assertions")
 
-	l, err := os.ReadDir(seedAssertsDir)
+	_, err = os.Open(filepath.Join(seedAssertsDir, "my-proxy-store.store"))
 	c.Assert(err, IsNil)
-	c.Check(l, HasLen, 13)
 
-	foundProxyAssertion := false
-	foundAccountAssertion := false
+	_, err = os.Open(filepath.Join(seedAssertsDir, "other-brand.account"))
+	c.Assert(err, IsNil)
+}
 
-	for _, fn := range l {
-		if fn.Name() == "my-proxy-store.store" {
-			foundProxyAssertion = true
-		}
+func (s *writerSuite) TestSeedWriterExtraAssertionsAlternateOrderCore18(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"gadget":       "pc=18",
+		"kernel":       "pc-kernel=18",
+		"base":         "core18",
+	})
 
-		if fn.Name() == "my-brand.account" {
-			foundAccountAssertion = true
-		}
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core18", "")
+	s.makeSnap(c, "pc-kernel=18", "")
+	s.makeSnap(c, "pc=18", "")
+
+	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":        "my-proxy-store",
+		"operator-id":  "other-brand",
+		"authority-id": "canonical",
+		"url":          "https://my-proxy-store.com",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
+		"type":         "account",
+		"authority-id": "canonical",
+		"account-id":   "other-brand",
+		"validation":   "verified",
+		"display-name": "Predef",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	s.opts.ExtraAssertions = []asserts.Assertion{accountAssertion, proxyStoreAssertion}
+
+	w, err := seedwriter.New(model, s.opts)
+	c.Assert(err, IsNil)
+
+	err = w.Start(s.db, s.rf)
+	c.Assert(err, IsNil)
+
+	snaps, err := w.SnapsToDownload()
+	c.Assert(err, IsNil)
+	c.Check(snaps, HasLen, 4)
+
+	c.Check(naming.SameSnap(snaps[0], naming.Snap("snapd")), Equals, true)
+	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[2], naming.Snap("core18")), Equals, true)
+	c.Check(naming.SameSnap(snaps[3], naming.Snap("pc")), Equals, true)
+
+	for _, sn := range snaps {
+		s.fillDownloadedSnap(c, w, sn)
 	}
 
-	c.Assert(foundProxyAssertion, Equals, true)
-	c.Assert(foundAccountAssertion, Equals, true)
+	complete, err := w.Downloaded(s.fetchAsserts(c))
+	c.Assert(err, IsNil)
+	c.Check(complete, Equals, true)
 
+	essSnaps, err := w.BootSnaps()
+	c.Assert(err, IsNil)
+	c.Check(essSnaps, DeepEquals, snaps[:4])
+
+	c.Check(w.Warnings(), HasLen, 0)
+
+	err = w.SeedSnaps(nil)
+	c.Assert(err, IsNil)
+
+	err = w.WriteMeta()
+	c.Assert(err, IsNil)
+
+	// check assertions
+	seedAssertsDir := filepath.Join(s.opts.SeedDir, "assertions")
+
+	_, err = os.Open(filepath.Join(seedAssertsDir, "my-proxy-store.store"))
+	c.Assert(err, IsNil)
+
+	_, err = os.Open(filepath.Join(seedAssertsDir, "other-brand.account"))
+	c.Assert(err, IsNil)
+}
+
+func (s *writerSuite) TestSeedWriterExtraAssertionsCore20(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"gadget":       "pc=20",
+		"kernel":       "pc-kernel=20",
+		"base":         "core20",
+	})
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+
+	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":        "my-proxy-store",
+		"operator-id":  "other-brand",
+		"authority-id": "canonical",
+		"url":          "https://my-proxy-store.com",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
+		"type":         "account",
+		"authority-id": "canonical",
+		"account-id":   "other-brand",
+		"validation":   "verified",
+		"display-name": "Predef",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	s.opts.ExtraAssertions = []asserts.Assertion{proxyStoreAssertion, accountAssertion}
+
+	w, err := seedwriter.New(model, s.opts)
+	c.Assert(err, IsNil)
+
+	err = w.Start(s.db, s.rf)
+	c.Assert(err, IsNil)
+
+	snaps, err := w.SnapsToDownload()
+	c.Assert(err, IsNil)
+	c.Check(snaps, HasLen, 4)
+
+	c.Check(naming.SameSnap(snaps[0], naming.Snap("snapd")), Equals, true)
+	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[2], naming.Snap("core20")), Equals, true)
+	c.Check(naming.SameSnap(snaps[3], naming.Snap("pc")), Equals, true)
+
+	for _, sn := range snaps {
+		s.fillDownloadedSnap(c, w, sn)
+	}
+
+	complete, err := w.Downloaded(s.fetchAsserts(c))
+	c.Assert(err, IsNil)
+	c.Check(complete, Equals, true)
+
+	essSnaps, err := w.BootSnaps()
+	c.Assert(err, IsNil)
+	c.Check(essSnaps, DeepEquals, snaps[:4])
+
+	c.Check(w.Warnings(), HasLen, 0)
+
+	err = w.SeedSnaps(nil)
+	c.Assert(err, IsNil)
+
+	err = w.WriteMeta()
+	c.Assert(err, IsNil)
+
+	// check assertions
+	seedAssertsDir := filepath.Join(s.opts.SeedDir, "assertions")
+
+	_, err = os.Open(filepath.Join(seedAssertsDir, "my-proxy-store.store"))
+	c.Assert(err, IsNil)
+
+	_, err = os.Open(filepath.Join(seedAssertsDir, "other-brand.account"))
+	c.Assert(err, IsNil)
+}
+
+func (s *writerSuite) TestSeedWriterExtraAssertionsAlternateOrderCore20(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"gadget":       "pc=20",
+		"kernel":       "pc-kernel=20",
+		"base":         "core20",
+	})
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+
+	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":        "my-proxy-store",
+		"operator-id":  "other-brand",
+		"authority-id": "canonical",
+		"url":          "https://my-proxy-store.com",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	accountAssertion, err := s.StoreSigning.Sign(asserts.AccountType, map[string]interface{}{
+		"type":         "account",
+		"authority-id": "canonical",
+		"account-id":   "other-brand",
+		"validation":   "verified",
+		"display-name": "Predef",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	s.opts.ExtraAssertions = []asserts.Assertion{accountAssertion, proxyStoreAssertion}
+
+	w, err := seedwriter.New(model, s.opts)
+	c.Assert(err, IsNil)
+
+	err = w.Start(s.db, s.rf)
+	c.Assert(err, IsNil)
+
+	snaps, err := w.SnapsToDownload()
+	c.Assert(err, IsNil)
+	c.Check(snaps, HasLen, 4)
+
+	c.Check(naming.SameSnap(snaps[0], naming.Snap("snapd")), Equals, true)
+	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[2], naming.Snap("core20")), Equals, true)
+	c.Check(naming.SameSnap(snaps[3], naming.Snap("pc")), Equals, true)
+
+	for _, sn := range snaps {
+		s.fillDownloadedSnap(c, w, sn)
+	}
+
+	complete, err := w.Downloaded(s.fetchAsserts(c))
+	c.Assert(err, IsNil)
+	c.Check(complete, Equals, true)
+
+	essSnaps, err := w.BootSnaps()
+	c.Assert(err, IsNil)
+	c.Check(essSnaps, DeepEquals, snaps[:4])
+
+	c.Check(w.Warnings(), HasLen, 0)
+
+	err = w.SeedSnaps(nil)
+	c.Assert(err, IsNil)
+
+	err = w.WriteMeta()
+	c.Assert(err, IsNil)
+
+	// check assertions
+	seedAssertsDir := filepath.Join(s.opts.SeedDir, "assertions")
+
+	_, err = os.Open(filepath.Join(seedAssertsDir, "my-proxy-store.store"))
+	c.Assert(err, IsNil)
+
+	_, err = os.Open(filepath.Join(seedAssertsDir, "other-brand.account"))
+	c.Assert(err, IsNil)
+}
+
+func (s *writerSuite) TestSeedWriterExtraAssertionsErrorPrerequisites(c *C) {
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"gadget":       "pc=20",
+		"kernel":       "pc-kernel=20",
+		"base":         "core20",
+	})
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+
+	proxyStoreAssertion, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":        "my-proxy-store",
+		"operator-id":  "other-brand",
+		"authority-id": "canonical",
+		"url":          "https://my-proxy-store.com",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	s.opts.ExtraAssertions = []asserts.Assertion{proxyStoreAssertion}
+
+	w, err := seedwriter.New(model, s.opts)
+	c.Assert(err, IsNil)
+
+	err = w.Start(s.db, s.rf)
+	c.Assert(err.Error(), testutil.Contains, "cannot fetch and check prerequisites for an injected assertion: account (other-brand) not found")
 }


### PR DESCRIPTION
image: added feature to inject proxy store assertions in build image

This PR adds the possibility of including extra assertions in the created image at build time.
The reason for this is avoiding workarounds such as stopping the build, including proxy store assertions and resuming the build.

The solution adds the necessary fields to `image.Options` and the necessary control flow so that assertions contained in files passed with the `--assert` option (and in the future in the calls from `ubuntu-image`) will be imported and saved to the seed.

For now, only store assertions are allowed as I couldn't see a way to have a truly polymorphic approach to decoding each kind of assertion, resulting in the code found [here](https://github.com/lorenzo-medici/snapd/blob/1d3f1ca8cadc282e1d529e9020aaa9c40d3fedca/image/image_linux.go#L1116). With this structure, making a new kind of assertion injectable would require adding its type to the 'switch`.