### PR TITLE
tests: skip confdb-cross-config on debian11

### DIFF
--- a/tests/main/confdb-cross-config/task.yaml
+++ b/tests/main/confdb-cross-config/task.yaml
@@ -4,8 +4,10 @@ details: |
   Check that we can configure confdbs across snaps and that the appropriate
   hooks are invoked.
 
-# the test snaps have a core24 base
-systems: [ -ubuntu-16.04 ]
+# the test snaps have a core24 base not supported on 16.04.
+# This conflicts with other tests on debian11 in a way that breaks snap-confine
+# (which this test runs many times due the hook calls).
+systems: [ -ubuntu-16.04, -debian-11-64 ]
 
 prepare: |
   snap set system experimental.confdbs=true


### PR DESCRIPTION
This test sometimes fails due to snap-confine issues when running after a specific set of tests (see https://warthogs.atlassian.net/browse/SNAPDENG-34356). I haven't been able to debug it yet but it doesn't happen if run by itself, on another system or even with a different set of sets running before, so it's likely not a confdb issue. I'm disabling this for debian11 while I debug it further so it doesn't impact other work.