### PR TITLE
tests: use quotation marks to support directories with spaces

### DIFF
--- a/.github/workflows/spread-results-reporter.yaml
+++ b/.github/workflows/spread-results-reporter.yaml
@@ -82,8 +82,8 @@ jobs:
         run: |
           find . -name "spread-json-${{ github.event.workflow_run.id }}*.zip" | while read filename; do 
             dir="${filename%.zip}"
-            mkdir $dir
-            unzip $filename -d $dir
+            mkdir "$dir"
+            unzip "$filename" -d "$dir"
           done
 
       - name: Echo collected output


### PR DESCRIPTION
Some spread results have spaces in the name. This ensures the directories are correctly created and accessed.