### PR TITLE
release: add optional fallback to /etc/initrd-release

### DIFF
--- a/release/export_test.go
+++ b/release/export_test.go
@@ -20,19 +20,8 @@
 package release
 
 var (
-	ReadOSRelease = readOSRelease
+	ReadOSReleaseFromRoot = readOSReleaseFromRoot
 )
-
-func MockOSReleasePath(filename string) (restore func()) {
-	old := osReleasePath
-	oldFallback := fallbackOsReleasePath
-	osReleasePath = filename
-	fallbackOsReleasePath = filename
-	return func() {
-		osReleasePath = old
-		fallbackOsReleasePath = oldFallback
-	}
-}
 
 func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
 	// Cannot use testutil.Backup due to import loop


### PR DESCRIPTION
Add /etc/initrd-release documented in os-release(5) as an optional fallback, for cases when the initrd lacks required symlinks.

Cherry picked from #15030 
