### PR TITLE
interfaces: Add missing OneSpan Device Product IDs

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -200,7 +200,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "OneSpan DIGIPASS FX Series",
 		VendorIDPattern:  "1a44",
-		ProductIDPattern: "1501|1502|1503|1506|1507",
+		ProductIDPattern: "1501|1502|1503|1506|1507|1508|1509|150A",
 	},
 }
 


### PR DESCRIPTION
This expands the list of OneSpan Product IDs.

OneSpan does not provide documentation that shows the VID/PID, so I cannot link to it.

