### PR TITLE
tests: tests fixes for sru validation

### DIFF
--- a/tests/main/apparmor-batch-reload/task.yaml
+++ b/tests/main/apparmor-batch-reload/task.yaml
@@ -22,20 +22,30 @@ environment:
     FAKE_LOG: /tmp/apparmor_parser.fake.log
 
 prepare: |
+    if not tests.info is-reexec-in-use; then
+        tests.exec skip-test "The test uses apparmor from the snapd snap, not valid whit no-reexec" && exit 0
+    fi
+
     snap install test-snapd-content-plug test-snapd-tools
     snap install --edge test-snapd-curl
     cp /sbin/apparmor_parser /sbin/apparmor_parser.real
     echo > "$FAKE_LOG"
 
 restore: |
+    tests.exec is-skipped && exit 0
+
     mv /sbin/apparmor_parser.real /sbin/apparmor_parser
     rm -f "$FAKE_LOG"
 
 debug: |
+    tests.exec is-skipped && exit 0
+
     "$TESTSTOOLS"/journal-state get-log -a | grep apparmor_parser.fake
     cat "$FAKE_LOG" || true
 
 execute: |
+    tests.exec is-skipped && exit 0
+
     systemctl stop snapd.{service,socket}
 
     echo "Update system key"

--- a/tests/main/apparmor-batch-reload/task.yaml
+++ b/tests/main/apparmor-batch-reload/task.yaml
@@ -23,7 +23,7 @@ environment:
 
 prepare: |
     if not tests.info is-reexec-in-use; then
-        tests.exec skip-test "The test uses apparmor from the snapd snap, not valid whit no-reexec" && exit 0
+        tests.exec skip-test "The test uses apparmor from the snapd snap; not valid with no-reexec" && exit 0
     fi
 
     snap install test-snapd-content-plug test-snapd-tools

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -14,12 +14,18 @@ systems:
   - ubuntu-core-*
 
 prepare: |
+    if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
+        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+    fi
+
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
     "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
     snap connect test-snapd-prompt-handler:snap-interfaces-requests-control
 
 restore: |
+    tests.exec is-skipped && exit 0
+
     echo "Restore: Reset start limit so that other queries can succeed"
     systemctl stop snapd.service snapd.socket || true
     systemctl stop snapd.failure.service || true
@@ -28,6 +34,8 @@ restore: |
     retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
 
 debug: |
+    tests.exec is-skipped && exit 0
+
     echo "Debug: Check if snapd service and socket are running"
     systemctl is-active snapd.service snapd.socket || true
     systemctl status snapd.service || true
@@ -54,6 +62,8 @@ debug: |
 
 
 execute: |
+    tests.exec is-skipped && exit 0
+
     . /etc/os-release
 
     # Necessary since we restart snapd many times

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -15,7 +15,7 @@ systems:
 
 prepare: |
     if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
-        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+        tests.exec skip-test "Ubuntu 22.04 AppArmor parser doesn't support prompting" && exit 0
     fi
 
     # prerequisite for having a prompts handler service

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -36,21 +36,30 @@ environment:
     VARIANT/write_read_multiple_actioned_by_other_pid_deny_allow: write_read_multiple_actioned_by_other_pid_deny_allow
 
     TIMEOUT: "30" # Define common timeout which can be modified as needed
+    SNAPD_NO_MEMORY_LIMIT: 1
 
     # we unfortunately (frequently) run out of memory while setting up prompting-client
     SNAPD_NO_MEMORY_LIMIT: 1
 
 prepare: |
+    if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
+        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+    fi
+
     tests.session prepare -u test
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
     snap install prompting-client
 
 restore: |
+    tests.exec is-skipped && exit 0
+
     snap set system experimental.apparmor-prompting=false
     tests.session -u test exec sh -c 'rm -rf "/home/test/integration-tests"'
     tests.session restore -u test
 
 debug: |
+    tests.exec is-skipped && exit 0
+
     TEST_UID="$(id -u test)"
     echo "outstanding prompts:"
     snap debug api "/v2/interfaces/requests/prompts?user-id=$TEST_UID" || true
@@ -58,6 +67,8 @@ debug: |
     snap debug api "/v2/interfaces/requests/rules?user-id=$TEST_UID" || true
 
 execute: |
+    tests.exec is-skipped && exit 0
+
     echo "Precondition check that snapd is active"
     systemctl is-active snapd.service snapd.socket
 

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -36,7 +36,6 @@ environment:
     VARIANT/write_read_multiple_actioned_by_other_pid_deny_allow: write_read_multiple_actioned_by_other_pid_deny_allow
 
     TIMEOUT: "30" # Define common timeout which can be modified as needed
-    SNAPD_NO_MEMORY_LIMIT: 1
 
     # we unfortunately (frequently) run out of memory while setting up prompting-client
     SNAPD_NO_MEMORY_LIMIT: 1
@@ -75,7 +74,7 @@ execute: |
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
-    if ! os.query is-ubuntu || os.query is-core || [ ! -f /sys/kernel/security/apparmor/features/policy/permstable32 ] || NOMATCH 'prompt' < /sys/kernel/security/apparmor/features/policy/permstable32 ; then
+    if ! os.query is-ubuntu || os.query is-core || os.query is-ubuntu-lt 22.04 || os.query is-ubuntu 22.04 && ! tests.info is-reexec-in-use ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -66,13 +66,16 @@ debug: |
     snap debug api "/v2/interfaces/requests/rules?user-id=$TEST_UID" || true
 
 execute: |
+    # Just to make sure the previous check didn't exit
+    tests.exec is-skipped && exit 0
+
     echo "Precondition check that snapd is active"
     systemctl is-active snapd.service snapd.socket
 
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
-    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 || ! tests.info is-reexec-in-use && os.query is-ubuntu 22.04 ; then
+    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out
@@ -82,10 +85,7 @@ execute: |
 
         exit 0
     fi
-
-    # Just to make sure the previous check didn't exit
-    tests.exec is-skipped && exit 0
-
+    
     SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
 
     echo "Enable AppArmor prompting experimental feature"

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -42,7 +42,7 @@ environment:
 
 prepare: |
     if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
-        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+        tests.exec skip-test "Ubuntu 22.04 AppArmor parser doesn't support prompting" && exit 0
     fi
 
     tests.session prepare -u test

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -45,7 +45,7 @@ prepare: |
         tests.exec skip-test "Ubuntu 22.04 AppArmor parser doesn't support prompting" && exit 0
     fi
 
-    tests.session prepare -u test
+    tests.session prepare -u test                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
     snap install prompting-client
 
@@ -74,7 +74,7 @@ execute: |
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting
-    if ! os.query is-ubuntu || os.query is-core || os.query is-ubuntu-lt 22.04 || os.query is-ubuntu 22.04 && ! tests.info is-reexec-in-use ; then
+    if ! os.query is-ubuntu || os.query is-core || ! grep 'prompt' /sys/kernel/security/apparmor/features/policy/permstable32 || ! tests.info is-reexec-in-use && os.query is-ubuntu 22.04 ; then
         not snap set system experimental.apparmor-prompting=true >& err.out
         if os.query is-core ; then
             MATCH "cannot enable prompting feature as it is not supported on Ubuntu Core systems" < err.out

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -66,8 +66,6 @@ debug: |
     snap debug api "/v2/interfaces/requests/rules?user-id=$TEST_UID" || true
 
 execute: |
-    tests.exec is-skipped && exit 0
-
     echo "Precondition check that snapd is active"
     systemctl is-active snapd.service snapd.socket
 
@@ -84,6 +82,9 @@ execute: |
 
         exit 0
     fi
+
+    # Just to make sure the previous check didn't exit
+    tests.exec is-skipped && exit 0
 
     SNAPD_PID="$(systemctl show --property MainPID snapd.service | cut -f2 -d=)"
 

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -11,12 +11,18 @@ systems:
   - ubuntu-2*
 
 prepare: |
+    if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
+        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+    fi
+
     # prerequisite for having a prompt handler service
     snap set system experimental.user-daemons=true
     "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
     snap connect test-snapd-prompt-handler:snap-interfaces-requests-control
 
 debug: |
+    tests.exec is-skipped && exit 0
+
     echo "Check kernel version"
     uname -a
     echo "Check kernel notification socket presence"
@@ -29,6 +35,8 @@ debug: |
     snap debug api /v2/system-info
 
 execute: |
+    tests.exec is-skipped && exit 0
+
     RULES_PATH="/var/lib/snapd/interfaces-requests/request-rules.json"
 
     echo "Write three rules to disk, one of which is partially expired,"

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -12,7 +12,7 @@ systems:
 
 prepare: |
     if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
-        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+        tests.exec skip-test "Ubuntu 22.04 AppArmor parser doesn't support prompting" && exit 0
     fi
 
     # prerequisite for having a prompt handler service

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -8,6 +8,10 @@ systems:
   - ubuntu-2*
 
 prepare: |
+    if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
+        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+    fi
+
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
     "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
@@ -15,9 +19,13 @@ prepare: |
     tests.session -u test prepare
 
 restore: |
+    tests.exec is-skipped && exit 0
+
     tests.session -u test restore
 
 debug: |
+    tests.exec is-skipped && exit 0
+
     echo "Check kernel version"
     uname -a
     echo "Check kernel notification socket presence"
@@ -30,6 +38,8 @@ debug: |
     snap debug api /v2/system-info
 
 execute: |
+    tests.exec is-skipped && exit 0
+
     echo "Enable prompting via snap client where possible"
     # Prompting is unsupported everywhere but the Ubuntu non-core systems with
     # kernels which support apparmor prompting

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -9,7 +9,7 @@ systems:
 
 prepare: |
     if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
-        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+        tests.exec skip-test "Ubuntu 22.04 AppArmor parser doesn't support prompting" && exit 0
     fi
 
     # prerequisite for having a prompts handler service

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -18,10 +18,16 @@ environment:
     PYTHONIOENCODING: utf-8
 
 prepare: |
+    if not tests.info is-reexec-in-use && os.query is-ubuntu 22.04; then
+        tests.exec skip-test "Ubuntu 22.04 kernel doesn't support prompting" && exit 0
+    fi
+
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
 
 debug: |
+    tests.exec is-skipped && exit 0
+
     echo "Check kernel version"
     uname -a
     echo "Check kernel notification socket presence"
@@ -34,6 +40,8 @@ debug: |
     snap debug api /v2/system-info
 
 execute: |
+    tests.exec is-skipped && exit 0
+
     "$TESTSTOOLS"/snaps-state install-local api-client
     echo "The snap-interfaces-requests-control plug on the api-client snap is initially disconnected"
     snap connections api-client | MATCH "snap-interfaces-requests-control +api-client:snap-interfaces-requests-control +- +-"

--- a/tests/main/remote-home/task.yaml
+++ b/tests/main/remote-home/task.yaml
@@ -108,9 +108,13 @@ prepare: |
     # Later on, restart snapd and ensure that nfs/cifs workaround is gone.
     # This cleanup handler is registered before we mount the cifs file system.
     if [ "$(snap debug confinement)" = strict ]; then
-        # We are testing on Ubuntu where we know that reexec is active and we
-        # use an internal apparmor userspace stack.
-        tests.cleanup defer test ! -e /var/lib/snapd/apparmor/snap-confine.internal/nfs-support
+        if tests.info is-reexec-in-use; then
+          # We are testing on Ubuntu where we know that reexec is active and we
+          # use an internal apparmor userspace stack.
+          tests.cleanup defer test ! -e /var/lib/snapd/apparmor/snap-confine.internal/nfs-support
+        else
+          tests.cleanup defer test ! -e /var/lib/snapd/apparmor/snap-confine/nfs-support
+        fi
     fi
     tests.cleanup defer systemctl restart snapd.service
     tests.cleanup defer systemctl reset-failed snapd.service snapd.socket
@@ -140,7 +144,11 @@ prepare: |
     systemctl reset-failed snapd.service snapd.socket
     systemctl restart snapd.service
     if [ "$(snap debug confinement)" = strict ]; then
-        MATCH 'network inet,' < /var/lib/snapd/apparmor/snap-confine.internal/nfs-support
+        if tests.info is-reexec-in-use; then
+          MATCH 'network inet,' < /var/lib/snapd/apparmor/snap-confine.internal/nfs-support
+        else
+          MATCH 'network inet,' < /var/lib/snapd/apparmor/snap-confine/nfs-support
+        fi
         MATCH 'network inet,' < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh.with-home-plug
     fi
 

--- a/tests/main/store-state/task.yaml
+++ b/tests/main/store-state/task.yaml
@@ -12,10 +12,20 @@ backends: [-external]
 systems: [-ubuntu-14.04-64]
 
 prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
     # acquire session macaroon
     snap find core
 
 execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
     # Check help
     "$TESTSTOOLS"/store-state | MATCH "usage: store-state setup-fake-store <DIR>"
     "$TESTSTOOLS"/store-state -h | MATCH "usage: store-state setup-fake-store <DIR>"


### PR DESCRIPTION
These fixes are needed to fix sru validation where the snap snap is not used and we use the snapd deb from proposed instead. 

The change include fixes for tests:

- tests/main/apparmor-batch-reload/task.yaml
- tests/main/apparmor-prompting-flag-restart/task.yaml
- tests/main/apparmor-prompting-integration-tests/task.yaml
- tests/main/apparmor-prompting-snapd-startup/task.yaml
- tests/main/interfaces-requests-activates-handlers/task.yaml
- tests/main/interfaces-snap-interfaces-requests-control/task.yaml
- tests/main/remote-home/task.yaml
- tests/main/store-state/task.yaml