### PR TITLE
o/snapstate: download, link, unlink, and discard snap icon in snapstate handlers

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -96,6 +96,8 @@ var (
 	SnapSectionsFile    string
 	SnapCommandsDB      string
 	SnapAuxStoreInfoDir string
+	SnapIconsPoolDir    string
+	SnapIconsDir        string
 
 	SnapBinariesDir        string
 	SnapServicesDir        string
@@ -512,6 +514,8 @@ func SetRootDir(rootdir string) {
 	SnapSectionsFile = filepath.Join(SnapCacheDir, "sections")
 	SnapCommandsDB = filepath.Join(SnapCacheDir, "commands.db")
 	SnapAuxStoreInfoDir = filepath.Join(SnapCacheDir, "aux")
+	SnapIconsPoolDir = filepath.Join(SnapCacheDir, "icons-pool")
+	SnapIconsDir = filepath.Join(SnapCacheDir, "icons")
 
 	SnapSeedDir = SnapSeedDirUnder(rootdir)
 	SnapDeviceDir = SnapDeviceDirUnder(rootdir)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1075,7 +1075,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 		hit := strings.Replace(hitTemplate, "@URL@", baseURL.String()+"/api/v1/snaps/download/"+name+"/"+revno, -1)
 		hit = strings.Replace(hit, "@NAME@", name, -1)
 		hit = strings.Replace(hit, "@SNAPID@", fakeSnapID(name), -1)
-		hit = strings.Replace(hit, "@ICON@", baseURL.String()+"/icon", -1)
+		hit = strings.Replace(hit, "@ICON@", "http://example.com/icon.svg", -1)
 		hit = strings.Replace(hit, "@VERSION@", info.Version, -1)
 		hit = strings.Replace(hit, "@REVISION@", revno, -1)
 		hit = strings.Replace(hit, `@TYPE@`, string(info.Type()), -1)
@@ -1092,6 +1092,14 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.storeObserver != nil {
 			s.storeObserver(r)
+		}
+
+		if r.URL.Path == "http://example.com/icon.svg" {
+			// the http server was hit while requesting the snap icon, so just
+			// write some stand-in data
+			iconContents := fmt.Sprintf("icon contents")
+			w.Write([]byte(iconContents))
+			return
 		}
 
 		// all URLS are /api/v1/snaps/... or /v2/snaps/ or /v2/assertions/... so

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -57,6 +57,8 @@ type StoreService interface {
 	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, *store.DownloadOptions) error
 	DownloadStream(context.Context, string, *snap.DownloadInfo, int64, *auth.UserState) (r io.ReadCloser, status int, err error)
 
+	DownloadIcon(context.Context, string, string, string) error
+
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 	SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error)
 	DownloadAssertions([]string, *asserts.Batch, *auth.UserState) error

--- a/overlord/snapstate/backend/aux_store_info.go
+++ b/overlord/snapstate/backend/aux_store_info.go
@@ -84,22 +84,22 @@ func keepAuxStoreInfo(snapID string, aux AuxStoreInfo) error {
 		return nil
 	}
 	if err := os.MkdirAll(dirs.SnapAuxStoreInfoDir, 0755); err != nil {
-		return fmt.Errorf("cannot create directory for auxiliary store info: %v", err)
+		return fmt.Errorf("cannot create directory for auxiliary store info: %w", err)
 	}
 
 	af, err := osutil.NewAtomicFile(AuxStoreInfoFilename(snapID), 0644, 0, osutil.NoChown, osutil.NoChown)
 	if err != nil {
-		return fmt.Errorf("cannot create file for auxiliary store info for snap %s: %v", snapID, err)
+		return fmt.Errorf("cannot create file for auxiliary store info: %w", err)
 	}
 	// on success, Cancel becomes a nop
 	defer af.Cancel()
 
 	if err := json.NewEncoder(af).Encode(aux); err != nil {
-		return fmt.Errorf("cannot encode auxiliary store info for snap %s: %v", snapID, err)
+		return fmt.Errorf("cannot encode auxiliary store info: %w", err)
 	}
 
 	if err := af.Commit(); err != nil {
-		return fmt.Errorf("cannot commit auxiliary store info file for snap %s: %v", snapID, err)
+		return fmt.Errorf("cannot commit auxiliary store info file: %w", err)
 	}
 	return nil
 }
@@ -110,7 +110,7 @@ func discardAuxStoreInfo(snapID string) error {
 		return nil
 	}
 	if err := os.Remove(AuxStoreInfoFilename(snapID)); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("cannot remove auxiliary store info file for snap %s: %v", snapID, err)
+		return fmt.Errorf("error removing auxiliary store info file: %w", err)
 	}
 	return nil
 }

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -39,6 +39,10 @@ var (
 
 	KeepAuxStoreInfo    = keepAuxStoreInfo
 	DiscardAuxStoreInfo = discardAuxStoreInfo
+
+	LinkSnapIcon    = linkSnapIcon
+	UnlinkSnapIcon  = unlinkSnapIcon
+	DiscardSnapIcon = discardSnapIcon
 )
 
 func MockWrappersAddSnapdSnapServices(f func(s *snap.Info, opts *wrappers.AddSnapdSnapServicesOptions, inter wrappers.Interacter) (wrappers.SnapdRestart, error)) (restore func()) {

--- a/overlord/snapstate/backend/icon.go
+++ b/overlord/snapstate/backend/icon.go
@@ -49,8 +49,6 @@ func IconInstallFilename(snapID string) string {
 	return filepath.Join(dirs.SnapIconsDir, fmt.Sprintf("%s.icon", snapID))
 }
 
-var errIconNotExist = errors.New("icon does not exist in the icons download pool")
-
 // linkSnapIcon creates a hardlink from the downloaded icons pool to the icons
 // directory for the given snap ID.
 func linkSnapIcon(snapID string) error {
@@ -62,15 +60,15 @@ func linkSnapIcon(snapID string) error {
 	installPath := IconInstallFilename(snapID)
 
 	if !osutil.FileExists(poolPath) {
-		return fmt.Errorf("cannot link snap icon for snap %s: %w", snapID, errIconNotExist)
+		return fmt.Errorf("icon for snap: %w", fs.ErrNotExist)
 	}
 
 	if err := os.MkdirAll(dirs.SnapIconsDir, 0o755); err != nil {
-		return fmt.Errorf("cannot create directory for snap icons: %v", err)
+		return fmt.Errorf("cannot create directory for snap icons: %w", err)
 	}
 
 	if err := osutil.AtomicLink(poolPath, installPath); err != nil {
-		return fmt.Errorf("cannot link snap icon for snap %s: %w", snapID, err)
+		return fmt.Errorf("cannot link snap icon: %w", err)
 	}
 	return nil
 }
@@ -82,7 +80,7 @@ func unlinkSnapIcon(snapID string) error {
 		return nil
 	}
 	if err := os.Remove(IconInstallFilename(snapID)); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("cannot unlink snap icon for snap %s: %w", snapID, err)
+		return fmt.Errorf("cannot unlink snap icon: %w", err)
 	}
 	return nil
 }
@@ -94,7 +92,7 @@ func discardSnapIcon(snapID string) error {
 		return nil
 	}
 	if err := os.Remove(IconDownloadFilename(snapID)); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("cannot remove snap icon from pool for snap %s: %v", snapID, err)
+		return fmt.Errorf("cannot remove snap icon from pool: %w", err)
 	}
 	return nil
 }

--- a/overlord/snapstate/backend/icon.go
+++ b/overlord/snapstate/backend/icon.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+// IconDownloadFilename returns the filepath of the icon in the icons pool
+// directory for the given snap ID.
+func IconDownloadFilename(snapID string) string {
+	if snapID == "" {
+		return ""
+	}
+	return filepath.Join(dirs.SnapIconsPoolDir, fmt.Sprintf("%s.icon", snapID))
+}
+
+// IconInstallFilename returns the filepath of the icon in the icons directory
+// for the given snap ID. This is where the icon should be hard-linked from the
+// iconDownloadFilename when the snap is installed on the system.
+func IconInstallFilename(snapID string) string {
+	if snapID == "" {
+		return ""
+	}
+	return filepath.Join(dirs.SnapIconsDir, fmt.Sprintf("%s.icon", snapID))
+}
+
+var errIconNotExist = errors.New("icon does not exist in the icons download pool")
+
+// linkSnapIcon creates a hardlink from the downloaded icons pool to the icons
+// directory for the given snap ID.
+func linkSnapIcon(snapID string) error {
+	if snapID == "" {
+		return nil
+	}
+
+	poolPath := IconDownloadFilename(snapID)
+	installPath := IconInstallFilename(snapID)
+
+	if !osutil.FileExists(poolPath) {
+		return fmt.Errorf("cannot link snap icon for snap %s: %w", snapID, errIconNotExist)
+	}
+
+	if err := os.MkdirAll(dirs.SnapIconsDir, 0o755); err != nil {
+		return fmt.Errorf("cannot create directory for snap icons: %v", err)
+	}
+
+	if err := osutil.AtomicLink(poolPath, installPath); err != nil {
+		return fmt.Errorf("cannot link snap icon for snap %s: %w", snapID, err)
+	}
+	return nil
+}
+
+// unlinkSnapIcon removes the hardlink from the downloaded icons pool to the
+// icons directory for the given snap ID.
+func unlinkSnapIcon(snapID string) error {
+	if snapID == "" {
+		return nil
+	}
+	if err := os.Remove(IconInstallFilename(snapID)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("cannot unlink snap icon for snap %s: %w", snapID, err)
+	}
+	return nil
+}
+
+// discardSnapIcon removes the icon for the given snap from the downloaded icons
+// pool.
+func discardSnapIcon(snapID string) error {
+	if snapID == "" {
+		return nil
+	}
+	if err := os.Remove(IconDownloadFilename(snapID)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("cannot remove snap icon from pool for snap %s: %v", snapID, err)
+	}
+	return nil
+}

--- a/overlord/snapstate/backend/icon_test.go
+++ b/overlord/snapstate/backend/icon_test.go
@@ -1,0 +1,133 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+)
+
+type iconSuite struct{}
+
+var _ = Suite(&iconSuite{})
+
+func (s *iconSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *iconSuite) TestIconDownloadFilename(c *C) {
+	filename := backend.IconDownloadFilename("some-snap-id")
+	c.Check(filename, Equals, filepath.Join(dirs.SnapIconsPoolDir, "some-snap-id.icon"))
+}
+
+func (s *iconSuite) TestIconInstallFilename(c *C) {
+	filename := backend.IconInstallFilename("some-snap-id")
+	c.Check(filename, Equals, filepath.Join(dirs.SnapIconsDir, "some-snap-id.icon"))
+}
+
+func (s *iconSuite) TestSnapIconLinkUnlinkDiscardPermutations(c *C) {
+	for i, testCase := range []struct {
+		functions                []func(snapID string) error
+		expectedErrors           []string
+		poolIconExistsAfter      []bool
+		installedIconExistsAfter []bool
+	}{
+		{
+			functions:                []func(string) error{backend.LinkSnapIcon, backend.UnlinkSnapIcon, backend.DiscardSnapIcon},
+			expectedErrors:           []string{"", "", ""},
+			poolIconExistsAfter:      []bool{true, true, false},
+			installedIconExistsAfter: []bool{true, false, false},
+		},
+		{
+			functions:                []func(string) error{backend.LinkSnapIcon, backend.DiscardSnapIcon, backend.UnlinkSnapIcon},
+			expectedErrors:           []string{"", "", ""},
+			poolIconExistsAfter:      []bool{true, false, false},
+			installedIconExistsAfter: []bool{true, true, false},
+		},
+		{
+			functions:                []func(string) error{backend.UnlinkSnapIcon, backend.LinkSnapIcon, backend.DiscardSnapIcon},
+			expectedErrors:           []string{"", "", ""},
+			poolIconExistsAfter:      []bool{true, true, false},
+			installedIconExistsAfter: []bool{false, true, true},
+		},
+		{
+			functions:                []func(string) error{backend.UnlinkSnapIcon, backend.DiscardSnapIcon, backend.LinkSnapIcon},
+			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons download pool"},
+			poolIconExistsAfter:      []bool{true, false, false},
+			installedIconExistsAfter: []bool{false, false, false},
+		},
+		{
+			functions:                []func(string) error{backend.DiscardSnapIcon, backend.LinkSnapIcon, backend.UnlinkSnapIcon},
+			expectedErrors:           []string{"", "cannot link snap icon for snap .*: icon does not exist in the icons download pool", ""},
+			poolIconExistsAfter:      []bool{false, false, false},
+			installedIconExistsAfter: []bool{false, false, false},
+		},
+		{
+			functions:                []func(string) error{backend.DiscardSnapIcon, backend.UnlinkSnapIcon, backend.LinkSnapIcon},
+			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons download pool"},
+			poolIconExistsAfter:      []bool{false, false, false},
+			installedIconExistsAfter: []bool{false, false, false},
+		},
+		{
+			functions:                []func(string) error{backend.LinkSnapIcon, backend.LinkSnapIcon, backend.UnlinkSnapIcon, backend.DiscardSnapIcon},
+			expectedErrors:           []string{"", "", "", ""},
+			poolIconExistsAfter:      []bool{true, true, true, false},
+			installedIconExistsAfter: []bool{true, true, false, false},
+		},
+		{
+			functions:                []func(string) error{backend.LinkSnapIcon, backend.DiscardSnapIcon, backend.LinkSnapIcon},
+			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons download pool"},
+			poolIconExistsAfter:      []bool{true, false, false},
+			installedIconExistsAfter: []bool{true, true, true},
+		},
+	} {
+		// consistency check on the test case itself
+		c.Assert(testCase.functions, HasLen, len(testCase.expectedErrors))
+		c.Assert(testCase.functions, HasLen, len(testCase.poolIconExistsAfter))
+		c.Assert(testCase.functions, HasLen, len(testCase.installedIconExistsAfter))
+
+		snapID := fmt.Sprintf("some-snap-id-%d", i)
+		poolIconPath := backend.IconDownloadFilename(snapID)
+		installedIconPath := backend.IconInstallFilename(snapID)
+
+		// create the initial snap icon in the icon pool directory
+		c.Assert(os.MkdirAll(dirs.SnapIconsPoolDir, 0o755), IsNil)
+		fileContents := []byte("image data")
+		c.Assert(os.WriteFile(poolIconPath, fileContents, 0o644), IsNil)
+
+		for step, f := range testCase.functions {
+			err := f(snapID)
+			if errStr := testCase.expectedErrors[step]; errStr != "" {
+				c.Check(err, ErrorMatches, errStr, Commentf("test case %d, step %d", i, step))
+			} else {
+				c.Check(err, IsNil, Commentf("test case %d, step %d", i, step))
+			}
+			c.Check(osutil.FileExists(poolIconPath), Equals, testCase.poolIconExistsAfter[step], Commentf("test case %d, step %d", i, step))
+			c.Check(osutil.FileExists(installedIconPath), Equals, testCase.installedIconExistsAfter[step], Commentf("test case %d, step %d", i, step))
+		}
+	}
+}

--- a/overlord/snapstate/backend/icon_test.go
+++ b/overlord/snapstate/backend/icon_test.go
@@ -21,6 +21,7 @@ package backend_test
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -76,19 +77,19 @@ func (s *iconSuite) TestSnapIconLinkUnlinkDiscardPermutations(c *C) {
 		},
 		{
 			functions:                []func(string) error{backend.UnlinkSnapIcon, backend.DiscardSnapIcon, backend.LinkSnapIcon},
-			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons download pool"},
+			expectedErrors:           []string{"", "", fmt.Sprintf("icon for snap: %v", fs.ErrNotExist)},
 			poolIconExistsAfter:      []bool{true, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
 		{
 			functions:                []func(string) error{backend.DiscardSnapIcon, backend.LinkSnapIcon, backend.UnlinkSnapIcon},
-			expectedErrors:           []string{"", "cannot link snap icon for snap .*: icon does not exist in the icons download pool", ""},
+			expectedErrors:           []string{"", fmt.Sprintf("icon for snap: %v", fs.ErrNotExist), ""},
 			poolIconExistsAfter:      []bool{false, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
 		{
 			functions:                []func(string) error{backend.DiscardSnapIcon, backend.UnlinkSnapIcon, backend.LinkSnapIcon},
-			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons download pool"},
+			expectedErrors:           []string{"", "", fmt.Sprintf("icon for snap: %v", fs.ErrNotExist)},
 			poolIconExistsAfter:      []bool{false, false, false},
 			installedIconExistsAfter: []bool{false, false, false},
 		},
@@ -100,7 +101,7 @@ func (s *iconSuite) TestSnapIconLinkUnlinkDiscardPermutations(c *C) {
 		},
 		{
 			functions:                []func(string) error{backend.LinkSnapIcon, backend.DiscardSnapIcon, backend.LinkSnapIcon},
-			expectedErrors:           []string{"", "", "cannot link snap icon for snap .*: icon does not exist in the icons download pool"},
+			expectedErrors:           []string{"", "", fmt.Sprintf("icon for snap: %v", fs.ErrNotExist)},
 			poolIconExistsAfter:      []bool{true, false, false},
 			installedIconExistsAfter: []bool{true, true, true},
 		},

--- a/overlord/snapstate/backend/metadata_test.go
+++ b/overlord/snapstate/backend/metadata_test.go
@@ -20,6 +20,8 @@
 package backend_test
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -164,7 +166,7 @@ func (s *metadataSuite) TestInstallStoreMetadataNoIcon(c *C) {
 	c.Check(err, IsNil)
 
 	// but a debug log is recorded
-	c.Check(logbuf.String(), testutil.Contains, "cannot link snap icon for snap my-id: icon does not exist in the icons download pool")
+	c.Check(logbuf.String(), testutil.Contains, fmt.Sprintf("cannot link snap icon for snap my-id: icon for snap: %v", fs.ErrNotExist))
 }
 
 func (s *metadataSuite) TestDiscardStoreMetadata(c *C) {

--- a/overlord/snapstate/backend/metadata_test.go
+++ b/overlord/snapstate/backend/metadata_test.go
@@ -26,6 +26,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -42,18 +43,46 @@ func (s *metadataSuite) SetUpTest(c *C) {
 func (s *metadataSuite) TestInstallStoreMetadataUndo(c *C) {
 	const snapID = "my-snap-id"
 	for _, testCase := range []struct {
-		hasOtherInstances bool
-		firstInstall      bool
-		shouldExistAfter  bool
+		hasOtherInstances    bool
+		firstInstall         bool
+		auxShouldExistAfter  bool
+		iconShouldExistAfter bool
 	}{
-		// undo should remove the auxinfo iff there are no other instances and it's an install
-		{hasOtherInstances: false, firstInstall: true, shouldExistAfter: false},
-		{hasOtherInstances: true, firstInstall: true, shouldExistAfter: true},
-		{hasOtherInstances: false, firstInstall: false, shouldExistAfter: true},
-		{hasOtherInstances: true, firstInstall: false, shouldExistAfter: true},
+		// undo should remove:
+		// - auxinfo iff there are no other instances and it's an install
+		// - icon iff there are no other instances
+		{
+			hasOtherInstances:    false,
+			firstInstall:         true,
+			auxShouldExistAfter:  false,
+			iconShouldExistAfter: false,
+		},
+		{
+			hasOtherInstances:    true,
+			firstInstall:         true,
+			auxShouldExistAfter:  true,
+			iconShouldExistAfter: true,
+		},
+		{
+			hasOtherInstances:    false,
+			firstInstall:         false,
+			auxShouldExistAfter:  true,
+			iconShouldExistAfter: false,
+		},
+		{
+			hasOtherInstances:    true,
+			firstInstall:         false,
+			auxShouldExistAfter:  true,
+			iconShouldExistAfter: true,
+		},
 	} {
 		// Need a new tmp root dir so test cases don't collide
 		dirs.SetRootDir(c.MkDir())
+
+		// set up icon in the download pool
+		iconContents := []byte("icon contents")
+		c.Assert(os.MkdirAll(filepath.Dir(backend.IconDownloadFilename(snapID)), 0o755), IsNil)
+		c.Assert(os.WriteFile(backend.IconDownloadFilename(snapID), iconContents, 0o644), IsNil)
 
 		c.Assert(backend.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
 		aux := backend.AuxStoreInfo{
@@ -93,10 +122,16 @@ func (s *metadataSuite) TestInstallStoreMetadataUndo(c *C) {
 
 		undo()
 
-		if testCase.shouldExistAfter {
+		if testCase.auxShouldExistAfter {
 			checkWrittenInfo()
 		} else {
 			c.Check(backend.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
+		}
+
+		if testCase.iconShouldExistAfter {
+			c.Check(backend.IconInstallFilename(snapID), testutil.FileEquals, iconContents)
+		} else {
+			c.Check(backend.IconInstallFilename(snapID), testutil.FileAbsent)
 		}
 	}
 }
@@ -114,23 +149,91 @@ func (s *metadataSuite) TestStoreMetadataEmptySnapID(c *C) {
 	c.Check(backend.DiscardStoreMetadata(snapID, hasOtherInstances), IsNil)
 }
 
+func (s *metadataSuite) TestInstallStoreMetadataNoIcon(c *C) {
+	const snapID = "my-id"
+	var aux backend.AuxStoreInfo    // contents don't matter for this test
+	var linkCtx backend.LinkContext // empty, doesn't matter for this test
+
+	logbuf, restore := logger.MockDebugLogger()
+	defer restore()
+
+	// Icon is not present in the icons download pool
+
+	// Check that lack of icon does not cause an error
+	_, err := backend.InstallStoreMetadata(snapID, aux, linkCtx)
+	c.Check(err, IsNil)
+
+	// but a debug log is recorded
+	c.Check(logbuf.String(), testutil.Contains, "cannot link snap icon for snap my-id: icon does not exist in the icons download pool")
+}
+
 func (s *metadataSuite) TestDiscardStoreMetadata(c *C) {
 	for _, testCase := range []struct {
+		inPool         bool
+		installed      bool
 		auxInfo        bool
 		otherInstances bool
 		expectRemoved  bool
 	}{
 		{
+			inPool:         true,
+			installed:      true,
 			auxInfo:        true,
 			otherInstances: false,
 			expectRemoved:  true,
 		},
 		{
+			inPool:         true,
+			installed:      false,
+			auxInfo:        true,
+			otherInstances: false,
+			expectRemoved:  true,
+		},
+		{
+			inPool:         false,
+			installed:      true,
+			auxInfo:        true,
+			otherInstances: false,
+			expectRemoved:  true,
+		},
+		{
+			inPool:         false,
+			installed:      false,
+			auxInfo:        true,
+			otherInstances: false,
+			expectRemoved:  true,
+		},
+		{
+			inPool:         true,
+			installed:      true,
 			auxInfo:        false,
 			otherInstances: false,
 			expectRemoved:  true,
 		},
 		{
+			inPool:         true,
+			installed:      false,
+			auxInfo:        false,
+			otherInstances: false,
+			expectRemoved:  true,
+		},
+		{
+			inPool:         false,
+			installed:      true,
+			auxInfo:        false,
+			otherInstances: false,
+			expectRemoved:  true,
+		},
+		{
+			inPool:         false,
+			installed:      false,
+			auxInfo:        false,
+			otherInstances: false,
+			expectRemoved:  true,
+		},
+		{
+			inPool:         true,
+			installed:      true,
 			auxInfo:        true,
 			otherInstances: true,
 			expectRemoved:  false,
@@ -140,7 +243,18 @@ func (s *metadataSuite) TestDiscardStoreMetadata(c *C) {
 		dirs.SetRootDir(c.MkDir())
 
 		const snapID = "my-id"
+		var iconContents = []byte("icon contents")
 		var auxinfo = []byte("some links")
+
+		if testCase.inPool {
+			c.Assert(os.MkdirAll(filepath.Dir(backend.IconDownloadFilename(snapID)), 0o755), IsNil)
+			c.Assert(os.WriteFile(backend.IconDownloadFilename(snapID), iconContents, 0o644), IsNil)
+		}
+
+		if testCase.installed {
+			c.Assert(os.MkdirAll(filepath.Dir(backend.IconInstallFilename(snapID)), 0o755), IsNil)
+			c.Assert(os.WriteFile(backend.IconInstallFilename(snapID), iconContents, 0o644), IsNil)
+		}
 
 		if testCase.auxInfo {
 			c.Assert(os.MkdirAll(filepath.Dir(backend.AuxStoreInfoFilename(snapID)), 0o755), IsNil)
@@ -151,8 +265,16 @@ func (s *metadataSuite) TestDiscardStoreMetadata(c *C) {
 		c.Check(err, IsNil)
 
 		if testCase.expectRemoved {
+			c.Check(backend.IconDownloadFilename(snapID), testutil.FileAbsent)
+			c.Check(backend.IconInstallFilename(snapID), testutil.FileAbsent)
 			c.Check(backend.AuxStoreInfoFilename(snapID), testutil.FileAbsent)
 		} else {
+			if testCase.inPool {
+				c.Check(backend.IconDownloadFilename(snapID), testutil.FileEquals, iconContents)
+			}
+			if testCase.installed {
+				c.Check(backend.IconInstallFilename(snapID), testutil.FileEquals, iconContents)
+			}
 			if testCase.auxInfo {
 				c.Check(backend.AuxStoreInfoFilename(snapID), testutil.FileEquals, auxinfo)
 			}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -154,6 +154,12 @@ type fakeDownload struct {
 	opts     *store.DownloadOptions
 }
 
+type fakeIconDownload struct {
+	name   string
+	target string
+	url    string
+}
+
 type byName []store.CurrentSnap
 
 func (bna byName) Len() int      { return len(bna) }
@@ -183,6 +189,7 @@ type fakeStore struct {
 	mu sync.Mutex
 
 	downloads           []fakeDownload
+	iconDownloads       []fakeIconDownload
 	refreshRevnos       map[string]snap.Revision
 	fakeBackend         *fakeSnappyBackend
 	fakeCurrentProgress int
@@ -196,7 +203,8 @@ type fakeStore struct {
 	// it should return the resources that the snap should have.
 	snapResourcesFn func(*snap.Info) []store.SnapResourceResult
 
-	downloadCallback func()
+	downloadCallback     func()
+	downloadIconCallback func(targetPath string)
 
 	namesToAssertedIDs map[string]string
 	idsToNames         map[string]string
@@ -248,6 +256,12 @@ func (f *fakeStore) appendDownload(dl *fakeDownload) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.downloads = append(f.downloads, *dl)
+}
+
+func (f *fakeStore) appendIconDownload(dl *fakeIconDownload) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.iconDownloads = append(f.iconDownloads, *dl)
 }
 
 type snapSpec struct {
@@ -927,6 +941,20 @@ func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInf
 	if e, ok := f.downloadError[name]; ok {
 		return e
 	}
+
+	return nil
+}
+
+func (f *fakeStore) DownloadIcon(ctx context.Context, name string, targetPath string, downloadURL string) error {
+	if f.downloadIconCallback != nil {
+		f.downloadIconCallback(targetPath)
+	}
+	f.appendIconDownload(&fakeIconDownload{
+		name:   name,
+		target: targetPath,
+		url:    downloadURL,
+	})
+	f.fakeBackend.appendOp(&fakeOp{op: "storesvc-download-icon", name: name})
 
 	return nil
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -946,6 +946,9 @@ func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInf
 }
 
 func (f *fakeStore) DownloadIcon(ctx context.Context, name string, targetPath string, downloadURL string) error {
+	// we don't want to hold state lock while waiting on the icon download
+	f.pokeStateLock()
+
 	if f.downloadIconCallback != nil {
 		f.downloadIconCallback(targetPath)
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -757,7 +757,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		}
 
 		timings.Run(perfTimings, "download", fmt.Sprintf("download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-			err = theStore.Download(nil, snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
+			err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
 		})
 		snapsup.SideInfo = &result.SideInfo
 		if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -756,33 +756,12 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 			return err
 		}
 
-		// Re-compute icon download filepath and URL if the result info has the
-		// necessary information
-		if result.SnapID != "" {
-			targetIconFn = backend.IconDownloadFilename(result.SnapID)
-		}
-		if resultIconURL := result.Media.IconURL(); resultIconURL != "" {
-			iconURL = resultIconURL
-		}
-
-		ctx := tomb.Context(nil) // XXX: should this be a real context?
-
 		timings.Run(perfTimings, "download", fmt.Sprintf("download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-			err = theStore.Download(ctx, snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
+			err = theStore.Download(nil, snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
 		})
 		snapsup.SideInfo = &result.SideInfo
 		if err != nil {
 			return err
-		}
-		// Snap download succeeded, now try to download the snap icon
-		if iconURL == "" {
-			logger.Debugf("cannot download snap icon for %q: no icon URL", snapsup.SnapName())
-		} else {
-			timings.Run(perfTimings, "download-icon", fmt.Sprintf("download snap icon for %q", snapsup.SnapName()), func(timings.Measurer) {
-				if iconErr := theStore.DownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
-					logger.Debugf("cannot download snap icon for %q: %#v", snapsup.SnapName(), iconErr)
-				}
-			})
 		}
 	} else {
 		ctx := tomb.Context(nil) // XXX: should this be a real context?
@@ -798,7 +777,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		} else {
 			timings.Run(perfTimings, "download-icon", fmt.Sprintf("download snap icon for %q", snapsup.SnapName()), func(timings.Measurer) {
 				if iconErr := theStore.DownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
-					logger.Debugf("cannot download snap icon for %q: %#v", snapsup.SnapName(), iconErr)
+					logger.Debugf("cannot download snap icon for %q: %v", snapsup.SnapName(), iconErr)
 				}
 			})
 		}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -726,6 +726,8 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 
 	meter := NewTaskProgressAdapterUnlocked(t)
 	targetFn := snapsup.BlobPath()
+	targetIconFn := backend.IconDownloadFilename(snapsup.SideInfo.SnapID)
+	iconURL := snapsup.Media.IconURL()
 
 	dlOpts := &store.DownloadOptions{
 		Scheduled: snapsup.IsAutoRefresh,
@@ -753,17 +755,53 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
+
+		// Re-compute icon download filepath and URL if the result info has the
+		// necessary information
+		if result.SnapID != "" {
+			targetIconFn = backend.IconDownloadFilename(result.SnapID)
+		}
+		if resultIconURL := result.Media.IconURL(); resultIconURL != "" {
+			iconURL = resultIconURL
+		}
+
+		ctx := tomb.Context(nil) // XXX: should this be a real context?
+
 		timings.Run(perfTimings, "download", fmt.Sprintf("download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-			err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
+			err = theStore.Download(ctx, snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
 		})
 		snapsup.SideInfo = &result.SideInfo
+		if err != nil {
+			return err
+		}
+		// Snap download succeeded, now try to download the snap icon
+		if iconURL == "" {
+			logger.Debugf("cannot download snap icon for %q: no icon URL", snapsup.SnapName())
+		} else {
+			timings.Run(perfTimings, "download-icon", fmt.Sprintf("download snap icon for %q", snapsup.SnapName()), func(timings.Measurer) {
+				if iconErr := theStore.DownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
+					logger.Debugf("cannot download snap icon for %q: %#v", snapsup.SnapName(), iconErr)
+				}
+			})
+		}
 	} else {
+		ctx := tomb.Context(nil) // XXX: should this be a real context?
 		timings.Run(perfTimings, "download", fmt.Sprintf("download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-			err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, snapsup.DownloadInfo, meter, user, dlOpts)
+			err = theStore.Download(ctx, snapsup.SnapName(), targetFn, snapsup.DownloadInfo, meter, user, dlOpts)
 		})
-	}
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		// Snap download succeeded, now try to download the snap icon
+		if iconURL == "" {
+			logger.Debugf("cannot download snap icon for %q: no icon URL", snapsup.SnapName())
+		} else {
+			timings.Run(perfTimings, "download-icon", fmt.Sprintf("download snap icon for %q", snapsup.SnapName()), func(timings.Measurer) {
+				if iconErr := theStore.DownloadIcon(ctx, snapsup.SnapName(), targetIconFn, iconURL); iconErr != nil {
+					logger.Debugf("cannot download snap icon for %q: %#v", snapsup.SnapName(), iconErr)
+				}
+			})
+		}
 	}
 
 	snapsup.SnapPath = targetFn

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -322,7 +322,7 @@ const (
 // ordinary unauthenticated file server, so this does not require store
 // authentication or user state, nor a progress bar. They are also not revision-
 // specific, and do not use a download cache.
-func DownloadIcon(ctx context.Context, name string, targetPath string, downloadURL string) error {
+func (s *Store) DownloadIcon(ctx context.Context, name string, targetPath string, downloadURL string) error {
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		return err
 	}

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1269,9 +1269,8 @@ func (s *storeDownloadSuite) TestDownloadIconOK(c *C) {
 	defer restore()
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
+	err := s.store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
-	defer os.Remove(path)
 
 	c.Assert(path, testutil.FileEquals, expectedContent)
 }
@@ -1303,7 +1302,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithNewEtag(c *C) {
 	defer restore()
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
+	err := s.store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
 
 	c.Check(path, testutil.FileEquals, expectedContent)
@@ -1340,7 +1339,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithExistingEtag(c *C) {
 	})
 	defer restore()
 
-	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
+	err := s.store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
 
 	// Existing file (and etag) should not have been overwritten
@@ -1376,7 +1375,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithChangedEtag(c *C) {
 	})
 	defer restore()
 
-	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
+	err := s.store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
 
 	c.Check(path, testutil.FileEquals, expectedContent)
@@ -1414,7 +1413,7 @@ func (s *storeDownloadSuite) TestDownloadIconOKWithEtagTooLong(c *C) {
 	})
 	defer restore()
 
-	err := store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
+	err := s.store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
 
 	c.Check(path, testutil.FileEquals, expectedContent)
@@ -1452,7 +1451,7 @@ func (s *storeDownloadSuite) TestDownloadIconDoesNotOverwriteLinks(c *C) {
 	err = os.Link(path, linkPath)
 	c.Assert(err, IsNil)
 
-	err = store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
+	err = s.store.DownloadIcon(s.ctx, expectedName, path, expectedURL)
 	c.Assert(err, IsNil)
 
 	c.Assert(path, testutil.FileEquals, newContent)
@@ -1475,7 +1474,7 @@ func (s *storeDownloadSuite) TestDownloadIconFails(c *C) {
 	defer restore()
 
 	// simulate a failed download
-	err := store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
+	err := s.store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
 	c.Assert(err, ErrorMatches, "uh, it failed")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -1499,7 +1498,7 @@ func (s *storeDownloadSuite) TestDownloadIconFailsDoesNotLeavePartial(c *C) {
 	defer restore()
 
 	// simulate a failed download
-	err := store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
+	err := s.store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
 	c.Assert(err, ErrorMatches, "uh, it failed")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -1550,7 +1549,7 @@ func (s *storeDownloadSuite) testDownloadIconSyncFailsGeneric(c *C, fakeName, fa
 	defer restore()
 
 	// simulate a failed sync
-	err := store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
+	err := s.store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
 	c.Assert(err, ErrorMatches, "cannot commit snap icon file for snap foo: .* file already closed")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -1575,6 +1574,6 @@ func (s *storeDownloadSuite) TestDownloadIconInfiniteRedirect(c *C) {
 	fakePath := filepath.Join(c.MkDir(), "foo.icon")
 	fakeURL := mockServer.URL
 
-	err := store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
+	err := s.store.DownloadIcon(s.ctx, fakeName, fakePath, fakeURL)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("Get %q: stopped after 10 redirects", fakeURL))
 }

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -71,6 +71,10 @@ func (Store) DownloadStream(ctx context.Context, name string, downloadInfo *snap
 	panic("Store.DownloadStream not expected")
 }
 
+func (Store) DownloadIcon(context.Context, string, string, string) error {
+	panic("Store.DownloadIcon not expected")
+}
+
 func (Store) SuggestedCurrency() string {
 	panic("Store.SuggestedCurrency not expected")
 }


### PR DESCRIPTION
This PR is based on #15051, and replaces #15003.

During the "download-snap" task, download the snap icon as well.

During "link-snap" and "unlink-snap", link/unlink the snap icon from the downloaded icons pool to the  installed icons directory. Do this by adding snap icon management helpers, and calling them from the store metadata helpers in the backend.

Lastly, discard the downloaded snap icon when the final revision of the snap is discarded from disk (and there are no other instances). We want to ensure that the snap icon remains in the pool during any situation when it's possible to install the snap without doing another "download-snap" task, such as via a revert.

This PR is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34436