### PR TITLE
gadget: make reinstalls honor existing sizes of partitions

### DIFF
--- a/gadget/gadgettest/examples.go
+++ b/gadget/gadgettest/examples.go
@@ -60,6 +60,36 @@ volumes:
       type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
 `
 
+// Save partition with min-size
+const RaspiSimplifiedMinSizeYaml = `
+volumes:
+  pi:
+    bootloader: u-boot
+    schema: mbr
+    structure:
+    - filesystem: vfat
+      name: ubuntu-seed
+      role: system-seed
+      size: 1200M
+      type: 0C
+    - filesystem: vfat
+      name: ubuntu-boot
+      role: system-boot
+      size: 750M
+      type: 0C
+    - filesystem: ext4
+      name: ubuntu-save
+      role: system-save
+      min-size: 8M
+      size: 32M
+      type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+    - filesystem: ext4
+      name: ubuntu-data
+      role: system-data
+      size: 1500M
+      type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+`
+
 // from a rpi without the kernel assets or content layout for simplicity's sake
 // and without ubuntu-save
 const RaspiSimplifiedNoSaveYaml = `

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -40,7 +40,7 @@ var (
 	RemoveCreatedPartitions = removeCreatedPartitions
 	EnsureNodesExist        = ensureNodesExist
 
-	CreatedDuringInstall        = createdDuringInstall
+	IndexIfCreatedDuringInstall = indexIfCreatedDuringInstall
 	TestCreateMissingPartitions = createMissingPartitions
 )
 

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -298,7 +298,12 @@ func createPartitions(volumes map[string]*gadget.Volume, gadgetRoot, bootDevice 
 	}
 
 	// remove partitions added during a previous install attempt
-	if err := removeCreatedPartitions(gadgetRoot, bootVol, diskVolume); err != nil {
+	// TODO we probably do not need to do this, as we are re-creating the
+	// partitions with the same sizes as the ones removed. We even check
+	// that labels are the same in gadget.EnsureVolumeCompatibility, so no
+	// data for the partition will actually change.
+	deletedOffsetSize, err := removeCreatedPartitions(gadgetRoot, bootVol, diskVolume)
+	if err != nil {
 		return "", nil, 0, fmt.Errorf("cannot remove partitions from previous install: %v", err)
 	}
 	// at this point we removed any existing partition, nuke any
@@ -315,7 +320,7 @@ func createPartitions(volumes map[string]*gadget.Volume, gadgetRoot, bootDevice 
 		opts := &CreateOptions{
 			GadgetRootDir: gadgetRoot,
 		}
-		created, err = createMissingPartitions(diskVolume, bootVol, opts)
+		created, err = createMissingPartitions(diskVolume, bootVol, opts, deletedOffsetSize)
 	})
 	if err != nil {
 		return "", nil, 0, fmt.Errorf("cannot create the partitions: %v", err)

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -238,6 +238,24 @@ func (s *installSuite) TestInstallRunExistingPartitions(c *C) {
 	})
 }
 
+func (s *installSuite) TestInstallRunExistingPartitionsMinSize(c *C) {
+	// When we have existing partitions with size within the interval
+	// [min-size, size), make sure that the current on disk size is honored
+	// and that "size" from the gadget is not used instead.
+	s.testInstall(c, installOpts{
+		gadgetYaml: gadgettest.RaspiSimplifiedMinSizeYaml,
+		diskMappings: map[string]*disks.MockDiskMapping{
+			"mmcblk0": gadgettest.ExpectedRaspiMockDiskMapping,
+		},
+		disks:      defaultDiskSetup,
+		traitsJSON: gadgettest.ExpectedRaspiDiskVolumeDeviceTraitsJSON,
+		traits: map[string]gadget.DiskVolumeDeviceTraits{
+			"pi": gadgettest.ExpectedRaspiDiskVolumeDeviceTraits,
+		},
+		existingParts: true,
+	})
+}
+
 func (s *installSuite) TestInstallRunEncryptionExistingPartitions(c *C) {
 	s.testInstall(c, installOpts{
 		gadgetYaml: gadgettest.RaspiSimplifiedYaml,


### PR DESCRIPTION
When performing a re-install, snapd uses "size" from the gadget when re-creating partitions that it just removed. However, in the case of using min-size there is a possibility that the deleted partition size was smaller but still compatible with the installed gadget. Use the size of the deleted partition, as we want to respect the already existing layout - otherewise we might destroy partitions that are not re-created in the re-install and that could appear after the partitions using min-size.