### PR TITLE
spread: include disk space information when debugging nested suites

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -607,6 +607,9 @@ debug-each: |
     go version || true
 
     if tests.nested is-nested; then
+        echo '# free space on the host'
+        df -h || true
+
         echo '# nested VM status'
         tests.nested vm status
         # filter out ^[ to ensure that the debug output gets not messed up

--- a/spread.yaml
+++ b/spread.yaml
@@ -609,6 +609,7 @@ debug-each: |
     if tests.nested is-nested; then
         echo '# free space on the host'
         df -h || true
+        du -ch /var/tmp/work-dir || true
 
         echo '# nested VM status'
         tests.nested vm status


### PR DESCRIPTION
Include the output of df so that we know how much space is left on disk.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
