### PR TITLE
cmd, secboot: add argon2 out-of-process kdf support

### DIFF
--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -41,10 +41,7 @@ such as initramfs.
 )
 
 func main() {
-	if err := secboot.MaybeRunArgon2OutOfProcessRequestHandler(); err != nil {
-		fmt.Fprintf(os.Stderr, "cannot run argon2 out-of-process helper command: %v", err)
-		os.Exit(1)
-	}
+	secboot.MaybeRunArgon2OutOfProcessRequestHandler()
 
 	err := run(os.Args[1:])
 	if err != nil {

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/secboot"
 )
 
 var (
@@ -40,6 +41,11 @@ such as initramfs.
 )
 
 func main() {
+	if err := secboot.MaybeRunArgon2OutOfProcessRequestHandler(); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot run argon2 out-of-process helper command: %v", err)
+		os.Exit(1)
+	}
+
 	err := run(os.Args[1:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -41,7 +41,7 @@ such as initramfs.
 )
 
 func main() {
-	secboot.MaybeRunArgon2OutOfProcessRequestHandler()
+	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"--argon2-proc"})
 
 	err := run(os.Args[1:])
 	if err != nil {

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -41,7 +41,7 @@ such as initramfs.
 )
 
 func main() {
-	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"--argon2-proc"})
+	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"argon2-proc"})
 
 	err := run(os.Args[1:])
 	if err != nil {

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/syscheck"
@@ -55,6 +56,11 @@ func main() {
 		logger.Noticef("running for preseeding")
 	} else {
 		snapdtool.ExecInSnapdOrCoreSnap()
+	}
+
+	if err := secboot.MaybeRunArgon2OutOfProcessRequestHandler(); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot run argon2 out-of-process helper command: %v", err)
+		os.Exit(1)
 	}
 
 	if err := snapdtool.MaybeSetupFIPS(); err != nil {

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -58,7 +58,7 @@ func main() {
 		snapdtool.ExecInSnapdOrCoreSnap()
 	}
 
-	secboot.MaybeRunArgon2OutOfProcessRequestHandler()
+	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"--argon2-proc"})
 
 	if err := snapdtool.MaybeSetupFIPS(); err != nil {
 		fmt.Fprintf(os.Stderr, "cannot check or enable FIPS mode: %v", err)

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -58,10 +58,7 @@ func main() {
 		snapdtool.ExecInSnapdOrCoreSnap()
 	}
 
-	if err := secboot.MaybeRunArgon2OutOfProcessRequestHandler(); err != nil {
-		fmt.Fprintf(os.Stderr, "cannot run argon2 out-of-process helper command: %v", err)
-		os.Exit(1)
-	}
+	secboot.MaybeRunArgon2OutOfProcessRequestHandler()
 
 	if err := snapdtool.MaybeSetupFIPS(); err != nil {
 		fmt.Fprintf(os.Stderr, "cannot check or enable FIPS mode: %v", err)

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -58,7 +58,7 @@ func main() {
 		snapdtool.ExecInSnapdOrCoreSnap()
 	}
 
-	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"--argon2-proc"})
+	secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"argon2-proc"})
 
 	if err := snapdtool.MaybeSetupFIPS(); err != nil {
 		fmt.Fprintf(os.Stderr, "cannot check or enable FIPS mode: %v", err)

--- a/secboot/argon2_out_of_process.go
+++ b/secboot/argon2_out_of_process.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import "os"
+
+func isOutOfProcessArgon2KDFMode(args []string) bool {
+	if len(os.Args) != len(args)+1 {
+		return false
+	}
+
+	for i := 0; i < len(args); i++ {
+		if os.Args[i+1] != args[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/secboot/argon2_out_of_process_dummy.go
+++ b/secboot/argon2_out_of_process_dummy.go
@@ -20,6 +20,4 @@
 
 package secboot
 
-func MaybeRunArgon2OutOfProcessRequestHandler() error {
-	return errBuildWithoutSecboot
-}
+func MaybeRunArgon2OutOfProcessRequestHandler() {}

--- a/secboot/argon2_out_of_process_dummy.go
+++ b/secboot/argon2_out_of_process_dummy.go
@@ -20,4 +20,8 @@
 
 package secboot
 
-func MaybeRunArgon2OutOfProcessRequestHandler() {}
+func HijackAndRunArgon2OutOfProcessHandlerOnArg(args []string) {
+	if isOutOfProcessArgon2KDFMode(args) {
+		panic("internal error: unexpected call to execute as argon2 runner in non-secboot binary")
+	}
+}

--- a/secboot/argon2_out_of_process_dummy.go
+++ b/secboot/argon2_out_of_process_dummy.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+func MaybeRunArgon2OutOfProcessRequestHandler() error {
+	return errBuildWithoutSecboot
+}

--- a/secboot/argon2_out_of_process_sb.go
+++ b/secboot/argon2_out_of_process_sb.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 const outOfProcessArgon2KDFTimeout = 100 * time.Millisecond
-const argon2Cmd = "run-argon2"
+const outOfProcessArgon2Arg = "--argon2-proc"
 
 func setArgon2KDF() error {
 	// This assumes that the calling binary uses MaybeRunArgon2OutOfProcessRequestHandler early in main().
@@ -45,7 +45,7 @@ func setArgon2KDF() error {
 	}
 
 	handlerCmd := func() (*exec.Cmd, error) {
-		cmd := exec.Command(exe, argon2Cmd)
+		cmd := exec.Command(exe, outOfProcessArgon2Arg)
 		return cmd, nil
 	}
 	argon2KDF := sb.NewOutOfProcessArgon2KDF(handlerCmd, outOfProcessArgon2KDFTimeout, nil)
@@ -61,15 +61,15 @@ var sbWaitForAndRunArgon2OutOfProcessRequest = sb.WaitForAndRunArgon2OutOfProces
 // from the main() of binaries involved with sealing/unsealing of
 // keys (i.e. snapd and snap-bootstrap).
 //
-// This switches the binary to a special mode where it acts as an
-// argon2 out-of-process helper command, and exits when its work
-// is done.
+// This switches the binary to a special mode when the --argon2-proc arg
+// is detected where it acts as an argon2 out-of-process helper command
+// and exits when its work is done.
 //
 // For more context, check docs for sb.WaitForAndRunArgon2OutOfProcessRequest
 // and sb.NewOutOfProcessArgon2KDF for details on how the flow works
 // in secboot.
 func MaybeRunArgon2OutOfProcessRequestHandler() error {
-	if len(os.Args) < 2 || os.Args[1] != argon2Cmd {
+	if len(os.Args) < 2 || os.Args[1] != outOfProcessArgon2Arg {
 		return nil
 	}
 

--- a/secboot/argon2_out_of_process_sb.go
+++ b/secboot/argon2_out_of_process_sb.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	sb "github.com/snapcore/secboot"
+
+	"github.com/snapcore/snapd/logger"
+)
+
+func init() {
+	setArgon2KDF()
+}
+
+const outOfProcessArgon2KDFTimeout = 100 * time.Millisecond
+const argon2Cmd = "run-argon2"
+
+func setArgon2KDF() error {
+	// This assumes that the calling binary uses MaybeRunArgon2OutOfProcessRequestHandler early in main().
+	exe, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		return err
+	}
+
+	handlerCmd := func() (*exec.Cmd, error) {
+		cmd := exec.Command(exe, argon2Cmd)
+		return cmd, nil
+	}
+	argon2KDF := sb.NewOutOfProcessArgon2KDF(handlerCmd, outOfProcessArgon2KDFTimeout, nil)
+	sb.SetArgon2KDF(argon2KDF)
+
+	return nil
+}
+
+var osExit = os.Exit
+var sbWaitForAndRunArgon2OutOfProcessRequest = sb.WaitForAndRunArgon2OutOfProcessRequest
+
+// MaybeRunArgon2OutOfProcessRequestHandler is supposed to be called
+// from the main() of binaries involved with sealing/unsealing of
+// keys (i.e. snapd and snap-bootstrap).
+//
+// This switches the binary to a special mode where it acts as an
+// argon2 out-of-process helper command, and exits when its work
+// is done.
+//
+// For more context, check docs for sb.WaitForAndRunArgon2OutOfProcessRequest
+// and sb.NewOutOfProcessArgon2KDF for details on how the flow works
+// in secboot.
+func MaybeRunArgon2OutOfProcessRequestHandler() error {
+	if len(os.Args) < 2 || os.Args[1] != argon2Cmd {
+		return nil
+	}
+
+	watchdog := sb.NoArgon2OutOfProcessWatchdogHandler()
+
+	logger.Noticef("running argon2 out-of-process helper")
+	// Lock will be released implicitly on process termination, but let's also
+	// explicitly release lock.
+	lockRelease, err := sbWaitForAndRunArgon2OutOfProcessRequest(os.Stdin, os.Stdout, watchdog)
+	defer lockRelease()
+	if err != nil {
+		return fmt.Errorf("cannot run request: %w", err)
+	}
+
+	// Argon2 request was processed successfully
+	osExit(0)
+
+	panic("internal error: not reachable")
+}

--- a/secboot/argon2_out_of_process_sb_test.go
+++ b/secboot/argon2_out_of_process_sb_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
 
 /*
  * Copyright (C) 2025 Canonical Ltd

--- a/secboot/argon2_out_of_process_sb_test.go
+++ b/secboot/argon2_out_of_process_sb_test.go
@@ -60,11 +60,12 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerArgon2Mode(c *C)
 	})
 	defer restore()
 
-	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--argon2-proc"})
+	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--test-special-argon2-mode"})
 	defer restore()
 
 	// Since we override os.Exit(0), we expect to panic (injected above)
-	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "os.Exit(0)")
+	f := func() { secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"--test-special-argon2-mode"}) }
+	c.Assert(f, Panics, "os.Exit(0)")
 
 	c.Check(setArgon2Called, Equals, 0)
 	c.Check(runArgon2Called, Equals, 1)
@@ -94,10 +95,11 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerArgon2ModeError(
 	})
 	defer restore()
 
-	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--argon2-proc"})
+	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--test-special-argon2-mode"})
 	defer restore()
 
-	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "os.Exit(1)")
+	f := func() { secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"--test-special-argon2-mode"}) }
+	c.Assert(f, Panics, "os.Exit(1)")
 
 	c.Check(setArgon2Called, Equals, 0)
 	c.Check(runArgon2Called, Equals, 1)
@@ -145,7 +147,7 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNormalMode(c *C)
 		cmd, err := newHandlerCmd()
 		c.Assert(err, IsNil)
 		c.Check(cmd.Path, Equals, "/path/to/cmd")
-		c.Check(cmd.Args, DeepEquals, []string{"/path/to/cmd", "--argon2-proc"})
+		c.Check(cmd.Args, DeepEquals, []string{"/path/to/cmd", "--test-special-argon2-mode"})
 
 		return argon2KDF
 	})
@@ -169,7 +171,7 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNormalMode(c *C)
 		restore := secboot.MockOsArgs(args)
 		defer restore()
 		// This should exit early before running the argon2 helper and calling os.Exit (and no injected panic)
-		secboot.MaybeRunArgon2OutOfProcessRequestHandler()
+		secboot.HijackAndRunArgon2OutOfProcessHandlerOnArg([]string{"--test-special-argon2-mode"})
 	}
 
 	c.Check(setArgon2Called, Equals, 4)

--- a/secboot/argon2_out_of_process_sb_test.go
+++ b/secboot/argon2_out_of_process_sb_test.go
@@ -52,7 +52,7 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandler(c *C) {
 	})
 	defer restore()
 
-	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "run-argon2"})
+	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--argon2-proc"})
 	defer restore()
 
 	// Since we override os.Exit(0), we expect to panic
@@ -85,7 +85,7 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNotTriggered(c *
 		{},
 		{"/path/to/cmd"},
 		{"/path/to/cmd", "not-run-argon2"},
-		{"/path/to/cmd", "not-run-argon2", "run-argon2"},
+		{"/path/to/cmd", "not-run-argon2", "--argon2-proc"},
 	} {
 		restore := secboot.MockOsArgs(args)
 		defer restore()
@@ -116,7 +116,7 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerError(c *C) {
 	})
 	defer restore()
 
-	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "run-argon2"})
+	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--argon2-proc"})
 	defer restore()
 
 	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler(), ErrorMatches, "cannot run request: boom!")

--- a/secboot/argon2_out_of_process_sb_test.go
+++ b/secboot/argon2_out_of_process_sb_test.go
@@ -23,6 +23,8 @@ package secboot_test
 import (
 	"errors"
 	"io"
+	"os/exec"
+	"time"
 
 	sb "github.com/snapcore/secboot"
 	. "gopkg.in/check.v1"
@@ -35,11 +37,18 @@ type argon2Suite struct {
 
 var _ = Suite(&argon2Suite{})
 
-func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandler(c *C) {
-	argon2Called := 0
+func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerArgon2Mode(c *C) {
+	runArgon2Called := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
-		argon2Called++
+		runArgon2Called++
 		return nil, nil
+	})
+	defer restore()
+
+	setArgon2Called := 0
+	restore = secboot.MockSbSetArgon2KDF(func(kdf sb.Argon2KDF) sb.Argon2KDF {
+		setArgon2Called++
+		return nil
 	})
 	defer restore()
 
@@ -57,47 +66,23 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandler(c *C) {
 	// Since we override os.Exit(0), we expect to panic (injected above)
 	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "os.Exit(0)")
 
-	c.Check(argon2Called, Equals, 1)
+	c.Check(setArgon2Called, Equals, 0)
+	c.Check(runArgon2Called, Equals, 1)
 	c.Check(exitCalled, Equals, 1)
 }
 
-func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNotTriggered(c *C) {
-	argon2Called := 0
+func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerArgon2ModeError(c *C) {
+	runArgon2Called := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
-		argon2Called++
-		return nil, nil
-	})
-	defer restore()
-
-	exitCalled := 0
-	restore = secboot.MockOsExit(func(code int) {
-		exitCalled++
-		c.Assert(code, Equals, 0)
-		panic("injected panic")
-	})
-	defer restore()
-
-	for _, args := range [][]string{
-		{},
-		{"/path/to/cmd"},
-		{"/path/to/cmd", "not-run-argon2"},
-		{"/path/to/cmd", "not-run-argon2", "--argon2-proc"},
-	} {
-		restore := secboot.MockOsArgs(args)
-		defer restore()
-		// This should exit early before running the argon2 helper and calling os.Exit (and no injected panic)
-		secboot.MaybeRunArgon2OutOfProcessRequestHandler()
-	}
-
-	c.Check(argon2Called, Equals, 0)
-	c.Check(exitCalled, Equals, 0)
-}
-
-func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerError(c *C) {
-	argon2Called := 0
-	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
-		argon2Called++
+		runArgon2Called++
 		return nil, errors.New("boom!")
+	})
+	defer restore()
+
+	setArgon2Called := 0
+	restore = secboot.MockSbSetArgon2KDF(func(kdf sb.Argon2KDF) sb.Argon2KDF {
+		setArgon2Called++
+		return nil
 	})
 	defer restore()
 
@@ -114,6 +99,80 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerError(c *C) {
 
 	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "os.Exit(1)")
 
-	c.Check(argon2Called, Equals, 1)
+	c.Check(setArgon2Called, Equals, 0)
+	c.Check(runArgon2Called, Equals, 1)
 	c.Check(exitCalled, Equals, 1)
+}
+
+type mockArgon2KDF struct{}
+
+func (*mockArgon2KDF) Derive(passphrase string, salt []byte, mode sb.Argon2Mode, params *sb.Argon2CostParams, keyLen uint32) ([]byte, error) {
+	return nil, nil
+}
+
+func (*mockArgon2KDF) Time(mode sb.Argon2Mode, params *sb.Argon2CostParams) (time.Duration, error) {
+	return 0, nil
+}
+
+func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNormalMode(c *C) {
+	runArgon2Called := 0
+	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
+		runArgon2Called++
+		return nil, nil
+	})
+	defer restore()
+
+	exitCalled := 0
+	restore = secboot.MockOsExit(func(code int) {
+		exitCalled++
+		c.Assert(code, Equals, 0)
+		panic("injected panic")
+	})
+	defer restore()
+
+	restore = secboot.MockOsReadlink(func(name string) (string, error) {
+		c.Assert(name, Equals, "/proc/self/exe")
+		return "/path/to/cmd", nil
+	})
+	defer restore()
+
+	argon2KDF := &mockArgon2KDF{}
+
+	restore = secboot.MockSbNewOutOfProcessArgon2KDF(func(newHandlerCmd func() (*exec.Cmd, error), timeout time.Duration, watchdog sb.Argon2OutOfProcessWatchdogMonitor) sb.Argon2KDF {
+		c.Check(timeout, Equals, 100*time.Millisecond)
+		c.Check(watchdog, IsNil)
+
+		cmd, err := newHandlerCmd()
+		c.Assert(err, IsNil)
+		c.Check(cmd.Path, Equals, "/path/to/cmd")
+		c.Check(cmd.Args, DeepEquals, []string{"/path/to/cmd", "--argon2-proc"})
+
+		return argon2KDF
+	})
+	defer restore()
+
+	setArgon2Called := 0
+	restore = secboot.MockSbSetArgon2KDF(func(kdf sb.Argon2KDF) sb.Argon2KDF {
+		setArgon2Called++
+		// Check pointer points to mock implementation
+		c.Assert(kdf, Equals, argon2KDF)
+		return nil
+	})
+	defer restore()
+
+	for _, args := range [][]string{
+		{},
+		{"/path/to/cmd"},
+		{"/path/to/cmd", "not-run-argon2"},
+		{"/path/to/cmd", "not-run-argon2", "--argon2-proc"},
+	} {
+		restore := secboot.MockOsArgs(args)
+		defer restore()
+		// This should exit early before running the argon2 helper and calling os.Exit (and no injected panic)
+		secboot.MaybeRunArgon2OutOfProcessRequestHandler()
+	}
+
+	c.Check(setArgon2Called, Equals, 4)
+	c.Check(runArgon2Called, Equals, 0)
+	c.Check(exitCalled, Equals, 0)
 }

--- a/secboot/argon2_out_of_process_sb_test.go
+++ b/secboot/argon2_out_of_process_sb_test.go
@@ -1,0 +1,127 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"errors"
+	"io"
+
+	sb "github.com/snapcore/secboot"
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/secboot"
+)
+
+type argon2Suite struct {
+}
+
+var _ = Suite(&argon2Suite{})
+
+func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandler(c *C) {
+	argon2Called := 0
+	lockReleaseCalled := 0
+	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
+		argon2Called++
+		return func() {
+			lockReleaseCalled++
+		}, nil
+	})
+	defer restore()
+
+	exitCalled := 0
+	restore = secboot.MockOsExit(func(code int) {
+		exitCalled++
+		c.Assert(code, Equals, 0)
+	})
+	defer restore()
+
+	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "run-argon2"})
+	defer restore()
+
+	// Since we override os.Exit(0), we expect to panic
+	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "internal error: not reachable")
+
+	c.Check(argon2Called, Equals, 1)
+	c.Check(exitCalled, Equals, 1)
+	c.Check(lockReleaseCalled, Equals, 1)
+}
+
+func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNotTriggered(c *C) {
+	argon2Called := 0
+	lockReleaseCalled := 0
+	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
+		argon2Called++
+		return func() {
+			lockReleaseCalled++
+		}, nil
+	})
+	defer restore()
+
+	exitCalled := 0
+	restore = secboot.MockOsExit(func(code int) {
+		exitCalled++
+		c.Assert(code, Equals, 0)
+	})
+	defer restore()
+
+	for _, args := range [][]string{
+		{},
+		{"/path/to/cmd"},
+		{"/path/to/cmd", "not-run-argon2"},
+		{"/path/to/cmd", "not-run-argon2", "run-argon2"},
+	} {
+		restore := secboot.MockOsArgs(args)
+		defer restore()
+		err := secboot.MaybeRunArgon2OutOfProcessRequestHandler()
+		c.Assert(err, IsNil)
+	}
+
+	c.Check(argon2Called, Equals, 0)
+	c.Check(exitCalled, Equals, 0)
+	c.Check(lockReleaseCalled, Equals, 0)
+}
+
+func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerError(c *C) {
+	argon2Called := 0
+	lockReleaseCalled := 0
+	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
+		argon2Called++
+		return func() {
+			lockReleaseCalled++
+		}, errors.New("boom!")
+	})
+	defer restore()
+
+	exitCalled := 0
+	restore = secboot.MockOsExit(func(code int) {
+		exitCalled++
+		c.Assert(code, Equals, 0)
+	})
+	defer restore()
+
+	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "run-argon2"})
+	defer restore()
+
+	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler(), ErrorMatches, "cannot run request: boom!")
+
+	c.Check(argon2Called, Equals, 1)
+	c.Check(exitCalled, Equals, 0)
+	c.Check(lockReleaseCalled, Equals, 1)
+}

--- a/secboot/argon2_out_of_process_sb_test.go
+++ b/secboot/argon2_out_of_process_sb_test.go
@@ -37,7 +37,7 @@ type argon2Suite struct {
 
 var _ = Suite(&argon2Suite{})
 
-func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerArgon2Mode(c *C) {
+func (*argon2Suite) TestHijackAndRunArgon2OutOfProcessHandlerOnArgArgon2Mode(c *C) {
 	runArgon2Called := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
 		runArgon2Called++
@@ -72,7 +72,7 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerArgon2Mode(c *C)
 	c.Check(exitCalled, Equals, 1)
 }
 
-func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerArgon2ModeError(c *C) {
+func (*argon2Suite) TestHijackAndRunArgon2OutOfProcessHandlerOnArgArgon2ModeError(c *C) {
 	runArgon2Called := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
 		runArgon2Called++
@@ -116,7 +116,7 @@ func (*mockArgon2KDF) Time(mode sb.Argon2Mode, params *sb.Argon2CostParams) (tim
 	return 0, nil
 }
 
-func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNormalMode(c *C) {
+func (*argon2Suite) TestHijackAndRunArgon2OutOfProcessHandlerOnArgNormalMode(c *C) {
 	runArgon2Called := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
 		runArgon2Called++

--- a/secboot/argon2_out_of_process_sb_test.go
+++ b/secboot/argon2_out_of_process_sb_test.go
@@ -36,12 +36,9 @@ var _ = Suite(&argon2Suite{})
 
 func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandler(c *C) {
 	argon2Called := 0
-	lockReleaseCalled := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
 		argon2Called++
-		return func() {
-			lockReleaseCalled++
-		}, nil
+		return nil, nil
 	})
 	defer restore()
 
@@ -49,28 +46,25 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandler(c *C) {
 	restore = secboot.MockOsExit(func(code int) {
 		exitCalled++
 		c.Assert(code, Equals, 0)
+		panic("os.Exit(0)")
 	})
 	defer restore()
 
 	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--argon2-proc"})
 	defer restore()
 
-	// Since we override os.Exit(0), we expect to panic
-	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "internal error: not reachable")
+	// Since we override os.Exit(0), we expect to panic (injected above)
+	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "os.Exit(0)")
 
 	c.Check(argon2Called, Equals, 1)
 	c.Check(exitCalled, Equals, 1)
-	c.Check(lockReleaseCalled, Equals, 1)
 }
 
 func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNotTriggered(c *C) {
 	argon2Called := 0
-	lockReleaseCalled := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
 		argon2Called++
-		return func() {
-			lockReleaseCalled++
-		}, nil
+		return nil, nil
 	})
 	defer restore()
 
@@ -78,6 +72,7 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNotTriggered(c *
 	restore = secboot.MockOsExit(func(code int) {
 		exitCalled++
 		c.Assert(code, Equals, 0)
+		panic("injected panic")
 	})
 	defer restore()
 
@@ -89,39 +84,35 @@ func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerNotTriggered(c *
 	} {
 		restore := secboot.MockOsArgs(args)
 		defer restore()
-		err := secboot.MaybeRunArgon2OutOfProcessRequestHandler()
-		c.Assert(err, IsNil)
+		// This should exit early before running the argon2 helper and calling os.Exit (and no injected panic)
+		secboot.MaybeRunArgon2OutOfProcessRequestHandler()
 	}
 
 	c.Check(argon2Called, Equals, 0)
 	c.Check(exitCalled, Equals, 0)
-	c.Check(lockReleaseCalled, Equals, 0)
 }
 
 func (*argon2Suite) TestMaybeRunArgon2OutOfProcessRequestHandlerError(c *C) {
 	argon2Called := 0
-	lockReleaseCalled := 0
 	restore := secboot.MockSbWaitForAndRunArgon2OutOfProcessRequest(func(_ io.Reader, _ io.WriteCloser, _ sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error) {
 		argon2Called++
-		return func() {
-			lockReleaseCalled++
-		}, errors.New("boom!")
+		return nil, errors.New("boom!")
 	})
 	defer restore()
 
 	exitCalled := 0
 	restore = secboot.MockOsExit(func(code int) {
 		exitCalled++
-		c.Assert(code, Equals, 0)
+		c.Assert(code, Equals, 1)
+		panic("os.Exit(1)")
 	})
 	defer restore()
 
 	restore = secboot.MockOsArgs([]string{"/path/to/cmd", "--argon2-proc"})
 	defer restore()
 
-	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler(), ErrorMatches, "cannot run request: boom!")
+	c.Assert(secboot.MaybeRunArgon2OutOfProcessRequestHandler, Panics, "os.Exit(1)")
 
 	c.Check(argon2Called, Equals, 1)
-	c.Check(exitCalled, Equals, 0)
-	c.Check(lockReleaseCalled, Equals, 1)
+	c.Check(exitCalled, Equals, 1)
 }

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -22,6 +22,7 @@ package secboot
 
 import (
 	"io"
+	"os"
 
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
@@ -448,4 +449,16 @@ func MockDisksDevlinks(f func(node string) ([]string, error)) (restore func()) {
 	return func() {
 		disksDevlinks = old
 	}
+}
+
+func MockOsArgs(args []string) (restore func()) {
+	return testutil.Mock(&os.Args, args)
+}
+
+func MockOsExit(f func(code int)) (restore func()) {
+	return testutil.Mock(&osExit, f)
+}
+
+func MockSbWaitForAndRunArgon2OutOfProcessRequest(f func(in io.Reader, out io.WriteCloser, watchdog sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error)) (restore func()) {
+	return testutil.Mock(&sbWaitForAndRunArgon2OutOfProcessRequest, f)
 }

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -23,6 +23,8 @@ package secboot
 import (
 	"io"
 	"os"
+	"os/exec"
+	"time"
 
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
@@ -459,6 +461,18 @@ func MockOsExit(f func(code int)) (restore func()) {
 	return testutil.Mock(&osExit, f)
 }
 
+func MockOsReadlink(f func(name string) (string, error)) (restore func()) {
+	return testutil.Mock(&osReadlink, f)
+}
+
 func MockSbWaitForAndRunArgon2OutOfProcessRequest(f func(in io.Reader, out io.WriteCloser, watchdog sb.Argon2OutOfProcessWatchdogHandler) (lockRelease func(), err error)) (restore func()) {
 	return testutil.Mock(&sbWaitForAndRunArgon2OutOfProcessRequest, f)
+}
+
+func MockSbNewOutOfProcessArgon2KDF(f func(newHandlerCmd func() (*exec.Cmd, error), timeout time.Duration, watchdog sb.Argon2OutOfProcessWatchdogMonitor) sb.Argon2KDF) (restore func()) {
+	return testutil.Mock(&sbNewOutOfProcessArgon2KDF, f)
+}
+
+func MockSbSetArgon2KDF(f func(kdf sb.Argon2KDF) sb.Argon2KDF) (restore func()) {
+	return testutil.Mock(&sbSetArgon2KDF, f)
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -26,6 +26,7 @@ package secboot
 
 import (
 	"errors"
+	"os"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
@@ -267,4 +268,18 @@ func MarkSuccessful() error {
 	}
 
 	return nil
+}
+
+func isOutOfProcessArgon2KDFMode(args []string) bool {
+	if len(os.Args) != len(args)+1 {
+		return false
+	}
+
+	for i := 0; i < len(args); i++ {
+		if os.Args[i+1] != args[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -26,7 +26,6 @@ package secboot
 
 import (
 	"errors"
-	"os"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
@@ -268,18 +267,4 @@ func MarkSuccessful() error {
 	}
 
 	return nil
-}
-
-func isOutOfProcessArgon2KDFMode(args []string) bool {
-	if len(os.Args) != len(args)+1 {
-		return false
-	}
-
-	for i := 0; i < len(args); i++ {
-		if os.Args[i+1] != args[i] {
-			return false
-		}
-	}
-
-	return true
 }

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1161,7 +1161,7 @@ func (s *secbootSuite) TestSealKey(c *C) {
 				expectedKDFOptions = &sb.Argon2Options{Mode: sb.Argon2id, TargetDuration: tc.volumesAuth.KDFTime}
 			case "argon2i":
 				expectedKDFOptions = &sb.Argon2Options{Mode: sb.Argon2i, TargetDuration: tc.volumesAuth.KDFTime}
-			case "pbkdf2", "":
+			case "pbkdf2":
 				expectedKDFOptions = &sb.PBKDF2Options{TargetDuration: tc.volumesAuth.KDFTime}
 			}
 			c.Assert(params.KDFOptions, DeepEquals, expectedKDFOptions)

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -487,20 +487,13 @@ func ProvisionForCVM(initramfsUbuntuSeedDir string) error {
 func kdfOptions(volumesAuth *device.VolumesAuthOptions) (sb.KDFOptions, error) {
 	switch volumesAuth.KDFType {
 	case "":
-		// TODO:FDEM:FIX: default to out-of-process argon2id implementation
-		return &sb.PBKDF2Options{
-			TargetDuration: volumesAuth.KDFTime,
-		}, nil
+		return nil, nil
 	case "argon2id":
-		// TODO:FDEM:FIX: sb.SetArgon2KDF(sb.InProcessArgon2KDF) or intentionally fail
-		// until out-of-process variant is implemented?
 		return &sb.Argon2Options{
 			Mode:           sb.Argon2id,
 			TargetDuration: volumesAuth.KDFTime,
 		}, nil
 	case "argon2i":
-		// TODO:FDEM:FIX: sb.SetArgon2KDF(sb.InProcessArgon2KDF) or intentionally fail
-		// until out-of-process variant is implemented?
 		return &sb.Argon2Options{
 			Mode:           sb.Argon2i,
 			TargetDuration: volumesAuth.KDFTime,


### PR DESCRIPTION

`MaybeRunArgon2OutOfProcessRequestHandler` is supposed to be called from the `main()` of binaries involved with sealing/unsealing of keys (i.e. `snapd` and `snap-bootstrap`).

This switches the binary to a special mode where it acts as an argon2 out-of-process helper command, and exits when its work is done.

For more context, check docs for [`sb.WaitForAndRunArgon2OutOfProcessRequest`](https://github.com/canonical/secboot/blob/30317622bbbc348db12d91659332ed66cd9da642/argon2_out_of_process_support.go#L453) and [`sb.NewOutOfProcessArgon2KDF` ](https://github.com/canonical/secboot/blob/30317622bbbc348db12d91659332ed66cd9da642/argon2_out_of_process_support.go#L1066)for details on how the flow works in secboot.

This PR also reverts workaround from https://github.com/canonical/snapd/pull/15058 as now the argon2 kdf variants are working.