### PR TITLE
dirs, many: auto detect snap mount dirs

### DIFF
--- a/cmd/snap/cmd_debug_paths.go
+++ b/cmd/snap/cmd_debug_paths.go
@@ -51,9 +51,10 @@ func (cmd cmdPaths) Execute(args []string) error {
 		name string
 		path string
 	}{
-		{"SNAPD_MOUNT", dirs.SnapMountDir},
-		{"SNAPD_BIN", dirs.SnapBinariesDir},
-		{"SNAPD_LIBEXEC", dirs.DistroLibExecDir},
+		// strip root directory for tests
+		{"SNAPD_MOUNT", dirs.StripRootDir(dirs.SnapMountDir)},
+		{"SNAPD_BIN", dirs.StripRootDir(dirs.SnapBinariesDir)},
+		{"SNAPD_LIBEXEC", dirs.StripRootDir(dirs.DistroLibExecDir)},
 	} {
 		fmt.Fprintf(Stdout, "%s=%s\n", p.name, p.path)
 	}

--- a/cmd/snap/cmd_debug_paths_test.go
+++ b/cmd/snap/cmd_debug_paths_test.go
@@ -31,9 +31,11 @@ import (
 func (s *SnapSuite) TestPathsUbuntu(c *C) {
 	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
 	defer restore()
+
+	dirstest.MustMockCanonicalSnapMountDir(dirs.GlobalRootDir)
+	dirs.SetRootDir(dirs.GlobalRootDir)
 	defer dirs.SetRootDir("/")
 
-	dirs.SetRootDir("/")
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
@@ -46,9 +48,11 @@ func (s *SnapSuite) TestPathsUbuntu(c *C) {
 func (s *SnapSuite) TestPathsFedora(c *C) {
 	restore := release.MockReleaseInfo(&release.OS{ID: "fedora"})
 	defer restore()
+
+	dirstest.MustMockAltSnapMountDir(dirs.GlobalRootDir)
+	dirs.SetRootDir(dirs.GlobalRootDir)
 	defer dirs.SetRootDir("/")
 
-	dirs.SetRootDir("/")
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
@@ -65,7 +69,9 @@ func (s *SnapSuite) TestPathsArch(c *C) {
 	restore := release.MockReleaseInfo(&release.OS{ID: "arch", IDLike: []string{"archlinux"}})
 	defer restore()
 
-	dirs.SetRootDir("/")
+	dirstest.MustMockAltSnapMountDir(dirs.GlobalRootDir)
+	dirs.SetRootDir(dirs.GlobalRootDir)
+
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
@@ -80,7 +86,8 @@ func (s *SnapSuite) TestPathsArch(c *C) {
 	restore = release.MockReleaseInfo(&release.OS{ID: "archlinux"})
 	defer restore()
 
-	dirs.SetRootDir("/")
+	dirs.SetRootDir(dirs.GlobalRootDir)
+
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
@@ -98,6 +105,7 @@ func (s *SnapSuite) TestPathsMyDistro(c *C) {
 	d := c.MkDir()
 	dirstest.MustMockAltSnapMountDir(d)
 	dirs.SetRootDir(d)
+
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	// since it's a custom distro, the test overrides root directory so the resulting paths

--- a/cmd/snap/cmd_debug_paths_test.go
+++ b/cmd/snap/cmd_debug_paths_test.go
@@ -24,6 +24,7 @@ import (
 
 	snap "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/release"
 )
 
@@ -82,6 +83,25 @@ func (s *SnapSuite) TestPathsArch(c *C) {
 	dirs.SetRootDir("/")
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals, ""+
+		"SNAPD_MOUNT=/var/lib/snapd/snap\n"+
+		"SNAPD_BIN=/var/lib/snapd/snap/bin\n"+
+		"SNAPD_LIBEXEC=/usr/lib/snapd\n")
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestPathsMyDistro(c *C) {
+	restore := release.MockReleaseInfo(&release.OS{ID: "my-distro"})
+	defer restore()
+	defer dirs.SetRootDir("/")
+
+	d := c.MkDir()
+	dirstest.MustMockAltSnapMountDir(d)
+	dirs.SetRootDir(d)
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
+	c.Assert(err, IsNil)
+	// since it's a custom distro, the test overrides root directory so the resulting paths
+	// include an explicit path
 	c.Assert(s.Stdout(), Equals, ""+
 		"SNAPD_MOUNT=/var/lib/snapd/snap\n"+
 		"SNAPD_BIN=/var/lib/snapd/snap/bin\n"+

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -96,6 +96,7 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	r := c.MkDir()
 	// using unknown distro, set up
 	dirstest.MustMockAltSnapMountDir(r)
+	dirstest.MustMockClassicConfinementAltDirSupport(r)
 	// reload dirs for release info to have effect
 	dirs.SetRootDir(r)
 
@@ -228,6 +229,7 @@ func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	r := c.MkDir()
 	// using unknown distro, set up
 	dirstest.MustMockAltSnapMountDir(r)
+	dirstest.MustMockClassicConfinementAltDirSupport(r)
 	// reload dirs for release info to have effect
 	dirs.SetRootDir(r)
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -504,7 +504,7 @@ func snapMountDirProbe(rootdir string) (string, error) {
 		p, err := os.Readlink(defaultDir)
 		switch {
 		case err != nil:
-			return "", fmt.Errorf("cannot read %s symlink path: %w", defaultDir, err)
+			return "", err
 		case p != AltSnapMountDir && p != AltSnapMountDir[1:] && p != altDir:
 			return "", fmt.Errorf("%v must be a symbolic link to %v", defaultDir, AltSnapMountDir)
 		default:

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -450,8 +450,8 @@ func AddRootDirCallback(c func(string)) {
 }
 
 var (
-	// distributions known to use /snap/
-	flakyDefaultDirDistros = []string{
+	// distributions known to use /snap/ but are packaged in a special way
+	specialDefaultDirDistros = []string{
 		"ubuntucoreinitramfs",
 	}
 
@@ -475,7 +475,7 @@ func snapMountDirProbe(rootdir string) (string, error) {
 	altDir := filepath.Join(rootdir, AltSnapMountDir)
 
 	// notable exception for Ubuntu Core initramfs
-	if release.DistroLike(flakyDefaultDirDistros...) {
+	if release.DistroLike(specialDefaultDirDistros...) {
 		return defaultDir, nil
 	}
 
@@ -496,10 +496,11 @@ func snapMountDirProbe(rootdir string) (string, error) {
 			return "", fmt.Errorf("cannot stat %s: %w", defaultDir, err)
 		}
 	case fi.Mode().Type()&fs.ModeSymlink != 0:
-		// exists and is a symlink, find out what the target is, but keep
-		// the checks simple and read the symlink rather than trying
+		// exists and is a symlink, find out what the target is, but keep the
+		// checks simple and read the symlink rather than trying
 		// filepath.EvalSymlinks() which needs intermediate directories to
-		// exist
+		// exist; the symlink can be relative so cehck both with and without the
+		// leading /
 		p, err := os.Readlink(defaultDir)
 		switch {
 		case err != nil:

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -457,6 +457,7 @@ var (
 	defaultDirDistros = []string{
 		"ubuntu",
 		"ubuntu-core",
+		"ubuntucoreinitramfs",
 		"debian",
 		"opensuse",
 		"suse",

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -20,7 +20,10 @@
 package dirs
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -33,6 +36,8 @@ import (
 
 // the various file paths
 var (
+	stderr io.Writer = os.Stderr
+
 	GlobalRootDir string = "/"
 
 	RunDir string
@@ -161,6 +166,7 @@ var (
 
 const (
 	defaultSnapMountDir = "/snap"
+	altSnapMountDir     = "/var/lib/snapd/snap"
 
 	// These are directories which are static inside the core snap and
 	// can never be prefixed as they will be always absolute once we
@@ -446,15 +452,19 @@ func AddRootDirCallback(c func(string)) {
 	callbacks = append(callbacks, c)
 }
 
-// SetRootDir allows settings a new global root directory, this is useful
-// for e.g. chroot operations
-func SetRootDir(rootdir string) {
-	if rootdir == "" {
-		rootdir = "/"
+var (
+	// distributions known to use /snap/
+	defaultDirDistros = []string{
+		"ubuntu",
+		"ubuntu-core",
+		"debian",
+		"opensuse",
+		"suse",
+		"yocto",
 	}
-	GlobalRootDir = rootdir
 
-	altDirDistros := []string{
+	// distributions known to use /var/lib/snapd/snap/
+	altDirDistros = []string{
 		"altlinux",
 		"antergos",
 		"arch",
@@ -464,12 +474,78 @@ func SetRootDir(rootdir string) {
 		"manjaro",
 		"manjaro-arm",
 	}
+)
+
+func snapMountDirProbe(rootdir string) string {
+
+	defaultDir := filepath.Join(rootdir, defaultSnapMountDir)
+	altDir := filepath.Join(rootdir, altSnapMountDir)
+
+	// a well known default value
+	dir := "mount-dir-is-unset"
+
+	switch {
+	case release.DistroLike(defaultDirDistros...):
+		dir = defaultDir
+
+	case release.DistroLike(altDirDistros...):
+		dir = altDir
+
+	default:
+		// observe the system state to find out how snapd was packaged,
+		// essentially use the same logic as
+		// sc_probe_snap_mount_dir_from_pid_1_mount_ns() used in snap-confine,
+		// except for hard errors
+		fi, err := os.Lstat(defaultDir)
+		switch {
+		case err != nil:
+			if errors.Is(err, fs.ErrNotExist) {
+				// path does not exist, given that well-known distros are
+				// handled explicitly we are dealing with a distribution we have
+				// no knowledge of and the packaging does not include a default
+				// mount path
+				dir = altDir
+			} else {
+				fmt.Fprintf(stderr, "cannot stat %s: %v\n", defaultDir, err)
+			}
+		case fi.Mode().Type()&fs.ModeSymlink != 0:
+			// exists and is a symlink, find out what the target is, but keep
+			// the checks simple and read the symlink rather than trying
+			// filepath.EvalSymlinks() which needs intermediate directories to
+			// exist
+			p, err := os.Readlink(defaultDir)
+			switch {
+			case err != nil:
+				fmt.Fprintf(stderr, "cannot read %s symlink path: %v\n", defaultDir, err)
+			case p != altSnapMountDir && p != altSnapMountDir[1:] && p != altDir:
+				fmt.Fprintf(stderr, "%v must be a symbolic link to %v\n", defaultDir, altSnapMountDir)
+			default:
+				// we read the symlink and it points to the alternative location
+				dir = altDir
+			}
+		case fi.Mode().Type().IsDir():
+			// exists and is a directory
+			dir = defaultDir
+		}
+	}
+
+	return dir
+}
+
+// SetRootDir allows settings a new global root directory, this is useful
+// for e.g. chroot operations
+func SetRootDir(rootdir string) {
+	if rootdir == "" {
+		rootdir = "/"
+	}
+	GlobalRootDir = rootdir
 
 	isInsideBase, _ := isInsideBaseSnap()
-	if !isInsideBase && release.DistroLike(altDirDistros...) {
-		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
-	} else {
+	if isInsideBase {
+		// when inside the base, the mount directory is always /snap
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)
+	} else {
+		SnapMountDir = snapMountDirProbe(rootdir)
 	}
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -22,7 +22,6 @@ package dirs
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -36,8 +35,6 @@ import (
 
 // the various file paths
 var (
-	stderr io.Writer = os.Stderr
-
 	GlobalRootDir string = "/"
 
 	RunDir string
@@ -165,8 +162,8 @@ var (
 )
 
 const (
-	defaultSnapMountDir = "/snap"
-	altSnapMountDir     = "/var/lib/snapd/snap"
+	DefaultSnapMountDir = "/snap"
+	AltSnapMountDir     = "/var/lib/snapd/snap"
 
 	// These are directories which are static inside the core snap and
 	// can never be prefixed as they will be always absolute once we
@@ -313,7 +310,7 @@ func SupportsClassicConfinement() bool {
 	// location for snaps, that is /snap or if using the alternate mount
 	// location, /var/lib/snapd/snap along with the /snap ->
 	// /var/lib/snapd/snap symlink in place.
-	smd := filepath.Join(GlobalRootDir, defaultSnapMountDir)
+	smd := filepath.Join(GlobalRootDir, DefaultSnapMountDir)
 	if SnapMountDir == smd {
 		return true
 	}
@@ -454,26 +451,8 @@ func AddRootDirCallback(c func(string)) {
 
 var (
 	// distributions known to use /snap/
-	defaultDirDistros = []string{
-		"ubuntu",
-		"ubuntu-core",
+	flakyDefaultDirDistros = []string{
 		"ubuntucoreinitramfs",
-		"debian",
-		"opensuse",
-		"suse",
-		"yocto",
-	}
-
-	// distributions known to use /var/lib/snapd/snap/
-	altDirDistros = []string{
-		"altlinux",
-		"antergos",
-		"arch",
-		"archlinux",
-		"fedora",
-		"gentoo",
-		"manjaro",
-		"manjaro-arm",
 	}
 
 	// snapMountDirDetectionError is set when it was not possible to resolve the
@@ -492,52 +471,48 @@ func SnapMountDirDetectionOutcome() error {
 }
 
 func snapMountDirProbe(rootdir string) (string, error) {
-	defaultDir := filepath.Join(rootdir, defaultSnapMountDir)
-	altDir := filepath.Join(rootdir, altSnapMountDir)
+	defaultDir := filepath.Join(rootdir, DefaultSnapMountDir)
+	altDir := filepath.Join(rootdir, AltSnapMountDir)
 
-	switch {
-	case release.DistroLike(defaultDirDistros...):
+	// notable exception for Ubuntu Core initramfs
+	if release.DistroLike(flakyDefaultDirDistros...) {
 		return defaultDir, nil
+	}
 
-	case release.DistroLike(altDirDistros...):
-		return altDir, nil
-
-	default:
-		// observe the system state to find out how snapd was packaged,
-		// essentially use the same logic as
-		// sc_probe_snap_mount_dir_from_pid_1_mount_ns() used in snap-confine,
-		// except for hard errors
-		fi, err := os.Lstat(defaultDir)
+	// observe the system state to find out how snapd was packaged,
+	// essentially use the same logic as
+	// sc_probe_snap_mount_dir_from_pid_1_mount_ns() used in snap-confine,
+	// except for hard errors
+	fi, err := os.Lstat(defaultDir)
+	switch {
+	case err != nil:
+		if errors.Is(err, fs.ErrNotExist) {
+			// path does not exist, given that well-known distros are
+			// handled explicitly we are dealing with a distribution we have
+			// no knowledge of and the packaging does not include a default
+			// mount path
+			return altDir, nil
+		} else {
+			return "", fmt.Errorf("cannot stat %s: %w", defaultDir, err)
+		}
+	case fi.Mode().Type()&fs.ModeSymlink != 0:
+		// exists and is a symlink, find out what the target is, but keep
+		// the checks simple and read the symlink rather than trying
+		// filepath.EvalSymlinks() which needs intermediate directories to
+		// exist
+		p, err := os.Readlink(defaultDir)
 		switch {
 		case err != nil:
-			if errors.Is(err, fs.ErrNotExist) {
-				// path does not exist, given that well-known distros are
-				// handled explicitly we are dealing with a distribution we have
-				// no knowledge of and the packaging does not include a default
-				// mount path
-				return altDir, nil
-			} else {
-				return "", fmt.Errorf("cannot stat %s: %w", defaultDir, err)
-			}
-		case fi.Mode().Type()&fs.ModeSymlink != 0:
-			// exists and is a symlink, find out what the target is, but keep
-			// the checks simple and read the symlink rather than trying
-			// filepath.EvalSymlinks() which needs intermediate directories to
-			// exist
-			p, err := os.Readlink(defaultDir)
-			switch {
-			case err != nil:
-				return "", fmt.Errorf("cannot read %s symlink path: %w", defaultDir, err)
-			case p != altSnapMountDir && p != altSnapMountDir[1:] && p != altDir:
-				return "", fmt.Errorf("%v must be a symbolic link to %v", defaultDir, altSnapMountDir)
-			default:
-				// we read the symlink and it points to the alternative location
-				return altDir, nil
-			}
-		case fi.Mode().Type().IsDir():
-			// exists and is a directory
-			return defaultDir, nil
+			return "", fmt.Errorf("cannot read %s symlink path: %w", defaultDir, err)
+		case p != AltSnapMountDir && p != AltSnapMountDir[1:] && p != altDir:
+			return "", fmt.Errorf("%v must be a symbolic link to %v", defaultDir, AltSnapMountDir)
+		default:
+			// we read the symlink and it points to the alternative location
+			return altDir, nil
 		}
+	case fi.Mode().Type().IsDir():
+		// exists and is a directory
+		return defaultDir, nil
 	}
 
 	return "", errors.New("internal error: unresolved snap mount dir")
@@ -554,7 +529,7 @@ func SetRootDir(rootdir string) {
 	isInsideBase, _ := isInsideBaseSnap()
 	if isInsideBase {
 		// when inside the base, the mount directory is always /snap
-		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)
+		SnapMountDir = filepath.Join(rootdir, DefaultSnapMountDir)
 	} else {
 		if dir, err := snapMountDirProbe(rootdir); err == nil {
 			SnapMountDir = dir

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -475,22 +475,32 @@ var (
 		"manjaro",
 		"manjaro-arm",
 	}
+
+	// snapMountDirDetectionError is set when it was not possible to resolve the
+	// snap mount directory location.
+	snapMountDirDetectionError error = nil
+	// a well known default value, with which it will be impossible to carry out
+	// operations on the filesystem
+	snapMountDirUnresolvedPlaceholder = "mount-dir-is-unset"
 )
 
-func snapMountDirProbe(rootdir string) string {
+// SnapMountDirDetectionOutcome returns an error, if any, which occurred when
+// probing the mount directory location. A non-nil error indicates that snap
+// mount dir could no thave been properly determined.
+func SnapMountDirDetectionOutcome() error {
+	return snapMountDirDetectionError
+}
 
+func snapMountDirProbe(rootdir string) (string, error) {
 	defaultDir := filepath.Join(rootdir, defaultSnapMountDir)
 	altDir := filepath.Join(rootdir, altSnapMountDir)
 
-	// a well known default value
-	dir := "mount-dir-is-unset"
-
 	switch {
 	case release.DistroLike(defaultDirDistros...):
-		dir = defaultDir
+		return defaultDir, nil
 
 	case release.DistroLike(altDirDistros...):
-		dir = altDir
+		return altDir, nil
 
 	default:
 		// observe the system state to find out how snapd was packaged,
@@ -505,9 +515,9 @@ func snapMountDirProbe(rootdir string) string {
 				// handled explicitly we are dealing with a distribution we have
 				// no knowledge of and the packaging does not include a default
 				// mount path
-				dir = altDir
+				return altDir, nil
 			} else {
-				fmt.Fprintf(stderr, "cannot stat %s: %v\n", defaultDir, err)
+				return "", fmt.Errorf("cannot stat %s: %w", defaultDir, err)
 			}
 		case fi.Mode().Type()&fs.ModeSymlink != 0:
 			// exists and is a symlink, find out what the target is, but keep
@@ -517,20 +527,20 @@ func snapMountDirProbe(rootdir string) string {
 			p, err := os.Readlink(defaultDir)
 			switch {
 			case err != nil:
-				fmt.Fprintf(stderr, "cannot read %s symlink path: %v\n", defaultDir, err)
+				return "", fmt.Errorf("cannot read %s symlink path: %w", defaultDir, err)
 			case p != altSnapMountDir && p != altSnapMountDir[1:] && p != altDir:
-				fmt.Fprintf(stderr, "%v must be a symbolic link to %v\n", defaultDir, altSnapMountDir)
+				return "", fmt.Errorf("%v must be a symbolic link to %v", defaultDir, altSnapMountDir)
 			default:
 				// we read the symlink and it points to the alternative location
-				dir = altDir
+				return altDir, nil
 			}
 		case fi.Mode().Type().IsDir():
 			// exists and is a directory
-			dir = defaultDir
+			return defaultDir, nil
 		}
 	}
 
-	return dir
+	return "", errors.New("internal error: unresolved snap mount dir")
 }
 
 // SetRootDir allows settings a new global root directory, this is useful
@@ -546,7 +556,13 @@ func SetRootDir(rootdir string) {
 		// when inside the base, the mount directory is always /snap
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)
 	} else {
-		SnapMountDir = snapMountDirProbe(rootdir)
+		if dir, err := snapMountDirProbe(rootdir); err == nil {
+			SnapMountDir = dir
+			snapMountDirDetectionError = nil
+		} else {
+			SnapMountDir = snapMountDirUnresolvedPlaceholder
+			snapMountDirDetectionError = fmt.Errorf("cannot resolve snap mount directory: %w", err)
+		}
 	}
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -174,7 +174,6 @@ func (s *DirsTestSuite) TestClassicConfinementSymlinkAltDistro(c *C) {
 	defer restore()
 
 	altRoot := c.MkDir()
-
 	c.Assert(os.Symlink(filepath.Join(altRoot, "/var/lib/snapd/snap"), filepath.Join(altRoot, "/snap")), IsNil)
 	dirs.SetRootDir(altRoot)
 	defer dirs.SetRootDir("/")
@@ -227,6 +226,7 @@ func (s *DirsTestSuite) TestMountDirKnownDistro(c *C) {
 		{"rhel", []string{"fedora"}, false},
 		{"centos", []string{"fedora"}, false},
 		{"ubuntu", []string{"debian"}, true},
+		{"ubuntucoreinitramfs", nil, true},
 		{"debian", nil, true},
 		{"suse", nil, true},
 		{"yocto", nil, true},

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -257,23 +257,27 @@ func (s *DirsTestSuite) TestMountDirProbeHappy(c *C) {
 	d := c.MkDir()
 	dirs.SetRootDir(d)
 	// no /snap or /var/lib/snapd/snap delivered through packaging
+	c.Check(dirs.SnapMountDirDetectionOutcome(), IsNil)
 	c.Check(dirs.SnapMountDir, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/snap"))
 
 	// pretend we have a directory
 	c.Assert(os.Mkdir(filepath.Join(d, "snap"), 0o755), IsNil)
 	dirs.SetRootDir(d)
+	c.Check(dirs.SnapMountDirDetectionOutcome(), IsNil)
 	c.Check(dirs.SnapMountDir, Equals, filepath.Join(dirs.GlobalRootDir, "/snap"))
 
 	c.Assert(os.Remove(filepath.Join(d, "/snap")), IsNil)
 	// pretend we have a relative symlink
 	c.Assert(os.Symlink("var/lib/snapd/snap", filepath.Join(d, "/snap")), IsNil)
 	dirs.SetRootDir(d)
+	c.Check(dirs.SnapMountDirDetectionOutcome(), IsNil)
 	c.Check(dirs.SnapMountDir, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/snap"))
 
 	c.Assert(os.Remove(filepath.Join(d, "/snap")), IsNil)
 	// pretend we have an absolute symlink
 	c.Assert(os.Symlink("/var/lib/snapd/snap", filepath.Join(d, "/snap")), IsNil)
 	dirs.SetRootDir(d)
+	c.Check(dirs.SnapMountDirDetectionOutcome(), IsNil)
 	c.Check(dirs.SnapMountDir, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/snap"))
 
 	// also accepts an absolute path under explicit root dir commonly set during tests
@@ -281,6 +285,7 @@ func (s *DirsTestSuite) TestMountDirProbeHappy(c *C) {
 	// pretend we have an absolute symlink
 	c.Assert(os.Symlink(filepath.Join(d, "/var/lib/snapd/snap"), filepath.Join(d, "/snap")), IsNil)
 	dirs.SetRootDir(d)
+	c.Check(dirs.SnapMountDirDetectionOutcome(), IsNil)
 	c.Check(dirs.SnapMountDir, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/snap"))
 }
 
@@ -294,6 +299,7 @@ func (s *DirsTestSuite) TestMountDirProbeErrBadSymlink(c *C) {
 	c.Assert(os.Symlink("foo/bar", filepath.Join(d, "/snap")), IsNil)
 	dirs.SetRootDir(d)
 	c.Check(dirs.SnapMountDir, Equals, "mount-dir-is-unset")
+	c.Check(dirs.SnapMountDirDetectionOutcome(), ErrorMatches, "cannot resolve snap mount directory: /.*/snap must be a symbolic link to /var/lib/snapd/snap")
 }
 
 func (s *DirsTestSuite) TestMountDirProbeErrBadStat(c *C) {
@@ -313,6 +319,7 @@ func (s *DirsTestSuite) TestMountDirProbeErrBadStat(c *C) {
 
 	dirs.SetRootDir(d)
 	c.Check(dirs.SnapMountDir, Equals, "mount-dir-is-unset")
+	c.Check(dirs.SnapMountDirDetectionOutcome(), ErrorMatches, "cannot resolve snap mount directory: cannot stat /.*/snap: lstat /.*/snap: permission denied")
 }
 
 func (s *DirsTestSuite) TestInsideBaseSnap(c *C) {

--- a/dirs/dirstest/mocks.go
+++ b/dirs/dirstest/mocks.go
@@ -1,0 +1,53 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package dirstest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MustMockClassicConfinementAltDirSupport set up classic confinement support with
+// alternative snap mount directory under a given root.
+func MustMockClassicConfinementAltDirSupport(root string) {
+	MustMockAltSnapMountDir(root)
+
+	if err := os.MkdirAll(filepath.Join(root, "/var/lib/snapd/snap"), 0o755); err != nil {
+		panic(fmt.Errorf("cannot mkdir path: %w", err))
+	}
+}
+
+// MustMockAltSnapMountDir set up alternative snap mount directory in a given root.
+func MustMockAltSnapMountDir(root string) {
+	if err := os.Symlink(
+		filepath.Join(root, "/var/lib/snapd/snap"),
+		filepath.Join(root, "/snap"),
+	); err != nil {
+		panic(fmt.Errorf("cannot set up symlink: %w", err))
+	}
+}
+
+// MustMockCanonicalSnapMountDir set up canonical snap mount directory in a given root.
+func MustMockCanonicalSnapMountDir(root string) {
+	if err := os.Mkdir(filepath.Join(root, "/snap"), 0o755); err != nil {
+		panic(fmt.Errorf("cannot set up symlink: %w", err))
+	}
+}

--- a/dirs/dirstest/mocks.go
+++ b/dirs/dirstest/mocks.go
@@ -28,20 +28,18 @@ import (
 // MustMockClassicConfinementAltDirSupport set up classic confinement support with
 // alternative snap mount directory under a given root.
 func MustMockClassicConfinementAltDirSupport(root string) {
-	MustMockAltSnapMountDir(root)
-
-	if err := os.MkdirAll(filepath.Join(root, "/var/lib/snapd/snap"), 0o755); err != nil {
-		panic(fmt.Errorf("cannot mkdir path: %w", err))
-	}
-}
-
-// MustMockAltSnapMountDir set up alternative snap mount directory in a given root.
-func MustMockAltSnapMountDir(root string) {
 	if err := os.Symlink(
 		filepath.Join(root, "/var/lib/snapd/snap"),
 		filepath.Join(root, "/snap"),
 	); err != nil {
 		panic(fmt.Errorf("cannot set up symlink: %w", err))
+	}
+}
+
+// MustMockAltSnapMountDir set up alternative snap mount directory in a given root.
+func MustMockAltSnapMountDir(root string) {
+	if err := os.MkdirAll(filepath.Join(root, "/var/lib/snapd/snap"), 0o755); err != nil {
+		panic(fmt.Errorf("cannot mkdir path: %w", err))
 	}
 }
 

--- a/dirs/export_test.go
+++ b/dirs/export_test.go
@@ -19,10 +19,6 @@
 
 package dirs
 
-import (
-	"io"
-)
-
 var (
 	IsInsideBaseSnap = isInsideBaseSnap
 )
@@ -32,13 +28,5 @@ func MockMetaSnapPath(path string) (restore func()) {
 	metaSnapPath = path
 	return func() {
 		metaSnapPath = old
-	}
-}
-
-func MockStderr(out io.Writer) (restore func()) {
-	old := stderr
-	stderr = out
-	return func() {
-		stderr = old
 	}
 }

--- a/dirs/export_test.go
+++ b/dirs/export_test.go
@@ -19,6 +19,10 @@
 
 package dirs
 
+import (
+	"io"
+)
+
 var (
 	IsInsideBaseSnap = isInsideBaseSnap
 )
@@ -28,5 +32,13 @@ func MockMetaSnapPath(path string) (restore func()) {
 	metaSnapPath = path
 	return func() {
 		metaSnapPath = old
+	}
+}
+
+func MockStderr(out io.Writer) (restore func()) {
+	old := stderr
+	stderr = out
+	return func() {
+		stderr = old
 	}
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -86,6 +87,7 @@ func (t *firstBootBaseTest) setupBaseTest(c *C, s *seedtest.SeedSnaps) {
 	}
 
 	tempdir := c.MkDir()
+	dirstest.MustMockCanonicalSnapMountDir(tempdir)
 	dirs.SetRootDir(tempdir)
 	t.AddCleanup(func() { dirs.SetRootDir("/") })
 

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
@@ -90,6 +91,7 @@ func (ovs *overlordSuite) SetUpTest(c *C) {
 	}
 
 	tmpdir := c.MkDir()
+	dirstest.MustMockCanonicalSnapMountDir(tmpdir)
 	dirs.SetRootDir(tmpdir)
 	ovs.AddCleanup(func() { dirs.SetRootDir("") })
 	ovs.AddCleanup(osutil.MockMountInfo(""))

--- a/overlord/snapstate/readme_test.go
+++ b/overlord/snapstate/readme_test.go
@@ -26,8 +26,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/overlord/snapstate"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -36,20 +36,18 @@ type readmeSuite struct{}
 var _ = Suite(&readmeSuite{})
 
 func (s *readmeSuite) TestSnapReadmeFedora(c *C) {
-	restore := release.MockReleaseInfo(&release.OS{ID: "fedora"})
-	defer restore()
-
-	dirs.SetRootDir("/")
+	d := c.MkDir()
+	dirstest.MustMockAltSnapMountDir(d)
+	dirs.SetRootDir(d)
 	defer dirs.SetRootDir("/")
 
 	c.Assert(snapstate.SnapReadme(), testutil.Contains, "/var/lib/snapd/snap/bin                   - Symlinks to snap applications.\n")
 }
 
 func (s *readmeSuite) TestSnapReadmeUbuntu(c *C) {
-	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
-	defer restore()
-
-	dirs.SetRootDir("/")
+	d := c.MkDir()
+	dirstest.MustMockCanonicalSnapMountDir(d)
+	dirs.SetRootDir(d)
 	defer dirs.SetRootDir("/")
 
 	c.Assert(snapstate.SnapReadme(), testutil.Contains, "/snap/bin                   - Symlinks to snap applications.\n")

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
@@ -3879,12 +3880,9 @@ func (s *snapmgrTestSuite) TestInstallFailsWhenClassicSnapsAreNotSupported(c *C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	reset := release.MockReleaseInfo(&release.OS{
-		ID: "fedora",
-	})
-	defer reset()
-
 	// this needs doing because dirs depends on the release info
+	c.Check(os.RemoveAll(dirs.SnapMountDir), IsNil)
+	dirstest.MustMockAltSnapMountDir(dirs.GlobalRootDir)
 	dirs.SetRootDir(dirs.GlobalRootDir)
 
 	opts := &snapstate.RevisionOptions{Channel: "channel-for-classic"}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
@@ -155,7 +156,9 @@ func (s *snapmgrBaseTest) mockSystemctlCallsUpdateMounts(c *C) (restore func()) 
 
 func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	dirs.SetRootDir(c.MkDir())
+	rd := c.MkDir()
+	dirstest.MustMockCanonicalSnapMountDir(rd)
+	dirs.SetRootDir(rd)
 
 	s.o = overlord.Mock()
 	s.state = s.o.State()

--- a/snapdtool/cmdutil_test.go
+++ b/snapdtool/cmdutil_test.go
@@ -29,6 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snapdtool"
@@ -92,7 +93,7 @@ func (s *cmdutilSuite) TestCommandFromSystemSnapOldTrick(c *C) {
 }
 
 func (s *cmdutilSuite) TestCommandFromSystemSnapNoTrickNeeded(c *C) {
-	defer release.MockReleaseInfo(&release.OS{ID: "ubuntu"})()
+	dirstest.MustMockCanonicalSnapMountDir(dirs.GlobalRootDir)
 	dirs.SetRootDir(dirs.GlobalRootDir)
 
 	c.Logf("mount dir: %v", dirs.SnapMountDir)

--- a/syscheck/dirs.go
+++ b/syscheck/dirs.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ f* Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+*/
+
+package syscheck
+
+import (
+	"github.com/snapcore/snapd/dirs"
+)
+
+func init() {
+	checks = append(checks, checkSnapMountDir)
+}
+
+func checkSnapMountDir() error {
+	// trivla helper, nothing to see really
+	return dirs.SnapMountDirDetectionOutcome()
+}

--- a/syscheck/dirs_test.go
+++ b/syscheck/dirs_test.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package syscheck_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/syscheck"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type dirsSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&dirsSuite{})
+
+func (s *dirsSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{
+		ID: "funkylunix",
+	}))
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func (s *dirsSuite) TestHappy(c *C) {
+	dir := c.MkDir()
+
+	dirstest.MustMockCanonicalSnapMountDir(dir)
+	dirs.SetRootDir(dir)
+	c.Check(dirs.SnapMountDirDetectionOutcome(), IsNil)
+
+	c.Check(syscheck.CheckSnapMountDir(), IsNil)
+}
+
+func (s *dirsSuite) TestUndetermined(c *C) {
+	d := c.MkDir()
+	// pretend we have a relative symlink
+	c.Assert(os.Symlink("foo/bar", filepath.Join(d, "/snap")), IsNil)
+	dirs.SetRootDir(d)
+	c.Logf("dir: %v", dirs.SnapMountDir)
+
+	c.Check(dirs.SnapMountDirDetectionOutcome(), NotNil)
+
+	c.Check(syscheck.CheckSnapMountDir(), ErrorMatches, "cannot resolve snap mount directory: .*")
+}

--- a/syscheck/export_test.go
+++ b/syscheck/export_test.go
@@ -25,6 +25,7 @@ var (
 	CheckApparmorUsable = checkApparmorUsable
 	CheckWSL            = checkWSL
 	CheckCgroup         = checkCgroup
+	CheckSnapMountDir   = checkSnapMountDir
 
 	CheckFuse = firstCheckFuse
 )

--- a/tests/main/core18-configure-hook/task.yaml
+++ b/tests/main/core18-configure-hook/task.yaml
@@ -11,6 +11,10 @@ prepare: |
     echo "Ensure empty state"
     echo "Ensure all snaps are gone"
     snapd.tool exec snap-mgmt --purge
+    # purge removes the snap mount directory, but we must restore it since it's
+    # part of packaging
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    mkdir -p "$SNAP_MOUNT_DIR"
 
     tests.systemd stop-unit snapd.service
     rm -f /var/lib/snapd/state.json

--- a/tests/main/mount-dir-detect-check/task.yaml
+++ b/tests/main/mount-dir-detect-check/task.yaml
@@ -1,0 +1,66 @@
+summary: Verify mount directory detection checks
+details: |
+  Verify that detection of snap mount directory will correctly identify and flag
+  unexpected path on a distribution where we have historical knowledge of the
+  correct location.
+
+systems:
+  - -ubuntu-core-*
+
+prepare: |
+  if tests.info is-snapd-from-archive ; then
+       tests.exec skip-test "snapd deb from archive has no mount detection" && exit 0
+  fi
+
+  tests.systemd stop-unit snapd.service
+  echo "Ensure all snaps are gone"
+  snapd.tool exec snap-mgmt --purge
+
+  SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+  tests.cleanup defer mkdir -p "$SNAP_MOUNT_DIR"
+
+  rm -f /var/lib/snapd/state.json
+
+  # prepare should have removed the mount directory
+  not test -d "$SNAP_MOUNT_DIR"
+
+  baddir=""
+  case "$SNAP_MOUNT_DIR" in
+  /snap)
+      baddir="/var/lib/snapd/snap"
+      ;;
+  /var/lib/snapd/snap)
+      baddir="/snap"
+      ;;
+  *)
+      echo "unexpected snap mount directory $SNAP_MOUNT_DIR"
+      exit 1
+      ;;
+  esac
+
+  mkdir -p "$baddir"
+  tests.cleanup defer rm -rf "$baddir"
+
+  echo "$baddir" > mock-mount-dir
+
+  systemctl start snapd
+  snap wait system seed.loaded
+
+  test "$(snap list | wc -l)" = "0"
+
+execute: |
+  tests.exec is-skipped && exit 0
+
+  SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+  baddir="$(cat mock-mount-dir)"
+
+  echo "No snaps can be installed if detection found unexpected snap mount directory"
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24 2>&1 | MATCH "unexpected snap mount directory"
+
+  echo "After restoring the correct snap mount directory"
+  rm -rf "$baddir"
+  mkdir -p "$SNAP_MOUNT_DIR"
+  systemctl restart snapd.service
+
+  echo "Snaps can be installed again"
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24

--- a/tests/main/mount-dir-detect-check/task.yaml
+++ b/tests/main/mount-dir-detect-check/task.yaml
@@ -21,6 +21,13 @@ prepare: |
 
   rm -f /var/lib/snapd/state.json
 
+  if [ -L /snap ]; then
+      # we have a symlink which is part of the snapd package, e.g. on Amazon
+      # Linux
+      mv /snap /snap.backup
+      tests.cleanup defer mv /snap.backup /snap
+  fi
+
   # prepare should have removed the mount directory
   not test -d "$SNAP_MOUNT_DIR"
 

--- a/tests/main/snapd-snap-removal/task.yaml
+++ b/tests/main/snapd-snap-removal/task.yaml
@@ -7,11 +7,19 @@ details: |
 systems: [-ubuntu-core-*]
 
 execute: |
-    echo "Ensure we have no core"
-    systemctl stop snapd
-    snapd.tool exec snap-mgmt --purge
-    systemctl start snapd
-    snap wait system seed.loaded
+    if snap list core ; then
+        echo "Ensure we have no core"
+        systemctl stop snapd
+        snapd.tool exec snap-mgmt --purge
+        # purge removes the snap mount directory, but we must restore it since it's
+        # part of packaging
+        SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+        mkdir -p "$SNAP_MOUNT_DIR"
+
+        systemctl start snapd
+        snap wait system seed.loaded
+    fi
+
     test "$(snap list | grep -v -c ^Name)" = 0
 
     echo "Ensure we have snapd + snap + core18 installed"

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -27,6 +27,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
@@ -286,8 +287,8 @@ WantedBy={{.ServicesTarget}}
 	case snap.SystemDaemon:
 		wrapperData.ServicesTarget = systemd.ServicesTarget
 		wrapperData.PrerequisiteTarget = systemd.PrerequisiteTarget
-		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir()))
-		wrapperData.WorkingDir = appInfo.Snap.DataDir()
+		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(dirs.StripRootDir(appInfo.Snap.MountDir())))
+		wrapperData.WorkingDir = dirs.StripRootDir(appInfo.Snap.DataDir())
 		wrapperData.After = append(wrapperData.After, "snapd.apparmor.service")
 	case snap.UserDaemon:
 		wrapperData.ServicesTarget = systemd.UserServicesTarget

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -28,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/gadget/quantity"
 	_ "github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/release"
@@ -162,7 +163,7 @@ apps:
 }
 
 func (s *serviceUnitGenSuite) TestGenerateSnapServiceOnCore(c *C) {
-	defer func() { dirs.SetRootDir("/") }()
+	defer dirs.SetRootDir("/")
 
 	expectedAppServiceOnCore := `[Unit]
 # Auto-generated, DO NOT EDIT
@@ -203,7 +204,9 @@ apps:
 	defer restore()
 	restore = release.MockReleaseInfo(&release.OS{ID: "ubuntu-core"})
 	defer restore()
-	dirs.SetRootDir("/")
+	r := c.MkDir()
+	dirstest.MustMockCanonicalSnapMountDir(r)
+	dirs.SetRootDir(r)
 
 	opts := internal.SnapServicesUnitOptions{
 		CoreMountedSnapdSnapDep: "",

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -33,6 +33,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/dirs/dirstest"
 	"github.com/snapcore/snapd/gadget/quantity"
 
 	// imported to ensure actual interfaces are defined (in production this is guaranteed by ifacestate)
@@ -72,6 +73,7 @@ func (s *servicesTestSuite) SetUpTest(c *C) {
 	s.DBusTest.SetUpTest(c)
 	s.tempdir = c.MkDir()
 	s.sysdLog = nil
+	dirstest.MustMockCanonicalSnapMountDir(s.tempdir)
 	dirs.SetRootDir(s.tempdir)
 
 	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
@@ -133,7 +135,7 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 		{"start", filepath.Base(svcFile)},
 	})
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -147,7 +149,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -157,7 +159,6 @@ Type=forking
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	))
 
 	s.sysdLog = nil
@@ -201,7 +202,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAdds(c *C) {
 		"hello-snap:svc1:service:svc1": true,
 	})
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -215,7 +216,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -225,7 +226,6 @@ Type=forking
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	))
 }
 
@@ -248,7 +248,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -262,7 +262,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -273,7 +273,6 @@ Slice=snap.foogroup.slice
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 
 	sliceTempl := `[Unit]
@@ -351,7 +350,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountQuotas(c *C) {
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -365,7 +364,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -376,7 +375,6 @@ Slice=snap.foogroup.slice
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 
 	sliceTempl := `[Unit]
@@ -450,7 +448,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountAndCpuSetQuota
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -464,7 +462,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -475,7 +473,6 @@ Slice=snap.foogroup.slice
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 
 	sliceTempl := `[Unit]
@@ -542,7 +539,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalNamespaceOnly(c *C)
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -556,7 +553,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -568,7 +565,6 @@ LogNamespace=snap-foogroup
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 	jconfTempl := `# Journald configuration for snap quota group %s
 [Journal]
@@ -657,7 +653,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotas(c *C) {
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -671,7 +667,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -683,7 +679,6 @@ LogNamespace=snap-foogroup
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 	jconfTempl := `# Journald configuration for snap quota group %s
 [Journal]
@@ -775,7 +770,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotaRateAsZero(c *
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -789,7 +784,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -801,7 +796,6 @@ LogNamespace=snap-foogroup
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 	jconfTempl := `# Journald configuration for snap quota group %s
 [Journal]
@@ -921,7 +915,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSnapServices(c *C) {
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svc1Content := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -935,17 +929,16 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 TimeoutStopSec=30
 Type=simple
-Slice=snap.%[3]s.slice
+Slice=snap.%[2]s.slice
 LogNamespace=snap-my-root
 
 [Install]
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		systemd.EscapeUnitNamePath("my-root"),
 	)
 	svc2Content := fmt.Sprintf(`[Unit]
@@ -961,17 +954,16 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc2
 SyslogIdentifier=hello-snap.svc2
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 TimeoutStopSec=30
 Type=simple
-Slice=snap.%[3]s.slice
+Slice=snap.%[2]s.slice
 LogNamespace=snap-my-root
 
 [Install]
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		systemd.EscapeUnitNamePath("my-root")+"-"+systemd.EscapeUnitNamePath("my-sub"),
 	)
 	jSvcContent := `[Service]
@@ -1115,7 +1107,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithIncludeServices(c *C) {
 		info: {QuotaGroup: grp},
 	}
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svc2Content := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc2
@@ -1129,17 +1121,16 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc2
 SyslogIdentifier=hello-snap.svc2
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 TimeoutStopSec=30
 Type=simple
-Slice=snap.%[3]s.slice
+Slice=snap.%[2]s.slice
 LogNamespace=snap-my-root
 
 [Install]
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		systemd.EscapeUnitNamePath("my-root")+"-"+systemd.EscapeUnitNamePath("my-sub"),
 	)
 	jSvcContent := `[Service]
@@ -1331,7 +1322,7 @@ TasksAccounting=true
 `
 	sliceFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.foogroup.slice")
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -1345,7 +1336,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -1356,7 +1347,6 @@ Slice=snap.foogroup.slice
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 
 	err := os.MkdirAll(filepath.Dir(sliceFile), 0755)
@@ -1433,7 +1423,7 @@ TasksMax=%[3]d
 `
 	sliceFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.foogroup.slice")
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	svcContent := fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -1447,7 +1437,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -1458,7 +1448,6 @@ Slice=snap.foogroup.slice
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	)
 
 	err := os.MkdirAll(filepath.Dir(sliceFile), 0755)
@@ -1625,31 +1614,29 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run %[1]s.svc1
 SyslogIdentifier=%[1]s.svc1
 Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/%[1]s/12
+WorkingDirectory=/var/snap/%[1]s/12
 ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
 TimeoutStopSec=30
 Type=forking
-Slice=%[4]s
+Slice=%[3]s
 
 [Install]
 WantedBy=multi-user.target
 `
 
-	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
-	dir2 := filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount")
+	dir1 := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
+	dir2 := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount"))
 
 	helloSnapContent := fmt.Sprintf(svcTemplate,
 		"hello-snap",
 		systemd.EscapeUnitNamePath(dir1),
-		dirs.GlobalRootDir,
 		"snap.foogroup.slice",
 	)
 
 	helloOtherSnapContent := fmt.Sprintf(svcTemplate,
 		"hello-other-snap",
 		systemd.EscapeUnitNamePath(dir2),
-		dirs.GlobalRootDir,
 		"snap.foogroup-subgroup.slice",
 	)
 
@@ -1746,23 +1733,22 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run %[1]s.svc1
 SyslogIdentifier=%[1]s.svc1
 Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/%[1]s/12
+WorkingDirectory=/var/snap/%[1]s/12
 ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
 TimeoutStopSec=30
 Type=forking
-Slice=%[4]s
+Slice=%[3]s
 
 [Install]
 WantedBy=multi-user.target
 `
 
-	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir1 := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 
 	c.Assert(svcFile1, testutil.FileEquals, fmt.Sprintf(svcTemplate,
 		"hello-snap",
 		systemd.EscapeUnitNamePath(dir1),
-		dirs.GlobalRootDir,
 		"snap.foogroup-subgroup.slice",
 	))
 
@@ -1846,7 +1832,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesPreseedingHappy(c *C) {
 		"hello-snap:svc1:service:svc1": true,
 	})
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -1860,7 +1846,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -1870,7 +1856,6 @@ Type=forking
 WantedBy=multi-user.target
 `,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 	))
 }
 
@@ -1940,30 +1925,28 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run %[1]s.svc1
 SyslogIdentifier=%[1]s.svc1
 Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/%[1]s/12
+WorkingDirectory=/var/snap/%[1]s/12
 ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
 TimeoutStopSec=30
 Type=forking
-%[4]s
+%[3]s
 [Install]
 WantedBy=multi-user.target
 `
 
-	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
-	dir2 := filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount")
+	dir1 := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
+	dir2 := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount"))
 
 	c.Assert(svcFile1, testutil.FileEquals, fmt.Sprintf(template,
 		"hello-snap",
 		systemd.EscapeUnitNamePath(dir1),
-		dirs.GlobalRootDir,
 		"OOMScoreAdjust=-899\n", // VitalityRank in effect
 	))
 
 	c.Assert(svcFile2, testutil.FileEquals, fmt.Sprintf(template,
 		"hello-other-snap",
 		systemd.EscapeUnitNamePath(dir2),
-		dirs.GlobalRootDir,
 		"", // no VitalityRank in effect
 	))
 }
@@ -1979,7 +1962,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesCallback(c *C) {
 	svc1File := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svc2File := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc2.service")
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	template := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.%[1]s
@@ -1993,19 +1976,18 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.%[1]s
 SyslogIdentifier=hello-snap.%[1]s
 Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
 TimeoutStopSec=30
 Type=forking
-%[4]s
+%[3]s
 [Install]
 WantedBy=multi-user.target
 `
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	)
 
@@ -2034,7 +2016,6 @@ WantedBy=multi-user.target
 	svc2New := fmt.Sprintf(template,
 		"svc2",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"OOMScoreAdjust=-899\n",
 	)
 	c.Assert(svc2File, testutil.FileEquals, svc2New)
@@ -2043,7 +2024,6 @@ WantedBy=multi-user.target
 	svc1New := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"OOMScoreAdjust=-899\n",
 	)
 	c.Assert(svc1File, testutil.FileEquals, svc1New)
@@ -2072,7 +2052,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAddsNewSvc(c *C) {
 	svc1File := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svc2File := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc2.service")
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	template := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.%[1]s
@@ -2086,19 +2066,18 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.%[1]s
 SyslogIdentifier=hello-snap.%[1]s
 Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
 TimeoutStopSec=30
 Type=forking
-%[4]s
+%[3]s
 [Install]
 WantedBy=multi-user.target
 `
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	)
 
@@ -2125,7 +2104,6 @@ WantedBy=multi-user.target
 	c.Assert(svc2File, testutil.FileEquals, fmt.Sprintf(template,
 		"svc2",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	))
 
@@ -2133,7 +2111,6 @@ WantedBy=multi-user.target
 	c.Assert(svc1File, testutil.FileEquals, fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	))
 }
@@ -2144,7 +2121,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesNoChangeNoop(c *C) {
 	// pretend we already have a unit file setup
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	template := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -2158,7 +2135,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -2169,7 +2146,6 @@ WantedBy=multi-user.target
 `
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	)
 
@@ -2212,7 +2188,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesChanges(c *C) {
 	// pretend we already have a unit file with no VitalityRank options set
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	template := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -2226,7 +2202,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -2237,7 +2213,6 @@ WantedBy=multi-user.target
 `
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	)
 
@@ -2265,7 +2240,6 @@ WantedBy=multi-user.target
 	// now the file has been modified to have OOMScoreAdjust set for it
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"OOMScoreAdjust=-899\n",
 	))
 }
@@ -2276,7 +2250,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRollsback(c *C) {
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	// pretend we already have a unit file with no VitalityRank options set
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	template := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -2290,7 +2264,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -2301,7 +2275,6 @@ WantedBy=multi-user.target
 `
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	)
 
@@ -2321,7 +2294,6 @@ WantedBy=multi-user.target
 			// for it
 			c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(template,
 				systemd.EscapeUnitNamePath(dir),
-				dirs.GlobalRootDir,
 				"OOMScoreAdjust=-899\n",
 			))
 
@@ -2360,7 +2332,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRemovesNewAddOnRollback(c *C) 
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	// pretend we already have a unit file with no VitalityRank options set
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	template := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -2374,7 +2346,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
@@ -2394,7 +2366,6 @@ WantedBy=multi-user.target
 			// daemon reload
 			c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(template,
 				systemd.EscapeUnitNamePath(dir),
-				dirs.GlobalRootDir,
 				"",
 			))
 
@@ -2438,7 +2409,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesOnlyRemovesNewAddOnRollback(c 
 	svc2File := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc2.service")
 
 	// pretend we already have a unit file with no VitalityRank options set
-	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 	template := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.%[1]s
@@ -2452,12 +2423,12 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.%[1]s
 SyslogIdentifier=hello-snap.%[1]s
 Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
 ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
 TimeoutStopSec=30
 Type=forking
-%[4]s
+%[3]s
 [Install]
 WantedBy=multi-user.target
 `
@@ -2465,13 +2436,11 @@ WantedBy=multi-user.target
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	)
 	svc2Content := fmt.Sprintf(template,
 		"svc2",
 		systemd.EscapeUnitNamePath(dir),
-		dirs.GlobalRootDir,
 		"",
 	)
 
@@ -2664,7 +2633,7 @@ plugs:
 			{"daemon-reload"},
 		}, comment)
 
-		dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+		dir := dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount"))
 		c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application hello-snap.svc1
@@ -2678,7 +2647,7 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run hello-snap.svc1
 SyslogIdentifier=hello-snap.svc1
 Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
+WorkingDirectory=/var/snap/hello-snap/12
 TimeoutStopSec=30
 Type=simple
 Delegate=true
@@ -2687,7 +2656,6 @@ Delegate=true
 WantedBy=multi-user.target
 `,
 			systemd.EscapeUnitNamePath(dir),
-			dirs.GlobalRootDir,
 		), comment)
 
 		s.sysdLog = nil


### PR DESCRIPTION
dirs: auto detect snap mount dir location on unknown distributions
Introduce automatic detection of snap mount directory, similarly to a
change introduced to snap-confine in
https://github.com/canonical/snapd/commit/0d60393deebbbd4972996639e6cf727745b4e2dc.

This enables proper support of mount dir on distributions which we have
no information on, but one of the expected mount locations is provided
by the packaging.

Related: [SNAPDENG-34258](https://warthogs.atlassian.net/browse/SNAPDENG-34258)

[SNAPDENG-34258]: https://warthogs.atlassian.net/browse/SNAPDENG-34258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ