### PR TITLE
tests: remove occurences of -bios parameters to qemu

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1326,7 +1326,8 @@ nested_start_core_vm_unit() {
                 PARAM_TPM="$PARAM_TPM -device tpm-tis,tpmdev=tpm0"
             fi
         fi
-        PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1"
+        # addr=5 is to make tests/nested/manual/install-volume-assignment have stable address
+        PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1,addr=5"
     else
         PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw,id=disk1,if=none -device ide-hd,drive=disk1"
     fi

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1273,11 +1273,6 @@ nested_start_core_vm_unit() {
     fi
     if nested_is_core_ge 20; then
         # use a bundle EFI bios by default
-        if os.query is-arm; then
-            PARAM_BIOS="-bios /usr/share/AAVMF/AAVMF_CODE.fd"
-        else
-            PARAM_BIOS="-bios /usr/share/ovmf/OVMF.fd"
-        fi
         local OVMF_CODE OVMF_VARS
         OVMF_CODE=""
         OVMF_VARS=""
@@ -1289,25 +1284,26 @@ nested_start_core_vm_unit() {
             mv OVMF_VARS.snakeoil.fd /usr/share/OVMF/OVMF_VARS.snakeoil.fd
             wget -q https://storage.googleapis.com/snapd-spread-tests/dependencies/OVMF_VARS.ms.fd
             mv OVMF_VARS.ms.fd /usr/share/OVMF/OVMF_VARS.ms.fd
-        fi
-
-        # In this case the kernel.efi is unsigned and signed with snaleoil certs
-        if [ "$NESTED_FORCE_MS_KEYS" != "true" ] && [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
-            OVMF_VARS="snakeoil"
-        else
-            OVMF_VARS="ms"
+            OVMF_CODE="_4M"
+            OVMF_VARS="_4M"
         fi
 
         if nested_is_secure_boot_enabled; then
-            OVMF_CODE="secboot"
-            if os.query is-arm; then
-                cp -f "/usr/share/AAVMF/AAVMF_VARS.fd" "$NESTED_ASSETS_DIR/AAVMF_VARS.fd"
-                PARAM_BIOS="-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$NESTED_ASSETS_DIR/AAVMF_VARS.fd,if=pflash,format=raw"
+            OVMF_CODE=".secboot"
+            if [ "$NESTED_FORCE_MS_KEYS" != "true" ] && [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
+                OVMF_VARS=".snakeoil"
             else
-                cp -f "/usr/share/OVMF/OVMF_VARS.${OVMF_VARS}.fd" "$NESTED_ASSETS_DIR/OVMF_VARS.${OVMF_VARS}.fd"
-                PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE.${OVMF_CODE}.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$NESTED_ASSETS_DIR/OVMF_VARS.${OVMF_VARS}.fd,if=pflash,format=raw"
-                PARAM_MACHINE="-machine q35${ATTR_KVM} -global ICH9-LPC.disable_s3=1"
+                OVMF_VARS=".ms"
             fi
+        fi
+
+        if os.query is-arm; then
+            cp -f "/usr/share/AAVMF/AAVMF_VARS.fd" "$NESTED_ASSETS_DIR/AAVMF_VARS.fd"
+            PARAM_BIOS="-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$NESTED_ASSETS_DIR/AAVMF_VARS.fd,if=pflash,format=raw"
+        else
+            cp -f "/usr/share/OVMF/OVMF_VARS${OVMF_VARS}.fd" "$NESTED_ASSETS_DIR/OVMF_VARS${OVMF_VARS}.fd"
+            PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE${OVMF_CODE}.fd,if=pflash,format=raw,unit=0,readonly=on -drive file=$NESTED_ASSETS_DIR/OVMF_VARS${OVMF_VARS}.fd,if=pflash,format=raw"
+            PARAM_MACHINE="-machine q35${ATTR_KVM} -global ICH9-LPC.disable_s3=1"
         fi
 
         if nested_is_tpm_enabled; then

--- a/tests/lib/tools/mkimage-uc22
+++ b/tests/lib/tools/mkimage-uc22
@@ -428,10 +428,12 @@ show_how_to_run_qemu() {
     local IMG="$1"
 
     echo "mkimage-uc22: mage ready, run as: "
-    echo kvm -m 1500 -snapshot \
+    echo cp /usr/share/OVMF/OVMF_VARS_4M.fd .
+    echo qemu-system-x86_64 -m q35,accel=kvm -m 1500 -snapshot \
         -netdev user,id=net.0,hostfwd=tcp::10022-:22 \
         -device rtl8139,netdev=net.0 \
-        -bios /usr/share/OVMF/OVMF_CODE.fd \
+        -drive file=/usr/share/OVMF/OVMF_CODE_4M.fd,if=pflash,format=raw,readonly=on \
+        -drive file=OVMF_VARS_4M.fd,if=pflash,format=raw \
         -drive file="$1",if=virtio \
         -serial stdio
 

--- a/tests/main/mkimage-uc22/task.yaml
+++ b/tests/main/mkimage-uc22/task.yaml
@@ -41,7 +41,8 @@ prepare: |
     MACHINE_PARAM="-machine ubuntu,accel=kvm"
   fi
 
-  tests.systemd create-and-start-unit "nested-vm" "qemu-system-x86_64 -m 1500 -nographic $MACHINE_PARAM -snapshot -netdev user,id=net.0,hostfwd=tcp::10022-:22 -device rtl8139,netdev=net.0 -bios /usr/share/OVMF/OVMF_CODE.fd -drive file=$PWD/boot.img,if=virtio -serial file:$PWD/serial.log"
+  cp /usr/share/OVMF/OVMF_VARS_4M.fd .
+  tests.systemd create-and-start-unit "nested-vm" "qemu-system-x86_64 -m 1500 -nographic $MACHINE_PARAM -snapshot -netdev user,id=net.0,hostfwd=tcp::10022-:22 -device rtl8139,netdev=net.0 -drive file=/usr/share/OVMF/OVMF_CODE_4M.fd,if=pflash,format=raw,readonly=on -drive file=${PWD}/OVMF_VARS_4M.fd,if=pflash,format=raw -drive file=$PWD/boot.img,if=virtio -serial file:$PWD/serial.log"
 
   # run built image
   remote.setup config --host localhost --port 10022 --user user1 --pass ubuntu
@@ -52,6 +53,10 @@ prepare: |
 
 restore: |
   tests.systemd stop-unit --remove "nested-vm"
+  rm -f OVMF_VARS_4M.fd
+
+debug: |
+  cat serial.log || true
 
 execute: |
   # Check the system loaded properly

--- a/tests/nested/manual/install-volume-assignment/task.yaml
+++ b/tests/nested/manual/install-volume-assignment/task.yaml
@@ -37,6 +37,8 @@ prepare: |
         device: /dev/disk/by-id/nvme0003
   - assignment-name: test-device
     assignment:
+      # FIXME: we should really not use those kind of paths, they are
+      # difficult to predict
       pc:
         device: /dev/disk/by-path/pci-0000:00:05.0
       backup:
@@ -72,8 +74,11 @@ execute: |
   BACKUP_VOLUME="$NESTED_IMAGES_DIR/$(nested_get_image_name_base core)-backup.img"
 
   # setup extra disk options for tests.nested
-  NESTED_PARAM_EXTRA="-drive file=$BACKUP_VOLUME,if=none,snapshot=off,format=raw,id=disk2 \
-      -device virtio-blk-pci,drive=disk2,serial=target"
+  params=(
+    "-drive" "file=${BACKUP_VOLUME},if=none,snapshot=off,format=raw,id=disk2"
+    "-device" "virtio-blk-pci,drive=disk2,addr=6"
+  )
+  NESTED_PARAM_EXTRA="${params[*]}"
 
   tests.nested create-vm core --extra-param "$NESTED_PARAM_EXTRA"
 


### PR DESCRIPTION
UEFI expects non volatile memory which `-bios` can not provide. So to have a behavior that every where what we expect, we should stop using `-bios`. Otherwise, we cannot test UEFI boot entries, sbat revocation, DBX update, etc.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
