### PR TITLE
strutil: extend unit test to cover more realistic version examples

### DIFF
--- a/strutil/version_test.go
+++ b/strutil/version_test.go
@@ -101,6 +101,15 @@ func (s *VersionTestSuite) TestVersionCompare(c *C) {
 		// where on the left is a version from CI built snapd snap, and
 		// on the right the distro package, where snap > package
 		{"1337.2.64+g81.9b95e8c", "1337.2.64", 1, nil},
+		// and more realistic example of what we have in the snapd package in
+		// various Ubuntu releases
+		{"2.67.1", "2.68+24.04", -1, nil},
+		{"2.68", "2.68+24.04", -1, nil},
+		{"2.68", "2.68+24.04.1", -1, nil},
+		{"2.68", "2.68+ubuntu24.04", -1, nil},
+		{"2.67.1", "2.68+ubuntu24.04", -1, nil},
+		{"2.68.1", "2.68+ubuntu24.04", 1, nil},
+		{"2.68.1", "2.68.1+24.04.1", -1, nil},
 	} {
 		res, err := strutil.VersionCompare(t.A, t.B)
 		if t.err != nil {


### PR DESCRIPTION
Extend strutil.VersionCompare() unit test with more examples corresponding to actual package versions used in Ubuntu.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
