### PR TITLE
o/snapstate: download/link/unlink/discard snap icons in snapstate handlers

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -96,6 +96,8 @@ var (
 	SnapSectionsFile    string
 	SnapCommandsDB      string
 	SnapAuxStoreInfoDir string
+	SnapIconsPoolDir    string
+	SnapIconsDir        string
 
 	SnapBinariesDir        string
 	SnapServicesDir        string
@@ -512,6 +514,8 @@ func SetRootDir(rootdir string) {
 	SnapSectionsFile = filepath.Join(SnapCacheDir, "sections")
 	SnapCommandsDB = filepath.Join(SnapCacheDir, "commands.db")
 	SnapAuxStoreInfoDir = filepath.Join(SnapCacheDir, "aux")
+	SnapIconsPoolDir = filepath.Join(SnapCacheDir, "icons-pool")
+	SnapIconsDir = filepath.Join(SnapCacheDir, "icons")
 
 	SnapSeedDir = SnapSeedDirUnder(rootdir)
 	SnapDeviceDir = SnapDeviceDirUnder(rootdir)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1075,7 +1075,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 		hit := strings.Replace(hitTemplate, "@URL@", baseURL.String()+"/api/v1/snaps/download/"+name+"/"+revno, -1)
 		hit = strings.Replace(hit, "@NAME@", name, -1)
 		hit = strings.Replace(hit, "@SNAPID@", fakeSnapID(name), -1)
-		hit = strings.Replace(hit, "@ICON@", baseURL.String()+"/icon", -1)
+		hit = strings.Replace(hit, "@ICON@", baseURL.String()+"/v2/icons/"+name+"/icon", -1)
 		hit = strings.Replace(hit, "@VERSION@", info.Version, -1)
 		hit = strings.Replace(hit, "@REVISION@", revno, -1)
 		hit = strings.Replace(hit, `@TYPE@`, string(info.Type()), -1)
@@ -1116,6 +1116,10 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 			if comps[2] == "assertions" {
 				// preserve "assertions" component
 				comps = comps[2:]
+			} else if comps[2] == "icons" {
+				// we're fetching the snap icon, just write some stand-in data
+				w.Write([]byte("icon contents"))
+				return
 			} else {
 				// drop common "snap" component
 				comps = comps[3:]

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -352,6 +352,10 @@ var (
 	DiscardSnapIcon      = discardSnapIcon
 )
 
+func MockStoreDownloadIcon(f func(ctx context.Context, name, targetPath, downloadURL string) error) (restore func()) {
+	return testutil.Mock(&storeDownloadIcon, f)
+}
+
 // link, misc handlers
 var (
 	MissingDisabledServices = missingDisabledServices

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -343,6 +343,15 @@ var (
 type AuxStoreInfo = auxStoreInfo
 type DisabledServices = disabledServices
 
+// snap icon helpers
+var (
+	IconDownloadFilename = iconDownloadFilename
+	IconInstallFilename  = iconInstallFilename
+	LinkSnapIcon         = linkSnapIcon
+	UnlinkSnapIcon       = unlinkSnapIcon
+	DiscardSnapIcon      = discardSnapIcon
+)
+
 // link, misc handlers
 var (
 	MissingDisabledServices = missingDisabledServices

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2448,10 +2448,15 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 			}()
 		}
 
-		if err := linkSnapIcon(cand.Snap.SnapID); err != nil {
+		if e := linkSnapIcon(cand.Snap.SnapID); e != nil {
+			// XXX: careful, if the error variable is `err` here, it'll be used
+			// in the check for `IsErrAndNotWait(err)` in the `else`, which
+			// means the real error will not be checked. Need to use new local
+			// variable explicitly.
+
 			// The snap icon may not exist in the icons pool, or another error
 			// occurred. This does not block the install, just log the error.
-			logger.Debugf("%v", err)
+			logger.Debugf("%v", e)
 		} else {
 			defer func() {
 				if IsErrAndNotWait(err) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -717,6 +717,8 @@ func downloadSnapParams(st *state.State, t *state.Task) (*SnapSetup, StoreServic
 	return snapsup, sto, user, nil
 }
 
+var storeDownloadIcon = store.DownloadIcon
+
 func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	st := t.State()
 	var rate int64
@@ -789,7 +791,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 				logger.Debugf("cannot download snap icon for %q: no icon URL", snapsup.SnapName())
 				return
 			}
-			if iconErr := store.DownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
+			if iconErr := storeDownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
 				logger.Debugf("cannot download snap icon for %q: %#v", snapsup.SnapName(), iconErr)
 			}
 		})
@@ -806,7 +808,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 				logger.Debugf("cannot download snap icon for %q: no icon URL", snapsup.SnapName())
 				return
 			}
-			if iconErr := store.DownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
+			if iconErr := storeDownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
 				logger.Debugf("cannot download snap icon for %q: %#v", snapsup.SnapName(), iconErr)
 			}
 		})

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3865,20 +3865,22 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 			return fmt.Errorf("cannot remove snap directory: %v", err)
 		}
 
-		// try to remove the auxiliary store info
-		if err := discardAuxStoreInfo(snapsup.SideInfo.SnapID); err != nil {
-			logger.Noticef("Cannot remove auxiliary store info for %q: %v", snapsup.InstanceName(), err)
-		}
+		if !otherInstances {
+			// try to remove the auxiliary store info
+			if err := discardAuxStoreInfo(snapsup.SideInfo.SnapID); err != nil {
+				logger.Noticef("Cannot remove auxiliary store info for %q: %v", snapsup.InstanceName(), err)
+			}
 
-		// try to remove the linked snap icon, if it exists
-		if err := unlinkSnapIcon(snapsup.SideInfo.SnapID); err != nil {
-			// icon not existing will not result in an error
-			logger.Noticef("cannot remove snap icon for %q: %v", snapsup.InstanceName(), err)
-		}
-		// also try to remove the icon from icons-pool, if it exists
-		if err := discardSnapIcon(snapsup.SideInfo.SnapID); err != nil {
-			// icon not existing will not result in an error
-			logger.Noticef("cannot remove downloaded icon for %q: %v", snapsup.InstanceName(), err)
+			// try to remove the linked snap icon, if it exists
+			if err := unlinkSnapIcon(snapsup.SideInfo.SnapID); err != nil {
+				// icon not existing will not result in an error
+				logger.Noticef("cannot remove snap icon for %q: %v", snapsup.InstanceName(), err)
+			}
+			// also try to remove the icon from icons-pool, if it exists
+			if err := discardSnapIcon(snapsup.SideInfo.SnapID); err != nil {
+				// icon not existing will not result in an error
+				logger.Noticef("cannot remove downloaded icon for %q: %v", snapsup.InstanceName(), err)
+			}
 		}
 
 		// XXX: also remove sequence files?

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -656,19 +656,6 @@ func (m *SnapManager) doPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	// TODO: add some telemetry here that reports the snaps that were being set
 	// up
-
-	// XXX: should discardSnapIcon() be called here, since this is the undo
-	// handler for doDownloadSnap? Or should doDownloadSnap get a new undo
-	// handler which calls discardSnapIcon() and then calls this function
-	// (undoPrepareSnap)? If either of these happens, discardSnapIcon should
-	// only be called if there is no revision of the snap otherwise present on
-	// the system, otherwise we end up removing the downloaded icon for a snap
-	// which is still present on the system, and on the next snap revert, the
-	// attempt to link the icon to the icons directory will fail, leaving the
-	// snap with no icon.
-	// XXX: or is doDiscardSnap (instead of undoPrepareSnap) responsible for
-	// removing snaps which were previously downloaded (and may or may not have
-	// been successfully installed), and thus can clean up the snap icon as well?
 	return nil
 }
 

--- a/overlord/snapstate/icon.go
+++ b/overlord/snapstate/icon.go
@@ -61,6 +61,7 @@ func linkSnapIcon(snapID string) error {
 	poolPath := iconDownloadFilename(snapID)
 	installPath := iconInstallFilename(snapID)
 	if err := os.Link(poolPath, installPath); err != nil {
+		// XXX: os.Link() will error if installPath already exists
 		return fmt.Errorf("cannot link snap icon for snap %s: %w", snapID, err)
 	}
 	return nil

--- a/overlord/snapstate/icon.go
+++ b/overlord/snapstate/icon.go
@@ -1,0 +1,87 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+// iconDownloadFilename returns the filepath of the icon in the icons pool
+// directory for the given snap ID.
+func iconDownloadFilename(snapID string) string {
+	if snapID == "" {
+		return ""
+	}
+	return filepath.Join(dirs.SnapIconsPoolDir, fmt.Sprintf("%s.icon", snapID))
+}
+
+// iconInstallFilename returns the filepath of the icon in the icons directory
+// for the given snap ID. This is where the icon should be hard-linked from the
+// iconDownloadFilename when the snap is installed on the system.
+func iconInstallFilename(snapID string) string {
+	if snapID == "" {
+		return ""
+	}
+	return filepath.Join(dirs.SnapIconsDir, fmt.Sprintf("%s.icon", snapID))
+}
+
+// linkSnapIcon creates a hardlink from the downloaded icons pool to the icons
+// directory for the given snap ID.
+func linkSnapIcon(snapID string) error {
+	if snapID == "" {
+		return nil
+	}
+	poolPath := iconDownloadFilename(snapID)
+	installPath := iconInstallFilename(snapID)
+	if err := os.Link(poolPath, installPath); err != nil {
+		return fmt.Errorf("cannot link snap icon for snap %s: %w", snapID, err)
+	}
+	return nil
+}
+
+// unlinkSnapIcon removes the hardlink from the downloaded icons pool to the
+// icons directory for the given snap ID.
+func unlinkSnapIcon(snapID string) error {
+	if snapID == "" {
+		return nil
+	}
+	if err := os.Remove(iconInstallFilename(snapID)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("cannot unlink snap icon for snap %s: %w", snapID, err)
+	}
+	return nil
+}
+
+// discardSnapIcon removes the icon for the given snap from the downloaded icons
+// pool.
+func discardSnapIcon(snapID string) error {
+	if snapID == "" {
+		return nil
+	}
+	if err := os.Remove(iconDownloadFilename(snapID)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("cannot remove snap icon from pool for snap %s: %v", snapID, err)
+	}
+	return nil
+}

--- a/overlord/snapstate/icon.go
+++ b/overlord/snapstate/icon.go
@@ -54,6 +54,10 @@ func linkSnapIcon(snapID string) error {
 	if snapID == "" {
 		return nil
 	}
+	if err := os.MkdirAll(dirs.SnapIconsDir, 0o755); err != nil {
+		return fmt.Errorf("cannot create directory for snap icons: %v", err)
+	}
+
 	poolPath := iconDownloadFilename(snapID)
 	installPath := iconInstallFilename(snapID)
 	if err := os.Link(poolPath, installPath); err != nil {

--- a/overlord/snapstate/icon.go
+++ b/overlord/snapstate/icon.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 // iconDownloadFilename returns the filepath of the icon in the icons pool
@@ -60,8 +61,12 @@ func linkSnapIcon(snapID string) error {
 
 	poolPath := iconDownloadFilename(snapID)
 	installPath := iconInstallFilename(snapID)
-	if err := os.Link(poolPath, installPath); err != nil {
-		// XXX: os.Link() will error if installPath already exists
+
+	if !osutil.FileExists(poolPath) {
+		return fmt.Errorf("cannot link snap icon for snap %s: icon does not exist in the icons pool", snapID)
+	}
+
+	if err := osutil.AtomicLink(poolPath, installPath); err != nil {
 		return fmt.Errorf("cannot link snap icon for snap %s: %w", snapID, err)
 	}
 	return nil

--- a/overlord/snapstate/icon_test.go
+++ b/overlord/snapstate/icon_test.go
@@ -76,29 +76,33 @@ func (s *iconSuite) TestSnapIconLinkUnlinkDiscardPermutations(c *C) {
 		},
 		{
 			functions:                []func(string) error{snapstate.UnlinkSnapIcon, snapstate.DiscardSnapIcon, snapstate.LinkSnapIcon},
-			expectedErrors:           []string{"", "", ".*no such file or directory"},
+			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons pool"},
 			poolIconExistsAfter:      []bool{true, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
 		{
 			functions:                []func(string) error{snapstate.DiscardSnapIcon, snapstate.LinkSnapIcon, snapstate.UnlinkSnapIcon},
-			expectedErrors:           []string{"", ".*no such file or directory", ""},
+			expectedErrors:           []string{"", "cannot link snap icon for snap .*: icon does not exist in the icons pool", ""},
 			poolIconExistsAfter:      []bool{false, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
 		{
 			functions:                []func(string) error{snapstate.DiscardSnapIcon, snapstate.UnlinkSnapIcon, snapstate.LinkSnapIcon},
-			expectedErrors:           []string{"", "", ".*no such file or directory"},
+			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons pool"},
 			poolIconExistsAfter:      []bool{false, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
-		// calling linkSnapIcon when the icon is already linked is an error
-		// XXX: should this be reconsidered? And if so, how to do it atomically?
 		{
-			functions:                []func(string) error{snapstate.LinkSnapIcon, snapstate.LinkSnapIcon},
-			expectedErrors:           []string{"", "cannot link snap icon .*: file exists"},
-			poolIconExistsAfter:      []bool{true, true},
-			installedIconExistsAfter: []bool{true, true},
+			functions:                []func(string) error{snapstate.LinkSnapIcon, snapstate.LinkSnapIcon, snapstate.UnlinkSnapIcon, snapstate.DiscardSnapIcon},
+			expectedErrors:           []string{"", "", "", ""},
+			poolIconExistsAfter:      []bool{true, true, true, false},
+			installedIconExistsAfter: []bool{true, true, false, false},
+		},
+		{
+			functions:                []func(string) error{snapstate.LinkSnapIcon, snapstate.DiscardSnapIcon, snapstate.LinkSnapIcon},
+			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons pool"},
+			poolIconExistsAfter:      []bool{true, false, false},
+			installedIconExistsAfter: []bool{true, true, true},
 		},
 	} {
 		// consistency check on the test case itself

--- a/overlord/snapstate/icon_test.go
+++ b/overlord/snapstate/icon_test.go
@@ -76,21 +76,29 @@ func (s *iconSuite) TestSnapIconLinkUnlinkDiscardPermutations(c *C) {
 		},
 		{
 			functions:                []func(string) error{snapstate.UnlinkSnapIcon, snapstate.DiscardSnapIcon, snapstate.LinkSnapIcon},
-			expectedErrors:           []string{"", "", ".*no such file or directory"}, // TODO: fix
+			expectedErrors:           []string{"", "", ".*no such file or directory"},
 			poolIconExistsAfter:      []bool{true, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
 		{
 			functions:                []func(string) error{snapstate.DiscardSnapIcon, snapstate.LinkSnapIcon, snapstate.UnlinkSnapIcon},
-			expectedErrors:           []string{"", ".*no such file or directory", ""}, // TODO: fix
+			expectedErrors:           []string{"", ".*no such file or directory", ""},
 			poolIconExistsAfter:      []bool{false, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
 		{
 			functions:                []func(string) error{snapstate.DiscardSnapIcon, snapstate.UnlinkSnapIcon, snapstate.LinkSnapIcon},
-			expectedErrors:           []string{"", "", ".*no such file or directory"}, // TODO: fix
+			expectedErrors:           []string{"", "", ".*no such file or directory"},
 			poolIconExistsAfter:      []bool{false, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
+		},
+		// calling linkSnapIcon when the icon is already linked is an error
+		// XXX: should this be reconsidered? And if so, how to do it atomically?
+		{
+			functions:                []func(string) error{snapstate.LinkSnapIcon, snapstate.LinkSnapIcon},
+			expectedErrors:           []string{"", "cannot link snap icon .*: file exists"},
+			poolIconExistsAfter:      []bool{true, true},
+			installedIconExistsAfter: []bool{true, true},
 		},
 	} {
 		// consistency check on the test case itself

--- a/overlord/snapstate/icon_test.go
+++ b/overlord/snapstate/icon_test.go
@@ -1,0 +1,121 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate"
+)
+
+type iconSuite struct{}
+
+var _ = Suite(&iconSuite{})
+
+func (s *iconSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *iconSuite) TestIconDownloadFilename(c *C) {
+	filename := snapstate.IconDownloadFilename("some-snap-id")
+	c.Check(filename, Equals, filepath.Join(dirs.SnapIconsPoolDir, "some-snap-id.icon"))
+}
+
+func (s *iconSuite) TestIconInstallFilename(c *C) {
+	filename := snapstate.IconInstallFilename("some-snap-id")
+	c.Check(filename, Equals, filepath.Join(dirs.SnapIconsDir, "some-snap-id.icon"))
+}
+
+func (s *iconSuite) TestSnapIconLinkUnlinkDiscardPermutations(c *C) {
+	for i, testCase := range []struct {
+		functions                []func(snapID string) error
+		expectedErrors           []string
+		poolIconExistsAfter      []bool
+		installedIconExistsAfter []bool
+	}{
+		{
+			functions:                []func(string) error{snapstate.LinkSnapIcon, snapstate.UnlinkSnapIcon, snapstate.DiscardSnapIcon},
+			expectedErrors:           []string{"", "", ""},
+			poolIconExistsAfter:      []bool{true, true, false},
+			installedIconExistsAfter: []bool{true, false, false},
+		},
+		{
+			functions:                []func(string) error{snapstate.LinkSnapIcon, snapstate.DiscardSnapIcon, snapstate.UnlinkSnapIcon},
+			expectedErrors:           []string{"", "", ""},
+			poolIconExistsAfter:      []bool{true, false, false},
+			installedIconExistsAfter: []bool{true, true, false},
+		},
+		{
+			functions:                []func(string) error{snapstate.UnlinkSnapIcon, snapstate.LinkSnapIcon, snapstate.DiscardSnapIcon},
+			expectedErrors:           []string{"", "", ""},
+			poolIconExistsAfter:      []bool{true, true, false},
+			installedIconExistsAfter: []bool{false, true, true},
+		},
+		{
+			functions:                []func(string) error{snapstate.UnlinkSnapIcon, snapstate.DiscardSnapIcon, snapstate.LinkSnapIcon},
+			expectedErrors:           []string{"", "", ".*no such file or directory"}, // TODO: fix
+			poolIconExistsAfter:      []bool{true, false, false},
+			installedIconExistsAfter: []bool{false, false, false},
+		},
+		{
+			functions:                []func(string) error{snapstate.DiscardSnapIcon, snapstate.LinkSnapIcon, snapstate.UnlinkSnapIcon},
+			expectedErrors:           []string{"", ".*no such file or directory", ""}, // TODO: fix
+			poolIconExistsAfter:      []bool{false, false, false},
+			installedIconExistsAfter: []bool{false, false, false},
+		},
+		{
+			functions:                []func(string) error{snapstate.DiscardSnapIcon, snapstate.UnlinkSnapIcon, snapstate.LinkSnapIcon},
+			expectedErrors:           []string{"", "", ".*no such file or directory"}, // TODO: fix
+			poolIconExistsAfter:      []bool{false, false, false},
+			installedIconExistsAfter: []bool{false, false, false},
+		},
+	} {
+		// consistency check on the test case itself
+		c.Assert(testCase.functions, HasLen, len(testCase.expectedErrors))
+		c.Assert(testCase.functions, HasLen, len(testCase.poolIconExistsAfter))
+		c.Assert(testCase.functions, HasLen, len(testCase.installedIconExistsAfter))
+
+		snapID := fmt.Sprintf("some-snap-id-%d", i)
+		poolIconPath := snapstate.IconDownloadFilename(snapID)
+		installedIconPath := snapstate.IconInstallFilename(snapID)
+
+		// create the initial snap icon in the icon pool directory
+		c.Assert(os.MkdirAll(dirs.SnapIconsPoolDir, 0o755), IsNil)
+		fileContents := []byte("image data")
+		c.Assert(os.WriteFile(poolIconPath, fileContents, 0o644), IsNil)
+
+		for step, f := range testCase.functions {
+			err := f(snapID)
+			if errStr := testCase.expectedErrors[step]; errStr != "" {
+				c.Check(err, ErrorMatches, errStr, Commentf("test case %d, step %d", i, step))
+			} else {
+				c.Check(err, IsNil, Commentf("test case %d, step %d", i, step))
+			}
+			c.Check(osutil.FileExists(poolIconPath), Equals, testCase.poolIconExistsAfter[step], Commentf("test case %d, step %d", i, step))
+			c.Check(osutil.FileExists(installedIconPath), Equals, testCase.installedIconExistsAfter[step], Commentf("test case %d, step %d", i, step))
+		}
+	}
+}


### PR DESCRIPTION
This PR is based on #14990 and also depends on #15019, #15040, and #15050, and will be rewritten to be based on #15051.

During the "download-snap" task, download the snap icon as well.
    
During "link-snap" and "unlink-snap", link/unlink the snap icon from the downloaded icons pool to the the installed icons directory, managed much the same way is snap auxinfo. This is because snap icons, like auxinfo, are not revision-specific. Instead, they reflect the current state of the snap listing in the snap store.
    
Lastly, discard the downloaded snap icon when the final revision of the snap is discarded from disk. We want to ensure that the snap icon remains in the pool during any situation when it's possible to install the snap without doing another "download-snap" task, such as via a revert.

This PR is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34436