### PR TITLE
interfaces: extend polkit backend to support custom polkit rules

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -107,6 +107,7 @@ var (
 	SnapDesktopFilesDir    string
 	SnapDesktopIconsDir    string
 	SnapPolkitPolicyDir    string
+	SnapPolkitRuleDir      string
 	SnapSystemdDir         string
 	SnapSystemdRunDir      string
 
@@ -552,6 +553,7 @@ func SetRootDir(rootdir string) {
 	SnapDBusSystemServicesDir = filepath.Join(rootdir, snappyDir, "dbus-1", "system-services")
 
 	SnapPolkitPolicyDir = filepath.Join(rootdir, "/usr/share/polkit-1/actions")
+	SnapPolkitRuleDir = filepath.Join(rootdir, "/etc/polkit-1/rules.d")
 
 	CloudInstanceDataFile = filepath.Join(rootdir, "/run/cloud-init/instance-data.json")
 

--- a/interfaces/polkit/backend.go
+++ b/interfaces/polkit/backend.go
@@ -91,15 +91,9 @@ func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.Confineme
 	// Get the rule files that this snap should have
 	glob = polkitRuleName(snapName, "*")
 	content = deriveRulesContent(spec.(*Specification), appSet)
-	dir = dirs.SnapPolkitRuleDir
-	// If we do not have any content to write, there is no point
-	// ensuring the directory exists.
-	if content != nil {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return fmt.Errorf("cannot create directory for polkit rule files %q: %s", dir, err)
-		}
-	}
-	_, _, err = osutil.EnsureDirState(dir, glob, content)
+	// Rules directory should already exist as it comes with distro packaging, don't attempt
+	// to create it to avoid messing with permissions and just fail if it doesn't exist.
+	_, _, err = osutil.EnsureDirState(dirs.SnapPolkitRuleDir, glob, content)
 	if err != nil {
 		return fmt.Errorf("cannot synchronize polkit rule files for snap %q: %s", snapName, err)
 	}

--- a/interfaces/polkit/spec.go
+++ b/interfaces/polkit/spec.go
@@ -78,6 +78,8 @@ func (spec *Specification) AddRule(nameSuffix string, content Rule) error {
 }
 
 // Rules returns a map of polkit rules added to the Specification.
+// This maps from rule name suffixes (without the ".rules" suffix)
+// to the content required to be installed.
 func (spec *Specification) Rules() map[string]Rule {
 	if spec.ruleFiles == nil {
 		return nil

--- a/interfaces/polkit/spec.go
+++ b/interfaces/polkit/spec.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/polkit/validate"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -63,6 +64,9 @@ func (spec *Specification) Policies() map[string]Policy {
 
 // AddRule adds a polkit rule file to install.
 func (spec *Specification) AddRule(nameSuffix string, content Rule) error {
+	if err := validate.ValidateRuleNameSuffix(nameSuffix); err != nil {
+		return err
+	}
 	if old, ok := spec.ruleFiles[nameSuffix]; ok && !bytes.Equal(old, content) {
 		return fmt.Errorf("internal error: polkit rule content for %q re-defined with different content", nameSuffix)
 	}

--- a/interfaces/polkit/spec_test.go
+++ b/interfaces/polkit/spec_test.go
@@ -115,3 +115,8 @@ func (s *specSuite) TestSpecificationIfaceAddRuleOverwriteError(c *C) {
 	c.Assert(s.spec.AddRule("test", polkit.Rule("content 1")), IsNil)
 	c.Assert(s.spec.AddRule("test", polkit.Rule("content 2")), ErrorMatches, "internal error: polkit rule content for \"test\" re-defined with different content")
 }
+
+func (s *specSuite) TestSpecificationIfaceAddRuleInvalidSuffix(c *C) {
+	c.Assert(s.spec.AddRule("?", polkit.Rule("content")), ErrorMatches, `"\?" does not match .*`)
+	c.Assert(s.spec.AddRule("..", polkit.Rule("content")), ErrorMatches, `"\.\." does not match .*`)
+}

--- a/interfaces/polkit/spec_test.go
+++ b/interfaces/polkit/spec_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/polkit"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 type specSuite struct {
@@ -41,16 +42,24 @@ var _ = Suite(&specSuite{
 	iface: &ifacetest.TestInterface{
 		InterfaceName: "test",
 		PolkitConnectedPlugCallback: func(spec *polkit.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-			return spec.AddPolicy("connected-plug", polkit.Policy("policy-connected-plug"))
+			policyErr := spec.AddPolicy("connected-plug", polkit.Policy("policy-connected-plug"))
+			ruleErr := spec.AddRule("connected-plug", polkit.Rule("rule-connected-plug"))
+			return strutil.JoinErrors(policyErr, ruleErr)
 		},
 		PolkitConnectedSlotCallback: func(spec *polkit.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-			return spec.AddPolicy("connected-slot", polkit.Policy("policy-connected-slot"))
+			policyErr := spec.AddPolicy("connected-slot", polkit.Policy("policy-connected-slot"))
+			ruleErr := spec.AddRule("connected-slot", polkit.Rule("rule-connected-slot"))
+			return strutil.JoinErrors(policyErr, ruleErr)
 		},
 		PolkitPermanentPlugCallback: func(spec *polkit.Specification, plug *snap.PlugInfo) error {
-			return spec.AddPolicy("permanent-plug", polkit.Policy("policy-permanent-plug"))
+			policyErr := spec.AddPolicy("permanent-plug", polkit.Policy("policy-permanent-plug"))
+			ruleErr := spec.AddRule("permanent-plug", polkit.Rule("rule-permanent-plug"))
+			return strutil.JoinErrors(policyErr, ruleErr)
 		},
 		PolkitPermanentSlotCallback: func(spec *polkit.Specification, slot *snap.SlotInfo) error {
-			return spec.AddPolicy("permanent-slot", polkit.Policy("policy-permanent-slot"))
+			policyErr := spec.AddPolicy("permanent-slot", polkit.Policy("policy-permanent-slot"))
+			ruleErr := spec.AddRule("permanent-slot", polkit.Rule("rule-permanent-slot"))
+			return strutil.JoinErrors(policyErr, ruleErr)
 		},
 	},
 })
@@ -89,4 +98,20 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 		"permanent-plug": polkit.Policy("policy-permanent-plug"),
 		"permanent-slot": polkit.Policy("policy-permanent-slot"),
 	})
+	c.Assert(s.spec.Rules(), DeepEquals, map[string]polkit.Rule{
+		"connected-plug": polkit.Rule("rule-connected-plug"),
+		"connected-slot": polkit.Rule("rule-connected-slot"),
+		"permanent-plug": polkit.Rule("rule-permanent-plug"),
+		"permanent-slot": polkit.Rule("rule-permanent-slot"),
+	})
+}
+
+func (s *specSuite) TestSpecificationIfaceAddPolicyOverwriteError(c *C) {
+	c.Assert(s.spec.AddPolicy("test", polkit.Policy("content 1")), IsNil)
+	c.Assert(s.spec.AddPolicy("test", polkit.Policy("content 2")), ErrorMatches, "internal error: polkit policy content for \"test\" re-defined with different content")
+}
+
+func (s *specSuite) TestSpecificationIfaceAddRuleOverwriteError(c *C) {
+	c.Assert(s.spec.AddRule("test", polkit.Rule("content 1")), IsNil)
+	c.Assert(s.spec.AddRule("test", polkit.Rule("content 2")), ErrorMatches, "internal error: polkit rule content for \"test\" re-defined with different content")
 }

--- a/polkit/validate/validate.go
+++ b/polkit/validate/validate.go
@@ -286,7 +286,7 @@ func validateDefaultAuth(auth []Element, name string) error {
 	return nil
 }
 
-var ruleNameSuffixRegexp = regexp.MustCompile(`^([\w-]+)(\.[\w-]+)*$`)
+var ruleNameSuffixRegexp = regexp.MustCompile(`^(\w[\w-]*)(\.\w[\w-]*)*$`)
 
 const maxRuleNameSuffixLength = 64
 

--- a/polkit/validate/validate.go
+++ b/polkit/validate/validate.go
@@ -23,6 +23,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -280,6 +282,44 @@ func validateDefaultAuth(auth []Element, name string) error {
 		}
 	default:
 		return fmt.Errorf("multiple %s elements found under <defaults>", name)
+	}
+	return nil
+}
+
+var ruleNameSuffixRegexp = regexp.MustCompile(`^([\w-]+)(\.[\w-]+)*$`)
+
+const maxRuleNameSuffixLength = 64
+
+// ValidateRuleFileName validates polkit rule file name to be installed
+// according to the following rules:
+//   - Suffix passes ValidateRuleNameSuffix.
+//   - Ends with ".rules".
+func ValidateRuleFileName(filename string) error {
+	base := filepath.Base(filename)
+	if !strings.HasSuffix(base, ".rules") {
+		return fmt.Errorf("invalid polkit rule file name: %q must end with \".rules\"", filename)
+	}
+	suffix := strings.TrimSuffix(base, ".rules")
+	if err := ValidateRuleNameSuffix(suffix); err != nil {
+		return fmt.Errorf("invalid polkit rule file name: %v", err)
+	}
+	return nil
+}
+
+// ValidateRuleFileName validates polkit rule file name suffix to be installed
+// according to the following rules:
+//   - A sequence of non-empty elements separated by dots.
+//   - Each of which contains only characters from the set [A-Za-z0-9-_].
+//   - Has maximum length of maxRuleFileNameLength characters.
+func ValidateRuleNameSuffix(suffix string) error {
+	if len(suffix) == 0 {
+		return fmt.Errorf("rule file name cannot be empty")
+	}
+	if len(suffix) > maxRuleNameSuffixLength {
+		return fmt.Errorf("%q is longer than %d characters", suffix, maxRuleNameSuffixLength)
+	}
+	if !ruleNameSuffixRegexp.MatchString(suffix) {
+		return fmt.Errorf("%q does not match %q", suffix, ruleNameSuffixRegexp)
 	}
 	return nil
 }

--- a/polkit/validate/validate_test.go
+++ b/polkit/validate/validate_test.go
@@ -390,8 +390,12 @@ func (s *validateSuite) TestValidateRuleFileName(c *C) {
 	c.Check(validate.ValidateRuleFileName("/path/to/rule/foo.bar.rules"), IsNil)
 	// Errors
 	c.Check(validate.ValidateRuleFileName(".rules"), ErrorMatches, `invalid polkit rule file name: rule file name cannot be empty`)
-	c.Check(validate.ValidateRuleFileName("test"), ErrorMatches, `invalid polkit rule file name: "test" must end with "\.rules"`)
-	c.Check(validate.ValidateRuleFileName(".ss.rules"), ErrorMatches, `invalid polkit rule file name: ".*" does not match .*`)
+	c.Check(validate.ValidateRuleFileName("foo"), ErrorMatches, `invalid polkit rule file name: "foo" must end with "\.rules"`)
+	c.Check(validate.ValidateRuleFileName(".foo.rules"), ErrorMatches, `invalid polkit rule file name: ".*" does not match .*`)
+	c.Check(validate.ValidateRuleFileName("---.rules"), ErrorMatches, `invalid polkit rule file name: ".*" does not match .*`)
+	c.Check(validate.ValidateRuleFileName("--.--.rules"), ErrorMatches, `invalid polkit rule file name: ".*" does not match .*`)
+	c.Check(validate.ValidateRuleFileName("foo.---.rules"), ErrorMatches, `invalid polkit rule file name: ".*" does not match .*`)
+	c.Check(validate.ValidateRuleFileName("foo..rules"), ErrorMatches, `invalid polkit rule file name: ".*" does not match .*`)
 	c.Check(validate.ValidateRuleFileName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.rules"), ErrorMatches, `invalid polkit rule file name: ".*" is longer than 64 characters`)
 }
 
@@ -402,4 +406,8 @@ func (s *validateSuite) TestValidateRuleNameSuffix(c *C) {
 	c.Check(validate.ValidateRuleNameSuffix(""), ErrorMatches, `rule file name cannot be empty`)
 	c.Check(validate.ValidateRuleNameSuffix("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), ErrorMatches, `".*" is longer than 64 characters`)
 	c.Check(validate.ValidateRuleNameSuffix("?"), ErrorMatches, `"\?" does not match .*`)
+	c.Check(validate.ValidateRuleNameSuffix("---"), ErrorMatches, `".*" does not match .*`)
+	c.Check(validate.ValidateRuleNameSuffix("--.--"), ErrorMatches, `".*" does not match .*`)
+	c.Check(validate.ValidateRuleNameSuffix("foo.---"), ErrorMatches, `".*" does not match .*`)
+	c.Check(validate.ValidateRuleNameSuffix("foo."), ErrorMatches, `".*" does not match .*`)
 }

--- a/polkit/validate/validate_test.go
+++ b/polkit/validate/validate_test.go
@@ -384,3 +384,22 @@ func (s *validateSuite) TestActionIDExtraction(c *C) {
 	sort.Strings(actionIDs)
 	c.Check(actionIDs, DeepEquals, []string{"action1", "action2", "action3", "action4"})
 }
+
+func (s *validateSuite) TestValidateRuleFileName(c *C) {
+	// Happy case
+	c.Check(validate.ValidateRuleFileName("/path/to/rule/foo.bar.rules"), IsNil)
+	// Errors
+	c.Check(validate.ValidateRuleFileName(".rules"), ErrorMatches, `invalid polkit rule file name: rule file name cannot be empty`)
+	c.Check(validate.ValidateRuleFileName("test"), ErrorMatches, `invalid polkit rule file name: "test" must end with "\.rules"`)
+	c.Check(validate.ValidateRuleFileName(".ss.rules"), ErrorMatches, `invalid polkit rule file name: ".*" does not match .*`)
+	c.Check(validate.ValidateRuleFileName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.rules"), ErrorMatches, `invalid polkit rule file name: ".*" is longer than 64 characters`)
+}
+
+func (s *validateSuite) TestValidateRuleNameSuffix(c *C) {
+	// Happy case
+	c.Check(validate.ValidateRuleNameSuffix("foo.bar"), IsNil)
+	// Errors
+	c.Check(validate.ValidateRuleNameSuffix(""), ErrorMatches, `rule file name cannot be empty`)
+	c.Check(validate.ValidateRuleNameSuffix("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), ErrorMatches, `".*" is longer than 64 characters`)
+	c.Check(validate.ValidateRuleNameSuffix("?"), ErrorMatches, `"\?" does not match .*`)
+}


### PR DESCRIPTION
This PR extends the polkit backend to allow adding custom rules supplied by a snap, actual use of the rules backend will be in a followup PR.

For reference please check SD198.