### PR TITLE
tests: run tests on master branch nightly

### DIFF
--- a/.github/workflows/nested-systems.json
+++ b/.github/workflows/nested-systems.json
@@ -1,0 +1,32 @@
+{
+    "include": [
+      {
+        "group": "nested-ubuntu-18.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-18.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      },
+      {
+        "group": "nested-ubuntu-20.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-20.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      },
+      {
+        "group": "nested-ubuntu-22.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-24.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      },
+      {
+        "group": "nested-ubuntu-24.04",
+        "backend": "google-nested",
+        "systems": "ubuntu-24.04-64",
+        "tasks": "tests/nested/...",
+        "rules": "nested"
+      }
+   ]
+}

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -85,6 +85,7 @@ jobs:
         run: |
           echo "fundamental-systems=$(jq -c . ./.github/workflows/fundamental-systems.json)" >> $GITHUB_OUTPUT
           echo "non-fundamental-systems=$(jq -c . ./.github/workflows/non-fundamental-systems.json)" >> $GITHUB_OUTPUT
+          echo "nested-systems=$(jq -c . ./.github/workflows/nested-systems.json)" >> $GITHUB_OUTPUT
 
   spread-master-fundamental:
     if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-fundamental') }}
@@ -124,3 +125,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}
+
+  spread-master-nested:
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-nested') }}
+    uses: ./.github/workflows/spread-tests.yaml
+    name: "spread master ${{ matrix.group }}"
+    with:
+      # Github doesn't support passing sequences as parameters.
+      # Instead here we create a json array and pass it as a string.
+      # Then in the spread workflow it turns it into a sequence
+      # using the fromJSON expression.
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: ${{ matrix.tasks }}
+      rules: ${{ matrix.rules }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.read-systems.outputs.nesteds-systems) }}

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -70,14 +70,26 @@ jobs:
       use-snapd-snap-from-master: true
       spread-experimental-features: gate-auto-refresh-hook
 
-  spread-test-openstack:
-    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-openstack') }}
+  spread-master-google:
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-google') }}
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: google
+      backend: google
+      systems: 'ALL'
+      tasks: 'tests/...'
+      rules: ''
+      use-snapd-snap-from-master: true
+
+  spread-master-openstack:
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-openstack') }}
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: 'openstack'
       backend: 'openstack'
       systems: 'ALL'
-      tasks: 'tests/main/...'
+      tasks: 'tests/...'
       rules: ''
       use-snapd-snap-from-master: true

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -143,4 +143,4 @@ jobs:
       rules: ${{ matrix.rules }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.read-systems.outputs.nesteds-systems) }}
+      matrix: ${{ fromJson(needs.read-systems.outputs.nested-systems) }}

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -75,6 +75,7 @@ jobs:
     outputs:
       fundamental-systems: ${{ steps.read-systems.outputs.fundamental-systems }}
       non-fundamental-systems: ${{ steps.read-systems.outputs.non-fundamental-systems }}
+      nested-systems: ${{ steps.read-systems.outputs.nested-systems }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -70,26 +70,57 @@ jobs:
       use-snapd-snap-from-master: true
       spread-experimental-features: gate-auto-refresh-hook
 
-  spread-master-google:
-    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-google') }}
-    uses: ./.github/workflows/spread-tests.yaml
-    with:
-      runs-on: '["self-hosted", "spread-enabled"]'
-      group: google
-      backend: google
-      systems: 'ALL'
-      tasks: 'tests/...'
-      rules: ''
-      use-snapd-snap-from-master: true
+  read-systems:
+    runs-on: ubuntu-latest
+    outputs:
+      fundamental-systems: ${{ steps.read-systems.outputs.fundamental-systems }}
+      non-fundamental-systems: ${{ steps.read-systems.outputs.non-fundamental-systems }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  spread-master-openstack:
-    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-openstack') }}
+      - name: Read matrix file
+        id: read-systems
+        shell: bash
+        run: |
+          echo "fundamental-systems=$(jq -c . ./.github/workflows/fundamental-systems.json)" >> $GITHUB_OUTPUT
+          echo "non-fundamental-systems=$(jq -c . ./.github/workflows/non-fundamental-systems.json)" >> $GITHUB_OUTPUT
+
+  spread-master-fundamental:
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-fundamental') }}
     uses: ./.github/workflows/spread-tests.yaml
+    name: "spread master ${{ matrix.group }}"
     with:
+      # Github doesn't support passing sequences as parameters.
+      # Instead here we create a json array and pass it as a string.
+      # Then in the spread workflow it turns it into a sequence
+      # using the fromJSON expression.
       runs-on: '["self-hosted", "spread-enabled"]'
-      group: 'openstack'
-      backend: 'openstack'
-      systems: 'ALL'
-      tasks: 'tests/...'
-      rules: ''
-      use-snapd-snap-from-master: true
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: ${{ matrix.tasks }}
+      rules: ${{ matrix.rules }}
+      is-fundamental: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.read-systems.outputs.fundamental-systems) }}
+
+  spread-master-not-fundamental:
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-master-not-fundamental') }}
+    uses: ./.github/workflows/spread-tests.yaml
+    name: "spread master ${{ matrix.group }}"
+    with:
+      # Github doesn't support passing sequences as parameters.
+      # Instead here we create a json array and pass it as a string.
+      # Then in the spread workflow it turns it into a sequence
+      # using the fromJSON expression.
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: ${{ matrix.tasks }}
+      rules: ${{ matrix.rules }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -257,7 +257,11 @@ jobs:
           export SPREAD_USE_PREBUILT_SNAPD_SNAP=true
           
           if [ "${{ inputs.use-snapd-snap-from-master }}" = true ]; then
-            export SPREAD_USE_SNAPD_SNAP_URL=https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
+            if [[ "${{ inputs.group }}" == *"-arm64"* ]]; then
+              export SPREAD_USE_SNAPD_SNAP_URL=https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_arm64.snap
+            else
+              export SPREAD_USE_SNAPD_SNAP_URL=https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
+            fi
           fi
 
           # This could be the case when either there are not systems for a group or

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
   push:
-    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
+    branches: [ "release/**", "core-snap-security-release/**", "security-release/**" ]
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -298,6 +298,7 @@ jobs:
     outputs:
       fundamental-systems: ${{ steps.read-systems.outputs.fundamental-systems }}
       non-fundamental-systems: ${{ steps.read-systems.outputs.non-fundamental-systems }}
+      nested-systems: ${{ steps.read-systems.outputs.nested-systems }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -308,6 +308,7 @@ jobs:
         run: |
           echo "fundamental-systems=$(jq -c . ./.github/workflows/fundamental-systems.json)" >> $GITHUB_OUTPUT
           echo "non-fundamental-systems=$(jq -c . ./.github/workflows/non-fundamental-systems.json)" >> $GITHUB_OUTPUT
+          echo "nested-systems=$(jq -c . ./.github/workflows/nested-systems.json)" >> $GITHUB_OUTPUT
 
   spread-fundamental:
     uses: ./.github/workflows/spread-tests.yaml
@@ -399,10 +400,10 @@ jobs:
       # using the fromJSON expression.
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
-      backend: 'google-nested'
+      backend: ${{ matrix.backend }}
       systems: ${{ matrix.systems }}
-      tasks: 'tests/nested/...'
-      rules: 'nested'
+      tasks: ${{ matrix.tasks }}
+      rules: ${{ matrix.rules }}
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems
@@ -410,17 +411,7 @@ jobs:
       # interrupting spread, notably, does not work today. As such disable
       # fail-fast while we tackle that problem upstream.
       fail-fast: false
-      matrix:
-        include:
-          - group: nested-ubuntu-18.04
-            systems: 'ubuntu-18.04-64'
-          - group: nested-ubuntu-20.04
-            systems: 'ubuntu-20.04-64'
-          - group: nested-ubuntu-22.04
-            systems: 'ubuntu-22.04-64'
-          - group: nested-ubuntu-24.04
-            systems: 'ubuntu-24.04-64'
-
+      matrix: ${{ fromJson(needs.read-systems.outputs.nested-systems) }}
 
   # The spread-results-reporter needs the PR number to be able to 
   # comment on the relevant PR with spread failures. Because the PR 


### PR DESCRIPTION
This change runs the tests using master branch nightly instead of after a change is pushed to master.

We do that in order to reduce the amount of instances used in google.

Also the nightly job was renamed to nightly-static-analysis which is a more representative name.
