### PR TITLE
interfaces: add configfiles backend

### DIFF
--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -22,6 +22,7 @@ package backends
 import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -76,6 +77,7 @@ func All() []interfaces.SecurityBackend {
 		&kmod.Backend{},
 		&polkit.Backend{},
 		&ldconfig.Backend{},
+		&configfiles.Backend{},
 	)
 
 	// TODO use something like:

--- a/interfaces/configfiles/backend.go
+++ b/interfaces/configfiles/backend.go
@@ -1,0 +1,150 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// configfiles is a backend that ensures that configuration files required by
+// interfaces are present in the system. Currently it works only on classic and
+// modifies the classic rootfs.
+package configfiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/timings"
+)
+
+// Backend is responsible for maintaining configfiles cache.
+type Backend struct{}
+
+var _ = interfaces.SecurityBackend(&Backend{})
+
+// Initialize does nothing for this backend.
+func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
+	return nil
+}
+
+// Name returns the name of the backend.
+func (b *Backend) Name() interfaces.SecuritySystem {
+	return "configfiles"
+}
+
+// Setup will make the configfiles backend generate the specified
+// configuration files.
+//
+// If the method fails it should be re-tried (with a sensible strategy) by the caller.
+func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
+	cfgPatterns := []string{}
+	for _, iface := range repo.AllInterfaces() {
+		if cfgIface, ok := iface.(interfaces.ConfigfilesUser); ok {
+			cfgPatterns = append(cfgPatterns, cfgIface.PathPatterns()...)
+		}
+	}
+	snapName := appSet.InstanceName()
+	// Get the snippets that apply to this snap
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
+	if err != nil {
+		return fmt.Errorf("cannot obtain configfiles specification for snap %q: %s",
+			snapName, err)
+	}
+
+	return b.ensureConfigfiles(spec.(*Specification), cfgPatterns)
+}
+
+// Remove removes modules configfiles files specific to a given snap.
+// This method should be called after removing a snap.
+//
+// If the method fails it should be re-tried (with a sensible strategy) by the caller.
+func (b *Backend) Remove(snapName string) error {
+	// If called for the system (snapd) snap, that is possible only in a
+	// classic scenario when all other snaps in the system must have been
+	// removed already to allow the removal of the snapd snap. In that
+	// case, the config files will have already been removed by a Setup
+	// call, so we do not need to do anything here.
+
+	// TODO but this needs to be revisited for when we start supporting
+	// configfiles plugs in snaps.
+	return nil
+}
+
+// NewSpecification returns a new specification associated with this backend.
+func (b *Backend) NewSpecification(*interfaces.SnapAppSet,
+	interfaces.ConfinementOptions) interfaces.Specification {
+	return &Specification{}
+}
+
+// SandboxFeatures returns the list of features supported by snapd for configfiles.
+func (b *Backend) SandboxFeatures() []string {
+	return []string{"mediated-configfiles"}
+}
+
+func (b *Backend) ensureConfigfiles(spec *Specification, cfgPatterns []string) error {
+	// Configuration files are created only if the files in the spec match
+	// the patterns registered by interfaces.
+	writtenPaths := make(map[string]bool, len(spec.pathContent))
+	for path := range spec.pathContent {
+		writtenPaths[path] = false
+	}
+	// TODO supported patterns apply currently only to a classic rootfs,
+	// not to the rootfs of a snap. For the latter, the paths will be
+	// relative to a directory in /var/lib/snapd/configfiles/<snap_name>/.
+	// Files in there would be bind mounted so they can be seen by the
+	// snap.
+	for _, pattern := range cfgPatterns {
+		matched := map[string]osutil.FileState{}
+		for path, fileState := range spec.pathContent {
+			match, err := filepath.Match(pattern, path)
+			if err != nil {
+				return fmt.Errorf("internal error in configfiles: %w", err)
+			}
+			if !match {
+				continue
+			}
+			matched[filepath.Base(path)] = fileState
+			writtenPaths[path] = true
+		}
+		targetDir := filepath.Dir(pattern)
+		if len(matched) > 0 {
+			if err := os.MkdirAll(targetDir, 0755); err != nil {
+				return fmt.Errorf("cannot create directory %q: %v", targetDir, err)
+			}
+		}
+		// Note that this still needs to run if there are no matches, to remove files
+		if _, _, err := osutil.EnsureDirState(targetDir,
+			filepath.Base(pattern), matched); err != nil {
+			return fmt.Errorf("cannot ensure state for %s files: %w", pattern, err)
+		}
+	}
+
+	notMatched := []string{}
+	for path, written := range writtenPaths {
+		if written {
+			continue
+		}
+		notMatched = append(notMatched, path)
+	}
+	if len(notMatched) > 0 {
+		return fmt.Errorf("internal error: %v not in any registered configfiles pattern",
+			notMatched)
+	}
+
+	return nil
+}

--- a/interfaces/configfiles/backend_test.go
+++ b/interfaces/configfiles/backend_test.go
@@ -1,0 +1,297 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configfiles_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type backendSuite struct {
+	Backend         interfaces.SecurityBackend
+	Repo            *interfaces.Repository
+	RootDir         string
+	restoreSanitize func()
+
+	testutil.BaseTest
+}
+
+func (s *backendSuite) SetUpTest(c *C) {
+	// Isolate this test to a temporary directory
+	s.RootDir = c.MkDir()
+	dirs.SetRootDir(s.RootDir)
+
+	// Create a fresh repository for each test
+	s.Repo = interfaces.NewRepository()
+
+	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+
+	s.Backend = &configfiles.Backend{}
+	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
+}
+
+func (s *backendSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+	s.restoreSanitize()
+}
+
+var _ = Suite(&backendSuite{})
+
+func (s *backendSuite) TestName(c *C) {
+	c.Check(s.Backend.Name(), Equals, interfaces.SecurityConfigfiles)
+}
+
+func (s *backendSuite) mockSlot(c *C, yaml string, slotName string) (*interfaces.SnapAppSet, *snap.SlotInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	if slotInfo, ok := info.Slots[slotName]; ok {
+		return set, slotInfo
+	}
+	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
+}
+
+func (s *backendSuite) mockPlugs(c *C, yaml string, plugNames []string) (*interfaces.SnapAppSet, []*snap.PlugInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	plugInfos := make([]*snap.PlugInfo, 0, len(plugNames))
+	for _, plug := range plugNames {
+		if plugInfo, ok := info.Plugs[plug]; ok {
+			plugInfos = append(plugInfos, plugInfo)
+			continue
+		}
+		panic(fmt.Sprintf("cannot find plug %q in snap %q", plug, info.InstanceName()))
+	}
+	return set, plugInfos
+}
+
+const eglProvider1 = `name: egl1
+version: 0
+type: app
+slots:
+  egl-driver-libs:
+`
+
+const eglProvider2 = `name: egl2
+version: 0
+type: app
+slots:
+  egl-driver-libs:
+`
+
+const otherProvider = `name: other
+version: 0
+type: app
+slots:
+  other-driver-libs:
+`
+
+const eglConsumer = `name: snapd
+version: 0
+type: snapd
+apps:
+  app:
+    plugs: [egl-driver-libs, other-driver-libs]
+`
+
+func checkConfigfilesFile(c *C, path, content string) {
+	c.Assert(filepath.Join(dirs.GlobalRootDir, path), testutil.FileEquals, content)
+}
+
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"mediated-configfiles"})
+}
+
+func (s *backendSuite) TestConnectDisconnect(c *C) {
+	// Add callback and register the interface
+	iface := &ifacetest.TestConfigFilesInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "egl-driver-libs",
+			ConfigfilesConnectedPlugCallback: func(spec *configfiles.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				switch slot.Snap().InstanceName() {
+				case "egl1":
+					spec.AddPathContent(
+						filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.conf"),
+						&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655})
+				case "egl2":
+					spec.AddPathContent(
+						filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.b.conf"),
+						&osutil.MemoryFileState{Content: []byte("bbbb"), Mode: 0655})
+				}
+				return nil
+			},
+		},
+		PathPatternsCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.*.conf")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface), IsNil)
+
+	// Mock plug/slots
+	appSet, plugInfos := s.mockPlugs(c, eglConsumer, []string{"egl-driver-libs"})
+	_, slotInfo1 := s.mockSlot(c, eglProvider1, "egl-driver-libs")
+	_, slotInfo2 := s.mockSlot(c, eglProvider2, "egl-driver-libs")
+
+	// Connect them
+	connRef1 := interfaces.NewConnRef(plugInfos[0], slotInfo1)
+	_, err := s.Repo.Connect(connRef1, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	connRef2 := interfaces.NewConnRef(plugInfos[0], slotInfo2)
+	_, err = s.Repo.Connect(connRef2, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Set-up the backend
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), IsNil)
+
+	checkConfigfilesFile(c, "/etc/conf1.d/snap.a.conf", "aaaa")
+	checkConfigfilesFile(c, "/etc/conf1.d/snap.b.conf", "bbbb")
+
+	// Now disconnect the first slot and set-up backends again
+	c.Assert(s.Repo.Disconnect(plugInfos[0].Snap.InstanceName(), plugInfos[0].Name,
+		slotInfo1.Snap.InstanceName(), slotInfo1.Name), IsNil)
+	s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil)
+
+	// Only files for the connected slots are around
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.conf"), testutil.FileAbsent)
+	checkConfigfilesFile(c, "/etc/conf1.d/snap.b.conf", "bbbb")
+}
+
+func (s *backendSuite) TestTwoPlugs(c *C) {
+	// Add interfaces
+	iface1 := &ifacetest.TestConfigFilesInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "egl-driver-libs",
+			ConfigfilesConnectedPlugCallback: func(spec *configfiles.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				spec.AddPathContent(
+					filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.conf"),
+					&osutil.MemoryFileState{Content: []byte("a"), Mode: 0655})
+				return nil
+			},
+		},
+		PathPatternsCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.*.conf")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface1), IsNil)
+	iface2 := &ifacetest.TestConfigFilesInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "other-driver-libs",
+			ConfigfilesConnectedPlugCallback: func(spec *configfiles.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				spec.AddPathContent(
+					filepath.Join(dirs.GlobalRootDir, "/etc/conf2.d/snap.a.conf"),
+					&osutil.MemoryFileState{Content: []byte("a"), Mode: 0655})
+				return nil
+			},
+		},
+		PathPatternsCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/etc/conf2.d/snap.*.conf")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface2), IsNil)
+
+	// Mock plugs/slots
+	appSet, plugInfos := s.mockPlugs(c, eglConsumer, []string{"egl-driver-libs", "other-driver-libs"})
+	_, slotInfo1 := s.mockSlot(c, eglProvider1, "egl-driver-libs")
+	_, slotInfo2 := s.mockSlot(c, otherProvider, "other-driver-libs")
+
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), IsNil)
+
+	// Connect them
+	connRef1 := interfaces.NewConnRef(plugInfos[0], slotInfo1)
+	_, err := s.Repo.Connect(connRef1, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	connRef2 := interfaces.NewConnRef(plugInfos[1], slotInfo2)
+	_, err = s.Repo.Connect(connRef2, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Set-up the backend
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), IsNil)
+
+	checkConfigfilesFile(c, "/etc/conf1.d/snap.a.conf", "a")
+	checkConfigfilesFile(c, "/etc/conf2.d/snap.a.conf", "a")
+
+	// Now disconnect the first slot and set-up backends again
+	c.Assert(s.Repo.Disconnect(plugInfos[0].Snap.InstanceName(), plugInfos[0].Name,
+		slotInfo1.Snap.InstanceName(), slotInfo1.Name), IsNil)
+	s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil)
+
+	// Only files for the connected slots are around
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.conf"), testutil.FileAbsent)
+	checkConfigfilesFile(c, "/etc/conf2.d/snap.a.conf", "a")
+}
+
+func (s *backendSuite) TestUnmatchedPattern(c *C) {
+	// Add callback and register the interface
+	iface := &ifacetest.TestConfigFilesInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "egl-driver-libs",
+			ConfigfilesConnectedPlugCallback: func(spec *configfiles.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				spec.AddPathContent(filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.txt"),
+					&osutil.MemoryFileState{Content: []byte("a"), Mode: 0655})
+				return nil
+			},
+		},
+		PathPatternsCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.*.conf")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface), IsNil)
+
+	// Mock plug/slots
+	appSet, plugInfos := s.mockPlugs(c, eglConsumer, []string{"egl-driver-libs"})
+	_, slotInfo1 := s.mockSlot(c, eglProvider1, "egl-driver-libs")
+
+	// Connect
+	connRef1 := interfaces.NewConnRef(plugInfos[0], slotInfo1)
+	_, err := s.Repo.Connect(connRef1, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Set-up the backend
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), ErrorMatches,
+		`internal error: .*/etc/conf1.d/snap.a.txt\] not in any registered configfiles pattern`)
+
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/a.txt"), testutil.FileAbsent)
+}

--- a/interfaces/configfiles/export_test.go
+++ b/interfaces/configfiles/export_test.go
@@ -1,0 +1,26 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configfiles
+
+import "github.com/snapcore/snapd/osutil"
+
+func (spec *Specification) PathContent() map[string]osutil.FileState {
+	return spec.pathContent
+}

--- a/interfaces/configfiles/spec.go
+++ b/interfaces/configfiles/spec.go
@@ -1,0 +1,121 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configfiles
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+)
+
+// Specification assists in collecting paths and content associated with an
+// interface.
+//
+// Unlike the Backend itself (which is stateless and non-persistent) this type
+// holds internal state that is used by the configfiles backend during the
+// interface setup process.
+type Specification struct {
+	// pathContent is a map from file paths (relative to the root directory
+	// seen by the snap) to their expected content/permissions expressed as
+	// a osutil.FileState.
+	pathContent map[string]osutil.FileState
+}
+
+// Methods called by interfaces
+
+// AddPathContent adds a configuration file with its content to the specification.
+func (spec *Specification) AddPathContent(path string, state osutil.FileState) error {
+	// The interfaces must specify a clean path (this also enforces
+	// non-slash terminated path - we do not allow directories).
+	if path != filepath.Clean(path) {
+		return fmt.Errorf("configfiles internal error: unclean path: %q", path)
+	}
+	// Only support absolute paths
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("configfiles internal error: relative paths not supported: %q", path)
+	}
+	if spec.pathContent == nil {
+		spec.pathContent = make(map[string]osutil.FileState)
+	}
+	if _, ok := spec.pathContent[path]; ok {
+		return fmt.Errorf("configfiles internal error: already managed path: %q", path)
+	}
+	spec.pathContent[path] = state
+	return nil
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// AddConnectedPlug records configfiles-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	type definer interface {
+		ConfigfilesConnectedPlug(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		if !interfaces.IsTheSystemSnap(plug.Snap().InstanceName()) {
+			return errors.New("internal error: configfiles plugs can be defined only by the system snap")
+		}
+		return iface.ConfigfilesConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records configfiles-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	type definer interface {
+		ConfigfilesConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		if !interfaces.IsTheSystemSnap(plug.Snap().InstanceName()) {
+			return errors.New("internal error: configfiles plugs can be defined only by the system snap")
+		}
+		return iface.ConfigfilesConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records configfiles-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *snap.PlugInfo) error {
+	type definer interface {
+		ConfigfilesPermanentPlug(spec *Specification, plug *snap.PlugInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		if !interfaces.IsTheSystemSnap(plug.Snap.InstanceName()) {
+			return errors.New("internal error: configfiles plugs can be defined only by the system snap")
+		}
+		return iface.ConfigfilesPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records configfiles-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *snap.SlotInfo) error {
+	type definer interface {
+		ConfigfilesPermanentSlot(spec *Specification, slot *snap.SlotInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.ConfigfilesPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/configfiles/spec_test.go
+++ b/interfaces/configfiles/spec_test.go
@@ -1,0 +1,150 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configfiles_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+)
+
+type specSuite struct {
+	spec     *configfiles.Specification
+	iface1   *ifacetest.TestInterface
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+}
+
+var _ = Suite(&specSuite{
+	iface1: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		ConfigfilesConnectedPlugCallback: func(spec *configfiles.Specification,
+			plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			spec.AddPathContent("/etc/conf1.d/a.conf",
+				&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655})
+			return nil
+		},
+		ConfigfilesConnectedSlotCallback: func(spec *configfiles.Specification,
+			plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			spec.AddPathContent("/etc/conf2.d/b.conf",
+				&osutil.MemoryFileState{Content: []byte("bbbb"), Mode: 0655})
+			return nil
+		},
+		ConfigfilesPermanentPlugCallback: func(spec *configfiles.Specification,
+			plug *snap.PlugInfo) error {
+			spec.AddPathContent("/etc/conf3.d/c.conf",
+				&osutil.MemoryFileState{Content: []byte("cccc"), Mode: 0655})
+			return nil
+		},
+		ConfigfilesPermanentSlotCallback: func(spec *configfiles.Specification,
+			slot *snap.SlotInfo) error {
+			spec.AddPathContent("/etc/conf4.d/d.conf",
+				&osutil.MemoryFileState{Content: []byte("dddd"), Mode: 0655})
+			return nil
+		},
+	},
+})
+
+func (s *specSuite) SetUpTest(c *C) {
+	s.spec = &configfiles.Specification{}
+	const plugYaml = `name: snapd
+version: 1
+apps:
+  app:
+    plugs: [name]
+`
+	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
+
+	const slotYaml = `name: snap
+version: 1
+slots:
+  name:
+    interface: test
+`
+	s.slot, s.slotInfo = ifacetest.MockConnectedSlot(c, slotYaml, nil, "name")
+}
+
+// The configfiles.Specification can be used through the interfaces.Specification interface
+func (s *specSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(s.spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		"/etc/conf1.d/a.conf": &osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655},
+	})
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(s.spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		"/etc/conf1.d/a.conf": &osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655},
+		"/etc/conf2.d/b.conf": &osutil.MemoryFileState{Content: []byte("bbbb"), Mode: 0655},
+	})
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), IsNil)
+	c.Assert(s.spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		"/etc/conf1.d/a.conf": &osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655},
+		"/etc/conf2.d/b.conf": &osutil.MemoryFileState{Content: []byte("bbbb"), Mode: 0655},
+		"/etc/conf3.d/c.conf": &osutil.MemoryFileState{Content: []byte("cccc"), Mode: 0655},
+	})
+	c.Assert(r.AddPermanentSlot(s.iface1, s.slotInfo), IsNil)
+	c.Assert(s.spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		"/etc/conf1.d/a.conf": &osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655},
+		"/etc/conf2.d/b.conf": &osutil.MemoryFileState{Content: []byte("bbbb"), Mode: 0655},
+		"/etc/conf3.d/c.conf": &osutil.MemoryFileState{Content: []byte("cccc"), Mode: 0655},
+		"/etc/conf4.d/d.conf": &osutil.MemoryFileState{Content: []byte("dddd"), Mode: 0655},
+	})
+}
+
+func (s *specSuite) TestPlugNotFromSystem(c *C) {
+	const plugYaml = `name: notsystem
+version: 1
+apps:
+  app:
+    plugs: [name]
+`
+	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
+
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), ErrorMatches,
+		"internal error: configfiles plugs can be defined only by the system snap")
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), ErrorMatches,
+		"internal error: configfiles plugs can be defined only by the system snap")
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), ErrorMatches,
+		"internal error: configfiles plugs can be defined only by the system snap")
+}
+
+func (s *specSuite) TestAddPathContentErrors(c *C) {
+	c.Check(s.spec.AddPathContent("/../conf/snap.name.conf",
+		&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655}), ErrorMatches,
+		`configfiles internal error: unclean path: "/../conf/snap.name.conf"`)
+	c.Check(s.spec.AddPathContent("/etc/conf/",
+		&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655}), ErrorMatches,
+		`configfiles internal error: unclean path: "/etc/conf/"`)
+	c.Check(s.spec.AddPathContent("../etc/conf/snap.name.conf",
+		&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655}), ErrorMatches,
+		`configfiles internal error: relative paths not supported: "../etc/conf/snap.name.conf"`)
+	c.Check(s.spec.AddPathContent("/etc/conf/snap.name.conf",
+		&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655}), IsNil)
+	c.Check(s.spec.AddPathContent("/etc/conf/snap.name.conf",
+		&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655}), ErrorMatches,
+		`configfiles internal error: already managed path: "/etc/conf/snap.name.conf"`)
+}

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -202,6 +202,20 @@ type SlotSanitizer interface {
 	BeforePrepareSlot(slot *snap.SlotInfo) error
 }
 
+// ConfigfilesUser must be implemented by Interfaces that use the configfiles backend.
+type ConfigfilesUser interface {
+	// PathPatterns is a list of globs for files that are under control of
+	// the interface. These globs apply to either the rootfs or to the
+	// mount namespace of a snap (TODO). AddPathContent from the backend is
+	// called to add files that match the pattern and that must be created.
+	// Other matching files will be removed if found.
+	//
+	// TODO it is possible that we might want to use different paths in the
+	// classic rootfs and in the mount namespace of a snap so the string
+	// could evolve to a type with path + rootfs type.
+	PathPatterns() []string
+}
+
 // StaticInfo describes various static-info of a given interface.
 //
 // The Summary must be a one-line string of length suitable for listing views.
@@ -312,6 +326,8 @@ const (
 	SecurityPolkit SecuritySystem = "polkit"
 	// SecurityLdconfig identifies the ldconfig security system.
 	SecurityLdconfig SecuritySystem = "ldconfig"
+	// SecurityConfigfiles identifies the configfiles security system.
+	SecurityConfigfiles SecuritySystem = "configfiles"
 )
 
 var isValidBusName = regexp.MustCompile(`^[a-zA-Z_-][a-zA-Z0-9_-]*(\.[a-zA-Z_-][a-zA-Z0-9_-]*)+$`).MatchString

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -22,6 +22,7 @@ package ifacetest
 import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/hotplug"
 	"github.com/snapcore/snapd/interfaces/kmod"
@@ -56,6 +57,13 @@ type TestInterface struct {
 	TestConnectedSlotCallback func(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
 	TestPermanentPlugCallback func(spec *Specification, plug *snap.PlugInfo) error
 	TestPermanentSlotCallback func(spec *Specification, slot *snap.SlotInfo) error
+
+	// Support for interacting with the configfiles backend.
+
+	ConfigfilesConnectedPlugCallback func(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	ConfigfilesConnectedSlotCallback func(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	ConfigfilesPermanentPlugCallback func(spec *configfiles.Specification, plug *snap.PlugInfo) error
+	ConfigfilesPermanentSlotCallback func(spec *configfiles.Specification, slot *snap.SlotInfo) error
 
 	// Support for interacting with the mount backend.
 
@@ -131,6 +139,15 @@ type TestHotplugInterface struct {
 	HotplugKeyCallback            func(deviceInfo *hotplug.HotplugDeviceInfo) (snap.HotplugKey, error)
 	HandledByGadgetCallback       func(deviceInfo *hotplug.HotplugDeviceInfo, slot *snap.SlotInfo) bool
 	HotplugDeviceDetectedCallback func(deviceInfo *hotplug.HotplugDeviceInfo) (*hotplug.ProposedSlot, error)
+}
+
+// TestConfigFilesInterface is used to test the configfiles backend,
+// which needs interfaces implementing ConfigfilesUser.
+type TestConfigFilesInterface struct {
+	TestInterface
+
+	// Support for interacting with configfiles backend.
+	PathPatternsCallback func() []string
 }
 
 // String() returns the same value as Name().
@@ -213,6 +230,36 @@ func (t *TestInterface) TestPermanentPlug(spec *Specification, plug *snap.PlugIn
 func (t *TestInterface) TestPermanentSlot(spec *Specification, slot *snap.SlotInfo) error {
 	if t.TestPermanentSlotCallback != nil {
 		return t.TestPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+// Support for interacting with the configfiles backend.
+
+func (t *TestInterface) ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if t.ConfigfilesConnectedPlugCallback != nil {
+		return t.ConfigfilesConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) ConfigfilesConnectedSlot(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if t.ConfigfilesConnectedSlotCallback != nil {
+		return t.ConfigfilesConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) ConfigfilesPermanentPlug(spec *configfiles.Specification, plug *snap.PlugInfo) error {
+	if t.ConfigfilesPermanentPlugCallback != nil {
+		return t.ConfigfilesPermanentPlugCallback(spec, plug)
+	}
+	return nil
+}
+
+func (t *TestInterface) ConfigfilesPermanentSlot(spec *configfiles.Specification, slot *snap.SlotInfo) error {
+	if t.ConfigfilesPermanentSlotCallback != nil {
+		return t.ConfigfilesPermanentSlotCallback(spec, slot)
 	}
 	return nil
 }
@@ -509,4 +556,13 @@ func (t *TestHotplugInterface) HandledByGadget(deviceInfo *hotplug.HotplugDevice
 		return t.HandledByGadgetCallback(deviceInfo, slot)
 	}
 	return false
+}
+
+// Support for interacting with configfiles backend.
+
+func (t *TestConfigFilesInterface) PathPatterns() []string {
+	if t.PathPatternsCallback != nil {
+		return t.PathPatternsCallback()
+	}
+	return nil
 }


### PR DESCRIPTION
The configfiles backend ensures the state of configuration files in the filesystem. Interfaces using it must provide a list of globs with the files that are under their control.

For the moment, only classic systems are supported (we write the configuration files in the rootfs). In the future, doing similar changes in the mount namespace of the application might be implemented.