### PR TITLE
snap/squashfs: do not exclude xattrs when packing snapd snap

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -589,7 +589,11 @@ func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
 		}
 	}
 	snapType := opts.SnapType
-	if snapType != "os" && snapType != "core" && snapType != "base" {
+	switch snapType {
+	case "os", "core", "base", "snapd":
+		// -xattrs is default, but let's be explicit about it
+		cmd.Args = append(cmd.Args, "-xattrs")
+	default:
 		cmd.Args = append(cmd.Args, "-all-root", "-no-xattrs")
 	}
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -791,7 +791,7 @@ func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcard
 		// the usual:
 		"mksquashfs", ".", snapPath, "-noappend", "-comp", "xz", "-no-fragments", "-no-progress",
 		// the interesting bits:
-		"-wildcards", "-ef", "exclude1", "-ef", "exclude2", "-ef", "exclude3",
+		"-wildcards", "-ef", "exclude1", "-ef", "exclude2", "-ef", "exclude3", "-xattrs",
 	})
 }
 
@@ -864,8 +864,9 @@ func (s *SquashfsTestSuite) TestBuildVariesArgsByType(c *C) {
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	snap := squashfs.New(filename)
 
-	permissiveTypeArgs := []string{".", filename, "-noappend", "-comp", "xz", "-no-fragments", "-no-progress"}
-	restrictedTypeArgs := append(permissiveTypeArgs, "-all-root", "-no-xattrs")
+	commonTypeArgs := []string{".", filename, "-noappend", "-comp", "xz", "-no-fragments", "-no-progress"}
+	permissiveTypeArgs := append(commonTypeArgs, "-xattrs")
+	restrictedTypeArgs := append(commonTypeArgs, "-all-root", "-no-xattrs")
 	tests := []struct {
 		snapType string
 		args     []string
@@ -874,7 +875,7 @@ func (s *SquashfsTestSuite) TestBuildVariesArgsByType(c *C) {
 		{"app", restrictedTypeArgs},
 		{"gadget", restrictedTypeArgs},
 		{"kernel", restrictedTypeArgs},
-		{"snapd", restrictedTypeArgs},
+		{"snapd", permissiveTypeArgs},
 		{"base", permissiveTypeArgs},
 		{"os", permissiveTypeArgs},
 		{"core", permissiveTypeArgs},


### PR DESCRIPTION
Do not exclude xattrs when packing the snapd snap. The xattrs need to be preserved in order to support non-setuid snap-confine work.

Related: [SNAPDENG-34240](https://warthogs.atlassian.net/browse/SNAPDENG-34240)


[SNAPDENG-23251]: https://warthogs.atlassian.net/browse/SNAPDENG-23251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNAPDENG-34240]: https://warthogs.atlassian.net/browse/SNAPDENG-34240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ