### PR TITLE
packaging/snapd.mk: drop randomized build ID generation

### DIFF
--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -72,7 +72,7 @@ $(builddir)/snap: GO_TAGS += nomanagers
 $(builddir)/snap $(builddir)/snap-seccomp $(builddir)/snapd-apparmor:
 	go build -o $@ $(if $(GO_TAGS),-tags "$(GO_TAGS)") \
 		-buildmode=pie \
-		-ldflags="-B 0x$$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') $(EXTRA_GO_LDFLAGS)" \
+		-ldflags="$(EXTRA_GO_LDFLAGS)" \
 		-mod=vendor \
 		$(EXTRA_GO_BUILD_FLAGS) \
 		$(import_path)/cmd/$(notdir $@)
@@ -94,7 +94,7 @@ $(builddir)/snap-update-ns $(builddir)/snap-exec $(builddir)/snapctl:
 # suite to add test assertions. Do not enable this in distribution packages.
 $(builddir)/snapd:
 	go build -o $@ -buildmode=pie \
-		-ldflags="-B 0x$$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') $(EXTRA_GO_LDFLAGS)" \
+		-ldflags="$(EXTRA_GO_LDFLAGS)" \
 		-mod=vendor \
 		$(if $(GO_TAGS),-tags "$(GO_TAGS)") \
 		$(EXTRA_GO_BUILD_FLAGS) \


### PR DESCRIPTION
Drop randomized build ID enforced by snapd.mk. Let the downstream distributions decide the best setting for that.

Cherry picked a downstream patch from https://github.com/canonical/snapd/pull/14472 which we carry in https://build.opensuse.org/package/show/system:snappy/snapd