### PR TITLE
cmd/clangd: add _GNU_SOURCE

### DIFF
--- a/cmd/.clangd
+++ b/cmd/.clangd
@@ -1,2 +1,8 @@
+# -*- Mode: yaml -*-
+
 CompileFlags:
-  Add: [-I/usr/include/glib-2.0, -Wall, -Wextra, -Wmissing-prototypes, -Wstrict-prototypes, -Wno-missing-field-initializers, -Wno-unused-parameter]
+  Add: [-I/usr/include/glib-2.0,
+        -Wall, -Wextra, -Wmissing-prototypes,
+        -Wstrict-prototypes, -Wno-missing-field-initializers,
+        -Wno-unused-parameter,
+        -D_GNU_SOURCE]


### PR DESCRIPTION
Add -D_GNU_SOURCE so that clangd doesn't complain about O_PATH.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
