### PR TITLE
interfaces/builtin, testutil: skip unit test when apparmor_parser is not in PATH

### DIFF
--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -20,6 +20,9 @@
 package builtin_test
 
 import (
+	"errors"
+	"os/exec"
+
 	"github.com/snapcore/snapd/strutil"
 	. "gopkg.in/check.v1"
 
@@ -868,6 +871,9 @@ ptrace (read, trace) peer=unconfined,
 
 	// Profile existing profile
 	expectedHash, err := testutil.AppArmorParseAndHashHelper("#include <tunables/global> \nprofile docker_support {" + privilegedProfile + "}")
+	if errors.Is(err, exec.ErrNotFound) {
+		c.Skip(err.Error())
+	}
 	c.Assert(err, IsNil)
 
 	// Profile generated using GenerateAAREExclusionPatterns

--- a/testutil/apparmor.go
+++ b/testutil/apparmor.go
@@ -28,23 +28,27 @@ import (
 )
 
 func AppArmorParseAndHashHelper(profile string) (string, error) {
+	p, err := exec.LookPath("apparmor_parser")
+	if err != nil {
+		return "", fmt.Errorf("cannot find apparmor_parser in $PATH: %w", err)
+	}
 	// Create app_armor parser command with arguments to only return the compiled
 	// policy to stdout. The profile is not cached or loaded.
-	apparmorParser := exec.Command("apparmor_parser", "-QKS")
+	apparmorParser := exec.Command(p, "-QKS")
 
 	// Get stdin and stdout to pipe the command
 	apparmorParserStdin, err := apparmorParser.StdinPipe()
 	if err != nil {
-		return "Error creating stdin pipe for apparmor_parser", err
+		return "", fmt.Errorf("cannot create stdin pipe for apparmor_parser: %w", err)
 	}
 	apparmorParserStdout, err := apparmorParser.StdoutPipe()
 	if err != nil {
-		return "Error creating stdout pipe for apparmor_parser", err
+		return "", fmt.Errorf("cannot create stdout pipe for apparmor_parser: %w", err)
 	}
 
 	// Start apparmor_parser command
 	if err := apparmorParser.Start(); err != nil {
-		return "Error starting apparmor_parser", err
+		return "", fmt.Errorf("cannot start apparmor_parser: %w", err)
 	}
 
 	// Write apparmor profile to apparmor_parser stdin
@@ -60,9 +64,9 @@ func AppArmorParseAndHashHelper(profile string) (string, error) {
 	// Get apparmor_parser command output
 	if err := apparmorParser.Wait(); err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
-			return fmt.Sprintf("apparmor_parser command exited with status code %d", exiterr.ExitCode()), err
+			return "", fmt.Errorf("apparmor_parser command exited with status code %v", exiterr.ExitCode())
 		} else {
-			return "Error waiting for apparmor_parser command", err
+			return "", fmt.Errorf("cannot wait() for apparmor_parser process: %w", err)
 		}
 	}
 


### PR DESCRIPTION
On some distros which support AppArmor, the apparmor_parser binary is located under /usr/sbin, which also happens to not be included in a regular user's $PATH. The sandbox/apparmor package code is able to locate it directly by checking a number of default paths, however the test code simply assumes that it is available in $PATH. Instead of complicating things further, let's skip the offending unit test.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
