### PR TITLE
tests: automatically run nested tests for certain go changes

### DIFF
--- a/tests/lib/spread/rules/nested.yaml
+++ b/tests/lib/spread/rules/nested.yaml
@@ -13,3 +13,28 @@ rules:
     from:
       - tests/lib/assertions/.*
     to: [tests/nested/]
+
+  exclude-tests:
+    from:
+      - .*_test.go
+    to: [$NONE]
+
+  code-changes:
+    from:
+      - secboot/.*
+      - boot/.*
+      - bootloader/.*
+      - overlord/devicestate/.*
+      - overlord/install/.*
+      - overlord/fdestate/.*
+      - overlord/restart/.*
+      - cmd/snap-bootstrap/.*
+      - kernel/.*
+      - gadget/.*
+      - seed/.*
+      - core-initrd/.*
+      - overlord/configstate/configcore/coredump.go
+      - overlord/configstate/configcore/kernel.go
+      - overlord/configstate/configcore/timezone.go
+      - wrappers/core18.go
+    to: [tests/nested/]


### PR DESCRIPTION
This will automatically trigger nested tests if certain key areas of the go code are changed, while excluding changes to go tests. The change will be helpful in cases where a developer makes a change and should have added the "Run nested" label but forgot to do so.

As an example, any changes inside the `kernel` directory will automatically trigger nested tests:
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p "google:ubuntu-24.04-64" -c kernel/fde/fde.go 
google:ubuntu-24.04-64:tests/nested/
```
while changes to a key directory but to a unit test will not:
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p "google:ubuntu-24.04-64" -c overlord/devicestate/systems_test.go 

$
```