### PR TITLE
o/snapstate: include store url in snap setup and auxinfo stored on disk

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -420,6 +420,7 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				URL:  "http://example.com",
 			},
 		}
+		info.StoreURL = "https://snapcraft.io/example-snap"
 	case "channel-for-desktop-file-ids":
 		info.Plugs = map[string]*snap.PlugInfo{
 			"desktop": {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2392,7 +2392,9 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	if cand.Snap.SnapID != "" {
 		// write the auxiliary store info
 		aux := &auxStoreInfo{
-			Media:   snapsup.Media,
+			Media:    snapsup.Media,
+			StoreURL: snapsup.StoreURL,
+			// XXX we store this for the benefit of old snapd
 			Website: snapsup.Website,
 		}
 		if err := keepAuxStoreInfo(cand.Snap.SnapID, aux); err != nil {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1513,6 +1513,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 			URL:  "http://example.com",
 		},
 	})
+	c.Check(info.StoreURL, Equals, "https://snapcraft.io/example-snap")
 }
 
 func (s *snapmgrTestSuite) testParallelInstanceInstallRunThrough(c *C, inputFlags, expectedFlags snapstate.Flags) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4604,6 +4604,7 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfo(c *C) {
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Description(), Equals, "Lots of text")
 	c.Check(info.Media, IsNil)
+	c.Check(info.StoreURL, Equals, "")
 	c.Check(info.Website(), Equals, "")
 }
 
@@ -4613,7 +4614,8 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoLoadsAuxiliaryStoreInfo(c *C
 			Type: "icon",
 			URL:  "http://example.com/favicon.ico",
 		}},
-		Website: "http://example.com/",
+		StoreURL: "https://snapcraft.io/my-snap-name",
+		Website:  "http://example.com/",
 	}
 
 	c.Assert(snapstate.KeepAuxStoreInfo("123123123", storeInfo), IsNil)
@@ -4635,6 +4637,7 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoLoadsAuxiliaryStoreInfo(c *C
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Description(), Equals, "Lots of text")
 	c.Check(info.Media, DeepEquals, storeInfo.Media)
+	c.Check(info.StoreURL, Equals, storeInfo.StoreURL)
 	c.Check(info.Website(), Equals, storeInfo.Website)
 }
 

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -169,7 +169,8 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		ExpectedProvenance: t.info.SnapProvenance,
 		Confdbs:            confdbs,
 		auxStoreInfo: auxStoreInfo{
-			Media: t.info.Media,
+			Media:    t.info.Media,
+			StoreURL: t.info.StoreURL,
 			// XXX we store this for the benefit of old snapd
 			Website: t.info.Website(),
 		},


### PR DESCRIPTION
This is a follow-up to f2c208e04808ce07e797c0c2ec4f8cefc7cd8232, which added the "store-url" field to snap auxinfo. However, the caller of keepAuxStoreInfo never actually set the `StoreURL` field, so the auxinfo stored to disk continued to be lacking it.

Other related commits are eee4a0e2f0c9fbcc8a6576385abbafb0a0a9cab6, which set up `cmd/snap` to look for store URL in the local snap's auxinfo, and 25ca26311f62ff4f39c4527029a52797eb43373f, which included store URL in the store request.

To see evidence of the store URL currently being missing from local snap info, see the following (assuming snapd and jq are installed):
```bash
# get snap info from the store (where the field exists)
snap debug api '/v2/find?name=snapd' | jq '.result.[0]' | grep '"store-url"'
# get store info for locally-installed snapd (where it's missing)
snap debug api '/v2/snaps/snapd' | jq '.result' | grep '"store-url"'
# check the cached auxinfo for snapd (missing here)
cat /var/cache/snapd/aux/PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4.json | jq | grep '"store-info"'
```

In contrast, top-level `"media"` and `"website"` fields are always present:
```bash
# get snap info from the store
snap debug api '/v2/find?name=snapd' | jq '.result.[0]' | grep '"media"'
snap debug api '/v2/find?name=snapd' | jq '.result.[0]' | grep '"website"'
# get store info for locally-installed snapd
snap debug api '/v2/snaps/snapd' | jq '.result' | grep '"media"'
snap debug api '/v2/snaps/snapd' | jq '.result' | grep '"website"'
# check the cached auxinfo for snapd
cat /var/cache/snapd/aux/PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4.json | jq | grep '"media"'
cat /var/cache/snapd/aux/PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4.json | jq | grep '"website"'
```

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34480