### PR TITLE
client, daemon, i/prompting: return error if patch results in no permissions

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -155,8 +155,8 @@ const (
 	// ErrorKindInterfacesRequestsInvalidFields: POST body to prompting API contains invalid fields.
 	ErrorKindInterfacesRequestsInvalidFields ErrorKind = "interfaces-requests-invalid-fields"
 
-	// ErrorKindInterfacesRequestsPatchedRuleNoPermissions: patched rule has no permission
-	ErrorKindInterfacesRequestsPatchedRuleNoPermissions ErrorKind = "interfaces-requests-patched-rule-no-permissions"
+	// ErrorKindInterfacesRequestsPatchedRuleHasNoPermissions: patched rule has no permission
+	ErrorKindInterfacesRequestsPatchedRuleHasNoPermissions ErrorKind = "interfaces-requests-patched-rule-has-no-permissions"
 
 	// ErrorKindInterfacesRequestsReplyNotMatchRequest: the prompt reply does not match the path and/or permissions which were requested.
 	ErrorKindInterfacesRequestsReplyNotMatchRequest ErrorKind = "interfaces-requests-reply-not-match-request"

--- a/client/errors.go
+++ b/client/errors.go
@@ -155,13 +155,16 @@ const (
 	// ErrorKindInterfacesRequestsInvalidFields: POST body to prompting API contains invalid fields.
 	ErrorKindInterfacesRequestsInvalidFields ErrorKind = "interfaces-requests-invalid-fields"
 
+	// ErrorKindInterfacesRequestsPatchedRuleNoPermissions: patched rule has no permission
+	ErrorKindInterfacesRequestsPatchedRuleNoPermissions ErrorKind = "interfaces-requests-patched-rule-no-permissions"
+
 	// ErrorKindInterfacesRequestsReplyNotMatchRequest: the prompt reply does not match the path and/or permissions which were requested.
 	ErrorKindInterfacesRequestsReplyNotMatchRequest ErrorKind = "interfaces-requests-reply-not-match-request"
 
 	// ErrorKindInterfacesRequestsRuleConflict: a rule with conflicting path pattern and permissions already exists.
 	ErrorKindInterfacesRequestsRuleConflict ErrorKind = "interfaces-requests-rule-conflict"
 
-	// ErrorKindInterfacesRequestsRuleConflict: cannot find a snap-resource-pair when attempting to sideload a component
+	// ErrorKindMissingSnapResourcePair: cannot find a snap-resource-pair when attempting to sideload a component
 	ErrorKindMissingSnapResourcePair ErrorKind = "missing-snap-resource-pair"
 )
 

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -245,9 +245,9 @@ func promptingError(err error) *apiError {
 		if errors.As(err, &parseErr) {
 			apiErr.Value = (*promptingParseError)(parseErr)
 		}
-	case errors.Is(err, prompting_errors.ErrPatchedRuleNoPerms):
+	case errors.Is(err, prompting_errors.ErrPatchedRuleHasNoPerms):
 		apiErr.Status = 400
-		apiErr.Kind = client.ErrorKindInterfacesRequestsPatchedRuleNoPermissions
+		apiErr.Kind = client.ErrorKindInterfacesRequestsPatchedRuleHasNoPermissions
 	case errors.Is(err, prompting_errors.ErrReplyNotMatchRequestedPath):
 		apiErr.Status = 400
 		apiErr.Kind = client.ErrorKindInterfacesRequestsReplyNotMatchRequest

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -245,6 +245,9 @@ func promptingError(err error) *apiError {
 		if errors.As(err, &parseErr) {
 			apiErr.Value = (*promptingParseError)(parseErr)
 		}
+	case errors.Is(err, prompting_errors.ErrPatchedRuleNoPerms):
+		apiErr.Status = 400
+		apiErr.Kind = client.ErrorKindInterfacesRequestsPatchedRuleNoPermissions
 	case errors.Is(err, prompting_errors.ErrReplyNotMatchRequestedPath):
 		apiErr.Status = 400
 		apiErr.Kind = client.ErrorKindInterfacesRequestsReplyNotMatchRequest

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -539,6 +539,18 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 			},
 		},
 		{
+			err: prompting_errors.ErrPatchedRuleNoPerms,
+			body: map[string]interface{}{
+				"result": map[string]interface{}{
+					"message": "cannot patch rule to have no permissions",
+					"kind":    "interfaces-requests-patched-rule-no-permissions",
+				},
+				"status":      "Bad Request",
+				"status-code": 400.0,
+				"type":        "error",
+			},
+		},
+		{
 			err: &prompting_errors.RequestedPathNotMatchedError{
 				Requested: "foo",
 				Replied:   "bar",

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -539,11 +539,11 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 			},
 		},
 		{
-			err: prompting_errors.ErrPatchedRuleNoPerms,
+			err: prompting_errors.ErrPatchedRuleHasNoPerms,
 			body: map[string]interface{}{
 				"result": map[string]interface{}{
 					"message": "cannot patch rule to have no permissions",
-					"kind":    "interfaces-requests-patched-rule-no-permissions",
+					"kind":    "interfaces-requests-patched-rule-has-no-permissions",
 				},
 				"status":      "Bad Request",
 				"status-code": 400.0,

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -254,6 +254,9 @@ func (c *RuleConstraintsPatch) PatchRuleConstraints(existing *RuleConstraints, i
 	if len(errs) > 0 {
 		return nil, strutil.JoinErrors(errs...)
 	}
+	if len(newPermissions) == 0 {
+		return nil, prompting_errors.ErrPatchedRuleNoPerms
+	}
 	ruleConstraints.Permissions = newPermissions
 	return ruleConstraints, nil
 }

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -255,7 +255,7 @@ func (c *RuleConstraintsPatch) PatchRuleConstraints(existing *RuleConstraints, i
 		return nil, strutil.JoinErrors(errs...)
 	}
 	if len(newPermissions) == 0 {
-		return nil, prompting_errors.ErrPatchedRuleNoPerms
+		return nil, prompting_errors.ErrPatchedRuleHasNoPerms
 	}
 	ruleConstraints.Permissions = newPermissions
 	return ruleConstraints, nil

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -904,7 +904,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
 		},
 	}
 	result, err = badPatch.PatchRuleConstraints(goodRule, iface, patchTime)
-	c.Check(err, Equals, prompting_errors.ErrPatchedRuleNoPerms)
+	c.Check(err, Equals, prompting_errors.ErrPatchedRuleHasNoPerms)
 	c.Check(result, IsNil)
 }
 

--- a/interfaces/prompting/errors/errors.go
+++ b/interfaces/prompting/errors/errors.go
@@ -36,7 +36,10 @@ var (
 	ErrRuleNotFound   = errors.New("cannot find rule with the given ID")
 	ErrRuleNotAllowed = errors.New("user not allowed to request the rule with the given ID")
 
-	// Validation errors, which should never be used directly apart from
+	// Validation errors which may be returned over the API
+	ErrPatchedRuleNoPerms = errors.New("cannot patch rule to have no permissions")
+
+	// Validation errors which should never be used directly apart from
 	// checking errors.Is(), and should otherwise always be wrapped in
 	// dedicated error types defined below.
 	ErrReplyNotMatchRequestedPath        = errors.New("path pattern in reply constraints does not match originally requested path")

--- a/interfaces/prompting/errors/errors.go
+++ b/interfaces/prompting/errors/errors.go
@@ -37,7 +37,7 @@ var (
 	ErrRuleNotAllowed = errors.New("user not allowed to request the rule with the given ID")
 
 	// Validation errors which may be returned over the API
-	ErrPatchedRuleNoPerms = errors.New("cannot patch rule to have no permissions")
+	ErrPatchedRuleHasNoPerms = errors.New("cannot patch rule to have no permissions")
 
 	// Validation errors which should never be used directly apart from
 	// checking errors.Is(), and should otherwise always be wrapped in


### PR DESCRIPTION
If applying a patch to a rule would result in that rule having no permissions, then return an error, including an error response from the snapd API.

This error warrants its own error kind because it is not an internal error or an invalid field error, it's a validation error when taking into account the state of the system, and it doesn't fit under any of the existing validation error kinds for prompting.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34373