### PR TITLE
cmd: drop unused check-syntax-c target

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -28,20 +28,6 @@ subdirs = \
 # TODO: conver those to autotools-style tests later
 check: check-unit-tests
 
-# Force particular coding style on all source and header files.
-.PHONY: check-syntax-c
-check-syntax-c:
-	echo "WARNING: check-syntax-c produces different results for different version of indent"
-	echo "Your version of indent: `indent --version`"
-	@d=`mktemp -d`; \
-	trap 'rm -rf $d' EXIT; \
-	for f in $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch])) ; do \
-	       out="$$d/`basename $$f.out`"; \
-	       echo "Checking $$f ... "; \
-	       HOME=$(srcdir) indent "$$f" -o "$$out"; \
-	       diff -Naur "$$f" "$$out" || exit 1; \
-	done;
-
 .PHONY: check-unit-tests
 if WITH_UNIT_TESTS
 check-unit-tests: snap-confine/unit-tests system-shutdown/unit-tests libsnap-confine-private/unit-tests snap-device-helper/unit-tests


### PR DESCRIPTION
The target is no longer used anywhere.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
