### PR TITLE
osutil: add AtomicLink function to create atomic hardlinks

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -220,7 +220,7 @@ func MockFindGidNoFallback(mock func(name string) (uint64, error)) (restore func
 	return func() { findGidNoGetentFallback = old }
 }
 
-const MaxSymlinkTries = maxSymlinkTries
+const MaxLinkTries = maxLinkTries
 
 var ParseRawEnvironment = parseRawEnvironment
 


### PR DESCRIPTION
Add `AtomicLink`, akin to `AtomicSymlink`, but with hardlinks instead of symlinks.

This functionality is needed for #15003.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34470