### PR TITLE
tests: preseed-core20 do not check for disable-sshd-keygen-if-cloud-init-active.conf

### DIFF
--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -113,7 +113,6 @@ execute: |
   MATCH "^etc/systemd/system/snapd.spread-tests-run-mode-tweaks.service" < files.log
   MATCH "^etc/systemd/system/dbus-fi.w1.wpa_supplicant1.service" < files.log
   MATCH "^etc/systemd/system/snapd.snap-repair.timer" < files.log
-  MATCH "^etc/systemd/system/sshd-keygen@.service.d/disable-sshd-keygen-if-cloud-init-active.conf" < files.log
   MATCH "^etc/systemd/system/snapd.service.wants/usr-lib-snapd.mount" < files.log
   MATCH "^etc/systemd/system/snapd.autoimport.service" < files.log
   MATCH "^etc/systemd/system/final.target.wants/snapd.system-shutdown.service" < files.log


### PR DESCRIPTION
This file has been moved due to a change in the `cloud-init` deb package on focal, breaking tests. It's not necessary to check for the file in this test anyway, so remove the check.
