### PR TITLE
many: use inf rather than 1337 as magic version

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -200,8 +200,8 @@ jobs:
       if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-default-test
-        # eg. snapd_1337.2.65.1+git97.gd35b459_amd64.snap
-        pattern: snapd_1337.*.snap
+        # eg. snapd_inf.2.65.1+git97.gd35b459_amd64.snap
+        pattern: snapd_inf.*.snap
         path: "${{ github.workspace }}/built-snap"
 
     - name: Download built snap (arm64)
@@ -209,8 +209,8 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: snap-files-arm64-default-test
-        pattern: snapd_1337.*.snap
-        # eg. snapd_1337.2.65.1+git97.gd35b459_amd64.snap
+        pattern: snapd_inf.*.snap
+        # eg. snapd_inf.2.65.1+git97.gd35b459_amd64.snap
         path: "${{ github.workspace }}/built-snap"
 
     - name: Download built FIPS snap (amd64)
@@ -219,14 +219,14 @@ jobs:
       if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-FIPS-test
-        # eg. snapd_1337.2.65.1+git97.gd35b459-fips_amd64.snap
-        pattern: snapd_1337.*-fips_*.snap
+        # eg. snapd_inf.2.65.1+git97.gd35b459-fips_amd64.snap
+        pattern: snapd_inf.*-fips_*.snap
         path: "${{ github.workspace }}/built-snap"
 
     - name: Rename imported snap
       if: "${{ !inputs.use-snapd-snap-from-master }}"
       run: |
-        for snap in built-snap/snapd_1337.*.snap; do
+        for snap in built-snap/snapd_inf.*.snap; do
           mv -v "${snap}" "${snap}.keep"
         done
 

--- a/.github/workflows/unit-tests-cross-distro.yaml
+++ b/.github/workflows/unit-tests-cross-distro.yaml
@@ -60,4 +60,4 @@ jobs:
 
     - name: Unit tests (C)
       run: |
-        su test-user sh -c "./mkversion.sh 1337-git && cd ./cmd && ./autogen.sh && make -j && make distcheck"
+        su test-user sh -c "./mkversion.sh inf-git && cd ./cmd && ./autogen.sh && make -j && make distcheck"

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -35,7 +35,7 @@ confinement: strict
 # creates) the following stamp files, which influence the build process:
 #
 # - test-build - created by the CI (or the in-repo test build script), indicates
-#   a test build with version override to 1337.*
+#   a test build with version override to inf.*
 # - fips-build - created by the CI or snapd part 'pull' stage to indicate a
 #   build with FIPS support
 # - fips-build-lp - only created by snapd part 'pull' stage, when the build
@@ -256,7 +256,7 @@ parts:
       fi
 
       if [ -f test-build ]; then
-          VERSION="1337.${VERSION}"
+          VERSION="inf.${VERSION}"
       fi
       craftctl set version="$VERSION"
 
@@ -358,21 +358,21 @@ parts:
 
         TAGS=()
 
-        # general build tags, note that version 1337 is used only in CI and
+        # general build tags, note that version inf is used only in CI and
         # triggers testing specific build tags which produce binaries that are
         # insecure for use in production systems
         case "${cmd}" in
           bin/snap)
             TAGS+=(nomanagers)
             case "${VERSION}" in
-              1337.*)
+              inf.*)
                 TAGS+=(withtestkeys faultinject)
                 ;;
             esac
             ;;
           *)
             case "${VERSION}" in
-              1337.*)
+              inf.*)
                 TAGS+=(withtestkeys withbootassetstesting faultinject)
                 ;;
             esac

--- a/strutil/version_test.go
+++ b/strutil/version_test.go
@@ -100,7 +100,7 @@ func (s *VersionTestSuite) TestVersionCompare(c *C) {
 		// more realistic example of what we deal with in spread tests
 		// where on the left is a version from CI built snapd snap, and
 		// on the right the distro package, where snap > package
-		{"1337.2.64+git81.g9b95e8c", "1337.2.64", 1, nil},
+		{"inf.2.64+git81.g9b95e8c", "inf.2.64", 1, nil},
 	} {
 		res, err := strutil.VersionCompare(t.A, t.B)
 		if t.err != nil {

--- a/tests/build-test-snapd-snap
+++ b/tests/build-test-snapd-snap
@@ -11,8 +11,8 @@ fi
 # Clean the snaps created in previous runs
 rm -rfv built-snap
 
-find . -name 'snapd_1337.*.snap' -delete -print
-find . -name 'snapd_1337.*.snap.keep' -delete -print
+find . -name 'snapd_inf.*.snap' -delete -print
+find . -name 'snapd_inf.*.snap.keep' -delete -print
 
 touch test-build
 mkdir -p built-snap
@@ -24,7 +24,7 @@ fi
 
 snapcraft --verbose
 
-for snap_file in snapd_1337.*.snap; do
+for snap_file in snapd_inf.*.snap; do
     mv "${snap_file}" built-snap/"${snap_file}.keep"
 done
 

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-all-results.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-all-results.log.spread
@@ -48,9 +48,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:11 WARNING: may181749-433163 (google-nested:ubuntu-16.04-64) running late. Current output:
@@ -63,9 +63,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:16 WARNING: may181749-433044 (google-nested:ubuntu-16.04-64) running late. Output unchanged.

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-project-restore.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-project-restore.log.spread
@@ -48,9 +48,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:11 WARNING: may181749-433163 (google-nested:ubuntu-16.04-64) running late. Current output:
@@ -63,9 +63,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:16 WARNING: may181749-433044 (google-nested:ubuntu-16.04-64) running late. Output unchanged.

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-repeated-and-aborted.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-repeated-and-aborted.log.spread
@@ -48,9 +48,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:11 WARNING: may181749-433163 (google-nested:ubuntu-16.04-64) running late. Current output:
@@ -63,9 +63,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:16 WARNING: may181749-433044 (google-nested:ubuntu-16.04-64) running late. Output unchanged.

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-repeated.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-repeated.log.spread
@@ -48,9 +48,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:11 WARNING: may181749-433163 (google-nested:ubuntu-16.04-64) running late. Current output:
@@ -63,9 +63,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:16 WARNING: may181749-433044 (google-nested:ubuntu-16.04-64) running late. Output unchanged.

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-suite-restore.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-failed-suite-restore.log.spread
@@ -48,9 +48,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:11 WARNING: may181749-433163 (google-nested:ubuntu-16.04-64) running late. Current output:
@@ -63,9 +63,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:16 WARNING: may181749-433044 (google-nested:ubuntu-16.04-64) running late. Output unchanged.

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/with-results-in-detail.log.spread
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/with-results-in-detail.log.spread
@@ -48,9 +48,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:11 WARNING: may181749-433163 (google-nested:ubuntu-16.04-64) running late. Current output:
@@ -63,9 +63,9 @@ dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is no
 make[1]: Leaving directory '/home/gopath/src/github.com/snapcore/snapd'
    dh_md5sums -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
    dh_builddeb -u-Zxz -O--buildsystem=golang -O--fail-missing -O--builddirectory=_build
-dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_1337.2.55.5_all.deb'.
-dpkg-deb: building package 'snapd' in '../snapd_1337.2.55.5_amd64.deb'.
+dpkg-deb: building package 'golang-github-ubuntu-core-snappy-dev' in '../golang-github-ubuntu-core-snappy-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'golang-github-snapcore-snapd-dev' in '../golang-github-snapcore-snapd-dev_inf.2.55.5_all.deb'.
+dpkg-deb: building package 'snapd' in '../snapd_inf.2.55.5_amd64.deb'.
 -----
 .
 2022-05-18 18:00:16 WARNING: may181749-433044 (google-nested:ubuntu-16.04-64) running late. Output unchanged.

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -73,7 +73,7 @@ build_deb(){
             ;;
     esac
     # Use fake version to ensure we are always bigger than anything else
-    dch --newversion "1337.$newver" "testing build"
+    dch --newversion "inf.$newver" "testing build"
 
     if os.query is-debian sid; then
         # ensure we really build without vendored packages
@@ -103,7 +103,7 @@ build_rpm() {
         release=2023
     fi
     base_version="$(head -1 debian/changelog | awk -F '[()]' '{print $2}')"
-    version="1337.$base_version"
+    version="inf.$base_version"
     packaging_path=packaging/$distro-$release
     rpm_dir=$(rpm --eval "%_topdir")
     pack_args=
@@ -154,7 +154,7 @@ build_rpm() {
 
 build_arch_pkg() {
     base_version="$(head -1 debian/changelog | awk -F '[()]' '{print $2}')"
-    version="1337.$base_version"
+    version="inf.$base_version"
     packaging_path=packaging/arch
     archive_name=snapd-$version.tar
 
@@ -216,9 +216,9 @@ install_dependencies_gce_bucket(){
             cp "$PROJECT_PATH"/../*.deb "$GOHOME"
             ;;
         fedora-*|opensuse-*|amazon-*|centos-*)
-            install_snapd_rpm_dependencies "$PROJECT_PATH"/../snapd-1337.*.src.rpm
+            install_snapd_rpm_dependencies "$PROJECT_PATH"/../snapd-inf.*.src.rpm
             # sources are not needed to run the tests
-            rm "$PROJECT_PATH"/../snapd-1337.*.src.rpm
+            rm "$PROJECT_PATH"/../snapd-inf.*.src.rpm
             find "$PROJECT_PATH"/.. -name '*.rpm' -exec cp -v {} "${GOPATH%%:*}" \;
             ;;
         arch-*)

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -537,7 +537,7 @@ build_snapd_snap() {
                 if [ -n "${USE_SNAPD_SNAP_URL}" ]; then
                     wget -q "$USE_SNAPD_SNAP_URL" -O "${snapd_snap_cache}/snapd_from_ci.snap"
                 else
-                    cp "${PROJECT_PATH}/built-snap"/snapd_1337.*.snap.keep "${snapd_snap_cache}/snapd_from_ci.snap"
+                    cp "${PROJECT_PATH}/built-snap"/snapd_inf.*.snap.keep "${snapd_snap_cache}/snapd_from_ci.snap"
                 fi
             else
                 # This is not reliable across classic releases so only allow on
@@ -585,7 +585,7 @@ build_snapd_snap_with_run_mode_firstboot_tweaks() {
         if [ -n "${USE_SNAPD_SNAP_URL}" ]; then
             wget -q "$USE_SNAPD_SNAP_URL" -O /tmp/snapd_from_snapcraft.snap
         else
-            cp "${PROJECT_PATH}/built-snap"/snapd_1337.*.snap.keep "/tmp/snapd_from_snapcraft.snap"
+            cp "${PROJECT_PATH}/built-snap"/snapd_inf.*.snap.keep "/tmp/snapd_from_snapcraft.snap"
         fi
     else
         chmod -R go+r "${PROJECT_PATH}/tests"
@@ -1547,7 +1547,7 @@ prepare_ubuntu_core() {
     # Wait for the snap command to become available.
     if [ "$SPREAD_BACKEND" != "external" ] && [ "$SPREAD_BACKEND" != "testflinger" ]; then
         # shellcheck disable=SC2016
-        retry -n 120 --wait 1 sh -c 'test "$(command -v snap)" = /usr/bin/snap && snap version | grep -E -q "snapd +1337.*"'
+        retry -n 120 --wait 1 sh -c 'test "$(command -v snap)" = /usr/bin/snap && snap version | grep -E -q "snapd +inf.*"'
     fi
 
     # Wait for seeding to finish.

--- a/tests/main/snapd-snap-transition-auto-install/task.yaml
+++ b/tests/main/snapd-snap-transition-auto-install/task.yaml
@@ -126,7 +126,7 @@ execute: |
         expect="DEBUG: re-exec disabled by user"
     elif [ "$SNAPD_SRC" = "deb" ]; then
         echo "Ensure exec from snapd deb"
-        expect="DEBUG: snap \(at \"$snap_mount_dir/snapd/current\"\) is older \(\"2\.[0-9.]*\"\) than distribution package \(\"1337.[0-9.]*\"\)"
+        expect="DEBUG: snap \(at \"$snap_mount_dir/snapd/current\"\) is older \(\"2\.[0-9.]*\"\) than distribution package \(\"inf.[0-9.]*\"\)"
     else
         echo "Ensure re-exec from snapd snap"
         expect="DEBUG: restarting into \"$snap_mount_dir/snapd/current/usr/bin/snap\""

--- a/tests/regression/lp-1871652/task.yaml
+++ b/tests/regression/lp-1871652/task.yaml
@@ -41,13 +41,13 @@ prepare: |
 
     # Overwrite the snap binary inside the container with the one from this
     # system. Given that snapd on the system has just been built from source it
-    # will have the custom 1337 version string.
-    # NOTE: For SRU validation snapd is not built from source, so version does not match 1337
-    # NOTE: When snapd is downloaded from the repo version does not match 1337
+    # will have the custom inf version string.
+    # NOTE: For SRU validation snapd is not built from source, so version does not match inf
+    # NOTE: When snapd is downloaded from the repo version does not match inf
     # NOTE: This step is only necessary while snapd in the store is older than the fix
     lxc file push /usr/bin/snap bionic/usr/bin/snap
     if [ ! "$SRU_VALIDATION" = 1 ] && ! tests.info is-snapd-from-archive ; then
-        lxc exec bionic -- snap version | MATCH 1337
+        lxc exec bionic -- snap version | MATCH inf
     fi
 
     # Hide real snap binary, ensuring we run the patched one we copied above.


### PR DESCRIPTION
We are hitting self-imposed snap version length limit with the current release of 2.67.1 and FIPS mode:

The version string "1337.2.67.1+git164.g6e703fb4+fips" is exactly one byte above the limit, as snapcraft is kind to inform us:

  error setting version: Value should have at most 32 items after validation, not 33

Since the magic string is not relevant anywhere outside of CI/CD environments, I'd rather not touch the fips suffix and instead replace 1337, as leet as it is, with inf, shorthand for infinity.

This also fixes the CI/CD bug after we actually release version 1337, whenever that may be.