### PR TITLE
cmd, github: consistently use clang-format

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -81,40 +81,17 @@ jobs:
           sudo apt-get install -y python3-yamlordereddictloader
           ./run-checks --static
 
-    - name: Cache prebuilt indent
-      id: cache-indent-bin
-      uses: actions/cache@v4
-      with:
-        path: indent-bin
-        key: ${{ runner.os }}-indent-2.2.13
-
-    # build indent 2.2.13 which has this patch
-    # https://git.savannah.gnu.org/cgit/indent.git/commit/?id=22b83d68e9a8b429590f42920e9f473a236123cf
-    - name: Build indent 2.2.13
-      if: steps.cache-indent-bin.outputs.cache-hit != 'true'
-      run: |
-          sudo apt install texinfo autopoint
-          curl -O https://ftp.gnu.org/gnu/indent/indent-2.2.13.tar.xz
-          tar xvf indent-2.2.13.tar.xz
-          cd indent-2.2.13
-          autoreconf -if
-          # set prefix in case we want to pack to tar/extract into system
-          ./configure --prefix=/opt/indent
-          make -j
-          make install DESTDIR=${{ github.workspace }}/indent-bin
-          find ${{ github.workspace }}/indent-bin -ls
-
     - name: Check C source code formatting
       run: |
           set -x
           cd cmd/
           ./autogen.sh
           # apply formatting
-          PATH=${{ github.workspace }}/indent-bin/opt/indent/bin:$PATH make fmt
+          make fmt
           set +x
           if [ -n "$(git diff --stat)" ]; then
               git diff
               echo "C files are not fomratted correctly, run 'make fmt'"
-              echo "make sure to have clang-format and indent 2.2.13+ installed"
+              echo "make sure to have clang-format installed"
               exit 1
           fi

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -54,45 +54,10 @@ check-unit-tests:
 	echo "unit tests are disabled (rebuild with --enable-unit-tests)"
 endif
 
-new_format = \
-	 libsnap-confine-private/bpf-support.c \
-	 libsnap-confine-private/bpf-support.h \
-	 libsnap-confine-private/cgroup-support.c \
-	 libsnap-confine-private/cgroup-support.h \
-	 libsnap-confine-private/cgroup-support-test.c \
-	 libsnap-confine-private/device-cgroup-support.c \
-	 libsnap-confine-private/device-cgroup-support.h \
-	 libsnap-confine-private/infofile-test.c \
-	 libsnap-confine-private/infofile.c \
-	 libsnap-confine-private/infofile.h \
-	 libsnap-confine-private/panic-test.h \
-	 libsnap-confine-private/panic.c \
-	 libsnap-confine-private/panic.h \
-	 libsnap-confine-private/snap-dir-test.c \
-	 libsnap-confine-private/snap-dir.c \
-	 libsnap-confine-private/snap-dir.h \
-	 snap-confine/seccomp-support-ext.c \
-	 snap-confine/seccomp-support-ext.h \
-	 snap-confine/selinux-support.c \
-	 snap-confine/selinux-support.h \
-	 snap-confine/snap-confine-invocation-test.c \
-	 snap-confine/snap-confine-invocation.c \
-	 snap-confine/snap-confine-invocation.h \
-	 snap-device-helper/main.c \
-	 snap-device-helper/snap-device-helper.c \
-	 snap-device-helper/snap-device-helper.h \
-	 snap-device-helper/snap-device-helper-test.c \
-	 snap-discard-ns/snap-discard-ns.c \
-	 snap-gdb-shim/snap-gdb-shim.c \
-	 snap-gdb-shim/snap-gdbserver-shim.c
-
 # NOTE: clang-format is using project-wide .clang-format file.
 .PHONY: fmt
-fmt:: $(filter     $(addprefix %,$(new_format)),$(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch])))
+fmt:: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
 	clang-format -i $^
-
-fmt:: $(filter-out $(addprefix %,$(new_format)),$(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch])))
-	HOME=$(srcdir) indent $^
 
 # The hack target helps developers work on snap-confine on their live system by
 # installing a fresh copy of snap confine and the appropriate apparmor profile.

--- a/cmd/libsnap-confine-private/apparmor-support.c
+++ b/cmd/libsnap-confine-private/apparmor-support.c
@@ -23,11 +23,11 @@
 #include "string-utils.h"
 #include "utils.h"
 
-#include <string.h>
 #include <errno.h>
+#include <string.h>
 #ifdef HAVE_APPARMOR
 #include <sys/apparmor.h>
-#endif				// ifdef HAVE_APPARMOR
+#endif  // ifdef HAVE_APPARMOR
 
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/utils.h"
@@ -40,125 +40,114 @@
 #define SC_AA_KILL_STR "kill"
 #define SC_AA_UNCONFINED_STR "unconfined"
 
-void sc_init_apparmor_support(struct sc_apparmor *apparmor)
-{
+void sc_init_apparmor_support(struct sc_apparmor *apparmor) {
 #ifdef HAVE_APPARMOR
-	// Use aa_is_enabled() to see if apparmor is available in the kernel and
-	// enabled at boot time. If it isn't log a diagnostic message and assume
-	// we're not confined.
-	if (aa_is_enabled() != true) {
-		switch (errno) {
-		case ENOSYS:
-			debug
-			    ("apparmor extensions to the system are not available");
-			break;
-		case ECANCELED:
-			debug
-			    ("apparmor is available on the system but has been disabled at boot");
-			break;
-		case EPERM:
-			// NOTE: fall-through
-		case EACCES:
-			debug
-			    ("insufficient permissions to determine if apparmor is enabled");
-			// since snap-confine is setuid root this should
-			// never happen so likely someone is trying to
-			// manipulate our execution environment - fail hard
+    // Use aa_is_enabled() to see if apparmor is available in the kernel and
+    // enabled at boot time. If it isn't log a diagnostic message and assume
+    // we're not confined.
+    if (aa_is_enabled() != true) {
+        switch (errno) {
+            case ENOSYS:
+                debug("apparmor extensions to the system are not available");
+                break;
+            case ECANCELED:
+                debug("apparmor is available on the system but has been disabled at boot");
+                break;
+            case EPERM:
+                // NOTE: fall-through
+            case EACCES:
+                debug("insufficient permissions to determine if apparmor is enabled");
+                // since snap-confine is setuid root this should
+                // never happen so likely someone is trying to
+                // manipulate our execution environment - fail hard
 
-			// fall-through
-		case ENOENT:
-		case ENOMEM:
-		default:
-			// this shouldn't happen under normal usage so it
-			// is possible someone is trying to manipulate our
-			// execution environment - fail hard
-			die("aa_is_enabled() failed unexpectedly (%s)",
-			    strerror(errno));
-			break;
-		}
-		apparmor->is_confined = false;
-		apparmor->mode = SC_AA_NOT_APPLICABLE;
-		return;
-	}
-	// Use aa_getcon() to check the label of the current process and
-	// confinement type. Note that the returned label must be released with
-	// free() but the mode is a constant string that must not be freed.
-	char *label SC_CLEANUP(sc_cleanup_string) = NULL;
-	char *mode = NULL;
-	if (aa_getcon(&label, &mode) < 0) {
-		die("cannot query current apparmor profile");
-	}
-	debug("apparmor label on snap-confine is: %s", label);
-	debug("apparmor mode is: %s", mode);
-	// expect to be confined by a profile with the name of a valid
-	// snap-confine binary since if not we may be executed under a
-	// profile with more permissions than expected
-	bool confined_mode = sc_streq(mode, SC_AA_ENFORCE_STR)
-	    || sc_streq(mode, SC_AA_KILL_STR);
-	if (label != NULL && confined_mode && sc_is_expected_path(label)) {
-		apparmor->is_confined = true;
-	} else {
-		apparmor->is_confined = false;
-	}
-	// There are several possible results for the confinement type (mode) that
-	// are checked for below.
-	if (mode != NULL && strcmp(mode, SC_AA_COMPLAIN_STR) == 0) {
-		apparmor->mode = SC_AA_COMPLAIN;
-	} else if (mode != NULL && strcmp(mode, SC_AA_ENFORCE_STR) == 0) {
-		apparmor->mode = SC_AA_ENFORCE;
-	} else if (mode != NULL && strcmp(mode, SC_AA_MIXED_STR) == 0) {
-		apparmor->mode = SC_AA_MIXED;
-	} else if (mode != NULL && strcmp(mode, SC_AA_KILL_STR) == 0) {
-		apparmor->mode = SC_AA_KILL;
-	} else {
-		apparmor->mode = SC_AA_INVALID;
-	}
+                // fall-through
+            case ENOENT:
+            case ENOMEM:
+            default:
+                // this shouldn't happen under normal usage so it
+                // is possible someone is trying to manipulate our
+                // execution environment - fail hard
+                die("aa_is_enabled() failed unexpectedly (%s)", strerror(errno));
+                break;
+        }
+        apparmor->is_confined = false;
+        apparmor->mode = SC_AA_NOT_APPLICABLE;
+        return;
+    }
+    // Use aa_getcon() to check the label of the current process and
+    // confinement type. Note that the returned label must be released with
+    // free() but the mode is a constant string that must not be freed.
+    char *label SC_CLEANUP(sc_cleanup_string) = NULL;
+    char *mode = NULL;
+    if (aa_getcon(&label, &mode) < 0) {
+        die("cannot query current apparmor profile");
+    }
+    debug("apparmor label on snap-confine is: %s", label);
+    debug("apparmor mode is: %s", mode);
+    // expect to be confined by a profile with the name of a valid
+    // snap-confine binary since if not we may be executed under a
+    // profile with more permissions than expected
+    bool confined_mode = sc_streq(mode, SC_AA_ENFORCE_STR) || sc_streq(mode, SC_AA_KILL_STR);
+    if (label != NULL && confined_mode && sc_is_expected_path(label)) {
+        apparmor->is_confined = true;
+    } else {
+        apparmor->is_confined = false;
+    }
+    // There are several possible results for the confinement type (mode) that
+    // are checked for below.
+    if (mode != NULL && strcmp(mode, SC_AA_COMPLAIN_STR) == 0) {
+        apparmor->mode = SC_AA_COMPLAIN;
+    } else if (mode != NULL && strcmp(mode, SC_AA_ENFORCE_STR) == 0) {
+        apparmor->mode = SC_AA_ENFORCE;
+    } else if (mode != NULL && strcmp(mode, SC_AA_MIXED_STR) == 0) {
+        apparmor->mode = SC_AA_MIXED;
+    } else if (mode != NULL && strcmp(mode, SC_AA_KILL_STR) == 0) {
+        apparmor->mode = SC_AA_KILL;
+    } else {
+        apparmor->mode = SC_AA_INVALID;
+    }
 #else
-	apparmor->mode = SC_AA_NOT_APPLICABLE;
-	apparmor->is_confined = false;
-#endif				// ifdef HAVE_APPARMOR
+    apparmor->mode = SC_AA_NOT_APPLICABLE;
+    apparmor->is_confined = false;
+#endif  // ifdef HAVE_APPARMOR
 }
 
-void
-sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile)
-{
+void sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile) {
 #ifdef HAVE_APPARMOR
-	if (apparmor->mode == SC_AA_NOT_APPLICABLE) {
-		return;
-	}
-	debug("requesting changing of apparmor profile on next exec to %s",
-	      profile);
-	if (aa_change_onexec(profile) < 0) {
-		/* Save errno because secure_getenv() can overwrite it */
-		int aa_change_onexec_errno = errno;
-		if (secure_getenv("SNAPPY_LAUNCHER_INSIDE_TESTS") == NULL) {
-			errno = aa_change_onexec_errno;
-			if (errno == ENOENT) {
-				fprintf(stderr, "missing profile %s.\n"
-					"Please make sure that the snapd.apparmor service is enabled and started\n",
-					profile);
-				exit(1);
-			} else {
-				die("cannot change profile for the next exec call");
-			}
-		}
-	}
-#endif				// ifdef HAVE_APPARMOR
+    if (apparmor->mode == SC_AA_NOT_APPLICABLE) {
+        return;
+    }
+    debug("requesting changing of apparmor profile on next exec to %s", profile);
+    if (aa_change_onexec(profile) < 0) {
+        /* Save errno because secure_getenv() can overwrite it */
+        int aa_change_onexec_errno = errno;
+        if (secure_getenv("SNAPPY_LAUNCHER_INSIDE_TESTS") == NULL) {
+            errno = aa_change_onexec_errno;
+            if (errno == ENOENT) {
+                fprintf(stderr,
+                        "missing profile %s.\n"
+                        "Please make sure that the snapd.apparmor service is enabled and started\n",
+                        profile);
+                exit(1);
+            } else {
+                die("cannot change profile for the next exec call");
+            }
+        }
+    }
+#endif  // ifdef HAVE_APPARMOR
 }
 
-void
-sc_maybe_aa_change_hat(struct sc_apparmor *apparmor,
-		       const char *subprofile, unsigned long magic_token)
-{
+void sc_maybe_aa_change_hat(struct sc_apparmor *apparmor, const char *subprofile, unsigned long magic_token) {
 #ifdef HAVE_APPARMOR
-	if (apparmor->mode == SC_AA_NOT_APPLICABLE) {
-		return;
-	}
-	if (apparmor->is_confined) {
-		debug("changing apparmor hat to %s", subprofile);
-		if (aa_change_hat(subprofile, magic_token) < 0) {
-			die("cannot change apparmor hat");
-		}
-	}
-#endif				// ifdef HAVE_APPARMOR
+    if (apparmor->mode == SC_AA_NOT_APPLICABLE) {
+        return;
+    }
+    if (apparmor->is_confined) {
+        debug("changing apparmor hat to %s", subprofile);
+        if (aa_change_hat(subprofile, magic_token) < 0) {
+            die("cannot change apparmor hat");
+        }
+    }
+#endif  // ifdef HAVE_APPARMOR
 }

--- a/cmd/libsnap-confine-private/apparmor-support.h
+++ b/cmd/libsnap-confine-private/apparmor-support.h
@@ -24,30 +24,30 @@
  * Type of apparmor confinement.
  **/
 enum sc_apparmor_mode {
-	// The enforcement mode was not recognized.
-	SC_AA_INVALID = -1,
-	// The enforcement mode is not applicable because apparmor is disabled.
-	SC_AA_NOT_APPLICABLE = 0,
-	// The enforcement mode is "enforcing"
-	SC_AA_ENFORCE = 1,
-	// The enforcement mode is "complain"
-	SC_AA_COMPLAIN,
-	// The enforcement mode is "mixed"
-	SC_AA_MIXED,
-	// The enforcement mode is "kill"
-	SC_AA_KILL,
+    // The enforcement mode was not recognized.
+    SC_AA_INVALID = -1,
+    // The enforcement mode is not applicable because apparmor is disabled.
+    SC_AA_NOT_APPLICABLE = 0,
+    // The enforcement mode is "enforcing"
+    SC_AA_ENFORCE = 1,
+    // The enforcement mode is "complain"
+    SC_AA_COMPLAIN,
+    // The enforcement mode is "mixed"
+    SC_AA_MIXED,
+    // The enforcement mode is "kill"
+    SC_AA_KILL,
 };
 
 /**
  * Data required to manage apparmor wrapper.
  **/
 struct sc_apparmor {
-	// The mode of enforcement. In addition to the two apparmor defined modes
-	// can be also SC_AA_INVALID (unknown mode reported by apparmor) and
-	// SC_AA_NOT_APPLICABLE (when we're not linked with apparmor).
-	enum sc_apparmor_mode mode;
-	// Flag indicating that the current process is confined.
-	bool is_confined;
+    // The mode of enforcement. In addition to the two apparmor defined modes
+    // can be also SC_AA_INVALID (unknown mode reported by apparmor) and
+    // SC_AA_NOT_APPLICABLE (when we're not linked with apparmor).
+    enum sc_apparmor_mode mode;
+    // Flag indicating that the current process is confined.
+    bool is_confined;
 };
 
 /**
@@ -76,8 +76,7 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor);
  * process termination. As an exception, when SNAPPY_LAUNCHER_INSIDE_TESTS
  * environment variable is set then the process is not terminated.
  **/
-void
-sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile);
+void sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile);
 
 /**
  * Maybe call aa_change_hat(2)
@@ -88,8 +87,6 @@ sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile);
  * As with many functions in the snap-confine tree, all errors result in
  * process termination.
  **/
-void
-sc_maybe_aa_change_hat(struct sc_apparmor *apparmor,
-		       const char *subprofile, unsigned long magic_token);
+void sc_maybe_aa_change_hat(struct sc_apparmor *apparmor, const char *subprofile, unsigned long magic_token);
 
 #endif

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -35,92 +35,83 @@
 
 static const char *freezer_cgroup_dir = "/sys/fs/cgroup/freezer";
 
-void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
-{
-	char buf[PATH_MAX] = { 0 };
-	sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
-	sc_cgroup_create_and_join(freezer_cgroup_dir, buf, pid);
+void sc_cgroup_freezer_join(const char *snap_name, pid_t pid) {
+    char buf[PATH_MAX] = {0};
+    sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
+    sc_cgroup_create_and_join(freezer_cgroup_dir, buf, pid);
 }
 
-bool sc_cgroup_freezer_occupied(const char *snap_name)
-{
-	// Format the name of the cgroup hierarchy.
-	char buf[PATH_MAX] = { 0 };
-	sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
+bool sc_cgroup_freezer_occupied(const char *snap_name) {
+    // Format the name of the cgroup hierarchy.
+    char buf[PATH_MAX] = {0};
+    sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
 
-	// Open the freezer cgroup directory.
-	int cgroup_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	cgroup_fd = open(freezer_cgroup_dir,
-			 O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-	if (cgroup_fd < 0) {
-		die("cannot open freezer cgroup (%s)", freezer_cgroup_dir);
-	}
-	// Open the proc directory.
-	int proc_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	proc_fd = open("/proc", O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-	if (proc_fd < 0) {
-		die("cannot open /proc");
-	}
-	// Open the hierarchy directory for the given snap.
-	int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	hierarchy_fd = openat(cgroup_fd, buf,
-			      O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-	if (hierarchy_fd < 0) {
-		if (errno == ENOENT) {
-			return false;
-		}
-		die("cannot open freezer cgroup hierarchy for snap %s",
-		    snap_name);
-	}
-	// Open the "cgroup.procs" file. Alternatively we could open the "tasks"
-	// file and see per-thread data but we don't need that.
-	int cgroup_procs_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	cgroup_procs_fd = openat(hierarchy_fd, "cgroup.procs",
-				 O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
-	if (cgroup_procs_fd < 0) {
-		die("cannot open cgroup.procs file for freezer cgroup hierarchy for snap %s", snap_name);
-	}
+    // Open the freezer cgroup directory.
+    int cgroup_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    cgroup_fd = open(freezer_cgroup_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (cgroup_fd < 0) {
+        die("cannot open freezer cgroup (%s)", freezer_cgroup_dir);
+    }
+    // Open the proc directory.
+    int proc_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    proc_fd = open("/proc", O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (proc_fd < 0) {
+        die("cannot open /proc");
+    }
+    // Open the hierarchy directory for the given snap.
+    int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    hierarchy_fd = openat(cgroup_fd, buf, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (hierarchy_fd < 0) {
+        if (errno == ENOENT) {
+            return false;
+        }
+        die("cannot open freezer cgroup hierarchy for snap %s", snap_name);
+    }
+    // Open the "cgroup.procs" file. Alternatively we could open the "tasks"
+    // file and see per-thread data but we don't need that.
+    int cgroup_procs_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    cgroup_procs_fd = openat(hierarchy_fd, "cgroup.procs", O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (cgroup_procs_fd < 0) {
+        die("cannot open cgroup.procs file for freezer cgroup hierarchy for snap %s", snap_name);
+    }
 
-	FILE *cgroup_procs SC_CLEANUP(sc_cleanup_file) = NULL;
-	cgroup_procs = fdopen(cgroup_procs_fd, "r");
-	if (cgroup_procs == NULL) {
-		die("cannot convert cgroups.procs file descriptor to FILE");
-	}
-	cgroup_procs_fd = -1;	// cgroup_procs_fd will now be closed by fclose.
+    FILE *cgroup_procs SC_CLEANUP(sc_cleanup_file) = NULL;
+    cgroup_procs = fdopen(cgroup_procs_fd, "r");
+    if (cgroup_procs == NULL) {
+        die("cannot convert cgroups.procs file descriptor to FILE");
+    }
+    cgroup_procs_fd = -1;  // cgroup_procs_fd will now be closed by fclose.
 
-	char *line_buf SC_CLEANUP(sc_cleanup_string) = NULL;
-	size_t line_buf_size = 0;
-	ssize_t num_read;
-	struct stat statbuf;
-	for (;;) {
-		num_read = getline(&line_buf, &line_buf_size, cgroup_procs);
-		if (num_read < 0 && errno != 0) {
-			die("cannot read next PID belonging to snap %s",
-			    snap_name);
-		}
-		if (num_read <= 0) {
-			break;
-		} else {
-			if (line_buf[num_read - 1] == '\n') {
-				line_buf[num_read - 1] = '\0';
-			} else {
-				die("could not find newline in cgroup.procs");
-			}
-		}
-		debug("found process id: %s\n", line_buf);
+    char *line_buf SC_CLEANUP(sc_cleanup_string) = NULL;
+    size_t line_buf_size = 0;
+    ssize_t num_read;
+    struct stat statbuf;
+    for (;;) {
+        num_read = getline(&line_buf, &line_buf_size, cgroup_procs);
+        if (num_read < 0 && errno != 0) {
+            die("cannot read next PID belonging to snap %s", snap_name);
+        }
+        if (num_read <= 0) {
+            break;
+        } else {
+            if (line_buf[num_read - 1] == '\n') {
+                line_buf[num_read - 1] = '\0';
+            } else {
+                die("could not find newline in cgroup.procs");
+            }
+        }
+        debug("found process id: %s\n", line_buf);
 
-		if (fstatat(proc_fd, line_buf, &statbuf, AT_SYMLINK_NOFOLLOW) <
-		    0) {
-			// The process may have died already.
-			if (errno != ENOENT) {
-				die("cannot stat /proc/%s", line_buf);
-			}
-			continue;
-		}
-		debug("found live process %s belonging to user %d",
-		      line_buf, statbuf.st_uid);
-		return true;
-	}
+        if (fstatat(proc_fd, line_buf, &statbuf, AT_SYMLINK_NOFOLLOW) < 0) {
+            // The process may have died already.
+            if (errno != ENOENT) {
+                die("cannot stat /proc/%s", line_buf);
+            }
+            continue;
+        }
+        debug("found live process %s belonging to user %d", line_buf, statbuf.st_uid);
+        return true;
+    }
 
-	return false;
+    return false;
 }

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.h
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.h
@@ -37,7 +37,7 @@
  *
  * For more details please review:
  * https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt
-**/
+ **/
 void sc_cgroup_freezer_join(const char *snap_name, pid_t pid);
 
 /**
@@ -45,7 +45,7 @@ void sc_cgroup_freezer_join(const char *snap_name, pid_t pid);
  *
  * This function examines the freezer cgroup called "snap.$snap_name" and looks
  * at each of its processes. If any process exists then the function returns true.
-**/
+ **/
 // TODO: Support per user filtering for eventual per-user mount namespaces
 bool sc_cgroup_freezer_occupied(const char *snap_name);
 

--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -21,202 +21,219 @@
 #include <glib.h>
 
 /* restore_os_release is an internal helper for mock_os_release */
-static void restore_os_release(gpointer *old)
-{
-	unlink(os_release);
-	os_release = (const char *)old;
+static void restore_os_release(gpointer *old) {
+    unlink(os_release);
+    os_release = (const char *)old;
 }
 
 /* mock_os_release replaces the presence and contents of /etc/os-release
    as seen by classic.c. The mocked value may be NULL to have the code refer
    to an absent file. */
-static void mock_os_release(const char *mocked)
-{
-	const char *old = os_release;
-	if (mocked != NULL) {
-		os_release = "os-release.test";
-		g_assert_true(g_file_set_contents
-			      (os_release, mocked, -1, NULL));
-	} else {
-		os_release = "os-release.missing";
-	}
-	g_test_queue_destroy((GDestroyNotify) restore_os_release,
-			     (gpointer) old);
+static void mock_os_release(const char *mocked) {
+    const char *old = os_release;
+    if (mocked != NULL) {
+        os_release = "os-release.test";
+        g_assert_true(g_file_set_contents(os_release, mocked, -1, NULL));
+    } else {
+        os_release = "os-release.missing";
+    }
+    g_test_queue_destroy((GDestroyNotify)restore_os_release, (gpointer)old);
 }
 
 /* restore_meta_snap_yaml is an internal helper for mock_meta_snap_yaml */
-static void restore_meta_snap_yaml(gpointer *old)
-{
-	unlink(meta_snap_yaml);
-	meta_snap_yaml = (const char *)old;
+static void restore_meta_snap_yaml(gpointer *old) {
+    unlink(meta_snap_yaml);
+    meta_snap_yaml = (const char *)old;
 }
 
 /* mock_meta_snap_yaml replaces the presence and contents of /meta/snap.yaml
    as seen by classic.c. The mocked value may be NULL to have the code refer
    to an absent file. */
-static void mock_meta_snap_yaml(const char *mocked)
-{
-	const char *old = meta_snap_yaml;
-	if (mocked != NULL) {
-		meta_snap_yaml = "snap-yaml.test";
-		g_assert_true(g_file_set_contents
-			      (meta_snap_yaml, mocked, -1, NULL));
-	} else {
-		meta_snap_yaml = "snap-yaml.missing";
-	}
-	g_test_queue_destroy((GDestroyNotify) restore_meta_snap_yaml,
-			     (gpointer) old);
+static void mock_meta_snap_yaml(const char *mocked) {
+    const char *old = meta_snap_yaml;
+    if (mocked != NULL) {
+        meta_snap_yaml = "snap-yaml.test";
+        g_assert_true(g_file_set_contents(meta_snap_yaml, mocked, -1, NULL));
+    } else {
+        meta_snap_yaml = "snap-yaml.missing";
+    }
+    g_test_queue_destroy((GDestroyNotify)restore_meta_snap_yaml, (gpointer)old);
 }
 
-static const char *os_release_classic = ""
+static const char *os_release_classic =
+    ""
     "NAME=\"Ubuntu\"\n"
-    "VERSION=\"17.04 (Zesty Zapus)\"\n" "ID=ubuntu\n" "ID_LIKE=debian\n";
+    "VERSION=\"17.04 (Zesty Zapus)\"\n"
+    "ID=ubuntu\n"
+    "ID_LIKE=debian\n";
 
-static void test_is_on_classic(void)
-{
-	mock_os_release(os_release_classic);
-	mock_meta_snap_yaml(NULL);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
+static void test_is_on_classic(void) {
+    mock_os_release(os_release_classic);
+    mock_meta_snap_yaml(NULL);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
 }
 
-static const char *os_release_core16 = ""
-    "NAME=\"Ubuntu Core\"\n" "VERSION_ID=\"16\"\n" "ID=ubuntu-core\n";
+static const char *os_release_core16 =
+    ""
+    "NAME=\"Ubuntu Core\"\n"
+    "VERSION_ID=\"16\"\n"
+    "ID=ubuntu-core\n";
 
-static const char *meta_snap_yaml_core16 = ""
+static const char *meta_snap_yaml_core16 =
+    ""
     "name: core\n"
-    "version: 16-something\n" "type: core\n" "architectures: [amd64]\n";
+    "version: 16-something\n"
+    "type: core\n"
+    "architectures: [amd64]\n";
 
-static void test_is_on_core_on16(void)
-{
-	mock_os_release(os_release_core16);
-	mock_meta_snap_yaml(meta_snap_yaml_core16);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE16);
+static void test_is_on_core_on16(void) {
+    mock_os_release(os_release_core16);
+    mock_meta_snap_yaml(meta_snap_yaml_core16);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE16);
 }
 
-static const char *os_release_core18 = ""
-    "NAME=\"Ubuntu Core\"\n" "VERSION_ID=\"18\"\n" "ID=ubuntu-core\n";
+static const char *os_release_core18 =
+    ""
+    "NAME=\"Ubuntu Core\"\n"
+    "VERSION_ID=\"18\"\n"
+    "ID=ubuntu-core\n";
 
-static const char *meta_snap_yaml_core18 = ""
-    "name: core18\n" "type: base\n" "architectures: [amd64]\n";
+static const char *meta_snap_yaml_core18 =
+    ""
+    "name: core18\n"
+    "type: base\n"
+    "architectures: [amd64]\n";
 
-static void test_is_on_core_on18(void)
-{
-	mock_os_release(os_release_core18);
-	mock_meta_snap_yaml(meta_snap_yaml_core18);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
+static void test_is_on_core_on18(void) {
+    mock_os_release(os_release_core18);
+    mock_meta_snap_yaml(meta_snap_yaml_core18);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
 }
 
-const char *os_release_core20 = ""
-    "NAME=\"Ubuntu Core\"\n" "VERSION_ID=\"20\"\n" "ID=ubuntu-core\n";
+const char *os_release_core20 =
+    ""
+    "NAME=\"Ubuntu Core\"\n"
+    "VERSION_ID=\"20\"\n"
+    "ID=ubuntu-core\n";
 
-static const char *meta_snap_yaml_core20 = ""
-    "name: core20\n" "type: base\n" "architectures: [amd64]\n";
+static const char *meta_snap_yaml_core20 =
+    ""
+    "name: core20\n"
+    "type: base\n"
+    "architectures: [amd64]\n";
 
-static void test_is_on_core_on20(void)
-{
-	mock_os_release(os_release_core20);
-	mock_meta_snap_yaml(meta_snap_yaml_core20);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
+static void test_is_on_core_on20(void) {
+    mock_os_release(os_release_core20);
+    mock_meta_snap_yaml(meta_snap_yaml_core20);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
 }
 
-static const char *os_release_classic_with_long_line = ""
+static const char *os_release_classic_with_long_line =
+    ""
     "NAME=\"Ubuntu\"\n"
     "VERSION=\"17.04 (Zesty Zapus)\"\n"
     "ID=ubuntu\n"
     "ID_LIKE=debian\n"
-    "LONG=line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.";
+    "LONG=line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line."
+    "line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line.line."
+    "line.line.line.line.line.line.line.line.line.";
 
-static void test_is_on_classic_with_long_line(void)
-{
-	mock_os_release(os_release_classic_with_long_line);
-	mock_meta_snap_yaml(NULL);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
+static void test_is_on_classic_with_long_line(void) {
+    mock_os_release(os_release_classic_with_long_line);
+    mock_meta_snap_yaml(NULL);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
 }
 
-static const char *os_release_fedora_base = ""
+static const char *os_release_fedora_base =
+    ""
     "NAME=Fedora\nID=fedora\nVARIANT_ID=snappy\n";
 
-static const char *meta_snap_yaml_fedora_base = ""
-    "name: fedora29\n" "type: base\n" "architectures: [amd64]\n";
+static const char *meta_snap_yaml_fedora_base =
+    ""
+    "name: fedora29\n"
+    "type: base\n"
+    "architectures: [amd64]\n";
 
-static void test_is_on_fedora_base(void)
-{
-	mock_os_release(os_release_fedora_base);
-	mock_meta_snap_yaml(meta_snap_yaml_fedora_base);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
+static void test_is_on_fedora_base(void) {
+    mock_os_release(os_release_fedora_base);
+    mock_meta_snap_yaml(meta_snap_yaml_fedora_base);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
 }
 
-static const char *os_release_fedora_ws = ""
+static const char *os_release_fedora_ws =
+    ""
     "NAME=Fedora\nID=fedora\nVARIANT_ID=workstation\n";
 
-static void test_is_on_fedora_ws(void)
-{
-	mock_os_release(os_release_fedora_ws);
-	mock_meta_snap_yaml(NULL);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
+static void test_is_on_fedora_ws(void) {
+    mock_os_release(os_release_fedora_ws);
+    mock_meta_snap_yaml(NULL);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
 }
 
-static const char *os_release_custom = ""
+static const char *os_release_custom =
+    ""
     "NAME=\"Custom Distribution\"\nID=custom\n";
 
-static const char *meta_snap_yaml_custom = ""
+static const char *meta_snap_yaml_custom =
+    ""
     "name: custom\n"
     "version: rolling\n"
     "summary: Runtime environment based on Custom Distribution\n"
-    "type: base\n" "architectures: [amd64]\n";
+    "type: base\n"
+    "architectures: [amd64]\n";
 
-static void test_is_on_custom_base(void)
-{
-	mock_os_release(os_release_custom);
+static void test_is_on_custom_base(void) {
+    mock_os_release(os_release_custom);
 
-	/* Without /meta/snap.yaml we treat "Custom Distribution" as classic. */
-	mock_meta_snap_yaml(NULL);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
+    /* Without /meta/snap.yaml we treat "Custom Distribution" as classic. */
+    mock_meta_snap_yaml(NULL);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
 
-	/* With /meta/snap.yaml we treat it as core instead. */
-	mock_meta_snap_yaml(meta_snap_yaml_custom);
-	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
+    /* With /meta/snap.yaml we treat it as core instead. */
+    mock_meta_snap_yaml(meta_snap_yaml_custom);
+    g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
 }
 
-static const char *os_release_debian_like_valid = ""
-    "ID=my-fun-distro\n" "ID_LIKE=debian\n";
+static const char *os_release_debian_like_valid =
+    ""
+    "ID=my-fun-distro\n"
+    "ID_LIKE=debian\n";
 
-static const char *os_release_debian_like_quoted_valid = ""
-    "ID=my-fun-distro\n" "ID_LIKE=\"debian\"\n";
+static const char *os_release_debian_like_quoted_valid =
+    ""
+    "ID=my-fun-distro\n"
+    "ID_LIKE=\"debian\"\n";
 
 /* actual debian only sets ID=debian */
 static const char *os_release_actual_debian_valid = "ID=debian\n";
 
 static const char *os_release_invalid = "garbage\n";
 
-static void test_is_debian_like(void)
-{
-	mock_os_release(os_release_debian_like_valid);
-	g_assert_true(sc_is_debian_like());
+static void test_is_debian_like(void) {
+    mock_os_release(os_release_debian_like_valid);
+    g_assert_true(sc_is_debian_like());
 
-	mock_os_release(os_release_debian_like_quoted_valid);
-	g_assert_true(sc_is_debian_like());
+    mock_os_release(os_release_debian_like_quoted_valid);
+    g_assert_true(sc_is_debian_like());
 
-	mock_os_release(os_release_actual_debian_valid);
-	g_assert_true(sc_is_debian_like());
+    mock_os_release(os_release_actual_debian_valid);
+    g_assert_true(sc_is_debian_like());
 
-	mock_os_release(os_release_fedora_ws);
-	g_assert_false(sc_is_debian_like());
+    mock_os_release(os_release_fedora_ws);
+    g_assert_false(sc_is_debian_like());
 
-	mock_os_release(os_release_invalid);
-	g_assert_false(sc_is_debian_like());
+    mock_os_release(os_release_invalid);
+    g_assert_false(sc_is_debian_like());
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/classic/on-classic", test_is_on_classic);
-	g_test_add_func("/classic/on-classic-with-long-line",
-			test_is_on_classic_with_long_line);
-	g_test_add_func("/classic/on-core-on16", test_is_on_core_on16);
-	g_test_add_func("/classic/on-core-on18", test_is_on_core_on18);
-	g_test_add_func("/classic/on-core-on20", test_is_on_core_on20);
-	g_test_add_func("/classic/on-fedora-base", test_is_on_fedora_base);
-	g_test_add_func("/classic/on-fedora-ws", test_is_on_fedora_ws);
-	g_test_add_func("/classic/on-custom-base", test_is_on_custom_base);
-	g_test_add_func("/classic/is-debian-like", test_is_debian_like);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/classic/on-classic", test_is_on_classic);
+    g_test_add_func("/classic/on-classic-with-long-line", test_is_on_classic_with_long_line);
+    g_test_add_func("/classic/on-core-on16", test_is_on_core_on16);
+    g_test_add_func("/classic/on-core-on18", test_is_on_core_on18);
+    g_test_add_func("/classic/on-core-on20", test_is_on_core_on20);
+    g_test_add_func("/classic/on-fedora-base", test_is_on_fedora_base);
+    g_test_add_func("/classic/on-fedora-ws", test_is_on_fedora_ws);
+    g_test_add_func("/classic/on-custom-base", test_is_on_custom_base);
+    g_test_add_func("/classic/is-debian-like", test_is_debian_like);
 }

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -1,8 +1,8 @@
-#include "config.h"
 #include "classic.h"
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/infofile.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "config.h"
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -12,80 +12,72 @@
 static const char *os_release = "/etc/os-release";
 static const char *meta_snap_yaml = "/meta/snap.yaml";
 
-sc_distro sc_classify_distro(void)
-{
-	FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
-	if (f == NULL) {
-		return SC_DISTRO_CLASSIC;
-	}
+sc_distro sc_classify_distro(void) {
+    FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
+    if (f == NULL) {
+        return SC_DISTRO_CLASSIC;
+    }
 
-	bool is_core = false;
-	int core_version = 0;
-	char buf[255] = { 0 };
+    bool is_core = false;
+    int core_version = 0;
+    char buf[255] = {0};
 
-	while (fgets(buf, sizeof buf, f) != NULL) {
-		size_t len = strlen(buf);
-		if (len > 0 && buf[len - 1] == '\n') {
-			buf[len - 1] = '\0';
-		}
-		if (sc_streq(buf, "ID=\"ubuntu-core\"")
-		    || sc_streq(buf, "ID=ubuntu-core")) {
-			is_core = true;
-		} else if (sc_streq(buf, "VERSION_ID=\"16\"")
-			   || sc_streq(buf, "VERSION_ID=16")) {
-			core_version = 16;
-		} else if (sc_streq(buf, "VARIANT_ID=\"snappy\"")
-			   || sc_streq(buf, "VARIANT_ID=snappy")) {
-			is_core = true;
-		}
-	}
+    while (fgets(buf, sizeof buf, f) != NULL) {
+        size_t len = strlen(buf);
+        if (len > 0 && buf[len - 1] == '\n') {
+            buf[len - 1] = '\0';
+        }
+        if (sc_streq(buf, "ID=\"ubuntu-core\"") || sc_streq(buf, "ID=ubuntu-core")) {
+            is_core = true;
+        } else if (sc_streq(buf, "VERSION_ID=\"16\"") || sc_streq(buf, "VERSION_ID=16")) {
+            core_version = 16;
+        } else if (sc_streq(buf, "VARIANT_ID=\"snappy\"") || sc_streq(buf, "VARIANT_ID=snappy")) {
+            is_core = true;
+        }
+    }
 
-	if (!is_core) {
-		/* Since classic systems don't have a /meta/snap.yaml file the simple
-		   presence of that file qualifies as SC_DISTRO_CORE_OTHER. */
-		if (access(meta_snap_yaml, F_OK) == 0) {
-			is_core = true;
-		}
-	}
+    if (!is_core) {
+        /* Since classic systems don't have a /meta/snap.yaml file the simple
+           presence of that file qualifies as SC_DISTRO_CORE_OTHER. */
+        if (access(meta_snap_yaml, F_OK) == 0) {
+            is_core = true;
+        }
+    }
 
-	if (is_core) {
-		if (core_version == 16) {
-			return SC_DISTRO_CORE16;
-		}
-		return SC_DISTRO_CORE_OTHER;
-	} else {
-		return SC_DISTRO_CLASSIC;
-	}
+    if (is_core) {
+        if (core_version == 16) {
+            return SC_DISTRO_CORE16;
+        }
+        return SC_DISTRO_CORE_OTHER;
+    } else {
+        return SC_DISTRO_CLASSIC;
+    }
 }
 
-bool sc_is_debian_like(void)
-{
-	FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
-	if (f == NULL) {
-		return false;
-	}
-	const char *const id_keys_to_try[] = {
-		"ID",		/* actual debian only sets ID */
-		"ID_LIKE",	/* distros based on debian */
-	};
-	size_t id_keys_to_try_len =
-	    sizeof id_keys_to_try / sizeof *id_keys_to_try;
-	for (size_t i = 0; i < id_keys_to_try_len; i++) {
-		if (fseek(f, 0L, SEEK_SET) == -1) {
-			return false;
-		}
-		char *id_val SC_CLEANUP(sc_cleanup_string) = NULL;
-		struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-		int rc =
-		    sc_infofile_get_key(f, id_keys_to_try[i], &id_val, &err);
-		if (rc != 0) {
-			/* only if sc_infofile_get_key failed */
-			return false;
-		}
-		if (sc_streq(id_val, "\"debian\"")
-		    || sc_streq(id_val, "debian")) {
-			return true;
-		}
-	}
-	return false;
+bool sc_is_debian_like(void) {
+    FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
+    if (f == NULL) {
+        return false;
+    }
+    const char *const id_keys_to_try[] = {
+        "ID",      /* actual debian only sets ID */
+        "ID_LIKE", /* distros based on debian */
+    };
+    size_t id_keys_to_try_len = sizeof id_keys_to_try / sizeof *id_keys_to_try;
+    for (size_t i = 0; i < id_keys_to_try_len; i++) {
+        if (fseek(f, 0L, SEEK_SET) == -1) {
+            return false;
+        }
+        char *id_val SC_CLEANUP(sc_cleanup_string) = NULL;
+        struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+        int rc = sc_infofile_get_key(f, id_keys_to_try[i], &id_val, &err);
+        if (rc != 0) {
+            /* only if sc_infofile_get_key failed */
+            return false;
+        }
+        if (sc_streq(id_val, "\"debian\"") || sc_streq(id_val, "debian")) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/cmd/libsnap-confine-private/classic.h
+++ b/cmd/libsnap-confine-private/classic.h
@@ -23,9 +23,9 @@
 #define SC_HOSTFS_DIR "/var/lib/snapd/hostfs"
 
 typedef enum sc_distro {
-	SC_DISTRO_CORE16,	// As present in both "core" and later on in "core16"
-	SC_DISTRO_CORE_OTHER,	// Any core distribution.
-	SC_DISTRO_CLASSIC,	// Any classic distribution.
+    SC_DISTRO_CORE16,      // As present in both "core" and later on in "core16"
+    SC_DISTRO_CORE_OTHER,  // Any core distribution.
+    SC_DISTRO_CLASSIC,     // Any classic distribution.
 } sc_distro;
 
 sc_distro sc_classify_distro(void);

--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -22,181 +22,167 @@
 #include <glib/gstdio.h>
 
 #include <fcntl.h>
-#include <sys/types.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/timerfd.h>
-#include <string.h>
+#include <sys/types.h>
 
 static int called = 0;
 
-static void cleanup_fn(int *ptr)
-{
-	called = 1;
-}
+static void cleanup_fn(int *ptr) { called = 1; }
 
 // Test that cleanup functions are applied as expected
-static void test_cleanup_sanity(void)
-{
-	{
-		int test SC_CLEANUP(cleanup_fn);
-		test = 0;
-		test++;
-	}
-	g_assert_cmpint(called, ==, 1);
+static void test_cleanup_sanity(void) {
+    {
+        int test SC_CLEANUP(cleanup_fn);
+        test = 0;
+        test++;
+    }
+    g_assert_cmpint(called, ==, 1);
 }
 
-static void test_cleanup_string(void)
-{
-	/* It is safe to use with a NULL pointer to a string. */
-	sc_cleanup_string(NULL);
+static void test_cleanup_string(void) {
+    /* It is safe to use with a NULL pointer to a string. */
+    sc_cleanup_string(NULL);
 
-	/* It is safe to use with a NULL string. */
-	char *str = NULL;
-	sc_cleanup_string(&str);
+    /* It is safe to use with a NULL string. */
+    char *str = NULL;
+    sc_cleanup_string(&str);
 
-	/* It is safe to use with a non-NULL string. */
-	str = malloc(1);
-	g_assert_nonnull(str);
-	sc_cleanup_string(&str);
-	g_assert_null(str);
+    /* It is safe to use with a non-NULL string. */
+    str = malloc(1);
+    g_assert_nonnull(str);
+    sc_cleanup_string(&str);
+    g_assert_null(str);
 }
 
-static void test_cleanup_file(void)
-{
-	/* It is safe to use with a NULL pointer to a FILE. */
-	sc_cleanup_file(NULL);
+static void test_cleanup_file(void) {
+    /* It is safe to use with a NULL pointer to a FILE. */
+    sc_cleanup_file(NULL);
 
-	/* It is safe to use with a NULL FILE. */
-	FILE *f = NULL;
-	sc_cleanup_file(&f);
+    /* It is safe to use with a NULL FILE. */
+    FILE *f = NULL;
+    sc_cleanup_file(&f);
 
-	/* It is safe to use with a non-NULL FILE. */
-	f = fmemopen(NULL, 10, "rt");
-	g_assert_nonnull(f);
-	sc_cleanup_file(&f);
-	g_assert_null(f);
+    /* It is safe to use with a non-NULL FILE. */
+    f = fmemopen(NULL, 10, "rt");
+    g_assert_nonnull(f);
+    sc_cleanup_file(&f);
+    g_assert_null(f);
 }
 
-static void test_cleanup_endmntent(void)
-{
-	/* It is safe to use with a NULL pointer to a FILE. */
-	sc_cleanup_endmntent(NULL);
+static void test_cleanup_endmntent(void) {
+    /* It is safe to use with a NULL pointer to a FILE. */
+    sc_cleanup_endmntent(NULL);
 
-	/* It is safe to use with a NULL FILE. */
-	FILE *f = NULL;
-	sc_cleanup_endmntent(&f);
+    /* It is safe to use with a NULL FILE. */
+    FILE *f = NULL;
+    sc_cleanup_endmntent(&f);
 
-	/* It is safe to use with a non-NULL FILE. */
-	GError *err = NULL;
-	char *mock_fstab = NULL;
-	gint mock_fstab_fd =
-	    g_file_open_tmp("s-c-test-fstab-mock.XXXXXX", &mock_fstab, &err);
-	g_assert_no_error(err);
-	g_assert_cmpint(mock_fstab_fd, >=, 0);
-	g_assert_true(g_close(mock_fstab_fd, NULL));
-	/* XXX: not strictly needed as the test only calls setmntent */
-	const char *mock_fstab_data = "/dev/foo / ext4 defaults 0 1";
-	g_assert_true(g_file_set_contents
-		      (mock_fstab, mock_fstab_data, -1, NULL));
+    /* It is safe to use with a non-NULL FILE. */
+    GError *err = NULL;
+    char *mock_fstab = NULL;
+    gint mock_fstab_fd = g_file_open_tmp("s-c-test-fstab-mock.XXXXXX", &mock_fstab, &err);
+    g_assert_no_error(err);
+    g_assert_cmpint(mock_fstab_fd, >=, 0);
+    g_assert_true(g_close(mock_fstab_fd, NULL));
+    /* XXX: not strictly needed as the test only calls setmntent */
+    const char *mock_fstab_data = "/dev/foo / ext4 defaults 0 1";
+    g_assert_true(g_file_set_contents(mock_fstab, mock_fstab_data, -1, NULL));
 
-	f = setmntent(mock_fstab, "rt");
-	g_assert_nonnull(f);
-	sc_cleanup_endmntent(&f);
-	g_assert_null(f);
+    f = setmntent(mock_fstab, "rt");
+    g_assert_nonnull(f);
+    sc_cleanup_endmntent(&f);
+    g_assert_null(f);
 
-	g_remove(mock_fstab);
+    g_remove(mock_fstab);
 
-	g_free(mock_fstab);
+    g_free(mock_fstab);
 }
 
-static void test_cleanup_closedir(void)
-{
-	/* It is safe to use with a NULL pointer to a DIR. */
-	sc_cleanup_closedir(NULL);
+static void test_cleanup_closedir(void) {
+    /* It is safe to use with a NULL pointer to a DIR. */
+    sc_cleanup_closedir(NULL);
 
-	/* It is safe to use with a NULL DIR. */
-	DIR *d = NULL;
-	sc_cleanup_closedir(&d);
+    /* It is safe to use with a NULL DIR. */
+    DIR *d = NULL;
+    sc_cleanup_closedir(&d);
 
-	/* It is safe to use with a non-NULL DIR. */
-	d = opendir(".");
-	g_assert_nonnull(d);
-	sc_cleanup_closedir(&d);
-	g_assert_null(d);
+    /* It is safe to use with a non-NULL DIR. */
+    d = opendir(".");
+    g_assert_nonnull(d);
+    sc_cleanup_closedir(&d);
+    g_assert_null(d);
 }
 
-static void test_cleanup_close(void)
-{
-	/* It is safe to use with a NULL pointer to an int. */
-	sc_cleanup_close(NULL);
+static void test_cleanup_close(void) {
+    /* It is safe to use with a NULL pointer to an int. */
+    sc_cleanup_close(NULL);
 
-	/* It is safe to use with a -1 file descriptor. */
-	int fd = -1;
-	sc_cleanup_close(&fd);
+    /* It is safe to use with a -1 file descriptor. */
+    int fd = -1;
+    sc_cleanup_close(&fd);
 
-	/* It is safe to use with a non-invalid file descriptor. */
-	/* Timerfd is a simple to use and widely available object that can be
-	 * created and closed without interacting with the filesystem. */
-	fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
-	g_assert_cmpint(fd, !=, -1);
-	sc_cleanup_close(&fd);
-	g_assert_cmpint(fd, ==, -1);
+    /* It is safe to use with a non-invalid file descriptor. */
+    /* Timerfd is a simple to use and widely available object that can be
+     * created and closed without interacting with the filesystem. */
+    fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
+    g_assert_cmpint(fd, !=, -1);
+    sc_cleanup_close(&fd);
+    g_assert_cmpint(fd, ==, -1);
 }
 
-static void test_cleanup_deep_strv(void)
-{
-	/* It is safe to use with a NULL pointer */
-	sc_cleanup_deep_strv(NULL);
+static void test_cleanup_deep_strv(void) {
+    /* It is safe to use with a NULL pointer */
+    sc_cleanup_deep_strv(NULL);
 
-	char **argses = NULL;
-	/* It is OK if the pointer value is NULL */
-	sc_cleanup_deep_strv(&argses);
-	g_assert_null(argses);
+    char **argses = NULL;
+    /* It is OK if the pointer value is NULL */
+    sc_cleanup_deep_strv(&argses);
+    g_assert_null(argses);
 
-	/* It is safe to call with an empty array */
-	argses = calloc(10, sizeof(char *));
-	g_assert_nonnull(argses);
-	sc_cleanup_deep_strv(&argses);
+    /* It is safe to call with an empty array */
+    argses = calloc(10, sizeof(char *));
+    g_assert_nonnull(argses);
+    sc_cleanup_deep_strv(&argses);
 
-	/* And of course the typical case works as well */
-	argses = calloc(10, sizeof(char *));
-	g_assert_nonnull(argses);
-	for (int i = 0; i < 9; i++) {
-		argses[i] = strdup("hello");
-	}
-	sc_cleanup_deep_strv(&argses);
-	g_assert_null(argses);
+    /* And of course the typical case works as well */
+    argses = calloc(10, sizeof(char *));
+    g_assert_nonnull(argses);
+    for (int i = 0; i < 9; i++) {
+        argses[i] = strdup("hello");
+    }
+    sc_cleanup_deep_strv(&argses);
+    g_assert_null(argses);
 }
 
-static void test_cleanup_shallow_strv(void)
-{
-	/* It is safe to use with a NULL pointer */
-	sc_cleanup_shallow_strv(NULL);
+static void test_cleanup_shallow_strv(void) {
+    /* It is safe to use with a NULL pointer */
+    sc_cleanup_shallow_strv(NULL);
 
-	const char **argses = NULL;
-	/* It is ok of the pointer value is NULL */
-	sc_cleanup_shallow_strv(&argses);
-	g_assert_null(argses);
+    const char **argses = NULL;
+    /* It is ok of the pointer value is NULL */
+    sc_cleanup_shallow_strv(&argses);
+    g_assert_null(argses);
 
-	argses = calloc(10, sizeof(char *));
-	g_assert_nonnull(argses);
-	/* Fill with bogus pointers so attempts to free them would segfault */
-	for (int i = 0; i < 10; i++) {
-		argses[i] = (char *)0x100 + i;
-	}
-	sc_cleanup_shallow_strv(&argses);
-	g_assert_null(argses);
-	/* If we are alive at this point, most likely only the array was free'd */
+    argses = calloc(10, sizeof(char *));
+    g_assert_nonnull(argses);
+    /* Fill with bogus pointers so attempts to free them would segfault */
+    for (int i = 0; i < 10; i++) {
+        argses[i] = (char *)0x100 + i;
+    }
+    sc_cleanup_shallow_strv(&argses);
+    g_assert_null(argses);
+    /* If we are alive at this point, most likely only the array was free'd */
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/cleanup/sanity", test_cleanup_sanity);
-	g_test_add_func("/cleanup/string", test_cleanup_string);
-	g_test_add_func("/cleanup/file", test_cleanup_file);
-	g_test_add_func("/cleanup/endmntent", test_cleanup_endmntent);
-	g_test_add_func("/cleanup/closedir", test_cleanup_closedir);
-	g_test_add_func("/cleanup/close", test_cleanup_close);
-	g_test_add_func("/cleanup/deep_strv", test_cleanup_deep_strv);
-	g_test_add_func("/cleanup/shallow_strv", test_cleanup_shallow_strv);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/cleanup/sanity", test_cleanup_sanity);
+    g_test_add_func("/cleanup/string", test_cleanup_string);
+    g_test_add_func("/cleanup/file", test_cleanup_file);
+    g_test_add_func("/cleanup/endmntent", test_cleanup_endmntent);
+    g_test_add_func("/cleanup/closedir", test_cleanup_closedir);
+    g_test_add_func("/cleanup/close", test_cleanup_close);
+    g_test_add_func("/cleanup/deep_strv", test_cleanup_deep_strv);
+    g_test_add_func("/cleanup/shallow_strv", test_cleanup_shallow_strv);
 }

--- a/cmd/libsnap-confine-private/cleanup-funcs.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs.c
@@ -20,61 +20,54 @@
 #include <mntent.h>
 #include <unistd.h>
 
-void sc_cleanup_string(char **ptr)
-{
-	if (ptr != NULL && *ptr != NULL) {
-		free(*ptr);
-		*ptr = NULL;
-	}
+void sc_cleanup_string(char **ptr) {
+    if (ptr != NULL && *ptr != NULL) {
+        free(*ptr);
+        *ptr = NULL;
+    }
 }
 
-void sc_cleanup_deep_strv(char ***ptr)
-{
-	if (ptr != NULL && *ptr != NULL) {
-		for (char **str = *ptr; *str != NULL; str++) {
-			free(*str);
-		}
-		free(*ptr);
-		*ptr = NULL;
-	}
+void sc_cleanup_deep_strv(char ***ptr) {
+    if (ptr != NULL && *ptr != NULL) {
+        for (char **str = *ptr; *str != NULL; str++) {
+            free(*str);
+        }
+        free(*ptr);
+        *ptr = NULL;
+    }
 }
 
-void sc_cleanup_shallow_strv(const char ***ptr)
-{
-	if (ptr != NULL && *ptr != NULL) {
-		free(*ptr);
-		*ptr = NULL;
-	}
+void sc_cleanup_shallow_strv(const char ***ptr) {
+    if (ptr != NULL && *ptr != NULL) {
+        free(*ptr);
+        *ptr = NULL;
+    }
 }
 
-void sc_cleanup_file(FILE **ptr)
-{
-	if (ptr != NULL && *ptr != NULL) {
-		fclose(*ptr);
-		*ptr = NULL;
-	}
+void sc_cleanup_file(FILE **ptr) {
+    if (ptr != NULL && *ptr != NULL) {
+        fclose(*ptr);
+        *ptr = NULL;
+    }
 }
 
-void sc_cleanup_endmntent(FILE **ptr)
-{
-	if (ptr != NULL && *ptr != NULL) {
-		endmntent(*ptr);
-		*ptr = NULL;
-	}
+void sc_cleanup_endmntent(FILE **ptr) {
+    if (ptr != NULL && *ptr != NULL) {
+        endmntent(*ptr);
+        *ptr = NULL;
+    }
 }
 
-void sc_cleanup_closedir(DIR **ptr)
-{
-	if (ptr != NULL && *ptr != NULL) {
-		closedir(*ptr);
-		*ptr = NULL;
-	}
+void sc_cleanup_closedir(DIR **ptr) {
+    if (ptr != NULL && *ptr != NULL) {
+        closedir(*ptr);
+        *ptr = NULL;
+    }
 }
 
-void sc_cleanup_close(int *ptr)
-{
-	if (ptr != NULL && *ptr != -1) {
-		close(*ptr);
-		*ptr = -1;
-	}
+void sc_cleanup_close(int *ptr) {
+    if (ptr != NULL && *ptr != -1) {
+        close(*ptr);
+        *ptr = -1;
+    }
 }

--- a/cmd/libsnap-confine-private/cleanup-funcs.h
+++ b/cmd/libsnap-confine-private/cleanup-funcs.h
@@ -20,12 +20,12 @@
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif				// HAVE_CONFIG_H
+#endif  // HAVE_CONFIG_H
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <sys/types.h>
 #include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
 
 // SC_CLEANUP will run the given cleanup function when the variable next
 // to it goes out of scope.
@@ -68,7 +68,7 @@ void sc_cleanup_shallow_strv(const char ***ptr);
  * The variable MUST be initialized for correct operation.
  * The safe initialisation value is NULL.
  **/
-void sc_cleanup_file(FILE ** ptr);
+void sc_cleanup_file(FILE **ptr);
 
 /**
  * Close an open file with endmntent(3)
@@ -77,7 +77,7 @@ void sc_cleanup_file(FILE ** ptr);
  * The variable MUST be initialized for correct operation.
  * The safe initialisation value is NULL.
  **/
-void sc_cleanup_endmntent(FILE ** ptr);
+void sc_cleanup_endmntent(FILE **ptr);
 
 /**
  * Close an open directory with closedir(3)
@@ -86,7 +86,7 @@ void sc_cleanup_endmntent(FILE ** ptr);
  * The variable MUST be initialized for correct operation.
  * The safe initialisation value is NULL.
  **/
-void sc_cleanup_closedir(DIR ** ptr);
+void sc_cleanup_closedir(DIR **ptr);
 
 /**
  * Close an open file descriptor with close(2)

--- a/cmd/libsnap-confine-private/error-test.c
+++ b/cmd/libsnap-confine-private/error-test.c
@@ -21,272 +21,238 @@
 #include <errno.h>
 #include <glib.h>
 
-static void test_sc_error_init(void)
-{
-	struct sc_error *err;
-	// Create an error
-	err = sc_error_init("domain", 42, "printer is on %s", "fire");
-	g_assert_nonnull(err);
-	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+static void test_sc_error_init(void) {
+    struct sc_error *err;
+    // Create an error
+    err = sc_error_init("domain", 42, "printer is on %s", "fire");
+    g_assert_nonnull(err);
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
 
-	// Inspect the exposed attributes
-	g_assert_cmpstr(sc_error_domain(err), ==, "domain");
-	g_assert_cmpint(sc_error_code(err), ==, 42);
-	g_assert_cmpstr(sc_error_msg(err), ==, "printer is on fire");
+    // Inspect the exposed attributes
+    g_assert_cmpstr(sc_error_domain(err), ==, "domain");
+    g_assert_cmpint(sc_error_code(err), ==, 42);
+    g_assert_cmpstr(sc_error_msg(err), ==, "printer is on fire");
 }
 
-static void test_sc_error_init_from_errno(void)
-{
-	struct sc_error *err;
-	// Create an error
-	err = sc_error_init_from_errno(ENOENT, "printer is on %s", "fire");
-	g_assert_nonnull(err);
-	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+static void test_sc_error_init_from_errno(void) {
+    struct sc_error *err;
+    // Create an error
+    err = sc_error_init_from_errno(ENOENT, "printer is on %s", "fire");
+    g_assert_nonnull(err);
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
 
-	// Inspect the exposed attributes
-	g_assert_cmpstr(sc_error_domain(err), ==, SC_ERRNO_DOMAIN);
-	g_assert_cmpint(sc_error_code(err), ==, ENOENT);
-	g_assert_cmpstr(sc_error_msg(err), ==, "printer is on fire");
+    // Inspect the exposed attributes
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_ERRNO_DOMAIN);
+    g_assert_cmpint(sc_error_code(err), ==, ENOENT);
+    g_assert_cmpstr(sc_error_msg(err), ==, "printer is on fire");
 }
 
-static void test_sc_error_init_simple(void)
-{
-	struct sc_error *err;
-	// Create an error
-	err = sc_error_init_simple("hello %s", "errors");
-	g_assert_nonnull(err);
-	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+static void test_sc_error_init_simple(void) {
+    struct sc_error *err;
+    // Create an error
+    err = sc_error_init_simple("hello %s", "errors");
+    g_assert_nonnull(err);
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
 
-	// Inspect the exposed attributes
-	g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
-	g_assert_cmpint(sc_error_code(err), ==, 0);
-	g_assert_cmpstr(sc_error_msg(err), ==, "hello errors");
+    // Inspect the exposed attributes
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
+    g_assert_cmpint(sc_error_code(err), ==, 0);
+    g_assert_cmpstr(sc_error_msg(err), ==, "hello errors");
 }
 
-static void test_sc_error_init_api_misuse(void)
-{
-	struct sc_error *err;
-	// Create an error
-	err = sc_error_init_api_misuse("foo cannot be %d", 42);
-	g_assert_nonnull(err);
-	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+static void test_sc_error_init_api_misuse(void) {
+    struct sc_error *err;
+    // Create an error
+    err = sc_error_init_api_misuse("foo cannot be %d", 42);
+    g_assert_nonnull(err);
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
 
-	// Inspect the exposed attributes
-	g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
-	g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
-	g_assert_cmpstr(sc_error_msg(err), ==, "foo cannot be 42");
+    // Inspect the exposed attributes
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
+    g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
+    g_assert_cmpstr(sc_error_msg(err), ==, "foo cannot be 42");
 }
 
-static void test_sc_error_cleanup(void)
-{
-	// Check that sc_error_cleanup() is safe to use.
+static void test_sc_error_cleanup(void) {
+    // Check that sc_error_cleanup() is safe to use.
 
-	// Cleanup is safe on NULL errors.
-	struct sc_error *err = NULL;
-	sc_cleanup_error(&err);
+    // Cleanup is safe on NULL errors.
+    struct sc_error *err = NULL;
+    sc_cleanup_error(&err);
 
-	// Cleanup is safe on non-NULL errors.
-	err = sc_error_init("domain", 123, "msg");
-	g_assert_nonnull(err);
-	sc_cleanup_error(&err);
-	g_assert_null(err);
+    // Cleanup is safe on non-NULL errors.
+    err = sc_error_init("domain", 123, "msg");
+    g_assert_nonnull(err);
+    sc_cleanup_error(&err);
+    g_assert_null(err);
 }
 
-static void test_sc_error_domain__NULL(void)
-{
-	// Check that sc_error_domain() dies if called with NULL error.
-	if (g_test_subprocess()) {
-		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
-		struct sc_error *err = NULL;
-		const char *domain = sc_error_domain(err);
-		(void)(domain);
-		g_test_message("expected not to reach this place");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot obtain error domain from NULL error\n");
+static void test_sc_error_domain__NULL(void) {
+    // Check that sc_error_domain() dies if called with NULL error.
+    if (g_test_subprocess()) {
+        // NOTE: the code below fools gcc 5.4 but your mileage may vary.
+        struct sc_error *err = NULL;
+        const char *domain = sc_error_domain(err);
+        (void)(domain);
+        g_test_message("expected not to reach this place");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot obtain error domain from NULL error\n");
 }
 
-static void test_sc_error_code__NULL(void)
-{
-	// Check that sc_error_code() dies if called with NULL error.
-	if (g_test_subprocess()) {
-		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
-		struct sc_error *err = NULL;
-		int code = sc_error_code(err);
-		(void)(code);
-		g_test_message("expected not to reach this place");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot obtain error code from NULL error\n");
+static void test_sc_error_code__NULL(void) {
+    // Check that sc_error_code() dies if called with NULL error.
+    if (g_test_subprocess()) {
+        // NOTE: the code below fools gcc 5.4 but your mileage may vary.
+        struct sc_error *err = NULL;
+        int code = sc_error_code(err);
+        (void)(code);
+        g_test_message("expected not to reach this place");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot obtain error code from NULL error\n");
 }
 
-static void test_sc_error_msg__NULL(void)
-{
-	// Check that sc_error_msg() dies if called with NULL error.
-	if (g_test_subprocess()) {
-		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
-		struct sc_error *err = NULL;
-		const char *msg = sc_error_msg(err);
-		(void)(msg);
-		g_test_message("expected not to reach this place");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot obtain error message from NULL error\n");
+static void test_sc_error_msg__NULL(void) {
+    // Check that sc_error_msg() dies if called with NULL error.
+    if (g_test_subprocess()) {
+        // NOTE: the code below fools gcc 5.4 but your mileage may vary.
+        struct sc_error *err = NULL;
+        const char *msg = sc_error_msg(err);
+        (void)(msg);
+        g_test_message("expected not to reach this place");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot obtain error message from NULL error\n");
 }
 
-static void test_sc_die_on_error__NULL(void)
-{
-	// Check that sc_die_on_error() does nothing if called with NULL error.
-	if (g_test_subprocess()) {
-		sc_die_on_error(NULL);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_passed();
+static void test_sc_die_on_error__NULL(void) {
+    // Check that sc_die_on_error() does nothing if called with NULL error.
+    if (g_test_subprocess()) {
+        sc_die_on_error(NULL);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_passed();
 }
 
-static void test_sc_die_on_error__regular(void)
-{
-	// Check that sc_die_on_error() dies if called with an error.
-	if (g_test_subprocess()) {
-		struct sc_error *err =
-		    sc_error_init("domain", 42, "just testing");
-		sc_die_on_error(err);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("just testing\n");
+static void test_sc_die_on_error__regular(void) {
+    // Check that sc_die_on_error() dies if called with an error.
+    if (g_test_subprocess()) {
+        struct sc_error *err = sc_error_init("domain", 42, "just testing");
+        sc_die_on_error(err);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("just testing\n");
 }
 
-static void test_sc_die_on_error__errno(void)
-{
-	// Check that sc_die_on_error() dies if called with an errno-based error.
-	if (g_test_subprocess()) {
-		struct sc_error *err =
-		    sc_error_init_from_errno(ENOENT, "just testing");
-		sc_die_on_error(err);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("just testing: No such file or directory\n");
+static void test_sc_die_on_error__errno(void) {
+    // Check that sc_die_on_error() dies if called with an errno-based error.
+    if (g_test_subprocess()) {
+        struct sc_error *err = sc_error_init_from_errno(ENOENT, "just testing");
+        sc_die_on_error(err);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("just testing: No such file or directory\n");
 }
 
-static void test_sc_error_forward__nothing(void)
-{
-	// Check that forwarding NULL does exactly that.
-	struct sc_error *recipient = (void *)0xDEADBEEF;
-	struct sc_error *err = NULL;
-	int rc;
-	rc = sc_error_forward(&recipient, err);
-	g_assert_null(recipient);
-	g_assert_cmpint(rc, ==, 0);
+static void test_sc_error_forward__nothing(void) {
+    // Check that forwarding NULL does exactly that.
+    struct sc_error *recipient = (void *)0xDEADBEEF;
+    struct sc_error *err = NULL;
+    int rc;
+    rc = sc_error_forward(&recipient, err);
+    g_assert_null(recipient);
+    g_assert_cmpint(rc, ==, 0);
 }
 
-static void test_sc_error_forward__something_somewhere(void)
-{
-	// Check that forwarding a real error works OK.
-	struct sc_error *recipient = NULL;
-	struct sc_error *err = sc_error_init("domain", 42, "just testing");
-	int rc;
-	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
-	g_assert_nonnull(err);
-	rc = sc_error_forward(&recipient, err);
-	g_assert_nonnull(recipient);
-	g_assert_cmpint(rc, ==, -1);
+static void test_sc_error_forward__something_somewhere(void) {
+    // Check that forwarding a real error works OK.
+    struct sc_error *recipient = NULL;
+    struct sc_error *err = sc_error_init("domain", 42, "just testing");
+    int rc;
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
+    g_assert_nonnull(err);
+    rc = sc_error_forward(&recipient, err);
+    g_assert_nonnull(recipient);
+    g_assert_cmpint(rc, ==, -1);
 }
 
-static void test_sc_error_forward__something_nowhere(void)
-{
-	// Check that forwarding a real error nowhere calls die()
-	if (g_test_subprocess()) {
-		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
-		struct sc_error **err_ptr = NULL;
-		struct sc_error *err =
-		    sc_error_init("domain", 42, "just testing");
-		g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
-		g_assert_nonnull(err);
-		sc_error_forward(err_ptr, err);
-		g_test_message("expected not to reach this place");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("just testing\n");
+static void test_sc_error_forward__something_nowhere(void) {
+    // Check that forwarding a real error nowhere calls die()
+    if (g_test_subprocess()) {
+        // NOTE: the code below fools gcc 5.4 but your mileage may vary.
+        struct sc_error **err_ptr = NULL;
+        struct sc_error *err = sc_error_init("domain", 42, "just testing");
+        g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
+        g_assert_nonnull(err);
+        sc_error_forward(err_ptr, err);
+        g_test_message("expected not to reach this place");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("just testing\n");
 }
 
-static void test_sc_error_match__typical(void)
-{
-	// NULL error doesn't match anything.
-	g_assert_false(sc_error_match(NULL, "domain", 42));
+static void test_sc_error_match__typical(void) {
+    // NULL error doesn't match anything.
+    g_assert_false(sc_error_match(NULL, "domain", 42));
 
-	// Non-NULL error matches if domain and code both match.
-	struct sc_error *err = sc_error_init("domain", 42, "just testing");
-	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
-	g_assert_true(sc_error_match(err, "domain", 42));
-	g_assert_false(sc_error_match(err, "domain", 1));
-	g_assert_false(sc_error_match(err, "other-domain", 42));
-	g_assert_false(sc_error_match(err, "other-domain", 1));
+    // Non-NULL error matches if domain and code both match.
+    struct sc_error *err = sc_error_init("domain", 42, "just testing");
+    g_test_queue_destroy((GDestroyNotify)sc_error_free, err);
+    g_assert_true(sc_error_match(err, "domain", 42));
+    g_assert_false(sc_error_match(err, "domain", 1));
+    g_assert_false(sc_error_match(err, "other-domain", 42));
+    g_assert_false(sc_error_match(err, "other-domain", 1));
 }
 
-static void test_sc_error_match__NULL_domain(void)
-{
-	// Using a NULL domain is a fatal bug.
-	if (g_test_subprocess()) {
-		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
-		struct sc_error *err = NULL;
-		const char *domain = NULL;
-		g_assert_false(sc_error_match(err, domain, 42));
-		g_test_message("expected not to reach this place");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot match error to a NULL domain\n");
+static void test_sc_error_match__NULL_domain(void) {
+    // Using a NULL domain is a fatal bug.
+    if (g_test_subprocess()) {
+        // NOTE: the code below fools gcc 5.4 but your mileage may vary.
+        struct sc_error *err = NULL;
+        const char *domain = NULL;
+        g_assert_false(sc_error_match(err, domain, 42));
+        g_test_message("expected not to reach this place");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot match error to a NULL domain\n");
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/error/sc_error_init", test_sc_error_init);
-	g_test_add_func("/error/sc_error_init_from_errno",
-			test_sc_error_init_from_errno);
-	g_test_add_func("/error/sc_error_init_simple",
-			test_sc_error_init_simple);
-	g_test_add_func("/error/sc_error_init_api_misue",
-			test_sc_error_init_api_misuse);
-	g_test_add_func("/error/sc_error_cleanup", test_sc_error_cleanup);
-	g_test_add_func("/error/sc_error_domain/NULL",
-			test_sc_error_domain__NULL);
-	g_test_add_func("/error/sc_error_code/NULL", test_sc_error_code__NULL);
-	g_test_add_func("/error/sc_error_msg/NULL", test_sc_error_msg__NULL);
-	g_test_add_func("/error/sc_die_on_error/NULL",
-			test_sc_die_on_error__NULL);
-	g_test_add_func("/error/sc_die_on_error/regular",
-			test_sc_die_on_error__regular);
-	g_test_add_func("/error/sc_die_on_error/errno",
-			test_sc_die_on_error__errno);
-	g_test_add_func("/error/sc_error_formward/nothing",
-			test_sc_error_forward__nothing);
-	g_test_add_func("/error/sc_error_formward/something_somewhere",
-			test_sc_error_forward__something_somewhere);
-	g_test_add_func("/error/sc_error_formward/something_nowhere",
-			test_sc_error_forward__something_nowhere);
-	g_test_add_func("/error/sc_error_match/typical",
-			test_sc_error_match__typical);
-	g_test_add_func("/error/sc_error_match/NULL_domain",
-			test_sc_error_match__NULL_domain);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/error/sc_error_init", test_sc_error_init);
+    g_test_add_func("/error/sc_error_init_from_errno", test_sc_error_init_from_errno);
+    g_test_add_func("/error/sc_error_init_simple", test_sc_error_init_simple);
+    g_test_add_func("/error/sc_error_init_api_misue", test_sc_error_init_api_misuse);
+    g_test_add_func("/error/sc_error_cleanup", test_sc_error_cleanup);
+    g_test_add_func("/error/sc_error_domain/NULL", test_sc_error_domain__NULL);
+    g_test_add_func("/error/sc_error_code/NULL", test_sc_error_code__NULL);
+    g_test_add_func("/error/sc_error_msg/NULL", test_sc_error_msg__NULL);
+    g_test_add_func("/error/sc_die_on_error/NULL", test_sc_die_on_error__NULL);
+    g_test_add_func("/error/sc_die_on_error/regular", test_sc_die_on_error__regular);
+    g_test_add_func("/error/sc_die_on_error/errno", test_sc_die_on_error__errno);
+    g_test_add_func("/error/sc_error_formward/nothing", test_sc_error_forward__nothing);
+    g_test_add_func("/error/sc_error_formward/something_somewhere", test_sc_error_forward__something_somewhere);
+    g_test_add_func("/error/sc_error_formward/something_nowhere", test_sc_error_forward__something_nowhere);
+    g_test_add_func("/error/sc_error_match/typical", test_sc_error_match__typical);
+    g_test_add_func("/error/sc_error_match/NULL_domain", test_sc_error_match__NULL_domain);
 }

--- a/cmd/libsnap-confine-private/error.c
+++ b/cmd/libsnap-confine-private/error.c
@@ -26,140 +26,122 @@
 #include <stdio.h>
 #include <string.h>
 
-static sc_error *sc_error_initv(const char *domain, int code,
-				const char *msgfmt, va_list ap)
-{
-	// Set errno in case we die.
-	errno = 0;
-	sc_error *err = calloc(1, sizeof *err);
-	if (err == NULL) {
-		die("cannot allocate memory for error object");
-	}
-	err->domain = domain;
-	err->code = code;
-	if (vasprintf(&err->msg, msgfmt, ap) == -1) {
-		die("cannot format error message");
-	}
-	return err;
+static sc_error *sc_error_initv(const char *domain, int code, const char *msgfmt, va_list ap) {
+    // Set errno in case we die.
+    errno = 0;
+    sc_error *err = calloc(1, sizeof *err);
+    if (err == NULL) {
+        die("cannot allocate memory for error object");
+    }
+    err->domain = domain;
+    err->code = code;
+    if (vasprintf(&err->msg, msgfmt, ap) == -1) {
+        die("cannot format error message");
+    }
+    return err;
 }
 
-sc_error *sc_error_init(const char *domain, int code, const char *msgfmt, ...)
-{
-	va_list ap;
-	va_start(ap, msgfmt);
-	sc_error *err = sc_error_initv(domain, code, msgfmt, ap);
-	va_end(ap);
-	return err;
+sc_error *sc_error_init(const char *domain, int code, const char *msgfmt, ...) {
+    va_list ap;
+    va_start(ap, msgfmt);
+    sc_error *err = sc_error_initv(domain, code, msgfmt, ap);
+    va_end(ap);
+    return err;
 }
 
-sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt, ...)
-{
-	va_list ap;
-	va_start(ap, msgfmt);
-	sc_error *err = sc_error_initv(SC_ERRNO_DOMAIN, errno_copy, msgfmt, ap);
-	va_end(ap);
-	return err;
+sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt, ...) {
+    va_list ap;
+    va_start(ap, msgfmt);
+    sc_error *err = sc_error_initv(SC_ERRNO_DOMAIN, errno_copy, msgfmt, ap);
+    va_end(ap);
+    return err;
 }
 
-sc_error *sc_error_init_simple(const char *msgfmt, ...)
-{
-	va_list ap;
-	va_start(ap, msgfmt);
-	sc_error *err = sc_error_initv(SC_LIBSNAP_DOMAIN,
-				       SC_UNSPECIFIED_ERROR, msgfmt, ap);
-	va_end(ap);
-	return err;
+sc_error *sc_error_init_simple(const char *msgfmt, ...) {
+    va_list ap;
+    va_start(ap, msgfmt);
+    sc_error *err = sc_error_initv(SC_LIBSNAP_DOMAIN, SC_UNSPECIFIED_ERROR, msgfmt, ap);
+    va_end(ap);
+    return err;
 }
 
-sc_error *sc_error_init_api_misuse(const char *msgfmt, ...)
-{
-	va_list ap;
-	va_start(ap, msgfmt);
-	sc_error *err = sc_error_initv(SC_LIBSNAP_DOMAIN,
-				       SC_API_MISUSE, msgfmt, ap);
-	va_end(ap);
-	return err;
+sc_error *sc_error_init_api_misuse(const char *msgfmt, ...) {
+    va_list ap;
+    va_start(ap, msgfmt);
+    sc_error *err = sc_error_initv(SC_LIBSNAP_DOMAIN, SC_API_MISUSE, msgfmt, ap);
+    va_end(ap);
+    return err;
 }
 
-const char *sc_error_domain(sc_error *err)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (err == NULL) {
-		die("cannot obtain error domain from NULL error");
-	}
-	return err->domain;
+const char *sc_error_domain(sc_error *err) {
+    // Set errno in case we die.
+    errno = 0;
+    if (err == NULL) {
+        die("cannot obtain error domain from NULL error");
+    }
+    return err->domain;
 }
 
-int sc_error_code(sc_error *err)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (err == NULL) {
-		die("cannot obtain error code from NULL error");
-	}
-	return err->code;
+int sc_error_code(sc_error *err) {
+    // Set errno in case we die.
+    errno = 0;
+    if (err == NULL) {
+        die("cannot obtain error code from NULL error");
+    }
+    return err->code;
 }
 
-const char *sc_error_msg(sc_error *err)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (err == NULL) {
-		die("cannot obtain error message from NULL error");
-	}
-	return err->msg;
+const char *sc_error_msg(sc_error *err) {
+    // Set errno in case we die.
+    errno = 0;
+    if (err == NULL) {
+        die("cannot obtain error message from NULL error");
+    }
+    return err->msg;
 }
 
-void sc_error_free(sc_error *err)
-{
-	if (err != NULL) {
-		free(err->msg);
-		err->msg = NULL;
-		free(err);
-	}
+void sc_error_free(sc_error *err) {
+    if (err != NULL) {
+        free(err->msg);
+        err->msg = NULL;
+        free(err);
+    }
 }
 
-void sc_cleanup_error(sc_error **ptr)
-{
-	sc_error_free(*ptr);
-	*ptr = NULL;
+void sc_cleanup_error(sc_error **ptr) {
+    sc_error_free(*ptr);
+    *ptr = NULL;
 }
 
-void sc_die_on_error(sc_error *error)
-{
-	if (error != NULL) {
-		if (strcmp(sc_error_domain(error), SC_ERRNO_DOMAIN) == 0) {
-			fprintf(stderr, "%s: %s\n", sc_error_msg(error),
-				strerror(sc_error_code(error)));
-		} else {
-			fprintf(stderr, "%s\n", sc_error_msg(error));
-		}
-		sc_error_free(error);
-		exit(1);
-	}
+void sc_die_on_error(sc_error *error) {
+    if (error != NULL) {
+        if (strcmp(sc_error_domain(error), SC_ERRNO_DOMAIN) == 0) {
+            fprintf(stderr, "%s: %s\n", sc_error_msg(error), strerror(sc_error_code(error)));
+        } else {
+            fprintf(stderr, "%s\n", sc_error_msg(error));
+        }
+        sc_error_free(error);
+        exit(1);
+    }
 }
 
-int sc_error_forward(sc_error **recipient, sc_error *error)
-{
-	if (recipient != NULL) {
-		*recipient = error;
-	} else {
-		sc_die_on_error(error);
-	}
-	return error != NULL ? -1 : 0;
+int sc_error_forward(sc_error **recipient, sc_error *error) {
+    if (recipient != NULL) {
+        *recipient = error;
+    } else {
+        sc_die_on_error(error);
+    }
+    return error != NULL ? -1 : 0;
 }
 
-bool sc_error_match(sc_error *error, const char *domain, int code)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (domain == NULL) {
-		die("cannot match error to a NULL domain");
-	}
-	if (error == NULL) {
-		return false;
-	}
-	return strcmp(sc_error_domain(error), domain) == 0
-	    && sc_error_code(error) == code;
+bool sc_error_match(sc_error *error, const char *domain, int code) {
+    // Set errno in case we die.
+    errno = 0;
+    if (domain == NULL) {
+        die("cannot match error to a NULL domain");
+    }
+    if (error == NULL) {
+        return false;
+    }
+    return strcmp(sc_error_domain(error), domain) == 0 && sc_error_code(error) == code;
 }

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -46,13 +46,13 @@
  * Error structure.
  **/
 typedef struct sc_error {
-	// Error domain defines a scope for particular error codes.
-	const char *domain;
-	// Code differentiates particular errors for the programmer.
-	// The code may be zero if the particular meaning is not relevant.
-	int code;
-	// Message carries a formatted description of the problem.
-	char *msg;
+    // Error domain defines a scope for particular error codes.
+    const char *domain;
+    // Code differentiates particular errors for the programmer.
+    // The code may be zero if the particular meaning is not relevant.
+    int code;
+    // Message carries a formatted description of the problem.
+    char *msg;
 } sc_error;
 
 /**
@@ -67,12 +67,12 @@ typedef struct sc_error {
 
 /** sc_libsnap_error represents distinct error codes used by libsnap-confine-private library. */
 typedef enum sc_libsnap_error {
-	/** SC_UNSPECIFIED_ERROR indicates an error not worthy of a distinct code. */
-	SC_UNSPECIFIED_ERROR = 0,
-	/** SC_API_MISUSE indicates that public API was called incorrectly. */
-	SC_API_MISUSE,
-	/** SC_BUG indicates that private API was called incorrectly. */
-	SC_BUG,
+    /** SC_UNSPECIFIED_ERROR indicates an error not worthy of a distinct code. */
+    SC_UNSPECIFIED_ERROR = 0,
+    /** SC_API_MISUSE indicates that public API was called incorrectly. */
+    SC_API_MISUSE,
+    /** SC_BUG indicates that private API was called incorrectly. */
+    SC_BUG,
 } sc_libsnap_error;
 
 /**
@@ -85,9 +85,8 @@ typedef enum sc_libsnap_error {
  *
  * This function calls die() in case of memory allocation failure.
  **/
-__attribute__((warn_unused_result,
-	       format(printf, 3, 4) SC_APPEND_RETURNS_NONNULL))
-sc_error *sc_error_init(const char *domain, int code, const char *msgfmt, ...);
+__attribute__((warn_unused_result, format(printf, 3, 4) SC_APPEND_RETURNS_NONNULL)) sc_error *sc_error_init(
+    const char *domain, int code, const char *msgfmt, ...);
 
 /**
  * Initialize an unspecified error with formatted message.
@@ -95,9 +94,8 @@ sc_error *sc_error_init(const char *domain, int code, const char *msgfmt, ...);
  * This is just syntactic sugar for sc_error_init(SC_LIBSNAP_ERROR,
  * SC_UNSPECIFIED_ERROR, msgfmt, ...) which is repeated often.
  **/
-__attribute__((warn_unused_result,
-	       format(printf, 1, 2) SC_APPEND_RETURNS_NONNULL))
-sc_error *sc_error_init_simple(const char *msgfmt, ...);
+__attribute__((warn_unused_result, format(printf, 1, 2) SC_APPEND_RETURNS_NONNULL)) sc_error *sc_error_init_simple(
+    const char *msgfmt, ...);
 
 /**
  * Initialize an API misuse error with formatted message.
@@ -105,9 +103,8 @@ sc_error *sc_error_init_simple(const char *msgfmt, ...);
  * This is just syntactic sugar for sc_error_init(SC_LIBSNAP_DOMAIN,
  * SC_API_MISUSE, msgfmt, ...) which is repeated often.
  **/
-__attribute__((warn_unused_result,
-	       format(printf, 1, 2) SC_APPEND_RETURNS_NONNULL))
-sc_error *sc_error_init_api_misuse(const char *msgfmt, ...);
+__attribute__((warn_unused_result, format(printf, 1, 2) SC_APPEND_RETURNS_NONNULL)) sc_error *sc_error_init_api_misuse(
+    const char *msgfmt, ...);
 
 /**
  * Initialize an errno-based error.
@@ -117,9 +114,8 @@ sc_error *sc_error_init_api_misuse(const char *msgfmt, ...);
  *
  * This function calls die() in case of memory allocation failure.
  **/
-__attribute__((warn_unused_result,
-	       format(printf, 2, 3) SC_APPEND_RETURNS_NONNULL))
-sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt, ...);
+__attribute__((warn_unused_result, format(printf, 2, 3) SC_APPEND_RETURNS_NONNULL)) sc_error *sc_error_init_from_errno(
+    int errno_copy, const char *msgfmt, ...);
 
 /**
  * Get the error domain out of an error object.
@@ -127,8 +123,7 @@ sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt, ...);
  * The error domain acts as a namespace for error codes.
  * No change of ownership takes place.
  **/
-__attribute__((warn_unused_result SC_APPEND_RETURNS_NONNULL))
-const char *sc_error_domain(sc_error *err);
+__attribute__((warn_unused_result SC_APPEND_RETURNS_NONNULL)) const char *sc_error_domain(sc_error *err);
 
 /**
  * Get the error code out of an error object.
@@ -140,8 +135,7 @@ const char *sc_error_domain(sc_error *err);
  * can rely on programmatically. This can be used to return an error message
  * without having to allocate a distinct code for each one.
  **/
-__attribute__((warn_unused_result))
-int sc_error_code(sc_error *err);
+__attribute__((warn_unused_result)) int sc_error_code(sc_error *err);
 
 /**
  * Get the error message out of an error object.
@@ -149,8 +143,7 @@ int sc_error_code(sc_error *err);
  * The error message is bound to the life-cycle of the error object.
  * No change of ownership takes place.
  **/
-__attribute__((warn_unused_result SC_APPEND_RETURNS_NONNULL))
-const char *sc_error_msg(sc_error *err);
+__attribute__((warn_unused_result SC_APPEND_RETURNS_NONNULL)) const char *sc_error_msg(sc_error *err);
 
 /**
  * Free an error object.
@@ -165,8 +158,7 @@ void sc_error_free(sc_error *error);
  * This function is designed to be used with
  * __attribute__((cleanup(sc_cleanup_error))).
  **/
-__attribute__((nonnull))
-void sc_cleanup_error(sc_error **ptr);
+__attribute__((nonnull)) void sc_cleanup_error(sc_error **ptr);
 
 /**
  *
@@ -202,7 +194,6 @@ int sc_error_forward(sc_error **recipient, sc_error *error);
  * It is okay to match a NULL error, the function simply returns false in that
  * case. The domain cannot be NULL though.
  **/
-__attribute__((warn_unused_result))
-bool sc_error_match(sc_error *error, const char *domain, int code);
+__attribute__((warn_unused_result)) bool sc_error_match(sc_error *error, const char *domain, int code);
 
 #endif

--- a/cmd/libsnap-confine-private/fault-injection-test.c
+++ b/cmd/libsnap-confine-private/fault-injection-test.c
@@ -21,43 +21,35 @@
 #include <errno.h>
 #include <glib.h>
 
-static bool broken(struct sc_fault_state *state, void *ptr)
-{
-	return true;
+static bool broken(struct sc_fault_state *state, void *ptr) { return true; }
+
+static bool broken_alter_msg(struct sc_fault_state *state, void *ptr) {
+    char **s = ptr;
+    *s = "broken";
+    return true;
 }
 
-static bool broken_alter_msg(struct sc_fault_state *state, void *ptr)
-{
-	char **s = ptr;
-	*s = "broken";
-	return true;
+static void test_fault_injection(void) {
+    g_assert_false(sc_faulty("foo", NULL));
+
+    sc_break("foo", broken);
+    g_assert_true(sc_faulty("foo", NULL));
+
+    sc_reset_faults();
+    g_assert_false(sc_faulty("foo", NULL));
+
+    const char *msg = NULL;
+    if (!sc_faulty("foo", &msg)) {
+        msg = "working";
+    }
+    g_assert_cmpstr(msg, ==, "working");
+
+    sc_break("foo", broken_alter_msg);
+    if (!sc_faulty("foo", &msg)) {
+        msg = "working";
+    }
+    g_assert_cmpstr(msg, ==, "broken");
+    sc_reset_faults();
 }
 
-static void test_fault_injection(void)
-{
-	g_assert_false(sc_faulty("foo", NULL));
-
-	sc_break("foo", broken);
-	g_assert_true(sc_faulty("foo", NULL));
-
-	sc_reset_faults();
-	g_assert_false(sc_faulty("foo", NULL));
-
-	const char *msg = NULL;
-	if (!sc_faulty("foo", &msg)) {
-		msg = "working";
-	}
-	g_assert_cmpstr(msg, ==, "working");
-
-	sc_break("foo", broken_alter_msg);
-	if (!sc_faulty("foo", &msg)) {
-		msg = "working";
-	}
-	g_assert_cmpstr(msg, ==, "broken");
-	sc_reset_faults();
-}
-
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/fault-injection", test_fault_injection);
-}
+static void __attribute__((constructor)) init(void) { g_test_add_func("/fault-injection", test_fault_injection); }

--- a/cmd/libsnap-confine-private/fault-injection.c
+++ b/cmd/libsnap-confine-private/fault-injection.c
@@ -23,56 +23,48 @@
 #include <string.h>
 
 struct sc_fault {
-	const char *name;
-	struct sc_fault *next;
-	sc_fault_fn fn;
-	struct sc_fault_state state;
+    const char *name;
+    struct sc_fault *next;
+    sc_fault_fn fn;
+    struct sc_fault_state state;
 };
 
 static struct sc_fault *sc_faults = NULL;
 
-bool sc_faulty(const char *name, void *ptr)
-{
-	for (struct sc_fault * fault = sc_faults; fault != NULL;
-	     fault = fault->next) {
-		if (strcmp(name, fault->name) == 0) {
-			bool is_faulty = fault->fn(&fault->state, ptr);
-			fault->state.ncalls++;
-			return is_faulty;
-		}
-	}
-	return false;
+bool sc_faulty(const char *name, void *ptr) {
+    for (struct sc_fault *fault = sc_faults; fault != NULL; fault = fault->next) {
+        if (strcmp(name, fault->name) == 0) {
+            bool is_faulty = fault->fn(&fault->state, ptr);
+            fault->state.ncalls++;
+            return is_faulty;
+        }
+    }
+    return false;
 }
 
-void sc_break(const char *name, sc_fault_fn fn)
-{
-	struct sc_fault *fault = calloc(1, sizeof *fault);
-	if (fault == NULL) {
-		abort();
-	}
-	fault->name = name;
-	fault->next = sc_faults;
-	fault->fn = fn;
-	fault->state.ncalls = 0;
-	sc_faults = fault;
+void sc_break(const char *name, sc_fault_fn fn) {
+    struct sc_fault *fault = calloc(1, sizeof *fault);
+    if (fault == NULL) {
+        abort();
+    }
+    fault->name = name;
+    fault->next = sc_faults;
+    fault->fn = fn;
+    fault->state.ncalls = 0;
+    sc_faults = fault;
 }
 
-void sc_reset_faults(void)
-{
-	struct sc_fault *next_fault;
-	for (struct sc_fault * fault = sc_faults; fault != NULL;
-	     fault = next_fault) {
-		next_fault = fault->next;
-		free(fault);
-	}
-	sc_faults = NULL;
+void sc_reset_faults(void) {
+    struct sc_fault *next_fault;
+    for (struct sc_fault *fault = sc_faults; fault != NULL; fault = next_fault) {
+        next_fault = fault->next;
+        free(fault);
+    }
+    sc_faults = NULL;
 }
 
-#else				// ifndef _ENABLE_FAULT_INJECTION
+#else  // ifndef _ENABLE_FAULT_INJECTION
 
-bool sc_faulty(const char *name, void *ptr)
-{
-	return false;
-}
+bool sc_faulty(const char *name, void *ptr) { return false; }
 
-#endif				// ifndef _ENABLE_FAULT_INJECTION
+#endif  // ifndef _ENABLE_FAULT_INJECTION

--- a/cmd/libsnap-confine-private/fault-injection.h
+++ b/cmd/libsnap-confine-private/fault-injection.h
@@ -37,10 +37,10 @@ bool sc_faulty(const char *name, void *ptr);
 
 struct sc_fault_state;
 
-typedef bool (*sc_fault_fn)(struct sc_fault_state * state, void *ptr);
+typedef bool (*sc_fault_fn)(struct sc_fault_state *state, void *ptr);
 
 struct sc_fault_state {
-	int ncalls;
+    int ncalls;
 };
 
 /**
@@ -62,6 +62,6 @@ void sc_break(const char *name, sc_fault_fn fn);
  **/
 void sc_reset_faults(void);
 
-#endif				// ifndef _ENABLE_FAULT_INJECTION
+#endif  // ifndef _ENABLE_FAULT_INJECTION
 
 #endif

--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -25,94 +25,77 @@
 #include "string-utils.h"
 #include "test-utils.h"
 
-static char *sc_testdir(void)
-{
-	char *d = g_dir_make_tmp(NULL, NULL);
-	g_assert_nonnull(d);
-	g_test_queue_free(d);
-	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp, d);
-	return d;
+static char *sc_testdir(void) {
+    char *d = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(d);
+    g_test_queue_free(d);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, d);
+    return d;
 }
 
 // Set the feature flag directory to given value, useful for cleanup handlers.
-static void set_feature_flag_dir(const char *dir)
-{
-	feature_flag_dir = dir;
-}
+static void set_feature_flag_dir(const char *dir) { feature_flag_dir = dir; }
 
 // Mock the location of the feature flag directory.
-static void sc_mock_feature_flag_dir(const char *d)
-{
-	g_test_queue_destroy((GDestroyNotify) set_feature_flag_dir,
-			     (void *)feature_flag_dir);
-	set_feature_flag_dir(d);
+static void sc_mock_feature_flag_dir(const char *d) {
+    g_test_queue_destroy((GDestroyNotify)set_feature_flag_dir, (void *)feature_flag_dir);
+    set_feature_flag_dir(d);
 }
 
-static void test_feature_enabled__missing_dir(void)
-{
-	const char *d = sc_testdir();
-	char subd[PATH_MAX];
-	sc_must_snprintf(subd, sizeof subd, "%s/absent", d);
-	sc_mock_feature_flag_dir(subd);
-	g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+static void test_feature_enabled__missing_dir(void) {
+    const char *d = sc_testdir();
+    char subd[PATH_MAX];
+    sc_must_snprintf(subd, sizeof subd, "%s/absent", d);
+    sc_mock_feature_flag_dir(subd);
+    g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
-static void test_feature_enabled__missing_file(void)
-{
-	const char *d = sc_testdir();
-	sc_mock_feature_flag_dir(d);
-	g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+static void test_feature_enabled__missing_file(void) {
+    const char *d = sc_testdir();
+    sc_mock_feature_flag_dir(d);
+    g_assert_false(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
-static void test_feature_enabled__present_file(void)
-{
-	const char *d = sc_testdir();
-	sc_mock_feature_flag_dir(d);
-	char pname[PATH_MAX];
-	sc_must_snprintf(pname, sizeof pname, "%s/per-user-mount-namespace", d);
-	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
+static void test_feature_enabled__present_file(void) {
+    const char *d = sc_testdir();
+    sc_mock_feature_flag_dir(d);
+    char pname[PATH_MAX];
+    sc_must_snprintf(pname, sizeof pname, "%s/per-user-mount-namespace", d);
+    g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-	g_assert_true(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
+    g_assert_true(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
-static void test_feature_parallel_instances(void)
-{
-	const char *d = sc_testdir();
-	sc_mock_feature_flag_dir(d);
+static void test_feature_parallel_instances(void) {
+    const char *d = sc_testdir();
+    sc_mock_feature_flag_dir(d);
 
-	g_assert_false(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
+    g_assert_false(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
 
-	char pname[PATH_MAX];
-	sc_must_snprintf(pname, sizeof pname, "%s/parallel-instances", d);
-	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
+    char pname[PATH_MAX];
+    sc_must_snprintf(pname, sizeof pname, "%s/parallel-instances", d);
+    g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-	g_assert_true(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
+    g_assert_true(sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES));
 }
 
-static void test_feature_hidden_snap_folder(void)
-{
-	const char *d = sc_testdir();
-	sc_mock_feature_flag_dir(d);
+static void test_feature_hidden_snap_folder(void) {
+    const char *d = sc_testdir();
+    sc_mock_feature_flag_dir(d);
 
-	g_assert_false(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+    g_assert_false(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 
-	char pname[PATH_MAX];
-	sc_must_snprintf(pname, sizeof pname, "%s/hidden-snap-folder", d);
-	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
+    char pname[PATH_MAX];
+    sc_must_snprintf(pname, sizeof pname, "%s/hidden-snap-folder", d);
+    g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-	g_assert_true(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
+    g_assert_true(sc_feature_enabled(SC_FEATURE_HIDDEN_SNAP_FOLDER));
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/feature/missing_dir",
-			test_feature_enabled__missing_dir);
-	g_test_add_func("/feature/missing_file",
-			test_feature_enabled__missing_file);
-	g_test_add_func("/feature/present_file",
-			test_feature_enabled__present_file);
-	g_test_add_func("/feature/parallel_instances",
-			test_feature_parallel_instances);
-	g_test_add_func("/feature/hidden_snap_folder",
-			test_feature_hidden_snap_folder);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/feature/missing_dir", test_feature_enabled__missing_dir);
+    g_test_add_func("/feature/missing_file", test_feature_enabled__missing_file);
+    g_test_add_func("/feature/present_file", test_feature_enabled__present_file);
+    g_test_add_func("/feature/parallel_instances", test_feature_parallel_instances);
+    g_test_add_func("/feature/hidden_snap_folder", test_feature_hidden_snap_folder);
 }

--- a/cmd/libsnap-confine-private/feature.c
+++ b/cmd/libsnap-confine-private/feature.c
@@ -30,44 +30,41 @@
 
 static const char *feature_flag_dir = "/var/lib/snapd/features";
 
-bool sc_feature_enabled(sc_feature_flag flag)
-{
-	const char *file_name;
-	switch (flag) {
-	case SC_FEATURE_PER_USER_MOUNT_NAMESPACE:
-		file_name = "per-user-mount-namespace";
-		break;
-	case SC_FEATURE_REFRESH_APP_AWARENESS:
-		file_name = "refresh-app-awareness";
-		break;
-	case SC_FEATURE_PARALLEL_INSTANCES:
-		file_name = "parallel-instances";
-		break;
-	case SC_FEATURE_HIDDEN_SNAP_FOLDER:
-		file_name = "hidden-snap-folder";
-		break;
-	default:
-		die("unknown feature flag code %d", flag);
-	}
+bool sc_feature_enabled(sc_feature_flag flag) {
+    const char *file_name;
+    switch (flag) {
+        case SC_FEATURE_PER_USER_MOUNT_NAMESPACE:
+            file_name = "per-user-mount-namespace";
+            break;
+        case SC_FEATURE_REFRESH_APP_AWARENESS:
+            file_name = "refresh-app-awareness";
+            break;
+        case SC_FEATURE_PARALLEL_INSTANCES:
+            file_name = "parallel-instances";
+            break;
+        case SC_FEATURE_HIDDEN_SNAP_FOLDER:
+            file_name = "hidden-snap-folder";
+            break;
+        default:
+            die("unknown feature flag code %d", flag);
+    }
 
-	int dirfd SC_CLEANUP(sc_cleanup_close) = -1;
-	dirfd =
-	    open(feature_flag_dir,
-		 O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_PATH);
-	if (dirfd < 0 && errno == ENOENT) {
-		return false;
-	}
-	if (dirfd < 0) {
-		die("cannot open path %s", feature_flag_dir);
-	}
+    int dirfd SC_CLEANUP(sc_cleanup_close) = -1;
+    dirfd = open(feature_flag_dir, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_PATH);
+    if (dirfd < 0 && errno == ENOENT) {
+        return false;
+    }
+    if (dirfd < 0) {
+        die("cannot open path %s", feature_flag_dir);
+    }
 
-	struct stat file_info;
-	if (fstatat(dirfd, file_name, &file_info, AT_SYMLINK_NOFOLLOW) < 0) {
-		if (errno == ENOENT) {
-			return false;
-		}
-		die("cannot inspect file %s/%s", feature_flag_dir, file_name);
-	}
+    struct stat file_info;
+    if (fstatat(dirfd, file_name, &file_info, AT_SYMLINK_NOFOLLOW) < 0) {
+        if (errno == ENOENT) {
+            return false;
+        }
+        die("cannot inspect file %s/%s", feature_flag_dir, file_name);
+    }
 
-	return S_ISREG(file_info.st_mode);
+    return S_ISREG(file_info.st_mode);
 }

--- a/cmd/libsnap-confine-private/feature.h
+++ b/cmd/libsnap-confine-private/feature.h
@@ -21,10 +21,10 @@
 #include <stdbool.h>
 
 typedef enum sc_feature_flag {
-	SC_FEATURE_PER_USER_MOUNT_NAMESPACE = 1 << 0,
-	SC_FEATURE_REFRESH_APP_AWARENESS = 1 << 1,
-	SC_FEATURE_PARALLEL_INSTANCES = 1 << 2,
-	SC_FEATURE_HIDDEN_SNAP_FOLDER = 1 << 3,
+    SC_FEATURE_PER_USER_MOUNT_NAMESPACE = 1 << 0,
+    SC_FEATURE_REFRESH_APP_AWARENESS = 1 << 1,
+    SC_FEATURE_PARALLEL_INSTANCES = 1 << 2,
+    SC_FEATURE_HIDDEN_SNAP_FOLDER = 1 << 3,
 } sc_feature_flag;
 
 /**
@@ -32,7 +32,7 @@ typedef enum sc_feature_flag {
  * by the user via "snap set core experimental.xxx=true". This is determined by
  * testing the presence of a file in /var/lib/snapd/features/ that is named
  * after the flag name.
-**/
+ **/
 bool sc_feature_enabled(sc_feature_flag flag);
 
 #endif

--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -27,196 +27,162 @@
 #include <glib/gstdio.h>
 
 // Set alternate locking directory
-static void sc_set_lock_dir(const char *dir)
-{
-	sc_lock_dir = dir;
-}
+static void sc_set_lock_dir(const char *dir) { sc_lock_dir = dir; }
 
 // A variant of unsetenv that is compatible with GDestroyNotify
-static void my_unsetenv(const char *k)
-{
-	unsetenv(k);
-}
+static void my_unsetenv(const char *k) { unsetenv(k); }
 
 // Use temporary directory for locking.
 //
 // The directory is automatically reset to the real value at the end of the
 // test.
-static const char *sc_test_use_fake_lock_dir(void)
-{
-	char *lock_dir = NULL;
-	if (g_test_subprocess()) {
-		// Check if the environment variable is set. If so then someone is already
-		// managing the temporary directory and we should not create a new one.
-		lock_dir = getenv("SNAP_CONFINE_LOCK_DIR");
-		g_assert_nonnull(lock_dir);
-	} else {
-		lock_dir = g_dir_make_tmp(NULL, NULL);
-		g_assert_nonnull(lock_dir);
-		g_test_queue_free(lock_dir);
-		g_assert_cmpint(setenv("SNAP_CONFINE_LOCK_DIR", lock_dir, 0),
-				==, 0);
-		g_test_queue_destroy((GDestroyNotify) my_unsetenv,
-				     "SNAP_CONFINE_LOCK_DIR");
-		g_test_queue_destroy((GDestroyNotify) rm_rf_tmp, lock_dir);
-	}
-	g_test_queue_destroy((GDestroyNotify) sc_set_lock_dir, SC_LOCK_DIR);
-	sc_set_lock_dir(lock_dir);
-	return lock_dir;
+static const char *sc_test_use_fake_lock_dir(void) {
+    char *lock_dir = NULL;
+    if (g_test_subprocess()) {
+        // Check if the environment variable is set. If so then someone is already
+        // managing the temporary directory and we should not create a new one.
+        lock_dir = getenv("SNAP_CONFINE_LOCK_DIR");
+        g_assert_nonnull(lock_dir);
+    } else {
+        lock_dir = g_dir_make_tmp(NULL, NULL);
+        g_assert_nonnull(lock_dir);
+        g_test_queue_free(lock_dir);
+        g_assert_cmpint(setenv("SNAP_CONFINE_LOCK_DIR", lock_dir, 0), ==, 0);
+        g_test_queue_destroy((GDestroyNotify)my_unsetenv, "SNAP_CONFINE_LOCK_DIR");
+        g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, lock_dir);
+    }
+    g_test_queue_destroy((GDestroyNotify)sc_set_lock_dir, SC_LOCK_DIR);
+    sc_set_lock_dir(lock_dir);
+    return lock_dir;
 }
 
 // Check that locking a namespace actually flock's the mutex with LOCK_EX
-static void test_sc_lock_unlock(void)
-{
-	if (geteuid() != 0) {
-		g_test_skip("this test only runs as root");
-		return;
-	}
+static void test_sc_lock_unlock(void) {
+    if (geteuid() != 0) {
+        g_test_skip("this test only runs as root");
+        return;
+    }
 
-	const char *lock_dir = sc_test_use_fake_lock_dir();
-	int fd = sc_lock_generic("foo", 123);
-	// Construct the name of the lock file
-	char *lock_file SC_CLEANUP(sc_cleanup_string) = NULL;
-	lock_file = g_strdup_printf("%s/foo.123.lock", lock_dir);
-	// Open the lock file again to obtain a separate file descriptor.
-	// According to flock(2) locks are associated with an open file table entry
-	// so this descriptor will be separate and can compete for the same lock.
-	int lock_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	lock_fd = open(lock_file, O_RDWR | O_CLOEXEC | O_NOFOLLOW);
-	g_assert_cmpint(lock_fd, !=, -1);
-	// The non-blocking lock operation should fail with EWOULDBLOCK as the lock
-	// file is locked by sc_nlock_ns_mutex() already.
-	int err = flock(lock_fd, LOCK_EX | LOCK_NB);
-	int saved_errno = errno;
-	g_assert_cmpint(err, ==, -1);
-	g_assert_cmpint(saved_errno, ==, EWOULDBLOCK);
-	// Unlock the lock.
-	sc_unlock(fd);
-	// Re-attempt the locking operation. This time it should succeed.
-	err = flock(lock_fd, LOCK_EX | LOCK_NB);
-	g_assert_cmpint(err, ==, 0);
+    const char *lock_dir = sc_test_use_fake_lock_dir();
+    int fd = sc_lock_generic("foo", 123);
+    // Construct the name of the lock file
+    char *lock_file SC_CLEANUP(sc_cleanup_string) = NULL;
+    lock_file = g_strdup_printf("%s/foo.123.lock", lock_dir);
+    // Open the lock file again to obtain a separate file descriptor.
+    // According to flock(2) locks are associated with an open file table entry
+    // so this descriptor will be separate and can compete for the same lock.
+    int lock_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    lock_fd = open(lock_file, O_RDWR | O_CLOEXEC | O_NOFOLLOW);
+    g_assert_cmpint(lock_fd, !=, -1);
+    // The non-blocking lock operation should fail with EWOULDBLOCK as the lock
+    // file is locked by sc_nlock_ns_mutex() already.
+    int err = flock(lock_fd, LOCK_EX | LOCK_NB);
+    int saved_errno = errno;
+    g_assert_cmpint(err, ==, -1);
+    g_assert_cmpint(saved_errno, ==, EWOULDBLOCK);
+    // Unlock the lock.
+    sc_unlock(fd);
+    // Re-attempt the locking operation. This time it should succeed.
+    err = flock(lock_fd, LOCK_EX | LOCK_NB);
+    g_assert_cmpint(err, ==, 0);
 }
 
 // Check that holding a lock is properly detected.
-static void test_sc_verify_snap_lock__locked(void)
-{
-	if (geteuid() != 0) {
-		g_test_skip("this test only runs as root");
-		return;
-	}
+static void test_sc_verify_snap_lock__locked(void) {
+    if (geteuid() != 0) {
+        g_test_skip("this test only runs as root");
+        return;
+    }
 
-	(void)sc_test_use_fake_lock_dir();
-	int fd = sc_lock_snap("foo");
-	sc_verify_snap_lock("foo");
-	sc_unlock(fd);
+    (void)sc_test_use_fake_lock_dir();
+    int fd = sc_lock_snap("foo");
+    sc_verify_snap_lock("foo");
+    sc_unlock(fd);
 }
 
 // Check that holding a lock is properly detected.
-static void test_sc_verify_snap_lock__unlocked(void)
-{
-	if (geteuid() != 0) {
-		g_test_skip("this test only runs as root");
-		return;
-	}
+static void test_sc_verify_snap_lock__unlocked(void) {
+    if (geteuid() != 0) {
+        g_test_skip("this test only runs as root");
+        return;
+    }
 
-	(void)sc_test_use_fake_lock_dir();
-	if (g_test_subprocess()) {
-		sc_verify_snap_lock("foo");
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("unexpectedly managed to acquire exclusive lock over snap foo\n");
+    (void)sc_test_use_fake_lock_dir();
+    if (g_test_subprocess()) {
+        sc_verify_snap_lock("foo");
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("unexpectedly managed to acquire exclusive lock over snap foo\n");
 }
 
-static void test_sc_enable_sanity_timeout(void)
-{
-	if (geteuid() != 0) {
-		g_test_skip("this test only runs as root");
-		return;
-	}
+static void test_sc_enable_sanity_timeout(void) {
+    if (geteuid() != 0) {
+        g_test_skip("this test only runs as root");
+        return;
+    }
 
-	if (g_test_subprocess()) {
-		sc_enable_sanity_timeout();
-		debug("waiting...");
-		usleep(7 * G_USEC_PER_SEC);
-		debug("woke up");
-		sc_disable_sanity_timeout();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 1 * G_USEC_PER_SEC,
-			       G_TEST_SUBPROCESS_INHERIT_STDERR);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("sanity timeout expired: Interrupted system call\n");
+    if (g_test_subprocess()) {
+        sc_enable_sanity_timeout();
+        debug("waiting...");
+        usleep(7 * G_USEC_PER_SEC);
+        debug("woke up");
+        sc_disable_sanity_timeout();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 1 * G_USEC_PER_SEC, G_TEST_SUBPROCESS_INHERIT_STDERR);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("sanity timeout expired: Interrupted system call\n");
 }
 
 // Set alternate inhibit directory
-static void sc_set_inhibit_dir(const char *dir)
-{
-	sc_inhibit_dir = dir;
-}
+static void sc_set_inhibit_dir(const char *dir) { sc_inhibit_dir = dir; }
 
 // Use temporary directory for inhibition.
 //
 // The directory is automatically reset to the real value at the end of the
 // test.
-static const char *sc_test_use_fake_inhibit_dir(void)
-{
-	char *inhibit_dir = g_dir_make_tmp(NULL, NULL);
-	g_assert_nonnull(inhibit_dir);
-	g_test_queue_free(inhibit_dir);
-	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp, inhibit_dir);
-	g_test_queue_destroy((GDestroyNotify) sc_set_inhibit_dir,
-			     SC_INHIBIT_DIR);
-	sc_set_inhibit_dir(inhibit_dir);
-	return inhibit_dir;
+static const char *sc_test_use_fake_inhibit_dir(void) {
+    char *inhibit_dir = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(inhibit_dir);
+    g_test_queue_free(inhibit_dir);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, inhibit_dir);
+    g_test_queue_destroy((GDestroyNotify)sc_set_inhibit_dir, SC_INHIBIT_DIR);
+    sc_set_inhibit_dir(inhibit_dir);
+    return inhibit_dir;
 }
 
-static void test_sc_snap_is_inhibited__missing_dir(void)
-{
-	char *d = g_dir_make_tmp(NULL, NULL);
-	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp, d);
+static void test_sc_snap_is_inhibited__missing_dir(void) {
+    char *d = g_dir_make_tmp(NULL, NULL);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, d);
 
-	char subd[PATH_MAX];
-	sc_must_snprintf(subd, sizeof subd, "%s/absent", d);
-	sc_set_inhibit_dir(subd);
-	g_assert_false(sc_snap_is_inhibited
-		       ("foo", SC_SNAP_HINT_INHIBITED_FOR_REMOVE));
+    char subd[PATH_MAX];
+    sc_must_snprintf(subd, sizeof subd, "%s/absent", d);
+    sc_set_inhibit_dir(subd);
+    g_assert_false(sc_snap_is_inhibited("foo", SC_SNAP_HINT_INHIBITED_FOR_REMOVE));
 }
 
-static void test_sc_snap_is_inhibited__missing_file(void)
-{
-	const char *d = sc_test_use_fake_inhibit_dir();
-	g_assert_false(sc_snap_is_inhibited
-		       ("foo", SC_SNAP_HINT_INHIBITED_FOR_REMOVE));
+static void test_sc_snap_is_inhibited__missing_file(void) {
+    const char *d = sc_test_use_fake_inhibit_dir();
+    g_assert_false(sc_snap_is_inhibited("foo", SC_SNAP_HINT_INHIBITED_FOR_REMOVE));
 }
 
-static void test_sc_snap_is_inhibited__present_file(void)
-{
-	const char *d = sc_test_use_fake_inhibit_dir();
-	char pname[PATH_MAX];
-	sc_must_snprintf(pname, sizeof pname, "%s/foo.remove", d);
-	g_assert_true(g_file_set_contents(pname, "", -1, NULL));
+static void test_sc_snap_is_inhibited__present_file(void) {
+    const char *d = sc_test_use_fake_inhibit_dir();
+    char pname[PATH_MAX];
+    sc_must_snprintf(pname, sizeof pname, "%s/foo.remove", d);
+    g_assert_true(g_file_set_contents(pname, "", -1, NULL));
 
-	g_assert_true(sc_snap_is_inhibited
-		      ("foo", SC_SNAP_HINT_INHIBITED_FOR_REMOVE));
+    g_assert_true(sc_snap_is_inhibited("foo", SC_SNAP_HINT_INHIBITED_FOR_REMOVE));
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/locking/sc_lock_unlock", test_sc_lock_unlock);
-	g_test_add_func("/locking/sc_enable_sanity_timeout",
-			test_sc_enable_sanity_timeout);
-	g_test_add_func("/locking/sc_verify_snap_lock__locked",
-			test_sc_verify_snap_lock__locked);
-	g_test_add_func("/locking/sc_verify_snap_lock__unlocked",
-			test_sc_verify_snap_lock__unlocked);
-	g_test_add_func("/locking/sc_snap_is_inhibited__missing_dir",
-			test_sc_snap_is_inhibited__missing_dir);
-	g_test_add_func("/locking/sc_snap_is_inhibited__missing_file",
-			test_sc_snap_is_inhibited__missing_file);
-	g_test_add_func("/locking/sc_snap_is_inhibited__present_file",
-			test_sc_snap_is_inhibited__present_file);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/locking/sc_lock_unlock", test_sc_lock_unlock);
+    g_test_add_func("/locking/sc_enable_sanity_timeout", test_sc_enable_sanity_timeout);
+    g_test_add_func("/locking/sc_verify_snap_lock__locked", test_sc_verify_snap_lock__locked);
+    g_test_add_func("/locking/sc_verify_snap_lock__unlocked", test_sc_verify_snap_lock__unlocked);
+    g_test_add_func("/locking/sc_snap_is_inhibited__missing_dir", test_sc_snap_is_inhibited__missing_dir);
+    g_test_add_func("/locking/sc_snap_is_inhibited__missing_file", test_sc_snap_is_inhibited__missing_file);
+    g_test_add_func("/locking/sc_snap_is_inhibited__present_file", test_sc_snap_is_inhibited__present_file);
 }

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -46,200 +46,169 @@ static volatile sig_atomic_t sanity_timeout_expired = 0;
 /**
  * Signal handler for SIGALRM that sets sanity_timeout_expired flag to 1.
  **/
-static void sc_SIGALRM_handler(int signum)
-{
-	sanity_timeout_expired = 1;
+static void sc_SIGALRM_handler(int signum) { sanity_timeout_expired = 1; }
+
+void sc_enable_sanity_timeout(void) {
+    sanity_timeout_expired = 0;
+    struct sigaction act = {.sa_handler = sc_SIGALRM_handler};
+    if (sigemptyset(&act.sa_mask) < 0) {
+        die("cannot initialize POSIX signal set");
+    }
+    // NOTE: we are using sigaction so that we can explicitly control signal
+    // flags and *not* pass the SA_RESTART flag. The intent is so that any
+    // system call we may be sleeping on to gets interrupted.
+    act.sa_flags = 0;
+    if (sigaction(SIGALRM, &act, NULL) < 0) {
+        die("cannot install signal handler for SIGALRM");
+    }
+    alarm(SANITY_TIMEOUT);
+    debug("sanity timeout initialized and set for %i seconds", SANITY_TIMEOUT);
 }
 
-void sc_enable_sanity_timeout(void)
-{
-	sanity_timeout_expired = 0;
-	struct sigaction act = {.sa_handler = sc_SIGALRM_handler };
-	if (sigemptyset(&act.sa_mask) < 0) {
-		die("cannot initialize POSIX signal set");
-	}
-	// NOTE: we are using sigaction so that we can explicitly control signal
-	// flags and *not* pass the SA_RESTART flag. The intent is so that any
-	// system call we may be sleeping on to gets interrupted.
-	act.sa_flags = 0;
-	if (sigaction(SIGALRM, &act, NULL) < 0) {
-		die("cannot install signal handler for SIGALRM");
-	}
-	alarm(SANITY_TIMEOUT);
-	debug("sanity timeout initialized and set for %i seconds",
-	      SANITY_TIMEOUT);
-}
-
-void sc_disable_sanity_timeout(void)
-{
-	if (sanity_timeout_expired) {
-		die("sanity timeout expired");
-	}
-	alarm(0);
-	struct sigaction act = {.sa_handler = SIG_DFL };
-	if (sigemptyset(&act.sa_mask) < 0) {
-		die("cannot initialize POSIX signal set");
-	}
-	if (sigaction(SIGALRM, &act, NULL) < 0) {
-		die("cannot uninstall signal handler for SIGALRM");
-	}
-	debug("sanity timeout reset and disabled");
+void sc_disable_sanity_timeout(void) {
+    if (sanity_timeout_expired) {
+        die("sanity timeout expired");
+    }
+    alarm(0);
+    struct sigaction act = {.sa_handler = SIG_DFL};
+    if (sigemptyset(&act.sa_mask) < 0) {
+        die("cannot initialize POSIX signal set");
+    }
+    if (sigaction(SIGALRM, &act, NULL) < 0) {
+        die("cannot uninstall signal handler for SIGALRM");
+    }
+    debug("sanity timeout reset and disabled");
 }
 
 #define SC_LOCK_DIR "/run/snapd/lock"
 
 static const char *sc_lock_dir = SC_LOCK_DIR;
 
-static int get_lock_directory(void)
-{
-	// Create (if required) and open the lock directory.
-	debug("creating lock directory %s (if missing)", sc_lock_dir);
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	if (sc_nonfatal_mkpath(sc_lock_dir, 0755) < 0) {
-		die("cannot create lock directory %s", sc_lock_dir);
-	}
-	debug("opening lock directory %s", sc_lock_dir);
-	int dir_fd =
-	    open(sc_lock_dir, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
-	(void)sc_set_effective_identity(old);
-	if (dir_fd < 0) {
-		die("cannot open lock directory");
-	}
-	return dir_fd;
+static int get_lock_directory(void) {
+    // Create (if required) and open the lock directory.
+    debug("creating lock directory %s (if missing)", sc_lock_dir);
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    if (sc_nonfatal_mkpath(sc_lock_dir, 0755) < 0) {
+        die("cannot create lock directory %s", sc_lock_dir);
+    }
+    debug("opening lock directory %s", sc_lock_dir);
+    int dir_fd = open(sc_lock_dir, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
+    (void)sc_set_effective_identity(old);
+    if (dir_fd < 0) {
+        die("cannot open lock directory");
+    }
+    return dir_fd;
 }
 
-static void get_lock_name(char *lock_fname, size_t size, const char *scope,
-			  uid_t uid)
-{
-	if (uid == 0) {
-		// The root user doesn't have a per-user mount namespace.
-		// Doing so would be confusing for services which use $SNAP_DATA
-		// as home, and not in $SNAP_USER_DATA.
-		sc_must_snprintf(lock_fname, size, "%s.lock", scope ? : "");
-	} else {
-		sc_must_snprintf(lock_fname, size, "%s.%d.lock",
-				 scope ? : "", uid);
-	}
+static void get_lock_name(char *lock_fname, size_t size, const char *scope, uid_t uid) {
+    if (uid == 0) {
+        // The root user doesn't have a per-user mount namespace.
+        // Doing so would be confusing for services which use $SNAP_DATA
+        // as home, and not in $SNAP_USER_DATA.
+        sc_must_snprintf(lock_fname, size, "%s.lock", scope ?: "");
+    } else {
+        sc_must_snprintf(lock_fname, size, "%s.%d.lock", scope ?: "", uid);
+    }
 }
 
-static int open_lock(const char *scope, uid_t uid)
-{
-	int dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	char lock_fname[PATH_MAX] = { 0 };
-	int lock_fd;
+static int open_lock(const char *scope, uid_t uid) {
+    int dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    char lock_fname[PATH_MAX] = {0};
+    int lock_fd;
 
-	dir_fd = get_lock_directory();
-	get_lock_name(lock_fname, sizeof lock_fname, scope, uid);
+    dir_fd = get_lock_directory();
+    get_lock_name(lock_fname, sizeof lock_fname, scope, uid);
 
-	// Open the lock file and acquire an exclusive lock.
-	debug("opening lock file: %s/%s", sc_lock_dir, lock_fname);
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	lock_fd = openat(dir_fd, lock_fname,
-			 O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
-	(void)sc_set_effective_identity(old);
-	if (lock_fd < 0) {
-		die("cannot open lock file: %s/%s", sc_lock_dir, lock_fname);
-	}
-	return lock_fd;
+    // Open the lock file and acquire an exclusive lock.
+    debug("opening lock file: %s/%s", sc_lock_dir, lock_fname);
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    lock_fd = openat(dir_fd, lock_fname, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
+    (void)sc_set_effective_identity(old);
+    if (lock_fd < 0) {
+        die("cannot open lock file: %s/%s", sc_lock_dir, lock_fname);
+    }
+    return lock_fd;
 }
 
-static int sc_lock_generic(const char *scope, uid_t uid)
-{
-	int lock_fd = open_lock(scope, uid);
-	sc_enable_sanity_timeout();
-	debug("acquiring exclusive lock (scope %s, uid %d)",
-	      scope ? : "(global)", uid);
-	if (flock(lock_fd, LOCK_EX) < 0) {
-		sc_disable_sanity_timeout();
-		close(lock_fd);
-		die("cannot acquire exclusive lock (scope %s, uid %d)",
-		    scope ? : "(global)", uid);
-	} else {
-		sc_disable_sanity_timeout();
-	}
-	return lock_fd;
+static int sc_lock_generic(const char *scope, uid_t uid) {
+    int lock_fd = open_lock(scope, uid);
+    sc_enable_sanity_timeout();
+    debug("acquiring exclusive lock (scope %s, uid %d)", scope ?: "(global)", uid);
+    if (flock(lock_fd, LOCK_EX) < 0) {
+        sc_disable_sanity_timeout();
+        close(lock_fd);
+        die("cannot acquire exclusive lock (scope %s, uid %d)", scope ?: "(global)", uid);
+    } else {
+        sc_disable_sanity_timeout();
+    }
+    return lock_fd;
 }
 
-int sc_lock_global(void)
-{
-	return sc_lock_generic(NULL, 0);
+int sc_lock_global(void) { return sc_lock_generic(NULL, 0); }
+
+int sc_lock_snap(const char *snap_name) { return sc_lock_generic(snap_name, 0); }
+
+void sc_verify_snap_lock(const char *snap_name) {
+    int lock_fd, retval;
+
+    lock_fd = open_lock(snap_name, 0);
+    debug("trying to verify whether exclusive lock over snap %s is held", snap_name);
+    retval = flock(lock_fd, LOCK_EX | LOCK_NB);
+    if (retval == 0) {
+        /* We managed to grab the lock, the lock was not held! */
+        flock(lock_fd, LOCK_UN);
+        close(lock_fd);
+        errno = 0;
+        die("unexpectedly managed to acquire exclusive lock over snap %s", snap_name);
+    }
+    if (retval < 0 && errno != EWOULDBLOCK) {
+        die("cannot verify exclusive lock over snap %s", snap_name);
+    }
+    /* We tried but failed to grab the lock because the file is already locked.
+     * Good, this is what we expected. */
 }
 
-int sc_lock_snap(const char *snap_name)
-{
-	return sc_lock_generic(snap_name, 0);
-}
+int sc_lock_snap_user(const char *snap_name, uid_t uid) { return sc_lock_generic(snap_name, uid); }
 
-void sc_verify_snap_lock(const char *snap_name)
-{
-	int lock_fd, retval;
-
-	lock_fd = open_lock(snap_name, 0);
-	debug("trying to verify whether exclusive lock over snap %s is held",
-	      snap_name);
-	retval = flock(lock_fd, LOCK_EX | LOCK_NB);
-	if (retval == 0) {
-		/* We managed to grab the lock, the lock was not held! */
-		flock(lock_fd, LOCK_UN);
-		close(lock_fd);
-		errno = 0;
-		die("unexpectedly managed to acquire exclusive lock over snap %s", snap_name);
-	}
-	if (retval < 0 && errno != EWOULDBLOCK) {
-		die("cannot verify exclusive lock over snap %s", snap_name);
-	}
-	/* We tried but failed to grab the lock because the file is already locked.
-	 * Good, this is what we expected. */
-}
-
-int sc_lock_snap_user(const char *snap_name, uid_t uid)
-{
-	return sc_lock_generic(snap_name, uid);
-}
-
-void sc_unlock(int lock_fd)
-{
-	// Release the lock and finish.
-	debug("releasing lock %d", lock_fd);
-	if (flock(lock_fd, LOCK_UN) < 0) {
-		die("cannot release lock %d", lock_fd);
-	}
-	close(lock_fd);
+void sc_unlock(int lock_fd) {
+    // Release the lock and finish.
+    debug("releasing lock %d", lock_fd);
+    if (flock(lock_fd, LOCK_UN) < 0) {
+        die("cannot release lock %d", lock_fd);
+    }
+    close(lock_fd);
 }
 
 #define SC_INHIBIT_DIR "/var/lib/snapd/inhibit"
 
 static const char *sc_inhibit_dir = SC_INHIBIT_DIR;
 
-bool sc_snap_is_inhibited(const char *snap_name, sc_snap_inhibition_hint hint)
-{
-	char file_name[PATH_MAX] = { 0 };
-	switch (hint) {
-	case SC_SNAP_HINT_INHIBITED_FOR_REMOVE:
-		sc_must_snprintf(file_name, sizeof file_name, "%s.remove",
-				 snap_name);
-		break;
-	default:
-		die("unknown inhibition hint %d", hint);
-	}
+bool sc_snap_is_inhibited(const char *snap_name, sc_snap_inhibition_hint hint) {
+    char file_name[PATH_MAX] = {0};
+    switch (hint) {
+        case SC_SNAP_HINT_INHIBITED_FOR_REMOVE:
+            sc_must_snprintf(file_name, sizeof file_name, "%s.remove", snap_name);
+            break;
+        default:
+            die("unknown inhibition hint %d", hint);
+    }
 
-	int dirfd SC_CLEANUP(sc_cleanup_close) = -1;
-	dirfd =
-	    open(sc_inhibit_dir, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_PATH);
-	if (dirfd < 0 && errno == ENOENT) {
-		return false;
-	}
-	if (dirfd < 0) {
-		die("cannot open path %s", sc_inhibit_dir);
-	}
+    int dirfd SC_CLEANUP(sc_cleanup_close) = -1;
+    dirfd = open(sc_inhibit_dir, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW | O_PATH);
+    if (dirfd < 0 && errno == ENOENT) {
+        return false;
+    }
+    if (dirfd < 0) {
+        die("cannot open path %s", sc_inhibit_dir);
+    }
 
-	struct stat file_info;
-	if (fstatat(dirfd, file_name, &file_info, AT_SYMLINK_NOFOLLOW) < 0) {
-		if (errno == ENOENT) {
-			return false;
-		}
-		die("cannot inspect file %s/%s", sc_inhibit_dir, file_name);
-	}
+    struct stat file_info;
+    if (fstatat(dirfd, file_name, &file_info, AT_SYMLINK_NOFOLLOW) < 0) {
+        if (errno == ENOENT) {
+            return false;
+        }
+        die("cannot inspect file %s/%s", sc_inhibit_dir, file_name);
+    }
 
-	return S_ISREG(file_info.st_mode);
+    return S_ISREG(file_info.st_mode);
 }

--- a/cmd/libsnap-confine-private/locking.h
+++ b/cmd/libsnap-confine-private/locking.h
@@ -24,8 +24,8 @@
 #include "config.h"
 #endif
 
-#include <sys/types.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
 /**
  * Obtain a flock-based, exclusive, globally scoped, lock.
@@ -106,13 +106,13 @@ void sc_enable_sanity_timeout(void);
 void sc_disable_sanity_timeout(void);
 
 typedef enum sc_snap_inhibition_hint {
-	SC_SNAP_HINT_INHIBITED_FOR_REMOVE = 1 << 0,
+    SC_SNAP_HINT_INHIBITED_FOR_REMOVE = 1 << 0,
 } sc_snap_inhibition_hint;
 
 /**
  * sc_snap_is_inhibited returns true if a given inhibition hint is set for given snap.
  * This is determined by testing the presence of a file in /var/lib/snapd/inhibit/<snap_name>.<hint>.
-**/
+ **/
 bool sc_snap_is_inhibited(const char *snap_name, sc_snap_inhibition_hint hint);
 
-#endif				// SNAP_CONFINE_LOCKING_H
+#endif  // SNAP_CONFINE_LOCKING_H

--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -23,324 +23,332 @@
 
 #include <glib.h>
 
-static void test_sc_mount_opt2str(void)
-{
-	char buf[1000] = { 0 };
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0), ==, "");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RDONLY), ==, "ro");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOSUID), ==,
-			"nosuid");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NODEV), ==,
-			"nodev");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOEXEC), ==,
-			"noexec");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SYNCHRONOUS), ==,
-			"sync");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REMOUNT), ==,
-			"remount");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_MANDLOCK), ==,
-			"mand");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_DIRSYNC), ==,
-			"dirsync");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOATIME), ==,
-			"noatime");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NODIRATIME), ==,
-			"nodiratime");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_BIND), ==, "bind");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_BIND), ==,
-			"rbind");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_MOVE), ==, "move");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SILENT), ==,
-			"silent");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_POSIXACL), ==,
-			"acl");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_UNBINDABLE), ==,
-			"unbindable");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_PRIVATE), ==,
-			"private");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_PRIVATE),
-			==, "rprivate");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SLAVE), ==,
-			"slave");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_SLAVE),
-			==, "rslave");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SHARED), ==,
-			"shared");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_SHARED),
-			==, "rshared");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RELATIME), ==,
-			"relatime");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_KERNMOUNT), ==,
-			"kernmount");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_I_VERSION), ==,
-			"iversion");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_STRICTATIME), ==,
-			"strictatime");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_LAZYTIME), ==,
-			"lazytime");
-	// MS_NOSEC is not defined in userspace
-	// MS_BORN is not defined in userspace
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_ACTIVE), ==,
-			"active");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOUSER), ==,
-			"nouser");
-	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0x300), ==, "0x300");
-	// random compositions do work
-	g_assert_cmpstr(sc_mount_opt2str
-			(buf, sizeof buf, MS_RDONLY | MS_NOEXEC | MS_BIND), ==,
-			"ro,noexec,bind");
+static void test_sc_mount_opt2str(void) {
+    char buf[1000] = {0};
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0), ==, "");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RDONLY), ==, "ro");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOSUID), ==, "nosuid");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NODEV), ==, "nodev");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOEXEC), ==, "noexec");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SYNCHRONOUS), ==, "sync");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REMOUNT), ==, "remount");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_MANDLOCK), ==, "mand");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_DIRSYNC), ==, "dirsync");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOATIME), ==, "noatime");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NODIRATIME), ==, "nodiratime");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_BIND), ==, "bind");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_BIND), ==, "rbind");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_MOVE), ==, "move");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SILENT), ==, "silent");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_POSIXACL), ==, "acl");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_UNBINDABLE), ==, "unbindable");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_PRIVATE), ==, "private");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_PRIVATE), ==, "rprivate");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SLAVE), ==, "slave");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_SLAVE), ==, "rslave");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SHARED), ==, "shared");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_SHARED), ==, "rshared");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RELATIME), ==, "relatime");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_KERNMOUNT), ==, "kernmount");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_I_VERSION), ==, "iversion");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_STRICTATIME), ==, "strictatime");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_LAZYTIME), ==, "lazytime");
+    // MS_NOSEC is not defined in userspace
+    // MS_BORN is not defined in userspace
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_ACTIVE), ==, "active");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOUSER), ==, "nouser");
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0x300), ==, "0x300");
+    // random compositions do work
+    g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RDONLY | MS_NOEXEC | MS_BIND), ==, "ro,noexec,bind");
 }
 
-static void test_sc_mount_cmd(void)
-{
-	char cmd[10000] = { 0 };
+static void test_sc_mount_cmd(void) {
+    char cmd[10000] = {0};
 
-	// Typical mount
-	sc_mount_cmd(cmd, sizeof cmd, "/dev/sda3", "/mnt", "ext4", MS_RDONLY,
-		     NULL);
-	g_assert_cmpstr(cmd, ==, "mount -t ext4 -o ro /dev/sda3 /mnt");
+    // Typical mount
+    sc_mount_cmd(cmd, sizeof cmd, "/dev/sda3", "/mnt", "ext4", MS_RDONLY, NULL);
+    g_assert_cmpstr(cmd, ==, "mount -t ext4 -o ro /dev/sda3 /mnt");
 
-	// Bind mount
-	sc_mount_cmd(cmd, sizeof cmd, "/source", "/target", NULL, MS_BIND,
-		     NULL);
-	g_assert_cmpstr(cmd, ==, "mount --bind /source /target");
+    // Bind mount
+    sc_mount_cmd(cmd, sizeof cmd, "/source", "/target", NULL, MS_BIND, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --bind /source /target");
 
-	// + recursive
-	sc_mount_cmd(cmd, sizeof cmd, "/source", "/target", NULL,
-		     MS_BIND | MS_REC, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --rbind /source /target");
+    // + recursive
+    sc_mount_cmd(cmd, sizeof cmd, "/source", "/target", NULL, MS_BIND | MS_REC, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --rbind /source /target");
 
-	// Shared subtree mount
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_SHARED, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-shared /place");
+    // Shared subtree mount
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_SHARED, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-shared /place");
 
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_SLAVE, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-slave /place");
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_SLAVE, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-slave /place");
 
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_PRIVATE, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-private /place");
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_PRIVATE, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-private /place");
 
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_UNBINDABLE,
-		     NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-unbindable /place");
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_UNBINDABLE, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-unbindable /place");
 
-	// + recursive
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL,
-		     MS_SHARED | MS_REC, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-rshared /place");
+    // + recursive
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_SHARED | MS_REC, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-rshared /place");
 
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_SLAVE | MS_REC,
-		     NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-rslave /place");
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_SLAVE | MS_REC, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-rslave /place");
 
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL,
-		     MS_PRIVATE | MS_REC, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-rprivate /place");
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_PRIVATE | MS_REC, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-rprivate /place");
 
-	sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL,
-		     MS_UNBINDABLE | MS_REC, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --make-runbindable /place");
+    sc_mount_cmd(cmd, sizeof cmd, "/place", "none", NULL, MS_UNBINDABLE | MS_REC, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --make-runbindable /place");
 
-	// Move
-	sc_mount_cmd(cmd, sizeof cmd, "/from", "/to", NULL, MS_MOVE, NULL);
-	g_assert_cmpstr(cmd, ==, "mount --move /from /to");
+    // Move
+    sc_mount_cmd(cmd, sizeof cmd, "/from", "/to", NULL, MS_MOVE, NULL);
+    g_assert_cmpstr(cmd, ==, "mount --move /from /to");
 
-	// Monster (invalid but let's format it)
-	char from[PATH_MAX] = { 0 };
-	char to[PATH_MAX] = { 0 };
-	for (int i = 1; i < PATH_MAX - 1; ++i) {
-		from[i] = 'a';
-		to[i] = 'b';
-	}
-	from[0] = '/';
-	to[0] = '/';
-	from[PATH_MAX - 1] = 0;
-	to[PATH_MAX - 1] = 0;
-	int opts = MS_BIND | MS_MOVE | MS_SHARED | MS_SLAVE | MS_PRIVATE |
-	    MS_UNBINDABLE | MS_REC | MS_RDONLY | MS_NOSUID | MS_NODEV |
-	    MS_NOEXEC | MS_SYNCHRONOUS | MS_REMOUNT | MS_MANDLOCK | MS_DIRSYNC |
-	    MS_NOATIME | MS_NODIRATIME | MS_BIND | MS_SILENT | MS_POSIXACL |
-	    MS_RELATIME | MS_KERNMOUNT | MS_I_VERSION | MS_STRICTATIME |
-	    MS_LAZYTIME;
-	const char *fstype = "fstype";
-	sc_mount_cmd(cmd, sizeof cmd, from, to, fstype, opts, NULL);
-	const char *expected =
-	    "mount -t fstype "
-	    "--rbind --move --make-rshared --make-rslave --make-rprivate --make-runbindable "
-	    "-o ro,nosuid,nodev,noexec,sync,remount,mand,dirsync,noatime,nodiratime,silent,"
-	    "acl,relatime,kernmount,iversion,strictatime,lazytime "
-	    "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
-	    "/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-	g_assert_cmpstr(cmd, ==, expected);
+    // Monster (invalid but let's format it)
+    char from[PATH_MAX] = {0};
+    char to[PATH_MAX] = {0};
+    for (int i = 1; i < PATH_MAX - 1; ++i) {
+        from[i] = 'a';
+        to[i] = 'b';
+    }
+    from[0] = '/';
+    to[0] = '/';
+    from[PATH_MAX - 1] = 0;
+    to[PATH_MAX - 1] = 0;
+    int opts = MS_BIND | MS_MOVE | MS_SHARED | MS_SLAVE | MS_PRIVATE | MS_UNBINDABLE | MS_REC | MS_RDONLY | MS_NOSUID |
+               MS_NODEV | MS_NOEXEC | MS_SYNCHRONOUS | MS_REMOUNT | MS_MANDLOCK | MS_DIRSYNC | MS_NOATIME |
+               MS_NODIRATIME | MS_BIND | MS_SILENT | MS_POSIXACL | MS_RELATIME | MS_KERNMOUNT | MS_I_VERSION |
+               MS_STRICTATIME | MS_LAZYTIME;
+    const char *fstype = "fstype";
+    sc_mount_cmd(cmd, sizeof cmd, from, to, fstype, opts, NULL);
+    const char *expected =
+        "mount -t fstype "
+        "--rbind --move --make-rshared --make-rslave --make-rprivate --make-runbindable "
+        "-o ro,nosuid,nodev,noexec,sync,remount,mand,dirsync,noatime,nodiratime,silent,"
+        "acl,relatime,kernmount,iversion,strictatime,lazytime "
+        "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaa "
+        "/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "bbbbbbbbbbbbbbbbbbbbbbbbb";
+    g_assert_cmpstr(cmd, ==, expected);
 }
 
-static void test_sc_umount_cmd(void)
-{
-	char cmd[1000] = { 0 };
+static void test_sc_umount_cmd(void) {
+    char cmd[1000] = {0};
 
-	// Typical umount
-	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", 0);
-	g_assert_cmpstr(cmd, ==, "umount /mnt/foo");
+    // Typical umount
+    sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", 0);
+    g_assert_cmpstr(cmd, ==, "umount /mnt/foo");
 
-	// Force
-	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", MNT_FORCE);
-	g_assert_cmpstr(cmd, ==, "umount --force /mnt/foo");
+    // Force
+    sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", MNT_FORCE);
+    g_assert_cmpstr(cmd, ==, "umount --force /mnt/foo");
 
-	// Detach
-	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", MNT_DETACH);
-	g_assert_cmpstr(cmd, ==, "umount --lazy /mnt/foo");
+    // Detach
+    sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", MNT_DETACH);
+    g_assert_cmpstr(cmd, ==, "umount --lazy /mnt/foo");
 
-	// Expire
-	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", MNT_EXPIRE);
-	g_assert_cmpstr(cmd, ==, "umount --expire /mnt/foo");
+    // Expire
+    sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", MNT_EXPIRE);
+    g_assert_cmpstr(cmd, ==, "umount --expire /mnt/foo");
 
-	// O_NOFOLLOW variant for umount
-	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", UMOUNT_NOFOLLOW);
-	g_assert_cmpstr(cmd, ==, "umount --no-follow /mnt/foo");
+    // O_NOFOLLOW variant for umount
+    sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", UMOUNT_NOFOLLOW);
+    g_assert_cmpstr(cmd, ==, "umount --no-follow /mnt/foo");
 
-	// Everything at once
-	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo",
-		      MNT_FORCE | MNT_DETACH | MNT_EXPIRE | UMOUNT_NOFOLLOW);
-	g_assert_cmpstr(cmd, ==,
-			"umount --force --lazy --expire --no-follow /mnt/foo");
+    // Everything at once
+    sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", MNT_FORCE | MNT_DETACH | MNT_EXPIRE | UMOUNT_NOFOLLOW);
+    g_assert_cmpstr(cmd, ==, "umount --force --lazy --expire --no-follow /mnt/foo");
 }
 
-static bool broken_mount(struct sc_fault_state *state, void *ptr)
-{
-	errno = EACCES;
-	return true;
+static bool broken_mount(struct sc_fault_state *state, void *ptr) {
+    errno = EACCES;
+    return true;
 }
 
-static void test_sc_do_mount(gconstpointer snap_debug)
-{
-	if (g_test_subprocess()) {
-		sc_break("mount", broken_mount);
-		if (GPOINTER_TO_INT(snap_debug) == 1) {
-			g_assert_true(g_setenv
-				      ("SNAP_CONFINE_DEBUG", "1", true));
-		}
-		sc_do_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
+static void test_sc_do_mount(gconstpointer snap_debug) {
+    if (g_test_subprocess()) {
+        sc_break("mount", broken_mount);
+        if (GPOINTER_TO_INT(snap_debug) == 1) {
+            g_assert_true(g_setenv("SNAP_CONFINE_DEBUG", "1", true));
+        }
+        sc_do_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
 
-		g_test_message("expected sc_do_mount not to return");
-		sc_reset_faults();
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	if (GPOINTER_TO_INT(snap_debug) == 0) {
-		g_test_trap_assert_stderr
-		    ("cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
-	} else {
-		/* with snap_debug the debug output hides the actual mount commands *but*
-		 * they are still shown if there was an error
-		 */
-		g_test_trap_assert_stderr
-		    ("DEBUG: performing operation: (disabled) use debug build to see details\n"
-		     "cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
-	}
+        g_test_message("expected sc_do_mount not to return");
+        sc_reset_faults();
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    if (GPOINTER_TO_INT(snap_debug) == 0) {
+        g_test_trap_assert_stderr("cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+    } else {
+        /* with snap_debug the debug output hides the actual mount commands *but*
+         * they are still shown if there was an error
+         */
+        g_test_trap_assert_stderr(
+            "DEBUG: performing operation: (disabled) use debug build to see details\n"
+            "cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+    }
 }
 
-static bool broken_umount(struct sc_fault_state *state, void *ptr)
-{
-	errno = EACCES;
-	return true;
+static bool broken_umount(struct sc_fault_state *state, void *ptr) {
+    errno = EACCES;
+    return true;
 }
 
-static void test_sc_do_umount(gconstpointer snap_debug)
-{
-	if (g_test_subprocess()) {
-		sc_break("umount", broken_umount);
-		if (GPOINTER_TO_INT(snap_debug) == 1) {
-			g_assert_true(g_setenv
-				      ("SNAP_CONFINE_DEBUG", "1", true));
-		}
-		sc_do_umount("/foo", MNT_DETACH);
+static void test_sc_do_umount(gconstpointer snap_debug) {
+    if (g_test_subprocess()) {
+        sc_break("umount", broken_umount);
+        if (GPOINTER_TO_INT(snap_debug) == 1) {
+            g_assert_true(g_setenv("SNAP_CONFINE_DEBUG", "1", true));
+        }
+        sc_do_umount("/foo", MNT_DETACH);
 
-		g_test_message("expected sc_do_umount not to return");
-		sc_reset_faults();
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	if (GPOINTER_TO_INT(snap_debug) == 0) {
-		g_test_trap_assert_stderr
-		    ("cannot perform operation: umount --lazy /foo: Permission denied\n");
-	} else {
-		/* with snap_debug the debug output hides the actual mount commands *but*
-		 * they are still shown if there was an error
-		 */
-		g_test_trap_assert_stderr
-		    ("DEBUG: performing operation: (disabled) use debug build to see details\n"
-		     "cannot perform operation: umount --lazy /foo: Permission denied\n");
-	}
+        g_test_message("expected sc_do_umount not to return");
+        sc_reset_faults();
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    if (GPOINTER_TO_INT(snap_debug) == 0) {
+        g_test_trap_assert_stderr("cannot perform operation: umount --lazy /foo: Permission denied\n");
+    } else {
+        /* with snap_debug the debug output hides the actual mount commands *but*
+         * they are still shown if there was an error
+         */
+        g_test_trap_assert_stderr(
+            "DEBUG: performing operation: (disabled) use debug build to see details\n"
+            "cannot perform operation: umount --lazy /foo: Permission denied\n");
+    }
 }
 
-static bool missing_mount(struct sc_fault_state *state, void *ptr)
-{
-	errno = ENOENT;
-	return true;
+static bool missing_mount(struct sc_fault_state *state, void *ptr) {
+    errno = ENOENT;
+    return true;
 }
 
-static void test_sc_do_optional_mount_missing(void)
-{
-	sc_break("mount", missing_mount);
-	bool ok = sc_do_optional_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
-	g_assert_false(ok);
-	sc_reset_faults();
+static void test_sc_do_optional_mount_missing(void) {
+    sc_break("mount", missing_mount);
+    bool ok = sc_do_optional_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
+    g_assert_false(ok);
+    sc_reset_faults();
 }
 
-static void test_sc_do_optional_mount_failure(gconstpointer snap_debug)
-{
-	if (g_test_subprocess()) {
-		sc_break("mount", broken_mount);
-		if (GPOINTER_TO_INT(snap_debug) == 1) {
-			g_assert_true(g_setenv
-				      ("SNAP_CONFINE_DEBUG", "1", true));
-		}
-		(void)sc_do_optional_mount("/foo", "/bar", "ext4", MS_RDONLY,
-					   NULL);
+static void test_sc_do_optional_mount_failure(gconstpointer snap_debug) {
+    if (g_test_subprocess()) {
+        sc_break("mount", broken_mount);
+        if (GPOINTER_TO_INT(snap_debug) == 1) {
+            g_assert_true(g_setenv("SNAP_CONFINE_DEBUG", "1", true));
+        }
+        (void)sc_do_optional_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
 
-		g_test_message("expected sc_do_mount not to return");
-		sc_reset_faults();
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	if (GPOINTER_TO_INT(snap_debug) == 0) {
-		g_test_trap_assert_stderr
-		    ("cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
-	} else {
-		/* with snap_debug the debug output hides the actual mount commands *but*
-		 * they are still shown if there was an error
-		 */
-		g_test_trap_assert_stderr
-		    ("DEBUG: performing operation: (disabled) use debug build to see details\n"
-		     "cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
-	}
+        g_test_message("expected sc_do_mount not to return");
+        sc_reset_faults();
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    if (GPOINTER_TO_INT(snap_debug) == 0) {
+        g_test_trap_assert_stderr("cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+    } else {
+        /* with snap_debug the debug output hides the actual mount commands *but*
+         * they are still shown if there was an error
+         */
+        g_test_trap_assert_stderr(
+            "DEBUG: performing operation: (disabled) use debug build to see details\n"
+            "cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+    }
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/mount/sc_mount_opt2str", test_sc_mount_opt2str);
-	g_test_add_func("/mount/sc_mount_cmd", test_sc_mount_cmd);
-	g_test_add_func("/mount/sc_umount_cmd", test_sc_umount_cmd);
-	g_test_add_data_func("/mount/sc_do_mount", GINT_TO_POINTER(0),
-			     test_sc_do_mount);
-	g_test_add_data_func("/mount/sc_do_umount", GINT_TO_POINTER(0),
-			     test_sc_do_umount);
-	g_test_add_data_func("/mount/sc_do_mount_with_debug",
-			     GINT_TO_POINTER(1), test_sc_do_mount);
-	g_test_add_data_func("/mount/sc_do_umount_with_debug",
-			     GINT_TO_POINTER(1), test_sc_do_umount);
-	g_test_add_func("/mount/sc_do_optional_mount_missing",
-			test_sc_do_optional_mount_missing);
-	g_test_add_data_func("/mount/sc_do_optional_mount_failure",
-			     GINT_TO_POINTER(0),
-			     test_sc_do_optional_mount_failure);
-	g_test_add_data_func("/mount/sc_do_optional_mount_failure_with_debug",
-			     GINT_TO_POINTER(1),
-			     test_sc_do_optional_mount_failure);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/mount/sc_mount_opt2str", test_sc_mount_opt2str);
+    g_test_add_func("/mount/sc_mount_cmd", test_sc_mount_cmd);
+    g_test_add_func("/mount/sc_umount_cmd", test_sc_umount_cmd);
+    g_test_add_data_func("/mount/sc_do_mount", GINT_TO_POINTER(0), test_sc_do_mount);
+    g_test_add_data_func("/mount/sc_do_umount", GINT_TO_POINTER(0), test_sc_do_umount);
+    g_test_add_data_func("/mount/sc_do_mount_with_debug", GINT_TO_POINTER(1), test_sc_do_mount);
+    g_test_add_data_func("/mount/sc_do_umount_with_debug", GINT_TO_POINTER(1), test_sc_do_umount);
+    g_test_add_func("/mount/sc_do_optional_mount_missing", test_sc_do_optional_mount_missing);
+    g_test_add_data_func("/mount/sc_do_optional_mount_failure", GINT_TO_POINTER(0), test_sc_do_optional_mount_failure);
+    g_test_add_data_func("/mount/sc_do_optional_mount_failure_with_debug", GINT_TO_POINTER(1),
+                         test_sc_do_optional_mount_failure);
 }

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -29,310 +29,294 @@
 #include "string-utils.h"
 #include "utils.h"
 
-const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags)
-{
-	unsigned long used = 0;
-	sc_string_init(buf, buf_size);
+const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags) {
+    unsigned long used = 0;
+    sc_string_init(buf, buf_size);
 
-#define F(FLAG, TEXT) do {                                         \
-    if (flags & (FLAG)) {                                          \
-      sc_string_append(buf, buf_size, #TEXT ","); flags ^= (FLAG); \
-    }                                                              \
-  } while (0)
+#define F(FLAG, TEXT)                                   \
+    do {                                                \
+        if (flags & (FLAG)) {                           \
+            sc_string_append(buf, buf_size, #TEXT ","); \
+            flags ^= (FLAG);                            \
+        }                                               \
+    } while (0)
 
-	F(MS_RDONLY, ro);
-	F(MS_NOSUID, nosuid);
-	F(MS_NODEV, nodev);
-	F(MS_NOEXEC, noexec);
-	F(MS_SYNCHRONOUS, sync);
-	F(MS_REMOUNT, remount);
-	F(MS_MANDLOCK, mand);
-	F(MS_DIRSYNC, dirsync);
-	F(MS_NOATIME, noatime);
-	F(MS_NODIRATIME, nodiratime);
-	if (flags & MS_BIND) {
-		if (flags & MS_REC) {
-			sc_string_append(buf, buf_size, "rbind,");
-			used |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, "bind,");
-		}
-		flags ^= MS_BIND;
-	}
-	F(MS_MOVE, move);
-	// The MS_REC flag handled separately by affected flags (MS_BIND,
-	// MS_PRIVATE, MS_SLAVE, MS_SHARED)
-	// XXX: kernel has MS_VERBOSE, glibc has MS_SILENT, both use the same constant
-	F(MS_SILENT, silent);
-	F(MS_POSIXACL, acl);
-	F(MS_UNBINDABLE, unbindable);
-	if (flags & MS_PRIVATE) {
-		if (flags & MS_REC) {
-			sc_string_append(buf, buf_size, "rprivate,");
-			used |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, "private,");
-		}
-		flags ^= MS_PRIVATE;
-	}
-	if (flags & MS_SLAVE) {
-		if (flags & MS_REC) {
-			sc_string_append(buf, buf_size, "rslave,");
-			used |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, "slave,");
-		}
-		flags ^= MS_SLAVE;
-	}
-	if (flags & MS_SHARED) {
-		if (flags & MS_REC) {
-			sc_string_append(buf, buf_size, "rshared,");
-			used |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, "shared,");
-		}
-		flags ^= MS_SHARED;
-	}
-	flags ^= used;		// this is just for MS_REC
-	F(MS_RELATIME, relatime);
-	F(MS_KERNMOUNT, kernmount);
-	F(MS_I_VERSION, iversion);
-	F(MS_STRICTATIME, strictatime);
+    F(MS_RDONLY, ro);
+    F(MS_NOSUID, nosuid);
+    F(MS_NODEV, nodev);
+    F(MS_NOEXEC, noexec);
+    F(MS_SYNCHRONOUS, sync);
+    F(MS_REMOUNT, remount);
+    F(MS_MANDLOCK, mand);
+    F(MS_DIRSYNC, dirsync);
+    F(MS_NOATIME, noatime);
+    F(MS_NODIRATIME, nodiratime);
+    if (flags & MS_BIND) {
+        if (flags & MS_REC) {
+            sc_string_append(buf, buf_size, "rbind,");
+            used |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, "bind,");
+        }
+        flags ^= MS_BIND;
+    }
+    F(MS_MOVE, move);
+    // The MS_REC flag handled separately by affected flags (MS_BIND,
+    // MS_PRIVATE, MS_SLAVE, MS_SHARED)
+    // XXX: kernel has MS_VERBOSE, glibc has MS_SILENT, both use the same constant
+    F(MS_SILENT, silent);
+    F(MS_POSIXACL, acl);
+    F(MS_UNBINDABLE, unbindable);
+    if (flags & MS_PRIVATE) {
+        if (flags & MS_REC) {
+            sc_string_append(buf, buf_size, "rprivate,");
+            used |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, "private,");
+        }
+        flags ^= MS_PRIVATE;
+    }
+    if (flags & MS_SLAVE) {
+        if (flags & MS_REC) {
+            sc_string_append(buf, buf_size, "rslave,");
+            used |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, "slave,");
+        }
+        flags ^= MS_SLAVE;
+    }
+    if (flags & MS_SHARED) {
+        if (flags & MS_REC) {
+            sc_string_append(buf, buf_size, "rshared,");
+            used |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, "shared,");
+        }
+        flags ^= MS_SHARED;
+    }
+    flags ^= used;  // this is just for MS_REC
+    F(MS_RELATIME, relatime);
+    F(MS_KERNMOUNT, kernmount);
+    F(MS_I_VERSION, iversion);
+    F(MS_STRICTATIME, strictatime);
 #ifndef MS_LAZYTIME
-#define MS_LAZYTIME (1<<25)
+#define MS_LAZYTIME (1 << 25)
 #endif
-	F(MS_LAZYTIME, lazytime);
+    F(MS_LAZYTIME, lazytime);
 #ifndef MS_NOSEC
 #define MS_NOSEC (1 << 28)
 #endif
-	F(MS_NOSEC, nosec);
+    F(MS_NOSEC, nosec);
 #ifndef MS_BORN
 #define MS_BORN (1 << 29)
 #endif
-	F(MS_BORN, born);
-	F(MS_ACTIVE, active);
-	F(MS_NOUSER, nouser);
+    F(MS_BORN, born);
+    F(MS_ACTIVE, active);
+    F(MS_NOUSER, nouser);
 #undef F
-	// Render any flags that are unaccounted for.
-	if (flags) {
-		char of[128] = { 0 };
-		sc_must_snprintf(of, sizeof of, "%#lx", flags);
-		sc_string_append(buf, buf_size, of);
-	}
-	// Chop the excess comma from the end.
-	size_t len = strnlen(buf, buf_size);
-	if (len > 0 && buf[len - 1] == ',') {
-		buf[len - 1] = 0;
-	}
-	return buf;
+    // Render any flags that are unaccounted for.
+    if (flags) {
+        char of[128] = {0};
+        sc_must_snprintf(of, sizeof of, "%#lx", flags);
+        sc_string_append(buf, buf_size, of);
+    }
+    // Chop the excess comma from the end.
+    size_t len = strnlen(buf, buf_size);
+    if (len > 0 && buf[len - 1] == ',') {
+        buf[len - 1] = 0;
+    }
+    return buf;
 }
 
-const char *sc_mount_cmd(char *buf, size_t buf_size, const char *source, const char
-			 *target, const char *fs_type, unsigned long mountflags, const
-			 void *data)
-{
-	sc_string_init(buf, buf_size);
-	sc_string_append(buf, buf_size, "mount");
+const char *sc_mount_cmd(char *buf, size_t buf_size, const char *source, const char *target, const char *fs_type,
+                         unsigned long mountflags, const void *data) {
+    sc_string_init(buf, buf_size);
+    sc_string_append(buf, buf_size, "mount");
 
-	// Add filesysystem type if it's there and doesn't have the special value "none"
-	if (fs_type != NULL && strncmp(fs_type, "none", 5) != 0) {
-		sc_string_append(buf, buf_size, " -t ");
-		sc_string_append(buf, buf_size, fs_type);
-	}
-	// Check for some special, dedicated options, that aren't represented with
-	// the generic mount option argument (mount -o ...), by collecting those
-	// options that we will display as command line arguments in
-	// used_special_flags. This is used below to filter out these arguments
-	// from mount_flags when calling sc_mount_opt2str().
-	int used_special_flags = 0;
+    // Add filesysystem type if it's there and doesn't have the special value "none"
+    if (fs_type != NULL && strncmp(fs_type, "none", 5) != 0) {
+        sc_string_append(buf, buf_size, " -t ");
+        sc_string_append(buf, buf_size, fs_type);
+    }
+    // Check for some special, dedicated options, that aren't represented with
+    // the generic mount option argument (mount -o ...), by collecting those
+    // options that we will display as command line arguments in
+    // used_special_flags. This is used below to filter out these arguments
+    // from mount_flags when calling sc_mount_opt2str().
+    int used_special_flags = 0;
 
-	// Bind-ounts (bind)
-	if (mountflags & MS_BIND) {
-		if (mountflags & MS_REC) {
-			sc_string_append(buf, buf_size, " --rbind");
-			used_special_flags |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, " --bind");
-		}
-		used_special_flags |= MS_BIND;
-	}
-	// Moving mount point location (move)
-	if (mountflags & MS_MOVE) {
-		sc_string_append(buf, buf_size, " --move");
-		used_special_flags |= MS_MOVE;
-	}
-	// Shared subtree operations (shared, slave, private, unbindable).
-	if (MS_SHARED & mountflags) {
-		if (mountflags & MS_REC) {
-			sc_string_append(buf, buf_size, " --make-rshared");
-			used_special_flags |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, " --make-shared");
-		}
-		used_special_flags |= MS_SHARED;
-	}
+    // Bind-ounts (bind)
+    if (mountflags & MS_BIND) {
+        if (mountflags & MS_REC) {
+            sc_string_append(buf, buf_size, " --rbind");
+            used_special_flags |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, " --bind");
+        }
+        used_special_flags |= MS_BIND;
+    }
+    // Moving mount point location (move)
+    if (mountflags & MS_MOVE) {
+        sc_string_append(buf, buf_size, " --move");
+        used_special_flags |= MS_MOVE;
+    }
+    // Shared subtree operations (shared, slave, private, unbindable).
+    if (MS_SHARED & mountflags) {
+        if (mountflags & MS_REC) {
+            sc_string_append(buf, buf_size, " --make-rshared");
+            used_special_flags |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, " --make-shared");
+        }
+        used_special_flags |= MS_SHARED;
+    }
 
-	if (MS_SLAVE & mountflags) {
-		if (mountflags & MS_REC) {
-			sc_string_append(buf, buf_size, " --make-rslave");
-			used_special_flags |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, " --make-slave");
-		}
-		used_special_flags |= MS_SLAVE;
-	}
+    if (MS_SLAVE & mountflags) {
+        if (mountflags & MS_REC) {
+            sc_string_append(buf, buf_size, " --make-rslave");
+            used_special_flags |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, " --make-slave");
+        }
+        used_special_flags |= MS_SLAVE;
+    }
 
-	if (MS_PRIVATE & mountflags) {
-		if (mountflags & MS_REC) {
-			sc_string_append(buf, buf_size, " --make-rprivate");
-			used_special_flags |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, " --make-private");
-		}
-		used_special_flags |= MS_PRIVATE;
-	}
+    if (MS_PRIVATE & mountflags) {
+        if (mountflags & MS_REC) {
+            sc_string_append(buf, buf_size, " --make-rprivate");
+            used_special_flags |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, " --make-private");
+        }
+        used_special_flags |= MS_PRIVATE;
+    }
 
-	if (MS_UNBINDABLE & mountflags) {
-		if (mountflags & MS_REC) {
-			sc_string_append(buf, buf_size, " --make-runbindable");
-			used_special_flags |= MS_REC;
-		} else {
-			sc_string_append(buf, buf_size, " --make-unbindable");
-		}
-		used_special_flags |= MS_UNBINDABLE;
-	}
-	// If regular option syntax exists then use it.
-	if (mountflags & ~used_special_flags) {
-		char opts_buf[1000] = { 0 };
-		sc_mount_opt2str(opts_buf, sizeof opts_buf, mountflags &
-				 ~used_special_flags);
-		sc_string_append(buf, buf_size, " -o ");
-		sc_string_append(buf, buf_size, opts_buf);
-	}
-	// Add source and target locations
-	if (source != NULL && strncmp(source, "none", 5) != 0) {
-		sc_string_append(buf, buf_size, " ");
-		sc_string_append(buf, buf_size, source);
-	}
-	if (target != NULL && strncmp(target, "none", 5) != 0) {
-		sc_string_append(buf, buf_size, " ");
-		sc_string_append(buf, buf_size, target);
-	}
+    if (MS_UNBINDABLE & mountflags) {
+        if (mountflags & MS_REC) {
+            sc_string_append(buf, buf_size, " --make-runbindable");
+            used_special_flags |= MS_REC;
+        } else {
+            sc_string_append(buf, buf_size, " --make-unbindable");
+        }
+        used_special_flags |= MS_UNBINDABLE;
+    }
+    // If regular option syntax exists then use it.
+    if (mountflags & ~used_special_flags) {
+        char opts_buf[1000] = {0};
+        sc_mount_opt2str(opts_buf, sizeof opts_buf, mountflags & ~used_special_flags);
+        sc_string_append(buf, buf_size, " -o ");
+        sc_string_append(buf, buf_size, opts_buf);
+    }
+    // Add source and target locations
+    if (source != NULL && strncmp(source, "none", 5) != 0) {
+        sc_string_append(buf, buf_size, " ");
+        sc_string_append(buf, buf_size, source);
+    }
+    if (target != NULL && strncmp(target, "none", 5) != 0) {
+        sc_string_append(buf, buf_size, " ");
+        sc_string_append(buf, buf_size, target);
+    }
 
-	return buf;
+    return buf;
 }
 
-const char *sc_umount_cmd(char *buf, size_t buf_size, const char *target,
-			  int flags)
-{
-	sc_string_init(buf, buf_size);
-	sc_string_append(buf, buf_size, "umount");
+const char *sc_umount_cmd(char *buf, size_t buf_size, const char *target, int flags) {
+    sc_string_init(buf, buf_size);
+    sc_string_append(buf, buf_size, "umount");
 
-	if (flags & MNT_FORCE) {
-		sc_string_append(buf, buf_size, " --force");
-	}
+    if (flags & MNT_FORCE) {
+        sc_string_append(buf, buf_size, " --force");
+    }
 
-	if (flags & MNT_DETACH) {
-		sc_string_append(buf, buf_size, " --lazy");
-	}
-	if (flags & MNT_EXPIRE) {
-		// NOTE: there's no real command line option for MNT_EXPIRE
-		sc_string_append(buf, buf_size, " --expire");
-	}
-	if (flags & UMOUNT_NOFOLLOW) {
-		// NOTE: there's no real command line option for UMOUNT_NOFOLLOW
-		sc_string_append(buf, buf_size, " --no-follow");
-	}
-	if (target != NULL) {
-		sc_string_append(buf, buf_size, " ");
-		sc_string_append(buf, buf_size, target);
-	}
+    if (flags & MNT_DETACH) {
+        sc_string_append(buf, buf_size, " --lazy");
+    }
+    if (flags & MNT_EXPIRE) {
+        // NOTE: there's no real command line option for MNT_EXPIRE
+        sc_string_append(buf, buf_size, " --expire");
+    }
+    if (flags & UMOUNT_NOFOLLOW) {
+        // NOTE: there's no real command line option for UMOUNT_NOFOLLOW
+        sc_string_append(buf, buf_size, " --no-follow");
+    }
+    if (target != NULL) {
+        sc_string_append(buf, buf_size, " ");
+        sc_string_append(buf, buf_size, target);
+    }
 
-	return buf;
+    return buf;
 }
 
 #ifndef SNAP_CONFINE_DEBUG_BUILD
-static const char *use_debug_build =
-    "(disabled) use debug build to see details";
+static const char *use_debug_build = "(disabled) use debug build to see details";
 #endif
 
-static bool sc_do_mount_ex(const char *source, const char *target,
-			   const char *fs_type,
-			   unsigned long mountflags, const void *data,
-			   bool optional)
-{
-	char buf[10000] = { 0 };
-	const char *mount_cmd = NULL;
+static bool sc_do_mount_ex(const char *source, const char *target, const char *fs_type, unsigned long mountflags,
+                           const void *data, bool optional) {
+    char buf[10000] = {0};
+    const char *mount_cmd = NULL;
 
-	if (sc_is_debug_enabled()) {
+    if (sc_is_debug_enabled()) {
 #ifdef SNAP_CONFINE_DEBUG_BUILD
-		mount_cmd = sc_mount_cmd(buf, sizeof(buf), source,
-					 target, fs_type, mountflags, data);
+        mount_cmd = sc_mount_cmd(buf, sizeof(buf), source, target, fs_type, mountflags, data);
 #else
-		mount_cmd = use_debug_build;
+        mount_cmd = use_debug_build;
 #endif
-		debug("performing operation: %s", mount_cmd);
-	}
-	if (sc_faulty("mount", NULL)
-	    || mount(source, target, fs_type, mountflags, data) < 0) {
-		int saved_errno = errno;
-		if (optional && saved_errno == ENOENT) {
-			// The special-cased value that is allowed to fail.
-			return false;
-		}
-		// Drop privileges so that we can compute our nice error message
-		// without risking an attack on one of the string functions there.
-		sc_privs_drop();
+        debug("performing operation: %s", mount_cmd);
+    }
+    if (sc_faulty("mount", NULL) || mount(source, target, fs_type, mountflags, data) < 0) {
+        int saved_errno = errno;
+        if (optional && saved_errno == ENOENT) {
+            // The special-cased value that is allowed to fail.
+            return false;
+        }
+        // Drop privileges so that we can compute our nice error message
+        // without risking an attack on one of the string functions there.
+        sc_privs_drop();
 
-		// Compute the equivalent mount command.
-		mount_cmd = sc_mount_cmd(buf, sizeof(buf), source,
-					 target, fs_type, mountflags, data);
-		// Restore errno and die.
-		errno = saved_errno;
-		die("cannot perform operation: %s", mount_cmd);
-	}
-	return true;
+        // Compute the equivalent mount command.
+        mount_cmd = sc_mount_cmd(buf, sizeof(buf), source, target, fs_type, mountflags, data);
+        // Restore errno and die.
+        errno = saved_errno;
+        die("cannot perform operation: %s", mount_cmd);
+    }
+    return true;
 }
 
-void sc_do_mount(const char *source, const char *target,
-		 const char *fs_type, unsigned long mountflags,
-		 const void *data)
-{
-	(void)sc_do_mount_ex(source, target, fs_type, mountflags, data, false);
+void sc_do_mount(const char *source, const char *target, const char *fs_type, unsigned long mountflags,
+                 const void *data) {
+    (void)sc_do_mount_ex(source, target, fs_type, mountflags, data, false);
 }
 
-bool sc_do_optional_mount(const char *source, const char *target,
-			  const char *fs_type, unsigned long mountflags,
-			  const void *data)
-{
-	return sc_do_mount_ex(source, target, fs_type, mountflags, data, true);
+bool sc_do_optional_mount(const char *source, const char *target, const char *fs_type, unsigned long mountflags,
+                          const void *data) {
+    return sc_do_mount_ex(source, target, fs_type, mountflags, data, true);
 }
 
-void sc_do_umount(const char *target, int flags)
-{
-	char buf[10000] = { 0 };
-	const char *umount_cmd = NULL;
+void sc_do_umount(const char *target, int flags) {
+    char buf[10000] = {0};
+    const char *umount_cmd = NULL;
 
-	if (sc_is_debug_enabled()) {
+    if (sc_is_debug_enabled()) {
 #ifdef SNAP_CONFINE_DEBUG_BUILD
-		umount_cmd = sc_umount_cmd(buf, sizeof(buf), target, flags);
+        umount_cmd = sc_umount_cmd(buf, sizeof(buf), target, flags);
 #else
-		umount_cmd = use_debug_build;
+        umount_cmd = use_debug_build;
 #endif
-		debug("performing operation: %s", umount_cmd);
-	}
-	if (sc_faulty("umount", NULL) || umount2(target, flags) < 0) {
-		// Save errno as ensure can clobber it.
-		int saved_errno = errno;
+        debug("performing operation: %s", umount_cmd);
+    }
+    if (sc_faulty("umount", NULL) || umount2(target, flags) < 0) {
+        // Save errno as ensure can clobber it.
+        int saved_errno = errno;
 
-		// Drop privileges so that we can compute our nice error message
-		// without risking an attack on one of the string functions there.
-		sc_privs_drop();
+        // Drop privileges so that we can compute our nice error message
+        // without risking an attack on one of the string functions there.
+        sc_privs_drop();
 
-		// Compute the equivalent umount command.
-		umount_cmd = sc_umount_cmd(buf, sizeof(buf), target, flags);
-		// Restore errno and die.
-		errno = saved_errno;
-		die("cannot perform operation: %s", umount_cmd);
-	}
+        // Compute the equivalent umount command.
+        umount_cmd = sc_umount_cmd(buf, sizeof(buf), target, flags);
+        // Restore errno and die.
+        errno = saved_errno;
+        die("cannot perform operation: %s", umount_cmd);
+    }
 }

--- a/cmd/libsnap-confine-private/mount-opt.h
+++ b/cmd/libsnap-confine-private/mount-opt.h
@@ -22,7 +22,7 @@
 #include <stddef.h>
 
 /**
- * Convert flags for mount(2) system call to a string representation. 
+ * Convert flags for mount(2) system call to a string representation.
  **/
 const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags);
 
@@ -38,9 +38,8 @@ const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags);
  *
  * The returned value is always buf, it is provided as a convenience.
  **/
-const char *sc_mount_cmd(char *buf, size_t buf_size, const char *source, const char
-			 *target, const char *fs_type, unsigned long mountflags,
-			 const void *data);
+const char *sc_mount_cmd(char *buf, size_t buf_size, const char *source, const char *target, const char *fs_type,
+                         unsigned long mountflags, const void *data);
 
 /**
  * Compute an equivalent umount(8) command from umount2(2) arguments.
@@ -58,15 +57,13 @@ const char *sc_mount_cmd(char *buf, size_t buf_size, const char *source, const c
  *
  * The returned value is always buf, it is provided as a convenience.
  **/
-const char *sc_umount_cmd(char *buf, size_t buf_size, const char *target,
-			  int flags);
+const char *sc_umount_cmd(char *buf, size_t buf_size, const char *target, int flags);
 
 /**
  * A thin wrapper around mount(2) with logging and error checks.
  **/
-void sc_do_mount(const char *source, const char *target,
-		 const char *fs_type, unsigned long mountflags,
-		 const void *data);
+void sc_do_mount(const char *source, const char *target, const char *fs_type, unsigned long mountflags,
+                 const void *data);
 
 /**
  * A thin wrapper around mount(2) with logging and error checks.
@@ -77,13 +74,12 @@ void sc_do_mount(const char *source, const char *target,
  *
  * The return value indicates if the operation was successful or not.
  **/
-bool sc_do_optional_mount(const char *source, const char *target,
-			  const char *fs_type, unsigned long mountflags,
-			  const void *data);
+bool sc_do_optional_mount(const char *source, const char *target, const char *fs_type, unsigned long mountflags,
+                          const void *data);
 
 /**
  * A thin wrapper around umount(2) with logging and error checks.
  **/
 void sc_do_umount(const char *target, int flags);
 
-#endif				// SNAP_CONFINE_MOUNT_OPT_H
+#endif  // SNAP_CONFINE_MOUNT_OPT_H

--- a/cmd/libsnap-confine-private/mountinfo-test.c
+++ b/cmd/libsnap-confine-private/mountinfo-test.c
@@ -20,291 +20,259 @@
 
 #include <glib.h>
 
-static void test_parse_mountinfo_entry__sysfs(void)
-{
-	const char *line =
-	    "19 25 0:18 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 19);
-	g_assert_cmpint(entry->parent_id, ==, 25);
-	g_assert_cmpint(entry->dev_major, ==, 0);
-	g_assert_cmpint(entry->dev_minor, ==, 18);
-	g_assert_cmpstr(entry->root, ==, "/");
-	g_assert_cmpstr(entry->mount_dir, ==, "/sys");
-	g_assert_cmpstr(entry->mount_opts, ==,
-			"rw,nosuid,nodev,noexec,relatime");
-	g_assert_cmpstr(entry->optional_fields, ==, "shared:7");
-	g_assert_cmpstr(entry->fs_type, ==, "sysfs");
-	g_assert_cmpstr(entry->mount_source, ==, "sysfs");
-	g_assert_cmpstr(entry->super_opts, ==, "rw");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__sysfs(void) {
+    const char *line = "19 25 0:18 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 19);
+    g_assert_cmpint(entry->parent_id, ==, 25);
+    g_assert_cmpint(entry->dev_major, ==, 0);
+    g_assert_cmpint(entry->dev_minor, ==, 18);
+    g_assert_cmpstr(entry->root, ==, "/");
+    g_assert_cmpstr(entry->mount_dir, ==, "/sys");
+    g_assert_cmpstr(entry->mount_opts, ==, "rw,nosuid,nodev,noexec,relatime");
+    g_assert_cmpstr(entry->optional_fields, ==, "shared:7");
+    g_assert_cmpstr(entry->fs_type, ==, "sysfs");
+    g_assert_cmpstr(entry->mount_source, ==, "sysfs");
+    g_assert_cmpstr(entry->super_opts, ==, "rw");
+    g_assert_null(entry->next);
 }
 
 // Parse the /run/snapd/ns bind mount (over itself)
 // Note that /run is itself a tmpfs mount point.
-static void test_parse_mountinfo_entry__snapd_ns(void)
-{
-	const char *line =
-	    "104 23 0:19 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=99840k,mode=755";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 104);
-	g_assert_cmpint(entry->parent_id, ==, 23);
-	g_assert_cmpint(entry->dev_major, ==, 0);
-	g_assert_cmpint(entry->dev_minor, ==, 19);
-	g_assert_cmpstr(entry->root, ==, "/snapd/ns");
-	g_assert_cmpstr(entry->mount_dir, ==, "/run/snapd/ns");
-	g_assert_cmpstr(entry->mount_opts, ==, "rw,nosuid,noexec,relatime");
-	g_assert_cmpstr(entry->optional_fields, ==, "");
-	g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
-	g_assert_cmpstr(entry->mount_source, ==, "tmpfs");
-	g_assert_cmpstr(entry->super_opts, ==, "rw,size=99840k,mode=755");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__snapd_ns(void) {
+    const char *line =
+        "104 23 0:19 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=99840k,mode=755";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 104);
+    g_assert_cmpint(entry->parent_id, ==, 23);
+    g_assert_cmpint(entry->dev_major, ==, 0);
+    g_assert_cmpint(entry->dev_minor, ==, 19);
+    g_assert_cmpstr(entry->root, ==, "/snapd/ns");
+    g_assert_cmpstr(entry->mount_dir, ==, "/run/snapd/ns");
+    g_assert_cmpstr(entry->mount_opts, ==, "rw,nosuid,noexec,relatime");
+    g_assert_cmpstr(entry->optional_fields, ==, "");
+    g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
+    g_assert_cmpstr(entry->mount_source, ==, "tmpfs");
+    g_assert_cmpstr(entry->super_opts, ==, "rw,size=99840k,mode=755");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__snapd_mnt(void)
-{
-	const char *line =
-	    "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 256);
-	g_assert_cmpint(entry->parent_id, ==, 104);
-	g_assert_cmpint(entry->dev_major, ==, 0);
-	g_assert_cmpint(entry->dev_minor, ==, 3);
-	g_assert_cmpstr(entry->root, ==, "mnt:[4026532509]");
-	g_assert_cmpstr(entry->mount_dir, ==, "/run/snapd/ns/hello-world.mnt");
-	g_assert_cmpstr(entry->mount_opts, ==, "rw");
-	g_assert_cmpstr(entry->optional_fields, ==, "");
-	g_assert_cmpstr(entry->fs_type, ==, "nsfs");
-	g_assert_cmpstr(entry->mount_source, ==, "nsfs");
-	g_assert_cmpstr(entry->super_opts, ==, "rw");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__snapd_mnt(void) {
+    const char *line = "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 256);
+    g_assert_cmpint(entry->parent_id, ==, 104);
+    g_assert_cmpint(entry->dev_major, ==, 0);
+    g_assert_cmpint(entry->dev_minor, ==, 3);
+    g_assert_cmpstr(entry->root, ==, "mnt:[4026532509]");
+    g_assert_cmpstr(entry->mount_dir, ==, "/run/snapd/ns/hello-world.mnt");
+    g_assert_cmpstr(entry->mount_opts, ==, "rw");
+    g_assert_cmpstr(entry->optional_fields, ==, "");
+    g_assert_cmpstr(entry->fs_type, ==, "nsfs");
+    g_assert_cmpstr(entry->mount_source, ==, "nsfs");
+    g_assert_cmpstr(entry->super_opts, ==, "rw");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__garbage(void)
-{
-	const char *line = "256 104 0:3";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_null(entry);
+static void test_parse_mountinfo_entry__garbage(void) {
+    const char *line = "256 104 0:3";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_null(entry);
 }
 
-static void test_parse_mountinfo_entry__no_tags(void)
-{
-	const char *line =
-	    "1 2 3:4 root mount-dir mount-opts - fs-type mount-source super-opts";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 1);
-	g_assert_cmpint(entry->parent_id, ==, 2);
-	g_assert_cmpint(entry->dev_major, ==, 3);
-	g_assert_cmpint(entry->dev_minor, ==, 4);
-	g_assert_cmpstr(entry->root, ==, "root");
-	g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
-	g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
-	g_assert_cmpstr(entry->optional_fields, ==, "");
-	g_assert_cmpstr(entry->fs_type, ==, "fs-type");
-	g_assert_cmpstr(entry->mount_source, ==, "mount-source");
-	g_assert_cmpstr(entry->super_opts, ==, "super-opts");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__no_tags(void) {
+    const char *line = "1 2 3:4 root mount-dir mount-opts - fs-type mount-source super-opts";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 1);
+    g_assert_cmpint(entry->parent_id, ==, 2);
+    g_assert_cmpint(entry->dev_major, ==, 3);
+    g_assert_cmpint(entry->dev_minor, ==, 4);
+    g_assert_cmpstr(entry->root, ==, "root");
+    g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
+    g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
+    g_assert_cmpstr(entry->optional_fields, ==, "");
+    g_assert_cmpstr(entry->fs_type, ==, "fs-type");
+    g_assert_cmpstr(entry->mount_source, ==, "mount-source");
+    g_assert_cmpstr(entry->super_opts, ==, "super-opts");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__one_tag(void)
-{
-	const char *line =
-	    "1 2 3:4 root mount-dir mount-opts tag:1 - fs-type mount-source super-opts";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 1);
-	g_assert_cmpint(entry->parent_id, ==, 2);
-	g_assert_cmpint(entry->dev_major, ==, 3);
-	g_assert_cmpint(entry->dev_minor, ==, 4);
-	g_assert_cmpstr(entry->root, ==, "root");
-	g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
-	g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
-	g_assert_cmpstr(entry->optional_fields, ==, "tag:1");
-	g_assert_cmpstr(entry->fs_type, ==, "fs-type");
-	g_assert_cmpstr(entry->mount_source, ==, "mount-source");
-	g_assert_cmpstr(entry->super_opts, ==, "super-opts");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__one_tag(void) {
+    const char *line = "1 2 3:4 root mount-dir mount-opts tag:1 - fs-type mount-source super-opts";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 1);
+    g_assert_cmpint(entry->parent_id, ==, 2);
+    g_assert_cmpint(entry->dev_major, ==, 3);
+    g_assert_cmpint(entry->dev_minor, ==, 4);
+    g_assert_cmpstr(entry->root, ==, "root");
+    g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
+    g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
+    g_assert_cmpstr(entry->optional_fields, ==, "tag:1");
+    g_assert_cmpstr(entry->fs_type, ==, "fs-type");
+    g_assert_cmpstr(entry->mount_source, ==, "mount-source");
+    g_assert_cmpstr(entry->super_opts, ==, "super-opts");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__many_tags(void)
-{
-	const char *line =
-	    "1 2 3:4 root mount-dir mount-opts tag:1 tag:2 tag:3 tag:4 - fs-type mount-source super-opts";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 1);
-	g_assert_cmpint(entry->parent_id, ==, 2);
-	g_assert_cmpint(entry->dev_major, ==, 3);
-	g_assert_cmpint(entry->dev_minor, ==, 4);
-	g_assert_cmpstr(entry->root, ==, "root");
-	g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
-	g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
-	g_assert_cmpstr(entry->optional_fields, ==, "tag:1 tag:2 tag:3 tag:4");
-	g_assert_cmpstr(entry->fs_type, ==, "fs-type");
-	g_assert_cmpstr(entry->mount_source, ==, "mount-source");
-	g_assert_cmpstr(entry->super_opts, ==, "super-opts");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__many_tags(void) {
+    const char *line = "1 2 3:4 root mount-dir mount-opts tag:1 tag:2 tag:3 tag:4 - fs-type mount-source super-opts";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 1);
+    g_assert_cmpint(entry->parent_id, ==, 2);
+    g_assert_cmpint(entry->dev_major, ==, 3);
+    g_assert_cmpint(entry->dev_minor, ==, 4);
+    g_assert_cmpstr(entry->root, ==, "root");
+    g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
+    g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
+    g_assert_cmpstr(entry->optional_fields, ==, "tag:1 tag:2 tag:3 tag:4");
+    g_assert_cmpstr(entry->fs_type, ==, "fs-type");
+    g_assert_cmpstr(entry->mount_source, ==, "mount-source");
+    g_assert_cmpstr(entry->super_opts, ==, "super-opts");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__empty_source(void)
-{
-	const char *line =
-	    "304 301 0:45 / /snap/test-snapd-content-advanced-plug/x1 rw,relatime - tmpfs  rw";
-	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 304);
-	g_assert_cmpint(entry->parent_id, ==, 301);
-	g_assert_cmpint(entry->dev_major, ==, 0);
-	g_assert_cmpint(entry->dev_minor, ==, 45);
-	g_assert_cmpstr(entry->root, ==, "/");
-	g_assert_cmpstr(entry->mount_dir, ==,
-			"/snap/test-snapd-content-advanced-plug/x1");
-	g_assert_cmpstr(entry->mount_opts, ==, "rw,relatime");
-	g_assert_cmpstr(entry->optional_fields, ==, "");
-	g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
-	g_assert_cmpstr(entry->mount_source, ==, "");
-	g_assert_cmpstr(entry->super_opts, ==, "rw");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__empty_source(void) {
+    const char *line = "304 301 0:45 / /snap/test-snapd-content-advanced-plug/x1 rw,relatime - tmpfs  rw";
+    sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 304);
+    g_assert_cmpint(entry->parent_id, ==, 301);
+    g_assert_cmpint(entry->dev_major, ==, 0);
+    g_assert_cmpint(entry->dev_minor, ==, 45);
+    g_assert_cmpstr(entry->root, ==, "/");
+    g_assert_cmpstr(entry->mount_dir, ==, "/snap/test-snapd-content-advanced-plug/x1");
+    g_assert_cmpstr(entry->mount_opts, ==, "rw,relatime");
+    g_assert_cmpstr(entry->optional_fields, ==, "");
+    g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
+    g_assert_cmpstr(entry->mount_source, ==, "");
+    g_assert_cmpstr(entry->super_opts, ==, "rw");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__octal_escaping(void)
-{
-	const char *line;
-	struct sc_mountinfo_entry *entry;
+static void test_parse_mountinfo_entry__octal_escaping(void) {
+    const char *line;
+    struct sc_mountinfo_entry *entry;
 
-	// The kernel escapes spaces as \040
-	line = "2 1 0:54 / /tmp rw - tmpfs tricky\\040path rw";
-	entry = sc_parse_mountinfo_entry(line);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_nonnull(entry);
-	g_assert_cmpstr(entry->mount_source, ==, "tricky path");
+    // The kernel escapes spaces as \040
+    line = "2 1 0:54 / /tmp rw - tmpfs tricky\\040path rw";
+    entry = sc_parse_mountinfo_entry(line);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_nonnull(entry);
+    g_assert_cmpstr(entry->mount_source, ==, "tricky path");
 
-	// kernel escapes newlines as \012
-	line = "2 1 0:54 / /tmp rw - tmpfs tricky\\012path rw";
-	entry = sc_parse_mountinfo_entry(line);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_nonnull(entry);
-	g_assert_cmpstr(entry->mount_source, ==, "tricky\npath");
+    // kernel escapes newlines as \012
+    line = "2 1 0:54 / /tmp rw - tmpfs tricky\\012path rw";
+    entry = sc_parse_mountinfo_entry(line);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_nonnull(entry);
+    g_assert_cmpstr(entry->mount_source, ==, "tricky\npath");
 
-	// kernel escapes tabs as \011
-	line = "2 1 0:54 / /tmp rw - tmpfs tricky\\011path rw";
-	entry = sc_parse_mountinfo_entry(line);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_nonnull(entry);
-	g_assert_cmpstr(entry->mount_source, ==, "tricky\tpath");
+    // kernel escapes tabs as \011
+    line = "2 1 0:54 / /tmp rw - tmpfs tricky\\011path rw";
+    entry = sc_parse_mountinfo_entry(line);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_nonnull(entry);
+    g_assert_cmpstr(entry->mount_source, ==, "tricky\tpath");
 
-	// kernel escapes forward slashes as \057
-	line = "2 1 0:54 / /tmp rw - tmpfs tricky\\057path rw";
-	entry = sc_parse_mountinfo_entry(line);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_nonnull(entry);
-	g_assert_cmpstr(entry->mount_source, ==, "tricky/path");
+    // kernel escapes forward slashes as \057
+    line = "2 1 0:54 / /tmp rw - tmpfs tricky\\057path rw";
+    entry = sc_parse_mountinfo_entry(line);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_nonnull(entry);
+    g_assert_cmpstr(entry->mount_source, ==, "tricky/path");
 }
 
-static void test_parse_mountinfo_entry__broken_octal_escaping(void)
-{
-	// Invalid octal escape sequences are left intact.
-	const char *line =
-	    "2074 27 0:54 / /tmp/strange-dir rw,relatime shared:1039 - tmpfs no\\888thing rw\\";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 2074);
-	g_assert_cmpint(entry->parent_id, ==, 27);
-	g_assert_cmpint(entry->dev_major, ==, 0);
-	g_assert_cmpint(entry->dev_minor, ==, 54);
-	g_assert_cmpstr(entry->root, ==, "/");
-	g_assert_cmpstr(entry->mount_dir, ==, "/tmp/strange-dir");
-	g_assert_cmpstr(entry->mount_opts, ==, "rw,relatime");
-	g_assert_cmpstr(entry->optional_fields, ==, "shared:1039");
-	g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
-	g_assert_cmpstr(entry->mount_source, ==, "no\\888thing");
-	g_assert_cmpstr(entry->super_opts, ==, "rw\\");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__broken_octal_escaping(void) {
+    // Invalid octal escape sequences are left intact.
+    const char *line = "2074 27 0:54 / /tmp/strange-dir rw,relatime shared:1039 - tmpfs no\\888thing rw\\";
+    struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 2074);
+    g_assert_cmpint(entry->parent_id, ==, 27);
+    g_assert_cmpint(entry->dev_major, ==, 0);
+    g_assert_cmpint(entry->dev_minor, ==, 54);
+    g_assert_cmpstr(entry->root, ==, "/");
+    g_assert_cmpstr(entry->mount_dir, ==, "/tmp/strange-dir");
+    g_assert_cmpstr(entry->mount_opts, ==, "rw,relatime");
+    g_assert_cmpstr(entry->optional_fields, ==, "shared:1039");
+    g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
+    g_assert_cmpstr(entry->mount_source, ==, "no\\888thing");
+    g_assert_cmpstr(entry->super_opts, ==, "rw\\");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__unescaped_whitespace(void)
-{
-	// The kernel does not escape '\r'
-	const char *line =
-	    "2074 27 0:54 / /tmp/strange\rdir rw,relatime shared:1039 - tmpfs tmpfs rw";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 2074);
-	g_assert_cmpint(entry->parent_id, ==, 27);
-	g_assert_cmpint(entry->dev_major, ==, 0);
-	g_assert_cmpint(entry->dev_minor, ==, 54);
-	g_assert_cmpstr(entry->root, ==, "/");
-	g_assert_cmpstr(entry->mount_dir, ==, "/tmp/strange\rdir");
-	g_assert_cmpstr(entry->mount_opts, ==, "rw,relatime");
-	g_assert_cmpstr(entry->optional_fields, ==, "shared:1039");
-	g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
-	g_assert_cmpstr(entry->mount_source, ==, "tmpfs");
-	g_assert_cmpstr(entry->super_opts, ==, "rw");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__unescaped_whitespace(void) {
+    // The kernel does not escape '\r'
+    const char *line = "2074 27 0:54 / /tmp/strange\rdir rw,relatime shared:1039 - tmpfs tmpfs rw";
+    struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 2074);
+    g_assert_cmpint(entry->parent_id, ==, 27);
+    g_assert_cmpint(entry->dev_major, ==, 0);
+    g_assert_cmpint(entry->dev_minor, ==, 54);
+    g_assert_cmpstr(entry->root, ==, "/");
+    g_assert_cmpstr(entry->mount_dir, ==, "/tmp/strange\rdir");
+    g_assert_cmpstr(entry->mount_opts, ==, "rw,relatime");
+    g_assert_cmpstr(entry->optional_fields, ==, "shared:1039");
+    g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
+    g_assert_cmpstr(entry->mount_source, ==, "tmpfs");
+    g_assert_cmpstr(entry->super_opts, ==, "rw");
+    g_assert_null(entry->next);
 }
 
-static void test_parse_mountinfo_entry__broken_9p_superblock(void)
-{
-	// Spaces in superblock options
-	const char *line =
-	    "1146 77 0:149 / /Docker/host rw,noatime - 9p drvfs rw,dirsync,aname=drvfs;path=C:\\Program Files\\Docker\\Docker\\resources;symlinkroot=/mnt/,mmap,access=client,msize=262144,trans=virtio";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(entry->mount_id, ==, 1146);
-	g_assert_cmpint(entry->parent_id, ==, 77);
-	g_assert_cmpint(entry->dev_major, ==, 0);
-	g_assert_cmpint(entry->dev_minor, ==, 149);
-	g_assert_cmpstr(entry->root, ==, "/");
-	g_assert_cmpstr(entry->mount_dir, ==, "/Docker/host");
-	g_assert_cmpstr(entry->mount_opts, ==, "rw,noatime");
-	g_assert_cmpstr(entry->optional_fields, ==, "");
-	g_assert_cmpstr(entry->fs_type, ==, "9p");
-	g_assert_cmpstr(entry->mount_source, ==, "drvfs");
-	g_assert_cmpstr(entry->super_opts, ==,
-			"rw,dirsync,aname=drvfs;path=C:\\Program Files\\Docker\\Docker\\resources;symlinkroot=/mnt/,mmap,access=client,msize=262144,trans=virtio");
-	g_assert_null(entry->next);
+static void test_parse_mountinfo_entry__broken_9p_superblock(void) {
+    // Spaces in superblock options
+    const char *line =
+        "1146 77 0:149 / /Docker/host rw,noatime - 9p drvfs rw,dirsync,aname=drvfs;path=C:\\Program "
+        "Files\\Docker\\Docker\\resources;symlinkroot=/mnt/,mmap,access=client,msize=262144,trans=virtio";
+    struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+    g_assert_nonnull(entry);
+    g_test_queue_destroy((GDestroyNotify)sc_free_mountinfo_entry, entry);
+    g_assert_cmpint(entry->mount_id, ==, 1146);
+    g_assert_cmpint(entry->parent_id, ==, 77);
+    g_assert_cmpint(entry->dev_major, ==, 0);
+    g_assert_cmpint(entry->dev_minor, ==, 149);
+    g_assert_cmpstr(entry->root, ==, "/");
+    g_assert_cmpstr(entry->mount_dir, ==, "/Docker/host");
+    g_assert_cmpstr(entry->mount_opts, ==, "rw,noatime");
+    g_assert_cmpstr(entry->optional_fields, ==, "");
+    g_assert_cmpstr(entry->fs_type, ==, "9p");
+    g_assert_cmpstr(entry->mount_source, ==, "drvfs");
+    g_assert_cmpstr(entry->super_opts, ==,
+                    "rw,dirsync,aname=drvfs;path=C:\\Program "
+                    "Files\\Docker\\Docker\\resources;symlinkroot=/mnt/,mmap,access=client,msize=262144,trans=virtio");
+    g_assert_null(entry->next);
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/sysfs",
-			test_parse_mountinfo_entry__sysfs);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/snapd-ns",
-			test_parse_mountinfo_entry__snapd_ns);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/snapd-mnt",
-			test_parse_mountinfo_entry__snapd_mnt);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/garbage",
-			test_parse_mountinfo_entry__garbage);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/no_tags",
-			test_parse_mountinfo_entry__no_tags);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/one_tags",
-			test_parse_mountinfo_entry__one_tag);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/many_tags",
-			test_parse_mountinfo_entry__many_tags);
-	g_test_add_func
-	    ("/mountinfo/parse_mountinfo_entry/empty_source",
-	     test_parse_mountinfo_entry__empty_source);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/octal_escaping",
-			test_parse_mountinfo_entry__octal_escaping);
-	g_test_add_func
-	    ("/mountinfo/parse_mountinfo_entry/broken_octal_escaping",
-	     test_parse_mountinfo_entry__broken_octal_escaping);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/unescaped_whitespace",
-			test_parse_mountinfo_entry__unescaped_whitespace);
-	g_test_add_func("/mountinfo/parse_mountinfo_entry/broken_9p_superblock",
-			test_parse_mountinfo_entry__broken_9p_superblock);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/sysfs", test_parse_mountinfo_entry__sysfs);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/snapd-ns", test_parse_mountinfo_entry__snapd_ns);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/snapd-mnt", test_parse_mountinfo_entry__snapd_mnt);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/garbage", test_parse_mountinfo_entry__garbage);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/no_tags", test_parse_mountinfo_entry__no_tags);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/one_tags", test_parse_mountinfo_entry__one_tag);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/many_tags", test_parse_mountinfo_entry__many_tags);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/empty_source", test_parse_mountinfo_entry__empty_source);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/octal_escaping", test_parse_mountinfo_entry__octal_escaping);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/broken_octal_escaping",
+                    test_parse_mountinfo_entry__broken_octal_escaping);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/unescaped_whitespace",
+                    test_parse_mountinfo_entry__unescaped_whitespace);
+    g_test_add_func("/mountinfo/parse_mountinfo_entry/broken_9p_superblock",
+                    test_parse_mountinfo_entry__broken_9p_superblock);
 }

--- a/cmd/libsnap-confine-private/mountinfo.c
+++ b/cmd/libsnap-confine-private/mountinfo.c
@@ -44,309 +44,260 @@
  * (10) mount source:  filesystem specific information or "none"
  * (11) super options:  per super block options
  **/
-static sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
-    __attribute__((nonnull(1)));
+static sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line) __attribute__((nonnull(1)));
 
 /**
  * Free a sc_mountinfo structure and all its entries.
  **/
-static void sc_free_mountinfo(sc_mountinfo * info)
-    __attribute__((nonnull(1)));
+static void sc_free_mountinfo(sc_mountinfo *info) __attribute__((nonnull(1)));
 
 /**
  * Free a sc_mountinfo entry.
  **/
-static void sc_free_mountinfo_entry(sc_mountinfo_entry * entry)
-    __attribute__((nonnull(1)));
+static void sc_free_mountinfo_entry(sc_mountinfo_entry *entry) __attribute__((nonnull(1)));
 
-sc_mountinfo_entry *sc_first_mountinfo_entry(sc_mountinfo *info)
-{
-	return info->first;
+sc_mountinfo_entry *sc_first_mountinfo_entry(sc_mountinfo *info) { return info->first; }
+
+sc_mountinfo_entry *sc_next_mountinfo_entry(sc_mountinfo_entry *entry) { return entry->next; }
+
+sc_mountinfo *sc_parse_mountinfo(const char *fname) {
+    sc_mountinfo *info = calloc(1, sizeof *info);
+    if (info == NULL) {
+        return NULL;
+    }
+    if (fname == NULL) {
+        fname = "/proc/self/mountinfo";
+    }
+    FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
+    f = fopen(fname, "rt");
+    if (f == NULL) {
+        free(info);
+        return NULL;
+    }
+    char *line SC_CLEANUP(sc_cleanup_string) = NULL;
+    size_t line_size = 0;
+    sc_mountinfo_entry *entry, *last = NULL;
+    for (;;) {
+        errno = 0;
+        if (getline(&line, &line_size, f) == -1) {
+            if (errno != 0) {
+                sc_free_mountinfo(info);
+                return NULL;
+            }
+            break;
+        };
+        entry = sc_parse_mountinfo_entry(line);
+        if (entry == NULL) {
+            sc_free_mountinfo(info);
+            return NULL;
+        }
+        if (last != NULL) {
+            last->next = entry;
+        } else {
+            info->first = entry;
+        }
+        last = entry;
+    }
+    return info;
 }
 
-sc_mountinfo_entry *sc_next_mountinfo_entry(sc_mountinfo_entry *entry)
-{
-	return entry->next;
-}
-
-sc_mountinfo *sc_parse_mountinfo(const char *fname)
-{
-	sc_mountinfo *info = calloc(1, sizeof *info);
-	if (info == NULL) {
-		return NULL;
-	}
-	if (fname == NULL) {
-		fname = "/proc/self/mountinfo";
-	}
-	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
-	f = fopen(fname, "rt");
-	if (f == NULL) {
-		free(info);
-		return NULL;
-	}
-	char *line SC_CLEANUP(sc_cleanup_string) = NULL;
-	size_t line_size = 0;
-	sc_mountinfo_entry *entry, *last = NULL;
-	for (;;) {
-		errno = 0;
-		if (getline(&line, &line_size, f) == -1) {
-			if (errno != 0) {
-				sc_free_mountinfo(info);
-				return NULL;
-			}
-			break;
-		};
-		entry = sc_parse_mountinfo_entry(line);
-		if (entry == NULL) {
-			sc_free_mountinfo(info);
-			return NULL;
-		}
-		if (last != NULL) {
-			last->next = entry;
-		} else {
-			info->first = entry;
-		}
-		last = entry;
-	}
-	return info;
-}
-
-static void show_buffers(const char *line, int offset,
-			 sc_mountinfo_entry *entry)
-{
+static void show_buffers(const char *line, int offset, sc_mountinfo_entry *entry) {
 #ifdef MOUNTINFO_DEBUG
-	fprintf(stderr, "Input buffer (first), with offset arrow\n");
-	fprintf(stderr, "Output buffer (second)\n");
+    fprintf(stderr, "Input buffer (first), with offset arrow\n");
+    fprintf(stderr, "Output buffer (second)\n");
 
-	fputc(' ', stderr);
-	for (int i = 0; i < offset - 1; ++i)
-		fputc('-', stderr);
-	fputc('v', stderr);
-	fputc('\n', stderr);
+    fputc(' ', stderr);
+    for (int i = 0; i < offset - 1; ++i) fputc('-', stderr);
+    fputc('v', stderr);
+    fputc('\n', stderr);
 
-	fprintf(stderr, ">%s<\n", line);
+    fprintf(stderr, ">%s<\n", line);
 
-	fputc('>', stderr);
-	for (size_t i = 0; i < strlen(line); ++i) {
-		int c = entry->line_buf[i];
-		fputc(c == 0 ? '@' : c == 1 ? '#' : c, stderr);
-	}
-	fputc('<', stderr);
-	fputc('\n', stderr);
+    fputc('>', stderr);
+    for (size_t i = 0; i < strlen(line); ++i) {
+        int c = entry->line_buf[i];
+        fputc(c == 0 ? '@' : c == 1 ? '#' : c, stderr);
+    }
+    fputc('<', stderr);
+    fputc('\n', stderr);
 
-	fputc('>', stderr);
-	for (size_t i = 0; i < strlen(line); ++i)
-		fputc('=', stderr);
-	fputc('<', stderr);
-	fputc('\n', stderr);
-#endif				// MOUNTINFO_DEBUG
+    fputc('>', stderr);
+    for (size_t i = 0; i < strlen(line); ++i) fputc('=', stderr);
+    fputc('<', stderr);
+    fputc('\n', stderr);
+#endif  // MOUNTINFO_DEBUG
 }
 
-static bool is_octal_digit(char c)
-{
-	return c >= '0' && c <= '7';
-}
+static bool is_octal_digit(char c) { return c >= '0' && c <= '7'; }
 
-static char *parse_next_string_field_ex(sc_mountinfo_entry *entry,
-					const char *line, size_t *offset,
-					bool allow_spaces_in_field)
-{
-	const char *input = &line[*offset];
-	char *output = &entry->line_buf[*offset];
-	size_t input_idx = 0;	// reading index
-	size_t output_idx = 0;	// writing index
+static char *parse_next_string_field_ex(sc_mountinfo_entry *entry, const char *line, size_t *offset,
+                                        bool allow_spaces_in_field) {
+    const char *input = &line[*offset];
+    char *output = &entry->line_buf[*offset];
+    size_t input_idx = 0;   // reading index
+    size_t output_idx = 0;  // writing index
 
-	// Scan characters until we run out of memory to scan or we find a
-	// space.  The kernel uses simple octal escape sequences for the
-	// following: space, tab, newline, backwards slash. Everything else is
-	// copied verbatim.
-	for (;;) {
-		int c = input[input_idx];
-		if (c == '\0') {
-			// The string is over before we see anything then
-			// return NULL. This is an indication of end-of-input
-			// to the caller.
-			if (output_idx == 0) {
-				return NULL;
-			}
-			// The scanned line is NUL terminated. This ensures that the
-			// terminator is copied to the output buffer.
-			output[output_idx] = '\0';
-			// NOTE: we must not advance the reading index since we
-			// reached the end of the buffer.
-			break;
-		} else if (c == ' ' && !allow_spaces_in_field) {
-			// Fields are space delimited or end-of-string terminated.
-			// Represent either as the end-of-string marker, skip over it,
-			// and stop parsing by terminating the output, then
-			// breaking out of the loop but advancing the reading
-			// index which is needed for subsequent calls.
-			//
-			// XXX: The last field may contain spaces.
-			output[output_idx] = '\0';
-			input_idx++;
-			break;
-		} else if (c == '\\') {
-			// Three *more* octal digits required for the escape
-			// sequence.  For reference see mangle_path() in
-			// fs/seq_file.c.  Note that is_octal_digit returns
-			// false on the string terminator character NUL and the
-			// short-circuiting behavior of && makes this check
-			// correct even if '\\' is the last character of the
-			// string.
-			const char *s = &input[input_idx];
-			if (is_octal_digit(s[1]) && is_octal_digit(s[2])
-			    && is_octal_digit(s[3])) {
-				// Unescape the octal value encoded in s[1],
-				// s[2] and s[3]. Because we are working with
-				// byte values there are no issues related to
-				// byte order.
-				output[output_idx++] =
-				    ((s[1] - '0') << 6) |
-				    ((s[2] - '0') << 3) | ((s[3] - '0'));
-				// Advance the reading index by the length of the escape
-				// sequence.
-				input_idx += 4;
-			} else {
-				// Partial escape sequence, copy verbatim and
-				// continue (since we don't use this).
-				output[output_idx++] = c;
-				input_idx++;
-			}
-		} else {
-			// All other characters are simply copied verbatim.
-			output[output_idx++] = c;
-			input_idx++;
-		}
-	}
-	*offset += input_idx;
+    // Scan characters until we run out of memory to scan or we find a
+    // space.  The kernel uses simple octal escape sequences for the
+    // following: space, tab, newline, backwards slash. Everything else is
+    // copied verbatim.
+    for (;;) {
+        int c = input[input_idx];
+        if (c == '\0') {
+            // The string is over before we see anything then
+            // return NULL. This is an indication of end-of-input
+            // to the caller.
+            if (output_idx == 0) {
+                return NULL;
+            }
+            // The scanned line is NUL terminated. This ensures that the
+            // terminator is copied to the output buffer.
+            output[output_idx] = '\0';
+            // NOTE: we must not advance the reading index since we
+            // reached the end of the buffer.
+            break;
+        } else if (c == ' ' && !allow_spaces_in_field) {
+            // Fields are space delimited or end-of-string terminated.
+            // Represent either as the end-of-string marker, skip over it,
+            // and stop parsing by terminating the output, then
+            // breaking out of the loop but advancing the reading
+            // index which is needed for subsequent calls.
+            //
+            // XXX: The last field may contain spaces.
+            output[output_idx] = '\0';
+            input_idx++;
+            break;
+        } else if (c == '\\') {
+            // Three *more* octal digits required for the escape
+            // sequence.  For reference see mangle_path() in
+            // fs/seq_file.c.  Note that is_octal_digit returns
+            // false on the string terminator character NUL and the
+            // short-circuiting behavior of && makes this check
+            // correct even if '\\' is the last character of the
+            // string.
+            const char *s = &input[input_idx];
+            if (is_octal_digit(s[1]) && is_octal_digit(s[2]) && is_octal_digit(s[3])) {
+                // Unescape the octal value encoded in s[1],
+                // s[2] and s[3]. Because we are working with
+                // byte values there are no issues related to
+                // byte order.
+                output[output_idx++] = ((s[1] - '0') << 6) | ((s[2] - '0') << 3) | ((s[3] - '0'));
+                // Advance the reading index by the length of the escape
+                // sequence.
+                input_idx += 4;
+            } else {
+                // Partial escape sequence, copy verbatim and
+                // continue (since we don't use this).
+                output[output_idx++] = c;
+                input_idx++;
+            }
+        } else {
+            // All other characters are simply copied verbatim.
+            output[output_idx++] = c;
+            input_idx++;
+        }
+    }
+    *offset += input_idx;
 #ifdef MOUNTINFO_DEBUG
-	fprintf(stderr,
-		"\nscanned: >%s< (%zd bytes), input idx: %zd, output idx: %zd\n",
-		output, strlen(output), input_idx, output_idx);
+    fprintf(stderr, "\nscanned: >%s< (%zd bytes), input idx: %zd, output idx: %zd\n", output, strlen(output), input_idx,
+            output_idx);
 #endif
-	show_buffers(line, *offset, entry);
-	return output;
+    show_buffers(line, *offset, entry);
+    return output;
 }
 
 // Return the next space separated string field in the given line
-static char *parse_next_string_field(sc_mountinfo_entry *entry,
-				     const char *line, size_t *offset)
-{
-	return parse_next_string_field_ex(entry, line, offset, false);
+static char *parse_next_string_field(sc_mountinfo_entry *entry, const char *line, size_t *offset) {
+    return parse_next_string_field_ex(entry, line, offset, false);
 }
 
 // Return the last string field in the given line, this means the field
 // is allowed to contain spaces (' ', 0x20)
-static char *parse_last_string_field(sc_mountinfo_entry *entry,
-				     const char *line, size_t *offset)
-{
-	return parse_next_string_field_ex(entry, line, offset, true);
+static char *parse_last_string_field(sc_mountinfo_entry *entry, const char *line, size_t *offset) {
+    return parse_next_string_field_ex(entry, line, offset, true);
 }
 
-static sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
-{
-	// NOTE: the sc_mountinfo structure is allocated along with enough extra
-	// storage to hold the whole line we are parsing. This is used as backing
-	// store for all text fields.
-	//
-	// The idea is that since the line has a given length and we are only after
-	// set of substrings we can easily predict the amount of required space
-	// (after all, it is just a set of non-overlapping substrings) and append
-	// it to the allocated entry structure.
-	//
-	// The parsing code below, specifically parse_next_string_field(), uses
-	// this extra memory to hold data parsed from the original line. In the
-	// end, the result is similar to using strtok except that the source and
-	// destination buffers are separate.
-	//
-	// At the end of the parsing process, the input buffer (line) and the
-	// output buffer (entry->line_buf) are the same except for where spaces
-	// were converted into NUL bytes (string terminators) and except for the
-	// leading part of the buffer that contains mount_id, parent_id, dev_major
-	// and dev_minor integer fields that are parsed separately.
-	//
-	// If MOUNTINFO_DEBUG is defined then extra debugging is printed to stderr
-	// and this allows for visual analysis of what is going on.
-	sc_mountinfo_entry *entry = calloc(1, sizeof *entry + strlen(line) + 1);
-	if (entry == NULL) {
-		return NULL;
-	}
+static sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line) {
+    // NOTE: the sc_mountinfo structure is allocated along with enough extra
+    // storage to hold the whole line we are parsing. This is used as backing
+    // store for all text fields.
+    //
+    // The idea is that since the line has a given length and we are only after
+    // set of substrings we can easily predict the amount of required space
+    // (after all, it is just a set of non-overlapping substrings) and append
+    // it to the allocated entry structure.
+    //
+    // The parsing code below, specifically parse_next_string_field(), uses
+    // this extra memory to hold data parsed from the original line. In the
+    // end, the result is similar to using strtok except that the source and
+    // destination buffers are separate.
+    //
+    // At the end of the parsing process, the input buffer (line) and the
+    // output buffer (entry->line_buf) are the same except for where spaces
+    // were converted into NUL bytes (string terminators) and except for the
+    // leading part of the buffer that contains mount_id, parent_id, dev_major
+    // and dev_minor integer fields that are parsed separately.
+    //
+    // If MOUNTINFO_DEBUG is defined then extra debugging is printed to stderr
+    // and this allows for visual analysis of what is going on.
+    sc_mountinfo_entry *entry = calloc(1, sizeof *entry + strlen(line) + 1);
+    if (entry == NULL) {
+        return NULL;
+    }
 #ifdef MOUNTINFO_DEBUG
-	// Poison the buffer with '\1' bytes that are printed as '#' characters
-	// by show_buffers() below. This is "unaltered" memory.
-	memset(entry->line_buf, 1, strlen(line));
-#endif				// MOUNTINFO_DEBUG
-	int nscanned, initial_offset = 0;
-	size_t offset = 0;
-	nscanned = sscanf(line, "%d %d %u:%u %n",
-			  &entry->mount_id, &entry->parent_id,
-			  &entry->dev_major, &entry->dev_minor,
-			  &initial_offset);
-	if (nscanned != 4)
-		goto fail;
-	offset += initial_offset;
+    // Poison the buffer with '\1' bytes that are printed as '#' characters
+    // by show_buffers() below. This is "unaltered" memory.
+    memset(entry->line_buf, 1, strlen(line));
+#endif  // MOUNTINFO_DEBUG
+    int nscanned, initial_offset = 0;
+    size_t offset = 0;
+    nscanned = sscanf(line, "%d %d %u:%u %n", &entry->mount_id, &entry->parent_id, &entry->dev_major, &entry->dev_minor,
+                      &initial_offset);
+    if (nscanned != 4) goto fail;
+    offset += initial_offset;
 
-	show_buffers(line, offset, entry);
+    show_buffers(line, offset, entry);
 
-	if ((entry->root =
-	     parse_next_string_field(entry, line, &offset)) == NULL)
-		goto fail;
-	if ((entry->mount_dir =
-	     parse_next_string_field(entry, line, &offset)) == NULL)
-		goto fail;
-	if ((entry->mount_opts =
-	     parse_next_string_field(entry, line, &offset)) == NULL)
-		goto fail;
-	entry->optional_fields = &entry->line_buf[0] + offset;
-	// NOTE: This ensures that optional_fields is never NULL. If this changes,
-	// must adjust all callers of parse_mountinfo_entry() accordingly.
-	for (int field_num = 0;; ++field_num) {
-		char *opt_field = parse_next_string_field(entry, line, &offset);
-		if (opt_field == NULL)
-			goto fail;
-		if (strcmp(opt_field, "-") == 0) {
-			opt_field[0] = 0;
-			break;
-		}
-		if (field_num > 0) {
-			opt_field[-1] = ' ';
-		}
-	}
-	if ((entry->fs_type =
-	     parse_next_string_field(entry, line, &offset)) == NULL)
-		goto fail;
-	if ((entry->mount_source =
-	     parse_next_string_field(entry, line, &offset)) == NULL)
-		goto fail;
-	if ((entry->super_opts =
-	     parse_last_string_field(entry, line, &offset)) == NULL)
-		goto fail;
-	return entry;
- fail:
-	free(entry);
-	return NULL;
+    if ((entry->root = parse_next_string_field(entry, line, &offset)) == NULL) goto fail;
+    if ((entry->mount_dir = parse_next_string_field(entry, line, &offset)) == NULL) goto fail;
+    if ((entry->mount_opts = parse_next_string_field(entry, line, &offset)) == NULL) goto fail;
+    entry->optional_fields = &entry->line_buf[0] + offset;
+    // NOTE: This ensures that optional_fields is never NULL. If this changes,
+    // must adjust all callers of parse_mountinfo_entry() accordingly.
+    for (int field_num = 0;; ++field_num) {
+        char *opt_field = parse_next_string_field(entry, line, &offset);
+        if (opt_field == NULL) goto fail;
+        if (strcmp(opt_field, "-") == 0) {
+            opt_field[0] = 0;
+            break;
+        }
+        if (field_num > 0) {
+            opt_field[-1] = ' ';
+        }
+    }
+    if ((entry->fs_type = parse_next_string_field(entry, line, &offset)) == NULL) goto fail;
+    if ((entry->mount_source = parse_next_string_field(entry, line, &offset)) == NULL) goto fail;
+    if ((entry->super_opts = parse_last_string_field(entry, line, &offset)) == NULL) goto fail;
+    return entry;
+fail:
+    free(entry);
+    return NULL;
 }
 
-void sc_cleanup_mountinfo(sc_mountinfo **ptr)
-{
-	if (*ptr != NULL) {
-		sc_free_mountinfo(*ptr);
-		*ptr = NULL;
-	}
+void sc_cleanup_mountinfo(sc_mountinfo **ptr) {
+    if (*ptr != NULL) {
+        sc_free_mountinfo(*ptr);
+        *ptr = NULL;
+    }
 }
 
-static void sc_free_mountinfo(sc_mountinfo *info)
-{
-	sc_mountinfo_entry *entry, *next;
-	for (entry = info->first; entry != NULL; entry = next) {
-		next = entry->next;
-		sc_free_mountinfo_entry(entry);
-	}
-	free(info);
+static void sc_free_mountinfo(sc_mountinfo *info) {
+    sc_mountinfo_entry *entry, *next;
+    for (entry = info->first; entry != NULL; entry = next) {
+        next = entry->next;
+        sc_free_mountinfo_entry(entry);
+    }
+    free(info);
 }
 
-static void sc_free_mountinfo_entry(sc_mountinfo_entry *entry)
-{
-	free(entry);
-}
+static void sc_free_mountinfo_entry(sc_mountinfo_entry *entry) { free(entry); }

--- a/cmd/libsnap-confine-private/mountinfo.h
+++ b/cmd/libsnap-confine-private/mountinfo.h
@@ -21,76 +21,76 @@
  * Structure describing a single entry in /proc/self/sc_mountinfo
  **/
 typedef struct sc_mountinfo_entry {
-	/**
-	 * The mount identifier of a given mount entry.
-	 **/
-	int mount_id;
-	/**
-	 * The parent mount identifier of a given mount entry.
-	 **/
-	int parent_id;
-	unsigned dev_major, dev_minor;
-	/**
-	 * The root directory of a given mount entry.
-	 **/
-	char *root;
-	/**
-	 * The mount point of a given mount entry.
-	 **/
-	char *mount_dir;
-	/**
-	 * The mount options of a given mount entry.
-	 **/
-	char *mount_opts;
-	/**
-	 * Optional tagged data associated of a given mount entry.
-	 *
-	 * The return value is a string (possibly empty but never NULL) in the format
-	 * tag[:value]. Known tags are:
-	 *
-	 * "shared:X":
-	 * 		mount is shared in peer group X
-	 * "master:X":
-	 * 		mount is slave to peer group X
-	 * "propagate_from:X"
-	 * 		mount is slave and receives propagation from peer group X (*)
-	 * "unbindable":
-	 * 		mount is unbindable
-	 *
-	 * (*) X is the closest dominant peer group under the process's root.
-	 * If X is the immediate master of the mount, or if there's no dominant peer
-	 * group under the same root, then only the "master:X" field is present and not
-	 * the "propagate_from:X" field.
-	 **/
-	char *optional_fields;
-	/**
-	 * The file system type of a given mount entry.
-	 **/
-	char *fs_type;
-	/**
-	 * The source of a given mount entry.
-	 **/
-	char *mount_source;
-	/**
-	 * The super block options of a given mount entry.
-	 **/
-	char *super_opts;
+    /**
+     * The mount identifier of a given mount entry.
+     **/
+    int mount_id;
+    /**
+     * The parent mount identifier of a given mount entry.
+     **/
+    int parent_id;
+    unsigned dev_major, dev_minor;
+    /**
+     * The root directory of a given mount entry.
+     **/
+    char *root;
+    /**
+     * The mount point of a given mount entry.
+     **/
+    char *mount_dir;
+    /**
+     * The mount options of a given mount entry.
+     **/
+    char *mount_opts;
+    /**
+     * Optional tagged data associated of a given mount entry.
+     *
+     * The return value is a string (possibly empty but never NULL) in the format
+     * tag[:value]. Known tags are:
+     *
+     * "shared:X":
+     * 		mount is shared in peer group X
+     * "master:X":
+     * 		mount is slave to peer group X
+     * "propagate_from:X"
+     * 		mount is slave and receives propagation from peer group X (*)
+     * "unbindable":
+     * 		mount is unbindable
+     *
+     * (*) X is the closest dominant peer group under the process's root.
+     * If X is the immediate master of the mount, or if there's no dominant peer
+     * group under the same root, then only the "master:X" field is present and not
+     * the "propagate_from:X" field.
+     **/
+    char *optional_fields;
+    /**
+     * The file system type of a given mount entry.
+     **/
+    char *fs_type;
+    /**
+     * The source of a given mount entry.
+     **/
+    char *mount_source;
+    /**
+     * The super block options of a given mount entry.
+     **/
+    char *super_opts;
 
-	struct sc_mountinfo_entry *next;
+    struct sc_mountinfo_entry *next;
 
-	// Buffer holding all of the text data above.
-	//
-	// The buffer must be the last element of the structure. It is allocated
-	// along with the structure itself and does not need to be freed
-	// separately.
-	char line_buf[0];
+    // Buffer holding all of the text data above.
+    //
+    // The buffer must be the last element of the structure. It is allocated
+    // along with the structure itself and does not need to be freed
+    // separately.
+    char line_buf[0];
 } sc_mountinfo_entry;
 
 /**
  * Structure describing entire /proc/self/sc_mountinfo file
  **/
 typedef struct sc_mountinfo {
-	sc_mountinfo_entry *first;
+    sc_mountinfo_entry *first;
 } sc_mountinfo;
 
 /**
@@ -108,8 +108,7 @@ sc_mountinfo *sc_parse_mountinfo(const char *fname);
  * This function is designed to be used with __attribute__((cleanup)) so it
  * takes a pointer to the freed object (which is also a pointer).
  **/
-void sc_cleanup_mountinfo(sc_mountinfo ** ptr)
-    __attribute__((nonnull(1)));
+void sc_cleanup_mountinfo(sc_mountinfo **ptr) __attribute__((nonnull(1)));
 
 /**
  * Get the first sc_mountinfo entry.
@@ -118,8 +117,7 @@ void sc_cleanup_mountinfo(sc_mountinfo ** ptr)
  * returned value is bound to the lifecycle of the whole sc_mountinfo structure
  * and should not be freed explicitly.
  **/
-sc_mountinfo_entry *sc_first_mountinfo_entry(sc_mountinfo * info)
-    __attribute__((nonnull(1)));
+sc_mountinfo_entry *sc_first_mountinfo_entry(sc_mountinfo *info) __attribute__((nonnull(1)));
 
 /**
  * Get the next sc_mountinfo entry.
@@ -128,7 +126,6 @@ sc_mountinfo_entry *sc_first_mountinfo_entry(sc_mountinfo * info)
  * was the last entry. The returned value is bound to the lifecycle of the
  * whole sc_mountinfo structure and should not be freed explicitly.
  **/
-sc_mountinfo_entry *sc_next_mountinfo_entry(sc_mountinfo_entry * entry)
-    __attribute__((nonnull(1)));
+sc_mountinfo_entry *sc_next_mountinfo_entry(sc_mountinfo_entry *entry) __attribute__((nonnull(1)));
 
 #endif

--- a/cmd/libsnap-confine-private/panic-test.c
+++ b/cmd/libsnap-confine-private/panic-test.c
@@ -20,69 +20,64 @@
 
 #include <glib.h>
 
-static void test_panic(void)
-{
-	if (g_test_subprocess()) {
-		errno = 0;
-		sc_panic("death message");
-		g_test_message("expected die not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("death message\n");
+static void test_panic(void) {
+    if (g_test_subprocess()) {
+        errno = 0;
+        sc_panic("death message");
+        g_test_message("expected die not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("death message\n");
 }
 
-static void test_panic_with_errno(void)
-{
-	if (g_test_subprocess()) {
-		errno = EPERM;
-		sc_panic("death message");
-		g_test_message("expected die not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("death message: Operation not permitted\n");
+static void test_panic_with_errno(void) {
+    if (g_test_subprocess()) {
+        errno = EPERM;
+        sc_panic("death message");
+        g_test_message("expected die not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("death message: Operation not permitted\n");
 }
 
-static void custom_panic_msg(const char *fmt, va_list ap, int errno_copy)
-{
-	fprintf(stderr, "PANIC: ");
-	vfprintf(stderr, fmt, ap);
-	fprintf(stderr, " (errno: %d)", errno_copy);
-	fprintf(stderr, "\n");
+static void custom_panic_msg(const char *fmt, va_list ap, int errno_copy) {
+    fprintf(stderr, "PANIC: ");
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, " (errno: %d)", errno_copy);
+    fprintf(stderr, "\n");
 }
 
-static void custom_panic_exit(void)
-{
-	fprintf(stderr, "EXITING\n");
-	exit(2);
+static void custom_panic_exit(void) {
+    fprintf(stderr, "EXITING\n");
+    exit(2);
 }
 
-static void test_panic_customization(void)
-{
-	if (g_test_subprocess()) {
-		sc_set_panic_msg_fn(custom_panic_msg);
-		sc_set_panic_exit_fn(custom_panic_exit);
-		errno = 123;
-		sc_panic("death message");
-		g_test_message("expected die not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("PANIC: death message (errno: 123)\n"
-				  "EXITING\n");
-	// NOTE: g_test doesn't offer facilities to observe the exit code.
+static void test_panic_customization(void) {
+    if (g_test_subprocess()) {
+        sc_set_panic_msg_fn(custom_panic_msg);
+        sc_set_panic_exit_fn(custom_panic_exit);
+        errno = 123;
+        sc_panic("death message");
+        g_test_message("expected die not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr(
+        "PANIC: death message (errno: 123)\n"
+        "EXITING\n");
+    // NOTE: g_test doesn't offer facilities to observe the exit code.
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/panic/panic", test_panic);
-	g_test_add_func("/panic/panic_with_errno", test_panic_with_errno);
-	g_test_add_func("/panic/panic_customization", test_panic_customization);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/panic/panic", test_panic);
+    g_test_add_func("/panic/panic_with_errno", test_panic_with_errno);
+    g_test_add_func("/panic/panic_customization", test_panic_customization);
 }

--- a/cmd/libsnap-confine-private/privs-test.c
+++ b/cmd/libsnap-confine-private/privs-test.c
@@ -21,47 +21,43 @@
 #include <glib.h>
 
 // Test that dropping permissions really works
-static void test_sc_privs_drop(void)
-{
-	if (geteuid() != 0 || getuid() == 0) {
-		g_test_skip("run this test after chown root:root; chmod u+s");
-		return;
-	}
-	if (getegid() != 0 || getgid() == 0) {
-		g_test_skip("run this test after chown root:root; chmod g+s");
-		return;
-	}
-	if (g_test_subprocess()) {
-		// We start as a regular user with effective-root identity.
-		g_assert_cmpint(getuid(), !=, 0);
-		g_assert_cmpint(getgid(), !=, 0);
+static void test_sc_privs_drop(void) {
+    if (geteuid() != 0 || getuid() == 0) {
+        g_test_skip("run this test after chown root:root; chmod u+s");
+        return;
+    }
+    if (getegid() != 0 || getgid() == 0) {
+        g_test_skip("run this test after chown root:root; chmod g+s");
+        return;
+    }
+    if (g_test_subprocess()) {
+        // We start as a regular user with effective-root identity.
+        g_assert_cmpint(getuid(), !=, 0);
+        g_assert_cmpint(getgid(), !=, 0);
 
-		g_assert_cmpint(geteuid(), ==, 0);
-		g_assert_cmpint(getegid(), ==, 0);
+        g_assert_cmpint(geteuid(), ==, 0);
+        g_assert_cmpint(getegid(), ==, 0);
 
-		// We drop the privileges.
-		sc_privs_drop();
+        // We drop the privileges.
+        sc_privs_drop();
 
-		// The we are no longer root.
-		g_assert_cmpint(getuid(), !=, 0);
-		g_assert_cmpint(geteuid(), !=, 0);
-		g_assert_cmpint(getgid(), !=, 0);
-		g_assert_cmpint(getegid(), !=, 0);
+        // The we are no longer root.
+        g_assert_cmpint(getuid(), !=, 0);
+        g_assert_cmpint(geteuid(), !=, 0);
+        g_assert_cmpint(getgid(), !=, 0);
+        g_assert_cmpint(getegid(), !=, 0);
 
-		// We don't have any supplementary groups.
-		gid_t groups[2];
-		int num_groups = getgroups(1, groups);
-		g_assert_cmpint(num_groups, ==, 1);
-		g_assert_cmpint(groups[0], ==, getgid());
+        // We don't have any supplementary groups.
+        gid_t groups[2];
+        int num_groups = getgroups(1, groups);
+        g_assert_cmpint(num_groups, ==, 1);
+        g_assert_cmpint(groups[0], ==, getgid());
 
-		// All done.
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, G_TEST_SUBPROCESS_INHERIT_STDERR);
-	g_test_trap_assert_passed();
+        // All done.
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, G_TEST_SUBPROCESS_INHERIT_STDERR);
+    g_test_trap_assert_passed();
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/privs/sc_privs_drop", test_sc_privs_drop);
-}
+static void __attribute__((constructor)) init(void) { g_test_add_func("/privs/sc_privs_drop", test_sc_privs_drop); }

--- a/cmd/libsnap-confine-private/privs.c
+++ b/cmd/libsnap-confine-private/privs.c
@@ -29,50 +29,48 @@
 
 #include "utils.h"
 
-static bool sc_has_capability(const char *cap_name)
-{
-	// Lookup capability with the given name.
-	cap_value_t cap;
-	if (cap_from_name(cap_name, &cap) < 0) {
-		die("cannot resolve capability name %s", cap_name);
-	}
-	// Get the capability state of the current process.
-	cap_t caps;
-	if ((caps = cap_get_proc()) == NULL) {
-		die("cannot obtain capability state (cap_get_proc)");
-	}
-	// Read the effective value of the flag we're dealing with
-	cap_flag_value_t cap_flags_value;
-	if (cap_get_flag(caps, cap, CAP_EFFECTIVE, &cap_flags_value) < 0) {
-		cap_free(caps);	// don't bother checking, we die anyway.
-		die("cannot obtain value of capability flag (cap_get_flag)");
-	}
-	// Free the representation of the capability state of the current process.
-	if (cap_free(caps) < 0) {
-		die("cannot free capability flag (cap_free)");
-	}
-	// Check if the effective bit of the capability is set.
-	return cap_flags_value == CAP_SET;
+static bool sc_has_capability(const char *cap_name) {
+    // Lookup capability with the given name.
+    cap_value_t cap;
+    if (cap_from_name(cap_name, &cap) < 0) {
+        die("cannot resolve capability name %s", cap_name);
+    }
+    // Get the capability state of the current process.
+    cap_t caps;
+    if ((caps = cap_get_proc()) == NULL) {
+        die("cannot obtain capability state (cap_get_proc)");
+    }
+    // Read the effective value of the flag we're dealing with
+    cap_flag_value_t cap_flags_value;
+    if (cap_get_flag(caps, cap, CAP_EFFECTIVE, &cap_flags_value) < 0) {
+        cap_free(caps);  // don't bother checking, we die anyway.
+        die("cannot obtain value of capability flag (cap_get_flag)");
+    }
+    // Free the representation of the capability state of the current process.
+    if (cap_free(caps) < 0) {
+        die("cannot free capability flag (cap_free)");
+    }
+    // Check if the effective bit of the capability is set.
+    return cap_flags_value == CAP_SET;
 }
 
-void sc_privs_drop(void)
-{
-	gid_t gid = getgid();
-	uid_t uid = getuid();
+void sc_privs_drop(void) {
+    gid_t gid = getgid();
+    uid_t uid = getuid();
 
-	// Drop extra group membership if we can.
-	if (sc_has_capability("cap_setgid")) {
-		gid_t gid_list[1] = { gid };
-		if (setgroups(1, gid_list) < 0) {
-			die("cannot set supplementary group identifiers");
-		}
-	}
-	// Switch to real group ID
-	if (setgid(getgid()) < 0) {
-		die("cannot set group identifier to %d", gid);
-	}
-	// Switch to real user ID
-	if (setuid(getuid()) < 0) {
-		die("cannot set user identifier to %d", uid);
-	}
+    // Drop extra group membership if we can.
+    if (sc_has_capability("cap_setgid")) {
+        gid_t gid_list[1] = {gid};
+        if (setgroups(1, gid_list) < 0) {
+            die("cannot set supplementary group identifiers");
+        }
+    }
+    // Switch to real group ID
+    if (setgid(getgid()) < 0) {
+        die("cannot set group identifier to %d", gid);
+    }
+    // Switch to real user ID
+    if (setuid(getuid()) < 0) {
+        die("cannot set user identifier to %d", uid);
+    }
 }

--- a/cmd/libsnap-confine-private/secure-getenv.c
+++ b/cmd/libsnap-confine-private/secure-getenv.c
@@ -20,12 +20,11 @@
 #include <sys/auxv.h>
 
 #ifndef HAVE_SECURE_GETENV
-char *secure_getenv(const char *name)
-{
-	unsigned long secure = getauxval(AT_SECURE);
-	if (secure != 0) {
-		return NULL;
-	}
-	return getenv(name);
+char *secure_getenv(const char *name) {
+    unsigned long secure = getauxval(AT_SECURE);
+    if (secure != 0) {
+        return NULL;
+    }
+    return getenv(name);
 }
-#endif				// ! HAVE_SECURE_GETENV
+#endif  // ! HAVE_SECURE_GETENV

--- a/cmd/libsnap-confine-private/secure-getenv.h
+++ b/cmd/libsnap-confine-private/secure-getenv.h
@@ -29,8 +29,7 @@
  * This is exactly the same as the GNU extension to the standard library. It is
  * only used when glibc is not available.
  **/
-char *secure_getenv(const char *name)
-    __attribute__((nonnull(1), warn_unused_result));
-#endif				// ! HAVE_SECURE_GETENV
+char *secure_getenv(const char *name) __attribute__((nonnull(1), warn_unused_result));
+#endif  // ! HAVE_SECURE_GETENV
 
 #endif

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -20,668 +20,538 @@
 
 #include <glib.h>
 
-static void test_sc_security_tag_validate(void)
-{
-	// First, test the names we know are good
-	g_assert_true(sc_security_tag_validate("snap.name.app", "name", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.network-manager.NetworkManager",
-		       "network-manager", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.f00.bar-baz1", "f00", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo.hook.bar", "foo", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo.hook.bar-baz", "foo", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo_instance.bar-baz", "foo_instance", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo_instance.hook.bar-baz", "foo_instance", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo_bar.hook.bar-baz", "foo_bar", NULL));
+static void test_sc_security_tag_validate(void) {
+    // First, test the names we know are good
+    g_assert_true(sc_security_tag_validate("snap.name.app", "name", NULL));
+    g_assert_true(sc_security_tag_validate("snap.network-manager.NetworkManager", "network-manager", NULL));
+    g_assert_true(sc_security_tag_validate("snap.f00.bar-baz1", "f00", NULL));
+    g_assert_true(sc_security_tag_validate("snap.foo.hook.bar", "foo", NULL));
+    g_assert_true(sc_security_tag_validate("snap.foo.hook.bar-baz", "foo", NULL));
+    g_assert_true(sc_security_tag_validate("snap.foo_instance.bar-baz", "foo_instance", NULL));
+    g_assert_true(sc_security_tag_validate("snap.foo_instance.hook.bar-baz", "foo_instance", NULL));
+    g_assert_true(sc_security_tag_validate("snap.foo_bar.hook.bar-baz", "foo_bar", NULL));
 
-	// Now, test the names we know are bad
-	g_assert_false(sc_security_tag_validate
-		       ("pkg-foo.bar.0binary-bar+baz", "bar", NULL));
-	g_assert_false(sc_security_tag_validate("pkg-foo_bar_1.1", NULL, NULL));
-	g_assert_false(sc_security_tag_validate("appname/..", NULL, NULL));
-	g_assert_false(sc_security_tag_validate("snap", NULL, NULL));
-	g_assert_false(sc_security_tag_validate("snap.", NULL, NULL));
-	g_assert_false(sc_security_tag_validate("snap.name", "name", NULL));
-	g_assert_false(sc_security_tag_validate("snap.name.", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app.", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.hook.", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap!name.app", "!name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.-name.app", "-name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name!app", "name!", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.-app", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app!hook.foo", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app.hook!foo", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app.hook.-foo", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app.hook.f00", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("sna.pname.app", "pname", NULL));
-	g_assert_false(sc_security_tag_validate("snap.n@me.app", "n@me", NULL));
-	g_assert_false(sc_security_tag_validate("SNAP.name.app", "name", NULL));
-	g_assert_false(sc_security_tag_validate("snap.Name.app", "Name", NULL));
-	// This used to be false but it's now allowed.
-	g_assert_true(sc_security_tag_validate
-		      ("snap.0name.app", "0name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.-name.app", "-name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.@app", "name", NULL));
-	g_assert_false(sc_security_tag_validate(".name.app", "name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap..name.app", ".name", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name..app", "name.", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.name.app..", "name", NULL));
-	// These contain invalid instance key
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_.bar-baz", "foo", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_toolonginstance.bar-baz", "foo", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_inst@nace.bar-baz", "foo", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_in-stan-ce.bar-baz", "foo", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_in stan.bar-baz", "foo", NULL));
+    // Now, test the names we know are bad
+    g_assert_false(sc_security_tag_validate("pkg-foo.bar.0binary-bar+baz", "bar", NULL));
+    g_assert_false(sc_security_tag_validate("pkg-foo_bar_1.1", NULL, NULL));
+    g_assert_false(sc_security_tag_validate("appname/..", NULL, NULL));
+    g_assert_false(sc_security_tag_validate("snap", NULL, NULL));
+    g_assert_false(sc_security_tag_validate("snap.", NULL, NULL));
+    g_assert_false(sc_security_tag_validate("snap.name", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.app.", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.hook.", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap!name.app", "!name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.-name.app", "-name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name!app", "name!", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.-app", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.app!hook.foo", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.app.hook!foo", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.app.hook.-foo", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.app.hook.f00", "name", NULL));
+    g_assert_false(sc_security_tag_validate("sna.pname.app", "pname", NULL));
+    g_assert_false(sc_security_tag_validate("snap.n@me.app", "n@me", NULL));
+    g_assert_false(sc_security_tag_validate("SNAP.name.app", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.Name.app", "Name", NULL));
+    // This used to be false but it's now allowed.
+    g_assert_true(sc_security_tag_validate("snap.0name.app", "0name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.-name.app", "-name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.@app", "name", NULL));
+    g_assert_false(sc_security_tag_validate(".name.app", "name", NULL));
+    g_assert_false(sc_security_tag_validate("snap..name.app", ".name", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name..app", "name.", NULL));
+    g_assert_false(sc_security_tag_validate("snap.name.app..", "name", NULL));
+    // These contain invalid instance key
+    g_assert_false(sc_security_tag_validate("snap.foo_.bar-baz", "foo", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo_toolonginstance.bar-baz", "foo", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo_inst@nace.bar-baz", "foo", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo_in-stan-ce.bar-baz", "foo", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo_in stan.bar-baz", "foo", NULL));
 
-	// Test names that are both good, but snap name doesn't match security tag
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo.hook.bar", "fo", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo.hook.bar", "fooo", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo.hook.bar", "snap", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo.hook.bar", "bar", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo_instance.bar", "foo_bar", NULL));
+    // Test names that are both good, but snap name doesn't match security tag
+    g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "fo", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "fooo", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "snap", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo.hook.bar", "bar", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo_instance.bar", "foo_bar", NULL));
 
-	// Regression test 12to8
-	g_assert_true(sc_security_tag_validate
-		      ("snap.12to8.128to8", "12to8", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.123test.123test", "123test", NULL));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.123test.hook.configure", "123test", NULL));
+    // Regression test 12to8
+    g_assert_true(sc_security_tag_validate("snap.12to8.128to8", "12to8", NULL));
+    g_assert_true(sc_security_tag_validate("snap.123test.123test", "123test", NULL));
+    g_assert_true(sc_security_tag_validate("snap.123test.hook.configure", "123test", NULL));
 
-	// regression test snap.eon-edg-shb-pulseaudio.hook.connect-plug-i2c
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo.hook.connect-plug-i2c", "foo", NULL));
+    // regression test snap.eon-edg-shb-pulseaudio.hook.connect-plug-i2c
+    g_assert_true(sc_security_tag_validate("snap.foo.hook.connect-plug-i2c", "foo", NULL));
 
-	// make sure that component hooks can be validated
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo+comp.hook.install", "foo", "comp"));
-	g_assert_true(sc_security_tag_validate
-		      ("snap.foo_instance+comp.hook.install", "foo_instance",
-		       "comp"));
-	// make sure that only hooks from components can be validated, not apps
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo+comp.app", "foo", "comp"));
+    // make sure that component hooks can be validated
+    g_assert_true(sc_security_tag_validate("snap.foo+comp.hook.install", "foo", "comp"));
+    g_assert_true(sc_security_tag_validate("snap.foo_instance+comp.hook.install", "foo_instance", "comp"));
+    // make sure that only hooks from components can be validated, not apps
+    g_assert_false(sc_security_tag_validate("snap.foo+comp.app", "foo", "comp"));
 
-	// unexpected component names should not work
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo+comp.hook.install", "foo", NULL));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo+comp.hook.install", "foo", NULL));
+    // unexpected component names should not work
+    g_assert_false(sc_security_tag_validate("snap.foo+comp.hook.install", "foo", NULL));
+    g_assert_false(sc_security_tag_validate("snap.foo+comp.hook.install", "foo", NULL));
 
-	// missing component names when we expect one should not work
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo.hook.install", "foo", "comp"));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo.hook.install", "foo", "comp"));
+    // missing component names when we expect one should not work
+    g_assert_false(sc_security_tag_validate("snap.foo.hook.install", "foo", "comp"));
+    g_assert_false(sc_security_tag_validate("snap.foo.hook.install", "foo", "comp"));
 
-	// mismatch component names should not work
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo+comp.hook.install", "foo", "component"));
+    // mismatch component names should not work
+    g_assert_false(sc_security_tag_validate("snap.foo+comp.hook.install", "foo", "component"));
 
-	// empty component name should not work
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo+comp.hook.install", "foo", ""));
+    // empty component name should not work
+    g_assert_false(sc_security_tag_validate("snap.foo+comp.hook.install", "foo", ""));
 
-	// invalid component names should not work
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo+coMp.hook.install", "foo", "coMp"));
-	g_assert_false(sc_security_tag_validate
-		       ("snap.foo+-omp.hook.install", "foo", "-omp"));
+    // invalid component names should not work
+    g_assert_false(sc_security_tag_validate("snap.foo+coMp.hook.install", "foo", "coMp"));
+    g_assert_false(sc_security_tag_validate("snap.foo+-omp.hook.install", "foo", "-omp"));
 
-	// Security tag that's too long. The extra +2 is for the string
-	// terminator and to allow us to make the tag too long to validate.
-	char long_tag[SNAP_SECURITY_TAG_MAX_LEN + 2];
-	memset(long_tag, 'b', sizeof long_tag);
-	memcpy(long_tag, "snap.foo.b", sizeof "snap.foo.b" - 1);
-	long_tag[sizeof long_tag - 1] = '\0';
-	g_assert_true(strlen(long_tag) == SNAP_SECURITY_TAG_MAX_LEN + 1);
-	g_assert_false(sc_security_tag_validate(long_tag, "foo", NULL));
+    // Security tag that's too long. The extra +2 is for the string
+    // terminator and to allow us to make the tag too long to validate.
+    char long_tag[SNAP_SECURITY_TAG_MAX_LEN + 2];
+    memset(long_tag, 'b', sizeof long_tag);
+    memcpy(long_tag, "snap.foo.b", sizeof "snap.foo.b" - 1);
+    long_tag[sizeof long_tag - 1] = '\0';
+    g_assert_true(strlen(long_tag) == SNAP_SECURITY_TAG_MAX_LEN + 1);
+    g_assert_false(sc_security_tag_validate(long_tag, "foo", NULL));
 
-	// If we make it one byte shorter it will be valid.
-	long_tag[sizeof long_tag - 2] = '\0';
-	g_assert_true(sc_security_tag_validate(long_tag, "foo", NULL));
-
+    // If we make it one byte shorter it will be valid.
+    long_tag[sizeof long_tag - 2] = '\0';
+    g_assert_true(sc_security_tag_validate(long_tag, "foo", NULL));
 }
 
-static void test_sc_is_hook_security_tag(void)
-{
-	// First, test the names we know are good
-	g_assert_true(sc_is_hook_security_tag("snap.foo.hook.bar"));
-	g_assert_true(sc_is_hook_security_tag("snap.foo.hook.bar-baz"));
-	g_assert_true(sc_is_hook_security_tag
-		      ("snap.foo_instance.hook.bar-baz"));
-	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.bar-baz"));
-	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.f00"));
-	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.f-0-0"));
+static void test_sc_is_hook_security_tag(void) {
+    // First, test the names we know are good
+    g_assert_true(sc_is_hook_security_tag("snap.foo.hook.bar"));
+    g_assert_true(sc_is_hook_security_tag("snap.foo.hook.bar-baz"));
+    g_assert_true(sc_is_hook_security_tag("snap.foo_instance.hook.bar-baz"));
+    g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.bar-baz"));
+    g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.f00"));
+    g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.f-0-0"));
 
-	// Now, test the names we know are not valid hook security tags
-	g_assert_false(sc_is_hook_security_tag("snap.foo_instance.bar-baz"));
-	g_assert_false(sc_is_hook_security_tag("snap.name.app!hook.foo"));
-	g_assert_false(sc_is_hook_security_tag("snap.name.app.hook!foo"));
-	g_assert_false(sc_is_hook_security_tag("snap.name.app.hook.-foo"));
-	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.0abcd"));
-	g_assert_false(sc_is_hook_security_tag("snap.foo.hook.abc--"));
-	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.!foo"));
-	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.-foo"));
-	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook!foo"));
-	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.!foo"));
+    // Now, test the names we know are not valid hook security tags
+    g_assert_false(sc_is_hook_security_tag("snap.foo_instance.bar-baz"));
+    g_assert_false(sc_is_hook_security_tag("snap.name.app!hook.foo"));
+    g_assert_false(sc_is_hook_security_tag("snap.name.app.hook!foo"));
+    g_assert_false(sc_is_hook_security_tag("snap.name.app.hook.-foo"));
+    g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.0abcd"));
+    g_assert_false(sc_is_hook_security_tag("snap.foo.hook.abc--"));
+    g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.!foo"));
+    g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.-foo"));
+    g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook!foo"));
+    g_assert_false(sc_is_hook_security_tag("snap.foo_bar.!foo"));
 }
 
-static void test_sc_snap_or_instance_name_validate(gconstpointer data)
-{
-	typedef void (*validate_func_t)(const char *, sc_error **);
+static void test_sc_snap_or_instance_name_validate(gconstpointer data) {
+    typedef void (*validate_func_t)(const char *, sc_error **);
 
-	validate_func_t validate = (validate_func_t) data;
-	bool is_instance =
-	    (validate == sc_instance_name_validate) ? true : false;
+    validate_func_t validate = (validate_func_t)data;
+    bool is_instance = (validate == sc_instance_name_validate) ? true : false;
 
-	sc_error *err = NULL;
+    sc_error *err = NULL;
 
-	// Smoke test, a valid snap name
-	validate("hello-world", &err);
-	g_assert_null(err);
+    // Smoke test, a valid snap name
+    validate("hello-world", &err);
+    g_assert_null(err);
 
-	// Smoke test: invalid character 
-	validate("hello world", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name must use lower case letters, digits or dashes");
-	sc_error_free(err);
+    // Smoke test: invalid character
+    validate("hello world", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name must use lower case letters, digits or dashes");
+    sc_error_free(err);
 
-	// Smoke test: no letters
-	validate("", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name must contain at least one letter");
-	sc_error_free(err);
+    // Smoke test: no letters
+    validate("", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name must contain at least one letter");
+    sc_error_free(err);
 
-	// Smoke test: leading dash
-	validate("-foo", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name cannot start with a dash");
-	sc_error_free(err);
+    // Smoke test: leading dash
+    validate("-foo", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name cannot start with a dash");
+    sc_error_free(err);
 
-	// Smoke test: trailing dash
-	validate("foo-", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name cannot end with a dash");
-	sc_error_free(err);
+    // Smoke test: trailing dash
+    validate("foo-", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name cannot end with a dash");
+    sc_error_free(err);
 
-	// Smoke test: double dash
-	validate("f--oo", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name cannot contain two consecutive dashes");
-	sc_error_free(err);
+    // Smoke test: double dash
+    validate("f--oo", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name cannot contain two consecutive dashes");
+    sc_error_free(err);
 
-	// Smoke test: NULL name is not valid
-	validate(NULL, &err);
-	g_assert_nonnull(err);
-	// the only case when instance name validation diverges from snap name
-	// validation
-	if (!is_instance) {
-		g_assert_true(sc_error_match
-			      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-		g_assert_cmpstr(sc_error_msg(err), ==,
-				"snap name cannot be NULL");
-	} else {
-		g_assert_true(sc_error_match
-			      (err, SC_SNAP_DOMAIN,
-			       SC_SNAP_INVALID_INSTANCE_NAME));
-		g_assert_cmpstr(sc_error_msg(err), ==,
-				"snap instance name cannot be NULL");
-	}
-	sc_error_free(err);
+    // Smoke test: NULL name is not valid
+    validate(NULL, &err);
+    g_assert_nonnull(err);
+    // the only case when instance name validation diverges from snap name
+    // validation
+    if (!is_instance) {
+        g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+        g_assert_cmpstr(sc_error_msg(err), ==, "snap name cannot be NULL");
+    } else {
+        g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME));
+        g_assert_cmpstr(sc_error_msg(err), ==, "snap instance name cannot be NULL");
+    }
+    sc_error_free(err);
 
-	const char *valid_names[] = {
-		"aa", "aaa", "aaaa",
-		"a-a", "aa-a", "a-aa", "a-b-c",
-		"a0", "a-0", "a-0a",
-		"01game", "1-or-2"
-	};
-	for (size_t i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
-		g_test_message("checking valid snap name: %s", valid_names[i]);
-		validate(valid_names[i], &err);
-		g_assert_null(err);
-	}
-	const char *invalid_names[] = {
-		// name cannot be empty
-		"",
-		// too short
-		"a",
-		// names cannot be too long
-		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		"xxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx",
-		"1111111111111111111111111111111111111111x",
-		"x1111111111111111111111111111111111111111",
-		"x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x",
-		// dashes alone are not a name
-		"-", "--",
-		// double dashes in a name are not allowed
-		"a--a",
-		// name should not end with a dash
-		"a-",
-		// name cannot have any spaces in it
-		"a ", " a", "a a",
-		// a number alone is not a name
-		"0", "123", "1-2-3",
-		// identifier must be plain ASCII
-		"日本語", "한글", "ру́сский язы́к",
-	};
-	for (size_t i = 0; i < sizeof invalid_names / sizeof *invalid_names;
-	     ++i) {
-		g_test_message("checking invalid snap name: >%s<",
-			       invalid_names[i]);
-		validate(invalid_names[i], &err);
-		g_assert_nonnull(err);
-		g_assert_true(sc_error_match
-			      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-		sc_error_free(err);
-	}
-	// Regression test: 12to8 and 123test
-	validate("12to8", &err);
-	g_assert_null(err);
-	validate("123test", &err);
-	g_assert_null(err);
+    const char *valid_names[] = {"aa",    "aaa", "aaaa", "a-a",  "aa-a",   "a-aa",
+                                 "a-b-c", "a0",  "a-0",  "a-0a", "01game", "1-or-2"};
+    for (size_t i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
+        g_test_message("checking valid snap name: %s", valid_names[i]);
+        validate(valid_names[i], &err);
+        g_assert_null(err);
+    }
+    const char *invalid_names[] = {
+        // name cannot be empty
+        "",
+        // too short
+        "a",
+        // names cannot be too long
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "xxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx",
+        "1111111111111111111111111111111111111111x",
+        "x1111111111111111111111111111111111111111",
+        "x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x",
+        // dashes alone are not a name
+        "-",
+        "--",
+        // double dashes in a name are not allowed
+        "a--a",
+        // name should not end with a dash
+        "a-",
+        // name cannot have any spaces in it
+        "a ",
+        " a",
+        "a a",
+        // a number alone is not a name
+        "0",
+        "123",
+        "1-2-3",
+        // identifier must be plain ASCII
+        "日本語",
+        "한글",
+        "ру́сский язы́к",
+    };
+    for (size_t i = 0; i < sizeof invalid_names / sizeof *invalid_names; ++i) {
+        g_test_message("checking invalid snap name: >%s<", invalid_names[i]);
+        validate(invalid_names[i], &err);
+        g_assert_nonnull(err);
+        g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+        sc_error_free(err);
+    }
+    // Regression test: 12to8 and 123test
+    validate("12to8", &err);
+    g_assert_null(err);
+    validate("123test", &err);
+    g_assert_null(err);
 
-	// In case we switch to a regex, here's a test that could break things.
-	const char good_bad_name[] = "u-94903713687486543234157734673284536758";
-	char varname[sizeof good_bad_name] = { 0 };
-	for (size_t i = 3; i <= sizeof varname - 1; i++) {
-		g_assert_nonnull(memcpy(varname, good_bad_name, i));
-		varname[i] = 0;
-		g_test_message("checking valid snap name: >%s<", varname);
-		validate(varname, &err);
-		g_assert_null(err);
-		sc_error_free(err);
-	}
+    // In case we switch to a regex, here's a test that could break things.
+    const char good_bad_name[] = "u-94903713687486543234157734673284536758";
+    char varname[sizeof good_bad_name] = {0};
+    for (size_t i = 3; i <= sizeof varname - 1; i++) {
+        g_assert_nonnull(memcpy(varname, good_bad_name, i));
+        varname[i] = 0;
+        g_test_message("checking valid snap name: >%s<", varname);
+        validate(varname, &err);
+        g_assert_null(err);
+        sc_error_free(err);
+    }
 }
 
-static void test_sc_snap_name_validate__respects_error_protocol(void)
-{
-	if (g_test_subprocess()) {
-		sc_snap_name_validate("hello world", NULL);
-		g_test_message("expected sc_snap_name_validate to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("snap name must use lower case letters, digits or dashes\n");
+static void test_sc_snap_name_validate__respects_error_protocol(void) {
+    if (g_test_subprocess()) {
+        sc_snap_name_validate("hello world", NULL);
+        g_test_message("expected sc_snap_name_validate to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("snap name must use lower case letters, digits or dashes\n");
 }
 
-static void test_sc_instance_name_validate(void)
-{
-	sc_error *err = NULL;
+static void test_sc_instance_name_validate(void) {
+    sc_error *err = NULL;
 
-	sc_instance_name_validate("hello-world", &err);
-	g_assert_null(err);
-	sc_instance_name_validate("hello-world_foo", &err);
-	g_assert_null(err);
+    sc_instance_name_validate("hello-world", &err);
+    g_assert_null(err);
+    sc_instance_name_validate("hello-world_foo", &err);
+    g_assert_null(err);
 
-	// just the separator
-	sc_instance_name_validate("_", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name must contain at least one letter");
-	sc_error_free(err);
+    // just the separator
+    sc_instance_name_validate("_", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name must contain at least one letter");
+    sc_error_free(err);
 
-	// just name, with separator, missing instance key
-	sc_instance_name_validate("hello-world_", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"instance key must contain at least one letter or digit");
-	sc_error_free(err);
+    // just name, with separator, missing instance key
+    sc_instance_name_validate("hello-world_", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY));
+    g_assert_cmpstr(sc_error_msg(err), ==, "instance key must contain at least one letter or digit");
+    sc_error_free(err);
 
-	// only separator and instance key, missing name
-	sc_instance_name_validate("_bar", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name must contain at least one letter");
-	sc_error_free(err);
+    // only separator and instance key, missing name
+    sc_instance_name_validate("_bar", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name must contain at least one letter");
+    sc_error_free(err);
 
-	sc_instance_name_validate("", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap name must contain at least one letter");
-	sc_error_free(err);
+    sc_instance_name_validate("", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap name must contain at least one letter");
+    sc_error_free(err);
 
-	// third separator
-	sc_instance_name_validate("foo_bar_baz", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap instance name can contain only one underscore");
-	sc_error_free(err);
+    // third separator
+    sc_instance_name_validate("foo_bar_baz", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap instance name can contain only one underscore");
+    sc_error_free(err);
 
-	// too long, 52
-	sc_instance_name_validate
-	    ("0123456789012345678901234567890123456789012345678901", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"snap instance name can be at most 51 characters long");
-	sc_error_free(err);
+    // too long, 52
+    sc_instance_name_validate("0123456789012345678901234567890123456789012345678901", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME));
+    g_assert_cmpstr(sc_error_msg(err), ==, "snap instance name can be at most 51 characters long");
+    sc_error_free(err);
 
-	const char *valid_names[] = {
-		"aa", "aaa", "aaaa",
-		"aa_a", "aa_1", "aa_123", "aa_0123456789",
-	};
-	for (size_t i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
-		g_test_message("checking valid instance name: %s",
-			       valid_names[i]);
-		sc_instance_name_validate(valid_names[i], &err);
-		g_assert_null(err);
-	}
-	const char *invalid_names[] = {
-		// too short
-		"a",
-		// only letters and digits in the instance key
-		"a_--23))", "a_ ", "a_091234#", "a_123_456",
-		// up to 10 characters for the instance key
-		"a_01234567891", "a_0123456789123",
-		// snap name must not be more than 40 characters, regardless of instance
-		// key
-		"01234567890123456789012345678901234567890_foobar",
-		"01234567890123456789-01234567890123456789_foobar",
-		// instance key  must be plain ASCII
-		"foobar_日本語",
-		// way too many underscores
-		"foobar_baz_zed_daz",
-		"foobar______",
-	};
-	for (size_t i = 0; i < sizeof invalid_names / sizeof *invalid_names;
-	     ++i) {
-		g_test_message("checking invalid instance name: >%s<",
-			       invalid_names[i]);
-		sc_instance_name_validate(invalid_names[i], &err);
-		g_assert_nonnull(err);
-		sc_error_free(err);
-	}
+    const char *valid_names[] = {
+        "aa", "aaa", "aaaa", "aa_a", "aa_1", "aa_123", "aa_0123456789",
+    };
+    for (size_t i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
+        g_test_message("checking valid instance name: %s", valid_names[i]);
+        sc_instance_name_validate(valid_names[i], &err);
+        g_assert_null(err);
+    }
+    const char *invalid_names[] = {
+        // too short
+        "a",
+        // only letters and digits in the instance key
+        "a_--23))",
+        "a_ ",
+        "a_091234#",
+        "a_123_456",
+        // up to 10 characters for the instance key
+        "a_01234567891",
+        "a_0123456789123",
+        // snap name must not be more than 40 characters, regardless of instance
+        // key
+        "01234567890123456789012345678901234567890_foobar",
+        "01234567890123456789-01234567890123456789_foobar",
+        // instance key  must be plain ASCII
+        "foobar_日本語",
+        // way too many underscores
+        "foobar_baz_zed_daz",
+        "foobar______",
+    };
+    for (size_t i = 0; i < sizeof invalid_names / sizeof *invalid_names; ++i) {
+        g_test_message("checking invalid instance name: >%s<", invalid_names[i]);
+        sc_instance_name_validate(invalid_names[i], &err);
+        g_assert_nonnull(err);
+        sc_error_free(err);
+    }
 }
 
-static void test_sc_snap_drop_instance_key_no_dest(void)
-{
-	if (g_test_subprocess()) {
-		sc_snap_drop_instance_key("foo_bar", NULL, 0);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-
+static void test_sc_snap_drop_instance_key_no_dest(void) {
+    if (g_test_subprocess()) {
+        sc_snap_drop_instance_key("foo_bar", NULL, 0);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_key_short_dest(void)
-{
-	if (g_test_subprocess()) {
-		char dest[10] = { 0 };
-		sc_snap_drop_instance_key("foo-foo-foo-foo-foo_bar", dest,
-					  sizeof dest);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
+static void test_sc_snap_drop_instance_key_short_dest(void) {
+    if (g_test_subprocess()) {
+        char dest[10] = {0};
+        sc_snap_drop_instance_key("foo-foo-foo-foo-foo_bar", dest, sizeof dest);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_key_short_dest2(void)
-{
-	if (g_test_subprocess()) {
-		char dest[3] = { 0 };	// "foo" sans the nil byte
-		sc_snap_drop_instance_key("foo", dest, sizeof dest);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
+static void test_sc_snap_drop_instance_key_short_dest2(void) {
+    if (g_test_subprocess()) {
+        char dest[3] = {0};  // "foo" sans the nil byte
+        sc_snap_drop_instance_key("foo", dest, sizeof dest);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_key_no_name(void)
-{
-	if (g_test_subprocess()) {
-		char dest[10] = { 0 };
-		sc_snap_drop_instance_key(NULL, dest, sizeof dest);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
+static void test_sc_snap_drop_instance_key_no_name(void) {
+    if (g_test_subprocess()) {
+        char dest[10] = {0};
+        sc_snap_drop_instance_key(NULL, dest, sizeof dest);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_key_short_dest_max(void)
-{
-	if (g_test_subprocess()) {
-		char dest[SNAP_NAME_LEN + 1] = { 0 };
-		/* 40 chars (max valid length), pretend dest is the same length, no space for terminator */
-		sc_snap_drop_instance_key
-		    ("01234567890123456789012345678901234567890", dest,
-		     sizeof dest - 1);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
+static void test_sc_snap_drop_instance_key_short_dest_max(void) {
+    if (g_test_subprocess()) {
+        char dest[SNAP_NAME_LEN + 1] = {0};
+        /* 40 chars (max valid length), pretend dest is the same length, no space for terminator */
+        sc_snap_drop_instance_key("01234567890123456789012345678901234567890", dest, sizeof dest - 1);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_key_basic(void)
-{
-	char name[SNAP_NAME_LEN + 1] = { 0xff };
+static void test_sc_snap_drop_instance_key_basic(void) {
+    char name[SNAP_NAME_LEN + 1] = {0xff};
 
-	sc_snap_drop_instance_key("foo_bar", name, sizeof name);
-	g_assert_cmpstr(name, ==, "foo");
+    sc_snap_drop_instance_key("foo_bar", name, sizeof name);
+    g_assert_cmpstr(name, ==, "foo");
 
-	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_key("foo-bar_bar", name, sizeof name);
-	g_assert_cmpstr(name, ==, "foo-bar");
+    memset(name, 0xff, sizeof name);
+    sc_snap_drop_instance_key("foo-bar_bar", name, sizeof name);
+    g_assert_cmpstr(name, ==, "foo-bar");
 
-	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_key("foo-bar", name, sizeof name);
-	g_assert_cmpstr(name, ==, "foo-bar");
+    memset(name, 0xff, sizeof name);
+    sc_snap_drop_instance_key("foo-bar", name, sizeof name);
+    g_assert_cmpstr(name, ==, "foo-bar");
 
-	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_key("_baz", name, sizeof name);
-	g_assert_cmpstr(name, ==, "");
+    memset(name, 0xff, sizeof name);
+    sc_snap_drop_instance_key("_baz", name, sizeof name);
+    g_assert_cmpstr(name, ==, "");
 
-	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_key("foo", name, sizeof name);
-	g_assert_cmpstr(name, ==, "foo");
+    memset(name, 0xff, sizeof name);
+    sc_snap_drop_instance_key("foo", name, sizeof name);
+    g_assert_cmpstr(name, ==, "foo");
 
-	memset(name, 0xff, sizeof name);
-	/* 40 chars - snap name length */
-	sc_snap_drop_instance_key("0123456789012345678901234567890123456789",
-				  name, sizeof name);
-	g_assert_cmpstr(name, ==, "0123456789012345678901234567890123456789");
+    memset(name, 0xff, sizeof name);
+    /* 40 chars - snap name length */
+    sc_snap_drop_instance_key("0123456789012345678901234567890123456789", name, sizeof name);
+    g_assert_cmpstr(name, ==, "0123456789012345678901234567890123456789");
 }
 
-static void test_sc_snap_split_instance_name_basic(void)
-{
-	char name[SNAP_NAME_LEN + 1] = { 0xff };
-	char instance[20] = { 0xff };
+static void test_sc_snap_split_instance_name_basic(void) {
+    char name[SNAP_NAME_LEN + 1] = {0xff};
+    char instance[20] = {0xff};
 
-	sc_snap_split_instance_name("foo_bar", name, sizeof name, instance,
-				    sizeof instance);
-	g_assert_cmpstr(name, ==, "foo");
-	g_assert_cmpstr(instance, ==, "bar");
+    sc_snap_split_instance_name("foo_bar", name, sizeof name, instance, sizeof instance);
+    g_assert_cmpstr(name, ==, "foo");
+    g_assert_cmpstr(instance, ==, "bar");
 }
 
-static void test_sc_snap_split_snap_component_basic(void)
-{
-	char snap_name[SNAP_NAME_LEN + 1] = { 0xff };
-	char component_name[SNAP_NAME_LEN + 1] = { 0xff };
+static void test_sc_snap_split_snap_component_basic(void) {
+    char snap_name[SNAP_NAME_LEN + 1] = {0xff};
+    char component_name[SNAP_NAME_LEN + 1] = {0xff};
 
-	sc_snap_split_snap_component("foo+bar", snap_name, sizeof snap_name,
-				     component_name, sizeof component_name);
-	g_assert_cmpstr(snap_name, ==, "foo");
-	g_assert_cmpstr(component_name, ==, "bar");
+    sc_snap_split_snap_component("foo+bar", snap_name, sizeof snap_name, component_name, sizeof component_name);
+    g_assert_cmpstr(snap_name, ==, "foo");
+    g_assert_cmpstr(component_name, ==, "bar");
 }
 
-static void test_sc_snap_component_validate(void)
-{
-	sc_error *err = NULL;
-	sc_snap_component_validate("snapname+compname", NULL, &err);
-	g_assert_null(err);
+static void test_sc_snap_component_validate(void) {
+    sc_error *err = NULL;
+    sc_snap_component_validate("snapname+compname", NULL, &err);
+    g_assert_null(err);
 
-	sc_snap_component_validate("snap-name+comp-name", NULL, &err);
-	g_assert_null(err);
+    sc_snap_component_validate("snap-name+comp-name", NULL, &err);
+    g_assert_null(err);
 
-	// check that we fail if the snap name isn't in the snap component
-	sc_snap_component_validate("snapname+compname", "othername", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
-	sc_error_free(err);
+    // check that we fail if the snap name isn't in the snap component
+    sc_snap_component_validate("snapname+compname", "othername", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+    sc_error_free(err);
 
-	sc_snap_component_validate("snapname+compname", "othername_instance",
-				   &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
-	sc_error_free(err);
+    sc_snap_component_validate("snapname+compname", "othername_instance", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+    sc_error_free(err);
 
-	// component name should never have an instance key in it, so this should
-	// fail
-	sc_snap_component_validate("snapname_instance+compname",
-				   "snapname_instance", &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
-	sc_error_free(err);
+    // component name should never have an instance key in it, so this should
+    // fail
+    sc_snap_component_validate("snapname_instance+compname", "snapname_instance", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+    sc_error_free(err);
 
-	sc_snap_component_validate("snapname_instance+compname", "snapname",
-				   &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
-	sc_error_free(err);
+    sc_snap_component_validate("snapname_instance+compname", "snapname", &err);
+    g_assert_nonnull(err);
+    g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+    sc_error_free(err);
 
-	// check that we can validate the snap name in the snap component
-	sc_snap_component_validate("snapname+compname", "snapname", &err);
-	g_assert_null(err);
-	sc_snap_component_validate("snapname+compname", "snapname_instance",
-				   &err);
-	g_assert_null(err);
+    // check that we can validate the snap name in the snap component
+    sc_snap_component_validate("snapname+compname", "snapname", &err);
+    g_assert_null(err);
+    sc_snap_component_validate("snapname+compname", "snapname_instance", &err);
+    g_assert_null(err);
 
-	const char *cases[] = {
-		NULL, "snap-name+", "+comp-name", "snap-name",
-		"snap-name+comp_name",
-		"loooooooooooooooooooooooooooong-snap-name+comp-name",
-		"snap-name+loooooooooooooooooooooooooooong-comp-name",
-	};
+    const char *cases[] = {
+        NULL,
+        "snap-name+",
+        "+comp-name",
+        "snap-name",
+        "snap-name+comp_name",
+        "loooooooooooooooooooooooooooong-snap-name+comp-name",
+        "snap-name+loooooooooooooooooooooooooooong-comp-name",
+    };
 
-	for (size_t i = 0; i < sizeof cases / sizeof *cases; ++i) {
-		g_test_message("checking invalid snap name: %s", cases[i]);
-		sc_snap_component_validate(cases[i], NULL, &err);
-		g_assert_nonnull(err);
-		g_assert_true(sc_error_match
-			      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
-		sc_error_free(err);
-	}
+    for (size_t i = 0; i < sizeof cases / sizeof *cases; ++i) {
+        g_test_message("checking invalid snap name: %s", cases[i]);
+        sc_snap_component_validate(cases[i], NULL, &err);
+        g_assert_nonnull(err);
+        g_assert_true(sc_error_match(err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT));
+        sc_error_free(err);
+    }
 }
 
-static void test_sc_snap_component_validate_respects_error_protocol(void)
-{
-	if (g_test_subprocess()) {
-		sc_snap_component_validate("hello world+comp name", NULL, NULL);
-		g_test_message("expected sc_snap_name_validate to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("snap name in component must use lower case letters, digits or dashes\n");
+static void test_sc_snap_component_validate_respects_error_protocol(void) {
+    if (g_test_subprocess()) {
+        sc_snap_component_validate("hello world+comp name", NULL, NULL);
+        g_test_message("expected sc_snap_name_validate to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("snap name in component must use lower case letters, digits or dashes\n");
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/snap/sc_security_tag_validate",
-			test_sc_security_tag_validate);
-	g_test_add_func("/snap/sc_is_hook_security_tag",
-			test_sc_is_hook_security_tag);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/snap/sc_security_tag_validate", test_sc_security_tag_validate);
+    g_test_add_func("/snap/sc_is_hook_security_tag", test_sc_is_hook_security_tag);
 
-	g_test_add_data_func("/snap/sc_snap_name_validate",
-			     sc_snap_name_validate,
-			     test_sc_snap_or_instance_name_validate);
-	g_test_add_func("/snap/sc_snap_name_validate/respects_error_protocol",
-			test_sc_snap_name_validate__respects_error_protocol);
+    g_test_add_data_func("/snap/sc_snap_name_validate", sc_snap_name_validate, test_sc_snap_or_instance_name_validate);
+    g_test_add_func("/snap/sc_snap_name_validate/respects_error_protocol",
+                    test_sc_snap_name_validate__respects_error_protocol);
 
-	g_test_add_data_func("/snap/sc_instance_name_validate/just_name",
-			     sc_instance_name_validate,
-			     test_sc_snap_or_instance_name_validate);
-	g_test_add_func("/snap/sc_instance_name_validate/full",
-			test_sc_instance_name_validate);
+    g_test_add_data_func("/snap/sc_instance_name_validate/just_name", sc_instance_name_validate,
+                         test_sc_snap_or_instance_name_validate);
+    g_test_add_func("/snap/sc_instance_name_validate/full", test_sc_instance_name_validate);
 
-	g_test_add_func("/snap/sc_snap_drop_instance_key/basic",
-			test_sc_snap_drop_instance_key_basic);
-	g_test_add_func("/snap/sc_snap_drop_instance_key/no_dest",
-			test_sc_snap_drop_instance_key_no_dest);
-	g_test_add_func("/snap/sc_snap_drop_instance_key/no_name",
-			test_sc_snap_drop_instance_key_no_name);
-	g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest",
-			test_sc_snap_drop_instance_key_short_dest);
-	g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest2",
-			test_sc_snap_drop_instance_key_short_dest2);
-	g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest_max",
-			test_sc_snap_drop_instance_key_short_dest_max);
+    g_test_add_func("/snap/sc_snap_drop_instance_key/basic", test_sc_snap_drop_instance_key_basic);
+    g_test_add_func("/snap/sc_snap_drop_instance_key/no_dest", test_sc_snap_drop_instance_key_no_dest);
+    g_test_add_func("/snap/sc_snap_drop_instance_key/no_name", test_sc_snap_drop_instance_key_no_name);
+    g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest", test_sc_snap_drop_instance_key_short_dest);
+    g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest2", test_sc_snap_drop_instance_key_short_dest2);
+    g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest_max", test_sc_snap_drop_instance_key_short_dest_max);
 
-	g_test_add_func("/snap/sc_snap_split_instance_name/basic",
-			test_sc_snap_split_instance_name_basic);
-	g_test_add_func("/snap/sc_snap_split_snap_component/basic",
-			test_sc_snap_split_snap_component_basic);
-	g_test_add_func("/snap/sc_snap_component_validate",
-			test_sc_snap_component_validate);
-	g_test_add_func
-	    ("/snap/sc_snap_component_validate/respects_error_protocol",
-	     test_sc_snap_component_validate_respects_error_protocol);
+    g_test_add_func("/snap/sc_snap_split_instance_name/basic", test_sc_snap_split_instance_name_basic);
+    g_test_add_func("/snap/sc_snap_split_snap_component/basic", test_sc_snap_split_snap_component_basic);
+    g_test_add_func("/snap/sc_snap_component_validate", test_sc_snap_component_validate);
+    g_test_add_func("/snap/sc_snap_component_validate/respects_error_protocol",
+                    test_sc_snap_component_validate_respects_error_protocol);
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -14,415 +14,341 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "config.h"
 #include "snap.h"
+#include "config.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <regex.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
-#include "utils.h"
-#include "string-utils.h"
 #include "cleanup-funcs.h"
+#include "string-utils.h"
+#include "utils.h"
 
-bool sc_security_tag_validate(const char *security_tag,
-			      const char *snap_instance,
-			      const char *component_name)
-{
-	/* Don't even check overly long tags. */
-	if (strlen(security_tag) > SNAP_SECURITY_TAG_MAX_LEN) {
-		return false;
-	}
-	const char *whitelist_re =
-	    "^snap\\.([a-z0-9](-?[a-z0-9])*(_[a-z0-9]{1,10})?)(\\.[a-zA-Z0-9](-?[a-zA-Z0-9])*|(\\+([a-z0-9](-?[a-z0-9])*))?\\.hook\\.[a-z](-?[a-z0-9])*)$";
-	regex_t re;
-	if (regcomp(&re, whitelist_re, REG_EXTENDED) != 0)
-		die("can not compile regex %s", whitelist_re);
+bool sc_security_tag_validate(const char *security_tag, const char *snap_instance, const char *component_name) {
+    /* Don't even check overly long tags. */
+    if (strlen(security_tag) > SNAP_SECURITY_TAG_MAX_LEN) {
+        return false;
+    }
+    const char *whitelist_re =
+        "^snap\\.([a-z0-9](-?[a-z0-9])*(_[a-z0-9]{1,10})?)(\\.[a-zA-Z0-9](-?[a-zA-Z0-9])*|(\\+([a-z0-9](-?[a-z0-9])*))?"
+        "\\.hook\\.[a-z](-?[a-z0-9])*)$";
+    regex_t re;
+    if (regcomp(&re, whitelist_re, REG_EXTENDED) != 0) die("can not compile regex %s", whitelist_re);
 
-	// first capture is for verifying the full security tag, second capture
-	// for verifying the snap_name is correct for this security tag, eighth capture
-	// for verifying the component_name is correct for this security tag. the
-	// expression currently contains 9 capture groups, but we only care about these 3,
-	// which unfortunately are not within the first 3 submatches, but rather group 1,
-	// 2, and 7, so for completeness capture all the groups.
-	enum { num_matches = 9 };
-	regmatch_t matches[num_matches];
-	if (num_matches != re.re_nsub) {
-		die("internal error: all regex capture groups not fully accounted for");
-	}
+    // first capture is for verifying the full security tag, second capture
+    // for verifying the snap_name is correct for this security tag, eighth capture
+    // for verifying the component_name is correct for this security tag. the
+    // expression currently contains 9 capture groups, but we only care about these 3,
+    // which unfortunately are not within the first 3 submatches, but rather group 1,
+    // 2, and 7, so for completeness capture all the groups.
+    enum { num_matches = 9 };
+    regmatch_t matches[num_matches];
+    if (num_matches != re.re_nsub) {
+        die("internal error: all regex capture groups not fully accounted for");
+    }
 
-	int status =
-	    regexec(&re, security_tag, sizeof matches / sizeof *matches,
-		    matches, 0);
-	regfree(&re);
+    int status = regexec(&re, security_tag, sizeof matches / sizeof *matches, matches, 0);
+    regfree(&re);
 
-	// Fail if no match or if snap name wasn't captured in the 2nd match group
-	if (status != 0 || matches[1].rm_so < 0) {
-		return false;
-	}
-	// if we expect a component name (a non-null string was passed in here),
-	// then we need to make sure that the regex captured a component name
-	if (component_name != NULL) {
-		// fail if the security tag doesn't contain a component name and we
-		// expected one
-		if (matches[7].rm_so < 0) {
-			return false;
-		}
+    // Fail if no match or if snap name wasn't captured in the 2nd match group
+    if (status != 0 || matches[1].rm_so < 0) {
+        return false;
+    }
+    // if we expect a component name (a non-null string was passed in here),
+    // then we need to make sure that the regex captured a component name
+    if (component_name != NULL) {
+        // fail if the security tag doesn't contain a component name and we
+        // expected one
+        if (matches[7].rm_so < 0) {
+            return false;
+        }
 
-		size_t component_name_len = strlen(component_name);
+        size_t component_name_len = strlen(component_name);
 
-		// don't allow empty component names, only allow NULL as an indication
-		// that we don't expect a component name.
-		if (component_name_len == 0) {
-			return false;
-		}
+        // don't allow empty component names, only allow NULL as an indication
+        // that we don't expect a component name.
+        if (component_name_len == 0) {
+            return false;
+        }
 
-		size_t len = matches[7].rm_eo - matches[7].rm_so;
-		if (len != component_name_len
-		    || strncmp(security_tag + matches[7].rm_so, component_name,
-			       len) != 0) {
-			return false;
-		}
-	} else if (matches[7].rm_so >= 0) {
-		// fail if the security tag contains a component name and we didn't
-		// expect one
-		return false;
-	}
+        size_t len = matches[7].rm_eo - matches[7].rm_so;
+        if (len != component_name_len || strncmp(security_tag + matches[7].rm_so, component_name, len) != 0) {
+            return false;
+        }
+    } else if (matches[7].rm_so >= 0) {
+        // fail if the security tag contains a component name and we didn't
+        // expect one
+        return false;
+    }
 
-	size_t len = matches[1].rm_eo - matches[1].rm_so;
-	return len == strlen(snap_instance)
-	    && strncmp(security_tag + matches[1].rm_so, snap_instance,
-		       len) == 0;
+    size_t len = matches[1].rm_eo - matches[1].rm_so;
+    return len == strlen(snap_instance) && strncmp(security_tag + matches[1].rm_so, snap_instance, len) == 0;
 }
 
-bool sc_is_hook_security_tag(const char *security_tag)
-{
-	const char *whitelist_re =
-	    "^snap\\.[a-z](-?[a-z0-9])*(_[a-z0-9]{1,10})?\\.(hook\\.[a-z](-?[a-z0-9])*)$";
+bool sc_is_hook_security_tag(const char *security_tag) {
+    const char *whitelist_re = "^snap\\.[a-z](-?[a-z0-9])*(_[a-z0-9]{1,10})?\\.(hook\\.[a-z](-?[a-z0-9])*)$";
 
-	regex_t re;
-	if (regcomp(&re, whitelist_re, REG_EXTENDED | REG_NOSUB) != 0)
-		die("can not compile regex %s", whitelist_re);
+    regex_t re;
+    if (regcomp(&re, whitelist_re, REG_EXTENDED | REG_NOSUB) != 0) die("can not compile regex %s", whitelist_re);
 
-	int status = regexec(&re, security_tag, 0, NULL, 0);
-	regfree(&re);
+    int status = regexec(&re, security_tag, 0, NULL, 0);
+    regfree(&re);
 
-	return status == 0;
+    return status == 0;
 }
 
-static int skip_lowercase_letters(const char **p)
-{
-	int skipped = 0;
-	for (const char *c = *p; *c >= 'a' && *c <= 'z'; ++c) {
-		skipped += 1;
-	}
-	*p = (*p) + skipped;
-	return skipped;
+static int skip_lowercase_letters(const char **p) {
+    int skipped = 0;
+    for (const char *c = *p; *c >= 'a' && *c <= 'z'; ++c) {
+        skipped += 1;
+    }
+    *p = (*p) + skipped;
+    return skipped;
 }
 
-static int skip_digits(const char **p)
-{
-	int skipped = 0;
-	for (const char *c = *p; *c >= '0' && *c <= '9'; ++c) {
-		skipped += 1;
-	}
-	*p = (*p) + skipped;
-	return skipped;
+static int skip_digits(const char **p) {
+    int skipped = 0;
+    for (const char *c = *p; *c >= '0' && *c <= '9'; ++c) {
+        skipped += 1;
+    }
+    *p = (*p) + skipped;
+    return skipped;
 }
 
-static int skip_one_char(const char **p, char c)
-{
-	if (**p == c) {
-		*p += 1;
-		return 1;
-	}
-	return 0;
+static int skip_one_char(const char **p, char c) {
+    if (**p == c) {
+        *p += 1;
+        return 1;
+    }
+    return 0;
 }
 
-static void validate_as_snap_or_component_name(const char *name,
-					       int err_code,
-					       const char *err_subject,
-					       sc_error **errorp)
-{
-	// NOTE: This function should be synchronized with the two other
-	// implementations: validate_snap_name and snap.ValidateName.
-	sc_error *err = NULL;
+static void validate_as_snap_or_component_name(const char *name, int err_code, const char *err_subject,
+                                               sc_error **errorp) {
+    // NOTE: This function should be synchronized with the two other
+    // implementations: validate_snap_name and snap.ValidateName.
+    sc_error *err = NULL;
 
-	// Ensure that name is not NULL
-	if (name == NULL) {
-		err = sc_error_init(SC_SNAP_DOMAIN, err_code,
-				    "%s cannot be NULL", err_subject);
-		goto out;
-	}
-	// This is a regexp-free routine hand-codes the following pattern:
-	//
-	// "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$"
-	//
-	// The only motivation for not using regular expressions is so that we
-	// don't run untrusted input against a potentially complex regular
-	// expression engine.
-	const char *p = name;
-	if (skip_one_char(&p, '-')) {
-		err = sc_error_init(SC_SNAP_DOMAIN, err_code,
-				    "%s cannot start with a dash", err_subject);
-		goto out;
-	}
-	bool got_letter = false;
-	int n = 0, m;
-	while (*p != '\0') {
-		if ((m = skip_lowercase_letters(&p)) > 0) {
-			n += m;
-			got_letter = true;
-			continue;
-		}
-		if ((m = skip_digits(&p)) > 0) {
-			n += m;
-			continue;
-		}
-		if (skip_one_char(&p, '-') > 0) {
-			n++;
-			if (*p == '\0') {
-				err =
-				    sc_error_init(SC_SNAP_DOMAIN,
-						  err_code,
-						  "%s cannot end with a dash",
-						  err_subject);
-				goto out;
-			}
-			if (skip_one_char(&p, '-') > 0) {
-				err =
-				    sc_error_init(SC_SNAP_DOMAIN,
-						  err_code,
-						  "%s cannot contain two consecutive dashes",
-						  err_subject);
-				goto out;
-			}
-			continue;
-		}
-		err = sc_error_init(SC_SNAP_DOMAIN, err_code,
-				    "%s must use lower case letters, digits or dashes",
-				    err_subject);
-		goto out;
-	}
-	if (!got_letter) {
-		err = sc_error_init(SC_SNAP_DOMAIN, err_code,
-				    "%s must contain at least one letter",
-				    err_subject);
-		goto out;
-	}
-	if (n < 2) {
-		err = sc_error_init(SC_SNAP_DOMAIN, err_code,
-				    "%s must be longer than 1 character",
-				    err_subject);
-		goto out;
-	}
-	if (n > SNAP_NAME_LEN) {
-		err = sc_error_init(SC_SNAP_DOMAIN, err_code,
-				    "%s must be shorter than 40 characters",
-				    err_subject);
-		goto out;
-	}
+    // Ensure that name is not NULL
+    if (name == NULL) {
+        err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s cannot be NULL", err_subject);
+        goto out;
+    }
+    // This is a regexp-free routine hand-codes the following pattern:
+    //
+    // "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$"
+    //
+    // The only motivation for not using regular expressions is so that we
+    // don't run untrusted input against a potentially complex regular
+    // expression engine.
+    const char *p = name;
+    if (skip_one_char(&p, '-')) {
+        err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s cannot start with a dash", err_subject);
+        goto out;
+    }
+    bool got_letter = false;
+    int n = 0, m;
+    while (*p != '\0') {
+        if ((m = skip_lowercase_letters(&p)) > 0) {
+            n += m;
+            got_letter = true;
+            continue;
+        }
+        if ((m = skip_digits(&p)) > 0) {
+            n += m;
+            continue;
+        }
+        if (skip_one_char(&p, '-') > 0) {
+            n++;
+            if (*p == '\0') {
+                err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s cannot end with a dash", err_subject);
+                goto out;
+            }
+            if (skip_one_char(&p, '-') > 0) {
+                err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s cannot contain two consecutive dashes", err_subject);
+                goto out;
+            }
+            continue;
+        }
+        err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s must use lower case letters, digits or dashes", err_subject);
+        goto out;
+    }
+    if (!got_letter) {
+        err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s must contain at least one letter", err_subject);
+        goto out;
+    }
+    if (n < 2) {
+        err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s must be longer than 1 character", err_subject);
+        goto out;
+    }
+    if (n > SNAP_NAME_LEN) {
+        err = sc_error_init(SC_SNAP_DOMAIN, err_code, "%s must be shorter than 40 characters", err_subject);
+        goto out;
+    }
 
- out:
-	sc_error_forward(errorp, err);
+out:
+    sc_error_forward(errorp, err);
 }
 
-void sc_instance_name_validate(const char *instance_name, sc_error **errorp)
-{
-	// NOTE: This function should be synchronized with the two other
-	// implementations: validate_instance_name and snap.ValidateInstanceName.
-	sc_error *err = NULL;
+void sc_instance_name_validate(const char *instance_name, sc_error **errorp) {
+    // NOTE: This function should be synchronized with the two other
+    // implementations: validate_instance_name and snap.ValidateInstanceName.
+    sc_error *err = NULL;
 
-	// Ensure that name is not NULL
-	if (instance_name == NULL) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME,
-				  "snap instance name cannot be NULL");
-		goto out;
-	}
+    // Ensure that name is not NULL
+    if (instance_name == NULL) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME, "snap instance name cannot be NULL");
+        goto out;
+    }
 
-	if (strlen(instance_name) > SNAP_INSTANCE_LEN) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME,
-				  "snap instance name can be at most %d characters long",
-				  SNAP_INSTANCE_LEN);
-		goto out;
-	}
-	// instance name length + 1 extra overflow + 1 NULL
-	char s[SNAP_INSTANCE_LEN + 1 + 1] = { 0 };
-	strncpy(s, instance_name, sizeof(s) - 1);
+    if (strlen(instance_name) > SNAP_INSTANCE_LEN) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME,
+                            "snap instance name can be at most %d characters long", SNAP_INSTANCE_LEN);
+        goto out;
+    }
+    // instance name length + 1 extra overflow + 1 NULL
+    char s[SNAP_INSTANCE_LEN + 1 + 1] = {0};
+    strncpy(s, instance_name, sizeof(s) - 1);
 
-	char *t = s;
-	const char *snap_name = strsep(&t, "_");
-	const char *instance_key = strsep(&t, "_");
-	const char *third_separator = strsep(&t, "_");
-	if (third_separator != NULL) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME,
-				  "snap instance name can contain only one underscore");
-		goto out;
-	}
+    char *t = s;
+    const char *snap_name = strsep(&t, "_");
+    const char *instance_key = strsep(&t, "_");
+    const char *third_separator = strsep(&t, "_");
+    if (third_separator != NULL) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_NAME,
+                            "snap instance name can contain only one underscore");
+        goto out;
+    }
 
-	sc_snap_name_validate(snap_name, &err);
-	if (err != NULL) {
-		goto out;
-	}
-	// When the instance_name is a normal snap name, instance_key will be
-	// NULL, so only validate instance_key when we found one.
-	if (instance_key != NULL) {
-		sc_instance_key_validate(instance_key, &err);
-	}
+    sc_snap_name_validate(snap_name, &err);
+    if (err != NULL) {
+        goto out;
+    }
+    // When the instance_name is a normal snap name, instance_key will be
+    // NULL, so only validate instance_key when we found one.
+    if (instance_key != NULL) {
+        sc_instance_key_validate(instance_key, &err);
+    }
 
- out:
-	sc_error_forward(errorp, err);
+out:
+    sc_error_forward(errorp, err);
 }
 
-void sc_instance_key_validate(const char *instance_key, sc_error **errorp)
-{
-	// NOTE: see snap.ValidateInstanceName for reference of a valid instance key
-	// format
-	sc_error *err = NULL;
+void sc_instance_key_validate(const char *instance_key, sc_error **errorp) {
+    // NOTE: see snap.ValidateInstanceName for reference of a valid instance key
+    // format
+    sc_error *err = NULL;
 
-	// Ensure that name is not NULL
-	if (instance_key == NULL) {
-		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
-				    "instance key cannot be NULL");
-		goto out;
-	}
-	// This is a regexp-free routine hand-coding the following pattern:
-	//
-	// "^[a-z]{1,10}$"
-	//
-	// The only motivation for not using regular expressions is so that we don't
-	// run untrusted input against a potentially complex regular expression
-	// engine.
-	int i = 0;
-	for (i = 0; instance_key[i] != '\0'; i++) {
-		if (islower(instance_key[i]) || isdigit(instance_key[i])) {
-			continue;
-		}
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
-				  "instance key must use lower case letters or digits");
-		goto out;
-	}
+    // Ensure that name is not NULL
+    if (instance_key == NULL) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME, "instance key cannot be NULL");
+        goto out;
+    }
+    // This is a regexp-free routine hand-coding the following pattern:
+    //
+    // "^[a-z]{1,10}$"
+    //
+    // The only motivation for not using regular expressions is so that we don't
+    // run untrusted input against a potentially complex regular expression
+    // engine.
+    int i = 0;
+    for (i = 0; instance_key[i] != '\0'; i++) {
+        if (islower(instance_key[i]) || isdigit(instance_key[i])) {
+            continue;
+        }
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
+                            "instance key must use lower case letters or digits");
+        goto out;
+    }
 
-	if (i == 0) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
-				  "instance key must contain at least one letter or digit");
-	} else if (i > SNAP_INSTANCE_KEY_LEN) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
-				  "instance key must be shorter than 10 characters");
-	}
- out:
-	sc_error_forward(errorp, err);
+    if (i == 0) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
+                            "instance key must contain at least one letter or digit");
+    } else if (i > SNAP_INSTANCE_KEY_LEN) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
+                            "instance key must be shorter than 10 characters");
+    }
+out:
+    sc_error_forward(errorp, err);
 }
 
-void sc_snap_component_validate(const char *snap_component,
-				const char *snap_instance, sc_error **errorp)
-{
-	sc_error *err = NULL;
+void sc_snap_component_validate(const char *snap_component, const char *snap_instance, sc_error **errorp) {
+    sc_error *err = NULL;
 
-	// ensure that name is not NULL
-	if (snap_component == NULL) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT,
-				  "snap component cannot be NULL");
-		goto out;
-	}
+    // ensure that name is not NULL
+    if (snap_component == NULL) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT, "snap component cannot be NULL");
+        goto out;
+    }
 
-	const char *pos = strchr(snap_component, '+');
-	if (pos == NULL) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT,
-				  "snap component must contain a +");
-		goto out;
-	}
+    const char *pos = strchr(snap_component, '+');
+    if (pos == NULL) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT, "snap component must contain a +");
+        goto out;
+    }
 
-	size_t snap_name_len = pos - snap_component;
-	if (snap_name_len > SNAP_NAME_LEN) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT,
-				  "snap name must be shorter than 40 characters");
-		goto out;
-	}
+    size_t snap_name_len = pos - snap_component;
+    if (snap_name_len > SNAP_NAME_LEN) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT, "snap name must be shorter than 40 characters");
+        goto out;
+    }
 
-	size_t component_name_len = strlen(pos + 1);
-	if (component_name_len > SNAP_NAME_LEN) {
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT,
-				  "component name must be shorter than 40 characters");
-		goto out;
-	}
+    size_t component_name_len = strlen(pos + 1);
+    if (component_name_len > SNAP_NAME_LEN) {
+        err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT,
+                            "component name must be shorter than 40 characters");
+        goto out;
+    }
 
-	char snap_name[SNAP_NAME_LEN + 1] = { 0 };
-	strncpy(snap_name, snap_component, snap_name_len);
+    char snap_name[SNAP_NAME_LEN + 1] = {0};
+    strncpy(snap_name, snap_component, snap_name_len);
 
-	char component_name[SNAP_NAME_LEN + 1] = { 0 };
-	strncpy(component_name, pos + 1, component_name_len);
+    char component_name[SNAP_NAME_LEN + 1] = {0};
+    strncpy(component_name, pos + 1, component_name_len);
 
-	validate_as_snap_or_component_name(snap_name, SC_SNAP_INVALID_COMPONENT,
-					   "snap name in component", &err);
-	if (err != NULL) {
-		goto out;
-	}
+    validate_as_snap_or_component_name(snap_name, SC_SNAP_INVALID_COMPONENT, "snap name in component", &err);
+    if (err != NULL) {
+        goto out;
+    }
 
-	validate_as_snap_or_component_name(component_name,
-					   SC_SNAP_INVALID_COMPONENT,
-					   "component name", &err);
-	if (err != NULL) {
-		goto out;
-	}
+    validate_as_snap_or_component_name(component_name, SC_SNAP_INVALID_COMPONENT, "component name", &err);
+    if (err != NULL) {
+        goto out;
+    }
 
-	if (snap_instance != NULL) {
-		char snap_name_in_instance[SNAP_NAME_LEN + 1] = { 0 };
-		sc_snap_drop_instance_key(snap_instance, snap_name_in_instance,
-					  sizeof snap_name_in_instance);
+    if (snap_instance != NULL) {
+        char snap_name_in_instance[SNAP_NAME_LEN + 1] = {0};
+        sc_snap_drop_instance_key(snap_instance, snap_name_in_instance, sizeof snap_name_in_instance);
 
-		if (strcmp(snap_name, snap_name_in_instance) != 0) {
-			err =
-			    sc_error_init(SC_SNAP_DOMAIN,
-					  SC_SNAP_INVALID_COMPONENT,
-					  "snap name in component must match snap name in instance");
-			goto out;
-		}
-	}
+        if (strcmp(snap_name, snap_name_in_instance) != 0) {
+            err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_COMPONENT,
+                                "snap name in component must match snap name in instance");
+            goto out;
+        }
+    }
 
- out:
-	sc_error_forward(errorp, err);
+out:
+    sc_error_forward(errorp, err);
 }
 
-void sc_snap_name_validate(const char *snap_name, sc_error **errorp)
-{
-	validate_as_snap_or_component_name(snap_name, SC_SNAP_INVALID_NAME,
-					   "snap name", errorp);
+void sc_snap_name_validate(const char *snap_name, sc_error **errorp) {
+    validate_as_snap_or_component_name(snap_name, SC_SNAP_INVALID_NAME, "snap name", errorp);
 }
 
-void sc_snap_drop_instance_key(const char *instance_name, char *snap_name,
-			       size_t snap_name_size)
-{
-	sc_snap_split_instance_name(instance_name, snap_name, snap_name_size,
-				    NULL, 0);
+void sc_snap_drop_instance_key(const char *instance_name, char *snap_name, size_t snap_name_size) {
+    sc_snap_split_instance_name(instance_name, snap_name, snap_name_size, NULL, 0);
 }
 
-void sc_snap_split_instance_name(const char *instance_name, char *snap_name,
-				 size_t snap_name_size, char *instance_key,
-				 size_t instance_key_size)
-{
-	sc_string_split(instance_name, '_', snap_name, snap_name_size,
-			instance_key, instance_key_size);
+void sc_snap_split_instance_name(const char *instance_name, char *snap_name, size_t snap_name_size, char *instance_key,
+                                 size_t instance_key_size) {
+    sc_string_split(instance_name, '_', snap_name, snap_name_size, instance_key, instance_key_size);
 }
 
-void sc_snap_split_snap_component(const char *snap_component,
-				  char *snap_name, size_t snap_name_size,
-				  char *component_name,
-				  size_t component_name_size)
-{
-	sc_string_split(snap_component, '+', snap_name, snap_name_size,
-			component_name, component_name_size);
+void sc_snap_split_snap_component(const char *snap_component, char *snap_name, size_t snap_name_size,
+                                  char *component_name, size_t component_name_size) {
+    sc_string_split(snap_component, '+', snap_name, snap_name_size, component_name, component_name_size);
 }

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -29,16 +29,16 @@
 #define SC_SNAP_DOMAIN "snap"
 
 enum {
-	/** The name of the snap is not valid. */
-	SC_SNAP_INVALID_NAME = 1,
-	/** The instance key of the snap is not valid. */
-	SC_SNAP_INVALID_INSTANCE_KEY = 2,
-	/** The instance of the snap is not valid. */
-	SC_SNAP_INVALID_INSTANCE_NAME = 3,
-	/** System configuration is not supported. */
-	SC_SNAP_MOUNT_DIR_UNSUPPORTED = 4,
-	/** The name of the snap component is not valid. */
-	SC_SNAP_INVALID_COMPONENT = 5,
+    /** The name of the snap is not valid. */
+    SC_SNAP_INVALID_NAME = 1,
+    /** The instance key of the snap is not valid. */
+    SC_SNAP_INVALID_INSTANCE_KEY = 2,
+    /** The instance of the snap is not valid. */
+    SC_SNAP_INVALID_INSTANCE_NAME = 3,
+    /** System configuration is not supported. */
+    SC_SNAP_MOUNT_DIR_UNSUPPORTED = 4,
+    /** The name of the snap component is not valid. */
+    SC_SNAP_INVALID_COMPONENT = 5,
 };
 
 /* SNAP_NAME_LEN is the maximum length of a snap name, enforced by snapd and the
@@ -79,8 +79,7 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp);
  * The error protocol is observed so if the caller doesn't provide an outgoing
  * error pointer the function will die on any error.
  **/
-void sc_instance_key_validate(const char *instance_key,
-			      struct sc_error **errorp);
+void sc_instance_key_validate(const char *instance_key, struct sc_error **errorp);
 
 /**
  * Validate the given snap component.
@@ -96,8 +95,7 @@ void sc_instance_key_validate(const char *instance_key,
  * The error protocol is observed so if the caller doesn't provide an outgoing
  * error pointer the function will die on any error.
  **/
-void sc_snap_component_validate(const char *snap_component,
-				const char *snap_instance, sc_error ** errorp);
+void sc_snap_component_validate(const char *snap_component, const char *snap_instance, sc_error **errorp);
 
 /**
  * Validate the given snap instance name.
@@ -108,8 +106,7 @@ void sc_snap_component_validate(const char *snap_component,
  * The error protocol is observed so if the caller doesn't provide an outgoing
  * error pointer the function will die on any error.
  **/
-void sc_instance_name_validate(const char *instance_name,
-			       struct sc_error **errorp);
+void sc_instance_name_validate(const char *instance_name, struct sc_error **errorp);
 
 /**
  * Validate security tag against strict naming requirements, snap name,
@@ -131,8 +128,7 @@ void sc_instance_name_validate(const char *instance_name,
  *  - <hookname must start with a lowercase letter, then may
  *   contain lowercase letters and '-'
  **/
-bool sc_security_tag_validate(const char *security_tag, const char *snap_name,
-			      const char *component_name);
+bool sc_security_tag_validate(const char *security_tag, const char *snap_name, const char *component_name);
 
 bool sc_is_hook_security_tag(const char *security_tag);
 
@@ -145,8 +141,7 @@ bool sc_is_hook_security_tag(const char *security_tag);
  *
  * For example: snap_instance => snap, just-snap => just-snap
  **/
-void sc_snap_drop_instance_key(const char *instance_name, char *snap_name,
-			       size_t snap_name_size);
+void sc_snap_drop_instance_key(const char *instance_name, char *snap_name, size_t snap_name_size);
 
 /**
  * Extract snap name and instance key out of an instance name.
@@ -160,9 +155,8 @@ void sc_snap_drop_instance_key(const char *instance_name, char *snap_name,
  *   just-name     => "just-name" & ""
  *
  **/
-void sc_snap_split_instance_name(const char *instance_name, char *snap_name,
-				 size_t snap_name_size, char *instance_key,
-				 size_t instance_key_size);
+void sc_snap_split_instance_name(const char *instance_name, char *snap_name, size_t snap_name_size, char *instance_key,
+                                 size_t instance_key_size);
 
 /**
  * Extract snap name and component name out of a snap component.
@@ -171,8 +165,7 @@ void sc_snap_split_instance_name(const char *instance_name, char *snap_name,
  *   snap+component => "snap" & "component"
  *
  **/
-void sc_snap_split_snap_component(const char *snap_component, char *snap_name,
-				  size_t snap_name_size, char *component_name,
-				  size_t component_name_size);
+void sc_snap_split_snap_component(const char *snap_component, char *snap_name, size_t snap_name_size,
+                                  char *component_name, size_t component_name_size);
 
 #endif

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -20,998 +20,906 @@
 
 #include <glib.h>
 
-static void test_sc_streq(void)
-{
-	g_assert_false(sc_streq(NULL, NULL));
-	g_assert_false(sc_streq(NULL, "text"));
-	g_assert_false(sc_streq("text", NULL));
-	g_assert_false(sc_streq("foo", "bar"));
-	g_assert_false(sc_streq("foo", "barbar"));
-	g_assert_false(sc_streq("foofoo", "bar"));
-	g_assert_true(sc_streq("text", "text"));
-	g_assert_true(sc_streq("", ""));
+static void test_sc_streq(void) {
+    g_assert_false(sc_streq(NULL, NULL));
+    g_assert_false(sc_streq(NULL, "text"));
+    g_assert_false(sc_streq("text", NULL));
+    g_assert_false(sc_streq("foo", "bar"));
+    g_assert_false(sc_streq("foo", "barbar"));
+    g_assert_false(sc_streq("foofoo", "bar"));
+    g_assert_true(sc_streq("text", "text"));
+    g_assert_true(sc_streq("", ""));
 }
 
-static void test_sc_endswith(void)
-{
-	// NULL doesn't end with anything, nothing ends with NULL
-	g_assert_false(sc_endswith("", NULL));
-	g_assert_false(sc_endswith(NULL, ""));
-	g_assert_false(sc_endswith(NULL, NULL));
-	// Empty string ends with an empty string
-	g_assert_true(sc_endswith("", ""));
-	// Ends-with (matches)
-	g_assert_true(sc_endswith("foobar", "bar"));
-	g_assert_true(sc_endswith("foobar", "ar"));
-	g_assert_true(sc_endswith("foobar", "r"));
-	g_assert_true(sc_endswith("foobar", ""));
-	g_assert_true(sc_endswith("bar", "bar"));
-	// Ends-with (non-matches)
-	g_assert_false(sc_endswith("foobar", "quux"));
-	g_assert_false(sc_endswith("", "bar"));
-	g_assert_false(sc_endswith("b", "bar"));
-	g_assert_false(sc_endswith("ba", "bar"));
+static void test_sc_endswith(void) {
+    // NULL doesn't end with anything, nothing ends with NULL
+    g_assert_false(sc_endswith("", NULL));
+    g_assert_false(sc_endswith(NULL, ""));
+    g_assert_false(sc_endswith(NULL, NULL));
+    // Empty string ends with an empty string
+    g_assert_true(sc_endswith("", ""));
+    // Ends-with (matches)
+    g_assert_true(sc_endswith("foobar", "bar"));
+    g_assert_true(sc_endswith("foobar", "ar"));
+    g_assert_true(sc_endswith("foobar", "r"));
+    g_assert_true(sc_endswith("foobar", ""));
+    g_assert_true(sc_endswith("bar", "bar"));
+    // Ends-with (non-matches)
+    g_assert_false(sc_endswith("foobar", "quux"));
+    g_assert_false(sc_endswith("", "bar"));
+    g_assert_false(sc_endswith("b", "bar"));
+    g_assert_false(sc_endswith("ba", "bar"));
 }
 
-static void test_sc_startswith(void)
-{
-	// NULL doesn't start with anything, nothing starts with NULL
-	g_assert_false(sc_startswith("", NULL));
-	g_assert_false(sc_startswith(NULL, ""));
-	g_assert_false(sc_startswith(NULL, NULL));
-	// Empty string starts with an empty string
-	g_assert_true(sc_startswith("", ""));
-	// Starts-with (matches)
-	g_assert_true(sc_startswith("foobar", "foo"));
-	g_assert_true(sc_startswith("foobar", "fo"));
-	g_assert_true(sc_startswith("foobar", "f"));
-	g_assert_true(sc_startswith("foobar", ""));
-	g_assert_true(sc_startswith("bar", "bar"));
-	// Starts-with (non-matches)
-	g_assert_false(sc_startswith("foobar", "quux"));
-	g_assert_false(sc_startswith("", "bar"));
-	g_assert_false(sc_startswith("b", "bar"));
-	g_assert_false(sc_startswith("ba", "bar"));
+static void test_sc_startswith(void) {
+    // NULL doesn't start with anything, nothing starts with NULL
+    g_assert_false(sc_startswith("", NULL));
+    g_assert_false(sc_startswith(NULL, ""));
+    g_assert_false(sc_startswith(NULL, NULL));
+    // Empty string starts with an empty string
+    g_assert_true(sc_startswith("", ""));
+    // Starts-with (matches)
+    g_assert_true(sc_startswith("foobar", "foo"));
+    g_assert_true(sc_startswith("foobar", "fo"));
+    g_assert_true(sc_startswith("foobar", "f"));
+    g_assert_true(sc_startswith("foobar", ""));
+    g_assert_true(sc_startswith("bar", "bar"));
+    // Starts-with (non-matches)
+    g_assert_false(sc_startswith("foobar", "quux"));
+    g_assert_false(sc_startswith("", "bar"));
+    g_assert_false(sc_startswith("b", "bar"));
+    g_assert_false(sc_startswith("ba", "bar"));
 }
 
-static void test_sc_must_snprintf(void)
-{
-	char buf[5] = { 0 };
-	sc_must_snprintf(buf, sizeof buf, "1234");
-	g_assert_cmpstr(buf, ==, "1234");
+static void test_sc_must_snprintf(void) {
+    char buf[5] = {0};
+    sc_must_snprintf(buf, sizeof buf, "1234");
+    g_assert_cmpstr(buf, ==, "1234");
 }
 
-static void test_sc_must_snprintf__fail(void)
-{
-	if (g_test_subprocess()) {
-		char buf[5];
-		sc_must_snprintf(buf, sizeof buf, "12345");
-		g_test_message("expected sc_must_snprintf not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot format string: 1234\n");
+static void test_sc_must_snprintf__fail(void) {
+    if (g_test_subprocess()) {
+        char buf[5];
+        sc_must_snprintf(buf, sizeof buf, "12345");
+        g_test_message("expected sc_must_snprintf not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot format string: 1234\n");
 }
 
 // Check that appending to a buffer works OK.
-static void test_sc_string_append(void)
-{
-	union {
-		char bigbuf[6];
-		struct {
-			signed char canary1;
-			char buf[4];
-			signed char canary2;
-		};
-	} data = {
-		.buf = {
-			'f', '\0', 0xFF, 0xFF},.canary1 = ~0,.canary2 = ~0,
-	};
+static void test_sc_string_append(void) {
+    union {
+        char bigbuf[6];
+        struct {
+            signed char canary1;
+            char buf[4];
+            signed char canary2;
+        };
+    } data = {
+        .buf = {'f', '\0', 0xFF, 0xFF},
+        .canary1 = ~0,
+        .canary2 = ~0,
+    };
 
-	// Sanity check, ensure that the layout of structures is as spelled above.
-	// (first canary1, then buf and finally canary2.
-	g_assert_cmpint(((char *)&data.buf[0]) - ((char *)&data.canary1), ==,
-			1);
-	g_assert_cmpint(((char *)&data.buf[4]) - ((char *)&data.canary2), ==,
-			0);
+    // Sanity check, ensure that the layout of structures is as spelled above.
+    // (first canary1, then buf and finally canary2.
+    g_assert_cmpint(((char *)&data.buf[0]) - ((char *)&data.canary1), ==, 1);
+    g_assert_cmpint(((char *)&data.buf[4]) - ((char *)&data.canary2), ==, 0);
 
-	sc_string_append(data.buf, sizeof data.buf, "oo");
+    sc_string_append(data.buf, sizeof data.buf, "oo");
 
-	// Check that we didn't corrupt either canary.
-	g_assert_cmpint(data.canary1, ==, ~0);
-	g_assert_cmpint(data.canary2, ==, ~0);
+    // Check that we didn't corrupt either canary.
+    g_assert_cmpint(data.canary1, ==, ~0);
+    g_assert_cmpint(data.canary2, ==, ~0);
 
-	// Check that we got the result that was expected.
-	g_assert_cmpstr(data.buf, ==, "foo");
+    // Check that we got the result that was expected.
+    g_assert_cmpstr(data.buf, ==, "foo");
 }
 
 // Check that appending an empty string to a full buffer is valid.
-static void test_sc_string_append__empty_to_full(void)
-{
-	union {
-		char bigbuf[6];
-		struct {
-			signed char canary1;
-			char buf[4];
-			signed char canary2;
-		};
-	} data = {
-		.buf = {
-			'f', 'o', 'o', '\0'},.canary1 = ~0,.canary2 = ~0,
-	};
+static void test_sc_string_append__empty_to_full(void) {
+    union {
+        char bigbuf[6];
+        struct {
+            signed char canary1;
+            char buf[4];
+            signed char canary2;
+        };
+    } data = {
+        .buf = {'f', 'o', 'o', '\0'},
+        .canary1 = ~0,
+        .canary2 = ~0,
+    };
 
-	// Sanity check, ensure that the layout of structures is as spelled above.
-	// (first canary1, then buf and finally canary2.
-	g_assert_cmpint(((char *)&data.buf[0]) - ((char *)&data.canary1), ==,
-			1);
-	g_assert_cmpint(((char *)&data.buf[4]) - ((char *)&data.canary2), ==,
-			0);
+    // Sanity check, ensure that the layout of structures is as spelled above.
+    // (first canary1, then buf and finally canary2.
+    g_assert_cmpint(((char *)&data.buf[0]) - ((char *)&data.canary1), ==, 1);
+    g_assert_cmpint(((char *)&data.buf[4]) - ((char *)&data.canary2), ==, 0);
 
-	sc_string_append(data.buf, sizeof data.buf, "");
+    sc_string_append(data.buf, sizeof data.buf, "");
 
-	// Check that we didn't corrupt either canary.
-	g_assert_cmpint(data.canary1, ==, ~0);
-	g_assert_cmpint(data.canary2, ==, ~0);
+    // Check that we didn't corrupt either canary.
+    g_assert_cmpint(data.canary1, ==, ~0);
+    g_assert_cmpint(data.canary2, ==, ~0);
 
-	// Check that we got the result that was expected.
-	g_assert_cmpstr(data.buf, ==, "foo");
+    // Check that we got the result that was expected.
+    g_assert_cmpstr(data.buf, ==, "foo");
 }
 
 // Check that the overflow detection works.
-static void test_sc_string_append__overflow(void)
-{
-	if (g_test_subprocess()) {
-		char buf[4] = { 0 };
+static void test_sc_string_append__overflow(void) {
+    if (g_test_subprocess()) {
+        char buf[4] = {0};
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-		// Try to append a string that's one character too long.
-		sc_string_append(buf, sizeof buf, "1234");
+        // Try to append a string that's one character too long.
+        sc_string_append(buf, sizeof buf, "1234");
 #pragma GCC diagnostic pop
-		g_test_message("expected sc_string_append not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append string: str is too long or unterminated\n");
+        g_test_message("expected sc_string_append not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append string: str is too long or unterminated\n");
 }
 
 // Check that the uninitialized buffer detection works.
-static void test_sc_string_append__uninitialized_buf(void)
-{
-	if (g_test_subprocess()) {
-		char buf[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+static void test_sc_string_append__uninitialized_buf(void) {
+    if (g_test_subprocess()) {
+        char buf[4] = {0xFF, 0xFF, 0xFF, 0xFF};
 
-		// Try to append a string to a buffer which is not a valic C-string.
-		sc_string_append(buf, sizeof buf, "");
+        // Try to append a string to a buffer which is not a valic C-string.
+        sc_string_append(buf, sizeof buf, "");
 
-		g_test_message("expected sc_string_append not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append string: dst is unterminated\n");
+        g_test_message("expected sc_string_append not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append string: dst is unterminated\n");
 }
 
 // Check that `buf' cannot be NULL.
-static void test_sc_string_append__NULL_buf(void)
-{
-	if (g_test_subprocess()) {
-		char buf[4];
+static void test_sc_string_append__NULL_buf(void) {
+    if (g_test_subprocess()) {
+        char buf[4];
 
-		sc_string_append(NULL, sizeof buf, "foo");
+        sc_string_append(NULL, sizeof buf, "foo");
 
-		g_test_message("expected sc_string_append not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot append string: buffer is NULL\n");
+        g_test_message("expected sc_string_append not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append string: buffer is NULL\n");
 }
 
 // Check that `src' cannot be NULL.
-static void test_sc_string_append__NULL_str(void)
-{
-	if (g_test_subprocess()) {
-		char buf[4];
+static void test_sc_string_append__NULL_str(void) {
+    if (g_test_subprocess()) {
+        char buf[4];
 
-		sc_string_append(buf, sizeof buf, NULL);
+        sc_string_append(buf, sizeof buf, NULL);
 
-		g_test_message("expected sc_string_append not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot append string: string is NULL\n");
+        g_test_message("expected sc_string_append not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append string: string is NULL\n");
 }
 
-static void test_sc_string_init__normal(void)
-{
-	char buf[1] = { 0xFF };
+static void test_sc_string_init__normal(void) {
+    char buf[1] = {0xFF};
 
-	sc_string_init(buf, sizeof buf);
-	g_assert_cmpint(buf[0], ==, 0);
+    sc_string_init(buf, sizeof buf);
+    g_assert_cmpint(buf[0], ==, 0);
 }
 
-static void test_sc_string_init__empty_buf(void)
-{
-	if (g_test_subprocess()) {
-		char buf[1] = { 0xFF };
+static void test_sc_string_init__empty_buf(void) {
+    if (g_test_subprocess()) {
+        char buf[1] = {0xFF};
 
-		sc_string_init(buf, 0);
+        sc_string_init(buf, 0);
 
-		g_test_message("expected sc_string_init not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot initialize string, buffer is too small\n");
+        g_test_message("expected sc_string_init not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot initialize string, buffer is too small\n");
 }
 
-static void test_sc_string_init__NULL_buf(void)
-{
-	if (g_test_subprocess()) {
-		sc_string_init(NULL, 1);
+static void test_sc_string_init__NULL_buf(void) {
+    if (g_test_subprocess()) {
+        sc_string_init(NULL, 1);
 
-		g_test_message("expected sc_string_init not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot initialize string, buffer is NULL\n");
+        g_test_message("expected sc_string_init not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot initialize string, buffer is NULL\n");
 }
 
-static void test_sc_string_append_char__uninitialized_buf(void)
-{
-	if (g_test_subprocess()) {
-		char buf[2] = { 0xFF, 0xFF };
-		sc_string_append_char(buf, sizeof buf, 'a');
+static void test_sc_string_append_char__uninitialized_buf(void) {
+    if (g_test_subprocess()) {
+        char buf[2] = {0xFF, 0xFF};
+        sc_string_append_char(buf, sizeof buf, 'a');
 
-		g_test_message("expected sc_string_append_char not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character: dst is unterminated\n");
+        g_test_message("expected sc_string_append_char not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character: dst is unterminated\n");
 }
 
-static void test_sc_string_append_char__NULL_buf(void)
-{
-	if (g_test_subprocess()) {
-		sc_string_append_char(NULL, 2, 'a');
+static void test_sc_string_append_char__NULL_buf(void) {
+    if (g_test_subprocess()) {
+        sc_string_append_char(NULL, 2, 'a');
 
-		g_test_message("expected sc_string_append_char not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot append character: buffer is NULL\n");
+        g_test_message("expected sc_string_append_char not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character: buffer is NULL\n");
 }
 
-static void test_sc_string_append_char__overflow(void)
-{
-	if (g_test_subprocess()) {
-		char buf[1] = { 0 };
+static void test_sc_string_append_char__overflow(void) {
+    if (g_test_subprocess()) {
+        char buf[1] = {0};
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-		sc_string_append_char(buf, sizeof buf, 'a');
+        sc_string_append_char(buf, sizeof buf, 'a');
 #pragma GCC diagnostic pop
-		g_test_message("expected sc_string_append_char not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character: not enough space\n");
+        g_test_message("expected sc_string_append_char not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character: not enough space\n");
 }
 
-static void test_sc_string_append_char__invalid_zero(void)
-{
-	if (g_test_subprocess()) {
-		char buf[2] = { 0 };
-		sc_string_append_char(buf, sizeof buf, '\0');
+static void test_sc_string_append_char__invalid_zero(void) {
+    if (g_test_subprocess()) {
+        char buf[2] = {0};
+        sc_string_append_char(buf, sizeof buf, '\0');
 
-		g_test_message("expected sc_string_append_char not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character: cannot append string terminator\n");
+        g_test_message("expected sc_string_append_char not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character: cannot append string terminator\n");
 }
 
-static void test_sc_string_append_char__normal(void)
-{
-	char buf[16];
-	size_t len;
-	sc_string_init(buf, sizeof buf);
+static void test_sc_string_append_char__normal(void) {
+    char buf[16];
+    size_t len;
+    sc_string_init(buf, sizeof buf);
 
-	len = sc_string_append_char(buf, sizeof buf, 'h');
-	g_assert_cmpstr(buf, ==, "h");
-	g_assert_cmpint(len, ==, 1);
-	len = sc_string_append_char(buf, sizeof buf, 'e');
-	g_assert_cmpstr(buf, ==, "he");
-	g_assert_cmpint(len, ==, 2);
-	len = sc_string_append_char(buf, sizeof buf, 'l');
-	g_assert_cmpstr(buf, ==, "hel");
-	g_assert_cmpint(len, ==, 3);
-	len = sc_string_append_char(buf, sizeof buf, 'l');
-	g_assert_cmpstr(buf, ==, "hell");
-	g_assert_cmpint(len, ==, 4);
-	len = sc_string_append_char(buf, sizeof buf, 'o');
-	g_assert_cmpstr(buf, ==, "hello");
-	g_assert_cmpint(len, ==, 5);
+    len = sc_string_append_char(buf, sizeof buf, 'h');
+    g_assert_cmpstr(buf, ==, "h");
+    g_assert_cmpint(len, ==, 1);
+    len = sc_string_append_char(buf, sizeof buf, 'e');
+    g_assert_cmpstr(buf, ==, "he");
+    g_assert_cmpint(len, ==, 2);
+    len = sc_string_append_char(buf, sizeof buf, 'l');
+    g_assert_cmpstr(buf, ==, "hel");
+    g_assert_cmpint(len, ==, 3);
+    len = sc_string_append_char(buf, sizeof buf, 'l');
+    g_assert_cmpstr(buf, ==, "hell");
+    g_assert_cmpint(len, ==, 4);
+    len = sc_string_append_char(buf, sizeof buf, 'o');
+    g_assert_cmpstr(buf, ==, "hello");
+    g_assert_cmpint(len, ==, 5);
 }
 
-static void test_sc_string_append_char_pair__uninitialized_buf(void)
-{
-	if (g_test_subprocess()) {
-		char buf[3] = { 0xFF, 0xFF, 0xFF };
-		sc_string_append_char_pair(buf, sizeof buf, 'a', 'b');
+static void test_sc_string_append_char_pair__uninitialized_buf(void) {
+    if (g_test_subprocess()) {
+        char buf[3] = {0xFF, 0xFF, 0xFF};
+        sc_string_append_char_pair(buf, sizeof buf, 'a', 'b');
 
-		g_test_message
-		    ("expected sc_string_append_char_pair not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character pair: dst is unterminated\n");
+        g_test_message("expected sc_string_append_char_pair not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character pair: dst is unterminated\n");
 }
 
-static void test_sc_string_append_char_pair__NULL_buf(void)
-{
-	if (g_test_subprocess()) {
-		sc_string_append_char_pair(NULL, 3, 'a', 'b');
+static void test_sc_string_append_char_pair__NULL_buf(void) {
+    if (g_test_subprocess()) {
+        sc_string_append_char_pair(NULL, 3, 'a', 'b');
 
-		g_test_message
-		    ("expected sc_string_append_char_pair not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character pair: buffer is NULL\n");
+        g_test_message("expected sc_string_append_char_pair not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character pair: buffer is NULL\n");
 }
 
-static void test_sc_string_append_char_pair__overflow(void)
-{
-	if (g_test_subprocess()) {
-		char buf[2] = { 0 };
+static void test_sc_string_append_char_pair__overflow(void) {
+    if (g_test_subprocess()) {
+        char buf[2] = {0};
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-		sc_string_append_char_pair(buf, sizeof buf, 'a', 'b');
+        sc_string_append_char_pair(buf, sizeof buf, 'a', 'b');
 #pragma GCC diagnostic pop
-		g_test_message
-		    ("expected sc_string_append_char_pair not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character pair: not enough space\n");
+        g_test_message("expected sc_string_append_char_pair not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character pair: not enough space\n");
 }
 
-static void test_sc_string_append_char_pair__invalid_zero_c1(void)
-{
-	if (g_test_subprocess()) {
-		char buf[3] = { 0 };
-		sc_string_append_char_pair(buf, sizeof buf, '\0', 'a');
+static void test_sc_string_append_char_pair__invalid_zero_c1(void) {
+    if (g_test_subprocess()) {
+        char buf[3] = {0};
+        sc_string_append_char_pair(buf, sizeof buf, '\0', 'a');
 
-		g_test_message
-		    ("expected sc_string_append_char_pair not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character pair: cannot append string terminator\n");
+        g_test_message("expected sc_string_append_char_pair not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character pair: cannot append string terminator\n");
 }
 
-static void test_sc_string_append_char_pair__invalid_zero_c2(void)
-{
-	if (g_test_subprocess()) {
-		char buf[3] = { 0 };
-		sc_string_append_char_pair(buf, sizeof buf, 'a', '\0');
+static void test_sc_string_append_char_pair__invalid_zero_c2(void) {
+    if (g_test_subprocess()) {
+        char buf[3] = {0};
+        sc_string_append_char_pair(buf, sizeof buf, 'a', '\0');
 
-		g_test_message
-		    ("expected sc_string_append_char_pair not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character pair: cannot append string terminator\n");
+        g_test_message("expected sc_string_append_char_pair not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot append character pair: cannot append string terminator\n");
 }
 
-static void test_sc_string_append_char_pair__normal(void)
-{
-	char buf[16];
-	size_t len;
-	sc_string_init(buf, sizeof buf);
+static void test_sc_string_append_char_pair__normal(void) {
+    char buf[16];
+    size_t len;
+    sc_string_init(buf, sizeof buf);
 
-	len = sc_string_append_char_pair(buf, sizeof buf, 'h', 'e');
-	g_assert_cmpstr(buf, ==, "he");
-	g_assert_cmpint(len, ==, 2);
-	len = sc_string_append_char_pair(buf, sizeof buf, 'l', 'l');
-	g_assert_cmpstr(buf, ==, "hell");
-	g_assert_cmpint(len, ==, 4);
-	len = sc_string_append_char_pair(buf, sizeof buf, 'o', '!');
-	g_assert_cmpstr(buf, ==, "hello!");
-	g_assert_cmpint(len, ==, 6);
+    len = sc_string_append_char_pair(buf, sizeof buf, 'h', 'e');
+    g_assert_cmpstr(buf, ==, "he");
+    g_assert_cmpint(len, ==, 2);
+    len = sc_string_append_char_pair(buf, sizeof buf, 'l', 'l');
+    g_assert_cmpstr(buf, ==, "hell");
+    g_assert_cmpint(len, ==, 4);
+    len = sc_string_append_char_pair(buf, sizeof buf, 'o', '!');
+    g_assert_cmpstr(buf, ==, "hello!");
+    g_assert_cmpint(len, ==, 6);
 }
 
-static void test_sc_string_quote_NULL_str(void)
-{
-	if (g_test_subprocess()) {
-		char buf[16] = { 0 };
-		sc_string_quote(buf, sizeof buf, NULL);
+static void test_sc_string_quote_NULL_str(void) {
+    if (g_test_subprocess()) {
+        char buf[16] = {0};
+        sc_string_quote(buf, sizeof buf, NULL);
 
-		g_test_message("expected sc_string_quote not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("cannot quote string: string is NULL\n");
+        g_test_message("expected sc_string_quote not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("cannot quote string: string is NULL\n");
 }
 
-static void test_quoting_of(bool tested[], int c, const char *expected)
-{
-	char buf[16];
+static void test_quoting_of(bool tested[], int c, const char *expected) {
+    char buf[16];
 
-	g_assert_cmpint(c, >=, 0);
-	g_assert_cmpint(c, <=, 255);
+    g_assert_cmpint(c, >=, 0);
+    g_assert_cmpint(c, <=, 255);
 
-	// Create an input string with one character.
-	char input[2] = { (unsigned char)c, 0 };
-	sc_string_quote(buf, sizeof buf, input);
+    // Create an input string with one character.
+    char input[2] = {(unsigned char)c, 0};
+    sc_string_quote(buf, sizeof buf, input);
 
-	// Ensure it was quoted as we expected.
-	g_assert_cmpstr(buf, ==, expected);
+    // Ensure it was quoted as we expected.
+    g_assert_cmpstr(buf, ==, expected);
 
-	tested[c] = true;
+    tested[c] = true;
 }
 
-static void test_sc_string_quote(void)
-{
+static void test_sc_string_quote(void) {
 #define DQ "\""
-	char buf[16];
-	bool is_tested[256] = { false };
+    char buf[16];
+    bool is_tested[256] = {false};
 
-	// Exhaustive test for quoting of every 8bit input.  This is very verbose
-	// but the goal is to have a very obvious and correct test that ensures no
-	// edge case is lost.
-	//
-	// block 1: 0x00 - 0x0f
-	test_quoting_of(is_tested, 0x00, DQ "" DQ);
-	test_quoting_of(is_tested, 0x01, DQ "\\x01" DQ);
-	test_quoting_of(is_tested, 0x02, DQ "\\x02" DQ);
-	test_quoting_of(is_tested, 0x03, DQ "\\x03" DQ);
-	test_quoting_of(is_tested, 0x04, DQ "\\x04" DQ);
-	test_quoting_of(is_tested, 0x05, DQ "\\x05" DQ);
-	test_quoting_of(is_tested, 0x06, DQ "\\x06" DQ);
-	test_quoting_of(is_tested, 0x07, DQ "\\x07" DQ);
-	test_quoting_of(is_tested, 0x08, DQ "\\x08" DQ);
-	test_quoting_of(is_tested, 0x09, DQ "\\t" DQ);
-	test_quoting_of(is_tested, 0x0a, DQ "\\n" DQ);
-	test_quoting_of(is_tested, 0x0b, DQ "\\v" DQ);
-	test_quoting_of(is_tested, 0x0c, DQ "\\x0c" DQ);
-	test_quoting_of(is_tested, 0x0d, DQ "\\r" DQ);
-	test_quoting_of(is_tested, 0x0e, DQ "\\x0e" DQ);
-	test_quoting_of(is_tested, 0x0f, DQ "\\x0f" DQ);
-	// block 2: 0x10 - 0x1f
-	test_quoting_of(is_tested, 0x10, DQ "\\x10" DQ);
-	test_quoting_of(is_tested, 0x11, DQ "\\x11" DQ);
-	test_quoting_of(is_tested, 0x12, DQ "\\x12" DQ);
-	test_quoting_of(is_tested, 0x13, DQ "\\x13" DQ);
-	test_quoting_of(is_tested, 0x14, DQ "\\x14" DQ);
-	test_quoting_of(is_tested, 0x15, DQ "\\x15" DQ);
-	test_quoting_of(is_tested, 0x16, DQ "\\x16" DQ);
-	test_quoting_of(is_tested, 0x17, DQ "\\x17" DQ);
-	test_quoting_of(is_tested, 0x18, DQ "\\x18" DQ);
-	test_quoting_of(is_tested, 0x19, DQ "\\x19" DQ);
-	test_quoting_of(is_tested, 0x1a, DQ "\\x1a" DQ);
-	test_quoting_of(is_tested, 0x1b, DQ "\\x1b" DQ);
-	test_quoting_of(is_tested, 0x1c, DQ "\\x1c" DQ);
-	test_quoting_of(is_tested, 0x1d, DQ "\\x1d" DQ);
-	test_quoting_of(is_tested, 0x1e, DQ "\\x1e" DQ);
-	test_quoting_of(is_tested, 0x1f, DQ "\\x1f" DQ);
-	// block 3: 0x20 - 0x2f
-	test_quoting_of(is_tested, 0x20, DQ " " DQ);
-	test_quoting_of(is_tested, 0x21, DQ "!" DQ);
-	test_quoting_of(is_tested, 0x22, DQ "\\\"" DQ);
-	test_quoting_of(is_tested, 0x23, DQ "#" DQ);
-	test_quoting_of(is_tested, 0x24, DQ "$" DQ);
-	test_quoting_of(is_tested, 0x25, DQ "%" DQ);
-	test_quoting_of(is_tested, 0x26, DQ "&" DQ);
-	test_quoting_of(is_tested, 0x27, DQ "'" DQ);
-	test_quoting_of(is_tested, 0x28, DQ "(" DQ);
-	test_quoting_of(is_tested, 0x29, DQ ")" DQ);
-	test_quoting_of(is_tested, 0x2a, DQ "*" DQ);
-	test_quoting_of(is_tested, 0x2b, DQ "+" DQ);
-	test_quoting_of(is_tested, 0x2c, DQ "," DQ);
-	test_quoting_of(is_tested, 0x2d, DQ "-" DQ);
-	test_quoting_of(is_tested, 0x2e, DQ "." DQ);
-	test_quoting_of(is_tested, 0x2f, DQ "/" DQ);
-	// block 4: 0x30 - 0x3f
-	test_quoting_of(is_tested, 0x30, DQ "0" DQ);
-	test_quoting_of(is_tested, 0x31, DQ "1" DQ);
-	test_quoting_of(is_tested, 0x32, DQ "2" DQ);
-	test_quoting_of(is_tested, 0x33, DQ "3" DQ);
-	test_quoting_of(is_tested, 0x34, DQ "4" DQ);
-	test_quoting_of(is_tested, 0x35, DQ "5" DQ);
-	test_quoting_of(is_tested, 0x36, DQ "6" DQ);
-	test_quoting_of(is_tested, 0x37, DQ "7" DQ);
-	test_quoting_of(is_tested, 0x38, DQ "8" DQ);
-	test_quoting_of(is_tested, 0x39, DQ "9" DQ);
-	test_quoting_of(is_tested, 0x3a, DQ ":" DQ);
-	test_quoting_of(is_tested, 0x3b, DQ ";" DQ);
-	test_quoting_of(is_tested, 0x3c, DQ "<" DQ);
-	test_quoting_of(is_tested, 0x3d, DQ "=" DQ);
-	test_quoting_of(is_tested, 0x3e, DQ ">" DQ);
-	test_quoting_of(is_tested, 0x3f, DQ "?" DQ);
-	// block 5: 0x40 - 0x4f
-	test_quoting_of(is_tested, 0x40, DQ "@" DQ);
-	test_quoting_of(is_tested, 0x41, DQ "A" DQ);
-	test_quoting_of(is_tested, 0x42, DQ "B" DQ);
-	test_quoting_of(is_tested, 0x43, DQ "C" DQ);
-	test_quoting_of(is_tested, 0x44, DQ "D" DQ);
-	test_quoting_of(is_tested, 0x45, DQ "E" DQ);
-	test_quoting_of(is_tested, 0x46, DQ "F" DQ);
-	test_quoting_of(is_tested, 0x47, DQ "G" DQ);
-	test_quoting_of(is_tested, 0x48, DQ "H" DQ);
-	test_quoting_of(is_tested, 0x49, DQ "I" DQ);
-	test_quoting_of(is_tested, 0x4a, DQ "J" DQ);
-	test_quoting_of(is_tested, 0x4b, DQ "K" DQ);
-	test_quoting_of(is_tested, 0x4c, DQ "L" DQ);
-	test_quoting_of(is_tested, 0x4d, DQ "M" DQ);
-	test_quoting_of(is_tested, 0x4e, DQ "N" DQ);
-	test_quoting_of(is_tested, 0x4f, DQ "O" DQ);
-	// block 6: 0x50 - 0x5f
-	test_quoting_of(is_tested, 0x50, DQ "P" DQ);
-	test_quoting_of(is_tested, 0x51, DQ "Q" DQ);
-	test_quoting_of(is_tested, 0x52, DQ "R" DQ);
-	test_quoting_of(is_tested, 0x53, DQ "S" DQ);
-	test_quoting_of(is_tested, 0x54, DQ "T" DQ);
-	test_quoting_of(is_tested, 0x55, DQ "U" DQ);
-	test_quoting_of(is_tested, 0x56, DQ "V" DQ);
-	test_quoting_of(is_tested, 0x57, DQ "W" DQ);
-	test_quoting_of(is_tested, 0x58, DQ "X" DQ);
-	test_quoting_of(is_tested, 0x59, DQ "Y" DQ);
-	test_quoting_of(is_tested, 0x5a, DQ "Z" DQ);
-	test_quoting_of(is_tested, 0x5b, DQ "[" DQ);
-	test_quoting_of(is_tested, 0x5c, DQ "\\\\" DQ);
-	test_quoting_of(is_tested, 0x5d, DQ "]" DQ);
-	test_quoting_of(is_tested, 0x5e, DQ "^" DQ);
-	test_quoting_of(is_tested, 0x5f, DQ "_" DQ);
-	// block 7: 0x60 - 0x6f
-	test_quoting_of(is_tested, 0x60, DQ "`" DQ);
-	test_quoting_of(is_tested, 0x61, DQ "a" DQ);
-	test_quoting_of(is_tested, 0x62, DQ "b" DQ);
-	test_quoting_of(is_tested, 0x63, DQ "c" DQ);
-	test_quoting_of(is_tested, 0x64, DQ "d" DQ);
-	test_quoting_of(is_tested, 0x65, DQ "e" DQ);
-	test_quoting_of(is_tested, 0x66, DQ "f" DQ);
-	test_quoting_of(is_tested, 0x67, DQ "g" DQ);
-	test_quoting_of(is_tested, 0x68, DQ "h" DQ);
-	test_quoting_of(is_tested, 0x69, DQ "i" DQ);
-	test_quoting_of(is_tested, 0x6a, DQ "j" DQ);
-	test_quoting_of(is_tested, 0x6b, DQ "k" DQ);
-	test_quoting_of(is_tested, 0x6c, DQ "l" DQ);
-	test_quoting_of(is_tested, 0x6d, DQ "m" DQ);
-	test_quoting_of(is_tested, 0x6e, DQ "n" DQ);
-	test_quoting_of(is_tested, 0x6f, DQ "o" DQ);
-	// block 8: 0x70 - 0x7f
-	test_quoting_of(is_tested, 0x70, DQ "p" DQ);
-	test_quoting_of(is_tested, 0x71, DQ "q" DQ);
-	test_quoting_of(is_tested, 0x72, DQ "r" DQ);
-	test_quoting_of(is_tested, 0x73, DQ "s" DQ);
-	test_quoting_of(is_tested, 0x74, DQ "t" DQ);
-	test_quoting_of(is_tested, 0x75, DQ "u" DQ);
-	test_quoting_of(is_tested, 0x76, DQ "v" DQ);
-	test_quoting_of(is_tested, 0x77, DQ "w" DQ);
-	test_quoting_of(is_tested, 0x78, DQ "x" DQ);
-	test_quoting_of(is_tested, 0x79, DQ "y" DQ);
-	test_quoting_of(is_tested, 0x7a, DQ "z" DQ);
-	test_quoting_of(is_tested, 0x7b, DQ "{" DQ);
-	test_quoting_of(is_tested, 0x7c, DQ "|" DQ);
-	test_quoting_of(is_tested, 0x7d, DQ "}" DQ);
-	test_quoting_of(is_tested, 0x7e, DQ "~" DQ);
-	test_quoting_of(is_tested, 0x7f, DQ "\\x7f" DQ);
-	// block 9 (8-bit): 0x80 - 0x8f
-	test_quoting_of(is_tested, 0x80, DQ "\\x80" DQ);
-	test_quoting_of(is_tested, 0x81, DQ "\\x81" DQ);
-	test_quoting_of(is_tested, 0x82, DQ "\\x82" DQ);
-	test_quoting_of(is_tested, 0x83, DQ "\\x83" DQ);
-	test_quoting_of(is_tested, 0x84, DQ "\\x84" DQ);
-	test_quoting_of(is_tested, 0x85, DQ "\\x85" DQ);
-	test_quoting_of(is_tested, 0x86, DQ "\\x86" DQ);
-	test_quoting_of(is_tested, 0x87, DQ "\\x87" DQ);
-	test_quoting_of(is_tested, 0x88, DQ "\\x88" DQ);
-	test_quoting_of(is_tested, 0x89, DQ "\\x89" DQ);
-	test_quoting_of(is_tested, 0x8a, DQ "\\x8a" DQ);
-	test_quoting_of(is_tested, 0x8b, DQ "\\x8b" DQ);
-	test_quoting_of(is_tested, 0x8c, DQ "\\x8c" DQ);
-	test_quoting_of(is_tested, 0x8d, DQ "\\x8d" DQ);
-	test_quoting_of(is_tested, 0x8e, DQ "\\x8e" DQ);
-	test_quoting_of(is_tested, 0x8f, DQ "\\x8f" DQ);
-	// block 10 (8-bit): 0x90 - 0x9f
-	test_quoting_of(is_tested, 0x90, DQ "\\x90" DQ);
-	test_quoting_of(is_tested, 0x91, DQ "\\x91" DQ);
-	test_quoting_of(is_tested, 0x92, DQ "\\x92" DQ);
-	test_quoting_of(is_tested, 0x93, DQ "\\x93" DQ);
-	test_quoting_of(is_tested, 0x94, DQ "\\x94" DQ);
-	test_quoting_of(is_tested, 0x95, DQ "\\x95" DQ);
-	test_quoting_of(is_tested, 0x96, DQ "\\x96" DQ);
-	test_quoting_of(is_tested, 0x97, DQ "\\x97" DQ);
-	test_quoting_of(is_tested, 0x98, DQ "\\x98" DQ);
-	test_quoting_of(is_tested, 0x99, DQ "\\x99" DQ);
-	test_quoting_of(is_tested, 0x9a, DQ "\\x9a" DQ);
-	test_quoting_of(is_tested, 0x9b, DQ "\\x9b" DQ);
-	test_quoting_of(is_tested, 0x9c, DQ "\\x9c" DQ);
-	test_quoting_of(is_tested, 0x9d, DQ "\\x9d" DQ);
-	test_quoting_of(is_tested, 0x9e, DQ "\\x9e" DQ);
-	test_quoting_of(is_tested, 0x9f, DQ "\\x9f" DQ);
-	// block 11 (8-bit): 0xa0 - 0xaf
-	test_quoting_of(is_tested, 0xa0, DQ "\\xa0" DQ);
-	test_quoting_of(is_tested, 0xa1, DQ "\\xa1" DQ);
-	test_quoting_of(is_tested, 0xa2, DQ "\\xa2" DQ);
-	test_quoting_of(is_tested, 0xa3, DQ "\\xa3" DQ);
-	test_quoting_of(is_tested, 0xa4, DQ "\\xa4" DQ);
-	test_quoting_of(is_tested, 0xa5, DQ "\\xa5" DQ);
-	test_quoting_of(is_tested, 0xa6, DQ "\\xa6" DQ);
-	test_quoting_of(is_tested, 0xa7, DQ "\\xa7" DQ);
-	test_quoting_of(is_tested, 0xa8, DQ "\\xa8" DQ);
-	test_quoting_of(is_tested, 0xa9, DQ "\\xa9" DQ);
-	test_quoting_of(is_tested, 0xaa, DQ "\\xaa" DQ);
-	test_quoting_of(is_tested, 0xab, DQ "\\xab" DQ);
-	test_quoting_of(is_tested, 0xac, DQ "\\xac" DQ);
-	test_quoting_of(is_tested, 0xad, DQ "\\xad" DQ);
-	test_quoting_of(is_tested, 0xae, DQ "\\xae" DQ);
-	test_quoting_of(is_tested, 0xaf, DQ "\\xaf" DQ);
-	// block 12 (8-bit): 0xb0 - 0xbf
-	test_quoting_of(is_tested, 0xb0, DQ "\\xb0" DQ);
-	test_quoting_of(is_tested, 0xb1, DQ "\\xb1" DQ);
-	test_quoting_of(is_tested, 0xb2, DQ "\\xb2" DQ);
-	test_quoting_of(is_tested, 0xb3, DQ "\\xb3" DQ);
-	test_quoting_of(is_tested, 0xb4, DQ "\\xb4" DQ);
-	test_quoting_of(is_tested, 0xb5, DQ "\\xb5" DQ);
-	test_quoting_of(is_tested, 0xb6, DQ "\\xb6" DQ);
-	test_quoting_of(is_tested, 0xb7, DQ "\\xb7" DQ);
-	test_quoting_of(is_tested, 0xb8, DQ "\\xb8" DQ);
-	test_quoting_of(is_tested, 0xb9, DQ "\\xb9" DQ);
-	test_quoting_of(is_tested, 0xba, DQ "\\xba" DQ);
-	test_quoting_of(is_tested, 0xbb, DQ "\\xbb" DQ);
-	test_quoting_of(is_tested, 0xbc, DQ "\\xbc" DQ);
-	test_quoting_of(is_tested, 0xbd, DQ "\\xbd" DQ);
-	test_quoting_of(is_tested, 0xbe, DQ "\\xbe" DQ);
-	test_quoting_of(is_tested, 0xbf, DQ "\\xbf" DQ);
-	// block 13 (8-bit): 0xc0 - 0xcf
-	test_quoting_of(is_tested, 0xc0, DQ "\\xc0" DQ);
-	test_quoting_of(is_tested, 0xc1, DQ "\\xc1" DQ);
-	test_quoting_of(is_tested, 0xc2, DQ "\\xc2" DQ);
-	test_quoting_of(is_tested, 0xc3, DQ "\\xc3" DQ);
-	test_quoting_of(is_tested, 0xc4, DQ "\\xc4" DQ);
-	test_quoting_of(is_tested, 0xc5, DQ "\\xc5" DQ);
-	test_quoting_of(is_tested, 0xc6, DQ "\\xc6" DQ);
-	test_quoting_of(is_tested, 0xc7, DQ "\\xc7" DQ);
-	test_quoting_of(is_tested, 0xc8, DQ "\\xc8" DQ);
-	test_quoting_of(is_tested, 0xc9, DQ "\\xc9" DQ);
-	test_quoting_of(is_tested, 0xca, DQ "\\xca" DQ);
-	test_quoting_of(is_tested, 0xcb, DQ "\\xcb" DQ);
-	test_quoting_of(is_tested, 0xcc, DQ "\\xcc" DQ);
-	test_quoting_of(is_tested, 0xcd, DQ "\\xcd" DQ);
-	test_quoting_of(is_tested, 0xce, DQ "\\xce" DQ);
-	test_quoting_of(is_tested, 0xcf, DQ "\\xcf" DQ);
-	// block 14 (8-bit): 0xd0 - 0xdf
-	test_quoting_of(is_tested, 0xd0, DQ "\\xd0" DQ);
-	test_quoting_of(is_tested, 0xd1, DQ "\\xd1" DQ);
-	test_quoting_of(is_tested, 0xd2, DQ "\\xd2" DQ);
-	test_quoting_of(is_tested, 0xd3, DQ "\\xd3" DQ);
-	test_quoting_of(is_tested, 0xd4, DQ "\\xd4" DQ);
-	test_quoting_of(is_tested, 0xd5, DQ "\\xd5" DQ);
-	test_quoting_of(is_tested, 0xd6, DQ "\\xd6" DQ);
-	test_quoting_of(is_tested, 0xd7, DQ "\\xd7" DQ);
-	test_quoting_of(is_tested, 0xd8, DQ "\\xd8" DQ);
-	test_quoting_of(is_tested, 0xd9, DQ "\\xd9" DQ);
-	test_quoting_of(is_tested, 0xda, DQ "\\xda" DQ);
-	test_quoting_of(is_tested, 0xdb, DQ "\\xdb" DQ);
-	test_quoting_of(is_tested, 0xdc, DQ "\\xdc" DQ);
-	test_quoting_of(is_tested, 0xdd, DQ "\\xdd" DQ);
-	test_quoting_of(is_tested, 0xde, DQ "\\xde" DQ);
-	test_quoting_of(is_tested, 0xdf, DQ "\\xdf" DQ);
-	// block 15 (8-bit): 0xe0 - 0xef
-	test_quoting_of(is_tested, 0xe0, DQ "\\xe0" DQ);
-	test_quoting_of(is_tested, 0xe1, DQ "\\xe1" DQ);
-	test_quoting_of(is_tested, 0xe2, DQ "\\xe2" DQ);
-	test_quoting_of(is_tested, 0xe3, DQ "\\xe3" DQ);
-	test_quoting_of(is_tested, 0xe4, DQ "\\xe4" DQ);
-	test_quoting_of(is_tested, 0xe5, DQ "\\xe5" DQ);
-	test_quoting_of(is_tested, 0xe6, DQ "\\xe6" DQ);
-	test_quoting_of(is_tested, 0xe7, DQ "\\xe7" DQ);
-	test_quoting_of(is_tested, 0xe8, DQ "\\xe8" DQ);
-	test_quoting_of(is_tested, 0xe9, DQ "\\xe9" DQ);
-	test_quoting_of(is_tested, 0xea, DQ "\\xea" DQ);
-	test_quoting_of(is_tested, 0xeb, DQ "\\xeb" DQ);
-	test_quoting_of(is_tested, 0xec, DQ "\\xec" DQ);
-	test_quoting_of(is_tested, 0xed, DQ "\\xed" DQ);
-	test_quoting_of(is_tested, 0xee, DQ "\\xee" DQ);
-	test_quoting_of(is_tested, 0xef, DQ "\\xef" DQ);
-	// block 16 (8-bit): 0xf0 - 0xff
-	test_quoting_of(is_tested, 0xf0, DQ "\\xf0" DQ);
-	test_quoting_of(is_tested, 0xf1, DQ "\\xf1" DQ);
-	test_quoting_of(is_tested, 0xf2, DQ "\\xf2" DQ);
-	test_quoting_of(is_tested, 0xf3, DQ "\\xf3" DQ);
-	test_quoting_of(is_tested, 0xf4, DQ "\\xf4" DQ);
-	test_quoting_of(is_tested, 0xf5, DQ "\\xf5" DQ);
-	test_quoting_of(is_tested, 0xf6, DQ "\\xf6" DQ);
-	test_quoting_of(is_tested, 0xf7, DQ "\\xf7" DQ);
-	test_quoting_of(is_tested, 0xf8, DQ "\\xf8" DQ);
-	test_quoting_of(is_tested, 0xf9, DQ "\\xf9" DQ);
-	test_quoting_of(is_tested, 0xfa, DQ "\\xfa" DQ);
-	test_quoting_of(is_tested, 0xfb, DQ "\\xfb" DQ);
-	test_quoting_of(is_tested, 0xfc, DQ "\\xfc" DQ);
-	test_quoting_of(is_tested, 0xfd, DQ "\\xfd" DQ);
-	test_quoting_of(is_tested, 0xfe, DQ "\\xfe" DQ);
-	test_quoting_of(is_tested, 0xff, DQ "\\xff" DQ);
+    // Exhaustive test for quoting of every 8bit input.  This is very verbose
+    // but the goal is to have a very obvious and correct test that ensures no
+    // edge case is lost.
+    //
+    // block 1: 0x00 - 0x0f
+    test_quoting_of(is_tested, 0x00, DQ "" DQ);
+    test_quoting_of(is_tested, 0x01, DQ "\\x01" DQ);
+    test_quoting_of(is_tested, 0x02, DQ "\\x02" DQ);
+    test_quoting_of(is_tested, 0x03, DQ "\\x03" DQ);
+    test_quoting_of(is_tested, 0x04, DQ "\\x04" DQ);
+    test_quoting_of(is_tested, 0x05, DQ "\\x05" DQ);
+    test_quoting_of(is_tested, 0x06, DQ "\\x06" DQ);
+    test_quoting_of(is_tested, 0x07, DQ "\\x07" DQ);
+    test_quoting_of(is_tested, 0x08, DQ "\\x08" DQ);
+    test_quoting_of(is_tested, 0x09, DQ "\\t" DQ);
+    test_quoting_of(is_tested, 0x0a, DQ "\\n" DQ);
+    test_quoting_of(is_tested, 0x0b, DQ "\\v" DQ);
+    test_quoting_of(is_tested, 0x0c, DQ "\\x0c" DQ);
+    test_quoting_of(is_tested, 0x0d, DQ "\\r" DQ);
+    test_quoting_of(is_tested, 0x0e, DQ "\\x0e" DQ);
+    test_quoting_of(is_tested, 0x0f, DQ "\\x0f" DQ);
+    // block 2: 0x10 - 0x1f
+    test_quoting_of(is_tested, 0x10, DQ "\\x10" DQ);
+    test_quoting_of(is_tested, 0x11, DQ "\\x11" DQ);
+    test_quoting_of(is_tested, 0x12, DQ "\\x12" DQ);
+    test_quoting_of(is_tested, 0x13, DQ "\\x13" DQ);
+    test_quoting_of(is_tested, 0x14, DQ "\\x14" DQ);
+    test_quoting_of(is_tested, 0x15, DQ "\\x15" DQ);
+    test_quoting_of(is_tested, 0x16, DQ "\\x16" DQ);
+    test_quoting_of(is_tested, 0x17, DQ "\\x17" DQ);
+    test_quoting_of(is_tested, 0x18, DQ "\\x18" DQ);
+    test_quoting_of(is_tested, 0x19, DQ "\\x19" DQ);
+    test_quoting_of(is_tested, 0x1a, DQ "\\x1a" DQ);
+    test_quoting_of(is_tested, 0x1b, DQ "\\x1b" DQ);
+    test_quoting_of(is_tested, 0x1c, DQ "\\x1c" DQ);
+    test_quoting_of(is_tested, 0x1d, DQ "\\x1d" DQ);
+    test_quoting_of(is_tested, 0x1e, DQ "\\x1e" DQ);
+    test_quoting_of(is_tested, 0x1f, DQ "\\x1f" DQ);
+    // block 3: 0x20 - 0x2f
+    test_quoting_of(is_tested, 0x20, DQ " " DQ);
+    test_quoting_of(is_tested, 0x21, DQ "!" DQ);
+    test_quoting_of(is_tested, 0x22, DQ "\\\"" DQ);
+    test_quoting_of(is_tested, 0x23, DQ "#" DQ);
+    test_quoting_of(is_tested, 0x24, DQ "$" DQ);
+    test_quoting_of(is_tested, 0x25, DQ "%" DQ);
+    test_quoting_of(is_tested, 0x26, DQ "&" DQ);
+    test_quoting_of(is_tested, 0x27, DQ "'" DQ);
+    test_quoting_of(is_tested, 0x28, DQ "(" DQ);
+    test_quoting_of(is_tested, 0x29, DQ ")" DQ);
+    test_quoting_of(is_tested, 0x2a, DQ "*" DQ);
+    test_quoting_of(is_tested, 0x2b, DQ "+" DQ);
+    test_quoting_of(is_tested, 0x2c, DQ "," DQ);
+    test_quoting_of(is_tested, 0x2d, DQ "-" DQ);
+    test_quoting_of(is_tested, 0x2e, DQ "." DQ);
+    test_quoting_of(is_tested, 0x2f, DQ "/" DQ);
+    // block 4: 0x30 - 0x3f
+    test_quoting_of(is_tested, 0x30, DQ "0" DQ);
+    test_quoting_of(is_tested, 0x31, DQ "1" DQ);
+    test_quoting_of(is_tested, 0x32, DQ "2" DQ);
+    test_quoting_of(is_tested, 0x33, DQ "3" DQ);
+    test_quoting_of(is_tested, 0x34, DQ "4" DQ);
+    test_quoting_of(is_tested, 0x35, DQ "5" DQ);
+    test_quoting_of(is_tested, 0x36, DQ "6" DQ);
+    test_quoting_of(is_tested, 0x37, DQ "7" DQ);
+    test_quoting_of(is_tested, 0x38, DQ "8" DQ);
+    test_quoting_of(is_tested, 0x39, DQ "9" DQ);
+    test_quoting_of(is_tested, 0x3a, DQ ":" DQ);
+    test_quoting_of(is_tested, 0x3b, DQ ";" DQ);
+    test_quoting_of(is_tested, 0x3c, DQ "<" DQ);
+    test_quoting_of(is_tested, 0x3d, DQ "=" DQ);
+    test_quoting_of(is_tested, 0x3e, DQ ">" DQ);
+    test_quoting_of(is_tested, 0x3f, DQ "?" DQ);
+    // block 5: 0x40 - 0x4f
+    test_quoting_of(is_tested, 0x40, DQ "@" DQ);
+    test_quoting_of(is_tested, 0x41, DQ "A" DQ);
+    test_quoting_of(is_tested, 0x42, DQ "B" DQ);
+    test_quoting_of(is_tested, 0x43, DQ "C" DQ);
+    test_quoting_of(is_tested, 0x44, DQ "D" DQ);
+    test_quoting_of(is_tested, 0x45, DQ "E" DQ);
+    test_quoting_of(is_tested, 0x46, DQ "F" DQ);
+    test_quoting_of(is_tested, 0x47, DQ "G" DQ);
+    test_quoting_of(is_tested, 0x48, DQ "H" DQ);
+    test_quoting_of(is_tested, 0x49, DQ "I" DQ);
+    test_quoting_of(is_tested, 0x4a, DQ "J" DQ);
+    test_quoting_of(is_tested, 0x4b, DQ "K" DQ);
+    test_quoting_of(is_tested, 0x4c, DQ "L" DQ);
+    test_quoting_of(is_tested, 0x4d, DQ "M" DQ);
+    test_quoting_of(is_tested, 0x4e, DQ "N" DQ);
+    test_quoting_of(is_tested, 0x4f, DQ "O" DQ);
+    // block 6: 0x50 - 0x5f
+    test_quoting_of(is_tested, 0x50, DQ "P" DQ);
+    test_quoting_of(is_tested, 0x51, DQ "Q" DQ);
+    test_quoting_of(is_tested, 0x52, DQ "R" DQ);
+    test_quoting_of(is_tested, 0x53, DQ "S" DQ);
+    test_quoting_of(is_tested, 0x54, DQ "T" DQ);
+    test_quoting_of(is_tested, 0x55, DQ "U" DQ);
+    test_quoting_of(is_tested, 0x56, DQ "V" DQ);
+    test_quoting_of(is_tested, 0x57, DQ "W" DQ);
+    test_quoting_of(is_tested, 0x58, DQ "X" DQ);
+    test_quoting_of(is_tested, 0x59, DQ "Y" DQ);
+    test_quoting_of(is_tested, 0x5a, DQ "Z" DQ);
+    test_quoting_of(is_tested, 0x5b, DQ "[" DQ);
+    test_quoting_of(is_tested, 0x5c, DQ "\\\\" DQ);
+    test_quoting_of(is_tested, 0x5d, DQ "]" DQ);
+    test_quoting_of(is_tested, 0x5e, DQ "^" DQ);
+    test_quoting_of(is_tested, 0x5f, DQ "_" DQ);
+    // block 7: 0x60 - 0x6f
+    test_quoting_of(is_tested, 0x60, DQ "`" DQ);
+    test_quoting_of(is_tested, 0x61, DQ "a" DQ);
+    test_quoting_of(is_tested, 0x62, DQ "b" DQ);
+    test_quoting_of(is_tested, 0x63, DQ "c" DQ);
+    test_quoting_of(is_tested, 0x64, DQ "d" DQ);
+    test_quoting_of(is_tested, 0x65, DQ "e" DQ);
+    test_quoting_of(is_tested, 0x66, DQ "f" DQ);
+    test_quoting_of(is_tested, 0x67, DQ "g" DQ);
+    test_quoting_of(is_tested, 0x68, DQ "h" DQ);
+    test_quoting_of(is_tested, 0x69, DQ "i" DQ);
+    test_quoting_of(is_tested, 0x6a, DQ "j" DQ);
+    test_quoting_of(is_tested, 0x6b, DQ "k" DQ);
+    test_quoting_of(is_tested, 0x6c, DQ "l" DQ);
+    test_quoting_of(is_tested, 0x6d, DQ "m" DQ);
+    test_quoting_of(is_tested, 0x6e, DQ "n" DQ);
+    test_quoting_of(is_tested, 0x6f, DQ "o" DQ);
+    // block 8: 0x70 - 0x7f
+    test_quoting_of(is_tested, 0x70, DQ "p" DQ);
+    test_quoting_of(is_tested, 0x71, DQ "q" DQ);
+    test_quoting_of(is_tested, 0x72, DQ "r" DQ);
+    test_quoting_of(is_tested, 0x73, DQ "s" DQ);
+    test_quoting_of(is_tested, 0x74, DQ "t" DQ);
+    test_quoting_of(is_tested, 0x75, DQ "u" DQ);
+    test_quoting_of(is_tested, 0x76, DQ "v" DQ);
+    test_quoting_of(is_tested, 0x77, DQ "w" DQ);
+    test_quoting_of(is_tested, 0x78, DQ "x" DQ);
+    test_quoting_of(is_tested, 0x79, DQ "y" DQ);
+    test_quoting_of(is_tested, 0x7a, DQ "z" DQ);
+    test_quoting_of(is_tested, 0x7b, DQ "{" DQ);
+    test_quoting_of(is_tested, 0x7c, DQ "|" DQ);
+    test_quoting_of(is_tested, 0x7d, DQ "}" DQ);
+    test_quoting_of(is_tested, 0x7e, DQ "~" DQ);
+    test_quoting_of(is_tested, 0x7f, DQ "\\x7f" DQ);
+    // block 9 (8-bit): 0x80 - 0x8f
+    test_quoting_of(is_tested, 0x80, DQ "\\x80" DQ);
+    test_quoting_of(is_tested, 0x81, DQ "\\x81" DQ);
+    test_quoting_of(is_tested, 0x82, DQ "\\x82" DQ);
+    test_quoting_of(is_tested, 0x83, DQ "\\x83" DQ);
+    test_quoting_of(is_tested, 0x84, DQ "\\x84" DQ);
+    test_quoting_of(is_tested, 0x85, DQ "\\x85" DQ);
+    test_quoting_of(is_tested, 0x86, DQ "\\x86" DQ);
+    test_quoting_of(is_tested, 0x87, DQ "\\x87" DQ);
+    test_quoting_of(is_tested, 0x88, DQ "\\x88" DQ);
+    test_quoting_of(is_tested, 0x89, DQ "\\x89" DQ);
+    test_quoting_of(is_tested, 0x8a, DQ "\\x8a" DQ);
+    test_quoting_of(is_tested, 0x8b, DQ "\\x8b" DQ);
+    test_quoting_of(is_tested, 0x8c, DQ "\\x8c" DQ);
+    test_quoting_of(is_tested, 0x8d, DQ "\\x8d" DQ);
+    test_quoting_of(is_tested, 0x8e, DQ "\\x8e" DQ);
+    test_quoting_of(is_tested, 0x8f, DQ "\\x8f" DQ);
+    // block 10 (8-bit): 0x90 - 0x9f
+    test_quoting_of(is_tested, 0x90, DQ "\\x90" DQ);
+    test_quoting_of(is_tested, 0x91, DQ "\\x91" DQ);
+    test_quoting_of(is_tested, 0x92, DQ "\\x92" DQ);
+    test_quoting_of(is_tested, 0x93, DQ "\\x93" DQ);
+    test_quoting_of(is_tested, 0x94, DQ "\\x94" DQ);
+    test_quoting_of(is_tested, 0x95, DQ "\\x95" DQ);
+    test_quoting_of(is_tested, 0x96, DQ "\\x96" DQ);
+    test_quoting_of(is_tested, 0x97, DQ "\\x97" DQ);
+    test_quoting_of(is_tested, 0x98, DQ "\\x98" DQ);
+    test_quoting_of(is_tested, 0x99, DQ "\\x99" DQ);
+    test_quoting_of(is_tested, 0x9a, DQ "\\x9a" DQ);
+    test_quoting_of(is_tested, 0x9b, DQ "\\x9b" DQ);
+    test_quoting_of(is_tested, 0x9c, DQ "\\x9c" DQ);
+    test_quoting_of(is_tested, 0x9d, DQ "\\x9d" DQ);
+    test_quoting_of(is_tested, 0x9e, DQ "\\x9e" DQ);
+    test_quoting_of(is_tested, 0x9f, DQ "\\x9f" DQ);
+    // block 11 (8-bit): 0xa0 - 0xaf
+    test_quoting_of(is_tested, 0xa0, DQ "\\xa0" DQ);
+    test_quoting_of(is_tested, 0xa1, DQ "\\xa1" DQ);
+    test_quoting_of(is_tested, 0xa2, DQ "\\xa2" DQ);
+    test_quoting_of(is_tested, 0xa3, DQ "\\xa3" DQ);
+    test_quoting_of(is_tested, 0xa4, DQ "\\xa4" DQ);
+    test_quoting_of(is_tested, 0xa5, DQ "\\xa5" DQ);
+    test_quoting_of(is_tested, 0xa6, DQ "\\xa6" DQ);
+    test_quoting_of(is_tested, 0xa7, DQ "\\xa7" DQ);
+    test_quoting_of(is_tested, 0xa8, DQ "\\xa8" DQ);
+    test_quoting_of(is_tested, 0xa9, DQ "\\xa9" DQ);
+    test_quoting_of(is_tested, 0xaa, DQ "\\xaa" DQ);
+    test_quoting_of(is_tested, 0xab, DQ "\\xab" DQ);
+    test_quoting_of(is_tested, 0xac, DQ "\\xac" DQ);
+    test_quoting_of(is_tested, 0xad, DQ "\\xad" DQ);
+    test_quoting_of(is_tested, 0xae, DQ "\\xae" DQ);
+    test_quoting_of(is_tested, 0xaf, DQ "\\xaf" DQ);
+    // block 12 (8-bit): 0xb0 - 0xbf
+    test_quoting_of(is_tested, 0xb0, DQ "\\xb0" DQ);
+    test_quoting_of(is_tested, 0xb1, DQ "\\xb1" DQ);
+    test_quoting_of(is_tested, 0xb2, DQ "\\xb2" DQ);
+    test_quoting_of(is_tested, 0xb3, DQ "\\xb3" DQ);
+    test_quoting_of(is_tested, 0xb4, DQ "\\xb4" DQ);
+    test_quoting_of(is_tested, 0xb5, DQ "\\xb5" DQ);
+    test_quoting_of(is_tested, 0xb6, DQ "\\xb6" DQ);
+    test_quoting_of(is_tested, 0xb7, DQ "\\xb7" DQ);
+    test_quoting_of(is_tested, 0xb8, DQ "\\xb8" DQ);
+    test_quoting_of(is_tested, 0xb9, DQ "\\xb9" DQ);
+    test_quoting_of(is_tested, 0xba, DQ "\\xba" DQ);
+    test_quoting_of(is_tested, 0xbb, DQ "\\xbb" DQ);
+    test_quoting_of(is_tested, 0xbc, DQ "\\xbc" DQ);
+    test_quoting_of(is_tested, 0xbd, DQ "\\xbd" DQ);
+    test_quoting_of(is_tested, 0xbe, DQ "\\xbe" DQ);
+    test_quoting_of(is_tested, 0xbf, DQ "\\xbf" DQ);
+    // block 13 (8-bit): 0xc0 - 0xcf
+    test_quoting_of(is_tested, 0xc0, DQ "\\xc0" DQ);
+    test_quoting_of(is_tested, 0xc1, DQ "\\xc1" DQ);
+    test_quoting_of(is_tested, 0xc2, DQ "\\xc2" DQ);
+    test_quoting_of(is_tested, 0xc3, DQ "\\xc3" DQ);
+    test_quoting_of(is_tested, 0xc4, DQ "\\xc4" DQ);
+    test_quoting_of(is_tested, 0xc5, DQ "\\xc5" DQ);
+    test_quoting_of(is_tested, 0xc6, DQ "\\xc6" DQ);
+    test_quoting_of(is_tested, 0xc7, DQ "\\xc7" DQ);
+    test_quoting_of(is_tested, 0xc8, DQ "\\xc8" DQ);
+    test_quoting_of(is_tested, 0xc9, DQ "\\xc9" DQ);
+    test_quoting_of(is_tested, 0xca, DQ "\\xca" DQ);
+    test_quoting_of(is_tested, 0xcb, DQ "\\xcb" DQ);
+    test_quoting_of(is_tested, 0xcc, DQ "\\xcc" DQ);
+    test_quoting_of(is_tested, 0xcd, DQ "\\xcd" DQ);
+    test_quoting_of(is_tested, 0xce, DQ "\\xce" DQ);
+    test_quoting_of(is_tested, 0xcf, DQ "\\xcf" DQ);
+    // block 14 (8-bit): 0xd0 - 0xdf
+    test_quoting_of(is_tested, 0xd0, DQ "\\xd0" DQ);
+    test_quoting_of(is_tested, 0xd1, DQ "\\xd1" DQ);
+    test_quoting_of(is_tested, 0xd2, DQ "\\xd2" DQ);
+    test_quoting_of(is_tested, 0xd3, DQ "\\xd3" DQ);
+    test_quoting_of(is_tested, 0xd4, DQ "\\xd4" DQ);
+    test_quoting_of(is_tested, 0xd5, DQ "\\xd5" DQ);
+    test_quoting_of(is_tested, 0xd6, DQ "\\xd6" DQ);
+    test_quoting_of(is_tested, 0xd7, DQ "\\xd7" DQ);
+    test_quoting_of(is_tested, 0xd8, DQ "\\xd8" DQ);
+    test_quoting_of(is_tested, 0xd9, DQ "\\xd9" DQ);
+    test_quoting_of(is_tested, 0xda, DQ "\\xda" DQ);
+    test_quoting_of(is_tested, 0xdb, DQ "\\xdb" DQ);
+    test_quoting_of(is_tested, 0xdc, DQ "\\xdc" DQ);
+    test_quoting_of(is_tested, 0xdd, DQ "\\xdd" DQ);
+    test_quoting_of(is_tested, 0xde, DQ "\\xde" DQ);
+    test_quoting_of(is_tested, 0xdf, DQ "\\xdf" DQ);
+    // block 15 (8-bit): 0xe0 - 0xef
+    test_quoting_of(is_tested, 0xe0, DQ "\\xe0" DQ);
+    test_quoting_of(is_tested, 0xe1, DQ "\\xe1" DQ);
+    test_quoting_of(is_tested, 0xe2, DQ "\\xe2" DQ);
+    test_quoting_of(is_tested, 0xe3, DQ "\\xe3" DQ);
+    test_quoting_of(is_tested, 0xe4, DQ "\\xe4" DQ);
+    test_quoting_of(is_tested, 0xe5, DQ "\\xe5" DQ);
+    test_quoting_of(is_tested, 0xe6, DQ "\\xe6" DQ);
+    test_quoting_of(is_tested, 0xe7, DQ "\\xe7" DQ);
+    test_quoting_of(is_tested, 0xe8, DQ "\\xe8" DQ);
+    test_quoting_of(is_tested, 0xe9, DQ "\\xe9" DQ);
+    test_quoting_of(is_tested, 0xea, DQ "\\xea" DQ);
+    test_quoting_of(is_tested, 0xeb, DQ "\\xeb" DQ);
+    test_quoting_of(is_tested, 0xec, DQ "\\xec" DQ);
+    test_quoting_of(is_tested, 0xed, DQ "\\xed" DQ);
+    test_quoting_of(is_tested, 0xee, DQ "\\xee" DQ);
+    test_quoting_of(is_tested, 0xef, DQ "\\xef" DQ);
+    // block 16 (8-bit): 0xf0 - 0xff
+    test_quoting_of(is_tested, 0xf0, DQ "\\xf0" DQ);
+    test_quoting_of(is_tested, 0xf1, DQ "\\xf1" DQ);
+    test_quoting_of(is_tested, 0xf2, DQ "\\xf2" DQ);
+    test_quoting_of(is_tested, 0xf3, DQ "\\xf3" DQ);
+    test_quoting_of(is_tested, 0xf4, DQ "\\xf4" DQ);
+    test_quoting_of(is_tested, 0xf5, DQ "\\xf5" DQ);
+    test_quoting_of(is_tested, 0xf6, DQ "\\xf6" DQ);
+    test_quoting_of(is_tested, 0xf7, DQ "\\xf7" DQ);
+    test_quoting_of(is_tested, 0xf8, DQ "\\xf8" DQ);
+    test_quoting_of(is_tested, 0xf9, DQ "\\xf9" DQ);
+    test_quoting_of(is_tested, 0xfa, DQ "\\xfa" DQ);
+    test_quoting_of(is_tested, 0xfb, DQ "\\xfb" DQ);
+    test_quoting_of(is_tested, 0xfc, DQ "\\xfc" DQ);
+    test_quoting_of(is_tested, 0xfd, DQ "\\xfd" DQ);
+    test_quoting_of(is_tested, 0xfe, DQ "\\xfe" DQ);
+    test_quoting_of(is_tested, 0xff, DQ "\\xff" DQ);
 
-	// Ensure the search was exhaustive.
-	for (int i = 0; i <= 0xff; ++i) {
-		g_assert_true(is_tested[i]);
-	}
+    // Ensure the search was exhaustive.
+    for (int i = 0; i <= 0xff; ++i) {
+        g_assert_true(is_tested[i]);
+    }
 
-	// Few extra tests (repeated) for specific things.
+    // Few extra tests (repeated) for specific things.
 
-	// Smoke test
-	sc_string_quote(buf, sizeof buf, "hello 123");
-	g_assert_cmpstr(buf, ==, DQ "hello 123" DQ);
+    // Smoke test
+    sc_string_quote(buf, sizeof buf, "hello 123");
+    g_assert_cmpstr(buf, ==, DQ "hello 123" DQ);
 
-	// Whitespace
-	sc_string_quote(buf, sizeof buf, "\n");
-	g_assert_cmpstr(buf, ==, DQ "\\n" DQ);
-	sc_string_quote(buf, sizeof buf, "\r");
-	g_assert_cmpstr(buf, ==, DQ "\\r" DQ);
-	sc_string_quote(buf, sizeof buf, "\t");
-	g_assert_cmpstr(buf, ==, DQ "\\t" DQ);
-	sc_string_quote(buf, sizeof buf, "\v");
-	g_assert_cmpstr(buf, ==, DQ "\\v" DQ);
+    // Whitespace
+    sc_string_quote(buf, sizeof buf, "\n");
+    g_assert_cmpstr(buf, ==, DQ "\\n" DQ);
+    sc_string_quote(buf, sizeof buf, "\r");
+    g_assert_cmpstr(buf, ==, DQ "\\r" DQ);
+    sc_string_quote(buf, sizeof buf, "\t");
+    g_assert_cmpstr(buf, ==, DQ "\\t" DQ);
+    sc_string_quote(buf, sizeof buf, "\v");
+    g_assert_cmpstr(buf, ==, DQ "\\v" DQ);
 
-	// Escape character itself
-	sc_string_quote(buf, sizeof buf, "\\");
-	g_assert_cmpstr(buf, ==, DQ "\\\\" DQ);
+    // Escape character itself
+    sc_string_quote(buf, sizeof buf, "\\");
+    g_assert_cmpstr(buf, ==, DQ "\\\\" DQ);
 
-	// Double quote character
-	sc_string_quote(buf, sizeof buf, "\"");
-	g_assert_cmpstr(buf, ==, DQ "\\\"" DQ);
+    // Double quote character
+    sc_string_quote(buf, sizeof buf, "\"");
+    g_assert_cmpstr(buf, ==, DQ "\\\"" DQ);
 
 #undef DQ
 }
 
-static void test_sc_strdup(void)
-{
-	char *s = sc_strdup("snap install everything");
-	g_assert_nonnull(s);
-	g_assert_cmpstr(s, ==, "snap install everything");
-	free(s);
+static void test_sc_strdup(void) {
+    char *s = sc_strdup("snap install everything");
+    g_assert_nonnull(s);
+    g_assert_cmpstr(s, ==, "snap install everything");
+    free(s);
 }
 
-static void test_sc_string_split_trailing_nil(void)
-{
-	if (g_test_subprocess()) {
-		char dest[3] = { 0 };
-		// pretend there is no place for trailing \0
-		sc_string_split("_", '_', NULL, 0, dest, 0);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
+static void test_sc_string_split_trailing_nil(void) {
+    if (g_test_subprocess()) {
+        char dest[3] = {0};
+        // pretend there is no place for trailing \0
+        sc_string_split("_", '_', NULL, 0, dest, 0);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_sc_string_split_short_instance_dest(void)
-{
-	if (g_test_subprocess()) {
-		char dest[10] = { 0 };
-		sc_string_split("foo_barbarbarbar", '_', NULL, 0,
-				dest, sizeof dest);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
+static void test_sc_string_split_short_instance_dest(void) {
+    if (g_test_subprocess()) {
+        char dest[10] = {0};
+        sc_string_split("foo_barbarbarbar", '_', NULL, 0, dest, sizeof dest);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_sc_string_split_null_string(void)
-{
-	if (g_test_subprocess()) {
-		char dest[10] = { 0 };
-		sc_string_split(NULL, '_', NULL, 0, dest, sizeof dest);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("internal error: cannot split string when it is unset\n");
+static void test_sc_string_split_null_string(void) {
+    if (g_test_subprocess()) {
+        char dest[10] = {0};
+        sc_string_split(NULL, '_', NULL, 0, dest, sizeof dest);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("internal error: cannot split string when it is unset\n");
 }
 
-static void test_sc_string_split_null_prefix_and_suffix(void)
-{
-	if (g_test_subprocess()) {
-		char dest[10] = { 0 };
-		sc_string_split("some_string", '_', NULL, 0, NULL, 0);
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("internal error: cannot split string when both prefix and suffix are unset\n");
+static void test_sc_string_split_null_prefix_and_suffix(void) {
+    if (g_test_subprocess()) {
+        char dest[10] = {0};
+        sc_string_split("some_string", '_', NULL, 0, NULL, 0);
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("internal error: cannot split string when both prefix and suffix are unset\n");
 }
 
-static void test_sc_string_split_basic(void)
-{
-	char prefix[41] = { 0xff };
-	char suffix[20] = { 0xff };
+static void test_sc_string_split_basic(void) {
+    char prefix[41] = {0xff};
+    char suffix[20] = {0xff};
 
-	sc_string_split("foo_bar", '_', prefix, sizeof prefix, suffix,
-			sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "foo");
-	g_assert_cmpstr(suffix, ==, "bar");
+    sc_string_split("foo_bar", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "foo");
+    g_assert_cmpstr(suffix, ==, "bar");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("foo-bar_bar", '_', prefix, sizeof prefix, suffix,
-			sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "foo-bar");
-	g_assert_cmpstr(suffix, ==, "bar");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("foo-bar_bar", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "foo-bar");
+    g_assert_cmpstr(suffix, ==, "bar");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("foo-bar_bar", '-', prefix, sizeof prefix, suffix,
-			sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "foo");
-	g_assert_cmpstr(suffix, ==, "bar_bar");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("foo-bar_bar", '-', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "foo");
+    g_assert_cmpstr(suffix, ==, "bar_bar");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("foo-bar", '_', prefix, sizeof prefix, suffix,
-			sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "foo-bar");
-	g_assert_cmpstr(suffix, ==, "");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("foo-bar", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "foo-bar");
+    g_assert_cmpstr(suffix, ==, "");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("_baz", '_', prefix, sizeof prefix, suffix,
-			sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "");
-	g_assert_cmpstr(suffix, ==, "baz");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("_baz", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "");
+    g_assert_cmpstr(suffix, ==, "baz");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("foo", '_', prefix, sizeof prefix, suffix,
-			sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "foo");
-	g_assert_cmpstr(suffix, ==, "");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("foo", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "foo");
+    g_assert_cmpstr(suffix, ==, "");
 
-	memset(prefix, 0xff, sizeof prefix);
-	sc_string_split("foo_bar", '_', prefix, sizeof prefix, NULL, 0);
-	g_assert_cmpstr(prefix, ==, "foo");
+    memset(prefix, 0xff, sizeof prefix);
+    sc_string_split("foo_bar", '_', prefix, sizeof prefix, NULL, 0);
+    g_assert_cmpstr(prefix, ==, "foo");
 
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("foo_bar", '_', NULL, 0, suffix, sizeof suffix);
-	g_assert_cmpstr(suffix, ==, "bar");
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("foo_bar", '_', NULL, 0, suffix, sizeof suffix);
+    g_assert_cmpstr(suffix, ==, "bar");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("hello_world_surprise", '_', prefix, sizeof prefix,
-			suffix, sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "hello");
-	g_assert_cmpstr(suffix, ==, "world_surprise");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("hello_world_surprise", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "hello");
+    g_assert_cmpstr(suffix, ==, "world_surprise");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("", '_', prefix, sizeof prefix, suffix, sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "");
-	g_assert_cmpstr(suffix, ==, "");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "");
+    g_assert_cmpstr(suffix, ==, "");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("_", '_', prefix, sizeof prefix, suffix, sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "");
-	g_assert_cmpstr(suffix, ==, "");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("_", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "");
+    g_assert_cmpstr(suffix, ==, "");
 
-	memset(prefix, 0xff, sizeof prefix);
-	memset(suffix, 0xff, sizeof suffix);
-	sc_string_split("foo_", '_', prefix, sizeof prefix, suffix,
-			sizeof suffix);
-	g_assert_cmpstr(prefix, ==, "foo");
-	g_assert_cmpstr(suffix, ==, "");
+    memset(prefix, 0xff, sizeof prefix);
+    memset(suffix, 0xff, sizeof suffix);
+    sc_string_split("foo_", '_', prefix, sizeof prefix, suffix, sizeof suffix);
+    g_assert_cmpstr(prefix, ==, "foo");
+    g_assert_cmpstr(suffix, ==, "");
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/string-utils/sc_streq", test_sc_streq);
-	g_test_add_func("/string-utils/sc_endswith", test_sc_endswith);
-	g_test_add_func("/string-utils/sc_startswith", test_sc_startswith);
-	g_test_add_func("/string-utils/sc_must_snprintf",
-			test_sc_must_snprintf);
-	g_test_add_func("/string-utils/sc_must_snprintf/fail",
-			test_sc_must_snprintf__fail);
-	g_test_add_func("/string-utils/sc_string_append/normal",
-			test_sc_string_append);
-	g_test_add_func("/string-utils/sc_string_append/empty_to_full",
-			test_sc_string_append__empty_to_full);
-	g_test_add_func("/string-utils/sc_string_append/overflow",
-			test_sc_string_append__overflow);
-	g_test_add_func("/string-utils/sc_string_append/uninitialized_buf",
-			test_sc_string_append__uninitialized_buf);
-	g_test_add_func("/string-utils/sc_string_append/NULL_buf",
-			test_sc_string_append__NULL_buf);
-	g_test_add_func("/string-utils/sc_string_append/NULL_str",
-			test_sc_string_append__NULL_str);
-	g_test_add_func("/string-utils/sc_string_init/normal",
-			test_sc_string_init__normal);
-	g_test_add_func("/string-utils/sc_string_init/empty_buf",
-			test_sc_string_init__empty_buf);
-	g_test_add_func("/string-utils/sc_string_init/NULL_buf",
-			test_sc_string_init__NULL_buf);
-	g_test_add_func
-	    ("/string-utils/sc_string_append_char__uninitialized_buf",
-	     test_sc_string_append_char__uninitialized_buf);
-	g_test_add_func("/string-utils/sc_string_append_char__NULL_buf",
-			test_sc_string_append_char__NULL_buf);
-	g_test_add_func("/string-utils/sc_string_append_char__overflow",
-			test_sc_string_append_char__overflow);
-	g_test_add_func("/string-utils/sc_string_append_char__invalid_zero",
-			test_sc_string_append_char__invalid_zero);
-	g_test_add_func("/string-utils/sc_string_append_char__normal",
-			test_sc_string_append_char__normal);
-	g_test_add_func
-	    ("/string-utils/sc_string_append_char_pair__NULL_buf",
-	     test_sc_string_append_char_pair__NULL_buf);
-	g_test_add_func("/string-utils/sc_string_append_char_pair__overflow",
-			test_sc_string_append_char_pair__overflow);
-	g_test_add_func
-	    ("/string-utils/sc_string_append_char_pair__invalid_zero_c1",
-	     test_sc_string_append_char_pair__invalid_zero_c1);
-	g_test_add_func
-	    ("/string-utils/sc_string_append_char_pair__invalid_zero_c2",
-	     test_sc_string_append_char_pair__invalid_zero_c2);
-	g_test_add_func("/string-utils/sc_string_append_char_pair__normal",
-			test_sc_string_append_char_pair__normal);
-	g_test_add_func("/string-utils/sc_string_quote__NULL_buf",
-			test_sc_string_quote_NULL_str);
-	g_test_add_func
-	    ("/string-utils/sc_string_append_char_pair__uninitialized_buf",
-	     test_sc_string_append_char_pair__uninitialized_buf);
-	g_test_add_func("/string-utils/sc_string_quote", test_sc_string_quote);
-	g_test_add_func("/string-utils/sc_strdup", test_sc_strdup);
-	g_test_add_func("/string-utils/sc_string_split/basic",
-			test_sc_string_split_basic);
-	g_test_add_func("/string-utils/sc_string_split/trailing_nil",
-			test_sc_string_split_trailing_nil);
-	g_test_add_func("/string-utils/sc_string_split/short_instance_dest",
-			test_sc_string_split_short_instance_dest);
-	g_test_add_func("/string-utils/sc_string_split/null_string",
-			test_sc_string_split_null_string);
-	g_test_add_func("/string-utils/sc_string_split/null_prefix_and_suffix",
-			test_sc_string_split_null_prefix_and_suffix);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/string-utils/sc_streq", test_sc_streq);
+    g_test_add_func("/string-utils/sc_endswith", test_sc_endswith);
+    g_test_add_func("/string-utils/sc_startswith", test_sc_startswith);
+    g_test_add_func("/string-utils/sc_must_snprintf", test_sc_must_snprintf);
+    g_test_add_func("/string-utils/sc_must_snprintf/fail", test_sc_must_snprintf__fail);
+    g_test_add_func("/string-utils/sc_string_append/normal", test_sc_string_append);
+    g_test_add_func("/string-utils/sc_string_append/empty_to_full", test_sc_string_append__empty_to_full);
+    g_test_add_func("/string-utils/sc_string_append/overflow", test_sc_string_append__overflow);
+    g_test_add_func("/string-utils/sc_string_append/uninitialized_buf", test_sc_string_append__uninitialized_buf);
+    g_test_add_func("/string-utils/sc_string_append/NULL_buf", test_sc_string_append__NULL_buf);
+    g_test_add_func("/string-utils/sc_string_append/NULL_str", test_sc_string_append__NULL_str);
+    g_test_add_func("/string-utils/sc_string_init/normal", test_sc_string_init__normal);
+    g_test_add_func("/string-utils/sc_string_init/empty_buf", test_sc_string_init__empty_buf);
+    g_test_add_func("/string-utils/sc_string_init/NULL_buf", test_sc_string_init__NULL_buf);
+    g_test_add_func("/string-utils/sc_string_append_char__uninitialized_buf",
+                    test_sc_string_append_char__uninitialized_buf);
+    g_test_add_func("/string-utils/sc_string_append_char__NULL_buf", test_sc_string_append_char__NULL_buf);
+    g_test_add_func("/string-utils/sc_string_append_char__overflow", test_sc_string_append_char__overflow);
+    g_test_add_func("/string-utils/sc_string_append_char__invalid_zero", test_sc_string_append_char__invalid_zero);
+    g_test_add_func("/string-utils/sc_string_append_char__normal", test_sc_string_append_char__normal);
+    g_test_add_func("/string-utils/sc_string_append_char_pair__NULL_buf", test_sc_string_append_char_pair__NULL_buf);
+    g_test_add_func("/string-utils/sc_string_append_char_pair__overflow", test_sc_string_append_char_pair__overflow);
+    g_test_add_func("/string-utils/sc_string_append_char_pair__invalid_zero_c1",
+                    test_sc_string_append_char_pair__invalid_zero_c1);
+    g_test_add_func("/string-utils/sc_string_append_char_pair__invalid_zero_c2",
+                    test_sc_string_append_char_pair__invalid_zero_c2);
+    g_test_add_func("/string-utils/sc_string_append_char_pair__normal", test_sc_string_append_char_pair__normal);
+    g_test_add_func("/string-utils/sc_string_quote__NULL_buf", test_sc_string_quote_NULL_str);
+    g_test_add_func("/string-utils/sc_string_append_char_pair__uninitialized_buf",
+                    test_sc_string_append_char_pair__uninitialized_buf);
+    g_test_add_func("/string-utils/sc_string_quote", test_sc_string_quote);
+    g_test_add_func("/string-utils/sc_strdup", test_sc_strdup);
+    g_test_add_func("/string-utils/sc_string_split/basic", test_sc_string_split_basic);
+    g_test_add_func("/string-utils/sc_string_split/trailing_nil", test_sc_string_split_trailing_nil);
+    g_test_add_func("/string-utils/sc_string_split/short_instance_dest", test_sc_string_split_short_instance_dest);
+    g_test_add_func("/string-utils/sc_string_split/null_string", test_sc_string_split_null_string);
+    g_test_add_func("/string-utils/sc_string_split/null_prefix_and_suffix",
+                    test_sc_string_split_null_prefix_and_suffix);
 }

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -24,287 +24,273 @@
 
 #include "utils.h"
 
-bool sc_streq(const char *a, const char *b)
-{
-	if (!a || !b) {
-		return false;
-	}
+bool sc_streq(const char *a, const char *b) {
+    if (!a || !b) {
+        return false;
+    }
 
-	return strcmp(a, b) == 0;
+    return strcmp(a, b) == 0;
 }
 
-bool sc_endswith(const char *str, const char *suffix)
-{
-	if (!str || !suffix) {
-		return false;
-	}
+bool sc_endswith(const char *str, const char *suffix) {
+    if (!str || !suffix) {
+        return false;
+    }
 
-	size_t xlen = strlen(suffix);
-	size_t slen = strlen(str);
+    size_t xlen = strlen(suffix);
+    size_t slen = strlen(str);
 
-	if (slen < xlen) {
-		return false;
-	}
+    if (slen < xlen) {
+        return false;
+    }
 
-	return strncmp(str - xlen + slen, suffix, xlen) == 0;
+    return strncmp(str - xlen + slen, suffix, xlen) == 0;
 }
 
-bool sc_startswith(const char *str, const char *prefix)
-{
-	if (!str || !prefix) {
-		return false;
-	}
+bool sc_startswith(const char *str, const char *prefix) {
+    if (!str || !prefix) {
+        return false;
+    }
 
-	size_t xlen = strlen(prefix);
-	return strncmp(str, prefix, xlen) == 0;
+    size_t xlen = strlen(prefix);
+    return strncmp(str, prefix, xlen) == 0;
 }
 
-char *sc_strdup(const char *str)
-{
-	// Set errno in case we die.
-	errno = 0;
-	size_t len;
-	char *copy;
-	if (str == NULL) {
-		die("cannot duplicate NULL string");
-	}
-	len = strlen(str);
-	copy = malloc(len + 1);
-	if (copy == NULL) {
-		die("cannot allocate string copy (len: %zd)", len);
-	}
-	memcpy(copy, str, len + 1);
-	return copy;
+char *sc_strdup(const char *str) {
+    // Set errno in case we die.
+    errno = 0;
+    size_t len;
+    char *copy;
+    if (str == NULL) {
+        die("cannot duplicate NULL string");
+    }
+    len = strlen(str);
+    copy = malloc(len + 1);
+    if (copy == NULL) {
+        die("cannot allocate string copy (len: %zd)", len);
+    }
+    memcpy(copy, str, len + 1);
+    return copy;
 }
 
-int sc_must_snprintf(char *str, size_t size, const char *format, ...)
-{
-	// Set errno in case we die.
-	errno = 0;
-	int n;
+int sc_must_snprintf(char *str, size_t size, const char *format, ...) {
+    // Set errno in case we die.
+    errno = 0;
+    int n;
 
-	va_list va;
-	va_start(va, format);
-	n = vsnprintf(str, size, format, va);
-	va_end(va);
+    va_list va;
+    va_start(va, format);
+    n = vsnprintf(str, size, format, va);
+    va_end(va);
 
-	if (n < 0 || (size_t)n >= size)
-		die("cannot format string: %s", str);
+    if (n < 0 || (size_t)n >= size) die("cannot format string: %s", str);
 
-	return n;
+    return n;
 }
 
-size_t sc_string_append(char *dst, size_t dst_size, const char *str)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (dst == NULL) {
-		die("cannot append string: buffer is NULL");
-	}
-	if (str == NULL) {
-		die("cannot append string: string is NULL");
-	}
-	size_t dst_len = strnlen(dst, dst_size);
-	if (dst_len == dst_size) {
-		die("cannot append string: dst is unterminated");
-	}
+size_t sc_string_append(char *dst, size_t dst_size, const char *str) {
+    // Set errno in case we die.
+    errno = 0;
+    if (dst == NULL) {
+        die("cannot append string: buffer is NULL");
+    }
+    if (str == NULL) {
+        die("cannot append string: string is NULL");
+    }
+    size_t dst_len = strnlen(dst, dst_size);
+    if (dst_len == dst_size) {
+        die("cannot append string: dst is unterminated");
+    }
 
-	size_t max_str_len = dst_size - dst_len;
-	size_t str_len = strnlen(str, max_str_len);
-	if (str_len == max_str_len) {
-		die("cannot append string: str is too long or unterminated");
-	}
-	// Append the string
-	memcpy(dst + dst_len, str, str_len);
-	// Ensure we are terminated
-	dst[dst_len + str_len] = '\0';
-	// return the new size
-	return strlen(dst);
+    size_t max_str_len = dst_size - dst_len;
+    size_t str_len = strnlen(str, max_str_len);
+    if (str_len == max_str_len) {
+        die("cannot append string: str is too long or unterminated");
+    }
+    // Append the string
+    memcpy(dst + dst_len, str, str_len);
+    // Ensure we are terminated
+    dst[dst_len + str_len] = '\0';
+    // return the new size
+    return strlen(dst);
 }
 
-size_t sc_string_append_char(char *dst, size_t dst_size, char c)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (dst == NULL) {
-		die("cannot append character: buffer is NULL");
-	}
-	size_t dst_len = strnlen(dst, dst_size);
-	if (dst_len == dst_size) {
-		die("cannot append character: dst is unterminated");
-	}
-	size_t max_str_len = dst_size - dst_len;
-	if (max_str_len < 2) {
-		die("cannot append character: not enough space");
-	}
-	if (c == 0) {
-		die("cannot append character: cannot append string terminator");
-	}
-	// Append the character and terminate the string.
-	dst[dst_len + 0] = c;
-	dst[dst_len + 1] = '\0';
-	// Return the new size
-	return dst_len + 1;
+size_t sc_string_append_char(char *dst, size_t dst_size, char c) {
+    // Set errno in case we die.
+    errno = 0;
+    if (dst == NULL) {
+        die("cannot append character: buffer is NULL");
+    }
+    size_t dst_len = strnlen(dst, dst_size);
+    if (dst_len == dst_size) {
+        die("cannot append character: dst is unterminated");
+    }
+    size_t max_str_len = dst_size - dst_len;
+    if (max_str_len < 2) {
+        die("cannot append character: not enough space");
+    }
+    if (c == 0) {
+        die("cannot append character: cannot append string terminator");
+    }
+    // Append the character and terminate the string.
+    dst[dst_len + 0] = c;
+    dst[dst_len + 1] = '\0';
+    // Return the new size
+    return dst_len + 1;
 }
 
-size_t sc_string_append_char_pair(char *dst, size_t dst_size, char c1, char c2)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (dst == NULL) {
-		die("cannot append character pair: buffer is NULL");
-	}
-	size_t dst_len = strnlen(dst, dst_size);
-	if (dst_len == dst_size) {
-		die("cannot append character pair: dst is unterminated");
-	}
-	size_t max_str_len = dst_size - dst_len;
-	if (max_str_len < 3) {
-		die("cannot append character pair: not enough space");
-	}
-	if (c1 == 0 || c2 == 0) {
-		die("cannot append character pair: cannot append string terminator");
-	}
-	// Append the two characters and terminate the string.
-	dst[dst_len + 0] = c1;
-	dst[dst_len + 1] = c2;
-	dst[dst_len + 2] = '\0';
-	// Return the new size
-	return dst_len + 2;
+size_t sc_string_append_char_pair(char *dst, size_t dst_size, char c1, char c2) {
+    // Set errno in case we die.
+    errno = 0;
+    if (dst == NULL) {
+        die("cannot append character pair: buffer is NULL");
+    }
+    size_t dst_len = strnlen(dst, dst_size);
+    if (dst_len == dst_size) {
+        die("cannot append character pair: dst is unterminated");
+    }
+    size_t max_str_len = dst_size - dst_len;
+    if (max_str_len < 3) {
+        die("cannot append character pair: not enough space");
+    }
+    if (c1 == 0 || c2 == 0) {
+        die("cannot append character pair: cannot append string terminator");
+    }
+    // Append the two characters and terminate the string.
+    dst[dst_len + 0] = c1;
+    dst[dst_len + 1] = c2;
+    dst[dst_len + 2] = '\0';
+    // Return the new size
+    return dst_len + 2;
 }
 
-void sc_string_init(char *buf, size_t buf_size)
-{
-	errno = 0;
-	if (buf == NULL) {
-		die("cannot initialize string, buffer is NULL");
-	}
-	if (buf_size == 0) {
-		die("cannot initialize string, buffer is too small");
-	}
-	buf[0] = '\0';
+void sc_string_init(char *buf, size_t buf_size) {
+    errno = 0;
+    if (buf == NULL) {
+        die("cannot initialize string, buffer is NULL");
+    }
+    if (buf_size == 0) {
+        die("cannot initialize string, buffer is too small");
+    }
+    buf[0] = '\0';
 }
 
-void sc_string_quote(char *buf, size_t buf_size, const char *str)
-{
-	// Set errno in case we die.
-	errno = 0;
-	if (str == NULL) {
-		die("cannot quote string: string is NULL");
-	}
-	const char *hex = "0123456789abcdef";
-	// NOTE: this also checks buf/buf_size sanity so that we don't have to.
-	sc_string_init(buf, buf_size);
-	sc_string_append_char(buf, buf_size, '"');
-	for (unsigned char c; (c = *str) != 0; ++str) {
-		switch (c) {
-			// Pass ASCII letters and digits unmodified.
-		case '0' ... '9':
-		case 'A' ... 'Z':
-		case 'a' ... 'z':
-			// Pass most of the punctuation unmodified.
-		case ' ':
-		case '!':
-		case '#':
-		case '$':
-		case '%':
-		case '&':
-		case '(':
-		case ')':
-		case '*':
-		case '+':
-		case ',':
-		case '-':
-		case '.':
-		case '/':
-		case ':':
-		case ';':
-		case '<':
-		case '=':
-		case '>':
-		case '?':
-		case '@':
-		case '[':
-		case '\'':
-		case ']':
-		case '^':
-		case '_':
-		case '`':
-		case '{':
-		case '|':
-		case '}':
-		case '~':
-			sc_string_append_char(buf, buf_size, c);
-			break;
-			// Escape special whitespace characters.
-		case '\n':
-			sc_string_append_char_pair(buf, buf_size, '\\', 'n');
-			break;
-		case '\r':
-			sc_string_append_char_pair(buf, buf_size, '\\', 'r');
-			break;
-		case '\t':
-			sc_string_append_char_pair(buf, buf_size, '\\', 't');
-			break;
-		case '\v':
-			sc_string_append_char_pair(buf, buf_size, '\\', 'v');
-			break;
-			// Escape the escape character.
-		case '\\':
-			sc_string_append_char_pair(buf, buf_size, '\\', '\\');
-			break;
-			// Escape double quote character.
-		case '"':
-			sc_string_append_char_pair(buf, buf_size, '\\', '"');
-			break;
-			// Escape everything else as a generic hexadecimal escape string.
-		default:
-			sc_string_append_char_pair(buf, buf_size, '\\', 'x');
-			sc_string_append_char_pair(buf, buf_size, hex[c >> 4],
-						   hex[c & 15]);
-			break;
-		}
-	}
-	sc_string_append_char(buf, buf_size, '"');
+void sc_string_quote(char *buf, size_t buf_size, const char *str) {
+    // Set errno in case we die.
+    errno = 0;
+    if (str == NULL) {
+        die("cannot quote string: string is NULL");
+    }
+    const char *hex = "0123456789abcdef";
+    // NOTE: this also checks buf/buf_size sanity so that we don't have to.
+    sc_string_init(buf, buf_size);
+    sc_string_append_char(buf, buf_size, '"');
+    for (unsigned char c; (c = *str) != 0; ++str) {
+        switch (c) {
+                // Pass ASCII letters and digits unmodified.
+            case '0' ... '9':
+            case 'A' ... 'Z':
+            case 'a' ... 'z':
+                // Pass most of the punctuation unmodified.
+            case ' ':
+            case '!':
+            case '#':
+            case '$':
+            case '%':
+            case '&':
+            case '(':
+            case ')':
+            case '*':
+            case '+':
+            case ',':
+            case '-':
+            case '.':
+            case '/':
+            case ':':
+            case ';':
+            case '<':
+            case '=':
+            case '>':
+            case '?':
+            case '@':
+            case '[':
+            case '\'':
+            case ']':
+            case '^':
+            case '_':
+            case '`':
+            case '{':
+            case '|':
+            case '}':
+            case '~':
+                sc_string_append_char(buf, buf_size, c);
+                break;
+                // Escape special whitespace characters.
+            case '\n':
+                sc_string_append_char_pair(buf, buf_size, '\\', 'n');
+                break;
+            case '\r':
+                sc_string_append_char_pair(buf, buf_size, '\\', 'r');
+                break;
+            case '\t':
+                sc_string_append_char_pair(buf, buf_size, '\\', 't');
+                break;
+            case '\v':
+                sc_string_append_char_pair(buf, buf_size, '\\', 'v');
+                break;
+                // Escape the escape character.
+            case '\\':
+                sc_string_append_char_pair(buf, buf_size, '\\', '\\');
+                break;
+                // Escape double quote character.
+            case '"':
+                sc_string_append_char_pair(buf, buf_size, '\\', '"');
+                break;
+                // Escape everything else as a generic hexadecimal escape string.
+            default:
+                sc_string_append_char_pair(buf, buf_size, '\\', 'x');
+                sc_string_append_char_pair(buf, buf_size, hex[c >> 4], hex[c & 15]);
+                break;
+        }
+    }
+    sc_string_append_char(buf, buf_size, '"');
 }
 
-void sc_string_split(const char *string, char delimiter,
-		     char *prefix_buf, size_t prefix_size,
-		     char *suffix_buf, size_t suffix_size)
-{
-	if (string == NULL) {
-		die("internal error: cannot split string when it is unset");
-	}
-	if (prefix_buf == NULL && suffix_buf == NULL) {
-		die("internal error: cannot split string when both prefix and suffix are unset");
-	}
+void sc_string_split(const char *string, char delimiter, char *prefix_buf, size_t prefix_size, char *suffix_buf,
+                     size_t suffix_size) {
+    if (string == NULL) {
+        die("internal error: cannot split string when it is unset");
+    }
+    if (prefix_buf == NULL && suffix_buf == NULL) {
+        die("internal error: cannot split string when both prefix and suffix are unset");
+    }
 
-	const char *pos = strchr(string, delimiter);
-	const char *suffix_start = "";
-	size_t prefix_len = 0;
-	size_t suffix_len = 0;
-	if (pos == NULL) {
-		prefix_len = strlen(string);
-	} else {
-		prefix_len = pos - string;
-		suffix_start = pos + 1;
-		suffix_len = strlen(suffix_start);
-	}
+    const char *pos = strchr(string, delimiter);
+    const char *suffix_start = "";
+    size_t prefix_len = 0;
+    size_t suffix_len = 0;
+    if (pos == NULL) {
+        prefix_len = strlen(string);
+    } else {
+        prefix_len = pos - string;
+        suffix_start = pos + 1;
+        suffix_len = strlen(suffix_start);
+    }
 
-	if (prefix_buf != NULL) {
-		if (prefix_len >= prefix_size) {
-			die("prefix buffer too small");
-		}
+    if (prefix_buf != NULL) {
+        if (prefix_len >= prefix_size) {
+            die("prefix buffer too small");
+        }
 
-		memcpy(prefix_buf, string, prefix_len);
-		prefix_buf[prefix_len] = '\0';
-	}
+        memcpy(prefix_buf, string, prefix_len);
+        prefix_buf[prefix_len] = '\0';
+    }
 
-	if (suffix_buf != NULL) {
-		if (suffix_len >= suffix_size) {
-			die("suffix buffer too small");
-		}
-		memcpy(suffix_buf, suffix_start, suffix_len);
-		suffix_buf[suffix_len] = '\0';
-	}
+    if (suffix_buf != NULL) {
+        if (suffix_len >= suffix_size) {
+            die("suffix buffer too small");
+        }
+        memcpy(suffix_buf, suffix_start, suffix_len);
+        suffix_buf[suffix_len] = '\0';
+    }
 }

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -38,7 +38,7 @@ bool sc_startswith(const char *str, const char *prefix);
 
 /**
  * Allocate and return a copy of a string.
-**/
+ **/
 char *sc_strdup(const char *str);
 
 /**
@@ -46,8 +46,7 @@ char *sc_strdup(const char *str);
  *
  * This version dies on any error condition.
  **/
-__attribute__((format(printf, 3, 4)))
-int sc_must_snprintf(char *str, size_t size, const char *format, ...);
+__attribute__((format(printf, 3, 4))) int sc_must_snprintf(char *str, size_t size, const char *format, ...);
 
 /**
  * Append a string to a buffer containing a string.
@@ -120,8 +119,7 @@ void sc_string_quote(char *buf, size_t buf_size, const char *str);
  * string, and the size of suffix must be large enough to hold the suffix part
  * of the string.
  **/
-void sc_string_split(const char *string, char delimiter,
-		     char *prefix_buf, size_t prefix_size,
-		     char *suffix_buf, size_t suffix_size);
+void sc_string_split(const char *string, char delimiter, char *prefix_buf, size_t prefix_size, char *suffix_buf,
+                     size_t suffix_size);
 
 #endif

--- a/cmd/libsnap-confine-private/test-utils-test.c
+++ b/cmd/libsnap-confine-private/test-utils-test.c
@@ -23,47 +23,43 @@
 #include <glib.h>
 
 // Check that rm_rf_tmp doesn't remove things outside of /tmp
-static void test_rm_rf_tmp(void)
-{
-	if (access("/nonexistent", F_OK) == 0) {
-		g_test_message
-		    ("/nonexistent exists but this test doesn't want it to");
-		g_test_fail();
-		return;
-	}
-	if (g_test_subprocess()) {
-		rm_rf_tmp("/nonexistent");
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
+static void test_rm_rf_tmp(void) {
+    if (access("/nonexistent", F_OK) == 0) {
+        g_test_message("/nonexistent exists but this test doesn't want it to");
+        g_test_fail();
+        return;
+    }
+    if (g_test_subprocess()) {
+        rm_rf_tmp("/nonexistent");
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
 }
 
-static void test_test_argc_argv(void)
-{
-	// Check that test_argc_argv() correctly stores data
-	int argc = 0;
-	char **argv = NULL;
+static void test_test_argc_argv(void) {
+    // Check that test_argc_argv() correctly stores data
+    int argc = 0;
+    char **argv = NULL;
 
-	test_argc_argv(&argc, &argv, NULL);
-	g_assert_cmpint(argc, ==, 0);
-	g_assert_nonnull(argv);
-	g_assert_null(argv[0]);
+    test_argc_argv(&argc, &argv, NULL);
+    g_assert_cmpint(argc, ==, 0);
+    g_assert_nonnull(argv);
+    g_assert_null(argv[0]);
 
-	argc = 0;
-	argv = NULL;
+    argc = 0;
+    argv = NULL;
 
-	test_argc_argv(&argc, &argv, "zero", "one", "two", NULL);
-	g_assert_cmpint(argc, ==, 3);
-	g_assert_nonnull(argv);
-	g_assert_cmpstr(argv[0], ==, "zero");
-	g_assert_cmpstr(argv[1], ==, "one");
-	g_assert_cmpstr(argv[2], ==, "two");
-	g_assert_null(argv[3]);
+    test_argc_argv(&argc, &argv, "zero", "one", "two", NULL);
+    g_assert_cmpint(argc, ==, 3);
+    g_assert_nonnull(argv);
+    g_assert_cmpstr(argv[0], ==, "zero");
+    g_assert_cmpstr(argv[1], ==, "one");
+    g_assert_cmpstr(argv[2], ==, "two");
+    g_assert_null(argv[3]);
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/test-utils/rm_rf_tmp", test_rm_rf_tmp);
-	g_test_add_func("/test-utils/test_argc_argv", test_test_argc_argv);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/test-utils/rm_rf_tmp", test_rm_rf_tmp);
+    g_test_add_func("/test-utils/test_argc_argv", test_test_argc_argv);
 }

--- a/cmd/libsnap-confine-private/test-utils.c
+++ b/cmd/libsnap-confine-private/test-utils.c
@@ -23,103 +23,87 @@
 
 #if !GLIB_CHECK_VERSION(2, 69, 0)
 // g_spawn_check_exit_status is considered deprecated since 2.69
-#define g_spawn_check_wait_status(x, y) (g_spawn_check_exit_status (x, y))
+#define g_spawn_check_wait_status(x, y) (g_spawn_check_exit_status(x, y))
 #endif
 
-void rm_rf_tmp(const char *dir)
-{
-	// Sanity check, don't remove anything that's not in the temporary
-	// directory. This is here to prevent unintended data loss.
-	if (!g_str_has_prefix(dir, "/tmp/"))
-		die("refusing to remove: %s", dir);
-	const gchar *working_directory = NULL;
-	gchar **argv = NULL;
-	gchar **envp = NULL;
-	GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
-	GSpawnChildSetupFunc child_setup = NULL;
-	gpointer user_data = NULL;
-	gchar **standard_output = NULL;
-	gchar **standard_error = NULL;
-	gint exit_status = 0;
-	GError *error = NULL;
+void rm_rf_tmp(const char *dir) {
+    // Sanity check, don't remove anything that's not in the temporary
+    // directory. This is here to prevent unintended data loss.
+    if (!g_str_has_prefix(dir, "/tmp/")) die("refusing to remove: %s", dir);
+    const gchar *working_directory = NULL;
+    gchar **argv = NULL;
+    gchar **envp = NULL;
+    GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
+    GSpawnChildSetupFunc child_setup = NULL;
+    gpointer user_data = NULL;
+    gchar **standard_output = NULL;
+    gchar **standard_error = NULL;
+    gint exit_status = 0;
+    GError *error = NULL;
 
-	argv = calloc(5, sizeof *argv);
-	if (argv == NULL)
-		die("cannot allocate command argument array");
-	argv[0] = g_strdup("rm");
-	if (argv[0] == NULL)
-		die("cannot allocate memory");
-	argv[1] = g_strdup("-rf");
-	if (argv[1] == NULL)
-		die("cannot allocate memory");
-	argv[2] = g_strdup("--");
-	if (argv[2] == NULL)
-		die("cannot allocate memory");
-	argv[3] = g_strdup(dir);
-	if (argv[3] == NULL)
-		die("cannot allocate memory");
-	argv[4] = NULL;
-	g_assert_true(g_spawn_sync
-		      (working_directory, argv, envp, flags, child_setup,
-		       user_data, standard_output, standard_error, &exit_status,
-		       &error));
-	g_assert_true(g_spawn_check_wait_status(exit_status, NULL));
-	if (error != NULL) {
-		g_test_message("cannot remove temporary directory: %s\n",
-			       error->message);
-		g_error_free(error);
-	}
-	g_free(argv[0]);
-	g_free(argv[1]);
-	g_free(argv[2]);
-	g_free(argv[3]);
-	g_free(argv);
+    argv = calloc(5, sizeof *argv);
+    if (argv == NULL) die("cannot allocate command argument array");
+    argv[0] = g_strdup("rm");
+    if (argv[0] == NULL) die("cannot allocate memory");
+    argv[1] = g_strdup("-rf");
+    if (argv[1] == NULL) die("cannot allocate memory");
+    argv[2] = g_strdup("--");
+    if (argv[2] == NULL) die("cannot allocate memory");
+    argv[3] = g_strdup(dir);
+    if (argv[3] == NULL) die("cannot allocate memory");
+    argv[4] = NULL;
+    g_assert_true(g_spawn_sync(working_directory, argv, envp, flags, child_setup, user_data, standard_output,
+                               standard_error, &exit_status, &error));
+    g_assert_true(g_spawn_check_wait_status(exit_status, NULL));
+    if (error != NULL) {
+        g_test_message("cannot remove temporary directory: %s\n", error->message);
+        g_error_free(error);
+    }
+    g_free(argv[0]);
+    g_free(argv[1]);
+    g_free(argv[2]);
+    g_free(argv[3]);
+    g_free(argv);
 }
 
-void
-    __attribute__((sentinel)) test_argc_argv(int *argcp, char ***argvp, ...)
-{
-	int argc = 0;
-	char **argv = NULL;
-	va_list ap;
+void __attribute__((sentinel)) test_argc_argv(int *argcp, char ***argvp, ...) {
+    int argc = 0;
+    char **argv = NULL;
+    va_list ap;
 
-	/* find out how many elements there are */
-	va_start(ap, argvp);
-	while (NULL != va_arg(ap, const char *)) {
-		argc += 1;
-	}
-	va_end(ap);
+    /* find out how many elements there are */
+    va_start(ap, argvp);
+    while (NULL != va_arg(ap, const char *)) {
+        argc += 1;
+    }
+    va_end(ap);
 
-	/* argc + terminating NULL entry */
-	argv = calloc(argc + 1, sizeof argv[0]);
-	g_assert_nonnull(argv);
+    /* argc + terminating NULL entry */
+    argv = calloc(argc + 1, sizeof argv[0]);
+    g_assert_nonnull(argv);
 
-	va_start(ap, argvp);
-	for (int i = 0; i < argc; i++) {
-		const char *arg = va_arg(ap, const char *);
-		char *arg_copy = sc_strdup(arg);
-		g_test_queue_free(arg_copy);
-		argv[i] = arg_copy;
-	}
-	va_end(ap);
+    va_start(ap, argvp);
+    for (int i = 0; i < argc; i++) {
+        const char *arg = va_arg(ap, const char *);
+        char *arg_copy = sc_strdup(arg);
+        g_test_queue_free(arg_copy);
+        argv[i] = arg_copy;
+    }
+    va_end(ap);
 
-	/* free argv last, so that entries do not leak */
-	g_test_queue_free(argv);
+    /* free argv last, so that entries do not leak */
+    g_test_queue_free(argv);
 
-	*argcp = argc;
-	*argvp = argv;
+    *argcp = argc;
+    *argvp = argv;
 }
 
 extern void sc_set_snap_mount_dir(const char *dir);
 
-void snap_mount_dir_fixture_setup(snap_mount_dir_fixture *fix,
-				  gconstpointer user_data)
-{
-	sc_set_snap_mount_dir((const char *)user_data);
+void snap_mount_dir_fixture_setup(snap_mount_dir_fixture *fix, gconstpointer user_data) {
+    sc_set_snap_mount_dir((const char *)user_data);
 }
 
-void snap_mount_dir_fixture_teardown(snap_mount_dir_fixture *fix,
-				     gconstpointer user_data)
-{
-	sc_set_snap_mount_dir(NULL);
+void snap_mount_dir_fixture_teardown(snap_mount_dir_fixture *fix, gconstpointer user_data) {
+    sc_set_snap_mount_dir(NULL);
 }

--- a/cmd/libsnap-confine-private/test-utils.h
+++ b/cmd/libsnap-confine-private/test-utils.h
@@ -28,16 +28,13 @@ void rm_rf_tmp(const char *dir);
 /**
  * Create an argc + argv pair out of a NULL terminated argument list.
  **/
-void
-    __attribute__((sentinel)) test_argc_argv(int *argcp, char ***argvp, ...);
+void __attribute__((sentinel)) test_argc_argv(int *argcp, char ***argvp, ...);
 
 typedef struct {
-	int unused;
+    int unused;
 } snap_mount_dir_fixture;
 
-void snap_mount_dir_fixture_setup(snap_mount_dir_fixture * fix,
-				  gconstpointer user_data);
-void snap_mount_dir_fixture_teardown(snap_mount_dir_fixture * fix,
-				     gconstpointer user_data);
+void snap_mount_dir_fixture_setup(snap_mount_dir_fixture *fix, gconstpointer user_data);
+void snap_mount_dir_fixture_teardown(snap_mount_dir_fixture *fix, gconstpointer user_data);
 
 #endif

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -39,7 +39,7 @@
  *
  * The executable is located based on the location of the currently executing process.
  * The returning file descriptor can be used with fexecve function, like in sc_call_snapd_tool.
-**/
+ **/
 static int sc_open_snapd_tool(const char *tool_name);
 
 /**
@@ -54,202 +54,157 @@ static int sc_open_snapd_tool(const char *tool_name);
  * If such string is present, the "x" is replaced with either "0" or "1" depending on
  * the result of is_sc_debug_enabled().
  **/
-static void sc_call_snapd_tool(int tool_fd, const char *tool_name, char **argv,
-			       char **envp);
+static void sc_call_snapd_tool(int tool_fd, const char *tool_name, char **argv, char **envp);
 
 /**
  * sc_call_snapd_tool_with_apparmor calls a snapd tool by file descriptor,
  * possibly confining the program with a specific apparmor profile.
-**/
-static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
-					     struct sc_apparmor *apparmor,
-					     const char *aa_profile,
-					     char **argv, char **envp);
+ **/
+static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name, struct sc_apparmor *apparmor,
+                                             const char *aa_profile, char **argv, char **envp);
 
-int sc_open_snap_update_ns(void)
-{
-	return sc_open_snapd_tool("snap-update-ns");
+int sc_open_snap_update_ns(void) { return sc_open_snapd_tool("snap-update-ns"); }
+
+void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name, struct sc_apparmor *apparmor) {
+    char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+    snap_name_copy = sc_strdup(snap_name);
+
+    char aa_profile[PATH_MAX] = {0};
+    sc_must_snprintf(aa_profile, sizeof aa_profile, "snap-update-ns.%s", snap_name);
+
+    char *argv[] = {"snap-update-ns",
+                    /* This tells snap-update-ns we are calling from snap-confine and locking is in place */
+                    "--from-snap-confine", snap_name_copy, NULL};
+    char *envp[] = {"SNAPD_DEBUG=x", NULL};
+
+    /* Switch the group to root so that directories, files and locks created by
+     * snap-update-ns are owned by the root group. */
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    sc_call_snapd_tool_with_apparmor(snap_update_ns_fd, "snap-update-ns", apparmor, aa_profile, argv, envp);
+    (void)sc_set_effective_identity(old);
 }
 
-void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
-			    struct sc_apparmor *apparmor)
-{
-	char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-	snap_name_copy = sc_strdup(snap_name);
+void sc_call_snap_update_ns_as_user(int snap_update_ns_fd, const char *snap_name, struct sc_apparmor *apparmor) {
+    char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+    snap_name_copy = sc_strdup(snap_name);
 
-	char aa_profile[PATH_MAX] = { 0 };
-	sc_must_snprintf(aa_profile, sizeof aa_profile, "snap-update-ns.%s",
-			 snap_name);
+    char aa_profile[PATH_MAX] = {0};
+    sc_must_snprintf(aa_profile, sizeof aa_profile, "snap-update-ns.%s", snap_name);
 
-	char *argv[] = {
-		"snap-update-ns",
-		/* This tells snap-update-ns we are calling from snap-confine and locking is in place */
-		"--from-snap-confine",
-		snap_name_copy, NULL
-	};
-	char *envp[] = { "SNAPD_DEBUG=x", NULL };
+    const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+    char xdg_runtime_dir_env[PATH_MAX + sizeof("XDG_RUNTIME_DIR=")] = {0};
+    if (xdg_runtime_dir != NULL) {
+        sc_must_snprintf(xdg_runtime_dir_env, sizeof(xdg_runtime_dir_env), "XDG_RUNTIME_DIR=%s", xdg_runtime_dir);
+    }
 
-	/* Switch the group to root so that directories, files and locks created by
-	 * snap-update-ns are owned by the root group. */
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	sc_call_snapd_tool_with_apparmor(snap_update_ns_fd,
-					 "snap-update-ns", apparmor,
-					 aa_profile, argv, envp);
-	(void)sc_set_effective_identity(old);
+    const char *snap_real_home = getenv("SNAP_REAL_HOME");
+    char snap_real_home_env[PATH_MAX + sizeof("SNAP_REAL_HOME=")] = {0};
+    if (snap_real_home != NULL) {
+        sc_must_snprintf(snap_real_home_env, sizeof(snap_real_home_env), "SNAP_REAL_HOME=%s", snap_real_home);
+    }
+
+    char *argv[] = {"snap-update-ns",
+                    /* This tells snap-update-ns we are calling from snap-confine and locking is in place */
+                    "--from-snap-confine",
+                    /* This tells snap-update-ns that we want to process the per-user profile */
+                    "--user-mounts", snap_name_copy, NULL};
+    char *envp[] = {/* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor
+                     * with either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function
+                     * for details. */
+                    "SNAPD_DEBUG=x", xdg_runtime_dir_env, snap_real_home_env, NULL};
+    sc_call_snapd_tool_with_apparmor(snap_update_ns_fd, "snap-update-ns", apparmor, aa_profile, argv, envp);
 }
 
-void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
-				    const char *snap_name,
-				    struct sc_apparmor *apparmor)
-{
-	char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-	snap_name_copy = sc_strdup(snap_name);
+int sc_open_snap_discard_ns(void) { return sc_open_snapd_tool("snap-discard-ns"); }
 
-	char aa_profile[PATH_MAX] = { 0 };
-	sc_must_snprintf(aa_profile, sizeof aa_profile, "snap-update-ns.%s",
-			 snap_name);
-
-	const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
-	char xdg_runtime_dir_env[PATH_MAX + sizeof("XDG_RUNTIME_DIR=")] = { 0 };
-	if (xdg_runtime_dir != NULL) {
-		sc_must_snprintf(xdg_runtime_dir_env,
-				 sizeof(xdg_runtime_dir_env),
-				 "XDG_RUNTIME_DIR=%s", xdg_runtime_dir);
-	}
-
-	const char *snap_real_home = getenv("SNAP_REAL_HOME");
-	char snap_real_home_env[PATH_MAX + sizeof("SNAP_REAL_HOME=")] = { 0 };
-	if (snap_real_home != NULL) {
-		sc_must_snprintf(snap_real_home_env,
-				 sizeof(snap_real_home_env),
-				 "SNAP_REAL_HOME=%s", snap_real_home);
-	}
-
-	char *argv[] = {
-		"snap-update-ns",
-		/* This tells snap-update-ns we are calling from snap-confine and locking is in place */
-		"--from-snap-confine",
-		/* This tells snap-update-ns that we want to process the per-user profile */
-		"--user-mounts", snap_name_copy, NULL
-	};
-	char *envp[] = {
-		/* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor
-		 * with either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function
-		 * for details. */
-		"SNAPD_DEBUG=x",
-		xdg_runtime_dir_env,
-		snap_real_home_env, NULL
-	};
-	sc_call_snapd_tool_with_apparmor(snap_update_ns_fd,
-					 "snap-update-ns", apparmor,
-					 aa_profile, argv, envp);
+void sc_call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name) {
+    char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+    snap_name_copy = sc_strdup(snap_name);
+    char *argv[] = {"snap-discard-ns", "--from-snap-confine", snap_name_copy, NULL};
+    /* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor with
+     * either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function for details. */
+    char *envp[] = {"SNAPD_DEBUG=x", NULL};
+    /* Switch the group to root so that directories and locks created by
+     * snap-discard-ns are owned by the root group. */
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    sc_call_snapd_tool(snap_discard_ns_fd, "snap-discard-ns", argv, envp);
+    (void)sc_set_effective_identity(old);
 }
 
-int sc_open_snap_discard_ns(void)
-{
-	return sc_open_snapd_tool("snap-discard-ns");
+static int sc_open_snapd_tool(const char *tool_name) {
+    // +1 is for the case where the link is exactly PATH_MAX long but we also
+    // want to store the terminating '\0'. The readlink system call doesn't add
+    // terminating null, but our initialization of buf handles this for us.
+    char buf[PATH_MAX + 1] = {0};
+    if (readlink("/proc/self/exe", buf, sizeof(buf) - 1) < 0) {
+        die("cannot readlink /proc/self/exe");
+    }
+    if (buf[0] != '/') {  // this shouldn't happen, but make sure have absolute path
+        die("readlink /proc/self/exe returned relative path");
+    }
+    // as we are looking up other tools relative to our own path, check
+    // we are located where we think we should be - otherwise we
+    // may have been hardlink'd elsewhere and then may execute the
+    // wrong tool as a result
+    if (!sc_is_expected_path(buf)) {
+        die("running from unexpected location: %s", buf);
+    }
+    char *dir_name = dirname(buf);
+    int dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    dir_fd = open(dir_name, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (dir_fd < 0) {
+        die("cannot open path %s", dir_name);
+    }
+    int tool_fd = -1;
+    tool_fd = openat(dir_fd, tool_name, O_PATH | O_NOFOLLOW | O_CLOEXEC);
+    if (tool_fd < 0) {
+        die("cannot open path %s/%s", dir_name, tool_name);
+    }
+    debug("opened %s executable as file descriptor %d", tool_name, tool_fd);
+    return tool_fd;
 }
 
-void sc_call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name)
-{
-	char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-	snap_name_copy = sc_strdup(snap_name);
-	char *argv[] =
-	    { "snap-discard-ns", "--from-snap-confine", snap_name_copy, NULL };
-	/* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor with
-	 * either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function for details. */
-	char *envp[] = { "SNAPD_DEBUG=x", NULL };
-	/* Switch the group to root so that directories and locks created by
-	 * snap-discard-ns are owned by the root group. */
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	sc_call_snapd_tool(snap_discard_ns_fd, "snap-discard-ns", argv, envp);
-	(void)sc_set_effective_identity(old);
+static void sc_call_snapd_tool(int tool_fd, const char *tool_name, char **argv, char **envp) {
+    sc_call_snapd_tool_with_apparmor(tool_fd, tool_name, NULL, NULL, argv, envp);
 }
 
-static int sc_open_snapd_tool(const char *tool_name)
-{
-	// +1 is for the case where the link is exactly PATH_MAX long but we also
-	// want to store the terminating '\0'. The readlink system call doesn't add
-	// terminating null, but our initialization of buf handles this for us.
-	char buf[PATH_MAX + 1] = { 0 };
-	if (readlink("/proc/self/exe", buf, sizeof(buf) - 1) < 0) {
-		die("cannot readlink /proc/self/exe");
-	}
-	if (buf[0] != '/') {	// this shouldn't happen, but make sure have absolute path
-		die("readlink /proc/self/exe returned relative path");
-	}
-	// as we are looking up other tools relative to our own path, check
-	// we are located where we think we should be - otherwise we
-	// may have been hardlink'd elsewhere and then may execute the
-	// wrong tool as a result
-	if (!sc_is_expected_path(buf)) {
-		die("running from unexpected location: %s", buf);
-	}
-	char *dir_name = dirname(buf);
-	int dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	dir_fd = open(dir_name, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-	if (dir_fd < 0) {
-		die("cannot open path %s", dir_name);
-	}
-	int tool_fd = -1;
-	tool_fd = openat(dir_fd, tool_name, O_PATH | O_NOFOLLOW | O_CLOEXEC);
-	if (tool_fd < 0) {
-		die("cannot open path %s/%s", dir_name, tool_name);
-	}
-	debug("opened %s executable as file descriptor %d", tool_name, tool_fd);
-	return tool_fd;
-}
-
-static void sc_call_snapd_tool(int tool_fd, const char *tool_name, char **argv,
-			       char **envp)
-{
-	sc_call_snapd_tool_with_apparmor(tool_fd, tool_name, NULL, NULL, argv,
-					 envp);
-}
-
-static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
-					     struct sc_apparmor *apparmor,
-					     const char *aa_profile,
-					     char **argv, char **envp)
-{
-	debug("calling snapd tool %s", tool_name);
-	pid_t child = fork();
-	if (child < 0) {
-		die("cannot fork to run snapd tool %s", tool_name);
-	}
-	if (child == 0) {
-		/* If the caller provided template environment entry for SNAPD_DEBUG
-		 * then expand it to the actual value. */
-		for (char **env = envp;
-		     /* Mama mia, that's a spicy meatball. */
-		     env != NULL && *env != NULL && **env != '\0'; env++) {
-			if (sc_streq(*env, "SNAPD_DEBUG=x")) {
-				/* NOTE: this is not released, on purpose. */
-				char *entry = sc_strdup(*env);
-				entry[strlen("SNAPD_DEBUG=x") - 1] =
-				    sc_is_debug_enabled()? '1' : '0';
-				*env = entry;
-			}
-		}
-		/* Switch apparmor profile for the process after exec. */
-		if (apparmor != NULL && aa_profile != NULL) {
-			sc_maybe_aa_change_onexec(apparmor, aa_profile);
-		}
-		fexecve(tool_fd, argv, envp);
-		die("cannot execute snapd tool %s", tool_name);
-	} else {
-		int status = 0;
-		debug("waiting for snapd tool %s to terminate", tool_name);
-		if (waitpid(child, &status, 0) < 0) {
-			die("cannot get snapd tool %s termination status via waitpid", tool_name);
-		}
-		if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
-			die("%s failed with code %i", tool_name,
-			    WEXITSTATUS(status));
-		} else if (WIFSIGNALED(status)) {
-			die("%s killed by signal %i", tool_name,
-			    WTERMSIG(status));
-		}
-		debug("%s finished successfully", tool_name);
-	}
+static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name, struct sc_apparmor *apparmor,
+                                             const char *aa_profile, char **argv, char **envp) {
+    debug("calling snapd tool %s", tool_name);
+    pid_t child = fork();
+    if (child < 0) {
+        die("cannot fork to run snapd tool %s", tool_name);
+    }
+    if (child == 0) {
+        /* If the caller provided template environment entry for SNAPD_DEBUG
+         * then expand it to the actual value. */
+        for (char **env = envp;
+             /* Mama mia, that's a spicy meatball. */
+             env != NULL && *env != NULL && **env != '\0'; env++) {
+            if (sc_streq(*env, "SNAPD_DEBUG=x")) {
+                /* NOTE: this is not released, on purpose. */
+                char *entry = sc_strdup(*env);
+                entry[strlen("SNAPD_DEBUG=x") - 1] = sc_is_debug_enabled() ? '1' : '0';
+                *env = entry;
+            }
+        }
+        /* Switch apparmor profile for the process after exec. */
+        if (apparmor != NULL && aa_profile != NULL) {
+            sc_maybe_aa_change_onexec(apparmor, aa_profile);
+        }
+        fexecve(tool_fd, argv, envp);
+        die("cannot execute snapd tool %s", tool_name);
+    } else {
+        int status = 0;
+        debug("waiting for snapd tool %s to terminate", tool_name);
+        if (waitpid(child, &status, 0) < 0) {
+            die("cannot get snapd tool %s termination status via waitpid", tool_name);
+        }
+        if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+            die("%s failed with code %i", tool_name, WEXITSTATUS(status));
+        } else if (WIFSIGNALED(status)) {
+            die("%s killed by signal %i", tool_name, WTERMSIG(status));
+        }
+        debug("%s finished successfully", tool_name);
+    }
 }

--- a/cmd/libsnap-confine-private/tool.h
+++ b/cmd/libsnap-confine-private/tool.h
@@ -23,30 +23,27 @@ struct sc_apparmor;
 
 /**
  * sc_open_snap_update_ns returns a file descriptor for the snap-update-ns tool.
-**/
+ **/
 int sc_open_snap_update_ns(void);
 
 /**
  * sc_call_snap_update_ns calls snap-update-ns from snap-confine
  **/
-void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
-			    struct sc_apparmor *apparmor);
+void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name, struct sc_apparmor *apparmor);
 
 /**
  * sc_call_snap_update_ns calls snap-update-ns --user-mounts from snap-confine
  **/
-void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
-				    const char *snap_name,
-				    struct sc_apparmor *apparmor);
+void sc_call_snap_update_ns_as_user(int snap_update_ns_fd, const char *snap_name, struct sc_apparmor *apparmor);
 
 /**
  * sc_open_snap_update_ns returns a file descriptor for the snap-discard-ns tool.
-**/
+ **/
 int sc_open_snap_discard_ns(void);
 
 /**
  * sc_call_snap_discard_ns calls the snap-discard-ns from snap confine.
-**/
+ **/
 void sc_call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name);
 
 #endif

--- a/cmd/libsnap-confine-private/unit-tests-main.c
+++ b/cmd/libsnap-confine-private/unit-tests-main.c
@@ -16,7 +16,4 @@
  */
 #include "unit-tests.h"
 
-int main(int argc, char **argv)
-{
-	return sc_run_unit_tests(&argc, &argv);
-}
+int main(int argc, char **argv) { return sc_run_unit_tests(&argc, &argv); }

--- a/cmd/libsnap-confine-private/unit-tests.c
+++ b/cmd/libsnap-confine-private/unit-tests.c
@@ -18,12 +18,11 @@
 #include "config.h"
 #endif
 
-#include "unit-tests.h"
 #include <glib.h>
+#include "unit-tests.h"
 
-int sc_run_unit_tests(int *argc, char ***argv)
-{
-	g_test_init(argc, argv, NULL);
-	g_test_set_nonfatal_assertions();
-	return g_test_run();
+int sc_run_unit_tests(int *argc, char ***argv) {
+    g_test_init(argc, argv, NULL);
+    g_test_set_nonfatal_assertions();
+    return g_test_run();
 }

--- a/cmd/libsnap-confine-private/unit-tests.h
+++ b/cmd/libsnap-confine-private/unit-tests.h
@@ -26,4 +26,4 @@
  */
 int sc_run_unit_tests(int *argc, char ***argv);
 
-#endif				// SNAP_CONFINE_SANITY_H
+#endif  // SNAP_CONFINE_SANITY_H

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -20,139 +20,131 @@
 
 #include <glib.h>
 
-static void test_parse_bool(void)
-{
-	int err;
-	bool value;
+static void test_parse_bool(void) {
+    int err;
+    bool value;
 
-	value = false;
-	err = parse_bool("yes", &value, false);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_true(value);
+    value = false;
+    err = parse_bool("yes", &value, false);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_true(value);
 
-	value = false;
-	err = parse_bool("1", &value, false);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_true(value);
+    value = false;
+    err = parse_bool("1", &value, false);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_true(value);
 
-	value = true;
-	err = parse_bool("no", &value, false);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_false(value);
+    value = true;
+    err = parse_bool("no", &value, false);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_false(value);
 
-	value = true;
-	err = parse_bool("0", &value, false);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_false(value);
+    value = true;
+    err = parse_bool("0", &value, false);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_false(value);
 
-	value = true;
-	err = parse_bool("", &value, false);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_false(value);
+    value = true;
+    err = parse_bool("", &value, false);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_false(value);
 
-	value = true;
-	err = parse_bool(NULL, &value, false);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_false(value);
+    value = true;
+    err = parse_bool(NULL, &value, false);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_false(value);
 
-	value = false;
-	err = parse_bool(NULL, &value, true);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_true(value);
+    value = false;
+    err = parse_bool(NULL, &value, true);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_true(value);
 
-	value = true;
-	err = parse_bool("flower", &value, false);
-	g_assert_cmpint(err, ==, -1);
-	g_assert_cmpint(errno, ==, EINVAL);
-	g_assert_true(value);
+    value = true;
+    err = parse_bool("flower", &value, false);
+    g_assert_cmpint(err, ==, -1);
+    g_assert_cmpint(errno, ==, EINVAL);
+    g_assert_true(value);
 
-	err = parse_bool("yes", NULL, false);
-	g_assert_cmpint(err, ==, -1);
-	g_assert_cmpint(errno, ==, EFAULT);
+    err = parse_bool("yes", NULL, false);
+    g_assert_cmpint(err, ==, -1);
+    g_assert_cmpint(errno, ==, EFAULT);
 }
 
-static void test_sc_is_expected_path(void)
-{
-	struct {
-		const char *path;
-		bool expected;
-	} test_cases[] = {
-		{"/tmp/snap-confine", false},
-		{"/tmp/foo", false},
-		{"/home/ ", false},
-		{"/usr/lib/snapd/snap-confine1", false},
-		{"/usr/lib/snapd/snap—confine", false},
-		{"/snap/core/usr/lib/snapd/snap-confine", false},
-		{"/snap/core/x1x/usr/lib/snapd/snap-confine", false},
-		{"/snap/core/z1/usr/lib/snapd/snap-confine", false},
-		{"/snap/cꓳre/1/usr/lib/snapd/snap-confine", false},
-		{"/snap/snapd1/1/usr/lib/snapd/snap-confine", false},
-		{"/snap/core/current/usr/lib/snapd/snap-confine", false},
-		{"/snap/snapd/1/usr/libexec/snapd/snap-confine", false},
-		{"/usr/lib/snapd/snap-confine", true},
-		{"/usr/libexec/snapd/snap-confine", true},
-		{"/snap/core/1/usr/lib/snapd/snap-confine", true},
-		{"/snap/core/x1/usr/lib/snapd/snap-confine", true},
-		{"/snap/snapd/1/usr/lib/snapd/snap-confine", true},
-		{"/var/lib/snapd/snap/snapd/23374/usr/lib/snapd/snap-confine",
-		 true},
-	};
-	size_t i;
-	for (i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
-		bool result = sc_is_expected_path(test_cases[i].path);
-		g_assert_cmpint(result, ==, test_cases[i].expected);
-	}
+static void test_sc_is_expected_path(void) {
+    struct {
+        const char *path;
+        bool expected;
+    } test_cases[] = {
+        {"/tmp/snap-confine", false},
+        {"/tmp/foo", false},
+        {"/home/ ", false},
+        {"/usr/lib/snapd/snap-confine1", false},
+        {"/usr/lib/snapd/snap—confine", false},
+        {"/snap/core/usr/lib/snapd/snap-confine", false},
+        {"/snap/core/x1x/usr/lib/snapd/snap-confine", false},
+        {"/snap/core/z1/usr/lib/snapd/snap-confine", false},
+        {"/snap/cꓳre/1/usr/lib/snapd/snap-confine", false},
+        {"/snap/snapd1/1/usr/lib/snapd/snap-confine", false},
+        {"/snap/core/current/usr/lib/snapd/snap-confine", false},
+        {"/snap/snapd/1/usr/libexec/snapd/snap-confine", false},
+        {"/usr/lib/snapd/snap-confine", true},
+        {"/usr/libexec/snapd/snap-confine", true},
+        {"/snap/core/1/usr/lib/snapd/snap-confine", true},
+        {"/snap/core/x1/usr/lib/snapd/snap-confine", true},
+        {"/snap/snapd/1/usr/lib/snapd/snap-confine", true},
+        {"/var/lib/snapd/snap/snapd/23374/usr/lib/snapd/snap-confine", true},
+    };
+    size_t i;
+    for (i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+        bool result = sc_is_expected_path(test_cases[i].path);
+        g_assert_cmpint(result, ==, test_cases[i].expected);
+    }
 }
 
-static void test_die(void)
-{
-	if (g_test_subprocess()) {
-		errno = 0;
-		die("death message");
-		g_test_message("expected die not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("death message\n");
+static void test_die(void) {
+    if (g_test_subprocess()) {
+        errno = 0;
+        die("death message");
+        g_test_message("expected die not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("death message\n");
 }
 
-static void test_die_with_errno(void)
-{
-	if (g_test_subprocess()) {
-		errno = EPERM;
-		die("death message");
-		g_test_message("expected die not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("death message: Operation not permitted\n");
+static void test_die_with_errno(void) {
+    if (g_test_subprocess()) {
+        errno = EPERM;
+        die("death message");
+        g_test_message("expected die not to return");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr("death message: Operation not permitted\n");
 }
 
 // A variant of rmdir that is compatible with GDestroyNotify
-static void my_rmdir(const char *path)
-{
-	if (rmdir(path) != 0) {
-		die("cannot rmdir %s", path);
-	}
+static void my_rmdir(const char *path) {
+    if (rmdir(path) != 0) {
+        die("cannot rmdir %s", path);
+    }
 }
 
 // A variant of chdir that is compatible with GDestroyNotify
-static void my_chdir(const char *path)
-{
-	if (chdir(path) != 0) {
-		die("cannot change dir to %s", path);
-	}
+static void my_chdir(const char *path) {
+    if (chdir(path) != 0) {
+        die("cannot change dir to %s", path);
+    }
 }
 
-static void my_unlink(const char *path)
-{
-	if (unlink(path) != 0 && errno != ENOENT) {
-		die("cannot unlink: %s", path);
-	}
+static void my_unlink(const char *path) {
+    if (unlink(path) != 0 && errno != ENOENT) {
+        die("cannot unlink: %s", path);
+    }
 }
 
 /**
@@ -162,122 +154,104 @@ static void my_unlink(const char *path)
  * operations at the end of the test.  If any additional directories or files
  * are created in this directory they must be removed by the caller.
  **/
-static void g_test_in_ephemeral_dir(void)
-{
-	gchar *temp_dir = g_dir_make_tmp(NULL, NULL);
-	gchar *orig_dir = g_get_current_dir();
-	int err = chdir(temp_dir);
-	g_assert_cmpint(err, ==, 0);
+static void g_test_in_ephemeral_dir(void) {
+    gchar *temp_dir = g_dir_make_tmp(NULL, NULL);
+    gchar *orig_dir = g_get_current_dir();
+    int err = chdir(temp_dir);
+    g_assert_cmpint(err, ==, 0);
 
-	g_test_queue_free(temp_dir);
-	g_test_queue_destroy((GDestroyNotify) my_rmdir, temp_dir);
-	g_test_queue_free(orig_dir);
-	g_test_queue_destroy((GDestroyNotify) my_chdir, orig_dir);
+    g_test_queue_free(temp_dir);
+    g_test_queue_destroy((GDestroyNotify)my_rmdir, temp_dir);
+    g_test_queue_free(orig_dir);
+    g_test_queue_destroy((GDestroyNotify)my_chdir, orig_dir);
 }
 
 /**
  * Test sc_nonfatal_mkpath() given two directories.
  **/
-static void _test_sc_nonfatal_mkpath(const gchar *dirname,
-				     const gchar *subdirname)
-{
-	// Check that directory does not exist.
-	g_assert_false(g_file_test(dirname, G_FILE_TEST_EXISTS |
-				   G_FILE_TEST_IS_DIR));
-	// Use sc_nonfatal_mkpath to create the directory and ensure that it worked
-	// as expected.
-	g_test_queue_destroy((GDestroyNotify) my_rmdir, (char *)dirname);
-	int err = sc_nonfatal_mkpath(dirname, 0755);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_cmpint(errno, ==, 0);
-	g_assert_true(g_file_test(dirname, G_FILE_TEST_EXISTS |
-				  G_FILE_TEST_IS_REGULAR));
-	// Use same function again to try to create the same directory and ensure
-	// that it didn't fail and properly retained EEXIST in errno.
-	err = sc_nonfatal_mkpath(dirname, 0755);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_cmpint(errno, ==, EEXIST);
-	// Now create a sub-directory of the original directory and observe the
-	// results. We should no longer see errno of EEXIST!
-	g_test_queue_destroy((GDestroyNotify) my_rmdir, (char *)subdirname);
-	err = sc_nonfatal_mkpath(subdirname, 0755);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_cmpint(errno, ==, 0);
+static void _test_sc_nonfatal_mkpath(const gchar *dirname, const gchar *subdirname) {
+    // Check that directory does not exist.
+    g_assert_false(g_file_test(dirname, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR));
+    // Use sc_nonfatal_mkpath to create the directory and ensure that it worked
+    // as expected.
+    g_test_queue_destroy((GDestroyNotify)my_rmdir, (char *)dirname);
+    int err = sc_nonfatal_mkpath(dirname, 0755);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_cmpint(errno, ==, 0);
+    g_assert_true(g_file_test(dirname, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR));
+    // Use same function again to try to create the same directory and ensure
+    // that it didn't fail and properly retained EEXIST in errno.
+    err = sc_nonfatal_mkpath(dirname, 0755);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_cmpint(errno, ==, EEXIST);
+    // Now create a sub-directory of the original directory and observe the
+    // results. We should no longer see errno of EEXIST!
+    g_test_queue_destroy((GDestroyNotify)my_rmdir, (char *)subdirname);
+    err = sc_nonfatal_mkpath(subdirname, 0755);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_cmpint(errno, ==, 0);
 }
 
 /**
  * Test that sc_nonfatal_mkpath behaves when using relative paths.
  **/
-static void test_sc_nonfatal_mkpath__relative(void)
-{
-	g_test_in_ephemeral_dir();
-	gchar *current_dir = g_get_current_dir();
-	g_test_queue_free(current_dir);
-	gchar *dirname = g_build_path("/", current_dir, "foo", NULL);
-	g_test_queue_free(dirname);
-	gchar *subdirname = g_build_path("/", current_dir, "foo", "bar", NULL);
-	g_test_queue_free(subdirname);
-	_test_sc_nonfatal_mkpath(dirname, subdirname);
+static void test_sc_nonfatal_mkpath__relative(void) {
+    g_test_in_ephemeral_dir();
+    gchar *current_dir = g_get_current_dir();
+    g_test_queue_free(current_dir);
+    gchar *dirname = g_build_path("/", current_dir, "foo", NULL);
+    g_test_queue_free(dirname);
+    gchar *subdirname = g_build_path("/", current_dir, "foo", "bar", NULL);
+    g_test_queue_free(subdirname);
+    _test_sc_nonfatal_mkpath(dirname, subdirname);
 }
 
 /**
  * Test that sc_nonfatal_mkpath behaves when using absolute paths.
  **/
-static void test_sc_nonfatal_mkpath__absolute(void)
-{
-	g_test_in_ephemeral_dir();
-	const char *dirname = "foo";
-	const char *subdirname = "foo/bar";
-	_test_sc_nonfatal_mkpath(dirname, subdirname);
+static void test_sc_nonfatal_mkpath__absolute(void) {
+    g_test_in_ephemeral_dir();
+    const char *dirname = "foo";
+    const char *subdirname = "foo/bar";
+    _test_sc_nonfatal_mkpath(dirname, subdirname);
 }
 
-static void test_sc_is_container__empty(void)
-{
-	g_test_in_ephemeral_dir();
-	g_test_queue_destroy((GDestroyNotify) my_unlink, "container");
-	g_assert_true(g_file_set_contents("container", "", -1, NULL));
-	g_assert_false(_sc_is_in_container("container"));
+static void test_sc_is_container__empty(void) {
+    g_test_in_ephemeral_dir();
+    g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
+    g_assert_true(g_file_set_contents("container", "", -1, NULL));
+    g_assert_false(_sc_is_in_container("container"));
 }
 
-static void test_sc_is_container__lxc(void)
-{
-	g_test_in_ephemeral_dir();
-	g_test_queue_destroy((GDestroyNotify) my_unlink, "container");
-	g_assert_true(g_file_set_contents("container", "lxc", -1, NULL));
-	g_assert_true(_sc_is_in_container("container"));
+static void test_sc_is_container__lxc(void) {
+    g_test_in_ephemeral_dir();
+    g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
+    g_assert_true(g_file_set_contents("container", "lxc", -1, NULL));
+    g_assert_true(_sc_is_in_container("container"));
 }
 
-static void test_sc_is_container__lxc_with_newline(void)
-{
-	g_test_in_ephemeral_dir();
-	g_test_queue_destroy((GDestroyNotify) my_unlink, "container");
-	g_assert_true(g_file_set_contents("container", "lxc\n", -1, NULL));
-	g_assert_true(_sc_is_in_container("container"));
+static void test_sc_is_container__lxc_with_newline(void) {
+    g_test_in_ephemeral_dir();
+    g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
+    g_assert_true(g_file_set_contents("container", "lxc\n", -1, NULL));
+    g_assert_true(_sc_is_in_container("container"));
 }
 
-static void test_sc_is_container__no_file(void)
-{
-	g_test_in_ephemeral_dir();
-	g_test_queue_destroy((GDestroyNotify) my_unlink, "container");
-	g_assert_false(_sc_is_in_container("container"));
+static void test_sc_is_container__no_file(void) {
+    g_test_in_ephemeral_dir();
+    g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
+    g_assert_false(_sc_is_in_container("container"));
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/utils/parse_bool", test_parse_bool);
-	g_test_add_func("/utils/sc_is_expected_path", test_sc_is_expected_path);
-	g_test_add_func("/utils/die", test_die);
-	g_test_add_func("/utils/die_with_errno", test_die_with_errno);
-	g_test_add_func("/utils/sc_nonfatal_mkpath/relative",
-			test_sc_nonfatal_mkpath__relative);
-	g_test_add_func("/utils/sc_nonfatal_mkpath/absolute",
-			test_sc_nonfatal_mkpath__absolute);
-	g_test_add_func("/utils/sc_is_in_container/empty",
-			test_sc_is_container__empty);
-	g_test_add_func("/utils/sc_is_in_container/no_file",
-			test_sc_is_container__no_file);
-	g_test_add_func("/utils/sc_is_in_container/lxc",
-			test_sc_is_container__lxc);
-	g_test_add_func("/utils/sc_is_in_container/lxc_newline",
-			test_sc_is_container__lxc_with_newline);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/utils/parse_bool", test_parse_bool);
+    g_test_add_func("/utils/sc_is_expected_path", test_sc_is_expected_path);
+    g_test_add_func("/utils/die", test_die);
+    g_test_add_func("/utils/die_with_errno", test_die_with_errno);
+    g_test_add_func("/utils/sc_nonfatal_mkpath/relative", test_sc_nonfatal_mkpath__relative);
+    g_test_add_func("/utils/sc_nonfatal_mkpath/absolute", test_sc_nonfatal_mkpath__absolute);
+    g_test_add_func("/utils/sc_is_in_container/empty", test_sc_is_container__empty);
+    g_test_add_func("/utils/sc_is_in_container/no_file", test_sc_is_container__no_file);
+    g_test_add_func("/utils/sc_is_in_container/lxc", test_sc_is_container__lxc);
+    g_test_add_func("/utils/sc_is_in_container/lxc_newline", test_sc_is_container__lxc_with_newline);
 }

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -28,25 +28,20 @@
 #include "panic.h"
 #include "utils.h"
 
-void die(const char *msg, ...)
-{
-	va_list ap;
-	va_start(ap, msg);
-	sc_panicv(msg, ap);
-	va_end(ap);
+void die(const char *msg, ...) {
+    va_list ap;
+    va_start(ap, msg);
+    sc_panicv(msg, ap);
+    va_end(ap);
 }
 
 struct sc_bool_name {
-	const char *text;
-	bool value;
+    const char *text;
+    bool value;
 };
 
 static const struct sc_bool_name sc_bool_names[] = {
-	{"yes", true},
-	{"no", false},
-	{"1", true},
-	{"0", false},
-	{"", false},
+    {"yes", true}, {"no", false}, {"1", true}, {"0", false}, {"", false},
 };
 
 /**
@@ -58,25 +53,23 @@ static const struct sc_bool_name sc_bool_names[] = {
  *
  * If the text cannot be recognized, the default value is used.
  **/
-static int parse_bool(const char *text, bool *value, bool default_value)
-{
-	if (value == NULL) {
-		errno = EFAULT;
-		return -1;
-	}
-	if (text == NULL) {
-		*value = default_value;
-		return 0;
-	}
-	for (size_t i = 0; i < sizeof sc_bool_names / sizeof *sc_bool_names;
-	     ++i) {
-		if (strcmp(text, sc_bool_names[i].text) == 0) {
-			*value = sc_bool_names[i].value;
-			return 0;
-		}
-	}
-	errno = EINVAL;
-	return -1;
+static int parse_bool(const char *text, bool *value, bool default_value) {
+    if (value == NULL) {
+        errno = EFAULT;
+        return -1;
+    }
+    if (text == NULL) {
+        *value = default_value;
+        return 0;
+    }
+    for (size_t i = 0; i < sizeof sc_bool_names / sizeof *sc_bool_names; ++i) {
+        if (strcmp(text, sc_bool_names[i].text) == 0) {
+            *value = sc_bool_names[i].value;
+            return 0;
+        }
+    }
+    errno = EINVAL;
+    return -1;
 }
 
 /**
@@ -87,218 +80,191 @@ static int parse_bool(const char *text, bool *value, bool default_value)
  * printed to stderr. If the environment variable is unset, set value to the
  * default_value as if the environment variable was set to default_value.
  **/
-bool getenv_bool(const char *name, bool default_value)
-{
-	const char *str_value = getenv(name);
-	bool value = default_value;
-	if (parse_bool(str_value, &value, default_value) < 0) {
-		if (errno == EINVAL) {
-			fprintf(stderr,
-				"WARNING: unrecognized value of environment variable %s (expected yes/no or 1/0)\n",
-				name);
-			return false;
-		} else {
-			die("cannot convert value of environment variable %s to a boolean", name);
-		}
-	}
-	return value;
+bool getenv_bool(const char *name, bool default_value) {
+    const char *str_value = getenv(name);
+    bool value = default_value;
+    if (parse_bool(str_value, &value, default_value) < 0) {
+        if (errno == EINVAL) {
+            fprintf(stderr, "WARNING: unrecognized value of environment variable %s (expected yes/no or 1/0)\n", name);
+            return false;
+        } else {
+            die("cannot convert value of environment variable %s to a boolean", name);
+        }
+    }
+    return value;
 }
 
-bool sc_is_debug_enabled(void)
-{
-	return getenv_bool("SNAP_CONFINE_DEBUG", false)
-	    || getenv_bool("SNAPD_DEBUG", false);
+bool sc_is_debug_enabled(void) { return getenv_bool("SNAP_CONFINE_DEBUG", false) || getenv_bool("SNAPD_DEBUG", false); }
+
+bool sc_is_reexec_enabled(void) { return getenv_bool("SNAP_REEXEC", true); }
+
+void debug(const char *msg, ...) {
+    if (sc_is_debug_enabled()) {
+        va_list va;
+        va_start(va, msg);
+        fprintf(stderr, "DEBUG: ");
+        vfprintf(stderr, msg, va);
+        fprintf(stderr, "\n");
+        va_end(va);
+    }
 }
 
-bool sc_is_reexec_enabled(void)
-{
-	return getenv_bool("SNAP_REEXEC", true);
+void write_string_to_file(const char *filepath, const char *buf) {
+    debug("write_string_to_file %s %s", filepath, buf);
+    FILE *f = fopen(filepath, "w");
+    if (f == NULL) die("fopen %s failed", filepath);
+    if (fwrite(buf, strlen(buf), 1, f) != 1) die("fwrite failed");
+    if (fflush(f) != 0) die("fflush failed");
+    if (fclose(f) != 0) die("fclose failed");
 }
 
-void debug(const char *msg, ...)
-{
-	if (sc_is_debug_enabled()) {
-		va_list va;
-		va_start(va, msg);
-		fprintf(stderr, "DEBUG: ");
-		vfprintf(stderr, msg, va);
-		fprintf(stderr, "\n");
-		va_end(va);
-	}
+sc_identity sc_set_effective_identity(sc_identity identity) {
+    debug("set_effective_identity uid:%d (change: %s), gid:%d (change: %s)", identity.uid,
+          identity.change_uid ? "yes" : "no", identity.gid, identity.change_gid ? "yes" : "no");
+    /* We are being careful not to return a value instructing us to change GID
+     * or UID by accident. */
+    sc_identity old = {
+        .change_gid = 0,
+        .change_uid = 0,
+    };
+
+    if (identity.change_gid) {
+        old.gid = getegid();
+        old.change_gid = 1;
+        if (setegid(identity.gid) < 0) {
+            die("cannot set effective group to %d", identity.gid);
+        }
+        if (getegid() != identity.gid) {
+            die("effective group change from %d to %d has failed", old.gid, identity.gid);
+        }
+    }
+    if (identity.change_uid) {
+        old.uid = geteuid();
+        old.change_uid = 1;
+        if (seteuid(identity.uid) < 0) {
+            die("cannot set effective user to %d", identity.uid);
+        }
+        if (geteuid() != identity.uid) {
+            die("effective user change from %d to %d has failed", old.uid, identity.uid);
+        }
+    }
+    return old;
 }
 
-void write_string_to_file(const char *filepath, const char *buf)
-{
-	debug("write_string_to_file %s %s", filepath, buf);
-	FILE *f = fopen(filepath, "w");
-	if (f == NULL)
-		die("fopen %s failed", filepath);
-	if (fwrite(buf, strlen(buf), 1, f) != 1)
-		die("fwrite failed");
-	if (fflush(f) != 0)
-		die("fflush failed");
-	if (fclose(f) != 0)
-		die("fclose failed");
+int sc_nonfatal_mkpath(const char *const path, mode_t mode) {
+    // If asked to create an empty path, return immediately.
+    if (strlen(path) == 0) {
+        return 0;
+    }
+    // We're going to use strtok_r, which needs to modify the path, so we'll
+    // make a copy of it.
+    char *path_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+    path_copy = strdup(path);
+    if (path_copy == NULL) {
+        return -1;
+    }
+    // Open flags to use while we walk the user data path:
+    // - Don't follow symlinks
+    // - Don't allow child access to file descriptor
+    // - Only open a directory (fail otherwise)
+    const int open_flags = O_NOFOLLOW | O_CLOEXEC | O_DIRECTORY;
+
+    // We're going to create each path segment via openat/mkdirat calls instead
+    // of mkdir calls, to avoid following symlinks and placing the user data
+    // directory somewhere we never intended for it to go. The first step is to
+    // get an initial file descriptor.
+    int fd SC_CLEANUP(sc_cleanup_close) = AT_FDCWD;
+    if (path_copy[0] == '/') {
+        fd = open("/", open_flags);
+        if (fd < 0) {
+            return -1;
+        }
+    }
+    // strtok_r needs a pointer to keep track of where it is in the string.
+    char *path_walker = NULL;
+
+    // Initialize tokenizer and obtain first path segment.
+    char *path_segment = strtok_r(path_copy, "/", &path_walker);
+    while (path_segment) {
+        // Try to create the directory.  It's okay if it already existed, but
+        // return with error on any other error. Reset errno before attempting
+        // this as it may stay stale (errno is not reset if mkdirat(2) returns
+        // successfully).
+        errno = 0;
+        if (mkdirat(fd, path_segment, mode) < 0 && errno != EEXIST) {
+            return -1;
+        }
+        // Open the parent directory we just made (and close the previous one
+        // (but not the special value AT_FDCWD) so we can continue down the
+        // path.
+        int previous_fd = fd;
+        fd = openat(fd, path_segment, open_flags);
+        if (previous_fd != AT_FDCWD && close(previous_fd) != 0) {
+            return -1;
+        }
+        if (fd < 0) {
+            return -1;
+        }
+        // Obtain the next path segment.
+        path_segment = strtok_r(NULL, "/", &path_walker);
+    }
+    return 0;
 }
 
-sc_identity sc_set_effective_identity(sc_identity identity)
-{
-	debug("set_effective_identity uid:%d (change: %s), gid:%d (change: %s)",
-	      identity.uid, identity.change_uid ? "yes" : "no",
-	      identity.gid, identity.change_gid ? "yes" : "no");
-	/* We are being careful not to return a value instructing us to change GID
-	 * or UID by accident. */
-	sc_identity old = {
-		.change_gid = 0,
-		.change_uid = 0,
-	};
-
-	if (identity.change_gid) {
-		old.gid = getegid();
-		old.change_gid = 1;
-		if (setegid(identity.gid) < 0) {
-			die("cannot set effective group to %d", identity.gid);
-		}
-		if (getegid() != identity.gid) {
-			die("effective group change from %d to %d has failed",
-			    old.gid, identity.gid);
-		}
-	}
-	if (identity.change_uid) {
-		old.uid = geteuid();
-		old.change_uid = 1;
-		if (seteuid(identity.uid) < 0) {
-			die("cannot set effective user to %d", identity.uid);
-		}
-		if (geteuid() != identity.uid) {
-			die("effective user change from %d to %d has failed",
-			    old.uid, identity.uid);
-		}
-	}
-	return old;
+bool sc_is_expected_path(const char *path) {
+    const char *expected_path_re =
+        "^((/var/lib/snapd)?/snap/(snapd|core)/x?[0-9]+/usr/lib|/usr/lib(exec)?)/snapd/snap-confine$";
+    regex_t re;
+    if (regcomp(&re, expected_path_re, REG_EXTENDED | REG_NOSUB) != 0)
+        die("can not compile regex %s", expected_path_re);
+    int status = regexec(&re, path, 0, NULL, 0);
+    regfree(&re);
+    return status == 0;
 }
 
-int sc_nonfatal_mkpath(const char *const path, mode_t mode)
-{
-	// If asked to create an empty path, return immediately.
-	if (strlen(path) == 0) {
-		return 0;
-	}
-	// We're going to use strtok_r, which needs to modify the path, so we'll
-	// make a copy of it.
-	char *path_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-	path_copy = strdup(path);
-	if (path_copy == NULL) {
-		return -1;
-	}
-	// Open flags to use while we walk the user data path:
-	// - Don't follow symlinks
-	// - Don't allow child access to file descriptor
-	// - Only open a directory (fail otherwise)
-	const int open_flags = O_NOFOLLOW | O_CLOEXEC | O_DIRECTORY;
-
-	// We're going to create each path segment via openat/mkdirat calls instead
-	// of mkdir calls, to avoid following symlinks and placing the user data
-	// directory somewhere we never intended for it to go. The first step is to
-	// get an initial file descriptor.
-	int fd SC_CLEANUP(sc_cleanup_close) = AT_FDCWD;
-	if (path_copy[0] == '/') {
-		fd = open("/", open_flags);
-		if (fd < 0) {
-			return -1;
-		}
-	}
-	// strtok_r needs a pointer to keep track of where it is in the string.
-	char *path_walker = NULL;
-
-	// Initialize tokenizer and obtain first path segment.
-	char *path_segment = strtok_r(path_copy, "/", &path_walker);
-	while (path_segment) {
-		// Try to create the directory.  It's okay if it already existed, but
-		// return with error on any other error. Reset errno before attempting
-		// this as it may stay stale (errno is not reset if mkdirat(2) returns
-		// successfully).
-		errno = 0;
-		if (mkdirat(fd, path_segment, mode) < 0 && errno != EEXIST) {
-			return -1;
-		}
-		// Open the parent directory we just made (and close the previous one
-		// (but not the special value AT_FDCWD) so we can continue down the
-		// path.
-		int previous_fd = fd;
-		fd = openat(fd, path_segment, open_flags);
-		if (previous_fd != AT_FDCWD && close(previous_fd) != 0) {
-			return -1;
-		}
-		if (fd < 0) {
-			return -1;
-		}
-		// Obtain the next path segment.
-		path_segment = strtok_r(NULL, "/", &path_walker);
-	}
-	return 0;
-}
-
-bool sc_is_expected_path(const char *path)
-{
-	const char *expected_path_re =
-	    "^((/var/lib/snapd)?/snap/(snapd|core)/x?[0-9]+/usr/lib|/usr/lib(exec)?)/snapd/snap-confine$";
-	regex_t re;
-	if (regcomp(&re, expected_path_re, REG_EXTENDED | REG_NOSUB) != 0)
-		die("can not compile regex %s", expected_path_re);
-	int status = regexec(&re, path, 0, NULL, 0);
-	regfree(&re);
-	return status == 0;
-}
-
-bool sc_wait_for_file(const char *path, size_t timeout_sec)
-{
-	for (size_t i = 0; i < timeout_sec; ++i) {
-		if (access(path, F_OK) == 0) {
-			return true;
-		}
-		sleep(1);
-	}
-	return false;
+bool sc_wait_for_file(const char *path, size_t timeout_sec) {
+    for (size_t i = 0; i < timeout_sec; ++i) {
+        if (access(path, F_OK) == 0) {
+            return true;
+        }
+        sleep(1);
+    }
+    return false;
 }
 
 const char *run_systemd_container = "/run/systemd/container";
 
-static bool _sc_is_in_container(const char *p)
-{
-	// see what systemd-detect-virt --container does in, see:
-	// https://github.com/systemd/systemd/blob/5dcd6b1d55a1cfe247621d70f0e25d020de6e0ed/src/basic/virt.c#L749-L755
-	// https://systemd.io/CONTAINER_INTERFACE/
-	FILE *in SC_CLEANUP(sc_cleanup_file) = fopen(p, "r");
-	if (in == NULL) {
-		return false;
-	}
+static bool _sc_is_in_container(const char *p) {
+    // see what systemd-detect-virt --container does in, see:
+    // https://github.com/systemd/systemd/blob/5dcd6b1d55a1cfe247621d70f0e25d020de6e0ed/src/basic/virt.c#L749-L755
+    // https://systemd.io/CONTAINER_INTERFACE/
+    FILE *in SC_CLEANUP(sc_cleanup_file) = fopen(p, "r");
+    if (in == NULL) {
+        return false;
+    }
 
-	char container[128] = { 0 };
+    char container[128] = {0};
 
-	if (fgets(container, sizeof(container), in) == NULL) {
-		/* nothing read or other error? */
-		return false;
-	}
+    if (fgets(container, sizeof(container), in) == NULL) {
+        /* nothing read or other error? */
+        return false;
+    }
 
-	size_t r = strnlen(container, sizeof container);
-	// TODO add sc_str_chomp()?
-	if (r > 0 && container[r - 1] == '\n') {
-		/* replace trailing newline */
-		container[r - 1] = 0;
-		r--;
-	}
+    size_t r = strnlen(container, sizeof container);
+    // TODO add sc_str_chomp()?
+    if (r > 0 && container[r - 1] == '\n') {
+        /* replace trailing newline */
+        container[r - 1] = 0;
+        r--;
+    }
 
-	if (r == 0) {
-		/* empty or just a newline */
-		return false;
-	}
+    if (r == 0) {
+        /* empty or just a newline */
+        return false;
+    }
 
-	debug("detected container environment: %s", container);
-	return true;
+    debug("detected container environment: %s", container);
+    return true;
 }
 
-bool sc_is_in_container(void)
-{
-	return _sc_is_in_container(run_systemd_container);
-}
+bool sc_is_in_container(void) { return _sc_is_in_container(run_systemd_container); }

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -17,15 +17,12 @@
 #ifndef CORE_LAUNCHER_UTILS_H
 #define CORE_LAUNCHER_UTILS_H
 
-#include <stdlib.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
-__attribute__((noreturn))
-    __attribute__((format(printf, 1, 2)))
-void die(const char *fmt, ...);
+__attribute__((noreturn)) __attribute__((format(printf, 1, 2))) void die(const char *fmt, ...);
 
-__attribute__((format(printf, 1, 2)))
-void debug(const char *fmt, ...);
+__attribute__((format(printf, 1, 2))) void debug(const char *fmt, ...);
 
 /**
  * Get an environment variable and convert it to a boolean.
@@ -59,12 +56,12 @@ bool sc_is_in_container(void);
  *
  * UID and GID represent user and group accounts numbers and are controlled by
  * change_uid and change_gid flags.
-**/
+ **/
 typedef struct sc_identity {
-	uid_t uid;
-	gid_t gid;
-	unsigned change_uid:1;
-	unsigned change_gid:1;
+    uid_t uid;
+    gid_t gid;
+    unsigned change_uid : 1;
+    unsigned change_gid : 1;
 } sc_identity;
 
 /**
@@ -74,16 +71,15 @@ typedef struct sc_identity {
  * causes the effective group to change to the root group. No change is made to
  * effective user identity.
  **/
-static inline sc_identity sc_root_group_identity(void)
-{
-	sc_identity id = {
-		/* Explicitly set our intent of changing just the GID.
-		 * Refactoring of this code must retain this property. */
-		.change_uid = 0,
-		.change_gid = 1,
-		.gid = 0,
-	};
-	return id;
+static inline sc_identity sc_root_group_identity(void) {
+    sc_identity id = {
+        /* Explicitly set our intent of changing just the GID.
+         * Refactoring of this code must retain this property. */
+        .change_uid = 0,
+        .change_gid = 1,
+        .gid = 0,
+    };
+    return id;
 }
 
 /**
@@ -95,7 +91,7 @@ static inline sc_identity sc_root_group_identity(void)
  *
  * The fields change_uid and change_gid control if user and group ID is changed.
  * The returned old identity has identical values of both use flags.
-**/
+ **/
 sc_identity sc_set_effective_identity(sc_identity identity);
 
 void write_string_to_file(const char *filepath, const char *buf);
@@ -114,14 +110,12 @@ void write_string_to_file(const char *filepath, const char *buf);
  *
  * The function returns -1 in case of any error.
  **/
-__attribute__((warn_unused_result))
-int sc_nonfatal_mkpath(const char *const path, mode_t mode);
+__attribute__((warn_unused_result)) int sc_nonfatal_mkpath(const char *const path, mode_t mode);
 
 /**
  * Return true if path is a valid path for the snap-confine binary
  **/
-__attribute__((warn_unused_result))
-bool sc_is_expected_path(const char *path);
+__attribute__((warn_unused_result)) bool sc_is_expected_path(const char *path);
 
 /**
  * Wait for file to appear for timeout_sec seconds. Returns true once the file

--- a/cmd/snap-confine/cookie-support.c
+++ b/cmd/snap-confine/cookie-support.c
@@ -26,8 +26,8 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #define SC_COOKIE_DIR "/var/lib/snapd/cookie"
@@ -37,39 +37,31 @@
  **/
 static const char *sc_cookie_dir = SC_COOKIE_DIR;
 
-char *sc_cookie_get_from_snapd(const char *snap_name, struct sc_error **errorp)
-{
-	char context_path[PATH_MAX] = { 0 };
-	struct sc_error *err = NULL;
-	char *context = NULL;
+char *sc_cookie_get_from_snapd(const char *snap_name, struct sc_error **errorp) {
+    char context_path[PATH_MAX] = {0};
+    struct sc_error *err = NULL;
+    char *context = NULL;
 
-	sc_must_snprintf(context_path, sizeof(context_path), "%s/snap.%s",
-			 sc_cookie_dir, snap_name);
-	int fd SC_CLEANUP(sc_cleanup_close) = -1;
-	fd = open(context_path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
-	if (fd < 0) {
-		err =
-		    sc_error_init_from_errno(errno,
-					     "warning: cannot open cookie file %s",
-					     context_path);
-		goto out;
-	}
-	// large enough buffer for opaque cookie string
-	char context_val[255] = { 0 };
-	ssize_t n = read(fd, context_val, sizeof(context_val) - 1);
-	if (n < 0) {
-		err =
-		    sc_error_init_from_errno(errno,
-					     "cannot read cookie file %s",
-					     context_path);
-		goto out;
-	}
-	context = strndup(context_val, n);
-	if (context == NULL) {
-		die("cannot duplicate snap cookie value");
-	}
+    sc_must_snprintf(context_path, sizeof(context_path), "%s/snap.%s", sc_cookie_dir, snap_name);
+    int fd SC_CLEANUP(sc_cleanup_close) = -1;
+    fd = open(context_path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0) {
+        err = sc_error_init_from_errno(errno, "warning: cannot open cookie file %s", context_path);
+        goto out;
+    }
+    // large enough buffer for opaque cookie string
+    char context_val[255] = {0};
+    ssize_t n = read(fd, context_val, sizeof(context_val) - 1);
+    if (n < 0) {
+        err = sc_error_init_from_errno(errno, "cannot read cookie file %s", context_path);
+        goto out;
+    }
+    context = strndup(context_val, n);
+    if (context == NULL) {
+        die("cannot duplicate snap cookie value");
+    }
 
- out:
-	sc_error_forward(errorp, err);
-	return context;
+out:
+    sc_error_forward(errorp, err);
+    return context;
 }

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -15,18 +15,18 @@
  *
  */
 
-#include "config.h"
 #include "mount-support-nvidia.h"
+#include "config.h"
 
 #include <errno.h>
 #include <fcntl.h>
 #include <glob.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <stdint.h>
 #include <unistd.h>
 /* POSIX version of basename() and dirname() */
 #include <libgen.h>
@@ -39,29 +39,27 @@
 
 #define SC_NVIDIA_DRIVER_VERSION_FILE "/sys/module/nvidia/version"
 
-#define SC_LIBGL_DIR   SC_EXTRA_LIB_DIR "/gl"
+#define SC_LIBGL_DIR SC_EXTRA_LIB_DIR "/gl"
 #define SC_LIBGL32_DIR SC_EXTRA_LIB_DIR "/gl32"
-#define SC_VULKAN_DIR  SC_EXTRA_LIB_DIR "/vulkan"
-#define SC_GLVND_DIR  SC_EXTRA_LIB_DIR "/glvnd"
+#define SC_VULKAN_DIR SC_EXTRA_LIB_DIR "/vulkan"
+#define SC_GLVND_DIR SC_EXTRA_LIB_DIR "/glvnd"
 
 #define SC_VULKAN_SOURCE_DIR "/usr/share/vulkan"
 #define SC_EGL_VENDOR_SOURCE_DIR "/usr/share/glvnd"
 
 // Location for NVIDIA vulkan files (including _wayland)
 static const char *vulkan_globs[] = {
-	"icd.d/*nvidia*.json",
+    "icd.d/*nvidia*.json",
 };
 
-static const size_t vulkan_globs_len =
-    sizeof vulkan_globs / sizeof *vulkan_globs;
+static const size_t vulkan_globs_len = sizeof vulkan_globs / sizeof *vulkan_globs;
 
 // Location of EGL vendor files
 static const char *egl_vendor_globs[] = {
-	"egl_vendor.d/*nvidia*.json",
+    "egl_vendor.d/*nvidia*.json",
 };
 
-static const size_t egl_vendor_globs_len =
-    sizeof egl_vendor_globs / sizeof *egl_vendor_globs;
+static const size_t egl_vendor_globs_len = sizeof egl_vendor_globs / sizeof *egl_vendor_globs;
 
 #if defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 
@@ -78,110 +76,102 @@ static const size_t egl_vendor_globs_len =
 // FIXME: this doesn't yet work with libGLX and libglvnd redirector
 // FIXME: this still doesn't work with the 361 driver
 static const char *nvidia_globs[] = {
-	"gbm/nvidia-drm_gbm.so*",
-	"libnvidia-allocator.so*",
-	"libnvidia-api.so*",
-	"libnvidia-cbl.so*",
-	"libnvidia-cfg.so*",
-	"libnvidia-compiler-next.so*",
-	"libnvidia-egl-gbm.so*",
-	"libnvidia-ngx.so*",
-	"libnvidia-nscq.so*",
-	"libnvidia-nvvm.so*",
-	"libnvidia-pkcs11-openssl3.so*",
-	"libnvidia-pkcs11.so*",
-	"libnvidia-vulkan-producer.so*",
-	"libnvidia-vksc-core.so.*",
+    "gbm/nvidia-drm_gbm.so*",
+    "libnvidia-allocator.so*",
+    "libnvidia-api.so*",
+    "libnvidia-cbl.so*",
+    "libnvidia-cfg.so*",
+    "libnvidia-compiler-next.so*",
+    "libnvidia-egl-gbm.so*",
+    "libnvidia-ngx.so*",
+    "libnvidia-nscq.so*",
+    "libnvidia-nvvm.so*",
+    "libnvidia-pkcs11-openssl3.so*",
+    "libnvidia-pkcs11.so*",
+    "libnvidia-vulkan-producer.so*",
+    "libnvidia-vksc-core.so.*",
 
-	"libEGL_nvidia.so*",
-	"libGLESv1_CM_nvidia.so*",
-	"libGLESv2_nvidia.so*",
-	"libGLX_nvidia.so*",
-	"libXvMCNVIDIA.so*",
-	"libXvMCNVIDIA_dynamic.so*",
-	"libnvidia-cfg.so*",
-	"libnvidia-compiler.so*",
-	"libnvidia-eglcore.so*",
-	"libnvidia-egl-wayland*",
-	"libnvidia-encode.so*",
-	"libnvidia-fatbinaryloader.so*",
-	"libnvidia-fbc.so*",
-	"libnvidia-glcore.so*",
-	"libnvidia-glsi.so*",
-	"libnvidia-glvkspirv.so*",
-	"libnvidia-gpucomp.so*",
-	"libnvidia-ifr.so*",
-	"libnvidia-ml.so*",
-	"libnvidia-opencl.so*",
-	"libnvidia-opticalflow.so*",
-	"libnvidia-ptxjitcompiler.so*",
-	"libnvidia-rtcore.so*",
-	"libnvidia-tls.so*",
-	"libnvoptix.so*",
-	"tls/libnvidia-tls.so*",
-	"vdpau/libvdpau_nvidia.so*",
+    "libEGL_nvidia.so*",
+    "libGLESv1_CM_nvidia.so*",
+    "libGLESv2_nvidia.so*",
+    "libGLX_nvidia.so*",
+    "libXvMCNVIDIA.so*",
+    "libXvMCNVIDIA_dynamic.so*",
+    "libnvidia-cfg.so*",
+    "libnvidia-compiler.so*",
+    "libnvidia-eglcore.so*",
+    "libnvidia-egl-wayland*",
+    "libnvidia-encode.so*",
+    "libnvidia-fatbinaryloader.so*",
+    "libnvidia-fbc.so*",
+    "libnvidia-glcore.so*",
+    "libnvidia-glsi.so*",
+    "libnvidia-glvkspirv.so*",
+    "libnvidia-gpucomp.so*",
+    "libnvidia-ifr.so*",
+    "libnvidia-ml.so*",
+    "libnvidia-opencl.so*",
+    "libnvidia-opticalflow.so*",
+    "libnvidia-ptxjitcompiler.so*",
+    "libnvidia-rtcore.so*",
+    "libnvidia-tls.so*",
+    "libnvoptix.so*",
+    "tls/libnvidia-tls.so*",
+    "vdpau/libvdpau_nvidia.so*",
 
-	// additional libraries for Tegra
-	// https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/manifest_tx2_tx2i.html
-	"libnvdc.so*",
-	"libnvos.so*",
-	"libnvrm_gpu.so*",
-	"libnvimp.so*",
-	"libnvrm.so*",
-	"libnvrm_graphics.so*",
-	// CUDA
-	// https://docs.nvidia.com/cuda/#cuda-api-references
-	"libcuda.so*",
-	"libcudart.so*",
-	"libnvcuvid.so*",
-	"libcufft.so*",
-	"libcublas.so*",
-	"libcublasLt.so*",
-	"libcusolver.so*",
-	"libcuparse.so*",
-	"libcurand.so*",
-	"libnppc.so*",
-	"libnppig.so*",
-	"libnppial.so*",
-	"libnppicc.so*",
-	"libnppidei.so*",
-	"libnppist.so*",
-	"libnppcif.so*",
-	"libnppim.so*",
-	"libnppitc.so*",
-	"libnvrtc*",
-	"libnvrtc-builtins*",
-	"libnvToolsExt.so*",
-	// libraries for CUDA DNN
-	// https://docs.nvidia.com/deeplearning/cudnn/api/index.html
-	// https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html
-	"libcudnn.so*",
-	"libcudnn_adv_infer*",
-	"libcudnn_adv_train*",
-	"libcudnn_cnn_infer*",
-	"libcudnn_cnn_train*",
-	"libcudnn_ops_infer*",
-	"libcudnn_ops_train*",
+    // additional libraries for Tegra
+    // https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/manifest_tx2_tx2i.html
+    "libnvdc.so*",
+    "libnvos.so*",
+    "libnvrm_gpu.so*",
+    "libnvimp.so*",
+    "libnvrm.so*",
+    "libnvrm_graphics.so*",
+    // CUDA
+    // https://docs.nvidia.com/cuda/#cuda-api-references
+    "libcuda.so*",
+    "libcudart.so*",
+    "libnvcuvid.so*",
+    "libcufft.so*",
+    "libcublas.so*",
+    "libcublasLt.so*",
+    "libcusolver.so*",
+    "libcuparse.so*",
+    "libcurand.so*",
+    "libnppc.so*",
+    "libnppig.so*",
+    "libnppial.so*",
+    "libnppicc.so*",
+    "libnppidei.so*",
+    "libnppist.so*",
+    "libnppcif.so*",
+    "libnppim.so*",
+    "libnppitc.so*",
+    "libnvrtc*",
+    "libnvrtc-builtins*",
+    "libnvToolsExt.so*",
+    // libraries for CUDA DNN
+    // https://docs.nvidia.com/deeplearning/cudnn/api/index.html
+    // https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html
+    "libcudnn.so*",
+    "libcudnn_adv_infer*",
+    "libcudnn_adv_train*",
+    "libcudnn_cnn_infer*",
+    "libcudnn_cnn_train*",
+    "libcudnn_ops_infer*",
+    "libcudnn_ops_train*",
 };
 
-static const size_t nvidia_globs_len =
-    sizeof nvidia_globs / sizeof *nvidia_globs;
+static const size_t nvidia_globs_len = sizeof nvidia_globs / sizeof *nvidia_globs;
 
 static const char *glvnd_globs[] = {
-	"libEGL.so*",
-	"libGL.so*",
-	"libOpenGL.so*",
-	"libGLESv1_CM.so*",
-	"libGLESv2.so*",
-	"libGLX_indirect.so*",
-	"libGLX.so*",
-	"libGLdispatch.so*",
-	"libGLU.so*",
+    "libEGL.so*",          "libGL.so*",  "libOpenGL.so*",     "libGLESv1_CM.so*", "libGLESv2.so*",
+    "libGLX_indirect.so*", "libGLX.so*", "libGLdispatch.so*", "libGLU.so*",
 };
 
 static const size_t glvnd_globs_len = sizeof glvnd_globs / sizeof *glvnd_globs;
 
-#endif				// defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
+#endif  // defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 
 // Populate libgl_dir with a symlink farm to files matching glob_list.
 //
@@ -193,162 +183,128 @@ static const size_t glvnd_globs_len = sizeof glvnd_globs / sizeof *glvnd_globs;
 //
 // The glob list passed to us is produced with paths relative to source dir,
 // to simplify the various tie-in points with this function.
-static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
-						   const char *source_dir,
-						   const char *glob_list[],
-						   size_t glob_list_len)
-{
-	size_t source_dir_len = strlen(source_dir);
-	glob_t glob_res SC_CLEANUP(globfree) = {
-		.gl_pathv = NULL
-	};
-	// Find all the entries matching the list of globs
-	for (size_t i = 0; i < glob_list_len; ++i) {
-		const char *glob_pattern = glob_list[i];
-		char glob_pattern_full[512] = { 0 };
-		sc_must_snprintf(glob_pattern_full, sizeof glob_pattern_full,
-				 "%s/%s", source_dir, glob_pattern);
+static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir, const char *source_dir,
+                                                   const char *glob_list[], size_t glob_list_len) {
+    size_t source_dir_len = strlen(source_dir);
+    glob_t glob_res SC_CLEANUP(globfree) = {.gl_pathv = NULL};
+    // Find all the entries matching the list of globs
+    for (size_t i = 0; i < glob_list_len; ++i) {
+        const char *glob_pattern = glob_list[i];
+        char glob_pattern_full[512] = {0};
+        sc_must_snprintf(glob_pattern_full, sizeof glob_pattern_full, "%s/%s", source_dir, glob_pattern);
 
-		int err = glob(glob_pattern_full, i ? GLOB_APPEND : 0, NULL,
-			       &glob_res);
-		// Not all of the files have to be there (they differ depending on the
-		// driver version used). Ignore all errors that are not GLOB_NOMATCH.
-		if (err != 0 && err != GLOB_NOMATCH) {
-			die("cannot search using glob pattern %s: %d",
-			    glob_pattern_full, err);
-		}
-	}
-	// Symlink each file found
-	for (size_t i = 0; i < glob_res.gl_pathc; ++i) {
-		char symlink_name[512] = { 0 };
-		char symlink_target[512] = { 0 };
-		char prefix_dir[512] = { 0 };
-		const char *pathname = glob_res.gl_pathv[i];
-		char *pathname_copy1
-		    SC_CLEANUP(sc_cleanup_string) = sc_strdup(pathname);
-		char *pathname_copy2
-		    SC_CLEANUP(sc_cleanup_string) = sc_strdup(pathname);
-		// POSIX dirname() and basename() may modify their input arguments
-		char *filename = basename(pathname_copy1);
-		char *directory_name = dirname(pathname_copy2);
-		sc_must_snprintf(prefix_dir, sizeof prefix_dir, "%s",
-				 libgl_dir);
+        int err = glob(glob_pattern_full, i ? GLOB_APPEND : 0, NULL, &glob_res);
+        // Not all of the files have to be there (they differ depending on the
+        // driver version used). Ignore all errors that are not GLOB_NOMATCH.
+        if (err != 0 && err != GLOB_NOMATCH) {
+            die("cannot search using glob pattern %s: %d", glob_pattern_full, err);
+        }
+    }
+    // Symlink each file found
+    for (size_t i = 0; i < glob_res.gl_pathc; ++i) {
+        char symlink_name[512] = {0};
+        char symlink_target[512] = {0};
+        char prefix_dir[512] = {0};
+        const char *pathname = glob_res.gl_pathv[i];
+        char *pathname_copy1 SC_CLEANUP(sc_cleanup_string) = sc_strdup(pathname);
+        char *pathname_copy2 SC_CLEANUP(sc_cleanup_string) = sc_strdup(pathname);
+        // POSIX dirname() and basename() may modify their input arguments
+        char *filename = basename(pathname_copy1);
+        char *directory_name = dirname(pathname_copy2);
+        sc_must_snprintf(prefix_dir, sizeof prefix_dir, "%s", libgl_dir);
 
-		if (strlen(directory_name) > source_dir_len) {
-			// Additional path elements between source_dir and dirname, meaning the
-			// actual file is not placed directly under source_dir but under one or
-			// more directories below source_dir. Make sure to recreate the whole
-			// prefix
-			sc_must_snprintf(prefix_dir, sizeof prefix_dir,
-					 "%s%s", libgl_dir,
-					 &directory_name[source_dir_len]);
-			sc_identity old =
-			    sc_set_effective_identity(sc_root_group_identity());
-			if (sc_nonfatal_mkpath(prefix_dir, 0755) != 0) {
-				die("failed to create prefix path: %s",
-				    prefix_dir);
-			}
-			(void)sc_set_effective_identity(old);
-		}
+        if (strlen(directory_name) > source_dir_len) {
+            // Additional path elements between source_dir and dirname, meaning the
+            // actual file is not placed directly under source_dir but under one or
+            // more directories below source_dir. Make sure to recreate the whole
+            // prefix
+            sc_must_snprintf(prefix_dir, sizeof prefix_dir, "%s%s", libgl_dir, &directory_name[source_dir_len]);
+            sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+            if (sc_nonfatal_mkpath(prefix_dir, 0755) != 0) {
+                die("failed to create prefix path: %s", prefix_dir);
+            }
+            (void)sc_set_effective_identity(old);
+        }
 
-		struct stat stat_buf;
-		int err = lstat(pathname, &stat_buf);
-		if (err != 0) {
-			die("cannot stat file %s", pathname);
-		}
-		switch (stat_buf.st_mode & S_IFMT) {
-		case S_IFLNK:;
-			// Read the target of the symbolic link
-			char hostfs_symlink_target[512] = { 0 };
-			ssize_t num_read;
-			hostfs_symlink_target[0] = 0;
-			num_read =
-			    readlink(pathname, hostfs_symlink_target,
-				     sizeof hostfs_symlink_target - 1);
-			if (num_read == -1) {
-				die("cannot read symbolic link %s", pathname);
-			}
-			hostfs_symlink_target[num_read] = 0;
-			if (hostfs_symlink_target[0] == '/') {
-				sc_must_snprintf(symlink_target,
-						 sizeof symlink_target,
-						 "/var/lib/snapd/hostfs%s",
-						 hostfs_symlink_target);
-			} else {
-				// Keep relative symlinks as-is, so that they point to -> libfoo.so.0.123
-				sc_must_snprintf(symlink_target,
-						 sizeof symlink_target, "%s",
-						 hostfs_symlink_target);
-			}
-			break;
-		case S_IFREG:
-			sc_must_snprintf(symlink_target,
-					 sizeof symlink_target,
-					 "/var/lib/snapd/hostfs%s", pathname);
-			break;
-		default:
-			debug("ignoring unsupported entry: %s", pathname);
-			continue;
-		}
-		sc_must_snprintf(symlink_name, sizeof symlink_name,
-				 "%s/%s", prefix_dir, filename);
-		debug("creating symbolic link %s -> %s", symlink_name,
-		      symlink_target);
+        struct stat stat_buf;
+        int err = lstat(pathname, &stat_buf);
+        if (err != 0) {
+            die("cannot stat file %s", pathname);
+        }
+        switch (stat_buf.st_mode & S_IFMT) {
+            case S_IFLNK:;
+                // Read the target of the symbolic link
+                char hostfs_symlink_target[512] = {0};
+                ssize_t num_read;
+                hostfs_symlink_target[0] = 0;
+                num_read = readlink(pathname, hostfs_symlink_target, sizeof hostfs_symlink_target - 1);
+                if (num_read == -1) {
+                    die("cannot read symbolic link %s", pathname);
+                }
+                hostfs_symlink_target[num_read] = 0;
+                if (hostfs_symlink_target[0] == '/') {
+                    sc_must_snprintf(symlink_target, sizeof symlink_target, "/var/lib/snapd/hostfs%s",
+                                     hostfs_symlink_target);
+                } else {
+                    // Keep relative symlinks as-is, so that they point to -> libfoo.so.0.123
+                    sc_must_snprintf(symlink_target, sizeof symlink_target, "%s", hostfs_symlink_target);
+                }
+                break;
+            case S_IFREG:
+                sc_must_snprintf(symlink_target, sizeof symlink_target, "/var/lib/snapd/hostfs%s", pathname);
+                break;
+            default:
+                debug("ignoring unsupported entry: %s", pathname);
+                continue;
+        }
+        sc_must_snprintf(symlink_name, sizeof symlink_name, "%s/%s", prefix_dir, filename);
+        debug("creating symbolic link %s -> %s", symlink_name, symlink_target);
 
-		// Make sure we don't have some link already (merged GLVND systems)
-		if (lstat(symlink_name, &stat_buf) == 0) {
-			if (unlink(symlink_name) != 0) {
-				die("cannot remove symbolic link target %s",
-				    symlink_name);
-			}
-		}
+        // Make sure we don't have some link already (merged GLVND systems)
+        if (lstat(symlink_name, &stat_buf) == 0) {
+            if (unlink(symlink_name) != 0) {
+                die("cannot remove symbolic link target %s", symlink_name);
+            }
+        }
 
-		if (symlink(symlink_target, symlink_name) != 0) {
-			die("cannot create symbolic link %s -> %s",
-			    symlink_name, symlink_target);
-		}
-	}
+        if (symlink(symlink_target, symlink_name) != 0) {
+            die("cannot create symbolic link %s -> %s", symlink_name, symlink_target);
+        }
+    }
 }
 
-static void sc_mkdir_and_mount_and_glob_files(const char *rootfs_dir,
-					      const char *source_dir[],
-					      size_t source_dir_len,
-					      const char *tgt_dir,
-					      const char *glob_list[],
-					      size_t glob_list_len)
-{
-	// Bind mount a tmpfs on $rootfs_dir/$tgt_dir (i.e. /var/lib/snapd/lib/gl)
-	char buf[512] = { 0 };
-	sc_must_snprintf(buf, sizeof(buf), "%s%s", rootfs_dir, tgt_dir);
-	const char *libgl_dir = buf;
+static void sc_mkdir_and_mount_and_glob_files(const char *rootfs_dir, const char *source_dir[], size_t source_dir_len,
+                                              const char *tgt_dir, const char *glob_list[], size_t glob_list_len) {
+    // Bind mount a tmpfs on $rootfs_dir/$tgt_dir (i.e. /var/lib/snapd/lib/gl)
+    char buf[512] = {0};
+    sc_must_snprintf(buf, sizeof(buf), "%s%s", rootfs_dir, tgt_dir);
+    const char *libgl_dir = buf;
 
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	int res = mkdir(libgl_dir, 0755);
-	if (res != 0 && errno != EEXIST) {
-		die("cannot create tmpfs target %s", libgl_dir);
-	}
-	if (res == 0 && (chown(libgl_dir, 0, 0) < 0)) {
-		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of %s", libgl_dir);
-	}
-	(void)sc_set_effective_identity(old);
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    int res = mkdir(libgl_dir, 0755);
+    if (res != 0 && errno != EEXIST) {
+        die("cannot create tmpfs target %s", libgl_dir);
+    }
+    if (res == 0 && (chown(libgl_dir, 0, 0) < 0)) {
+        // Adjust the ownership only if we created the directory.
+        die("cannot change ownership of %s", libgl_dir);
+    }
+    (void)sc_set_effective_identity(old);
 
-	debug("mounting tmpfs at %s", libgl_dir);
-	if (mount("none", libgl_dir, "tmpfs", MS_NODEV | MS_NOEXEC, NULL) != 0) {
-		die("cannot mount tmpfs at %s", libgl_dir);
-	};
+    debug("mounting tmpfs at %s", libgl_dir);
+    if (mount("none", libgl_dir, "tmpfs", MS_NODEV | MS_NOEXEC, NULL) != 0) {
+        die("cannot mount tmpfs at %s", libgl_dir);
+    };
 
-	for (size_t i = 0; i < source_dir_len; i++) {
-		// Populate libgl_dir with symlinks to libraries from hostfs
-		sc_populate_libgl_with_hostfs_symlinks(libgl_dir, source_dir[i],
-						       glob_list,
-						       glob_list_len);
-	}
-	// Remount $tgt_dir (i.e. .../lib/gl) read only
-	debug("remounting tmpfs as read-only %s", libgl_dir);
-	if (mount(NULL, buf, NULL, MS_REMOUNT | MS_BIND | MS_RDONLY, NULL) != 0) {
-		die("cannot remount %s as read-only", buf);
-	}
+    for (size_t i = 0; i < source_dir_len; i++) {
+        // Populate libgl_dir with symlinks to libraries from hostfs
+        sc_populate_libgl_with_hostfs_symlinks(libgl_dir, source_dir[i], glob_list, glob_list_len);
+    }
+    // Remount $tgt_dir (i.e. .../lib/gl) read only
+    debug("remounting tmpfs as read-only %s", libgl_dir);
+    if (mount(NULL, buf, NULL, MS_REMOUNT | MS_BIND | MS_RDONLY, NULL) != 0) {
+        die("cannot remount %s as read-only", buf);
+    }
 }
 
 #ifdef NVIDIA_BIARCH
@@ -370,284 +326,243 @@ static void sc_mkdir_and_mount_and_glob_files(const char *rootfs_dir,
 //
 // In non GLVND cases we just copy across the exposed libGLs and NVIDIA
 // libraries from wherever we find, and clobbering is also harmless.
-static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir,
-					  const char **globs, size_t globs_len)
-{
-
-	static const char *native_sources[] = {
-		NATIVE_LIBDIR,
-		NATIVE_LIBDIR "/nvidia*",
-	};
-	const size_t native_sources_len =
-	    sizeof native_sources / sizeof *native_sources;
+static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir, const char **globs, size_t globs_len) {
+    static const char *native_sources[] = {
+        NATIVE_LIBDIR,
+        NATIVE_LIBDIR "/nvidia*",
+    };
+    const size_t native_sources_len = sizeof native_sources / sizeof *native_sources;
 
 #if UINTPTR_MAX == 0xffffffffffffffff
-	// Alternative 32-bit support
-	static const char *lib32_sources[] = {
-		LIB32_DIR,
-		LIB32_DIR "/nvidia*",
-	};
-	const size_t lib32_sources_len =
-	    sizeof lib32_sources / sizeof *lib32_sources;
+    // Alternative 32-bit support
+    static const char *lib32_sources[] = {
+        LIB32_DIR,
+        LIB32_DIR "/nvidia*",
+    };
+    const size_t lib32_sources_len = sizeof lib32_sources / sizeof *lib32_sources;
 #endif
 
-	// Primary arch
-	sc_mkdir_and_mount_and_glob_files(rootfs_dir,
-					  native_sources, native_sources_len,
-					  SC_LIBGL_DIR, globs, globs_len);
+    // Primary arch
+    sc_mkdir_and_mount_and_glob_files(rootfs_dir, native_sources, native_sources_len, SC_LIBGL_DIR, globs, globs_len);
 
 #if UINTPTR_MAX == 0xffffffffffffffff
-	// Alternative 32-bit support
-	sc_mkdir_and_mount_and_glob_files(rootfs_dir, lib32_sources,
-					  lib32_sources_len, SC_LIBGL32_DIR,
-					  globs, globs_len);
+    // Alternative 32-bit support
+    sc_mkdir_and_mount_and_glob_files(rootfs_dir, lib32_sources, lib32_sources_len, SC_LIBGL32_DIR, globs, globs_len);
 #endif
 }
 
-#endif				// ifdef NVIDIA_BIARCH
+#endif  // ifdef NVIDIA_BIARCH
 
 #ifdef NVIDIA_MULTIARCH
 
 typedef struct {
-	int major;
-	// Driver version format is MAJOR.MINOR[.MICRO] but we only care about the
-	// major version and the full version string. The micro component has been
-	// seen with relevant leading zeros (e.g. "440.48.02").
-	char raw[128];		// The size was picked as "big enough" for version strings.
+    int major;
+    // Driver version format is MAJOR.MINOR[.MICRO] but we only care about the
+    // major version and the full version string. The micro component has been
+    // seen with relevant leading zeros (e.g. "440.48.02").
+    char raw[128];  // The size was picked as "big enough" for version strings.
 } sc_nv_version;
 
-static void sc_probe_nvidia_driver(sc_nv_version *version)
-{
-	memset(version, 0, sizeof *version);
+static void sc_probe_nvidia_driver(sc_nv_version *version) {
+    memset(version, 0, sizeof *version);
 
-	FILE *file SC_CLEANUP(sc_cleanup_file) = NULL;
-	debug("opening file describing nvidia driver version");
-	file = fopen(SC_NVIDIA_DRIVER_VERSION_FILE, "rt");
-	if (file == NULL) {
-		if (errno == ENOENT) {
-			debug("nvidia driver version file doesn't exist");
-			return;
-		}
-		die("cannot open file describing nvidia driver version");
-	}
-	int nread = fread(version->raw, 1, sizeof version->raw - 1, file);
-	if (nread < 0) {
-		die("cannot read nvidia driver version string");
-	}
-	if (nread == sizeof version->raw - 1 && !feof(file)) {
-		die("cannot fit entire nvidia driver version string");
-	}
-	version->raw[nread] = '\0';
-	if (nread > 0 && version->raw[nread - 1] == '\n') {
-		version->raw[nread - 1] = '\0';
-	}
-	if (sscanf(version->raw, "%d.", &version->major) != 1) {
-		die("cannot parse major version from nvidia driver version string");
-	}
+    FILE *file SC_CLEANUP(sc_cleanup_file) = NULL;
+    debug("opening file describing nvidia driver version");
+    file = fopen(SC_NVIDIA_DRIVER_VERSION_FILE, "rt");
+    if (file == NULL) {
+        if (errno == ENOENT) {
+            debug("nvidia driver version file doesn't exist");
+            return;
+        }
+        die("cannot open file describing nvidia driver version");
+    }
+    int nread = fread(version->raw, 1, sizeof version->raw - 1, file);
+    if (nread < 0) {
+        die("cannot read nvidia driver version string");
+    }
+    if (nread == sizeof version->raw - 1 && !feof(file)) {
+        die("cannot fit entire nvidia driver version string");
+    }
+    version->raw[nread] = '\0';
+    if (nread > 0 && version->raw[nread - 1] == '\n') {
+        version->raw[nread - 1] = '\0';
+    }
+    if (sscanf(version->raw, "%d.", &version->major) != 1) {
+        die("cannot parse major version from nvidia driver version string");
+    }
 }
 
-static void sc_mkdir_and_mount_and_bind(const char *rootfs_dir,
-					const char *src_dir,
-					const char *tgt_dir)
-{
-	sc_nv_version version;
+static void sc_mkdir_and_mount_and_bind(const char *rootfs_dir, const char *src_dir, const char *tgt_dir) {
+    sc_nv_version version;
 
-	// Probe sysfs to get the version of the driver that is currently inserted.
-	sc_probe_nvidia_driver(&version);
+    // Probe sysfs to get the version of the driver that is currently inserted.
+    sc_probe_nvidia_driver(&version);
 
-	// If there's driver in the kernel then don't mount userspace.
-	if (version.major == 0) {
-		return;
-	}
-	// Construct the paths for the driver userspace libraries
-	// and for the gl directory.
-	char src[PATH_MAX] = { 0 };
-	char dst[PATH_MAX] = { 0 };
-	sc_must_snprintf(src, sizeof src, "%s-%d", src_dir, version.major);
-	sc_must_snprintf(dst, sizeof dst, "%s%s", rootfs_dir, tgt_dir);
+    // If there's driver in the kernel then don't mount userspace.
+    if (version.major == 0) {
+        return;
+    }
+    // Construct the paths for the driver userspace libraries
+    // and for the gl directory.
+    char src[PATH_MAX] = {0};
+    char dst[PATH_MAX] = {0};
+    sc_must_snprintf(src, sizeof src, "%s-%d", src_dir, version.major);
+    sc_must_snprintf(dst, sizeof dst, "%s%s", rootfs_dir, tgt_dir);
 
-	// If there is no userspace driver available then don't try to mount it.
-	// This can happen for any number of reasons but one interesting one is
-	// that that snapd runs in a lxd container on a host that uses nvidia. In
-	// that case the container may not have the userspace library installed but
-	// the kernel will still have the module around.
-	if (access(src, F_OK) != 0) {
-		return;
-	}
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	int res = mkdir(dst, 0755);
-	if (res != 0 && errno != EEXIST) {
-		die("cannot create directory %s", dst);
-	}
-	if (res == 0 && (chown(dst, 0, 0) < 0)) {
-		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of %s", dst);
-	}
-	(void)sc_set_effective_identity(old);
-	// Bind mount the binary nvidia driver into $tgt_dir (i.e. /var/lib/snapd/lib/gl).
-	debug("bind mounting nvidia driver %s -> %s", src, dst);
-	if (mount(src, dst, NULL, MS_BIND, NULL) != 0) {
-		die("cannot bind mount nvidia driver %s -> %s", src, dst);
-	}
+    // If there is no userspace driver available then don't try to mount it.
+    // This can happen for any number of reasons but one interesting one is
+    // that that snapd runs in a lxd container on a host that uses nvidia. In
+    // that case the container may not have the userspace library installed but
+    // the kernel will still have the module around.
+    if (access(src, F_OK) != 0) {
+        return;
+    }
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    int res = mkdir(dst, 0755);
+    if (res != 0 && errno != EEXIST) {
+        die("cannot create directory %s", dst);
+    }
+    if (res == 0 && (chown(dst, 0, 0) < 0)) {
+        // Adjust the ownership only if we created the directory.
+        die("cannot change ownership of %s", dst);
+    }
+    (void)sc_set_effective_identity(old);
+    // Bind mount the binary nvidia driver into $tgt_dir (i.e. /var/lib/snapd/lib/gl).
+    debug("bind mounting nvidia driver %s -> %s", src, dst);
+    if (mount(src, dst, NULL, MS_BIND, NULL) != 0) {
+        die("cannot bind mount nvidia driver %s -> %s", src, dst);
+    }
 }
 
-static int sc_mount_nvidia_is_driver_in_dir(const char *dir)
-{
-	char driver_path[512] = { 0 };
+static int sc_mount_nvidia_is_driver_in_dir(const char *dir) {
+    char driver_path[512] = {0};
 
-	sc_nv_version version;
+    sc_nv_version version;
 
-	// Probe sysfs to get the version of the driver that is currently inserted.
-	sc_probe_nvidia_driver(&version);
+    // Probe sysfs to get the version of the driver that is currently inserted.
+    sc_probe_nvidia_driver(&version);
 
-	// If there's no driver then we should not bother ourselves with finding the
-	// matching library
-	if (version.major == 0) {
-		return 0;
-	}
+    // If there's no driver then we should not bother ourselves with finding the
+    // matching library
+    if (version.major == 0) {
+        return 0;
+    }
 
-	// Probe if a well known library is found in directory dir. We must use the
-	// raw version because it may contain more than just major.minor. In
-	// practice the micro version may have leading zeros that are relevant.
-	sc_must_snprintf(driver_path, sizeof driver_path,
-			 "%s/libnvidia-glcore.so.%s", dir, version.raw);
+    // Probe if a well known library is found in directory dir. We must use the
+    // raw version because it may contain more than just major.minor. In
+    // practice the micro version may have leading zeros that are relevant.
+    sc_must_snprintf(driver_path, sizeof driver_path, "%s/libnvidia-glcore.so.%s", dir, version.raw);
 
-	debug("looking for nvidia canary file %s", driver_path);
-	if (access(driver_path, F_OK) == 0) {
-		debug("nvidia library detected at path %s", driver_path);
-		return 1;
-	}
-	return 0;
+    debug("looking for nvidia canary file %s", driver_path);
+    if (access(driver_path, F_OK) == 0) {
+        debug("nvidia library detected at path %s", driver_path);
+        return 1;
+    }
+    return 0;
 }
 
-static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir,
-					     const char **globs,
-					     size_t globs_len)
-{
-	const char *native_libdir = NATIVE_LIBDIR "/" HOST_ARCH_TRIPLET;
-	const char *lib32_libdir = NATIVE_LIBDIR "/" HOST_ARCH32_TRIPLET;
+static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir, const char **globs, size_t globs_len) {
+    const char *native_libdir = NATIVE_LIBDIR "/" HOST_ARCH_TRIPLET;
+    const char *lib32_libdir = NATIVE_LIBDIR "/" HOST_ARCH32_TRIPLET;
 
-	if ((strlen(HOST_ARCH_TRIPLET) > 0) &&
-	    (sc_mount_nvidia_is_driver_in_dir(native_libdir) == 1)) {
+    if ((strlen(HOST_ARCH_TRIPLET) > 0) && (sc_mount_nvidia_is_driver_in_dir(native_libdir) == 1)) {
+        // sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
+        // initialize native_sources accordingly, but calculate the array length
+        // dynamically to make adjustments to native_sources easier.
+        const char *native_sources[] = {native_libdir};
+        const size_t native_sources_len = sizeof native_sources / sizeof *native_sources;
+        // Primary arch
+        sc_mkdir_and_mount_and_glob_files(rootfs_dir, native_sources, native_sources_len, SC_LIBGL_DIR, globs,
+                                          globs_len);
 
-		// sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
-		// initialize native_sources accordingly, but calculate the array length
-		// dynamically to make adjustments to native_sources easier.
-		const char *native_sources[] = { native_libdir };
-		const size_t native_sources_len =
-		    sizeof native_sources / sizeof *native_sources;
-		// Primary arch
-		sc_mkdir_and_mount_and_glob_files(rootfs_dir,
-						  native_sources,
-						  native_sources_len,
-						  SC_LIBGL_DIR, globs,
-						  globs_len);
-
-		// Alternative 32-bit support
-		if ((strlen(HOST_ARCH32_TRIPLET) > 0) &&
-		    (sc_mount_nvidia_is_driver_in_dir(lib32_libdir) == 1)) {
-
-			// sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
-			// initialize lib32_sources accordingly, but calculate the array length
-			// dynamically to make adjustments to lib32_sources easier.
-			const char *lib32_sources[] = { lib32_libdir };
-			const size_t lib32_sources_len =
-			    sizeof lib32_sources / sizeof *lib32_sources;
-			sc_mkdir_and_mount_and_glob_files(rootfs_dir,
-							  lib32_sources,
-							  lib32_sources_len,
-							  SC_LIBGL32_DIR,
-							  globs, globs_len);
-		}
-	} else {
-		// Attempt mount of both the native and 32-bit variants of the driver if they exist
-		sc_mkdir_and_mount_and_bind(rootfs_dir, "/usr/lib/nvidia",
-					    SC_LIBGL_DIR);
-		// Alternative 32-bit support
-		sc_mkdir_and_mount_and_bind(rootfs_dir, "/usr/lib32/nvidia",
-					    SC_LIBGL32_DIR);
-	}
+        // Alternative 32-bit support
+        if ((strlen(HOST_ARCH32_TRIPLET) > 0) && (sc_mount_nvidia_is_driver_in_dir(lib32_libdir) == 1)) {
+            // sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
+            // initialize lib32_sources accordingly, but calculate the array length
+            // dynamically to make adjustments to lib32_sources easier.
+            const char *lib32_sources[] = {lib32_libdir};
+            const size_t lib32_sources_len = sizeof lib32_sources / sizeof *lib32_sources;
+            sc_mkdir_and_mount_and_glob_files(rootfs_dir, lib32_sources, lib32_sources_len, SC_LIBGL32_DIR, globs,
+                                              globs_len);
+        }
+    } else {
+        // Attempt mount of both the native and 32-bit variants of the driver if they exist
+        sc_mkdir_and_mount_and_bind(rootfs_dir, "/usr/lib/nvidia", SC_LIBGL_DIR);
+        // Alternative 32-bit support
+        sc_mkdir_and_mount_and_bind(rootfs_dir, "/usr/lib32/nvidia", SC_LIBGL32_DIR);
+    }
 }
 
-#endif				// ifdef NVIDIA_MULTIARCH
+#endif  // ifdef NVIDIA_MULTIARCH
 
-static void sc_mount_vulkan(const char *rootfs_dir)
-{
-	const char *vulkan_sources[] = {
-		SC_VULKAN_SOURCE_DIR,
-	};
-	const size_t vulkan_sources_len =
-	    sizeof vulkan_sources / sizeof *vulkan_sources;
+static void sc_mount_vulkan(const char *rootfs_dir) {
+    const char *vulkan_sources[] = {
+        SC_VULKAN_SOURCE_DIR,
+    };
+    const size_t vulkan_sources_len = sizeof vulkan_sources / sizeof *vulkan_sources;
 
-	sc_mkdir_and_mount_and_glob_files(rootfs_dir, vulkan_sources,
-					  vulkan_sources_len, SC_VULKAN_DIR,
-					  vulkan_globs, vulkan_globs_len);
+    sc_mkdir_and_mount_and_glob_files(rootfs_dir, vulkan_sources, vulkan_sources_len, SC_VULKAN_DIR, vulkan_globs,
+                                      vulkan_globs_len);
 }
 
-static void sc_mount_egl(const char *rootfs_dir)
-{
-	const char *egl_vendor_sources[] = { SC_EGL_VENDOR_SOURCE_DIR };
-	const size_t egl_vendor_sources_len =
-	    sizeof egl_vendor_sources / sizeof *egl_vendor_sources;
+static void sc_mount_egl(const char *rootfs_dir) {
+    const char *egl_vendor_sources[] = {SC_EGL_VENDOR_SOURCE_DIR};
+    const size_t egl_vendor_sources_len = sizeof egl_vendor_sources / sizeof *egl_vendor_sources;
 
-	sc_mkdir_and_mount_and_glob_files(rootfs_dir, egl_vendor_sources,
-					  egl_vendor_sources_len, SC_GLVND_DIR,
-					  egl_vendor_globs,
-					  egl_vendor_globs_len);
+    sc_mkdir_and_mount_and_glob_files(rootfs_dir, egl_vendor_sources, egl_vendor_sources_len, SC_GLVND_DIR,
+                                      egl_vendor_globs, egl_vendor_globs_len);
 }
 
-void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
-{
-	/* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
-	if (access(SC_NVIDIA_DRIVER_VERSION_FILE, F_OK) != 0) {
-		return;
-	}
+void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name) {
+    /* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
+    if (access(SC_NVIDIA_DRIVER_VERSION_FILE, F_OK) != 0) {
+        return;
+    }
 
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755);
-	if (res != 0) {
-		die("cannot create " SC_EXTRA_LIB_DIR);
-	}
-	if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
-		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of " SC_EXTRA_LIB_DIR);
-	}
-	(void)sc_set_effective_identity(old);
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755);
+    if (res != 0) {
+        die("cannot create " SC_EXTRA_LIB_DIR);
+    }
+    if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
+        // Adjust the ownership only if we created the directory.
+        die("cannot change ownership of " SC_EXTRA_LIB_DIR);
+    }
+    (void)sc_set_effective_identity(old);
 
 #if defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
-	/* We include the globs for the glvnd libraries for old snaps
-	 * based on core, Ubuntu 16.04 did not include glvnd itself.
-	 *
-	 * While there is no guarantee that the host system's glvnd
-	 * libGL will be compatible (as it is built with the host
-	 * system's glibc), the Mesa libGL included with the snap will
-	 * definitely not be compatible (as it expects to find the Mesa
-	 * implementation of the GLX extension)..
-	 */
-	const char **globs = nvidia_globs;
-	size_t globs_len = nvidia_globs_len;
-	const char **full_globs SC_CLEANUP(sc_cleanup_shallow_strv) = NULL;
-	if (sc_streq(base_snap_name, "core")) {
-		full_globs = malloc(sizeof nvidia_globs + sizeof glvnd_globs);
-		if (full_globs == NULL) {
-			die("cannot allocate globs array");
-		}
-		memcpy(full_globs, nvidia_globs, sizeof nvidia_globs);
-		memcpy(&full_globs[nvidia_globs_len], glvnd_globs,
-		       sizeof glvnd_globs);
-		globs = full_globs;
-		globs_len = nvidia_globs_len + glvnd_globs_len;
-	}
+    /* We include the globs for the glvnd libraries for old snaps
+     * based on core, Ubuntu 16.04 did not include glvnd itself.
+     *
+     * While there is no guarantee that the host system's glvnd
+     * libGL will be compatible (as it is built with the host
+     * system's glibc), the Mesa libGL included with the snap will
+     * definitely not be compatible (as it expects to find the Mesa
+     * implementation of the GLX extension)..
+     */
+    const char **globs = nvidia_globs;
+    size_t globs_len = nvidia_globs_len;
+    const char **full_globs SC_CLEANUP(sc_cleanup_shallow_strv) = NULL;
+    if (sc_streq(base_snap_name, "core")) {
+        full_globs = malloc(sizeof nvidia_globs + sizeof glvnd_globs);
+        if (full_globs == NULL) {
+            die("cannot allocate globs array");
+        }
+        memcpy(full_globs, nvidia_globs, sizeof nvidia_globs);
+        memcpy(&full_globs[nvidia_globs_len], glvnd_globs, sizeof glvnd_globs);
+        globs = full_globs;
+        globs_len = nvidia_globs_len + glvnd_globs_len;
+    }
 #endif
 
 #ifdef NVIDIA_MULTIARCH
-	sc_mount_nvidia_driver_multiarch(rootfs_dir, globs, globs_len);
-#endif				// ifdef NVIDIA_MULTIARCH
+    sc_mount_nvidia_driver_multiarch(rootfs_dir, globs, globs_len);
+#endif  // ifdef NVIDIA_MULTIARCH
 #ifdef NVIDIA_BIARCH
-	sc_mount_nvidia_driver_biarch(rootfs_dir, globs, globs_len);
-#endif				// ifdef NVIDIA_BIARCH
+    sc_mount_nvidia_driver_biarch(rootfs_dir, globs, globs_len);
+#endif  // ifdef NVIDIA_BIARCH
 
-	// Common for both driver mechanisms
-	sc_mount_vulkan(rootfs_dir);
-	sc_mount_egl(rootfs_dir);
+    // Common for both driver mechanisms
+    sc_mount_vulkan(rootfs_dir);
+    sc_mount_egl(rootfs_dir);
 }

--- a/cmd/snap-confine/mount-support-test.c
+++ b/cmd/snap-confine/mount-support-test.c
@@ -16,86 +16,79 @@
  */
 
 #include "mount-support.h"
-#include "mount-support.c"
-#include "mount-support-nvidia.h"
 #include "mount-support-nvidia.c"
+#include "mount-support-nvidia.h"
+#include "mount-support.c"
 
 #include <glib.h>
 #include <glib/gstdio.h>
 
-static void replace_slashes_with_NUL(char *path, size_t len)
-{
-	for (size_t i = 0; i < len; i++) {
-		if (path[i] == '/')
-			path[i] = '\0';
-	}
+static void replace_slashes_with_NUL(char *path, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        if (path[i] == '/') path[i] = '\0';
+    }
 }
 
-static void test_get_nextpath__typical(void)
-{
-	char path[] = "/some/path";
-	size_t offset = 0;
-	size_t fulllen = strlen(path);
+static void test_get_nextpath__typical(void) {
+    char path[] = "/some/path";
+    size_t offset = 0;
+    size_t fulllen = strlen(path);
 
-	// Prepare path for usage with get_nextpath() by replacing
-	// all path separators with the NUL byte.
-	replace_slashes_with_NUL(path, fulllen);
+    // Prepare path for usage with get_nextpath() by replacing
+    // all path separators with the NUL byte.
+    replace_slashes_with_NUL(path, fulllen);
 
-	// Run get_nextpath a few times to see what happens.
-	char *result;
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, "some");
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, "path");
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, NULL);
+    // Run get_nextpath a few times to see what happens.
+    char *result;
+    result = get_nextpath(path, &offset, fulllen);
+    g_assert_cmpstr(result, ==, "some");
+    result = get_nextpath(path, &offset, fulllen);
+    g_assert_cmpstr(result, ==, "path");
+    result = get_nextpath(path, &offset, fulllen);
+    g_assert_cmpstr(result, ==, NULL);
 }
 
-static void test_get_nextpath__weird(void)
-{
-	char path[] = "..///path";
-	size_t offset = 0;
-	size_t fulllen = strlen(path);
+static void test_get_nextpath__weird(void) {
+    char path[] = "..///path";
+    size_t offset = 0;
+    size_t fulllen = strlen(path);
 
-	// Prepare path for usage with get_nextpath() by replacing
-	// all path separators with the NUL byte.
-	replace_slashes_with_NUL(path, fulllen);
+    // Prepare path for usage with get_nextpath() by replacing
+    // all path separators with the NUL byte.
+    replace_slashes_with_NUL(path, fulllen);
 
-	// Run get_nextpath a few times to see what happens.
-	char *result;
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, "path");
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, NULL);
+    // Run get_nextpath a few times to see what happens.
+    char *result;
+    result = get_nextpath(path, &offset, fulllen);
+    g_assert_cmpstr(result, ==, "path");
+    result = get_nextpath(path, &offset, fulllen);
+    g_assert_cmpstr(result, ==, NULL);
 }
 
-static void test_is_subdir(void)
-{
-	// Sensible exaples are sensible
-	g_assert_true(is_subdir("/dir/subdir", "/dir/"));
-	g_assert_true(is_subdir("/dir/subdir", "/dir"));
-	g_assert_true(is_subdir("/dir/", "/dir"));
-	g_assert_true(is_subdir("/dir", "/dir"));
-	// Also without leading slash
-	g_assert_true(is_subdir("dir/subdir", "dir/"));
-	g_assert_true(is_subdir("dir/subdir", "dir"));
-	g_assert_true(is_subdir("dir/", "dir"));
-	g_assert_true(is_subdir("dir", "dir"));
-	// Some more ideas
-	g_assert_true(is_subdir("//", "/"));
-	g_assert_true(is_subdir("/", "/"));
-	g_assert_true(is_subdir("", ""));
-	// but this is not true
-	g_assert_false(is_subdir("/", "/dir"));
-	g_assert_false(is_subdir("/rid", "/dir"));
-	g_assert_false(is_subdir("/different/dir", "/dir"));
-	g_assert_false(is_subdir("/", ""));
+static void test_is_subdir(void) {
+    // Sensible exaples are sensible
+    g_assert_true(is_subdir("/dir/subdir", "/dir/"));
+    g_assert_true(is_subdir("/dir/subdir", "/dir"));
+    g_assert_true(is_subdir("/dir/", "/dir"));
+    g_assert_true(is_subdir("/dir", "/dir"));
+    // Also without leading slash
+    g_assert_true(is_subdir("dir/subdir", "dir/"));
+    g_assert_true(is_subdir("dir/subdir", "dir"));
+    g_assert_true(is_subdir("dir/", "dir"));
+    g_assert_true(is_subdir("dir", "dir"));
+    // Some more ideas
+    g_assert_true(is_subdir("//", "/"));
+    g_assert_true(is_subdir("/", "/"));
+    g_assert_true(is_subdir("", ""));
+    // but this is not true
+    g_assert_false(is_subdir("/", "/dir"));
+    g_assert_false(is_subdir("/rid", "/dir"));
+    g_assert_false(is_subdir("/different/dir", "/dir"));
+    g_assert_false(is_subdir("/", ""));
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/mount/get_nextpath/typical",
-			test_get_nextpath__typical);
-	g_test_add_func("/mount/get_nextpath/weird", test_get_nextpath__weird);
-	g_test_add_func("/mount/is_subdir", test_is_subdir);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/mount/get_nextpath/typical", test_get_nextpath__typical);
+    g_test_add_func("/mount/get_nextpath/weird", test_get_nextpath__weird);
+    g_test_add_func("/mount/is_subdir", test_is_subdir);
 }

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -57,178 +57,162 @@ static void sc_detach_views_of_writable(sc_distro distro, bool normal_mode);
 
 // TODO: simplify this, after all it is just a tmpfs
 // TODO: fold this into bootstrap
-static void setup_private_tmp(const char *snap_instance)
-{
-	// Create a 0700 base directory. This is the "base" directory that is
-	// protected from other users. This directory name is NOT randomly
-	// generated. This has several properties:
-	//
-	// Users can relate to the name and can find the temporary directory as
-	// visible from within the snap. If this directory was random it would be
-	// harder to find because there may be situations in which multiple
-	// directories related to the same snap name would exist.
-	//
-	// Snapd can partially manage the directory. Specifically on snap remove
-	// snapd could remove the directory and everything in it, potentially
-	// avoiding runaway disk use on a machine that either never reboots or uses
-	// persistent /tmp directory.
-	//
-	// Underneath the base directory there is a "tmp" sub-directory that has
-	// mode 1777 and behaves as a typical /tmp directory would. That directory
-	// is used as a bind-mounted /tmp directory.
-	//
-	// Because the directories are reused across invocations by distinct users
-	// and because the directories are trivially guessable, each invocation
-	// unconditionally chowns/chmods them to appropriate values.
-	char base[MAX_BUF] = { 0 };
-	char tmp_dir[MAX_BUF] = { 0 };
-	int private_tmp_root_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	int base_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	int tmp_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
+static void setup_private_tmp(const char *snap_instance) {
+    // Create a 0700 base directory. This is the "base" directory that is
+    // protected from other users. This directory name is NOT randomly
+    // generated. This has several properties:
+    //
+    // Users can relate to the name and can find the temporary directory as
+    // visible from within the snap. If this directory was random it would be
+    // harder to find because there may be situations in which multiple
+    // directories related to the same snap name would exist.
+    //
+    // Snapd can partially manage the directory. Specifically on snap remove
+    // snapd could remove the directory and everything in it, potentially
+    // avoiding runaway disk use on a machine that either never reboots or uses
+    // persistent /tmp directory.
+    //
+    // Underneath the base directory there is a "tmp" sub-directory that has
+    // mode 1777 and behaves as a typical /tmp directory would. That directory
+    // is used as a bind-mounted /tmp directory.
+    //
+    // Because the directories are reused across invocations by distinct users
+    // and because the directories are trivially guessable, each invocation
+    // unconditionally chowns/chmods them to appropriate values.
+    char base[MAX_BUF] = {0};
+    char tmp_dir[MAX_BUF] = {0};
+    int private_tmp_root_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    int base_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    int tmp_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
 
-	/* Switch to root group so that mkdir and open calls below create
-	 * filesystem elements that are not owned by the user calling into
-	 * snap-confine. */
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    /* Switch to root group so that mkdir and open calls below create
+     * filesystem elements that are not owned by the user calling into
+     * snap-confine. */
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
 
-	// /tmp/snap-private-tmp should have already been created by
-	// systemd-tmpfiles but we can try create it anyway since snapd may have
-	// just been installed in which case the tmpfiles conf would not have
-	// got executed yet
-	if (mkdir(SNAP_PRIVATE_TMP_ROOT_DIR, 0700) < 0 && errno != EEXIST) {
-		die("cannot create /tmp/snap-private-tmp");
-	}
-	private_tmp_root_fd = open(SNAP_PRIVATE_TMP_ROOT_DIR,
-				   O_RDONLY | O_DIRECTORY | O_CLOEXEC |
-				   O_NOFOLLOW);
-	if (private_tmp_root_fd < 0) {
-		die("cannot open %s", SNAP_PRIVATE_TMP_ROOT_DIR);
-	}
-	struct stat st;
-	if (fstat(private_tmp_root_fd, &st) < 0) {
-		die("cannot stat %s", SNAP_PRIVATE_TMP_ROOT_DIR);
-	}
-	if (st.st_uid != 0 || st.st_gid != 0 || st.st_mode != (S_IFDIR | 0700)) {
-		die("%s has unexpected ownership / permissions",
-		    SNAP_PRIVATE_TMP_ROOT_DIR);
-	}
-	// Create /tmp/snap-private-tmp/snap.$SNAP_INSTANCE_NAME/ 0700 root:root.
-	sc_must_snprintf(base, sizeof(base), "snap.%s", snap_instance);
-	if (mkdirat(private_tmp_root_fd, base, 0700) < 0 && errno != EEXIST) {
-		die("cannot create base directory: %s", base);
-	}
-	base_dir_fd =
-	    openat(private_tmp_root_fd, base,
-		   O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
-	if (base_dir_fd < 0) {
-		die("cannot open base directory: %s", base);
-	}
-	if (fstat(base_dir_fd, &st) < 0) {
-		die("cannot stat %s/%s", SNAP_PRIVATE_TMP_ROOT_DIR, base);
-	}
-	if (st.st_uid != 0 || st.st_gid != 0 || st.st_mode != (S_IFDIR | 0700)) {
-		die("%s/%s has unexpected ownership / permissions",
-		    SNAP_PRIVATE_TMP_ROOT_DIR, base);
-	}
-	// Create /tmp/$PRIVATE/snap.$SNAP_NAME/tmp 01777 root:root Ignore EEXIST since we
-	// want to reuse and we will open with O_NOFOLLOW, below.
-	if (mkdirat(base_dir_fd, "tmp", 01777) < 0 && errno != EEXIST) {
-		die("cannot create private tmp directory %s/tmp", base);
-	}
-	(void)sc_set_effective_identity(old);
-	tmp_dir_fd = openat(base_dir_fd, "tmp",
-			    O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
-	if (tmp_dir_fd < 0) {
-		die("cannot open private tmp directory %s/tmp", base);
-	}
-	if (fstat(tmp_dir_fd, &st) < 0) {
-		die("cannot stat %s/%s/tmp", SNAP_PRIVATE_TMP_ROOT_DIR, base);
-	}
-	if (st.st_uid != 0 || st.st_gid != 0 || st.st_mode != (S_IFDIR | 01777)) {
-		die("%s/%s/tmp has unexpected ownership / permissions",
-		    SNAP_PRIVATE_TMP_ROOT_DIR, base);
-	}
-	// use the path to the file-descriptor in proc as the source mount point
-	// as this is a symlink itself to the real directory at
-	// /tmp/snap-private-tmp/snap.$SNAP_INSTANCE/tmp but doing it this way
-	// helps avoid any potential race
-	sc_must_snprintf(tmp_dir, sizeof(tmp_dir),
-			 "/proc/self/fd/%d", tmp_dir_fd);
-	sc_do_mount(tmp_dir, "/tmp", NULL, MS_BIND, NULL);
-	sc_do_mount("none", "/tmp", NULL, MS_PRIVATE, NULL);
+    // /tmp/snap-private-tmp should have already been created by
+    // systemd-tmpfiles but we can try create it anyway since snapd may have
+    // just been installed in which case the tmpfiles conf would not have
+    // got executed yet
+    if (mkdir(SNAP_PRIVATE_TMP_ROOT_DIR, 0700) < 0 && errno != EEXIST) {
+        die("cannot create /tmp/snap-private-tmp");
+    }
+    private_tmp_root_fd = open(SNAP_PRIVATE_TMP_ROOT_DIR, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (private_tmp_root_fd < 0) {
+        die("cannot open %s", SNAP_PRIVATE_TMP_ROOT_DIR);
+    }
+    struct stat st;
+    if (fstat(private_tmp_root_fd, &st) < 0) {
+        die("cannot stat %s", SNAP_PRIVATE_TMP_ROOT_DIR);
+    }
+    if (st.st_uid != 0 || st.st_gid != 0 || st.st_mode != (S_IFDIR | 0700)) {
+        die("%s has unexpected ownership / permissions", SNAP_PRIVATE_TMP_ROOT_DIR);
+    }
+    // Create /tmp/snap-private-tmp/snap.$SNAP_INSTANCE_NAME/ 0700 root:root.
+    sc_must_snprintf(base, sizeof(base), "snap.%s", snap_instance);
+    if (mkdirat(private_tmp_root_fd, base, 0700) < 0 && errno != EEXIST) {
+        die("cannot create base directory: %s", base);
+    }
+    base_dir_fd = openat(private_tmp_root_fd, base, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (base_dir_fd < 0) {
+        die("cannot open base directory: %s", base);
+    }
+    if (fstat(base_dir_fd, &st) < 0) {
+        die("cannot stat %s/%s", SNAP_PRIVATE_TMP_ROOT_DIR, base);
+    }
+    if (st.st_uid != 0 || st.st_gid != 0 || st.st_mode != (S_IFDIR | 0700)) {
+        die("%s/%s has unexpected ownership / permissions", SNAP_PRIVATE_TMP_ROOT_DIR, base);
+    }
+    // Create /tmp/$PRIVATE/snap.$SNAP_NAME/tmp 01777 root:root Ignore EEXIST since we
+    // want to reuse and we will open with O_NOFOLLOW, below.
+    if (mkdirat(base_dir_fd, "tmp", 01777) < 0 && errno != EEXIST) {
+        die("cannot create private tmp directory %s/tmp", base);
+    }
+    (void)sc_set_effective_identity(old);
+    tmp_dir_fd = openat(base_dir_fd, "tmp", O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (tmp_dir_fd < 0) {
+        die("cannot open private tmp directory %s/tmp", base);
+    }
+    if (fstat(tmp_dir_fd, &st) < 0) {
+        die("cannot stat %s/%s/tmp", SNAP_PRIVATE_TMP_ROOT_DIR, base);
+    }
+    if (st.st_uid != 0 || st.st_gid != 0 || st.st_mode != (S_IFDIR | 01777)) {
+        die("%s/%s/tmp has unexpected ownership / permissions", SNAP_PRIVATE_TMP_ROOT_DIR, base);
+    }
+    // use the path to the file-descriptor in proc as the source mount point
+    // as this is a symlink itself to the real directory at
+    // /tmp/snap-private-tmp/snap.$SNAP_INSTANCE/tmp but doing it this way
+    // helps avoid any potential race
+    sc_must_snprintf(tmp_dir, sizeof(tmp_dir), "/proc/self/fd/%d", tmp_dir_fd);
+    sc_do_mount(tmp_dir, "/tmp", NULL, MS_BIND, NULL);
+    sc_do_mount("none", "/tmp", NULL, MS_PRIVATE, NULL);
 }
 
 // TODO: fold this into bootstrap
-static void setup_private_pts(void)
-{
-	// See https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
-	//
-	// Ubuntu by default uses devpts 'single-instance' mode where
-	// /dev/pts/ptmx is mounted with ptmxmode=0000. We don't want to change
-	// the startup scripts though, so we follow the instructions in point
-	// '4' of 'User-space changes' in the above doc. In other words, after
-	// unshare(CLONE_NEWNS), we mount devpts with -o
-	// newinstance,ptmxmode=0666 and then bind mount /dev/pts/ptmx onto
-	// /dev/ptmx
+static void setup_private_pts(void) {
+    // See https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+    //
+    // Ubuntu by default uses devpts 'single-instance' mode where
+    // /dev/pts/ptmx is mounted with ptmxmode=0000. We don't want to change
+    // the startup scripts though, so we follow the instructions in point
+    // '4' of 'User-space changes' in the above doc. In other words, after
+    // unshare(CLONE_NEWNS), we mount devpts with -o
+    // newinstance,ptmxmode=0666 and then bind mount /dev/pts/ptmx onto
+    // /dev/ptmx
 
-	struct stat st;
+    struct stat st;
 
-	// Make sure /dev/pts/ptmx exists, otherwise the system doesn't provide the
-	// isolation we require.
-	if (stat("/dev/pts/ptmx", &st) != 0) {
-		die("cannot stat /dev/pts/ptmx");
-	}
-	// Make sure /dev/ptmx exists so we can bind mount over it
-	if (stat("/dev/ptmx", &st) != 0) {
-		die("cannot stat /dev/ptmx");
-	}
-	// Since multi-instance, use ptmxmode=0666. The other options are
-	// copied from /etc/default/devpts
-	sc_do_mount("devpts", "/dev/pts", "devpts", MS_MGC_VAL,
-		    "newinstance,ptmxmode=0666,mode=0620,gid=5");
-	sc_do_mount("/dev/pts/ptmx", "/dev/ptmx", "none", MS_BIND, NULL);
+    // Make sure /dev/pts/ptmx exists, otherwise the system doesn't provide the
+    // isolation we require.
+    if (stat("/dev/pts/ptmx", &st) != 0) {
+        die("cannot stat /dev/pts/ptmx");
+    }
+    // Make sure /dev/ptmx exists so we can bind mount over it
+    if (stat("/dev/ptmx", &st) != 0) {
+        die("cannot stat /dev/ptmx");
+    }
+    // Since multi-instance, use ptmxmode=0666. The other options are
+    // copied from /etc/default/devpts
+    sc_do_mount("devpts", "/dev/pts", "devpts", MS_MGC_VAL, "newinstance,ptmxmode=0666,mode=0620,gid=5");
+    sc_do_mount("/dev/pts/ptmx", "/dev/ptmx", "none", MS_BIND, NULL);
 }
 
 struct sc_mount {
-	const char *path;
-	bool is_bidirectional;
-	// Alternate path defines the rbind mount "alternative" of path.
-	// It exists so that we can make /media on systems that use /run/media.
-	const char *altpath;
-	// Optional mount points are not processed unless the source and
-	// destination both exist.
-	bool is_optional;
+    const char *path;
+    bool is_bidirectional;
+    // Alternate path defines the rbind mount "alternative" of path.
+    // It exists so that we can make /media on systems that use /run/media.
+    const char *altpath;
+    // Optional mount points are not processed unless the source and
+    // destination both exist.
+    bool is_optional;
 };
 
 struct sc_mount_config {
-	const char *rootfs_dir;
-	// The struct is terminated with an entry with NULL path.
-	const struct sc_mount *mounts;
-	// Same as the structure above, but this is malloc-allocated.
-	struct sc_mount *dynamic_mounts;
-	sc_distro distro;
-	bool normal_mode;
-	const char *base_snap_name;
-	const char *snap_instance;
+    const char *rootfs_dir;
+    // The struct is terminated with an entry with NULL path.
+    const struct sc_mount *mounts;
+    // Same as the structure above, but this is malloc-allocated.
+    struct sc_mount *dynamic_mounts;
+    sc_distro distro;
+    bool normal_mode;
+    const char *base_snap_name;
+    const char *snap_instance;
 };
 
 /**
  * Ensures all required mount points have been created
  */
-static void sc_create_mount_points(const char *scratch_dir,
-				   const struct sc_mount *mounts)
-{
-	char dst[PATH_MAX] = { 0 };
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	for (const struct sc_mount * mnt = mounts; mnt && mnt->path != NULL;
-	     mnt++) {
-		sc_must_snprintf(dst, sizeof(dst), "%s/%s", scratch_dir,
-				 mnt->path);
-		if (sc_nonfatal_mkpath(dst, 0755) < 0) {
-			die("cannot create mount point %s", dst);
-		}
-	}
-	(void)sc_set_effective_identity(old);
+static void sc_create_mount_points(const char *scratch_dir, const struct sc_mount *mounts) {
+    char dst[PATH_MAX] = {0};
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    for (const struct sc_mount *mnt = mounts; mnt && mnt->path != NULL; mnt++) {
+        sc_must_snprintf(dst, sizeof(dst), "%s/%s", scratch_dir, mnt->path);
+        if (sc_nonfatal_mkpath(dst, 0755) < 0) {
+            die("cannot create mount point %s", dst);
+        }
+    }
+    (void)sc_set_effective_identity(old);
 }
 
 /**
@@ -243,63 +227,55 @@ static void sc_create_mount_points(const char *scratch_dir,
  * - All the target directories must exist
  * - All the source directories must exist, unless the mount is bi-directional
  */
-static void sc_do_mounts(const char *scratch_dir, const struct sc_mount *mounts)
-{
-	char dst[PATH_MAX] = { 0 };
-	// Bind mount certain directories from the host filesystem to the scratch
-	// directory. By default mount events will propagate in both into and out
-	// of the peer group. This way the running application can alter any global
-	// state visible on the host and in other snaps. This can be restricted by
-	// disabling the "is_bidirectional" flag as can be seen below.
-	for (const struct sc_mount * mnt = mounts; mnt && mnt->path != NULL;
-	     mnt++) {
-
-		if (mnt->is_bidirectional) {
-			sc_identity old =
-			    sc_set_effective_identity(sc_root_group_identity());
-			if (mkdir(mnt->path, 0755) < 0 && errno != EEXIST) {
-				die("cannot create %s", mnt->path);
-			}
-			(void)sc_set_effective_identity(old);
-		}
-		sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir,
-				 mnt->path);
-		if (mnt->is_optional) {
-			bool ok = sc_do_optional_mount(mnt->path, dst, NULL,
-						       MS_REC | MS_BIND, NULL);
-			if (!ok) {
-				// If we cannot mount it, just continue.
-				continue;
-			}
-		} else {
-			sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND,
-				    NULL);
-		}
-		if (!mnt->is_bidirectional) {
-			// Mount events will only propagate inwards to the namespace. This
-			// way the running application cannot alter any global state apart
-			// from that of its own snap.
-			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
-		}
-		if (mnt->altpath == NULL) {
-			continue;
-		}
-		// An alternate path of mnt->path is provided at another location.
-		// It should behave exactly the same as the original.
-		sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir,
-				 mnt->altpath);
-		struct stat stat_buf;
-		if (lstat(dst, &stat_buf) < 0) {
-			die("cannot lstat %s", dst);
-		}
-		if ((stat_buf.st_mode & S_IFMT) == S_IFLNK) {
-			die("cannot bind mount alternate path over a symlink: %s", dst);
-		}
-		sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
-		if (!mnt->is_bidirectional) {
-			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
-		}
-	}
+static void sc_do_mounts(const char *scratch_dir, const struct sc_mount *mounts) {
+    char dst[PATH_MAX] = {0};
+    // Bind mount certain directories from the host filesystem to the scratch
+    // directory. By default mount events will propagate in both into and out
+    // of the peer group. This way the running application can alter any global
+    // state visible on the host and in other snaps. This can be restricted by
+    // disabling the "is_bidirectional" flag as can be seen below.
+    for (const struct sc_mount *mnt = mounts; mnt && mnt->path != NULL; mnt++) {
+        if (mnt->is_bidirectional) {
+            sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+            if (mkdir(mnt->path, 0755) < 0 && errno != EEXIST) {
+                die("cannot create %s", mnt->path);
+            }
+            (void)sc_set_effective_identity(old);
+        }
+        sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir, mnt->path);
+        if (mnt->is_optional) {
+            bool ok = sc_do_optional_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
+            if (!ok) {
+                // If we cannot mount it, just continue.
+                continue;
+            }
+        } else {
+            sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
+        }
+        if (!mnt->is_bidirectional) {
+            // Mount events will only propagate inwards to the namespace. This
+            // way the running application cannot alter any global state apart
+            // from that of its own snap.
+            sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
+        }
+        if (mnt->altpath == NULL) {
+            continue;
+        }
+        // An alternate path of mnt->path is provided at another location.
+        // It should behave exactly the same as the original.
+        sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir, mnt->altpath);
+        struct stat stat_buf;
+        if (lstat(dst, &stat_buf) < 0) {
+            die("cannot lstat %s", dst);
+        }
+        if ((stat_buf.st_mode & S_IFMT) == S_IFLNK) {
+            die("cannot bind mount alternate path over a symlink: %s", dst);
+        }
+        sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
+        if (!mnt->is_bidirectional) {
+            sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
+        }
+    }
 }
 
 /**
@@ -309,37 +285,34 @@ static void sc_do_mounts(const char *scratch_dir, const struct sc_mount *mounts)
  * tmpfs), so that snap-update-ns will know about it and won't try to unmount
  * it.
  */
-static void sc_initialize_ns_fstab(const char *snap_instance_name)
-{
-	FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
-	char info_path[PATH_MAX] = { 0 };
-	sc_must_snprintf(info_path, sizeof info_path,
-			 "/run/snapd/ns/snap.%s.fstab", snap_instance_name);
-	int fd = -1;
-	fd = open(info_path,
-		  O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0644);
-	if (fd < 0) {
-		die("cannot open %s", info_path);
-	}
-	if (fchown(fd, 0, 0) < 0) {
-		die("cannot chown %s to root:root", info_path);
-	}
-	// The stream now owns the file descriptor.
-	stream = fdopen(fd, "w");
-	if (stream == NULL) {
-		die("cannot get stream from file descriptor");
-	}
-	// We need to store an entry for the root directory, so that snap-update-ns
-	// will know that it's a tmpfs created by us. It's not going to remount it,
-	// so there's no need to be precise with the mount flags.
-	fprintf(stream, "tmpfs / tmpfs x-snapd.origin=rootfs 0 0\n");
-	if (ferror(stream) != 0) {
-		die("I/O error when writing to %s", info_path);
-	}
-	if (fflush(stream) == EOF) {
-		die("cannot flush %s", info_path);
-	}
-	debug("saved rootfs fstab entry to %s", info_path);
+static void sc_initialize_ns_fstab(const char *snap_instance_name) {
+    FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
+    char info_path[PATH_MAX] = {0};
+    sc_must_snprintf(info_path, sizeof info_path, "/run/snapd/ns/snap.%s.fstab", snap_instance_name);
+    int fd = -1;
+    fd = open(info_path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0644);
+    if (fd < 0) {
+        die("cannot open %s", info_path);
+    }
+    if (fchown(fd, 0, 0) < 0) {
+        die("cannot chown %s to root:root", info_path);
+    }
+    // The stream now owns the file descriptor.
+    stream = fdopen(fd, "w");
+    if (stream == NULL) {
+        die("cannot get stream from file descriptor");
+    }
+    // We need to store an entry for the root directory, so that snap-update-ns
+    // will know that it's a tmpfs created by us. It's not going to remount it,
+    // so there's no need to be precise with the mount flags.
+    fprintf(stream, "tmpfs / tmpfs x-snapd.origin=rootfs 0 0\n");
+    if (ferror(stream) != 0) {
+        die("I/O error when writing to %s", info_path);
+    }
+    if (fflush(stream) == EOF) {
+        die("cannot flush %s", info_path);
+    }
+    debug("saved rootfs fstab entry to %s", info_path);
 }
 
 /**
@@ -353,129 +326,113 @@ static void sc_initialize_ns_fstab(const char *snap_instance_name)
  * later directly from the "/" directory of the system, so this function will
  * not touch them.
  */
-static void sc_replicate_base_rootfs(const char *scratch_dir,
-				     const char *rootfs_dir,
-				     const struct sc_mount *root_mounts)
-{
-	// First of all, fix the root filesystem:
-	// - remove write permissions for group and others
-	// - set the owner to root:root
-	if (chmod(scratch_dir, 0755) < 0) {
-		die("cannot change permissions on \"%s\"", scratch_dir);
-	}
-	if (chown(scratch_dir, 0, 0) < 0) {
-		die("cannot change ownership on \"%s\"", scratch_dir);
-	}
+static void sc_replicate_base_rootfs(const char *scratch_dir, const char *rootfs_dir,
+                                     const struct sc_mount *root_mounts) {
+    // First of all, fix the root filesystem:
+    // - remove write permissions for group and others
+    // - set the owner to root:root
+    if (chmod(scratch_dir, 0755) < 0) {
+        die("cannot change permissions on \"%s\"", scratch_dir);
+    }
+    if (chown(scratch_dir, 0, 0) < 0) {
+        die("cannot change ownership on \"%s\"", scratch_dir);
+    }
 
-	int rootfs_fd = -1;
-	// Note that the rootfs here is a path like /snap/<snap>/current, which is
-	// always a symbolic link. Therefore, we cannot use O_NOFOLLOW here.
-	rootfs_fd = open(rootfs_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-	if (rootfs_fd < 0) {
-		die("cannot open directory \"%s\"", rootfs_dir);
-	}
-	// rootfs_fd is now managed by fdopendir() and should not be used after
-	DIR *rootfs SC_CLEANUP(sc_cleanup_closedir) = fdopendir(rootfs_fd);
-	if (rootfs == NULL) {
-		die("cannot open directory \"%s\" from file descriptor",
-		    rootfs_dir);
-	}
-	// Will create folders/links as 0:0
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    int rootfs_fd = -1;
+    // Note that the rootfs here is a path like /snap/<snap>/current, which is
+    // always a symbolic link. Therefore, we cannot use O_NOFOLLOW here.
+    rootfs_fd = open(rootfs_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (rootfs_fd < 0) {
+        die("cannot open directory \"%s\"", rootfs_dir);
+    }
+    // rootfs_fd is now managed by fdopendir() and should not be used after
+    DIR *rootfs SC_CLEANUP(sc_cleanup_closedir) = fdopendir(rootfs_fd);
+    if (rootfs == NULL) {
+        die("cannot open directory \"%s\" from file descriptor", rootfs_dir);
+    }
+    // Will create folders/links as 0:0
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
 
-	char full_path[PATH_MAX];
-	// After we construct each entry's full path, we'll need to obtain the
-	// entry's absolute path in the new rootfs, that is with the `scratch_dir`
-	// prefix removed (the path_in_rootfs variable below). We'll do this by
-	// computing the length of the `scratch_dir` prefix now and then using it
-	// as the offset in `full_path` where the '/' of the confined silesystem is
-	// located.
-	const size_t scratch_dir_length = strlen(scratch_dir);
+    char full_path[PATH_MAX];
+    // After we construct each entry's full path, we'll need to obtain the
+    // entry's absolute path in the new rootfs, that is with the `scratch_dir`
+    // prefix removed (the path_in_rootfs variable below). We'll do this by
+    // computing the length of the `scratch_dir` prefix now and then using it
+    // as the offset in `full_path` where the '/' of the confined silesystem is
+    // located.
+    const size_t scratch_dir_length = strlen(scratch_dir);
 
-	while (true) {
-		errno = 0;
-		struct dirent *ent = readdir(rootfs);
-		if (ent == NULL)
-			break;
+    while (true) {
+        errno = 0;
+        struct dirent *ent = readdir(rootfs);
+        if (ent == NULL) break;
 
-		if (sc_streq(ent->d_name, ".") || sc_streq(ent->d_name, "..")) {
-			continue;
-		}
+        if (sc_streq(ent->d_name, ".") || sc_streq(ent->d_name, "..")) {
+            continue;
+        }
 
-		sc_must_snprintf(full_path, sizeof(full_path), "%s/%s",
-				 scratch_dir, ent->d_name);
-		if (ent->d_type == DT_DIR) {
-			if (mkdir(full_path, 0755) < 0) {
-				die("cannot create directory \"%s\"",
-				    full_path);
-			}
-			// If the directory is listed in root_mounts skip it,
-			// as it will be created and mounted in
-			// sc_bootstrap_mount_namespace() later.
-			bool skip_dir = false;
-			const char *path_in_rootfs =
-			    full_path + scratch_dir_length;
-			for (const struct sc_mount * mnt = root_mounts;
-			     mnt->path != NULL; mnt++) {
-				if (sc_streq(path_in_rootfs, mnt->path)
-				    || sc_streq(path_in_rootfs, mnt->altpath)) {
-					skip_dir = true;
-					break;
-				}
-			}
-			if (skip_dir) {
-				continue;
-			}
-			// Also skip the /snap directory, as we'll mount it later
-			if (sc_streq(path_in_rootfs, "/snap")) {
-				continue;
-			}
+        sc_must_snprintf(full_path, sizeof(full_path), "%s/%s", scratch_dir, ent->d_name);
+        if (ent->d_type == DT_DIR) {
+            if (mkdir(full_path, 0755) < 0) {
+                die("cannot create directory \"%s\"", full_path);
+            }
+            // If the directory is listed in root_mounts skip it,
+            // as it will be created and mounted in
+            // sc_bootstrap_mount_namespace() later.
+            bool skip_dir = false;
+            const char *path_in_rootfs = full_path + scratch_dir_length;
+            for (const struct sc_mount *mnt = root_mounts; mnt->path != NULL; mnt++) {
+                if (sc_streq(path_in_rootfs, mnt->path) || sc_streq(path_in_rootfs, mnt->altpath)) {
+                    skip_dir = true;
+                    break;
+                }
+            }
+            if (skip_dir) {
+                continue;
+            }
+            // Also skip the /snap directory, as we'll mount it later
+            if (sc_streq(path_in_rootfs, "/snap")) {
+                continue;
+            }
 
-			char src_path[PATH_MAX];
-			sc_must_snprintf(src_path, sizeof(src_path), "%s/%s",
-					 rootfs_dir, ent->d_name);
-			sc_do_mount(src_path, full_path, NULL, MS_REC | MS_BIND,
-				    NULL);
-		} else if (ent->d_type == DT_LNK) {
-			char link_target[PATH_MAX + 1];
-			ssize_t len = readlinkat(rootfs_fd, ent->d_name,
-						 link_target,
-						 sizeof(link_target) - 1);
-			if (len < 0) {
-				die("cannot read symbolic link \"%s/%s\"",
-				    rootfs_dir, ent->d_name);
-			}
-			// make sure the string is null terminated
-			link_target[len] = '\0';
+            char src_path[PATH_MAX];
+            sc_must_snprintf(src_path, sizeof(src_path), "%s/%s", rootfs_dir, ent->d_name);
+            sc_do_mount(src_path, full_path, NULL, MS_REC | MS_BIND, NULL);
+        } else if (ent->d_type == DT_LNK) {
+            char link_target[PATH_MAX + 1];
+            ssize_t len = readlinkat(rootfs_fd, ent->d_name, link_target, sizeof(link_target) - 1);
+            if (len < 0) {
+                die("cannot read symbolic link \"%s/%s\"", rootfs_dir, ent->d_name);
+            }
+            // make sure the string is null terminated
+            link_target[len] = '\0';
 
-			// Both relative and absolute links will work out of the box, since
-			// we are going to do a pivot_root to scratch_dir.
-			if (symlink(link_target, full_path) < 0) {
-				die("cannot create symbolic link \"%s\"",
-				    full_path);
-			}
-		} else if (ent->d_type == DT_REG) {
-			// Create an empty file which can be used as a mount point
-			int fd = open(full_path, O_CREAT | O_TRUNC, 0644);
-			if (fd < 0) {
-				die("cannot create mount point for file \"%s\"",
-				    full_path);
-			}
-			close(fd);
-			char src_path[PATH_MAX];
-			sc_must_snprintf(src_path, sizeof(src_path), "%s/%s",
-					 rootfs_dir, ent->d_name);
-			sc_do_mount(src_path, full_path, NULL, MS_BIND, NULL);
-		} else {
-			die("unexpected directory entry \"%s\" of type %i encountered in \"%s\"", ent->d_name, ent->d_type, rootfs_dir);
-		}
-	}
+            // Both relative and absolute links will work out of the box, since
+            // we are going to do a pivot_root to scratch_dir.
+            if (symlink(link_target, full_path) < 0) {
+                die("cannot create symbolic link \"%s\"", full_path);
+            }
+        } else if (ent->d_type == DT_REG) {
+            // Create an empty file which can be used as a mount point
+            int fd = open(full_path, O_CREAT | O_TRUNC, 0644);
+            if (fd < 0) {
+                die("cannot create mount point for file \"%s\"", full_path);
+            }
+            close(fd);
+            char src_path[PATH_MAX];
+            sc_must_snprintf(src_path, sizeof(src_path), "%s/%s", rootfs_dir, ent->d_name);
+            sc_do_mount(src_path, full_path, NULL, MS_BIND, NULL);
+        } else {
+            die("unexpected directory entry \"%s\" of type %i encountered in \"%s\"", ent->d_name, ent->d_type,
+                rootfs_dir);
+        }
+    }
 
-	if (errno != 0) {
-		die("cannot read directory entry in \"%s\"", rootfs_dir);
-	}
+    if (errno != 0) {
+        die("cannot read directory entry in \"%s\"", rootfs_dir);
+    }
 
-	(void)sc_set_effective_identity(old);
+    (void)sc_set_effective_identity(old);
 }
 
 /**
@@ -513,351 +470,322 @@ static void sc_replicate_base_rootfs(const char *scratch_dir,
  * the system (both the main mount namespace and namespaces of individual
  * snaps) or remove them, through the unmount system call.
  **/
-static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
-{
-	char scratch_dir[] = "/tmp/snap.rootfs_XXXXXX";
-	char src[PATH_MAX] = { 0 };
-	char dst[PATH_MAX] = { 0 };
-	if (mkdtemp(scratch_dir) == NULL) {
-		die("cannot create temporary directory for the root file system");
-	}
-	// NOTE: at this stage we just called unshare(CLONE_NEWNS). We are in a new
-	// mount namespace and have a private list of mounts.
-	debug("scratch directory for constructing namespace: %s", scratch_dir);
-	// Make the root filesystem recursively shared. This way propagation events
-	// will be shared with main mount namespace.
-	sc_do_mount("none", "/", NULL, MS_REC | MS_SHARED, NULL);
-	// Bind mount the temporary scratch directory for root filesystem over
-	// itself so that it is a mount point. This is done so that it can become
-	// unbindable as explained below.
-	sc_do_mount(scratch_dir, scratch_dir, NULL, MS_BIND, NULL);
-	// Make the scratch directory unbindable.
-	//
-	// This is necessary as otherwise a mount loop can occur and the kernel
-	// would crash. The term unbindable simply states that it cannot be bind
-	// mounted anywhere. When we construct recursive bind mounts below this
-	// guarantees that this directory will not be replicated anywhere.
-	sc_do_mount("none", scratch_dir, NULL, MS_UNBINDABLE, NULL);
-	if (config->normal_mode) {
-		sc_initialize_ns_fstab(config->snap_instance);
-		// Create a tmpfs on scratch_dir; we'll them mount all the root
-		// directories of the base snap onto it.
-		sc_do_mount("none", scratch_dir, "tmpfs", 0, "uid=0,gid=0");
-		sc_replicate_base_rootfs(scratch_dir, config->rootfs_dir,
-					 config->mounts);
-	} else {
-		// Recursively bind mount desired root filesystem directory over the
-		// scratch directory. This puts the initial content into the scratch
-		// space and serves as a foundation for all subsequent operations
-		// below.
-		//
-		// The mount is recursive because we need to accurately replicate the
-		// state of the root filesystem into the scratch directory.
-		sc_do_mount(config->rootfs_dir, scratch_dir, NULL,
-			    MS_REC | MS_BIND, NULL);
-	}
-	// Make the scratch directory recursively slave. Nothing done there will be
-	// shared with the initial mount namespace. This effectively detaches us,
-	// in one way, from the original namespace and coupled with pivot_root
-	// below serves as the foundation of the mount sandbox.
-	sc_do_mount("none", scratch_dir, NULL, MS_REC | MS_SLAVE, NULL);
-	sc_do_mounts(scratch_dir, config->mounts);
+static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config) {
+    char scratch_dir[] = "/tmp/snap.rootfs_XXXXXX";
+    char src[PATH_MAX] = {0};
+    char dst[PATH_MAX] = {0};
+    if (mkdtemp(scratch_dir) == NULL) {
+        die("cannot create temporary directory for the root file system");
+    }
+    // NOTE: at this stage we just called unshare(CLONE_NEWNS). We are in a new
+    // mount namespace and have a private list of mounts.
+    debug("scratch directory for constructing namespace: %s", scratch_dir);
+    // Make the root filesystem recursively shared. This way propagation events
+    // will be shared with main mount namespace.
+    sc_do_mount("none", "/", NULL, MS_REC | MS_SHARED, NULL);
+    // Bind mount the temporary scratch directory for root filesystem over
+    // itself so that it is a mount point. This is done so that it can become
+    // unbindable as explained below.
+    sc_do_mount(scratch_dir, scratch_dir, NULL, MS_BIND, NULL);
+    // Make the scratch directory unbindable.
+    //
+    // This is necessary as otherwise a mount loop can occur and the kernel
+    // would crash. The term unbindable simply states that it cannot be bind
+    // mounted anywhere. When we construct recursive bind mounts below this
+    // guarantees that this directory will not be replicated anywhere.
+    sc_do_mount("none", scratch_dir, NULL, MS_UNBINDABLE, NULL);
+    if (config->normal_mode) {
+        sc_initialize_ns_fstab(config->snap_instance);
+        // Create a tmpfs on scratch_dir; we'll them mount all the root
+        // directories of the base snap onto it.
+        sc_do_mount("none", scratch_dir, "tmpfs", 0, "uid=0,gid=0");
+        sc_replicate_base_rootfs(scratch_dir, config->rootfs_dir, config->mounts);
+    } else {
+        // Recursively bind mount desired root filesystem directory over the
+        // scratch directory. This puts the initial content into the scratch
+        // space and serves as a foundation for all subsequent operations
+        // below.
+        //
+        // The mount is recursive because we need to accurately replicate the
+        // state of the root filesystem into the scratch directory.
+        sc_do_mount(config->rootfs_dir, scratch_dir, NULL, MS_REC | MS_BIND, NULL);
+    }
+    // Make the scratch directory recursively slave. Nothing done there will be
+    // shared with the initial mount namespace. This effectively detaches us,
+    // in one way, from the original namespace and coupled with pivot_root
+    // below serves as the foundation of the mount sandbox.
+    sc_do_mount("none", scratch_dir, NULL, MS_REC | MS_SLAVE, NULL);
+    sc_do_mounts(scratch_dir, config->mounts);
 
-	// Dynamic mounts handle things like user-specified home directories. These
-	// can change between runs, so they are stored separately. As we don't know
-	// these in advance, make sure paths also exist in the scratch dir.
-	sc_create_mount_points(scratch_dir, config->dynamic_mounts);
-	sc_do_mounts(scratch_dir, config->dynamic_mounts);
+    // Dynamic mounts handle things like user-specified home directories. These
+    // can change between runs, so they are stored separately. As we don't know
+    // these in advance, make sure paths also exist in the scratch dir.
+    sc_create_mount_points(scratch_dir, config->dynamic_mounts);
+    sc_do_mounts(scratch_dir, config->dynamic_mounts);
 
-	if (config->normal_mode) {
-		// Since we mounted /etc from the host filesystem to the scratch directory,
-		// we may need to put certain directories from the desired root filesystem
-		// (e.g. the core snap) back. This way the behavior of running snaps is not
-		// affected by the alternatives directory from the host, if one exists.
-		//
-		// Fixes the following bugs:
-		//  - https://bugs.launchpad.net/snap-confine/+bug/1580018
-		//  - https://bugzilla.opensuse.org/show_bug.cgi?id=1028568
-		static const char *dirs_from_core[] = {
-			"/etc/alternatives", "/etc/nsswitch.conf",
-			// Some specific and privileged interfaces (e.g docker-support) give
-			// access to apparmor_parser from the base snap which at a minimum
-			// needs to use matching configuration from the base snap instead
-			// of from the users host system.
-			"/etc/apparmor", "/etc/apparmor.d",
-			// Use ssl certs from the base by default unless
-			// using Debian/Ubuntu classic (see below)
-			"/etc/ssl",
-			NULL
-		};
+    if (config->normal_mode) {
+        // Since we mounted /etc from the host filesystem to the scratch directory,
+        // we may need to put certain directories from the desired root filesystem
+        // (e.g. the core snap) back. This way the behavior of running snaps is not
+        // affected by the alternatives directory from the host, if one exists.
+        //
+        // Fixes the following bugs:
+        //  - https://bugs.launchpad.net/snap-confine/+bug/1580018
+        //  - https://bugzilla.opensuse.org/show_bug.cgi?id=1028568
+        static const char *dirs_from_core[] = {"/etc/alternatives", "/etc/nsswitch.conf",
+                                               // Some specific and privileged interfaces (e.g docker-support) give
+                                               // access to apparmor_parser from the base snap which at a minimum
+                                               // needs to use matching configuration from the base snap instead
+                                               // of from the users host system.
+                                               "/etc/apparmor", "/etc/apparmor.d",
+                                               // Use ssl certs from the base by default unless
+                                               // using Debian/Ubuntu classic (see below)
+                                               "/etc/ssl", NULL};
 
-		for (const char **dirs = dirs_from_core; *dirs != NULL; dirs++) {
-			const char *dir = *dirs;
+        for (const char **dirs = dirs_from_core; *dirs != NULL; dirs++) {
+            const char *dir = *dirs;
 
-			// Special case for ubuntu/debian based
-			// classic distros that use the core* snap:
-			// here we use the host /etc/ssl
-			// to support custom ca-cert setups
-			if (sc_streq(dir, "/etc/ssl") &&
-			    config->distro == SC_DISTRO_CLASSIC &&
-			    sc_is_debian_like() &&
-			    sc_startswith(config->base_snap_name, "core")) {
-				continue;
-			}
+            // Special case for ubuntu/debian based
+            // classic distros that use the core* snap:
+            // here we use the host /etc/ssl
+            // to support custom ca-cert setups
+            if (sc_streq(dir, "/etc/ssl") && config->distro == SC_DISTRO_CLASSIC && sc_is_debian_like() &&
+                sc_startswith(config->base_snap_name, "core")) {
+                continue;
+            }
 
-			if (access(dir, F_OK) != 0) {
-				continue;
-			}
-			struct stat dst_stat;
-			struct stat src_stat;
-			sc_must_snprintf(src, sizeof src, "%s%s",
-					 config->rootfs_dir, dir);
-			sc_must_snprintf(dst, sizeof dst, "%s%s",
-					 scratch_dir, dir);
-			if (lstat(src, &src_stat) != 0) {
-				if (errno == ENOENT) {
-					continue;
-				}
-				die("cannot stat %s from desired rootfs", src);
-			}
-			if (!S_ISREG(src_stat.st_mode)
-			    && !S_ISDIR(src_stat.st_mode)) {
-				debug
-				    ("entry %s from the desired rootfs is not a file or directory, skipping mount",
-				     src);
-				continue;
-			}
+            if (access(dir, F_OK) != 0) {
+                continue;
+            }
+            struct stat dst_stat;
+            struct stat src_stat;
+            sc_must_snprintf(src, sizeof src, "%s%s", config->rootfs_dir, dir);
+            sc_must_snprintf(dst, sizeof dst, "%s%s", scratch_dir, dir);
+            if (lstat(src, &src_stat) != 0) {
+                if (errno == ENOENT) {
+                    continue;
+                }
+                die("cannot stat %s from desired rootfs", src);
+            }
+            if (!S_ISREG(src_stat.st_mode) && !S_ISDIR(src_stat.st_mode)) {
+                debug("entry %s from the desired rootfs is not a file or directory, skipping mount", src);
+                continue;
+            }
 
-			if (lstat(dst, &dst_stat) != 0) {
-				if (errno == ENOENT) {
-					continue;
-				}
-				die("cannot stat %s from host", src);
-			}
-			if (!S_ISREG(dst_stat.st_mode)
-			    && !S_ISDIR(dst_stat.st_mode)) {
-				debug
-				    ("entry %s from the host is not a file or directory, skipping mount",
-				     src);
-				continue;
-			}
+            if (lstat(dst, &dst_stat) != 0) {
+                if (errno == ENOENT) {
+                    continue;
+                }
+                die("cannot stat %s from host", src);
+            }
+            if (!S_ISREG(dst_stat.st_mode) && !S_ISDIR(dst_stat.st_mode)) {
+                debug("entry %s from the host is not a file or directory, skipping mount", src);
+                continue;
+            }
 
-			if ((dst_stat.st_mode & S_IFMT) !=
-			    (src_stat.st_mode & S_IFMT)) {
-				debug
-				    ("entries %s and %s are of different types, skipping mount",
-				     dst, src);
-				continue;
-			}
-			// both source and destination exist where both are either files
-			// or both are directories
-			sc_do_mount(src, dst, NULL, MS_BIND, NULL);
-			sc_do_mount("none", dst, NULL, MS_SLAVE, NULL);
-		}
-	}
-	// The "core" base snap is special as it contains snapd and friends.
-	// Other base snaps do not, so whenever a base snap other than core is
-	// in use we need extra provisions for setting up internal tooling to
-	// be available.
-	//
-	// However on a core18 (and similar) system the core snap is not
-	// a special base anymore and we should map our own tooling in.
-	if (config->distro == SC_DISTRO_CORE_OTHER
-	    || !sc_streq(config->base_snap_name, "core")) {
-		// when bases are used we need to bind-mount the libexecdir
-		// (that contains snap-exec) into /usr/lib/snapd of the
-		// base snap so that snap-exec is available for the snaps
-		// (base snaps do not ship snapd)
+            if ((dst_stat.st_mode & S_IFMT) != (src_stat.st_mode & S_IFMT)) {
+                debug("entries %s and %s are of different types, skipping mount", dst, src);
+                continue;
+            }
+            // both source and destination exist where both are either files
+            // or both are directories
+            sc_do_mount(src, dst, NULL, MS_BIND, NULL);
+            sc_do_mount("none", dst, NULL, MS_SLAVE, NULL);
+        }
+    }
+    // The "core" base snap is special as it contains snapd and friends.
+    // Other base snaps do not, so whenever a base snap other than core is
+    // in use we need extra provisions for setting up internal tooling to
+    // be available.
+    //
+    // However on a core18 (and similar) system the core snap is not
+    // a special base anymore and we should map our own tooling in.
+    if (config->distro == SC_DISTRO_CORE_OTHER || !sc_streq(config->base_snap_name, "core")) {
+        // when bases are used we need to bind-mount the libexecdir
+        // (that contains snap-exec) into /usr/lib/snapd of the
+        // base snap so that snap-exec is available for the snaps
+        // (base snaps do not ship snapd)
 
-		// dst is always /usr/lib/snapd as this is where snapd
-		// assumes to find snap-exec
-		sc_must_snprintf(dst, sizeof dst, "%s/usr/lib/snapd",
-				 scratch_dir);
+        // dst is always /usr/lib/snapd as this is where snapd
+        // assumes to find snap-exec
+        sc_must_snprintf(dst, sizeof dst, "%s/usr/lib/snapd", scratch_dir);
 
-		// bind mount the current $ROOT/usr/lib/snapd path,
-		// where $ROOT is either "/" or the "/snap/{core,snapd}/current"
-		// that we are re-execing from
-		char *src = NULL;
-		char self[PATH_MAX + 1] = { 0 };
-		ssize_t nread;
-		nread = readlink("/proc/self/exe", self, sizeof self - 1);
-		if (nread < 0) {
-			die("cannot read /proc/self/exe");
-		}
-		// Though we initialized self to NULs and passed one less to
-		// readlink, therefore guaranteeing that self is
-		// zero-terminated, perform an explicit assignment to make
-		// Coverity happy.
-		self[nread] = '\0';
-		// this cannot happen except when the kernel is buggy
-		if (strstr(self, "/snap-confine") == NULL) {
-			die("cannot use result from readlink: %s", self);
-		}
-		src = dirname(self);
-		// dirname(path) might return '.' depending on path.
-		// /proc/self/exe should always point
-		// to an absolute path, but let's guarantee that.
-		if (src[0] != '/') {
-			die("cannot use the result of dirname(): %s", src);
-		}
+        // bind mount the current $ROOT/usr/lib/snapd path,
+        // where $ROOT is either "/" or the "/snap/{core,snapd}/current"
+        // that we are re-execing from
+        char *src = NULL;
+        char self[PATH_MAX + 1] = {0};
+        ssize_t nread;
+        nread = readlink("/proc/self/exe", self, sizeof self - 1);
+        if (nread < 0) {
+            die("cannot read /proc/self/exe");
+        }
+        // Though we initialized self to NULs and passed one less to
+        // readlink, therefore guaranteeing that self is
+        // zero-terminated, perform an explicit assignment to make
+        // Coverity happy.
+        self[nread] = '\0';
+        // this cannot happen except when the kernel is buggy
+        if (strstr(self, "/snap-confine") == NULL) {
+            die("cannot use result from readlink: %s", self);
+        }
+        src = dirname(self);
+        // dirname(path) might return '.' depending on path.
+        // /proc/self/exe should always point
+        // to an absolute path, but let's guarantee that.
+        if (src[0] != '/') {
+            die("cannot use the result of dirname(): %s", src);
+        }
 
-		sc_do_mount(src, dst, NULL, MS_BIND | MS_RDONLY, NULL);
-		sc_do_mount("none", dst, NULL, MS_SLAVE, NULL);
-	}
-	// Bind mount the directory where all snaps are mounted. The location of
-	// the this directory on the host filesystem may not match the location in
-	// the desired root filesystem. In the "core" and "ubuntu-core" snaps the
-	// directory is always /snap. On the host it is a build-time configuration
-	// option stored in SNAP_MOUNT_DIR. In legacy mode (or in other words, not
-	// in normal mode), we don't need to do this because /snap is fixed and
-	// already contains the correct view of the mounted snaps.
-	if (config->normal_mode) {
-		sc_must_snprintf(dst, sizeof dst, "%s/snap", scratch_dir);
-		sc_do_mount(sc_snap_mount_dir(NULL), dst, NULL,
-			    MS_BIND | MS_REC, NULL);
-		sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
-	}
-	// Ensure that hostfs exists and is group-owned by root. We may have (now
-	// or earlier) created the directory as the user who first ran a snap on a
-	// given system and the group identity of that user is visible on disk.
-	// This was LP:#1665004. We do this by trying to create the hostfs directory
-	// if one is missing. This directory is a part of packaging now so perhaps
-	// this code can be removed later. Note: we use 0000 as permissions here, to
-	// avoid the risk that the user manages to fiddle with the newly created
-	// directory before we have the chance to chown it to root:root. We are
-	// setting the usual 0755 permissions just after the chown below.
-	if (mkdir(SC_HOSTFS_DIR, 0000) < 0) {
-		if (errno == EEXIST) {
-			// The directory exists, verify its ownership.
-			struct stat sb;
-			if (stat(SC_HOSTFS_DIR, &sb) < 0) {
-				die("cannot stat %s", SC_HOSTFS_DIR);
-			} else if (sb.st_uid != 0 || sb.st_gid != 0) {
-				die("%s is not owned by root", SC_HOSTFS_DIR);
-			}
-		} else {
-			die("cannot perform operation: mkdir %s",
-			    SC_HOSTFS_DIR);
-		}
-	} else {
-		if (chown(SC_HOSTFS_DIR, 0, 0) < 0) {
-			die("cannot set root ownership on %s directory",
-			    SC_HOSTFS_DIR);
-		}
-		if (chmod(SC_HOSTFS_DIR, 0755) < 0) {
-			die("cannot set 0755 permissions on %s directory",
-			    SC_HOSTFS_DIR);
-		}
-	}
-	// Make the upcoming "put_old" directory for pivot_root private so that
-	// mount events don't propagate to any peer group. In practice pivot root
-	// has a number of undocumented requirements and one of them is that the
-	// "put_old" directory (the second argument) cannot be shared in any way.
-	sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir, SC_HOSTFS_DIR);
-	sc_do_mount(dst, dst, NULL, MS_BIND, NULL);
-	sc_do_mount("none", dst, NULL, MS_PRIVATE, NULL);
-	// On classic mount the nvidia driver. Ideally this would be done in an
-	// uniform way after pivot_root but this is good enough and requires less
-	// code changes the nvidia code assumes it has access to the existing
-	// pre-pivot filesystem.
-	if (config->distro == SC_DISTRO_CLASSIC) {
-		sc_mount_nvidia_driver(scratch_dir, config->base_snap_name);
-	}
-	// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-	//                    pivot_root
-	// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-	// Use pivot_root to "chroot" into the scratch directory.
-	//
-	// Q: Why are we using something as esoteric as pivot_root(2)?
-	// A: Because this makes apparmor handling easy. Using a normal chroot
-	// makes all apparmor rules conditional.  We are either running on an
-	// all-snap system where this would-be chroot didn't happen and all the
-	// rules see / as the root file system _OR_ we are running on top of a
-	// classic distribution and this chroot has now moved all paths to
-	// /tmp/snap.rootfs_*.
-	//
-	// Because we are using unshare(2) with CLONE_NEWNS we can essentially use
-	// pivot_root just like chroot but this makes apparmor unaware of the old
-	// root so everything works okay.
-	//
-	// HINT: If you are debugging this and are trying to see why pivot_root
-	// happens to return EINVAL with any changes you may be making, please
-	// consider applying
-	// misc/0001-Add-printk-based-debugging-to-pivot_root.patch to your tree
-	// kernel.
-	debug("performing operation: pivot_root %s %s", scratch_dir, dst);
-	if (syscall(SYS_pivot_root, scratch_dir, dst) < 0) {
-		die("cannot perform operation: pivot_root %s %s", scratch_dir,
-		    dst);
-	}
-	// Unmount the self-bind mount over the scratch directory created earlier
-	// in the original root filesystem (which is now mounted on SC_HOSTFS_DIR).
-	// This way we can remove the temporary directory we created and "clean up"
-	// after ourselves nicely.
-	sc_must_snprintf(dst, sizeof dst, "%s/%s", SC_HOSTFS_DIR, scratch_dir);
-	sc_do_umount(dst, UMOUNT_NOFOLLOW);
-	// Remove the scratch directory. Note that we are using the path that is
-	// based on the old root filesystem as after pivot_root we cannot guarantee
-	// what is present at the same location normally. (It is probably an empty
-	// /tmp directory that is populated in another place).
-	debug("performing operation: rmdir %s", dst);
-	if (rmdir(scratch_dir) < 0) {
-		die("cannot perform operation: rmdir %s", dst);
-	};
-	// Make the old root filesystem recursively slave. This way operations
-	// performed in this mount namespace will not propagate to the peer group.
-	// This is another essential part of the confinement system.
-	sc_do_mount("none", SC_HOSTFS_DIR, NULL, MS_REC | MS_SLAVE, NULL);
-	// Detach the redundant hostfs version of sysfs since it shows up in the
-	// mount table and software inspecting the mount table may become confused
-	// (eg, docker and LP:# 162601).
-	sc_must_snprintf(src, sizeof src, "%s/sys", SC_HOSTFS_DIR);
-	sc_do_umount(src, UMOUNT_NOFOLLOW | MNT_DETACH);
-	// Detach the redundant hostfs version of /dev since it shows up in the
-	// mount table and software inspecting the mount table may become confused.
-	sc_must_snprintf(src, sizeof src, "%s/dev", SC_HOSTFS_DIR);
-	sc_do_umount(src, UMOUNT_NOFOLLOW | MNT_DETACH);
-	// Detach the redundant hostfs version of /proc since it shows up in the
-	// mount table and software inspecting the mount table may become confused.
-	sc_must_snprintf(src, sizeof src, "%s/proc", SC_HOSTFS_DIR);
-	sc_do_umount(src, UMOUNT_NOFOLLOW | MNT_DETACH);
-	// Detach both views of /writable: the one from hostfs and the one directly
-	// visible in /writable. Interfaces don't grant access to this directory
-	// and it has a large duplicated view of many mount points.  Note that this
-	// is only applicable to ubuntu-core systems.
-	sc_detach_views_of_writable(config->distro, config->normal_mode);
+        sc_do_mount(src, dst, NULL, MS_BIND | MS_RDONLY, NULL);
+        sc_do_mount("none", dst, NULL, MS_SLAVE, NULL);
+    }
+    // Bind mount the directory where all snaps are mounted. The location of
+    // the this directory on the host filesystem may not match the location in
+    // the desired root filesystem. In the "core" and "ubuntu-core" snaps the
+    // directory is always /snap. On the host it is a build-time configuration
+    // option stored in SNAP_MOUNT_DIR. In legacy mode (or in other words, not
+    // in normal mode), we don't need to do this because /snap is fixed and
+    // already contains the correct view of the mounted snaps.
+    if (config->normal_mode) {
+        sc_must_snprintf(dst, sizeof dst, "%s/snap", scratch_dir);
+        sc_do_mount(sc_snap_mount_dir(NULL), dst, NULL, MS_BIND | MS_REC, NULL);
+        sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
+    }
+    // Ensure that hostfs exists and is group-owned by root. We may have (now
+    // or earlier) created the directory as the user who first ran a snap on a
+    // given system and the group identity of that user is visible on disk.
+    // This was LP:#1665004. We do this by trying to create the hostfs directory
+    // if one is missing. This directory is a part of packaging now so perhaps
+    // this code can be removed later. Note: we use 0000 as permissions here, to
+    // avoid the risk that the user manages to fiddle with the newly created
+    // directory before we have the chance to chown it to root:root. We are
+    // setting the usual 0755 permissions just after the chown below.
+    if (mkdir(SC_HOSTFS_DIR, 0000) < 0) {
+        if (errno == EEXIST) {
+            // The directory exists, verify its ownership.
+            struct stat sb;
+            if (stat(SC_HOSTFS_DIR, &sb) < 0) {
+                die("cannot stat %s", SC_HOSTFS_DIR);
+            } else if (sb.st_uid != 0 || sb.st_gid != 0) {
+                die("%s is not owned by root", SC_HOSTFS_DIR);
+            }
+        } else {
+            die("cannot perform operation: mkdir %s", SC_HOSTFS_DIR);
+        }
+    } else {
+        if (chown(SC_HOSTFS_DIR, 0, 0) < 0) {
+            die("cannot set root ownership on %s directory", SC_HOSTFS_DIR);
+        }
+        if (chmod(SC_HOSTFS_DIR, 0755) < 0) {
+            die("cannot set 0755 permissions on %s directory", SC_HOSTFS_DIR);
+        }
+    }
+    // Make the upcoming "put_old" directory for pivot_root private so that
+    // mount events don't propagate to any peer group. In practice pivot root
+    // has a number of undocumented requirements and one of them is that the
+    // "put_old" directory (the second argument) cannot be shared in any way.
+    sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir, SC_HOSTFS_DIR);
+    sc_do_mount(dst, dst, NULL, MS_BIND, NULL);
+    sc_do_mount("none", dst, NULL, MS_PRIVATE, NULL);
+    // On classic mount the nvidia driver. Ideally this would be done in an
+    // uniform way after pivot_root but this is good enough and requires less
+    // code changes the nvidia code assumes it has access to the existing
+    // pre-pivot filesystem.
+    if (config->distro == SC_DISTRO_CLASSIC) {
+        sc_mount_nvidia_driver(scratch_dir, config->base_snap_name);
+    }
+    // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    //                    pivot_root
+    // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    // Use pivot_root to "chroot" into the scratch directory.
+    //
+    // Q: Why are we using something as esoteric as pivot_root(2)?
+    // A: Because this makes apparmor handling easy. Using a normal chroot
+    // makes all apparmor rules conditional.  We are either running on an
+    // all-snap system where this would-be chroot didn't happen and all the
+    // rules see / as the root file system _OR_ we are running on top of a
+    // classic distribution and this chroot has now moved all paths to
+    // /tmp/snap.rootfs_*.
+    //
+    // Because we are using unshare(2) with CLONE_NEWNS we can essentially use
+    // pivot_root just like chroot but this makes apparmor unaware of the old
+    // root so everything works okay.
+    //
+    // HINT: If you are debugging this and are trying to see why pivot_root
+    // happens to return EINVAL with any changes you may be making, please
+    // consider applying
+    // misc/0001-Add-printk-based-debugging-to-pivot_root.patch to your tree
+    // kernel.
+    debug("performing operation: pivot_root %s %s", scratch_dir, dst);
+    if (syscall(SYS_pivot_root, scratch_dir, dst) < 0) {
+        die("cannot perform operation: pivot_root %s %s", scratch_dir, dst);
+    }
+    // Unmount the self-bind mount over the scratch directory created earlier
+    // in the original root filesystem (which is now mounted on SC_HOSTFS_DIR).
+    // This way we can remove the temporary directory we created and "clean up"
+    // after ourselves nicely.
+    sc_must_snprintf(dst, sizeof dst, "%s/%s", SC_HOSTFS_DIR, scratch_dir);
+    sc_do_umount(dst, UMOUNT_NOFOLLOW);
+    // Remove the scratch directory. Note that we are using the path that is
+    // based on the old root filesystem as after pivot_root we cannot guarantee
+    // what is present at the same location normally. (It is probably an empty
+    // /tmp directory that is populated in another place).
+    debug("performing operation: rmdir %s", dst);
+    if (rmdir(scratch_dir) < 0) {
+        die("cannot perform operation: rmdir %s", dst);
+    };
+    // Make the old root filesystem recursively slave. This way operations
+    // performed in this mount namespace will not propagate to the peer group.
+    // This is another essential part of the confinement system.
+    sc_do_mount("none", SC_HOSTFS_DIR, NULL, MS_REC | MS_SLAVE, NULL);
+    // Detach the redundant hostfs version of sysfs since it shows up in the
+    // mount table and software inspecting the mount table may become confused
+    // (eg, docker and LP:# 162601).
+    sc_must_snprintf(src, sizeof src, "%s/sys", SC_HOSTFS_DIR);
+    sc_do_umount(src, UMOUNT_NOFOLLOW | MNT_DETACH);
+    // Detach the redundant hostfs version of /dev since it shows up in the
+    // mount table and software inspecting the mount table may become confused.
+    sc_must_snprintf(src, sizeof src, "%s/dev", SC_HOSTFS_DIR);
+    sc_do_umount(src, UMOUNT_NOFOLLOW | MNT_DETACH);
+    // Detach the redundant hostfs version of /proc since it shows up in the
+    // mount table and software inspecting the mount table may become confused.
+    sc_must_snprintf(src, sizeof src, "%s/proc", SC_HOSTFS_DIR);
+    sc_do_umount(src, UMOUNT_NOFOLLOW | MNT_DETACH);
+    // Detach both views of /writable: the one from hostfs and the one directly
+    // visible in /writable. Interfaces don't grant access to this directory
+    // and it has a large duplicated view of many mount points.  Note that this
+    // is only applicable to ubuntu-core systems.
+    sc_detach_views_of_writable(config->distro, config->normal_mode);
 }
 
-static void sc_detach_views_of_writable(sc_distro distro, bool normal_mode)
-{
-	// Note that prior to detaching either mount point we switch the
-	// propagation to private to both limit the change to just this view and to
-	// prevent otherwise occurring event propagation from self-conflicting and
-	// returning EBUSY. A similar approach is used by snap-update-ns and is
-	// documented in umount(2).
-	const char *writable_dir = "/writable";
-	const char *hostfs_writable_dir = "/var/lib/snapd/hostfs/writable";
+static void sc_detach_views_of_writable(sc_distro distro, bool normal_mode) {
+    // Note that prior to detaching either mount point we switch the
+    // propagation to private to both limit the change to just this view and to
+    // prevent otherwise occurring event propagation from self-conflicting and
+    // returning EBUSY. A similar approach is used by snap-update-ns and is
+    // documented in umount(2).
+    const char *writable_dir = "/writable";
+    const char *hostfs_writable_dir = "/var/lib/snapd/hostfs/writable";
 
-	// Writable only exists on ubuntu-core.
-	if (distro == SC_DISTRO_CLASSIC) {
-		return;
-	}
-	// On all core distributions we see /var/lib/snapd/hostfs/writable that
-	// exposes writable, with a structure specific to ubuntu-core.
-	debug("detaching %s", hostfs_writable_dir);
-	sc_do_mount("none", hostfs_writable_dir, NULL,
-		    MS_REC | MS_PRIVATE, NULL);
-	sc_do_umount(hostfs_writable_dir, UMOUNT_NOFOLLOW | MNT_DETACH);
+    // Writable only exists on ubuntu-core.
+    if (distro == SC_DISTRO_CLASSIC) {
+        return;
+    }
+    // On all core distributions we see /var/lib/snapd/hostfs/writable that
+    // exposes writable, with a structure specific to ubuntu-core.
+    debug("detaching %s", hostfs_writable_dir);
+    sc_do_mount("none", hostfs_writable_dir, NULL, MS_REC | MS_PRIVATE, NULL);
+    sc_do_umount(hostfs_writable_dir, UMOUNT_NOFOLLOW | MNT_DETACH);
 
-	// On ubuntu-core 16, when the executed snap uses core as base we also see
-	// the /writable that we directly inherited from the initial mount
-	// namespace.
-	if (distro == SC_DISTRO_CORE16 && !normal_mode) {
-		debug("detaching %s", writable_dir);
-		sc_do_mount("none", writable_dir, NULL, MS_REC | MS_PRIVATE,
-			    NULL);
-		sc_do_umount(writable_dir, UMOUNT_NOFOLLOW | MNT_DETACH);
-	}
+    // On ubuntu-core 16, when the executed snap uses core as base we also see
+    // the /writable that we directly inherited from the initial mount
+    // namespace.
+    if (distro == SC_DISTRO_CORE16 && !normal_mode) {
+        debug("detaching %s", writable_dir);
+        sc_do_mount("none", writable_dir, NULL, MS_REC | MS_PRIVATE, NULL);
+        sc_do_umount(writable_dir, UMOUNT_NOFOLLOW | MNT_DETACH);
+    }
 }
 
 /**
@@ -867,282 +795,252 @@ static void sc_detach_views_of_writable(sc_distro distro, bool normal_mode)
  * @fulllen: full original path length.
  * Returns a pointer to the next path segment, or NULL if done.
  */
-static char * __attribute__((used))
-    get_nextpath(char *path, size_t *offsetp, size_t fulllen)
-{
-	size_t offset = *offsetp;
+static char *__attribute__((used)) get_nextpath(char *path, size_t *offsetp, size_t fulllen) {
+    size_t offset = *offsetp;
 
-	if (offset >= fulllen)
-		return NULL;
+    if (offset >= fulllen) return NULL;
 
-	while (offset < fulllen && path[offset] != '\0')
-		offset++;
-	while (offset < fulllen && path[offset] == '\0')
-		offset++;
+    while (offset < fulllen && path[offset] != '\0') offset++;
+    while (offset < fulllen && path[offset] == '\0') offset++;
 
-	*offsetp = offset;
-	return (offset < fulllen) ? &path[offset] : NULL;
+    *offsetp = offset;
+    return (offset < fulllen) ? &path[offset] : NULL;
 }
 
 /**
  * Check that @subdir is a subdir of @dir.
-**/
-static bool __attribute__((used))
-    is_subdir(const char *subdir, const char *dir)
-{
-	size_t dirlen = strlen(dir);
-	size_t subdirlen = strlen(subdir);
+ **/
+static bool __attribute__((used)) is_subdir(const char *subdir, const char *dir) {
+    size_t dirlen = strlen(dir);
+    size_t subdirlen = strlen(subdir);
 
-	// @dir has to be at least as long as @subdir
-	if (subdirlen < dirlen)
-		return false;
-	// @dir has to be a prefix of @subdir
-	if (strncmp(subdir, dir, dirlen) != 0)
-		return false;
-	// @dir can look like "path/" (that is, end with the directory separator).
-	// When that is the case then given the test above we can be sure @subdir
-	// is a real subdirectory.
-	if (dirlen > 0 && dir[dirlen - 1] == '/')
-		return true;
-	// @subdir can look like "path/stuff" and when the directory separator
-	// is exactly at the spot where @dir ends (that is, it was not caught
-	// by the test above) then @subdir is a real subdirectory.
-	if (subdir[dirlen] == '/' && dirlen > 0)
-		return true;
-	// If both @dir and @subdir have identical length then given that the
-	// prefix check above @subdir is a real subdirectory.
-	if (subdirlen == dirlen)
-		return true;
-	return false;
+    // @dir has to be at least as long as @subdir
+    if (subdirlen < dirlen) return false;
+    // @dir has to be a prefix of @subdir
+    if (strncmp(subdir, dir, dirlen) != 0) return false;
+    // @dir can look like "path/" (that is, end with the directory separator).
+    // When that is the case then given the test above we can be sure @subdir
+    // is a real subdirectory.
+    if (dirlen > 0 && dir[dirlen - 1] == '/') return true;
+    // @subdir can look like "path/stuff" and when the directory separator
+    // is exactly at the spot where @dir ends (that is, it was not caught
+    // by the test above) then @subdir is a real subdirectory.
+    if (subdir[dirlen] == '/' && dirlen > 0) return true;
+    // If both @dir and @subdir have identical length then given that the
+    // prefix check above @subdir is a real subdirectory.
+    if (subdirlen == dirlen) return true;
+    return false;
 }
 
-static struct sc_mount *sc_homedir_mounts(const struct sc_invocation *inv)
-{
-	if (inv->num_homedirs == 0) {
-		return NULL;
-	}
-	// We add one element for the end-of-array indicator.
-	struct sc_mount *mounts =
-	    calloc(inv->num_homedirs + 1, sizeof(struct sc_mount));
-	if (mounts == NULL) {
-		die("cannot allocate mount data for homedirs");
-	}
-	// Copy inv->homedirs to the mount structures
-	for (int i = 0; i < inv->num_homedirs; i++) {
-		debug("Adding homedir: %s", inv->homedirs[i]);
-		mounts[i].path = sc_strdup(inv->homedirs[i]);
-		// Note that we are not setting bidirectional flag, so anything mounted
-		// here will not propagate to the host.
-	}
-	return mounts;
+static struct sc_mount *sc_homedir_mounts(const struct sc_invocation *inv) {
+    if (inv->num_homedirs == 0) {
+        return NULL;
+    }
+    // We add one element for the end-of-array indicator.
+    struct sc_mount *mounts = calloc(inv->num_homedirs + 1, sizeof(struct sc_mount));
+    if (mounts == NULL) {
+        die("cannot allocate mount data for homedirs");
+    }
+    // Copy inv->homedirs to the mount structures
+    for (int i = 0; i < inv->num_homedirs; i++) {
+        debug("Adding homedir: %s", inv->homedirs[i]);
+        mounts[i].path = sc_strdup(inv->homedirs[i]);
+        // Note that we are not setting bidirectional flag, so anything mounted
+        // here will not propagate to the host.
+    }
+    return mounts;
 }
 
-static void sc_free_dynamic_mounts(struct sc_mount *mounts)
-{
-	// This is in line with normal free semantics.
-	if (mounts == NULL) {
-		return;
-	}
-	// Cleanup allocated resources by each of the mount
-	// structures. The array will be terminated by a single zeroed
-	// entry.
-	for (int i = 0; mounts[i].path != NULL; i++) {
-		free((void *)mounts[i].path);
-	}
-	free(mounts);
+static void sc_free_dynamic_mounts(struct sc_mount *mounts) {
+    // This is in line with normal free semantics.
+    if (mounts == NULL) {
+        return;
+    }
+    // Cleanup allocated resources by each of the mount
+    // structures. The array will be terminated by a single zeroed
+    // entry.
+    for (int i = 0; mounts[i].path != NULL; i++) {
+        free((void *)mounts[i].path);
+    }
+    free(mounts);
 }
 
-void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
-			  const sc_invocation *inv, const gid_t real_gid,
-			  const gid_t saved_gid)
-{
-	// Classify the current distribution, as claimed by /etc/os-release.
-	sc_distro distro = sc_classify_distro();
+void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd, const sc_invocation *inv,
+                          const gid_t real_gid, const gid_t saved_gid) {
+    // Classify the current distribution, as claimed by /etc/os-release.
+    sc_distro distro = sc_classify_distro();
 
-	// Check which mode we should run in, normal or legacy.
-	if (inv->is_normal_mode) {
-		// In normal mode we use the base snap as / and set up several bind mounts.
-		static const struct sc_mount mounts[] = {
-			{.path = "/dev"},	// because it contains devices on host OS
-			{.path = "/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
-			{.path = "/home"},	// to support /home/*/snap and home interface
-			{.path = "/root"},	// because that is $HOME for services
-			{.path = "/proc"},	// fundamental filesystem
-			{.path = "/sys"},	// fundamental filesystem
-			{.path = "/tmp"},	// to get writable tmp
-			{.path = "/var/snap"},	// to get access to global snap data
-			{.path = "/var/lib/snapd"},	// to get access to snapd state and seccomp profiles
-			{.path = "/var/tmp"},	// to get access to the other temporary directory
-			{.path = "/run"},	// to get /run with sockets and what not
-			{.path = "/lib/modules",.is_optional = true},	// access to the modules of the running kernel
-			{.path = "/lib/firmware",.is_optional = true},	// access to the firmware of the running kernel
-			{.path = "/usr/src"},	// FIXME: move to SecurityMounts in system-trace interface
-			{.path = "/var/log"},	// FIXME: move to SecurityMounts in log-observe interface
+    // Check which mode we should run in, normal or legacy.
+    if (inv->is_normal_mode) {
+        // In normal mode we use the base snap as / and set up several bind mounts.
+        static const struct sc_mount mounts[] = {
+            {.path = "/dev"},            // because it contains devices on host OS
+            {.path = "/etc"},            // because that's where /etc/resolv.conf lives, perhaps a bad idea
+            {.path = "/home"},           // to support /home/*/snap and home interface
+            {.path = "/root"},           // because that is $HOME for services
+            {.path = "/proc"},           // fundamental filesystem
+            {.path = "/sys"},            // fundamental filesystem
+            {.path = "/tmp"},            // to get writable tmp
+            {.path = "/var/snap"},       // to get access to global snap data
+            {.path = "/var/lib/snapd"},  // to get access to snapd state and seccomp profiles
+            {.path = "/var/tmp"},        // to get access to the other temporary directory
+            {.path = "/run"},            // to get /run with sockets and what not
+            {.path = "/lib/modules", .is_optional = true},   // access to the modules of the running kernel
+            {.path = "/lib/firmware", .is_optional = true},  // access to the firmware of the running kernel
+            {.path = "/usr/src"},                            // FIXME: move to SecurityMounts in system-trace interface
+            {.path = "/var/log"},                            // FIXME: move to SecurityMounts in log-observe interface
 #ifdef MERGED_USR
-			{.path = "/run/media",.is_bidirectional = true,.altpath = "/media"},	// access to the users removable devices
+            {.path = "/run/media",
+             .is_bidirectional = true,
+             .altpath = "/media"},  // access to the users removable devices
 #else
-			{.path = "/media",.is_bidirectional = true},	// access to the users removable devices
-#endif				// MERGED_USR
-			{.path = "/run/netns",.is_bidirectional = true},	// access to the 'ip netns' network namespaces
-			// The /mnt directory is optional in base snaps to ensure backwards
-			// compatibility with the first version of base snaps that was
-			// released.
-			{.path = "/mnt",.is_optional = true},	// to support the removable-media interface
-			{.path = "/var/lib/extrausers",.is_optional = true},	// access to UID/GID of extrausers (if available)
-			{},
-		};
-		struct sc_mount_config normal_config = {
-			.rootfs_dir = inv->rootfs_dir,
-			.mounts = mounts,
-			// Homedir mounts are user-specified paths that snaps are allowed
-			// to access, which don't reside in the regular home path. They can change
-			// between runs, so we must dynamically handle them.
-			.dynamic_mounts = sc_homedir_mounts(inv),
-			.distro = distro,
-			.normal_mode = true,
-			.base_snap_name = inv->base_snap_name,
-			.snap_instance = inv->snap_instance,
-		};
-		sc_bootstrap_mount_namespace(&normal_config);
-		sc_free_dynamic_mounts(normal_config.dynamic_mounts);
-		normal_config.dynamic_mounts = NULL;
-	} else {
-		// In legacy mode we don't pivot to a base snap's rootfs and instead
-		// just arrange bi-directional mount propagation for two directories.
-		static const struct sc_mount mounts[] = {
-			{.path = "/media",.is_bidirectional = true},
-			{.path = "/run/netns",.is_bidirectional = true},
-			{},
-		};
-		struct sc_mount_config legacy_config = {
-			.rootfs_dir = "/",
-			.mounts = mounts,
-			// XXX: should we support Homedir mount in legacy mode?
-			.distro = distro,
-			.normal_mode = false,
-			.base_snap_name = inv->base_snap_name,
-		};
-		sc_bootstrap_mount_namespace(&legacy_config);
-	}
+            {.path = "/media", .is_bidirectional = true},  // access to the users removable devices
+#endif                                                         // MERGED_USR
+            {.path = "/run/netns", .is_bidirectional = true},  // access to the 'ip netns' network namespaces
+            // The /mnt directory is optional in base snaps to ensure backwards
+            // compatibility with the first version of base snaps that was
+            // released.
+            {.path = "/mnt", .is_optional = true},                 // to support the removable-media interface
+            {.path = "/var/lib/extrausers", .is_optional = true},  // access to UID/GID of extrausers (if available)
+            {},
+        };
+        struct sc_mount_config normal_config = {
+            .rootfs_dir = inv->rootfs_dir,
+            .mounts = mounts,
+            // Homedir mounts are user-specified paths that snaps are allowed
+            // to access, which don't reside in the regular home path. They can change
+            // between runs, so we must dynamically handle them.
+            .dynamic_mounts = sc_homedir_mounts(inv),
+            .distro = distro,
+            .normal_mode = true,
+            .base_snap_name = inv->base_snap_name,
+            .snap_instance = inv->snap_instance,
+        };
+        sc_bootstrap_mount_namespace(&normal_config);
+        sc_free_dynamic_mounts(normal_config.dynamic_mounts);
+        normal_config.dynamic_mounts = NULL;
+    } else {
+        // In legacy mode we don't pivot to a base snap's rootfs and instead
+        // just arrange bi-directional mount propagation for two directories.
+        static const struct sc_mount mounts[] = {
+            {.path = "/media", .is_bidirectional = true},
+            {.path = "/run/netns", .is_bidirectional = true},
+            {},
+        };
+        struct sc_mount_config legacy_config = {
+            .rootfs_dir = "/",
+            .mounts = mounts,
+            // XXX: should we support Homedir mount in legacy mode?
+            .distro = distro,
+            .normal_mode = false,
+            .base_snap_name = inv->base_snap_name,
+        };
+        sc_bootstrap_mount_namespace(&legacy_config);
+    }
 
-	// TODO: rename this and fold it into bootstrap
-	setup_private_tmp(inv->snap_instance);
-	// set up private /dev/pts
-	// TODO: fold this into bootstrap
-	setup_private_pts();
+    // TODO: rename this and fold it into bootstrap
+    setup_private_tmp(inv->snap_instance);
+    // set up private /dev/pts
+    // TODO: fold this into bootstrap
+    setup_private_pts();
 
-	// setup the security backend bind mounts
-	sc_call_snap_update_ns(snap_update_ns_fd, inv->snap_instance, apparmor);
+    // setup the security backend bind mounts
+    sc_call_snap_update_ns(snap_update_ns_fd, inv->snap_instance, apparmor);
 }
 
-static bool is_mounted_with_shared_option(const char *dir)
-    __attribute__((nonnull(1)));
+static bool is_mounted_with_shared_option(const char *dir) __attribute__((nonnull(1)));
 
-static bool is_mounted_with_shared_option(const char *dir)
-{
-	sc_mountinfo *sm SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
-	sm = sc_parse_mountinfo(NULL);
-	if (sm == NULL) {
-		die("cannot parse /proc/self/mountinfo");
-	}
-	sc_mountinfo_entry *entry = sc_first_mountinfo_entry(sm);
-	while (entry != NULL) {
-		const char *mount_dir = entry->mount_dir;
-		if (sc_streq(mount_dir, dir)) {
-			const char *optional_fields = entry->optional_fields;
-			if (strstr(optional_fields, "shared:") != NULL) {
-				return true;
-			}
-		}
-		entry = sc_next_mountinfo_entry(entry);
-	}
-	return false;
+static bool is_mounted_with_shared_option(const char *dir) {
+    sc_mountinfo *sm SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+    sm = sc_parse_mountinfo(NULL);
+    if (sm == NULL) {
+        die("cannot parse /proc/self/mountinfo");
+    }
+    sc_mountinfo_entry *entry = sc_first_mountinfo_entry(sm);
+    while (entry != NULL) {
+        const char *mount_dir = entry->mount_dir;
+        if (sc_streq(mount_dir, dir)) {
+            const char *optional_fields = entry->optional_fields;
+            if (strstr(optional_fields, "shared:") != NULL) {
+                return true;
+            }
+        }
+        entry = sc_next_mountinfo_entry(entry);
+    }
+    return false;
 }
 
-void sc_ensure_shared_snap_mount(void)
-{
-	if (!is_mounted_with_shared_option("/")
-	    && !is_mounted_with_shared_option(sc_snap_mount_dir(NULL))) {
-		// TODO: We could be more aggressive and refuse to function but since
-		// we have no data on actual environments that happen to limp along in
-		// this configuration let's not do that yet.  This code should be
-		// removed once we have a measurement and feedback mechanism that lets
-		// us decide based on measurable data.
-		sc_do_mount(sc_snap_mount_dir(NULL), sc_snap_mount_dir(NULL),
-			    "none", MS_BIND | MS_REC, NULL);
-		sc_do_mount("none", sc_snap_mount_dir(NULL), NULL,
-			    MS_SHARED | MS_REC, NULL);
-	}
+void sc_ensure_shared_snap_mount(void) {
+    if (!is_mounted_with_shared_option("/") && !is_mounted_with_shared_option(sc_snap_mount_dir(NULL))) {
+        // TODO: We could be more aggressive and refuse to function but since
+        // we have no data on actual environments that happen to limp along in
+        // this configuration let's not do that yet.  This code should be
+        // removed once we have a measurement and feedback mechanism that lets
+        // us decide based on measurable data.
+        sc_do_mount(sc_snap_mount_dir(NULL), sc_snap_mount_dir(NULL), "none", MS_BIND | MS_REC, NULL);
+        sc_do_mount("none", sc_snap_mount_dir(NULL), NULL, MS_SHARED | MS_REC, NULL);
+    }
 }
 
-void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd,
-			  const char *snap_name)
-{
-	debug("%s: %s", __FUNCTION__, snap_name);
+void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd, const char *snap_name) {
+    debug("%s: %s", __FUNCTION__, snap_name);
 
-	char profile_path[PATH_MAX];
-	struct stat st;
+    char profile_path[PATH_MAX];
+    struct stat st;
 
-	sc_must_snprintf(profile_path, sizeof(profile_path),
-			 "/var/lib/snapd/mount/snap.%s.user-fstab", snap_name);
-	if (stat(profile_path, &st) != 0) {
-		// It is ok for the user fstab to not exist.
-		return;
-	}
+    sc_must_snprintf(profile_path, sizeof(profile_path), "/var/lib/snapd/mount/snap.%s.user-fstab", snap_name);
+    if (stat(profile_path, &st) != 0) {
+        // It is ok for the user fstab to not exist.
+        return;
+    }
 
-	// In our new mount namespace, recursively change all mounts
-	// to slave mode, so we see changes from the parent namespace
-	// but don't propagate our own changes.
-	sc_do_mount("none", "/", NULL, MS_REC | MS_SLAVE, NULL);
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	sc_call_snap_update_ns_as_user(snap_update_ns_fd, snap_name, apparmor);
-	(void)sc_set_effective_identity(old);
+    // In our new mount namespace, recursively change all mounts
+    // to slave mode, so we see changes from the parent namespace
+    // but don't propagate our own changes.
+    sc_do_mount("none", "/", NULL, MS_REC | MS_SLAVE, NULL);
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    sc_call_snap_update_ns_as_user(snap_update_ns_fd, snap_name, apparmor);
+    (void)sc_set_effective_identity(old);
 }
 
-void sc_ensure_snap_dir_shared_mounts(void)
-{
-	const char *dirs[] = { sc_snap_mount_dir(NULL), "/var/snap", NULL };
-	for (int i = 0; dirs[i] != NULL; i++) {
-		const char *dir = dirs[i];
-		if (!is_mounted_with_shared_option(dir)) {
-			/* Since this directory isn't yet shared (but it should be),
-			 * recursively bind mount it, then recursively share it so that
-			 * changes to the host are seen in the snap and vice-versa. This
-			 * allows us to fine-tune propagation events elsewhere for this new
-			 * mountpoint.
-			 *
-			 * Not using MS_SLAVE because it's too late for SNAP_MOUNT_DIR,
-			 * since snaps are already mounted, and it's not needed for
-			 * /var/snap.
-			 */
-			sc_do_mount(dir, dir, "none", MS_BIND | MS_REC, NULL);
-			sc_do_mount("none", dir, NULL, MS_REC | MS_SHARED,
-				    NULL);
-		}
-	}
+void sc_ensure_snap_dir_shared_mounts(void) {
+    const char *dirs[] = {sc_snap_mount_dir(NULL), "/var/snap", NULL};
+    for (int i = 0; dirs[i] != NULL; i++) {
+        const char *dir = dirs[i];
+        if (!is_mounted_with_shared_option(dir)) {
+            /* Since this directory isn't yet shared (but it should be),
+             * recursively bind mount it, then recursively share it so that
+             * changes to the host are seen in the snap and vice-versa. This
+             * allows us to fine-tune propagation events elsewhere for this new
+             * mountpoint.
+             *
+             * Not using MS_SLAVE because it's too late for SNAP_MOUNT_DIR,
+             * since snaps are already mounted, and it's not needed for
+             * /var/snap.
+             */
+            sc_do_mount(dir, dir, "none", MS_BIND | MS_REC, NULL);
+            sc_do_mount("none", dir, NULL, MS_REC | MS_SHARED, NULL);
+        }
+    }
 }
 
-void sc_setup_parallel_instance_classic_mounts(const char *snap_name,
-					       const char *snap_instance_name)
-{
-	char src[PATH_MAX] = { 0 };
-	char dst[PATH_MAX] = { 0 };
+void sc_setup_parallel_instance_classic_mounts(const char *snap_name, const char *snap_instance_name) {
+    char src[PATH_MAX] = {0};
+    char dst[PATH_MAX] = {0};
 
-	const char *dirs[] = { sc_snap_mount_dir(NULL), "/var/snap", NULL };
-	for (int i = 0; dirs[i] != NULL; i++) {
-		const char *dir = dirs[i];
-		sc_do_mount("none", dir, NULL, MS_REC | MS_SLAVE, NULL);
-	}
+    const char *dirs[] = {sc_snap_mount_dir(NULL), "/var/snap", NULL};
+    for (int i = 0; dirs[i] != NULL; i++) {
+        const char *dir = dirs[i];
+        sc_do_mount("none", dir, NULL, MS_REC | MS_SLAVE, NULL);
+    }
 
-	/* Mount SNAP_MOUNT_DIR/<snap>_<key> on SNAP_MOUNT_DIR/<snap> */
-	sc_must_snprintf(src, sizeof src, "%s/%s", sc_snap_mount_dir(NULL),
-			 snap_instance_name);
-	sc_must_snprintf(dst, sizeof dst, "%s/%s", sc_snap_mount_dir(NULL),
-			 snap_name);
-	sc_do_mount(src, dst, "none", MS_BIND | MS_REC, NULL);
+    /* Mount SNAP_MOUNT_DIR/<snap>_<key> on SNAP_MOUNT_DIR/<snap> */
+    sc_must_snprintf(src, sizeof src, "%s/%s", sc_snap_mount_dir(NULL), snap_instance_name);
+    sc_must_snprintf(dst, sizeof dst, "%s/%s", sc_snap_mount_dir(NULL), snap_name);
+    sc_do_mount(src, dst, "none", MS_BIND | MS_REC, NULL);
 
-	/* Mount /var/snap/<snap>_<key> on /var/snap/<snap> */
-	sc_must_snprintf(src, sizeof src, "/var/snap/%s", snap_instance_name);
-	sc_must_snprintf(dst, sizeof dst, "/var/snap/%s", snap_name);
-	sc_do_mount(src, dst, "none", MS_BIND | MS_REC, NULL);
+    /* Mount /var/snap/<snap>_<key> on /var/snap/<snap> */
+    sc_must_snprintf(src, sizeof src, "/var/snap/%s", snap_instance_name);
+    sc_must_snprintf(dst, sizeof dst, "/var/snap/%s", snap_name);
+    sc_do_mount(src, dst, "none", MS_BIND | MS_REC, NULL);
 }

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -18,9 +18,9 @@
 #ifndef SNAP_MOUNT_SUPPORT_H
 #define SNAP_MOUNT_SUPPORT_H
 
+#include <sys/types.h>
 #include "../libsnap-confine-private/apparmor-support.h"
 #include "snap-confine-invocation.h"
-#include <sys/types.h>
 
 /* Base location where extra libraries might be made available to the snap.
  * This is currently used for graphics drivers, but could pontentially be used
@@ -41,9 +41,8 @@
  * - creates private /dev/pts
  * - processes mount profiles
  **/
-void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
-			  const sc_invocation * inv, const gid_t real_gid,
-			  const gid_t saved_gid);
+void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd, const sc_invocation *inv,
+                          const gid_t real_gid, const gid_t saved_gid);
 
 /**
  * Ensure that / or /snap is mounted with the SHARED option.
@@ -63,8 +62,7 @@ void sc_ensure_shared_snap_mount(void);
  * - reconfigure all existing mounts to slave mode
  * - perform all user mounts
  */
-void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd,
-			  const char *snap_name);
+void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd, const char *snap_name);
 
 /**
  * Ensure that SNAP_MOUNT_DIR and /var/snap are mount points.
@@ -80,6 +78,5 @@ void sc_ensure_snap_dir_shared_mounts(void);
  *
  * Create bind mounts from instance specific locations to non-instance ones.
  */
-void sc_setup_parallel_instance_classic_mounts(const char *snap_name,
-					       const char *snap_instance_name);
+void sc_setup_parallel_instance_classic_mounts(const char *snap_name, const char *snap_instance_name);
 #endif

--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -22,7 +22,7 @@
 #include "../libsnap-confine-private/test-utils.h"
 
 #include <errno.h>
-#include <linux/magic.h>	// for NSFS_MAGIC
+#include <linux/magic.h>  // for NSFS_MAGIC
 #include <sys/utsname.h>
 #include <sys/vfs.h>
 
@@ -30,125 +30,110 @@
 #include <glib/gstdio.h>
 
 // Set alternate namespace directory
-static void sc_set_ns_dir(const char *dir)
-{
-	sc_ns_dir = dir;
-}
+static void sc_set_ns_dir(const char *dir) { sc_ns_dir = dir; }
 
 // A variant of unsetenv that is compatible with GDestroyNotify
-static void my_unsetenv(const char *k)
-{
-	unsetenv(k);
-}
+static void my_unsetenv(const char *k) { unsetenv(k); }
 
 // Use temporary directory for namespace groups.
 //
 // The directory is automatically reset to the real value at the end of the
 // test.
-static const char *sc_test_use_fake_ns_dir(void)
-{
-	char *ns_dir = NULL;
-	if (g_test_subprocess()) {
-		// Check if the environment variable is set. If so then someone is already
-		// managing the temporary directory and we should not create a new one.
-		ns_dir = getenv("SNAP_CONFINE_NS_DIR");
-		g_assert_nonnull(ns_dir);
-	} else {
-		ns_dir = g_dir_make_tmp(NULL, NULL);
-		g_assert_nonnull(ns_dir);
-		g_test_queue_free(ns_dir);
-		g_assert_cmpint(setenv("SNAP_CONFINE_NS_DIR", ns_dir, 0), ==,
-				0);
-		g_test_queue_destroy((GDestroyNotify) my_unsetenv,
-				     "SNAP_CONFINE_NS_DIR");
-		g_test_queue_destroy((GDestroyNotify) rm_rf_tmp, ns_dir);
-	}
-	g_test_queue_destroy((GDestroyNotify) sc_set_ns_dir, SC_NS_DIR);
-	sc_set_ns_dir(ns_dir);
-	return ns_dir;
+static const char *sc_test_use_fake_ns_dir(void) {
+    char *ns_dir = NULL;
+    if (g_test_subprocess()) {
+        // Check if the environment variable is set. If so then someone is already
+        // managing the temporary directory and we should not create a new one.
+        ns_dir = getenv("SNAP_CONFINE_NS_DIR");
+        g_assert_nonnull(ns_dir);
+    } else {
+        ns_dir = g_dir_make_tmp(NULL, NULL);
+        g_assert_nonnull(ns_dir);
+        g_test_queue_free(ns_dir);
+        g_assert_cmpint(setenv("SNAP_CONFINE_NS_DIR", ns_dir, 0), ==, 0);
+        g_test_queue_destroy((GDestroyNotify)my_unsetenv, "SNAP_CONFINE_NS_DIR");
+        g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, ns_dir);
+    }
+    g_test_queue_destroy((GDestroyNotify)sc_set_ns_dir, SC_NS_DIR);
+    sc_set_ns_dir(ns_dir);
+    return ns_dir;
 }
 
 // Check that allocating a namespace group sets up internal data structures to
 // safe values.
-static void test_sc_alloc_mount_ns(void)
-{
-	struct sc_mount_ns *group = NULL;
-	group = sc_alloc_mount_ns();
-	g_test_queue_free(group);
-	g_assert_nonnull(group);
-	g_assert_cmpint(group->dir_fd, ==, -1);
-	g_assert_cmpint(group->pipe_master[0], ==, -1);
-	g_assert_cmpint(group->pipe_master[1], ==, -1);
-	g_assert_cmpint(group->pipe_helper[0], ==, -1);
-	g_assert_cmpint(group->pipe_helper[1], ==, -1);
-	g_assert_cmpint(group->child, ==, 0);
-	g_assert_null(group->name);
+static void test_sc_alloc_mount_ns(void) {
+    struct sc_mount_ns *group = NULL;
+    group = sc_alloc_mount_ns();
+    g_test_queue_free(group);
+    g_assert_nonnull(group);
+    g_assert_cmpint(group->dir_fd, ==, -1);
+    g_assert_cmpint(group->pipe_master[0], ==, -1);
+    g_assert_cmpint(group->pipe_master[1], ==, -1);
+    g_assert_cmpint(group->pipe_helper[0], ==, -1);
+    g_assert_cmpint(group->pipe_helper[1], ==, -1);
+    g_assert_cmpint(group->child, ==, 0);
+    g_assert_null(group->name);
 }
 
 // Initialize a namespace group.
 //
 // The group is automatically destroyed at the end of the test.
-static struct sc_mount_ns *sc_test_open_mount_ns(const char *group_name)
-{
-	// Initialize a namespace group
-	struct sc_mount_ns *group = NULL;
-	if (group_name == NULL) {
-		group_name = "test-group";
-	}
-	group = sc_open_mount_ns(group_name);
-	g_test_queue_destroy((GDestroyNotify) sc_close_mount_ns, group);
-	// Check if the returned group data looks okay
-	g_assert_nonnull(group);
-	g_assert_cmpint(group->dir_fd, !=, -1);
-	g_assert_cmpint(group->pipe_master[0], ==, -1);
-	g_assert_cmpint(group->pipe_master[1], ==, -1);
-	g_assert_cmpint(group->pipe_helper[0], ==, -1);
-	g_assert_cmpint(group->pipe_helper[1], ==, -1);
-	g_assert_cmpint(group->child, ==, 0);
-	g_assert_cmpstr(group->name, ==, group_name);
-	return group;
+static struct sc_mount_ns *sc_test_open_mount_ns(const char *group_name) {
+    // Initialize a namespace group
+    struct sc_mount_ns *group = NULL;
+    if (group_name == NULL) {
+        group_name = "test-group";
+    }
+    group = sc_open_mount_ns(group_name);
+    g_test_queue_destroy((GDestroyNotify)sc_close_mount_ns, group);
+    // Check if the returned group data looks okay
+    g_assert_nonnull(group);
+    g_assert_cmpint(group->dir_fd, !=, -1);
+    g_assert_cmpint(group->pipe_master[0], ==, -1);
+    g_assert_cmpint(group->pipe_master[1], ==, -1);
+    g_assert_cmpint(group->pipe_helper[0], ==, -1);
+    g_assert_cmpint(group->pipe_helper[1], ==, -1);
+    g_assert_cmpint(group->child, ==, 0);
+    g_assert_cmpstr(group->name, ==, group_name);
+    return group;
 }
 
 // Check that initializing a namespace group creates the appropriate
 // filesystem structure.
-static void test_sc_open_mount_ns(void)
-{
-	const char *ns_dir = sc_test_use_fake_ns_dir();
-	sc_test_open_mount_ns(NULL);
-	// Check that the group directory exists
-	g_assert_true(g_file_test
-		      (ns_dir, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR));
+static void test_sc_open_mount_ns(void) {
+    const char *ns_dir = sc_test_use_fake_ns_dir();
+    sc_test_open_mount_ns(NULL);
+    // Check that the group directory exists
+    g_assert_true(g_file_test(ns_dir, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR));
 }
 
 // Sanity check, ensure that the namespace filesystem identifier is what we
 // expect, aka NSFS_MAGIC.
-static void test_nsfs_fs_id(void)
-{
-	struct utsname uts;
-	if (uname(&uts) < 0) {
-		g_test_message("cannot use uname(2)");
-		g_test_fail();
-		return;
-	}
-	int major, minor;
-	if (sscanf(uts.release, "%d.%d", &major, &minor) != 2) {
-		g_test_message("cannot use sscanf(2) to parse kernel release");
-		g_test_fail();
-		return;
-	}
-	if (major < 3 || (major == 3 && minor < 19)) {
-		g_test_skip("this test needs kernel 3.19+");
-		return;
-	}
-	struct statfs buf;
-	int err = statfs("/proc/self/ns/mnt", &buf);
-	g_assert_cmpint(err, ==, 0);
-	g_assert_cmpint(buf.f_type, ==, NSFS_MAGIC);
+static void test_nsfs_fs_id(void) {
+    struct utsname uts;
+    if (uname(&uts) < 0) {
+        g_test_message("cannot use uname(2)");
+        g_test_fail();
+        return;
+    }
+    int major, minor;
+    if (sscanf(uts.release, "%d.%d", &major, &minor) != 2) {
+        g_test_message("cannot use sscanf(2) to parse kernel release");
+        g_test_fail();
+        return;
+    }
+    if (major < 3 || (major == 3 && minor < 19)) {
+        g_test_skip("this test needs kernel 3.19+");
+        return;
+    }
+    struct statfs buf;
+    int err = statfs("/proc/self/ns/mnt", &buf);
+    g_assert_cmpint(err, ==, 0);
+    g_assert_cmpint(buf.f_type, ==, NSFS_MAGIC);
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/ns/sc_alloc_mount_ns", test_sc_alloc_mount_ns);
-	g_test_add_func("/ns/sc_open_mount_ns", test_sc_open_mount_ns);
-	g_test_add_func("/ns/nsfs_fs_id", test_nsfs_fs_id);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/ns/sc_alloc_mount_ns", test_sc_alloc_mount_ns);
+    g_test_add_func("/ns/sc_open_mount_ns", test_sc_open_mount_ns);
+    g_test_add_func("/ns/nsfs_fs_id", test_nsfs_fs_id);
 }

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -50,8 +50,8 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
-#include "user-support.h"
 #include "mount-support.h"
+#include "user-support.h"
 
 /**
  * Directory where snap-confine keeps namespace files.
@@ -66,330 +66,303 @@
 static const char *sc_ns_dir = SC_NS_DIR;
 
 enum {
-	HELPER_CMD_EXIT,
-	HELPER_CMD_CAPTURE_MOUNT_NS,
-	HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS,
+    HELPER_CMD_EXIT,
+    HELPER_CMD_CAPTURE_MOUNT_NS,
+    HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS,
 };
 
-void sc_reassociate_with_pid1_mount_ns(void)
-{
-	int init_mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	int self_mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	const char *path_pid_1 = "/proc/1/ns/mnt";
-	const char *path_pid_self = "/proc/self/ns/mnt";
+void sc_reassociate_with_pid1_mount_ns(void) {
+    int init_mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    int self_mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    const char *path_pid_1 = "/proc/1/ns/mnt";
+    const char *path_pid_self = "/proc/self/ns/mnt";
 
-	init_mnt_fd = open(path_pid_1,
-			   O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_PATH);
-	if (init_mnt_fd < 0) {
-		die("cannot open path %s", path_pid_1);
-	}
-	self_mnt_fd = open(path_pid_self,
-			   O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_PATH);
-	if (self_mnt_fd < 0) {
-		die("cannot open path %s", path_pid_1);
-	}
-	char init_buf[128] = { 0 };
-	char self_buf[128] = { 0 };
-	memset(init_buf, 0, sizeof init_buf);
-	if (readlinkat(init_mnt_fd, "", init_buf, sizeof init_buf) < 0) {
-		if (errno == ENOENT) {
-			// According to namespaces(7) on a pre 3.8 kernel the namespace
-			// files are hardlinks, not symlinks. If that happens readlinkat
-			// fails with ENOENT. As a quick workaround for this special-case
-			// functionality, just bail out and do nothing without raising an
-			// error.
-			return;
-		}
-		die("cannot read mount namespace identifier of pid 1");
-	}
-	memset(self_buf, 0, sizeof self_buf);
-	if (readlinkat(self_mnt_fd, "", self_buf, sizeof self_buf) < 0) {
-		die("cannot read mount namespace identifier of the current process");
-	}
-	if (memcmp(init_buf, self_buf, sizeof init_buf) != 0) {
-		debug("moving to mount namespace of pid 1");
-		// We cannot use O_NOFOLLOW here because that file will always be a
-		// symbolic link. We actually want to open it this way.
-		int init_mnt_fd_real SC_CLEANUP(sc_cleanup_close) = -1;
-		init_mnt_fd_real = open(path_pid_1, O_RDONLY | O_CLOEXEC);
-		if (init_mnt_fd_real < 0) {
-			die("cannot open %s", path_pid_1);
-		}
-		if (setns(init_mnt_fd_real, CLONE_NEWNS) < 0) {
-			die("cannot join mount namespace of pid 1");
-		}
-	}
+    init_mnt_fd = open(path_pid_1, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_PATH);
+    if (init_mnt_fd < 0) {
+        die("cannot open path %s", path_pid_1);
+    }
+    self_mnt_fd = open(path_pid_self, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_PATH);
+    if (self_mnt_fd < 0) {
+        die("cannot open path %s", path_pid_1);
+    }
+    char init_buf[128] = {0};
+    char self_buf[128] = {0};
+    memset(init_buf, 0, sizeof init_buf);
+    if (readlinkat(init_mnt_fd, "", init_buf, sizeof init_buf) < 0) {
+        if (errno == ENOENT) {
+            // According to namespaces(7) on a pre 3.8 kernel the namespace
+            // files are hardlinks, not symlinks. If that happens readlinkat
+            // fails with ENOENT. As a quick workaround for this special-case
+            // functionality, just bail out and do nothing without raising an
+            // error.
+            return;
+        }
+        die("cannot read mount namespace identifier of pid 1");
+    }
+    memset(self_buf, 0, sizeof self_buf);
+    if (readlinkat(self_mnt_fd, "", self_buf, sizeof self_buf) < 0) {
+        die("cannot read mount namespace identifier of the current process");
+    }
+    if (memcmp(init_buf, self_buf, sizeof init_buf) != 0) {
+        debug("moving to mount namespace of pid 1");
+        // We cannot use O_NOFOLLOW here because that file will always be a
+        // symbolic link. We actually want to open it this way.
+        int init_mnt_fd_real SC_CLEANUP(sc_cleanup_close) = -1;
+        init_mnt_fd_real = open(path_pid_1, O_RDONLY | O_CLOEXEC);
+        if (init_mnt_fd_real < 0) {
+            die("cannot open %s", path_pid_1);
+        }
+        if (setns(init_mnt_fd_real, CLONE_NEWNS) < 0) {
+            die("cannot join mount namespace of pid 1");
+        }
+    }
 }
 
-void sc_initialize_mount_ns(unsigned int experimental_features)
-{
-	debug("unsharing snap namespace directory");
+void sc_initialize_mount_ns(unsigned int experimental_features) {
+    debug("unsharing snap namespace directory");
 
-	/* Ensure that /run/snapd/ns is a directory. */
-	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	if (sc_nonfatal_mkpath(sc_ns_dir, 0755) < 0) {
-		die("cannot create directory %s", sc_ns_dir);
-	}
-	(void)sc_set_effective_identity(old);
+    /* Ensure that /run/snapd/ns is a directory. */
+    sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+    if (sc_nonfatal_mkpath(sc_ns_dir, 0755) < 0) {
+        die("cannot create directory %s", sc_ns_dir);
+    }
+    (void)sc_set_effective_identity(old);
 
-	/* Read and analyze the mount table. We need to see whether /run/snapd/ns
-	 * is a mount point with private event propagation. */
-	sc_mountinfo *info SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
-	info = sc_parse_mountinfo(NULL);
-	if (info == NULL) {
-		die("cannot parse /proc/self/mountinfo");
-	}
+    /* Read and analyze the mount table. We need to see whether /run/snapd/ns
+     * is a mount point with private event propagation. */
+    sc_mountinfo *info SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+    info = sc_parse_mountinfo(NULL);
+    if (info == NULL) {
+        die("cannot parse /proc/self/mountinfo");
+    }
 
-	bool is_mnt = false;
-	bool is_private = false;
-	for (sc_mountinfo_entry * entry = sc_first_mountinfo_entry(info);
-	     entry != NULL; entry = sc_next_mountinfo_entry(entry)) {
-		/* Find /run/snapd/ns */
-		if (!sc_streq(entry->mount_dir, sc_ns_dir)) {
-			continue;
-		}
-		is_mnt = true;
-		if (strstr(entry->optional_fields, "shared:") == NULL) {
-			/* Mount event propagation is not set to shared, good. */
-			is_private = true;
-		}
-		break;
-	}
+    bool is_mnt = false;
+    bool is_private = false;
+    for (sc_mountinfo_entry *entry = sc_first_mountinfo_entry(info); entry != NULL;
+         entry = sc_next_mountinfo_entry(entry)) {
+        /* Find /run/snapd/ns */
+        if (!sc_streq(entry->mount_dir, sc_ns_dir)) {
+            continue;
+        }
+        is_mnt = true;
+        if (strstr(entry->optional_fields, "shared:") == NULL) {
+            /* Mount event propagation is not set to shared, good. */
+            is_private = true;
+        }
+        break;
+    }
 
-	if (!is_mnt) {
-		if (mount(sc_ns_dir, sc_ns_dir, NULL, MS_BIND | MS_REC, NULL) <
-		    0) {
-			die("cannot self-bind mount %s", sc_ns_dir);
-		}
-	}
+    if (!is_mnt) {
+        if (mount(sc_ns_dir, sc_ns_dir, NULL, MS_BIND | MS_REC, NULL) < 0) {
+            die("cannot self-bind mount %s", sc_ns_dir);
+        }
+    }
 
-	if (!is_private) {
-		if (mount(NULL, sc_ns_dir, NULL, MS_PRIVATE, NULL) < 0) {
-			die("cannot change propagation type to MS_PRIVATE in %s", sc_ns_dir);
-		}
-	}
+    if (!is_private) {
+        if (mount(NULL, sc_ns_dir, NULL, MS_PRIVATE, NULL) < 0) {
+            die("cannot change propagation type to MS_PRIVATE in %s", sc_ns_dir);
+        }
+    }
 
-	/* code that follows is experimental */
-	if (experimental_features & SC_FEATURE_PARALLEL_INSTANCES) {
-		// Ensure that SNAP_MOUNT_DIR and /var/snap are shared mount points
-		debug
-		    ("(experimental) ensuring snap mount and data directories are mount points");
-		sc_ensure_snap_dir_shared_mounts();
-	}
+    /* code that follows is experimental */
+    if (experimental_features & SC_FEATURE_PARALLEL_INSTANCES) {
+        // Ensure that SNAP_MOUNT_DIR and /var/snap are shared mount points
+        debug("(experimental) ensuring snap mount and data directories are mount points");
+        sc_ensure_snap_dir_shared_mounts();
+    }
 }
 
 struct sc_mount_ns {
-	// Name of the namespace group ($SNAP_NAME).
-	char *name;
-	// Descriptor to the namespace group control directory.  This descriptor is
-	// opened with O_PATH|O_DIRECTORY so it's only used for openat() calls.
-	int dir_fd;
-	// Pair of descriptors for a pair for a pipe file descriptors (read end,
-	// write end) that snap-confine uses to send messages to the helper
-	// process and back.
-	int pipe_helper[2];
-	int pipe_master[2];
-	// Identifier of the child process that is used during the one-time (per
-	// group) initialization and capture process.
-	pid_t child;
+    // Name of the namespace group ($SNAP_NAME).
+    char *name;
+    // Descriptor to the namespace group control directory.  This descriptor is
+    // opened with O_PATH|O_DIRECTORY so it's only used for openat() calls.
+    int dir_fd;
+    // Pair of descriptors for a pair for a pipe file descriptors (read end,
+    // write end) that snap-confine uses to send messages to the helper
+    // process and back.
+    int pipe_helper[2];
+    int pipe_master[2];
+    // Identifier of the child process that is used during the one-time (per
+    // group) initialization and capture process.
+    pid_t child;
 };
 
-static struct sc_mount_ns *sc_alloc_mount_ns(void)
-{
-	struct sc_mount_ns *group = calloc(1, sizeof *group);
-	if (group == NULL) {
-		die("cannot allocate memory for sc_mount_ns");
-	}
-	group->dir_fd = -1;
-	group->pipe_helper[0] = -1;
-	group->pipe_helper[1] = -1;
-	group->pipe_master[0] = -1;
-	group->pipe_master[1] = -1;
-	// Redundant with calloc but some functions check for the non-zero value so
-	// I'd like to keep this explicit in the code.
-	group->child = 0;
-	return group;
+static struct sc_mount_ns *sc_alloc_mount_ns(void) {
+    struct sc_mount_ns *group = calloc(1, sizeof *group);
+    if (group == NULL) {
+        die("cannot allocate memory for sc_mount_ns");
+    }
+    group->dir_fd = -1;
+    group->pipe_helper[0] = -1;
+    group->pipe_helper[1] = -1;
+    group->pipe_master[0] = -1;
+    group->pipe_master[1] = -1;
+    // Redundant with calloc but some functions check for the non-zero value so
+    // I'd like to keep this explicit in the code.
+    group->child = 0;
+    return group;
 }
 
-struct sc_mount_ns *sc_open_mount_ns(const char *group_name)
-{
-	struct sc_mount_ns *group = sc_alloc_mount_ns();
-	group->dir_fd = open(sc_ns_dir,
-			     O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
-	if (group->dir_fd < 0) {
-		die("cannot open directory %s", sc_ns_dir);
-	}
-	group->name = sc_strdup(group_name);
-	return group;
+struct sc_mount_ns *sc_open_mount_ns(const char *group_name) {
+    struct sc_mount_ns *group = sc_alloc_mount_ns();
+    group->dir_fd = open(sc_ns_dir, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
+    if (group->dir_fd < 0) {
+        die("cannot open directory %s", sc_ns_dir);
+    }
+    group->name = sc_strdup(group_name);
+    return group;
 }
 
-void sc_close_mount_ns(struct sc_mount_ns *group)
-{
-	if (group->child != 0) {
-		sc_wait_for_helper(group);
-	}
-	sc_cleanup_close(&group->dir_fd);
-	sc_cleanup_close(&group->pipe_master[0]);
-	sc_cleanup_close(&group->pipe_master[1]);
-	sc_cleanup_close(&group->pipe_helper[0]);
-	sc_cleanup_close(&group->pipe_helper[1]);
-	free(group->name);
-	free(group);
+void sc_close_mount_ns(struct sc_mount_ns *group) {
+    if (group->child != 0) {
+        sc_wait_for_helper(group);
+    }
+    sc_cleanup_close(&group->dir_fd);
+    sc_cleanup_close(&group->pipe_master[0]);
+    sc_cleanup_close(&group->pipe_master[1]);
+    sc_cleanup_close(&group->pipe_helper[0]);
+    sc_cleanup_close(&group->pipe_helper[1]);
+    free(group->name);
+    free(group);
 }
 
-static dev_t find_base_snap_device(const char *base_snap_name,
-				   const char *base_snap_rev)
-{
-	// Find the backing device of the base snap.
-	// TODO: add support for "try mode" base snaps that also need
-	// consideration of the mie->root component.
-	dev_t base_snap_dev = 0;
-	char base_squashfs_path[PATH_MAX];
-	sc_must_snprintf(base_squashfs_path, sizeof base_squashfs_path,
-			 "%s/%s/%s", sc_snap_mount_dir(NULL), base_snap_name,
-			 base_snap_rev);
-	sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
-	mi = sc_parse_mountinfo(NULL);
-	if (mi == NULL) {
-		die("cannot parse mountinfo of the current process");
-	}
-	bool found = false;
-	for (sc_mountinfo_entry * mie =
-	     sc_first_mountinfo_entry(mi); mie != NULL;
-	     mie = sc_next_mountinfo_entry(mie)) {
-		if (sc_streq(mie->mount_dir, base_squashfs_path)) {
-			base_snap_dev = makedev(mie->dev_major, mie->dev_minor);
-			debug("block device of snap %s, revision %s is %d:%d",
-			      base_snap_name, base_snap_rev, mie->dev_major,
-			      mie->dev_minor);
-			// Don't break when found, we are interested in the last
-			// entry as this is the "effective" one.
-			found = true;
-		}
-	}
-	if (!found) {
-		die("cannot find mount entry for snap %s revision %s",
-		    base_snap_name, base_snap_rev);
-	}
-	return base_snap_dev;
+static dev_t find_base_snap_device(const char *base_snap_name, const char *base_snap_rev) {
+    // Find the backing device of the base snap.
+    // TODO: add support for "try mode" base snaps that also need
+    // consideration of the mie->root component.
+    dev_t base_snap_dev = 0;
+    char base_squashfs_path[PATH_MAX];
+    sc_must_snprintf(base_squashfs_path, sizeof base_squashfs_path, "%s/%s/%s", sc_snap_mount_dir(NULL), base_snap_name,
+                     base_snap_rev);
+    sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+    mi = sc_parse_mountinfo(NULL);
+    if (mi == NULL) {
+        die("cannot parse mountinfo of the current process");
+    }
+    bool found = false;
+    for (sc_mountinfo_entry *mie = sc_first_mountinfo_entry(mi); mie != NULL; mie = sc_next_mountinfo_entry(mie)) {
+        if (sc_streq(mie->mount_dir, base_squashfs_path)) {
+            base_snap_dev = makedev(mie->dev_major, mie->dev_minor);
+            debug("block device of snap %s, revision %s is %d:%d", base_snap_name, base_snap_rev, mie->dev_major,
+                  mie->dev_minor);
+            // Don't break when found, we are interested in the last
+            // entry as this is the "effective" one.
+            found = true;
+        }
+    }
+    if (!found) {
+        die("cannot find mount entry for snap %s revision %s", base_snap_name, base_snap_rev);
+    }
+    return base_snap_dev;
 }
 
-static bool base_snap_device_changed(sc_mountinfo *mi, dev_t base_snap_dev)
-{
-	sc_mountinfo_entry *mie;
+static bool base_snap_device_changed(sc_mountinfo *mi, dev_t base_snap_dev) {
+    sc_mountinfo_entry *mie;
 
-	/* We are looking for a mount entry matching the device ID of the base
-	 * snap. We need to take these cases into account:
-	 * 1) In the typical case, this will be mounted on the "/" directory.
-	 * 2) If the root directory is a tmpfs, the base snap would be mounted
-	 *    under /usr.
-	 * 3) If the snap has a layout that adds directories or files directly
-	 *    under /usr, a writable mimic will be created: /usr will be a tmpfs,
-	 *    with all of the original directory entries inside of /usr being
-	 *    bind-mounted onto mount-points created into the tmpfs.
-	 * In light of the above, we do ignore all tmpfs entries and accept that
-	 * our base snap might be mounted under /, /usr, or anywhere under /usr.
-	 */
-	for (mie = sc_first_mountinfo_entry(mi); mie != NULL;
-	     mie = sc_next_mountinfo_entry(mie)) {
-		if (sc_streq(mie->fs_type, "tmpfs")) {
-			continue;
-		}
+    /* We are looking for a mount entry matching the device ID of the base
+     * snap. We need to take these cases into account:
+     * 1) In the typical case, this will be mounted on the "/" directory.
+     * 2) If the root directory is a tmpfs, the base snap would be mounted
+     *    under /usr.
+     * 3) If the snap has a layout that adds directories or files directly
+     *    under /usr, a writable mimic will be created: /usr will be a tmpfs,
+     *    with all of the original directory entries inside of /usr being
+     *    bind-mounted onto mount-points created into the tmpfs.
+     * In light of the above, we do ignore all tmpfs entries and accept that
+     * our base snap might be mounted under /, /usr, or anywhere under /usr.
+     */
+    for (mie = sc_first_mountinfo_entry(mi); mie != NULL; mie = sc_next_mountinfo_entry(mie)) {
+        if (sc_streq(mie->fs_type, "tmpfs")) {
+            continue;
+        }
 
-		if (base_snap_dev == makedev(mie->dev_major, mie->dev_minor) &&
-		    (sc_streq(mie->mount_dir, "/") ||
-		     sc_streq(mie->mount_dir, "/usr") ||
-		     sc_startswith(mie->mount_dir, "/usr/"))) {
-			debug("found base snap device %d:%d on %s",
-			      mie->dev_major, mie->dev_minor, mie->mount_dir);
-			return false;
-		}
-	}
-	debug("base snap device %d:%d not found in existing mount ns",
-	      major(base_snap_dev), minor(base_snap_dev));
-	return true;
+        if (base_snap_dev == makedev(mie->dev_major, mie->dev_minor) &&
+            (sc_streq(mie->mount_dir, "/") || sc_streq(mie->mount_dir, "/usr") ||
+             sc_startswith(mie->mount_dir, "/usr/"))) {
+            debug("found base snap device %d:%d on %s", mie->dev_major, mie->dev_minor, mie->mount_dir);
+            return false;
+        }
+    }
+    debug("base snap device %d:%d not found in existing mount ns", major(base_snap_dev), minor(base_snap_dev));
+    return true;
 }
 
-static bool homedirs_are_mounted(sc_mountinfo *mi, char **homedirs,
-				 int num_homedirs)
-{
-	if (num_homedirs == 0) {
-		return true;
-	}
+static bool homedirs_are_mounted(sc_mountinfo *mi, char **homedirs, int num_homedirs) {
+    if (num_homedirs == 0) {
+        return true;
+    }
 
-	/* We know that the number of homedirs is not going to be huge, so let's
-	 * just allocare this vector on the stack */
-	bool homedir_seen[num_homedirs];
-	for (int i = 0; i < num_homedirs; i++) {
-		homedir_seen[i] = false;
-	}
+    /* We know that the number of homedirs is not going to be huge, so let's
+     * just allocare this vector on the stack */
+    bool homedir_seen[num_homedirs];
+    for (int i = 0; i < num_homedirs; i++) {
+        homedir_seen[i] = false;
+    }
 
-	sc_mountinfo_entry *mie;
-	for (mie = sc_first_mountinfo_entry(mi); mie != NULL;
-	     mie = sc_next_mountinfo_entry(mie)) {
-		for (int i = 0; i < num_homedirs; i++) {
-			if (sc_streq(mie->mount_dir, homedirs[i])) {
-				homedir_seen[i] = true;
-			}
-		}
-	}
+    sc_mountinfo_entry *mie;
+    for (mie = sc_first_mountinfo_entry(mi); mie != NULL; mie = sc_next_mountinfo_entry(mie)) {
+        for (int i = 0; i < num_homedirs; i++) {
+            if (sc_streq(mie->mount_dir, homedirs[i])) {
+                homedir_seen[i] = true;
+            }
+        }
+    }
 
-	bool all_seen = true;
-	for (int i = 0; i < num_homedirs; i++) {
-		if (!homedir_seen[i]) {
-			debug("Homedir %s missing from namespace", homedirs[i]);
-			all_seen = false;
-			break;
-		}
-	}
-	return all_seen;
+    bool all_seen = true;
+    for (int i = 0; i < num_homedirs; i++) {
+        if (!homedir_seen[i]) {
+            debug("Homedir %s missing from namespace", homedirs[i]);
+            all_seen = false;
+            break;
+        }
+    }
+    return all_seen;
 }
 
 // Inspect the namespace and check if we should discard it.
-static bool should_discard_current_ns(const struct sc_invocation *inv,
-				      dev_t base_snap_dev)
-{
-	sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+static bool should_discard_current_ns(const struct sc_invocation *inv, dev_t base_snap_dev) {
+    sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 
-	mi = sc_parse_mountinfo(NULL);
-	if (mi == NULL) {
-		die("cannot parse mountinfo of the current process");
-	}
-	// The namespace may become "stale" when the rootfs is not the same
-	// device we found above. This will happen whenever the base snap is
-	// refreshed since the namespace was first created.
-	if (base_snap_device_changed(mi, base_snap_dev)) {
-		return true;
-	}
-	// Another reason for becoming stale is if the homedirs configuration has
-	// changed: so this code will check that all homedirs are mounted in the
-	// namespace.
-	if (!homedirs_are_mounted(mi, inv->homedirs, inv->num_homedirs)) {
-		return true;
-	}
+    mi = sc_parse_mountinfo(NULL);
+    if (mi == NULL) {
+        die("cannot parse mountinfo of the current process");
+    }
+    // The namespace may become "stale" when the rootfs is not the same
+    // device we found above. This will happen whenever the base snap is
+    // refreshed since the namespace was first created.
+    if (base_snap_device_changed(mi, base_snap_dev)) {
+        return true;
+    }
+    // Another reason for becoming stale is if the homedirs configuration has
+    // changed: so this code will check that all homedirs are mounted in the
+    // namespace.
+    if (!homedirs_are_mounted(mi, inv->homedirs, inv->num_homedirs)) {
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 enum sc_discard_vote {
-	/**
-	 * SC_DISCARD_NO denotes that the mount namespace doesn't have to be
-	 * discarded. This happens when the base snap has not changed.
-	 **/
-	SC_DISCARD_NO = 1,
-	/**
-	 * SC_DISCARD_SHOULD indicates that the mount namespace should be discarded
-	 * but may be reused if it is still inhabited by processes. This only
-	 * happens when the base snap revision changes but the name of the base
-	 * snap is the same as before.
-	 **/
-	SC_DISCARD_SHOULD = 2,
-	/**
-	 * SC_DISCARD_MUST indicates that the mount namespace must be discarded
-	 * even if it still inhabited by processes. This only happens when the name
-	 * of the base snap changes.
-	 **/
-	SC_DISCARD_MUST = 3,
+    /**
+     * SC_DISCARD_NO denotes that the mount namespace doesn't have to be
+     * discarded. This happens when the base snap has not changed.
+     **/
+    SC_DISCARD_NO = 1,
+    /**
+     * SC_DISCARD_SHOULD indicates that the mount namespace should be discarded
+     * but may be reused if it is still inhabited by processes. This only
+     * happens when the base snap revision changes but the name of the base
+     * snap is the same as before.
+     **/
+    SC_DISCARD_SHOULD = 2,
+    /**
+     * SC_DISCARD_MUST indicates that the mount namespace must be discarded
+     * even if it still inhabited by processes. This only happens when the name
+     * of the base snap changes.
+     **/
+    SC_DISCARD_MUST = 3,
 };
 
 /**
@@ -401,40 +374,36 @@ enum sc_discard_vote {
  * differ then a base transition is occurring. If the info file is absent or
  * does not record the name of the base snap then transition cannot be
  * detected.
-**/
-static bool is_base_transition(const sc_invocation *inv)
-{
-	char info_path[PATH_MAX] = { 0 };
-	sc_must_snprintf(info_path,
-			 sizeof info_path,
-			 "/run/snapd/ns/snap.%s.info", inv->snap_instance);
+ **/
+static bool is_base_transition(const sc_invocation *inv) {
+    char info_path[PATH_MAX] = {0};
+    sc_must_snprintf(info_path, sizeof info_path, "/run/snapd/ns/snap.%s.info", inv->snap_instance);
 
-	FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
-	stream = fopen(info_path, "r");
-	if (stream == NULL && errno == ENOENT) {
-		// If the info file is absent then we cannot decide if a transition had
-		// occurred. For people upgrading from snap-confine without the info
-		// file, that is the best we can do.
-		return false;
-	}
-	if (stream == NULL) {
-		die("cannot open %s", info_path);
-	}
+    FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
+    stream = fopen(info_path, "r");
+    if (stream == NULL && errno == ENOENT) {
+        // If the info file is absent then we cannot decide if a transition had
+        // occurred. For people upgrading from snap-confine without the info
+        // file, that is the best we can do.
+        return false;
+    }
+    if (stream == NULL) {
+        die("cannot open %s", info_path);
+    }
 
-	char *base_snap_name SC_CLEANUP(sc_cleanup_string) = NULL;
-	sc_error *err = NULL;
-	if (sc_infofile_get_key
-	    (stream, "base-snap-name", &base_snap_name, &err) < 0) {
-		sc_die_on_error(err);
-	}
+    char *base_snap_name SC_CLEANUP(sc_cleanup_string) = NULL;
+    sc_error *err = NULL;
+    if (sc_infofile_get_key(stream, "base-snap-name", &base_snap_name, &err) < 0) {
+        sc_die_on_error(err);
+    }
 
-	if (base_snap_name == NULL) {
-		// If the info file doesn't record the name of the base snap then,
-		// again, we cannot decide if a transition had occurred.
-		return false;
-	}
+    if (base_snap_name == NULL) {
+        // If the info file doesn't record the name of the base snap then,
+        // again, we cannot decide if a transition had occurred.
+        return false;
+    }
 
-	return !sc_streq(inv->orig_base_snap_name, base_snap_name);
+    return !sc_streq(inv->orig_base_snap_name, base_snap_name);
 }
 
 static bool sc_is_mount_ns_in_use(const char *snap_instance);
@@ -444,554 +413,507 @@ static bool sc_is_mount_ns_in_use(const char *snap_instance);
 // To work around this we'll fork a child and use it to probe. The child will
 // inspect the namespace and send information back via eventfd and then exit
 // unconditionally.
-static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
-						 const sc_invocation *inv,
-						 int snap_discard_ns_fd)
-{
-	char base_snap_rev[PATH_MAX] = { 0 };
-	dev_t base_snap_dev;
-	int event_fd SC_CLEANUP(sc_cleanup_close) = -1;
+static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd, const sc_invocation *inv, int snap_discard_ns_fd) {
+    char base_snap_rev[PATH_MAX] = {0};
+    dev_t base_snap_dev;
+    int event_fd SC_CLEANUP(sc_cleanup_close) = -1;
 
-	// Read the revision of the base snap by looking at the current symlink.
-	if (readlink(inv->rootfs_dir, base_snap_rev, sizeof base_snap_rev) < 0) {
-		die("cannot read current revision of snap %s",
-		    inv->snap_instance);
-	}
-	if (base_snap_rev[sizeof base_snap_rev - 1] != '\0') {
-		die("cannot read current revision of snap %s: value too long",
-		    inv->snap_instance);
-	}
-	// Find the device that is backing the current revision of the base snap.
-	base_snap_dev =
-	    find_base_snap_device(inv->base_snap_name, base_snap_rev);
+    // Read the revision of the base snap by looking at the current symlink.
+    if (readlink(inv->rootfs_dir, base_snap_rev, sizeof base_snap_rev) < 0) {
+        die("cannot read current revision of snap %s", inv->snap_instance);
+    }
+    if (base_snap_rev[sizeof base_snap_rev - 1] != '\0') {
+        die("cannot read current revision of snap %s: value too long", inv->snap_instance);
+    }
+    // Find the device that is backing the current revision of the base snap.
+    base_snap_dev = find_base_snap_device(inv->base_snap_name, base_snap_rev);
 
-	// Store the PID of this process. This is done instead of calls to
-	// getppid() below because then we can reliably track the PID of the
-	// parent even if the child process is re-parented.
-	pid_t parent = getpid();
+    // Store the PID of this process. This is done instead of calls to
+    // getppid() below because then we can reliably track the PID of the
+    // parent even if the child process is re-parented.
+    pid_t parent = getpid();
 
-	// Create an eventfd for the communication with the child.
-	event_fd = eventfd(0, EFD_CLOEXEC);
-	if (event_fd < 0) {
-		die("cannot create eventfd");
-	}
-	// Fork a child, it will do the inspection for us.
-	pid_t child = fork();
-	if (child < 0) {
-		die("cannot fork support process");
-	}
+    // Create an eventfd for the communication with the child.
+    event_fd = eventfd(0, EFD_CLOEXEC);
+    if (event_fd < 0) {
+        die("cannot create eventfd");
+    }
+    // Fork a child, it will do the inspection for us.
+    pid_t child = fork();
+    if (child < 0) {
+        die("cannot fork support process");
+    }
 
-	if (child == 0) {
-		// This is the child process which will inspect the mount namespace.
-		//
-		// Configure the child to die as soon as the parent dies. In an odd
-		// case where the parent is killed then we don't want to complete our
-		// task or wait for anything.
-		if (prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0) < 0) {
-			die("cannot set parent process death notification signal to SIGINT");
-		}
-		// Check that parent process is still alive. If this is the case then
-		// we can *almost* reliably rely on the PR_SET_PDEATHSIG signal to wake
-		// us up from eventfd_read() below. In the rare case that the PID
-		// numbers overflow and the now-dead parent PID is recycled we will
-		// still hang forever on the read from eventfd below.
-		if (kill(parent, 0) < 0) {
-			switch (errno) {
-			case ESRCH:
-				debug("parent process has terminated");
-				abort();
-			default:
-				die("cannot confirm that parent process is alive");
-				break;
-			}
-		}
+    if (child == 0) {
+        // This is the child process which will inspect the mount namespace.
+        //
+        // Configure the child to die as soon as the parent dies. In an odd
+        // case where the parent is killed then we don't want to complete our
+        // task or wait for anything.
+        if (prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0) < 0) {
+            die("cannot set parent process death notification signal to SIGINT");
+        }
+        // Check that parent process is still alive. If this is the case then
+        // we can *almost* reliably rely on the PR_SET_PDEATHSIG signal to wake
+        // us up from eventfd_read() below. In the rare case that the PID
+        // numbers overflow and the now-dead parent PID is recycled we will
+        // still hang forever on the read from eventfd below.
+        if (kill(parent, 0) < 0) {
+            switch (errno) {
+                case ESRCH:
+                    debug("parent process has terminated");
+                    abort();
+                default:
+                    die("cannot confirm that parent process is alive");
+                    break;
+            }
+        }
 
-		debug("joining preserved mount namespace for inspection");
-		// Move to the mount namespace of the snap we're trying to inspect.
-		if (setns(mnt_fd, CLONE_NEWNS) < 0) {
-			die("cannot join preserved mount namespace");
-		}
-		// Check if the namespace needs to be discarded.
-		eventfd_t value = SC_DISCARD_NO;
-		const char *value_str = "no";
+        debug("joining preserved mount namespace for inspection");
+        // Move to the mount namespace of the snap we're trying to inspect.
+        if (setns(mnt_fd, CLONE_NEWNS) < 0) {
+            die("cannot join preserved mount namespace");
+        }
+        // Check if the namespace needs to be discarded.
+        eventfd_t value = SC_DISCARD_NO;
+        const char *value_str = "no";
 
-		// TODO: enable this for core distributions. This is complex because on
-		// core the rootfs is mounted in initrd and is _not_ changed (no
-		// pivot_root) and the base snap is again mounted (2nd time) by
-		// systemd. This makes us end up in a situation where the outer base
-		// snap will never match the rootfs inside the mount namespace.
-		if (inv->is_normal_mode
-		    && should_discard_current_ns(inv, base_snap_dev)) {
-			value = SC_DISCARD_SHOULD;
-			value_str = "should";
-		}
-		// If the base snap changed, we must discard the mount namespace and
-		// start over to allow the newly started process to see the requested
-		// base snap. Due to the TODO above always perform explicit transition
-		// check to protect against LP:#1819875 and LP:#1861901
-		if (is_base_transition(inv)) {
-			// The base snap has changed. We must discard ...
-			value = SC_DISCARD_MUST;
-			value_str = "must";
-		}
-		// Send this back to the parent: 3 - force discard 2 - prefer discard, 1 - keep.
-		// Note that we cannot just use 0 and 1 because of the semantics of eventfd(2).
-		if (eventfd_write(event_fd, value) < 0) {
-			die("cannot send information to %s preserved mount namespace", value_str);
-		}
-		// Exit, we're done.
-		exit(0);
-	}
-	// This is back in the parent process.
-	//
-	// Enable a sanity timeout in case the read blocks for unbound amount of
-	// time. This will ensure we will not hang around while holding the lock.
-	// Next, read the value written by the child process.
-	sc_enable_sanity_timeout();
-	eventfd_t value = 0;
-	if (eventfd_read(event_fd, &value) < 0) {
-		die("cannot read from eventfd");
-	}
-	sc_disable_sanity_timeout();
+        // TODO: enable this for core distributions. This is complex because on
+        // core the rootfs is mounted in initrd and is _not_ changed (no
+        // pivot_root) and the base snap is again mounted (2nd time) by
+        // systemd. This makes us end up in a situation where the outer base
+        // snap will never match the rootfs inside the mount namespace.
+        if (inv->is_normal_mode && should_discard_current_ns(inv, base_snap_dev)) {
+            value = SC_DISCARD_SHOULD;
+            value_str = "should";
+        }
+        // If the base snap changed, we must discard the mount namespace and
+        // start over to allow the newly started process to see the requested
+        // base snap. Due to the TODO above always perform explicit transition
+        // check to protect against LP:#1819875 and LP:#1861901
+        if (is_base_transition(inv)) {
+            // The base snap has changed. We must discard ...
+            value = SC_DISCARD_MUST;
+            value_str = "must";
+        }
+        // Send this back to the parent: 3 - force discard 2 - prefer discard, 1 - keep.
+        // Note that we cannot just use 0 and 1 because of the semantics of eventfd(2).
+        if (eventfd_write(event_fd, value) < 0) {
+            die("cannot send information to %s preserved mount namespace", value_str);
+        }
+        // Exit, we're done.
+        exit(0);
+    }
+    // This is back in the parent process.
+    //
+    // Enable a sanity timeout in case the read blocks for unbound amount of
+    // time. This will ensure we will not hang around while holding the lock.
+    // Next, read the value written by the child process.
+    sc_enable_sanity_timeout();
+    eventfd_t value = 0;
+    if (eventfd_read(event_fd, &value) < 0) {
+        die("cannot read from eventfd");
+    }
+    sc_disable_sanity_timeout();
 
-	// Wait for the child process to exit and collect its exit status.
-	errno = 0;
-	int status = 0;
-	if (waitpid(child, &status, 0) < 0) {
-		die("cannot wait for the support process for mount namespace inspection");
-	}
-	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		die("support process for mount namespace inspection exited abnormally");
-	}
-	// If the namespace is up-to-date then we are done.
-	switch (value) {
-	case SC_DISCARD_NO:
-		debug("preserved mount is not stale, reusing");
-		return 0;
-	case SC_DISCARD_SHOULD:
-		if (sc_is_mount_ns_in_use(inv->snap_instance)) {
-			// Some processes are still using the namespace so we cannot discard it
-			// as that would fracture the view that the set of processes inside
-			// have on what is mounted.
-			debug
-			    ("preserved mount namespace is stale but occupied, reusing");
-			return 0;
-		}
-		break;
-	case SC_DISCARD_MUST:
-		debug
-		    ("preserved mount namespace is stale and base snap has changed, discarding");
-		break;
-	}
-	sc_call_snap_discard_ns(snap_discard_ns_fd, inv->snap_instance);
-	return EAGAIN;
+    // Wait for the child process to exit and collect its exit status.
+    errno = 0;
+    int status = 0;
+    if (waitpid(child, &status, 0) < 0) {
+        die("cannot wait for the support process for mount namespace inspection");
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        die("support process for mount namespace inspection exited abnormally");
+    }
+    // If the namespace is up-to-date then we are done.
+    switch (value) {
+        case SC_DISCARD_NO:
+            debug("preserved mount is not stale, reusing");
+            return 0;
+        case SC_DISCARD_SHOULD:
+            if (sc_is_mount_ns_in_use(inv->snap_instance)) {
+                // Some processes are still using the namespace so we cannot discard it
+                // as that would fracture the view that the set of processes inside
+                // have on what is mounted.
+                debug("preserved mount namespace is stale but occupied, reusing");
+                return 0;
+            }
+            break;
+        case SC_DISCARD_MUST:
+            debug("preserved mount namespace is stale and base snap has changed, discarding");
+            break;
+    }
+    sc_call_snap_discard_ns(snap_discard_ns_fd, inv->snap_instance);
+    return EAGAIN;
 }
 
-static void helper_fork(struct sc_mount_ns *group,
-			struct sc_apparmor *apparmor);
-static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor,
-			pid_t parent);
+static void helper_fork(struct sc_mount_ns *group, struct sc_apparmor *apparmor);
+static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor, pid_t parent);
 static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent);
 static void helper_capture_per_user_ns(struct sc_mount_ns *group, pid_t parent);
 
-int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
-			 *apparmor, const sc_invocation *inv,
-			 int snap_discard_ns_fd)
-{
-	// Open the mount namespace file.
-	char mnt_fname[PATH_MAX] = { 0 };
-	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s.mnt", group->name);
-	int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	// NOTE: There is no O_EXCL here because the file can be around but
-	// doesn't have to be a mounted namespace.
-	mnt_fd = openat(group->dir_fd, mnt_fname,
-			O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0600);
-	if (mnt_fd < 0 && errno == ENOENT) {
-		return ESRCH;
-	}
-	if (mnt_fd < 0) {
-		die("cannot open preserved mount namespace %s", group->name);
-	}
-	// Check if we got an nsfs-based or procfs file or a regular file. This can
-	// be reliably tested because nsfs has an unique filesystem type
-	// NSFS_MAGIC.  On older kernels that don't support nsfs yet we can look
-	// for PROC_SUPER_MAGIC instead.
-	// We can just ensure that this is the case thanks to fstatfs.
-	struct statfs ns_statfs_buf;
-	if (fstatfs(mnt_fd, &ns_statfs_buf) < 0) {
-		die("cannot inspect filesystem of preserved mount namespace file");
-	}
-	// Stat the mount namespace as well, this is later used to check if the
-	// namespace is used by other processes if we are considering discarding a
-	// stale namespace.
-	struct stat ns_stat_buf;
-	if (fstat(mnt_fd, &ns_stat_buf) < 0) {
-		die("cannot inspect preserved mount namespace file");
-	}
+int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor *apparmor, const sc_invocation *inv,
+                         int snap_discard_ns_fd) {
+    // Open the mount namespace file.
+    char mnt_fname[PATH_MAX] = {0};
+    sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s.mnt", group->name);
+    int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    // NOTE: There is no O_EXCL here because the file can be around but
+    // doesn't have to be a mounted namespace.
+    mnt_fd = openat(group->dir_fd, mnt_fname, O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (mnt_fd < 0 && errno == ENOENT) {
+        return ESRCH;
+    }
+    if (mnt_fd < 0) {
+        die("cannot open preserved mount namespace %s", group->name);
+    }
+    // Check if we got an nsfs-based or procfs file or a regular file. This can
+    // be reliably tested because nsfs has an unique filesystem type
+    // NSFS_MAGIC.  On older kernels that don't support nsfs yet we can look
+    // for PROC_SUPER_MAGIC instead.
+    // We can just ensure that this is the case thanks to fstatfs.
+    struct statfs ns_statfs_buf;
+    if (fstatfs(mnt_fd, &ns_statfs_buf) < 0) {
+        die("cannot inspect filesystem of preserved mount namespace file");
+    }
+    // Stat the mount namespace as well, this is later used to check if the
+    // namespace is used by other processes if we are considering discarding a
+    // stale namespace.
+    struct stat ns_stat_buf;
+    if (fstat(mnt_fd, &ns_stat_buf) < 0) {
+        die("cannot inspect preserved mount namespace file");
+    }
 #ifndef NSFS_MAGIC
 // Account for kernel headers old enough to not know about NSFS_MAGIC.
 #define NSFS_MAGIC 0x6e736673
 #endif
-	if (ns_statfs_buf.f_type == NSFS_MAGIC
-	    || ns_statfs_buf.f_type == PROC_SUPER_MAGIC) {
-
-		// Inspect and perhaps discard the preserved mount namespace.
-		if (sc_inspect_and_maybe_discard_stale_ns
-		    (mnt_fd, inv, snap_discard_ns_fd) == EAGAIN) {
-			return ESRCH;
-		}
-		// Move to the mount namespace of the snap we're trying to start.
-		if (setns(mnt_fd, CLONE_NEWNS) < 0) {
-			die("cannot join preserved mount namespace %s",
-			    group->name);
-		}
-		debug("joined preserved mount namespace %s", group->name);
-		return 0;
-	}
-	return ESRCH;
+    if (ns_statfs_buf.f_type == NSFS_MAGIC || ns_statfs_buf.f_type == PROC_SUPER_MAGIC) {
+        // Inspect and perhaps discard the preserved mount namespace.
+        if (sc_inspect_and_maybe_discard_stale_ns(mnt_fd, inv, snap_discard_ns_fd) == EAGAIN) {
+            return ESRCH;
+        }
+        // Move to the mount namespace of the snap we're trying to start.
+        if (setns(mnt_fd, CLONE_NEWNS) < 0) {
+            die("cannot join preserved mount namespace %s", group->name);
+        }
+        debug("joined preserved mount namespace %s", group->name);
+        return 0;
+    }
+    return ESRCH;
 }
 
-int sc_join_preserved_per_user_ns(struct sc_mount_ns *group,
-				  const char *snap_name)
-{
-	uid_t uid = getuid();
-	char mnt_fname[PATH_MAX] = { 0 };
-	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s.%d.mnt", group->name,
-			 (int)uid);
+int sc_join_preserved_per_user_ns(struct sc_mount_ns *group, const char *snap_name) {
+    uid_t uid = getuid();
+    char mnt_fname[PATH_MAX] = {0};
+    sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s.%d.mnt", group->name, (int)uid);
 
-	int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	mnt_fd = openat(group->dir_fd, mnt_fname,
-			O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0600);
-	if (mnt_fd < 0 && errno == ENOENT) {
-		return ESRCH;
-	}
-	if (mnt_fd < 0) {
-		die("cannot open preserved mount namespace %s", group->name);
-	}
-	struct statfs ns_statfs_buf;
-	if (fstatfs(mnt_fd, &ns_statfs_buf) < 0) {
-		die("cannot inspect filesystem of preserved mount namespace file");
-	}
-	struct stat ns_stat_buf;
-	if (fstat(mnt_fd, &ns_stat_buf) < 0) {
-		die("cannot inspect preserved mount namespace file");
-	}
+    int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    mnt_fd = openat(group->dir_fd, mnt_fname, O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (mnt_fd < 0 && errno == ENOENT) {
+        return ESRCH;
+    }
+    if (mnt_fd < 0) {
+        die("cannot open preserved mount namespace %s", group->name);
+    }
+    struct statfs ns_statfs_buf;
+    if (fstatfs(mnt_fd, &ns_statfs_buf) < 0) {
+        die("cannot inspect filesystem of preserved mount namespace file");
+    }
+    struct stat ns_stat_buf;
+    if (fstat(mnt_fd, &ns_stat_buf) < 0) {
+        die("cannot inspect preserved mount namespace file");
+    }
 #ifndef NSFS_MAGIC
-	/* Define NSFS_MAGIC for Ubuntu 14.04 and other older systems. */
+    /* Define NSFS_MAGIC for Ubuntu 14.04 and other older systems. */
 #define NSFS_MAGIC 0x6e736673
 #endif
-	if (ns_statfs_buf.f_type == NSFS_MAGIC
-	    || ns_statfs_buf.f_type == PROC_SUPER_MAGIC) {
-		if (setns(mnt_fd, CLONE_NEWNS) < 0) {
-			die("cannot join preserved per-user mount namespace %s",
-			    group->name);
-		}
-		debug("joined preserved mount namespace %s", group->name);
-		return 0;
-	}
-	return ESRCH;
+    if (ns_statfs_buf.f_type == NSFS_MAGIC || ns_statfs_buf.f_type == PROC_SUPER_MAGIC) {
+        if (setns(mnt_fd, CLONE_NEWNS) < 0) {
+            die("cannot join preserved per-user mount namespace %s", group->name);
+        }
+        debug("joined preserved mount namespace %s", group->name);
+        return 0;
+    }
+    return ESRCH;
 }
 
-static void setup_signals_for_helper(void)
-{
-	/* Ignore the SIGPIPE signal so that we get EPIPE on the read / write
-	 * operations attempting to work with a closed pipe. This ensures that we
-	 * are not killed by the default disposition (terminate) and can return a
-	 * non-signal-death return code to the program invoking snap-confine. */
-	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
-		die("cannot install ignore handler for SIGPIPE");
-	}
+static void setup_signals_for_helper(void) {
+    /* Ignore the SIGPIPE signal so that we get EPIPE on the read / write
+     * operations attempting to work with a closed pipe. This ensures that we
+     * are not killed by the default disposition (terminate) and can return a
+     * non-signal-death return code to the program invoking snap-confine. */
+    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+        die("cannot install ignore handler for SIGPIPE");
+    }
 }
 
-static void teardown_signals_for_helper(void)
-{
-	/* Undo operations done by setup_signals_for_helper. */
-	if (signal(SIGPIPE, SIG_DFL) == SIG_ERR) {
-		die("cannot restore default handler for SIGPIPE");
-	}
+static void teardown_signals_for_helper(void) {
+    /* Undo operations done by setup_signals_for_helper. */
+    if (signal(SIGPIPE, SIG_DFL) == SIG_ERR) {
+        die("cannot restore default handler for SIGPIPE");
+    }
 }
 
-static void helper_fork(struct sc_mount_ns *group, struct sc_apparmor *apparmor)
-{
-	// Create a pipe for sending commands to the helper process.
-	if (pipe2(group->pipe_master, O_CLOEXEC | O_DIRECT) < 0) {
-		die("cannot create pipes for commanding the helper process");
-	}
-	if (pipe2(group->pipe_helper, O_CLOEXEC | O_DIRECT) < 0) {
-		die("cannot create pipes for responding to master process");
-	}
-	// Store the PID of the "parent" process. This done instead of calls to
-	// getppid() because then we can reliably track the PID of the parent even
-	// if the child process is re-parented.
-	pid_t parent = getpid();
+static void helper_fork(struct sc_mount_ns *group, struct sc_apparmor *apparmor) {
+    // Create a pipe for sending commands to the helper process.
+    if (pipe2(group->pipe_master, O_CLOEXEC | O_DIRECT) < 0) {
+        die("cannot create pipes for commanding the helper process");
+    }
+    if (pipe2(group->pipe_helper, O_CLOEXEC | O_DIRECT) < 0) {
+        die("cannot create pipes for responding to master process");
+    }
+    // Store the PID of the "parent" process. This done instead of calls to
+    // getppid() because then we can reliably track the PID of the parent even
+    // if the child process is re-parented.
+    pid_t parent = getpid();
 
-	// For rationale of forking see this:
-	// https://lists.linuxfoundation.org/pipermail/containers/2013-August/033386.html
-	pid_t pid = fork();
-	if (pid < 0) {
-		die("cannot fork helper process for mount namespace capture");
-	}
-	if (pid == 0) {
-		/* helper */
-		sc_cleanup_close(&group->pipe_master[1]);
-		sc_cleanup_close(&group->pipe_helper[0]);
-		helper_main(group, apparmor, parent);
-	} else {
-		setup_signals_for_helper();
+    // For rationale of forking see this:
+    // https://lists.linuxfoundation.org/pipermail/containers/2013-August/033386.html
+    pid_t pid = fork();
+    if (pid < 0) {
+        die("cannot fork helper process for mount namespace capture");
+    }
+    if (pid == 0) {
+        /* helper */
+        sc_cleanup_close(&group->pipe_master[1]);
+        sc_cleanup_close(&group->pipe_helper[0]);
+        helper_main(group, apparmor, parent);
+    } else {
+        setup_signals_for_helper();
 
-		/* master */
-		sc_cleanup_close(&group->pipe_master[0]);
-		sc_cleanup_close(&group->pipe_helper[1]);
+        /* master */
+        sc_cleanup_close(&group->pipe_master[0]);
+        sc_cleanup_close(&group->pipe_helper[1]);
 
-		// Glibc defines pid as a signed 32bit integer. There's no standard way to
-		// print pid's portably so this is the best we can do.
-		debug("forked support process %d", (int)pid);
-		group->child = pid;
-	}
+        // Glibc defines pid as a signed 32bit integer. There's no standard way to
+        // print pid's portably so this is the best we can do.
+        debug("forked support process %d", (int)pid);
+        group->child = pid;
+    }
 }
 
-static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor,
-			pid_t parent)
-{
-	// This is the child process which will capture the mount namespace.
-	//
-	// It will do so by bind-mounting the .mnt after the parent process calls
-	// unshare() and finishes setting up the namespace completely. Change the
-	// hat to a sub-profile that has limited permissions necessary to
-	// accomplish the capture of the mount namespace.
-	sc_maybe_aa_change_hat(apparmor, "mount-namespace-capture-helper", 0);
-	// Configure the child to die as soon as the parent dies. In an odd
-	// case where the parent is killed then we don't want to complete our
-	// task or wait for anything.
-	if (prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0) < 0) {
-		die("cannot set parent process death notification signal to SIGINT");
-	}
-	// Check that parent process is still alive. If this is the case then we
-	// can *almost* reliably rely on the PR_SET_PDEATHSIG signal to wake us up
-	// from read(2) below. In the rare case that the PID numbers overflow and
-	// the now-dead parent PID is recycled we will still hang forever on the
-	// read from the pipe below.
-	if (kill(parent, 0) < 0) {
-		switch (errno) {
-		case ESRCH:
-			// When snap-confine executes it will fork a helper process. That
-			// process establishes an elaborate dance to ensure both itself and
-			// the parent are operating exactly as specified, so that no
-			// processes are left behind for unbound amount of time. As a part
-			// of that dance the child pings the parent to ensure it is still
-			// alive after establishing a notification signal to be sent in
-			// case the parent dies. This is a race avoidance mechanism, we set
-			// up the notification and then check if the parent is alive by the
-			// time we are done.
-			//
-			// In the case when the parent does go away we used to call
-			// abort(). On some distributions this would trigger an unclean
-			// process termination error report to be sent. One such example is
-			// the Ubuntu error tracker. Since the parent process can be
-			// legitimately interrupted and killed, this should not generate an
-			// error report. As such, perform clean exit in this specific case.
-			debug("parent process has terminated");
-			exit(0);
-		default:
-			die("cannot confirm that parent process is alive");
-			break;
-		}
-	}
-	if (fchdir(group->dir_fd) < 0) {
-		die("cannot move to directory with preserved namespaces");
-	}
-	int command = -1;
-	int run = 1;
-	while (run) {
-		debug("helper process waiting for command");
-		sc_enable_sanity_timeout();
-		if (read(group->pipe_master[0], &command, sizeof command) < 0) {
-			int saved_errno = errno;
-			// This will ensure we get the correct error message
-			// if there is a read error because the timeout
-			// expired.
-			sc_disable_sanity_timeout();
-			errno = saved_errno;
-			die("cannot read command from the pipe");
-		}
-		sc_disable_sanity_timeout();
-		debug("helper process received command %d", command);
-		switch (command) {
-		case HELPER_CMD_EXIT:
-			run = 0;
-			break;
-		case HELPER_CMD_CAPTURE_MOUNT_NS:
-			helper_capture_ns(group, parent);
-			break;
-		case HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS:
-			helper_capture_per_user_ns(group, parent);
-			break;
-		}
-		if (write(group->pipe_helper[1], &command, sizeof command) < 0) {
-			die("cannot write ack");
-		}
-	}
-	debug("helper process exiting");
-	exit(0);
+static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor, pid_t parent) {
+    // This is the child process which will capture the mount namespace.
+    //
+    // It will do so by bind-mounting the .mnt after the parent process calls
+    // unshare() and finishes setting up the namespace completely. Change the
+    // hat to a sub-profile that has limited permissions necessary to
+    // accomplish the capture of the mount namespace.
+    sc_maybe_aa_change_hat(apparmor, "mount-namespace-capture-helper", 0);
+    // Configure the child to die as soon as the parent dies. In an odd
+    // case where the parent is killed then we don't want to complete our
+    // task or wait for anything.
+    if (prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0) < 0) {
+        die("cannot set parent process death notification signal to SIGINT");
+    }
+    // Check that parent process is still alive. If this is the case then we
+    // can *almost* reliably rely on the PR_SET_PDEATHSIG signal to wake us up
+    // from read(2) below. In the rare case that the PID numbers overflow and
+    // the now-dead parent PID is recycled we will still hang forever on the
+    // read from the pipe below.
+    if (kill(parent, 0) < 0) {
+        switch (errno) {
+            case ESRCH:
+                // When snap-confine executes it will fork a helper process. That
+                // process establishes an elaborate dance to ensure both itself and
+                // the parent are operating exactly as specified, so that no
+                // processes are left behind for unbound amount of time. As a part
+                // of that dance the child pings the parent to ensure it is still
+                // alive after establishing a notification signal to be sent in
+                // case the parent dies. This is a race avoidance mechanism, we set
+                // up the notification and then check if the parent is alive by the
+                // time we are done.
+                //
+                // In the case when the parent does go away we used to call
+                // abort(). On some distributions this would trigger an unclean
+                // process termination error report to be sent. One such example is
+                // the Ubuntu error tracker. Since the parent process can be
+                // legitimately interrupted and killed, this should not generate an
+                // error report. As such, perform clean exit in this specific case.
+                debug("parent process has terminated");
+                exit(0);
+            default:
+                die("cannot confirm that parent process is alive");
+                break;
+        }
+    }
+    if (fchdir(group->dir_fd) < 0) {
+        die("cannot move to directory with preserved namespaces");
+    }
+    int command = -1;
+    int run = 1;
+    while (run) {
+        debug("helper process waiting for command");
+        sc_enable_sanity_timeout();
+        if (read(group->pipe_master[0], &command, sizeof command) < 0) {
+            int saved_errno = errno;
+            // This will ensure we get the correct error message
+            // if there is a read error because the timeout
+            // expired.
+            sc_disable_sanity_timeout();
+            errno = saved_errno;
+            die("cannot read command from the pipe");
+        }
+        sc_disable_sanity_timeout();
+        debug("helper process received command %d", command);
+        switch (command) {
+            case HELPER_CMD_EXIT:
+                run = 0;
+                break;
+            case HELPER_CMD_CAPTURE_MOUNT_NS:
+                helper_capture_ns(group, parent);
+                break;
+            case HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS:
+                helper_capture_per_user_ns(group, parent);
+                break;
+        }
+        if (write(group->pipe_helper[1], &command, sizeof command) < 0) {
+            die("cannot write ack");
+        }
+    }
+    debug("helper process exiting");
+    exit(0);
 }
 
-static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent)
-{
-	char src[PATH_MAX] = { 0 };
-	char dst[PATH_MAX] = { 0 };
+static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent) {
+    char src[PATH_MAX] = {0};
+    char dst[PATH_MAX] = {0};
 
-	debug("capturing per-snap mount namespace");
-	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
-	sc_must_snprintf(dst, sizeof dst, "%s.mnt", group->name);
+    debug("capturing per-snap mount namespace");
+    sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
+    sc_must_snprintf(dst, sizeof dst, "%s.mnt", group->name);
 
-	/* Ensure the bind mount destination exists. */
-	int fd = open(dst, O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_RDONLY, 0600);
-	if (fd < 0) {
-		die("cannot create file %s", dst);
-	}
-	close(fd);
+    /* Ensure the bind mount destination exists. */
+    int fd = open(dst, O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_RDONLY, 0600);
+    if (fd < 0) {
+        die("cannot create file %s", dst);
+    }
+    close(fd);
 
-	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
-		die("cannot preserve mount namespace of process %d as %s",
-		    (int)parent, dst);
-	}
-	debug("mount namespace of process %d preserved as %s",
-	      (int)parent, dst);
+    if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
+        die("cannot preserve mount namespace of process %d as %s", (int)parent, dst);
+    }
+    debug("mount namespace of process %d preserved as %s", (int)parent, dst);
 }
 
-static void helper_capture_per_user_ns(struct sc_mount_ns *group, pid_t parent)
-{
-	char src[PATH_MAX] = { 0 };
-	char dst[PATH_MAX] = { 0 };
-	uid_t uid = getuid();
+static void helper_capture_per_user_ns(struct sc_mount_ns *group, pid_t parent) {
+    char src[PATH_MAX] = {0};
+    char dst[PATH_MAX] = {0};
+    uid_t uid = getuid();
 
-	debug("capturing per-snap, per-user mount namespace");
-	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
-	sc_must_snprintf(dst, sizeof dst, "%s.%d.mnt", group->name, (int)uid);
+    debug("capturing per-snap, per-user mount namespace");
+    sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
+    sc_must_snprintf(dst, sizeof dst, "%s.%d.mnt", group->name, (int)uid);
 
-	/* Ensure the bind mount destination exists. */
-	int fd = open(dst, O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_RDONLY, 0600);
-	if (fd < 0) {
-		die("cannot create file %s", dst);
-	}
-	close(fd);
+    /* Ensure the bind mount destination exists. */
+    int fd = open(dst, O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_RDONLY, 0600);
+    if (fd < 0) {
+        die("cannot create file %s", dst);
+    }
+    close(fd);
 
-	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
-		die("cannot preserve per-user mount namespace of process %d as %s", (int)parent, dst);
-	}
-	debug("per-user mount namespace of process %d preserved as %s",
-	      (int)parent, dst);
+    if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
+        die("cannot preserve per-user mount namespace of process %d as %s", (int)parent, dst);
+    }
+    debug("per-user mount namespace of process %d preserved as %s", (int)parent, dst);
 }
 
-static void sc_message_capture_helper(struct sc_mount_ns *group, int command_id)
-{
-	int ack;
-	if (group->child == 0) {
-		die("precondition failed: we don't have a helper process");
-	}
-	if (group->pipe_master[1] < 0) {
-		die("precondition failed: we don't have a pipe");
-	}
-	if (group->pipe_helper[0] < 0) {
-		die("precondition failed: we don't have a pipe");
-	}
-	debug("sending command %d to helper process (pid: %d)",
-	      command_id, group->child);
-	if (write(group->pipe_master[1], &command_id, sizeof command_id) < 0) {
-		die("cannot send command %d to helper process", command_id);
-	}
-	debug("waiting for response from helper");
-	int read_n = read(group->pipe_helper[0], &ack, sizeof ack);
-	if (read_n < 0) {
-		die("cannot receive ack from helper process");
-	}
-	if (read_n == 0) {
-		die("unexpected eof from helper process");
-	}
+static void sc_message_capture_helper(struct sc_mount_ns *group, int command_id) {
+    int ack;
+    if (group->child == 0) {
+        die("precondition failed: we don't have a helper process");
+    }
+    if (group->pipe_master[1] < 0) {
+        die("precondition failed: we don't have a pipe");
+    }
+    if (group->pipe_helper[0] < 0) {
+        die("precondition failed: we don't have a pipe");
+    }
+    debug("sending command %d to helper process (pid: %d)", command_id, group->child);
+    if (write(group->pipe_master[1], &command_id, sizeof command_id) < 0) {
+        die("cannot send command %d to helper process", command_id);
+    }
+    debug("waiting for response from helper");
+    int read_n = read(group->pipe_helper[0], &ack, sizeof ack);
+    if (read_n < 0) {
+        die("cannot receive ack from helper process");
+    }
+    if (read_n == 0) {
+        die("unexpected eof from helper process");
+    }
 }
 
-static void sc_wait_for_capture_helper(struct sc_mount_ns *group)
-{
-	if (group->child == 0) {
-		die("precondition failed: we don't have a helper process");
-	}
-	debug("waiting for the helper process to exit");
-	int status = 0;
-	errno = 0;
-	if (waitpid(group->child, &status, 0) < 0) {
-		die("cannot wait for the helper process");
-	}
-	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		die("helper process exited abnormally");
-	}
-	debug("helper process exited normally");
-	group->child = 0;
-	teardown_signals_for_helper();
+static void sc_wait_for_capture_helper(struct sc_mount_ns *group) {
+    if (group->child == 0) {
+        die("precondition failed: we don't have a helper process");
+    }
+    debug("waiting for the helper process to exit");
+    int status = 0;
+    errno = 0;
+    if (waitpid(group->child, &status, 0) < 0) {
+        die("cannot wait for the helper process");
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        die("helper process exited abnormally");
+    }
+    debug("helper process exited normally");
+    group->child = 0;
+    teardown_signals_for_helper();
 }
 
-void sc_fork_helper(struct sc_mount_ns *group, struct sc_apparmor *apparmor)
-{
-	helper_fork(group, apparmor);
+void sc_fork_helper(struct sc_mount_ns *group, struct sc_apparmor *apparmor) { helper_fork(group, apparmor); }
+
+void sc_preserve_populated_mount_ns(struct sc_mount_ns *group) {
+    sc_message_capture_helper(group, HELPER_CMD_CAPTURE_MOUNT_NS);
 }
 
-void sc_preserve_populated_mount_ns(struct sc_mount_ns *group)
-{
-	sc_message_capture_helper(group, HELPER_CMD_CAPTURE_MOUNT_NS);
+void sc_preserve_populated_per_user_mount_ns(struct sc_mount_ns *group) {
+    sc_message_capture_helper(group, HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS);
 }
 
-void sc_preserve_populated_per_user_mount_ns(struct sc_mount_ns *group)
-{
-	sc_message_capture_helper(group, HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS);
+void sc_wait_for_helper(struct sc_mount_ns *group) {
+    sc_message_capture_helper(group, HELPER_CMD_EXIT);
+    sc_wait_for_capture_helper(group);
 }
 
-void sc_wait_for_helper(struct sc_mount_ns *group)
-{
-	sc_message_capture_helper(group, HELPER_CMD_EXIT);
-	sc_wait_for_capture_helper(group);
+void sc_store_ns_info(const sc_invocation *inv) {
+    FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
+    char info_path[PATH_MAX] = {0};
+    sc_must_snprintf(info_path, sizeof info_path, "/run/snapd/ns/snap.%s.info", inv->snap_instance);
+    int fd = -1;
+    fd = open(info_path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0644);
+    if (fd < 0) {
+        die("cannot open %s", info_path);
+    }
+    if (fchown(fd, 0, 0) < 0) {
+        die("cannot chown %s to root:root", info_path);
+    }
+    // The stream now owns the file descriptor.
+    stream = fdopen(fd, "w");
+    if (stream == NULL) {
+        die("cannot get stream from file descriptor");
+    }
+    fprintf(stream, "base-snap-name=%s\n", inv->orig_base_snap_name);
+    if (ferror(stream) != 0) {
+        die("I/O error when writing to %s", info_path);
+    }
+    if (fflush(stream) == EOF) {
+        die("cannot flush %s", info_path);
+    }
+    debug("saved mount namespace meta-data to %s", info_path);
 }
 
-void sc_store_ns_info(const sc_invocation *inv)
-{
-	FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
-	char info_path[PATH_MAX] = { 0 };
-	sc_must_snprintf(info_path, sizeof info_path,
-			 "/run/snapd/ns/snap.%s.info", inv->snap_instance);
-	int fd = -1;
-	fd = open(info_path,
-		  O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0644);
-	if (fd < 0) {
-		die("cannot open %s", info_path);
-	}
-	if (fchown(fd, 0, 0) < 0) {
-		die("cannot chown %s to root:root", info_path);
-	}
-	// The stream now owns the file descriptor.
-	stream = fdopen(fd, "w");
-	if (stream == NULL) {
-		die("cannot get stream from file descriptor");
-	}
-	fprintf(stream, "base-snap-name=%s\n", inv->orig_base_snap_name);
-	if (ferror(stream) != 0) {
-		die("I/O error when writing to %s", info_path);
-	}
-	if (fflush(stream) == EOF) {
-		die("cannot flush %s", info_path);
-	}
-	debug("saved mount namespace meta-data to %s", info_path);
-}
-
-bool sc_is_mount_ns_in_use(const char *snap_instance)
-{
-	// perform an indirect check of whether the mount namespace is occupied,
-	// with cgroups v1, each snap process is attached to a group under the
-	// freezer controller, however with cgroups v2, we must check for any groups
-	// tracking the snap
-	bool occupied = false;
-	if (sc_cgroup_is_v2()) {
-		// cgroup v2 must consult the tracking groups
-		occupied = sc_cgroup_v2_is_tracking_snap(snap_instance);
-	} else {
-		occupied = sc_cgroup_freezer_occupied(snap_instance);
-	}
-	return occupied;
+bool sc_is_mount_ns_in_use(const char *snap_instance) {
+    // perform an indirect check of whether the mount namespace is occupied,
+    // with cgroups v1, each snap process is attached to a group under the
+    // freezer controller, however with cgroups v2, we must check for any groups
+    // tracking the snap
+    bool occupied = false;
+    if (sc_cgroup_is_v2()) {
+        // cgroup v2 must consult the tracking groups
+        occupied = sc_cgroup_v2_is_tracking_snap(snap_instance);
+    } else {
+        occupied = sc_cgroup_freezer_occupied(snap_instance);
+    }
+    return occupied;
 }

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -93,9 +93,8 @@ void sc_close_mount_ns(struct sc_mount_ns *group);
  * was discarded the function returns ESRCH. If the mount namespace was joined
  * it returns zero.
  **/
-int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
-			 *apparmor, const sc_invocation * inv,
-			 int snap_discard_ns_fd);
+int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor *apparmor, const sc_invocation *inv,
+                         int snap_discard_ns_fd);
 
 /**
  * Join a preserved, per-user, mount namespace if one exists.
@@ -105,9 +104,8 @@ int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
  *
  * The return is ESRCH if a preserved per-user mount namespace does not exist
  * and cannot be joined or zero otherwise.
-**/
-int sc_join_preserved_per_user_ns(struct sc_mount_ns *group,
-				  const char *snap_name);
+ **/
+int sc_join_preserved_per_user_ns(struct sc_mount_ns *group, const char *snap_name);
 
 /**
  * Fork off a helper process for mount namespace capture.
@@ -148,6 +146,6 @@ void sc_preserve_populated_per_user_mount_ns(struct sc_mount_ns *group);
  **/
 void sc_wait_for_helper(struct sc_mount_ns *group);
 
-void sc_store_ns_info(const sc_invocation * inv);
+void sc_store_ns_info(const sc_invocation *inv);
 
 #endif

--- a/cmd/snap-confine/seccomp-support-test.c
+++ b/cmd/snap-confine/seccomp-support-test.c
@@ -15,179 +15,150 @@
  *
  */
 
-#include "seccomp-support-ext.c"
 #include "seccomp-support.c"
+#include "seccomp-support-ext.c"
 
 #include <glib.h>
 #include <glib/gstdio.h>
 
-static void make_seccomp_profile(struct sc_seccomp_file_header *hdr, int *fd,
-				 char **fname)
-{
-	*fd = g_file_open_tmp(NULL, fname, NULL);
-	g_assert_true(*fd > 0);
-	int written = write(*fd, hdr, sizeof(struct sc_seccomp_file_header));
-	g_assert_true(written == sizeof(struct sc_seccomp_file_header));
+static void make_seccomp_profile(struct sc_seccomp_file_header *hdr, int *fd, char **fname) {
+    *fd = g_file_open_tmp(NULL, fname, NULL);
+    g_assert_true(*fd > 0);
+    int written = write(*fd, hdr, sizeof(struct sc_seccomp_file_header));
+    g_assert_true(written == sizeof(struct sc_seccomp_file_header));
 }
 
-static void test_must_read_and_validate_header_from_file__happy(void)
-{
-	struct sc_seccomp_file_header hdr = {
-		.header[0] = 'S',
-		.header[1] = 'C',
-		.version = 1,
-	};
-	char SC_CLEANUP(sc_cleanup_string) * profile = NULL;
-	int SC_CLEANUP(sc_cleanup_close) fd = 0;
-	make_seccomp_profile(&hdr, &fd, &profile);
+static void test_must_read_and_validate_header_from_file__happy(void) {
+    struct sc_seccomp_file_header hdr = {
+        .header[0] = 'S',
+        .header[1] = 'C',
+        .version = 1,
+    };
+    char SC_CLEANUP(sc_cleanup_string) *profile = NULL;
+    int SC_CLEANUP(sc_cleanup_close) fd = 0;
+    make_seccomp_profile(&hdr, &fd, &profile);
 
-	FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile, "rb");
-	sc_must_read_and_validate_header_from_file(file, profile, &hdr);
-	g_assert_true(file != NULL);
+    FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile, "rb");
+    sc_must_read_and_validate_header_from_file(file, profile, &hdr);
+    g_assert_true(file != NULL);
 }
 
-static void test_must_read_and_validate_header_from_file__missing_file(void)
-{
-	struct sc_seccomp_file_header hdr;
-	const char *profile = "/path/to/missing/file";
-	const char *expected_err =
-	    "cannot open seccomp filter /path/to/missing/file: No such file or directory\n";
+static void test_must_read_and_validate_header_from_file__missing_file(void) {
+    struct sc_seccomp_file_header hdr;
+    const char *profile = "/path/to/missing/file";
+    const char *expected_err = "cannot open seccomp filter /path/to/missing/file: No such file or directory\n";
 
-	if (g_test_subprocess()) {
-		FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile, "rb");
-		sc_must_read_and_validate_header_from_file(file, profile, &hdr);
-		// the function above is expected to call die()
-		g_assert_not_reached();
-		// reference "file" to keep the compiler from warning
-		// that "file" is unused
-		g_assert_null(file);
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr(expected_err);
+    if (g_test_subprocess()) {
+        FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile, "rb");
+        sc_must_read_and_validate_header_from_file(file, profile, &hdr);
+        // the function above is expected to call die()
+        g_assert_not_reached();
+        // reference "file" to keep the compiler from warning
+        // that "file" is unused
+        g_assert_null(file);
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr(expected_err);
 }
 
-static void must_read_and_validate_header_from_file_dies_with(struct
-							      sc_seccomp_file_header
-							      hdr, const char
-							      *err_msg)
-{
-	if (g_test_subprocess()) {
-		char SC_CLEANUP(sc_cleanup_string) * profile = NULL;
-		int SC_CLEANUP(sc_cleanup_close) fd = 0;
-		make_seccomp_profile(&hdr, &fd, &profile);
+static void must_read_and_validate_header_from_file_dies_with(struct sc_seccomp_file_header hdr, const char *err_msg) {
+    if (g_test_subprocess()) {
+        char SC_CLEANUP(sc_cleanup_string) *profile = NULL;
+        int SC_CLEANUP(sc_cleanup_close) fd = 0;
+        make_seccomp_profile(&hdr, &fd, &profile);
 
-		FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile, "rb");
-		sc_must_read_and_validate_header_from_file(file, profile, &hdr);
-		// the function above is expected to call die()
-		g_assert_not_reached();
-		// reference "file" to keep the compiler from warning
-		// that "file" is unused
-		g_assert_null(file);
-	}
+        FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile, "rb");
+        sc_must_read_and_validate_header_from_file(file, profile, &hdr);
+        // the function above is expected to call die()
+        g_assert_not_reached();
+        // reference "file" to keep the compiler from warning
+        // that "file" is unused
+        g_assert_null(file);
+    }
 
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr(err_msg);
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr(err_msg);
 }
 
-static void test_must_read_and_validate_header_from_file__invalid_header(void)
-{
-	//  when we stop supporting 14.04 we could just use hdr = {0}
-	struct sc_seccomp_file_header hdr;
-	memset(&hdr, 0, sizeof hdr);
-	const char *expected_err = "unexpected seccomp header: 00\n";
-	must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
+static void test_must_read_and_validate_header_from_file__invalid_header(void) {
+    //  when we stop supporting 14.04 we could just use hdr = {0}
+    struct sc_seccomp_file_header hdr;
+    memset(&hdr, 0, sizeof hdr);
+    const char *expected_err = "unexpected seccomp header: 00\n";
+    must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
 }
 
-static void test_must_read_and_validate_header_from_file__invalid_version(void)
-{
-	struct sc_seccomp_file_header hdr = {
-		.header[0] = 'S',
-		.header[1] = 'C',
-		.version = 0,
-	};
-	const char *expected_err = "unexpected seccomp file version: 0\n";
-	must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
+static void test_must_read_and_validate_header_from_file__invalid_version(void) {
+    struct sc_seccomp_file_header hdr = {
+        .header[0] = 'S',
+        .header[1] = 'C',
+        .version = 0,
+    };
+    const char *expected_err = "unexpected seccomp file version: 0\n";
+    must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
 }
 
-static void
-test_must_read_and_validate_header_from_file__len_allow_too_big(void)
-{
-	struct sc_seccomp_file_header hdr = {
-		.header[0] = 'S',
-		.header[1] = 'C',
-		.version = 1,
-		.len_allow_filter = MAX_BPF_SIZE + 1,
-	};
-	const char *expected_err = "allow filter size too big 32769\n";
-	must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
+static void test_must_read_and_validate_header_from_file__len_allow_too_big(void) {
+    struct sc_seccomp_file_header hdr = {
+        .header[0] = 'S',
+        .header[1] = 'C',
+        .version = 1,
+        .len_allow_filter = MAX_BPF_SIZE + 1,
+    };
+    const char *expected_err = "allow filter size too big 32769\n";
+    must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
 }
 
-static void
-test_must_read_and_validate_header_from_file__len_allow_no_multiplier(void)
-{
-	struct sc_seccomp_file_header hdr = {
-		.header[0] = 'S',
-		.header[1] = 'C',
-		.version = 1,
-		.len_allow_filter = sizeof(struct sock_filter) + 1,
-	};
-	const char *expected_err =
-	    "allow filter size not multiple of sock_filter\n";
-	must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
+static void test_must_read_and_validate_header_from_file__len_allow_no_multiplier(void) {
+    struct sc_seccomp_file_header hdr = {
+        .header[0] = 'S',
+        .header[1] = 'C',
+        .version = 1,
+        .len_allow_filter = sizeof(struct sock_filter) + 1,
+    };
+    const char *expected_err = "allow filter size not multiple of sock_filter\n";
+    must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
 }
 
-static void test_must_read_and_validate_header_from_file__len_deny_too_big(void)
-{
-	struct sc_seccomp_file_header hdr = {
-		.header[0] = 'S',
-		.header[1] = 'C',
-		.version = 1,
-		.len_deny_filter = MAX_BPF_SIZE + 1,
-	};
-	const char *expected_err = "deny filter size too big 32769\n";
-	must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
+static void test_must_read_and_validate_header_from_file__len_deny_too_big(void) {
+    struct sc_seccomp_file_header hdr = {
+        .header[0] = 'S',
+        .header[1] = 'C',
+        .version = 1,
+        .len_deny_filter = MAX_BPF_SIZE + 1,
+    };
+    const char *expected_err = "deny filter size too big 32769\n";
+    must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
 }
 
-static void
-test_must_read_and_validate_header_from_file__len_deny_no_multiplier(void)
-{
-	struct sc_seccomp_file_header hdr = {
-		.header[0] = 'S',
-		.header[1] = 'C',
-		.version = 1,
-		.len_deny_filter = sizeof(struct sock_filter) + 1,
-	};
-	const char *expected_err =
-	    "deny filter size not multiple of sock_filter\n";
-	must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
+static void test_must_read_and_validate_header_from_file__len_deny_no_multiplier(void) {
+    struct sc_seccomp_file_header hdr = {
+        .header[0] = 'S',
+        .header[1] = 'C',
+        .version = 1,
+        .len_deny_filter = sizeof(struct sock_filter) + 1,
+    };
+    const char *expected_err = "deny filter size not multiple of sock_filter\n";
+    must_read_and_validate_header_from_file_dies_with(hdr, expected_err);
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/happy",
-	     test_must_read_and_validate_header_from_file__happy);
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/missing_file",
-	     test_must_read_and_validate_header_from_file__missing_file);
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/invalid_header",
-	     test_must_read_and_validate_header_from_file__invalid_header);
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/invalid_version",
-	     test_must_read_and_validate_header_from_file__invalid_version);
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/len_allow_too_big",
-	     test_must_read_and_validate_header_from_file__len_allow_too_big);
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/len_allow_no_multiplier",
-	     test_must_read_and_validate_header_from_file__len_allow_no_multiplier);
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/len_deny_too_big",
-	     test_must_read_and_validate_header_from_file__len_deny_too_big);
-	g_test_add_func
-	    ("/seccomp/must_read_and_validate_header_from_file/len_deny_no_multiplier",
-	     test_must_read_and_validate_header_from_file__len_deny_no_multiplier);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/happy",
+                    test_must_read_and_validate_header_from_file__happy);
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/missing_file",
+                    test_must_read_and_validate_header_from_file__missing_file);
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/invalid_header",
+                    test_must_read_and_validate_header_from_file__invalid_header);
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/invalid_version",
+                    test_must_read_and_validate_header_from_file__invalid_version);
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/len_allow_too_big",
+                    test_must_read_and_validate_header_from_file__len_allow_too_big);
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/len_allow_no_multiplier",
+                    test_must_read_and_validate_header_from_file__len_allow_no_multiplier);
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/len_deny_too_big",
+                    test_must_read_and_validate_header_from_file__len_deny_too_big);
+    g_test_add_func("/seccomp/must_read_and_validate_header_from_file/len_deny_no_multiplier",
+                    test_must_read_and_validate_header_from_file__len_deny_no_multiplier);
 }

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -14,16 +14,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "config.h"
 #include "seccomp-support.h"
+#include "config.h"
 
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdint.h>
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
@@ -51,235 +51,206 @@ typedef struct sock_filter bpf_instr;
 //
 // Header of a seccomp.bin2 filter file in native byte order.
 struct __attribute__((__packed__)) sc_seccomp_file_header {
-	// header: "SC"
-	char header[2];
-	// version: 0x1
-	uint8_t version;
-	// flags
-	uint8_t unrestricted;
-	// unused
-	uint8_t padding[4];
+    // header: "SC"
+    char header[2];
+    // version: 0x1
+    uint8_t version;
+    // flags
+    uint8_t unrestricted;
+    // unused
+    uint8_t padding[4];
 
-	// size of allow filter in byte
-	uint32_t len_allow_filter;
-	// size of deny filter in byte
-	uint32_t len_deny_filter;
-	// reserved for future use
-	uint8_t reserved2[112];
+    // size of allow filter in byte
+    uint32_t len_allow_filter;
+    // size of deny filter in byte
+    uint32_t len_deny_filter;
+    // reserved for future use
+    uint8_t reserved2[112];
 };
 
-static_assert(sizeof(struct sc_seccomp_file_header) == 128,
-	      "unexpected struct size");
+static_assert(sizeof(struct sc_seccomp_file_header) == 128, "unexpected struct size");
 
-static void validate_path_has_strict_perms(const char *path)
-{
-	struct stat stat_buf;
-	if (stat(path, &stat_buf) < 0) {
-		die("cannot stat %s", path);
-	}
+static void validate_path_has_strict_perms(const char *path) {
+    struct stat stat_buf;
+    if (stat(path, &stat_buf) < 0) {
+        die("cannot stat %s", path);
+    }
 
-	errno = 0;
-	if (stat_buf.st_uid != 0 || stat_buf.st_gid != 0) {
-		die("%s not root-owned %i:%i", path, stat_buf.st_uid,
-		    stat_buf.st_gid);
-	}
+    errno = 0;
+    if (stat_buf.st_uid != 0 || stat_buf.st_gid != 0) {
+        die("%s not root-owned %i:%i", path, stat_buf.st_uid, stat_buf.st_gid);
+    }
 
-	if (stat_buf.st_mode & S_IWOTH) {
-		die("%s has 'other' write %o", path, stat_buf.st_mode);
-	}
+    if (stat_buf.st_mode & S_IWOTH) {
+        die("%s has 'other' write %o", path, stat_buf.st_mode);
+    }
 }
 
-static void validate_bpfpath_is_safe(const char *path)
-{
-	if (path == NULL || strlen(path) == 0 || path[0] != '/') {
-		die("valid_bpfpath_is_safe needs an absolute path as input");
-	}
-	// strtok_r() modifies its first argument, so work on a copy
-	char *tokenized SC_CLEANUP(sc_cleanup_string) = NULL;
-	tokenized = sc_strdup(path);
-	// allocate a string large enough to hold path, and initialize it to
-	// '/'
-	size_t checked_path_size = strlen(path) + 1;
-	char *checked_path SC_CLEANUP(sc_cleanup_string) = NULL;
-	checked_path = calloc(checked_path_size, 1);
-	if (checked_path == NULL) {
-		die("cannot allocate memory for checked_path");
-	}
+static void validate_bpfpath_is_safe(const char *path) {
+    if (path == NULL || strlen(path) == 0 || path[0] != '/') {
+        die("valid_bpfpath_is_safe needs an absolute path as input");
+    }
+    // strtok_r() modifies its first argument, so work on a copy
+    char *tokenized SC_CLEANUP(sc_cleanup_string) = NULL;
+    tokenized = sc_strdup(path);
+    // allocate a string large enough to hold path, and initialize it to
+    // '/'
+    size_t checked_path_size = strlen(path) + 1;
+    char *checked_path SC_CLEANUP(sc_cleanup_string) = NULL;
+    checked_path = calloc(checked_path_size, 1);
+    if (checked_path == NULL) {
+        die("cannot allocate memory for checked_path");
+    }
 
-	checked_path[0] = '/';
-	checked_path[1] = '\0';
+    checked_path[0] = '/';
+    checked_path[1] = '\0';
 
-	// validate '/'
-	validate_path_has_strict_perms(checked_path);
+    // validate '/'
+    validate_path_has_strict_perms(checked_path);
 
-	// strtok_r needs a pointer to keep track of where it is in the
-	// string.
-	char *buf_saveptr = NULL;
+    // strtok_r needs a pointer to keep track of where it is in the
+    // string.
+    char *buf_saveptr = NULL;
 
-	// reconstruct the path from '/' down to profile_name
-	char *buf_token = strtok_r(tokenized, "/", &buf_saveptr);
-	while (buf_token != NULL) {
-		char *prev SC_CLEANUP(sc_cleanup_string) = NULL;
-		prev = sc_strdup(checked_path);	// needed by vsnprintf in sc_must_snprintf
-		// append '<buf_token>' if checked_path is '/', otherwise '/<buf_token>'
-		if (strlen(checked_path) == 1) {
-			sc_must_snprintf(checked_path, checked_path_size,
-					 "%s%s", prev, buf_token);
-		} else {
-			sc_must_snprintf(checked_path, checked_path_size,
-					 "%s/%s", prev, buf_token);
-		}
-		validate_path_has_strict_perms(checked_path);
+    // reconstruct the path from '/' down to profile_name
+    char *buf_token = strtok_r(tokenized, "/", &buf_saveptr);
+    while (buf_token != NULL) {
+        char *prev SC_CLEANUP(sc_cleanup_string) = NULL;
+        prev = sc_strdup(checked_path);  // needed by vsnprintf in sc_must_snprintf
+        // append '<buf_token>' if checked_path is '/', otherwise '/<buf_token>'
+        if (strlen(checked_path) == 1) {
+            sc_must_snprintf(checked_path, checked_path_size, "%s%s", prev, buf_token);
+        } else {
+            sc_must_snprintf(checked_path, checked_path_size, "%s/%s", prev, buf_token);
+        }
+        validate_path_has_strict_perms(checked_path);
 
-		buf_token = strtok_r(NULL, "/", &buf_saveptr);
-	}
+        buf_token = strtok_r(NULL, "/", &buf_saveptr);
+    }
 }
 
-static void sc_cleanup_sock_fprog(struct sock_fprog *prog)
-{
-	free(prog->filter);
-	prog->filter = NULL;
+static void sc_cleanup_sock_fprog(struct sock_fprog *prog) {
+    free(prog->filter);
+    prog->filter = NULL;
 }
 
-static void sc_must_read_filter_from_file(FILE *file, uint32_t len_bytes,
-					  char *what, struct sock_fprog *prog)
-{
-	if (len_bytes == 0) {
-		die("%s filter may only be empty in unrestricted profiles",
-		    what);
-	}
-	if (len_bytes > MAX_BPF_SIZE) {
-		die("%s filter size too big %u", what, len_bytes);
-	}
-	prog->len = len_bytes / sizeof(struct sock_filter);
-	prog->filter = malloc(len_bytes);
-	if (prog->filter == NULL) {
-		die("cannot allocate %u bytes of memory for %s seccomp filter ",
-		    len_bytes, what);
-	}
-	size_t num_read =
-	    fread(prog->filter, 1, prog->len * sizeof(struct sock_filter),
-		  file);
-	if (ferror(file)) {
-		die("cannot read %s filter", what);
-	}
-	if (num_read != len_bytes) {
-		die("short read for filter %s %zu != %i", what, num_read,
-		    len_bytes);
-	}
+static void sc_must_read_filter_from_file(FILE *file, uint32_t len_bytes, char *what, struct sock_fprog *prog) {
+    if (len_bytes == 0) {
+        die("%s filter may only be empty in unrestricted profiles", what);
+    }
+    if (len_bytes > MAX_BPF_SIZE) {
+        die("%s filter size too big %u", what, len_bytes);
+    }
+    prog->len = len_bytes / sizeof(struct sock_filter);
+    prog->filter = malloc(len_bytes);
+    if (prog->filter == NULL) {
+        die("cannot allocate %u bytes of memory for %s seccomp filter ", len_bytes, what);
+    }
+    size_t num_read = fread(prog->filter, 1, prog->len * sizeof(struct sock_filter), file);
+    if (ferror(file)) {
+        die("cannot read %s filter", what);
+    }
+    if (num_read != len_bytes) {
+        die("short read for filter %s %zu != %i", what, num_read, len_bytes);
+    }
 }
 
-static void sc_must_read_and_validate_header_from_file(FILE *file,
-						       const char *profile_path,
-						       struct
-						       sc_seccomp_file_header
-						       *hdr)
-{
-	if (file == NULL) {
-		die("cannot open seccomp filter %s", profile_path);
-	}
-	size_t num_read =
-	    fread(hdr, 1, sizeof(struct sc_seccomp_file_header), file);
-	if (ferror(file) != 0) {
-		die("cannot read seccomp profile %s", profile_path);
-	}
-	if (num_read < sizeof(struct sc_seccomp_file_header)) {
-		die("short read on seccomp header: %zu", num_read);
-	}
-	if (hdr->header[0] != 'S' || hdr->header[1] != 'C') {
-		die("unexpected seccomp header: %x%x", hdr->header[0],
-		    hdr->header[1]);
-	}
-	if (hdr->version != 1) {
-		die("unexpected seccomp file version: %x", hdr->version);
-	}
-	if (hdr->len_allow_filter > MAX_BPF_SIZE) {
-		die("allow filter size too big %u", hdr->len_allow_filter);
-	}
-	if (hdr->len_allow_filter % sizeof(struct sock_filter) != 0) {
-		die("allow filter size not multiple of sock_filter");
-	}
-	if (hdr->len_deny_filter > MAX_BPF_SIZE) {
-		die("deny filter size too big %u", hdr->len_deny_filter);
-	}
-	if (hdr->len_deny_filter % sizeof(struct sock_filter) != 0) {
-		die("deny filter size not multiple of sock_filter");
-	}
-	struct stat stat_buf;
-	if (fstat(fileno(file), &stat_buf) != 0) {
-		die("cannot fstat the seccomp file");
-	}
-	off_t expected_size =
-	    sizeof(struct sc_seccomp_file_header) + hdr->len_allow_filter +
-	    hdr->len_deny_filter;
-	if (stat_buf.st_size != expected_size) {
-		die("unexpected filesize %ju != %ju", stat_buf.st_size,
-		    expected_size);
-	}
+static void sc_must_read_and_validate_header_from_file(FILE *file, const char *profile_path,
+                                                       struct sc_seccomp_file_header *hdr) {
+    if (file == NULL) {
+        die("cannot open seccomp filter %s", profile_path);
+    }
+    size_t num_read = fread(hdr, 1, sizeof(struct sc_seccomp_file_header), file);
+    if (ferror(file) != 0) {
+        die("cannot read seccomp profile %s", profile_path);
+    }
+    if (num_read < sizeof(struct sc_seccomp_file_header)) {
+        die("short read on seccomp header: %zu", num_read);
+    }
+    if (hdr->header[0] != 'S' || hdr->header[1] != 'C') {
+        die("unexpected seccomp header: %x%x", hdr->header[0], hdr->header[1]);
+    }
+    if (hdr->version != 1) {
+        die("unexpected seccomp file version: %x", hdr->version);
+    }
+    if (hdr->len_allow_filter > MAX_BPF_SIZE) {
+        die("allow filter size too big %u", hdr->len_allow_filter);
+    }
+    if (hdr->len_allow_filter % sizeof(struct sock_filter) != 0) {
+        die("allow filter size not multiple of sock_filter");
+    }
+    if (hdr->len_deny_filter > MAX_BPF_SIZE) {
+        die("deny filter size too big %u", hdr->len_deny_filter);
+    }
+    if (hdr->len_deny_filter % sizeof(struct sock_filter) != 0) {
+        die("deny filter size not multiple of sock_filter");
+    }
+    struct stat stat_buf;
+    if (fstat(fileno(file), &stat_buf) != 0) {
+        die("cannot fstat the seccomp file");
+    }
+    off_t expected_size = sizeof(struct sc_seccomp_file_header) + hdr->len_allow_filter + hdr->len_deny_filter;
+    if (stat_buf.st_size != expected_size) {
+        die("unexpected filesize %ju != %ju", stat_buf.st_size, expected_size);
+    }
 }
 
-bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
-{
-	debug("loading bpf program for security tag %s", security_tag);
+bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag) {
+    debug("loading bpf program for security tag %s", security_tag);
 
-	char profile_path[PATH_MAX] = { 0 };
-	struct sock_fprog SC_CLEANUP(sc_cleanup_sock_fprog) prog_allow = { 0 };
-	struct sock_fprog SC_CLEANUP(sc_cleanup_sock_fprog) prog_deny = { 0 };
-	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin2",
-			 filter_profile_dir, security_tag);
+    char profile_path[PATH_MAX] = {0};
+    struct sock_fprog SC_CLEANUP(sc_cleanup_sock_fprog) prog_allow = {0};
+    struct sock_fprog SC_CLEANUP(sc_cleanup_sock_fprog) prog_deny = {0};
+    sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin2", filter_profile_dir, security_tag);
 
-	// Wait some time for the security profile to show up. When
-	// the system boots snapd will created security profiles, but
-	// a service snap (e.g. network-manager) starts in parallel with
-	// snapd so for such snaps, the profiles may not be generated
-	// yet
-	long max_wait = 120;
-	const char *MAX_PROFILE_WAIT = getenv("SNAP_CONFINE_MAX_PROFILE_WAIT");
-	if (MAX_PROFILE_WAIT != NULL) {
-		char *endptr = NULL;
-		errno = 0;
-		long env_max_wait = strtol(MAX_PROFILE_WAIT, &endptr, 10);
-		if (errno != 0 || MAX_PROFILE_WAIT == endptr || *endptr != '\0'
-		    || env_max_wait <= 0) {
-			die("SNAP_CONFINE_MAX_PROFILE_WAIT invalid");
-		}
-		max_wait = env_max_wait > 0 ? env_max_wait : max_wait;
-	}
-	if (max_wait > 3600) {
-		max_wait = 3600;
-	}
+    // Wait some time for the security profile to show up. When
+    // the system boots snapd will created security profiles, but
+    // a service snap (e.g. network-manager) starts in parallel with
+    // snapd so for such snaps, the profiles may not be generated
+    // yet
+    long max_wait = 120;
+    const char *MAX_PROFILE_WAIT = getenv("SNAP_CONFINE_MAX_PROFILE_WAIT");
+    if (MAX_PROFILE_WAIT != NULL) {
+        char *endptr = NULL;
+        errno = 0;
+        long env_max_wait = strtol(MAX_PROFILE_WAIT, &endptr, 10);
+        if (errno != 0 || MAX_PROFILE_WAIT == endptr || *endptr != '\0' || env_max_wait <= 0) {
+            die("SNAP_CONFINE_MAX_PROFILE_WAIT invalid");
+        }
+        max_wait = env_max_wait > 0 ? env_max_wait : max_wait;
+    }
+    if (max_wait > 3600) {
+        max_wait = 3600;
+    }
 
-	if (!sc_wait_for_file(profile_path, max_wait)) {
-		/* log but proceed, we'll die a bit later */
-		debug("timeout waiting for seccomp binary profile file at %s",
-		      profile_path);
-	}
-	// TODO: move over to open/openat as an additional hardening measure.
+    if (!sc_wait_for_file(profile_path, max_wait)) {
+        /* log but proceed, we'll die a bit later */
+        debug("timeout waiting for seccomp binary profile file at %s", profile_path);
+    }
+    // TODO: move over to open/openat as an additional hardening measure.
 
-	// validate '/' down to profile_path are root-owned and not
-	// 'other' writable to avoid possibility of privilege
-	// escalation via bpf program load when paths are incorrectly
-	// set on the system.
-	validate_bpfpath_is_safe(profile_path);
+    // validate '/' down to profile_path are root-owned and not
+    // 'other' writable to avoid possibility of privilege
+    // escalation via bpf program load when paths are incorrectly
+    // set on the system.
+    validate_bpfpath_is_safe(profile_path);
 
-	//  when we stop supporting 14.04 we could just use hdr = {0}
-	struct sc_seccomp_file_header hdr;
-	memset(&hdr, 0, sizeof hdr);
-	FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile_path, "rb");
+    //  when we stop supporting 14.04 we could just use hdr = {0}
+    struct sc_seccomp_file_header hdr;
+    memset(&hdr, 0, sizeof hdr);
+    FILE *file SC_CLEANUP(sc_cleanup_file) = fopen(profile_path, "rb");
 
-	sc_must_read_and_validate_header_from_file(file, profile_path, &hdr);
-	if (hdr.unrestricted & 0x1) {
-		return false;
-	}
-	// populate allow
-	sc_must_read_filter_from_file(file, hdr.len_allow_filter, "allow",
-				      &prog_allow);
-	sc_must_read_filter_from_file(file, hdr.len_deny_filter, "deny",
-				      &prog_deny);
+    sc_must_read_and_validate_header_from_file(file, profile_path, &hdr);
+    if (hdr.unrestricted & 0x1) {
+        return false;
+    }
+    // populate allow
+    sc_must_read_filter_from_file(file, hdr.len_allow_filter, "allow", &prog_allow);
+    sc_must_read_filter_from_file(file, hdr.len_deny_filter, "deny", &prog_deny);
 
-	// apply both filters
-	sc_apply_seccomp_filter(&prog_deny);
-	sc_apply_seccomp_filter(&prog_allow);
+    // apply both filters
+    sc_apply_seccomp_filter(&prog_deny);
+    sc_apply_seccomp_filter(&prog_allow);
 
-	return true;
+    return true;
 }

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -19,7 +19,7 @@
 
 #include <stdbool.h>
 
-/** 
+/**
  * sc_apply_seccomp_profile_for_security_tag applies a seccomp profile to the
  * current process. The filter is loaded from a pre-compiled bpf bytecode
  * stored in "/var/lib/snap/seccomp/bpf" using the security tag and the

--- a/cmd/snap-confine/snap-confine-args-test.c
+++ b/cmd/snap-confine/snap-confine-args-test.c
@@ -25,373 +25,322 @@
 
 #include <glib.h>
 
-static void test_sc_nonfatal_parse_args__typical(void)
-{
-	// Test that typical invocation of snap-confine is parsed correctly.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__typical(void) {
+    // Test that typical invocation of snap-confine is parsed correctly.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv,
-		       "/usr/lib/snapd/snap-confine", "snap.SNAP_NAME.APP_NAME",
-		       "/usr/lib/snapd/snap-exec", "--option", "arg", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "snap.SNAP_NAME.APP_NAME", "/usr/lib/snapd/snap-exec",
+                   "--option", "arg", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_null(err);
-	g_assert_nonnull(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_null(err);
+    g_assert_nonnull(args);
 
-	// Check supported switches and arguments
-	g_assert_cmpstr(sc_args_security_tag(args), ==,
-			"snap.SNAP_NAME.APP_NAME");
-	g_assert_cmpstr(sc_args_executable(args), ==,
-			"/usr/lib/snapd/snap-exec");
-	g_assert_cmpint(sc_args_is_version_query(args), ==, false);
-	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
-	g_assert_null(sc_args_base_snap(args));
+    // Check supported switches and arguments
+    g_assert_cmpstr(sc_args_security_tag(args), ==, "snap.SNAP_NAME.APP_NAME");
+    g_assert_cmpstr(sc_args_executable(args), ==, "/usr/lib/snapd/snap-exec");
+    g_assert_cmpint(sc_args_is_version_query(args), ==, false);
+    g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
+    g_assert_null(sc_args_base_snap(args));
 
-	// Check remaining arguments
-	g_assert_cmpint(argc, ==, 3);
-	g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
-	g_assert_cmpstr(argv[1], ==, "--option");
-	g_assert_cmpstr(argv[2], ==, "arg");
-	g_assert_null(argv[3]);
+    // Check remaining arguments
+    g_assert_cmpint(argc, ==, 3);
+    g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
+    g_assert_cmpstr(argv[1], ==, "--option");
+    g_assert_cmpstr(argv[2], ==, "arg");
+    g_assert_null(argv[3]);
 }
 
-static void test_sc_cleanup_args(void)
-{
-	// Check that NULL argument parser can be cleaned up
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args = NULL;
-	sc_cleanup_args(&args);
+static void test_sc_cleanup_args(void) {
+    // Check that NULL argument parser can be cleaned up
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args = NULL;
+    sc_cleanup_args(&args);
 
-	// Check that a non-NULL argument parser can be cleaned up
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
-		       "snap.SNAP_NAME.APP_NAME", "/usr/lib/snapd/snap-exec",
-		       NULL);
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_null(err);
-	g_assert_nonnull(args);
+    // Check that a non-NULL argument parser can be cleaned up
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "snap.SNAP_NAME.APP_NAME", "/usr/lib/snapd/snap-exec",
+                   NULL);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_null(err);
+    g_assert_nonnull(args);
 
-	sc_cleanup_args(&args);
-	g_assert_null(args);
+    sc_cleanup_args(&args);
+    g_assert_null(args);
 }
 
-static void test_sc_nonfatal_parse_args__typical_classic(void)
-{
-	// Test that typical invocation of snap-confine is parsed correctly.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__typical_classic(void) {
+    // Test that typical invocation of snap-confine is parsed correctly.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv,
-		       "/usr/lib/snapd/snap-confine", "--classic",
-		       "snap.SNAP_NAME.APP_NAME", "/usr/lib/snapd/snap-exec",
-		       "--option", "arg", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--classic", "snap.SNAP_NAME.APP_NAME",
+                   "/usr/lib/snapd/snap-exec", "--option", "arg", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_null(err);
-	g_assert_nonnull(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_null(err);
+    g_assert_nonnull(args);
 
-	// Check supported switches and arguments
-	g_assert_cmpstr(sc_args_security_tag(args), ==,
-			"snap.SNAP_NAME.APP_NAME");
-	g_assert_cmpstr(sc_args_executable(args), ==,
-			"/usr/lib/snapd/snap-exec");
-	g_assert_cmpint(sc_args_is_version_query(args), ==, false);
-	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, true);
+    // Check supported switches and arguments
+    g_assert_cmpstr(sc_args_security_tag(args), ==, "snap.SNAP_NAME.APP_NAME");
+    g_assert_cmpstr(sc_args_executable(args), ==, "/usr/lib/snapd/snap-exec");
+    g_assert_cmpint(sc_args_is_version_query(args), ==, false);
+    g_assert_cmpint(sc_args_is_classic_confinement(args), ==, true);
 
-	// Check remaining arguments
-	g_assert_cmpint(argc, ==, 3);
-	g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
-	g_assert_cmpstr(argv[1], ==, "--option");
-	g_assert_cmpstr(argv[2], ==, "arg");
-	g_assert_null(argv[3]);
+    // Check remaining arguments
+    g_assert_cmpint(argc, ==, 3);
+    g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
+    g_assert_cmpstr(argv[1], ==, "--option");
+    g_assert_cmpstr(argv[2], ==, "arg");
+    g_assert_null(argv[3]);
 }
 
-static void test_sc_nonfatal_parse_args__version(void)
-{
-	// Test that snap-confine --version is detected.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__version(void) {
+    // Test that snap-confine --version is detected.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv,
-		       "/usr/lib/snapd/snap-confine", "--version", "ignored",
-		       "garbage", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--version", "ignored", "garbage", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_null(err);
-	g_assert_nonnull(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_null(err);
+    g_assert_nonnull(args);
 
-	// Check supported switches and arguments
-	g_assert_null(sc_args_security_tag(args));
-	g_assert_null(sc_args_executable(args));
-	g_assert_cmpint(sc_args_is_version_query(args), ==, true);
-	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
+    // Check supported switches and arguments
+    g_assert_null(sc_args_security_tag(args));
+    g_assert_null(sc_args_executable(args));
+    g_assert_cmpint(sc_args_is_version_query(args), ==, true);
+    g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
 
-	// Check remaining arguments
-	g_assert_cmpint(argc, ==, 3);
-	g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
-	g_assert_cmpstr(argv[1], ==, "ignored");
-	g_assert_cmpstr(argv[2], ==, "garbage");
-	g_assert_null(argv[3]);
+    // Check remaining arguments
+    g_assert_cmpint(argc, ==, 3);
+    g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
+    g_assert_cmpstr(argv[1], ==, "ignored");
+    g_assert_cmpstr(argv[2], ==, "garbage");
+    g_assert_null(argv[3]);
 }
 
-static void test_sc_nonfatal_parse_args__evil_input(void)
-{
-	// Check that calling without any arguments is reported as error.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__evil_input(void) {
+    // Check that calling without any arguments is reported as error.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	// NULL argcp/argvp attack
-	args = sc_nonfatal_parse_args(NULL, NULL, &err);
+    // NULL argcp/argvp attack
+    args = sc_nonfatal_parse_args(NULL, NULL, &err);
 
-	g_assert_nonnull(err);
-	g_assert_null(args);
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"cannot parse arguments, argcp or argvp is NULL");
-	sc_cleanup_error(&err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
+    g_assert_cmpstr(sc_error_msg(err), ==, "cannot parse arguments, argcp or argvp is NULL");
+    sc_cleanup_error(&err);
 
-	int argc;
-	char **argv;
+    int argc;
+    char **argv;
 
-	// NULL argv attack
-	argc = 0;
-	argv = NULL;
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    // NULL argv attack
+    argc = 0;
+    argv = NULL;
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
 
-	g_assert_nonnull(err);
-	g_assert_null(args);
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"cannot parse arguments, argc is zero or argv is NULL");
-	sc_cleanup_error(&err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
+    g_assert_cmpstr(sc_error_msg(err), ==, "cannot parse arguments, argc is zero or argv is NULL");
+    sc_cleanup_error(&err);
 
-	// NULL argv[i] attack
-	test_argc_argv(&argc, &argv,
-		       "/usr/lib/snapd/snap-confine", "--version", "ignored",
-		       "garbage", NULL);
-	argv[1] = NULL;		// overwrite --version with NULL
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    // NULL argv[i] attack
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--version", "ignored", "garbage", NULL);
+    argv[1] = NULL;  // overwrite --version with NULL
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
 
-	g_assert_nonnull(err);
-	g_assert_null(args);
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"cannot parse arguments, argument at index 1 is NULL");
+    g_assert_nonnull(err);
+    g_assert_null(args);
+    g_assert_cmpstr(sc_error_msg(err), ==, "cannot parse arguments, argument at index 1 is NULL");
 }
 
-static void test_sc_nonfatal_parse_args__nothing_to_parse(void)
-{
-	// Check that calling without any arguments is reported as error.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__nothing_to_parse(void) {
+    // Check that calling without any arguments is reported as error.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv, NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_nonnull(err);
-	g_assert_null(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
 
-	// Check the error that we've got
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"cannot parse arguments, argc is zero or argv is NULL");
+    // Check the error that we've got
+    g_assert_cmpstr(sc_error_msg(err), ==, "cannot parse arguments, argc is zero or argv is NULL");
 }
 
-static void test_sc_nonfatal_parse_args__no_security_tag(void)
-{
-	// Check that lack of security tag is reported as error.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__no_security_tag(void) {
+    // Check that lack of security tag is reported as error.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_nonnull(err);
-	g_assert_null(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
 
-	// Check the error that we've got
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"Usage: snap-confine <security-tag> <executable>\n"
-			"\napplication or hook security tag was not provided");
+    // Check the error that we've got
+    g_assert_cmpstr(sc_error_msg(err), ==,
+                    "Usage: snap-confine <security-tag> <executable>\n"
+                    "\napplication or hook security tag was not provided");
 
-	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+    g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
 }
 
-static void test_sc_nonfatal_parse_args__no_executable(void)
-{
-	// Check that lack of security tag is reported as error.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__no_executable(void) {
+    // Check that lack of security tag is reported as error.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
-		       "snap.SNAP_NAME.APP_NAME", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "snap.SNAP_NAME.APP_NAME", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_nonnull(err);
-	g_assert_null(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
 
-	// Check the error that we've got
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"Usage: snap-confine <security-tag> <executable>\n"
-			"\nexecutable name was not provided");
-	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+    // Check the error that we've got
+    g_assert_cmpstr(sc_error_msg(err), ==,
+                    "Usage: snap-confine <security-tag> <executable>\n"
+                    "\nexecutable name was not provided");
+    g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
 }
 
-static void test_sc_nonfatal_parse_args__unknown_option(void)
-{
-	// Check that unrecognized option switch is reported as error.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__unknown_option(void) {
+    // Check that unrecognized option switch is reported as error.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
-		       "--frozbonicator", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--frozbonicator", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_nonnull(err);
-	g_assert_null(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
 
-	// Check the error that we've got
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"Usage: snap-confine <security-tag> <executable>\n"
-			"\nunrecognized command line option: --frozbonicator");
-	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+    // Check the error that we've got
+    g_assert_cmpstr(sc_error_msg(err), ==,
+                    "Usage: snap-confine <security-tag> <executable>\n"
+                    "\nunrecognized command line option: --frozbonicator");
+    g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
 }
 
-static void test_sc_nonfatal_parse_args__forwards_error(void)
-{
-	// Check that sc_nonfatal_parse_args() forwards errors.
-	if (g_test_subprocess()) {
-		int argc;
-		char **argv;
-		test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
-			       "--frozbonicator", NULL);
+static void test_sc_nonfatal_parse_args__forwards_error(void) {
+    // Check that sc_nonfatal_parse_args() forwards errors.
+    if (g_test_subprocess()) {
+        int argc;
+        char **argv;
+        test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--frozbonicator", NULL);
 
-		// Call sc_nonfatal_parse_args() without an error handle
-		struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
-		args = sc_nonfatal_parse_args(&argc, &argv, NULL);
-		(void)args;
+        // Call sc_nonfatal_parse_args() without an error handle
+        struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+        args = sc_nonfatal_parse_args(&argc, &argv, NULL);
+        (void)args;
 
-		g_test_message("expected not to reach this place");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("Usage: snap-confine <security-tag> <executable>\n"
-	     "\nunrecognized command line option: --frozbonicator\n");
+        g_test_message("expected not to reach this place");
+        g_test_fail();
+        return;
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr(
+        "Usage: snap-confine <security-tag> <executable>\n"
+        "\nunrecognized command line option: --frozbonicator\n");
 }
 
-static void test_sc_nonfatal_parse_args__base_snap(void)
-{
-	// Check that --base specifies the name of the base snap.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__base_snap(void) {
+    // Check that --base specifies the name of the base snap.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv,
-		       "/usr/lib/snapd/snap-confine", "--base", "base-snap",
-		       "snap.SNAP_NAME.APP_NAME", "/usr/lib/snapd/snap-exec",
-		       NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--base", "base-snap", "snap.SNAP_NAME.APP_NAME",
+                   "/usr/lib/snapd/snap-exec", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_null(err);
-	g_assert_nonnull(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_null(err);
+    g_assert_nonnull(args);
 
-	// Check the --base switch
-	g_assert_cmpstr(sc_args_base_snap(args), ==, "base-snap");
-	// Check other arguments
-	g_assert_cmpstr(sc_args_security_tag(args), ==,
-			"snap.SNAP_NAME.APP_NAME");
-	g_assert_cmpstr(sc_args_executable(args), ==,
-			"/usr/lib/snapd/snap-exec");
-	g_assert_cmpint(sc_args_is_version_query(args), ==, false);
-	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
+    // Check the --base switch
+    g_assert_cmpstr(sc_args_base_snap(args), ==, "base-snap");
+    // Check other arguments
+    g_assert_cmpstr(sc_args_security_tag(args), ==, "snap.SNAP_NAME.APP_NAME");
+    g_assert_cmpstr(sc_args_executable(args), ==, "/usr/lib/snapd/snap-exec");
+    g_assert_cmpint(sc_args_is_version_query(args), ==, false);
+    g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
 }
 
-static void test_sc_nonfatal_parse_args__base_snap__missing_arg(void)
-{
-	// Check that --base specifies the name of the base snap.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__base_snap__missing_arg(void) {
+    // Check that --base specifies the name of the base snap.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv,
-		       "/usr/lib/snapd/snap-confine", "--base", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--base", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_nonnull(err);
-	g_assert_null(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
 
-	// Check the error that we've got
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"Usage: snap-confine <security-tag> <executable>\n"
-			"\nthe --base option requires an argument");
-	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+    // Check the error that we've got
+    g_assert_cmpstr(sc_error_msg(err), ==,
+                    "Usage: snap-confine <security-tag> <executable>\n"
+                    "\nthe --base option requires an argument");
+    g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
 }
 
-static void test_sc_nonfatal_parse_args__base_snap__twice(void)
-{
-	// Check that --base specifies the name of the base snap.
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+static void test_sc_nonfatal_parse_args__base_snap__twice(void) {
+    // Check that --base specifies the name of the base snap.
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
-	int argc;
-	char **argv;
-	test_argc_argv(&argc, &argv,
-		       "/usr/lib/snapd/snap-confine",
-		       "--base", "base1", "--base", "base2", NULL);
+    int argc;
+    char **argv;
+    test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", "--base", "base1", "--base", "base2", NULL);
 
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	g_assert_nonnull(err);
-	g_assert_null(args);
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    g_assert_nonnull(err);
+    g_assert_null(args);
 
-	// Check the error that we've got
-	g_assert_cmpstr(sc_error_msg(err), ==,
-			"Usage: snap-confine <security-tag> <executable>\n"
-			"\nthe --base option can be used only once");
-	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+    // Check the error that we've got
+    g_assert_cmpstr(sc_error_msg(err), ==,
+                    "Usage: snap-confine <security-tag> <executable>\n"
+                    "\nthe --base option can be used only once");
+    g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
 }
 
-static void __attribute__((constructor)) init(void)
-{
-	g_test_add_func("/args/sc_cleanup_args", test_sc_cleanup_args);
-	g_test_add_func("/args/sc_nonfatal_parse_args/typical",
-			test_sc_nonfatal_parse_args__typical);
-	g_test_add_func("/args/sc_nonfatal_parse_args/typical_classic",
-			test_sc_nonfatal_parse_args__typical_classic);
-	g_test_add_func("/args/sc_nonfatal_parse_args/version",
-			test_sc_nonfatal_parse_args__version);
-	g_test_add_func("/args/sc_nonfatal_parse_args/nothing_to_parse",
-			test_sc_nonfatal_parse_args__nothing_to_parse);
-	g_test_add_func("/args/sc_nonfatal_parse_args/evil_input",
-			test_sc_nonfatal_parse_args__evil_input);
-	g_test_add_func("/args/sc_nonfatal_parse_args/no_security_tag",
-			test_sc_nonfatal_parse_args__no_security_tag);
-	g_test_add_func("/args/sc_nonfatal_parse_args/no_executable",
-			test_sc_nonfatal_parse_args__no_executable);
-	g_test_add_func("/args/sc_nonfatal_parse_args/unknown_option",
-			test_sc_nonfatal_parse_args__unknown_option);
-	g_test_add_func("/args/sc_nonfatal_parse_args/forwards_error",
-			test_sc_nonfatal_parse_args__forwards_error);
-	g_test_add_func("/args/sc_nonfatal_parse_args/base_snap",
-			test_sc_nonfatal_parse_args__base_snap);
-	g_test_add_func("/args/sc_nonfatal_parse_args/base_snap/missing-arg",
-			test_sc_nonfatal_parse_args__base_snap__missing_arg);
-	g_test_add_func("/args/sc_nonfatal_parse_args/base_snap/twice",
-			test_sc_nonfatal_parse_args__base_snap__twice);
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/args/sc_cleanup_args", test_sc_cleanup_args);
+    g_test_add_func("/args/sc_nonfatal_parse_args/typical", test_sc_nonfatal_parse_args__typical);
+    g_test_add_func("/args/sc_nonfatal_parse_args/typical_classic", test_sc_nonfatal_parse_args__typical_classic);
+    g_test_add_func("/args/sc_nonfatal_parse_args/version", test_sc_nonfatal_parse_args__version);
+    g_test_add_func("/args/sc_nonfatal_parse_args/nothing_to_parse", test_sc_nonfatal_parse_args__nothing_to_parse);
+    g_test_add_func("/args/sc_nonfatal_parse_args/evil_input", test_sc_nonfatal_parse_args__evil_input);
+    g_test_add_func("/args/sc_nonfatal_parse_args/no_security_tag", test_sc_nonfatal_parse_args__no_security_tag);
+    g_test_add_func("/args/sc_nonfatal_parse_args/no_executable", test_sc_nonfatal_parse_args__no_executable);
+    g_test_add_func("/args/sc_nonfatal_parse_args/unknown_option", test_sc_nonfatal_parse_args__unknown_option);
+    g_test_add_func("/args/sc_nonfatal_parse_args/forwards_error", test_sc_nonfatal_parse_args__forwards_error);
+    g_test_add_func("/args/sc_nonfatal_parse_args/base_snap", test_sc_nonfatal_parse_args__base_snap);
+    g_test_add_func("/args/sc_nonfatal_parse_args/base_snap/missing-arg",
+                    test_sc_nonfatal_parse_args__base_snap__missing_arg);
+    g_test_add_func("/args/sc_nonfatal_parse_args/base_snap/twice", test_sc_nonfatal_parse_args__base_snap__twice);
 }

--- a/cmd/snap-confine/snap-confine-args.c
+++ b/cmd/snap-confine/snap-confine-args.c
@@ -19,218 +19,201 @@
 
 #include <string.h>
 
-#include "../libsnap-confine-private/utils.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
 
 struct sc_args {
-	// The security tag that the application is intended to run with
-	char *security_tag;
-	// The executable that should be invoked
-	char *executable;
-	// Name of the base snap to use.
-	char *base_snap;
+    // The security tag that the application is intended to run with
+    char *security_tag;
+    // The executable that should be invoked
+    char *executable;
+    // Name of the base snap to use.
+    char *base_snap;
 
-	// Flag indicating that --version was passed on command line.
-	bool is_version_query;
-	// Flag indicating that --classic was passed on command line.
-	bool is_classic_confinement;
+    // Flag indicating that --version was passed on command line.
+    bool is_version_query;
+    // Flag indicating that --classic was passed on command line.
+    bool is_classic_confinement;
 };
 
-struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
-				       sc_error **errorp)
-{
-	struct sc_args *args = NULL;
-	sc_error *err = NULL;
+struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp, sc_error **errorp) {
+    struct sc_args *args = NULL;
+    sc_error *err = NULL;
 
-	if (argcp == NULL || argvp == NULL) {
-		err = sc_error_init(SC_ARGS_DOMAIN, 0,
-				    "cannot parse arguments, argcp or argvp is NULL");
-		goto out;
-	}
-	// Use dereferenced versions of argcp and argvp for convenience.
-	int argc = *argcp;
-	char **const argv = *argvp;
+    if (argcp == NULL || argvp == NULL) {
+        err = sc_error_init(SC_ARGS_DOMAIN, 0, "cannot parse arguments, argcp or argvp is NULL");
+        goto out;
+    }
+    // Use dereferenced versions of argcp and argvp for convenience.
+    int argc = *argcp;
+    char **const argv = *argvp;
 
-	if (argc == 0 || argv == NULL) {
-		err = sc_error_init(SC_ARGS_DOMAIN, 0,
-				    "cannot parse arguments, argc is zero or argv is NULL");
-		goto out;
-	}
-	// Sanity check, look for NULL argv entries.
-	for (int i = 0; i < argc; ++i) {
-		if (argv[i] == NULL) {
-			err = sc_error_init(SC_ARGS_DOMAIN, 0,
-					    "cannot parse arguments, argument at index %d is NULL",
-					    i);
-			goto out;
-		}
-	}
+    if (argc == 0 || argv == NULL) {
+        err = sc_error_init(SC_ARGS_DOMAIN, 0, "cannot parse arguments, argc is zero or argv is NULL");
+        goto out;
+    }
+    // Sanity check, look for NULL argv entries.
+    for (int i = 0; i < argc; ++i) {
+        if (argv[i] == NULL) {
+            err = sc_error_init(SC_ARGS_DOMAIN, 0, "cannot parse arguments, argument at index %d is NULL", i);
+            goto out;
+        }
+    }
 
-	args = calloc(1, sizeof *args);
-	if (args == NULL) {
-		die("cannot allocate memory for command line arguments object");
-	}
-	// Parse option switches.
-	int optind;
-	for (optind = 1; optind < argc; ++optind) {
-		// Look at all the options switches that start with the minus sign ('-')
-		if (argv[optind][0] != '-') {
-			// On first non-switch argument break the loop. The next loop looks
-			// just for non-option arguments. This ensures that options and
-			// positional arguments cannot be mixed.
-			break;
-		}
-		// Handle option switches
-		if (strcmp(argv[optind], "--version") == 0) {
-			args->is_version_query = true;
-			// NOTE: --version short-circuits the parser to finish
-			goto done;
-		} else if (strcmp(argv[optind], "--classic") == 0) {
-			args->is_classic_confinement = true;
-		} else if (strcmp(argv[optind], "--base") == 0) {
-			if (optind + 1 >= argc) {
-				err =
-				    sc_error_init(SC_ARGS_DOMAIN,
-						  SC_ARGS_ERR_USAGE,
-						  "Usage: snap-confine <security-tag> <executable>\n"
-						  "\n"
-						  "the --base option requires an argument");
-				goto out;
-			}
-			if (args->base_snap != NULL) {
-				err =
-				    sc_error_init(SC_ARGS_DOMAIN,
-						  SC_ARGS_ERR_USAGE,
-						  "Usage: snap-confine <security-tag> <executable>\n"
-						  "\n"
-						  "the --base option can be used only once");
-				goto out;
+    args = calloc(1, sizeof *args);
+    if (args == NULL) {
+        die("cannot allocate memory for command line arguments object");
+    }
+    // Parse option switches.
+    int optind;
+    for (optind = 1; optind < argc; ++optind) {
+        // Look at all the options switches that start with the minus sign ('-')
+        if (argv[optind][0] != '-') {
+            // On first non-switch argument break the loop. The next loop looks
+            // just for non-option arguments. This ensures that options and
+            // positional arguments cannot be mixed.
+            break;
+        }
+        // Handle option switches
+        if (strcmp(argv[optind], "--version") == 0) {
+            args->is_version_query = true;
+            // NOTE: --version short-circuits the parser to finish
+            goto done;
+        } else if (strcmp(argv[optind], "--classic") == 0) {
+            args->is_classic_confinement = true;
+        } else if (strcmp(argv[optind], "--base") == 0) {
+            if (optind + 1 >= argc) {
+                err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
+                                    "Usage: snap-confine <security-tag> <executable>\n"
+                                    "\n"
+                                    "the --base option requires an argument");
+                goto out;
+            }
+            if (args->base_snap != NULL) {
+                err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
+                                    "Usage: snap-confine <security-tag> <executable>\n"
+                                    "\n"
+                                    "the --base option can be used only once");
+                goto out;
+            }
+            args->base_snap = sc_strdup(argv[optind + 1]);
+            optind += 1;
+        } else {
+            // Report unhandled option switches
+            err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
+                                "Usage: snap-confine <security-tag> <executable>\n"
+                                "\n"
+                                "unrecognized command line option: %s",
+                                argv[optind]);
+            goto out;
+        }
+    }
 
-			}
-			args->base_snap = sc_strdup(argv[optind + 1]);
-			optind += 1;
-		} else {
-			// Report unhandled option switches
-			err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
-					    "Usage: snap-confine <security-tag> <executable>\n"
-					    "\n"
-					    "unrecognized command line option: %s",
-					    argv[optind]);
-			goto out;
-		}
-	}
+    // Parse positional arguments.
+    //
+    // NOTE: optind is not reset, we just continue from where we left off in
+    // the loop above.
+    for (; optind < argc; ++optind) {
+        if (args->security_tag == NULL) {
+            // The first positional argument becomes the security tag.
+            args->security_tag = sc_strdup(argv[optind]);
+        } else if (args->executable == NULL) {
+            // The second positional argument becomes the executable name.
+            args->executable = sc_strdup(argv[optind]);
+            // No more positional arguments are required.
+            // Stop the parsing process.
+            break;
+        }
+    }
 
-	// Parse positional arguments.
-	//
-	// NOTE: optind is not reset, we just continue from where we left off in
-	// the loop above.
-	for (; optind < argc; ++optind) {
-		if (args->security_tag == NULL) {
-			// The first positional argument becomes the security tag.
-			args->security_tag = sc_strdup(argv[optind]);
-		} else if (args->executable == NULL) {
-			// The second positional argument becomes the executable name.
-			args->executable = sc_strdup(argv[optind]);
-			// No more positional arguments are required.
-			// Stop the parsing process.
-			break;
-		}
-	}
+    // Verify that all mandatory positional arguments are present.
+    // Ensure that we have the security tag
+    if (args->security_tag == NULL) {
+        err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
+                            "Usage: snap-confine <security-tag> <executable>\n"
+                            "\n"
+                            "application or hook security tag was not provided");
+        goto out;
+    }
+    // Ensure that we have the executable name
+    if (args->executable == NULL) {
+        err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
+                            "Usage: snap-confine <security-tag> <executable>\n"
+                            "\n"
+                            "executable name was not provided");
+        goto out;
+    }
 
-	// Verify that all mandatory positional arguments are present.
-	// Ensure that we have the security tag
-	if (args->security_tag == NULL) {
-		err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
-				    "Usage: snap-confine <security-tag> <executable>\n"
-				    "\n"
-				    "application or hook security tag was not provided");
-		goto out;
-	}
-	// Ensure that we have the executable name
-	if (args->executable == NULL) {
-		err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
-				    "Usage: snap-confine <security-tag> <executable>\n"
-				    "\n" "executable name was not provided");
-		goto out;
-	}
+    int i;
+done:
+    // "shift" the argument vector left, except for argv[0], to "consume" the
+    // arguments that were scanned / parsed correctly.
+    for (i = 1; optind + i < argc; ++i) {
+        argv[i] = argv[optind + i];
+    }
+    argv[i] = NULL;
 
-	int i;
- done:
-	// "shift" the argument vector left, except for argv[0], to "consume" the
-	// arguments that were scanned / parsed correctly.
-	for (i = 1; optind + i < argc; ++i) {
-		argv[i] = argv[optind + i];
-	}
-	argv[i] = NULL;
+    // Write the updated argc back, argv is never modified.
+    *argcp = argc - optind;
 
-	// Write the updated argc back, argv is never modified.
-	*argcp = argc - optind;
-
- out:
-	// Don't return anything in case of an error.
-	if (err != NULL) {
-		sc_cleanup_args(&args);
-	}
-	// Forward the error and return
-	sc_error_forward(errorp, err);
-	return args;
+out:
+    // Don't return anything in case of an error.
+    if (err != NULL) {
+        sc_cleanup_args(&args);
+    }
+    // Forward the error and return
+    sc_error_forward(errorp, err);
+    return args;
 }
 
-void sc_args_free(struct sc_args *args)
-{
-	if (args != NULL) {
-		free(args->security_tag);
-		args->security_tag = NULL;
-		free(args->executable);
-		args->executable = NULL;
-		free(args->base_snap);
-		args->base_snap = NULL;
-		free(args);
-	}
+void sc_args_free(struct sc_args *args) {
+    if (args != NULL) {
+        free(args->security_tag);
+        args->security_tag = NULL;
+        free(args->executable);
+        args->executable = NULL;
+        free(args->base_snap);
+        args->base_snap = NULL;
+        free(args);
+    }
 }
 
-void sc_cleanup_args(struct sc_args **ptr)
-{
-	sc_args_free(*ptr);
-	*ptr = NULL;
+void sc_cleanup_args(struct sc_args **ptr) {
+    sc_args_free(*ptr);
+    *ptr = NULL;
 }
 
-bool sc_args_is_version_query(const struct sc_args *args)
-{
-	if (args == NULL) {
-		die("cannot obtain version query flag from NULL argument parser");
-	}
-	return args->is_version_query;
+bool sc_args_is_version_query(const struct sc_args *args) {
+    if (args == NULL) {
+        die("cannot obtain version query flag from NULL argument parser");
+    }
+    return args->is_version_query;
 }
 
-bool sc_args_is_classic_confinement(const struct sc_args *args)
-{
-	if (args == NULL) {
-		die("cannot obtain classic confinement flag from NULL argument parser");
-	}
-	return args->is_classic_confinement;
+bool sc_args_is_classic_confinement(const struct sc_args *args) {
+    if (args == NULL) {
+        die("cannot obtain classic confinement flag from NULL argument parser");
+    }
+    return args->is_classic_confinement;
 }
 
-const char *sc_args_security_tag(const struct sc_args *args)
-{
-	if (args == NULL) {
-		die("cannot obtain security tag from NULL argument parser");
-	}
-	return args->security_tag;
+const char *sc_args_security_tag(const struct sc_args *args) {
+    if (args == NULL) {
+        die("cannot obtain security tag from NULL argument parser");
+    }
+    return args->security_tag;
 }
 
-const char *sc_args_executable(const struct sc_args *args)
-{
-	if (args == NULL) {
-		die("cannot obtain executable from NULL argument parser");
-	}
-	return args->executable;
+const char *sc_args_executable(const struct sc_args *args) {
+    if (args == NULL) {
+        die("cannot obtain executable from NULL argument parser");
+    }
+    return args->executable;
 }
 
-const char *sc_args_base_snap(const struct sc_args *args)
-{
-	if (args == NULL) {
-		die("cannot obtain base snap name from NULL argument parser");
-	}
-	return args->base_snap;
+const char *sc_args_base_snap(const struct sc_args *args) {
+    if (args == NULL) {
+        die("cannot obtain base snap name from NULL argument parser");
+    }
+    return args->base_snap;
 }

--- a/cmd/snap-confine/snap-confine-args.h
+++ b/cmd/snap-confine/snap-confine-args.h
@@ -28,11 +28,11 @@
 #define SC_ARGS_DOMAIN "args"
 
 enum {
-	/**
-	 * Error indicating that the command line arguments could not be parsed
-	 * correctly and usage message should be displayed to the user.
-	 **/
-	SC_ARGS_ERR_USAGE = 1,
+    /**
+     * Error indicating that the command line arguments could not be parsed
+     * correctly and usage message should be displayed to the user.
+     **/
+    SC_ARGS_ERR_USAGE = 1,
 };
 
 /**
@@ -60,9 +60,8 @@ struct sc_args;
  * Both argc and argv are modified so the caller can look at the first unparsed
  * argument at argc[0]. This is only done if argument parsing is successful.
  **/
-__attribute__((warn_unused_result))
-struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
-				       sc_error **errorp);
+__attribute__((warn_unused_result)) struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
+                                                                           sc_error **errorp);
 
 /**
  * Free the object describing command-line arguments to snap-confine.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -29,8 +29,8 @@
 #include <string.h>
 #include <sys/capability.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "../libsnap-confine-private/apparmor-support.h"
@@ -62,54 +62,53 @@
 // sc_maybe_fixup_permissions fixes incorrect permissions
 // inside the mount namespace for /var/lib. Before 1ccce4
 // this directory was created with permissions 1777.
-static void sc_maybe_fixup_permissions(void)
-{
-	int fd SC_CLEANUP(sc_cleanup_close) = -1;
-	struct stat buf;
-	fd = open("/var/lib", O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
-	if (fd < 0) {
-		die("cannot open /var/lib");
-	}
-	if (fstat(fd, &buf) < 0) {
-		die("cannot stat /var/lib");
-	}
-	if ((buf.st_mode & 0777) == 0777) {
-		if (fchmod(fd, 0755) != 0) {
-			die("cannot chmod /var/lib");
-		}
-		if (fchown(fd, 0, 0) != 0) {
-			die("cannot chown /var/lib");
-		}
-	}
+static void sc_maybe_fixup_permissions(void) {
+    int fd SC_CLEANUP(sc_cleanup_close) = -1;
+    struct stat buf;
+    fd = open("/var/lib", O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (fd < 0) {
+        die("cannot open /var/lib");
+    }
+    if (fstat(fd, &buf) < 0) {
+        die("cannot stat /var/lib");
+    }
+    if ((buf.st_mode & 0777) == 0777) {
+        if (fchmod(fd, 0755) != 0) {
+            die("cannot chmod /var/lib");
+        }
+        if (fchown(fd, 0, 0) != 0) {
+            die("cannot chown /var/lib");
+        }
+    }
 }
 
 // sc_maybe_fixup_udev will remove incorrectly created udev tags
 // that cause libudev on 16.04 to fail with "udev_enumerate_scan failed".
 // See also:
 // https://forum.snapcraft.io/t/weird-udev-enumerate-error/2360/17
-static void sc_maybe_fixup_udev(void)
-{
-	glob_t glob_res SC_CLEANUP(globfree) = {
-		.gl_pathv = NULL,.gl_pathc = 0,.gl_offs = 0,
-	};
-	const char *glob_pattern = "/run/udev/tags/snap_*/*nvidia*";
-	int err = glob(glob_pattern, 0, NULL, &glob_res);
-	if (err == GLOB_NOMATCH) {
-		return;
-	}
-	if (err != 0) {
-		die("cannot search using glob pattern %s: %d",
-		    glob_pattern, err);
-	}
-	// kill bogus udev tags for nvidia. They confuse udev, this
-	// undoes the damage from github.com/snapcore/snapd/pull/3671.
-	//
-	// The udev tagging of nvidia got reverted in:
-	// https://github.com/snapcore/snapd/pull/4022
-	// but leftover files need to get removed or apps won't start
-	for (size_t i = 0; i < glob_res.gl_pathc; ++i) {
-		unlink(glob_res.gl_pathv[i]);
-	}
+static void sc_maybe_fixup_udev(void) {
+    glob_t glob_res SC_CLEANUP(globfree) = {
+        .gl_pathv = NULL,
+        .gl_pathc = 0,
+        .gl_offs = 0,
+    };
+    const char *glob_pattern = "/run/udev/tags/snap_*/*nvidia*";
+    int err = glob(glob_pattern, 0, NULL, &glob_res);
+    if (err == GLOB_NOMATCH) {
+        return;
+    }
+    if (err != 0) {
+        die("cannot search using glob pattern %s: %d", glob_pattern, err);
+    }
+    // kill bogus udev tags for nvidia. They confuse udev, this
+    // undoes the damage from github.com/snapcore/snapd/pull/3671.
+    //
+    // The udev tagging of nvidia got reverted in:
+    // https://github.com/snapcore/snapd/pull/4022
+    // but leftover files need to get removed or apps won't start
+    for (size_t i = 0; i < glob_res.gl_pathc; ++i) {
+        unlink(glob_res.gl_pathv[i]);
+    }
 }
 
 /**
@@ -117,11 +116,11 @@ static void sc_maybe_fixup_udev(void)
  *
  * The umask is preserved and restored to ensure consistent permissions for
  * runtime system. The value is preserved and restored perfectly.
-**/
+ **/
 typedef struct sc_preserved_process_state {
-	mode_t orig_umask;
-	int orig_cwd_fd;
-	struct stat file_info_orig_cwd;
+    mode_t orig_umask;
+    int orig_cwd_fd;
+    struct stat file_info_orig_cwd;
 } sc_preserved_process_state;
 
 /**
@@ -134,772 +133,700 @@ typedef struct sc_preserved_process_state {
  * The original values are stored to be restored later. Currently only the
  * umask is altered. It is set to zero to make the ownership of created files
  * and directories more predictable.
-**/
-static void sc_preserve_and_sanitize_process_state(sc_preserved_process_state
-						   *proc_state)
-{
-	/* Reset umask to zero, storing the old value. */
-	proc_state->orig_umask = umask(0);
-	debug("umask reset, old umask was %#4o", proc_state->orig_umask);
-	/* Remember a file descriptor corresponding to the original working
-	 * directory. This is an O_PATH file descriptor. The descriptor is
-	 * used as explained below. */
-	proc_state->orig_cwd_fd =
-	    openat(AT_FDCWD, ".",
-		   O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
-	if (proc_state->orig_cwd_fd < 0) {
-		die("cannot open path of the current working directory");
-	}
-	if (fstat(proc_state->orig_cwd_fd, &proc_state->file_info_orig_cwd) < 0) {
-		die("cannot stat path of the current working directory");
-	}
-	/* Move to the root directory. */
-	if (chdir("/") < 0) {
-		die("cannot move to /");
-	}
+ **/
+static void sc_preserve_and_sanitize_process_state(sc_preserved_process_state *proc_state) {
+    /* Reset umask to zero, storing the old value. */
+    proc_state->orig_umask = umask(0);
+    debug("umask reset, old umask was %#4o", proc_state->orig_umask);
+    /* Remember a file descriptor corresponding to the original working
+     * directory. This is an O_PATH file descriptor. The descriptor is
+     * used as explained below. */
+    proc_state->orig_cwd_fd = openat(AT_FDCWD, ".", O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (proc_state->orig_cwd_fd < 0) {
+        die("cannot open path of the current working directory");
+    }
+    if (fstat(proc_state->orig_cwd_fd, &proc_state->file_info_orig_cwd) < 0) {
+        die("cannot stat path of the current working directory");
+    }
+    /* Move to the root directory. */
+    if (chdir("/") < 0) {
+        die("cannot move to /");
+    }
 }
 
 /**
  *  sc_restore_process_state restores values stored earlier.
-**/
-static void sc_restore_process_state(const sc_preserved_process_state
-				     *proc_state)
-{
-	/* Restore original umask */
-	umask(proc_state->orig_umask);
-	debug("umask restored to %#4o", proc_state->orig_umask);
+ **/
+static void sc_restore_process_state(const sc_preserved_process_state *proc_state) {
+    /* Restore original umask */
+    umask(proc_state->orig_umask);
+    debug("umask restored to %#4o", proc_state->orig_umask);
 
-	/* Restore original current working directory.
-	 *
-	 * This part is more involved for the following reasons. While we hold an
-	 * O_PATH file descriptor that still points to the original working
-	 * directory, that directory may not be representable in the target mount
-	 * namespace. A quick example may be /custom that exists on the host but
-	 * not in the base snap of the application.
-	 *
-	 * Also consider when the path of the original working directory now
-	 * maps to a different inode we cannot use fchdir(2). One example of
-	 * that is the /tmp directory, which exists in both the host mount
-	 * namespace and the per-snap mount namespace but actually represents a
-	 * different directory.
-	 **/
+    /* Restore original current working directory.
+     *
+     * This part is more involved for the following reasons. While we hold an
+     * O_PATH file descriptor that still points to the original working
+     * directory, that directory may not be representable in the target mount
+     * namespace. A quick example may be /custom that exists on the host but
+     * not in the base snap of the application.
+     *
+     * Also consider when the path of the original working directory now
+     * maps to a different inode we cannot use fchdir(2). One example of
+     * that is the /tmp directory, which exists in both the host mount
+     * namespace and the per-snap mount namespace but actually represents a
+     * different directory.
+     **/
 
-	/* Read the target of symlink at /proc/self/fd/<fd-of-orig-cwd> */
-	char fd_path[PATH_MAX] = { 0 };
-	char orig_cwd[PATH_MAX] = { 0 };
-	ssize_t nread;
-	/* If the original working directory cannot be used for whatever reason then
-	 * move the process to a special void directory. */
-	const char *sc_void_dir = "/var/lib/snapd/void";
-	int void_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    /* Read the target of symlink at /proc/self/fd/<fd-of-orig-cwd> */
+    char fd_path[PATH_MAX] = {0};
+    char orig_cwd[PATH_MAX] = {0};
+    ssize_t nread;
+    /* If the original working directory cannot be used for whatever reason then
+     * move the process to a special void directory. */
+    const char *sc_void_dir = "/var/lib/snapd/void";
+    int void_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
 
-	sc_must_snprintf(fd_path, sizeof fd_path, "/proc/self/fd/%d",
-			 proc_state->orig_cwd_fd);
-	nread = readlink(fd_path, orig_cwd, sizeof orig_cwd);
-	if (nread < 0) {
-		die("cannot read symbolic link target %s", fd_path);
-	}
-	if (nread == sizeof orig_cwd) {
-		die("cannot fit symbolic link target %s", fd_path);
-	}
-	orig_cwd[nread] = 0;
+    sc_must_snprintf(fd_path, sizeof fd_path, "/proc/self/fd/%d", proc_state->orig_cwd_fd);
+    nread = readlink(fd_path, orig_cwd, sizeof orig_cwd);
+    if (nread < 0) {
+        die("cannot read symbolic link target %s", fd_path);
+    }
+    if (nread == sizeof orig_cwd) {
+        die("cannot fit symbolic link target %s", fd_path);
+    }
+    orig_cwd[nread] = 0;
 
-	/* Open path corresponding to the original working directory in the
-	 * execution environment. This may normally fail if the path no longer
-	 * exists here, this is not a fatal error. It may also fail if we don't
-	 * have permissions to view that path, that is not a fatal error either. */
-	int inner_cwd_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	inner_cwd_fd =
-	    open(orig_cwd, O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
-	if (inner_cwd_fd < 0) {
-		if (errno == EPERM || errno == EACCES || errno == ENOENT) {
-			debug
-			    ("cannot open path of the original working directory %s",
-			     orig_cwd);
-			goto the_void;
-		}
-		/* Any error other than the three above is unexpected. */
-		die("cannot open path of the original working directory %s",
-		    orig_cwd);
-	}
+    /* Open path corresponding to the original working directory in the
+     * execution environment. This may normally fail if the path no longer
+     * exists here, this is not a fatal error. It may also fail if we don't
+     * have permissions to view that path, that is not a fatal error either. */
+    int inner_cwd_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    inner_cwd_fd = open(orig_cwd, O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (inner_cwd_fd < 0) {
+        if (errno == EPERM || errno == EACCES || errno == ENOENT) {
+            debug("cannot open path of the original working directory %s", orig_cwd);
+            goto the_void;
+        }
+        /* Any error other than the three above is unexpected. */
+        die("cannot open path of the original working directory %s", orig_cwd);
+    }
 
-	/* The original working directory exists in the execution environment
-	 * which lets us check if it points to the same inode as before. */
-	struct stat file_info_inner;
-	if (fstat(inner_cwd_fd, &file_info_inner) < 0) {
-		die("cannot stat path of working directory in the execution environment");
-	}
+    /* The original working directory exists in the execution environment
+     * which lets us check if it points to the same inode as before. */
+    struct stat file_info_inner;
+    if (fstat(inner_cwd_fd, &file_info_inner) < 0) {
+        die("cannot stat path of working directory in the execution environment");
+    }
 
-	/* Note that we cannot use proc_state->orig_cwd_fd as that points to the
-	 * directory but in another mount namespace and using that causes
-	 * weird and undesired effects.
-	 *
-	 * By the time this code runs we are already running as the
-	 * designated user so UNIX permissions are in effect. */
-	if (fchdir(inner_cwd_fd) < 0) {
-		if (errno == EPERM || errno == EACCES) {
-			debug("cannot access original working directory %s",
-			      orig_cwd);
-			goto the_void;
-		}
-		die("cannot restore original working directory via path");
-	}
-	/* The distinction below is only logged and not acted upon. Perhaps someday
-	 * this will be somehow communicated to cooperating applications that can
-	 * instruct the user and avoid potential confusion. This mostly applies to
-	 * tools that are invoked from /tmp. */
-	if (proc_state->file_info_orig_cwd.st_dev ==
-	    file_info_inner.st_dev
-	    && proc_state->file_info_orig_cwd.st_ino ==
-	    file_info_inner.st_ino) {
-		/* The path of the original working directory points to the same
-		 * inode as before. */
-		debug("working directory restored to %s", orig_cwd);
-	} else {
-		/* The path of the original working directory points to a different
-		 * inode inside inside the execution environment than the host
-		 * environment. */
-		debug("working directory re-interpreted to %s", orig_cwd);
-	}
-	return;
- the_void:
-	/* The void directory may be absent. On core18 system, and other
-	 * systems using bootable base snap coupled with snapd snap, the
-	 * /var/lib/snapd directory structure is not provided with packages but
-	 * created on demand. */
-	void_dir_fd = open(sc_void_dir,
-			   O_DIRECTORY | O_PATH | O_NOFOLLOW | O_CLOEXEC);
-	if (void_dir_fd < 0 && errno == ENOENT) {
-		if (mkdir(sc_void_dir, 0111) < 0) {
-			die("cannot create void directory: %s", sc_void_dir);
-		}
-		if (lchown(sc_void_dir, 0, 0) < 0) {
-			die("cannot change ownership of void directory %s",
-			    sc_void_dir);
-		}
-		void_dir_fd = open(sc_void_dir,
-				   O_DIRECTORY | O_PATH | O_NOFOLLOW |
-				   O_CLOEXEC);
-	}
-	if (void_dir_fd < 0) {
-		die("cannot open the void directory %s", sc_void_dir);
-	}
-	if (fchdir(void_dir_fd) < 0) {
-		die("cannot move to void directory %s", sc_void_dir);
-	}
-	debug("the process has been placed in the special void directory");
+    /* Note that we cannot use proc_state->orig_cwd_fd as that points to the
+     * directory but in another mount namespace and using that causes
+     * weird and undesired effects.
+     *
+     * By the time this code runs we are already running as the
+     * designated user so UNIX permissions are in effect. */
+    if (fchdir(inner_cwd_fd) < 0) {
+        if (errno == EPERM || errno == EACCES) {
+            debug("cannot access original working directory %s", orig_cwd);
+            goto the_void;
+        }
+        die("cannot restore original working directory via path");
+    }
+    /* The distinction below is only logged and not acted upon. Perhaps someday
+     * this will be somehow communicated to cooperating applications that can
+     * instruct the user and avoid potential confusion. This mostly applies to
+     * tools that are invoked from /tmp. */
+    if (proc_state->file_info_orig_cwd.st_dev == file_info_inner.st_dev &&
+        proc_state->file_info_orig_cwd.st_ino == file_info_inner.st_ino) {
+        /* The path of the original working directory points to the same
+         * inode as before. */
+        debug("working directory restored to %s", orig_cwd);
+    } else {
+        /* The path of the original working directory points to a different
+         * inode inside inside the execution environment than the host
+         * environment. */
+        debug("working directory re-interpreted to %s", orig_cwd);
+    }
+    return;
+the_void:
+    /* The void directory may be absent. On core18 system, and other
+     * systems using bootable base snap coupled with snapd snap, the
+     * /var/lib/snapd directory structure is not provided with packages but
+     * created on demand. */
+    void_dir_fd = open(sc_void_dir, O_DIRECTORY | O_PATH | O_NOFOLLOW | O_CLOEXEC);
+    if (void_dir_fd < 0 && errno == ENOENT) {
+        if (mkdir(sc_void_dir, 0111) < 0) {
+            die("cannot create void directory: %s", sc_void_dir);
+        }
+        if (lchown(sc_void_dir, 0, 0) < 0) {
+            die("cannot change ownership of void directory %s", sc_void_dir);
+        }
+        void_dir_fd = open(sc_void_dir, O_DIRECTORY | O_PATH | O_NOFOLLOW | O_CLOEXEC);
+    }
+    if (void_dir_fd < 0) {
+        die("cannot open the void directory %s", sc_void_dir);
+    }
+    if (fchdir(void_dir_fd) < 0) {
+        die("cannot move to void directory %s", sc_void_dir);
+    }
+    debug("the process has been placed in the special void directory");
 }
 
-static void log_startup_stage(const char *stage)
-{
-	if (!sc_is_debug_enabled()) {
-		return;
-	}
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lu.%06lu\"}",
-	      stage, tv.tv_sec, tv.tv_usec);
+static void log_startup_stage(const char *stage) {
+    if (!sc_is_debug_enabled()) {
+        return;
+    }
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lu.%06lu\"}", stage, tv.tv_sec, tv.tv_usec);
 }
 
 /**
  *  sc_cleanup_preserved_process_state releases system resources.
-**/
-static void sc_cleanup_preserved_process_state(sc_preserved_process_state
-					       *proc_state)
-{
-	sc_cleanup_close(&proc_state->orig_cwd_fd);
+ **/
+static void sc_cleanup_preserved_process_state(sc_preserved_process_state *proc_state) {
+    sc_cleanup_close(&proc_state->orig_cwd_fd);
 }
 
-static void enter_classic_execution_environment(const sc_invocation * inv,
-						gid_t real_gid,
-						gid_t saved_gid);
-static void enter_non_classic_execution_environment(sc_invocation * inv,
-						    struct sc_apparmor *aa,
-						    uid_t real_uid,
-						    gid_t real_gid,
-						    gid_t saved_gid);
+static void enter_classic_execution_environment(const sc_invocation *inv, gid_t real_gid, gid_t saved_gid);
+static void enter_non_classic_execution_environment(sc_invocation *inv, struct sc_apparmor *aa, uid_t real_uid,
+                                                    gid_t real_gid, gid_t saved_gid);
 
-int main(int argc, char **argv)
-{
-	sc_error *err = NULL;
+int main(int argc, char **argv) {
+    sc_error *err = NULL;
 
-	log_startup_stage("snap-confine enter");
+    log_startup_stage("snap-confine enter");
 
-	// Figure out what is the SNAP_MOUNT_DIR in practice.
-	sc_probe_snap_mount_dir_from_pid_1_mount_ns(AT_FDCWD, &err);
-	sc_die_on_error(err);
+    // Figure out what is the SNAP_MOUNT_DIR in practice.
+    sc_probe_snap_mount_dir_from_pid_1_mount_ns(AT_FDCWD, &err);
+    sc_die_on_error(err);
 
-	debug("SNAP_MOUNT_DIR (probed): %s", sc_snap_mount_dir(NULL));
+    debug("SNAP_MOUNT_DIR (probed): %s", sc_snap_mount_dir(NULL));
 
-	// Use our super-defensive parser to figure out what we've been asked to do.
-	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
-	sc_preserved_process_state proc_state
-	    SC_CLEANUP(sc_cleanup_preserved_process_state) = {
-		.orig_umask = 0,.orig_cwd_fd = -1
-	};
-	args = sc_nonfatal_parse_args(&argc, &argv, &err);
-	sc_die_on_error(err);
+    // Use our super-defensive parser to figure out what we've been asked to do.
+    struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
+    sc_preserved_process_state proc_state SC_CLEANUP(sc_cleanup_preserved_process_state) = {.orig_umask = 0,
+                                                                                            .orig_cwd_fd = -1};
+    args = sc_nonfatal_parse_args(&argc, &argv, &err);
+    sc_die_on_error(err);
 
-	// Remember certain properties of the process that are clobbered by
-	// snap-confine during execution. Those are restored just before calling
-	// execv.
-	sc_preserve_and_sanitize_process_state(&proc_state);
+    // Remember certain properties of the process that are clobbered by
+    // snap-confine during execution. Those are restored just before calling
+    // execv.
+    sc_preserve_and_sanitize_process_state(&proc_state);
 
-	// We've been asked to print the version string so let's just do that.
-	if (sc_args_is_version_query(args)) {
-		printf("%s %s\n", PACKAGE, PACKAGE_VERSION);
-		return 0;
-	}
+    // We've been asked to print the version string so let's just do that.
+    if (sc_args_is_version_query(args)) {
+        printf("%s %s\n", PACKAGE, PACKAGE_VERSION);
+        return 0;
+    }
 
-	/* Collect all invocation parameters. This gives us authoritative
-	 * information about what needs to be invoked and how. The data comes
-	 * from either the environment or from command line arguments */
-	sc_invocation SC_CLEANUP(sc_cleanup_invocation) invocation;
-	const char *snap_instance_name_env = getenv("SNAP_INSTANCE_NAME");
-	if (snap_instance_name_env == NULL) {
-		die("SNAP_INSTANCE_NAME is not set");
-	}
-	// SNAP_COMPONENT_NAME might not be set by the environment, so callers
-	// should be prepared to handle NULL.
-	const char *snap_component_name_env = getenv("SNAP_COMPONENT_NAME");
+    /* Collect all invocation parameters. This gives us authoritative
+     * information about what needs to be invoked and how. The data comes
+     * from either the environment or from command line arguments */
+    sc_invocation SC_CLEANUP(sc_cleanup_invocation) invocation;
+    const char *snap_instance_name_env = getenv("SNAP_INSTANCE_NAME");
+    if (snap_instance_name_env == NULL) {
+        die("SNAP_INSTANCE_NAME is not set");
+    }
+    // SNAP_COMPONENT_NAME might not be set by the environment, so callers
+    // should be prepared to handle NULL.
+    const char *snap_component_name_env = getenv("SNAP_COMPONENT_NAME");
 
-	sc_init_invocation(&invocation, args, snap_instance_name_env,
-			   snap_component_name_env);
+    sc_init_invocation(&invocation, args, snap_instance_name_env, snap_component_name_env);
 
-	// Who are we?
-	uid_t real_uid, effective_uid, saved_uid;
-	gid_t real_gid, effective_gid, saved_gid;
-	if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0) {
-		die("getresuid failed");
-	}
-	if (getresgid(&real_gid, &effective_gid, &saved_gid) != 0) {
-		die("getresgid failed");
-	}
-	debug("ruid: %d, euid: %d, suid: %d",
-	      real_uid, effective_uid, saved_uid);
-	debug("rgid: %d, egid: %d, sgid: %d",
-	      real_gid, effective_gid, saved_gid);
+    // Who are we?
+    uid_t real_uid, effective_uid, saved_uid;
+    gid_t real_gid, effective_gid, saved_gid;
+    if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0) {
+        die("getresuid failed");
+    }
+    if (getresgid(&real_gid, &effective_gid, &saved_gid) != 0) {
+        die("getresgid failed");
+    }
+    debug("ruid: %d, euid: %d, suid: %d", real_uid, effective_uid, saved_uid);
+    debug("rgid: %d, egid: %d, sgid: %d", real_gid, effective_gid, saved_gid);
 
-	// snap-confine needs to run as root for cgroup/udev/mount/apparmor/etc setup.
-	if (effective_uid != 0) {
-		die("need to run as root or suid");
-	}
+    // snap-confine needs to run as root for cgroup/udev/mount/apparmor/etc setup.
+    if (effective_uid != 0) {
+        die("need to run as root or suid");
+    }
 
-	char *snap_context SC_CLEANUP(sc_cleanup_string) = NULL;
-	// Do no get snap context value if running a hook (we don't want to overwrite hook's SNAP_COOKIE)
-	if (!sc_is_hook_security_tag(invocation.security_tag)) {
-		sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-		snap_context =
-		    sc_cookie_get_from_snapd(invocation.snap_instance, &err);
-		/* While the cookie is normally present due to various protection
-		 * mechanisms ensuring its creation from snapd, we are not considering
-		 * it a critical error for snap-confine in the case it is absent. When
-		 * absent snaps attempting to utilize snapctl to interact with snapd
-		 * will fail but it is more important to run a little than break
-		 * entirely in case snapd-side code is incorrect. Therefore error
-		 * information is collected but discarded. */
-	}
+    char *snap_context SC_CLEANUP(sc_cleanup_string) = NULL;
+    // Do no get snap context value if running a hook (we don't want to overwrite hook's SNAP_COOKIE)
+    if (!sc_is_hook_security_tag(invocation.security_tag)) {
+        sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+        snap_context = sc_cookie_get_from_snapd(invocation.snap_instance, &err);
+        /* While the cookie is normally present due to various protection
+         * mechanisms ensuring its creation from snapd, we are not considering
+         * it a critical error for snap-confine in the case it is absent. When
+         * absent snaps attempting to utilize snapctl to interact with snapd
+         * will fail but it is more important to run a little than break
+         * entirely in case snapd-side code is incorrect. Therefore error
+         * information is collected but discarded. */
+    }
 
-	struct sc_apparmor apparmor;
-	sc_init_apparmor_support(&apparmor);
-	if (!apparmor.is_confined && apparmor.mode != SC_AA_NOT_APPLICABLE
-	    && getuid() != 0 && geteuid() == 0) {
-		// Refuse to run when this process is running unconfined on a system
-		// that supports AppArmor when the effective uid is root and the real
-		// id is non-root.  This protects against, for example, unprivileged
-		// users trying to leverage the snap-confine in the core snap to
-		// escalate privileges.
-		errno = 0;	// errno is insignificant here
-		die("snap-confine has elevated permissions and is not confined"
-		    " but should be. Refusing to continue to avoid"
-		    " permission escalation attacks\n"
-		    "Please make sure that the snapd.apparmor service is enabled and started.");
-	}
+    struct sc_apparmor apparmor;
+    sc_init_apparmor_support(&apparmor);
+    if (!apparmor.is_confined && apparmor.mode != SC_AA_NOT_APPLICABLE && getuid() != 0 && geteuid() == 0) {
+        // Refuse to run when this process is running unconfined on a system
+        // that supports AppArmor when the effective uid is root and the real
+        // id is non-root.  This protects against, for example, unprivileged
+        // users trying to leverage the snap-confine in the core snap to
+        // escalate privileges.
+        errno = 0;  // errno is insignificant here
+        die("snap-confine has elevated permissions and is not confined"
+            " but should be. Refusing to continue to avoid"
+            " permission escalation attacks\n"
+            "Please make sure that the snapd.apparmor service is enabled and started.");
+    }
 
-	log_startup_stage("snap-confine mount namespace start");
+    log_startup_stage("snap-confine mount namespace start");
 
-	/* perform global initialization of mount namespace support for non-classic
-	 * snaps or both classic and non-classic when parallel-instances feature is
-	 * enabled */
-	if (!invocation.classic_confinement ||
-	    sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES)) {
+    /* perform global initialization of mount namespace support for non-classic
+     * snaps or both classic and non-classic when parallel-instances feature is
+     * enabled */
+    if (!invocation.classic_confinement || sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES)) {
+        /* snap-confine uses privately-shared /run/snapd/ns to store bind-mounted
+         * mount namespaces of each snap. In the case that snap-confine is invoked
+         * from the mount namespace it typically constructs, the said directory
+         * does not contain mount entries for preserved namespaces as those are
+         * only visible in the main, outer namespace.
+         *
+         * In order to operate in such an environment snap-confine must first
+         * re-associate its own process with another namespace in which the
+         * /run/snapd/ns directory is visible. The most obvious candidate is pid
+         * one, which definitely doesn't run in a snap-specific namespace, has a
+         * predictable PID and is long lived.
+         */
+        sc_reassociate_with_pid1_mount_ns();
+        // Do global initialization:
+        int global_lock_fd = sc_lock_global();
+        // Ensure that "/" or "/snap" is mounted with the
+        // "shared" option on legacy systems, see LP:#1668659
+        debug("ensuring that snap mount directory is shared");
+        sc_ensure_shared_snap_mount();
+        unsigned int experimental_features = 0;
+        if (sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES)) {
+            experimental_features |= SC_FEATURE_PARALLEL_INSTANCES;
+        }
+        sc_initialize_mount_ns(experimental_features);
+        sc_unlock(global_lock_fd);
+    }
 
-		/* snap-confine uses privately-shared /run/snapd/ns to store bind-mounted
-		 * mount namespaces of each snap. In the case that snap-confine is invoked
-		 * from the mount namespace it typically constructs, the said directory
-		 * does not contain mount entries for preserved namespaces as those are
-		 * only visible in the main, outer namespace.
-		 *
-		 * In order to operate in such an environment snap-confine must first
-		 * re-associate its own process with another namespace in which the
-		 * /run/snapd/ns directory is visible. The most obvious candidate is pid
-		 * one, which definitely doesn't run in a snap-specific namespace, has a
-		 * predictable PID and is long lived.
-		 */
-		sc_reassociate_with_pid1_mount_ns();
-		// Do global initialization:
-		int global_lock_fd = sc_lock_global();
-		// Ensure that "/" or "/snap" is mounted with the
-		// "shared" option on legacy systems, see LP:#1668659
-		debug("ensuring that snap mount directory is shared");
-		sc_ensure_shared_snap_mount();
-		unsigned int experimental_features = 0;
-		if (sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES)) {
-			experimental_features |= SC_FEATURE_PARALLEL_INSTANCES;
-		}
-		sc_initialize_mount_ns(experimental_features);
-		sc_unlock(global_lock_fd);
-	}
+    if (invocation.classic_confinement) {
+        enter_classic_execution_environment(&invocation, real_gid, saved_gid);
+    } else {
+        enter_non_classic_execution_environment(&invocation, &apparmor, real_uid, real_gid, saved_gid);
+    }
 
-	if (invocation.classic_confinement) {
-		enter_classic_execution_environment(&invocation, real_gid,
-						    saved_gid);
-	} else {
-		enter_non_classic_execution_environment(&invocation,
-							&apparmor,
-							real_uid,
-							real_gid, saved_gid);
-	}
+    log_startup_stage("snap-confine mount namespace finish");
 
-	log_startup_stage("snap-confine mount namespace finish");
-
-	// Temporarily drop privileges back to the calling user until we can
-	// permanently drop (which we can't do just yet due to seccomp, see
-	// below).
-	sc_identity real_user_identity = {
-		.uid = real_uid,
-		.gid = real_gid,
-		.change_uid = 1,
-		.change_gid = 1,
-	};
-	sc_set_effective_identity(real_user_identity);
-	// Ensure that the user data path exists. When creating it use the identity
-	// of the calling user (by using real user and group identifiers). This
-	// allows the creation of directories inside ~/ on NFS with root_squash
-	// attribute.
-	setup_user_data();
+    // Temporarily drop privileges back to the calling user until we can
+    // permanently drop (which we can't do just yet due to seccomp, see
+    // below).
+    sc_identity real_user_identity = {
+        .uid = real_uid,
+        .gid = real_gid,
+        .change_uid = 1,
+        .change_gid = 1,
+    };
+    sc_set_effective_identity(real_user_identity);
+    // Ensure that the user data path exists. When creating it use the identity
+    // of the calling user (by using real user and group identifiers). This
+    // allows the creation of directories inside ~/ on NFS with root_squash
+    // attribute.
+    setup_user_data();
 #if 0
 	setup_user_xdg_runtime_dir();
 #endif
-	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
-	sc_maybe_aa_change_onexec(&apparmor, invocation.security_tag);
+    // https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
+    sc_maybe_aa_change_onexec(&apparmor, invocation.security_tag);
 #ifdef HAVE_SELINUX
-	// For classic and confined snaps
-	sc_selinux_set_snap_execcon();
+    // For classic and confined snaps
+    sc_selinux_set_snap_execcon();
 #endif
-	if (snap_context != NULL) {
-		setenv("SNAP_COOKIE", snap_context, 1);
-		// for compatibility, if facing older snapd.
-		setenv("SNAP_CONTEXT", snap_context, 1);
-	}
-	// Normally setuid/setgid not only permanently drops the UID/GID, but
-	// also clears the capabilities bounding sets (see "Effect of user ID
-	// changes on capabilities" in 'man capabilities'). To load a seccomp
-	// profile, we need either CAP_SYS_ADMIN or PR_SET_NO_NEW_PRIVS. Since
-	// NNP causes issues with AppArmor and exec transitions in certain
-	// snapd interfaces, keep CAP_SYS_ADMIN temporarily when we are
-	// permanently dropping privileges.
-	if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0) {
-		die("getresuid failed");
-	}
-	debug("ruid: %d, euid: %d, suid: %d",
-	      real_uid, effective_uid, saved_uid);
-	struct __user_cap_header_struct hdr =
-	    { _LINUX_CAPABILITY_VERSION_3, 0 };
-	struct __user_cap_data_struct cap_data[2] = { {0} };
+    if (snap_context != NULL) {
+        setenv("SNAP_COOKIE", snap_context, 1);
+        // for compatibility, if facing older snapd.
+        setenv("SNAP_CONTEXT", snap_context, 1);
+    }
+    // Normally setuid/setgid not only permanently drops the UID/GID, but
+    // also clears the capabilities bounding sets (see "Effect of user ID
+    // changes on capabilities" in 'man capabilities'). To load a seccomp
+    // profile, we need either CAP_SYS_ADMIN or PR_SET_NO_NEW_PRIVS. Since
+    // NNP causes issues with AppArmor and exec transitions in certain
+    // snapd interfaces, keep CAP_SYS_ADMIN temporarily when we are
+    // permanently dropping privileges.
+    if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0) {
+        die("getresuid failed");
+    }
+    debug("ruid: %d, euid: %d, suid: %d", real_uid, effective_uid, saved_uid);
+    struct __user_cap_header_struct hdr = {_LINUX_CAPABILITY_VERSION_3, 0};
+    struct __user_cap_data_struct cap_data[2] = {{0}};
 
-	// At this point in time, if we are going to permanently drop our
-	// effective_uid will not be '0' but our saved_uid will be '0'. Detect
-	// and save when we are in the this state so know when to setup the
-	// capabilities bounding set, regain CAP_SYS_ADMIN and later drop it.
-	bool keep_sys_admin = effective_uid != 0 && saved_uid == 0;
-	if (keep_sys_admin) {
-		debug("setting capabilities bounding set");
-		// clear all 32 bit caps but SYS_ADMIN, with none inheritable
-		cap_data[0].effective = CAP_TO_MASK(CAP_SYS_ADMIN);
-		cap_data[0].permitted = cap_data[0].effective;
-		cap_data[0].inheritable = 0;
-		// clear all 64 bit caps
-		cap_data[1].effective = 0;
-		cap_data[1].permitted = 0;
-		cap_data[1].inheritable = 0;
-		if (capset(&hdr, cap_data) != 0) {
-			die("capset failed");
-		}
-	}
-	// Permanently drop if not root
-	if (effective_uid == 0) {
-		// Note that we do not call setgroups() here because its ok
-		// that the user keeps the groups he already belongs to
-		if (setgid(real_gid) != 0)
-			die("setgid failed");
-		if (setuid(real_uid) != 0)
-			die("setuid failed");
+    // At this point in time, if we are going to permanently drop our
+    // effective_uid will not be '0' but our saved_uid will be '0'. Detect
+    // and save when we are in the this state so know when to setup the
+    // capabilities bounding set, regain CAP_SYS_ADMIN and later drop it.
+    bool keep_sys_admin = effective_uid != 0 && saved_uid == 0;
+    if (keep_sys_admin) {
+        debug("setting capabilities bounding set");
+        // clear all 32 bit caps but SYS_ADMIN, with none inheritable
+        cap_data[0].effective = CAP_TO_MASK(CAP_SYS_ADMIN);
+        cap_data[0].permitted = cap_data[0].effective;
+        cap_data[0].inheritable = 0;
+        // clear all 64 bit caps
+        cap_data[1].effective = 0;
+        cap_data[1].permitted = 0;
+        cap_data[1].inheritable = 0;
+        if (capset(&hdr, cap_data) != 0) {
+            die("capset failed");
+        }
+    }
+    // Permanently drop if not root
+    if (effective_uid == 0) {
+        // Note that we do not call setgroups() here because its ok
+        // that the user keeps the groups he already belongs to
+        if (setgid(real_gid) != 0) die("setgid failed");
+        if (setuid(real_uid) != 0) die("setuid failed");
 
-		if (real_gid != 0 && (getuid() == 0 || geteuid() == 0))
-			die("permanently dropping privs did not work");
-		if (real_uid != 0 && (getgid() == 0 || getegid() == 0))
-			die("permanently dropping privs did not work");
-	}
-	// Now that we've permanently dropped, regain SYS_ADMIN
-	if (keep_sys_admin) {
-		debug("regaining SYS_ADMIN");
-		cap_data[0].effective = CAP_TO_MASK(CAP_SYS_ADMIN);
-		cap_data[0].permitted = cap_data[0].effective;
-		if (capset(&hdr, cap_data) != 0) {
-			die("capset regain failed");
-		}
-	}
-	// Now that we've dropped and regained SYS_ADMIN, we can load the
-	// seccomp profiles.
-	sc_apply_seccomp_profile_for_security_tag(invocation.security_tag);
-	// Even though we set inheritable to 0, let's clear SYS_ADMIN
-	// explicitly
-	if (keep_sys_admin) {
-		debug("clearing SYS_ADMIN");
-		cap_data[0].effective = 0;
-		cap_data[0].permitted = cap_data[0].effective;
-		if (capset(&hdr, cap_data) != 0) {
-			die("capset clear failed");
-		}
-	}
-	// and exec the new executable
-	argv[0] = (char *)invocation.executable;
-	debug("execv(%s, %s...)", invocation.executable, argv[0]);
-	for (int i = 1; i < argc; ++i) {
-		debug(" argv[%i] = %s", i, argv[i]);
-	}
-	// Restore process state that was recorded earlier.
-	sc_restore_process_state(&proc_state);
-	log_startup_stage("snap-confine to snap-exec");
-	execv(invocation.executable, (char *const *)&argv[0]);
-	perror("execv failed");
-	return 1;
+        if (real_gid != 0 && (getuid() == 0 || geteuid() == 0)) die("permanently dropping privs did not work");
+        if (real_uid != 0 && (getgid() == 0 || getegid() == 0)) die("permanently dropping privs did not work");
+    }
+    // Now that we've permanently dropped, regain SYS_ADMIN
+    if (keep_sys_admin) {
+        debug("regaining SYS_ADMIN");
+        cap_data[0].effective = CAP_TO_MASK(CAP_SYS_ADMIN);
+        cap_data[0].permitted = cap_data[0].effective;
+        if (capset(&hdr, cap_data) != 0) {
+            die("capset regain failed");
+        }
+    }
+    // Now that we've dropped and regained SYS_ADMIN, we can load the
+    // seccomp profiles.
+    sc_apply_seccomp_profile_for_security_tag(invocation.security_tag);
+    // Even though we set inheritable to 0, let's clear SYS_ADMIN
+    // explicitly
+    if (keep_sys_admin) {
+        debug("clearing SYS_ADMIN");
+        cap_data[0].effective = 0;
+        cap_data[0].permitted = cap_data[0].effective;
+        if (capset(&hdr, cap_data) != 0) {
+            die("capset clear failed");
+        }
+    }
+    // and exec the new executable
+    argv[0] = (char *)invocation.executable;
+    debug("execv(%s, %s...)", invocation.executable, argv[0]);
+    for (int i = 1; i < argc; ++i) {
+        debug(" argv[%i] = %s", i, argv[i]);
+    }
+    // Restore process state that was recorded earlier.
+    sc_restore_process_state(&proc_state);
+    log_startup_stage("snap-confine to snap-exec");
+    execv(invocation.executable, (char *const *)&argv[0]);
+    perror("execv failed");
+    return 1;
 }
 
-static void enter_classic_execution_environment(const sc_invocation *inv,
-						gid_t real_gid, gid_t saved_gid)
-{
-	/* with parallel-instances enabled, main() reassociated with the mount ns of
-	 * PID 1 to make /run/snapd/ns visible */
+static void enter_classic_execution_environment(const sc_invocation *inv, gid_t real_gid, gid_t saved_gid) {
+    /* with parallel-instances enabled, main() reassociated with the mount ns of
+     * PID 1 to make /run/snapd/ns visible */
 
-	/* 'classic confinement' is designed to run without the sandbox inside the
-	 * shared namespace. Specifically:
-	 * - snap-confine skips using the snap-specific, private, mount namespace
-	 * - snap-confine skips using device cgroups
-	 * - snapd sets up a lenient AppArmor profile for snap-confine to use
-	 * - snapd sets up a lenient seccomp profile for snap-confine to use
-	 */
-	debug("preparing classic execution environment");
+    /* 'classic confinement' is designed to run without the sandbox inside the
+     * shared namespace. Specifically:
+     * - snap-confine skips using the snap-specific, private, mount namespace
+     * - snap-confine skips using device cgroups
+     * - snapd sets up a lenient AppArmor profile for snap-confine to use
+     * - snapd sets up a lenient seccomp profile for snap-confine to use
+     */
+    debug("preparing classic execution environment");
 
-	if (!sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES)) {
-		return;
-	}
+    if (!sc_feature_enabled(SC_FEATURE_PARALLEL_INSTANCES)) {
+        return;
+    }
 
-	/* all of the following code is experimental and part of parallel instances
-	 * of classic snaps support */
+    /* all of the following code is experimental and part of parallel instances
+     * of classic snaps support */
 
-	debug
-	    ("(experimental) unsharing the mount namespace (per-classic-snap)");
+    debug("(experimental) unsharing the mount namespace (per-classic-snap)");
 
-	/* Construct a mount namespace where the snap instance directories are
-	 * visible under the regular snap name. In order to do that we will:
-	 *
-	 * - convert SNAP_MOUNT_DIR into a mount point (global init)
-	 * - convert /var/snap into a mount point (global init)
-	 * - always create a new mount namespace
-	 * - for snaps with non empty instance key:
-	 *   - set slave propagation recursively on SNAP_MOUNT_DIR and /var/snap
-	 *   - recursively bind mount SNAP_MOUNT_DIR/<snap>_<key> on top of SNAP_MOUNT_DIR/<snap>
-	 *   - recursively bind mount /var/snap/<snap>_<key> on top of /var/snap/<snap>
-	 *
-	 * The destination directories /var/snap/<snap> and SNAP_MOUNT_DIR/<snap>
-	 * are guaranteed to exist and were created during installation of a given
-	 * instance.
-	 */
+    /* Construct a mount namespace where the snap instance directories are
+     * visible under the regular snap name. In order to do that we will:
+     *
+     * - convert SNAP_MOUNT_DIR into a mount point (global init)
+     * - convert /var/snap into a mount point (global init)
+     * - always create a new mount namespace
+     * - for snaps with non empty instance key:
+     *   - set slave propagation recursively on SNAP_MOUNT_DIR and /var/snap
+     *   - recursively bind mount SNAP_MOUNT_DIR/<snap>_<key> on top of SNAP_MOUNT_DIR/<snap>
+     *   - recursively bind mount /var/snap/<snap>_<key> on top of /var/snap/<snap>
+     *
+     * The destination directories /var/snap/<snap> and SNAP_MOUNT_DIR/<snap>
+     * are guaranteed to exist and were created during installation of a given
+     * instance.
+     */
 
-	if (unshare(CLONE_NEWNS) < 0) {
-		die("cannot unshare the mount namespace for parallel installed classic snap");
-	}
+    if (unshare(CLONE_NEWNS) < 0) {
+        die("cannot unshare the mount namespace for parallel installed classic snap");
+    }
 
-	/* Parallel installed classic snap get special handling */
-	if (!sc_streq(inv->snap_instance, inv->snap_name)) {
-		debug
-		    ("(experimental) setting up environment for classic snap instance %s",
-		     inv->snap_instance);
+    /* Parallel installed classic snap get special handling */
+    if (!sc_streq(inv->snap_instance, inv->snap_name)) {
+        debug("(experimental) setting up environment for classic snap instance %s", inv->snap_instance);
 
-		/* set up mappings for snap and data directories */
-		sc_setup_parallel_instance_classic_mounts(inv->snap_name,
-							  inv->snap_instance);
-	}
+        /* set up mappings for snap and data directories */
+        sc_setup_parallel_instance_classic_mounts(inv->snap_name, inv->snap_instance);
+    }
 }
 
 /* max wait time for /var/lib/snapd/cgroup/<snap>.devices to appear */
 static const size_t DEVICES_FILE_MAX_WAIT = 120;
 
 struct sc_device_cgroup_options {
-	bool self_managed;
-	bool non_strict;
+    bool self_managed;
+    bool non_strict;
 };
 
-static void sc_get_device_cgroup_setup(const sc_invocation *inv, struct sc_device_cgroup_options
-				       *devsetup)
-{
-	if (devsetup == NULL) {
-		die("internal error: devsetup is NULL");
-	}
+static void sc_get_device_cgroup_setup(const sc_invocation *inv, struct sc_device_cgroup_options *devsetup) {
+    if (devsetup == NULL) {
+        die("internal error: devsetup is NULL");
+    }
 
-	char info_path[PATH_MAX] = { 0 };
-	sc_must_snprintf(info_path,
-			 sizeof info_path,
-			 "/var/lib/snapd/cgroup/snap.%s.device",
-			 inv->snap_instance);
+    char info_path[PATH_MAX] = {0};
+    sc_must_snprintf(info_path, sizeof info_path, "/var/lib/snapd/cgroup/snap.%s.device", inv->snap_instance);
 
-	/* TODO allow overriding timeout through env? */
-	if (!sc_wait_for_file(info_path, DEVICES_FILE_MAX_WAIT)) {
-		/* don't die explicitly here, we'll die when trying to open the file
-		 * (unless it shows up) */
-		debug("timeout waiting for devices file at %s", info_path);
-	}
+    /* TODO allow overriding timeout through env? */
+    if (!sc_wait_for_file(info_path, DEVICES_FILE_MAX_WAIT)) {
+        /* don't die explicitly here, we'll die when trying to open the file
+         * (unless it shows up) */
+        debug("timeout waiting for devices file at %s", info_path);
+    }
 
-	FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
-	stream = fopen(info_path, "r");
-	if (stream == NULL) {
-		die("cannot open %s", info_path);
-	}
+    FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
+    stream = fopen(info_path, "r");
+    if (stream == NULL) {
+        die("cannot open %s", info_path);
+    }
 
-	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-	char *self_managed_value SC_CLEANUP(sc_cleanup_string) = NULL;
-	if (sc_infofile_get_key
-	    (stream, "self-managed", &self_managed_value, &err) < 0) {
-		sc_die_on_error(err);
-	}
-	rewind(stream);
+    sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    char *self_managed_value SC_CLEANUP(sc_cleanup_string) = NULL;
+    if (sc_infofile_get_key(stream, "self-managed", &self_managed_value, &err) < 0) {
+        sc_die_on_error(err);
+    }
+    rewind(stream);
 
-	char *non_strict_value SC_CLEANUP(sc_cleanup_string) = NULL;
-	if (sc_infofile_get_key(stream, "non-strict", &non_strict_value, &err) <
-	    0) {
-		sc_die_on_error(err);
-	}
+    char *non_strict_value SC_CLEANUP(sc_cleanup_string) = NULL;
+    if (sc_infofile_get_key(stream, "non-strict", &non_strict_value, &err) < 0) {
+        sc_die_on_error(err);
+    }
 
-	devsetup->self_managed = sc_streq(self_managed_value, "true");
-	devsetup->non_strict = sc_streq(non_strict_value, "true");
+    devsetup->self_managed = sc_streq(self_managed_value, "true");
+    devsetup->non_strict = sc_streq(non_strict_value, "true");
 }
 
-static sc_device_cgroup_mode device_cgroup_mode_for_snap(sc_invocation *inv)
-{
+static sc_device_cgroup_mode device_cgroup_mode_for_snap(sc_invocation *inv) {
     /** Conditionally create, populate and join the device cgroup. */
-	sc_device_cgroup_mode mode = SC_DEVICE_CGROUP_MODE_REQUIRED;
+    sc_device_cgroup_mode mode = SC_DEVICE_CGROUP_MODE_REQUIRED;
 
-	/* Preserve the legacy behavior of no default device cgroup for snaps
-	 * using one of the following bases. Snaps using core24 and later bases
-	 * will be placed within a device cgroup. Note that 'bare' base is also
-	 * subject to the new behavior. */
-	const char *non_required_cgroup_bases[] = {
-		"core", "core16", "core18", "core20", "core22",
-		NULL,
-	};
-	for (const char **non_required_on_base =
-	     non_required_cgroup_bases; *non_required_on_base != NULL;
-	     non_required_on_base++) {
-		if (sc_streq(inv->base_snap_name, *non_required_on_base)) {
-			debug
-			    ("device cgroup not required due to base %s",
-			     *non_required_on_base);
-			mode = SC_DEVICE_CGROUP_MODE_OPTIONAL;
-			break;
-		}
-	}
+    /* Preserve the legacy behavior of no default device cgroup for snaps
+     * using one of the following bases. Snaps using core24 and later bases
+     * will be placed within a device cgroup. Note that 'bare' base is also
+     * subject to the new behavior. */
+    const char *non_required_cgroup_bases[] = {
+        "core", "core16", "core18", "core20", "core22", NULL,
+    };
+    for (const char **non_required_on_base = non_required_cgroup_bases; *non_required_on_base != NULL;
+         non_required_on_base++) {
+        if (sc_streq(inv->base_snap_name, *non_required_on_base)) {
+            debug("device cgroup not required due to base %s", *non_required_on_base);
+            mode = SC_DEVICE_CGROUP_MODE_OPTIONAL;
+            break;
+        }
+    }
 
-	return mode;
+    return mode;
 }
 
-static void enter_non_classic_execution_environment(sc_invocation *inv,
-						    struct sc_apparmor *aa,
-						    uid_t real_uid,
-						    gid_t real_gid,
-						    gid_t saved_gid)
-{
-	// main() reassociated with the mount ns of PID 1 to make /run/snapd/ns
-	// visible
+static void enter_non_classic_execution_environment(sc_invocation *inv, struct sc_apparmor *aa, uid_t real_uid,
+                                                    gid_t real_gid, gid_t saved_gid) {
+    // main() reassociated with the mount ns of PID 1 to make /run/snapd/ns
+    // visible
 
-	// Find and open snap-update-ns and snap-discard-ns from the same
-	// path as where we (snap-confine) were called.
-	int snap_update_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	snap_update_ns_fd = sc_open_snap_update_ns();
-	int snap_discard_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	snap_discard_ns_fd = sc_open_snap_discard_ns();
+    // Find and open snap-update-ns and snap-discard-ns from the same
+    // path as where we (snap-confine) were called.
+    int snap_update_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    snap_update_ns_fd = sc_open_snap_update_ns();
+    int snap_discard_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    snap_discard_ns_fd = sc_open_snap_discard_ns();
 
-	// Do per-snap initialization.
-	int snap_lock_fd = sc_lock_snap(inv->snap_instance);
+    // Do per-snap initialization.
+    int snap_lock_fd = sc_lock_snap(inv->snap_instance);
 
-	// This is a workaround for systemd v237 (used by Ubuntu 18.04) for non-root users
-	// where a transient scope cgroup is not created for a snap hence it cannot be tracked
-	// before the freezer cgroup is created (and joined) below.
-	if (sc_snap_is_inhibited
-	    (inv->snap_instance, SC_SNAP_HINT_INHIBITED_FOR_REMOVE)) {
-		// Prevent starting new snap processes when snap is being removed until
-		// the freezer cgroup is created below and the snap lock is released so
-		// that remove change can track running processes through pids under the
-		// freezer cgroup.
-		die("snap is currently being removed");
-	}
+    // This is a workaround for systemd v237 (used by Ubuntu 18.04) for non-root users
+    // where a transient scope cgroup is not created for a snap hence it cannot be tracked
+    // before the freezer cgroup is created (and joined) below.
+    if (sc_snap_is_inhibited(inv->snap_instance, SC_SNAP_HINT_INHIBITED_FOR_REMOVE)) {
+        // Prevent starting new snap processes when snap is being removed until
+        // the freezer cgroup is created below and the snap lock is released so
+        // that remove change can track running processes through pids under the
+        // freezer cgroup.
+        die("snap is currently being removed");
+    }
 
-	debug("initializing mount namespace: %s", inv->snap_instance);
-	struct sc_mount_ns *group = NULL;
-	group = sc_open_mount_ns(inv->snap_instance);
+    debug("initializing mount namespace: %s", inv->snap_instance);
+    struct sc_mount_ns *group = NULL;
+    group = sc_open_mount_ns(inv->snap_instance);
 
-	// Init and check rootfs_dir, apply any fallback behaviors.
-	sc_check_rootfs_dir(inv);
+    // Init and check rootfs_dir, apply any fallback behaviors.
+    sc_check_rootfs_dir(inv);
 
-	// Set up a device cgroup, unless the snap has been allowed to manage the
-	// device cgroup by itself.
-	struct sc_device_cgroup_options cgdevopts = { false, false };
-	sc_get_device_cgroup_setup(inv, &cgdevopts);
-	bool in_container = sc_is_in_container();
-	if (cgdevopts.self_managed) {
-		debug("device cgroup is self-managed by the snap");
-	} else if (cgdevopts.non_strict) {
-		debug("device cgroup skipped, snap in non-strict confinement");
-	} else if (in_container) {
-		debug("device cgroup skipped, executing inside a container");
-	} else {
-		sc_device_cgroup_mode mode = device_cgroup_mode_for_snap(inv);
-		sc_setup_device_cgroup(inv->security_tag, mode);
-	}
+    // Set up a device cgroup, unless the snap has been allowed to manage the
+    // device cgroup by itself.
+    struct sc_device_cgroup_options cgdevopts = {false, false};
+    sc_get_device_cgroup_setup(inv, &cgdevopts);
+    bool in_container = sc_is_in_container();
+    if (cgdevopts.self_managed) {
+        debug("device cgroup is self-managed by the snap");
+    } else if (cgdevopts.non_strict) {
+        debug("device cgroup skipped, snap in non-strict confinement");
+    } else if (in_container) {
+        debug("device cgroup skipped, executing inside a container");
+    } else {
+        sc_device_cgroup_mode mode = device_cgroup_mode_for_snap(inv);
+        sc_setup_device_cgroup(inv->security_tag, mode);
+    }
 
-	/**
-	 * is_normal_mode controls if we should pivot into the base snap.
-	 *
-	 * There are two modes of execution for snaps that are not using classic
-	 * confinement: normal and legacy. The normal mode is where snap-confine
-	 * sets up a rootfs and then pivots into it using pivot_root(2). The legacy
-	 * mode is when snap-confine just unshares the initial mount namespace,
-	 * makes some extra changes but largely runs with what was presented to it
-	 * initially.
-	 *
-	 * Historically the ubuntu-core distribution used the now-legacy mode. This
-	 * was sensible then since snaps already (kind of) have the right root
-	 * file-system and just need some privacy and isolation features applied.
-	 * With the introduction of snaps to classic distributions as well as the
-	 * introduction of bases, where each snap can use a different root
-	 * filesystem, this lost sensibility and thus became legacy.
-	 *
-	 * For compatibility with current installations of ubuntu-core
-	 * distributions the legacy mode is used when: the distribution is
-	 * SC_DISTRO_CORE16 or when the base snap name is not "core" or
-	 * "ubuntu-core".
-	 *
-	 * The SC_DISTRO_CORE16 is applied to systems that boot with the "core",
-	 * "ubuntu-core" or "core16" snap. Systems using the "core18" base snap do
-	 * not qualify for that classification.
-	 **/
-	sc_distro distro = sc_classify_distro();
-	inv->is_normal_mode = distro != SC_DISTRO_CORE16 ||
-	    !sc_streq(inv->orig_base_snap_name, "core");
+    /**
+     * is_normal_mode controls if we should pivot into the base snap.
+     *
+     * There are two modes of execution for snaps that are not using classic
+     * confinement: normal and legacy. The normal mode is where snap-confine
+     * sets up a rootfs and then pivots into it using pivot_root(2). The legacy
+     * mode is when snap-confine just unshares the initial mount namespace,
+     * makes some extra changes but largely runs with what was presented to it
+     * initially.
+     *
+     * Historically the ubuntu-core distribution used the now-legacy mode. This
+     * was sensible then since snaps already (kind of) have the right root
+     * file-system and just need some privacy and isolation features applied.
+     * With the introduction of snaps to classic distributions as well as the
+     * introduction of bases, where each snap can use a different root
+     * filesystem, this lost sensibility and thus became legacy.
+     *
+     * For compatibility with current installations of ubuntu-core
+     * distributions the legacy mode is used when: the distribution is
+     * SC_DISTRO_CORE16 or when the base snap name is not "core" or
+     * "ubuntu-core".
+     *
+     * The SC_DISTRO_CORE16 is applied to systems that boot with the "core",
+     * "ubuntu-core" or "core16" snap. Systems using the "core18" base snap do
+     * not qualify for that classification.
+     **/
+    sc_distro distro = sc_classify_distro();
+    inv->is_normal_mode = distro != SC_DISTRO_CORE16 || !sc_streq(inv->orig_base_snap_name, "core");
 
-	/* Read the homedirs configuration: this information is needed both by our
-	 * namespace helper (in order to detect if the homedirs are mounted) and by
-	 * snap-confine itself to mount the homedirs.
-	 */
-	sc_invocation_init_homedirs(inv);
+    /* Read the homedirs configuration: this information is needed both by our
+     * namespace helper (in order to detect if the homedirs are mounted) and by
+     * snap-confine itself to mount the homedirs.
+     */
+    sc_invocation_init_homedirs(inv);
 
-	/* Stale mount namespace discarded or no mount namespace to
-	   join. We need to construct a new mount namespace ourselves.
-	   To capture it we will need a helper process so make one. */
-	sc_fork_helper(group, aa);
-	int retval = sc_join_preserved_ns(group, aa, inv, snap_discard_ns_fd);
-	if (retval == ESRCH) {
-		/* Create and populate the mount namespace. This performs all
-		   of the bootstrapping mounts, pivots into the new root filesystem and
-		   applies the per-snap mount profile using snap-update-ns. */
-		debug("unsharing the mount namespace (per-snap)");
-		if (unshare(CLONE_NEWNS) < 0) {
-			die("cannot unshare the mount namespace");
-		}
-		sc_populate_mount_ns(aa, snap_update_ns_fd, inv, real_gid,
-				     saved_gid);
-		sc_store_ns_info(inv);
+    /* Stale mount namespace discarded or no mount namespace to
+       join. We need to construct a new mount namespace ourselves.
+       To capture it we will need a helper process so make one. */
+    sc_fork_helper(group, aa);
+    int retval = sc_join_preserved_ns(group, aa, inv, snap_discard_ns_fd);
+    if (retval == ESRCH) {
+        /* Create and populate the mount namespace. This performs all
+           of the bootstrapping mounts, pivots into the new root filesystem and
+           applies the per-snap mount profile using snap-update-ns. */
+        debug("unsharing the mount namespace (per-snap)");
+        if (unshare(CLONE_NEWNS) < 0) {
+            die("cannot unshare the mount namespace");
+        }
+        sc_populate_mount_ns(aa, snap_update_ns_fd, inv, real_gid, saved_gid);
+        sc_store_ns_info(inv);
 
-		/* Preserve the mount namespace. */
-		sc_preserve_populated_mount_ns(group);
-	}
+        /* Preserve the mount namespace. */
+        sc_preserve_populated_mount_ns(group);
+    }
 
-	/* Older versions of snap-confine created incorrect 777 permissions
-	   for /var/lib and we need to fixup for systems that had their NS created
-	   with an old version. */
-	sc_maybe_fixup_permissions();
-	sc_maybe_fixup_udev();
+    /* Older versions of snap-confine created incorrect 777 permissions
+       for /var/lib and we need to fixup for systems that had their NS created
+       with an old version. */
+    sc_maybe_fixup_permissions();
+    sc_maybe_fixup_udev();
 
-	/* User mount profiles only apply to non-root users. */
-	if (real_uid != 0) {
-		debug("joining preserved per-user mount namespace");
-		retval =
-		    sc_join_preserved_per_user_ns(group, inv->snap_instance);
-		if (retval == ESRCH) {
-			debug("unsharing the mount namespace (per-user)");
-			if (unshare(CLONE_NEWNS) < 0) {
-				die("cannot unshare the mount namespace");
-			}
-			sc_setup_user_mounts(aa, snap_update_ns_fd,
-					     inv->snap_instance);
-			/* Preserve the mount per-user namespace. But only if the
-			 * experimental feature is enabled. This way if the feature is
-			 * disabled user mount namespaces will still exist but will be
-			 * entirely ephemeral. In addition the call
-			 * sc_join_preserved_user_ns() will never find a preserved mount
-			 * namespace and will always enter this code branch. */
-			if (sc_feature_enabled
-			    (SC_FEATURE_PER_USER_MOUNT_NAMESPACE)) {
-				sc_preserve_populated_per_user_mount_ns(group);
-			} else {
-				debug
-				    ("NOT preserving per-user mount namespace");
-			}
-		}
-	}
-	// With cgroups v1, associate each snap process with a dedicated
-	// snap freezer cgroup and snap pids cgroup. All snap processes
-	// belonging to one snap share the freezer cgroup. All snap
-	// processes belonging to one app or one hook share the pids cgroup.
-	//
-	// This simplifies testing if any processes belonging to a given snap are
-	// still alive as well as to properly account for each application and
-	// service.
-	//
-	// Note that with cgroups v2 there is no separate freeezer controller,
-	// but the freezer is associated with each group. The call chain when
-	// starting the snap application has already ensure that the process has
-	// been put in a dedicated group.
-	if (!sc_cgroup_is_v2()) {
-		sc_cgroup_freezer_join(inv->snap_instance, getpid());
-	}
+    /* User mount profiles only apply to non-root users. */
+    if (real_uid != 0) {
+        debug("joining preserved per-user mount namespace");
+        retval = sc_join_preserved_per_user_ns(group, inv->snap_instance);
+        if (retval == ESRCH) {
+            debug("unsharing the mount namespace (per-user)");
+            if (unshare(CLONE_NEWNS) < 0) {
+                die("cannot unshare the mount namespace");
+            }
+            sc_setup_user_mounts(aa, snap_update_ns_fd, inv->snap_instance);
+            /* Preserve the mount per-user namespace. But only if the
+             * experimental feature is enabled. This way if the feature is
+             * disabled user mount namespaces will still exist but will be
+             * entirely ephemeral. In addition the call
+             * sc_join_preserved_user_ns() will never find a preserved mount
+             * namespace and will always enter this code branch. */
+            if (sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE)) {
+                sc_preserve_populated_per_user_mount_ns(group);
+            } else {
+                debug("NOT preserving per-user mount namespace");
+            }
+        }
+    }
+    // With cgroups v1, associate each snap process with a dedicated
+    // snap freezer cgroup and snap pids cgroup. All snap processes
+    // belonging to one snap share the freezer cgroup. All snap
+    // processes belonging to one app or one hook share the pids cgroup.
+    //
+    // This simplifies testing if any processes belonging to a given snap are
+    // still alive as well as to properly account for each application and
+    // service.
+    //
+    // Note that with cgroups v2 there is no separate freeezer controller,
+    // but the freezer is associated with each group. The call chain when
+    // starting the snap application has already ensure that the process has
+    // been put in a dedicated group.
+    if (!sc_cgroup_is_v2()) {
+        sc_cgroup_freezer_join(inv->snap_instance, getpid());
+    }
 
-	sc_unlock(snap_lock_fd);
+    sc_unlock(snap_lock_fd);
 
-	sc_close_mount_ns(group);
+    sc_close_mount_ns(group);
 
-	// Reset path as we cannot rely on the path from the host OS to make sense.
-	// The classic distribution may use any PATH that makes sense but we cannot
-	// assume it makes sense for the core snap layout. Note that the /usr/local
-	// directories are explicitly left out as they are not part of the core
-	// snap.
-	debug("resetting PATH to values in sync with core snap");
-	setenv("PATH",
-	       "/usr/local/sbin:"
-	       "/usr/local/bin:"
-	       "/usr/sbin:"
-	       "/usr/bin:"
-	       "/sbin:" "/bin:" "/usr/games:" "/usr/local/games", 1);
-	// Ensure we set the various TMPDIRs to /tmp. One of the parts of setting
-	// up the mount namespace is to create a private /tmp directory (this is
-	// done in sc_populate_mount_ns() above). The host environment may point to
-	// a directory not accessible by snaps so we need to reset it here.
-	const char *tmpd[] = { "TMPDIR", "TEMPDIR", NULL };
-	int i;
-	for (i = 0; tmpd[i] != NULL; i++) {
-		if (setenv(tmpd[i], "/tmp", 1) != 0) {
-			die("cannot set environment variable '%s'", tmpd[i]);
-		}
-	}
+    // Reset path as we cannot rely on the path from the host OS to make sense.
+    // The classic distribution may use any PATH that makes sense but we cannot
+    // assume it makes sense for the core snap layout. Note that the /usr/local
+    // directories are explicitly left out as they are not part of the core
+    // snap.
+    debug("resetting PATH to values in sync with core snap");
+    setenv("PATH",
+           "/usr/local/sbin:"
+           "/usr/local/bin:"
+           "/usr/sbin:"
+           "/usr/bin:"
+           "/sbin:"
+           "/bin:"
+           "/usr/games:"
+           "/usr/local/games",
+           1);
+    // Ensure we set the various TMPDIRs to /tmp. One of the parts of setting
+    // up the mount namespace is to create a private /tmp directory (this is
+    // done in sc_populate_mount_ns() above). The host environment may point to
+    // a directory not accessible by snaps so we need to reset it here.
+    const char *tmpd[] = {"TMPDIR", "TEMPDIR", NULL};
+    int i;
+    for (i = 0; tmpd[i] != NULL; i++) {
+        if (setenv(tmpd[i], "/tmp", 1) != 0) {
+            die("cannot set environment variable '%s'", tmpd[i]);
+        }
+    }
 }

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -17,17 +17,17 @@
 #include "config.h"
 
 #include <ctype.h>
+#include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <limits.h>
-#include <stdint.h>
-#include <dlfcn.h>
 
 #include <libudev.h>
 
@@ -40,18 +40,17 @@
 #include "udev-support.h"
 
 /* Allow access to common devices. */
-static void sc_udev_allow_common(sc_device_cgroup *cgroup)
-{
-	/* The devices we add here have static number allocation.
-	 * https://www.kernel.org/doc/html/v4.11/admin-guide/devices.html */
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 3);	// /dev/null
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 5);	// /dev/zero
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 7);	// /dev/full
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 8);	// /dev/random
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 9);	// /dev/urandom
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 5, 0);	// /dev/tty
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 5, 1);	// /dev/console
-	sc_device_cgroup_allow(cgroup, S_IFCHR, 5, 2);	// /dev/ptmx
+static void sc_udev_allow_common(sc_device_cgroup *cgroup) {
+    /* The devices we add here have static number allocation.
+     * https://www.kernel.org/doc/html/v4.11/admin-guide/devices.html */
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 3);  // /dev/null
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 5);  // /dev/zero
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 7);  // /dev/full
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 8);  // /dev/random
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 1, 9);  // /dev/urandom
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 5, 0);  // /dev/tty
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 5, 1);  // /dev/console
+    sc_device_cgroup_allow(cgroup, S_IFCHR, 5, 2);  // /dev/ptmx
 }
 
 /** Allow access to current and future PTY slaves.
@@ -62,12 +61,10 @@ static void sc_udev_allow_common(sc_device_cgroup *cgroup)
  * See also:
  * https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
  **/
-static void sc_udev_allow_pty_slaves(sc_device_cgroup *cgroup)
-{
-	for (unsigned pty_major = 136; pty_major <= 143; pty_major++) {
-		sc_device_cgroup_allow(cgroup, S_IFCHR, pty_major,
-				       SC_DEVICE_MINOR_ANY);
-	}
+static void sc_udev_allow_pty_slaves(sc_device_cgroup *cgroup) {
+    for (unsigned pty_major = 136; pty_major <= 143; pty_major++) {
+        sc_device_cgroup_allow(cgroup, S_IFCHR, pty_major, SC_DEVICE_MINOR_ANY);
+    }
 }
 
 /** Allow access to Nvidia devices.
@@ -82,38 +79,32 @@ static void sc_udev_allow_pty_slaves(sc_device_cgroup *cgroup)
  *
  * https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
  **/
-static void sc_udev_allow_nvidia(sc_device_cgroup *cgroup)
-{
-	struct stat sbuf;
+static void sc_udev_allow_nvidia(sc_device_cgroup *cgroup) {
+    struct stat sbuf;
 
-	/* Allow access to /dev/nvidia0 through /dev/nvidia254 */
-	for (unsigned nv_minor = 0; nv_minor < 255; nv_minor++) {
-		char nv_path[15] = { 0 };	// /dev/nvidiaXXX
-		sc_must_snprintf(nv_path, sizeof(nv_path), "/dev/nvidia%u",
-				 nv_minor);
+    /* Allow access to /dev/nvidia0 through /dev/nvidia254 */
+    for (unsigned nv_minor = 0; nv_minor < 255; nv_minor++) {
+        char nv_path[15] = {0};  // /dev/nvidiaXXX
+        sc_must_snprintf(nv_path, sizeof(nv_path), "/dev/nvidia%u", nv_minor);
 
-		/* Stop trying to find devices after one is not found. In this manner,
-		 * we'll add /dev/nvidia0 and /dev/nvidia1 but stop trying to find
-		 * nvidia3 - nvidia254 if nvidia2 is not found. */
-		if (stat(nv_path, &sbuf) < 0) {
-			break;
-		}
-		sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev),
-				       minor(sbuf.st_rdev));
-	}
+        /* Stop trying to find devices after one is not found. In this manner,
+         * we'll add /dev/nvidia0 and /dev/nvidia1 but stop trying to find
+         * nvidia3 - nvidia254 if nvidia2 is not found. */
+        if (stat(nv_path, &sbuf) < 0) {
+            break;
+        }
+        sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));
+    }
 
-	if (stat("/dev/nvidiactl", &sbuf) == 0) {
-		sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev),
-				       minor(sbuf.st_rdev));
-	}
-	if (stat("/dev/nvidia-uvm", &sbuf) == 0) {
-		sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev),
-				       minor(sbuf.st_rdev));
-	}
-	if (stat("/dev/nvidia-modeset", &sbuf) == 0) {
-		sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev),
-				       minor(sbuf.st_rdev));
-	}
+    if (stat("/dev/nvidiactl", &sbuf) == 0) {
+        sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));
+    }
+    if (stat("/dev/nvidia-uvm", &sbuf) == 0) {
+        sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));
+    }
+    if (stat("/dev/nvidia-modeset", &sbuf) == 0) {
+        sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));
+    }
 }
 
 /**
@@ -122,14 +113,12 @@ static void sc_udev_allow_nvidia(sc_device_cgroup *cgroup)
  * Currently /dev/uhid isn't represented in sysfs, so add it to the device
  * cgroup if it exists and let AppArmor handle the mediation.
  **/
-static void sc_udev_allow_uhid(sc_device_cgroup *cgroup)
-{
-	struct stat sbuf;
+static void sc_udev_allow_uhid(sc_device_cgroup *cgroup) {
+    struct stat sbuf;
 
-	if (stat("/dev/uhid", &sbuf) == 0) {
-		sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev),
-				       minor(sbuf.st_rdev));
-	}
+    if (stat("/dev/uhid", &sbuf) == 0) {
+        sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));
+    }
 }
 
 /**
@@ -141,14 +130,12 @@ static void sc_udev_allow_uhid(sc_device_cgroup *cgroup)
  * it unconditionally to the cgroup and rely on AppArmor to mediate the
  * access. LP: #1859084
  **/
-static void sc_udev_allow_dev_net_tun(sc_device_cgroup *cgroup)
-{
-	struct stat sbuf;
+static void sc_udev_allow_dev_net_tun(sc_device_cgroup *cgroup) {
+    struct stat sbuf;
 
-	if (stat("/dev/net/tun", &sbuf) == 0) {
-		sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev),
-				       minor(sbuf.st_rdev));
-	}
+    if (stat("/dev/net/tun", &sbuf) == 0) {
+        sc_device_cgroup_allow(cgroup, S_IFCHR, major(sbuf.st_rdev), minor(sbuf.st_rdev));
+    }
 }
 
 /**
@@ -158,74 +145,67 @@ static void sc_udev_allow_dev_net_tun(sc_device_cgroup *cgroup)
  * tags corresponding to snap applications. Here we interrogate udev and allow
  * access to all assigned devices.
  **/
-static void sc_udev_allow_assigned_device(sc_device_cgroup *cgroup,
-					  struct udev_device *device)
-{
-	const char *path = udev_device_get_syspath(device);
-	dev_t devnum = udev_device_get_devnum(device);
-	unsigned int major = major(devnum);
-	unsigned int minor = minor(devnum);
-	/* The manual page of udev_device_get_devnum says:
-	 * > On success, udev_device_get_devnum() returns the device type of
-	 * > the passed device. On failure, a device type with minor and major
-	 * > number set to 0 is returned. */
-	if (major == 0 && minor == 0) {
-		debug("cannot get major/minor numbers for syspath %s", path);
-		return;
-	}
-	/* devnode is bound to the lifetime of the device and we cannot release
-	 * it separately. */
-	const char *devnode = udev_device_get_devnode(device);
-	if (devnode == NULL) {
-		debug("cannot find /dev node from udev device");
-		return;
-	}
-	debug("inspecting type of device: %s", devnode);
-	struct stat file_info;
-	if (stat(devnode, &file_info) < 0) {
-		debug("cannot stat %s", devnode);
-		return;
-	}
-	int devtype = file_info.st_mode & S_IFMT;
-	if (devtype == S_IFBLK || devtype == S_IFCHR) {
-		sc_device_cgroup_allow(cgroup, devtype, major, minor);
-	}
+static void sc_udev_allow_assigned_device(sc_device_cgroup *cgroup, struct udev_device *device) {
+    const char *path = udev_device_get_syspath(device);
+    dev_t devnum = udev_device_get_devnum(device);
+    unsigned int major = major(devnum);
+    unsigned int minor = minor(devnum);
+    /* The manual page of udev_device_get_devnum says:
+     * > On success, udev_device_get_devnum() returns the device type of
+     * > the passed device. On failure, a device type with minor and major
+     * > number set to 0 is returned. */
+    if (major == 0 && minor == 0) {
+        debug("cannot get major/minor numbers for syspath %s", path);
+        return;
+    }
+    /* devnode is bound to the lifetime of the device and we cannot release
+     * it separately. */
+    const char *devnode = udev_device_get_devnode(device);
+    if (devnode == NULL) {
+        debug("cannot find /dev node from udev device");
+        return;
+    }
+    debug("inspecting type of device: %s", devnode);
+    struct stat file_info;
+    if (stat(devnode, &file_info) < 0) {
+        debug("cannot stat %s", devnode);
+        return;
+    }
+    int devtype = file_info.st_mode & S_IFMT;
+    if (devtype == S_IFBLK || devtype == S_IFCHR) {
+        sc_device_cgroup_allow(cgroup, devtype, major, minor);
+    }
 }
 
-static void sc_udev_setup_acls_common(sc_device_cgroup *cgroup)
-{
-
-	/* Allow access to various devices. */
-	sc_udev_allow_common(cgroup);
-	sc_udev_allow_pty_slaves(cgroup);
-	sc_udev_allow_nvidia(cgroup);
-	sc_udev_allow_uhid(cgroup);
-	sc_udev_allow_dev_net_tun(cgroup);
+static void sc_udev_setup_acls_common(sc_device_cgroup *cgroup) {
+    /* Allow access to various devices. */
+    sc_udev_allow_common(cgroup);
+    sc_udev_allow_pty_slaves(cgroup);
+    sc_udev_allow_nvidia(cgroup);
+    sc_udev_allow_uhid(cgroup);
+    sc_udev_allow_dev_net_tun(cgroup);
 }
 
-static char *sc_security_to_udev_tag(const char *security_tag)
-{
-	char *udev_tag = sc_strdup(security_tag);
-	for (char *c = strchr(udev_tag, '.'); c != NULL; c = strchr(c, '.')) {
-		*c = '_';
-	}
-	return udev_tag;
+static char *sc_security_to_udev_tag(const char *security_tag) {
+    char *udev_tag = sc_strdup(security_tag);
+    for (char *c = strchr(udev_tag, '.'); c != NULL; c = strchr(c, '.')) {
+        *c = '_';
+    }
+    return udev_tag;
 }
 
-static void sc_cleanup_udev(struct udev **udev)
-{
-	if (udev != NULL && *udev != NULL) {
-		udev_unref(*udev);
-		*udev = NULL;
-	}
+static void sc_cleanup_udev(struct udev **udev) {
+    if (udev != NULL && *udev != NULL) {
+        udev_unref(*udev);
+        *udev = NULL;
+    }
 }
 
-static void sc_cleanup_udev_enumerate(struct udev_enumerate **enumerate)
-{
-	if (enumerate != NULL && *enumerate != NULL) {
-		udev_enumerate_unref(*enumerate);
-		*enumerate = NULL;
-	}
+static void sc_cleanup_udev_enumerate(struct udev_enumerate **enumerate) {
+    if (enumerate != NULL && *enumerate != NULL) {
+        udev_enumerate_unref(*enumerate);
+        *enumerate = NULL;
+    }
 }
 
 /* __sc_udev_device_has_current_tag will be filled at runtime if the libudev has
@@ -237,157 +217,141 @@ static void sc_cleanup_udev_enumerate(struct udev_enumerate **enumerate)
  * when the binary itself is build with recent enough toolchain (eg. gcc &
  * binutils on Ubuntu 20.04)
  */
-static int (*__sc_udev_device_has_current_tag)(struct udev_device * udev_device,
-					       const char *tag) = NULL;
-static void setup_current_tags_support(void)
-{
-	void *lib = dlopen("libudev.so.1", RTLD_NOW);
-	if (lib == NULL) {
-		debug("cannot load libudev.so.1: %s", dlerror());
-		/* bit unexpected as we use the library from the host and it's stable */
-		return;
-	}
-	/* check whether we have the symbol introduced in systemd v247 to inspect
-	 * the CURRENT_TAGS property */
-	void *sym = dlsym(lib, "udev_device_has_current_tag");
-	if (sym == NULL) {
-		debug("cannot find current tags symbol: %s", dlerror());
-		/* symbol is not found in the library version */
-		(void)dlclose(lib);
-		return;
-	}
-	debug("libudev has current tags support");
-	__sc_udev_device_has_current_tag = sym;
-	/* lib goes out of scope and is leaked but we need sym and hence
-	 * lib to be valid for the entire lifetime of the application
-	 * lifecycle so this is fine. */
-	/* coverity[leaked_storage] */
+static int (*__sc_udev_device_has_current_tag)(struct udev_device *udev_device, const char *tag) = NULL;
+static void setup_current_tags_support(void) {
+    void *lib = dlopen("libudev.so.1", RTLD_NOW);
+    if (lib == NULL) {
+        debug("cannot load libudev.so.1: %s", dlerror());
+        /* bit unexpected as we use the library from the host and it's stable */
+        return;
+    }
+    /* check whether we have the symbol introduced in systemd v247 to inspect
+     * the CURRENT_TAGS property */
+    void *sym = dlsym(lib, "udev_device_has_current_tag");
+    if (sym == NULL) {
+        debug("cannot find current tags symbol: %s", dlerror());
+        /* symbol is not found in the library version */
+        (void)dlclose(lib);
+        return;
+    }
+    debug("libudev has current tags support");
+    __sc_udev_device_has_current_tag = sym;
+    /* lib goes out of scope and is leaked but we need sym and hence
+     * lib to be valid for the entire lifetime of the application
+     * lifecycle so this is fine. */
+    /* coverity[leaked_storage] */
 }
 
-void sc_setup_device_cgroup(const char *security_tag,
-			    sc_device_cgroup_mode mode)
-{
-	debug("setting up device cgroup, mode \"%s\"",
-	      mode == SC_DEVICE_CGROUP_MODE_REQUIRED ? "required" : "optional");
+void sc_setup_device_cgroup(const char *security_tag, sc_device_cgroup_mode mode) {
+    debug("setting up device cgroup, mode \"%s\"", mode == SC_DEVICE_CGROUP_MODE_REQUIRED ? "required" : "optional");
 
-	setup_current_tags_support();
-	if (__sc_udev_device_has_current_tag == NULL) {
-		debug("no current tags support present");
-	}
+    setup_current_tags_support();
+    if (__sc_udev_device_has_current_tag == NULL) {
+        debug("no current tags support present");
+    }
 
-	/* Derive the udev tag from the snap security tag.
-	 *
-	 * Because udev does not allow for dots in tag names, those are replaced by
-	 * underscores in snapd. We just match that behavior. */
-	char *udev_tag SC_CLEANUP(sc_cleanup_string) = NULL;
-	udev_tag = sc_security_to_udev_tag(security_tag);
+    /* Derive the udev tag from the snap security tag.
+     *
+     * Because udev does not allow for dots in tag names, those are replaced by
+     * underscores in snapd. We just match that behavior. */
+    char *udev_tag SC_CLEANUP(sc_cleanup_string) = NULL;
+    udev_tag = sc_security_to_udev_tag(security_tag);
 
-	/* Use udev APIs to talk to udev-the-daemon to determine the list of
-	 * "devices" with that tag assigned. The list may be empty, in which case
-	 * there's no udev tagging in effect and we must refrain from constructing
-	 * the cgroup as it would interfere with the execution of a program. */
-	struct udev SC_CLEANUP(sc_cleanup_udev) * udev = NULL;
-	udev = udev_new();
-	if (udev == NULL) {
-		die("cannot connect to udev");
-	}
-	struct udev_enumerate SC_CLEANUP(sc_cleanup_udev_enumerate) * devices =
-	    NULL;
-	devices = udev_enumerate_new(udev);
-	if (devices == NULL) {
-		die("cannot create udev device enumeration");
-	}
-	if (udev_enumerate_add_match_tag(devices, udev_tag) < 0) {
-		die("cannot add tag match to udev device enumeration");
-	}
-	if (udev_enumerate_scan_devices(devices) < 0) {
-		die("cannot enumerate udev devices");
-	}
-	/* NOTE: udev_list_entry is bound to life-cycle of the used udev_enumerate */
-	struct udev_list_entry *assigned;
-	assigned = udev_enumerate_get_list_entry(devices);
-	if (assigned == NULL) {
-		if (mode == SC_DEVICE_CGROUP_MODE_OPTIONAL) {
-			/* NOTE: Nothing is assigned, don't create or use the device cgroup. */
-			debug
-			    ("no devices tagged with %s, skipping device cgroup setup",
-			     udev_tag);
-			return;
-		} else {
-			/* the device cgroup was requested to be set up despite of no
-			 * devices being assigned to this snap */
-			debug
-			    ("no devices tagged with %s, but device cgroup is required, proceeding with setup",
-			     udev_tag);
-		}
-	}
+    /* Use udev APIs to talk to udev-the-daemon to determine the list of
+     * "devices" with that tag assigned. The list may be empty, in which case
+     * there's no udev tagging in effect and we must refrain from constructing
+     * the cgroup as it would interfere with the execution of a program. */
+    struct udev SC_CLEANUP(sc_cleanup_udev) *udev = NULL;
+    udev = udev_new();
+    if (udev == NULL) {
+        die("cannot connect to udev");
+    }
+    struct udev_enumerate SC_CLEANUP(sc_cleanup_udev_enumerate) *devices = NULL;
+    devices = udev_enumerate_new(udev);
+    if (devices == NULL) {
+        die("cannot create udev device enumeration");
+    }
+    if (udev_enumerate_add_match_tag(devices, udev_tag) < 0) {
+        die("cannot add tag match to udev device enumeration");
+    }
+    if (udev_enumerate_scan_devices(devices) < 0) {
+        die("cannot enumerate udev devices");
+    }
+    /* NOTE: udev_list_entry is bound to life-cycle of the used udev_enumerate */
+    struct udev_list_entry *assigned;
+    assigned = udev_enumerate_get_list_entry(devices);
+    if (assigned == NULL) {
+        if (mode == SC_DEVICE_CGROUP_MODE_OPTIONAL) {
+            /* NOTE: Nothing is assigned, don't create or use the device cgroup. */
+            debug("no devices tagged with %s, skipping device cgroup setup", udev_tag);
+            return;
+        } else {
+            /* the device cgroup was requested to be set up despite of no
+             * devices being assigned to this snap */
+            debug("no devices tagged with %s, but device cgroup is required, proceeding with setup", udev_tag);
+        }
+    }
 
-	/* cgroup wrapper is lazily initialized when devices are actually
-	 * assigned */
-	sc_device_cgroup *cgroup SC_CLEANUP(sc_device_cgroup_cleanup) = NULL;
+    /* cgroup wrapper is lazily initialized when devices are actually
+     * assigned */
+    sc_device_cgroup *cgroup SC_CLEANUP(sc_device_cgroup_cleanup) = NULL;
 
-	if (mode == SC_DEVICE_CGROUP_MODE_REQUIRED) {
-		/* Normally the cgroup setup is done lazily, but since device cgroup is
-		 * required, prepare for mediation of device access regardless of
-		 * devices being properly tagged. */
-		cgroup = sc_device_cgroup_new(security_tag, 0);
-		/* Setup the device group access control list */
-		sc_udev_setup_acls_common(cgroup);
-	}
+    if (mode == SC_DEVICE_CGROUP_MODE_REQUIRED) {
+        /* Normally the cgroup setup is done lazily, but since device cgroup is
+         * required, prepare for mediation of device access regardless of
+         * devices being properly tagged. */
+        cgroup = sc_device_cgroup_new(security_tag, 0);
+        /* Setup the device group access control list */
+        sc_udev_setup_acls_common(cgroup);
+    }
 
-	for (struct udev_list_entry * entry = assigned; entry != NULL;
-	     entry = udev_list_entry_get_next(entry)) {
-		const char *path = udev_list_entry_get_name(entry);
-		if (path == NULL) {
-			die("udev_list_entry_get_name failed");
-		}
-		struct udev_device *device =
-		    udev_device_new_from_syspath(udev, path);
-		/** This is a non-fatal error as devices can disappear asynchronously
-		 * and on slow devices we may indeed observe a device that no longer
-		 * exists.
-		 *
-		 * Similar debug + continue pattern repeats in all the udev calls in
-		 * this function. Related to LP: #1881209 */
-		if (device == NULL) {
-			debug("cannot find device from syspath %s", path);
-			continue;
-		}
-		/* If we are able to query if the device has a current tag,
-		 * do so and if there are no current tags, continue to prevent
-		 * allowing assigned devices to the cgroup - this has the net
-		 * desired effect of not re-creating device cgroups that were
-		 * previously created/setup but should no longer be setup due
-		 * to interface disconnection, etc. */
-		if (__sc_udev_device_has_current_tag != NULL) {
-			if (__sc_udev_device_has_current_tag(device, udev_tag)
-			    <= 0) {
-				debug("device %s has no matching current tag",
-				      path);
-				udev_device_unref(device);
-				continue;
-			}
-			debug("device %s has matching current tag", path);
-		}
+    for (struct udev_list_entry *entry = assigned; entry != NULL; entry = udev_list_entry_get_next(entry)) {
+        const char *path = udev_list_entry_get_name(entry);
+        if (path == NULL) {
+            die("udev_list_entry_get_name failed");
+        }
+        struct udev_device *device = udev_device_new_from_syspath(udev, path);
+        /** This is a non-fatal error as devices can disappear asynchronously
+         * and on slow devices we may indeed observe a device that no longer
+         * exists.
+         *
+         * Similar debug + continue pattern repeats in all the udev calls in
+         * this function. Related to LP: #1881209 */
+        if (device == NULL) {
+            debug("cannot find device from syspath %s", path);
+            continue;
+        }
+        /* If we are able to query if the device has a current tag,
+         * do so and if there are no current tags, continue to prevent
+         * allowing assigned devices to the cgroup - this has the net
+         * desired effect of not re-creating device cgroups that were
+         * previously created/setup but should no longer be setup due
+         * to interface disconnection, etc. */
+        if (__sc_udev_device_has_current_tag != NULL) {
+            if (__sc_udev_device_has_current_tag(device, udev_tag) <= 0) {
+                debug("device %s has no matching current tag", path);
+                udev_device_unref(device);
+                continue;
+            }
+            debug("device %s has matching current tag", path);
+        }
 
-		if (cgroup == NULL) {
-			/* Lazy initialization of cgroup wrapper only when we are sure that
-			 * there are devices assigned to this snap */
-			cgroup = sc_device_cgroup_new(security_tag, 0);
-			/* Setup the device group access control list */
-			sc_udev_setup_acls_common(cgroup);
-		}
+        if (cgroup == NULL) {
+            /* Lazy initialization of cgroup wrapper only when we are sure that
+             * there are devices assigned to this snap */
+            cgroup = sc_device_cgroup_new(security_tag, 0);
+            /* Setup the device group access control list */
+            sc_udev_setup_acls_common(cgroup);
+        }
 
-		sc_udev_allow_assigned_device(cgroup, device);
-		udev_device_unref(device);
-	}
-	if (cgroup != NULL) {
-		/* Move ourselves to the device cgroup */
-		sc_device_cgroup_attach_pid(cgroup, getpid());
-		debug
-		    ("associated snap application process %i with device cgroup %s",
-		     getpid(), security_tag);
-	} else {
-		debug("device cgroup not set up for  %s", udev_tag);
-	}
+        sc_udev_allow_assigned_device(cgroup, device);
+        udev_device_unref(device);
+    }
+    if (cgroup != NULL) {
+        /* Move ourselves to the device cgroup */
+        sc_device_cgroup_attach_pid(cgroup, getpid());
+        debug("associated snap application process %i with device cgroup %s", getpid(), security_tag);
+    } else {
+        debug("device cgroup not set up for  %s", udev_tag);
+    }
 }

--- a/cmd/snap-confine/udev-support.h
+++ b/cmd/snap-confine/udev-support.h
@@ -19,14 +19,13 @@
 #define SNAP_CONFINE_UDEV_SUPPORT_H
 
 typedef enum {
-	/* Require device cgroup, even if no devices are assigned to the snap */
-	SC_DEVICE_CGROUP_MODE_REQUIRED = 0x0,
-	/* Device cgroup is optional if no devices are assigned to the snap. This is
-	 * to comply with the legacy behavior */
-	SC_DEVICE_CGROUP_MODE_OPTIONAL = 0x1,
+    /* Require device cgroup, even if no devices are assigned to the snap */
+    SC_DEVICE_CGROUP_MODE_REQUIRED = 0x0,
+    /* Device cgroup is optional if no devices are assigned to the snap. This is
+     * to comply with the legacy behavior */
+    SC_DEVICE_CGROUP_MODE_OPTIONAL = 0x1,
 } sc_device_cgroup_mode;
 
-void sc_setup_device_cgroup(const char *security_tag,
-			    sc_device_cgroup_mode mode);
+void sc_setup_device_cgroup(const char *security_tag, sc_device_cgroup_mode mode);
 
 #endif

--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "config.h"
 #include "user-support.h"
+#include "config.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -24,50 +24,45 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
-void setup_user_data(void)
-{
-	const char *user_data = getenv("SNAP_USER_DATA");
+void setup_user_data(void) {
+    const char *user_data = getenv("SNAP_USER_DATA");
 
-	if (user_data == NULL)
-		return;
+    if (user_data == NULL) return;
 
-	// Only support absolute paths.
-	if (user_data[0] != '/') {
-		die("user data directory must be an absolute path");
-	}
+    // Only support absolute paths.
+    if (user_data[0] != '/') {
+        die("user data directory must be an absolute path");
+    }
 
-	debug("creating user data directory: %s", user_data);
-	if (sc_nonfatal_mkpath(user_data, 0755) < 0) {
-		if ((errno == EROFS || errno == EACCES)
-		    && !sc_startswith(user_data, "/home/")) {
-			// clear errno or it will be displayed in die()
-			errno = 0;
-			// XXX: may point to the right config option here?
-			die("Sorry, home directories outside of /home needs configuration.\nSee https://forum.snapcraft.io/t/11209 for details.");
-		}
-		die("cannot create user data directory: %s", user_data);
-	};
+    debug("creating user data directory: %s", user_data);
+    if (sc_nonfatal_mkpath(user_data, 0755) < 0) {
+        if ((errno == EROFS || errno == EACCES) && !sc_startswith(user_data, "/home/")) {
+            // clear errno or it will be displayed in die()
+            errno = 0;
+            // XXX: may point to the right config option here?
+            die("Sorry, home directories outside of /home needs configuration.\nSee https://forum.snapcraft.io/t/11209 "
+                "for details.");
+        }
+        die("cannot create user data directory: %s", user_data);
+    };
 }
 
-void setup_user_xdg_runtime_dir(void)
-{
-	const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+void setup_user_xdg_runtime_dir(void) {
+    const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
 
-	if (xdg_runtime_dir == NULL)
-		return;
-	// Only support absolute paths.
-	if (xdg_runtime_dir[0] != '/') {
-		die("XDG_RUNTIME_DIR must be an absolute path");
-	}
+    if (xdg_runtime_dir == NULL) return;
+    // Only support absolute paths.
+    if (xdg_runtime_dir[0] != '/') {
+        die("XDG_RUNTIME_DIR must be an absolute path");
+    }
 
-	errno = 0;
-	debug("creating user XDG_RUNTIME_DIR directory: %s", xdg_runtime_dir);
-	if (sc_nonfatal_mkpath(xdg_runtime_dir, 0755) < 0) {
-		die("cannot create user XDG_RUNTIME_DIR directory: %s",
-		    xdg_runtime_dir);
-	}
-	// if successfully created the directory (ie, not EEXIST), then chmod it.
-	if (errno == 0 && chmod(xdg_runtime_dir, 0700) != 0) {
-		die("cannot change permissions of user XDG_RUNTIME_DIR directory to 0700");
-	}
+    errno = 0;
+    debug("creating user XDG_RUNTIME_DIR directory: %s", xdg_runtime_dir);
+    if (sc_nonfatal_mkpath(xdg_runtime_dir, 0755) < 0) {
+        die("cannot create user XDG_RUNTIME_DIR directory: %s", xdg_runtime_dir);
+    }
+    // if successfully created the directory (ie, not EEXIST), then chmod it.
+    if (errno == 0 && chmod(xdg_runtime_dir, 0700) != 0) {
+        die("cannot change permissions of user XDG_RUNTIME_DIR directory to 0700");
+    }
 }

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -46,466 +46,439 @@ int bootstrap_errno = 0;
 const char *bootstrap_msg = NULL;
 
 // setns_into_snap switches mount namespace into that of a given snap.
-static int setns_into_snap(const char *snap_name)
-{
-	// Construct the name of the .mnt file to open.
-	char buf[PATH_MAX] = {
-		0,
-	};
-	int n = snprintf(buf, sizeof buf, "/run/snapd/ns/%s.mnt", snap_name);
-	if (n >= sizeof buf || n < 0) {
-		bootstrap_errno = 0;
-		bootstrap_msg = "cannot format mount namespace file name";
-		return -1;
-	}
-	// Open the mount namespace file.
-	int fd = open(buf, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
-	if (fd < 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg = "cannot open mount namespace file";
-		return -1;
-	}
-	// Switch to the mount namespace of the given snap.
-	int err = setns(fd, CLONE_NEWNS);
-	if (err < 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg = "cannot switch mount namespace";
-	};
+static int setns_into_snap(const char *snap_name) {
+    // Construct the name of the .mnt file to open.
+    char buf[PATH_MAX] = {
+        0,
+    };
+    int n = snprintf(buf, sizeof buf, "/run/snapd/ns/%s.mnt", snap_name);
+    if (n >= sizeof buf || n < 0) {
+        bootstrap_errno = 0;
+        bootstrap_msg = "cannot format mount namespace file name";
+        return -1;
+    }
+    // Open the mount namespace file.
+    int fd = open(buf, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (fd < 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot open mount namespace file";
+        return -1;
+    }
+    // Switch to the mount namespace of the given snap.
+    int err = setns(fd, CLONE_NEWNS);
+    if (err < 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot switch mount namespace";
+    };
 
-	close(fd);
-	return err;
+    close(fd);
+    return err;
 }
 
 // switch_to_privileged_user drops to the real user ID while retaining
 // CAP_SYS_ADMIN, for operations such as mount().
-static int switch_to_privileged_user()
-{
-	uid_t real_uid;
-	gid_t real_gid;
+static int switch_to_privileged_user() {
+    uid_t real_uid;
+    gid_t real_gid;
 
-	real_uid = getuid();
-	if (real_uid == 0) {
-		// We're running as root: no need to switch IDs
-		return 0;
-	}
-	real_gid = getgid();
+    real_uid = getuid();
+    if (real_uid == 0) {
+        // We're running as root: no need to switch IDs
+        return 0;
+    }
+    real_gid = getgid();
 
-	// _LINUX_CAPABILITY_VERSION_3 valid for kernel >= 2.6.26. See
-	// https://github.com/torvalds/linux/blob/master/kernel/capability.c
-	struct __user_cap_header_struct hdr =
-	    { _LINUX_CAPABILITY_VERSION_3, 0 };
-	struct __user_cap_data_struct data[2] = { {0} };
+    // _LINUX_CAPABILITY_VERSION_3 valid for kernel >= 2.6.26. See
+    // https://github.com/torvalds/linux/blob/master/kernel/capability.c
+    struct __user_cap_header_struct hdr = {_LINUX_CAPABILITY_VERSION_3, 0};
+    struct __user_cap_data_struct data[2] = {{0}};
 
-	data[0].effective = (CAP_TO_MASK(CAP_SYS_ADMIN) |
-			     CAP_TO_MASK(CAP_SETUID) | CAP_TO_MASK(CAP_SETGID));
-	data[0].permitted = data[0].effective;
-	data[0].inheritable = 0;
-	data[1].effective = 0;
-	data[1].permitted = 0;
-	data[1].inheritable = 0;
+    data[0].effective = (CAP_TO_MASK(CAP_SYS_ADMIN) | CAP_TO_MASK(CAP_SETUID) | CAP_TO_MASK(CAP_SETGID));
+    data[0].permitted = data[0].effective;
+    data[0].inheritable = 0;
+    data[1].effective = 0;
+    data[1].permitted = 0;
+    data[1].inheritable = 0;
 
-	if (capset(&hdr, data) != 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg = "cannot set permitted capabilities mask";
-		return -1;
-	}
+    if (capset(&hdr, data) != 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot set permitted capabilities mask";
+        return -1;
+    }
 
-	if (prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0) != 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg =
-		    "cannot tell kernel to keep capabilities over setuid";
-		return -1;
-	}
+    if (prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0) != 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot tell kernel to keep capabilities over setuid";
+        return -1;
+    }
 
-	if (setgroups(1, &real_gid) != 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg = "cannot drop supplementary groups";
-		return -1;
-	}
+    if (setgroups(1, &real_gid) != 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot drop supplementary groups";
+        return -1;
+    }
 
-	if (setgid(real_gid) != 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg = "cannot switch to real group ID";
-		return -1;
-	}
+    if (setgid(real_gid) != 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot switch to real group ID";
+        return -1;
+    }
 
-	if (setuid(real_uid) != 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg = "cannot switch to real user ID";
-		return -1;
-	}
-	// After changing uid, our effective capabilities were dropped.
-	// Reacquire CAP_SYS_ADMIN, and discard CAP_SETUID/CAP_SETGID.
-	data[0].effective = CAP_TO_MASK(CAP_SYS_ADMIN);
-	data[0].permitted = data[0].effective;
-	if (capset(&hdr, data) != 0) {
-		bootstrap_errno = errno;
-		bootstrap_msg =
-		    "cannot enable capabilities after switching to real user";
-		return -1;
-	}
+    if (setuid(real_uid) != 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot switch to real user ID";
+        return -1;
+    }
+    // After changing uid, our effective capabilities were dropped.
+    // Reacquire CAP_SYS_ADMIN, and discard CAP_SETUID/CAP_SETGID.
+    data[0].effective = CAP_TO_MASK(CAP_SYS_ADMIN);
+    data[0].permitted = data[0].effective;
+    if (capset(&hdr, data) != 0) {
+        bootstrap_errno = errno;
+        bootstrap_msg = "cannot enable capabilities after switching to real user";
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 // TODO: reuse the code from snap-confine, if possible.
-static int skip_lowercase_letters(const char **p)
-{
-	int skipped = 0;
-	const char *c;
-	for (c = *p; *c >= 'a' && *c <= 'z'; ++c) {
-		skipped += 1;
-	}
-	*p = (*p) + skipped;
-	return skipped;
+static int skip_lowercase_letters(const char **p) {
+    int skipped = 0;
+    const char *c;
+    for (c = *p; *c >= 'a' && *c <= 'z'; ++c) {
+        skipped += 1;
+    }
+    *p = (*p) + skipped;
+    return skipped;
 }
 
 // TODO: reuse the code from snap-confine, if possible.
-static int skip_digits(const char **p)
-{
-	int skipped = 0;
-	const char *c;
-	for (c = *p; *c >= '0' && *c <= '9'; ++c) {
-		skipped += 1;
-	}
-	*p = (*p) + skipped;
-	return skipped;
+static int skip_digits(const char **p) {
+    int skipped = 0;
+    const char *c;
+    for (c = *p; *c >= '0' && *c <= '9'; ++c) {
+        skipped += 1;
+    }
+    *p = (*p) + skipped;
+    return skipped;
 }
 
 // TODO: reuse the code from snap-confine, if possible.
-static int skip_one_char(const char **p, char c)
-{
-	if (**p == c) {
-		*p += 1;
-		return 1;
-	}
-	return 0;
+static int skip_one_char(const char **p, char c) {
+    if (**p == c) {
+        *p += 1;
+        return 1;
+    }
+    return 0;
 }
 
 // validate_snap_name performs full validation of the given name.
-int validate_snap_name(const char *snap_name)
-{
-	// NOTE: This function should be synchronized with the two other
-	// implementations: sc_snap_name_validate and snap.ValidateName.
+int validate_snap_name(const char *snap_name) {
+    // NOTE: This function should be synchronized with the two other
+    // implementations: sc_snap_name_validate and snap.ValidateName.
 
-	// Ensure that name is not NULL
-	if (snap_name == NULL) {
-		bootstrap_msg = "snap name cannot be NULL";
-		return -1;
-	}
-	// This is a regexp-free routine hand-codes the following pattern:
-	//
-	// "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$"
-	//
-	// The only motivation for not using regular expressions is so that we
-	// don't run untrusted input against a potentially complex regular
-	// expression engine.
-	const char *p = snap_name;
-	if (skip_one_char(&p, '-')) {
-		bootstrap_msg = "snap name cannot start with a dash";
-		return -1;
-	}
-	bool got_letter = false;
-	int n = 0, m;
-	for (; *p != '\0';) {
-		if ((m = skip_lowercase_letters(&p)) > 0) {
-			n += m;
-			got_letter = true;
-			continue;
-		}
-		if ((m = skip_digits(&p)) > 0) {
-			n += m;
-			continue;
-		}
-		if (skip_one_char(&p, '-') > 0) {
-			n++;
-			if (*p == '\0') {
-				bootstrap_msg =
-				    "snap name cannot end with a dash";
-				return -1;
-			}
-			if (skip_one_char(&p, '-') > 0) {
-				bootstrap_msg =
-				    "snap name cannot contain two consecutive dashes";
-				return -1;
-			}
-			continue;
-		}
-		bootstrap_msg =
-		    "snap name must use lower case letters, digits or dashes";
-		return -1;
-	}
-	if (!got_letter) {
-		bootstrap_msg = "snap name must contain at least one letter";
-		return -1;
-	}
-	if (n < 2) {
-		bootstrap_msg = "snap name must be longer than 1 character";
-		return -1;
-	}
-	if (n > 40) {
-		bootstrap_msg = "snap name must be shorter than 40 characters";
-		return -1;
-	}
+    // Ensure that name is not NULL
+    if (snap_name == NULL) {
+        bootstrap_msg = "snap name cannot be NULL";
+        return -1;
+    }
+    // This is a regexp-free routine hand-codes the following pattern:
+    //
+    // "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$"
+    //
+    // The only motivation for not using regular expressions is so that we
+    // don't run untrusted input against a potentially complex regular
+    // expression engine.
+    const char *p = snap_name;
+    if (skip_one_char(&p, '-')) {
+        bootstrap_msg = "snap name cannot start with a dash";
+        return -1;
+    }
+    bool got_letter = false;
+    int n = 0, m;
+    for (; *p != '\0';) {
+        if ((m = skip_lowercase_letters(&p)) > 0) {
+            n += m;
+            got_letter = true;
+            continue;
+        }
+        if ((m = skip_digits(&p)) > 0) {
+            n += m;
+            continue;
+        }
+        if (skip_one_char(&p, '-') > 0) {
+            n++;
+            if (*p == '\0') {
+                bootstrap_msg = "snap name cannot end with a dash";
+                return -1;
+            }
+            if (skip_one_char(&p, '-') > 0) {
+                bootstrap_msg = "snap name cannot contain two consecutive dashes";
+                return -1;
+            }
+            continue;
+        }
+        bootstrap_msg = "snap name must use lower case letters, digits or dashes";
+        return -1;
+    }
+    if (!got_letter) {
+        bootstrap_msg = "snap name must contain at least one letter";
+        return -1;
+    }
+    if (n < 2) {
+        bootstrap_msg = "snap name must be longer than 1 character";
+        return -1;
+    }
+    if (n > 40) {
+        bootstrap_msg = "snap name must be shorter than 40 characters";
+        return -1;
+    }
 
-	bootstrap_msg = NULL;
-	return 0;
+    bootstrap_msg = NULL;
+    return 0;
 }
 
-static int instance_key_validate(const char *instance_key)
-{
-	// NOTE: see snap.ValidateInstanceName for reference of a valid instance key
-	// format
+static int instance_key_validate(const char *instance_key) {
+    // NOTE: see snap.ValidateInstanceName for reference of a valid instance key
+    // format
 
-	// Ensure that name is not NULL
-	if (instance_key == NULL) {
-		bootstrap_msg = "instance key cannot be NULL";
-		return -1;
-	}
-	// This is a regexp-free routine hand-coding the following pattern:
-	//
-	// "^[a-z]{1,10}$"
-	//
-	// The only motivation for not using regular expressions is so that we don't
-	// run untrusted input against a potentially complex regular expression
-	// engine.
-	int i = 0;
-	for (i = 0; instance_key[i] != '\0'; i++) {
-		char c = instance_key[i];
-		/* NOTE: We are reimplementing islower() and isdigit()
-		 * here. For context see
-		 * https://github.com/golang/go/issues/29689 */
-		if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
-			continue;
-		}
-		bootstrap_msg =
-		    "instance key must use lower case letters or digits";
-		return -1;
-	}
+    // Ensure that name is not NULL
+    if (instance_key == NULL) {
+        bootstrap_msg = "instance key cannot be NULL";
+        return -1;
+    }
+    // This is a regexp-free routine hand-coding the following pattern:
+    //
+    // "^[a-z]{1,10}$"
+    //
+    // The only motivation for not using regular expressions is so that we don't
+    // run untrusted input against a potentially complex regular expression
+    // engine.
+    int i = 0;
+    for (i = 0; instance_key[i] != '\0'; i++) {
+        char c = instance_key[i];
+        /* NOTE: We are reimplementing islower() and isdigit()
+         * here. For context see
+         * https://github.com/golang/go/issues/29689 */
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+            continue;
+        }
+        bootstrap_msg = "instance key must use lower case letters or digits";
+        return -1;
+    }
 
-	if (i == 0) {
-		bootstrap_msg =
-		    "instance key must contain at least one letter or digit";
-		return -1;
-	} else if (i > 10) {
-		bootstrap_msg =
-		    "instance key must be shorter than 10 characters";
-		return -1;
-	}
-	return 0;
+    if (i == 0) {
+        bootstrap_msg = "instance key must contain at least one letter or digit";
+        return -1;
+    } else if (i > 10) {
+        bootstrap_msg = "instance key must be shorter than 10 characters";
+        return -1;
+    }
+    return 0;
 }
 
 // validate_instance_name performs full validation of the given snap instance name.
-int validate_instance_name(const char *instance_name)
-{
-	// NOTE: This function should be synchronized with the two other
-	// implementations: sc_instance_name_validate and snap.ValidateInstanceName.
+int validate_instance_name(const char *instance_name) {
+    // NOTE: This function should be synchronized with the two other
+    // implementations: sc_instance_name_validate and snap.ValidateInstanceName.
 
-	if (instance_name == NULL) {
-		bootstrap_msg = "snap instance name cannot be NULL";
-		return -1;
-	}
-	// 40 char snap_name + '_' + 10 char instance_key + 1 extra overflow + 1
-	// NULL
-	char s[53] = { 0 };
-	strncpy(s, instance_name, sizeof(s) - 1);
+    if (instance_name == NULL) {
+        bootstrap_msg = "snap instance name cannot be NULL";
+        return -1;
+    }
+    // 40 char snap_name + '_' + 10 char instance_key + 1 extra overflow + 1
+    // NULL
+    char s[53] = {0};
+    strncpy(s, instance_name, sizeof(s) - 1);
 
-	char *t = s;
-	const char *snap_name = strsep(&t, "_");
-	const char *instance_key = strsep(&t, "_");
-	const char *third_separator = strsep(&t, "_");
-	if (third_separator != NULL) {
-		bootstrap_msg =
-		    "snap instance name can contain only one underscore";
-		return -1;
-	}
+    char *t = s;
+    const char *snap_name = strsep(&t, "_");
+    const char *instance_key = strsep(&t, "_");
+    const char *third_separator = strsep(&t, "_");
+    if (third_separator != NULL) {
+        bootstrap_msg = "snap instance name can contain only one underscore";
+        return -1;
+    }
 
-	if (validate_snap_name(snap_name) < 0) {
-		return -1;
-	}
-	// When the instance_name is a normal snap name, instance_key will be
-	// NULL, so only validate instance_key when we found one.
-	if (instance_key != NULL && instance_key_validate(instance_key) < 0) {
-		return -1;
-	}
+    if (validate_snap_name(snap_name) < 0) {
+        return -1;
+    }
+    // When the instance_name is a normal snap name, instance_key will be
+    // NULL, so only validate instance_key when we found one.
+    if (instance_key != NULL && instance_key_validate(instance_key) < 0) {
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 // parse the -u argument, returns -1 on failure or 0 on success.
-static int parse_arg_u(int argc, char *const *argv, int *optind,
-		       unsigned long *uid_out)
-{
-	if (*optind + 1 == argc || argv[*optind + 1] == NULL) {
-		bootstrap_msg = "-u requires an argument";
-		bootstrap_errno = 0;
-		return -1;
-	}
-	const char *uid_text = argv[*optind + 1];
-	errno = 0;
-	char *uid_text_end = NULL;
-	unsigned long parsed_uid = strtoul(uid_text, &uid_text_end, 10);
-	int saved_errno = errno;
-	char c = *uid_text;
-	if (
-		   /* Reject overflow in parsed representation */
-		   (parsed_uid == ULONG_MAX && errno != 0)
-		   /* Reject leading whitespace allowed by strtoul. */
-		   /* NOTE: We are reimplementing isspace() here.
-		    * For context see
-		    * https://github.com/golang/go/issues/29689 */
-		   || c == ' ' || c == '\t' || c == '\v' || c == '\r'
-		   || c == '\n'
-		   /* Reject empty string. */
-		   || (*uid_text == '\0')
-		   /* Reject partially parsed strings. */
-		   || (*uid_text != '\0' && uid_text_end != NULL
-		       && *uid_text_end != '\0')) {
-		bootstrap_msg = "cannot parse user id";
-		bootstrap_errno = saved_errno;
-		return -1;
-	}
-	if ((long)parsed_uid < 0) {
-		bootstrap_msg = "user id cannot be negative";
-		bootstrap_errno = 0;
-		return -1;
-	}
-	if (uid_out != NULL) {
-		*uid_out = parsed_uid;
-	}
-	*optind += 1;		// Account for the argument to -u.
-	return 0;
+static int parse_arg_u(int argc, char *const *argv, int *optind, unsigned long *uid_out) {
+    if (*optind + 1 == argc || argv[*optind + 1] == NULL) {
+        bootstrap_msg = "-u requires an argument";
+        bootstrap_errno = 0;
+        return -1;
+    }
+    const char *uid_text = argv[*optind + 1];
+    errno = 0;
+    char *uid_text_end = NULL;
+    unsigned long parsed_uid = strtoul(uid_text, &uid_text_end, 10);
+    int saved_errno = errno;
+    char c = *uid_text;
+    if (
+        /* Reject overflow in parsed representation */
+        (parsed_uid == ULONG_MAX && errno != 0)
+        /* Reject leading whitespace allowed by strtoul. */
+        /* NOTE: We are reimplementing isspace() here.
+         * For context see
+         * https://github.com/golang/go/issues/29689 */
+        || c == ' ' || c == '\t' || c == '\v' || c == '\r' ||
+        c == '\n'
+        /* Reject empty string. */
+        || (*uid_text == '\0')
+        /* Reject partially parsed strings. */
+        || (*uid_text != '\0' && uid_text_end != NULL && *uid_text_end != '\0')) {
+        bootstrap_msg = "cannot parse user id";
+        bootstrap_errno = saved_errno;
+        return -1;
+    }
+    if ((long)parsed_uid < 0) {
+        bootstrap_msg = "user id cannot be negative";
+        bootstrap_errno = 0;
+        return -1;
+    }
+    if (uid_out != NULL) {
+        *uid_out = parsed_uid;
+    }
+    *optind += 1;  // Account for the argument to -u.
+    return 0;
 }
 
 // process_arguments parses given a command line
 // argc and argv are defined as for the main() function
-void process_arguments(int argc, char *const *argv, const char **snap_name_out,
-		       bool *should_setns_out, bool *process_user_fstab,
-		       unsigned long *uid_out)
-{
-	// Find the name of the called program. If it is ending with ".test" then do nothing.
-	// NOTE: This lets us use cgo/go to write tests without running the bulk
-	// of the code automatically.
-	//
-	if (argv == NULL || argc < 1) {
-		bootstrap_errno = 0;
-		bootstrap_msg = "argv0 is corrupted";
-		return;
-	}
-	const char *argv0 = argv[0];
-	const char *argv0_suffix_maybe = strstr(argv0, ".test");
-	if (argv0_suffix_maybe != NULL
-	    && argv0_suffix_maybe[strlen(".test")] == '\0') {
-		bootstrap_errno = 0;
-		bootstrap_msg = "bootstrap is not enabled while testing";
-		return;
-	}
+void process_arguments(int argc, char *const *argv, const char **snap_name_out, bool *should_setns_out,
+                       bool *process_user_fstab, unsigned long *uid_out) {
+    // Find the name of the called program. If it is ending with ".test" then do nothing.
+    // NOTE: This lets us use cgo/go to write tests without running the bulk
+    // of the code automatically.
+    //
+    if (argv == NULL || argc < 1) {
+        bootstrap_errno = 0;
+        bootstrap_msg = "argv0 is corrupted";
+        return;
+    }
+    const char *argv0 = argv[0];
+    const char *argv0_suffix_maybe = strstr(argv0, ".test");
+    if (argv0_suffix_maybe != NULL && argv0_suffix_maybe[strlen(".test")] == '\0') {
+        bootstrap_errno = 0;
+        bootstrap_msg = "bootstrap is not enabled while testing";
+        return;
+    }
 
-	bool should_setns = true;
-	bool user_fstab = false;
-	const char *snap_name = NULL;
+    bool should_setns = true;
+    bool user_fstab = false;
+    const char *snap_name = NULL;
 
-	// Sanity check the command line arguments.  The go parts will
-	// scan this too.
-	int i;
-	for (i = 1; i < argc; i++) {
-		const char *arg = argv[i];
-		if (arg[0] == '-') {
-			/* We have an option */
-			if (!strcmp(arg, "--from-snap-confine")) {
-				// When we are running under "--from-snap-confine"
-				// option skip the setns call as snap-confine has
-				// already placed us in the right namespace.
-				should_setns = false;
-			} else if (!strcmp(arg, "--user-mounts")) {
-				user_fstab = true;
-				// Processing the user-fstab file implies we're being
-				// called from snap-confine.
-				should_setns = false;
-			} else if (!strcmp(arg, "-u")) {
-				if (parse_arg_u(argc, argv, &i, uid_out) < 0) {
-					return;
-				}
-				// Providing an user identifier implies we are performing an
-				// update of a specific user mount namespace and that we are
-				// invoked from snapd and we should setns ourselves. When
-				// invoked from snap-confine we are only called with
-				// --from-snap-confine and with --user-mounts.
-				should_setns = true;
-				user_fstab = true;
-			} else {
-				bootstrap_errno = 0;
-				bootstrap_msg = "unsupported option";
-				return;
-			}
-		} else {
-			// We expect a single positional argument: the snap name
-			if (snap_name != NULL) {
-				bootstrap_errno = 0;
-				bootstrap_msg = "too many positional arguments";
-				return;
-			}
-			snap_name = arg;
-		}
-	}
+    // Sanity check the command line arguments.  The go parts will
+    // scan this too.
+    int i;
+    for (i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+        if (arg[0] == '-') {
+            /* We have an option */
+            if (!strcmp(arg, "--from-snap-confine")) {
+                // When we are running under "--from-snap-confine"
+                // option skip the setns call as snap-confine has
+                // already placed us in the right namespace.
+                should_setns = false;
+            } else if (!strcmp(arg, "--user-mounts")) {
+                user_fstab = true;
+                // Processing the user-fstab file implies we're being
+                // called from snap-confine.
+                should_setns = false;
+            } else if (!strcmp(arg, "-u")) {
+                if (parse_arg_u(argc, argv, &i, uid_out) < 0) {
+                    return;
+                }
+                // Providing an user identifier implies we are performing an
+                // update of a specific user mount namespace and that we are
+                // invoked from snapd and we should setns ourselves. When
+                // invoked from snap-confine we are only called with
+                // --from-snap-confine and with --user-mounts.
+                should_setns = true;
+                user_fstab = true;
+            } else {
+                bootstrap_errno = 0;
+                bootstrap_msg = "unsupported option";
+                return;
+            }
+        } else {
+            // We expect a single positional argument: the snap name
+            if (snap_name != NULL) {
+                bootstrap_errno = 0;
+                bootstrap_msg = "too many positional arguments";
+                return;
+            }
+            snap_name = arg;
+        }
+    }
 
-	// If there's no snap name given, just bail out.
-	if (snap_name == NULL) {
-		bootstrap_errno = 0;
-		bootstrap_msg = "snap name not provided";
-		return;
-	}
-	// Ensure that the snap instance name is valid so that we don't blindly setns into
-	// something that is controlled by a potential attacker.
-	if (validate_instance_name(snap_name) < 0) {
-		bootstrap_errno = 0;
-		// bootstap_msg is set by validate_instance_name;
-		return;
-	}
-	// We have a valid snap name now so let's store it.
-	if (snap_name_out != NULL) {
-		*snap_name_out = snap_name;
-	}
-	if (should_setns_out != NULL) {
-		*should_setns_out = should_setns;
-	}
-	if (process_user_fstab != NULL) {
-		*process_user_fstab = user_fstab;
-	}
-	bootstrap_errno = 0;
-	bootstrap_msg = NULL;
+    // If there's no snap name given, just bail out.
+    if (snap_name == NULL) {
+        bootstrap_errno = 0;
+        bootstrap_msg = "snap name not provided";
+        return;
+    }
+    // Ensure that the snap instance name is valid so that we don't blindly setns into
+    // something that is controlled by a potential attacker.
+    if (validate_instance_name(snap_name) < 0) {
+        bootstrap_errno = 0;
+        // bootstap_msg is set by validate_instance_name;
+        return;
+    }
+    // We have a valid snap name now so let's store it.
+    if (snap_name_out != NULL) {
+        *snap_name_out = snap_name;
+    }
+    if (should_setns_out != NULL) {
+        *should_setns_out = should_setns;
+    }
+    if (process_user_fstab != NULL) {
+        *process_user_fstab = user_fstab;
+    }
+    bootstrap_errno = 0;
+    bootstrap_msg = NULL;
 }
 
 // bootstrap prepares snap-update-ns to work in the namespace of the snap given
 // on command line.
-void bootstrap(int argc, char **argv, char **envp)
-{
-	// We may have been started via a setuid-root snap-confine. In order to
-	// prevent environment-based attacks we start by erasing all environment
-	// variables.
-	char *snapd_debug = getenv("SNAPD_DEBUG");
-	if (clearenv() != 0) {
-		bootstrap_errno = 0;
-		bootstrap_msg = "bootstrap could not clear the environment";
-		return;
-	}
-	if (snapd_debug != NULL) {
-		setenv("SNAPD_DEBUG", snapd_debug, 0);
-	}
-	// Analyze the read process cmdline to find the snap name and decide if we
-	// should use setns to jump into the mount namespace of a particular snap.
-	// This is spread out for easier testability.
-	const char *snap_name = NULL;
-	bool should_setns = false;
-	bool process_user_fstab = false;
-	unsigned long uid = 0;
-	process_arguments(argc, argv, &snap_name, &should_setns,
-			  &process_user_fstab, &uid);
-	if (process_user_fstab) {
-		switch_to_privileged_user();
-		// switch_to_privileged_user sets bootstrap_{errno,msg}
-	} else if (snap_name != NULL && should_setns) {
-		setns_into_snap(snap_name);
-		// setns_into_snap sets bootstrap_{errno,msg}
-	}
+void bootstrap(int argc, char **argv, char **envp) {
+    // We may have been started via a setuid-root snap-confine. In order to
+    // prevent environment-based attacks we start by erasing all environment
+    // variables.
+    char *snapd_debug = getenv("SNAPD_DEBUG");
+    if (clearenv() != 0) {
+        bootstrap_errno = 0;
+        bootstrap_msg = "bootstrap could not clear the environment";
+        return;
+    }
+    if (snapd_debug != NULL) {
+        setenv("SNAPD_DEBUG", snapd_debug, 0);
+    }
+    // Analyze the read process cmdline to find the snap name and decide if we
+    // should use setns to jump into the mount namespace of a particular snap.
+    // This is spread out for easier testability.
+    const char *snap_name = NULL;
+    bool should_setns = false;
+    bool process_user_fstab = false;
+    unsigned long uid = 0;
+    process_arguments(argc, argv, &snap_name, &should_setns, &process_user_fstab, &uid);
+    if (process_user_fstab) {
+        switch_to_privileged_user();
+        // switch_to_privileged_user sets bootstrap_{errno,msg}
+    } else if (snap_name != NULL && should_setns) {
+        setns_into_snap(snap_name);
+        // setns_into_snap sets bootstrap_{errno,msg}
+    }
 }

--- a/cmd/snap-update-ns/bootstrap.h
+++ b/cmd/snap-update-ns/bootstrap.h
@@ -27,9 +27,8 @@ extern int bootstrap_errno;
 extern const char *bootstrap_msg;
 
 void bootstrap(int argc, char **argv, char **envp);
-void process_arguments(int argc, char *const *argv, const char **snap_name_out,
-		       bool *should_setns_out, bool *process_user_fstab,
-		       unsigned long *uid_out);
+void process_arguments(int argc, char *const *argv, const char **snap_name_out, bool *should_setns_out,
+                       bool *process_user_fstab, unsigned long *uid_out);
 int validate_instance_name(const char *instance_name);
 
 #endif

--- a/cmd/snapd-env-generator/main.c
+++ b/cmd/snapd-env-generator/main.c
@@ -15,10 +15,10 @@
  *
  */
 
-#include<stdlib.h>
-#include<string.h>
-#include<stdio.h>
-#include<linux/limits.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "libsnap-confine-private/string-utils.h"
 
@@ -26,26 +26,24 @@
 
 // Systemd environment generators work since version 233 which ships
 // in Ubuntu 17.10+
-int main(int argc, char **argv)
-{
-	const char *snap_bin_dir = STATIC_SNAP_MOUNT_DIR "/bin";
+int main(int argc, char **argv) {
+    const char *snap_bin_dir = STATIC_SNAP_MOUNT_DIR "/bin";
 
-	char *path = getenv("PATH");
-	if (path == NULL || sc_streq(path, "")) {
-		// do nothing, until systemd is fixed, see LP#1791691
-		return 0;
-	}
-	char buf[PATH_MAX + 1] = { 0 };
-	strncpy(buf, path, sizeof(buf) - 1);
-	char *s = buf;
+    char *path = getenv("PATH");
+    if (path == NULL || sc_streq(path, "")) {
+        // do nothing, until systemd is fixed, see LP#1791691
+        return 0;
+    }
+    char buf[PATH_MAX + 1] = {0};
+    strncpy(buf, path, sizeof(buf) - 1);
+    char *s = buf;
 
-	char *tok = strsep(&s, ":");
-	while (tok != NULL) {
-		if (sc_streq(tok, snap_bin_dir))
-			return 0;
-		tok = strsep(&s, ":");
-	}
+    char *tok = strsep(&s, ":");
+    while (tok != NULL) {
+        if (sc_streq(tok, snap_bin_dir)) return 0;
+        tok = strsep(&s, ":");
+    }
 
-	printf("PATH=%s:%s\n", path, snap_bin_dir);
-	return 0;
+    printf("PATH=%s:%s\n", path, snap_bin_dir);
+    return 0;
 }

--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -15,13 +15,13 @@
  *
  */
 
+#include <dirent.h>
+#include <errno.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <dirent.h>
-#include <errno.h>
 #include <unistd.h>
 
 #include "config.h"
@@ -31,19 +31,16 @@
 #include "../libsnap-confine-private/mountinfo.h"
 #include "../libsnap-confine-private/string-utils.h"
 
-static sc_mountinfo_entry *find_dir_mountinfo(sc_mountinfo *mounts,
-					      const char *mnt_dir)
-{
-	sc_mountinfo_entry *cur, *root = NULL;
-	for (cur = sc_first_mountinfo_entry(mounts); cur != NULL;
-	     cur = sc_next_mountinfo_entry(cur)) {
-		// Look for the mount info entry. We take the last one, which
-		// would be the last mount on top of mnt_dir.
-		if (sc_streq(mnt_dir, cur->mount_dir)) {
-			root = cur;
-		}
-	}
-	return root;
+static sc_mountinfo_entry *find_dir_mountinfo(sc_mountinfo *mounts, const char *mnt_dir) {
+    sc_mountinfo_entry *cur, *root = NULL;
+    for (cur = sc_first_mountinfo_entry(mounts); cur != NULL; cur = sc_next_mountinfo_entry(cur)) {
+        // Look for the mount info entry. We take the last one, which
+        // would be the last mount on top of mnt_dir.
+        if (sc_streq(mnt_dir, cur->mount_dir)) {
+            root = cur;
+        }
+    }
+    return root;
 }
 
 // Create a mount unit in normal_dir that is performed at early stages for
@@ -52,63 +49,57 @@ static sc_mountinfo_entry *find_dir_mountinfo(sc_mountinfo *mounts,
 // name. We should do the same as systemd-escape(1), but for simplicity we just
 // replace slashes with dashes, which is fine for the moment as this is called
 // currently for mountpoints /usr/lib/{modules,firmware} only.
-static int create_early_mount(const char *normal_dir,
-			      const char *what, const char *where)
-{
-	// Replace directory separators with dashes to build the unit name.
-	char *unit_name SC_CLEANUP(sc_cleanup_string) = NULL;
-	// (... + 1) to remove the initial '/'
-	unit_name = sc_strdup(where + 1);
-	for (char *p = unit_name; (p = strchr(p, '/')) != NULL; *p = '-') ;
+static int create_early_mount(const char *normal_dir, const char *what, const char *where) {
+    // Replace directory separators with dashes to build the unit name.
+    char *unit_name SC_CLEANUP(sc_cleanup_string) = NULL;
+    // (... + 1) to remove the initial '/'
+    unit_name = sc_strdup(where + 1);
+    for (char *p = unit_name; (p = strchr(p, '/')) != NULL; *p = '-');
 
-	// Construct the file name for a new systemd mount unit.
-	char fname[PATH_MAX + 1] = { 0 };
-	sc_must_snprintf(fname, sizeof fname,
-			 "%s/%s.mount", normal_dir, unit_name);
+    // Construct the file name for a new systemd mount unit.
+    char fname[PATH_MAX + 1] = {0};
+    sc_must_snprintf(fname, sizeof fname, "%s/%s.mount", normal_dir, unit_name);
 
-	// Open the mount unit and write the contents.
-	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
-	f = fopen(fname, "w");
-	if (!f) {
-		fprintf(stderr, "cannot write to %s: %m\n", fname);
-		return 1;
-	}
-	fprintf(f, "[Unit]\n");
-	fprintf(f, "Description=Early mount of kernel drivers tree\n");
-	fprintf(f, "DefaultDependencies=no\n");
-	fprintf(f, "After=systemd-remount-fs.service\n");
-	fprintf(f, "Before=sysinit.target\n");
-	fprintf(f,
-		"Before=systemd-udevd.service systemd-modules-load.service\n");
-	fprintf(f, "Before=umount.target\n");
-	fprintf(f, "Conflicts=umount.target\n");
-	fprintf(f, "\n");
-	fprintf(f, "[Mount]\n");
-	fprintf(f, "What=%s\n", what);
-	fprintf(f, "Where=%s\n", where);
-	fprintf(f, "Options=bind,shared\n");
+    // Open the mount unit and write the contents.
+    FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
+    f = fopen(fname, "w");
+    if (!f) {
+        fprintf(stderr, "cannot write to %s: %m\n", fname);
+        return 1;
+    }
+    fprintf(f, "[Unit]\n");
+    fprintf(f, "Description=Early mount of kernel drivers tree\n");
+    fprintf(f, "DefaultDependencies=no\n");
+    fprintf(f, "After=systemd-remount-fs.service\n");
+    fprintf(f, "Before=sysinit.target\n");
+    fprintf(f, "Before=systemd-udevd.service systemd-modules-load.service\n");
+    fprintf(f, "Before=umount.target\n");
+    fprintf(f, "Conflicts=umount.target\n");
+    fprintf(f, "\n");
+    fprintf(f, "[Mount]\n");
+    fprintf(f, "What=%s\n", what);
+    fprintf(f, "Where=%s\n", where);
+    fprintf(f, "Options=bind,shared\n");
 
-	// Wanted by sysinit.target.wants - create folders if needed and symlink
+    // Wanted by sysinit.target.wants - create folders if needed and symlink
 
-	char wants_d[PATH_MAX + 1] = { 0 };
-	sc_must_snprintf(wants_d, sizeof wants_d,
-			 "%s/sysinit.target.wants", normal_dir);
-	if (mkdir(wants_d, 0755) != 0 && errno != EEXIST) {
-		fprintf(stderr, "cannot create %s directory: %m\n", wants_d);
-		return 1;
-	}
+    char wants_d[PATH_MAX + 1] = {0};
+    sc_must_snprintf(wants_d, sizeof wants_d, "%s/sysinit.target.wants", normal_dir);
+    if (mkdir(wants_d, 0755) != 0 && errno != EEXIST) {
+        fprintf(stderr, "cannot create %s directory: %m\n", wants_d);
+        return 1;
+    }
 
-	char target[PATH_MAX + 1] = { 0 };
-	char lnpath[PATH_MAX + 1] = { 0 };
-	sc_must_snprintf(target, sizeof target, "../%s.mount", unit_name);
-	sc_must_snprintf(lnpath, sizeof lnpath,
-			 "%s/%s.mount", wants_d, unit_name);
-	if (symlink(target, lnpath) != 0) {
-		fprintf(stderr, "cannot create symlink %s: %m\n", lnpath);
-		return 1;
-	}
+    char target[PATH_MAX + 1] = {0};
+    char lnpath[PATH_MAX + 1] = {0};
+    sc_must_snprintf(target, sizeof target, "../%s.mount", unit_name);
+    sc_must_snprintf(lnpath, sizeof lnpath, "%s/%s.mount", wants_d, unit_name);
+    if (symlink(target, lnpath) != 0) {
+        fprintf(stderr, "cannot create symlink %s: %m\n", lnpath);
+        return 1;
+    }
 
-	return 0;
+    return 0;
 }
 
 #define MAJOR_LOOP_DEV 7
@@ -118,317 +109,280 @@ static int create_early_mount(const char *normal_dir,
 #define FIRMWARE_MNTPOINT "/usr/lib/" FIRMWARE_DIR
 #define MODULES_MNTPOINT "/usr/lib/" MODULES_DIR
 
-static int ensure_kernel_drivers_mounts(const char *normal_dir)
-{
-	const char *const kern_mnt_dir = "/run/mnt/kernel";
-	// Find mount information
-	sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
-	mounts = sc_parse_mountinfo("/proc/1/mountinfo");
-	if (!mounts) {
-		fprintf(stderr, "cannot open or parse /proc/1/mountinfo\n");
-		return 1;
-	}
-	// Create mount units only if not already present (which would be the
-	// case for an old initramfs) - otherwise systemd-fstab-generator
-	// complains, and older initramfs won't come in a kernel snap with
-	// support for components anyway.
-	const char *const kern_mntpts[] =
-	    { FIRMWARE_MNTPOINT, MODULES_MNTPOINT };
-	for (size_t i = 0; i < sizeof kern_mntpts / sizeof(char *); ++i) {
-		sc_mountinfo_entry *minfo =
-		    find_dir_mountinfo(mounts, kern_mntpts[i]);
-		// If the mounts already exist (old initramfs), do not create them -
-		// note that we additionally check for SNAPD_DRIVERS_TREE_DIR in the
-		// mount source to make sure the units created here are still
-		// generated on "systemctl daemon-reload".
-		if (minfo
-		    && strstr(minfo->root, SNAPD_DRIVERS_TREE_DIR) == NULL) {
-			return 0;
-		}
-	}
+static int ensure_kernel_drivers_mounts(const char *normal_dir) {
+    const char *const kern_mnt_dir = "/run/mnt/kernel";
+    // Find mount information
+    sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+    mounts = sc_parse_mountinfo("/proc/1/mountinfo");
+    if (!mounts) {
+        fprintf(stderr, "cannot open or parse /proc/1/mountinfo\n");
+        return 1;
+    }
+    // Create mount units only if not already present (which would be the
+    // case for an old initramfs) - otherwise systemd-fstab-generator
+    // complains, and older initramfs won't come in a kernel snap with
+    // support for components anyway.
+    const char *const kern_mntpts[] = {FIRMWARE_MNTPOINT, MODULES_MNTPOINT};
+    for (size_t i = 0; i < sizeof kern_mntpts / sizeof(char *); ++i) {
+        sc_mountinfo_entry *minfo = find_dir_mountinfo(mounts, kern_mntpts[i]);
+        // If the mounts already exist (old initramfs), do not create them -
+        // note that we additionally check for SNAPD_DRIVERS_TREE_DIR in the
+        // mount source to make sure the units created here are still
+        // generated on "systemctl daemon-reload".
+        if (minfo && strstr(minfo->root, SNAPD_DRIVERS_TREE_DIR) == NULL) {
+            return 0;
+        }
+    }
 
-	// Find active kernel name and revision by looking at what was
-	// mounted in /run/mnt/kernel by snap-bootstrap.
+    // Find active kernel name and revision by looking at what was
+    // mounted in /run/mnt/kernel by snap-bootstrap.
 
-	sc_mountinfo_entry *kern_minfo =
-	    find_dir_mountinfo(mounts, kern_mnt_dir);
-	if (!kern_minfo) {
-		// This is not Ubuntu Core / hybrid, do nothing and do not fail
-		return 0;
-	}
-	// Mount source should be a snap
-	if (!sc_streq(kern_minfo->fs_type, "squashfs")) {
-		fprintf(stderr, "unexpected fs type (%s) for %s\n",
-			kern_minfo->fs_type, kern_mnt_dir);
-		return 1;
-	}
-	// We expect a loop device as source
-	if (kern_minfo->dev_major != MAJOR_LOOP_DEV) {
-		fprintf(stderr, "mount source %s for %s is not a loop device\n",
-			kern_minfo->mount_source, kern_mnt_dir);
-		return 1;
-	}
-	// Find out backing file
-	char fname[PATH_MAX + 1] = { 0 };
-	sc_must_snprintf(fname, sizeof fname,
-			 "/sys/dev/block/%u:%u/loop/backing_file",
-			 kern_minfo->dev_major, kern_minfo->dev_minor);
-	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
-	f = fopen(fname, "r");
-	if (!f) {
-		fprintf(stderr, "cannot open %s: %m\n", fname);
-		return 1;
-	}
-	char snap_path[PATH_MAX + 1] = { 0 };
-	if (fgets(snap_path, sizeof snap_path, f) == NULL) {
-		fprintf(stderr, "while reading %s: %m\n", fname);
-		return 1;
-	}
-	// Now parse the snap path
-	size_t i;
-	for (i = strlen(snap_path); i > 0 && snap_path[--i] != '/';) ;
-	char *snap_fname = snap_path + i + 1;
+    sc_mountinfo_entry *kern_minfo = find_dir_mountinfo(mounts, kern_mnt_dir);
+    if (!kern_minfo) {
+        // This is not Ubuntu Core / hybrid, do nothing and do not fail
+        return 0;
+    }
+    // Mount source should be a snap
+    if (!sc_streq(kern_minfo->fs_type, "squashfs")) {
+        fprintf(stderr, "unexpected fs type (%s) for %s\n", kern_minfo->fs_type, kern_mnt_dir);
+        return 1;
+    }
+    // We expect a loop device as source
+    if (kern_minfo->dev_major != MAJOR_LOOP_DEV) {
+        fprintf(stderr, "mount source %s for %s is not a loop device\n", kern_minfo->mount_source, kern_mnt_dir);
+        return 1;
+    }
+    // Find out backing file
+    char fname[PATH_MAX + 1] = {0};
+    sc_must_snprintf(fname, sizeof fname, "/sys/dev/block/%u:%u/loop/backing_file", kern_minfo->dev_major,
+                     kern_minfo->dev_minor);
+    FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
+    f = fopen(fname, "r");
+    if (!f) {
+        fprintf(stderr, "cannot open %s: %m\n", fname);
+        return 1;
+    }
+    char snap_path[PATH_MAX + 1] = {0};
+    if (fgets(snap_path, sizeof snap_path, f) == NULL) {
+        fprintf(stderr, "while reading %s: %m\n", fname);
+        return 1;
+    }
+    // Now parse the snap path
+    size_t i;
+    for (i = strlen(snap_path); i > 0 && snap_path[--i] != '/';);
+    char *snap_fname = snap_path + i + 1;
 
-	// snap_fname is expected to contain "<name>_<rev>.snap\n" - fgets includes
-	// that new line at the end, but anyway we ignore what comes after the dot.
-	char *saveptr = NULL;
-	char *snap_name = strtok_r(snap_fname, "_", &saveptr);
-	if (snap_name == NULL) {
-		fprintf(stderr, "snap name not found in loop backing file\n");
-		return 1;
-	}
-	char *snap_rev = strtok_r(NULL, ".", &saveptr);
-	if (snap_rev == NULL) {
-		fprintf(stderr,
-			"snap revision not found in loop backing file\n");
-		return 1;
-	}
+    // snap_fname is expected to contain "<name>_<rev>.snap\n" - fgets includes
+    // that new line at the end, but anyway we ignore what comes after the dot.
+    char *saveptr = NULL;
+    char *snap_name = strtok_r(snap_fname, "_", &saveptr);
+    if (snap_name == NULL) {
+        fprintf(stderr, "snap name not found in loop backing file\n");
+        return 1;
+    }
+    char *snap_rev = strtok_r(NULL, ".", &saveptr);
+    if (snap_rev == NULL) {
+        fprintf(stderr, "snap revision not found in loop backing file\n");
+        return 1;
+    }
 
-	int res;
-	char what[PATH_MAX + 1] = { 0 };
-	sc_must_snprintf(what, sizeof what,
-			 SNAPD_DRIVERS_TREE_DIR "/%s/%s/lib/" MODULES_DIR,
-			 snap_name, snap_rev);
-	res = create_early_mount(normal_dir, what, MODULES_MNTPOINT);
-	if (res != 0) {
-		return res;
-	}
-	sc_must_snprintf(what, sizeof what,
-			 SNAPD_DRIVERS_TREE_DIR "/%s/%s/lib/" FIRMWARE_DIR,
-			 snap_name, snap_rev);
-	return create_early_mount(normal_dir, what, FIRMWARE_MNTPOINT);
+    int res;
+    char what[PATH_MAX + 1] = {0};
+    sc_must_snprintf(what, sizeof what, SNAPD_DRIVERS_TREE_DIR "/%s/%s/lib/" MODULES_DIR, snap_name, snap_rev);
+    res = create_early_mount(normal_dir, what, MODULES_MNTPOINT);
+    if (res != 0) {
+        return res;
+    }
+    sc_must_snprintf(what, sizeof what, SNAPD_DRIVERS_TREE_DIR "/%s/%s/lib/" FIRMWARE_DIR, snap_name, snap_rev);
+    return create_early_mount(normal_dir, what, FIRMWARE_MNTPOINT);
 }
 
-static int ensure_root_fs_shared(const char *normal_dir)
-{
-	// Load /proc/1/mountinfo so that we can inspect the root filesystem.
-	sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
-	mounts = sc_parse_mountinfo("/proc/1/mountinfo");
-	if (!mounts) {
-		fprintf(stderr, "cannot open or parse /proc/1/mountinfo\n");
-		return 1;
-	}
-	sc_mountinfo_entry *root = find_dir_mountinfo(mounts, "/");
-	if (!root) {
-		fprintf(stderr,
-			"cannot find mountinfo entry of the root filesystem\n");
-		return 1;
-	}
-	// Check if the root file-system is mounted with shared option.
-	if (strstr(root->optional_fields, "shared:") != NULL) {
-		// The workaround is not needed, everything is good as-is.
-		return 0;
-	}
-	// Construct the file name for a new systemd mount unit.
-	char fname[PATH_MAX + 1] = { 0 };
-	sc_must_snprintf(fname, sizeof fname,
-			 "%s/" SNAP_MOUNT_DIR_SYSTEMD_UNIT ".mount",
-			 normal_dir);
+static int ensure_root_fs_shared(const char *normal_dir) {
+    // Load /proc/1/mountinfo so that we can inspect the root filesystem.
+    sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+    mounts = sc_parse_mountinfo("/proc/1/mountinfo");
+    if (!mounts) {
+        fprintf(stderr, "cannot open or parse /proc/1/mountinfo\n");
+        return 1;
+    }
+    sc_mountinfo_entry *root = find_dir_mountinfo(mounts, "/");
+    if (!root) {
+        fprintf(stderr, "cannot find mountinfo entry of the root filesystem\n");
+        return 1;
+    }
+    // Check if the root file-system is mounted with shared option.
+    if (strstr(root->optional_fields, "shared:") != NULL) {
+        // The workaround is not needed, everything is good as-is.
+        return 0;
+    }
+    // Construct the file name for a new systemd mount unit.
+    char fname[PATH_MAX + 1] = {0};
+    sc_must_snprintf(fname, sizeof fname, "%s/" SNAP_MOUNT_DIR_SYSTEMD_UNIT ".mount", normal_dir);
 
-	// Open the mount unit and write the contents.
-	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
-	f = fopen(fname, "wt");
-	if (!f) {
-		fprintf(stderr, "cannot open %s: %m\n", fname);
-		return 1;
-	}
-	fprintf(f,
-		"# Ensure that snap mount directory is mounted \"shared\" "
-		"so snaps can be refreshed correctly (LP: #1668759).\n");
-	fprintf(f, "[Unit]\n");
-	fprintf(f,
-		"Description=Ensure that the snap directory "
-		"shares mount events.\n");
-	fprintf(f, "[Mount]\n");
-	fprintf(f, "What=" STATIC_SNAP_MOUNT_DIR "\n");
-	fprintf(f, "Where=" STATIC_SNAP_MOUNT_DIR "\n");
-	fprintf(f, "Type=none\n");
-	fprintf(f, "Options=bind,shared\n");
+    // Open the mount unit and write the contents.
+    FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
+    f = fopen(fname, "wt");
+    if (!f) {
+        fprintf(stderr, "cannot open %s: %m\n", fname);
+        return 1;
+    }
+    fprintf(f,
+            "# Ensure that snap mount directory is mounted \"shared\" "
+            "so snaps can be refreshed correctly (LP: #1668759).\n");
+    fprintf(f, "[Unit]\n");
+    fprintf(f,
+            "Description=Ensure that the snap directory "
+            "shares mount events.\n");
+    fprintf(f, "[Mount]\n");
+    fprintf(f, "What=" STATIC_SNAP_MOUNT_DIR "\n");
+    fprintf(f, "Where=" STATIC_SNAP_MOUNT_DIR "\n");
+    fprintf(f, "Type=none\n");
+    fprintf(f, "Options=bind,shared\n");
 
-	/* We do not need to create symlinks from any target since
-	 * this generated mount will automically be added to implicit
-	 * dependencies of sub mount units through
-	 * `RequiresMountsFor`.
-	 */
+    /* We do not need to create symlinks from any target since
+     * this generated mount will automically be added to implicit
+     * dependencies of sub mount units through
+     * `RequiresMountsFor`.
+     */
 
-	return 0;
+    return 0;
 }
 
-static bool file_exists(const char *path)
-{
-	struct stat buf;
-	// Not using lstat to automatically resolve symbolic links,
-	// including handling, as an error, dangling symbolic links.
-	return stat(path, &buf) == 0 && (buf.st_mode & S_IFMT) == S_IFREG;
+static bool file_exists(const char *path) {
+    struct stat buf;
+    // Not using lstat to automatically resolve symbolic links,
+    // including handling, as an error, dangling symbolic links.
+    return stat(path, &buf) == 0 && (buf.st_mode & S_IFMT) == S_IFREG;
 }
 
 // PATH may not be set (the case on 16.04), in which case this is the fallback
 // for looking up squashfuse / snapfuse executable.
 // Based on what systemd uses when compiled for systems with "unmerged /usr"
 // (see man systemd.exec).
-static const char *const path_fallback =
-    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+static const char *const path_fallback = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
-static bool executable_exists(const char *name)
-{
-	char *path = getenv("PATH");
-	char *path_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-	if (path == NULL) {
-		path_copy = sc_strdup(path_fallback);
-	} else {
-		path_copy = sc_strdup(path);
-	}
+static bool executable_exists(const char *name) {
+    char *path = getenv("PATH");
+    char *path_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+    if (path == NULL) {
+        path_copy = sc_strdup(path_fallback);
+    } else {
+        path_copy = sc_strdup(path);
+    }
 
-	char *ptr = NULL;
-	char *token = strtok_r(path_copy, ":", &ptr);
-	char fname[PATH_MAX + 1] = { 0 };
-	while (token) {
-		sc_must_snprintf(fname, sizeof fname, "%s/%s", token, name);
-		if (access(fname, X_OK) == 0) {
-			return true;
-		}
-		token = strtok_r(NULL, ":", &ptr);
-	}
-	return false;
+    char *ptr = NULL;
+    char *token = strtok_r(path_copy, ":", &ptr);
+    char fname[PATH_MAX + 1] = {0};
+    while (token) {
+        sc_must_snprintf(fname, sizeof fname, "%s/%s", token, name);
+        if (access(fname, X_OK) == 0) {
+            return true;
+        }
+        token = strtok_r(NULL, ":", &ptr);
+    }
+    return false;
 }
 
-static bool is_snap_try_snap_unit(const char *units_dir,
-				  const char *mount_unit_name)
-{
-	char fname[PATH_MAX + 1] = { 0 };
-	sc_must_snprintf(fname, sizeof fname, "%s/%s", units_dir,
-			 mount_unit_name);
-	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
-	f = fopen(fname, "r");
-	if (!f) {
-		// not really expected
-		fprintf(stderr, "cannot open mount unit %s: %m\n", fname);
-		return false;
-	}
+static bool is_snap_try_snap_unit(const char *units_dir, const char *mount_unit_name) {
+    char fname[PATH_MAX + 1] = {0};
+    sc_must_snprintf(fname, sizeof fname, "%s/%s", units_dir, mount_unit_name);
+    FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
+    f = fopen(fname, "r");
+    if (!f) {
+        // not really expected
+        fprintf(stderr, "cannot open mount unit %s: %m\n", fname);
+        return false;
+    }
 
-	char *what SC_CLEANUP(sc_cleanup_string) = NULL;
-	sc_error *err = NULL;
-	if (sc_infofile_get_ini_section_key(f, "Mount", "What", &what, &err) <
-	    0) {
-		fprintf(stderr, "cannot read mount unit %s: %s\n", fname,
-			sc_error_msg(err));
-		sc_cleanup_error(&err);
-		return false;
-	}
+    char *what SC_CLEANUP(sc_cleanup_string) = NULL;
+    sc_error *err = NULL;
+    if (sc_infofile_get_ini_section_key(f, "Mount", "What", &what, &err) < 0) {
+        fprintf(stderr, "cannot read mount unit %s: %s\n", fname, sc_error_msg(err));
+        sc_cleanup_error(&err);
+        return false;
+    }
 
-	struct stat st;
-	// if What points to a directory, then it's a snap try unit.
-	return stat(what, &st) == 0 && (st.st_mode & S_IFMT) == S_IFDIR;
+    struct stat st;
+    // if What points to a directory, then it's a snap try unit.
+    return stat(what, &st) == 0 && (st.st_mode & S_IFMT) == S_IFDIR;
 }
 
-static int ensure_fusesquashfs_inside_container(const char *normal_dir)
-{
-	// check if we are running inside a container, systemd
-	// provides this file all the way back to trusty if run in a
-	// container
-	if (!file_exists("/run/systemd/container")) {
-		return 0;
-	}
+static int ensure_fusesquashfs_inside_container(const char *normal_dir) {
+    // check if we are running inside a container, systemd
+    // provides this file all the way back to trusty if run in a
+    // container
+    if (!file_exists("/run/systemd/container")) {
+        return 0;
+    }
 
-	const char *fstype;
-	if (executable_exists("squashfuse")) {
-		fstype = "fuse.squashfuse";
-	} else if (executable_exists("snapfuse")) {
-		fstype = "fuse.snapfuse";
-	} else {
-		fprintf(stderr,
-			"cannot find squashfuse or snapfuse executable\n");
-		return 2;
-	}
+    const char *fstype;
+    if (executable_exists("squashfuse")) {
+        fstype = "fuse.squashfuse";
+    } else if (executable_exists("snapfuse")) {
+        fstype = "fuse.snapfuse";
+    } else {
+        fprintf(stderr, "cannot find squashfuse or snapfuse executable\n");
+        return 2;
+    }
 
-	DIR *units_dir SC_CLEANUP(sc_cleanup_closedir) = NULL;
-	units_dir = opendir("/etc/systemd/system");
-	if (units_dir == NULL) {
-		// nothing to do
-		return 0;
-	}
+    DIR *units_dir SC_CLEANUP(sc_cleanup_closedir) = NULL;
+    units_dir = opendir("/etc/systemd/system");
+    if (units_dir == NULL) {
+        // nothing to do
+        return 0;
+    }
 
-	char fname[PATH_MAX + 1] = { 0 };
+    char fname[PATH_MAX + 1] = {0};
 
-	struct dirent *ent;
-	while ((ent = readdir(units_dir))) {
-		// find snap mount units, i.e:
-		// snap-somename.mount or var-lib-snapd-snap-somename.mount
-		if (!sc_endswith(ent->d_name, ".mount")) {
-			continue;
-		}
-		if (!(sc_startswith(ent->d_name, "snap-")
-		      || sc_startswith(ent->d_name, "var-lib-snapd-snap-"))) {
-			continue;
-		}
-		if (is_snap_try_snap_unit("/etc/systemd/system", ent->d_name)) {
-			continue;
-		}
-		sc_must_snprintf(fname, sizeof fname,
-				 "%s/%s.d", normal_dir, ent->d_name);
-		if (mkdir(fname, 0755) != 0) {
-			if (errno != EEXIST) {
-				fprintf(stderr,
-					"cannot create %s directory: %m\n",
-					fname);
-				return 2;
-			}
-		}
+    struct dirent *ent;
+    while ((ent = readdir(units_dir))) {
+        // find snap mount units, i.e:
+        // snap-somename.mount or var-lib-snapd-snap-somename.mount
+        if (!sc_endswith(ent->d_name, ".mount")) {
+            continue;
+        }
+        if (!(sc_startswith(ent->d_name, "snap-") || sc_startswith(ent->d_name, "var-lib-snapd-snap-"))) {
+            continue;
+        }
+        if (is_snap_try_snap_unit("/etc/systemd/system", ent->d_name)) {
+            continue;
+        }
+        sc_must_snprintf(fname, sizeof fname, "%s/%s.d", normal_dir, ent->d_name);
+        if (mkdir(fname, 0755) != 0) {
+            if (errno != EEXIST) {
+                fprintf(stderr, "cannot create %s directory: %m\n", fname);
+                return 2;
+            }
+        }
 
-		sc_must_snprintf(fname, sizeof fname,
-				 "%s/%s.d/container.conf", normal_dir,
-				 ent->d_name);
+        sc_must_snprintf(fname, sizeof fname, "%s/%s.d/container.conf", normal_dir, ent->d_name);
 
-		FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
-		f = fopen(fname, "w");
-		if (!f) {
-			fprintf(stderr, "cannot open %s: %m\n", fname);
-			return 2;
-		}
-		fprintf(f,
-			"[Mount]\nType=%s\nOptions=nodev,ro,x-gdu.hide,x-gvfs-hide,allow_other\nLazyUnmount=yes\n",
-			fstype);
-	}
+        FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
+        f = fopen(fname, "w");
+        if (!f) {
+            fprintf(stderr, "cannot open %s: %m\n", fname);
+            return 2;
+        }
+        fprintf(f, "[Mount]\nType=%s\nOptions=nodev,ro,x-gdu.hide,x-gvfs-hide,allow_other\nLazyUnmount=yes\n", fstype);
+    }
 
-	return 0;
+    return 0;
 }
 
-int main(int argc, char **argv)
-{
-	if (argc != 4) {
-		printf
-		    ("usage: snapd-generator normal-dir early-dir late-dir\n");
-		return 1;
-	}
-	const char *normal_dir = argv[1];
-	// For reference, but we don't use those variables here.
-	// const char *early_dir = argv[2];
-	// const char *late_dir = argv[3];
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        printf("usage: snapd-generator normal-dir early-dir late-dir\n");
+        return 1;
+    }
+    const char *normal_dir = argv[1];
+    // For reference, but we don't use those variables here.
+    // const char *early_dir = argv[2];
+    // const char *late_dir = argv[3];
 
-	int status = 0;
-	status = ensure_root_fs_shared(normal_dir);
-	status |= ensure_fusesquashfs_inside_container(normal_dir);
-	status |= ensure_kernel_drivers_mounts(normal_dir);
+    int status = 0;
+    status = ensure_root_fs_shared(normal_dir);
+    status |= ensure_fusesquashfs_inside_container(normal_dir);
+    status |= ensure_kernel_drivers_mounts(normal_dir);
 
-	return status;
+    return status;
 }

--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -17,131 +17,123 @@
 
 #include "system-shutdown-utils.h"
 
-#include <errno.h>		// errno, sys_errlist
-#include <fcntl.h>		// open
-#include <linux/loop.h>		// LOOP_CLR_FD
+#include <errno.h>       // errno, sys_errlist
+#include <fcntl.h>       // open
+#include <linux/loop.h>  // LOOP_CLR_FD
 #include <linux/major.h>
-#include <stdarg.h>		// va_*
-#include <stdio.h>		// fprintf, stderr
-#include <stdlib.h>		// exit
-#include <string.h>		// strcmp, strncmp
-#include <sys/ioctl.h>		// ioctl
-#include <sys/mount.h>		// umount
-#include <sys/reboot.h>		// reboot, RB_*
-#include <sys/stat.h>		// mkdir
-#include <unistd.h>		// getpid, close
+#include <stdarg.h>      // va_*
+#include <stdio.h>       // fprintf, stderr
+#include <stdlib.h>      // exit
+#include <string.h>      // strcmp, strncmp
+#include <sys/ioctl.h>   // ioctl
+#include <sys/mount.h>   // umount
+#include <sys/reboot.h>  // reboot, RB_*
+#include <sys/stat.h>    // mkdir
+#include <unistd.h>      // getpid, close
 
 #include "../libsnap-confine-private/mountinfo.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
-__attribute__((format(printf, 1, 2)))
-void kmsg(const char *fmt, ...)
-{
-	static FILE *kmsg = NULL;
-	static char *head = NULL;
-	if (!kmsg) {
-		// TODO: figure out why writing to /dev/kmsg doesn't work from here
-		kmsg = stderr;
-		head = "snapd system-shutdown helper: ";
-	}
+__attribute__((format(printf, 1, 2))) void kmsg(const char *fmt, ...) {
+    static FILE *kmsg = NULL;
+    static char *head = NULL;
+    if (!kmsg) {
+        // TODO: figure out why writing to /dev/kmsg doesn't work from here
+        kmsg = stderr;
+        head = "snapd system-shutdown helper: ";
+    }
 
-	va_list va;
-	va_start(va, fmt);
-	fputs(head, kmsg);
-	vfprintf(kmsg, fmt, va);
-	fprintf(kmsg, "\n");
-	va_end(va);
+    va_list va;
+    va_start(va, fmt);
+    fputs(head, kmsg);
+    vfprintf(kmsg, fmt, va);
+    fprintf(kmsg, "\n");
+    va_end(va);
 }
 
-int sc_read_reboot_arg(char *arg, size_t max_size)
-{
-	FILE *f;
+int sc_read_reboot_arg(char *arg, size_t max_size) {
+    FILE *f;
 
-	// This file is used by systemd to pass around a reboot parameter See
-	// https://github.com/systemd/systemd/blob/v229/src/basic/def.h#L44
-	f = fopen("/run/systemd/reboot-param", "r");
-	if (!f) {
-		return -1;
-	}
+    // This file is used by systemd to pass around a reboot parameter See
+    // https://github.com/systemd/systemd/blob/v229/src/basic/def.h#L44
+    f = fopen("/run/systemd/reboot-param", "r");
+    if (!f) {
+        return -1;
+    }
 
-	if (!fgets(arg, max_size, f)) {
-		fclose(f);
-		return -1;
-	}
-	arg[strcspn(arg, "\n")] = '\0';
+    if (!fgets(arg, max_size, f)) {
+        fclose(f);
+        return -1;
+    }
+    arg[strcspn(arg, "\n")] = '\0';
 
-	kmsg("reboot arg is %s", arg);
-	fclose(f);
-	return 0;
+    kmsg("reboot arg is %s", arg);
+    fclose(f);
+    return 0;
 }
 
-static void detach_loop(const char *src)
-{
-	int fd = open(src, O_RDONLY);
-	if (fd < 0) {
-		kmsg("* unable to open loop device %s: %s", src,
-		     strerror(errno));
-	} else {
-		if (ioctl(fd, LOOP_CLR_FD) < 0) {
-			kmsg("* unable to disassociate loop device %s: %s",
-			     src, strerror(errno));
-		}
-		close(fd);
-	}
+static void detach_loop(const char *src) {
+    int fd = open(src, O_RDONLY);
+    if (fd < 0) {
+        kmsg("* unable to open loop device %s: %s", src, strerror(errno));
+    } else {
+        if (ioctl(fd, LOOP_CLR_FD) < 0) {
+            kmsg("* unable to disassociate loop device %s: %s", src, strerror(errno));
+        }
+        close(fd);
+    }
 }
 
 // tries to umount all (well, most) things. Returns whether in the last pass it
 // no longer found writable.
-bool umount_all(void)
-{
-	bool did_umount = true;
-	bool had_writable = false;
+bool umount_all(void) {
+    bool did_umount = true;
+    bool had_writable = false;
 
-	for (int i = 0; i < 10 && did_umount; i++) {
-		sc_mountinfo *mounts = sc_parse_mountinfo(NULL);
-		if (!mounts) {
-			// oh dear
-			die("unable to get mount info; giving up");
-		}
-		sc_mountinfo_entry *cur = sc_first_mountinfo_entry(mounts);
+    for (int i = 0; i < 10 && did_umount; i++) {
+        sc_mountinfo *mounts = sc_parse_mountinfo(NULL);
+        if (!mounts) {
+            // oh dear
+            die("unable to get mount info; giving up");
+        }
+        sc_mountinfo_entry *cur = sc_first_mountinfo_entry(mounts);
 
-		had_writable = false;
-		did_umount = false;
-		while (cur) {
-			const char *dir = cur->mount_dir;
-			const char *src = cur->mount_source;
-			unsigned major = cur->dev_major;
+        had_writable = false;
+        did_umount = false;
+        while (cur) {
+            const char *dir = cur->mount_dir;
+            const char *src = cur->mount_source;
+            unsigned major = cur->dev_major;
 
-			cur = sc_next_mountinfo_entry(cur);
+            cur = sc_next_mountinfo_entry(cur);
 
-			if (sc_streq("/", dir)) {
-				continue;
-			}
+            if (sc_streq("/", dir)) {
+                continue;
+            }
 
-			if (sc_streq("/dev", dir)) {
-				continue;
-			}
+            if (sc_streq("/dev", dir)) {
+                continue;
+            }
 
-			if (sc_streq("/proc", dir)) {
-				continue;
-			}
+            if (sc_streq("/proc", dir)) {
+                continue;
+            }
 
-			if (major != 0 && major != LOOP_MAJOR
-			    && sc_endswith(dir, "/writable")) {
-				had_writable = true;
-			}
+            if (major != 0 && major != LOOP_MAJOR && sc_endswith(dir, "/writable")) {
+                had_writable = true;
+            }
 
-			if (umount(dir) == 0) {
-				if (major == LOOP_MAJOR) {
-					detach_loop(src);
-				}
+            if (umount(dir) == 0) {
+                if (major == LOOP_MAJOR) {
+                    detach_loop(src);
+                }
 
-				did_umount = true;
-			}
-		}
-		sc_cleanup_mountinfo(&mounts);
-	}
+                did_umount = true;
+            }
+        }
+        sc_cleanup_mountinfo(&mounts);
+    }
 
-	return !had_writable;
+    return !had_writable;
 }

--- a/cmd/system-shutdown/system-shutdown-utils.h
+++ b/cmd/system-shutdown/system-shutdown-utils.h
@@ -19,14 +19,13 @@
 #define SYSTEM_SHUTDOWN_UTILS_H
 
 #include <stdbool.h>
-#include <stddef.h>		// size_t
+#include <stddef.h>  // size_t
 
 // tries to umount all (well, most) things. Returns whether in the last pass it
 // no longer found writable.
 bool umount_all(void);
 
-__attribute__((format(printf, 1, 2)))
-void kmsg(const char *fmt, ...);
+__attribute__((format(printf, 1, 2))) void kmsg(const char *fmt, ...);
 
 // Reads a possible argument for reboot syscall in /run/systemd/reboot-param,
 // which is the place where systemd stores it.

--- a/cmd/system-shutdown/system-shutdown.c
+++ b/cmd/system-shutdown/system-shutdown.c
@@ -15,145 +15,137 @@
  *
  */
 
-#include <stdbool.h>		// bools
-#include <stdarg.h>		// va_*
-#include <sys/mount.h>		// umount
-#include <sys/stat.h>		// mkdir
-#include <unistd.h>		// getpid, close
-#include <stdlib.h>		// exit
-#include <stdio.h>		// fprintf, stderr
-#include <string.h>		// strerror
-#include <sys/ioctl.h>		// ioctl
-#include <linux/loop.h>		// LOOP_CLR_FD
-#include <sys/reboot.h>		// reboot, RB_*
-#include <fcntl.h>		// open
-#include <errno.h>		// errno, sys_errlist
-#include <linux/reboot.h>	// LINUX_REBOOT_MAGIC*
-#include <sys/syscall.h>	// SYS_reboot
+#include <errno.h>         // errno, sys_errlist
+#include <fcntl.h>         // open
+#include <linux/loop.h>    // LOOP_CLR_FD
+#include <linux/reboot.h>  // LINUX_REBOOT_MAGIC*
+#include <stdarg.h>        // va_*
+#include <stdbool.h>       // bools
+#include <stdio.h>         // fprintf, stderr
+#include <stdlib.h>        // exit
+#include <string.h>        // strerror
+#include <sys/ioctl.h>     // ioctl
+#include <sys/mount.h>     // umount
+#include <sys/reboot.h>    // reboot, RB_*
+#include <sys/stat.h>      // mkdir
+#include <sys/syscall.h>   // SYS_reboot
+#include <unistd.h>        // getpid, close
 
-#include "system-shutdown-utils.h"
 #include "../libsnap-confine-private/panic.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
+#include "system-shutdown-utils.h"
 
-static void show_error(const char *fmt, va_list ap, int errno_copy)
-{
-	fprintf(stderr, "snapd system-shutdown helper: ");
-	fprintf(stderr, "*** ");
-	vfprintf(stderr, fmt, ap);
-	if (errno_copy != 0) {
-		fprintf(stderr, ": %s", strerror(errno_copy));
-	}
-	fprintf(stderr, "\n");
+static void show_error(const char *fmt, va_list ap, int errno_copy) {
+    fprintf(stderr, "snapd system-shutdown helper: ");
+    fprintf(stderr, "*** ");
+    vfprintf(stderr, fmt, ap);
+    if (errno_copy != 0) {
+        fprintf(stderr, ": %s", strerror(errno_copy));
+    }
+    fprintf(stderr, "\n");
 }
 
-static void sync_and_halt(void)
-{
-	sync();
-	reboot(RB_HALT_SYSTEM);
+static void sync_and_halt(void) {
+    sync();
+    reboot(RB_HALT_SYSTEM);
 }
 
-int main(int argc, char *argv[])
-{
-	sc_set_panic_msg_fn(show_error);
-	sc_set_panic_exit_fn(sync_and_halt);
+int main(int argc, char *argv[]) {
+    sc_set_panic_msg_fn(show_error);
+    sc_set_panic_exit_fn(sync_and_halt);
 
-	// 256 should be more than enough...
-	char reboot_arg[256] = { 0 };
+    // 256 should be more than enough...
+    char reboot_arg[256] = {0};
 
-	errno = 0;
-	if (getpid() != 1) {
-		fprintf(stderr,
-			"This is a shutdown helper program; don't call it directly.\n");
-		exit(1);
-	}
+    errno = 0;
+    if (getpid() != 1) {
+        fprintf(stderr, "This is a shutdown helper program; don't call it directly.\n");
+        exit(1);
+    }
 
-	kmsg("started.");
+    kmsg("started.");
 
-	/*
-	   This program is started by systemd exec'ing the "shutdown" binary
-	   inside what used to be /run/initramfs. That is: the system's
-	   /run/initramfs is now /, and the old / is now /oldroot. Our job is
-	   to disentagle /oldroot and /oldroot/writable, which contain each
-	   other in the "live" system. We do this by creating a new /writable
-	   and moving the old mount there, previous to which we need to unmount
-	   as much as we can. Having done that we should be able to detach the
-	   oldroot loop device and finally unmount writable itself.
-	 */
+    /*
+       This program is started by systemd exec'ing the "shutdown" binary
+       inside what used to be /run/initramfs. That is: the system's
+       /run/initramfs is now /, and the old / is now /oldroot. Our job is
+       to disentagle /oldroot and /oldroot/writable, which contain each
+       other in the "live" system. We do this by creating a new /writable
+       and moving the old mount there, previous to which we need to unmount
+       as much as we can. Having done that we should be able to detach the
+       oldroot loop device and finally unmount writable itself.
+     */
 
-	/*
-	   There are two¹ ways out of this program: we die, which calls sync
-	   before halting the system; or we umount everything successfully
-	   before doing whatever we were told to do, in which case there's
-	   nothing left to sync.
+    /*
+       There are two¹ ways out of this program: we die, which calls sync
+       before halting the system; or we umount everything successfully
+       before doing whatever we were told to do, in which case there's
+       nothing left to sync.
 
-	   1) ... apart from the third way that we never talk about: we somehow
-	   are unable to umount everything cleanly, but go ahead with the
-	   reboot anyway because no error was returned. That's the only path
-	   we need to sync on explicitly.
-	 */
+       1) ... apart from the third way that we never talk about: we somehow
+       are unable to umount everything cleanly, but go ahead with the
+       reboot anyway because no error was returned. That's the only path
+       we need to sync on explicitly.
+     */
 
-	if (mkdir("/writable", 0755) < 0) {
-		die("cannot create directory /writable");
-	}
-	// We are reading a file from /run and need to do this before unmounting
-	if (sc_read_reboot_arg(reboot_arg, sizeof reboot_arg) < 0) {
-		kmsg("no reboot parameter");
-	}
+    if (mkdir("/writable", 0755) < 0) {
+        die("cannot create directory /writable");
+    }
+    // We are reading a file from /run and need to do this before unmounting
+    if (sc_read_reboot_arg(reboot_arg, sizeof reboot_arg) < 0) {
+        kmsg("no reboot parameter");
+    }
 
-	if (umount_all()) {
-		kmsg("- found no hard-to-unmount writable partition.");
-	} else {
-		if (mount("/oldroot/writable", "/writable", NULL, MS_MOVE, NULL)
-		    < 0) {
-			die("cannot move writable out of the way");
-		}
+    if (umount_all()) {
+        kmsg("- found no hard-to-unmount writable partition.");
+    } else {
+        if (mount("/oldroot/writable", "/writable", NULL, MS_MOVE, NULL) < 0) {
+            die("cannot move writable out of the way");
+        }
 
-		if (umount_all()) {
-			kmsg("- was able to unmount writable cleanly");
-		} else {
-			kmsg("* was *NOT* able to unmount writable cleanly");
-			sync();	// we don't know what happened but we're going ahead
-		}
-	}
+        if (umount_all()) {
+            kmsg("- was able to unmount writable cleanly");
+        } else {
+            kmsg("* was *NOT* able to unmount writable cleanly");
+            sync();  // we don't know what happened but we're going ahead
+        }
+    }
 
-	// argv[1] can be one of at least: halt, reboot, poweroff.
-	// FIXME: might also be kexec, hibernate or hybrid-sleep -- support those!
+    // argv[1] can be one of at least: halt, reboot, poweroff.
+    // FIXME: might also be kexec, hibernate or hybrid-sleep -- support those!
 
-	int cmd = RB_HALT_SYSTEM;
+    int cmd = RB_HALT_SYSTEM;
 
-	if (argc < 2) {
-		kmsg("* called without verb; halting.");
-	} else {
-		if (sc_streq("reboot", argv[1])) {
-			cmd = RB_AUTOBOOT;
-			kmsg("- rebooting.");
-		} else if (sc_streq("poweroff", argv[1])) {
-			cmd = RB_POWER_OFF;
-			kmsg("- powering off.");
-		} else if (sc_streq("halt", argv[1])) {
-			kmsg("- halting.");
-		} else {
-			kmsg("* called with unsupported verb %s; halting.",
-			     argv[1]);
-		}
-	}
+    if (argc < 2) {
+        kmsg("* called without verb; halting.");
+    } else {
+        if (sc_streq("reboot", argv[1])) {
+            cmd = RB_AUTOBOOT;
+            kmsg("- rebooting.");
+        } else if (sc_streq("poweroff", argv[1])) {
+            cmd = RB_POWER_OFF;
+            kmsg("- powering off.");
+        } else if (sc_streq("halt", argv[1])) {
+            kmsg("- halting.");
+        } else {
+            kmsg("* called with unsupported verb %s; halting.", argv[1]);
+        }
+    }
 
-	// glibc reboot wrapper does not expose the optional reboot syscall
-	// parameter
+    // glibc reboot wrapper does not expose the optional reboot syscall
+    // parameter
 
-	long ret;
-	if (cmd == RB_AUTOBOOT && reboot_arg[0] != '\0') {
-		ret = syscall(SYS_reboot,
-			      LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2,
-			      LINUX_REBOOT_CMD_RESTART2, reboot_arg);
-	} else {
-		ret = reboot(cmd);
-	}
+    long ret;
+    if (cmd == RB_AUTOBOOT && reboot_arg[0] != '\0') {
+        ret = syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2, LINUX_REBOOT_CMD_RESTART2, reboot_arg);
+    } else {
+        ret = reboot(cmd);
+    }
 
-	if (ret == -1) {
-		kmsg("cannot reboot the system: %s", strerror(errno));
-	}
+    if (ret == -1) {
+        kmsg("cannot reboot the system: %s", strerror(errno));
+    }
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
We have historically avoided reformatting all code with clang-format,
with the main motivator being more complicated tracking of previous
changes. However with tight integration of git blame in various IDEs,
github UI and even Emacs, following change history is now trivial.

Additionally GNU indent itself is a source of issues.. The version which
was present included in 22.04 (2.2.12) was notoriously producing
incorrect formatting, to the point that the CI process in snapd built
its own 2.2.13 binary. On top of this, formatting with indent does not
produce stable results. One has to run indent at least twice to produce
stable output. In contrast, clang-format, at least 19.x which I use at
time this change is done, has none of those issues and has been used in
community with success.