### PR TITLE
progress: look at stdout rather than stdin when choosing a suitable meter

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -94,7 +94,7 @@ func MockMeter(meter Meter) func() {
 var inTesting bool = (osutil.IsTestBinary()) || os.Getenv("SPREAD_SYSTEM") != ""
 
 var isTerminal = func() bool {
-	return !inTesting && terminal.IsTerminal(int(os.Stdin.Fd()))
+	return !inTesting && terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // MakeProgressBar creates an appropriate progress.Meter for the environ in

--- a/tests/main/progress/task.yaml
+++ b/tests/main/progress/task.yaml
@@ -4,7 +4,12 @@ details: |
   Verify that progress reporting from snap command works as expected depending
   on whether the command is ran with a tty attached or not.
 
-systems: [-ubuntu-core-*]
+systems:
+  # no way to install socat
+  - -ubuntu-core-*
+  # observed to fail randomly?
+  # TODO investigate once we can spin up instances in openstack manually
+  - -fedora-*
 
 prepare: |
   tests.pkgs install socat

--- a/tests/main/progress/task.yaml
+++ b/tests/main/progress/task.yaml
@@ -1,0 +1,41 @@
+summary: Verify progress reporting from snap command
+
+details: |
+  Verify that progress reporting from snap command works as expected depending
+  on whether the command is ran with a tty attached or not.
+
+systems: [-ubuntu-core-*]
+
+prepare: |
+  tests.pkgs install socat
+
+execute: |
+  echo "Minimal status reported when stdout is redirected"
+  # no stdin, stdout to a pipe
+  snap install test-snapd-tools-core24 </dev/null | tee -a non-tty-install.log
+  snap remove test-snapd-tools-core24 </dev/null | tee -a non-tty-remove.log
+  # a single summary line for both operations
+  test "$(wc -l < non-tty-install.log)" = "1"
+  MATCH "test-snapd-tools-core24 .* installed" < non-tty-install.log
+  test "$(wc -l < non-tty-remove.log)" = "1"
+  MATCH "test-snapd-tools-core24 removed" < non-tty-remove.log
+
+  echo "Rich status reporting when stdout is on a tty"
+  (
+  # work around progress.go check for SPREAD_SYSTEM
+  unset SPREAD_SYSTEM;
+  socat system:'snap install test-snapd-tools-core24',pty,raw,echo=0 - | tr '\r' '\n' > tty-install.log
+  socat system:'snap remove test-snapd-tools-core24',pty,raw,echo=0 - | tr '\r' '\n' > tty-remove.log
+  )
+  # more than one line for each operation
+  test "$(wc -l < tty-install.log)" -gt "1"
+  test "$(wc -l < tty-remove.log)" -gt "1"
+  # expecting multiple status messages and a summary, but we cannot check for
+  # every status message as the client only displays a currently running task
+  # and may have missed short lived tasks
+  # XXX relax or drop this check if fails randomly
+  MATCH "(Fetch|Mount|Setup)" < tty-install.log
+  MATCH "test-snapd-tools-core24 .* installed" < tty-install.log
+
+  MATCH "Remove snap" < tty-remove.log
+  MATCH "test-snapd-tools-core24 removed" < tty-remove.log


### PR DESCRIPTION
Look at stdout rather than stdin when trying to choose appropriate progress meter. The ensures that when snap is invoked under dpkg, it will emit progress regardless of stdin being closed/redirected. At the same time, do not produce a rich output when stdout is redirected.

Related: [SNAPDENG-34147](https://warthogs.atlassian.net/browse/SNAPDENG-34147)
Fixes: LP#1886414

[SNAPDENG-34147]: https://warthogs.atlassian.net/browse/SNAPDENG-34147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ