### PR TITLE
tests/assertions: fix recovery-system-reboot:factory_reset test

### DIFF
--- a/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-22.json
+++ b/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-22.json
@@ -1,0 +1,53 @@
+{
+    "type": "model",
+    "authority-id": "test-snapd",
+    "series": "16",
+    "brand-id": "test-snapd",
+    "model": "my-model",
+    "revision": "1",
+    "architecture": "amd64",
+    "timestamp": "2024-01-04T15:49:41+00:00",
+    "grade": "dangerous",
+    "base": "core22",
+    "serial-authority": ["generic"],
+    "snaps": [
+        {
+            "default-channel": "22/stable",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "22/stable",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+            "name": "core22",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+            "name": "core",
+            "type": "core",
+            "modes": ["run", "ephemeral"]
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+            "name": "hello-world",
+            "type": "app",
+            "modes": ["run", "ephemeral"]
+        }
+    ]
+}

--- a/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-22.model
+++ b/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-22.model
@@ -1,0 +1,61 @@
+type: model
+authority-id: test-snapd
+revision: 1
+series: 16
+brand-id: test-snapd
+model: my-model
+architecture: amd64
+base: core22
+grade: dangerous
+serial-authority:
+  - generic
+snaps:
+  -
+    default-channel: 22/stable
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 22/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    name: core22
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/stable
+    id: 99T7MUlRhtI3U0QFgl5mXXESAiSwt776
+    modes:
+      - run
+      - ephemeral
+    name: core
+    type: core
+  -
+    default-channel: latest/stable
+    id: buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ
+    modes:
+      - run
+      - ephemeral
+    name: hello-world
+    type: app
+timestamp: 2024-01-04T15:49:41+00:00
+sign-key-sha3-384: 7qWG-Uwck6Dji43a3Z8ZZrm7rAziZAch3xf76iFvqe4GaD0LI7U9lYPWMSJAsEgu
+
+AcLBcwQAAQoAHRYhBGESvKlz1RXG1IBOC0MdJKf2hr9ABQJl4gLjAAoJEEMdJKf2hr9ACKkP/12Z
+uix52q9+WujCDSNlJthql1xBmN5/IccbUWOff4P2Zv3V3c0j5HMon5lnnfcPSu69Wv9L8JT0xdr+
+Ee5Blaqw9549dtwJ2JtMtCpJmNcKHXYleJQOIEVtK2zL5YvYDShUG1cx1gEIls7fiKAAbebtpKcv
+uNbZZnxf3gGkIaqxSjJInv4t8Txd2BBlmMvIG0C7r/iWV93UYwPKm9FPRPWAFE4DauippViQkWGP
+NbeZJ8D9/iWwEUuY21scCE+l7JcXpOjIhNFH34PnisfW050QNxCnfH6XUNmplfVGimWt9W7g+v7m
+nSIWE/MoBCz8H0eaf9V8hroqy5vG+IqUg5Tb91FvLspc2lq1eRhei0DA/Ys47QLnVViOmHwgXGJY
+pFBz52m6BEE67ByNN/U0DLeRT5AEl5CSZP4DFRfn+r/y3EHWQ10MXZ4zN7HQb7SMuxvRlx6FUl46
+TESmnS2U7QIToe9h31tKMTI1jNkgd22Y4h9aLT+FMNvUVrz49FN/5eLAkCy2oaUKnme8qv0VzTbp
+W2Rv3cXgQqu1NhOK1QMTj+7kJUn4fi1/UAD8lo7K2G+FJdyznQKDcstLZnCsRr8+k9kp7yRjZzF6
+cgRHFrvtfsxUYfUFNN2nCZ7NWqVUdYgheoVc6suTUcQvuvx1lQAH2OvNJYu4DMI5cMffD0TJ

--- a/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-24.json
+++ b/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-24.json
@@ -1,0 +1,53 @@
+{
+    "type": "model",
+    "authority-id": "test-snapd",
+    "series": "16",
+    "brand-id": "test-snapd",
+    "model": "my-model",
+    "revision": "1",
+    "architecture": "amd64",
+    "timestamp": "2024-04-24T00:00:00+00:00",
+    "grade": "dangerous",
+    "base": "core24",
+    "serial-authority": ["generic"],
+    "snaps": [
+        {
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "24/beta",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+            "name": "core",
+            "type": "core",
+            "modes": ["run", "ephemeral"]
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+            "name": "hello-world",
+            "type": "app",
+            "modes": ["run", "ephemeral"]
+        }
+    ]
+}

--- a/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-24.model
+++ b/tests/lib/assertions/test-snapd-recovery-system-reboot-pc-24.model
@@ -1,0 +1,61 @@
+type: model
+authority-id: test-snapd
+revision: 1
+series: 16
+brand-id: test-snapd
+model: my-model
+architecture: amd64
+base: core24
+grade: dangerous
+serial-authority:
+  - generic
+snaps:
+  -
+    default-channel: 24/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 24/beta
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/stable
+    id: 99T7MUlRhtI3U0QFgl5mXXESAiSwt776
+    modes:
+      - run
+      - ephemeral
+    name: core
+    type: core
+  -
+    default-channel: latest/stable
+    id: buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ
+    modes:
+      - run
+      - ephemeral
+    name: hello-world
+    type: app
+timestamp: 2024-04-24T00:00:00+00:00
+sign-key-sha3-384: rrP2xy5LOU-OjnYtfHm7h8QSOkySgyrZoJKT_YqlTKJrWMA8j-0SoClorTN6XR9Z
+
+AcLBcwQAAQoAHRYhBMEAb2Q1SgOrrGcnJ4b6Yn/LKbBXBQJnopEZAAoJEIb6Yn/LKbBXUn4QAMj6
+fgX3bhFYvr7bvIOwKasvHd2fDcgNTwNAR/pkAKKS4/bdzGvrEAOaiuERxZCi+Zk2uK/8IbzyFsGd
+88Wj3Dmsas41RD/DzUabRC0ExRfr4WEQkKPZt/eX02mjO5jDSH1pRrF/CFTHbQiSqDZAAN7yoB5z
+dDL6NJFzP0hDpYNHCMNz4Q72P9PefLfItHKQu4f8478SyhP7G+yPiRnXkrHsQ8DpOVl/TFttKtMJ
+QnaO6AH0/aJpFVh9ai/S3ScrqYznHEbVIaMLCYNxypqwsIvd4rlefa5pv7fdNg4w05/iHc+YmlfP
+T2eMXv2u8/fKuNPxMikics64T5sSI5iJjaXfI5dOwTaVnw4W80MDy4vO6VBgbX/o0demfwWKcQMR
+kQZtzqO1UT+ZK4KaXBg25PuvFMGbqq5/7B+zysIGazNU0WeBl8MySjkr6kKUcDYRCGMVT3dKD9Uw
+Wt5YvB6+kaM9EqIrWyY2uObdy3wzgKk6e6loGL5LkMXBMlvr69nquZkf4RKP89YynF+0E/dEvx4v
+DneQXKyk/vrm96Ba4A5nWdd1EgEHuxZmUKkZBkZCE59OglF6Q4OsmQRE5oRm/v3ArKqeY76HzdQT
+l6OO/WEZpKjTWZ3UoGu30ZJSQ2a8PheNHQLmpmM7g0SSYtkHO6oA8ce0p3nyT9Xxbgr/d0yb

--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -7,7 +7,7 @@ details: |
 systems: [ubuntu-22.04-64, ubuntu-24.04-64]
 
 environment:
-  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/test-snapd-recovery-system-pc-{VERSION}.model
+  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/test-snapd-recovery-system-reboot-pc-{VERSION}.model
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true


### PR DESCRIPTION
recovery-system-reboot:factory_reset creates a recovery system and does a factory reset using it, also using a validation-set assertion that pins some snaps, including pc-kernel 1869. That revision has a kernel signed with a Canonical key. However, when a refresh is triggered after the factory reset, the system refreshes to a pc-kernel from 24/edge as this is the channel specified in the model used in the test. This kernel is signed with a test key. This makes the refresh fail as Secure Boot is enabled. This seems to be random as the re-refresh some times does not refresh all the snaps pending.

This change moves the model assertion to use pc-kernel from 24/beta so we have a kernel with a good signature.

Fwiw, the original seed created by the test is fine because we override the model channel to beta in nested_create_core_vm.