### PR TITLE
core-initrd,snap-bootstrap: look at env to mount directly to /sysroot

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -346,6 +346,9 @@ func (s *baseInitramfsMountsSuite) SetUpTest(c *C) {
 
 	s.tmpDir = c.MkDir()
 
+	restore = main.MockOsGetenv(func(envVar string) string { return "" })
+	s.AddCleanup(restore)
+
 	// mock /run/mnt
 	dirs.SetRootDir(s.tmpDir)
 	restore = func() { dirs.SetRootDir("") }
@@ -811,6 +814,12 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallModeWithCompsHappy(c *C
 	default:
 		c.Skip("Unknown EFI arch")
 	}
+	defer main.MockOsGetenv(func(envVar string) string {
+		if envVar == "CORE24_PLUS_INITRAMFS" {
+			return "1"
+		}
+		return ""
+	})()
 
 	var systemctlArgs [][]string
 	systemctlNumCalls := 0
@@ -3607,6 +3616,12 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeHappy(c *C) {
 		return nil, nil
 	})
 	defer systemctlMock()
+	defer main.MockOsGetenv(func(envVar string) string {
+		if envVar == "CORE24_PLUS_INITRAMFS" {
+			return "1"
+		}
+		return ""
+	})()
 
 	// setup a bootloader for setting the bootenv after we are done
 	bloader := bootloadertest.Mock("mock", c.MkDir())

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -249,3 +249,11 @@ func MockBuildInstallObserver(f func(model *asserts.Model, gadgetDir string, use
 		installBuildInstallObserver = old
 	}
 }
+
+func MockOsGetenv(mock func(string) string) (restore func()) {
+	old := osGetenv
+	osGetenv = mock
+	return func() {
+		osGetenv = old
+	}
+}

--- a/core-initrd/latest/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
@@ -13,6 +13,7 @@ After=dbus.socket
 [Service]
 Type=oneshot
 RemainAfterExit=true
+Environment="CORE24_PLUS_INITRAMFS=1"
 ExecStart=/usr/lib/snapd/snap-bootstrap initramfs-mounts
 StandardOutput=journal+console
 StandardError=journal+console


### PR DESCRIPTION
Previously we looked at the model and mounted base/rootfs directly if it was Ubuntu 24+. Now, we check instead an environment variable that is set if the initramfs is 24+.

This is done so now the kernels that contain the 24+ initramfs can be booted in older Ubuntu releases with older bases. This situation is not something we really support, as the systemd of the initramfs will not match the one in the system, but it is something that could happen while remodeling and it seems safer to allow this at least temporarily.