### PR TITLE
features: add experimental gpio-chardev-interface flag

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -75,8 +75,8 @@ const (
 	ConfdbControl
 	// AppArmorPrompting enables AppArmor to prompt the user for permission when apps perform certain operations.
 	AppArmorPrompting
-	// GPIOChardevSupport enables experimental gpio-chardev interface.
-	GPIOChardevSupport
+	// GPIOChardevInterface enables experimental gpio-chardev interface.
+	GPIOChardevInterface
 
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
@@ -127,7 +127,7 @@ var featureNames = map[SnapdFeature]string{
 
 	AppArmorPrompting: "apparmor-prompting",
 
-	GPIOChardevSupport: "gpio-chardev-support",
+	GPIOChardevInterface: "gpio-chardev-interface",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
@@ -151,7 +151,7 @@ var featuresExported = map[SnapdFeature]bool{
 	RefreshAppAwarenessUX: true,
 	Confdbs:               true,
 	AppArmorPrompting:     true,
-	GPIOChardevSupport:    true,
+	GPIOChardevInterface:  true,
 }
 
 var (

--- a/features/features.go
+++ b/features/features.go
@@ -75,6 +75,8 @@ const (
 	ConfdbControl
 	// AppArmorPrompting enables AppArmor to prompt the user for permission when apps perform certain operations.
 	AppArmorPrompting
+	// GPIOChardevSupport enables experimental gpio-chardev interface.
+	GPIOChardevSupport
 
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
@@ -124,6 +126,8 @@ var featureNames = map[SnapdFeature]string{
 	ConfdbControl: "confdb-control",
 
 	AppArmorPrompting: "apparmor-prompting",
+
+	GPIOChardevSupport: "gpio-chardev-support",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.

--- a/features/features.go
+++ b/features/features.go
@@ -151,6 +151,7 @@ var featuresExported = map[SnapdFeature]bool{
 	RefreshAppAwarenessUX: true,
 	Confdbs:               true,
 	AppArmorPrompting:     true,
+	GPIOChardevSupport:    true,
 }
 
 var (

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -64,6 +64,7 @@ func (*featureSuite) TestName(c *C) {
 	check(features.Confdbs, "confdbs")
 	check(features.ConfdbControl, "confdb-control")
 	check(features.AppArmorPrompting, "apparmor-prompting")
+	check(features.GPIOChardevSupport, "gpio-chardev-support")
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
@@ -104,6 +105,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.Confdbs, true)
 	check(features.ConfdbControl, false)
 	check(features.AppArmorPrompting, true)
+	check(features.GPIOChardevSupport, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }
@@ -229,6 +231,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.Confdbs, false)
 	check(features.AppArmorPrompting, false)
 	check(features.ConfdbControl, false)
+	check(features.GPIOChardevSupport, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -105,7 +105,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.Confdbs, true)
 	check(features.ConfdbControl, false)
 	check(features.AppArmorPrompting, true)
-	check(features.GPIOChardevSupport, false)
+	check(features.GPIOChardevSupport, true)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -64,7 +64,7 @@ func (*featureSuite) TestName(c *C) {
 	check(features.Confdbs, "confdbs")
 	check(features.ConfdbControl, "confdb-control")
 	check(features.AppArmorPrompting, "apparmor-prompting")
-	check(features.GPIOChardevSupport, "gpio-chardev-support")
+	check(features.GPIOChardevInterface, "gpio-chardev-interface")
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
@@ -105,7 +105,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.Confdbs, true)
 	check(features.ConfdbControl, false)
 	check(features.AppArmorPrompting, true)
-	check(features.GPIOChardevSupport, true)
+	check(features.GPIOChardevInterface, true)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }
@@ -231,7 +231,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.Confdbs, false)
 	check(features.AppArmorPrompting, false)
 	check(features.ConfdbControl, false)
-	check(features.GPIOChardevSupport, false)
+	check(features.GPIOChardevInterface, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }


### PR DESCRIPTION
Due to limitations imposed by the kernel support, the `gpio-chardev` interface (not implemented yet) is considered experimental and needs `experimental.gpio-chardev-interface` setting to be enabled in snapd, either explicitly at runtime or through the defaults section in gadget.yaml.