### PR TITLE
spread: drop Fedora 39

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -220,9 +220,6 @@ backends:
                   storage: 12G
                   workers: 6
 
-            - fedora-39-64:
-                  workers: 6
-
             - amazon-linux-2-64:
                   workers: 6
                   storage: preserve-size


### PR DESCRIPTION
Fedora 39 has reached EOL in Nov 2024.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
