### PR TITLE
cmd/snap: fix behavior of snap get with tty

### DIFF
--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -213,7 +213,7 @@ func (x *cmdGet) outputDefault(conf map[string]interface{}, snapName string, con
 
 	// conf looks like a map
 	if cfg, ok := confToPrint.(map[string]interface{}); ok {
-		if isStdinTTY {
+		if isStdoutTTY {
 			return x.outputList(cfg)
 		}
 

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -111,7 +111,7 @@ func (s *SnapSuite) runTests(cmds []getCmdArgs, c *C) {
 
 		c.Logf("Test: %s", test.args)
 
-		restore := snapset.MockIsStdinTTY(test.isTerminal)
+		restore := snapset.MockIsStdoutTTY(test.isTerminal)
 		defer restore()
 
 		_, err := snapset.Parser(snapset.Client()).ParseArgs(strings.Fields(test.args))
@@ -313,7 +313,7 @@ func (s *confdbSuite) TestConfdbGetAsDocument(c *C) {
 }
 
 func (s *confdbSuite) TestConfdbGetMany(c *C) {
-	restore := snapset.MockIsStdinTTY(true)
+	restore := snapset.MockIsStdoutTTY(true)
 	defer restore()
 
 	restore = s.mockConfdbFlag(c)
@@ -354,7 +354,7 @@ xyz  false
 }
 
 func (s *confdbSuite) TestConfdbGetManyAsDocument(c *C) {
-	restore := snapset.MockIsStdinTTY(true)
+	restore := snapset.MockIsStdoutTTY(true)
 	defer restore()
 
 	restore = s.mockConfdbFlag(c)

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -24,8 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/crypto/ssh/terminal"
-
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/snap"
 )
@@ -88,8 +86,6 @@ func canUnicode(mode string) bool {
 	lang = strings.ToUpper(lang)
 	return strings.Contains(lang, "UTF-8") || strings.Contains(lang, "UTF8")
 }
-
-var isStdoutTTY = terminal.IsTerminal(1)
 
 func colorTable(mode string) escapes {
 	switch mode {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -366,6 +366,7 @@ func Parser(cli *client.Client) *flags.Parser {
 }
 
 var isStdinTTY = terminal.IsTerminal(0)
+var isStdoutTTY = terminal.IsTerminal(1)
 
 // ClientConfig is the configuration of the Client used by all commands.
 var ClientConfig = client.Config{


### PR DESCRIPTION
The output of 'snap get' command changes depending on whether the
process is attached to a tty or not. However, instead of checking
whether stdout is attached to a tty, and thus produce a compact listing,
the code checked stdin. Thus redirecting the output did not produce a
desired change in the format.

Related: [SNAPDENG-34147](https://warthogs.atlassian.net/browse/SNAPDENG-34147)

[SNAPDENG-34147]: https://warthogs.atlassian.net/browse/SNAPDENG-34147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ