### PR TITLE
many: handle components during an offline remodel

### DIFF
--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -133,7 +133,7 @@ func (s *modelSuite) testPostRemodel(c *check.C, offline bool) {
 	defer restore()
 
 	var devicestateRemodelGotModel *asserts.Model
-	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model, localSnaps []devicestate.LocalSnap, opts devicestate.RemodelOptions) (*state.Change, error) {
+	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model, opts devicestate.RemodelOptions) (*state.Change, error) {
 		c.Check(opts.Offline, check.Equals, offline)
 		devicestateRemodelGotModel = nm
 		chg := st.NewChange("remodel", "...")
@@ -599,13 +599,12 @@ func (s *modelSuite) testPostOfflineRemodel(c *check.C, params *testPostOfflineR
 	snapName := "snap1"
 	snapRev := 1001
 	var devicestateRemodelGotModel *asserts.Model
-	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model,
-		localSnaps []devicestate.LocalSnap, opts devicestate.RemodelOptions) (*state.Change, error) {
+	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model, opts devicestate.RemodelOptions) (*state.Change, error) {
 		c.Check(opts.Offline, check.Equals, true)
-		c.Check(len(localSnaps), check.Equals, 1)
-		c.Check(localSnaps[0].SideInfo.RealName, check.Equals, snapName)
-		c.Check(localSnaps[0].SideInfo.Revision, check.Equals, snap.Revision{N: snapRev})
-		c.Check(strings.HasSuffix(localSnaps[0].Path,
+		c.Check(len(opts.LocalSnaps), check.Equals, 1)
+		c.Check(opts.LocalSnaps[0].SideInfo.RealName, check.Equals, snapName)
+		c.Check(opts.LocalSnaps[0].SideInfo.Revision, check.Equals, snap.Revision{N: snapRev})
+		c.Check(strings.HasSuffix(opts.LocalSnaps[0].Path,
 			"/var/lib/snapd/snaps/"+snapName+"_"+strconv.Itoa(snapRev)+".snap"),
 			check.Equals, true)
 

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -28,6 +28,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -39,13 +41,17 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 var modelDefaults = map[string]interface{}{
@@ -673,4 +679,149 @@ func (s *modelSuite) testPostOfflineRemodel(c *check.C, params *testPostOfflineR
 
 		c.Assert(soon, check.Equals, 1)
 	}
+}
+
+func (s *modelSuite) TestPostOfflineRemodelWithComponents(c *check.C) {
+	s.expectRootAccess()
+
+	oldModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
+	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]interface{}{
+		"revision": "2",
+	})
+
+	d := s.daemonWithOverlordMockAndStore()
+	hookMgr, err := hookstate.Manager(d.Overlord().State(), d.Overlord().TaskRunner())
+	c.Assert(err, check.IsNil)
+	deviceMgr, err := devicestate.Manager(d.Overlord().State(), hookMgr, d.Overlord().TaskRunner(), nil)
+	c.Assert(err, check.IsNil)
+	d.Overlord().AddManager(deviceMgr)
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	st.Set("seeded", true)
+
+	assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
+	s.mockModel(st, oldModel)
+
+	signer := assertstest.NewStoreStack("can0nical", nil)
+	assertstatetest.AddMany(st, signer.StoreAccountKey(""))
+
+	account := assertstest.NewAccount(signer, "developer1", nil, "")
+	c.Assert(signer.Add(account), check.IsNil)
+
+	const snapName = "some-snap"
+	snapID := snaptest.AssertedSnapID(snapName)
+	snapFormData := make(map[string]string)
+
+	snapPath := snaptest.MakeTestSnapWithFiles(c, withComponents("name: some-snap\nversion: 1", []string{"comp"}), nil)
+	digest, size, err := asserts.SnapFileSHA3_384(snapPath)
+	c.Assert(err, check.IsNil)
+
+	content, err := os.ReadFile(snapPath)
+	c.Assert(err, check.IsNil)
+	snapFormData[filepath.Base(snapPath)] = string(content)
+
+	rev := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapRevisionType, map[string]interface{}{
+		"snap-id":       snapID,
+		"snap-sha3-384": digest,
+		"developer-id":  account.AccountID(),
+		"snap-size":     strconv.Itoa(int(size)),
+		"snap-revision": "10",
+	})
+
+	decl := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapDeclarationType, map[string]interface{}{
+		"series":       "16",
+		"snap-id":      snapID,
+		"snap-name":    snapName,
+		"publisher-id": account.AccountID(),
+	})
+
+	compPath, resRev, resPair := makeStandardComponent(c, signer, signer.AuthorityID, account.AccountID(), snapName, "comp")
+	content, err = os.ReadFile(compPath)
+	c.Assert(err, check.IsNil)
+	snapFormData[filepath.Base(compPath)] = string(content)
+
+	// we handle components that are not associated with any of the snaps that
+	// are being uploaded a little differently, this part of the test helps
+	// cover that case
+	extraSnapDecl := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapDeclarationType, map[string]interface{}{
+		"series":       "16",
+		"snap-id":      snaptest.AssertedSnapID("other-snap"),
+		"snap-name":    "other-snap",
+		"publisher-id": account.AccountID(),
+	})
+	extraCompPath, extraResRev, extraResPair := makeStandardComponent(c, signer, signer.AuthorityID, account.AccountID(), "other-snap", "comp")
+	content, err = os.ReadFile(extraCompPath)
+	c.Assert(err, check.IsNil)
+	snapFormData[filepath.Base(extraCompPath)] = string(content)
+
+	snapstate.Set(st, "other-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
+			RealName: "other-snap",
+			Revision: snap.R(10),
+			SnapID:   snaptest.AssertedSnapID("other-snap"),
+		}}),
+		Current: snap.R(10),
+		Active:  true,
+	})
+
+	var assertions strings.Builder
+	encoder := asserts.NewEncoder(&assertions)
+
+	for _, a := range []asserts.Assertion{rev, decl, resRev, resPair, extraSnapDecl, extraResRev, extraResPair, account} {
+		err := encoder.Encode(a)
+		c.Assert(err, check.IsNil)
+	}
+
+	fields := map[string][]string{
+		"new-model": {string(asserts.Encode(newModel))},
+		"assertion": {assertions.String()},
+	}
+	form, boundary := createFormData(c, fields, snapFormData)
+
+	defer daemon.MockDevicestateRemodel(func(st *state.State, nm *asserts.Model, opts devicestate.RemodelOptions) (*state.Change, error) {
+		c.Check(opts.Offline, check.Equals, true)
+		c.Assert(len(opts.LocalSnaps), check.Equals, 1)
+		c.Check(opts.LocalSnaps[0].SideInfo.RealName, check.Equals, snapName)
+		c.Check(opts.LocalSnaps[0].SideInfo.Revision, check.Equals, snap.Revision{N: 10})
+
+		snapPath := filepath.Join(dirs.SnapBlobDir, "some-snap_10.snap")
+		c.Check(strings.HasSuffix(opts.LocalSnaps[0].Path, snapPath), check.Equals, true)
+
+		c.Assert(len(opts.LocalComponents), check.Equals, 2)
+		compPath := filepath.Join(dirs.SnapBlobDir, "some-snap+comp_20.comp")
+		c.Check(strings.HasSuffix(opts.LocalComponents[0].Path, compPath), check.Equals, true)
+
+		extraCompPath := filepath.Join(dirs.SnapBlobDir, "other-snap+comp_20.comp")
+		c.Check(strings.HasSuffix(opts.LocalComponents[1].Path, extraCompPath), check.Equals, true)
+
+		c.Check(nm, check.DeepEquals, newModel)
+
+		chg := st.NewChange("remodel", "...")
+		return chg, nil
+	})()
+
+	req, err := http.NewRequest("POST", "/v2/model", &form)
+	c.Assert(err, check.IsNil)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.Header.Set("Content-Length", strconv.Itoa(form.Len()))
+
+	st.Unlock()
+	rsp := s.asyncReq(c, req, nil)
+	st.Lock()
+
+	c.Assert(rsp.Status, check.Equals, 202)
+	c.Check(rsp.Change, check.DeepEquals, "1")
+
+	chg := st.Change(rsp.Change)
+	c.Assert(chg, check.NotNil)
+
+	c.Assert(st.Changes(), check.HasLen, 1)
+	chg1 := st.Changes()[0]
+	c.Assert(chg, check.DeepEquals, chg1)
+	c.Assert(chg.Kind(), check.Equals, "remodel")
+	c.Assert(chg.Err(), check.IsNil)
 }

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1422,10 +1422,20 @@ func (s *systemsCreateSuite) mockDevAssertion(c *check.C, t *asserts.AssertionTy
 }
 
 func (s *systemsCreateSuite) mockStoreAssertion(c *check.C, t *asserts.AssertionType, extras map[string]interface{}) asserts.Assertion {
+	return mockStoreAssertion(c, s.storeSigning, s.storeSigning.AuthorityID, s.dev1acct.AccountID(), t, extras)
+}
+
+func mockStoreAssertion(
+	c *check.C,
+	signer assertstest.SignerDB,
+	authorityID, accountID string,
+	t *asserts.AssertionType,
+	extras map[string]interface{},
+) asserts.Assertion {
 	headers := map[string]interface{}{
 		"type":         t.Name,
-		"authority-id": s.storeSigning.AuthorityID,
-		"account-id":   s.dev1acct.AccountID(),
+		"authority-id": authorityID,
+		"account-id":   accountID,
 		"series":       "16",
 		"revision":     "5",
 		"timestamp":    "2030-11-06T09:16:26Z",
@@ -1435,7 +1445,7 @@ func (s *systemsCreateSuite) mockStoreAssertion(c *check.C, t *asserts.Assertion
 		headers[k] = v
 	}
 
-	vs, err := s.storeSigning.Sign(t, headers, nil, "")
+	vs, err := signer.Sign(t, headers, nil, "")
 	c.Assert(err, check.IsNil)
 	return vs
 }
@@ -2089,15 +2099,26 @@ func (s *systemsCreateSuite) TestCreateSystemActionWithComponentsOffline(c *chec
 }
 
 func (s *systemsCreateSuite) makeStandardComponent(c *check.C, snapName string, compName string) (compPath string, resourceRev, resourcePair asserts.Assertion) {
+	return makeStandardComponent(c, s.storeSigning, s.storeSigning.AuthorityID, s.dev1acct.AccountID(), snapName, compName)
+}
+
+func makeStandardComponent(
+	c *check.C,
+	signer assertstest.SignerDB,
+	authorityID string,
+	accountID string,
+	snapName string,
+	compName string,
+) (compPath string, resourceRev, resourcePair asserts.Assertion) {
 	yaml := fmt.Sprintf("component: %s+%s\nversion: 1\ntype: standard", snapName, compName)
 	compPath = snaptest.MakeTestComponent(c, yaml)
 
 	digest, size, err := asserts.SnapFileSHA3_384(compPath)
 	c.Assert(err, check.IsNil)
 
-	resRev := s.mockStoreAssertion(c, asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev := mockStoreAssertion(c, signer, authorityID, accountID, asserts.SnapResourceRevisionType, map[string]interface{}{
 		"snap-id":           snaptest.AssertedSnapID(snapName),
-		"developer-id":      s.dev1acct.AccountID(),
+		"developer-id":      accountID,
 		"resource-name":     compName,
 		"resource-sha3-384": digest,
 		"resource-revision": "20",
@@ -2105,9 +2126,9 @@ func (s *systemsCreateSuite) makeStandardComponent(c *check.C, snapName string, 
 		"timestamp":         time.Now().Format(time.RFC3339),
 	})
 
-	resPair := s.mockStoreAssertion(c, asserts.SnapResourcePairType, map[string]interface{}{
+	resPair := mockStoreAssertion(c, signer, authorityID, accountID, asserts.SnapResourcePairType, map[string]interface{}{
 		"snap-id":           snaptest.AssertedSnapID(snapName),
-		"developer-id":      s.dev1acct.AccountID(),
+		"developer-id":      accountID,
 		"resource-name":     compName,
 		"resource-revision": "20",
 		"snap-revision":     "10",

--- a/daemon/export_api_model_test.go
+++ b/daemon/export_api_model_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-func MockDevicestateRemodel(mock func(*state.State, *asserts.Model, []devicestate.LocalSnap, devicestate.RemodelOptions) (*state.Change, error)) (restore func()) {
+func MockDevicestateRemodel(mock func(*state.State, *asserts.Model, devicestate.RemodelOptions) (*state.Change, error)) (restore func()) {
 	oldDevicestateRemodel := devicestateRemodel
 	devicestateRemodel = mock
 	return func() {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -620,7 +620,7 @@ func (r *remodeler) maybeInstallOrUpdate(ctx context.Context, st *state.State, r
 
 		return remodelChannelSwitch, []*state.TaskSet{ts}, nil
 	case needsComponentChanges:
-		tss, err := r.installComponents(ctx, st, currentInfo, rt, requiredComponents)
+		tss, err := r.installComponents(ctx, st, currentInfo, requiredComponents)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -857,13 +857,13 @@ func (r *remodeler) updateGoal(st *state.State, sn remodelSnapTarget, components
 	}), nil
 }
 
-func (r *remodeler) installComponents(ctx context.Context, st *state.State, info *snap.Info, rt remodelSnapTarget, components []string) ([]*state.TaskSet, error) {
+func (r *remodeler) installComponents(ctx context.Context, st *state.State, info *snap.Info, components []string) ([]*state.TaskSet, error) {
 	r.tracker.Add(info)
 
 	if r.offline {
 		var tss []*state.TaskSet
 		for _, c := range components {
-			ref := naming.NewComponentRef(rt.name, c)
+			ref := naming.NewComponentRef(info.SnapName(), c)
 
 			lc, ok := r.localComponents[ref.String()]
 			if !ok {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -735,6 +735,9 @@ func (r *remodeler) installGoal(sn remodelSnapTarget, components []string) (snap
 			ValidationSets: r.vsets,
 		}
 
+		// TODO: snapstate for by-path installs doesn't verify validation sets.
+		// decide if we want to manually verify the given rules here or not.
+
 		return snapstatePathInstallGoal(snapstate.PathSnap{
 			Path:       ls.Path,
 			SideInfo:   ls.SideInfo,
@@ -833,8 +836,8 @@ func (r *remodeler) updateGoal(st *state.State, sn remodelSnapTarget, components
 			ValidationSets: r.vsets,
 		}
 
-		// TODO: verify against validation sets, since we don't do that in
-		// snapstate for by-path installs (why don't we?)
+		// TODO: snapstate for by-path installs doesn't verify validation sets.
+		// decide if we want to manually verify the given rules here or not.
 
 		return snapstatePathUpdateGoal(snapstate.PathSnap{
 			Path:       ls.Path,
@@ -880,8 +883,8 @@ func (r *remodeler) installComponents(ctx context.Context, st *state.State, info
 			}
 			tss = append(tss, ts)
 
-			// TODO: verify against validation sets, since we don't do that in
-			// snapstate for by-path installs (why don't we?)
+			// TODO: snapstate for by-path installs doesn't verify validation sets.
+			// decide if we want to manually verify the given rules here or not.
 		}
 		return tss, nil
 	}

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -320,7 +320,7 @@ func (m *DeviceManager) doPrepareRemodeling(t *state.Task, tmb *tomb.Tomb) error
 
 	chgID := t.Change().ID()
 
-	tss, err := remodelTasks(tmb.Context(nil), st, current, remodCtx.Model(), remodCtx, chgID, nil, RemodelOptions{})
+	tss, err := remodelTasks(tmb.Context(nil), st, current, remodCtx.Model(), remodCtx, chgID, RemodelOptions{})
 	if err != nil {
 		return err
 	}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -5173,7 +5173,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAdded(c *C) {
 		"revision":       "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	c.Check(devicestate.RemodelingChange(st), NotNil)
@@ -5282,7 +5282,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -5349,7 +5349,7 @@ type: base`
 		"revision": "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, ErrorMatches, "cannot remodel from core to bases yet")
 	c.Assert(chg, IsNil)
 }
@@ -5456,7 +5456,7 @@ version: 20.04`
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -5628,7 +5628,7 @@ version: 20.04`
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -5789,7 +5789,7 @@ version: 20.04`
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6164,7 +6164,7 @@ func (s *kernelSuite) TestRemodelSwitchKernelTrack(c *C) {
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6218,7 +6218,7 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernel(c *C) {
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6310,7 +6310,7 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndo(c *C) {
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6368,7 +6368,7 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndoOnRollback(c *C) {
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
 	defer devicestate.InjectSetModelError(nil)
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6490,7 +6490,7 @@ func (s *mgrsSuiteCore) TestRemodelStoreSwitch(c *C) {
 	s.expectedStore = "switched-store"
 	s.sessionMacaroon = "switched-store-session"
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6604,7 +6604,7 @@ volumes:
 	})
 	defer r()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6772,7 +6772,7 @@ volumes:
 		"revision": "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -6907,7 +6907,7 @@ volumes:
 		"revision": "1",
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -7148,7 +7148,7 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 	s.expectedStore = "my-brand-substore"
 	s.sessionMacaroon = "other-store-session"
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	st.Unlock()
@@ -7651,7 +7651,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 		c.Check(fdeState, NotNil)
 	}
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 
 	c.Check(devicestate.RemodelingChange(st), NotNil)
@@ -8038,7 +8038,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentKernelChannel(c *C) {
 	})
 	defer r()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8198,7 +8198,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentGadgetChannel(c *C) {
 	})
 	defer restore()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8322,7 +8322,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentBaseChannel(c *C) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8489,7 +8489,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20BackToPreviousGadget(c *C) {
 	})
 	defer restore()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8677,7 +8677,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20ExistingGadgetSnapDifferentChannel(c *C) 
 	})
 	defer restore()
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -8853,7 +8853,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 		},
 	})
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 
 	msg := `cannot remodel to model that is not self contained:
   - cannot use snap "prereq": base "prereq-base" is missing
@@ -9162,7 +9162,7 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	dumpTasks(c, "at the beginning", chg.Tasks())
 
@@ -9622,7 +9622,7 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	dumpTasks(c, "at the beginning", chg.Tasks())
 
@@ -9930,7 +9930,7 @@ func (s *mgrsSuiteCore) testRemodelUC20ToUC22(c *C, mockSnapdRefresh bool) {
 	now := time.Now()
 	expectedLabel := now.Format("20060102")
 
-	chg, err := devicestate.Remodel(st, newModel, nil, devicestate.RemodelOptions{})
+	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
 	c.Assert(err, IsNil)
 	dumpTasks(c, "at the beginning", chg.Tasks())
 

--- a/tests/nested/manual/remodel-with-components-offline/task.yaml
+++ b/tests/nested/manual/remodel-with-components-offline/task.yaml
@@ -1,0 +1,123 @@
+summary: remodel to a model that contains components
+
+details: |
+  This test remodels to a model that contains components. Specifically, this
+  tests updating the kernel snap to a version that supports the newly required
+  component and installing that component.
+
+  validates that the newly created system can be rebooted into.
+
+systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
+
+environment:
+  INITIAL_MODEL_JSON: $TESTSLIB/assertions/test-snapd-component-remodel-initial-pc-24.json
+  NEW_MODEL_JSON: $TESTSLIB/assertions/test-snapd-component-remodel-new-pc-24.json
+  NESTED_ENABLE_TPM: true
+  NESTED_ENABLE_SECURE_BOOT: true
+  NESTED_BUILD_SNAPD_FROM_CURRENT: true
+  NESTED_REPACK_GADGET_SNAP: true
+  NESTED_REPACK_KERNEL_SNAP: true
+  NESTED_REPACK_BASE_SNAP: true
+  NESTED_REPACK_FOR_FAKESTORE: true
+  NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
+  NESTED_SIGN_SNAPS_FAKESTORE: true
+  NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+
+prepare: |
+    if [ "${TRUST_TEST_KEYS}" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # although nested_start_core_vm_unit usually installs this, the fake store
+    # will already have been set up, so we need to install it here
+    snap install test-snapd-swtpm --edge
+
+    "${TESTSTOOLS}/store-state" setup-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+
+    gendeveloper1 sign-model < "${INITIAL_MODEL_JSON}" > initial-model.assert
+
+    cp "${TESTSLIB}/assertions/testrootorg-store.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp "${TESTSLIB}/assertions/developer1.account" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp "${TESTSLIB}/assertions/developer1.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp initial-model.assert "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+
+    tests.nested prepare-essential-snaps
+
+    export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
+    ubuntu-image snap --image-size 10G ./initial-model.assert
+
+    image_dir=$(tests.nested get images-path)
+    image_name=$(tests.nested get image-name core)
+    cp ./pc.img "${image_dir}/${image_name}"
+    tests.nested configure-default-user
+
+    # run the fake device service too, so that the device can be initialised
+    systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
+
+    tests.nested build-image core
+    tests.nested create-vm core
+
+    #shellcheck source=tests/lib/core-config.sh
+    . "$TESTSLIB"/core-config.sh
+    wait_for_first_boot_change
+
+    remote.exec 'sudo systemctl stop snapd snapd.socket'
+
+    remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data.auth.device."session-macaroon"="fake-session"' > state.json
+    remote.push state.json
+    remote.exec 'sudo mv state.json /var/lib/snapd/state.json'
+    remote.exec 'sudo systemctl start snapd snapd.socket'
+
+restore: |
+    systemctl stop fakedevicesvc
+    "${TESTSTOOLS}/store-state" teardown-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+
+execute: |
+  unsquashfs "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel.snap"
+  sed -i -e '/^version/ s/$/-with-comps/' squashfs-root/meta/snap.yaml
+  snap pack --filename=pc-kernel-with-comps.snap ./squashfs-root
+  "${TESTSTOOLS}"/build_kernel_with_comps.sh mac80211_hwsim wifi-comp pc-kernel-with-comps.snap
+
+  kernel_id='pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza'
+
+  # bump the available kernel version in the fake store
+  "${TESTSTOOLS}"/store-state make-snap-installable --noack \
+    --revision 2 \
+    "${NESTED_FAKESTORE_BLOB_DIR}" \
+    ./pc-kernel-with-comps.snap \
+    "${kernel_id}"
+
+  "${TESTSTOOLS}"/store-state make-component-installable --noack \
+    --snap-revision 2 \
+    --component-revision 1 \
+    --snap-id "${kernel_id}" \
+    "${NESTED_FAKESTORE_BLOB_DIR}" \
+    ./pc-kernel+wifi-comp.comp
+
+  gendeveloper1 sign-model < "${NEW_MODEL_JSON}" > new-model.assert
+  remote.push new-model.assert
+
+  boot_id="$(tests.nested boot-id)"
+  remote.exec 'SNAPPY_FORCE_API_URL=http://10.0.2.2:11028 snap download pc-kernel+wifi-comp --basename=pc-kernel'
+  change_id="$(remote.exec "sudo snap remodel --no-wait --offline \
+    --snap=./pc-kernel.snap \
+    --snap=./pc-kernel+wifi-comp.comp \
+    --assertion=./pc-kernel.assert \
+    new-model.assert")"
+  remote.wait-for reboot "${boot_id}"
+
+  # this remodel expects two reboots, once for testing the recovery system
+  # and once for rebooting into the new kernel
+  boot_id="$(tests.nested boot-id)"
+  remote.wait-for reboot "${boot_id}"
+
+  remote.exec "snap watch ${change_id}"
+  remote.exec 'snap list pc-kernel' | awk '$NR != 1 { print $3 }' | MATCH '2'
+  remote.exec 'snap components pc-kernel' | sed 1d | MATCH 'pc-kernel\+wifi-comp\s+installed'
+
+  # make sure that the kernel module got installed and is loaded from our
+  # component
+  remote.exec sudo modprobe mac80211_hwsim
+  remote.exec ip link show wlan0
+  remote.exec modinfo --filename mac80211_hwsim | MATCH '/lib/modules/.*/updates/wifi-comp'

--- a/tests/nested/manual/remodel-with-components-offline/task.yaml
+++ b/tests/nested/manual/remodel-with-components-offline/task.yaml
@@ -1,11 +1,10 @@
-summary: remodel to a model that contains components
+summary: remodel to a model that contains components in an offline context
 
 details: |
   This test remodels to a model that contains components. Specifically, this
   tests updating the kernel snap to a version that supports the newly required
-  component and installing that component.
-
-  validates that the newly created system can be rebooted into.
+  component and installing that component. This is done in an offline context,
+  and the snaps an components are provided via local files.
 
 systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
 

--- a/tests/nested/manual/remodel-with-components/task.yaml
+++ b/tests/nested/manual/remodel-with-components/task.yaml
@@ -74,19 +74,6 @@ restore: |
     "${TESTSTOOLS}/store-state" teardown-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
 
 execute: |
-  function post_json_data() {
-    route=$1
-    template=$2
-    shift 2
-
-    # shellcheck disable=SC2059
-    response=$(printf "${template}" "$@" | remote.exec "sudo snap debug api -X POST -H 'Content-Type: application/json' ${route}")
-    if ! gojq -e .change <<< "${response}"; then
-      echo "could not get change id from response: ${response}"
-      false
-    fi
-  }
-
   unsquashfs "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel.snap"
   sed -i -e '/^version/ s/$/-with-comps/' squashfs-root/meta/snap.yaml
   snap pack --filename=pc-kernel-with-comps.snap ./squashfs-root


### PR DESCRIPTION
This change enables us to remodel in an offline context, while including components.