### PR TITLE
i/prompting: do not error when converting empty abstract perms to AA perms

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -541,11 +541,8 @@ func AbstractPermissionsFromAppArmorPermissions(iface string, permissions any) (
 // AbstractPermissionsToAppArmorPermissions returns AppArmor permissions
 // corresponding to the given permissions for the given interface.
 func AbstractPermissionsToAppArmorPermissions(iface string, permissions []string) (any, error) {
-	if len(permissions) == 0 {
-		availablePerms, _ := AvailablePermissions(iface)
-		// Caller should have already validated iface, so no error can occur
-		return notify.FilePermission(0), prompting_errors.NewPermissionsEmptyError(iface, availablePerms)
-	}
+	// permissions may be empty, e.g. if we're constructing allowed permissions
+	// and denying all of them.
 	filePermsMap, exists := interfaceFilePermissionsMaps[iface]
 	if !exists {
 		// Should not occur, since we already validated iface and permissions

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -1099,6 +1099,11 @@ func (s *constraintsSuite) TestAbstractPermissionsToAppArmorPermissionsHappy(c *
 	}{
 		{
 			"home",
+			[]string{},
+			notify.FilePermission(0),
+		},
+		{
+			"home",
 			[]string{"read"},
 			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_GETATTR,
 		},
@@ -1138,11 +1143,6 @@ func (s *constraintsSuite) TestAbstractPermissionsToAppArmorPermissionsUnhappy(c
 		perms  []string
 		errStr string
 	}{
-		{
-			"home",
-			[]string{},
-			"invalid permissions for home interface: permissions empty",
-		},
 		{
 			"foo",
 			[]string{"read"},


### PR DESCRIPTION
It's reasonable that one might wish to convert an empty list of abstract permissions to AppArmor permissions, such as when one is constructing an allowed permissions set where all permissions are denied.

It was incorrect to treat this as an error, and furthermore, the only current caller of `AbstractPermissionsToAppArmorPermissions` which actually uses the error value is in `requestprompts`, which logs a logger notice on an error. So we were getting false-positive errors in the journalctl log. This commit fixes that issue.

This addresses https://warthogs.atlassian.net/browse/SNAPDENG-31322
