### PR TITLE
overlord/fdestate: re-factor listing of the disks

### DIFF
--- a/overlord/fdestate/dbx_test.go
+++ b/overlord/fdestate/dbx_test.go
@@ -112,7 +112,7 @@ func (s *fdeMgrSuite) TestEFIDBXPrepareHappy(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealCalls := 0
 	defer fdestate.MockBackendResealKeysForSignaturesDBUpdate(func(mgr backend.FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, update []byte) error {
@@ -208,7 +208,7 @@ func (s *fdeMgrSuite) TestEFIDBXPrepareConflictSelf(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealCalls := 0
 	defer fdestate.MockBackendResealKeysForSignaturesDBUpdate(func(mgr backend.FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, update []byte) error {
@@ -258,7 +258,7 @@ func (s *fdeMgrSuite) TestEFIDBXPrepareConflictOperationNotInDoingYet(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealCalls := 0
 	defer fdestate.MockBackendResealKeysForSignaturesDBUpdate(func(mgr backend.FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, update []byte) error {
@@ -302,7 +302,7 @@ func (s *fdeMgrSuite) TestEFIDBXPrepareConflictSnapChanges(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	defer testutil.Mock(&snapstate.EnforcedValidationSets, func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		return nil, nil
@@ -352,7 +352,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateAndCleanupRunningAction(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealForDBUPdateCalls := 0
 	resealForBootChainsCalls := 0
@@ -480,7 +480,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateAndUnexpectedStartupAction(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealForDBUPdateCalls := 0
 	resealForBootChainsCalls := 0
@@ -621,7 +621,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateAbort(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealForDBUpdateCalls := 0
 	resealForBootChainsCalls := 0
@@ -726,7 +726,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateResealFailedAborts(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealForDBUPdateCalls := 0
 	resealForBootChainsCalls := 0
@@ -788,7 +788,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdatePostUpdateResealFailed(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealForDBUPdateCalls := 0
 	resealForBootChainsCalls := 0
@@ -866,7 +866,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateUndoResealFails(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealForDBUPdateCalls := 0
 	resealForBootChainsCalls := 0
@@ -1141,7 +1141,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateAffectedSnaps(c *C) {
 	s.startedManager(c, onClassic)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	st.Lock()
 	defer st.Unlock()
@@ -1170,7 +1170,7 @@ func (s *fdeMgrSuite) TestEFIDBXConflictingSnaps(c *C) {
 	c.Assert(s.o.StartUp(), IsNil)
 
 	model := s.mockBootAssetsStateForModeenv(c)
-	s.mockDeviceInState(model)
+	s.mockDeviceInState(model, "run")
 
 	resealForDBUPdateCalls := 0
 	resealForBootChainsCalls := 0

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -21,6 +21,7 @@ package fdestate
 
 import (
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/testutil"
@@ -62,3 +63,19 @@ func MockBackendResealKeysForSignaturesDBUpdate(f func(updateState backend.FDESt
 var NewModel = newModel
 
 func (m *FDEManager) IsFunctional() error { return m.isFunctional() }
+
+func MockBootHostUbuntuDataForMode(f func(mode string, mod gadget.Model) ([]string, error)) (restore func()) {
+	old := bootHostUbuntuDataForMode
+	bootHostUbuntuDataForMode = f
+	return func() {
+		bootHostUbuntuDataForMode = old
+	}
+}
+
+func EncryptedContainer(uuid string, containerRole string, legacyKeys map[string]string) *encryptedContainer {
+	return &encryptedContainer{
+		uuid:          uuid,
+		containerRole: containerRole,
+		legacyKeys:    legacyKeys,
+	}
+}

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -34,9 +34,11 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/fdestate"
@@ -98,7 +100,7 @@ func (s *fdeMgrSuite) SetUpTest(c *C) {
 		func(manager backend.FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 			panic("BackendResealKeyForBootChains not mocked")
 		}))
-	s.AddCleanup(fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+	s.AddCleanup(fdestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		panic("MockDMCryptUUIDFromMountPoint is not mocked")
 	}))
 	s.AddCleanup(fdestate.MockGetPrimaryKeyDigest(func(devicePath string, alg crypto.Hash) ([]byte, []byte, error) {
@@ -115,12 +117,14 @@ func (s *fdeMgrSuite) SetUpTest(c *C) {
 		panic("secbootGetPCRHandle is not mocked")
 	}))
 
+	mountinfo := `26 27 8:3 / %s/var/lib/snapd/save rw,relatime shared:7 - ext4 /dev/fakedevice0p1 rw,data=ordered`
+	s.AddCleanup(osutil.MockMountInfo(fmt.Sprintf(mountinfo, dirs.GlobalRootDir)))
+
 	m := boot.Modeenv{
 		Mode: boot.ModeRun,
 	}
 	err := m.WriteTo(dirs.GlobalRootDir)
 	c.Assert(err, IsNil)
-
 }
 
 func (s *fdeMgrSuite) TearDownTest(c *C) {
@@ -129,12 +133,13 @@ func (s *fdeMgrSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *fdeMgrSuite) mockDeviceInState(model *asserts.Model) {
+func (s *fdeMgrSuite) mockDeviceInState(model *asserts.Model, sysMode string) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
 	s.AddCleanup(snapstatetest.MockDeviceContext(&snapstatetest.TrivialDeviceContext{
 		DeviceModel: model,
+		SysMode:     sysMode,
 	}))
 }
 
@@ -165,13 +170,15 @@ func (u *instrumentedUnlocker) Relock() {
 }
 
 func (s *fdeMgrSuite) startedManager(c *C, onClassic bool) *fdestate.FDEManager {
-	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+	s.mockDeviceInState(&asserts.Model{}, "run")
+
+	defer fdestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		switch mountpoint {
 		case dirs.GlobalRootDir:
-			c.Check(onClassic, Equals, true)
 			return "aaa", nil
 		case filepath.Join(dirs.GlobalRootDir, "writable"):
-			c.Check(onClassic, Equals, false)
+			return "aaa", nil
+		case filepath.Join(dirs.GlobalRootDir, "run/mnt/data"):
 			return "aaa", nil
 		case dirs.SnapSaveDir:
 			return "bbb", nil
@@ -193,22 +200,35 @@ func (s *fdeMgrSuite) startedManager(c *C, onClassic bool) *fdestate.FDEManager 
 		return true, nil
 	})()
 
+	err := os.MkdirAll(filepath.Dir(device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir)), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir), []byte{}, 0644)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Dir(device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir), []byte{}, 0644)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Dir(device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)), 0755)
+	c.Assert(err, IsNil)
+	err = os.WriteFile(device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir), []byte{}, 0644)
+	c.Assert(err, IsNil)
+
 	defer fdestate.MockSecbootGetPCRHandle(func(devicePath, keySlot, keyFile string) (uint32, error) {
 		switch devicePath {
 		case "/dev/disk/by-uuid/aaa":
 			switch keySlot {
 			case "default":
-				c.Check(keyFile, Equals, device.DataSealedKeyUnder(dirs.SnapSaveDir))
+				c.Check(keyFile, Equals, device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir))
 				return 41, nil
 			case "default-fallback":
-				c.Check(keyFile, Equals, device.FallbackDataSealedKeyUnder(dirs.SnapSaveDir))
+				c.Check(keyFile, Equals, device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir))
 				return 42, nil
 			default:
 				c.Errorf("unexpected keyslot %s", keySlot)
 			}
 		case "/dev/disk/by-uuid/bbb":
 			c.Check(keySlot, Equals, "default-fallback")
-			c.Check(keyFile, Equals, device.FallbackDataSealedKeyUnder(dirs.SnapSaveDir))
+			c.Check(keyFile, Equals, device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir))
 			return 42, nil
 		default:
 			c.Errorf("unexpected device path %s", devicePath)
@@ -397,9 +417,11 @@ type mountResolveTestCase struct {
 }
 
 func (s *fdeMgrSuite) testMountResolveError(c *C, tc mountResolveTestCase) {
-	defer fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+	s.mockDeviceInState(&asserts.Model{}, "run")
+
+	defer fdestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		switch mountpoint {
-		case dirs.GlobalRootDir:
+		case filepath.Join(dirs.GlobalRootDir, "run/mnt/data"):
 			// ubuntu-data
 			if tc.dataResolveErr != nil {
 				return "", tc.dataResolveErr
@@ -426,6 +448,10 @@ func (s *fdeMgrSuite) testMountResolveError(c *C, tc mountResolveTestCase) {
 			return false, fmt.Errorf("unexpected call to get primary key")
 		}
 		return true, nil
+	})()
+
+	defer fdestate.MockSecbootGetPCRHandle(func(devicePath, keySlot, keyFile string) (uint32, error) {
+		return 41, nil
 	})()
 
 	manager, err := fdestate.Manager(s.st, s.runner)
@@ -464,14 +490,14 @@ func (s *fdeMgrSuite) TestStateInitMountResolveError_NoDataNoSaveNoError(c *C) {
 func (s *fdeMgrSuite) TestStateInitMountResolveError_NoDataFails(c *C) {
 	s.testMountResolveError(c, mountResolveTestCase{
 		dataResolveErr: fmt.Errorf("mock error data"),
-		expectedError:  "cannot initialize FDE state: cannot resolve data partition mount: mock error data",
+		expectedError:  "cannot initialize FDE state: .*: mock error data",
 	})
 }
 
 func (s *fdeMgrSuite) TestStatetInitMountResolveError_NoSaveFails(c *C) {
 	s.testMountResolveError(c, mountResolveTestCase{
 		saveResolveErr: fmt.Errorf("mock error save"),
-		expectedError:  "cannot initialize FDE state: cannot resolve save partition mount: mock error save",
+		expectedError:  "cannot initialize FDE state: .*: mock error save",
 	})
 }
 
@@ -586,4 +612,53 @@ func (s *fdeMgrSuite) TestGetParameters(c *C) {
 	hasParameters, _, _, _, err = manager.GetParameters("run", "something-that-is-not-specific")
 	c.Assert(err, IsNil)
 	c.Check(hasParameters, Equals, false)
+}
+
+func (s *fdeMgrSuite) TestGetEncryptedContainers(c *C) {
+	dataPath := filepath.Join(dirs.GlobalRootDir, "path/to/data")
+
+	err := os.MkdirAll(filepath.Dir(dataPath), 0755)
+	c.Assert(err, IsNil)
+
+	onClassic := false
+	mgr := s.startedManager(c, onClassic)
+
+	model := &asserts.Model{}
+	s.mockDeviceInState(model, "run")
+
+	defer fdestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+		switch mountpoint {
+		case dataPath:
+			return "aaa", nil
+		case dirs.SnapSaveDir:
+			return "bbb", nil
+		}
+		panic(fmt.Sprintf("missing mocked mount point %q", mountpoint))
+	})()
+
+	defer fdestate.MockBootHostUbuntuDataForMode(func(mode string, mod gadget.Model) ([]string, error) {
+		c.Check(mode, Equals, "run")
+		c.Check(mod, Equals, model)
+		return []string{dataPath}, nil
+	})()
+
+	disks, err := mgr.GetEncryptedContainers()
+	c.Assert(err, IsNil)
+	c.Check(disks, DeepEquals, []backend.EncryptedContainer{
+		fdestate.EncryptedContainer(
+			"aaa",
+			"system-data",
+			map[string]string{
+				"default":          filepath.Join(dirs.GlobalRootDir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"),
+				"default-fallback": filepath.Join(dirs.GlobalRootDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"),
+			},
+		),
+		fdestate.EncryptedContainer(
+			"bbb",
+			"system-save",
+			map[string]string{
+				"default-fallback": filepath.Join(dirs.GlobalRootDir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"),
+			},
+		),
+	})
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -7469,11 +7469,11 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	})
 	defer restore()
 
-	restore = fdestate.MockDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+	restore = fdestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
 		switch mountpoint {
 		case filepath.Join(dirs.GlobalRootDir, "writable"):
 			return "root-uuid", nil
-		case dirs.GlobalRootDir:
+		case filepath.Join(dirs.GlobalRootDir, "run/mnt/data"):
 			return "root-uuid", nil
 		case dirs.SnapSaveDir:
 			return "save-uuid", nil


### PR DESCRIPTION
Both the state and reseal needed to know where disk and keys were
located. This now always takes the run mode and the model to correctly
resolve the paths. The device paths are not compatible with the path
used in the keyring. And the disks are annotated with the same
container role names used in the FDE state.