### PR TITLE
confdb: support marking paths in schemas as ephemeral

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -125,6 +125,10 @@ type Schema interface {
 
 	// Type returns the SchemaType corresponding to the Schema.
 	Type() SchemaType
+
+	// Ephemeral returns true if the data corresponding to this type should not be
+	// saved by snapd.
+	Ephemeral() bool
 }
 
 type SchemaType uint
@@ -1591,4 +1595,8 @@ func (v JSONSchema) SchemaAt(path []string) ([]Schema, error) {
 
 func (v JSONSchema) Type() SchemaType {
 	return Any
+}
+
+func (v JSONSchema) Ephemeral() bool {
+	return false
 }

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -52,6 +52,10 @@ func (f *failingSchema) Type() confdb.SchemaType {
 	return confdb.Any
 }
 
+func (f *failingSchema) Ephemeral() bool {
+	return false
+}
+
 func (*viewSuite) TestNewConfdb(c *C) {
 	type testcase struct {
 		confdb map[string]interface{}

--- a/confdb/schema.go
+++ b/confdb/schema.go
@@ -332,8 +332,6 @@ func (s *StorageSchema) parseAlternatives(alternatives []json.RawMessage) (*alte
 		return nil, errors.New(`alternatives must all be ephemeral or non-ephemeral`)
 	}
 
-	alt.baseSchema.ephemeral = len(ephemeralAlts) != 0
-
 	if len(alt.schemas) == 0 {
 		return nil, fmt.Errorf(`alternative type list cannot be empty`)
 	}
@@ -394,8 +392,6 @@ func (s *StorageSchema) getAlias(ref string) (*aliasReference, error) {
 }
 
 type alternativesSchema struct {
-	baseSchema
-
 	// schemas holds schemas for the types allowed for the corresponding value.
 	schemas []Schema
 }
@@ -480,6 +476,8 @@ func (v *alternativesSchema) SchemaAt(path []string) ([]Schema, error) {
 func (v *alternativesSchema) Type() SchemaType {
 	return Alt
 }
+
+func (v *alternativesSchema) Ephemeral() bool { return false }
 
 type mapSchema struct {
 	baseSchema

--- a/overlord/confdbstate/transaction_test.go
+++ b/overlord/confdbstate/transaction_test.go
@@ -143,6 +143,8 @@ func (f *failingSchema) Type() confdb.SchemaType {
 	return confdb.Any
 }
 
+func (f *failingSchema) Ephemeral() bool { return false }
+
 func (s *transactionTestSuite) TestRollBackOnCommitError(c *C) {
 	tx, err := confdbstate.NewTransaction(s.state, "my-account", "my-confdb")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This adds support for marking parts of a databag as ephemeral, by allowing us to add a `"ephemeral": true` constraint to type definitions. It also adds an `Ephemeral() bool` function to expose this. In reality, I expect that the most natural implementation of the pruning will just recursively prune parts of the data based on the ephemeral field without using this function directly but I needed some way of testing the parsing without having to also implement the pruning in this commit. We also use Ephemeral() to forbid user-defined types from using ephemeral so, when we support that, we can remove it from the interface and move the functions to export_test just for white-box testing.