### PR TITLE
tests: update opensuse tumbleweed dependecies

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -817,7 +817,7 @@ pkg_dependencies_opensuse(){
         "
     if os.query is-opensuse tumbleweed; then
         echo "
-            libfwupd2
+            libfwupd3
         "
     fi
 }


### PR DESCRIPTION
As libfwupd2 is not available any more for tumbleweed, we need to install libfwupd3 instead.

This missing lib is breaking tests in tumbleweed currently

