### PR TITLE
tests: have dependency on fundamental systems only for PRs

### DIFF
--- a/.github/workflows/fundamental-systems.json
+++ b/.github/workflows/fundamental-systems.json
@@ -1,0 +1,60 @@
+{
+    "include": [
+      {
+        "group": "debian-req (fundamental)",
+        "backend": "google-distro-1", 
+        "systems": "debian-11-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "fedora (fundamental)",
+        "backend": "openstack",
+        "systems": "fedora-41-64", 
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-focal (fundamental)",
+        "backend": "google",
+        "systems": "ubuntu-20.04-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-noble (fundamental)",
+        "backend": "google",
+        "systems": "ubuntu-24.04-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-interim (fundamental)",
+        "backend": "google",
+        "systems": "ubuntu-24.10-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-core-18 (fundamental)",
+        "backend": "google-core",
+        "systems": "ubuntu-core-18-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-core-20 (fundamental)",
+        "backend": "google-core",
+        "systems": "ubuntu-core-20-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-core-24 (fundamental)",
+        "backend": "google-core",
+        "systems": "ubuntu-core-24-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      }
+    ]
+  }

--- a/.github/workflows/non-fundamental-systems.json
+++ b/.github/workflows/non-fundamental-systems.json
@@ -1,0 +1,130 @@
+{
+    "include": [
+      {
+        "group": "amazon-linux",
+        "backend": "google-distro-1",
+        "systems": "amazon-linux-2-64 amazon-linux-2023-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "arch-linux",
+        "backend": "google-distro-2",
+        "systems": "arch-linux-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "centos",
+        "backend": "openstack",
+        "systems": "centos-9-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "debian-not-req",
+        "backend": "openstack",
+        "systems": "debian-12-64 debian-sid-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "fedora",
+        "backend": "openstack",
+        "systems": "fedora-40-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "opensuse",
+        "backend": "openstack", 
+        "systems": "opensuse-15.6-64 opensuse-tumbleweed-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-trusty",
+        "backend": "google",
+        "systems": "ubuntu-14.04-64",
+        "tasks": "tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04",
+        "rules": "trusty"
+      },
+      {
+        "group": "ubuntu-xenial-bionic",
+        "backend": "google",
+        "systems": "ubuntu-16.04-64 ubuntu-18.04-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-jammy",
+        "backend": "google",
+        "systems": "ubuntu-22.04-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-daily",
+        "backend": "google",
+        "systems": "ubuntu-25.04-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-core-22",
+        "backend": "google-core",
+        "systems": "ubuntu-core-22-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-arm64",
+        "backend": "google-arm",
+        "systems": "ubuntu-20.04-arm-64 ubuntu-core-22-arm-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-secboot",
+        "backend": "google",
+        "systems": "ubuntu-secboot-20.04-64",
+        "tasks": "tests/...",
+        "rules": "main"
+      },
+      {
+        "group": "ubuntu-fips",
+        "backend": "google-pro",
+        "systems": "ubuntu-fips-22.04-64",
+        "tasks": "tests/fips/...",
+        "rules": "fips"
+      },
+      {
+        "group": "nested-ubuntu-18.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-18.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      },
+      {
+        "group": "nested-ubuntu-20.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-20.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      },
+      {
+        "group": "nested-ubuntu-22.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-22.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      },
+      {
+        "group": "nested-ubuntu-24.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-24.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      }
+    ]
+  }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -272,9 +272,25 @@ jobs:
         files: .coverage/coverage-*.cov
         verbose: true
 
+  read-systems:
+    runs-on: ubuntu-latest
+    outputs:
+      fundamental-systems: ${{ steps.read-systems.outputs.fundamental-systems }}
+      non-fundamental-systems: ${{ steps.read-systems.outputs.non-fundamental-systems }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Read matrix file
+        id: read-systems
+        shell: bash
+        run: |
+          echo "fundamental-systems=$(jq -c . ./.github/workflows/fundamental-systems.json)" >> $GITHUB_OUTPUT
+          echo "non-fundamental-systems=$(jq -c . ./.github/workflows/non-fundamental-systems.json)" >> $GITHUB_OUTPUT
+
   spread-fundamental:
     uses: ./.github/workflows/spread-tests.yaml
-    needs: [unit-tests, snap-builds]
+    needs: [unit-tests, snap-builds, read-systems]
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.
@@ -295,52 +311,12 @@ jobs:
       # interrupting spread, notably, does not work today. As such disable
       # fail-fast while we tackle that problem upstream.
       fail-fast: false
-      matrix:
-        include:
-          - group: 'debian-req (fundamental)'
-            backend: google-distro-1
-            systems: 'debian-11-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'fedora (fundamental)'
-            backend: openstack
-            systems: 'fedora-41-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'ubuntu-focal (fundamental)'
-            backend: google
-            systems: 'ubuntu-20.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'ubuntu-noble (fundamental)'
-            backend: google
-            systems: 'ubuntu-24.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'ubuntu-interim (fundamental)'
-            backend: google
-            systems: 'ubuntu-24.10-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'ubuntu-core-18 (fundamental)'
-            backend: google-core
-            systems: 'ubuntu-core-18-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'ubuntu-core-20 (fundamental)'
-            backend: google-core
-            systems: 'ubuntu-core-20-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: 'ubuntu-core-24 (fundamental)'
-            backend: google-core
-            systems: 'ubuntu-core-24-64'
-            tasks: 'tests/...'
-            rules: 'main'
+      matrix: ${{ fromJson(needs.read-systems.outputs.fundamental-systems) }}
 
-  spread-not-fundamental:
+  spread-not-fundamental-pr:
     uses: ./.github/workflows/spread-tests.yaml
-    needs: [unit-tests, snap-builds, spread-fundamental]
+    if: github.event_name == 'pull_request'
+    needs: [unit-tests, snap-builds, read-systems, spread-fundamental]
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.
@@ -360,99 +336,33 @@ jobs:
       # interrupting spread, notably, does not work today. As such disable
       # fail-fast while we tackle that problem upstream.
       fail-fast: false
-      matrix:
-        include:
-          - group: amazon-linux
-            backend: google-distro-1
-            systems: 'amazon-linux-2-64 amazon-linux-2023-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: arch-linux
-            backend: google-distro-2
-            systems: 'arch-linux-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: centos
-            backend: openstack
-            systems: 'centos-9-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: debian-not-req
-            backend: openstack
-            systems: 'debian-12-64 debian-sid-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: fedora
-            backend: openstack
-            systems: 'fedora-40-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: opensuse
-            backend: openstack
-            systems: 'opensuse-15.6-64 opensuse-tumbleweed-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-trusty
-            backend: google
-            systems: 'ubuntu-14.04-64'
-            tasks: 'tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04'
-            rules: 'trusty'
-          - group: ubuntu-xenial-bionic
-            backend: google
-            systems: 'ubuntu-16.04-64 ubuntu-18.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-jammy
-            backend: google
-            systems: 'ubuntu-22.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-daily
-            backend: google
-            systems: 'ubuntu-25.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-core-22
-            backend: google-core
-            systems: 'ubuntu-core-22-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-arm64
-            backend: google-arm
-            systems: 'ubuntu-20.04-arm-64 ubuntu-core-22-arm-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-secboot
-            backend: google
-            systems: 'ubuntu-secboot-20.04-64'
-            tasks: 'tests/...'
-            rules: 'main'
-          - group: ubuntu-fips
-            backend: google-pro
-            systems: 'ubuntu-fips-22.04-64'
-            tasks: 'tests/fips/...'
-            # XXX fips test suite comes with separate ruless file
-            rules: 'fips'
-          - group: nested-ubuntu-18.04
-            backend: google-nested
-            systems: 'ubuntu-18.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
-          - group: nested-ubuntu-20.04
-            backend: google-nested
-            systems: 'ubuntu-20.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
-          - group: nested-ubuntu-22.04
-            backend: google-nested
-            systems: 'ubuntu-22.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
-          - group: nested-ubuntu-24.04
-            backend: google-nested
-            systems: 'ubuntu-24.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
+      matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}
+
+  spread-not-fundamental-not-pr:
+    uses: ./.github/workflows/spread-tests.yaml
+    if: github.event_name != 'pull_request'
+    needs: [unit-tests, snap-builds, read-systems]
+    name: "spread ${{ matrix.group }}"
+    with:
+      # Github doesn't support passing sequences as parameters.
+      # Instead here we create a json array and pass it as a string.
+      # Then in the spread workflow it turns it into a sequence 
+      # using the fromJSON expression.
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: ${{ matrix.tasks }}
+      rules: ${{ matrix.rules }}
+    strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      # Disable fail-fast mode as it doesn't function with spread. It seems
+      # that cancelling tasks requires short, interruptible actions and
+      # interrupting spread, notably, does not work today. As such disable
+      # fail-fast while we tackle that problem upstream.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}
+
 
   # The spread-results-reporter needs the PR number to be able to 
   # comment on the relevant PR with spread failures. Because the PR 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,17 +111,18 @@ jobs:
     - name: check-branch-ubuntu-daily-spread
       run: |
         # Compare the daily system in master and in the current branch
-        wget -q -O test_master.yaml https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/test.yaml
         get_daily_system() {
-          file=$1
-          system_daily="$(yq '.jobs."spread-not-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems' $file)" 
-          if [ -z "$system_daily" ]; then
-            system_daily="$(yq '.jobs."spread-fundamental".strategy.matrix.include.[] | select(.group == "ubuntu-daily") | .systems' $file)" 
-          fi
-          echo $system_daily
+          json1=$1
+          json2=$2
+          jq -s '{ include: [ .[0].include, .[1].include ] | add }' "$json1" "$json2" | \
+            jq '.include.[] | select(.group == "ubuntu-daily") | .systems'
         }
-        master_daily="$(get_daily_system test_master.yaml)"
-        branch_daily="$(get_daily_system .github/workflows/test.yaml)"
+
+        wget -q -O master_fundsys.json https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/fundamental-systems.json
+        wget -q -O master_nonfundsys.json https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/non-fundamental-systems.json
+        
+        master_daily="$(get_daily_system master_fundsys.json master_nonfundsys.json)"
+        branch_daily="$(get_daily_system .github/workflows/fundamental-systems.json .github/workflows/non-fundamental-systems.json)"
         test "$master_daily" == "$branch_daily"
       shell: bash
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -316,6 +316,8 @@ jobs:
   spread-not-fundamental-pr:
     uses: ./.github/workflows/spread-tests.yaml
     if: github.event_name == 'pull_request'
+    # For workflow runs that are PRs, run this non-fundamental systems job
+    # only after the fundamental systems job succeeds.
     needs: [unit-tests, snap-builds, read-systems, spread-fundamental]
     name: "spread ${{ matrix.group }}"
     with:
@@ -341,6 +343,8 @@ jobs:
   spread-not-fundamental-not-pr:
     uses: ./.github/workflows/spread-tests.yaml
     if: github.event_name != 'pull_request'
+    # For workflow runs that are not for PRs, no need to impose a dependency
+    # on the fundamental systems job's success before running this job.
     needs: [unit-tests, snap-builds, read-systems]
     name: "spread ${{ matrix.group }}"
     with:


### PR DESCRIPTION
With each push on the designated branches, all tests should run, even if fundamental systems do not pass. This fixes the issue by dividing the non-fundamental job into two: one for PRs and one for everything else. Note that github does not support conditional needs for jobs.