### PR TITLE
tests: remove 'set -x' from "Run spread tests" step in Tests workflow

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -247,7 +247,7 @@ jobs:
       run: |
           # Register a problem matcher to highlight spread failures
           echo "::add-matcher::.github/spread-problem-matcher.json"
-          set -x
+
           SPREAD=spread
           if [[ "${{ inputs.group }}" =~ nested- ]]; then
             export NESTED_BUILD_SNAPD_FROM_CURRENT=true


### PR DESCRIPTION
We need to remove the 'set -x' because it is including in the output a huge list of tests when doing

spread_list="$($SPREAD -list $RUN_TESTS 2>&1 || true)"
