### PR TITLE
daemon,i/prompting: replace PermissionsListEmptyError with PermissionsEmptyError

### DIFF
--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -466,10 +466,10 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 			},
 		},
 		{
-			err: prompting_errors.NewPermissionsListEmptyError("foo", []string{"bar", "baz"}),
+			err: prompting_errors.NewPermissionsEmptyError("foo", []string{"bar", "baz"}),
 			body: map[string]interface{}{
 				"result": map[string]interface{}{
-					"message": `invalid permissions for foo interface: permissions list empty`,
+					"message": `invalid permissions for foo interface: permissions empty`,
 					"kind":    "interfaces-requests-invalid-fields",
 					"value": map[string]interface{}{
 						"permissions": map[string]interface{}{

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -153,7 +153,7 @@ func (c *ReplyConstraints) ToConstraints(iface string, outcome OutcomeType, life
 		return nil, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
 	}
 	if len(c.Permissions) == 0 {
-		return nil, prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
+		return nil, prompting_errors.NewPermissionsEmptyError(iface, availablePerms)
 	}
 	var invalidPerms []string
 	permissionMap := make(PermissionMap, len(c.Permissions))
@@ -273,7 +273,7 @@ func (pm PermissionMap) toRulePermissionMap(iface string, currTime time.Time) (R
 		return nil, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
 	}
 	if len(pm) == 0 {
-		return nil, prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
+		return nil, prompting_errors.NewPermissionsEmptyError(iface, availablePerms)
 	}
 	var errs []error
 	var invalidPerms []string
@@ -314,7 +314,7 @@ func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Tim
 		return false, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
 	}
 	if len(pm) == 0 {
-		return false, prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
+		return false, prompting_errors.NewPermissionsEmptyError(iface, availablePerms)
 	}
 	var errs []error
 	var invalidPerms []string
@@ -544,7 +544,7 @@ func AbstractPermissionsToAppArmorPermissions(iface string, permissions []string
 	if len(permissions) == 0 {
 		availablePerms, _ := AvailablePermissions(iface)
 		// Caller should have already validated iface, so no error can occur
-		return notify.FilePermission(0), prompting_errors.NewPermissionsListEmptyError(iface, availablePerms)
+		return notify.FilePermission(0), prompting_errors.NewPermissionsEmptyError(iface, availablePerms)
 	}
 	filePermsMap, exists := interfaceFilePermissionsMaps[iface]
 	if !exists {

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -234,7 +234,7 @@ func (s *constraintsSuite) TestConstraintsToRuleConstraintsUnhappy(c *C) {
 	}{
 		{
 			perms:  nil,
-			errStr: `invalid permissions for home interface: permissions list empty`,
+			errStr: `invalid permissions for home interface: permissions empty`,
 		},
 		{
 			perms: prompting.PermissionMap{
@@ -324,7 +324,7 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
 		{
 			"home",
 			prompting.RulePermissionMap{},
-			prompting_errors.NewPermissionsListEmptyError("home", nil).Error(),
+			prompting_errors.NewPermissionsEmptyError("home", nil).Error(),
 		},
 		{
 			"home",
@@ -621,7 +621,7 @@ func (s *constraintsSuite) TestReplyConstraintsToConstraintsUnhappy(c *C) {
 		},
 		{
 			permissions: make([]string, 0),
-			errStr:      `invalid permissions for home interface: permissions list empty`,
+			errStr:      `invalid permissions for home interface: permissions empty`,
 		},
 		{
 			permissions: []string{"read", "append", "write", "create", "execute"},
@@ -1141,7 +1141,7 @@ func (s *constraintsSuite) TestAbstractPermissionsToAppArmorPermissionsUnhappy(c
 		{
 			"home",
 			[]string{},
-			"invalid permissions for home interface: permissions list empty",
+			"invalid permissions for home interface: permissions empty",
 		},
 		{
 			"foo",

--- a/interfaces/prompting/errors/errors.go
+++ b/interfaces/prompting/errors/errors.go
@@ -123,13 +123,10 @@ func NewInvalidPermissionsError(iface string, unsupported []string, supported []
 	}
 }
 
-func NewPermissionsListEmptyError(iface string, supported []string) *UnsupportedValueError {
-	// TODO: change language to "permissions empty" rather than "permissions list empty",
-	// since permissions now come as a list in prompt replies but as a map when creating
-	// or modifying rules directly.
+func NewPermissionsEmptyError(iface string, supported []string) *UnsupportedValueError {
 	return &UnsupportedValueError{
 		Field:     "permissions",
-		Msg:       fmt.Sprintf("invalid permissions for %s interface: permissions list empty", iface),
+		Msg:       fmt.Sprintf("invalid permissions for %s interface: permissions empty", iface),
 		Value:     []string{}, // client prefers empty list over null value
 		Supported: supported,
 	}


### PR DESCRIPTION
Previously, both prompts and rules used lists of permissions, but now that rules use a map from permission to outcome and lifespan, language around permission lists is no longer accurate. Simply remove the "list" from the error name and error message, and it can continue to be used in both situations.

This is a drive-by fix while working on https://warthogs.atlassian.net/browse/SNAPDENG-31322
