### PR TITLE
github: unit-tests: split unit tests to code specific workflows

### DIFF
--- a/.github/actions/download-install-debian-deps/action.yaml
+++ b/.github/actions/download-install-debian-deps/action.yaml
@@ -26,4 +26,5 @@ runs:
     run: |
         sudo apt update
         sudo apt build-dep -y "${{ inputs.snapd-src-dir }}"
+        sudo apt install -y clang
         rm -rf ./debian-deps

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -167,24 +167,41 @@ jobs:
     needs:
       - go-channels
       - static-checks 
-    name: "unit-tests default ${{ matrix.gochannel }}"
+    name: "unit-tests (Go default ${{ matrix.gochannel }})"
     with:
       runs-on: ubuntu-latest
       gochannel: ${{ matrix.gochannel }}
       skip-coverage: ${{ matrix.gochannel == 'latest/stable' }}
+      code: 'go'
     strategy:
       # we cache successful runs so it's fine to keep going
       fail-fast: false      
       matrix:
         gochannel: ${{ fromJson(needs.go-channels.outputs.go-channels) }}
 
-  # TODO run unit tests of C code
+  unit-tests-c:
+    uses: ./.github/workflows/unit-tests.yaml
+    needs:
+      - cache-build-deps
+    name: "unit-tests (C ${{ matrix.test-case.c-compiler }})"
+    with:
+      runs-on: ubuntu-latest
+      code: 'c'
+      c-compiler: ${{ matrix.test-case.c-compiler }}
+    strategy:
+      # we cache successful runs so it's fine to keep going
+      fail-fast: false
+      matrix:
+        test-case:
+          - { c-compiler: gcc }
+          - { c-compiler: clang }
+
   unit-tests-special:
     uses: ./.github/workflows/unit-tests.yaml
     needs:
       - go-channels
       - static-checks
-    name: "unit-tests (${{ matrix.gochannel }} ${{ matrix.test-case.go-build-tags }}
+    name: "unit-tests (Go ${{ matrix.gochannel }} ${{ matrix.test-case.go-build-tags }}
           ${{ matrix.test-case.go-test-race && ' test-race' || ''}}
           ${{ matrix.test-case.snapd-debug && ' snapd-debug' || ''}})"
     with:
@@ -194,6 +211,7 @@ jobs:
       go-build-tags: ${{ matrix.test-case.go-build-tags }}
       go-test-race: ${{ matrix.test-case.go-test-race }}
       snapd-debug: ${{ matrix.test-case.snapd-debug }}
+      code: 'go'
     strategy:
       # we cache successful runs so it's fine to keep going
       fail-fast: false
@@ -232,6 +250,7 @@ jobs:
     needs:
       - unit-tests
       - unit-tests-special
+      - unit-tests-c
       - unit-tests-cross-distro
     if: always()
     steps:
@@ -244,7 +263,7 @@ jobs:
           needs-json: ${{ toJSON(needs) }}
 
   code-coverage:
-    needs: [unit-tests, unit-tests-special]
+    needs: [unit-tests, unit-tests-special, unit-tests-c]
     runs-on: ubuntu-20.04
     env:
       GOPATH: ${{ github.workspace }}
@@ -292,7 +311,7 @@ jobs:
 
   spread-fundamental:
     uses: ./.github/workflows/spread-tests.yaml
-    needs: [unit-tests, snap-builds, read-systems]
+    needs: [unit-tests, unit-tests-c, snap-builds, read-systems]
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.
@@ -320,7 +339,7 @@ jobs:
     if: github.event_name == 'pull_request'
     # For workflow runs that are PRs, run this non-fundamental systems job
     # only after the fundamental systems job succeeds.
-    needs: [unit-tests, snap-builds, read-systems, spread-fundamental]
+    needs: [unit-tests, unit-tests-c, snap-builds, read-systems, spread-fundamental]
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.
@@ -347,7 +366,7 @@ jobs:
     if: github.event_name != 'pull_request'
     # For workflow runs that are not for PRs, no need to impose a dependency
     # on the fundamental systems job's success before running this job.
-    needs: [unit-tests, snap-builds, read-systems]
+    needs: [unit-tests, unit-tests-c, snap-builds, read-systems]
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.
@@ -371,7 +390,7 @@ jobs:
 
   spread-nested:
     uses: ./.github/workflows/spread-tests.yaml
-    needs: [unit-tests, snap-builds]
+    needs: [unit-tests, unit-tests-c, snap-builds]
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -5,9 +5,18 @@ on:
         description: 'A tag to indicate which runner to use'
         required: true
         type: string
+      code:
+        description: 'Code to test (c, go)'
+        required: true
+        type: string
+      c-compiler:
+        description: 'Compiler for C code'
+        type: string
+        default: ''
+        required: false
       gochannel:
         description: 'The snap store channel to use to install the go snap'
-        required: true
+        required: false
         type: string
       skip-coverage:
         description: 'If true, will not generate test coverage files'
@@ -31,9 +40,6 @@ on:
 
 jobs:
   unit-tests:
-    name: "unit-tests (${{ inputs.gochannel }} ${{ inputs.go-build-tags }}
-          ${{ inputs.go-test-race && ' test-race' || ''}}
-          ${{ inputs.snapd-debug && ' snapd-debug' || ''}})"
     runs-on: ${{ inputs.runs-on }}
     env:
       # Set PATH to ignore the load of magic binaries from /usr/local/bin And
@@ -43,6 +49,7 @@ jobs:
       PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
       GOROOT: ""
       GO_BUILD_TAGS: ${{ inputs.go-build-tags }}
+      CC: ${{ inputs.c-compiler }}
       
     steps:
     - name: Checkout code
@@ -56,24 +63,37 @@ jobs:
 
     # golang latest ensures things work on the edge
     - name: Install the go snap
+      if: ${{ inputs.code == 'go' }}
       run: |
+          if [ -z "${{ inputs.gochannel }}" ]; then
+              echo "gochannel is unset"
+              exit 1
+          fi
           sudo snap install --classic --channel=${{ inputs.gochannel }} go
 
     - name: Get deps
+      if: ${{ inputs.code == 'go' }}
       run: |
           ./get-deps.sh
 
     - name: Build C
+      if: ${{ inputs.code == 'c' }}
       run: |
+          if [ -z "${{ inputs.c-compiler }}" ]; then
+              echo "c-compiler is unset"
+              exit 1
+          fi
           cd cmd/
           ./autogen.sh
           make -j$(nproc)
 
     - name: Build Go
+      if: ${{ inputs.code == 'go' }}
       run: |
           go build ./...
 
     - name: Test C
+      if: ${{ inputs.code == 'c' }}
       run: |
           cd cmd/ && make distcheck
     
@@ -90,14 +110,15 @@ jobs:
       run: echo "SKIP_COVERAGE=1" >> $GITHUB_ENV
 
     - name: Test Go
+      if: ${{ inputs.code == 'go' }}
       run: |
           ./run-checks --unit
 
     - name: Create coverage results name
       if: ${{ ! inputs.skip-coverage }}
       run: |
-        converted=$(tr '/' '-' <<<${{ inputs.gochannel }})
-        name="coverage-files-${converted}-${{ inputs.go-build-tags || 'notags' }}${{ inputs.go-test-race && '-race' || ''}}${{ inputs.snapd-debug && '-snapddebug' || ''}}"
+        converted=$(tr '/' '-' <<<'${{ inputs.gochannel }}')
+        name="coverage-files-${{ inputs.code }}-${converted}-${{ inputs.go-build-tags || 'notags' }}${{ inputs.go-test-race && '-race' || ''}}${{ inputs.snapd-debug && '-snapddebug' || ''}}${{ inputs.c-compiler }}"
         echo "COVERAGE_NAME=$name" >> $GITHUB_ENV
 
     - name: Upload the coverage results


### PR DESCRIPTION
Split unit-tests to Go and C specific workflows.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
