### PR TITLE
o/snapstate: make monitoring removal more robust

### DIFF
--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -224,6 +224,10 @@ func clientHealthFromHealthstate(h *healthstate.HealthState) *client.SnapHealth 
 
 func clientSnapRefreshInhibit(st *state.State, snapst *snapstate.SnapState, instanceName string) *client.SnapRefreshInhibit {
 	proceedTime := snapst.RefreshInhibitProceedTime(st)
+	if proceedTime.IsZero() {
+		return nil
+	}
+
 	if proceedTime.After(time.Now()) || snapstate.IsSnapMonitored(st, instanceName) {
 		return &client.SnapRefreshInhibit{
 			ProceedTime: proceedTime,

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -968,6 +968,12 @@ func removeMonitoring(st *state.State, snapName string) error {
 		return fmt.Errorf("cannot get refresh-candidates: %v", err)
 	}
 
+	// There are cases where refresh hint of a snap could have been removed
+	// while the monitoring abort channel is still there. So we should continue
+	// deleting the monitoring abort channel regardless a refresh hint entry
+	// for the given snap exists or not.
+	// For example this could happen due to calls to updateRefreshCandidates
+	// where our snap could be removed from refresh candidates.
 	if _, ok := refreshHints[snapName]; ok {
 		refreshHints[snapName].Monitored = false
 		st.Set("refresh-candidates", refreshHints)


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/snap-store-desktop/+bug/2089195. Snaps could be falsely marked as being monitored due to absent refresh-candidate entry which could have been pruned or overwritten.

This PR makes the removal more robust so it doesn't early exit when the corresponding refresh-candidate entry is missing. Also, as an extra measure I added a check for Zero proceed time on the API level.

![image](https://github.com/user-attachments/assets/4431f040-35de-46db-8a4c-23a083437c52)

