### PR TITLE
store: add functions to download snap icons

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -42,6 +42,8 @@ var (
 	ApiURL        = apiURL
 	Download      = download
 
+	DownloadIconImpl = downloadIcon
+
 	ApplyDelta = applyDelta
 
 	AuthLocation      = authLocation
@@ -147,6 +149,10 @@ func MockDownload(f func(ctx context.Context, name, sha3_384, downloadURL string
 	return func() {
 		download = origDownload
 	}
+}
+
+func MockDownloadIcon(f func(ctx context.Context, name, downloadURL string, w io.ReadWriteSeeker) error) (restore func()) {
+	return testutil.Mock(&downloadIcon, f)
 }
 
 func MockDoDownloadReq(f func(ctx context.Context, storeURL *url.URL, cdnHeader string, resume int64, s *Store, user *auth.UserState) (*http.Response, error)) (restore func()) {

--- a/store/store.go
+++ b/store/store.go
@@ -766,6 +766,31 @@ func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *
 	}
 }
 
+func doIconRequest(ctx context.Context, client *http.Client, reqOptions *requestOptions) (*http.Response, error) {
+	var body io.Reader // empty body
+	req, err := http.NewRequest(reqOptions.Method, reqOptions.URL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	if reqOptions.ContentType != "" {
+		req.Header.Set("Content-Type", reqOptions.ContentType)
+	}
+	for header, value := range reqOptions.ExtraHeaders {
+		req.Header.Set(header, value)
+	}
+
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, err
+}
+
 func (s *Store) buildLocationString() (string, error) {
 	if s.dauthCtx == nil {
 		return "", nil


### PR DESCRIPTION
These new functions, `downloadIconImpl` and `DownloadIcon`, mirror their non-icon counterparts `downloadImpl` and `Download`, except that because snap icons are small, simple assets on a fileserver, there is no need for snap-specific headers, authentication, partial downloads, or caching.

These will be used in the future in order to download a snap's icon whenever the new `.snap` blob is downloaded for that snap and linked to a snap icons directory so that the snapd API can serve snap icons from local icon files, rather than returning an error if the snap does not ship an icon at `meta/gui/icon.*`.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34095
