### PR TITLE
i/builtin: allow fwupd access to shim/fallback shim

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -126,6 +126,10 @@ const fwupdPermanentSlotAppArmor = `
   /boot/efi/{,**/} r,
   # allow access to fwupd* and fw/ under boot/ for core systems
   /boot/efi/EFI/*/fwupd*.efi* rw,
+  # allow access to the shim and fallback shim
+  /boot/efi/EFI/*/shim*.efi* r,
+  /boot/efi/EFI/BOOT/BOOT*.EFI r,
+  /boot/efi/EFI/*/grub*.efi* r,
   /boot/efi/EFI/*/ rw,
   /boot/efi/EFI/*/fw/ rw,
   /boot/efi/EFI/*/fw/** rw,


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
