### PR TITLE
tests: move nested tests to its own job

### DIFF
--- a/.github/workflows/non-fundamental-systems.json
+++ b/.github/workflows/non-fundamental-systems.json
@@ -97,34 +97,6 @@
         "systems": "ubuntu-fips-22.04-64",
         "tasks": "tests/fips/...",
         "rules": "fips"
-      },
-      {
-        "group": "nested-ubuntu-18.04",
-        "backend": "google-nested",
-        "systems": "ubuntu-18.04-64",
-        "tasks": "tests/nested/...",
-        "rules": "nested"
-      },
-      {
-        "group": "nested-ubuntu-20.04",
-        "backend": "google-nested",
-        "systems": "ubuntu-20.04-64",
-        "tasks": "tests/nested/...",
-        "rules": "nested"
-      },
-      {
-        "group": "nested-ubuntu-22.04",
-        "backend": "google-nested",
-        "systems": "ubuntu-22.04-64",
-        "tasks": "tests/nested/...",
-        "rules": "nested"
-      },
-      {
-        "group": "nested-ubuntu-24.04",
-        "backend": "google-nested",
-        "systems": "ubuntu-24.04-64",
-        "tasks": "tests/nested/...",
-        "rules": "nested"
       }
     ]
   }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -369,6 +369,51 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}
 
+  spread-nested:
+    uses: ./.github/workflows/spread-tests.yaml
+    needs: [unit-tests, snap-builds]
+    name: "spread ${{ matrix.group }}"
+    with:
+      # Github doesn't support passing sequences as parameters.
+      # Instead here we create a json array and pass it as a string.
+      # Then in the spread workflow it turns it into a sequence 
+      # using the fromJSON expression.
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: ${{ matrix.tasks }}
+      rules: ${{ matrix.rules }}
+    strategy:
+      # FIXME: enable fail-fast mode once spread can cancel an executing job.
+      # Disable fail-fast mode as it doesn't function with spread. It seems
+      # that cancelling tasks requires short, interruptible actions and
+      # interrupting spread, notably, does not work today. As such disable
+      # fail-fast while we tackle that problem upstream.
+      fail-fast: false
+      matrix:
+        include:
+          - group: nested-ubuntu-18.04
+            backend: google-nested
+            systems: 'ubuntu-18.04-64'
+            tasks: 'tests/nested/...'
+            rules: 'nested'
+          - group: nested-ubuntu-20.04
+            backend: google-nested
+            systems: 'ubuntu-20.04-64'
+            tasks: 'tests/nested/...'
+            rules: 'nested'
+          - group: nested-ubuntu-22.04
+            backend: google-nested
+            systems: 'ubuntu-22.04-64'
+            tasks: 'tests/nested/...'
+            rules: 'nested'
+          - group: nested-ubuntu-24.04
+            backend: google-nested
+            systems: 'ubuntu-24.04-64'
+            tasks: 'tests/nested/...'
+            rules: 'nested'
+
 
   # The spread-results-reporter needs the PR number to be able to 
   # comment on the relevant PR with spread failures. Because the PR 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -380,10 +380,10 @@ jobs:
       # using the fromJSON expression.
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
-      backend: ${{ matrix.backend }}
+      backend: 'google-nested'
       systems: ${{ matrix.systems }}
-      tasks: ${{ matrix.tasks }}
-      rules: ${{ matrix.rules }}
+      tasks: 'tests/nested/...'
+      rules: 'nested'
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems
@@ -394,25 +394,13 @@ jobs:
       matrix:
         include:
           - group: nested-ubuntu-18.04
-            backend: google-nested
             systems: 'ubuntu-18.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
           - group: nested-ubuntu-20.04
-            backend: google-nested
             systems: 'ubuntu-20.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
           - group: nested-ubuntu-22.04
-            backend: google-nested
             systems: 'ubuntu-22.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
           - group: nested-ubuntu-24.04
-            backend: google-nested
             systems: 'ubuntu-24.04-64'
-            tasks: 'tests/nested/...'
-            rules: 'nested'
 
 
   # The spread-results-reporter needs the PR number to be able to 


### PR DESCRIPTION
Moves nested tests outside of the fundamental/non-fundamental systems division to run parallel to fundamental systems