### PR TITLE
daemon,o/devicestate,asserts: add confdb-control api

### DIFF
--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -187,9 +187,6 @@ func assembleConfdbControl(assert assertionBase) (Assertion, error) {
 	if err != nil {
 		return nil, err
 	}
-	if groups == nil {
-		return nil, errors.New(`"groups" stanza is mandatory`)
-	}
 
 	cc, err := parseConfdbControlGroups(groups)
 	if err != nil {

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -326,7 +326,6 @@ func (s *confdbCtrlSuite) TestDecodeInvalid(c *C) {
 		{"serial: 03961d5d-26e5-443f-838d-6db046126bea\n", "", `"serial" header is mandatory`},
 		{"serial: 03961d5d-26e5-443f-838d-6db046126bea\n", "serial: \n", `"serial" header should not be empty`},
 		{"groups:", "groups: foo\nviews:", `"groups" header must be a list`},
-		{"groups:", "views:", `"groups" stanza is mandatory`},
 		{"groups:", "groups:\n  - bar", `cannot parse group at position 1: must be a map`},
 		{"    operators:\n      - jane\n", "", `cannot parse group at position 3: "operators" must be provided`},
 		{

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -312,6 +312,24 @@ func (s *confdbCtrlSuite) TestDecodeOK(c *C) {
 	c.Check(delegated, Equals, true)
 }
 
+func (s *confdbCtrlSuite) TestDecodeEmptyAssertionOK(c *C) {
+	emptyAssertion := `type: confdb-control
+brand-id: generic
+model: generic-classic
+serial: 03961d5d-26e5-443f-838d-6db046126bea
+sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp
+
+AXNpZw==`
+
+	a, err := asserts.Decode([]byte(emptyAssertion))
+	c.Assert(err, IsNil)
+	c.Assert(a, NotNil)
+
+	ctrl := a.(*asserts.ConfdbControl).Control()
+	groups := ctrl.Groups()
+	c.Assert(groups, HasLen, 0)
+}
+
 func (s *confdbCtrlSuite) TestDecodeInvalid(c *C) {
 	encoded := confdbControlExample
 	const validationSetErrPrefix = "assertion confdb-control: "
@@ -424,7 +442,16 @@ func (s *confdbCtrlSuite) TestAckAssertionOK(c *C) {
 	s.addSerial(c)
 
 	headers := map[string]interface{}{
-		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []interface{}{},
+		"brand-id": "canonical",
+		"model":    "pc",
+		"serial":   "42",
+		"groups": []interface{}{
+			map[string]interface{}{
+				"operators":       []interface{}{"aa", "cc"},
+				"authentications": []interface{}{"operator-key"},
+				"views":           []interface{}{"pp/qq/rr"},
+			},
+		},
 	}
 	a, err := asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey0)
 	c.Assert(err, IsNil)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/strutil"
@@ -83,6 +84,7 @@ var api = []*Command{
 	quotaGroupsCmd,
 	quotaGroupInfoCmd,
 	confdbCmd,
+	confdbControlCmd,
 	noticesCmd,
 	noticeCmd,
 	requestsPromptsCmd,
@@ -177,6 +179,8 @@ var (
 	confdbstateGetTransactionToSet = confdbstate.GetTransactionToSet
 	confdbstateSetViaView          = confdbstate.SetViaView
 	confdbstateLoadConfdbAsync     = confdbstate.LoadConfdbAsync
+
+	devicestateSignConfdbControl = (*devicestate.DeviceManager).SignConfdbControl
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -179,10 +179,7 @@ func handleConfdbControlAction(c *Command, r *http.Request, user *auth.UserState
 
 	var ctrl confdb.Control
 	var revision int
-	if cc == nil {
-		ctrl = confdb.Control{}
-		revision = 0
-	} else {
+	if cc != nil {
 		ctrl = cc.Control()
 		revision = cc.Revision() + 1
 	}

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -173,7 +173,7 @@ func handleConfdbControlAction(c *Command, r *http.Request, user *auth.UserState
 
 	devMgr := c.d.overlord.DeviceManager()
 	cc, err := devMgr.ConfdbControl()
-	if err != nil {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return InternalError(err.Error())
 	}
 

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -176,7 +176,7 @@ func handleConfdbControlAction(c *Command, r *http.Request, user *auth.UserState
 	cc, err := devMgr.ConfdbControl()
 	if err != nil &&
 		(!errors.Is(err, state.ErrNoState) ||
-			errors.Is(err, devicestate.ErrNoDeviceIdentityYet{})) {
+			errors.Is(err, devicestate.ErrNoDeviceIdentityYet)) {
 		return InternalError(err.Error())
 	}
 

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -53,7 +53,7 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	if err := validateFeatureFlag(st, features.Confdbs); err != nil {
+	if err := validateFeatureFlag(st, features.Confdb); err != nil {
 		return err
 	}
 
@@ -85,7 +85,7 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	if err := validateFeatureFlag(st, features.Confdbs); err != nil {
+	if err := validateFeatureFlag(st, features.Confdb); err != nil {
 		return err
 	}
 
@@ -164,7 +164,7 @@ func handleConfdbControlAction(c *Command, r *http.Request, user *auth.UserState
 	st.Lock()
 	defer st.Unlock()
 
-	if err := validateFeatureFlag(st, features.Confdbs); err != nil {
+	if err := validateFeatureFlag(st, features.Confdb); err != nil {
 		return err
 	}
 	if err := validateFeatureFlag(st, features.ConfdbControl); err != nil {

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -173,7 +174,9 @@ func handleConfdbControlAction(c *Command, r *http.Request, user *auth.UserState
 
 	devMgr := c.d.overlord.DeviceManager()
 	cc, err := devMgr.ConfdbControl()
-	if err != nil && !errors.Is(err, state.ErrNoState) {
+	if err != nil &&
+		(!errors.Is(err, state.ErrNoState) ||
+			errors.Is(err, devicestate.ErrNoDeviceIdentityYet{})) {
 		return InternalError(err.Error())
 	}
 

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -24,16 +24,24 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
+	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -479,4 +487,256 @@ func (s *confdbSuite) TestGetNoFields(c *C) {
 	rspe := s.asyncReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 202)
 	c.Check(rspe.Change, Equals, "123")
+}
+
+type confdbControlSuite struct {
+	apiBaseSuite
+
+	st     *state.State
+	brands *assertstest.SigningAccounts
+	serial *asserts.Serial
+}
+
+var _ = Suite(&confdbControlSuite{})
+
+var (
+	deviceKey, _ = assertstest.GenerateKey(752)
+)
+
+func (s *confdbControlSuite) SetUpTest(c *C) {
+	s.apiBaseSuite.SetUpTest(c)
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
+
+	s.st = state.New(nil)
+	o := overlord.MockWithState(s.st)
+	s.d = daemon.NewWithOverlord(o)
+
+	hookMgr, err := hookstate.Manager(s.st, o.TaskRunner())
+	c.Assert(err, check.IsNil)
+
+	deviceMgr, err := devicestate.Manager(s.st, hookMgr, o.TaskRunner(), nil)
+	c.Assert(err, check.IsNil)
+	o.AddManager(deviceMgr)
+
+	assertMgr, err := assertstate.Manager(s.st, o.TaskRunner())
+	c.Assert(err, check.IsNil)
+	o.AddManager(assertMgr)
+
+	storeStack := assertstest.NewStoreStack("can0nical", nil)
+	s.brands = assertstest.NewSigningAccounts(storeStack)
+}
+
+func (s *confdbControlSuite) setFeatureFlag(c *C, confName string) {
+	s.st.Lock()
+	tr := config.NewTransaction(s.st)
+	err := tr.Set("core", confName, true)
+	c.Assert(err, IsNil)
+	tr.Commit()
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) prereqs(c *C) {
+	s.setFeatureFlag(c, "experimental.confdbs")
+	s.setFeatureFlag(c, "experimental.confdb-control")
+
+	s.st.Lock()
+	encDevKey, _ := asserts.EncodePublicKey(deviceKey.PublicKey())
+	a, err := s.brands.Signing("can0nical").Sign(asserts.SerialType, map[string]interface{}{
+		"brand-id":            "can0nical",
+		"model":               "generic-classic",
+		"serial":              "serial-serial",
+		"device-key":          string(encDevKey),
+		"device-key-sha3-384": deviceKey.PublicKey().ID(),
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	err = assertstate.Add(s.st, a)
+	c.Assert(err, IsNil)
+	s.serial = a.(*asserts.Serial)
+
+	devicestatetest.SetDevice(s.st, &auth.DeviceState{
+		Brand:  "can0nical",
+		Model:  "generic-classic",
+		Serial: "serial-serial",
+	})
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) TestConfdbFlagNotEnabled(c *C) {
+	req, err := http.NewRequest("POST", "/v2/confdb", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 400)
+	c.Check(rspe.Message, Equals, `"confdbs" feature flag is disabled: set 'experimental.confdbs' to true`)
+}
+
+func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
+	s.setFeatureFlag(c, "experimental.confdbs")
+
+	req, err := http.NewRequest("POST", "/v2/confdb", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 400)
+	c.Check(rspe.Message, Equals, `"confdb-control" feature flag is disabled: set 'experimental.confdb-control' to true`)
+}
+
+func (s *confdbSuite) TestValidateFeatureFlagErr(c *C) {
+	s.st.Lock()
+	tr := config.NewTransaction(s.st)
+	tr.Set("core", "experimental.confdb-control", "wut")
+	tr.Commit()
+
+	err := daemon.ValidateFeatureFlag(s.st, features.ConfdbControl)
+	c.Check(
+		err.Message, Equals,
+		`internal error: cannot check confdb-control feature flag: confdb-control can only be set to 'true' or 'false', got "wut"`,
+	)
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionNoSerial(c *C) {
+	s.setFeatureFlag(c, "experimental.confdbs")
+	s.setFeatureFlag(c, "experimental.confdb-control")
+
+	req, err := http.NewRequest("POST", "/v2/confdb", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 500)
+	c.Check(rspe.Message, Equals, "device has no serial assertion")
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionOK(c *C) {
+	s.prereqs(c)
+	jane := map[string]interface{}{
+		"operators":       []interface{}{"jane"},
+		"authentications": []interface{}{"store"},
+		"views":           []interface{}{"account/confdb/view"},
+	}
+	restore := daemon.MockDeviceStateSignConfdbControl(func(m *devicestate.DeviceManager, groups []interface{}, revision int) (*asserts.ConfdbControl, error) {
+		a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]interface{}{
+			"brand-id": "can0nical",
+			"model":    "generic-classic",
+			"serial":   "serial-serial",
+			"groups":   []interface{}{jane},
+		}, nil, deviceKey)
+		c.Assert(err, IsNil)
+		return a.(*asserts.ConfdbControl), nil
+	})
+	defer restore()
+
+	body := `{"action": "delegate", "operator-id": "jane", "authentications": ["store"], "views": ["account/confdb/view"]}`
+	req, err := http.NewRequest("POST", "/v2/confdb", bytes.NewBufferString(body))
+	c.Assert(err, IsNil)
+	s.asUserAuth(c, req)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Assert(rsp.Status, Equals, 200)
+	c.Check(rsp.Result, DeepEquals, nil)
+
+	s.st.Lock()
+	a, err := assertstate.DB(s.st).Find(
+		asserts.ConfdbControlType,
+		map[string]string{"brand-id": "can0nical", "model": "generic-classic", "serial": "serial-serial"},
+	)
+	c.Assert(err, IsNil)
+	cc := a.(*asserts.ConfdbControl)
+	ctrl := cc.Control()
+	c.Check(ctrl.Groups(), DeepEquals, []interface{}{jane})
+	s.st.Unlock()
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionSigningErr(c *C) {
+	s.prereqs(c)
+
+	body := `{"action": "delegate", "operator-id": "jane", "authentications": ["store"], "views": ["account/confdb/view"]}`
+	req, err := http.NewRequest("POST", "/v2/confdb", bytes.NewBufferString(body))
+	c.Assert(err, IsNil)
+	s.asUserAuth(c, req)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 500)
+	c.Check(rspe.Message, Equals, "cannot sign confdb-control without device key")
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionAckErr(c *C) {
+	s.prereqs(c)
+	restore := daemon.MockDeviceStateSignConfdbControl(func(m *devicestate.DeviceManager, groups []interface{}, revision int) (*asserts.ConfdbControl, error) {
+		a := assertstest.FakeAssertion(
+			map[string]interface{}{
+				"type":     "confdb-control",
+				"brand-id": "can0nical",
+				"model":    "generic-classic",
+				"serial":   "serial-serial",
+				"groups":   []interface{}{},
+			},
+		)
+		return a.(*asserts.ConfdbControl), nil
+	})
+	defer restore()
+
+	s.st.Lock()
+	jane := map[string]interface{}{
+		"operators":       []interface{}{"jane"},
+		"authentications": []interface{}{"store"},
+		"views":           []interface{}{"account/confdb/view"},
+	}
+	a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]interface{}{
+		"brand-id": "can0nical",
+		"model":    "generic-classic",
+		"serial":   "serial-serial",
+		"groups":   []interface{}{jane},
+	}, nil, deviceKey)
+	c.Assert(err, IsNil)
+	assertstate.Add(s.st, a)
+	s.st.Unlock()
+
+	body := `{"action": "undelegate", "operator-id": "jane", "authentications": ["store"]}`
+	req, err := http.NewRequest("POST", "/v2/confdb", bytes.NewBufferString(body))
+	c.Assert(err, IsNil)
+	s.asUserAuth(c, req)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 500)
+	c.Check(
+		rspe.Message,
+		Equals,
+		`cannot check no-authority assertion type "confdb-control": confdb-control's signing key doesn't match the device key`,
+	)
+}
+
+func (s *confdbControlSuite) TestConfdbControlActionInvalidRequest(c *C) {
+	s.prereqs(c)
+
+	type testcase struct {
+		body   string
+		errMsg string
+	}
+	tcs := []testcase{
+		{
+			body:   "}",
+			errMsg: "cannot decode request body: invalid character '}' looking for beginning of value",
+		},
+		{
+			body:   `{"action": "unknown", "operator-id": "jane"}`,
+			errMsg: `unknown action "unknown"`,
+		},
+		{
+			body:   `{"action": "delegate", "operator-id": "jane", "authentications": ["unknown"]}`,
+			errMsg: "cannot delegate: invalid authentication method: unknown",
+		},
+	}
+
+	for _, tc := range tcs {
+		req, err := http.NewRequest("POST", "/v2/confdb", bytes.NewBufferString(tc.body))
+		c.Assert(err, IsNil)
+		s.asUserAuth(c, req)
+
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, Equals, 400)
+		c.Check(rspe.Message, Equals, tc.errMsg)
+	}
 }

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -569,7 +569,7 @@ func (s *confdbControlSuite) TestConfdbFlagNotEnabled(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `"confdbs" feature flag is disabled: set 'experimental.confdbs' to true`)
+	c.Check(rspe.Message, Equals, `feature flag "confdbs" is disabled: set 'experimental.confdbs' to true`)
 }
 
 func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
@@ -580,21 +580,7 @@ func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `"confdb-control" feature flag is disabled: set 'experimental.confdb-control' to true`)
-}
-
-func (s *confdbSuite) TestValidateFeatureFlagErr(c *C) {
-	s.st.Lock()
-	tr := config.NewTransaction(s.st)
-	tr.Set("core", "experimental.confdb-control", "wut")
-	tr.Commit()
-
-	err := daemon.ValidateFeatureFlag(s.st, features.ConfdbControl)
-	c.Check(
-		err.Message, Equals,
-		`internal error: cannot check confdb-control feature flag: confdb-control can only be set to 'true' or 'false', got "wut"`,
-	)
-	s.st.Unlock()
+	c.Check(rspe.Message, Equals, `feature flag "confdb-control" is disabled: set 'experimental.confdb-control' to true`)
 }
 
 func (s *confdbControlSuite) TestConfdbControlActionNoSerial(c *C) {

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -592,7 +592,7 @@ func (s *confdbControlSuite) TestConfdbControlActionNoSerial(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 500)
-	c.Check(rspe.Message, Equals, "device has no serial assertion")
+	c.Check(rspe.Message, Equals, "device has no identity yet")
 }
 
 func (s *confdbControlSuite) TestConfdbControlActionOK(c *C) {

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -449,7 +449,7 @@ func (s *confdbSuite) TestSetFailUnsetFeatureFlag(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `"confdb" feature flag is disabled: set 'experimental.confdb' to true`)
+	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled: set 'experimental.confdb' to true`)
 	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
 }
 
@@ -459,7 +459,7 @@ func (s *confdbSuite) TestGetFailUnsetFeatureFlag(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `"confdb" feature flag is disabled: set 'experimental.confdb' to true`)
+	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled: set 'experimental.confdb' to true`)
 	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
 }
 
@@ -536,7 +536,7 @@ func (s *confdbControlSuite) setFeatureFlag(c *C, confName string) {
 }
 
 func (s *confdbControlSuite) prereqs(c *C) {
-	s.setFeatureFlag(c, "experimental.confdbs")
+	s.setFeatureFlag(c, "experimental.confdb")
 	s.setFeatureFlag(c, "experimental.confdb-control")
 
 	s.st.Lock()
@@ -569,11 +569,11 @@ func (s *confdbControlSuite) TestConfdbFlagNotEnabled(c *C) {
 
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `feature flag "confdbs" is disabled: set 'experimental.confdbs' to true`)
+	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled: set 'experimental.confdb' to true`)
 }
 
 func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
-	s.setFeatureFlag(c, "experimental.confdbs")
+	s.setFeatureFlag(c, "experimental.confdb")
 
 	req, err := http.NewRequest("POST", "/v2/confdb", nil)
 	c.Assert(err, IsNil)
@@ -584,7 +584,7 @@ func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
 }
 
 func (s *confdbControlSuite) TestConfdbControlActionNoSerial(c *C) {
-	s.setFeatureFlag(c, "experimental.confdbs")
+	s.setFeatureFlag(c, "experimental.confdb")
 	s.setFeatureFlag(c, "experimental.confdb-control")
 
 	req, err := http.NewRequest("POST", "/v2/confdb", nil)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -26,14 +26,17 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/confdb"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/confdbstate"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -431,4 +434,12 @@ func MockAssertstateFetchAllValidationSets(f func(*state.State, int, *assertstat
 
 func MockConfdbstateLoadConfdbAsync(f func(_ *state.State, _ *confdb.View, _ []string) (string, error)) (restore func()) {
 	return testutil.Mock(&confdbstateLoadConfdbAsync, f)
+}
+
+func ValidateFeatureFlag(st *state.State, feature features.SnapdFeature) *apiError {
+	return validateFeatureFlag(st, feature)
+}
+
+func MockDeviceStateSignConfdbControl(f func(m *devicestate.DeviceManager, groups []interface{}, revision int) (*asserts.ConfdbControl, error)) (restore func()) {
+	return testutil.Mock(&devicestateSignConfdbControl, f)
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -80,14 +80,17 @@ var EarlyConfig func(st *state.State, preloadGadget func() (sysconfig.Device, *g
 
 // ErrNoDeviceIdentityYet is returned when the device doesn't have a serial assertion.
 // It's a special case of ErrNoState.
-type ErrNoDeviceIdentityYet struct{}
+var ErrNoDeviceIdentityYet = &noDeviceIdentityYetError{}
 
-func (e ErrNoDeviceIdentityYet) Error() string {
+// noDeviceIdentityYetError is returned when the device doesn't have a serial assertion.
+type noDeviceIdentityYetError struct{}
+
+func (e *noDeviceIdentityYetError) Error() string {
 	return "device has no identity yet"
 }
 
-func (e ErrNoDeviceIdentityYet) Is(err error) bool {
-	_, ok := err.(ErrNoDeviceIdentityYet)
+func (e *noDeviceIdentityYetError) Is(err error) bool {
+	_, ok := err.(*noDeviceIdentityYetError)
 	return ok || errors.Is(err, state.ErrNoState)
 }
 
@@ -2072,7 +2075,7 @@ func (m *DeviceManager) Serial() (*asserts.Serial, error) {
 func (m *DeviceManager) ConfdbControl() (*asserts.ConfdbControl, error) {
 	serial, err := m.Serial()
 	if err != nil {
-		return nil, ErrNoDeviceIdentityYet{}
+		return nil, ErrNoDeviceIdentityYet
 	}
 
 	db := assertstate.DB(m.state)

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -86,9 +86,9 @@ func (e ErrNoDeviceIdentityYet) Error() string {
 	return "device has no identity yet"
 }
 
-func (e ErrNoDeviceIdentityYet) Is(target error) bool {
-	_, ok := target.(ErrNoDeviceIdentityYet)
-	return ok || target == state.ErrNoState
+func (e ErrNoDeviceIdentityYet) Is(err error) bool {
+	_, ok := err.(ErrNoDeviceIdentityYet)
+	return ok || errors.Is(err, state.ErrNoState)
 }
 
 // DeviceManager is responsible for managing the device identity and device

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -78,6 +78,19 @@ var (
 // during managers' startup.
 var EarlyConfig func(st *state.State, preloadGadget func() (sysconfig.Device, *gadget.Info, error)) error
 
+// ErrNoDeviceIdentityYet is returned when the device doesn't have a serial assertion.
+// It's a special case of ErrNoState.
+type ErrNoDeviceIdentityYet struct{}
+
+func (e ErrNoDeviceIdentityYet) Error() string {
+	return "device has no identity yet"
+}
+
+func (e ErrNoDeviceIdentityYet) Is(target error) bool {
+	_, ok := target.(ErrNoDeviceIdentityYet)
+	return ok || target == state.ErrNoState
+}
+
 // DeviceManager is responsible for managing the device identity and device
 // policies.
 type DeviceManager struct {
@@ -2059,7 +2072,7 @@ func (m *DeviceManager) Serial() (*asserts.Serial, error) {
 func (m *DeviceManager) ConfdbControl() (*asserts.ConfdbControl, error) {
 	serial, err := m.Serial()
 	if err != nil {
-		return nil, errors.New("device has no serial assertion")
+		return nil, ErrNoDeviceIdentityYet{}
 	}
 
 	db := assertstate.DB(m.state)

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2055,6 +2055,29 @@ func (m *DeviceManager) Serial() (*asserts.Serial, error) {
 	return findSerial(m.state, nil)
 }
 
+// ConfdbControl returns the device's confdb-control assertion.
+func (m *DeviceManager) ConfdbControl() (*asserts.ConfdbControl, error) {
+	serial, err := m.Serial()
+	if err != nil {
+		return nil, errors.New("device has no serial assertion")
+	}
+
+	db := assertstate.DB(m.state)
+	a, err := db.Find(asserts.ConfdbControlType, map[string]string{
+		"brand-id": serial.BrandID(),
+		"model":    serial.Model(),
+		"serial":   serial.Serial(),
+	})
+	if errors.Is(err, &asserts.NotFoundError{}) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return a.(*asserts.ConfdbControl), nil
+}
+
 type SystemModeInfo struct {
 	Mode              string
 	HasModeenv        bool

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2069,13 +2069,19 @@ func (m *DeviceManager) ConfdbControl() (*asserts.ConfdbControl, error) {
 		"serial":   serial.Serial(),
 	})
 	if errors.Is(err, &asserts.NotFoundError{}) {
-		return nil, nil
+		return nil, state.ErrNoState
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	return a.(*asserts.ConfdbControl), nil
+	cc := a.(*asserts.ConfdbControl)
+	key := serial.DeviceKey()
+	if key.ID() != cc.SignKeyID() {
+		return nil, errors.New("confdb-control's signing key doesn't match the device key")
+	}
+
+	return cc, nil
 }
 
 type SystemModeInfo struct {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -461,22 +461,18 @@ func (s *deviceMgrBaseSuite) makeSerialAssertionInState(c *C, brandID, model, se
 	return makeSerialAssertionInState(c, s.brands, s.state, brandID, model, serialN)
 }
 
-func (s *deviceMgrBaseSuite) addKeyToManagerInState(c *C, key asserts.PrivateKey) {
-	if key == nil {
-		key = devKey
-	}
-
+func (s *deviceMgrBaseSuite) addKeyToManagerInState(c *C) {
 	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 
-	err = devicestate.KeypairManager(s.mgr).Put(key)
+	err = devicestate.KeypairManager(s.mgr).Put(devKey)
 	c.Assert(err, IsNil)
 
 	err = devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  device.Brand,
 		Model:  device.Model,
 		Serial: device.Serial,
-		KeyID:  key.PublicKey().ID(),
+		KeyID:  devKey.PublicKey().ID(),
 	})
 	c.Assert(err, IsNil)
 }
@@ -2852,7 +2848,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlInvalid(c *C) {
 	defer s.state.Unlock()
 
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
-	s.addKeyToManagerInState(c, devKey)
+	s.addKeyToManagerInState(c)
 
 	groups := []interface{}{map[string]interface{}{"operators": []interface{}{"jane"}}}
 	_, err := s.mgr.SignConfdbControl(groups, 4)
@@ -2869,7 +2865,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlOK(c *C) {
 	defer s.state.Unlock()
 
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
-	s.addKeyToManagerInState(c, devKey)
+	s.addKeyToManagerInState(c)
 
 	jane := map[string]interface{}{
 		"operators":       []interface{}{"jane"},
@@ -2903,7 +2899,7 @@ func (s *deviceMgrSuite) TestConfdbControlNotFound(c *C) {
 	defer s.state.Unlock()
 
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
-	s.addKeyToManagerInState(c, devKey)
+	s.addKeyToManagerInState(c)
 
 	cc, err := s.mgr.ConfdbControl()
 	c.Assert(cc, IsNil)
@@ -2916,7 +2912,7 @@ func (s *deviceMgrSuite) TestConfbControlUnknownSigningKey(c *C) {
 	defer s.state.Unlock()
 
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
-	s.addKeyToManagerInState(c, devKey)
+	s.addKeyToManagerInState(c)
 
 	cc, err := s.mgr.SignConfdbControl([]interface{}{}, 10)
 	c.Assert(err, IsNil)
@@ -2952,7 +2948,7 @@ func (s *deviceMgrSuite) TestConfdbControlFindExisting(c *C) {
 	defer s.state.Unlock()
 
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
-	s.addKeyToManagerInState(c, devKey)
+	s.addKeyToManagerInState(c)
 
 	// add assertion
 	cc, err := s.mgr.SignConfdbControl([]interface{}{}, 10)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2890,7 +2890,7 @@ func (s *deviceMgrSuite) TestConfdbControlNoSerial(c *C) {
 	defer s.state.Unlock()
 
 	_, err := s.mgr.ConfdbControl()
-	c.Assert(err, ErrorMatches, "device has no serial assertion")
+	c.Assert(err, ErrorMatches, "device has no identity yet")
 }
 
 func (s *deviceMgrSuite) TestConfdbControlNotFound(c *C) {


### PR DESCRIPTION
This PR adds the confdb-control API as specified in SD186.

I've removed the mandatory requirement for `groups` since it's possible to have a confdb-control assertion without any delegations. Previously, it would raise an error:

```console
$ sudo curl --unix-socket /run/snapd.socket -X POST \
  -d '{"action": "delegate", "operator-id": "alice", "views": ["canonical/confdb/view", "canonical/another/view"], "authentications": ["operator-key"]}' \
  "http://localhost/v2/confdb"
{"type":"sync","status-code":200,"status":"OK","result":null}

$ snap known confdb-control
type: confdb-control
brand-id: generic
model: generic-classic
serial: <serial>
groups:
  -
    authentications:
      - operator-key
    operators:
      - alice
    views:
      - canonical/another/view
      - canonical/confdb/view
sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp

AcLBUgQAAQoABgUCZ7bRbAAATAUQAHPCWwk5LfdGdU+A1iuaoHEA6Hxnd+WgaNWFQuCyUldDzDAR
NF3F9Js8Zj/nDjFkWAtf6I09+6O9f4mHFEltfkCfyDbUzs/c68M4Ti3kigpDuqMkoggNzF07j0tE
aYwNo3KtWQtD9kJz/rrAh48ZlKUuLfXdnDPuLuYP6gGy2AtlyKRhvE6ZZ4wrNiDlIf5TXE4CaiKh
/IxOyLZMDg5pcJTMwIUdEHWIX8+DBG9t9Ix3WZwJptwuPWIQDq5isKuhlR6Ul/P1sarMeQbxivKG
VUMlL/Sjt+PqRBKeufWtlkUf3Lg3OoUc3XJzCnj1Y1coRtWpXfSgtcCH2MF7/HoMlL1TLf8HSYX+
8bwGtlQYddYzsf/mY4Y35JAYaqqh62KLgTtem/BfZEdasIduOb/ZiljZ7ETDndr3PEgelfeUgY5m
4Z3jxOTjvdE7tWDRdDdw2L9J+VXvqbx3fprPy2Go/ewU7fpMcxxfkVRp3uyRqyLUefYk3dbLULmx
3lrqtAIY1cA7pPocS6ntpv1khjNBI30GAuJSxz1h8fQozZGNiFrw1pR8xLTvt/1z6iTPnGsXi9Bn
IodMN3Od2clhVV3L3BrFPwze4CKPgd0PXa/kNULf8KRnHzCDVuyJDrYfplWQzCwKWZWJF8vxEGPV
lvqt7pQh8PkLMQRkzhSM62VufmdA

$ sudo curl --unix-socket /run/snapd.socket -X POST \
  -d '{"action": "undelegate", "operator-id": "alice"}' \
  "http://localhost/v2/confdb"
{"type":"sync","status-code":200,"status":"OK","result":null}%

$ snap known confdb-control
error: searching assertions failed: broken assertion storage, searching for confdb-control:
       broken assertion storage, cannot decode assertion: assertion confdb-control: "groups" stanza
       is mandatory

$ cat /var/lib/snapd/assertions/asserts-v0/confdb-control/generic/generic-classic/<serial>/active
type: confdb-control
revision: 1
brand-id: generic
model: generic-classic
serial: <serial>
sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp

AcLBUgQAAQoABgUCZ7bRfgAAnOYQACRgCaFL3hGaDAfNsM9YIx7m0KqXSEYrF4TOLj4JtdjlH8l3
8yqkmgI9wD98OekqwRzjziBLFgY5HId3jVz6u91KfArA8BCj1Gru56c2dY8RusoPX94eVtNKMjpJ
EuUx276x7hEHNQe72QOGH5khFB5zSwmSNHjgUTCtzGz7hLZL6tY32Gt4TF+sT1Nf5kiA7JTdV2tw
WCDSEORf2bs4IsJR3jTvNSydYeqn95RvGkDL4zA5lmYygVQtCWemWjjhpZWJVQ5aPlm7IxEf14RC
QU7Ja6UnV9KOGQbIQcdUYQZMC7u2QXaMes0OcXFo1JO+EmTW9nJA0YYill8nAB+e22OS4eUekFLd
5F2mttxJC7az7UEO3B2dLvaQyvQ7Vsx5qbOyu7fq8HazwNQiMH1C34RpfBAXd2mCCQRmVWWpiNDv
sp25Xr6PiM8kg/uRYHAAfRFj1PgNAJPDA5qLW1kfCnq4R3KvpLA+iqCLVDv261kQZY8ArQN4dBaf
92ixC8Fo+uwh4H7hMI+6XeVQy5XLolOCuBYK5VaArY8Wttya44+CYWQLeDGzTJ5b7lyemKHZ9C0W
s5FFh7Q7zeZcL2/xlCgYiGjmbNmK9SqbCbSYxpma9RDaUGxRrWKt+gEOhdvj8Qj4RUaJsLS10K3Y
vmYbsQbEWBI50lU4tRpEitMLFiFZ
```