### PR TITLE
interfaces: Add more kernel fusion driver files to opengl

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -200,7 +200,7 @@ unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 /dev/kfd rw,
 /sys/module/amdgpu/initstate r,
 /sys/devices/virtual/kfd/kfd/dev r,
-/sys/devices/virtual/kfd/kfd/uevent rw,
+/sys/devices/virtual/kfd/kfd/uevent r,
 /sys/devices/virtual/kfd/kfd/topology/{,generation_id,system_properties} r,
 /sys/devices/virtual/kfd/kfd/topology/nodes/[0-9]*/{,gpu_id,properties,io_links/[0-9]*/properties,caches/[0-9]*/properties,mem_banks/[0-9]*/properties} r,
 `

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -198,6 +198,11 @@ unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 
 # Kernel Fusion Driver for AMD GPUs
 /dev/kfd rw,
+/sys/module/amdgpu/initstate r,
+/sys/devices/virtual/kfd/kfd/dev r,
+/sys/devices/virtual/kfd/kfd/uevent rw,
+/sys/devices/virtual/kfd/kfd/topology/{,generation_id,system_properties} r,
+/sys/devices/virtual/kfd/kfd/topology/nodes/[0-9]*/{,gpu_id,properties,io_links/[0-9]*/properties,caches/[0-9]*/properties,mem_banks/[0-9]*/properties} r,
 `
 
 type openglInterface struct {


### PR DESCRIPTION
This is a follow-up of #14685.

I am trying to create [a snap](https://github.com/pedro-avalos/rocminfo-snap) of [`rocminfo`](https://github.com/rocm/rocminfo), and I noticed that `rocminfo` is accessing the Kernel Fusion Driver via the `/sys/devices/virtual/kfd` path to retrieve the GPUs' properties. I've added the files that `rocminfo` was specifically accessing, but there are other subdirectories/files that are not included here.

These denials seem to also be blocking `rocm-validation-suite` from querying these properties when running some of its tests.

I also noticed that the Mir team is also [interested](https://github.com/canonical/graphics-test-tools/issues/18) in including `rocminfo` in their graphics-test-tools, so I'm sure they'd run into these issues eventually.

Let me know if you need anything or if I missed anything.