### PR TITLE
many: fix swapping back and forth between kernels with components during remodeling

### DIFF
--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -3100,8 +3100,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 		c.Logf("%s: %s", t.Kind(), t.Summary())
 	}
 
-	// 3 snaps (2 tasks for each) + assets update and setup from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 3*2+2+3+2+1)
+	// 3 snaps (2 tasks for each) + assets update + gadget (3 tasks) + recovery system (2 tasks) + set-model
+	c.Assert(tl, HasLen, 3*2+1+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -3115,26 +3115,23 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 
 	// check the tasks
 	tPrepareKernel := tl[0]
-	tSetupKernelSnap := tl[1]
-	tUpdateAssetsKernel := tl[2]
-	tLinkKernel := tl[3]
-	tPrepareBase := tl[4]
-	tLinkBase := tl[5]
-	tPrepareGadget := tl[6]
-	tUpdateAssets := tl[7]
-	tUpdateCmdline := tl[8]
-	tValidateApp := tl[9]
-	tInstallApp := tl[10]
-	tCreateRecovery := tl[11]
-	tFinalizeRecovery := tl[12]
-	tSetModel := tl[13]
+	tUpdateAssetsKernel := tl[1]
+	tLinkKernel := tl[2]
+	tPrepareBase := tl[3]
+	tLinkBase := tl[4]
+	tPrepareGadget := tl[5]
+	tUpdateAssets := tl[6]
+	tUpdateCmdline := tl[7]
+	tValidateApp := tl[8]
+	tInstallApp := tl[9]
+	tCreateRecovery := tl[10]
+	tFinalizeRecovery := tl[11]
+	tSetModel := tl[12]
 
 	// check the tasks
 	c.Assert(tPrepareKernel.Kind(), Equals, "prepare-snap")
 	c.Assert(tPrepareKernel.Summary(), Equals, `Prepare snap "pc-kernel-new" (222) for remodel`)
 	c.Assert(tPrepareKernel.WaitTasks(), HasLen, 0)
-	c.Assert(tSetupKernelSnap.Kind(), Equals, "prepare-kernel-snap")
-	c.Assert(tSetupKernelSnap.Summary(), Equals, `Prepare kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
 	c.Assert(tLinkKernel.Summary(), Equals, `Make snap "pc-kernel-new" (222) available to the system during remodel`)
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
@@ -3169,14 +3166,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	c.Assert(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsKernel,
 	})
-	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
 		tValidateApp,
 		tCreateRecovery,
 		tFinalizeRecovery,
-	})
-	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
-		tSetupKernelSnap,
 	})
 	c.Assert(tPrepareBase.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
@@ -3208,7 +3202,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tPrepareKernel, tSetupKernelSnap, tUpdateAssetsKernel,
+		tPrepareKernel, tUpdateAssetsKernel,
 		tLinkKernel, tPrepareBase, tLinkBase,
 		tPrepareGadget, tUpdateAssets, tUpdateCmdline,
 		tValidateApp, tInstallApp,
@@ -3369,8 +3363,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 		c.Logf("%s: %s", t.Kind(), t.Summary())
 	}
 
-	// 3 snaps (2 tasks for each) + assets update and setup from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 3*2+2+3+2+1)
+	// 3 snaps (2 tasks for each) + assets update from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
+	c.Assert(tl, HasLen, 3*2+1+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -3384,26 +3378,23 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 
 	// check the tasks
 	tSwitchKernel := tl[0]
-	tSetupKernelSnap := tl[1]
-	tUpdateAssetsKernel := tl[2]
-	tLinkKernel := tl[3]
-	tPrepareBase := tl[4]
-	tLinkBase := tl[5]
-	tSwitchGadget := tl[6]
-	tUpdateAssets := tl[7]
-	tUpdateCmdline := tl[8]
-	tValidateApp := tl[9]
-	tInstallApp := tl[10]
-	tCreateRecovery := tl[11]
-	tFinalizeRecovery := tl[12]
-	tSetModel := tl[13]
+	tUpdateAssetsKernel := tl[1]
+	tLinkKernel := tl[2]
+	tPrepareBase := tl[3]
+	tLinkBase := tl[4]
+	tSwitchGadget := tl[5]
+	tUpdateAssets := tl[6]
+	tUpdateCmdline := tl[7]
+	tValidateApp := tl[8]
+	tInstallApp := tl[9]
+	tCreateRecovery := tl[10]
+	tFinalizeRecovery := tl[11]
+	tSetModel := tl[12]
 
 	// check the tasks
 	c.Assert(tSwitchKernel.Kind(), Equals, "switch-snap")
 	c.Assert(tSwitchKernel.Summary(), Equals, `Switch snap "pc-kernel-new" from channel "20/stable" to "20/edge"`)
 	c.Assert(tSwitchKernel.WaitTasks(), HasLen, 0)
-	c.Assert(tSetupKernelSnap.Kind(), Equals, "prepare-kernel-snap")
-	c.Assert(tSetupKernelSnap.Summary(), Equals, `Prepare kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
 	c.Assert(tLinkKernel.Summary(), Equals, `Make snap "pc-kernel-new" (222) available to the system during remodel`)
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
@@ -3438,14 +3429,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	c.Assert(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsKernel,
 	})
-	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tSwitchKernel,
 		tValidateApp,
 		tCreateRecovery,
 		tFinalizeRecovery,
-	})
-	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
-		tSetupKernelSnap,
 	})
 	c.Assert(tPrepareBase.WaitTasks(), DeepEquals, []*state.Task{
 		tSwitchKernel,
@@ -3477,7 +3465,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tSwitchKernel, tSetupKernelSnap, tUpdateAssetsKernel,
+		tSwitchKernel, tUpdateAssetsKernel,
 		tLinkKernel, tPrepareBase, tLinkBase,
 		tSwitchGadget, tUpdateAssets, tUpdateCmdline,
 		tValidateApp, tInstallApp,
@@ -3635,7 +3623,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 
 	tl := chg.Tasks()
 	// 2 snaps (2 tasks for each) + assets update and setup from kernel + gadget (3 tasks) + recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 2*2+2+3+2+1)
+	c.Assert(tl, HasLen, 2*2+1+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -3649,24 +3637,21 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 
 	// check the tasks
 	tPrepareKernel := tl[0]
-	tSetupKernelSnap := tl[1]
-	tUpdateAssetsKernel := tl[2]
-	tLinkKernel := tl[3]
-	tPrepareBase := tl[4]
-	tLinkBase := tl[5]
-	tPrepareGadget := tl[6]
-	tUpdateAssets := tl[7]
-	tUpdateCmdline := tl[8]
-	tCreateRecovery := tl[9]
-	tFinalizeRecovery := tl[10]
-	tSetModel := tl[11]
+	tUpdateAssetsKernel := tl[1]
+	tLinkKernel := tl[2]
+	tPrepareBase := tl[3]
+	tLinkBase := tl[4]
+	tPrepareGadget := tl[5]
+	tUpdateAssets := tl[6]
+	tUpdateCmdline := tl[7]
+	tCreateRecovery := tl[8]
+	tFinalizeRecovery := tl[9]
+	tSetModel := tl[10]
 
 	// check the tasks
 	c.Assert(tPrepareKernel.Kind(), Equals, "prepare-snap")
 	c.Assert(tPrepareKernel.Summary(), Equals, `Prepare snap "pc-kernel-new" (222) for remodel`)
 	c.Assert(tPrepareKernel.WaitTasks(), HasLen, 0)
-	c.Assert(tSetupKernelSnap.Kind(), Equals, "prepare-kernel-snap")
-	c.Assert(tSetupKernelSnap.Summary(), Equals, `Prepare kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
 	c.Assert(tLinkKernel.Summary(), Equals, `Make snap "pc-kernel-new" (222) available to the system during remodel`)
 	c.Assert(tUpdateAssetsKernel.Kind(), Equals, "update-gadget-assets")
@@ -3697,14 +3682,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	c.Assert(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsKernel,
 	})
-	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
 		tPrepareGadget,
 		tCreateRecovery,
 		tFinalizeRecovery,
-	})
-	c.Assert(tUpdateAssetsKernel.WaitTasks(), DeepEquals, []*state.Task{
-		tSetupKernelSnap,
 	})
 	c.Assert(tPrepareBase.WaitTasks(), DeepEquals, []*state.Task{
 		tPrepareKernel,
@@ -3736,7 +3718,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tPrepareKernel, tSetupKernelSnap, tUpdateAssetsKernel,
+		tPrepareKernel, tUpdateAssetsKernel,
 		tLinkKernel, tPrepareBase, tLinkBase,
 		tPrepareGadget, tUpdateAssets, tUpdateCmdline,
 		tCreateRecovery, tFinalizeRecovery,
@@ -3922,14 +3904,17 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	for _, alreadyInstalledName := range []string{"pc-kernel-new", "core24-new", "pc-new"} {
 		snapYaml := "name: pc-kernel-new\nversion: 1\ntype: kernel\n"
 		channel := "other/edge"
+		rev := snap.R(222)
 		if alreadyInstalledName == "core24-new" {
 			snapYaml = "name: core24-new\nversion: 1\ntype: base\n"
+			rev = snap.R(223)
 		} else if alreadyInstalledName == "pc-new" {
 			snapYaml = "name: pc-new\nversion: 1\ntype: gadget\nbase: core24-new\n"
+			rev = snap.R(224)
 		}
 		si := &snap.SideInfo{
 			RealName: alreadyInstalledName,
-			Revision: snap.R(222),
+			Revision: rev,
 			SnapID:   snaptest.AssertedSnapID(alreadyInstalledName),
 		}
 		info := snaptest.MakeSnapFileAndDir(c, snapYaml, nil, si)
@@ -3997,10 +3982,10 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	}
 
 	tl := chg.Tasks()
-	// 2 snaps with (snap switch channel + link snap) + assets update and setup
-	// for the kernel snap + gadget snap (switch channel, assets update, cmdline update) +
-	// recovery system (2 tasks) + set-model
-	c.Assert(tl, HasLen, 2*2+2+3+2+1)
+	// 2 snaps with (snap switch channel + link snap) + assets update for the
+	// kernel snap + gadget snap (switch channel, assets update, cmdline update)
+	// + recovery system (2 tasks) + set-model
+	c.Assert(tl, HasLen, 2*2+1+3+2+1)
 
 	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
@@ -4014,24 +3999,21 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 
 	// check the tasks
 	tSwitchChannelKernel := tl[0]
-	tSetupKernelSnap := tl[1]
-	tUpdateAssetsFromKernel := tl[2]
-	tLinkKernel := tl[3]
-	tSwitchChannelBase := tl[4]
-	tLinkBase := tl[5]
-	tSwitchChannelGadget := tl[6]
-	tUpdateAssetsFromGadget := tl[7]
-	tUpdateCmdlineFromGadget := tl[8]
-	tCreateRecovery := tl[9]
-	tFinalizeRecovery := tl[10]
-	tSetModel := tl[11]
+	tUpdateAssetsFromKernel := tl[1]
+	tLinkKernel := tl[2]
+	tSwitchChannelBase := tl[3]
+	tLinkBase := tl[4]
+	tSwitchChannelGadget := tl[5]
+	tUpdateAssetsFromGadget := tl[6]
+	tUpdateCmdlineFromGadget := tl[7]
+	tCreateRecovery := tl[8]
+	tFinalizeRecovery := tl[9]
+	tSetModel := tl[10]
 
 	// check the tasks
 	c.Assert(tSwitchChannelKernel.Kind(), Equals, "switch-snap-channel")
 	c.Assert(tSwitchChannelKernel.Summary(), Equals, `Switch pc-kernel-new channel to 20/stable`)
 	c.Assert(tSwitchChannelKernel.WaitTasks(), HasLen, 0)
-	c.Assert(tSetupKernelSnap.Kind(), Equals, "prepare-kernel-snap")
-	c.Assert(tSetupKernelSnap.Summary(), Equals, `Prepare kernel driver tree for "pc-kernel-new" (222) for remodel`)
 	c.Assert(tUpdateAssetsFromKernel.Kind(), Equals, "update-gadget-assets")
 	c.Assert(tUpdateAssetsFromKernel.Summary(), Equals, `Update assets from kernel "pc-kernel-new" (222) for remodel`)
 	c.Assert(tLinkKernel.Kind(), Equals, "link-snap")
@@ -4069,12 +4051,9 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		tCreateRecovery,
 		tSwitchChannelGadget,
 	})
-	c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
+	c.Assert(tUpdateAssetsFromKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tSwitchChannelKernel, tSwitchChannelGadget,
 		tCreateRecovery, tFinalizeRecovery,
-	})
-	c.Assert(tUpdateAssetsFromKernel.WaitTasks(), DeepEquals, []*state.Task{
-		tSetupKernelSnap,
 	})
 	c.Check(tLinkKernel.WaitTasks(), DeepEquals, []*state.Task{
 		tUpdateAssetsFromKernel,
@@ -4084,7 +4063,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	})
 	// setModel waits for everything in the change
 	c.Assert(tSetModel.WaitTasks(), DeepEquals, []*state.Task{
-		tSwitchChannelKernel, tSetupKernelSnap, tUpdateAssetsFromKernel,
+		tSwitchChannelKernel, tUpdateAssetsFromKernel,
 		tLinkKernel, tSwitchChannelBase, tLinkBase,
 		tSwitchChannelGadget, tUpdateAssetsFromGadget, tUpdateCmdlineFromGadget,
 		tCreateRecovery, tFinalizeRecovery,

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -178,6 +178,9 @@ func expectedDoInstallTasks(typ snap.Type, opts, compOpts, discards int, startTa
 		expected = append(expected, "run-hook[default-configure]")
 	}
 
+	// TODO: it seems that removing this line doesn't break any tests
+	expected = append(expected, tasksBeforeDiscard...)
+
 	expected = append(expected, "start-snap-services")
 	for i := 0; i < discards; i++ {
 		expected = append(expected,

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8061,7 +8061,7 @@ version: 1`), &snap.SideInfo{Revision: snap.R("5")})
 	c.Check(ignoreValidation, DeepEquals, map[string]bool{"bar": true})
 }
 
-func (s *snapmgrTestSuite) addSnapsForRemodel(c *C) {
+func (s *snapmgrTestSuite) addSnapsForRemodel(c *C, withComponents bool) {
 	si := &snap.SideInfo{
 		RealName: "some-base", Revision: snap.R(1),
 	}
@@ -8077,12 +8077,25 @@ func (s *snapmgrTestSuite) addSnapsForRemodel(c *C) {
 		RealName: "some-kernel", Revision: snap.R(2),
 	}
 	snaptest.MockSnapCurrent(c, "name: some-kernel\nversion: 1.0\ntype: kernel\n", si)
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si})
+	if withComponents {
+		seq.AddComponentForRevision(si.Revision, sequence.NewComponentState(&snap.ComponentSideInfo{
+			Component: naming.NewComponentRef("some-kernel", "comp-1"),
+			Revision:  snap.R(22),
+		}, snap.KernelModulesComponent))
+
+		seq.AddComponentForRevision(si.Revision, sequence.NewComponentState(&snap.ComponentSideInfo{
+			Component: naming.NewComponentRef("some-kernel", "comp-2"),
+			Revision:  snap.R(33),
+		}, snap.KernelModulesComponent))
+	}
 	snapstate.Set(s.state, "some-kernel", &snapstate.SnapState{
 		Active:   true,
-		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
+		Sequence: seq,
 		Current:  si.Revision,
 		SnapType: "kernel",
 	})
+
 	si = &snap.SideInfo{
 		RealName: "some-gadget", Revision: snap.R(3),
 	}
@@ -8096,6 +8109,7 @@ func (s *snapmgrTestSuite) addSnapsForRemodel(c *C) {
 }
 
 var nonReLinkKinds = []string{
+	"prepare-kernel-snap",
 	"copy-snap-data",
 	"setup-profiles",
 	"auto-connect",
@@ -8107,6 +8121,7 @@ var nonReLinkKinds = []string{
 	"run-hook[configure]",
 	"run-hook[check-health]",
 	"discard-old-kernel-snap-setup",
+	"mount-component",
 }
 
 func kindsToSet(kinds []string) map[string]bool {
@@ -8122,6 +8137,10 @@ func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrKernelHappy(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrUC20KernelHappy(c *C) {
+	s.testRemodelLinkNewBaseOrKernelHappy(c, MakeModel20("brand-gadget", nil), 0)
+}
+
+func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrUC20KernelHappyWithKmodComponent(c *C) {
 	s.testRemodelLinkNewBaseOrKernelHappy(c, MakeModel20("brand-gadget", nil), 0)
 }
 
@@ -8142,27 +8161,20 @@ func (s *snapmgrTestSuite) testRemodelLinkNewBaseOrKernelHappy(c *C, model *asse
 
 	defer snapstatetest.MockDeviceModel(model)()
 
-	s.addSnapsForRemodel(c)
+	const withComponents = false
+	s.addSnapsForRemodel(c, withComponents)
 
 	ts, err := snapstate.LinkNewBaseOrKernel(s.state, "some-kernel", "")
 	c.Assert(err, IsNil)
+
 	tasks := ts.Tasks()
 	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, 0, []string{"prepare-snap"}, nil, kindsToSet(nonReLinkKinds)))
+	c.Assert(tasks, HasLen, 3)
+
 	tPrepare := tasks[0]
-	var tLink, tUpdateGadgetAssets *state.Task
-	if opts&needsKernelSetup != 0 {
-		c.Assert(tasks, HasLen, 4)
-		tSetupKernelSnap := tasks[1]
-		c.Assert(tSetupKernelSnap.Kind(), Equals, "prepare-kernel-snap")
-		c.Assert(tSetupKernelSnap.Summary(), Equals, `Prepare kernel driver tree for "some-kernel" (2) for remodel`)
-		c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{tPrepare})
-		tUpdateGadgetAssets = tasks[2]
-		tLink = tasks[3]
-	} else {
-		c.Assert(tasks, HasLen, 3)
-		tUpdateGadgetAssets = tasks[1]
-		tLink = tasks[2]
-	}
+	tUpdateGadgetAssets := tasks[1]
+	tLink := tasks[2]
+
 	c.Assert(tPrepare.Kind(), Equals, "prepare-snap")
 	c.Assert(tPrepare.Summary(), Equals, `Prepare snap "some-kernel" (2) for remodel`)
 	c.Assert(tPrepare.Has("snap-setup"), Equals, true)
@@ -8188,6 +8200,92 @@ func (s *snapmgrTestSuite) testRemodelLinkNewBaseOrKernelHappy(c *C, model *asse
 	c.Assert(ts.MaybeEdge(snapstate.MaybeRebootEdge), Equals, tLink)
 }
 
+func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrKernelWithComponent(c *C) {
+	model := MakeModel20("brand-gadget", nil)
+
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	defer snapstatetest.MockDeviceModel(model)()
+
+	const withComponents = true
+	s.addSnapsForRemodel(c, withComponents)
+
+	ts, err := snapstate.LinkNewBaseOrKernel(s.state, "some-kernel", "")
+	c.Assert(err, IsNil)
+
+	comps := []string{"comp-1", "comp-2"}
+	startTasks := []string{"prepare-snap"}
+
+	tasks := ts.Tasks()
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, 0, 0, 0, startTasks, comps, kindsToSet(nonReLinkKinds)))
+	c.Assert(tasks, HasLen, 5)
+
+	prepare := ts.MaybeEdge(snapstate.SnapSetupEdge)
+	c.Assert(prepare, NotNil)
+	c.Assert(prepare.Kind(), Equals, "prepare-snap")
+	c.Assert(prepare.Has("snap-setup"), Equals, true)
+
+	link := ts.MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(link, NotNil)
+	c.Assert(link.Kind(), Equals, "link-snap")
+
+	for _, t := range ts.Tasks() {
+		if t.Kind() == "link-component" {
+			c.Assert(t.Has("component-setup"), Equals, true)
+		}
+	}
+}
+
+func (s *snapmgrTestSuite) TestRemodelAddLinkNewBaseOrKernelWithComponent(c *C) {
+	model := MakeModel20("brand-gadget", nil)
+
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	defer snapstatetest.MockDeviceModel(model)()
+
+	const withComponents = true
+	s.addSnapsForRemodel(c, withComponents)
+
+	switchSnap := s.state.NewTask("switch-snap", "switch snap")
+	switchSnap.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "some-kernel", Revision: snap.R(2)},
+		Type:     "kernel",
+		Channel:  "new-channel",
+	})
+
+	ts := state.NewTaskSet(switchSnap)
+
+	ts, err := snapstate.AddLinkNewBaseOrKernel(s.state, ts)
+	c.Assert(err, IsNil)
+
+	comps := []string{"comp-1", "comp-2"}
+	startTasks := []string{"switch-snap"}
+
+	tasks := ts.Tasks()
+	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, 0, 0, 0, startTasks, comps, kindsToSet(nonReLinkKinds)))
+	c.Assert(tasks, HasLen, 5)
+
+	link := ts.MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(link, NotNil)
+	c.Assert(link.Kind(), Equals, "link-snap")
+
+	for _, t := range ts.Tasks() {
+		if t.Kind() == "link-component" {
+			c.Assert(t.Has("component-setup"), Equals, true)
+		}
+	}
+}
+
 func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrKernelBadType(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -8195,7 +8293,9 @@ func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrKernelBadType(c *C) {
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.addSnapsForRemodel(c)
+
+	const withComponents = false
+	s.addSnapsForRemodel(c, withComponents)
 
 	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(3)}
 	snaptest.MockSnapCurrent(c, "name: snap-gadget\nversion: 1.0\n", si)
@@ -8221,7 +8321,9 @@ func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrKernelNoRemodelConflict(c *C)
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.addSnapsForRemodel(c)
+
+	const withComponents = false
+	s.addSnapsForRemodel(c, withComponents)
 
 	tugc := s.state.NewTask("update-managed-boot-config", "update managed boot config")
 	chg := s.state.NewChange("remodel", "remodel")
@@ -8256,6 +8358,8 @@ func (s *snapmgrTestSuite) testRemodelAddLinkNewBaseOrKernel(c *C, model *assert
 
 	defer snapstatetest.MockDeviceModel(model)()
 
+	s.addSnapsForRemodel(c, false)
+
 	// try a kernel snap first
 	si := &snap.SideInfo{RealName: "some-kernel", Revision: snap.R(2)}
 	tPrepare := s.state.NewTask("prepare-snap", "test task")
@@ -8273,22 +8377,9 @@ func (s *snapmgrTestSuite) testRemodelAddLinkNewBaseOrKernel(c *C, model *assert
 	tasks := tsNew.Tasks()
 	c.Check(taskKinds(tasks), DeepEquals, expectedDoInstallTasks(snap.TypeKernel, opts, 0, 0, []string{"prepare-snap", "test-task"}, nil, kindsToSet(nonReLinkKinds)))
 	// since this is the kernel, we have our task + test task + update-gadget-assets + link-snap
-	var tLink, tUpdateGadgetAssets *state.Task
-	if opts&needsKernelSetup != 0 {
-		c.Assert(tasks, HasLen, 5)
-		tSetupKernelSnap := tasks[2]
-		c.Assert(tSetupKernelSnap.Kind(), Equals, "prepare-kernel-snap")
-		c.Assert(tSetupKernelSnap.Summary(), Equals, `Prepare kernel driver tree for "some-kernel" (2) for remodel`)
-		c.Assert(tSetupKernelSnap.WaitTasks(), DeepEquals, []*state.Task{
-			testTask,
-		})
-		tUpdateGadgetAssets = tasks[3]
-		tLink = tasks[4]
-	} else {
-		c.Assert(tasks, HasLen, 4)
-		tUpdateGadgetAssets = tasks[2]
-		tLink = tasks[3]
-	}
+	c.Assert(tasks, HasLen, 4)
+	tUpdateGadgetAssets := tasks[2]
+	tLink := tasks[3]
 	c.Assert(tUpdateGadgetAssets.Kind(), Equals, "update-gadget-assets")
 	c.Assert(tUpdateGadgetAssets.Summary(), Equals, `Update assets from kernel "some-kernel" (2) for remodel`)
 	c.Assert(tLink.Kind(), Equals, "link-snap")
@@ -8341,7 +8432,9 @@ func (s *snapmgrTestSuite) TestRemodelSwitchNewGadget(c *C) {
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.addSnapsForRemodel(c)
+
+	const withComponents = false
+	s.addSnapsForRemodel(c, withComponents)
 
 	ts, err := snapstate.SwitchToNewGadget(s.state, "some-gadget", "")
 	c.Assert(err, IsNil)
@@ -8371,7 +8464,9 @@ func (s *snapmgrTestSuite) TestRemodelSwitchNewGadgetNoRemodelConflict(c *C) {
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.addSnapsForRemodel(c)
+
+	const withComponents = false
+	s.addSnapsForRemodel(c, withComponents)
 
 	tugc := s.state.NewTask("update-managed-boot-config", "update managed boot config")
 	chg := s.state.NewChange("remodel", "remodel")
@@ -8388,7 +8483,9 @@ func (s *snapmgrTestSuite) TestRemodelSwitchNewGadgetBadType(c *C) {
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.addSnapsForRemodel(c)
+
+	const withComponent = false
+	s.addSnapsForRemodel(c, withComponent)
 
 	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(3)}
 	snaptest.MockSnapCurrent(c, "name: snap-gadget\nversion: 1.0\n", si)
@@ -8416,7 +8513,9 @@ func (s *snapmgrTestSuite) TestRemodelSwitchNewGadgetConflict(c *C) {
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.addSnapsForRemodel(c)
+
+	const withComponents = false
+	s.addSnapsForRemodel(c, withComponents)
 
 	tugc := s.state.NewTask("update-gadget-cmdline", "update gadget cmdline")
 	chg := s.state.NewChange("optional-kernel-cmdline", "optional kernel cmdline")
@@ -8442,7 +8541,9 @@ func (s *snapmgrTestSuite) TestRemodelSwitchNewGadgetConflictExclusiveKind(c *C)
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(snap.ReadInfo))
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.addSnapsForRemodel(c)
+
+	const withComponent = false
+	s.addSnapsForRemodel(c, withComponent)
 
 	tugc := s.state.NewTask("some-random-task", "...")
 	chg := s.state.NewChange("transition-ubuntu-core", "...")

--- a/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-24.json
+++ b/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-24.json
@@ -1,0 +1,38 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "model",
+    "architecture": "amd64",
+    "timestamp": "2024-04-24T00:00:00+00:00",
+    "grade": "dangerous",
+    "base": "core24",
+    "serial-authority": ["generic"],
+    "snaps": [
+        {
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        }
+    ]
+}

--- a/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-rev-1-24.json
+++ b/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-rev-1-24.json
@@ -1,0 +1,42 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "model",
+    "revision": "1",
+    "architecture": "amd64",
+    "timestamp": "2024-04-24T00:00:00+00:00",
+    "grade": "dangerous",
+    "base": "core24",
+    "serial-authority": ["generic"],
+    "snaps": [
+        {
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "qYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel-mac80211-hwsim",
+            "type": "kernel",
+            "components": {
+              "wifi-comp": "required"
+            }
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        }
+    ]
+}

--- a/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-rev-2-24.json
+++ b/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-rev-2-24.json
@@ -1,0 +1,42 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "model",
+    "revision": "2",
+    "architecture": "amd64",
+    "timestamp": "2024-04-24T00:00:00+00:00",
+    "grade": "dangerous",
+    "base": "core24",
+    "serial-authority": ["generic"],
+    "snaps": [
+        {
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "rYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel-efi-pstore",
+            "type": "kernel",
+            "components": {
+              "efi-comp": "required"
+            }
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        }
+    ]
+}

--- a/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-rev-3-24.json
+++ b/tests/lib/assertions/test-snapd-remodel-to-installed-kernel-rev-3-24.json
@@ -1,0 +1,42 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "model",
+    "revision": "3",
+    "architecture": "amd64",
+    "timestamp": "2024-04-24T00:00:00+00:00",
+    "grade": "dangerous",
+    "base": "core24",
+    "serial-authority": ["generic"],
+    "snaps": [
+        {
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "qYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel-mac80211-hwsim",
+            "type": "kernel",
+            "components": {
+              "wifi-comp": "required"
+            }
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        }
+    ]
+}

--- a/tests/lib/tools/build_kernel_with_comps.sh
+++ b/tests/lib/tools/build_kernel_with_comps.sh
@@ -13,7 +13,11 @@ build_kernel_with_comp() {
     comp_name=$2
     kernel_snap_file=${3:-}
 
-    if [ -z "${kernel_snap_file}" ]; then
+    test -z "$kernel_snap_file"
+    # shellcheck disable=SC2319
+    use_provided_kernel=$?
+
+    if [ "${use_provided_kernel}" -eq 0 ]; then
         nested_prepare_kernel
         cp "$(tests.nested get extra-snaps-path)/pc-kernel.snap" "pc-kernel.snap"
         kernel_snap_file="pc-kernel.snap"
@@ -49,7 +53,7 @@ EOF
     printf 'components:\n  %s:\n    type: kernel-modules\n' "$comp_name" >> kernel/meta/snap.yaml
     snap pack --filename="${kernel_snap_file}" kernel
 
-    if [ -z "${kernel_snap_file}" ]; then
+    if [ "${use_provided_kernel}" -eq 0 ]; then
         # Just so that nested_prepare_kernel does not recopy the old one
         cp "${kernel_snap_file}" "${NESTED_ASSETS_DIR}/pc-kernel.snap"
     fi

--- a/tests/lib/tools/build_kernel_with_comps.sh
+++ b/tests/lib/tools/build_kernel_with_comps.sh
@@ -48,6 +48,12 @@ EOF
     # append component meta-information
     printf 'components:\n  %s:\n    type: kernel-modules\n' "$comp_name" >> kernel/meta/snap.yaml
     snap pack --filename="${kernel_snap_file}" kernel
+
+    if [ -z "${kernel_snap_file}" ]; then
+        # Just so that nested_prepare_kernel does not recopy the old one
+        cp "${kernel_snap_file}" "${NESTED_ASSETS_DIR}/pc-kernel.snap"
+    fi
+
     rm -r kernel
 }
 

--- a/tests/nested/manual/remodel-to-installed-kernel/task.yaml
+++ b/tests/nested/manual/remodel-to-installed-kernel/task.yaml
@@ -1,0 +1,189 @@
+summary: Remodel to a model with a different kernel and then back to the original kernel again
+
+details: |
+  This test covers a few remodeling edge cases:
+  * Switching the kernel to a new snap (changing kernel snap names, not just
+    revision) works properly.
+  * The drivers tree mounted at /usr/lib/modules is correctly updated and
+    maintained across remodels.
+  * When returning to a kernel that was left behind on the system because of a
+    previous remodel, the drivers tree is reused.
+
+  Note that the implementation of this last feature relies on the fact that
+  switching the kernel snap during a remodel does not remove the old kernel's
+  snap or drivers tree. We reuse the drivers tree that was originally created
+  when the kernel was installed.
+
+systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
+
+environment:
+  INITIAL_MODEL_JSON: $TESTSLIB/assertions/test-snapd-remodel-to-installed-kernel-24.json
+  SECOND_MODEL_JSON: $TESTSLIB/assertions/test-snapd-remodel-to-installed-kernel-rev-1-24.json
+  THIRD_MODEL_JSON: $TESTSLIB/assertions/test-snapd-remodel-to-installed-kernel-rev-2-24.json
+  FOURTH_MODEL_JSON: $TESTSLIB/assertions/test-snapd-remodel-to-installed-kernel-rev-3-24.json
+  NESTED_ENABLE_TPM: true
+  NESTED_ENABLE_SECURE_BOOT: true
+  NESTED_BUILD_SNAPD_FROM_CURRENT: true
+  NESTED_REPACK_GADGET_SNAP: true
+  NESTED_REPACK_KERNEL_SNAP: true
+  NESTED_REPACK_BASE_SNAP: true
+  NESTED_REPACK_FOR_FAKESTORE: true
+  NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
+  NESTED_SIGN_SNAPS_FAKESTORE: true
+  NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+
+prepare: |
+    if [ "${TRUST_TEST_KEYS}" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # although nested_start_core_vm_unit usually installs this, the fake store
+    # will already have been set up, so we need to install it here
+    snap install test-snapd-swtpm --edge
+
+    "${TESTSTOOLS}/store-state" setup-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+
+    gendeveloper1 sign-model < "${INITIAL_MODEL_JSON}" > initial-model.assert
+
+    cp "${TESTSLIB}/assertions/testrootorg-store.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp "${TESTSLIB}/assertions/developer1.account" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp "${TESTSLIB}/assertions/developer1.account-key" "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+    cp initial-model.assert "${NESTED_FAKESTORE_BLOB_DIR}/asserts"
+
+    tests.nested prepare-essential-snaps
+
+    export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
+    ubuntu-image snap --image-size 10G ./initial-model.assert
+
+    image_dir=$(tests.nested get images-path)
+    image_name=$(tests.nested get image-name core)
+    cp ./pc.img "${image_dir}/${image_name}"
+    tests.nested configure-default-user
+
+    # run the fake device service too, so that the device can be initialised
+    systemd-run --collect --unit fakedevicesvc fakedevicesvc localhost:11029
+
+    tests.nested build-image core
+    tests.nested create-vm core
+
+    #shellcheck source=tests/lib/core-config.sh
+    . "$TESTSLIB"/core-config.sh
+    wait_for_first_boot_change
+
+    remote.exec 'sudo systemctl stop snapd snapd.socket'
+
+    remote.exec 'sudo cat /var/lib/snapd/state.json' | gojq '.data.auth.device."session-macaroon"="fake-session"' > state.json
+    remote.push state.json
+    remote.exec 'sudo mv state.json /var/lib/snapd/state.json'
+    remote.exec 'sudo systemctl start snapd snapd.socket'
+
+    # here unpack the kernel snap that was used to build the original image. we
+    # take that kernel and create a component from one of its kernel modules.
+    # upload the new kernel and component to the fake store.
+    unsquashfs -d mac80211-hwsim "${NESTED_FAKESTORE_BLOB_DIR}/pc-kernel.snap"
+
+    # we will use this copy of the original kernel soon
+    cp -ar mac80211-hwsim efi-pstore
+
+    sed -i -e '/^name:/ s/$/-mac80211-hwsim/' mac80211-hwsim/meta/snap.yaml
+    snap pack --filename=pc-kernel-mac80211-hwsim.snap ./mac80211-hwsim
+    "${TESTSTOOLS}"/build_kernel_with_comps.sh mac80211_hwsim wifi-comp pc-kernel-mac80211-hwsim.snap
+
+    "${TESTSTOOLS}"/store-state make-snap-installable --noack \
+      --revision 1 \
+      "${NESTED_FAKESTORE_BLOB_DIR}" \
+      ./pc-kernel-mac80211-hwsim.snap \
+      'qYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza'
+
+    "${TESTSTOOLS}"/store-state make-component-installable --noack \
+      --snap-revision 1 \
+      --component-revision 1 \
+      --snap-id 'qYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza' \
+      "${NESTED_FAKESTORE_BLOB_DIR}" \
+      ./pc-kernel-mac80211-hwsim+wifi-comp.comp
+
+    # do the same thing for a different kernel module.
+    sed -i -e '/^name:/ s/$/-efi-pstore/' efi-pstore/meta/snap.yaml
+    snap pack --filename=pc-kernel-efi-pstore.snap ./efi-pstore
+    "${TESTSTOOLS}"/build_kernel_with_comps.sh efi_pstore efi-comp pc-kernel-efi-pstore.snap
+
+    "${TESTSTOOLS}"/store-state make-snap-installable --noack \
+      --revision 1 \
+      "${NESTED_FAKESTORE_BLOB_DIR}" \
+      ./pc-kernel-efi-pstore.snap \
+      'rYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza'
+
+    "${TESTSTOOLS}"/store-state make-component-installable --noack \
+      --snap-revision 1 \
+      --component-revision 1 \
+      --snap-id 'rYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza' \
+      "${NESTED_FAKESTORE_BLOB_DIR}" \
+      ./pc-kernel-efi-pstore+efi-comp.comp
+
+restore: |
+    systemctl stop fakedevicesvc
+    "${TESTSTOOLS}/store-state" teardown-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+
+execute: |
+  echo 'Swap to the first new kernel and component pc-kernel-mac80211-hwsim+wifi-comp'
+  gendeveloper1 sign-model < "${SECOND_MODEL_JSON}" > second-model.assert
+  remote.push second-model.assert
+
+  boot_id="$(tests.nested boot-id)"
+  change_id="$(remote.exec 'sudo snap remodel --no-wait second-model.assert')"
+  remote.wait-for reboot "${boot_id}"
+
+  # this remodel expects two reboots, once for testing the recovery system
+  # and once for rebooting into the new kernel
+  boot_id="$(tests.nested boot-id)"
+  remote.wait-for reboot "${boot_id}"
+
+  remote.exec "snap watch ${change_id}"
+  remote.exec 'snap list pc-kernel-mac80211-hwsim' | awk '$NR != 1 { print $3 }' | MATCH '1'
+  remote.exec 'snap components pc-kernel-mac80211-hwsim' | sed 1d | MATCH 'pc-kernel-mac80211-hwsim\+wifi-comp\s+installed'
+
+  # make sure that the kernel module got installed and is loaded from our
+  # component
+  remote.exec sudo modprobe mac80211_hwsim
+  remote.exec ip link show wlan0
+  remote.exec modinfo --filename mac80211_hwsim | MATCH '/lib/modules/.*/updates/wifi-comp'
+
+  echo 'Swap to the second new kernel and component pc-kernel-efi-pstore+efi-comp'
+  gendeveloper1 sign-model < "${THIRD_MODEL_JSON}" > third-model.assert
+  remote.push third-model.assert
+
+  boot_id="$(tests.nested boot-id)"
+  change_id="$(remote.exec 'sudo snap remodel --no-wait third-model.assert')"
+  remote.wait-for reboot "${boot_id}"
+
+  # same deal here, we expect two reboots
+  boot_id="$(tests.nested boot-id)"
+  remote.wait-for reboot "${boot_id}"
+
+  remote.exec "snap watch ${change_id}"
+  remote.exec 'snap list pc-kernel-efi-pstore' | awk '$NR != 1 { print $3 }' | MATCH '1'
+  remote.exec 'snap components pc-kernel-efi-pstore' | sed 1d | MATCH 'pc-kernel-efi-pstore\+efi-comp\s+installed'
+
+  remote.exec sudo modprobe efi_pstore
+  remote.exec modinfo --filename efi_pstore | MATCH '/lib/modules/.*/updates/efi-comp'
+
+  echo 'Swap back to the first new kernel and component pc-kernel-mac80211-hwsim+wifi-comp again'
+  gendeveloper1 sign-model < "${FOURTH_MODEL_JSON}" > fourth-model.assert
+  remote.push fourth-model.assert
+
+  boot_id="$(tests.nested boot-id)"
+  change_id="$(remote.exec 'sudo snap remodel --no-wait fourth-model.assert')"
+  remote.wait-for reboot "${boot_id}"
+
+  # same deal here, we expect two reboots
+  boot_id="$(tests.nested boot-id)"
+  remote.wait-for reboot "${boot_id}"
+
+  remote.exec "snap watch ${change_id}"
+  remote.exec 'snap list pc-kernel-mac80211-hwsim' | awk '$NR != 1 { print $3 }' | MATCH '1'
+  remote.exec 'snap components pc-kernel-mac80211-hwsim' | sed 1d | MATCH 'pc-kernel-mac80211-hwsim\+wifi-comp\s+installed'
+
+  remote.exec sudo modprobe mac80211_hwsim
+  remote.exec ip link show wlan0
+  remote.exec modinfo --filename mac80211_hwsim | MATCH '/lib/modules/.*/updates/wifi-comp'

--- a/tests/nested/manual/remodel-to-installed-kernel/task.yaml
+++ b/tests/nested/manual/remodel-to-installed-kernel/task.yaml
@@ -122,8 +122,8 @@ prepare: |
       ./pc-kernel-efi-pstore+efi-comp.comp
 
 restore: |
-    systemctl stop fakedevicesvc
-    "${TESTSTOOLS}/store-state" teardown-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
+  systemctl stop fakedevicesvc
+  "${TESTSTOOLS}/store-state" teardown-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
 
 execute: |
   echo 'Swap to the first new kernel and component pc-kernel-mac80211-hwsim+wifi-comp'


### PR DESCRIPTION
This fixes and tests the case where we remodel to a kernel snap that is already installed on the system, but is not the current kernel due to a previous remodel.

Note that this PR removes the existing "prepare-kernel-snap" task from the created tasks here, because the task is superfluous in this case. The kernel's drivers tree is already generated from the original installation of the kernel. 