### PR TITLE
many: add passphrase and PINs quality checks system actions

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -166,6 +166,15 @@ const (
 
 	// ErrorKindMissingSnapResourcePair: cannot find a snap-resource-pair when attempting to sideload a component
 	ErrorKindMissingSnapResourcePair ErrorKind = "missing-snap-resource-pair"
+
+	// ErrorKindInvalidPassphrase: passphrase is invalid and/or does not pass quality checks.
+	ErrorKindInvalidPassphrase ErrorKind = "invalid-passphrase"
+
+	// ErrorKindInvalidPIN: PIN is invalid and/or does not pass quality checks.
+	ErrorKindInvalidPIN ErrorKind = "invalid-pin"
+
+	// ErrorKindUnsupported: target system does not support corresponding feature (e.g. client.StorageEncryptionFeaturePassphraseAuth)
+	ErrorKindUnsupportedTargetSystem ErrorKind = "unsupported"
 )
 
 // Maintenance error kinds.

--- a/client/errors.go
+++ b/client/errors.go
@@ -174,7 +174,7 @@ const (
 	ErrorKindInvalidPIN ErrorKind = "invalid-pin"
 
 	// ErrorKindUnsupported: target system does not support corresponding feature (e.g. client.StorageEncryptionFeaturePassphraseAuth)
-	ErrorKindUnsupportedTargetSystem ErrorKind = "unsupported"
+	ErrorKindUnsupportedByTargetSystem ErrorKind = "unsupported"
 )
 
 // Maintenance error kinds.

--- a/client/systems.go
+++ b/client/systems.go
@@ -310,3 +310,9 @@ type CreateSystemOptions struct {
 	// snaps/assertions will be considered.
 	Offline bool `json:"offline,omitempty"`
 }
+
+// QualityCheckOptions contains the passphrase or PIN whose quality should be checked.
+type QualityCheckOptions struct {
+	Passphrase string `json:"passphrase,omitempty"`
+	PIN        string `json:"pin,omitempty"`
+}

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -642,8 +642,8 @@ func postSystemActionCheckPassphrase(c *Command, systemLabel string, req *system
 	if !encryptionInfo.PassphraseAuthAvailable {
 		return &apiError{
 			Status:  400,
-			Kind:    client.ErrorKindUnsupportedTargetSystem,
-			Message: "target system does not support passphrases",
+			Kind:    client.ErrorKindUnsupportedByTargetSystem,
+			Message: "target system does not support passphrase authentication",
 		}
 	}
 
@@ -683,8 +683,8 @@ func postSystemActionCheckPIN(c *Command, systemLabel string, req *systemActionR
 	if !encryptionInfo.PINAuthAvailable {
 		return &apiError{
 			Status:  400,
-			Kind:    client.ErrorKindUnsupportedTargetSystem,
-			Message: "target system does not support pins",
+			Kind:    client.ErrorKindUnsupportedByTargetSystem,
+			Message: "target system does not support PIN authentication",
 		}
 	}
 
@@ -697,7 +697,7 @@ func postSystemActionCheckPIN(c *Command, systemLabel string, req *systemActionR
 		return &apiError{
 			Status:  400,
 			Kind:    client.ErrorKindInvalidPIN,
-			Message: "pin did not pass quality checks",
+			Message: "PIN did not pass quality checks",
 			Value: map[string]interface{}{
 				"reasons":     reasons,
 				"entropy":     entropy,

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -660,9 +660,9 @@ func postSystemActionCheckPassphrase(c *Command, systemLabel string, req *system
 				Kind:    client.ErrorKindInvalidPassphrase,
 				Message: "passphrase did not pass quality checks",
 				Value: map[string]interface{}{
-					"reasons":     qualityErr.Reasons,
-					"entropy":     qualityErr.Entropy,
-					"min-entropy": qualityErr.MinEntropy,
+					"reasons":          qualityErr.Reasons,
+					"entropy-bits":     qualityErr.Entropy,
+					"min-entropy-bits": qualityErr.MinEntropy,
 				},
 			}
 		}
@@ -701,9 +701,9 @@ func postSystemActionCheckPIN(c *Command, systemLabel string, req *systemActionR
 				Kind:    client.ErrorKindInvalidPIN,
 				Message: "PIN did not pass quality checks",
 				Value: map[string]interface{}{
-					"reasons":     qualityErr.Reasons,
-					"entropy":     qualityErr.Entropy,
-					"min-entropy": qualityErr.MinEntropy,
+					"reasons":          qualityErr.Reasons,
+					"entropy-bits":     qualityErr.Entropy,
+					"min-entropy-bits": qualityErr.MinEntropy,
 				},
 			}
 		}

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -605,8 +605,8 @@ type encryptionSupportInfoKey struct{ systemLabel string }
 
 func cachedEncryptionSupportInfoByLabel(c *Command, systemLabel string) (*install.EncryptionSupportInfo, error) {
 	c.d.state.Lock()
-	defer c.d.state.Unlock()
 	cached := c.d.state.Cached(encryptionSupportInfoKey{systemLabel})
+	c.d.state.Unlock()
 	if cached != nil {
 		encryptionSupportInfo, ok := cached.(*install.EncryptionSupportInfo)
 		if ok {
@@ -619,7 +619,9 @@ func cachedEncryptionSupportInfoByLabel(c *Command, systemLabel string) (*instal
 	if err != nil {
 		return nil, err
 	}
+	c.d.state.Lock()
 	c.d.state.Cache(encryptionSupportInfoKey{systemLabel}, encryptionInfo)
+	c.d.state.Unlock()
 	return encryptionInfo, nil
 }
 

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -603,6 +603,10 @@ func postSystemActionRemove(c *Command, systemLabel string) Response {
 
 type encryptionSupportInfoKey struct{ systemLabel string }
 
+// cachedEncryptionSupportInfoByLabel returns encryption support info for specified system from cache.
+// If no cached value exist it is computed once and reused for future calls.
+//
+// Note that the cached value is never cleared as system seeds are assumed to be immutable.
 func cachedEncryptionSupportInfoByLabel(c *Command, systemLabel string) (*install.EncryptionSupportInfo, error) {
 	c.d.state.Lock()
 	cached := c.d.state.Cached(encryptionSupportInfoKey{systemLabel})

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1389,6 +1389,224 @@ func (s *systemsSuite) TestSystemInstallActionError(c *check.C) {
 	c.Check(rspe.Error(), check.Equals, `unsupported install step "unknown-install-step" (api)`)
 }
 
+func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
+	d := s.daemon(c)
+
+	// just mock values for output matching
+	const expectedEntropy = float64(10)
+	const expectedMinEntropy = float64(20)
+
+	for _, tc := range []struct {
+		passphrase  string
+		noLabel     bool
+		unavailable bool
+
+		expectedStatus   int
+		expectedErrKind  client.ErrorKind
+		expectedErrMsg   string
+		expectedErrValue interface{}
+
+		mockSupportErr error
+		mockEntropyErr error
+	}{
+		{
+			noLabel:        true,
+			expectedStatus: 400, expectedErrMsg: "system action requires the system label to be provided",
+		},
+		{
+			passphrase:     "",
+			expectedStatus: 400, expectedErrMsg: `passphrase must be provided in request body for action "check-passphrase"`,
+		},
+		{
+			passphrase: "this is a good password", unavailable: true,
+			expectedStatus: 400, expectedErrKind: "unsupported", expectedErrMsg: "target system does not support passphrases",
+		},
+		{
+			passphrase: "this is a good password", mockSupportErr: errors.New("mock error"),
+			expectedStatus: 500, expectedErrMsg: "mock error",
+		},
+		{
+			passphrase: "bad-passphrase", mockEntropyErr: errors.New("mock error"),
+			expectedStatus: 400, expectedErrKind: "invalid-passphrase", expectedErrMsg: "passphrase did not pass quality checks",
+			expectedErrValue: map[string]interface{}{
+				"reasons":     []string{"low-entropy"},
+				"entropy":     expectedEntropy,
+				"min-entropy": expectedMinEntropy,
+			},
+		},
+	} {
+		body := map[string]string{
+			"action":     "check-passphrase",
+			"passphrase": tc.passphrase,
+		}
+
+		route := "/v2/systems/20250122"
+		if tc.noLabel {
+			route = "/v2/systems"
+		}
+
+		restore := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(dm *devicestate.DeviceManager, s string) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
+			return nil, nil, &install.EncryptionSupportInfo{PassphraseAuthAvailable: !tc.unavailable}, tc.mockSupportErr
+		})
+		defer restore()
+
+		restore = daemon.MockDeviceValidatePassphraseOrPINEntropy(func(mode device.AuthMode, s string) (float64, float64, error) {
+			c.Check(mode, check.Equals, device.AuthModePassphrase)
+			return expectedEntropy, expectedMinEntropy, tc.mockEntropyErr
+		})
+		defer restore()
+
+		st := d.Overlord().State()
+		st.Lock()
+		daemon.ClearCachedEncryptionSupportInfoForLabel(d.Overlord().State(), "20250122")
+		st.Unlock()
+
+		b, err := json.Marshal(body)
+		c.Assert(err, check.IsNil)
+		buf := bytes.NewBuffer(b)
+		req, err := http.NewRequest("POST", route, buf)
+		c.Assert(err, check.IsNil)
+
+		rspe := s.errorReq(c, req, nil)
+		c.Assert(rspe.Status, check.Equals, tc.expectedStatus)
+		c.Assert(rspe.Kind, check.Equals, tc.expectedErrKind)
+		c.Assert(rspe.Message, check.Matches, tc.expectedErrMsg)
+		c.Assert(rspe.Value, check.DeepEquals, tc.expectedErrValue)
+	}
+}
+
+func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
+	d := s.daemon(c)
+
+	// just mock values for output matching
+	const expectedEntropy = float64(10)
+	const expectedMinEntropy = float64(20)
+
+	for _, tc := range []struct {
+		pin         string
+		noLabel     bool
+		unavailable bool
+
+		expectedStatus   int
+		expectedErrKind  client.ErrorKind
+		expectedErrMsg   string
+		expectedErrValue interface{}
+
+		mockSupportErr error
+		mockEntropyErr error
+	}{
+		{
+			noLabel:        true,
+			expectedStatus: 400, expectedErrMsg: "system action requires the system label to be provided",
+		},
+		{
+			pin:            "",
+			expectedStatus: 400, expectedErrMsg: `pin must be provided in request body for action "check-pin"`,
+		},
+		{
+			pin: "123456", unavailable: true,
+			expectedStatus: 400, expectedErrKind: "unsupported", expectedErrMsg: "target system does not support pins",
+		},
+		{
+			pin: "123456", mockSupportErr: errors.New("mock error"),
+			expectedStatus: 500, expectedErrMsg: "mock error",
+		},
+		{
+			pin: "0", mockEntropyErr: errors.New("mock error"),
+			expectedStatus: 400, expectedErrKind: "invalid-pin", expectedErrMsg: "pin did not pass quality checks",
+			expectedErrValue: map[string]interface{}{
+				"reasons":     []string{"low-entropy"},
+				"entropy":     expectedEntropy,
+				"min-entropy": expectedMinEntropy,
+			},
+		},
+	} {
+		body := map[string]string{
+			"action": "check-pin",
+			"pin":    tc.pin,
+		}
+
+		route := "/v2/systems/20250122"
+		if tc.noLabel {
+			route = "/v2/systems"
+		}
+
+		restore := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(dm *devicestate.DeviceManager, s string) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
+			return nil, nil, &install.EncryptionSupportInfo{PINAuthAvailable: !tc.unavailable}, tc.mockSupportErr
+		})
+		defer restore()
+
+		restore = daemon.MockDeviceValidatePassphraseOrPINEntropy(func(mode device.AuthMode, s string) (float64, float64, error) {
+			c.Check(mode, check.Equals, device.AuthModePIN)
+			return expectedEntropy, expectedMinEntropy, tc.mockEntropyErr
+		})
+		defer restore()
+
+		st := d.Overlord().State()
+		st.Lock()
+		daemon.ClearCachedEncryptionSupportInfoForLabel(d.Overlord().State(), "20250122")
+		st.Unlock()
+
+		b, err := json.Marshal(body)
+		c.Assert(err, check.IsNil)
+		buf := bytes.NewBuffer(b)
+		req, err := http.NewRequest("POST", route, buf)
+		c.Assert(err, check.IsNil)
+
+		rspe := s.errorReq(c, req, nil)
+		c.Assert(rspe.Status, check.Equals, tc.expectedStatus)
+		c.Assert(rspe.Kind, check.Equals, tc.expectedErrKind)
+		c.Assert(rspe.Message, check.Matches, tc.expectedErrMsg)
+		c.Assert(rspe.Value, check.DeepEquals, tc.expectedErrValue)
+	}
+}
+
+func (s *systemsSuite) TestSystemActionCheckPassphraseOrPINCacheEncryptionInfo(c *check.C) {
+	s.daemon(c)
+
+	called := 0
+	restore := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(dm *devicestate.DeviceManager, s string) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
+		called++
+		return nil, nil, &install.EncryptionSupportInfo{PassphraseAuthAvailable: true, PINAuthAvailable: true}, nil
+	})
+	defer restore()
+
+	body := map[string]string{
+		"action":     "check-passphrase",
+		"passphrase": "this is a good passphrase",
+	}
+
+	for i := 0; i < 10; i++ {
+		b, err := json.Marshal(body)
+		c.Assert(err, check.IsNil)
+		buf := bytes.NewBuffer(b)
+		req, err := http.NewRequest("POST", "/v2/systems/20250122", buf)
+		c.Assert(err, check.IsNil)
+
+		rsp := s.syncReq(c, req, nil)
+		c.Assert(rsp.Status, check.Equals, 200)
+	}
+
+	body = map[string]string{
+		"action": "check-pin",
+		"pin":    "123456",
+	}
+
+	for i := 0; i < 10; i++ {
+		b, err := json.Marshal(body)
+		c.Assert(err, check.IsNil)
+		buf := bytes.NewBuffer(b)
+		req, err := http.NewRequest("POST", "/v2/systems/20250122", buf)
+		c.Assert(err, check.IsNil)
+
+		rsp := s.syncReq(c, req, nil)
+		c.Assert(rsp.Status, check.Equals, 200)
+	}
+
+	// Verify that encryption info calculation is called once and retrieved from cache otherwise.
+	c.Check(called, check.Equals, 1)
+}
+
 var _ = check.Suite(&systemsCreateSuite{})
 
 type systemsCreateSuite struct {

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1428,9 +1428,9 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 			passphrase:     "bad-passphrase",
 			expectedStatus: 400, expectedErrKind: "invalid-passphrase", expectedErrMsg: "passphrase did not pass quality checks",
 			expectedErrValue: map[string]interface{}{
-				"reasons":     []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
-				"entropy":     expectedEntropy,
-				"min-entropy": expectedMinEntropy,
+				"reasons":          []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
+				"entropy-bits":     expectedEntropy,
+				"min-entropy-bits": expectedMinEntropy,
 			},
 		},
 	} {
@@ -1517,9 +1517,9 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 			pin:            "0",
 			expectedStatus: 400, expectedErrKind: "invalid-pin", expectedErrMsg: "PIN did not pass quality checks",
 			expectedErrValue: map[string]interface{}{
-				"reasons":     []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
-				"entropy":     expectedEntropy,
-				"min-entropy": expectedMinEntropy,
+				"reasons":          []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
+				"entropy-bits":     expectedEntropy,
+				"min-entropy-bits": expectedMinEntropy,
 			},
 		},
 	} {

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1407,7 +1407,6 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 		expectedErrValue interface{}
 
 		mockSupportErr error
-		mockEntropyErr error
 	}{
 		{
 			noLabel:        true,
@@ -1426,10 +1425,10 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 			expectedStatus: 500, expectedErrMsg: "mock error",
 		},
 		{
-			passphrase: "bad-passphrase", mockEntropyErr: errors.New("mock error"),
+			passphrase:     "bad-passphrase",
 			expectedStatus: 400, expectedErrKind: "invalid-passphrase", expectedErrMsg: "passphrase did not pass quality checks",
 			expectedErrValue: map[string]interface{}{
-				"reasons":     []string{"low-entropy"},
+				"reasons":     []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
 				"entropy":     expectedEntropy,
 				"min-entropy": expectedMinEntropy,
 			},
@@ -1450,9 +1449,13 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 		})
 		defer restore()
 
-		restore = daemon.MockDeviceValidatePassphraseOrPINEntropy(func(mode device.AuthMode, s string) (float64, float64, error) {
+		restore = daemon.MockDeviceValidatePassphraseOrPINEntropy(func(mode device.AuthMode, s string) error {
 			c.Check(mode, check.Equals, device.AuthModePassphrase)
-			return expectedEntropy, expectedMinEntropy, tc.mockEntropyErr
+			return &device.AuthQualityError{
+				Reasons:    []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
+				Entropy:    expectedEntropy,
+				MinEntropy: expectedMinEntropy,
+			}
 		})
 		defer restore()
 
@@ -1493,7 +1496,6 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 		expectedErrValue interface{}
 
 		mockSupportErr error
-		mockEntropyErr error
 	}{
 		{
 			noLabel:        true,
@@ -1512,10 +1514,10 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 			expectedStatus: 500, expectedErrMsg: "mock error",
 		},
 		{
-			pin: "0", mockEntropyErr: errors.New("mock error"),
+			pin:            "0",
 			expectedStatus: 400, expectedErrKind: "invalid-pin", expectedErrMsg: "PIN did not pass quality checks",
 			expectedErrValue: map[string]interface{}{
-				"reasons":     []string{"low-entropy"},
+				"reasons":     []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
 				"entropy":     expectedEntropy,
 				"min-entropy": expectedMinEntropy,
 			},
@@ -1541,9 +1543,13 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 		})
 		defer restore()
 
-		restore = daemon.MockDeviceValidatePassphraseOrPINEntropy(func(mode device.AuthMode, s string) (float64, float64, error) {
+		restore = daemon.MockDeviceValidatePassphraseOrPINEntropy(func(mode device.AuthMode, s string) error {
 			c.Check(mode, check.Equals, device.AuthModePIN)
-			return expectedEntropy, expectedMinEntropy, tc.mockEntropyErr
+			return &device.AuthQualityError{
+				Reasons:    []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
+				Entropy:    expectedEntropy,
+				MinEntropy: expectedMinEntropy,
+			}
 		})
 		defer restore()
 

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1419,7 +1419,7 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 		},
 		{
 			passphrase: "this is a good password", unavailable: true,
-			expectedStatus: 400, expectedErrKind: "unsupported", expectedErrMsg: "target system does not support passphrases",
+			expectedStatus: 400, expectedErrKind: "unsupported", expectedErrMsg: "target system does not support passphrase authentication",
 		},
 		{
 			passphrase: "this is a good password", mockSupportErr: errors.New("mock error"),
@@ -1505,7 +1505,7 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 		},
 		{
 			pin: "123456", unavailable: true,
-			expectedStatus: 400, expectedErrKind: "unsupported", expectedErrMsg: "target system does not support pins",
+			expectedStatus: 400, expectedErrKind: "unsupported", expectedErrMsg: "target system does not support PIN authentication",
 		},
 		{
 			pin: "123456", mockSupportErr: errors.New("mock error"),
@@ -1513,7 +1513,7 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 		},
 		{
 			pin: "0", mockEntropyErr: errors.New("mock error"),
-			expectedStatus: 400, expectedErrKind: "invalid-pin", expectedErrMsg: "pin did not pass quality checks",
+			expectedStatus: 400, expectedErrKind: "invalid-pin", expectedErrMsg: "PIN did not pass quality checks",
 			expectedErrValue: map[string]interface{}{
 				"reasons":     []string{"low-entropy"},
 				"entropy":     expectedEntropy,

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -70,7 +70,7 @@ func MockDevicestateRemoveRecoverySystem(f func(*state.State, string) (*state.Ch
 	return restore
 }
 
-func MockDeviceValidatePassphraseOrPINEntropy(f func(device.AuthMode, string) (float64, float64, error)) (restore func()) {
+func MockDeviceValidatePassphraseOrPINEntropy(f func(device.AuthMode, string) error) (restore func()) {
 	restore = testutil.Backup(&deviceValidatePassphraseOrPINEntropy)
 	deviceValidatePassphraseOrPINEntropy = f
 	return restore

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -69,3 +69,13 @@ func MockDevicestateRemoveRecoverySystem(f func(*state.State, string) (*state.Ch
 	devicestateRemoveRecoverySystem = f
 	return restore
 }
+
+func MockDeviceValidatePassphraseOrPINEntropy(f func(device.AuthMode, string) (float64, float64, error)) (restore func()) {
+	restore = testutil.Backup(&deviceValidatePassphraseOrPINEntropy)
+	deviceValidatePassphraseOrPINEntropy = f
+	return restore
+}
+
+func ClearCachedEncryptionSupportInfoForLabel(st *state.State, systemLabel string) {
+	st.Cache(encryptionSupportInfoKey{systemLabel}, nil)
+}

--- a/gadget/device/encrypt.go
+++ b/gadget/device/encrypt.go
@@ -212,9 +212,18 @@ const (
 	AuthQualityErrorReasonLowEntropy AuthQualityErrorReason = "low-entropy"
 )
 
+// AuthQualityError contains rich inforamtion on why some auth value
+// did not pass quality checks.
 type AuthQualityError struct {
-	Reasons             []AuthQualityErrorReason
-	Entropy, MinEntropy float64
+	// Reasons is a list of reason enums to explain exactly what quality
+	// criteria failed e.g. AuthQualityErrorReasonLowEntropy.
+	Reasons []AuthQualityErrorReason
+	// Entropy is the calculated entropy in bits for the passed passphrase
+	// or PIN.
+	Entropy float64
+	// MinEntropy is the minimum entropy in bits for the corresponding
+	// authentication mode i.e. passhrase or PIN.
+	MinEntropy float64
 
 	err error
 }

--- a/gadget/device/encrypt.go
+++ b/gadget/device/encrypt.go
@@ -169,7 +169,6 @@ const (
 type VolumesAuthOptions struct {
 	Mode       AuthMode      `json:"mode,omitempty"`
 	Passphrase string        `json:"passphrase,omitempty"`
-	PIN        string        `json:"pin,omitempty"`
 	KDFType    string        `json:"kdf-type,omitempty"`
 	KDFTime    time.Duration `json:"kdf-time,omitempty"`
 }
@@ -185,18 +184,9 @@ func (o *VolumesAuthOptions) Validate() error {
 		if len(o.Passphrase) == 0 {
 			return fmt.Errorf("passphrase cannot be empty")
 		}
-		if _, _, err := ValidatePassphraseOrPINEntropy(AuthModePassphrase, o.Passphrase); err != nil {
-			return fmt.Errorf("invalid passphrase: %v", err)
-		}
 	case AuthModePIN:
 		if o.KDFType != "" {
 			return fmt.Errorf("%q authentication mode does not support custom kdf types", AuthModePIN)
-		}
-		if len(o.PIN) == 0 {
-			return fmt.Errorf("pin cannot be empty")
-		}
-		if _, _, err := ValidatePassphraseOrPINEntropy(AuthModePIN, o.PIN); err != nil {
-			return fmt.Errorf("invalid pin: %v", err)
 		}
 		return fmt.Errorf("%q authentication mode is not implemented", AuthModePIN)
 	default:

--- a/gadget/device/encrypt_test.go
+++ b/gadget/device/encrypt_test.go
@@ -161,34 +161,43 @@ func (s *deviceSuite) TestVolumesAuthOptionsValidateHappy(c *C) {
 	for _, kdfType := range []string{"argon2i", "argon2id", "pbkdf2"} {
 		opts = &device.VolumesAuthOptions{
 			Mode:       device.AuthModePassphrase,
-			Passphrase: "1234",
+			Passphrase: "this is a good password",
 			KDFType:    kdfType,
 			KDFTime:    2 * time.Second,
 		}
 		c.Assert(opts.Validate(), IsNil)
 	}
 	// KDF type and time are optional
-	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234"}
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "this is a good password"}
 	c.Assert(opts.Validate(), IsNil)
 }
 
 func (s *deviceSuite) TestVolumesAuthOptionsValidateError(c *C) {
 	// Bad auth mode
-	opts := &device.VolumesAuthOptions{Mode: "bad-mode", Passphrase: "1234"}
+	opts := &device.VolumesAuthOptions{Mode: "bad-mode", Passphrase: "this is a good password"}
 	c.Assert(opts.Validate(), ErrorMatches, `invalid authentication mode "bad-mode", only "passphrase" and "pin" modes are supported`)
 	// Empty passphrase
 	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase}
 	c.Assert(opts.Validate(), ErrorMatches, "passphrase cannot be empty")
-	// PIN mode not implemented yet
+	// Passphrase with low entropy
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234567"}
+	c.Assert(opts.Validate(), ErrorMatches, `invalid passphrase: calculated entropy .* is less than the required minimum entropy \(42.00\) for the "passphrase" authentication mode`)
+	// Empty PIN
 	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN}
+	c.Assert(opts.Validate(), ErrorMatches, `pin cannot be empty`)
+	// PIN with low entropy
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN, PIN: "1234"}
+	c.Assert(opts.Validate(), ErrorMatches, `invalid pin: calculated entropy .* is less than the required minimum entropy \(13.30\) for the "pin" authentication mode`)
+	// PIN mode not implemented yet
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN, PIN: "12345"}
 	c.Assert(opts.Validate(), ErrorMatches, `"pin" authentication mode is not implemented`)
 	// PIN mode + custom kdf type
 	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN, KDFType: "argon2i"}
 	c.Assert(opts.Validate(), ErrorMatches, `"pin" authentication mode does not support custom kdf types`)
 	// Bad kdf type
-	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234", KDFType: "bad-type"}
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "this is a good password", KDFType: "bad-type"}
 	c.Assert(opts.Validate(), ErrorMatches, `invalid kdf type "bad-type", only "argon2i", "argon2id" and "pbkdf2" are supported`)
 	// Negative kdf time
-	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234", KDFTime: -1}
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "this is a good password", KDFTime: -1}
 	c.Assert(opts.Validate(), ErrorMatches, "kdf time cannot be negative")
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -3512,6 +3512,11 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionVolumeA
 	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts)
 	c.Check(err, ErrorMatches, `invalid authentication mode "bad-mode", only "passphrase" and "pin" modes are supported`)
 	c.Check(chg, IsNil)
+
+	volumeOpts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"}
+	chg, err = devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts)
+	c.Check(err, ErrorMatches, `invalid passphrase: calculated entropy .* is less than the required minimum entropy \(42.00\) for the "passphrase" authentication mode`)
+	c.Check(chg, IsNil)
 }
 
 func (s *installStepSuite) testDeviceManagerInstallSetupStorageEncryptionTasksAndChange(c *C, withVolumesAuth bool) {
@@ -3520,7 +3525,7 @@ func (s *installStepSuite) testDeviceManagerInstallSetupStorageEncryptionTasksAn
 
 	var volumesAuth *device.VolumesAuthOptions
 	if withVolumesAuth {
-		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234"}
+		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "this is a good passphrase"}
 	}
 
 	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumesAuth)

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -3512,11 +3512,6 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionVolumeA
 	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts)
 	c.Check(err, ErrorMatches, `invalid authentication mode "bad-mode", only "passphrase" and "pin" modes are supported`)
 	c.Check(chg, IsNil)
-
-	volumeOpts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "test"}
-	chg, err = devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumeOpts)
-	c.Check(err, ErrorMatches, `invalid passphrase: calculated entropy .* is less than the required minimum entropy \(42.00\) for the "passphrase" authentication mode`)
-	c.Check(chg, IsNil)
 }
 
 func (s *installStepSuite) testDeviceManagerInstallSetupStorageEncryptionTasksAndChange(c *C, withVolumesAuth bool) {
@@ -3525,7 +3520,7 @@ func (s *installStepSuite) testDeviceManagerInstallSetupStorageEncryptionTasksAn
 
 	var volumesAuth *device.VolumesAuthOptions
 	if withVolumesAuth {
-		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "this is a good passphrase"}
+		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234"}
 	}
 
 	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes, volumesAuth)

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -84,6 +84,9 @@ type EncryptionSupportInfo struct {
 	// PassphraseAuthAvailable is set if the passphrase authentication
 	// is supported.
 	PassphraseAuthAvailable bool
+
+	// PINAuthAvailable is set if the pin authentication is supported.
+	PINAuthAvailable bool
 }
 
 // ComponentSeedInfo contains information for a component from the seed and
@@ -223,6 +226,8 @@ func GetEncryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvision
 		// support is implemented.
 		// TODO: Check that the target system supports passphrase
 		// authentication (e.g. supported kernel/snapd versions).
+		// TODO: Set res.PINAuthAvailable when passphrase
+		// support is implemented.
 		opts := &gadget.ValidationConstraints{
 			EncryptedData: true,
 		}

--- a/strutil/entropy.go
+++ b/strutil/entropy.go
@@ -79,7 +79,7 @@ func removeChar(s []rune, idx int) []rune {
 	return append(s[0:idx], s[idx+1:]...)
 }
 
-// Entropy returns a heuristic value of the passed string entropy.
+// Entropy returns a heuristic value of the passed string entropy in bits.
 func Entropy(s string) float64 {
 	base := getBase(s)
 	length := getPrunedLength(s)

--- a/strutil/entropy.go
+++ b/strutil/entropy.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil
+
+import (
+	"math"
+	"strings"
+)
+
+var symbolPools = []string{
+	`abcdefghijklmnopqrstuvwxyz`, // lowercase
+	`ABCDEFGHIJKLMNOPQRSTUVWXYZ`, // uppercase
+	`0123456789`,                 // digits
+	`"#%'()+/:;<=>?[\]^{|}~`,     // special characters
+	`_-., `,                      // separator characters
+	`!@$&*`,                      // replace characters (e.g. S -> $)
+}
+
+func getBase(s string) int {
+	matchedSymbolPools := make(map[string]bool, 0)
+	runes := []rune(s)
+	for i := range runes {
+		matched := false
+		for j := 0; j < len(symbolPools); j++ {
+			if strings.ContainsAny(string(runes[i]), symbolPools[j]) {
+				matchedSymbolPools[symbolPools[j]] = true
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			// Account for non-ASCII characters as a pool of size one.
+			// FIXME: A better unicode-aware approach is needed.
+			matchedSymbolPools[string(runes[i])] = true
+		}
+	}
+
+	base := 0
+	for symbolPool := range matchedSymbolPools {
+		base += len([]rune(symbolPool))
+	}
+	return base
+}
+
+func getPrunedLength(s string) int {
+	runes := []rune(s)
+	// remove more than two repeating chars
+	for i := 0; i < len(runes)-2; i++ {
+		for i < len(runes)-2 && runes[i] == runes[i+1] && runes[i] == runes[i+2] {
+			runes = removeChar(runes, i)
+		}
+	}
+	// FIXME: Prune common character patterns (e.g. qwerty,1234) from counting towards the length.
+	return len(runes)
+}
+
+func removeChar(s []rune, idx int) []rune {
+	if idx >= len(s) || idx < 0 {
+		return s
+	}
+	return append(s[0:idx], s[idx+1:]...)
+}
+
+// Entropy returns a heuristic value of the passed string entropy.
+func Entropy(s string) float64 {
+	base := getBase(s)
+	length := getPrunedLength(s)
+	return math.Log2(float64(base)) * float64(length)
+}

--- a/strutil/entropy.go
+++ b/strutil/entropy.go
@@ -33,28 +33,29 @@ var symbolPools = []string{
 	`!@$&*`,                      // replace characters (e.g. S -> $)
 }
 
-func getBase(s string) int {
-	matchedSymbolPools := make(map[string]bool, 0)
-	runes := []rune(s)
-	for i := range runes {
+func getBase(s string) (base int) {
+	// find the total size of the rune corpus composed of unique pools that
+	// match individual runes form the string
+	matchedSymbolPools := make(map[string]struct{}, 0)
+	for _, r := range s {
 		matched := false
-		for j := 0; j < len(symbolPools); j++ {
-			if strings.ContainsAny(string(runes[i]), symbolPools[j]) {
-				matchedSymbolPools[symbolPools[j]] = true
+		for _, pool := range symbolPools {
+			if strings.ContainsRune(pool, r) {
 				matched = true
+				if _, ok := matchedSymbolPools[pool]; !ok {
+					base += len([]rune(pool))
+					matchedSymbolPools[pool] = struct{}{}
+				}
 				break
 			}
 		}
 		if !matched {
 			// Account for non-ASCII characters as a pool of size one.
 			// FIXME: A better unicode-aware approach is needed.
-			matchedSymbolPools[string(runes[i])] = true
+			if _, ok := matchedSymbolPools[string(r)]; !ok {
+				base += 1
+			}
 		}
-	}
-
-	base := 0
-	for symbolPool := range matchedSymbolPools {
-		base += len([]rune(symbolPool))
 	}
 	return base
 }

--- a/strutil/entropy.go
+++ b/strutil/entropy.go
@@ -43,7 +43,7 @@ func getBase(s string) (base int) {
 			if strings.ContainsRune(pool, r) {
 				matched = true
 				if _, ok := matchedSymbolPools[pool]; !ok {
-					base += len([]rune(pool))
+					base += len(pool)
 					matchedSymbolPools[pool] = struct{}{}
 				}
 				break

--- a/strutil/entropy_test.go
+++ b/strutil/entropy_test.go
@@ -38,6 +38,7 @@ func (s *entropySuite) TestEntropy(c *C) {
 		{"aaaaaaaaaaaaaaaa", math.Log2(26) * 2},       // 26 lowercase pool, passphrase translates to aa after prunning
 		{"aaaaaaBBBaaaa111", math.Log2(26+26+10) * 8}, // 26+26+10 (upper,lower,digits), passphrase translates to aaBBaa11 after prunning
 		{"لينكس", math.Log2(5) * 5},                   // 5 non-ASCII character adding 1 to the base each
+		{"Hello, 世界", math.Log2(26+26+5+1+1) * 9},     // 2 non-ACII, 2*26 lowercase and uppercase, 1*5 pool of symbols
 	} {
 		c.Assert(strutil.Entropy(tc.s), Equals, tc.expectedEntropy)
 	}

--- a/strutil/entropy_test.go
+++ b/strutil/entropy_test.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil_test
+
+import (
+	"math"
+
+	"github.com/snapcore/snapd/strutil"
+	. "gopkg.in/check.v1"
+)
+
+type entropySuite struct{}
+
+var _ = Suite(&entropySuite{})
+
+func (s *entropySuite) TestEntropy(c *C) {
+	for _, tc := range []struct {
+		s               string
+		expectedEntropy float64
+	}{
+		{"aaaaaaaaaaaaaaaa", math.Log2(26) * 2},       // 26 lowercase pool, passphrase translates to aa after prunning
+		{"aaaaaaBBBaaaa111", math.Log2(26+26+10) * 8}, // 26+26+10 (upper,lower,digits), passphrase translates to aaBBaa11 after prunning
+		{"لينكس", math.Log2(5) * 5},                   // 5 non-ASCII character adding 1 to the base each
+	} {
+		c.Assert(strutil.Entropy(tc.s), Equals, tc.expectedEntropy)
+	}
+}


### PR DESCRIPTION
This PR adds entropy checks for passphrases and PINs used during installation ass specified in SD201 and FO197.

The underlying entropy check implementation itself is naive and is expected to improve. The passphrase/PIN quality checks are expected to be used by snapd before using passphrase/PIN and also by the installer through the new `check-passphrase` and `check-pin` system actions which are added to the `/v2/systems/<label>` endpoint to display to the user in real-time their passphrase/PIN strength.

The PR is split into 3 parts:
- Adding entropy calculation helper `strutil.Entropy()`
- Using entropy-based checks before accepting a passphrase/PIN in snapd during installation
- Extending the /v2/systems API with `check-passphrase` and `check-pin` actions to expose a single source of truth of entropy calculation for installers