### PR TITLE
many: abbreviate version from git by three bytes

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -200,7 +200,7 @@ jobs:
       if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-default-test
-        # eg. snapd_1337.2.65.1+git97.gd35b459_amd64.snap
+        # eg. snapd_1337.2.65.1+97.gd35b459_amd64.snap
         pattern: snapd_1337.*.snap
         path: "${{ github.workspace }}/built-snap"
 
@@ -210,7 +210,7 @@ jobs:
       with:
         name: snap-files-arm64-default-test
         pattern: snapd_1337.*.snap
-        # eg. snapd_1337.2.65.1+git97.gd35b459_amd64.snap
+        # eg. snapd_1337.2.65.1+97.gd35b459_amd64.snap
         path: "${{ github.workspace }}/built-snap"
 
     - name: Download built FIPS snap (amd64)
@@ -219,7 +219,7 @@ jobs:
       if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-FIPS-test
-        # eg. snapd_1337.2.65.1+git97.gd35b459-fips_amd64.snap
+        # eg. snapd_1337.2.65.1+97.gd35b459-fips_amd64.snap
         pattern: snapd_1337.*-fips_*.snap
         path: "${{ github.workspace }}/built-snap"
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -200,7 +200,7 @@ jobs:
       if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-default-test
-        # eg. snapd_1337.2.65.1+97.gd35b459_amd64.snap
+        # eg. snapd_1337.2.65.1+g97.d35b459_amd64.snap
         pattern: snapd_1337.*.snap
         path: "${{ github.workspace }}/built-snap"
 
@@ -210,7 +210,7 @@ jobs:
       with:
         name: snap-files-arm64-default-test
         pattern: snapd_1337.*.snap
-        # eg. snapd_1337.2.65.1+97.gd35b459_amd64.snap
+        # eg. snapd_1337.2.65.1+g97.d35b459_amd64.snap
         path: "${{ github.workspace }}/built-snap"
 
     - name: Download built FIPS snap (amd64)
@@ -219,7 +219,7 @@ jobs:
       if: "${{ !inputs.use-snapd-snap-from-master && !contains(inputs.group, '-arm64') && endsWith(inputs.group, '-fips') }}"
       with:
         name: snap-files-amd64-FIPS-test
-        # eg. snapd_1337.2.65.1+97.gd35b459-fips_amd64.snap
+        # eg. snapd_1337.2.65.1+g97.d35b459-fips_amd64.snap
         pattern: snapd_1337.*-fips_*.snap
         path: "${{ github.workspace }}/built-snap"
 

--- a/confdb/schema_test.go
+++ b/confdb/schema_test.go
@@ -753,7 +753,7 @@ func (*schemaSuite) TestStringBasedAlias(c *C) {
 		},
 		"snapd": {
 			"name": "snapd",
-			"version": "2.59.5+git948.gb447044",
+			"version": "2.59.5+948.gb447044",
 			"status": "inactive"
 		}
 	}

--- a/confdb/schema_test.go
+++ b/confdb/schema_test.go
@@ -753,7 +753,7 @@ func (*schemaSuite) TestStringBasedAlias(c *C) {
 		},
 		"snapd": {
 			"name": "snapd",
-			"version": "2.59.5+948.gb447044",
+			"version": "2.59.5+g948.b447044",
 			"status": "inactive"
 		}
 	}

--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -244,9 +244,9 @@ func (s *preseedSuite) TestChooseTargetSnapdVersion(c *C) {
 	}{
 		{
 			fromDeb:  "2.44.0",
-			fromSnap: "2.45.3+git123",
+			fromSnap: "2.45.3+123",
 			// snap version wins
-			expectedVersion: "2.45.3+git123",
+			expectedVersion: "2.45.3+123",
 			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
 		},
 		{

--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -244,9 +244,9 @@ func (s *preseedSuite) TestChooseTargetSnapdVersion(c *C) {
 	}{
 		{
 			fromDeb:  "2.44.0",
-			fromSnap: "2.45.3+123",
+			fromSnap: "2.45.3+g123",
 			// snap version wins
-			expectedVersion: "2.45.3+123",
+			expectedVersion: "2.45.3+g123",
 			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
 		},
 		{

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -48,11 +48,11 @@ if command -v git >/dev/null && [ -d "$(dirname "$0")/.git" ] ; then
     # dirty and append that last, including it here will make dirty trees 
     # directly on top of tags show up with version_from_git as 2.46-dirty which
     # will not match 2.46 from the changelog and then result in a final version
-    # like 2.46+2.46.2.46 which is silly and unhelpful
+    # like 2.46+g2.46.2.46 which is silly and unhelpful
     # tracking the dirty independently like this will produce instead 2.46-dirty
-    # for a dirty tree on top of a tag, and 2.46+83.g1671726-dirty for a
+    # for a dirty tree on top of a tag, and 2.46+g83.1671726-dirty for a
     # commit not directly on top of a tag
-    version_from_git="$(git describe --always | sed -e 's/-/+/;y/-/./' )"
+    version_from_git="$(git describe --always | sed -e  's/-/+/;y/-/./;s/\.g/g./;s/\([0-9]\+\)g/g\1/' )"
 
     # check if we are using a dirty tree
     if git describe --always --dirty | grep -q dirty; then
@@ -99,8 +99,8 @@ if [ -z "$version_from_user" ] && [ "$version_from_git" != "" ] && \
         exit 1
     else
         revno=$(git describe --always --abbrev=7|cut -d- -f2)
-        commit=$(git describe --always --abbrev=7|cut -d- -f3)
-        v="${version_from_changelog}+${revno}.${commit}"
+        commit=$(git describe --always --abbrev=7|cut -d- -f3|sed -e 's/^g//')
+        v="${version_from_changelog}+g${revno}.${commit}"
         o="changelog+git"
     fi
 fi

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -48,11 +48,11 @@ if command -v git >/dev/null && [ -d "$(dirname "$0")/.git" ] ; then
     # dirty and append that last, including it here will make dirty trees 
     # directly on top of tags show up with version_from_git as 2.46-dirty which
     # will not match 2.46 from the changelog and then result in a final version
-    # like 2.46+git2.46.2.46 which is silly and unhelpful
+    # like 2.46+2.46.2.46 which is silly and unhelpful
     # tracking the dirty independently like this will produce instead 2.46-dirty
-    # for a dirty tree on top of a tag, and 2.46+git83.g1671726-dirty for a 
+    # for a dirty tree on top of a tag, and 2.46+83.g1671726-dirty for a
     # commit not directly on top of a tag
-    version_from_git="$(git describe --always | sed -e 's/-/+git/;y/-/./' )"
+    version_from_git="$(git describe --always | sed -e 's/-/+/;y/-/./' )"
 
     # check if we are using a dirty tree
     if git describe --always --dirty | grep -q dirty; then
@@ -100,7 +100,7 @@ if [ -z "$version_from_user" ] && [ "$version_from_git" != "" ] && \
     else
         revno=$(git describe --always --abbrev=7|cut -d- -f2)
         commit=$(git describe --always --abbrev=7|cut -d- -f3)
-        v="${version_from_changelog}+git${revno}.${commit}"
+        v="${version_from_changelog}+${revno}.${commit}"
         o="changelog+git"
     fi
 fi

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1359,7 +1359,7 @@ version: 1.0
 	// the info file is needed by the Ensure() loop of snapstate manager
 	snapdSnapFiles := [][]string{
 		{"usr/lib/snapd/info", `
-VERSION=2.54.3+1.g479e745-dirty
+VERSION=2.54.3+g1.479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `},
 	}

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1359,7 +1359,7 @@ version: 1.0
 	// the info file is needed by the Ensure() loop of snapstate manager
 	snapdSnapFiles := [][]string{
 		{"usr/lib/snapd/info", `
-VERSION=2.54.3+git1.g479e745-dirty
+VERSION=2.54.3+1.g479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `},
 	}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -480,7 +480,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 
 	// commonly used core and snapd revisions in tests
 	defaultInfoFile := `
-VERSION=2.54.3+1.g479e745-dirty
+VERSION=2.54.3+g1.479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 	for _, snapName := range []string{"snapd", "core"} {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -480,7 +480,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 
 	// commonly used core and snapd revisions in tests
 	defaultInfoFile := `
-VERSION=2.54.3+git1.g479e745-dirty
+VERSION=2.54.3+1.g479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 	for _, snapName := range []string{"snapd", "core"} {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -330,7 +330,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 
 	// commonly used revisions in tests
 	defaultInfoFile := `
-VERSION=2.54.3+1.g479e745-dirty
+VERSION=2.54.3+g1.479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 	for _, snapName := range []string{"snapd", "core"} {
@@ -3540,11 +3540,11 @@ func (s *snapmgrTestSuite) testEnsureRemovesVulnerableSnap(c *C, snapName string
 	// make the currently installed snap info file fixed but an old version
 	// vulnerable
 	fixedInfoFile := `
-VERSION=2.57.6+1.g479e745-dirty
+VERSION=2.57.6+g1.479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 	vulnInfoFile := `
-VERSION=2.57.5+1.g479e745-dirty
+VERSION=2.57.5+g1.479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -330,7 +330,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 
 	// commonly used revisions in tests
 	defaultInfoFile := `
-VERSION=2.54.3+git1.g479e745-dirty
+VERSION=2.54.3+1.g479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 	for _, snapName := range []string{"snapd", "core"} {
@@ -3540,11 +3540,11 @@ func (s *snapmgrTestSuite) testEnsureRemovesVulnerableSnap(c *C, snapName string
 	// make the currently installed snap info file fixed but an old version
 	// vulnerable
 	fixedInfoFile := `
-VERSION=2.57.6+git1.g479e745-dirty
+VERSION=2.57.6+1.g479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 	vulnInfoFile := `
-VERSION=2.57.5+git1.g479e745-dirty
+VERSION=2.57.5+1.g479e745-dirty
 SNAPD_APPARMOR_REEXEC=1
 `
 

--- a/strutil/version_test.go
+++ b/strutil/version_test.go
@@ -100,7 +100,7 @@ func (s *VersionTestSuite) TestVersionCompare(c *C) {
 		// more realistic example of what we deal with in spread tests
 		// where on the left is a version from CI built snapd snap, and
 		// on the right the distro package, where snap > package
-		{"1337.2.64+81.g9b95e8c", "1337.2.64", 1, nil},
+		{"1337.2.64+g81.9b95e8c", "1337.2.64", 1, nil},
 	} {
 		res, err := strutil.VersionCompare(t.A, t.B)
 		if t.err != nil {

--- a/strutil/version_test.go
+++ b/strutil/version_test.go
@@ -100,7 +100,7 @@ func (s *VersionTestSuite) TestVersionCompare(c *C) {
 		// more realistic example of what we deal with in spread tests
 		// where on the left is a version from CI built snapd snap, and
 		// on the right the distro package, where snap > package
-		{"1337.2.64+git81.g9b95e8c", "1337.2.64", 1, nil},
+		{"1337.2.64+81.g9b95e8c", "1337.2.64", 1, nil},
 	} {
 		res, err := strutil.VersionCompare(t.A, t.B)
 		if t.err != nil {

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -16,13 +16,14 @@ execute: |
     echo "List prints core snap version"
     # all core versions will start with something like "16-2.61.4", so "[0-9]{2}-[0-9.]+"
     # with core in security maintenance it has additional date like "16-2.61.4-20240607", so optional "(-[0-9]+)?"
-    # in edge it has additional git identifier like "16-2.63+git5348.e45449bd5", so optional "(\\+git[0-9]+\\.[0-9a-f]+)?"
+    # in edge it has additional git identifier like "16-2.63+5348.e45449bd5", so optional "(\\+(git)?[0-9]+\\.[0-9a-f]+)?"
+    # In the past the word "git" was included in such version so it is retained for compatibility.
 
     # Expressions for version and revision
     NUMERIC_VERSION="[0-9]+(\.[0-9]+)*"
-    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)?" # core on  edge, beta, candidate, stable & sideload
-    CORE_STABLE_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?"                         # core on stable for SRU/PPA
-    SNAPD_GIT_VERSION="+[0-9.]+(\\+git[0-9]+\\.[0-9a-z]+)?(-dirty)?"         # snapd on edge, beta, candidate, stable, sideload & dirty
+    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?(\\+(git)?[0-9]+\\.[0-9a-f]+)?" # core on  edge, beta, candidate, stable & sideload
+    CORE_STABLE_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?"                            # core on stable for SRU/PPA
+    SNAPD_GIT_VERSION="+[0-9.]+(\\+(git)?[0-9]+\\.[0-9a-z]+)?(-dirty)?"         # snapd on edge, beta, candidate, stable, sideload & dirty
     SIDELOAD_REV="x[0-9]+"
     NUMBER_REV="[0-9]+"
 

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -16,14 +16,14 @@ execute: |
     echo "List prints core snap version"
     # all core versions will start with something like "16-2.61.4", so "[0-9]{2}-[0-9.]+"
     # with core in security maintenance it has additional date like "16-2.61.4-20240607", so optional "(-[0-9]+)?"
-    # in edge it has additional git identifier like "16-2.63+5348.e45449bd5", so optional "(\\+(git)?[0-9]+\\.[0-9a-f]+)?"
+    # in edge it has additional git identifier like "16-2.63+g5348.e45449bd5", so optional "(\\+(git|g)[0-9]+\\.[0-9a-f]+)?"
     # In the past the word "git" was included in such version so it is retained for compatibility.
 
     # Expressions for version and revision
     NUMERIC_VERSION="[0-9]+(\.[0-9]+)*"
-    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?(\\+(git)?[0-9]+\\.[0-9a-f]+)?" # core on  edge, beta, candidate, stable & sideload
-    CORE_STABLE_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?"                            # core on stable for SRU/PPA
-    SNAPD_GIT_VERSION="+[0-9.]+(\\+(git)?[0-9]+\\.[0-9a-z]+)?(-dirty)?"         # snapd on edge, beta, candidate, stable, sideload & dirty
+    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?(\\+(git|g)[0-9]+\\.[0-9a-f]+)?" # core on  edge, beta, candidate, stable & sideload
+    CORE_STABLE_VERSION="[0-9]{2}-[0-9.]+(-[0-9]+)?"                             # core on stable for SRU/PPA
+    SNAPD_GIT_VERSION="+g?[0-9.]+(\\+(git|g)?[0-9]+\\.[0-9a-z]+)?(-dirty)?"      # snapd on edge, beta, candidate, stable, sideload & dirty
     SIDELOAD_REV="x[0-9]+"
     NUMBER_REV="[0-9]+"
 


### PR DESCRIPTION
The snap ecosystem enforces a length limit on snap versions and the version of snapd, especially non-tagged versions that include git hashes and the FIPS marker, are simply too long.

Abbreviate the longest variant of the version by three bytes by dropping the word "git". This in itself should not impact sorting as the plus byte following git is retained.
