### PR TITLE
cmd: libsnap-confine-private: enable checks in when building with unit-tests, fix errors

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -562,7 +562,8 @@ install-exec-local:
 AM_DISTCHECK_CONFIGURE_FLAGS =								\
 	SYSTEMD_PREFIX=$${dc_install_base}						\
 	SYSTEMD_SYSTEM_GENERATOR_DIR=$${dc_install_base}/lib/systemd/system-generators	\
-	$(APPARMOR_DISTCHECK_CONFIGURE_FLAGS)
+	$(APPARMOR_DISTCHECK_CONFIGURE_FLAGS) \
+	--with-unit-tests
 
 if APPARMOR
 APPARMOR_DISTCHECK_CONFIGURE_FLAGS=--with-apparmorconfigdir=$${dc_install_base}/etc/apparmor.d

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -319,6 +319,8 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
   AX_APPEND_COMPILE_FLAGS([-Werror], [CHECK_CFLAGS])
 ])
 
+AC_SUBST([CHECK_CFLAGS])
+
 AC_ARG_WITH([apparmorconfigdir],
     [AS_HELP_STRING([--with-apparmorconfigdir], [path to apparmor.d configuration directory])], [
   APPARMOR_SYSCONFIG="${withval}"

--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -166,7 +166,7 @@ static void test_sc_snap_is_inhibited__missing_dir(void) {
 }
 
 static void test_sc_snap_is_inhibited__missing_file(void) {
-    const char *d = sc_test_use_fake_inhibit_dir();
+    sc_test_use_fake_inhibit_dir();
     g_assert_false(sc_snap_is_inhibited("foo", SC_SNAP_HINT_INHIBITED_FOR_REMOVE));
 }
 

--- a/cmd/libsnap-confine-private/snap-dir-test.c
+++ b/cmd/libsnap-confine-private/snap-dir-test.c
@@ -24,7 +24,7 @@
 #include "test-utils.h"  // For rm_rf_tmp
 
 // For compatibility with g_test_queue_destroy.
-static void close_noerr(uintptr_t fd) { (void)close((int)fd); }
+static void close_noerr(gpointer fd) { (void)close(GPOINTER_TO_INT(fd)); }
 
 static void test_sc_probe_snap_mount_dir__absent(void) {
     char *root_dir = g_dir_make_tmp(NULL, NULL);
@@ -34,7 +34,7 @@ static void test_sc_probe_snap_mount_dir__absent(void) {
 
     int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
     g_assert_cmpint(root_fd, !=, -1);
-    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
 
     sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
     const char *snap_mount_dir = sc_snap_mount_dir(NULL);
@@ -55,7 +55,7 @@ static void test_sc_probe_snap_mount_dir__canonical(void) {
 
     int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
     g_assert_cmpint(root_fd, !=, -1);
-    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
 
     sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
     const char *snap_mount_dir = sc_snap_mount_dir(NULL);
@@ -81,7 +81,7 @@ static void test_sc_probe_snap_mount_dir__alternate_absolute(void) {
 
     int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
     g_assert_cmpint(root_fd, !=, -1);
-    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
 
     sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
     const char *snap_mount_dir = sc_snap_mount_dir(NULL);
@@ -107,7 +107,7 @@ static void test_sc_probe_snap_mount_dir__alternate_relative(void) {
 
     int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
     g_assert_cmpint(root_fd, !=, -1);
-    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
 
     sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, NULL);
     const char *snap_mount_dir = sc_snap_mount_dir(NULL);
@@ -133,7 +133,7 @@ static void test_sc_probe_snap_mount_dir__bad_symlink_target(void) {
 
     int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
     g_assert_cmpint(root_fd, !=, -1);
-    g_test_queue_destroy((GDestroyNotify)close_noerr, (void *)(uintptr_t)root_fd);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
 
     struct sc_error *err = NULL;
     (void)sc_probe_snap_mount_dir_from_pid_1_mount_ns(root_fd, &err);

--- a/cmd/libsnap-confine-private/snap-dir.c
+++ b/cmd/libsnap-confine-private/snap-dir.c
@@ -88,7 +88,7 @@ void sc_probe_snap_mount_dir_from_pid_1_mount_ns(int root_fd, sc_error **errorp)
             }
 
             if (strncmp(target, SC_ALTERNATE_SNAP_MOUNT_DIR, n) != 0 &&
-                strncmp(target, SC_ALTERNATE_SNAP_MOUNT_DIR + 1, n) != 0) {
+                strncmp(target, (const char *)(SC_ALTERNATE_SNAP_MOUNT_DIR) + 1, n) != 0) {
                 err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_MOUNT_DIR_UNSUPPORTED,
                                     SC_CANONICAL_SNAP_MOUNT_DIR
                                     " must be a symbolic link to " SC_ALTERNATE_SNAP_MOUNT_DIR);

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -308,7 +308,7 @@ void sc_snap_component_validate(const char *snap_component, const char *snap_ins
     strncpy(snap_name, snap_component, snap_name_len);
 
     char component_name[SNAP_NAME_LEN + 1] = {0};
-    strncpy(component_name, pos + 1, component_name_len);
+    strncpy(component_name, pos + 1, SNAP_NAME_LEN);
 
     validate_as_snap_or_component_name(snap_name, SC_SNAP_INVALID_COMPONENT, "snap name in component", &err);
     if (err != NULL) {

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -308,7 +308,7 @@ void sc_snap_component_validate(const char *snap_component, const char *snap_ins
     strncpy(snap_name, snap_component, snap_name_len);
 
     char component_name[SNAP_NAME_LEN + 1] = {0};
-    strncpy(component_name, pos + 1, SNAP_NAME_LEN);
+    strncpy(component_name, pos + 1, sizeof(component_name) - 1);
 
     validate_as_snap_or_component_name(snap_name, SC_SNAP_INVALID_COMPONENT, "snap name in component", &err);
     if (err != NULL) {

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -803,7 +803,6 @@ static void test_sc_string_split_null_string(void) {
 
 static void test_sc_string_split_null_prefix_and_suffix(void) {
     if (g_test_subprocess()) {
-        char dest[10] = {0};
         sc_string_split("some_string", '_', NULL, 0, NULL, 0);
         return;
     }


### PR DESCRIPTION
I noticed that CHECK_CFLAGS is never substituted, so the flags, even though we collect them in configure.ac, are never passed down to Makefile.

Once I fixed that, a number of compilation errors in libsnap-confine-private turned up, which are all addressed in separate patches.

Note, this PR should be merged with rebase & merge.