### PR TITLE
overlord/fdestate: relax change cleanliness checks in dbx unit tests

### DIFF
--- a/overlord/fdestate/dbx_test.go
+++ b/overlord/fdestate/dbx_test.go
@@ -454,7 +454,6 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateAndCleanupRunningAction(c *C) {
 	})
 
 	c.Check(chg.IsReady(), Equals, true)
-	c.Check(chg.IsClean(), Equals, false)
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 	c.Check(chg.Err(), IsNil)
 
@@ -582,7 +581,6 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateAndUnexpectedStartupAction(c *C) {
 
 	// change has an error now
 	c.Check(chg.IsReady(), Equals, true)
-	c.Check(chg.IsClean(), Equals, false)
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err(), ErrorMatches, "cannot perform the following tasks:\n"+
 		"- Reseal after external EFI DBX update .'startup' action invoked while an operation is in progress.")
@@ -690,7 +688,6 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateAbort(c *C) {
 
 	// change has been undone
 	c.Check(chg.IsReady(), Equals, true)
-	c.Check(chg.IsClean(), Equals, false)
 	c.Check(chg.Status(), Equals, state.UndoneStatus)
 	c.Check(tsks[0].Status(), Equals, state.UndoneStatus)
 	c.Check(tsks[1].Status(), Equals, state.HoldStatus)


### PR DESCRIPTION
The cleanliness status of a change was checked too early. The test were subsequently fixed to properly expect a status at a later moment, but the initial check was never removed.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
