### PR TITLE
data, packaging: separate check and implicit build makefile targets

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -7,3 +7,6 @@ all install clean:
 	$(MAKE) -C env $@
 	$(MAKE) -C desktop $@
 	$(MAKE) -C polkit $@
+
+check:
+	$(MAKE) -C systemd $@

--- a/data/systemd/Makefile
+++ b/data/systemd/Makefile
@@ -27,7 +27,7 @@ SYSTEMD_UNITS_GENERATED := $(wildcard *.in)
 SYSTEMD_UNITS = $(sort $(SYSTEMD_UNITS_GENERATED:.in=) $(wildcard *.service) $(wildcard *.timer) $(wildcard *.socket) $(wildcard *.target))
 
 .PHONY: all
-all: $(SYSTEMD_UNITS) check
+all: $(SYSTEMD_UNITS)
 
 .PHONY: check
 check: snapd.run-from-snap snapd.core-fixup.sh

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -116,6 +116,7 @@ check() {
   # done, not after building the tree.
   # ./run-checks --static
   TMPDIR=/tmp make -C cmd -k check
+  TMPDIR=/tmp make -C data -k check
 }
 
 package() {

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -134,7 +134,7 @@ package() {
     "$pkgdir/usr/share/zsh/site-functions/_snap"
 
   # Install systemd units, dbus services and a script for environment variables
-  make -C data/ install \
+  make -C data install \
      DBUSSERVICESDIR=/usr/share/dbus-1/services \
      BINDIR=/usr/bin \
      SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -801,9 +801,9 @@ export GO111MODULE=off
 %endif
 
 # snap-confine tests (these always run!)
-pushd ./cmd
-make check
-popd
+make -C cmd -k check
+# and data files
+make -C data -k check
 
 %files
 #define license tag if not already defined

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -267,7 +267,8 @@ for binary in snap-exec snap-update-ns snapctl; do
     ldd $binary 2>&1 | grep 'not a dynamic executable'
 done
 
-%make_build -C %{indigo_srcdir}/cmd check
+%make_build -C %{indigo_srcdir}/cmd -k check
+%make_build -C %{indigo_srcdir}/data -k check
 # Use the common packaging helper for testing.
 %make_build -C %{indigo_srcdir} -f %{indigo_srcdir}/packaging/snapd.mk \
             GOPATH=%{indigo_gopath}:$GOPATH SNAPD_DEFINES_DIR=%{_builddir} \

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -169,7 +169,9 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 endif
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# run the snap-confine tests
-	$(MAKE) -C cmd check
+	$(MAKE) -C cmd -k check
+	# and data files tests
+	$(MAKE) -C data -k check
 endif
 
 override_dh_install:

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -289,7 +289,9 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 endif
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# run the snap-confine tests
-	$(MAKE) -C cmd check
+	$(MAKE) -C cmd -k check
+	# and data files tests
+	$(MAKE) -C data -k check
 endif
 
 


### PR DESCRIPTION
When building from AUR it is surprisingly common to not perform the builds in chroots or allow one's PATH to leak into the build environment. Turns out, if one has shellcheck installed form a snap, it could be picked up by the build and then trip over the sandbox. However, this highlights a separate issue, where running `make -C data` invokes an implicit default target in `data/systemd` which then happens to run checks/tests. Those are normally reserved for (dist)check like targets and expected to be invoked explicitly. The branch introduces a separate `check` target in top level Makefile under `data` which subsequently invokes `check` for the sole directly having an implementation.
