### PR TITLE
o/devicestate, tests: setup bind mount from /run/mnt/ubuntu-seed to /var/lib/snapd/seed on hybrid system install

### DIFF
--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -423,7 +423,7 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 			Name:             "pc-kernel",
 			Revision:         snap.R(1),
 			MountPoint:       kernelMountDir,
-			IsCore:           false,
+			IsCore:           !opts.installClassic,
 			ModulesComps:     modulesComps,
 			NeedsDriversTree: true,
 		})

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1076,13 +1076,9 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 
 	snapInfos := systemAndSnaps.InfosByType
 	snapSeeds := systemAndSnaps.SeedSnapsByType
-	deviceCtx, err := DeviceCtx(st, t, nil)
-	if err != nil {
-		return fmt.Errorf("cannot get device context: %v", err)
-	}
 
 	// Find out kernel-modules components in the seed
-	isCore := !deviceCtx.Classic()
+	isCore := !systemAndSnaps.Model.Classic()
 	kBootInfo := kBootInfo(systemAndSnaps, kernMntPoint, mntPtForComps, isCore)
 
 	logger.Debugf("writing content to partitions")

--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -567,14 +567,17 @@ func run(seedLabel, bootDevice, rootfsCreator, optionalInstallPath string) error
 	if err != nil {
 		return fmt.Errorf("cannot create filesystems: %v", err)
 	}
-	if !isCore {
+
+	if isCore {
+		if err := copySeedToDataPartition(); err != nil {
+			return fmt.Errorf("cannot create seed on data partition: %v", err)
+		}
+	} else {
 		if err := createClassicRootfsIfNeeded(rootfsCreator); err != nil {
 			return fmt.Errorf("cannot create classic rootfs: %v", err)
 		}
 	}
-	if err := copySeedToDataPartition(); err != nil {
-		return fmt.Errorf("cannot create seed on data partition: %v", err)
-	}
+
 	if err := unmountFilesystems(mntPts); err != nil {
 		return fmt.Errorf("cannot unmount filesystems: %v", err)
 	}

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -56,7 +56,6 @@ run_muinstaller() {
         ./classic-seed
 
     mv ./classic-seed/system-seed/systems/* "./classic-seed/system-seed/systems/${label}"
-    cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
     if [ -n "${store_dir}" ]; then
         # if we have a store setup, then we should take it down for now

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -329,6 +329,13 @@ execute: |
   echo "asserted snaps"
   remote.exec "ls /run/mnt/ubuntu-seed/snaps"
 
+  # on hybrid systems, we bind mount the seed from the mount that is set up by
+  # snap-bootstrap (/run/mnt/ubuntu-seed) to /var/lib/snapd/seed. we inject the
+  # systemd mount unit for the bind mount at install time, during the
+  # "install-finish" task.
+  test "$(remote.exec "findmnt /run/mnt/ubuntu-seed/ -o source -n")" = "$(remote.exec "findmnt /var/lib/snapd/seed -o source -n")"
+  remote.exec "systemctl is-active var-lib-snapd-seed.mount"
+
   # check for unasserted snaps
   for sn in pc pc-kernel snapd; do
       sn_version=$(remote.exec "snap list ${sn}" | awk 'NR != 1 { print $2 }' | sed 's/+fake1//')


### PR DESCRIPTION
Hybrid systems might not have this mountpoint setup in the pre-existing rootfs. Here, this change makes it so when we install a hybrid system and copy the seed over, we also install and enable a mount unit that will bind mount `/run/mnt/ubuntu-seed` (which is mounted in the initramfs) to `/var/lib/snapd/seed`.