### PR TITLE
cmd/snap-failure: add fixme about running snapd with keyring access

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -185,6 +185,9 @@ func (c *cmdSnapd) Execute(args []string) error {
 		}
 	}
 	// start previous snapd
+	// FIXME: we should either run through systemd with
+	// KeyringMode=shared or make the re-seeding not initialize
+	// fdestate
 	cmd := runCmd(snapdPath, nil, []string{"SNAPD_REVERT_TO_REV=" + prevRev, "SNAPD_DEBUG=1"})
 	if err = cmd.Run(); err != nil {
 		return fmt.Errorf("snapd failed: %v", err)


### PR DESCRIPTION
Snapd needs `KeyringMode=shared`, but `snap-failure` runs it without. We either need to add access to the keyring or disable initialization of FDE state when re-seeding.