### PR TITLE
cmd: github: generate coverage data from C code executed in unit tests workflow

### DIFF
--- a/.github/actions/download-install-debian-deps/action.yaml
+++ b/.github/actions/download-install-debian-deps/action.yaml
@@ -26,4 +26,6 @@ runs:
     run: |
         sudo apt update
         sudo apt build-dep -y "${{ inputs.snapd-src-dir }}"
+        # TODO: this should be added to debian/control?
+        sudo apt install -y gcovr lcov
         rm -rf ./debian-deps

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -63,20 +63,6 @@ jobs:
       run: |
           ./get-deps.sh
 
-    - name: Build C
-      run: |
-          cd cmd/
-          ./autogen.sh
-          make -j$(nproc)
-
-    - name: Build Go
-      run: |
-          go build ./...
-
-    - name: Test C
-      run: |
-          cd cmd/ && make distcheck
-    
     - name: Set SNAPD_DEBUG=1
       if: ${{ inputs.snapd-debug }}
       run: echo "SNAPD_DEBUG=1" >> $GITHUB_ENV
@@ -88,6 +74,32 @@ jobs:
     - name: Set SKIP_COVERAGE=1
       if: ${{ inputs.skip-coverage }}
       run: echo "SKIP_COVERAGE=1" >> $GITHUB_ENV
+
+    - name: Build C
+      run: |
+          cd cmd/
+          ./autogen.sh \
+              --enable-test-coverage \
+              --enable-code-coverage
+          make -j$(nproc)
+
+    - name: Build Go
+      run: |
+          go build ./...
+
+    - name: Test C (distcheck)
+      run: |
+          cd cmd/ && make distcheck
+
+    - name: Test C (check & coverage)
+      run: |
+          cd cmd/
+          if [ -n "$SKIP_COVERAGE" ]; then
+              make check
+          else
+              make check-code-coverage
+              cp -v snap-confine-*-coverage.info "${{ github.workspace}}/.coverage/"
+          fi
 
     - name: Test Go
       run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -105,6 +105,7 @@ jobs:
               cp coverage.csv "${{ github.workspace }}/.coverage/coverage-c-code-gcovr.cov"
               make clean
           fi
+          rm -f cmd/aminclude_static.am
 
     - name: Test Go
       run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -97,10 +97,12 @@ jobs:
           if [ -n "$SKIP_COVERAGE" ]; then
               make check
           else
-              # make check-code-coverage
-              # cp -v snap-confine-*-coverage.info "${{ github.workspace}}/.coverage/"
+              make check-code-coverage
+              cp -v snap-confine-*-coverage.info "${{ github.workspace}}/.coverage/coverage-c-code-lcov.cov"
+              make clean
               make coverage.csv
-              cp coverage.csv "${{ github.workspace }}/.coverage/coverage-c-code.cov"
+              cp coverage.csv "${{ github.workspace }}/.coverage/coverage-c-code-gcovr.cov"
+              make clean
           fi
 
     - name: Test Go

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -105,7 +105,7 @@ jobs:
               cp coverage.csv "${{ github.workspace }}/.coverage/coverage-c-code-gcovr.cov"
               make clean
           fi
-          rm -f cmd/aminclude_static.am
+          rm -fv aminclude_static.am
 
     - name: Test Go
       run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -97,8 +97,10 @@ jobs:
           if [ -n "$SKIP_COVERAGE" ]; then
               make check
           else
-              make check-code-coverage
-              cp -v snap-confine-*-coverage.info "${{ github.workspace}}/.coverage/"
+              # make check-code-coverage
+              # cp -v snap-confine-*-coverage.info "${{ github.workspace}}/.coverage/"
+              make coverage.csv
+              cp coverage.csv "${{ github.workspace }}/.coverage/coverage-c-code.cov"
           fi
 
     - name: Test Go

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -97,6 +97,7 @@ jobs:
           if [ -n "$SKIP_COVERAGE" ]; then
               make check
           else
+              mkdir -p "${{ github.workspace}}/.coverage"
               make check-code-coverage
               cp -v snap-confine-*-coverage.info "${{ github.workspace}}/.coverage/coverage-c-code-lcov.cov"
               make clean

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -592,7 +592,6 @@ CLEANFILES += coverage.csv
 coverage.csv: check
 	gcovr \
 		--csv \
-		--merge-mode-functions=separate \
 		-o $@ $(builddir)
 
 include $(top_srcdir)/aminclude_static.am

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -14,9 +14,8 @@ if USE_INTERNAL_BPF_HEADERS
 VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor
 endif
 
-CODE_COVERAGE_LCOV_SHOPTS = --ignore-errors unused \
-	--exclude '*-test.c'
-CODE_COVERAGE_GENHTML_OPTIONS = --ignore-errors inconsistent
+CODE_COVERAGE_LCOV_SHOPTS = --exclude '*-test.c'
+CODE_COVERAGE_GENHTML_OPTIONS =
 
 subdirs = \
 		  libsnap-confine-private \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -564,7 +564,8 @@ else
 APPARMOR_DISTCHECK_CONFIGURE_FLAGS=--disable-apparmor
 endif
 
-coverage.xml: check
+coverage.csv: check
 	gcovr \
+		--csv \
 		--merge-mode-functions=separate \
 		-o $@ .

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -8,6 +8,7 @@ noinst_PROGRAMS =
 noinst_LIBRARIES =
 
 AM_CFLAGS = $(CHECK_CFLAGS)
+AM_LDFLAGS = $(CHECK_LDFLAGS)
 
 if USE_INTERNAL_BPF_HEADERS
 VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -358,7 +358,9 @@ snap_confine_unit_tests_SOURCES = \
 	snap-confine/seccomp-support.c \
 	snap-confine/seccomp-support-ext.c \
 	snap-confine/seccomp-support-test.c \
+	snap-confine/snap-confine-args.c \
 	snap-confine/snap-confine-args-test.c \
+	snap-confine/snap-confine-invocation.c \
 	snap-confine/snap-confine-invocation-test.c
 snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_snap_confine_LDADD) $(GLIB_LIBS) libsnap-confine-private-test-support.a

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -563,3 +563,8 @@ APPARMOR_DISTCHECK_CONFIGURE_FLAGS=--with-apparmorconfigdir=$${dc_install_base}/
 else
 APPARMOR_DISTCHECK_CONFIGURE_FLAGS=--disable-apparmor
 endif
+
+coverage.xml: check
+	gcovr \
+		--merge-mode-functions=separate \
+		-o $@ .

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -14,6 +14,10 @@ if USE_INTERNAL_BPF_HEADERS
 VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor
 endif
 
+CODE_COVERAGE_LCOV_SHOPTS = --ignore-errors inconsistent,corrupt,unused \
+	--exclude '*-test.c'
+CODE_COVERAGE_GENHTML_OPTIONS = --ignore-errors inconsistent,corrupt
+
 subdirs = \
 		  libsnap-confine-private \
 		  snap-confine \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -97,10 +97,12 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/cgroup-freezer-support.h \
 	libsnap-confine-private/cgroup-support.c \
 	libsnap-confine-private/cgroup-support.h \
+	libsnap-confine-private/cgroup-support-private.h \
 	libsnap-confine-private/device-cgroup-support.c \
 	libsnap-confine-private/device-cgroup-support.h \
 	libsnap-confine-private/classic.c \
 	libsnap-confine-private/classic.h \
+	libsnap-confine-private/classic-private.h \
 	libsnap-confine-private/cleanup-funcs.c \
 	libsnap-confine-private/cleanup-funcs.h \
 	libsnap-confine-private/error.c \
@@ -109,14 +111,17 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/fault-injection.h \
 	libsnap-confine-private/feature.c \
 	libsnap-confine-private/feature.h \
+	libsnap-confine-private/feature-private.h \
 	libsnap-confine-private/infofile.c \
 	libsnap-confine-private/infofile.h \
 	libsnap-confine-private/locking.c \
 	libsnap-confine-private/locking.h \
+	libsnap-confine-private/locking-private.h \
 	libsnap-confine-private/mount-opt.c \
 	libsnap-confine-private/mount-opt.h \
 	libsnap-confine-private/mountinfo.c \
 	libsnap-confine-private/mountinfo.h \
+	libsnap-confine-private/mountinfo-private.h \
 	libsnap-confine-private/panic.c \
 	libsnap-confine-private/panic.h \
 	libsnap-confine-private/privs.c \
@@ -125,6 +130,7 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/secure-getenv.h \
 	libsnap-confine-private/snap-dir.c \
 	libsnap-confine-private/snap-dir.h \
+	libsnap-confine-private/snap-dir-private.h \
 	libsnap-confine-private/snap.c \
 	libsnap-confine-private/snap.h \
 	libsnap-confine-private/string-utils.c \
@@ -132,7 +138,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/tool.c \
 	libsnap-confine-private/tool.h \
 	libsnap-confine-private/utils.c \
-	libsnap-confine-private/utils.h
+	libsnap-confine-private/utils.h \
+	libsnap-confine-private/utils-private.h
 if ENABLE_BPF
 libsnap_confine_private_a_SOURCES += \
 	libsnap-confine-private/bpf-support.c \
@@ -165,6 +172,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/classic-test.c \
 	libsnap-confine-private/cleanup-funcs-test.c \
 	libsnap-confine-private/error-test.c \
+	libsnap-confine-private/fault-injection.c \
 	libsnap-confine-private/fault-injection-test.c \
 	libsnap-confine-private/feature-test.c \
 	libsnap-confine-private/infofile-test.c \
@@ -181,7 +189,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/utils-test.c
 
 libsnap_confine_private_unit_tests_CFLAGS = $(AM_CFLAGS) $(VENDOR_BPF_HEADERS_CFLAGS) $(GLIB_CFLAGS)
-libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS) libsnap-confine-private-test-support.a
+libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS) libsnap-confine-private.a libsnap-confine-private-test-support.a
 libsnap_confine_private_unit_tests_CFLAGS += -D_ENABLE_FAULT_INJECTION
 libsnap_confine_private_unit_tests_STATIC =
 

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -249,16 +249,20 @@ EXTRA_DIST += snap-confine/snap-confine.apparmor.in
 snap_confine_snap_confine_SOURCES = \
 	snap-confine/cookie-support.c \
 	snap-confine/cookie-support.h \
+	snap-confine/cookie-support-private.h \
 	snap-confine/mount-support-nvidia.c \
 	snap-confine/mount-support-nvidia.h \
 	snap-confine/mount-support.c \
 	snap-confine/mount-support.h \
+	snap-confine/mount-support-private.h \
 	snap-confine/ns-support.c \
 	snap-confine/ns-support.h \
+	snap-confine/ns-support-private.h \
 	snap-confine/seccomp-support-ext.c \
 	snap-confine/seccomp-support-ext.h \
 	snap-confine/seccomp-support.c \
 	snap-confine/seccomp-support.h \
+	snap-confine/seccomp-support-private.h \
 	snap-confine/snap-confine-args.c \
 	snap-confine/snap-confine-args.h \
 	snap-confine/snap-confine-invocation.c \
@@ -341,9 +345,15 @@ snap-confine/snap-confine-debug$(EXEEXT): LIBS += -Wl,-Bstatic $(snap_confine_sn
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += snap-confine/unit-tests
 snap_confine_unit_tests_SOURCES = \
+	snap-confine/cookie-support.c \
 	snap-confine/cookie-support-test.c \
+	snap-confine/mount-support.c \
+	snap-confine/mount-support-nvidia.c \
 	snap-confine/mount-support-test.c \
+	snap-confine/ns-support.c \
 	snap-confine/ns-support-test.c \
+	snap-confine/seccomp-support.c \
+	snap-confine/seccomp-support-ext.c \
 	snap-confine/seccomp-support-test.c \
 	snap-confine/snap-confine-args-test.c \
 	snap-confine/snap-confine-invocation-test.c

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -14,9 +14,10 @@ if USE_INTERNAL_BPF_HEADERS
 VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor
 endif
 
-CODE_COVERAGE_LCOV_SHOPTS = --ignore-errors inconsistent,corrupt,unused \
-	--exclude '*-test.c'
-CODE_COVERAGE_GENHTML_OPTIONS = --ignore-errors inconsistent,corrupt
+CODE_COVERAGE_LCOV_SHOPTS = --ignore-errors unused \
+	--exclude '*-test.c' \
+	--branch-coverage
+CODE_COVERAGE_GENHTML_OPTIONS = --ignore-errors inconsistent --branch-coverage
 
 subdirs = \
 		  libsnap-confine-private \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -436,7 +436,9 @@ snap_device_helper_snap_device_helper_LDADD = libsnap-confine-private.a
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += snap-device-helper/unit-tests
 snap_device_helper_unit_tests_SOURCES = \
-	snap-device-helper/snap-device-helper-test.c
+	snap-device-helper/snap-device-helper-test.c \
+	snap-device-helper/snap-device-helper.c \
+	snap-device-helper/snap-device-helper.h
 snap_device_helper_unit_tests_CFLAGS = $(AM_CFLAGS) $(snap_device_helper_snap_device_helper_CFLAGS) $(GLIB_CFLAGS)
 snap_device_helper_unit_tests_LDADD = $(GLIB_LIBS) libsnap-confine-private.a libsnap-confine-private-test-support.a
 snap_device_helper_unit_tests_LDFLAGS =$(snap_device_helper_snap_device_helper_LDFLAGS)

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,4 +1,3 @@
-
 EXTRA_DIST = VERSION snap-confine/PORTING
 CLEANFILES =
 TESTS =
@@ -7,8 +6,9 @@ dist_man_MANS =
 noinst_PROGRAMS =
 noinst_LIBRARIES =
 
-AM_CFLAGS = $(CHECK_CFLAGS)
+AM_CFLAGS = $(CHECK_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CHECK_LDFLAGS)
+AM_LIBS = $(CODE_COVERAGE_LIBS)
 
 if USE_INTERNAL_BPF_HEADERS
 VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor
@@ -224,7 +224,7 @@ decode-mount-opts/decode-mount-opts$(EXEEXT): $(decode_mount_opts_decode_mount_o
 	@rm -f decode-mount-opts/decode-mount-opts$(EXEEXT)
 	$(AM_V_CCLD)$(decode_mount_opts_decode_mount_opts_LINK) $(decode_mount_opts_decode_mount_opts_OBJECTS) $(decode_mount_opts_decode_mount_opts_LDADD) $(LIBS)
 
-decode-mount-opts/decode-mount-opts$(EXEEXT): LIBS += -Wl,-Bstatic $(decode_mount_opts_decode_mount_opts_STATIC) -Wl,-Bdynamic
+decode-mount-opts/decode-mount-opts$(EXEEXT): LIBS += -Wl,-Bstatic $(decode_mount_opts_decode_mount_opts_STATIC) -Wl,-Bdynamic $(AM_LIBS)
 
 ##
 ## snap-confine
@@ -564,8 +564,16 @@ else
 APPARMOR_DISTCHECK_CONFIGURE_FLAGS=--disable-apparmor
 endif
 
+CLEANFILES += coverage.csv
 coverage.csv: check
 	gcovr \
 		--csv \
 		--merge-mode-functions=separate \
-		-o $@ .
+		-o $@ $(builddir)
+
+include $(top_srcdir)/aminclude_static.am
+
+if CODE_COVERAGE_ENABLED
+clean-local: code-coverage-clean
+distclean-local: code-coverage-dist-clean
+endif

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -15,9 +15,8 @@ VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor
 endif
 
 CODE_COVERAGE_LCOV_SHOPTS = --ignore-errors unused \
-	--exclude '*-test.c' \
-	--branch-coverage
-CODE_COVERAGE_GENHTML_OPTIONS = --ignore-errors inconsistent --branch-coverage
+	--exclude '*-test.c'
+CODE_COVERAGE_GENHTML_OPTIONS = --ignore-errors inconsistent
 
 subdirs = \
 		  libsnap-confine-private \

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -333,10 +333,7 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
   AX_APPEND_COMPILE_FLAGS([-Werror], [CHECK_CFLAGS])
 ])
 
-AS_IF([test "x$enable_test_coverage" = "xyes"], [
-  AX_APPEND_COMPILE_FLAGS([--coverage], [CHECK_CFLAGS])
-  AX_APPEND_LINK_FLAGS([--coverage], [CHECK_LDFLAGS])
-])
+AX_CODE_COVERAGE
 
 AC_SUBST([CHECK_CFLAGS])
 AC_SUBST([CHECK_LDFLAGS])

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -303,6 +303,20 @@ AC_ARG_ENABLE([host-binaries],
     [build_host_binaries=yes])
 AM_CONDITIONAL([BUILD_HOST_BINARIES], [test "x$build_host_binaries" = "xyes"])
 
+AC_ARG_ENABLE([test-coverage],
+    AS_HELP_STRING([--enable-test-coverage], [Enable test coverage]),
+    [case "${enableval}" in
+        yes) enable_test_coverage=yes ;;
+        no)  enable_test_coverage=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-test-coverage])
+    esac], [enable_test_coverage=no])
+AM_CONDITIONAL([TEST_COVERAGE], [test "x$enable_test_coverage" = "xyes"])
+
+AC_PATH_PROGS([HAVE_GCOVR],[gcovr])
+AS_IF([test "x$HAVE_GCOVR" = "x" -a "x$enable_test_coverage" = "xyes"], [
+  AC_MSG_ERROR(["gcovr is required for coverage data"])
+])
+
 AX_APPEND_COMPILE_FLAGS([ dnl
   -Wall dnl
   -Wextra dnl
@@ -317,6 +331,10 @@ AS_IF([test "x$snapd_cv_missing_field_initializers_works" = "xno"], [
 
 AS_IF([test "x$with_unit_tests" = "xyes"], [
   AX_APPEND_COMPILE_FLAGS([-Werror], [CHECK_CFLAGS])
+])
+
+AS_IF([test "x$enable_test_coverage" = "xyes"], [
+  AX_APPEND_COMPILE_FLAGS([--coverage], [CHECK_CFLAGS])
 ])
 
 AC_SUBST([CHECK_CFLAGS])

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -335,9 +335,11 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 
 AS_IF([test "x$enable_test_coverage" = "xyes"], [
   AX_APPEND_COMPILE_FLAGS([--coverage], [CHECK_CFLAGS])
+  AX_APPEND_LINK_FLAGS([--coverage], [CHECK_LDFLAGS])
 ])
 
 AC_SUBST([CHECK_CFLAGS])
+AC_SUBST([CHECK_LDFLAGS])
 
 AC_ARG_WITH([apparmorconfigdir],
     [AS_HELP_STRING([--with-apparmorconfigdir], [path to apparmor.d configuration directory])], [

--- a/cmd/libsnap-confine-private/cgroup-support-private.h
+++ b/cmd/libsnap-confine-private/cgroup-support-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -15,8 +15,17 @@
  *
  */
 
-#include "secure-getenv.h"
+#ifndef SC_CGROUP_SUPPORT_PRIVATE_H
+#define SC_CGROUP_SUPPORT_PRIVATE_H
 
-#include <glib.h>
+#include "cgroup-support.h"
 
-// TODO: write some tests
+void sc_set_cgroup_root(const char *dir);
+
+const char *sc_get_default_cgroup_root(void);
+
+void sc_set_self_cgroup_path(const char *path);
+
+const char *sc_get_default_self_cgroup_path(void);
+
+#endif

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -17,7 +17,7 @@
 
 #define _GNU_SOURCE
 
-#include "cgroup-support.h"
+#include "cgroup-support-private.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -69,7 +69,8 @@ void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid) 
     debug("moved process %ld to cgroup hierarchy %s/%s", (long)pid, parent, name);
 }
 
-static const char *cgroup_dir = "/sys/fs/cgroup";
+static const char *const default_cgroup_dir = "/sys/fs/cgroup";
+static const char *cgroup_dir = default_cgroup_dir;
 
 // from statfs(2)
 #ifndef CGROUP2_SUPER_MAGIC
@@ -200,7 +201,8 @@ bool sc_cgroup_v2_is_tracking_snap(const char *snap_instance) {
     return traverse_looking_for_prefix_in_dir(root, tracking_group_name, just_leaf, 1);
 }
 
-static const char *self_cgroup = "/proc/self/cgroup";
+static const char *const default_self_cgroup = "/proc/self/cgroup";
+static const char *self_cgroup = default_self_cgroup;
 
 char *sc_cgroup_v2_own_path_full(void) {
     FILE *in SC_CLEANUP(sc_cleanup_file) = fopen(self_cgroup, "r");
@@ -239,3 +241,11 @@ char *sc_cgroup_v2_own_path_full(void) {
     }
     return own_group;
 }
+
+void sc_set_cgroup_root(const char *dir) { cgroup_dir = dir; }
+
+const char *sc_get_default_cgroup_root(void) { return default_cgroup_dir; }
+
+void sc_set_self_cgroup_path(const char *path) { self_cgroup = path; };
+
+const char *sc_get_default_self_cgroup_path(void) { return default_self_cgroup; }

--- a/cmd/libsnap-confine-private/classic-private.h
+++ b/cmd/libsnap-confine-private/classic-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -14,9 +14,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#ifndef SNAP_CONFINE_CLASSIC_PRIVATE_H
+#define SNAP_CONFINE_CLASSIC_PRIVATE_H
 
-#include "secure-getenv.h"
+#include "classic.h"
 
-#include <glib.h>
+void sc_set_os_release(const char *path);
+const char *sc_get_default_os_release(void);
 
-// TODO: write some tests
+void sc_set_meta_snap_yaml(const char *path);
+const char *sc_get_default_meta_snap_yaml(void);
+
+#endif

--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -15,49 +15,51 @@
  *
  */
 
-#include "classic.h"
-#include "classic.c"
+#include "classic-private.h"
 
 #include <glib.h>
+#include <unistd.h>
 
 /* restore_os_release is an internal helper for mock_os_release */
-static void restore_os_release(gpointer *old) {
-    unlink(os_release);
-    os_release = (const char *)old;
+static void restore_os_release(gpointer mocked) {
+    unlink(mocked);
+    sc_set_os_release(sc_get_default_os_release());
 }
 
 /* mock_os_release replaces the presence and contents of /etc/os-release
    as seen by classic.c. The mocked value may be NULL to have the code refer
    to an absent file. */
 static void mock_os_release(const char *mocked) {
-    const char *old = os_release;
+    const char *mocked_path = "os-release.missing";
+
     if (mocked != NULL) {
-        os_release = "os-release.test";
-        g_assert_true(g_file_set_contents(os_release, mocked, -1, NULL));
-    } else {
-        os_release = "os-release.missing";
+        mocked_path = "os-release.test";
+        g_assert_true(g_file_set_contents(mocked_path, mocked, -1, NULL));
     }
-    g_test_queue_destroy((GDestroyNotify)restore_os_release, (gpointer)old);
+
+    sc_set_os_release(mocked_path);
+    g_test_queue_destroy((GDestroyNotify)restore_os_release, (gpointer)mocked_path);
 }
 
 /* restore_meta_snap_yaml is an internal helper for mock_meta_snap_yaml */
-static void restore_meta_snap_yaml(gpointer *old) {
-    unlink(meta_snap_yaml);
-    meta_snap_yaml = (const char *)old;
+static void restore_meta_snap_yaml(gpointer mocked) {
+    unlink(mocked);
+    sc_set_meta_snap_yaml(sc_get_default_meta_snap_yaml());
 }
 
 /* mock_meta_snap_yaml replaces the presence and contents of /meta/snap.yaml
    as seen by classic.c. The mocked value may be NULL to have the code refer
    to an absent file. */
 static void mock_meta_snap_yaml(const char *mocked) {
-    const char *old = meta_snap_yaml;
+    const char *mocked_path = "snap-yaml.missing";
+
     if (mocked != NULL) {
-        meta_snap_yaml = "snap-yaml.test";
-        g_assert_true(g_file_set_contents(meta_snap_yaml, mocked, -1, NULL));
-    } else {
-        meta_snap_yaml = "snap-yaml.missing";
+        mocked_path = "snap-yaml.test";
+        g_assert_true(g_file_set_contents(mocked_path, mocked, -1, NULL));
     }
-    g_test_queue_destroy((GDestroyNotify)restore_meta_snap_yaml, (gpointer)old);
+
+    sc_set_meta_snap_yaml(mocked_path);
+    g_test_queue_destroy((GDestroyNotify)restore_meta_snap_yaml, (gpointer)mocked_path);
 }
 
 static const char *os_release_classic =

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -1,16 +1,23 @@
-#include "classic.h"
+#include "classic-private.h"
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/infofile.h"
 #include "../libsnap-confine-private/string-utils.h"
-#include "config.h"
 
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 
-static const char *os_release = "/etc/os-release";
-static const char *meta_snap_yaml = "/meta/snap.yaml";
+static const char *const default_os_release = "/etc/os-release";
+static const char *const default_meta_snap_yaml = "/meta/snap.yaml";
+
+static const char *os_release = default_os_release;
+static const char *meta_snap_yaml = default_meta_snap_yaml;
 
 sc_distro sc_classify_distro(void) {
     FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
@@ -81,3 +88,9 @@ bool sc_is_debian_like(void) {
     }
     return false;
 }
+
+void sc_set_os_release(const char *path) { os_release = path; }
+const char *sc_get_default_os_release(void) { return default_os_release; }
+
+void sc_set_meta_snap_yaml(const char *path) { meta_snap_yaml = path; }
+const char *sc_get_default_meta_snap_yaml(void) { return default_meta_snap_yaml; }

--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -16,12 +16,12 @@
  */
 
 #include "cleanup-funcs.h"
-#include "cleanup-funcs.c"
 
 #include <glib.h>
 #include <glib/gstdio.h>
 
 #include <fcntl.h>
+#include <mntent.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/timerfd.h>

--- a/cmd/libsnap-confine-private/error-test.c
+++ b/cmd/libsnap-confine-private/error-test.c
@@ -16,7 +16,6 @@
  */
 
 #include "error.h"
-#include "error.c"
 
 #include <errno.h>
 #include <glib.h>

--- a/cmd/libsnap-confine-private/fault-injection-test.c
+++ b/cmd/libsnap-confine-private/fault-injection-test.c
@@ -16,9 +16,7 @@
  */
 
 #include "fault-injection.h"
-#include "fault-injection.c"
 
-#include <errno.h>
 #include <glib.h>
 
 static bool broken(struct sc_fault_state *state, void *ptr) { return true; }

--- a/cmd/libsnap-confine-private/fault-injection.c
+++ b/cmd/libsnap-confine-private/fault-injection.c
@@ -31,7 +31,7 @@ struct sc_fault {
 
 static struct sc_fault *sc_faults = NULL;
 
-bool sc_faulty(const char *name, void *ptr) {
+static bool _sc_faulty(const char *name, void *ptr) {
     for (struct sc_fault *fault = sc_faults; fault != NULL; fault = fault->next) {
         if (strcmp(name, fault->name) == 0) {
             bool is_faulty = fault->fn(&fault->state, ptr);
@@ -65,6 +65,8 @@ void sc_reset_faults(void) {
 
 #else  // ifndef _ENABLE_FAULT_INJECTION
 
-bool sc_faulty(const char *name, void *ptr) { return false; }
+static bool _sc_faulty(const char *name, void *ptr) { return false; }
 
 #endif  // ifndef _ENABLE_FAULT_INJECTION
+
+bool sc_faulty(const char *name, void *ptr) { return _sc_faulty(name, ptr); }

--- a/cmd/libsnap-confine-private/feature-private.h
+++ b/cmd/libsnap-confine-private/feature-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -15,8 +15,13 @@
  *
  */
 
-#include "secure-getenv.h"
+#ifndef SNAP_CONFINE_FEATURE_PRIVATE_H
+#define SNAP_CONFINE_FEATURE_PRIVATE_H
 
-#include <glib.h>
+#include "feature.h"
 
-// TODO: write some tests
+void sc_set_feature_flag_dir(const char *dir);
+
+const char *sc_get_default_feature_flag_dir(void);
+
+#endif

--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -15,8 +15,7 @@
  *
  */
 
-#include "feature.h"
-#include "feature.c"
+#include "feature-private.h"
 
 #include <limits.h>
 
@@ -33,13 +32,12 @@ static char *sc_testdir(void) {
     return d;
 }
 
-// Set the feature flag directory to given value, useful for cleanup handlers.
-static void set_feature_flag_dir(const char *dir) { feature_flag_dir = dir; }
+static void my_restore_feature_flag_dir(gpointer data) { sc_set_feature_flag_dir(sc_get_default_feature_flag_dir()); }
 
 // Mock the location of the feature flag directory.
 static void sc_mock_feature_flag_dir(const char *d) {
-    g_test_queue_destroy((GDestroyNotify)set_feature_flag_dir, (void *)feature_flag_dir);
-    set_feature_flag_dir(d);
+    g_test_queue_destroy((GDestroyNotify)my_restore_feature_flag_dir, NULL);
+    sc_set_feature_flag_dir(d);
 }
 
 static void test_feature_enabled__missing_dir(void) {

--- a/cmd/libsnap-confine-private/feature.c
+++ b/cmd/libsnap-confine-private/feature.c
@@ -17,7 +17,7 @@
 
 #define _GNU_SOURCE
 
-#include "feature.h"
+#include "feature-private.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -28,7 +28,8 @@
 #include "cleanup-funcs.h"
 #include "utils.h"
 
-static const char *feature_flag_dir = "/var/lib/snapd/features";
+static const char *const default_feature_flag_dir = "/var/lib/snapd/features";
+static const char *feature_flag_dir = default_feature_flag_dir;
 
 bool sc_feature_enabled(sc_feature_flag flag) {
     const char *file_name;
@@ -68,3 +69,8 @@ bool sc_feature_enabled(sc_feature_flag flag) {
 
     return S_ISREG(file_info.st_mode);
 }
+
+// Set the feature flag directory to given value, useful for cleanup handlers.
+void sc_set_feature_flag_dir(const char *dir) { feature_flag_dir = dir; }
+
+const char *sc_get_default_feature_flag_dir(void) { return default_feature_flag_dir; }

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -20,8 +20,6 @@
 #include <glib.h>
 #include <unistd.h>
 
-#include "infofile.c"
-
 static void test_infofile_get_key(void) {
     int rc;
     sc_error *err;

--- a/cmd/libsnap-confine-private/locking-private.h
+++ b/cmd/libsnap-confine-private/locking-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -14,9 +14,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#ifndef SNAP_CONFINE_LOCKING_PRIVATE_H
+#define SNAP_CONFINE_LOCKING_PRIVATE_H
 
-#include "secure-getenv.h"
+#include "locking.h"
 
-#include <glib.h>
+int sc_lock_generic(const char *scope, uid_t uid);
 
-// TODO: write some tests
+// Set alternate inhibit directory
+void sc_set_inhibit_dir(const char *dir);
+
+const char *sc_get_default_inhibit_dir(void);
+
+// Set alternate locking directory
+void sc_set_lock_dir(const char *dir);
+
+const char *sc_get_default_lock_dir(void);
+
+#endif  // SNAP_CONFINE_LOCKING_PRIVATE_H

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -19,7 +19,7 @@
 #include "config.h"
 #endif
 
-#include "locking.h"
+#include "locking-private.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -130,7 +130,7 @@ static int open_lock(const char *scope, uid_t uid) {
     return lock_fd;
 }
 
-static int sc_lock_generic(const char *scope, uid_t uid) {
+int sc_lock_generic(const char *scope, uid_t uid) {
     int lock_fd = open_lock(scope, uid);
     sc_enable_sanity_timeout();
     debug("acquiring exclusive lock (scope %s, uid %d)", scope ?: "(global)", uid);
@@ -212,3 +212,11 @@ bool sc_snap_is_inhibited(const char *snap_name, sc_snap_inhibition_hint hint) {
 
     return S_ISREG(file_info.st_mode);
 }
+
+void sc_set_inhibit_dir(const char *dir) { sc_inhibit_dir = dir; }
+
+const char *sc_get_default_inhibit_dir(void) { return SC_INHIBIT_DIR; }
+
+void sc_set_lock_dir(const char *dir) { sc_lock_dir = dir; }
+
+const char *sc_get_default_lock_dir(void) { return SC_LOCK_DIR; }

--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -16,7 +16,7 @@
  */
 
 #include "mount-opt.h"
-#include "mount-opt.c"
+#include "fault-injection.h"
 
 #include <errno.h>
 #include <sys/mount.h>

--- a/cmd/libsnap-confine-private/mountinfo-private.h
+++ b/cmd/libsnap-confine-private/mountinfo-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -12,11 +12,14 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
-#include "secure-getenv.h"
+#ifndef SNAP_CONFINE_MOUNTINFO_PRIVATE_H
+#define SNAP_CONFINE_MOUNTINFO_PRIVATE_H
 
-#include <glib.h>
+#include "mountinfo.h"
 
-// TODO: write some tests
+sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line) __attribute__((nonnull(1)));
+void sc_free_mountinfo_entry(sc_mountinfo_entry *entry) __attribute__((nonnull(1)));
+
+#endif

--- a/cmd/libsnap-confine-private/mountinfo-test.c
+++ b/cmd/libsnap-confine-private/mountinfo-test.c
@@ -15,8 +15,7 @@
  *
  */
 
-#include "mountinfo.h"
-#include "mountinfo.c"
+#include "mountinfo-private.h"
 
 #include <glib.h>
 

--- a/cmd/libsnap-confine-private/mountinfo.c
+++ b/cmd/libsnap-confine-private/mountinfo.c
@@ -296,4 +296,4 @@ static void sc_free_mountinfo(sc_mountinfo *info) {
 /**
  * Free a sc_mountinfo entry.
  **/
-void sc_free_mountinfo_entry(sc_mountinfo_entry *entry) { free(entry); }
+void __attribute__((noinline)) sc_free_mountinfo_entry(sc_mountinfo_entry *entry) { free(entry); }

--- a/cmd/libsnap-confine-private/panic-test.c
+++ b/cmd/libsnap-confine-private/panic-test.c
@@ -16,9 +16,9 @@
  */
 
 #include "panic.h"
-#include "panic.c"
 
 #include <glib.h>
+#include <stdio.h>
 
 static void test_panic(void) {
     if (g_test_subprocess()) {

--- a/cmd/libsnap-confine-private/privs-test.c
+++ b/cmd/libsnap-confine-private/privs-test.c
@@ -16,7 +16,8 @@
  */
 
 #include "privs.h"
-#include "privs.c"
+
+#include <sys/unistd.h>
 
 #include <glib.h>
 

--- a/cmd/libsnap-confine-private/snap-dir-private.h
+++ b/cmd/libsnap-confine-private/snap-dir-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -15,8 +15,11 @@
  *
  */
 
-#include "secure-getenv.h"
+#ifndef SNAP_CONFINE_SNAP_DIR_PRIVATE_H
+#define SNAP_CONFINE_SNAP_DIR_PRIVATE_H
 
-#include <glib.h>
+#include "snap-dir.h"
 
-// TODO: write some tests
+void sc_set_snap_mount_dir(const char *dir);
+
+#endif

--- a/cmd/libsnap-confine-private/snap-dir-test.c
+++ b/cmd/libsnap-confine-private/snap-dir-test.c
@@ -15,11 +15,15 @@
  *
  */
 
-#include "snap-dir.h"
-#include "snap-dir.c"
+#define _GNU_SOURCE
 
+#include "snap-dir-private.h"
+#include "snap.h"
+
+#include <fcntl.h>
 #include <glib.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include "test-utils.h"  // For rm_rf_tmp
 
@@ -144,7 +148,7 @@ static void test_sc_probe_snap_mount_dir__bad_symlink_target(void) {
 }
 
 static void test_sc_snap_mount_dir__not_probed(void) {
-    _snap_mount_dir = NULL;
+    sc_set_snap_mount_dir(NULL);
 
     struct sc_error *err = NULL;
     const char *snap_mount_dir = sc_snap_mount_dir(&err);

--- a/cmd/libsnap-confine-private/snap-dir.c
+++ b/cmd/libsnap-confine-private/snap-dir.c
@@ -17,7 +17,7 @@
 
 #define _GNU_SOURCE
 
-#include "snap-dir.h"
+#include "snap-dir-private.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -33,7 +33,6 @@
 static const char *_snap_mount_dir = NULL;
 
 // Function is exported only for tests.
-void sc_set_snap_mount_dir(const char *dir);
 void sc_set_snap_mount_dir(const char *dir) { _snap_mount_dir = dir; }
 
 const char *sc_snap_mount_dir(sc_error **errorp) {

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -16,7 +16,6 @@
  */
 
 #include "snap.h"
-#include "snap.c"
 
 #include <glib.h>
 

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -16,7 +16,6 @@
  */
 
 #include "string-utils.h"
-#include "string-utils.c"
 
 #include <glib.h>
 

--- a/cmd/libsnap-confine-private/test-utils.c
+++ b/cmd/libsnap-confine-private/test-utils.c
@@ -16,9 +16,9 @@
  */
 
 #include "test-utils.h"
+#include "snap-dir-private.h"
 #include "string-utils.h"
 
-#include "error.h"
 #include "utils.h"
 
 #if !GLIB_CHECK_VERSION(2, 69, 0)
@@ -97,8 +97,6 @@ void __attribute__((sentinel)) test_argc_argv(int *argcp, char ***argvp, ...) {
     *argcp = argc;
     *argvp = argv;
 }
-
-extern void sc_set_snap_mount_dir(const char *dir);
 
 void snap_mount_dir_fixture_setup(snap_mount_dir_fixture *fix, gconstpointer user_data) {
     sc_set_snap_mount_dir((const char *)user_data);

--- a/cmd/libsnap-confine-private/utils-private.h
+++ b/cmd/libsnap-confine-private/utils-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -14,9 +14,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#ifndef SC_UTILS_PRIVATE_H
+#define SC_UTILS_PRIVATE_H
 
-#include "secure-getenv.h"
+#include "utils.h"
 
-#include <glib.h>
+int parse_bool(const char *text, bool *value, bool default_value);
 
-// TODO: write some tests
+bool sc_is_in_container_with_marker(const char *container_marker_file);
+
+#endif

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -15,10 +15,10 @@
  *
  */
 
-#include "utils.h"
-#include "utils.c"
+#include "utils-private.h"
 
 #include <glib.h>
+#include <unistd.h>
 
 static void test_parse_bool(void) {
     int err;
@@ -220,27 +220,27 @@ static void test_sc_is_container__empty(void) {
     g_test_in_ephemeral_dir();
     g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
     g_assert_true(g_file_set_contents("container", "", -1, NULL));
-    g_assert_false(_sc_is_in_container("container"));
+    g_assert_false(sc_is_in_container_with_marker("container"));
 }
 
 static void test_sc_is_container__lxc(void) {
     g_test_in_ephemeral_dir();
     g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
     g_assert_true(g_file_set_contents("container", "lxc", -1, NULL));
-    g_assert_true(_sc_is_in_container("container"));
+    g_assert_true(sc_is_in_container_with_marker("container"));
 }
 
 static void test_sc_is_container__lxc_with_newline(void) {
     g_test_in_ephemeral_dir();
     g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
     g_assert_true(g_file_set_contents("container", "lxc\n", -1, NULL));
-    g_assert_true(_sc_is_in_container("container"));
+    g_assert_true(sc_is_in_container_with_marker("container"));
 }
 
 static void test_sc_is_container__no_file(void) {
     g_test_in_ephemeral_dir();
     g_test_queue_destroy((GDestroyNotify)my_unlink, "container");
-    g_assert_false(_sc_is_in_container("container"));
+    g_assert_false(sc_is_in_container_with_marker("container"));
 }
 
 static void __attribute__((constructor)) init(void) {

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -26,7 +26,7 @@
 
 #include "cleanup-funcs.h"
 #include "panic.h"
-#include "utils.h"
+#include "utils-private.h"
 
 void die(const char *msg, ...) {
     va_list ap;
@@ -53,7 +53,7 @@ static const struct sc_bool_name sc_bool_names[] = {
  *
  * If the text cannot be recognized, the default value is used.
  **/
-static int parse_bool(const char *text, bool *value, bool default_value) {
+int parse_bool(const char *text, bool *value, bool default_value) {
     if (value == NULL) {
         errno = EFAULT;
         return -1;
@@ -234,11 +234,11 @@ bool sc_wait_for_file(const char *path, size_t timeout_sec) {
 
 const char *run_systemd_container = "/run/systemd/container";
 
-static bool _sc_is_in_container(const char *p) {
+bool sc_is_in_container_with_marker(const char *container_marker_file) {
     // see what systemd-detect-virt --container does in, see:
     // https://github.com/systemd/systemd/blob/5dcd6b1d55a1cfe247621d70f0e25d020de6e0ed/src/basic/virt.c#L749-L755
     // https://systemd.io/CONTAINER_INTERFACE/
-    FILE *in SC_CLEANUP(sc_cleanup_file) = fopen(p, "r");
+    FILE *in SC_CLEANUP(sc_cleanup_file) = fopen(container_marker_file, "r");
     if (in == NULL) {
         return false;
     }
@@ -267,4 +267,4 @@ static bool _sc_is_in_container(const char *p) {
     return true;
 }
 
-bool sc_is_in_container(void) { return _sc_is_in_container(run_systemd_container); }
+bool sc_is_in_container(void) { return sc_is_in_container_with_marker(run_systemd_container); }

--- a/cmd/snap-confine/cookie-support-private.h
+++ b/cmd/snap-confine/cookie-support-private.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_CONTEXT_SUPPORT_PRIVATE_H
+#define SNAP_CONFINE_CONTEXT_SUPPORT_PRIVATE_H
+
+#include "cookie-support.h"
+
+void sc_set_cookie_dir(const char *dir);
+
+const char *sc_get_default_cookie_dir(void);
+
+#endif

--- a/cmd/snap-confine/cookie-support.c
+++ b/cmd/snap-confine/cookie-support.c
@@ -15,7 +15,7 @@
  *
  */
 
-#include "cookie-support.h"
+#include "cookie-support-private.h"
 
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/string-utils.h"
@@ -65,3 +65,8 @@ out:
     sc_error_forward(errorp, err);
     return context;
 }
+
+// Set alternate cookie directory
+void sc_set_cookie_dir(const char *dir) { sc_cookie_dir = dir; }
+
+const char *sc_get_default_cookie_dir(void) { return SC_COOKIE_DIR; }

--- a/cmd/snap-confine/mount-support-private.h
+++ b/cmd/snap-confine/mount-support-private.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_MOUNT_SUPPORT_PRIVATE_H
+#define SNAP_MOUNT_SUPPORT_PRIVATE_H
+
+#include "mount-support.h"
+
+char *__attribute__((used)) get_nextpath(char *path, size_t *offsetp, size_t fulllen);
+bool __attribute__((used)) is_subdir(const char *subdir, const char *dir);
+
+#endif

--- a/cmd/snap-confine/mount-support-test.c
+++ b/cmd/snap-confine/mount-support-test.c
@@ -15,10 +15,7 @@
  *
  */
 
-#include "mount-support.h"
-#include "mount-support-nvidia.c"
-#include "mount-support-nvidia.h"
-#include "mount-support.c"
+#include "mount-support-private.h"
 
 #include <glib.h>
 #include <glib/gstdio.h>

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -19,7 +19,7 @@
 #include "config.h"
 #endif
 
-#include "mount-support.h"
+#include "mount-support-private.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -795,7 +795,7 @@ static void sc_detach_views_of_writable(sc_distro distro, bool normal_mode) {
  * @fulllen: full original path length.
  * Returns a pointer to the next path segment, or NULL if done.
  */
-static char *__attribute__((used)) get_nextpath(char *path, size_t *offsetp, size_t fulllen) {
+char *__attribute__((used)) get_nextpath(char *path, size_t *offsetp, size_t fulllen) {
     size_t offset = *offsetp;
 
     if (offset >= fulllen) return NULL;
@@ -810,7 +810,7 @@ static char *__attribute__((used)) get_nextpath(char *path, size_t *offsetp, siz
 /**
  * Check that @subdir is a subdir of @dir.
  **/
-static bool __attribute__((used)) is_subdir(const char *subdir, const char *dir) {
+bool __attribute__((used)) is_subdir(const char *subdir, const char *dir) {
     size_t dirlen = strlen(dir);
     size_t subdirlen = strlen(subdir);
 

--- a/cmd/snap-confine/ns-support-private.h
+++ b/cmd/snap-confine/ns-support-private.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_NAMESPACE_SUPPORT_PRIVATE_H
+#define SNAP_NAMESPACE_SUPPORT_PRIVATE_H
+
+#include <sys/types.h>
+
+#include "ns-support.h"
+
+void sc_set_ns_dir(const char *dir);
+
+const char *sc_get_default_ns_dir(void);
+
+struct sc_mount_ns {
+    // Name of the namespace group ($SNAP_NAME).
+    char *name;
+    // Descriptor to the namespace group control directory.  This descriptor is
+    // opened with O_PATH|O_DIRECTORY so it's only used for openat() calls.
+    int dir_fd;
+    // Pair of descriptors for a pair for a pipe file descriptors (read end,
+    // write end) that snap-confine uses to send messages to the helper
+    // process and back.
+    int pipe_helper[2];
+    int pipe_master[2];
+    // Identifier of the child process that is used during the one-time (per
+    // group) initialization and capture process.
+    pid_t child;
+};
+
+struct sc_mount_ns *sc_mount_ns_new(void);
+
+#endif

--- a/cmd/snap-confine/seccomp-support-private.h
+++ b/cmd/snap-confine/seccomp-support-private.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef SNAP_CONFINE_SECCOMP_SUPPORT_PRIVATE_H
+#define SNAP_CONFINE_SECCOMP_SUPPORT_PRIVATE_H
+
+#include "seccomp-support-ext.h"
+#include "seccomp-support.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// Keep in sync with snap-seccomp/main.go
+//
+// Header of a seccomp.bin2 filter file in native byte order.
+struct __attribute__((__packed__)) sc_seccomp_file_header {
+    // header: "SC"
+    char header[2];
+    // version: 0x1
+    uint8_t version;
+    // flags
+    uint8_t unrestricted;
+    // unused
+    uint8_t padding[4];
+
+    // size of allow filter in byte
+    uint32_t len_allow_filter;
+    // size of deny filter in byte
+    uint32_t len_deny_filter;
+    // reserved for future use
+    uint8_t reserved2[112];
+};
+
+static_assert(sizeof(struct sc_seccomp_file_header) == 128, "unexpected struct size");
+
+// MAX_BPF_SIZE is an arbitrary limit.
+#define MAX_BPF_SIZE (32 * 1024)
+
+void sc_must_read_and_validate_header_from_file(FILE *file, const char *profile_path,
+                                                struct sc_seccomp_file_header *hdr);
+
+#endif

--- a/cmd/snap-confine/seccomp-support-test.c
+++ b/cmd/snap-confine/seccomp-support-test.c
@@ -15,11 +15,12 @@
  *
  */
 
-#include "seccomp-support.c"
-#include "seccomp-support-ext.c"
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "seccomp-support-private.h"
 
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <unistd.h>
 
 static void make_seccomp_profile(struct sc_seccomp_file_header *hdr, int *fd, char **fname) {
     *fd = g_file_open_tmp(NULL, fname, NULL);

--- a/cmd/snap-confine/snap-confine-args-test.c
+++ b/cmd/snap-confine/snap-confine-args-test.c
@@ -16,7 +16,6 @@
  */
 
 #include "snap-confine-args.h"
-#include "snap-confine-args.c"
 
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/test-utils.h"

--- a/cmd/snap-confine/snap-confine-args.c
+++ b/cmd/snap-confine/snap-confine-args.c
@@ -183,7 +183,7 @@ void sc_cleanup_args(struct sc_args **ptr) {
     *ptr = NULL;
 }
 
-bool sc_args_is_version_query(const struct sc_args *args) {
+bool __attribute__((noinline)) sc_args_is_version_query(const struct sc_args *args) {
     if (args == NULL) {
         die("cannot obtain version query flag from NULL argument parser");
     }

--- a/cmd/snap-confine/snap-confine-invocation-test.c
+++ b/cmd/snap-confine/snap-confine-invocation-test.c
@@ -17,9 +17,9 @@
 
 #include "snap-confine-invocation.h"
 #include "snap-confine-args.h"
-#include "snap-confine-invocation.c"
 
 #include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/snap-dir.h"
 #include "../libsnap-confine-private/test-utils.h"
 
 #include <stdarg.h>

--- a/cmd/snap-device-helper/snap-device-helper-test.c
+++ b/cmd/snap-device-helper/snap-device-helper-test.c
@@ -26,7 +26,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "snap-device-helper.c"
+#include "snap-device-helper.h"
 
 #include "../libsnap-confine-private/device-cgroup-support.h"
 


### PR DESCRIPTION
Generate coverage data from C code executed in `make distcheck`. Include the artifacts in upload to codecov.