### PR TITLE
interfaces/u2f: add Arculus AuthentiKey

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -202,6 +202,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "1a44",
 		ProductIDPattern: "1501|1502|1503|1506|1507|1508|1509|150A",
 	},
+	{
+		Name:             "Arculus AuthentiKey",
+		VendorIDPattern:  "3752",
+		ProductIDPattern: "0001",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -93,7 +93,7 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 33)
+	c.Assert(spec.Snippets(), HasLen, 34)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
Adds Arculus AuthentiKey USB security key device that supports FIDO U2F, CTAP2.1, and PIV.

http://www.linux-usb.org/usb.ids has the 3752:0001 device id as well as https://ccid.apdu.fr/ccid/shouldwork.html#0x37520x0001

Tested webauthn.io register and authenticate with chromium-browser and firefox snaps under a snapcraft built local install and also did ./run-checks.

This is a redo of https://github.com/canonical/snapd/pull/15071 which will be closed.
