### PR TITLE
osutil/chattr.go: avoid possible garbage collection of unsafe pointer

### DIFF
--- a/osutil/chattr.go
+++ b/osutil/chattr.go
@@ -54,8 +54,7 @@ const (
 )
 
 func ioctl(f *os.File, request uintptr, attrp *int32) error {
-	argp := uintptr(unsafe.Pointer(attrp))
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), request, argp)
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), request, uintptr(unsafe.Pointer(attrp)))
 	if errno != 0 {
 		return os.NewSyscallError("ioctl", errno)
 	}


### PR DESCRIPTION
Documentation for `unsafe.Pointer` explicitly mentions that uintptr cannot be stored in variable before implicit conversion back to Pointer during system call.

https://pkg.go.dev/unsafe#Pointer
> (4) Conversion of a Pointer to a uintptr when calling functions like [syscall.Syscall](https://pkg.go.dev/syscall#Syscall).
> 
> The Syscall functions in package syscall pass their uintptr arguments directly to the operating system, which then may, depending on the details of the call, reinterpret some of them as pointers. That is, the system call implementation is implicitly converting certain arguments back from uintptr to pointer.
>
> If a pointer argument must be converted to uintptr for use as an argument, that conversion must appear in the call expression itself:
> 
> syscall.Syscall(SYS_READ, uintptr(fd), uintptr(unsafe.Pointer(p)), uintptr(n))
> 
> The compiler handles a Pointer converted to a uintptr in the argument list of a call to a function implemented in assembly by arranging that the referenced allocated object, if any, is retained and not moved until the call completes, even though from the types alone it would appear that the object is no longer needed during the call.
> 
> For the compiler to recognize this pattern, the conversion must appear in the argument list:
> 
> // INVALID: uintptr cannot be stored in variable
> // before implicit conversion back to Pointer during system call.
> u := uintptr(unsafe.Pointer(p))
> syscall.Syscall(SYS_READ, uintptr(fd), u, uintptr(n))