### PR TITLE
tests: wait more time until the openstack intance is with Active state

### DIFF
--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -2,6 +2,7 @@
         key: '$(HOST: echo "$SPREAD_OPENSTACK_ENV")'
         plan: staging-cpu2-ram4-disk20
         halt-timeout: 2h
+        wait-timeout: 5m
         groups: [default]        
         environment:
             HTTP_PROXY: 'http://squid.internal:3128'


### PR DESCRIPTION
The wait timeout is used to configure the time that spread waits until the instances is allocated with ACTIVE state (and ready to be used).

This is needed to deal with timeouts trying to allocate instances.
