### PR TITLE
logger: add function to mock logger with debug enabled

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -120,9 +120,19 @@ func NoGuardDebugf(format string, v ...interface{}) {
 // MockLogger replaces the existing logger with a buffer and returns
 // the log buffer and a restore function.
 func MockLogger() (buf *bytes.Buffer, restore func()) {
+	return mockLogger(&LoggerOptions{})
+}
+
+// MockDebugLogger replaces the existing logger with a buffer and returns
+// the log buffer and a restore function. The logger records debug messages.
+func MockDebugLogger() (buf *bytes.Buffer, restore func()) {
+	return mockLogger(&LoggerOptions{ForceDebug: true})
+}
+
+func mockLogger(opts *LoggerOptions) (buf *bytes.Buffer, restore func()) {
 	buf = &bytes.Buffer{}
 	oldLogger := logger
-	l, err := New(buf, DefaultFlags, &LoggerOptions{})
+	l, err := New(buf, DefaultFlags, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -244,3 +244,10 @@ func (s *LogSuite) TestForceDebug(c *C) {
 	l.Debug("xyzzy")
 	c.Check(buf.String(), testutil.Contains, `DEBUG: xyzzy`)
 }
+
+func (s *LogSuite) TestMockDebugLogger(c *C) {
+	logbuf, restore := logger.MockDebugLogger()
+	defer restore()
+	logger.Debugf("xyzzy")
+	c.Check(logbuf.String(), testutil.Contains, "DEBUG: xyzzy")
+}


### PR DESCRIPTION
A dependency for both #15003 and now #15032, might as well break out this into its own PR.