### PR TITLE
store: record snap icon etag and use If-None-Match header

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -120,9 +120,19 @@ func NoGuardDebugf(format string, v ...interface{}) {
 // MockLogger replaces the existing logger with a buffer and returns
 // the log buffer and a restore function.
 func MockLogger() (buf *bytes.Buffer, restore func()) {
+	return mockLogger(&LoggerOptions{})
+}
+
+// MockDebugLogger replaces the existing logger with a buffer and returns
+// the log buffer and a restore function. The logger records debug messages.
+func MockDebugLogger() (buf *bytes.Buffer, restore func()) {
+	return mockLogger(&LoggerOptions{ForceDebug: true})
+}
+
+func mockLogger(opts *LoggerOptions) (buf *bytes.Buffer, restore func()) {
 	buf = &bytes.Buffer{}
 	oldLogger := logger
-	l, err := New(buf, DefaultFlags, &LoggerOptions{})
+	l, err := New(buf, DefaultFlags, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -244,3 +244,10 @@ func (s *LogSuite) TestForceDebug(c *C) {
 	l.Debug("xyzzy")
 	c.Check(buf.String(), testutil.Contains, `DEBUG: xyzzy`)
 }
+
+func (s *LogSuite) TestMockDebugLogger(c *C) {
+	logbuf, restore := logger.MockDebugLogger()
+	defer restore()
+	logger.Debugf("xyzzy")
+	c.Check(logbuf.String(), testutil.Contains, "DEBUG: xyzzy")
+}

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -44,6 +44,7 @@ var (
 
 	DownloadIconImpl = downloadIcon
 	ErrIconUnchanged = errIconUnchanged
+	MaxEtagSize      = maxEtagSize
 
 	ApplyDelta = applyDelta
 

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -43,6 +43,7 @@ var (
 	Download      = download
 
 	DownloadIconImpl = downloadIcon
+	ErrIconUnchanged = errIconUnchanged
 
 	ApplyDelta = applyDelta
 
@@ -155,7 +156,7 @@ func MockMaxIconFilesize(maxSize int64) (restore func()) {
 	return testutil.Mock(&maxIconFilesize, maxSize)
 }
 
-func MockDownloadIcon(f func(ctx context.Context, name, downloadURL string, w ReadWriteSeekTruncater) error) (restore func()) {
+func MockDownloadIcon(f func(ctx context.Context, name, etag, downloadURL string, w ReadWriteSeekTruncater) (string, error)) (restore func()) {
 	return testutil.Mock(&downloadIcon, f)
 }
 

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -45,6 +45,7 @@ var (
 	DownloadIconImpl = downloadIcon
 	ErrIconUnchanged = errIconUnchanged
 	MaxEtagSize      = maxEtagSize
+	EtagXattrName    = etagXattrName
 
 	ApplyDelta = applyDelta
 

--- a/store/store.go
+++ b/store/store.go
@@ -617,8 +617,8 @@ func (r *requestOptions) addHeader(k, v string) {
 // iconRequestOptions specifies parameters for icon requests, which do not
 // require headers related to the store or snap. Just an ordinary GET request.
 type iconRequestOptions struct {
-	URL  *url.URL
-	Etag string
+	url  *url.URL
+	etag string
 }
 
 func cancelled(ctx context.Context) bool {
@@ -774,15 +774,15 @@ func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *
 }
 
 // doIconRequest does an unauthenticated GET request to the given URL.
-func doIconRequest(ctx context.Context, client *http.Client, reqOptions *iconRequestOptions) (*http.Response, error) {
+func doIconRequest(ctx context.Context, client *http.Client, reqOptions iconRequestOptions) (*http.Response, error) {
 	var body io.Reader // empty body
-	req, err := http.NewRequestWithContext(ctx, "GET", reqOptions.URL.String(), body)
+	req, err := http.NewRequestWithContext(ctx, "GET", reqOptions.url.String(), body)
 	if err != nil {
 		return nil, err
 	}
 
-	if reqOptions.Etag != "" {
-		req.Header.Set("If-None-Match", reqOptions.Etag)
+	if reqOptions.etag != "" {
+		req.Header.Set("If-None-Match", reqOptions.etag)
 	}
 
 	resp, err := client.Do(req)

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -744,14 +744,7 @@ func downloadIconImpl(ctx context.Context, name, etag, downloadURL string, w Rea
 			}
 
 			// Save etag, if it exists.
-			// Some servers (Apache) don't use proper header names, so try
-			// multiple variations. This is why we can't use resp.Header.Get().
-			for _, headerName := range []string{http.CanonicalHeaderKey("etag"), "ETag", "Etag", "etag"} {
-				if maybeEtag, ok := resp.Header[headerName]; ok && len(maybeEtag) > 0 {
-					newEtag = maybeEtag[0] // see textproto.MIMEHeader.Get()
-					break
-				}
-			}
+			newEtag = resp.Header.Get("etag")
 
 			return nil
 		}()

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -311,8 +311,8 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 
 var errIconUnchanged = errors.New("existing icon unchanged")
 
-// Etags should all be smaller than 1kiB.
-const maxEtagSize = 1024
+// Etags should all be smaller than 256B.
+const maxEtagSize = 256
 
 // DownloadIcon downloads the icon for the snap from the given download URL to
 // the given target path. Snap icons are small (<256kB) files served from an
@@ -363,7 +363,7 @@ func DownloadIcon(ctx context.Context, name string, targetPath string, downloadU
 	// Success, now try to store the etag
 	if etag != "" {
 		if len(etag) >= maxEtagSize { // len doesn't include trailing '\0'
-			logger.Debugf("snap icon etag exceeds maximum etag length: %q", etag)
+			logger.Debugf("snap icon etag exceeds maximum etag length (%d): %d", maxEtagSize, len(etag))
 		} else {
 			// If the filesystem does not support xattrs, we'll just redownload
 			// the whole icon next time, so log but do not return any error.

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -324,7 +324,7 @@ func DownloadIcon(ctx context.Context, name string, targetPath string, downloadU
 	// Read etag of existing file at targetPath, if it exists
 	var etag string
 	etagBuf := make([]byte, 256) // all etags should be smaller than 256B
-	if size, err := unix.Getxattr(targetPath, "user.etag", etagBuf); err == nil {
+	if size, err := unix.Getxattr(targetPath, "user.snapstore-etag", etagBuf); err == nil {
 		etag = string(etagBuf[:size])
 	}
 
@@ -358,9 +358,9 @@ func DownloadIcon(ctx context.Context, name string, targetPath string, downloadU
 
 	// Success, now try to store the etag
 	if etag != "" {
-		// Ignore any error. If it fails, we'll just redownload the whole icon
-		// next time. No problem.
-		unix.Setxattr(targetPath, "user.etag", []byte(etag), 0)
+		// Ignore any error in case the filesystem does not support xattrs.
+		// If it fails, we'll just redownload the whole icon next time.
+		unix.Setxattr(targetPath, "user.snapstore-etag", []byte(etag), 0)
 	}
 	return nil
 }

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1297,7 +1297,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithNewEtag(c *C) {
 
 	c.Check(path, testutil.FileEquals, expectedContent)
 	etagBuf := make([]byte, 256)
-	size, err := unix.Getxattr(path, "user.etag", etagBuf)
+	size, err := unix.Getxattr(path, "user.snapstore-etag", etagBuf)
 	c.Assert(err, IsNil)
 	writtenEtag := string(etagBuf[:size])
 	c.Check(writtenEtag, Equals, newEtag)
@@ -1314,7 +1314,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
 	// Create existing file
 	c.Assert(os.WriteFile(path, existingContent, 0o644), IsNil)
 	// Set etag xattr
-	c.Assert(unix.Setxattr(path, "user.etag", []byte(existingEtag), 0), IsNil)
+	c.Assert(unix.Setxattr(path, "user.snapstore-etag", []byte(existingEtag), 0), IsNil)
 
 	restore := store.MockDownloadIcon(func(ctx context.Context, name, etag, url string, w store.ReadWriteSeekTruncater) (string, error) {
 		c.Check(name, Equals, expectedName)
@@ -1335,7 +1335,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
 	// Existing file (and etag) should not have been overwritten
 	c.Check(path, testutil.FileEquals, existingContent)
 	etagBuf := make([]byte, 256)
-	size, err := unix.Getxattr(path, "user.etag", etagBuf)
+	size, err := unix.Getxattr(path, "user.snapstore-etag", etagBuf)
 	c.Assert(err, IsNil)
 	writtenEtag := string(etagBuf[:size])
 	c.Check(writtenEtag, Equals, existingEtag)
@@ -1353,7 +1353,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
 	// Create existing file
 	c.Assert(os.WriteFile(path, existingContent, 0o644), IsNil)
 	// Set etag xattr
-	c.Assert(unix.Setxattr(path, "user.etag", []byte(existingEtag), 0), IsNil)
+	c.Assert(unix.Setxattr(path, "user.snapstore-etag", []byte(existingEtag), 0), IsNil)
 
 	restore := store.MockDownloadIcon(func(ctx context.Context, name, etag, url string, w store.ReadWriteSeekTruncater) (string, error) {
 		c.Check(name, Equals, expectedName)
@@ -1370,7 +1370,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
 
 	c.Check(path, testutil.FileEquals, expectedContent)
 	etagBuf := make([]byte, 256)
-	size, err := unix.Getxattr(path, "user.etag", etagBuf)
+	size, err := unix.Getxattr(path, "user.snapstore-etag", etagBuf)
 	c.Assert(err, IsNil)
 	writtenEtag := string(etagBuf[:size])
 	c.Check(writtenEtag, Equals, newEtag)

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1308,7 +1308,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithNewEtag(c *C) {
 
 	c.Check(path, testutil.FileEquals, expectedContent)
 	etagBuf := make([]byte, 256)
-	size, err := unix.Getxattr(path, "user.snapstore-etag", etagBuf)
+	size, err := unix.Getxattr(path, store.EtagXattrName, etagBuf)
 	c.Assert(err, IsNil)
 	writtenEtag := string(etagBuf[:size])
 	c.Check(writtenEtag, Equals, newEtag)
@@ -1326,7 +1326,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
 	// Create existing file
 	c.Assert(os.WriteFile(path, existingContent, 0o644), IsNil)
 	// Set etag xattr
-	c.Assert(unix.Setxattr(path, "user.snapstore-etag", []byte(existingEtag), 0), IsNil)
+	c.Assert(unix.Setxattr(path, store.EtagXattrName, []byte(existingEtag), 0), IsNil)
 
 	restore := store.MockDownloadIcon(func(ctx context.Context, name, etag, url string, w store.ReadWriteSeekTruncater) (string, error) {
 		c.Check(name, Equals, expectedName)
@@ -1346,7 +1346,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
 	// Existing file (and etag) should not have been overwritten
 	c.Check(path, testutil.FileEquals, existingContent)
 	etagBuf := make([]byte, 256)
-	size, err := unix.Getxattr(path, "user.snapstore-etag", etagBuf)
+	size, err := unix.Getxattr(path, store.EtagXattrName, etagBuf)
 	c.Assert(err, IsNil)
 	writtenEtag := string(etagBuf[:size])
 	c.Check(writtenEtag, Equals, existingEtag)
@@ -1365,7 +1365,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
 	// Create existing file
 	c.Assert(os.WriteFile(path, existingContent, 0o644), IsNil)
 	// Set etag xattr
-	c.Assert(unix.Setxattr(path, "user.snapstore-etag", []byte(existingEtag), 0), IsNil)
+	c.Assert(unix.Setxattr(path, store.EtagXattrName, []byte(existingEtag), 0), IsNil)
 
 	restore := store.MockDownloadIcon(func(ctx context.Context, name, etag, url string, w store.ReadWriteSeekTruncater) (string, error) {
 		c.Check(name, Equals, expectedName)
@@ -1381,7 +1381,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
 
 	c.Check(path, testutil.FileEquals, expectedContent)
 	etagBuf := make([]byte, 256)
-	size, err := unix.Getxattr(path, "user.snapstore-etag", etagBuf)
+	size, err := unix.Getxattr(path, store.EtagXattrName, etagBuf)
 	c.Assert(err, IsNil)
 	writtenEtag := string(etagBuf[:size])
 	c.Check(writtenEtag, Equals, newEtag)
@@ -1400,7 +1400,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithEtagTooLong(c *C) {
 	// Create existing file
 	c.Assert(os.WriteFile(path, existingContent, 0o644), IsNil)
 	// Set etag xattr
-	c.Assert(unix.Setxattr(path, "user.snapstore-etag", []byte(existingEtag), 0), IsNil)
+	c.Assert(unix.Setxattr(path, store.EtagXattrName, []byte(existingEtag), 0), IsNil)
 
 	logbuf, restore := logger.MockDebugLogger()
 	defer restore()
@@ -1420,7 +1420,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithEtagTooLong(c *C) {
 	c.Check(path, testutil.FileEquals, expectedContent)
 	// Etag exceeded max size, so no etag should have been written
 	etagBuf := make([]byte, 2*store.MaxEtagSize)
-	_, err = unix.Getxattr(path, "user.snapstore-etag", etagBuf)
+	_, err = unix.Getxattr(path, store.EtagXattrName, etagBuf)
 	c.Check(err, testutil.ErrorIs, unix.ENODATA)
 	c.Check(logbuf.String(), testutil.Contains, "snap icon etag exceeds maximum etag length")
 }

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1305,7 +1305,6 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithNewEtag(c *C) {
 	path := filepath.Join(c.MkDir(), "downloaded-file")
 	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
-	defer os.Remove(path)
 
 	c.Check(path, testutil.FileEquals, expectedContent)
 	etagBuf := make([]byte, 256)
@@ -1343,7 +1342,6 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
 
 	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
-	defer os.Remove(path)
 
 	// Existing file (and etag) should not have been overwritten
 	c.Check(path, testutil.FileEquals, existingContent)
@@ -1380,7 +1378,6 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
 
 	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
-	defer os.Remove(path)
 
 	c.Check(path, testutil.FileEquals, expectedContent)
 	etagBuf := make([]byte, 256)
@@ -1419,7 +1416,6 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithEtagTooLong(c *C) {
 
 	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
-	defer os.Remove(path)
 
 	c.Check(path, testutil.FileEquals, expectedContent)
 	// Etag exceeded max size, so no etag should have been written
@@ -1458,7 +1454,6 @@ func (s *storeDownloadSuite) TestDownloadIconDoesNotOverwriteLinks(c *C) {
 
 	err = store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
-	defer os.Remove(path)
 
 	c.Assert(path, testutil.FileEquals, newContent)
 	// Check that the contents of the existing hard-linked file were not overwritten

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1276,7 +1276,18 @@ func (s *storeDownloadSuite) TestDownloadIconOK(c *C) {
 	c.Assert(path, testutil.FileEquals, expectedContent)
 }
 
+func skipIfXattrsUnsupported(c *C) {
+	f, err := os.CreateTemp(c.MkDir(), "xattr-probe")
+	c.Assert(err, IsNil)
+	defer f.Close()
+	err = unix.Fsetxattr(int(f.Fd()), "user.xattr-probe", []byte("working"), 0)
+	if err != nil {
+		c.Skip("xattrs not supported on this system")
+	}
+}
+
 func (s *storeDownloadSuite) TestDownloadIconOKWithNewEtag(c *C) {
+	skipIfXattrsUnsupported(c)
 	const expectedName = "foo"
 	const expectedURL = "URL"
 	expectedContent := []byte("I was downloaded")
@@ -1305,6 +1316,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithNewEtag(c *C) {
 }
 
 func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
+	skipIfXattrsUnsupported(c)
 	const expectedName = "foo"
 	const expectedURL = "URL"
 	existingContent := []byte("I was already here")
@@ -1343,6 +1355,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
 }
 
 func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
+	skipIfXattrsUnsupported(c)
 	const expectedName = "foo"
 	const expectedURL = "URL"
 	existingContent := []byte("I was already here")
@@ -1378,6 +1391,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
 }
 
 func (s *storeDownloadSuite) TestDownloadIconOKWithEtagTooLong(c *C) {
+	skipIfXattrsUnsupported(c)
 	const expectedName = "foo"
 	const expectedURL = "URL"
 	existingContent := []byte("I was already here")


### PR DESCRIPTION
This PR is based on #14990 and #15050.

Store the etag for the snap icon (if etag exists) in the xattrs of the icon file on disk. When attempting to update an existing icon, first try to read the etag, and if it does exist, send it in the `If-None-Match` header of the HTTP request to the server.
    
If the current store icon has the same etag as the existing icon on disk (and the server behaves), the server should respond with 304 Not Modified, and not send the whole icon contents in the response body. The download icon function can then exit early, discarding its pending changes to the filesystem.
    
If the etag from the server differs from that on disk (or one of them lacks an etag), then the server should respond with a 200, and send the whole icon file contents. The icon download function should save the file with the new etag from the response, if it exists.
    
Xattr names must be namespaced, and the `user` namespace is the appropriate one for arbitrary data like etag values. Thus, we use `user.etag` as the xattr name, with the etag as the value.

This work is tracked by https://warthogs.atlassian.net/browse/SNAPDENG-34471