### PR TITLE
daemon: rename confdb API to /v2/confdbs/...

### DIFF
--- a/client/confdb.go
+++ b/client/confdb.go
@@ -31,7 +31,7 @@ func (c *Client) ConfdbGetViaView(viewID string, requests []string) (result map[
 	query := url.Values{}
 	query.Add("fields", strings.Join(requests, ","))
 
-	endpoint := fmt.Sprintf("/v2/confdbs/%s", viewID)
+	endpoint := fmt.Sprintf("/v2/confdb/%s", viewID)
 	_, err = c.doSync("GET", endpoint, query, nil, nil, &result)
 	if err != nil {
 		return nil, err
@@ -49,6 +49,6 @@ func (c *Client) ConfdbSetViaView(viewID string, requestValues map[string]interf
 	headers := make(map[string]string)
 	headers["Content-Type"] = "application/json"
 
-	endpoint := fmt.Sprintf("/v2/confdbs/%s", viewID)
+	endpoint := fmt.Sprintf("/v2/confdb/%s", viewID)
 	return c.doAsync("PUT", endpoint, nil, headers, bytes.NewReader(body))
 }

--- a/client/confdb_test.go
+++ b/client/confdb_test.go
@@ -35,7 +35,7 @@ func (cs *clientSuite) TestConfdbGet(c *C) {
 	c.Check(res, DeepEquals, map[string]interface{}{"foo": "baz", "bar": json.Number("1")})
 	c.Assert(cs.reqs, HasLen, 1)
 	c.Check(cs.reqs[0].Method, Equals, "GET")
-	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/confdbs/a/b/c")
+	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/confdb/a/b/c")
 	c.Check(cs.reqs[0].URL.Query(), DeepEquals, url.Values{"fields": []string{"foo,bar"}})
 }
 
@@ -49,7 +49,7 @@ func (cs *clientSuite) TestConfdbSet(c *C) {
 	c.Assert(cs.reqs, HasLen, 1)
 	c.Check(cs.reqs[0].Method, Equals, "PUT")
 	c.Check(cs.reqs[0].Header.Get("Content-Type"), Equals, "application/json")
-	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/confdbs/a/b/c")
+	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/confdb/a/b/c")
 	data, err := io.ReadAll(cs.reqs[0].Body)
 	c.Assert(err, IsNil)
 

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -246,7 +246,7 @@ func (s *confdbSuite) TestConfdbGet(c *C) {
 		switch reqs {
 		case 0:
 			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Path, Equals, "/v2/confdbs/foo/bar/baz")
+			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
@@ -283,7 +283,7 @@ func (s *confdbSuite) TestConfdbGetAsDocument(c *C) {
 		switch reqs {
 		case 0:
 			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Path, Equals, "/v2/confdbs/foo/bar/baz")
+			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
@@ -324,7 +324,7 @@ func (s *confdbSuite) TestConfdbGetMany(c *C) {
 		switch reqs {
 		case 0:
 			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Path, Equals, "/v2/confdbs/foo/bar/baz")
+			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
@@ -365,7 +365,7 @@ func (s *confdbSuite) TestConfdbGetManyAsDocument(c *C) {
 		switch reqs {
 		case 0:
 			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Path, Equals, "/v2/confdbs/foo/bar/baz")
+			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
@@ -431,7 +431,7 @@ func (s *confdbSuite) TestConfdbGetNoFields(c *check.C) {
 		switch reqs {
 		case 0:
 			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Path, Equals, "/v2/confdbs/foo/bar/baz")
+			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			fields := r.URL.Query().Get("fields")
 			c.Check(fields, Equals, "")

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -205,7 +205,7 @@ func (s *confdbSuite) mockConfdbServer(c *check.C, expectedRequest string, nowai
 		switch reqs {
 		case 0:
 			c.Check(r.Method, check.Equals, "PUT")
-			c.Check(r.URL.Path, check.Equals, "/v2/confdbs/foo/bar/baz")
+			c.Check(r.URL.Path, check.Equals, "/v2/confdb/foo/bar/baz")
 			c.Check(r.URL.Query(), check.HasLen, 0)
 
 			raw, err := io.ReadAll(r.Body)

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	confdbCmd = &Command{
-		Path:        "/v2/confdbs/{account}/{confdb}/{view}",
+		Path:        "/v2/confdb/{account}/{confdb}/{view}",
 		GET:         getView,
 		PUT:         setView,
 		ReadAccess:  authenticatedAccess{Polkit: polkitActionManage},

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -99,7 +99,7 @@ func (s *confdbSuite) TestGetView(c *C) {
 
 			return map[string]interface{}{"ssid": t.value}, nil
 		})
-		req, err := http.NewRequest("GET", "/v2/confdbs/system/network/wifi-setup?fields=ssid", nil)
+		req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid", nil)
 		c.Assert(err, IsNil, cmt)
 
 		rspe := s.syncReq(c, req, nil)
@@ -127,7 +127,7 @@ func (s *confdbSuite) TestViewGetMany(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/system/network/wifi-setup?fields=ssid,password", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid,password", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.syncReq(c, req, nil)
@@ -152,7 +152,7 @@ func (s *confdbSuite) TestViewGetSomeFieldNotFound(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/system/network/wifi-setup?fields=ssid,password", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid,password", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.syncReq(c, req, nil)
@@ -177,7 +177,7 @@ func (s *confdbSuite) TestGetViewNoFieldsFound(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/system/network/wifi-setup?fields=ssid,password", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid,password", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.errorReq(c, req, nil)
@@ -193,7 +193,7 @@ func (s *confdbSuite) TestViewGetDatabagNotFound(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/foo/network/wifi-setup?fields=ssid", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/foo/network/wifi-setup?fields=ssid", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.errorReq(c, req, nil)
@@ -241,7 +241,7 @@ func (s *confdbSuite) TestViewSetMany(c *C) {
 	defer restore()
 
 	buf := bytes.NewBufferString(`{"ssid": "foo", "password": "bar"}`)
-	req, err := http.NewRequest("PUT", "/v2/confdbs/system/network/wifi-setup", buf)
+	req, err := http.NewRequest("PUT", "/v2/confdb/system/network/wifi-setup", buf)
 	c.Assert(err, IsNil)
 
 	rspe := s.asyncReq(c, req, nil)
@@ -279,7 +279,7 @@ func (s *confdbSuite) TestGetViewError(c *C) {
 			return nil, t.err
 		})
 
-		req, err := http.NewRequest("GET", "/v2/confdbs/system/network/wifi-setup?fields=ssid", nil)
+		req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid", nil)
 		c.Assert(err, IsNil, Commentf("%s test", t.name))
 
 		rspe := s.errorReq(c, req, nil)
@@ -306,7 +306,7 @@ func (s *confdbSuite) TestGetViewMisshapenQuery(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/system/network/wifi-setup?fields=,foo.bar,,[1].foo,foo,", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=,foo.bar,,[1].foo,foo,", nil)
 	c.Assert(err, IsNil)
 
 	rsp := s.syncReq(c, req, nil)
@@ -365,7 +365,7 @@ func (s *confdbSuite) TestSetView(c *C) {
 		c.Check(err, IsNil, cmt)
 
 		buf := bytes.NewBufferString(fmt.Sprintf(`{"ssid": %s}`, jsonVal))
-		req, err := http.NewRequest("PUT", "/v2/confdbs/system/network/wifi-setup", buf)
+		req, err := http.NewRequest("PUT", "/v2/confdb/system/network/wifi-setup", buf)
 		c.Check(err, IsNil, cmt)
 		req.Header.Set("Content-Type", "application/json")
 
@@ -421,7 +421,7 @@ func (s *confdbSuite) TestUnsetView(c *C) {
 	defer restore()
 
 	buf := bytes.NewBufferString(`{"ssid": null}`)
-	req, err := http.NewRequest("PUT", "/v2/confdbs/system/network/wifi-setup", buf)
+	req, err := http.NewRequest("PUT", "/v2/confdb/system/network/wifi-setup", buf)
 	c.Check(err, IsNil)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -469,7 +469,7 @@ func (s *confdbSuite) TestSetViewError(c *C) {
 		cmt := Commentf("%s test", t.name)
 
 		buf := bytes.NewBufferString(`{"ssid": "foo"}`)
-		req, err := http.NewRequest("PUT", "/v2/confdbs/system/network/wifi-setup", buf)
+		req, err := http.NewRequest("PUT", "/v2/confdb/system/network/wifi-setup", buf)
 		c.Assert(err, IsNil, cmt)
 		req.Header.Set("Content-Type", "application/json")
 
@@ -505,7 +505,7 @@ func (s *confdbSuite) TestSetViewBadRequests(c *C) {
 	}
 
 	for _, tc := range tcs {
-		req, err := http.NewRequest("PUT", "/v2/confdbs/system/network/wifi-setup", tc.body)
+		req, err := http.NewRequest("PUT", "/v2/confdb/system/network/wifi-setup", tc.body)
 		req.Header.Set("Content-Type", "application/json")
 		c.Assert(err, IsNil)
 
@@ -530,7 +530,7 @@ func (s *confdbSuite) TestGetBadRequest(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/acc/db/foo?fields=foo", &bytes.Buffer{})
+	req, err := http.NewRequest("GET", "/v2/confdb/acc/db/foo?fields=foo", &bytes.Buffer{})
 	c.Assert(err, IsNil)
 
 	rspe := s.errorReq(c, req, nil)
@@ -557,7 +557,7 @@ func (s *confdbSuite) TestSetBadRequest(c *C) {
 	defer restore()
 
 	buf := bytes.NewBufferString(`{"a.b.c": "foo"}`)
-	req, err := http.NewRequest("PUT", "/v2/confdbs/acc/db/foo", buf)
+	req, err := http.NewRequest("PUT", "/v2/confdb/acc/db/foo", buf)
 	req.Header.Set("Content-Type", "application/json")
 	c.Assert(err, IsNil)
 
@@ -577,7 +577,7 @@ func (s *confdbSuite) TestSetFailUnsetFeatureFlag(c *C) {
 	defer restore()
 
 	buf := bytes.NewBufferString(`{"a.b.c": "foo"}`)
-	req, err := http.NewRequest("PUT", "/v2/confdbs/acc/db/foo", buf)
+	req, err := http.NewRequest("PUT", "/v2/confdb/acc/db/foo", buf)
 	req.Header.Set("Content-Type", "application/json")
 	c.Assert(err, IsNil)
 
@@ -595,7 +595,7 @@ func (s *confdbSuite) TestGetFailUnsetFeatureFlag(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/acc/db/foo?fields=my-field", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/acc/db/foo?fields=my-field", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.errorReq(c, req, nil)
@@ -614,7 +614,7 @@ func (s *confdbSuite) TestGetNoFields(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdbs/acc/db/foo", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/acc/db/foo", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.syncReq(c, req, nil)


### PR DESCRIPTION
This reverts commit 8a2f81ece5bfe15e79d541138aaa6a6aed19d9db to make the confdb API singular to give the impression of accessing a single configuration database.