### PR TITLE
tests: ensure spread tests have lsof preinstalled

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -552,15 +552,11 @@ pkg_dependencies_ubuntu_classic(){
         fish
         fontconfig
         gnome-keyring
-        jq
-        lsof
-        man
         nfs-kernel-server
         printer-driver-cups-pdf
         python3-dbus
         python3-gi
         python3-yaml
-        upower
         weston
         xdg-user-dirs
         xdg-utils

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -531,6 +531,7 @@ pkg_dependencies_ubuntu_generic(){
         libglib2.0-dev
         libseccomp-dev
         libudev-dev
+        lsof
         man
         mtools
         netcat-openbsd
@@ -552,6 +553,7 @@ pkg_dependencies_ubuntu_classic(){
         fontconfig
         gnome-keyring
         jq
+        lsof
         man
         nfs-kernel-server
         printer-driver-cups-pdf
@@ -706,6 +708,7 @@ pkg_dependencies_fedora_centos_common(){
         jq
         iptables
         iptables-services
+        lsof
         man
         net-tools
         nmap-ncat
@@ -764,6 +767,7 @@ pkg_dependencies_amazon(){
         jq
         iptables-services
         libcap-static
+        lsof
         man
         nc
         net-tools
@@ -798,6 +802,7 @@ pkg_dependencies_opensuse(){
         iptables
         jq
         lsb-release
+        lsof
         man
         man-pages
         nfs-kernel-server
@@ -843,6 +848,7 @@ pkg_dependencies_arch(){
     libseccomp
     libcap
     libx11
+    lsof
     man
     net-tools
     nfs-utils

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -49,9 +49,6 @@ prepare: |
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
     snap install prompting-client
 
-    # Ensure lsof is installed
-    command -v lsof || tests.pkgs install lsof
-
 restore: |
     tests.exec is-skipped && exit 0
 

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -45,9 +45,12 @@ prepare: |
         tests.exec skip-test "Ubuntu 22.04 AppArmor parser doesn't support prompting" && exit 0
     fi
 
-    tests.session prepare -u test                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+    tests.session prepare -u test
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
     snap install prompting-client
+
+    # Ensure lsof is installed (for now, assumes apt)
+    command -v lsof || apt install -y lsof
 
 restore: |
     tests.exec is-skipped && exit 0

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -49,8 +49,8 @@ prepare: |
     tests.session -u test exec sh -c 'mkdir -p "/home/test/integration-tests"'
     snap install prompting-client
 
-    # Ensure lsof is installed (for now, assumes apt)
-    command -v lsof || apt install -y lsof
+    # Ensure lsof is installed
+    command -v lsof || tests.pkgs install lsof
 
 restore: |
     tests.exec is-skipped && exit 0


### PR DESCRIPTION
The github CI images have lsof, but when running spread on qemu or elsewhere, it may not be installed. Ensure it is.

Additionally, drive-by cleanup some extraneous whitespace.