### PR TITLE
s/a/notify: implement protocol v5 with metadata tagging parser

### DIFF
--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -18,6 +18,10 @@ func MockSyscall(syscall func(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err uni
 	return testutil.Mock(&doSyscall, syscall)
 }
 
+func MockApparmorKernelFeatures(f func() ([]string, error)) (restore func()) {
+	return testutil.Mock(&apparmorKernelFeatures, f)
+}
+
 // VersionAndCheck couples protocol version with a support check function which
 // returns true if the version is supported. This type is used so that
 // `versions` and `versionLikelySupportedChecks` can be mocked to avoid

--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -49,6 +49,14 @@ func MockVersionLikelySupportedChecks(pairs []VersionAndCheck) (restore func()) 
 	return restore
 }
 
+// TODO: remove this once v5 is no longer manually disabled
+func OverrideV5ManuallyDisabled() (restore func()) {
+	v5ManuallyDisabled = false
+	return func() {
+		v5ManuallyDisabled = true
+	}
+}
+
 func MockIoctl(f func(fd uintptr, req IoctlRequest, buf IoctlRequestBuffer) ([]byte, error)) (restore func()) {
 	return testutil.Mock(&doIoctl, f)
 }

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -433,11 +433,11 @@ func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
 	})
 }
 
-func (s *messageSuite) TestMsgNotificationFileMarshalUnmarshalBinary(c *C) {
+func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 	if arch.Endian() == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
-	// Notification for accessing a the /root/.ssh/ file.
+	// Notification for accessing the /root/.ssh/ directory.
 	bytes := []byte{
 		0x4c, 0x0, // Length == 76 bytes
 		0x3, 0x0, // Protocol
@@ -463,7 +463,7 @@ func (s *messageSuite) TestMsgNotificationFileMarshalUnmarshalBinary(c *C) {
 	var msg notify.MsgNotificationFile
 	err := msg.UnmarshalBinary(bytes)
 	c.Assert(err, IsNil)
-	c.Assert(msg, DeepEquals, notify.MsgNotificationFile{
+	expected := notify.MsgNotificationFile{
 		MsgNotificationOp: notify.MsgNotificationOp{
 			MsgNotification: notify.MsgNotification{
 				MsgHeader: notify.MsgHeader{
@@ -481,11 +481,336 @@ func (s *messageSuite) TestMsgNotificationFileMarshalUnmarshalBinary(c *C) {
 			Class: notify.AA_CLASS_FILE,
 		},
 		Name: "/root/.ssh/",
-	})
+	}
+	c.Assert(msg, DeepEquals, expected)
 
+	// Check that MsgNotificationFiles can be marshalled and are identical
+	// after unmarshal.
 	buf, err := msg.MarshalBinary()
 	c.Assert(err, IsNil)
-	c.Assert(buf, DeepEquals, bytes)
+	var roundTripMsg notify.MsgNotificationFile
+	err = roundTripMsg.UnmarshalBinary(buf)
+	c.Assert(err, IsNil)
+	c.Assert(roundTripMsg, DeepEquals, expected)
+}
+
+func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C) {
+	if arch.Endian() == binary.BigEndian {
+		c.Skip("test only written for little-endian architectures")
+	}
+	// Notification for accessing the /root/.ssh/ directory.
+	bytes := []byte{
+		0x52, 0x0, // Length == 82 bytes
+		0x5, 0x0, // Protocol
+		0x4, 0x0, // Notification type == notify.APPARMOR_NOTIF_OP
+		0x0,                                    // Signalled
+		0x0,                                    // Reserved
+		0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // ID (request #2, just a number)
+		0xf3, 0xff, 0xff, 0xff, // Error -13 EACCESS
+		0x4, 0x0, 0x0, 0x0, // Allow - ???
+		0x4, 0x0, 0x0, 0x0, // Deny - ???
+		0x19, 0x8, 0x0, 0x0, // PID
+		0x3a, 0x0, 0x0, 0x0, // Label at +58 bytes into buffer
+		0x2, 0x0, // Class - AA_CLASS_FILE
+		0x0, 0x0, // Op - ???
+		0x0, 0x0, 0x0, 0x0, // SUID
+		0x0, 0x0, 0x0, 0x0, // OUID
+		0x46, 0x0, 0x0, 0x0, // Name at +70 bytes into buffer
+		0x0, 0x0, 0x0, 0x0, // Tagset headers empty
+		0x0, 0x0, // Tagset count - 0
+		0x74, 0x65, 0x73, 0x74, 0x2d, 0x70, 0x72, 0x6f, 0x6d, 0x70, 0x74, 0x0, // "test-prompt\0"
+		0x2f, 0x72, 0x6f, 0x6f, 0x74, 0x2f, 0x2e, 0x73, 0x73, 0x68, 0x2f, 0x0, // "/root/.ssh/\0"
+	}
+	c.Assert(bytes, HasLen, 82)
+
+	var msg notify.MsgNotificationFile
+	err := msg.UnmarshalBinary(bytes)
+	c.Assert(err, IsNil)
+	expected := notify.MsgNotificationFile{
+		MsgNotificationOp: notify.MsgNotificationOp{
+			MsgNotification: notify.MsgNotification{
+				MsgHeader: notify.MsgHeader{
+					Length:  82,
+					Version: 5,
+				},
+				NotificationType: notify.APPARMOR_NOTIF_OP,
+				ID:               2,
+				Error:            -13,
+			},
+			Allow: 4,
+			Deny:  4,
+			Pid:   0x819,
+			Label: "test-prompt",
+			Class: notify.AA_CLASS_FILE,
+		},
+		Name: "/root/.ssh/",
+	}
+	c.Assert(msg, DeepEquals, expected)
+
+	// Check that MsgNotificationFiles can be marshalled and are identical
+	// after unmarshal.
+	buf, err := msg.MarshalBinary()
+	c.Assert(err, IsNil)
+	var roundTripMsg notify.MsgNotificationFile
+	err = roundTripMsg.UnmarshalBinary(buf)
+	c.Assert(err, IsNil)
+	c.Assert(roundTripMsg, DeepEquals, expected)
+}
+
+func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
+	if arch.Endian() == binary.BigEndian {
+		c.Skip("test only written for little-endian architectures")
+	}
+	// Notification for accessing /file
+	bytes := []byte{
+		0x7f, 0x0, // Length == 127 bytes
+		0x5, 0x0, // Protocol
+		0x4, 0x0, // Notification type == notify.APPARMOR_NOTIF_OP
+		0x0,                                    // Signalled
+		0x0,                                    // Reserved
+		0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // ID (request #2, just a number)
+		0xf3, 0xff, 0xff, 0xff, // Error -13 EACCESS
+		0xaa, 0xaa, 0xaa, 0xaa, // Allow - ???
+		0x55, 0x55, 0x55, 0x55, // Deny - ???
+		0x19, 0x8, 0x0, 0x0, // PID
+		0x40, 0x0, 0x0, 0x0, // Label at +64 bytes into buffer
+		0x2, 0x0, // Class - AA_CLASS_FILE
+		0x0, 0x0, // Op - ???
+		0xe8, 0x03, 0x0, 0x0, // SUID - 1000
+		0xe8, 0x03, 0x0, 0x0, // OUID
+		0x48, 0x0, 0x0, 0x0, // Name at +72 bytes into buffer
+		0x50, 0x0, 0x0, 0x0, // Tagset headers at +80 bytes into the buffer (need to be 8-byte-aligned)
+		0x02, 0x0, // Tagset count - 2
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // padding to make []data 8-byte-aligned
+		0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x0, // "profile\0"
+		0x2f, 0x66, 0x69, 0x6c, 0x65, 0x0, // "/file\0"
+		0x0, 0x0, // padding to make tagset headers 8-byte-aligned
+		0x03, 0x01, 0x00, 0x00, // tagset 1 permission mask
+		0x03, 0x00, 0x00, 0x00, // tagset 1 tag count
+		0x68, 0x00, 0x00, 0x00, // tagset 1 starts at +104 into the buffer
+		0x0c, 0x00, 0x00, 0x00, // tagset 2 permission mask
+		0x02, 0x00, 0x00, 0x00, // tagset 2 tag count
+		0x77, 0x00, 0x00, 0x00, // tagset 2 starts at +119 into the buffer
+		0x6f, 0x6e, 0x65, 0x00, // "one\0"
+		0x74, 0x77, 0x6f, 0x00, // "two\0"
+		0x74, 0x68, 0x72, 0x65, 0x65, 0x00, // "three\0"
+		0x00,                   // end of tagset 1
+		0x61, 0x62, 0x63, 0x00, // "abc\0"
+		0x65, 0x66, 0x00, // "ef\0"
+		0x00, // end of tagset 2
+	}
+	c.Assert(bytes, HasLen, 127)
+
+	var msg notify.MsgNotificationFile
+	err := msg.UnmarshalBinary(bytes)
+	c.Assert(err, IsNil)
+	expected := notify.MsgNotificationFile{
+		MsgNotificationOp: notify.MsgNotificationOp{
+			MsgNotification: notify.MsgNotification{
+				MsgHeader: notify.MsgHeader{
+					Length:  127,
+					Version: 5,
+				},
+				NotificationType: notify.APPARMOR_NOTIF_OP,
+				ID:               2,
+				Error:            -13,
+			},
+			Allow: 0xaaaaaaaa,
+			Deny:  0x55555555,
+			Pid:   0x819,
+			Label: "profile",
+			Class: notify.AA_CLASS_FILE,
+		},
+		SUID: 1000,
+		OUID: 1000,
+		Name: "/file",
+		Tagsets: map[notify.AppArmorPermission][]string{
+			notify.FilePermission(0x0103): {
+				"one",
+				"two",
+				"three",
+			},
+			notify.FilePermission(0x000c): {
+				"abc",
+				"ef",
+			},
+		},
+	}
+	c.Assert(msg, DeepEquals, expected)
+
+	// Check that MsgNotificationFiles can be marshalled and are identical
+	// after unmarshal.
+	buf, err := msg.MarshalBinary()
+	c.Assert(err, IsNil)
+	var roundTripMsg notify.MsgNotificationFile
+	err = roundTripMsg.UnmarshalBinary(buf)
+	c.Assert(err, IsNil)
+	// Messages may be marshalled slightly different, so length needs to be adjusted
+	expected.Length = roundTripMsg.Length
+	c.Assert(roundTripMsg, DeepEquals, expected)
+}
+
+func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAndEmptyTagsets(c *C) {
+	if arch.Endian() == binary.BigEndian {
+		c.Skip("test only written for little-endian architectures")
+	}
+	// Notification for accessing /file
+	bytes := []byte{
+		0x93, 0x0, // Length == 147 bytes
+		0x5, 0x0, // Protocol
+		0x4, 0x0, // Notification type == notify.APPARMOR_NOTIF_OP
+		0x0,                                    // Signalled
+		0x0,                                    // Reserved
+		0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // ID (request #2, just a number)
+		0xf3, 0xff, 0xff, 0xff, // Error -13 EACCESS
+		0xaa, 0xaa, 0xaa, 0xaa, // Allow - ???
+		0x55, 0x55, 0x55, 0x55, // Deny - ???
+		0x19, 0x8, 0x0, 0x0, // PID
+		0x40, 0x0, 0x0, 0x0, // Label at +64 bytes into buffer
+		0x2, 0x0, // Class - AA_CLASS_FILE
+		0x0, 0x0, // Op - ???
+		0xe8, 0x03, 0x0, 0x0, // SUID - 1000
+		0xe8, 0x03, 0x0, 0x0, // OUID
+		0x48, 0x0, 0x0, 0x0, // Name at +72 bytes into buffer
+		0x50, 0x0, 0x0, 0x0, // Tagset headers at +80 bytes into the buffer (need to be 8-byte-aligned)
+		0x04, 0x0, // Tagset count - 4
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // padding to make []data 8-byte-aligned
+		0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x0, // "profile\0"
+		0x2f, 0x66, 0x69, 0x6c, 0x65, 0x0, // "/file\0"
+		0x0, 0x0, // padding to make tagset headers 8-byte-aligned
+		// tagset 1 has no tags -- this should not happen in practice
+		0x01, 0x00, 0x00, 0x00, // tagset 1 permission mask
+		0x00, 0x00, 0x00, 0x00, // tagset 1 tag count
+		0x00, 0x00, 0x00, 0x00, // tagset 1 is empty
+		// tagsets 2-4 overlap, 3->(2/4), where 4 is a sebset of 2
+		0x02, 0x00, 0x00, 0x00, // tagset 2 permission mask
+		0x03, 0x00, 0x00, 0x00, // tagset 2 tag count
+		0x84, 0x00, 0x00, 0x00, // tagset 2 starts at +132 into the buffer
+		0x04, 0x00, 0x00, 0x00, // tagset 3 permission mask
+		0x02, 0x00, 0x00, 0x00, // tagset 3 tag count
+		0x80, 0x00, 0x00, 0x00, // tagset 3 starts at +128 into the buffer
+		0x08, 0x00, 0x00, 0x00, // tagset 4 permission mask
+		0x02, 0x00, 0x00, 0x00, // tagset 4 tag count
+		0x84, 0x00, 0x00, 0x00, // tagset 4 starts at +132 into the buffer
+		0x6f, 0x6e, 0x65, 0x00, // "one\0"
+		0x74, 0x77, 0x6f, 0x00, // "two\0"
+		0x74, 0x68, 0x72, 0x65, 0x65, 0x00, // "three\0"
+		0x66, 0x6f, 0x75, 0x72, 0x00, // "four\0"
+	}
+	c.Assert(bytes, HasLen, 147)
+
+	var msg notify.MsgNotificationFile
+	err := msg.UnmarshalBinary(bytes)
+	c.Assert(err, IsNil)
+	expected := notify.MsgNotificationFile{
+		MsgNotificationOp: notify.MsgNotificationOp{
+			MsgNotification: notify.MsgNotification{
+				MsgHeader: notify.MsgHeader{
+					Length:  147,
+					Version: 5,
+				},
+				NotificationType: notify.APPARMOR_NOTIF_OP,
+				ID:               2,
+				Error:            -13,
+			},
+			Allow: 0xaaaaaaaa,
+			Deny:  0x55555555,
+			Pid:   0x819,
+			Label: "profile",
+			Class: notify.AA_CLASS_FILE,
+		},
+		SUID: 1000,
+		OUID: 1000,
+		Name: "/file",
+		Tagsets: map[notify.AppArmorPermission][]string{
+			notify.FilePermission(0x01): []string(nil),
+			notify.FilePermission(0x02): {
+				"two",
+				"three",
+				"four",
+			},
+			notify.FilePermission(0x04): {
+				"one",
+				"two",
+			},
+			notify.FilePermission(0x08): {
+				"two",
+				"three",
+			},
+		},
+	}
+	c.Assert(msg, DeepEquals, expected)
+
+	// Check that MsgNotificationFiles can be marshalled and are identical
+	// after unmarshal.
+	buf, err := msg.MarshalBinary()
+	c.Assert(err, IsNil)
+	var roundTripMsg notify.MsgNotificationFile
+	err = roundTripMsg.UnmarshalBinary(buf)
+	c.Assert(err, IsNil)
+	// Messages may be marshalled slightly different, so length needs to be adjusted
+	expected.Length = roundTripMsg.Length
+	c.Assert(roundTripMsg, DeepEquals, expected)
+}
+
+func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5Errors(c *C) {
+	if arch.Endian() == binary.BigEndian {
+		c.Skip("test only written for little-endian architectures")
+	}
+	bytesTemplate := []byte{
+		0x60, 0x0, // Length == 96 bytes
+		0x5, 0x0, // Protocol
+		0x4, 0x0, // Notification type == notify.APPARMOR_NOTIF_OP
+		0x0,                                    // Signalled
+		0x0,                                    // Reserved
+		0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // ID (request #2, just a number)
+		0xf3, 0xff, 0xff, 0xff, // Error -13 EACCESS
+		0xaa, 0xaa, 0xaa, 0xaa, // Allow - ???
+		0x55, 0x55, 0x55, 0x55, // Deny - ???
+		0x19, 0x8, 0x0, 0x0, // PID
+		0x40, 0x0, 0x0, 0x0, // Label at +64 bytes into buffer
+		0x2, 0x0, // Class - AA_CLASS_FILE
+		0x0, 0x0, // Op - ???
+		0xe8, 0x03, 0x0, 0x0, // SUID - 1000
+		0xe8, 0x03, 0x0, 0x0, // OUID
+		0x48, 0x0, 0x0, 0x0, // Name at +72 bytes into buffer
+		0x50, 0x0, 0x0, 0x0, // Tagset headers at +80 bytes into the buffer (need to be 8-byte-aligned)
+		0x01, 0x0, // Tagset count - 1
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // padding to make []data 8-byte-aligned
+		0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x0, // "profile\0"
+		0x2f, 0x66, 0x69, 0x6c, 0x65, 0x0, // "/file\0"
+		0x0, 0x0, // padding to make tagset headers 8-byte-aligned
+		// put tagset headers here
+	}
+
+	for _, testCase := range []struct {
+		remainingBytes []byte
+		expectedError  string
+	}{
+		{
+			remainingBytes: []byte{
+				0x01, 0x02, 0x03, 0x04, // permission mask
+				0x01, 0x00, 0x00, 0x00, // tag count
+				0x60, 0x00, 0x00, 0x00, // tag offset (out of range)
+				0x00, 0x00, 0x00, 0x00, // filler data to make the lengths the same
+			},
+			expectedError: ".* address 96 points outside of message body",
+		},
+		{
+			remainingBytes: []byte{
+				0x87, 0x65, 0x43, 0x21, // permission mask
+				0x01, 0x00, 0x00, 0x00, // tag count
+				0x5c, 0x00, 0x00, 0x00, // tag starts at +92 into the buffer
+				0x61, 0x62, 0x63, 0x64, // "abcd" but missing the trailing '\0'
+			},
+			expectedError: ".* unterminated string at address 92",
+		},
+	} {
+		bytes := append(bytesTemplate, testCase.remainingBytes...)
+		var msg notify.MsgNotificationFile
+		err := msg.UnmarshalBinary(bytes)
+		c.Check(err, ErrorMatches, testCase.expectedError)
+	}
 }
 
 func (s *messageSuite) TestMsgNotificationValidate(c *C) {

--- a/sandbox/apparmor/notify/strings.go
+++ b/sandbox/apparmor/notify/strings.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"sort"
+
+	"github.com/snapcore/snapd/arch"
 )
 
 // stringPacker assists in packing apparmor data structures with
@@ -22,14 +25,13 @@ func newStringPacker(rawStruct any) stringPacker {
 	}
 }
 
-// PackString computes the layout of a string encoded in an apparmor message.
-// The return value is the offset of the beginning of the string relative to
-// the start of the fixed portion of the structure, captured by baseOffset.
+// packString writes the given string into the packer returns the offset of the
+// beginning of the string relative to the start of the structure.
 //
 // Empty strings use a special encoding that requires no space and always return
 // a fixed offset of zero to indicate that the string is empty. The actual
 // string is always nil-terminated, for compatibility with C.
-func (sp *stringPacker) PackString(s string) uint32 {
+func (sp *stringPacker) packString(s string) uint32 {
 	if s == "" {
 		return 0
 	}
@@ -39,14 +41,89 @@ func (sp *stringPacker) PackString(s string) uint32 {
 	return offset + uint32(sp.baseOffset)
 }
 
-// TotalLen returns the total length of the data which is being packed,
+// packTagsets computes headers for the given tagsets, packs the tagsets and
+// headers, and returns the offset of the beginning of the first header
+// relative to the start of the structure.
+//
+// If there are no tagsets, nothing is new is packed, and returns 0.
+//
+// Tagset headers are contiguous, and the start of the first header must be
+// 8-byte-aligned. Each header contains information about a tagset, including
+// its associated permission mask, the number of tags in the tagset, and the
+// offset of the beginning of the first tag, again relative to the start of the
+// structure.
+//
+// Any tagset which does not have any tags is ignored.
+//
+// The tagsets themselves may occur before or after the tagset headers, and
+// need not be contiguous, either between tagsets or with the tagset headers.
+// All the tags in any given tagset must be contiguous, however.
+//
+// For code simplicity, we encode all the tagsets first, then the headers.
+// By convention, there is an additional \0 byte after the end of each tagset,
+// but in the future, tagsets may overlap to save space, so this should not be
+// relied upon, so we do not include it here.
+//
+// It should never be necessary to pack tagsets outside of test code, since
+// snapd should never need to send a message containing tagsets to the kernel.
+func (sp *stringPacker) packTagsets(ts map[AppArmorPermission][]string) uint32 {
+	if len(ts) == 0 {
+		return 0
+	}
+	headers := make([]tagsetHeader, len(ts))
+
+	// Make marshalled message deterministic by including tagsets sorted by
+	// their associated permissions.
+	perms := make([]AppArmorPermission, 0, len(ts))
+	for perm := range ts {
+		perms = append(perms, perm)
+	}
+	// TODO: use slices.Sort() once we're on go 1.21+
+	sort.Slice(perms, func(i, j int) bool {
+		return perms[i].AsAppArmorOpMask() < perms[j].AsAppArmorOpMask()
+	})
+
+	for i, perm := range perms {
+		tags := ts[perm]
+		headers[i].PermissionMask = perm.AsAppArmorOpMask()
+		headers[i].TagCount = uint32(len(tags))
+		if len(tags) == 0 {
+			// tagset has no tags, so set offset to 0. Still include the tagset
+			// in the message, since it may be meaningful that there are no
+			// tags for the given permission mask.
+			headers[i].TagOffset = 0
+			continue
+		}
+		// Pack the first tag, and set the tagset's tag offset to its start
+		headers[i].TagOffset = sp.packString(tags[0])
+		// Pack the rest of the tags in this tagset immediately following
+		for _, tag := range tags[1:] {
+			sp.packString(tag)
+		}
+	}
+
+	// Now add padding to align the tagset headers
+	totalLength := sp.buffer.Len() + int(sp.baseOffset)
+	alignmentPadding := make([]byte, totalLength%8)
+	sp.buffer.Write(alignmentPadding)
+
+	headerOffset := uint32(sp.buffer.Len())
+
+	// Now write the headers themselves
+	order := arch.Endian()
+	binary.Write(&sp.buffer, order, headers)
+
+	return headerOffset + uint32(sp.baseOffset)
+}
+
+// totalLen returns the total length of the data which is being packed,
 // equal to the base offset plus the length of the data buffer.
-func (sp *stringPacker) TotalLen() uint16 {
+func (sp *stringPacker) totalLen() uint16 {
 	return sp.baseOffset + uint16(sp.buffer.Len())
 }
 
-// Bytes returns the underlying byte array into which data base been packed.
-func (sp *stringPacker) Bytes() []byte {
+// bytes returns the underlying byte array into which data base been packed.
+func (sp *stringPacker) bytes() []byte {
 	return sp.buffer.Bytes()
 }
 
@@ -63,8 +140,8 @@ func newStringUnpacker(data []byte) stringUnpacker {
 	}
 }
 
-// UnpackString unpacks NUL-terminated string at a given offset into the buffer.
-func (su *stringUnpacker) UnpackString(offset uint32) (string, error) {
+// unpackString unpacks NUL-terminated string at a given offset into the buffer.
+func (su *stringUnpacker) unpackString(offset uint32) (string, error) {
 	if offset == 0 {
 		return "", nil
 	}
@@ -77,4 +154,26 @@ func (su *stringUnpacker) UnpackString(offset uint32) (string, error) {
 		return "", fmt.Errorf("unterminated string at address %d", offset)
 	}
 	return string(tmp[:idx]), nil
+}
+
+// unpackStrings unpacks N contiguous NUL-terminated strings at a given offset
+// into the buffer.
+func (su *stringUnpacker) unpackStrings(offset uint32, n uint32) ([]string, error) {
+	if offset == 0 || n == 0 {
+		return nil, nil
+	}
+	if offset >= uint32(len(su.Bytes)) {
+		return nil, fmt.Errorf("address %d points outside of message body", offset)
+	}
+	strs := make([]string, n)
+	for i := uint32(0); i < n; i++ {
+		tmp := su.Bytes[offset:]
+		idx := bytes.IndexByte(tmp, 0)
+		if idx < 0 {
+			return nil, fmt.Errorf("unterminated string at address %d", offset)
+		}
+		strs[i] = string(tmp[:idx])
+		offset += uint32(idx) + 1 // advance offset to start of next string
+	}
+	return strs, nil
 }

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -21,6 +21,9 @@ package notify
 
 import (
 	"fmt"
+
+	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // ProtocolVersion denotes a notification protocol version.
@@ -30,7 +33,10 @@ var (
 	// versions holds the notification protocols snapd supports, in order of
 	// preference. If the first version is supported, try to use it, else try
 	// the next version, etc.
-	versions = []ProtocolVersion{3}
+	versions = []ProtocolVersion{5, 3}
+
+	// apparmorKernelFeatures allows tests to mock kernel features.
+	apparmorKernelFeatures = apparmor.KernelFeatures
 
 	// versionLikelySupportedChecks provides a function for each known protocol
 	// version which returns true if that version is supported by snapd and
@@ -42,8 +48,34 @@ var (
 	// the next version in the list.
 	versionLikelySupportedChecks = map[ProtocolVersion]func() bool{
 		3: func() bool {
-			// If prompting is supported, version 3 is always assumed to be
-			// supported.
+			kernelFeatures, err := apparmorKernelFeatures()
+			if err != nil {
+				return false
+			}
+			// Older kernels which only support v3 don't have notify_versions
+			// dir at all. If the dir does exist, protocol support for version
+			// 3 requires a v3 file to be present.
+			if strutil.ListContains(kernelFeatures, "policy:notify_versions") {
+				if !strutil.ListContains(kernelFeatures, "policy:notify_versions:v3") {
+					return false
+				}
+			}
+			return true
+		},
+		5: func() bool {
+			kernelFeatures, err := apparmorKernelFeatures()
+			if err != nil {
+				return false
+			}
+			// Support for protocol version 5 requires that the notify_versions
+			// directory must exist and contain a file named v5.
+			if !strutil.ListContains(kernelFeatures, "policy:notify_versions:v5") {
+				return false
+			}
+			if !strutil.ListContains(kernelFeatures, "policy:notify:user:tags") {
+				// Don't use v5 if tags are not supported
+				return false
+			}
 			return true
 		},
 	}

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -76,9 +76,15 @@ var (
 				// Don't use v5 if tags are not supported
 				return false
 			}
-			return true
+			return !v5ManuallyDisabled // TODO: return true once restarts work lands
 		},
 	}
+
+	// v5ManuallyDisabled disables support for protocol v5, which is necessary
+	// until support for restarts has landed. The protocol changes for restarts
+	// were originally part of protocol v7, but are now being rolled into v5 in
+	// addition to tagging. Until it's all landed, mark v5 as disabled.
+	v5ManuallyDisabled = true
 
 	// versionKnown returns true if the given protocol version is known by
 	// snapd. Even if true, the version may still be unsupported by snapd or

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -20,6 +20,8 @@
 package notify_test
 
 import (
+	"fmt"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
@@ -30,7 +32,7 @@ type versionSuite struct{}
 
 var _ = Suite(&versionSuite{})
 
-func (s *versionSuite) TestVersionsAndSupportedChecks(c *C) {
+func (s *versionSuite) TestVersionsAndSupportedChecksAlign(c *C) {
 	// Check both directions so we get pretty printing for the values on error
 	c.Check(notify.Versions, HasLen, len(notify.VersionLikelySupportedChecks))
 	c.Check(notify.VersionLikelySupportedChecks, HasLen, len(notify.Versions))
@@ -44,6 +46,70 @@ func (s *versionSuite) TestVersionsAndSupportedChecks(c *C) {
 	for ver, checkFn := range notify.VersionLikelySupportedChecks {
 		c.Check(checkFn, NotNil, Commentf("version has nil supported check: %v", ver))
 		c.Check(notify.Versions, testutil.Contains, ver, Commentf("version in versionLikelySupportedChecks missing from versions: %v", ver))
+	}
+}
+
+func (s *versionSuite) TestVersionsLikelySupportedChecks(c *C) {
+	for _, testCase := range []struct {
+		featuresList    []string
+		featuresErr     error
+		expectedSupport []bool // corresponds to ordered list notify.Versions
+	}{
+		{
+			// error getting features
+			featuresList:    nil,
+			featuresErr:     fmt.Errorf("couldn't get kernel features"),
+			expectedSupport: []bool{false, false},
+		},
+		{
+			// no features related to prompting support
+			featuresList:    nil,
+			featuresErr:     nil,
+			expectedSupport: []bool{false, true},
+		},
+		{
+			// policy:notify_versions dir present, but no versions
+			featuresList:    []string{"policy:notify_versions"},
+			featuresErr:     nil,
+			expectedSupport: []bool{false, false},
+		},
+		{
+			// policy:notify_versions:v3 present
+			featuresList:    []string{"policy:notify_versions", "policy:notify_versions:v3"},
+			featuresErr:     nil,
+			expectedSupport: []bool{false, true},
+		},
+		{
+			// policy:notify_versions:v5 present
+			featuresList:    []string{"policy:notify_versions", "policy:notify_versions:v5"},
+			featuresErr:     nil,
+			expectedSupport: []bool{false, false},
+		},
+		{
+			// policy:notify_versions:v5 and policy:notify:user:tags present
+			featuresList:    []string{"policy:notify_versions", "policy:notify_versions:v5", "policy:notify:user:tags"},
+			featuresErr:     nil,
+			expectedSupport: []bool{true, false},
+		},
+		{
+			// only policy:notify:user:tags present
+			featuresList:    []string{"policy:notify:user:tags"},
+			featuresErr:     nil,
+			expectedSupport: []bool{false, true},
+		},
+	} {
+		c.Assert(testCase.expectedSupport, HasLen, len(notify.Versions))
+
+		restore := notify.MockApparmorKernelFeatures(func() ([]string, error) {
+			return testCase.featuresList, testCase.featuresErr
+		})
+		defer restore()
+
+		for i, version := range notify.Versions {
+			supported, err := notify.LikelySupported(version)
+			c.Assert(err, IsNil)
+			c.Check(supported, Equals, testCase.expectedSupport[i], Commentf("version: %d\ntestCase: %+v", version, testCase))
+		}
 	}
 }
 

--- a/sandbox/apparmor/notify/version_test.go
+++ b/sandbox/apparmor/notify/version_test.go
@@ -50,6 +50,10 @@ func (s *versionSuite) TestVersionsAndSupportedChecksAlign(c *C) {
 }
 
 func (s *versionSuite) TestVersionsLikelySupportedChecks(c *C) {
+	// TODO: remove this once v5 is no longer manually disabled
+	restore := notify.OverrideV5ManuallyDisabled()
+	defer restore()
+
 	for _, testCase := range []struct {
 		featuresList    []string
 		featuresErr     error


### PR DESCRIPTION
This PR is based on #15130 and #15131.

Implement version 5 of the apparmor notification protocol, as defined here: https://docs.google.com/document/d/1_WvEM9Qi2Je2Vwulzv5TzHwLJ8ld0W8gTNESZZd9VsY/edit?tab=t.0#heading=h.q2d8zdyargyy

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-32517
