### PR TITLE
cmd/libsnap-confine-private/tool: switch identity only after forking a child

### DIFF
--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -60,8 +60,8 @@ bool sc_is_in_container(void);
 typedef struct sc_identity {
     uid_t uid;
     gid_t gid;
-    unsigned change_uid : 1;
-    unsigned change_gid : 1;
+    bool change_uid : 1;
+    bool change_gid : 1;
 } sc_identity;
 
 /**
@@ -75,8 +75,8 @@ static inline sc_identity sc_root_group_identity(void) {
     sc_identity id = {
         /* Explicitly set our intent of changing just the GID.
          * Refactoring of this code must retain this property. */
-        .change_uid = 0,
-        .change_gid = 1,
+        .change_uid = false,
+        .change_gid = true,
         .gid = 0,
     };
     return id;


### PR DESCRIPTION
We had a recurring pattern of switching the identity, then calling a tool, followed by restoring the old identity. Since the tool is called in a forked child process anyway, there is no clear win to switch the identity in the parent process, which then requires a followup restore operation. Move switching of identity to the child process, this simplifying the code path.

Cherry picked from https://github.com/canonical/snapd/pull/15094 where it allows the code to not need PR_SET_KEEPCAPS.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Related: [SNAPDENG-34419](https://warthogs.atlassian.net/browse/SNAPDENG-34419)

[SNAPDENG-34419]: https://warthogs.atlassian.net/browse/SNAPDENG-34419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ