### PR TITLE
secboot,fdestate: use boot mode for FDE hooks

### DIFF
--- a/overlord/fdestate/backend/export_test.go
+++ b/overlord/fdestate/backend/export_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/snapcore/snapd/secboot"
 )
 
-func MockSecbootResealKeysWithFDESetupHook(f func(keys []secboot.KeyDataLocation, primaryKeyFile string, models []secboot.ModelForSealing) error) (restore func()) {
+func MockSecbootResealKeysWithFDESetupHook(f func(keys []secboot.KeyDataLocation, primaryKeyFile string, models []secboot.ModelForSealing, bootModes []string) error) (restore func()) {
 	old := secbootResealKeysWithFDESetupHook
 	secbootResealKeysWithFDESetupHook = f
 	return func() {

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -155,12 +155,12 @@ func doReseal(manager FDEStateManager, method device.SealingMethod, rootdir stri
 	case device.SealingMethodFDESetupHook:
 		primaryKeyFile := filepath.Join(boot.InstallHostFDESaveDir, "aux-key")
 		if runParams != nil {
-			if err := secbootResealKeysWithFDESetupHook(runKeys, primaryKeyFile, runParams.Models); err != nil {
+			if err := secbootResealKeysWithFDESetupHook(runKeys, primaryKeyFile, runParams.Models, runParams.BootModes); err != nil {
 				return err
 			}
 		}
 		if recoveryParams != nil {
-			if err := secbootResealKeysWithFDESetupHook(recoveryKeys, primaryKeyFile, recoveryParams.Models); err != nil {
+			if err := secbootResealKeysWithFDESetupHook(recoveryKeys, primaryKeyFile, recoveryParams.Models, recoveryParams.BootModes); err != nil {
 				return err
 			}
 		}

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -1827,6 +1827,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 			c.Check(primaryKeyFile, Equals, filepath.Join(s.rootdir, "run/mnt/ubuntu-save/device/fde/aux-key"))
 			c.Assert(models, HasLen, 1)
 			c.Check(models[0].Model(), Equals, model.Model())
+			c.Check(bootModes, DeepEquals, []string{"run", "recover"})
 		case 2:
 			// Resealing the recovery key for both data partition
 			c.Check(keys, DeepEquals, []secboot.KeyDataLocation{
@@ -1839,6 +1840,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 			c.Check(primaryKeyFile, Equals, filepath.Join(s.rootdir, "run/mnt/ubuntu-save/device/fde/aux-key"))
 			c.Assert(models, HasLen, 1)
 			c.Check(models[0].Model(), Equals, model.Model())
+			c.Check(bootModes, DeepEquals, []string{"recover"})
 		case 3:
 			// Resealing the recovery key for both save partition
 			c.Check(keys, DeepEquals, []secboot.KeyDataLocation{
@@ -1851,6 +1853,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 			c.Check(primaryKeyFile, Equals, filepath.Join(s.rootdir, "run/mnt/ubuntu-save/device/fde/aux-key"))
 			c.Assert(models, HasLen, 1)
 			c.Check(models[0].Model(), Equals, model.Model())
+			c.Check(bootModes, DeepEquals, []string{"recover", "factory-reset"})
 		default:
 			c.Errorf("unexpected additional call to secboot.ResealKey (call # %d)", resealCalls)
 		}

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -1793,7 +1793,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 	}
 
 	resealCalls := 0
-	restore := fdeBackend.MockSecbootResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKeyFile string, models []secboot.ModelForSealing) error {
+	restore := fdeBackend.MockSecbootResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKeyFile string, models []secboot.ModelForSealing, bootModes []string) error {
 		resealCalls++
 
 		switch resealCalls {

--- a/overlord/fdestate/backend/seal.go
+++ b/overlord/fdestate/backend/seal.go
@@ -84,9 +84,7 @@ func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factory
 			KeyName:               "ubuntu-data",
 			SlotName:              "default-fallback",
 			KeyFile:               dataFallbackKey,
-			// TODO:FDEM:FIX we should not not have "factory-reset" here, but for now
-			// we want to have the same as the pcr profile
-			BootModes: []string{"recover", "factory-reset"},
+			BootModes:             []string{"recover"},
 		},
 		{
 			BootstrappedContainer: saveKey,

--- a/overlord/fdestate/backend/seal.go
+++ b/overlord/fdestate/backend/seal.go
@@ -58,6 +58,7 @@ func runKeySealRequests(key secboot.BootstrappedContainer, useTokens bool) []sec
 			KeyName:               "ubuntu-data",
 			SlotName:              "default",
 			KeyFile:               keyFile,
+			BootModes:             []string{"run", "recover"},
 		},
 	}
 }
@@ -83,12 +84,16 @@ func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factory
 			KeyName:               "ubuntu-data",
 			SlotName:              "default-fallback",
 			KeyFile:               dataFallbackKey,
+			// TODO:FDEM:FIX we should not not have "factory-reset" here, but for now
+			// we want to have the same as the pcr profile
+			BootModes: []string{"recover", "factory-reset"},
 		},
 		{
 			BootstrappedContainer: saveKey,
 			KeyName:               "ubuntu-save",
 			SlotName:              "default-fallback",
 			KeyFile:               saveFallbackKey,
+			BootModes:             []string{"recover", "factory-reset"},
 		},
 	}
 }

--- a/overlord/fdestate/backend/seal_test.go
+++ b/overlord/fdestate/backend/seal_test.go
@@ -179,7 +179,7 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 				// the fallback object seals the ubuntu-data and the ubuntu-save keys
 				c.Check(params.TPMPolicyAuthKeyFile, Equals, "")
 
-				expectedDataSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey, KeyName: "ubuntu-data", SlotName: "default-fallback", BootModes: []string{"recover", "factory-reset"}}
+				expectedDataSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey, KeyName: "ubuntu-data", SlotName: "default-fallback", BootModes: []string{"recover"}}
 				expectedSaveSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey2, KeyName: "ubuntu-save", SlotName: "default-fallback", BootModes: []string{"recover", "factory-reset"}}
 				if tc.disableTokens {
 					expectedDataSKR.KeyFile = filepath.Join(rootdir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key")

--- a/overlord/fdestate/backend/seal_test.go
+++ b/overlord/fdestate/backend/seal_test.go
@@ -170,7 +170,7 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 				// the run object seals only the ubuntu-data key
 				c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-policy-auth-key"))
 
-				expectedSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey, KeyName: "ubuntu-data", SlotName: "default"}
+				expectedSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey, KeyName: "ubuntu-data", SlotName: "default", BootModes: []string{"run", "recover"}}
 				if tc.disableTokens {
 					expectedSKR.KeyFile = filepath.Join(rootdir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key")
 				}
@@ -179,8 +179,8 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 				// the fallback object seals the ubuntu-data and the ubuntu-save keys
 				c.Check(params.TPMPolicyAuthKeyFile, Equals, "")
 
-				expectedDataSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey, KeyName: "ubuntu-data", SlotName: "default-fallback"}
-				expectedSaveSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey2, KeyName: "ubuntu-save", SlotName: "default-fallback"}
+				expectedDataSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey, KeyName: "ubuntu-data", SlotName: "default-fallback", BootModes: []string{"recover", "factory-reset"}}
+				expectedSaveSKR := secboot.SealKeyRequest{BootstrappedContainer: myKey2, KeyName: "ubuntu-save", SlotName: "default-fallback", BootModes: []string{"recover", "factory-reset"}}
 				if tc.disableTokens {
 					expectedDataSKR.KeyFile = filepath.Join(rootdir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key")
 					if tc.factoryReset {

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -397,6 +397,14 @@ func MockSetAuthorizedSnapModelsOnHooksKeydata(f func(kd *sb_hooks.KeyData, rand
 	}
 }
 
+func MockSetAuthorizedBootModesOnHooksKeydata(f func(kd *sb_hooks.KeyData, rand io.Reader, key sb.PrimaryKey, bootModes ...string) error) (restore func()) {
+	old := setAuthorizedBootModesOnHooksKeydata
+	setAuthorizedBootModesOnHooksKeydata = f
+	return func() {
+		setAuthorizedBootModesOnHooksKeydata = old
+	}
+}
+
 type DefaultKeyLoader = defaultKeyLoader
 
 var ReadKeyFile = readKeyFile

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -87,6 +87,8 @@ type SealKeyRequest struct {
 	// The file to store the key data. If empty, the key data will
 	// be saved to the token.
 	KeyFile string
+	// The boot modes allow (i.e. snapd_recovery_mode kernel parameter)
+	BootModes []string
 }
 
 // ModelForSealing provides information about the model for use in the context

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -186,6 +186,11 @@ type ResealKeysParams struct {
 	TPMPolicyAuthKeyFile string
 }
 
+type ResealKeysParamsForHooks struct {
+	Models    []ModelForSealing
+	BootModes []string
+}
+
 // UnlockVolumeUsingSealedKeyOptions contains options for unlocking encrypted
 // volumes using keys sealed to the TPM.
 type UnlockVolumeUsingSealedKeyOptions struct {

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -87,7 +87,7 @@ type SealKeyRequest struct {
 	// The file to store the key data. If empty, the key data will
 	// be saved to the token.
 	KeyFile string
-	// The boot modes allow (i.e. snapd_recovery_mode kernel parameter)
+	// The boot modes allowed (i.e. snapd_recovery_mode kernel parameter)
 	BootModes []string
 }
 
@@ -184,11 +184,6 @@ type ResealKeysParams struct {
 	Keys []KeyDataLocation
 	// The path to the authorization policy update key file (only relevant for TPM)
 	TPMPolicyAuthKeyFile string
-}
-
-type ResealKeysParamsForHooks struct {
-	Models    []ModelForSealing
-	BootModes []string
 }
 
 // UnlockVolumeUsingSealedKeyOptions contains options for unlocking encrypted

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -91,7 +91,7 @@ func VerifyPrimaryKeyDigest(devicePath string, alg crypto.Hash, salt []byte, dig
 	return false, errBuildWithoutSecboot
 }
 
-func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, models []ModelForSealing) error {
+func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, models []ModelForSealing, bootModes []string) error {
 	return errBuildWithoutSecboot
 }
 

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -92,7 +92,7 @@ func SealKeysWithFDESetupHook(runHook fde.RunSetupHookFunc, keys []SealKeyReques
 			AuthorizedSnapModels: []sb.SnapModel{
 				params.Model,
 			},
-			// TODO:FDEM:FIX: add boot modes
+			AuthorizedBootModes: skr.BootModes,
 		}
 
 		protectedKey, primaryKeyOut, unlockKey, err := sb_hooks.NewProtectedKey(rand.Reader, params)
@@ -132,9 +132,15 @@ func setAuthorizedSnapModelsOnHooksKeydataImpl(kd *sb_hooks.KeyData, rand io.Rea
 
 var setAuthorizedSnapModelsOnHooksKeydata = setAuthorizedSnapModelsOnHooksKeydataImpl
 
+func setAuthorizedBootModesOnHooksKeydataImpl(kd *sb_hooks.KeyData, rand io.Reader, key sb.PrimaryKey, bootmodes ...string) error {
+	return kd.SetAuthorizedBootModes(rand, key, bootmodes...)
+}
+
+var setAuthorizedBootModesOnHooksKeydata = setAuthorizedBootModesOnHooksKeydataImpl
+
 // ResealKeysWithFDESetupHook updates hook based keydatas for given
 // files with a specific list of models
-func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, models []ModelForSealing) error {
+func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, models []ModelForSealing, bootModes []string) error {
 	// TODO:FDEM:FIX: load primary key from keyring when available
 	primaryKeyBuf, err := os.ReadFile(primaryKeyFile)
 	if err != nil {
@@ -185,6 +191,9 @@ func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, m
 				return err
 			}
 			if err := setAuthorizedSnapModelsOnHooksKeydata(hooksKeyData, rand.Reader, primaryKey, sbModels...); err != nil {
+				return err
+			}
+			if err := setAuthorizedBootModesOnHooksKeydata(hooksKeyData, rand.Reader, primaryKey, bootModes...); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
2 commits:

* secboot,overlord/fdestate: seal with boot mode for FDE hooks
 
Set the authorized boot modes for FDE hook keys. For now the run+recover key allows "run" and "recover", while the recover key allows "recover" and "factory-reset".

* overlord/fdestate/backend: split profiles for data and save partitions

There should be 3 different keys for FDE hooks. The run+recover key should be allowed for boot modes "run" and "recover". While recover key on data disk should be allowed on "recover". And finally recovery  on save disk should be allowed in "recover" and "factory-reset". Here we split the profiles for "recover" for disks "data" and "save", so that we can set different authorized boot modes.