### PR TITLE
o/install: hide passphrase support until out-of-process argon2i* is implemented

### DIFF
--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -888,11 +888,13 @@ func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionHappy(c *C) 
 	s.testInstallSetupStorageEncryption(c, hasTPM, withVolumesAuth)
 }
 
-func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionWithVolumesAuth(c *C) {
-	const hasTPM = true
-	const withVolumesAuth = true
-	s.testInstallSetupStorageEncryption(c, hasTPM, withVolumesAuth)
-}
+// TODO:FDEM: passphrases will be supported when out-of-process argon2i* kdf is implemented
+//
+// func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionWithVolumesAuth(c *C) {
+// 	const hasTPM = true
+// 	const withVolumesAuth = true
+// 	s.testInstallSetupStorageEncryption(c, hasTPM, withVolumesAuth)
+// }
 
 func (s *deviceMgrInstallAPISuite) TestInstallSetupStorageEncryptionNoCrypto(c *C) {
 	const hasTPM = false

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -3017,14 +3017,16 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseS
 	s.testSystemAndGadgetAndEncyptionInfoPassphraseSupport(c, snapdVersionByType, hasPassphraseSupport)
 }
 
-func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseSupportAvailable(c *C) {
-	snapdVersionByType := map[snap.Type]string{
-		snap.TypeSnapd:  "2.68",
-		snap.TypeKernel: "2.68",
-	}
-	const hasPassphraseSupport = true
-	s.testSystemAndGadgetAndEncyptionInfoPassphraseSupport(c, snapdVersionByType, hasPassphraseSupport)
-}
+// TODO:FDEM: passphrases will be supported when out-of-process argon2i* kdf is implemented
+//
+// func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoPassphraseSupportAvailable(c *C) {
+// 	snapdVersionByType := map[snap.Type]string{
+// 		snap.TypeSnapd:  "2.68",
+// 		snap.TypeKernel: "2.68",
+// 	}
+// 	const hasPassphraseSupport = true
+// 	s.testSystemAndGadgetAndEncyptionInfoPassphraseSupport(c, snapdVersionByType, hasPassphraseSupport)
+// }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorInvalidLabel(c *C) {
 	_, _, _, err := s.mgr.SystemAndGadgetAndEncryptionInfo("invalid/label")

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -174,7 +174,9 @@ func MockSecbootCheckTPMKeySealingSupported(f func(tpmMode secboot.TPMProvisionM
 }
 
 func checkPassphraseSupportedByTargetSystem(sysVer *SystemSnapdVersions) (bool, error) {
-	const minSnapdVersion = "2.68"
+	// TODO:FDEM:FIX: the minimum snapd version needs to be updated after passphrase
+	// support is re-enabled when out-of-process argon2i* kdf variants are implemented.
+	const minSnapdVersion = "2.68.1"
 	if sysVer == nil {
 		return false, nil
 	}
@@ -264,7 +266,11 @@ func GetEncryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvision
 		// Hook based setup support does not make sense (at least for now) because
 		// it is usually in the context of embedded systems where passphrase
 		// authentication is not practical.
-		if checkSecbootEncryption {
+		//
+		// TODO:FDEM:FIX: mark passphrase as supported when out-of-process argon2i* kdf
+		// variants are implemented.
+		const disablePassphraseAuth = true
+		if !disablePassphraseAuth && checkSecbootEncryption {
 			passphraseAuthAvailable, err := checkPassphraseSupportedByTargetSystem(systemSnapdVersions)
 			if err != nil {
 				return res, fmt.Errorf("cannot check passphrase support: %v", err)

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -324,43 +324,45 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 				UnavailableErr: fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: no tpm"),
 			},
 		},
+		// TODO:FDEM:FIX: passphrases will be supported when out-of-process argon2i* kdf is implemented
+		//
 		// Passphrase support requires snapd 2.68+
-		{
-			"secured", "encrypted", "2.68", "2.68", nil,
-			install.EncryptionSupportInfo{
-				Available: true, Disabled: false,
-				StorageSafety:           asserts.StorageSafetyEncrypted,
-				Type:                    device.EncryptionTypeLUKS,
-				PassphraseAuthAvailable: true,
-			},
-		},
-		{
-			"secured", "encrypted", "2.69", "2.69", nil,
-			install.EncryptionSupportInfo{
-				Available: true, Disabled: false,
-				StorageSafety:           asserts.StorageSafetyEncrypted,
-				Type:                    device.EncryptionTypeLUKS,
-				PassphraseAuthAvailable: true,
-			},
-		},
-		{
-			"secured", "encrypted", "2.67", "2.68", nil,
-			install.EncryptionSupportInfo{
-				Available: true, Disabled: false,
-				StorageSafety:           asserts.StorageSafetyEncrypted,
-				Type:                    device.EncryptionTypeLUKS,
-				PassphraseAuthAvailable: false,
-			},
-		},
-		{
-			"secured", "encrypted", "2.68", "2.67", nil,
-			install.EncryptionSupportInfo{
-				Available: true, Disabled: false,
-				StorageSafety:           asserts.StorageSafetyEncrypted,
-				Type:                    device.EncryptionTypeLUKS,
-				PassphraseAuthAvailable: false,
-			},
-		},
+		// {
+		// 	"secured", "encrypted", "2.68", "2.68", nil,
+		// 	install.EncryptionSupportInfo{
+		// 		Available: true, Disabled: false,
+		// 		StorageSafety:           asserts.StorageSafetyEncrypted,
+		// 		Type:                    device.EncryptionTypeLUKS,
+		// 		PassphraseAuthAvailable: true,
+		// 	},
+		// },
+		// {
+		// 	"secured", "encrypted", "2.69", "2.69", nil,
+		// 	install.EncryptionSupportInfo{
+		// 		Available: true, Disabled: false,
+		// 		StorageSafety:           asserts.StorageSafetyEncrypted,
+		// 		Type:                    device.EncryptionTypeLUKS,
+		// 		PassphraseAuthAvailable: true,
+		// 	},
+		// },
+		// {
+		// 	"secured", "encrypted", "2.67", "2.68", nil,
+		// 	install.EncryptionSupportInfo{
+		// 		Available: true, Disabled: false,
+		// 		StorageSafety:           asserts.StorageSafetyEncrypted,
+		// 		Type:                    device.EncryptionTypeLUKS,
+		// 		PassphraseAuthAvailable: false,
+		// 	},
+		// },
+		// {
+		// 	"secured", "encrypted", "2.68", "2.67", nil,
+		// 	install.EncryptionSupportInfo{
+		// 		Available: true, Disabled: false,
+		// 		StorageSafety:           asserts.StorageSafetyEncrypted,
+		// 		Type:                    device.EncryptionTypeLUKS,
+		// 		PassphraseAuthAvailable: false,
+		// 	},
+		// },
 	}
 	for _, tc := range testCases {
 		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmErr })


### PR DESCRIPTION
Currently the default kdf-type "argon2id" and "argon2i" are not implemented and the ready made in-process variant is not suitable for long running processes with garbage collection. We explicitly mark passphrase as not available on the API level until the out-of-process argon2i* variants are implemented.
