### PR TITLE
tests/main/document-interfaces-url: exclude missing checkbox-support

### DIFF
--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -49,6 +49,9 @@ execute: |
     exclusion_map["confdb"]="2025/03"
     # we're actually missing this page but can't add it yet due to the same Discourse issues
     exclusion_map["nomad-support"]="2024/12"
+    # need to add https://snapcraft.io/docs/checkbox-support-interface
+    # as well as a link to it on https://snapcraft.io/docs/supported-interfaces
+    exclusion_map["checkbox-support"]="2025/03"
 
     # If the interface is in the exclusion_map and it is currently sooner
     # than its specified expiration date, then return true


### PR DESCRIPTION
Expected documentation https://snapcraft.io/docs/checkbox-support-interface does not exist. Exclude this from the test until 2025/03 to provide sufficient time to put it in place.