### PR TITLE
boot: fix paths to snap blobs in unit tests

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -3456,7 +3456,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyWithReseal(c *C, cmdlineAppen
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
+	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snaps/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-hash-1",
@@ -3674,7 +3674,7 @@ volumes:
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
-	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
+	runKernelBf := bootloader.NewBootFile("/var/lib/snapd/snaps/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	recoveryKernelBf := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-hash-1",
@@ -3821,7 +3821,7 @@ func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 	s.mockCmdline(c, "snapd_recovery_mode=run this is mocked panic=-1")
 	s.gadgetSnap = snaptest.MakeTestSnapWithFiles(c, gadgetSnapYaml, nil)
 	s.uc20dev = boottest.MockUC20Device("", boottest.MakeMockUC20Model(nil))
-	s.runKernelBf = bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
+	s.runKernelBf = bootloader.NewBootFile("/var/lib/snapd/snaps/pc-kernel_600.snap", "kernel.efi", bootloader.RoleRunMode)
 	s.recoveryKernelBf = bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -147,7 +147,7 @@ func (s *modelSuite) SetUpTest(c *C) {
 	s.AddCleanup(func() { bootloader.Force(nil) })
 
 	// run kernel
-	s.runKernelBf = bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_500.snap",
+	s.runKernelBf = bootloader.NewBootFile("/var/lib/snapd/snaps/pc-kernel_500.snap",
 		"kernel.efi", bootloader.RoleRunMode)
 	// seed (recovery) kernel
 	s.recoveryKernelBf = bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap",

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -90,7 +90,7 @@ func (s *systemsSuite) SetUpTest(c *C) {
 	s.uc20dev = boottest.MockUC20Device("", nil)
 
 	// run kernel
-	s.runKernelBf = bootloader.NewBootFile("/var/lib/snapd/snap/pc-kernel_500.snap",
+	s.runKernelBf = bootloader.NewBootFile("/var/lib/snapd/snaps/pc-kernel_500.snap",
 		"kernel.efi", bootloader.RoleRunMode)
 	// seed (recovery) kernel
 	s.recoveryKernelBf = bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap",


### PR DESCRIPTION
Fix paths to snap blobs appearing in unit tests, so that they are closer to what's actually used.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Cherry picked from #15030 