### PR TITLE
i/default: allow owner read on @{PROC}/@{pid}/fdinfo/*

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -266,6 +266,7 @@ var templateCommon = `
   owner @{PROC}/@{pid}/cgroup rk,
   @{PROC}/@{pid}/cpuset r,
   @{PROC}/@{pid}/io r,
+  owner @{PROC}/@{pid}/fdinfo/* r,
   owner @{PROC}/@{pid}/limits r,
   owner @{PROC}/@{pid}/loginuid r,
   owner @{PROC}/@{pid}/sessionid r,


### PR DESCRIPTION
This is used by newer Mesa for GPU accounting.