### PR TITLE
data/systemd: add gpio-chardev systemd ordering target

### DIFF
--- a/data/systemd/snapd.gpio-chardev-setup.target
+++ b/data/systemd/snapd.gpio-chardev-setup.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=Synchronization target for gpio-chardev interface setup
+After=sysinit.target
+After=snapd.mounts.target
+Requires=sysinit.target
+Requires=snapd.mounts.target
+
+[Install]
+WantedBy=multi-user.target

--- a/data/systemd/snapd.gpio-chardev-setup.target
+++ b/data/systemd/snapd.gpio-chardev-setup.target
@@ -1,9 +1,4 @@
 [Unit]
 Description=Synchronization target for gpio-chardev interface setup
-After=sysinit.target
-After=snapd.mounts.target
-Requires=sysinit.target
-Requires=snapd.mounts.target
-
-[Install]
-WantedBy=multi-user.target
+# Started from gpio-chardev setup services
+# X-Snapd-Snap: do-not-start

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -170,4 +170,7 @@ package() {
   rm -fv "$pkgdir/usr/lib/systemd/system/snapd.aa-prompt-listener.service"
   rm -fv "$pkgdir/usr/lib/systemd/user/snapd.aa-prompt-ui.service"
   rm -fv "$pkgdir/usr/share/dbus-1/services/io.snapcraft.Prompt.service"
+
+  # Remove gpio-chardev ordering target
+  rm -fv "$pkgdir/usr/lib/systemd/system/snapd.gpio-chardev-setup.target"
 }

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -270,6 +270,9 @@ override_dh_install-arch:
 	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.snap-repair.timer
 	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.system-shutdown.service
 	rm $(CURDIR)/debian/snapd/usr/lib/snapd/snapd.run-from-snap
+	# New gpio-chardev interface only support on ubuntu for now, we don't need
+	# to install the ordering target
+	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.gpio-chardev-setup.target
 
 	dh_install
 

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -737,6 +737,9 @@ rm %{buildroot}%{_libexecdir}/snapd/system-shutdown
 rm -f %{buildroot}%{_unitdir}/snapd.apparmor.service
 rm -f %{buildroot}%{_libexecdir}/snapd/snapd-apparmor
 
+# Remove gpio-chardev ordering target
+rm -f %{buildroot}%{_unitdir}/snapd.gpio-chardev-setup.target
+
 # Disable re-exec by default
 echo 'SNAP_REEXEC=0' > %{buildroot}%{_sysconfdir}/sysconfig/snapd
 

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -65,7 +65,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target snapd.gpio-chardev-setup.target
+%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target
 %global snappy_user_svcs snapd.session-agent.service snapd.session-agent.socket
 
 # Until we have a way to add more extldflags to gobuild macro...
@@ -843,7 +843,6 @@ make -C data -k check
 %{_unitdir}/snapd.seeded.service
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
-%{_unitdir}/snapd.gpio-chardev-setup.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 %{_tmpfilesdir}/snapd.conf

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -65,7 +65,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target
+%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target snapd.gpio-chardev-setup.target
 %global snappy_user_svcs snapd.session-agent.service snapd.session-agent.socket
 
 # Until we have a way to add more extldflags to gobuild macro...
@@ -843,6 +843,7 @@ make -C data -k check
 %{_unitdir}/snapd.seeded.service
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
+%{_unitdir}/snapd.gpio-chardev-setup.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 %{_tmpfilesdir}/snapd.conf

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -31,7 +31,7 @@
 
 # The list of systemd services we are expected to ship. Note that this does
 # not include services that are only required on core systems.
-%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service} snapd.mounts.target snapd.mounts-pre.target snapd.gpio-chardev-setup.target
+%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service} snapd.mounts.target snapd.mounts-pre.target
 %global systemd_user_services_list snapd.session-agent.socket
 
 # Alternate snap mount directory: not used by openSUSE.
@@ -506,7 +506,6 @@ fi
 %{_unitdir}/snapd.socket
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
-%{_unitdir}/snapd.gpio-chardev-setup.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -345,6 +345,9 @@ install -pm 644 -D %{indigo_srcdir}/data/completion/bash/etelpmoc.sh %{buildroot
 install -d -p %{buildroot}%{_datadir}/zsh/site-functions
 install -pm 644 -D %{indigo_srcdir}/data/completion/zsh/_snap %{buildroot}%{_datadir}/zsh/site-functions/_snap
 
+# Remove gpio-chardev ordering target
+rm -f %{buildroot}%{_unitdir}/snapd.gpio-chardev-setup.target
+
 %verifyscript
 %verify_permissions -e %{_libexecdir}/snapd/snap-confine
 

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -31,7 +31,7 @@
 
 # The list of systemd services we are expected to ship. Note that this does
 # not include services that are only required on core systems.
-%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service} snapd.mounts.target snapd.mounts-pre.target
+%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service} snapd.mounts.target snapd.mounts-pre.target snapd.gpio-chardev-setup.target
 %global systemd_user_services_list snapd.session-agent.socket
 
 # Alternate snap mount directory: not used by openSUSE.
@@ -506,6 +506,7 @@ fi
 %{_unitdir}/snapd.socket
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
+%{_unitdir}/snapd.gpio-chardev-setup.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 


### PR DESCRIPTION
The `snapd.gpio-chardev-setup.target` will be used for synchronization of app services and virtual device setup during boot.
