### PR TITLE
interfaces/microstack-support: support AMD SEV capability

### DIFF
--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -209,6 +209,9 @@ ptrace (read, trace) peer=libvirt-*,
 
 # Used by neutron-ovn-agent.
 unmount /run/netns/ovnmeta-*,
+
+# Required by libvirtd to detect and utilise AMD SEV capabilities for AMD CPU's
+/dev/sev rw,
 `
 
 const microStackSupportConnectedPlugSecComp = `


### PR DESCRIPTION
MicroStack requires the libvirt in openstack-hypervisor snap to detect SEV capabilities in AMD CPU's.

Add rule to allow access to /dev/sev in microstack-support interface.
