### PR TITLE
i/b/block_device: allow eMMC RPMB access

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -54,7 +54,7 @@ const blockDevicesConnectedPlugAppArmor = `
 /sys/block/ r,
 /sys/devices/**/block/** r,
 /sys/dev/block/ r,
-/sys/devices/platform/soc/**/mmc_host/** r,
+/sys/devices/platform/{soc,bus@[0-9]*}/**/mmc_host/** r,
 # Allow reading major and minor numbers for block special files of NVMe namespaces.
 /sys/devices/**/nvme/**/dev r,
 

--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -65,6 +65,7 @@ const blockDevicesConnectedPlugAppArmor = `
 /dev/i2o/hd{,[a-c]}[a-z] rwk,                              # I2O hard disk
 /dev/i2o/hdd[a-x] rwk,                                     # I2O hard disk continued
 /dev/mmcblk[0-9]{,[0-9],[0-9][0-9]} rwk,                   # MMC (up to 1000 devices)
+/dev/mmcblk[0-9]{,[0-9],[0-9][0-9]}rpmb rwk,               # MMC RPMB
 /dev/vd[a-z] rwk,                                          # virtio
 /dev/loop[0-9]{,[0-9],[0-9][0-9]} rwk,                     # loopback (up to 1000 devices)
 /dev/loop-control rw,                                      # loopback control
@@ -118,6 +119,7 @@ var blockDevicesConnectedPlugUDev = []string{
 	// allow for manipulation of the block devices and so are grouped here as
 	// well
 	`SUBSYSTEM=="nvme"`,
+	`SUBSYSTEM=="mmc_rpmb"`,
 	`KERNEL=="mpt2ctl*"`,
 	`KERNEL=="megaraid_sas_ioctl_node"`,
 }

--- a/interfaces/builtin/block_devices_test.go
+++ b/interfaces/builtin/block_devices_test.go
@@ -95,7 +95,7 @@ func (s *blockDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 5)
+	c.Assert(spec.Snippets(), HasLen, 6)
 	c.Assert(spec.Snippets()[0], Equals, `# block-devices
 KERNEL=="megaraid_sas_ioctl_node", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))


### PR DESCRIPTION
Allows access to the Replay Protected Memory Block (RPMB) associated with eMMC storage. Consumers will still need to provision and correctly used the authentication key to interact with the RPMB, but this gives them the ability to do so. 

This has been tested on the Nvidia Jetson Orin AGX platform. In the process, I noticed that it presents its MMC host controller a little differently than previously accounted-for platforms (under `/sys/devices/platform/bus@0/<addr>.mmc/mmc_host/` as opposed to `/sys/devices/platform/soc/<addr>.mmc/mmc_host/`) so I added an allowance for that. Happy to rework if it would be better to express this differently.
