### PR TITLE
tests/nested/manual/remodel-uc20-to-uc22: remove encrypted case

### DIFF
--- a/tests/nested/manual/remodel-uc20-to-uc22/task.yaml
+++ b/tests/nested/manual/remodel-uc20-to-uc22/task.yaml
@@ -7,14 +7,9 @@ details: |
 systems: [ubuntu-20.04-64]
 
 environment:
-  # encrypted case
-  NESTED_ENABLE_TPM/encrypted: true
-  NESTED_ENABLE_SECURE_BOOT/encrypted: true
-  SAVE_PART_LABEL/encrypted: ubuntu-save-enc
-  # unencrypted case
-  NESTED_ENABLE_TPM/notencrypted: false
-  NESTED_ENABLE_SECURE_BOOT/notencrypted: false
-  SAVE_PART_LABEL/notencrypted: ubuntu-save
+  NESTED_ENABLE_TPM: false
+  NESTED_ENABLE_SECURE_BOOT: false
+  SAVE_PART_LABEL: ubuntu-save
   # needed to use snakeoil keys
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
 


### PR DESCRIPTION
The encrypted case is more complex and is covered in tests/nested/manual/remodel-uc-to-next-version-fakestore
