### PR TITLE
cmd: add support for building with address and undefined behavior sanitizers

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -98,7 +98,7 @@ jobs:
       run: |
           cd cmd/ && make distcheck
 
-    - name: Test C (check & ASan)
+    - name: Test C (check & ASan & UBsan)
       if: ${{ inputs.code == 'c' }}
       run: |
           cd cmd/

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -86,17 +86,27 @@ jobs:
           cd cmd/
           ./autogen.sh
           make -j$(nproc)
+          make clean
 
     - name: Build Go
       if: ${{ inputs.code == 'go' }}
       run: |
           go build ./...
 
-    - name: Test C
+    - name: Test C (distcheck)
       if: ${{ inputs.code == 'c' }}
       run: |
           cd cmd/ && make distcheck
-    
+
+    - name: Test C (check & ASan)
+      if: ${{ inputs.code == 'c' }}
+      run: |
+          cd cmd/
+          ./autogen.sh --enable-sanitize
+          make -j$(nproc)
+          make check
+          make clean
+
     - name: Set SNAPD_DEBUG=1
       if: ${{ inputs.snapd-debug }}
       run: echo "SNAPD_DEBUG=1" >> $GITHUB_ENV

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -14,3 +14,5 @@ ignore_files:
   - packaging/ubuntu-14.04/changelog
   - packaging/ubuntu-16.04/changelog
   - tests/lib/snaps/store/test-snapd-ovmf/snapcraft.yaml
+  - cmd/configure.ac
+  - cmd/Makefile.am

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -9,8 +9,8 @@ noinst_LIBRARIES =
 
 AM_CFLAGS = $(CHECK_CFLAGS)
 if ENABLE_SANITIZE
-SANITIZE_CFLAGS = -fsanitize=address
-SANITIZE_LDFLAGS = -fsanitize=address
+SANITIZE_CFLAGS = -fsanitize=address -fsanitize=undefined
+SANITIZE_LDFLAGS = -fsanitize=address -fsanitize=undefined
 endif
 
 if USE_INTERNAL_BPF_HEADERS

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -8,6 +8,10 @@ noinst_PROGRAMS =
 noinst_LIBRARIES =
 
 AM_CFLAGS = $(CHECK_CFLAGS)
+if ENABLE_SANITIZE
+SANITIZE_CFLAGS = -fsanitize=address
+SANITIZE_LDFLAGS = -fsanitize=address
+endif
 
 if USE_INTERNAL_BPF_HEADERS
 VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor
@@ -30,11 +34,18 @@ check: check-unit-tests
 
 .PHONY: check-unit-tests
 if WITH_UNIT_TESTS
+# valgrind and asan cannot be used together
+if ENABLE_SANITIZE
+UNIT_TESTS_CMD =
+else
+UNIT_TESTS_CMD = $(if $(HAVE_VALGRIND),$(HAVE_VALGRIND) --leak-check=full)
+endif
+
 check-unit-tests: snap-confine/unit-tests system-shutdown/unit-tests libsnap-confine-private/unit-tests snap-device-helper/unit-tests
-	$(if $(HAVE_VALGRIND),$(HAVE_VALGRIND) --leak-check=full) ./libsnap-confine-private/unit-tests
-	$(if $(HAVE_VALGRIND),$(HAVE_VALGRIND) --leak-check=full) ./snap-confine/unit-tests
-	$(if $(HAVE_VALGRIND),$(HAVE_VALGRIND) --leak-check=full) ./system-shutdown/unit-tests
-	$(if $(HAVE_VALGRIND),$(HAVE_VALGRIND) --leak-check=full) ./snap-device-helper/unit-tests
+	$(UNIT_TESTS_CMD) ./libsnap-confine-private/unit-tests
+	$(UNIT_TESTS_CMD) ./snap-confine/unit-tests
+	$(UNIT_TESTS_CMD) ./system-shutdown/unit-tests
+	$(UNIT_TESTS_CMD) ./snap-device-helper/unit-tests
 else
 check-unit-tests:
 	echo "unit tests are disabled (rebuild with --enable-unit-tests)"
@@ -123,11 +134,11 @@ libsnap_confine_private_a_SOURCES += \
 	libsnap-confine-private/bpf-support.c \
 	libsnap-confine-private/bpf-support.h
 endif
-libsnap_confine_private_a_CFLAGS = $(AM_CFLAGS) $(VENDOR_BPF_HEADERS_CFLAGS)
+libsnap_confine_private_a_CFLAGS = $(AM_CFLAGS) $(VENDOR_BPF_HEADERS_CFLAGS) $(SANITIZE_CFLAGS)
 
 noinst_LIBRARIES += libsnap-confine-private-debug.a
 libsnap_confine_private_debug_a_SOURCES = $(libsnap_confine_private_a_SOURCES)
-libsnap_confine_private_debug_a_CFLAGS = $(AM_CFLAGS) $(VENDOR_BPF_HEADERS_CFLAGS) -DSNAP_CONFINE_DEBUG_BUILD=1
+libsnap_confine_private_debug_a_CFLAGS = $(AM_CFLAGS) $(VENDOR_BPF_HEADERS_CFLAGS) $(SANITIZE_CFLAGS) -DSNAP_CONFINE_DEBUG_BUILD=1
 
 if WITH_UNIT_TESTS
 
@@ -165,7 +176,8 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/test-utils-test.c \
 	libsnap-confine-private/utils-test.c
 
-libsnap_confine_private_unit_tests_CFLAGS = $(AM_CFLAGS) $(VENDOR_BPF_HEADERS_CFLAGS) $(GLIB_CFLAGS)
+libsnap_confine_private_unit_tests_CFLAGS = $(AM_CFLAGS) $(VENDOR_BPF_HEADERS_CFLAGS) $(GLIB_CFLAGS) $(SANITIZE_CFLAGS)
+libsnap_confine_private_unit_tests_LDFLAGS = $(SANITIZE_LDFLAGS)
 libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS) libsnap-confine-private-test-support.a
 libsnap_confine_private_unit_tests_CFLAGS += -D_ENABLE_FAULT_INJECTION
 libsnap_confine_private_unit_tests_STATIC =
@@ -193,6 +205,7 @@ noinst_PROGRAMS += decode-mount-opts/decode-mount-opts
 decode_mount_opts_decode_mount_opts_SOURCES = \
 	decode-mount-opts/decode-mount-opts.c
 decode_mount_opts_decode_mount_opts_LDADD = libsnap-confine-private.a
+decode_mount_opts_decode_mount_opts_LDFLAGS = $(SANITIZE_LDFLAGS)
 decode_mount_opts_decode_mount_opts_STATIC =
 
 if STATIC_LIBCAP
@@ -246,8 +259,8 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/user-support.c \
 	snap-confine/user-support.h
 
-snap_confine_snap_confine_CFLAGS = $(AM_CFLAGS) -DLIBEXECDIR=\"$(libexecdir)\" -DNATIVE_LIBDIR=\"$(libdir)\"
-snap_confine_snap_confine_LDFLAGS = $(AM_LDFLAGS)
+snap_confine_snap_confine_CFLAGS = $(AM_CFLAGS) -DLIBEXECDIR=\"$(libexecdir)\" -DNATIVE_LIBDIR=\"$(libdir)\" $(SANITIZE_CFLAGS)
+snap_confine_snap_confine_LDFLAGS = $(AM_LDFLAGS) $(SANITIZE_LDFLAGS)
 snap_confine_snap_confine_LDADD = libsnap-confine-private.a
 snap_confine_snap_confine_CFLAGS += $(LIBUDEV_CFLAGS)
 snap_confine_snap_confine_LDADD += $(snap_confine_snap_confine_extra_libs)
@@ -324,9 +337,9 @@ snap_confine_unit_tests_SOURCES = \
 	snap-confine/seccomp-support-test.c \
 	snap-confine/snap-confine-args-test.c \
 	snap-confine/snap-confine-invocation-test.c
-snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS)
+snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS) $(SANITIZE_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_snap_confine_LDADD) $(GLIB_LIBS) libsnap-confine-private-test-support.a
-snap_confine_unit_tests_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
+snap_confine_unit_tests_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS) $(SANITIZE_LDFLAGS)
 snap_confine_unit_tests_STATIC = $(snap_confine_snap_confine_STATIC)
 
 # Use a hacked rule if we're doing static build. This allows us to inject the LIBS += .. rule below.
@@ -415,7 +428,7 @@ snap_device_helper_snap_device_helper_SOURCES = \
 	snap-device-helper/main.c \
 	snap-device-helper/snap-device-helper.c \
 	snap-device-helper/snap-device-helper.h
-snap_device_helper_snap_device_helper_LDFLAGS = $(AM_LDFLAGS)
+snap_device_helper_snap_device_helper_LDFLAGS = $(AM_LDFLAGS) $(SANITIZE_LDFLAGS)
 snap_device_helper_snap_device_helper_LDADD = libsnap-confine-private.a
 
 if WITH_UNIT_TESTS
@@ -441,7 +454,7 @@ EXTRA_DIST += snap-discard-ns/snap-discard-ns.rst
 
 snap_discard_ns_snap_discard_ns_SOURCES = \
 	snap-discard-ns/snap-discard-ns.c
-snap_discard_ns_snap_discard_ns_LDFLAGS = $(AM_LDFLAGS)
+snap_discard_ns_snap_discard_ns_LDFLAGS = $(AM_LDFLAGS) $(SANITIZE_LDFLAGS)
 snap_discard_ns_snap_discard_ns_LDADD = libsnap-confine-private.a
 snap_discard_ns_snap_discard_ns_STATIC =
 
@@ -463,6 +476,7 @@ system_shutdown_system_shutdown_SOURCES = \
 	system-shutdown/system-shutdown-utils.h \
 	system-shutdown/system-shutdown.c
 system_shutdown_system_shutdown_LDADD = libsnap-confine-private.a
+system_shutdown_system_shutdown_LDFLAGS = $(SANITIZE_LDFLAGS)
 
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += system-shutdown/unit-tests
@@ -471,13 +485,18 @@ system_shutdown_unit_tests_SOURCES = \
 system_shutdown_unit_tests_LDADD = libsnap-confine-private.a libsnap-confine-private-test-support.a
 system_shutdown_unit_tests_CFLAGS = $(AM_CFLAGS) $(GLIB_CFLAGS)
 system_shutdown_unit_tests_LDADD +=  $(GLIB_LIBS)
+system_shutdown_unit_tests_LDFLAGS =  $(system_shutdown_system_shutdown_LDFLAGS)
 endif
 
 ##
 ## snap-gdb-shim
 ##
 
+if !ENABLE_SANITIZE
+# snap-gdb-shim is statically linked and cannot be built when using
+# -fsanitize=address
 libexec_PROGRAMS += snap-gdb-shim/snap-gdb-shim
+endif
 
 snap_gdb_shim_snap_gdb_shim_SOURCES = \
 	snap-gdb-shim/snap-gdb-shim.c
@@ -489,7 +508,11 @@ snap_gdb_shim_snap_gdb_shim_LDFLAGS = -static
 ## snap-gdbserver-shim
 ##
 
+if !ENABLE_SANITIZE
+# snap-gdbserver-shim is statically linked and cannot be built when using
+# -fsanitize=address
 libexec_PROGRAMS += snap-gdb-shim/snap-gdbserver-shim
+endif
 
 snap_gdb_shim_snap_gdbserver_shim_SOURCES = \
 	snap-gdb-shim/snap-gdbserver-shim.c
@@ -510,6 +533,7 @@ endif
 
 snapd_generator_snapd_generator_SOURCES = snapd-generator/main.c
 snapd_generator_snapd_generator_LDADD = libsnap-confine-private.a
+snapd_generator_snapd_generator_LDFLAGS = $(SANITIZE_LDFLAGS)
 
 ##
 ## snapd-env-generator
@@ -525,6 +549,7 @@ endif
 
 snapd_env_generator_snapd_env_generator_SOURCES = snapd-env-generator/main.c
 snapd_env_generator_snapd_env_generator_LDADD = libsnap-confine-private.a
+snapd_env_generator_snapd_env_generator_LDFLAGS = $(SANITIZE_LDFLAGS)
 EXTRA_DIST += snapd-env-generator/snapd-env-generator.rst
 
 if BUILD_HOST_BINARIES

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -319,6 +319,20 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
   AX_APPEND_COMPILE_FLAGS([-Werror], [CHECK_CFLAGS])
 ])
 
+AC_ARG_ENABLE([sanitize],
+    AS_HELP_STRING([--enable-sanitize], [Build binaries with address sanitizer (-fsanitize=address)]),
+    [case "$enableval" in
+        yes)
+          enable_sanitize=yes
+          ;;
+        no)
+          enable_sanitize=no
+          ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-sanitize])
+    esac],
+    [enable_sanitize=no])
+AM_CONDITIONAL([ENABLE_SANITIZE], [test "x$enable_sanitize" = "xyes"])
+
 AC_SUBST([CHECK_CFLAGS])
 
 AC_ARG_WITH([apparmorconfigdir],

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -320,7 +320,9 @@ AS_IF([test "x$with_unit_tests" = "xyes"], [
 ])
 
 AC_ARG_ENABLE([sanitize],
-    AS_HELP_STRING([--enable-sanitize], [Build binaries with address sanitizer (-fsanitize=address)]),
+    AS_HELP_STRING([--enable-sanitize], [Build binaries with sanitizers (ASan and UBSan).
+                                        Note, this will perform a partial build, skipping binaries which
+                                        cannot be built with sanitizers enabled.]),
     [case "$enableval" in
         yes)
           enable_sanitize=yes


### PR DESCRIPTION
The branch builds on #15045 and adds support for building with asan and ubsan. This is only useful for testing local installation or running unit tests, as otherwise we'd have to ship libasan/libubsan in the snapd snap to make it universally useful in all scenarios.

Note, some binaries which are linked statically, `snap-gdb*-shim` specifically, had to be skipped, since libasan relies on dlopen().