### PR TITLE
osutil: account for Go 1.24 when reading build ID in the tests

### DIFF
--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -90,7 +90,7 @@ func readGenericBuildID(fname, elfNote string, hdrType uint32) (string, error) {
 			return "", err
 		}
 
-		// We are only interested in GNU build IDs
+		// We are only in a specific note
 		if string(noteName) != elfNote {
 			continue
 		}

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -149,6 +149,9 @@ func (s *buildIDSuite) TestReadBuildGo(c *C) {
 	err := os.WriteFile(goTruth+".go", []byte(`package main; func main(){}`), 0644)
 	c.Assert(err, IsNil)
 	// force specific Go BuildID
+	//
+	// XXX: note, Go toolchain, specifically 1.24+ started adding GNU BuildID by
+	// default which the code tries to read first
 	cmd := exec.Command("go", "build", "-o", goTruth, "-ldflags=-buildid=foobar", goTruth+".go")
 	// set custom homedir to ensure tests work in an sbuild environment
 	// that force a non-existing homedir
@@ -158,7 +161,7 @@ func (s *buildIDSuite) TestReadBuildGo(c *C) {
 	c.Assert(string(output), Equals, "")
 	c.Assert(err, IsNil)
 
-	id, err := osutil.ReadBuildID(goTruth)
+	id, err := osutil.ReadGoBuildID(goTruth)
 	c.Assert(err, IsNil)
 
 	// ReadBuildID returns a hex encoded string, however buildID()

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -239,3 +239,7 @@ func ParseRawExpandableEnv(entries []string) (ExpandableEnv, error) {
 	}
 	return ExpandableEnv{OrderedMap: om}, nil
 }
+
+func ReadGoBuildID(fname string) (string, error) {
+	return readGenericBuildID(fname, goElfNote, goHdrType)
+}


### PR DESCRIPTION
With Go 1.24, GNU build ID is added to binaries by default, unless -B none is added. Since osutil.ReadBuildID() attempts to read GNU build ID first, the test broke since it expected the Go build ID to be returned.

Related: [SNAPDENG-34507](https://warthogs.atlassian.net/browse/SNAPDENG-34507)
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-34507]: https://warthogs.atlassian.net/browse/SNAPDENG-34507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ