### PR TITLE
spread: stop disabling metalink for Fedora

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -756,14 +756,6 @@ prepare: |
 
     # Note that os.query or any other tool cannot be used here before the current.delta file is unpacked
     if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
-        # The Fedora archive mirror seems to be unreliable.
-        # Switch to the main archive by commenting out metalink and uncommenting
-        # baseurl with a tweak to go to dl.fedoraproject.org which doens't redirect
-        # to mirrors again.
-        #
-        # https://forum.snapcraft.io/t/issues-with-the-fedora-mirror-network/3489/
-        sed -i -s -E -e 's@^#?baseurl=http://download.fedoraproject.org/@baseurl=http://dl.fedoraproject.org/@g' -e 's@^metalink=@#metalink@g' /etc/yum.repos.d/fedora*.repo
-
         dnf --refresh -y makecache
 
         # enable audit daemon


### PR DESCRIPTION
We should be using metalink instead of putting more pressure on the main mirrors.