### PR TITLE
many: add passphrase authentication support v2

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -256,7 +256,7 @@ func isAssetHashTrackedInMap(bam bootAssetsMap, assetName, assetHash string) boo
 type TrustedAssetsInstallObserver interface {
 	BootLoaderSupportsEfiVariables() bool
 	ObserveExistingTrustedRecoveryAssets(recoveryRootDir string) error
-	SetBootstrappedContainersAndPrimaryKey(key, saveKey secboot.BootstrappedContainer, primaryKey []byte)
+	SetEncryptionParams(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions)
 	UpdateBootEntry() error
 	Observe(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error)
 }
@@ -286,6 +286,8 @@ type trustedAssetsInstallObserverImpl struct {
 	seedBootloader bootloader.Bootloader
 
 	primaryKey []byte
+
+	volumesAuth *device.VolumesAuthOptions
 }
 
 func (o *trustedAssetsInstallObserverImpl) BootLoaderSupportsEfiVariables() bool {
@@ -370,11 +372,12 @@ func (o *trustedAssetsInstallObserverImpl) currentTrustedRecoveryBootAssetsMap()
 	return o.trackedRecoveryAssets
 }
 
-func (o *trustedAssetsInstallObserverImpl) SetBootstrappedContainersAndPrimaryKey(key, saveKey secboot.BootstrappedContainer, primaryKey []byte) {
+func (o *trustedAssetsInstallObserverImpl) SetEncryptionParams(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions) {
 	o.useEncryption = true
 	o.dataBootstrappedContainer = key
 	o.saveBootstrappedContainer = saveKey
 	o.primaryKey = primaryKey
+	o.volumesAuth = volumesAuth
 }
 
 func (o *trustedAssetsInstallObserverImpl) UpdateBootEntry() error {

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -256,6 +256,8 @@ func isAssetHashTrackedInMap(bam bootAssetsMap, assetName, assetHash string) boo
 type TrustedAssetsInstallObserver interface {
 	BootLoaderSupportsEfiVariables() bool
 	ObserveExistingTrustedRecoveryAssets(recoveryRootDir string) error
+	// FIXME: Combine relevant FDE params into some FDE context that can be
+	// passed around instead of passing around many params.
 	SetEncryptionParams(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions)
 	UpdateBootEntry() error
 	Observe(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error)

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -480,13 +480,15 @@ func (s *assetsSuite) TestInstallObserverNonTrustedBootloader(c *C) {
 	dataBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
 	saveBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
 	c.Assert(dataBootstrappedContainer, Not(Equals), saveBootstrappedContainer)
-	obs.SetBootstrappedContainersAndPrimaryKey(dataBootstrappedContainer, saveBootstrappedContainer, nil)
+	volumesAuth := &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"}
+	obs.SetEncryptionParams(dataBootstrappedContainer, saveBootstrappedContainer, nil, volumesAuth)
 
 	observerImpl, ok := obs.(*boot.TrustedAssetsInstallObserverImpl)
 	c.Assert(ok, Equals, true)
 
 	c.Check(observerImpl.CurrentDataBootstrappedContainer(), DeepEquals, dataBootstrappedContainer)
 	c.Check(observerImpl.CurrentSaveBootstrappedContainer(), DeepEquals, saveBootstrappedContainer)
+	c.Check(observerImpl.CurrentVolumesAuth(), Equals, volumesAuth)
 }
 
 func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
@@ -507,7 +509,7 @@ func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
 	c.Assert(obs, NotNil)
 	dataBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
 	saveBootstrappedContainer := secboot.CreateMockBootstrappedContainer()
-	obs.SetBootstrappedContainersAndPrimaryKey(dataBootstrappedContainer, saveBootstrappedContainer, nil)
+	obs.SetEncryptionParams(dataBootstrappedContainer, saveBootstrappedContainer, nil, nil)
 
 	observerImpl, ok := obs.(*boot.TrustedAssetsInstallObserverImpl)
 	c.Assert(ok, Equals, true)

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -108,6 +108,10 @@ func (o *trustedAssetsInstallObserverImpl) CurrentSaveBootstrappedContainer() se
 	return o.saveBootstrappedContainer
 }
 
+func (o *trustedAssetsInstallObserverImpl) CurrentVolumesAuth() *device.VolumesAuthOptions {
+	return o.volumesAuth
+}
+
 func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash string, recovery bool) {
 	ta := &trackedAsset{
 		blName: blName,
@@ -224,7 +228,7 @@ func MockResealKeyForBootChains(f func(unlocker Unlocker, method device.SealingM
 	}
 }
 
-func MockSealKeyForBootChains(f func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, params *SealKeyForBootChainsParams) error) (restore func()) {
+func MockSealKeyForBootChains(f func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, params *SealKeyForBootChainsParams) error) (restore func()) {
 	old := SealKeyForBootChains
 	SealKeyForBootChains = f
 	return func() {

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -631,7 +631,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 			flags.SnapsDir = snapBlobDir
 		}
 		// seal the encryption key to the parameters specified in modeenv
-		if err := sealKeyToModeenv(observerImpl.dataBootstrappedContainer, observerImpl.saveBootstrappedContainer, observerImpl.primaryKey, model, modeenv, flags); err != nil {
+		if err := sealKeyToModeenv(observerImpl.dataBootstrappedContainer, observerImpl.saveBootstrappedContainer, observerImpl.primaryKey, observerImpl.volumesAuth, model, modeenv, flags); err != nil {
 			return err
 		}
 	}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -664,7 +664,8 @@ version: 5.0
 	myKey := secboot.CreateMockBootstrappedContainer()
 	myKey2 := secboot.CreateMockBootstrappedContainer()
 	chosenPrimaryKey := []byte("primarykey!")
-	obs.SetBootstrappedContainersAndPrimaryKey(myKey, myKey2, chosenPrimaryKey)
+	volumesAuth := &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"}
+	obs.SetEncryptionParams(myKey, myKey2, chosenPrimaryKey, volumesAuth)
 
 	// set a mock recovery kernel
 	readSystemEssentialCalls := 0
@@ -680,12 +681,13 @@ version: 5.0
 	defer restore()
 
 	sealKeyForBootChainsCalled := 0
-	restore = boot.MockSealKeyForBootChains(func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, params *boot.SealKeyForBootChainsParams) error {
+	restore = boot.MockSealKeyForBootChains(func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, params *boot.SealKeyForBootChainsParams) error {
 		sealKeyForBootChainsCalled++
 		c.Check(method, Equals, device.SealingMethodTPM)
 		c.Check(key, Equals, myKey)
 		c.Check(saveKey, Equals, myKey2)
 		c.Check(primaryKey, DeepEquals, chosenPrimaryKey)
+		c.Check(volumesAuth, Equals, volumesAuth)
 
 		recoveryBootLoader, hasRecovery := params.RoleToBlName[bootloader.RoleRecovery]
 		c.Assert(hasRecovery, Equals, true)
@@ -1154,7 +1156,7 @@ version: 5.0
 	myKey := secboot.CreateMockBootstrappedContainer()
 	myKey2 := secboot.CreateMockBootstrappedContainer()
 	chosenPrimaryKey := []byte("primarykey!")
-	obs.SetBootstrappedContainersAndPrimaryKey(myKey, myKey2, chosenPrimaryKey)
+	obs.SetEncryptionParams(myKey, myKey2, chosenPrimaryKey, nil)
 
 	// set a mock recovery kernel
 	readSystemEssentialCalls := 0
@@ -1165,7 +1167,7 @@ version: 5.0
 	defer restore()
 
 	sealKeyForBootChainsCalled := 0
-	restore = boot.MockSealKeyForBootChains(func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, params *boot.SealKeyForBootChainsParams) error {
+	restore = boot.MockSealKeyForBootChains(func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, params *boot.SealKeyForBootChainsParams) error {
 		sealKeyForBootChainsCalled++
 		c.Check(method, Equals, device.SealingMethodTPM)
 		c.Check(key, Equals, myKey)
@@ -1349,7 +1351,7 @@ version: 5.0
 	myKey := secboot.CreateMockBootstrappedContainer()
 	myKey2 := secboot.CreateMockBootstrappedContainer()
 	chosenPrimaryKey := []byte("primarykey!")
-	obs.SetBootstrappedContainersAndPrimaryKey(myKey, myKey2, chosenPrimaryKey)
+	obs.SetEncryptionParams(myKey, myKey2, chosenPrimaryKey, nil)
 
 	// set a mock recovery kernel
 	readSystemEssentialCalls := 0
@@ -1360,7 +1362,7 @@ version: 5.0
 	defer restore()
 
 	sealKeyForBootChainsCalled := 0
-	restore = boot.MockSealKeyForBootChains(func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, params *boot.SealKeyForBootChainsParams) error {
+	restore = boot.MockSealKeyForBootChains(func(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, params *boot.SealKeyForBootChainsParams) error {
 		sealKeyForBootChainsCalled++
 		c.Check(method, Equals, device.SealingMethodTPM)
 		c.Check(key, DeepEquals, myKey)

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -107,7 +107,14 @@ type sealKeyToModeenvFlags struct {
 // sealKeyToModeenvImpl seals the supplied keys to the parameters specified
 // in modeenv.
 // It assumes to be invoked in install mode.
-func sealKeyToModeenvImpl(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, model *asserts.Model, modeenv *Modeenv, flags sealKeyToModeenvFlags) error {
+func sealKeyToModeenvImpl(
+	key, saveKey secboot.BootstrappedContainer,
+	primaryKey []byte,
+	volumesAuth *device.VolumesAuthOptions,
+	model *asserts.Model,
+	modeenv *Modeenv,
+	flags sealKeyToModeenvFlags,
+) error {
 	if !isModeeenvLocked() {
 		return fmt.Errorf("internal error: cannot seal without the modeenv lock")
 	}
@@ -160,13 +167,27 @@ type SealKeyForBootChainsParams struct {
 	PrimaryKey []byte
 }
 
-func sealKeyForBootChainsImpl(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, params *SealKeyForBootChainsParams) error {
+func sealKeyForBootChainsImpl(
+	method device.SealingMethod,
+	key, saveKey secboot.BootstrappedContainer,
+	primaryKey []byte,
+	volumesAuth *device.VolumesAuthOptions,
+	params *SealKeyForBootChainsParams,
+) error {
 	return fmt.Errorf("FDE manager backend was not built in")
 }
 
 var SealKeyForBootChains = sealKeyForBootChainsImpl
 
-func sealKeyToModeenvForMethod(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, model *asserts.Model, modeenv *Modeenv, flags sealKeyToModeenvFlags) error {
+func sealKeyToModeenvForMethod(
+	method device.SealingMethod,
+	key, saveKey secboot.BootstrappedContainer,
+	primaryKey []byte,
+	volumesAuth *device.VolumesAuthOptions,
+	model *asserts.Model,
+	modeenv *Modeenv,
+	flags sealKeyToModeenvFlags,
+) error {
 	params := &SealKeyForBootChainsParams{
 		FactoryReset:           flags.FactoryReset,
 		UseTokens:              flags.UseTokens,

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -76,7 +76,7 @@ func MockResealKeyToModeenv(f func(rootdir string, modeenv *Modeenv, expectResea
 type MockSealKeyToModeenvFlags = sealKeyToModeenvFlags
 
 // MockSealKeyToModeenv is used for testing from other packages.
-func MockSealKeyToModeenv(f func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, model *asserts.Model, modeenv *Modeenv, flags MockSealKeyToModeenvFlags) error) (restore func()) {
+func MockSealKeyToModeenv(f func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, model *asserts.Model, modeenv *Modeenv, flags MockSealKeyToModeenvFlags) error) (restore func()) {
 	old := sealKeyToModeenv
 	sealKeyToModeenv = f
 	return func() {
@@ -107,7 +107,7 @@ type sealKeyToModeenvFlags struct {
 // sealKeyToModeenvImpl seals the supplied keys to the parameters specified
 // in modeenv.
 // It assumes to be invoked in install mode.
-func sealKeyToModeenvImpl(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, model *asserts.Model, modeenv *Modeenv, flags sealKeyToModeenvFlags) error {
+func sealKeyToModeenvImpl(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, model *asserts.Model, modeenv *Modeenv, flags sealKeyToModeenvFlags) error {
 	if !isModeeenvLocked() {
 		return fmt.Errorf("internal error: cannot seal without the modeenv lock")
 	}
@@ -135,7 +135,7 @@ func sealKeyToModeenvImpl(key, saveKey secboot.BootstrappedContainer, primaryKey
 		}
 	}
 
-	return sealKeyToModeenvForMethod(method, key, saveKey, primaryKey, model, modeenv, flags)
+	return sealKeyToModeenvForMethod(method, key, saveKey, primaryKey, volumesAuth, model, modeenv, flags)
 }
 
 type SealKeyForBootChainsParams struct {
@@ -160,13 +160,13 @@ type SealKeyForBootChainsParams struct {
 	PrimaryKey []byte
 }
 
-func sealKeyForBootChainsImpl(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, params *SealKeyForBootChainsParams) error {
+func sealKeyForBootChainsImpl(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, params *SealKeyForBootChainsParams) error {
 	return fmt.Errorf("FDE manager backend was not built in")
 }
 
 var SealKeyForBootChains = sealKeyForBootChainsImpl
 
-func sealKeyToModeenvForMethod(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, model *asserts.Model, modeenv *Modeenv, flags sealKeyToModeenvFlags) error {
+func sealKeyToModeenvForMethod(method device.SealingMethod, key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions, model *asserts.Model, modeenv *Modeenv, flags sealKeyToModeenvFlags) error {
 	params := &SealKeyForBootChainsParams{
 		FactoryReset:           flags.FactoryReset,
 		UseTokens:              flags.UseTokens,
@@ -231,7 +231,7 @@ func sealKeyToModeenvForMethod(method device.SealingMethod, key, saveKey secboot
 		params.RoleToBlName[bootloader.RoleRunMode] = bl.Name()
 	}
 
-	return SealKeyForBootChains(method, key, saveKey, primaryKey, params)
+	return SealKeyForBootChains(method, key, saveKey, primaryKey, volumesAuth, params)
 }
 
 var resealKeyToModeenv = resealKeyToModeenvImpl

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -430,7 +430,7 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 	}
 
 	if useEncryption {
-		if err := install.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, trustedInstallObserver); err != nil {
+		if err := install.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, trustedInstallObserver); err != nil {
 			return err
 		}
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -41,6 +41,7 @@ import (
 	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/gadget/install"
 	gadgetInstall "github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/logger"
@@ -955,7 +956,7 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallModeWithCompsHappy(c *C
 			observeExistingTrustedRecoveryAssetsCalled += 1
 			return nil
 		},
-		SetBootstrappedContainersAndPrimaryKeyFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte) {
+		SetEncryptionParamsFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions) {
 		},
 		UpdateBootEntryFunc: func() error {
 			return nil
@@ -8322,11 +8323,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunMissingFdeSetup(c
 }
 
 type MockObserver struct {
-	BootLoaderSupportsEfiVariablesFunc         func() bool
-	ObserveExistingTrustedRecoveryAssetsFunc   func(recoveryRootDir string) error
-	SetBootstrappedContainersAndPrimaryKeyFunc func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte)
-	UpdateBootEntryFunc                        func() error
-	ObserveFunc                                func(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error)
+	BootLoaderSupportsEfiVariablesFunc       func() bool
+	ObserveExistingTrustedRecoveryAssetsFunc func(recoveryRootDir string) error
+	SetEncryptionParamsFunc                  func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions)
+	UpdateBootEntryFunc                      func() error
+	ObserveFunc                              func(op gadget.ContentOperation, partRole, root, relativeTarget string, data *gadget.ContentChange) (gadget.ContentChangeAction, error)
 }
 
 func (m *MockObserver) BootLoaderSupportsEfiVariables() bool {
@@ -8337,8 +8338,8 @@ func (m *MockObserver) ObserveExistingTrustedRecoveryAssets(recoveryRootDir stri
 	return m.ObserveExistingTrustedRecoveryAssetsFunc(recoveryRootDir)
 }
 
-func (m *MockObserver) SetBootstrappedContainersAndPrimaryKey(key, saveKey secboot.BootstrappedContainer, primaryKey []byte) {
-	m.SetBootstrappedContainersAndPrimaryKeyFunc(key, saveKey, primaryKey)
+func (m *MockObserver) SetEncryptionParams(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions) {
+	m.SetEncryptionParamsFunc(key, saveKey, primaryKey, volumesAuth)
 }
 
 func (m *MockObserver) UpdateBootEntry() error {
@@ -8478,7 +8479,7 @@ echo '{"features":[]}'
 			observeExistingTrustedRecoveryAssetsCalled += 1
 			return nil
 		},
-		SetBootstrappedContainersAndPrimaryKeyFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte) {
+		SetEncryptionParamsFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions) {
 			setBootstrappedContainersCalled++
 			c.Check(key, Equals, dataContainer)
 			c.Check(saveKey, Equals, saveContainer)
@@ -8639,7 +8640,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunFdeSetupNotPresen
 			observeExistingTrustedRecoveryAssetsCalled += 1
 			return nil
 		},
-		SetBootstrappedContainersAndPrimaryKeyFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte) {
+		SetEncryptionParamsFunc: func(key, saveKey secboot.BootstrappedContainer, primaryKey []byte, volumesAuth *device.VolumesAuthOptions) {
 			c.Errorf("unexpected call")
 		},
 		UpdateBootEntryFunc: func() error {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -680,10 +680,9 @@ func EncryptPartitions(
 	encryptionType device.EncryptionType, model *asserts.Model,
 	gadgetRoot, kernelRoot string, perfTimings timings.Measurer,
 ) (*EncryptionSetupData, error) {
-	// TODO: Attach passed volumes auth options to encryption setup data.
-
 	setupData := &EncryptionSetupData{
-		parts: make(map[string]partEncryptionData),
+		parts:       make(map[string]partEncryptionData),
+		volumesAuth: volumesAuth,
 	}
 	for volName, vol := range onVolumes {
 		onDiskVol, err := gadget.OnDiskVolumeFromGadgetVol(vol)

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1478,6 +1478,7 @@ func (s *installSuite) TestInstallWriteContentDeviceNotFound(c *C) {
 
 type encryptPartitionsOpts struct {
 	encryptType device.EncryptionType
+	volumesAuth *device.VolumesAuthOptions
 }
 
 func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
@@ -1518,9 +1519,10 @@ func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
 		return nil
 	})()
 
-	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, nil, opts.encryptType, model, gadgetRoot, "", timings.New(nil))
+	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, opts.volumesAuth, opts.encryptType, model, gadgetRoot, "", timings.New(nil))
 	c.Assert(err, IsNil)
 	c.Assert(encryptSetup, NotNil)
+	c.Assert(encryptSetup.VolumesAuth(), Equals, opts.volumesAuth)
 	err = install.CheckEncryptionSetupData(encryptSetup, map[string]string{
 		"ubuntu-save": "/dev/mapper/ubuntu-save",
 		"ubuntu-data": "/dev/mapper/ubuntu-data",
@@ -1531,6 +1533,13 @@ func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
 func (s *installSuite) TestInstallEncryptPartitionsLUKSHappy(c *C) {
 	s.testEncryptPartitions(c, encryptPartitionsOpts{
 		encryptType: device.EncryptionTypeLUKS,
+	})
+}
+
+func (s *installSuite) TestInstallEncryptPartitions(c *C) {
+	s.testEncryptPartitions(c, encryptPartitionsOpts{
+		encryptType: device.EncryptionTypeLUKS,
+		volumesAuth: &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"},
 	})
 }
 

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1430,7 +1430,7 @@ func (s *installSuite) testWriteContent(c *C, opts writeContentOpts) {
 				EncryptedDevice: "/dev/mapper/ubuntu-data",
 			},
 		}
-		esd = install.MockEncryptionSetupData(labelToEncData)
+		esd = install.MockEncryptionSetupData(labelToEncData, nil)
 	}
 	onDiskVols, err := install.WriteContent(ginfo.Volumes, allLaidOutVols, esd, nil, nil, timings.New(nil))
 	c.Assert(err, IsNil)
@@ -1663,7 +1663,7 @@ func (s *installSuite) testMountVolumes(c *C, opts mountVolumesOpts) {
 				EncryptedDevice: "/dev/mapper/ubuntu-data",
 			},
 		}
-		esd = install.MockEncryptionSetupData(labelToEncData)
+		esd = install.MockEncryptionSetupData(labelToEncData, nil)
 	}
 
 	// 10 million mocks later ...

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -89,9 +89,11 @@ type MockEncryptedDeviceAndRole struct {
 
 // MockEncryptionSetupData is meant to be used for unit tests from other
 // packages.
-func MockEncryptionSetupData(labelToEncDevice map[string]*MockEncryptedDeviceAndRole) *EncryptionSetupData {
+func MockEncryptionSetupData(labelToEncDevice map[string]*MockEncryptedDeviceAndRole, volumesAuth *device.VolumesAuthOptions) *EncryptionSetupData {
 	esd := &EncryptionSetupData{
-		parts: map[string]partEncryptionData{}}
+		parts:       map[string]partEncryptionData{},
+		volumesAuth: volumesAuth,
+	}
 	for label, encryptData := range labelToEncDevice {
 		//TODO:FDEM: we should use a mock for the bootstrap key. However,
 		//this is still used in place where LegacyKeptKey will be

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -62,6 +62,8 @@ type partEncryptionData struct {
 type EncryptionSetupData struct {
 	// maps from partition label to data
 	parts map[string]partEncryptionData
+	// optional volume authentication options
+	volumesAuth *device.VolumesAuthOptions
 }
 
 // EncryptedDevices returns a map partition role -> LUKS mapper device.
@@ -71,6 +73,11 @@ func (esd *EncryptionSetupData) EncryptedDevices() map[string]string {
 		m[p.role] = p.encryptedDevice
 	}
 	return m
+}
+
+// VolumesAuth returns attached volumes authentication options if any.
+func (esd *EncryptionSetupData) VolumesAuth() *device.VolumesAuthOptions {
+	return esd.volumesAuth
 }
 
 // MockEncryptedDeviceAndRole is meant to be used for unit tests from other

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250124132100-452552189677
+	github.com/snapcore/secboot v0.0.0-20250128125141-12230bb269ec
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraK
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20250124132100-452552189677 h1:B2Bf7T1aBXOgkwAEFnR/g8d2l9hjrzS/X6BsnVrBNI4=
-github.com/snapcore/secboot v0.0.0-20250124132100-452552189677/go.mod h1:2cqUsx8AzOpyo7IAkeAln8SEr9ymC/GVOrFEYNL0RrI=
+github.com/snapcore/secboot v0.0.0-20250128125141-12230bb269ec h1:TfkF2dkq6g0+SDw+0vOZMD0G6G4I5/sUSVP8T4KO5n0=
+github.com/snapcore/secboot v0.0.0-20250128125141-12230bb269ec/go.mod h1:2cqUsx8AzOpyo7IAkeAln8SEr9ymC/GVOrFEYNL0RrI=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -850,6 +850,8 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 	c.Check(ok, Equals, true)
 	// Check that state has been stored in the cache
 	c.Check(devicestate.CheckEncryptionSetupDataFromCache(s.state, label), IsNil)
+	// Cached auth options are cleaned
+	c.Check(s.state.Cached(devicestate.VolumesAuthOptionsKeyByLabel(label)), IsNil)
 }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionHappy(c *C) {
@@ -986,4 +988,6 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionBadVolumesAu
 	// Checks now
 	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:
 - install API set-up encryption step \(internal error: wrong data type under volumesAuthOptionsKey\)`)
+	// Cached auth options are cleaned
+	c.Check(s.state.Cached(devicestate.VolumesAuthOptionsKeyByLabel(label)), IsNil)
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -572,7 +572,7 @@ func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, asser
 	return restore
 }
 
-func MockEncryptionSetupDataInCache(st *state.State, label string) (restore func()) {
+func MockEncryptionSetupDataInCache(st *state.State, label string, volumesAuth *device.VolumesAuthOptions) (restore func()) {
 	st.Lock()
 	defer st.Unlock()
 	var esd *install.EncryptionSetupData
@@ -586,7 +586,7 @@ func MockEncryptionSetupDataInCache(st *state.State, label string) (restore func
 			EncryptedDevice: "/dev/mapper/ubuntu-data",
 		},
 	}
-	esd = install.MockEncryptionSetupData(labelToEncData)
+	esd = install.MockEncryptionSetupData(labelToEncData, volumesAuth)
 	st.Cache(encryptionSetupDataKey{label}, esd)
 	return func() { CleanUpEncryptionSetupDataInCache(st, label) }
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -310,7 +310,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if useEncryption {
-		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, trustedInstallObserver); err != nil {
+		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -637,7 +637,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 		}
 		installedSystem.BootstrappedContainerForRole[gadget.SystemSave] = saveBoostrapContainer
 
-		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, trustedInstallObserver); err != nil {
+		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -1166,7 +1166,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 
 	if useEncryption {
 		if trustedInstallObserver != nil {
-			if err := installLogic.PrepareEncryptedSystemData(systemAndSnaps.Model, install.BootstrappedContainersForRole(encryptSetupData), trustedInstallObserver); err != nil {
+			if err := installLogic.PrepareEncryptedSystemData(systemAndSnaps.Model, install.BootstrappedContainersForRole(encryptSetupData), encryptSetupData.VolumesAuth(), trustedInstallObserver); err != nil {
 				return err
 			}
 		}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1262,6 +1262,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		if cached == nil {
 			return errors.New("volumes authentication is required but cannot find corresponding cached options")
 		}
+		st.Cache(volumesAuthOptionsKey{systemLabel}, nil)
 		var ok bool
 		volumesAuth, ok = cached.(*device.VolumesAuthOptions)
 		if !ok {

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -319,7 +319,10 @@ func BuildInstallObserver(model *asserts.Model, gadgetDir string, useEncryption 
 // * save keys and markers for ubuntu-data being able to safely open ubuntu-save
 // It is the responsibility of the caller to call
 // ObserveExistingTrustedRecoveryAssets on trustedInstallObserver.
-func PrepareEncryptedSystemData(model *asserts.Model, installKeyForRole map[string]secboot.BootstrappedContainer, trustedInstallObserver boot.TrustedAssetsInstallObserver) error {
+func PrepareEncryptedSystemData(
+	model *asserts.Model, installKeyForRole map[string]secboot.BootstrappedContainer,
+	volumesAuth *device.VolumesAuthOptions, trustedInstallObserver boot.TrustedAssetsInstallObserver,
+) error {
 	// validity check
 	if len(installKeyForRole) == 0 || installKeyForRole[gadget.SystemData] == nil || installKeyForRole[gadget.SystemSave] == nil {
 		return fmt.Errorf("internal error: system encryption keys are unset")
@@ -377,8 +380,8 @@ func PrepareEncryptedSystemData(model *asserts.Model, installKeyForRole map[stri
 		return err
 	}
 
-	// make note of the encryption keys
-	trustedInstallObserver.SetBootstrappedContainersAndPrimaryKey(dataBootstrappedContainer, saveBootstrappedContainer, primaryKey)
+	// make note of the encryption keys and auth options
+	trustedInstallObserver.SetEncryptionParams(dataBootstrappedContainer, saveBootstrappedContainer, primaryKey, volumesAuth)
 
 	return nil
 }

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -901,7 +901,7 @@ func (s *installSuite) TestPrepareEncryptedSystemData(c *C) {
 		gadget.SystemData: secboot.CreateMockBootstrappedContainer(),
 		gadget.SystemSave: saveDisk,
 	}
-	err = install.PrepareEncryptedSystemData(mockModel, installKeyForRole, to)
+	err = install.PrepareEncryptedSystemData(mockModel, installKeyForRole, nil, to)
 	c.Assert(err, IsNil)
 
 	marker, err := os.ReadFile(filepath.Join(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde"), "marker"))
@@ -948,7 +948,7 @@ func (s *installSuite) TestPrepareEncryptedSystemDataLegacyKeys(c *C) {
 		gadget.SystemData: secboot.CreateMockBootstrappedContainer(),
 		gadget.SystemSave: saveDisk,
 	}
-	err = install.PrepareEncryptedSystemData(mockModel, installKeyForRole, to)
+	err = install.PrepareEncryptedSystemData(mockModel, installKeyForRole, nil, to)
 	c.Assert(err, IsNil)
 
 	marker, err := os.ReadFile(filepath.Join(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde"), "marker"))

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -230,6 +230,14 @@ func MockSbNewTPMProtectedKey(f func(tpm *sb_tpm2.Connection, params *sb_tpm2.Pr
 	}
 }
 
+func MockSbNewTPMPassphraseProtectedKey(f func(tpm *sb_tpm2.Connection, params *sb_tpm2.PassphraseProtectKeyParams, passphrase string) (protectedKey *sb.KeyData, primaryKey sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error)) (restore func()) {
+	old := sbNewTPMPassphraseProtectedKey
+	sbNewTPMPassphraseProtectedKey = f
+	return func() {
+		sbNewTPMPassphraseProtectedKey = old
+	}
+}
+
 func MockSbSetModel(f func(model sb.SnapModel)) (restore func()) {
 	old := sbSetModel
 	sbSetModel = f

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -141,6 +141,8 @@ type SealKeysParams struct {
 	// The path to the authorization policy update key file (only relevant for TPM,
 	// if empty the key will not be saved)
 	TPMPolicyAuthKeyFile string
+	// Optional volume authentication options
+	VolumesAuth *device.VolumesAuthOptions
 }
 
 type SealKeysWithFDESetupHookParams struct {

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -225,7 +225,7 @@ func (fh *fdeHookV2DataHandler) RecoverKeys(data *sb.PlatformKeyData, encryptedP
 	return fde.Reveal(&p)
 }
 
-func (fh *fdeHookV2DataHandler) ChangeAuthKey(data *sb.PlatformKeyData, old, new []byte) ([]byte, error) {
+func (fh *fdeHookV2DataHandler) ChangeAuthKey(data *sb.PlatformKeyData, old, new []byte, context any) ([]byte, error) {
 	return nil, fmt.Errorf("cannot change auth key yet")
 }
 

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"time"
 
 	"github.com/canonical/go-tpm2"
 	"github.com/canonical/go-tpm2/linux"
@@ -891,12 +892,22 @@ func (s *secbootSuite) TestProvisionTPM(c *C) {
 
 }
 
+func mockAuthOptions(mode device.AuthMode, kdfType string) *device.VolumesAuthOptions {
+	return &device.VolumesAuthOptions{
+		Mode:       mode,
+		KDFType:    kdfType,
+		KDFTime:    200 * time.Millisecond,
+		Passphrase: "test",
+	}
+}
+
 func (s *secbootSuite) TestSealKey(c *C) {
 	mockErr := errors.New("some error")
 
 	for idx, tc := range []struct {
 		tpmErr               error
 		tpmEnabled           bool
+		volumesAuth          *device.VolumesAuthOptions
 		missingFile          bool
 		badSnapFile          bool
 		addPCRProfileErr     error
@@ -905,6 +916,7 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		provisioningErr      error
 		sealErr              error
 		sealCalls            int
+		passphraseSealCalls  int
 		expectedErr          string
 		saveToFile           bool
 	}{
@@ -918,6 +930,15 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		{tpmEnabled: true, sealErr: mockErr, sealCalls: 1, expectedErr: "some error"},
 		{tpmEnabled: true, sealCalls: 2, expectedErr: ""},
 		{tpmEnabled: true, sealCalls: 2, expectedErr: "", saveToFile: true},
+		{tpmEnabled: true, passphraseSealCalls: 2, volumesAuth: mockAuthOptions("passphrase", ""), expectedErr: ""},
+		{tpmEnabled: true, passphraseSealCalls: 2, volumesAuth: mockAuthOptions("passphrase", "argon2i"), expectedErr: ""},
+		{tpmEnabled: true, passphraseSealCalls: 2, volumesAuth: mockAuthOptions("passphrase", "argon2id"), expectedErr: ""},
+		{tpmEnabled: true, passphraseSealCalls: 2, volumesAuth: mockAuthOptions("passphrase", "pbkdf2"), expectedErr: ""},
+		{tpmEnabled: true, volumesAuth: mockAuthOptions("passphrase", "bad-kdf"), expectedErr: `internal error: unknown kdfType passed "bad-kdf"`},
+		{tpmEnabled: true, sealErr: mockErr, passphraseSealCalls: 1, volumesAuth: mockAuthOptions("passphrase", ""), expectedErr: "some error"},
+		{tpmErr: mockErr, volumesAuth: mockAuthOptions("passphrase", ""), expectedErr: `cannot connect to TPM: some error`},
+		{tpmEnabled: true, volumesAuth: mockAuthOptions("pin", ""), expectedErr: `"pin" authentication mode is not implemented`},
+		{tpmEnabled: true, volumesAuth: mockAuthOptions("bad-mode", ""), expectedErr: `internal error: invalid authentication mode "bad-mode"`},
 	} {
 		c.Logf("tc: %v", idx)
 		tmpDir := c.MkDir()
@@ -973,9 +994,9 @@ func (s *secbootSuite) TestSealKey(c *C) {
 					Model:          &asserts.Model{},
 				},
 			},
-			TPMPolicyAuthKeyFile: filepath.Join(tmpDir, "policy-auth-key-file"),
-
+			TPMPolicyAuthKeyFile:   filepath.Join(tmpDir, "policy-auth-key-file"),
 			PCRPolicyCounterHandle: 42,
+			VolumesAuth:            tc.volumesAuth,
 		}
 
 		containerA := secboot.CreateMockBootstrappedContainer()
@@ -1113,6 +1134,25 @@ func (s *secbootSuite) TestSealKey(c *C) {
 			return &sb.KeyData{}, sb.PrimaryKey{}, sb.DiskUnlockKey{}, tc.sealErr
 		})
 		defer restore()
+		passphraseSealCalls := 0
+		restore = secboot.MockSbNewTPMPassphraseProtectedKey(func(t *sb_tpm2.Connection, params *sb_tpm2.PassphraseProtectKeyParams, passphrase string) (protectedKey *sb.KeyData, primaryKey sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error) {
+			passphraseSealCalls++
+			c.Assert(t, Equals, tpm)
+			c.Assert(params.PCRPolicyCounterHandle, Equals, tpm2.Handle(42))
+			var expectedKDFOptions sb.KDFOptions
+			switch tc.volumesAuth.KDFType {
+			case "argon2id":
+				expectedKDFOptions = &sb.Argon2Options{Mode: sb.Argon2id, TargetDuration: tc.volumesAuth.KDFTime}
+			case "argon2i":
+				expectedKDFOptions = &sb.Argon2Options{Mode: sb.Argon2i, TargetDuration: tc.volumesAuth.KDFTime}
+			case "pbkdf2":
+				expectedKDFOptions = &sb.PBKDF2Options{TargetDuration: tc.volumesAuth.KDFTime}
+			}
+			c.Assert(params.KDFOptions, DeepEquals, expectedKDFOptions)
+			c.Assert(passphrase, Equals, tc.volumesAuth.Passphrase)
+			return &sb.KeyData{}, sb.PrimaryKey{}, sb.DiskUnlockKey{}, tc.sealErr
+		})
+		defer restore()
 
 		// mock TPM enabled check
 		restore = secboot.MockIsTPMEnabled(func(t *sb_tpm2.Connection) bool {
@@ -1148,6 +1188,7 @@ func (s *secbootSuite) TestSealKey(c *C) {
 			c.Assert(err, ErrorMatches, tc.expectedErr)
 		}
 		c.Assert(sealCalls, Equals, tc.sealCalls)
+		c.Assert(passphraseSealCalls, Equals, tc.passphraseSealCalls)
 
 	}
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/efi"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/randutil"
@@ -64,6 +65,7 @@ var (
 	sbReadKeyData                                   = sb.ReadKeyData
 	sbReadSealedKeyObjectFromFile                   = sb_tpm2.ReadSealedKeyObjectFromFile
 	sbNewTPMProtectedKey                            = sb_tpm2.NewTPMProtectedKey
+	sbNewTPMPassphraseProtectedKey                  = sb_tpm2.NewTPMPassphraseProtectedKey
 	sbNewKeyDataFromSealedKeyObjectFile             = sb_tpm2.NewKeyDataFromSealedKeyObjectFile
 
 	randutilRandomKernelUUID = randutil.RandomKernelUUID
@@ -482,6 +484,55 @@ func ProvisionForCVM(initramfsUbuntuSeedDir string) error {
 	return nil
 }
 
+func kdfOptions(volumesAuth *device.VolumesAuthOptions) (sb.KDFOptions, error) {
+	switch volumesAuth.KDFType {
+	case "":
+		return nil, nil
+	case "argon2id":
+		return &sb.Argon2Options{
+			Mode:           sb.Argon2id,
+			TargetDuration: volumesAuth.KDFTime,
+		}, nil
+	case "argon2i":
+		return &sb.Argon2Options{
+			Mode:           sb.Argon2i,
+			TargetDuration: volumesAuth.KDFTime,
+		}, nil
+	case "pbkdf2":
+		return &sb.PBKDF2Options{
+			TargetDuration: volumesAuth.KDFTime,
+		}, nil
+	default:
+		return nil, fmt.Errorf("internal error: unknown kdfType passed %q", volumesAuth.KDFType)
+	}
+}
+
+func newTPMProtectedKey(tpm *sb_tpm2.Connection, creationParams *sb_tpm2.ProtectKeyParams, volumesAuth *device.VolumesAuthOptions) (protectedKey *sb.KeyData, primaryKey sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error) {
+	if volumesAuth != nil {
+		switch volumesAuth.Mode {
+		case device.AuthModePassphrase:
+			kdfOptions, kdferr := kdfOptions(volumesAuth)
+			if kdferr != nil {
+				return nil, nil, nil, kdferr
+			}
+			passphraseParams := &sb_tpm2.PassphraseProtectKeyParams{
+				ProtectKeyParams: *creationParams,
+				KDFOptions:       kdfOptions,
+			}
+			protectedKey, primaryKey, unlockKey, err = sbNewTPMPassphraseProtectedKey(tpm, passphraseParams, volumesAuth.Passphrase)
+		case device.AuthModePIN:
+			// TODO: Implement PIN authentication mode.
+			return nil, nil, nil, fmt.Errorf("%q authentication mode is not implemented", device.AuthModePIN)
+		default:
+			return nil, nil, nil, fmt.Errorf("internal error: invalid authentication mode %q", volumesAuth.Mode)
+		}
+	} else {
+		protectedKey, primaryKey, unlockKey, err = sbNewTPMProtectedKey(tpm, creationParams)
+	}
+
+	return protectedKey, primaryKey, unlockKey, err
+}
+
 // SealKeys seals the encryption keys according to the specified parameters. The
 // TPM must have already been provisioned. If sealed key already exists at the
 // PCR handle, SealKeys will fail and return an error.
@@ -519,7 +570,7 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) ([]byte, error) {
 			PCRPolicyCounterHandle: tpm2.Handle(pcrHandle),
 			PrimaryKey:             primaryKey,
 		}
-		protectedKey, primaryKeyOut, unlockKey, err := sbNewTPMProtectedKey(tpm, creationParams)
+		protectedKey, primaryKeyOut, unlockKey, err := newTPMProtectedKey(tpm, creationParams, params.VolumesAuth)
 		if primaryKey == nil {
 			primaryKey = primaryKeyOut
 		}


### PR DESCRIPTION
This PR is a re-implementation of https://github.com/canonical/snapd/pull/14918 with suggestion from @valentindavid https://github.com/canonical/snapd/pull/14918#pullrequestreview-2558738600 of not having volumes authentication options attached to the bootstrapped containers but rather passed along with the rest of other FDE params. A followup PR could be created to tidy up the passed FDE parameters (e.g. data/save bootstrap containers, primary key, volume auth options).

This PR implements passphrase authentication support during installation. Currently all volumes created during installation are passphrase encrypted, i.e. `ubuntu-data` and `ubuntu-save`.

Note: This is still not exposed through the API until target system (#14943) and entropy checks are added. This is done by not including `passphrase-auth` in the list of supported encryption features (Check SD201).

The TPM connection workaround can be removed once https://github.com/canonical/secboot/pull/360 lands.