### PR TITLE
core-initrd: symlink /etc/os-release to /etc/initrd-release

### DIFF
--- a/core-initrd/latest/factory/etc/os-release
+++ b/core-initrd/latest/factory/etc/os-release
@@ -1,0 +1,1 @@
+initrd-release


### PR DESCRIPTION
Add a symlink /etc/os-release pointing to /etc/initrd-release to ensure that the environment can correcly be identified by snap-bootstrap and snapd.

This also completes the recommendation described in os-release(5) regarding execution in initrd/exitrd environments.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Cherry picked from #15030 