### PR TITLE
image, seed: check snap-bootstrap compatibility for FDE

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -54,12 +54,13 @@ type cmdPrepareImage struct {
 	Customize string `long:"customize" hidden:"yes"`
 
 	// TODO: introduce SnapWithChannel?
-	Snaps              []string `long:"snap" value-name:"<snap>[=<channel>]"`
-	Components         []string `long:"comp" value-name:"<snap>+<comp>"`
-	ExtraSnaps         []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED
-	RevisionsFile      string   `long:"revisions"`
-	WriteRevisionsFile string   `long:"write-revisions" optional:"true" optional-value:"./seed.manifest"`
-	Validation         string   `long:"validation" choice:"ignore" choice:"enforce"`
+	Snaps                    []string `long:"snap" value-name:"<snap>[=<channel>]"`
+	Components               []string `long:"comp" value-name:"<snap>+<comp>"`
+	ExtraSnaps               []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED
+	RevisionsFile            string   `long:"revisions"`
+	WriteRevisionsFile       string   `long:"write-revisions" optional:"true" optional-value:"./seed.manifest"`
+	Validation               string   `long:"validation" choice:"ignore" choice:"enforce"`
+	AllowSnapdKernelMismatch bool     `long:"allow-snapd-kernel-mismatch"`
 }
 
 func init() {
@@ -103,6 +104,8 @@ For preparing classic images it supports a --classic mode`),
 			"customize": i18n.G("Image customizations specified as JSON file."),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"validation": i18n.G("Control whether validations should be ignored or enforced. (default: ignore)"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"allow-snapd-kernel-mismatch": i18n.G("Whether a mismatch between versions of the snapd snap and snapd in kernel is allowed"),
 		}, []argDesc{
 			{
 				// TRANSLATORS: This needs to begin with < and end with >
@@ -128,12 +131,13 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	snap.SanitizePlugsSlots = builtin.SanitizePlugsSlots
 
 	opts := &image.Options{
-		Snaps:            x.ExtraSnaps,
-		Components:       x.Components,
-		ModelFile:        x.Positional.ModelAssertionFn,
-		Channel:          x.Channel,
-		Architecture:     x.Architecture,
-		SeedManifestPath: x.WriteRevisionsFile,
+		Snaps:                    x.ExtraSnaps,
+		Components:               x.Components,
+		ModelFile:                x.Positional.ModelAssertionFn,
+		Channel:                  x.Channel,
+		Architecture:             x.Architecture,
+		SeedManifestPath:         x.WriteRevisionsFile,
+		AllowSnapdKernelMismatch: x.AllowSnapdKernelMismatch,
 	}
 
 	if x.RevisionsFile != "" {

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -208,6 +208,26 @@ func (s *SnapPrepareImageSuite) TestPrepareImageCustomizeValidated(c *C) {
 	})
 }
 
+func (s *SnapPrepareImageSuite) TestPrepareImageAllowSnapdKernelMismatch(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := cmdsnap.MockImagePrepare(prep)
+	defer r()
+
+	rest, err := cmdsnap.Parser(cmdsnap.Client()).ParseArgs([]string{"prepare-image", "model", "prepare-dir", "--allow-snapd-kernel-mismatch"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		ModelFile:                "model",
+		PrepareDir:               "prepare-dir",
+		AllowSnapdKernelMismatch: true,
+	})
+}
+
 func (s *SnapPrepareImageSuite) TestReadSeedManifest(c *C) {
 	var opts *image.Options
 	prep := func(o *image.Options) error {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -842,6 +842,10 @@ func (s *imageSeeder) warnOnUnassertedSnaps() error {
 }
 
 func (s *imageSeeder) finish() error {
+	if err := s.w.VerifySnapBootstrapCompatibility(); err != nil {
+		fmt.Fprintf(Stderr, "WARNING: %v\n", err)
+	}
+
 	// print any warnings that occurred during the download phase
 	for _, warn := range s.w.Warnings() {
 		fmt.Fprintf(Stderr, "WARNING: %s\n", warn)

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -284,11 +284,12 @@ type imageSeeder struct {
 	model *asserts.Model
 	tsto  *tooling.ToolingStore
 
-	classic        bool
-	prepareDir     string
-	wideCohortKey  string
-	customizations *Customizations
-	architecture   string
+	classic                  bool
+	prepareDir               string
+	wideCohortKey            string
+	customizations           *Customizations
+	architecture             string
+	allowSnapdKernelMismatch bool
 
 	hasModes    bool
 	rootDir     string
@@ -313,12 +314,17 @@ func newImageSeeder(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opti
 		wideCohortKey: opts.WideCohortKey,
 		// keep a pointer to the customization object in opts as the Validation
 		// member might be defaulted if not set.
-		customizations: &opts.Customizations,
-		architecture:   determineImageArchitecture(model, opts),
+		customizations:           &opts.Customizations,
+		architecture:             determineImageArchitecture(model, opts),
+		allowSnapdKernelMismatch: opts.AllowSnapdKernelMismatch,
 
 		hasModes: model.Grade() != asserts.ModelGradeUnset,
 		model:    model,
 		tsto:     tsto,
+	}
+
+	if os.Getenv("SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH") == "true" {
+		s.allowSnapdKernelMismatch = true
 	}
 
 	if !s.hasModes {
@@ -842,7 +848,14 @@ func (s *imageSeeder) warnOnUnassertedSnaps() error {
 }
 
 func (s *imageSeeder) finish() error {
+	// Ensure that the snapd snap is compatible with the snap-bootstrap
+	// contained within the kernel snap.
 	if err := s.w.VerifySnapBootstrapCompatibility(); err != nil {
+		if !s.allowSnapdKernelMismatch {
+			// If not, error out as there is no reason to allow
+			// this as the resulting image will be invalid.
+			return err
+		}
 		fmt.Fprintf(Stderr, "WARNING: %v\n", err)
 	}
 

--- a/image/options.go
+++ b/image/options.go
@@ -69,6 +69,10 @@ type Options struct {
 	// useful only for classic mode. If set must match the model otherwise.
 	Architecture string
 
+	// AllowSnapdKernelMismatch if set, will allow building images with a snap/kernel
+	// combination that would otherwise be unsupported.
+	AllowSnapdKernelMismatch bool
+
 	Customizations Customizations
 }
 

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1800,7 +1800,7 @@ func (w *Writer) VerifySnapBootstrapCompatibility() error {
 			return fmt.Errorf("could not parse version %s: %w", kernelVersion, err)
 		}
 		if res < 0 {
-			return fmt.Errorf("snapd 2.68+ will not work in the same seed as kernel with snapd less then 2.68")
+			return fmt.Errorf("snapd 2.68+ is not compatible with a kernel containing snapd prior to 2.68")
 		}
 	}
 

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -1756,4 +1757,52 @@ func (w *Writer) UnassertedSnaps() ([]naming.SnapRef, error) {
 		res = append(res, sn.SnapRef)
 	}
 	return res, nil
+}
+
+func (w *Writer) VerifySnapBootstrapCompatibility() error {
+	var kernelSnap, snapdSnap *SeedSnap
+
+	saveSnap := func(sn *SeedSnap) {
+		switch sn.Info.SnapType {
+		case snap.TypeSnapd:
+			snapdSnap = sn
+		case snap.TypeKernel:
+			kernelSnap = sn
+		}
+	}
+	for _, sn := range w.snapsFromModel {
+		saveSnap(sn)
+	}
+	for _, sn := range w.extraSnaps {
+		saveSnap(sn)
+	}
+
+	if kernelSnap == nil || snapdSnap == nil {
+		return nil
+	}
+
+	kernelVersion, _, err := snap.SnapdInfoFromSnapFile(squashfs.New(kernelSnap.Path), snap.TypeKernel)
+	if err != nil {
+		return fmt.Errorf("error while reading snapd-info from kernel snap: %w", err)
+	}
+	snapdVersion, _, err := snap.SnapdInfoFromSnapFile(squashfs.New(snapdSnap.Path), snap.TypeSnapd)
+	if err != nil {
+		return fmt.Errorf("error while reading snapd-info from snapd snap: %w", err)
+	}
+
+	res, err := strutil.VersionCompare(snapdVersion, "2.68")
+	if err != nil {
+		return fmt.Errorf("could not parse version %s: %w", snapdVersion, err)
+	}
+	if res >= 0 {
+		res, err = strutil.VersionCompare(kernelVersion, "2.68")
+		if err != nil {
+			return fmt.Errorf("could not parse version %s: %w", kernelVersion, err)
+		}
+		if res < 0 {
+			return fmt.Errorf("snapd 2.68+ will not work in the same seed as kernel with snapd less then 2.68")
+		}
+	}
+
+	return nil
 }

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -5288,5 +5288,5 @@ func (s *writerSuite) TestVerifySnapBootstrapCompatibility(c *C) {
 	}
 
 	err = w.VerifySnapBootstrapCompatibility()
-	c.Check(err, ErrorMatches, `snapd 2.68[+] will not work in the same seed as kernel with snapd less then 2.68`)
+	c.Check(err, ErrorMatches, `snapd 2.68[+] is not compatible with a kernel containing snapd prior to 2.68`)
 }

--- a/spread.yaml
+++ b/spread.yaml
@@ -86,6 +86,8 @@ environment:
     SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/var/tmp/work-dir}")'
     # Threshold used to determine which stake locks have to be collected during runtime
     SNAPD_STATE_LOCK_TRACE_THRESHOLD_MS: '$(HOST: echo "${SPREAD_SNAPD_STATE_LOCK_TRACE_THRESHOLD_MS:-0}")'
+    # Allow mismatch in snapd/kernel versions
+    SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH: '$(HOST: echo "${SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH:-true}")'
 
     # Directory where the nested images and test assets are stored
     NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/var/tmp/work-dir}")'


### PR DESCRIPTION
Snapd 2.68 or later is not compatible in the same seed as snap-bootstrap 2.67 or before. We need to make it a bit more obvious to image builders by forbidding that combination.
