### PR TITLE
o/confdbstate: add helper to schedule load confdb hook/tasks

### DIFF
--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -197,7 +197,7 @@ func (h *saveViewHandler) Error(origErr error) (ignoreErr bool, err error) {
 	st := h.ctx.State()
 
 	var commitTaskID string
-	if err := t.Get("commit-task", &commitTaskID); err != nil {
+	if err := t.Get("tx-task", &commitTaskID); err != nil {
 		return false, err
 	}
 
@@ -220,7 +220,7 @@ func (h *saveViewHandler) Error(origErr error) (ignoreErr bool, err error) {
 		// if we fail to rollback, there's nothing we can do
 		ignoreError := true
 		rollbackTask := setupConfdbHook(st, hooksup.Snap, hooksup.Hook, ignoreError)
-		rollbackTask.Set("commit-task", commitTaskID)
+		rollbackTask.Set("tx-task", commitTaskID)
 		rollbackTask.WaitFor(last)
 		curTask.Change().AddTask(rollbackTask)
 		last = rollbackTask

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -64,6 +64,12 @@ func Manager(st *state.State, hookMgr *hookstate.HookManager, runner *state.Task
 	hookMgr.Register(regexp.MustCompile("^.+-view-changed$"), func(context *hookstate.Context) hookstate.Handler {
 		return &hookstate.SnapHookHandler{}
 	})
+	hookMgr.Register(regexp.MustCompile("^query-view-.+$"), func(context *hookstate.Context) hookstate.Handler {
+		return &hookstate.SnapHookHandler{}
+	})
+	hookMgr.Register(regexp.MustCompile("^load-view-.+$"), func(context *hookstate.Context) hookstate.Handler {
+		return &hookstate.SnapHookHandler{}
+	})
 
 	return m
 }

--- a/overlord/confdbstate/confdbmgr_test.go
+++ b/overlord/confdbstate/confdbmgr_test.go
@@ -210,7 +210,7 @@ func (s *hookHandlerSuite) TestSaveViewHookErrorRollsBackSaves(c *C) {
 	secondTask.WaitFor(firstTask)
 	secondTask.SetStatus(state.DoingStatus)
 	secondTask.Set("hook-setup", hooksup)
-	secondTask.Set("commit-task", commitTask.ID())
+	secondTask.Set("tx-task", commitTask.ID())
 
 	ctx, err := hookstate.NewContext(secondTask, s.state, hooksup, nil, "")
 	c.Assert(err, IsNil)
@@ -298,7 +298,7 @@ func (s *hookHandlerSuite) TestSaveViewHookErrorHoldsTasks(c *C) {
 	chg.AddTask(firstTask)
 	firstTask.SetStatus(state.DoingStatus)
 	firstTask.Set("hook-setup", hooksup)
-	firstTask.Set("commit-task", commitTask.ID())
+	firstTask.Set("tx-task", commitTask.ID())
 
 	// Error looks for a non run-hook task in order to stop
 	prereq := s.state.NewTask("other", "")
@@ -451,7 +451,7 @@ func (s *confdbTestSuite) TestClearOngoingTransaction(c *C) {
 
 	t := s.state.NewTask("clear-confdb-tx", "")
 	chg.AddTask(t)
-	t.Set("commit-task", commitTask.ID())
+	t.Set("tx-task", commitTask.ID())
 
 	confdbstate.SetOngoingTransaction(s.state, s.devAccID, "network", commitTask.ID())
 
@@ -481,7 +481,7 @@ func (s *confdbTestSuite) TestClearTransactionOnError(c *C) {
 	commitTask := s.state.NewTask("commit-confdb-tx", "")
 	chg.AddTask(commitTask)
 	commitTask.WaitFor(clearTask)
-	clearTask.Set("commit-task", commitTask.ID())
+	clearTask.Set("tx-task", commitTask.ID())
 
 	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 	c.Assert(err, IsNil)

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -389,7 +389,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 	commitTask.Set("confdb-transaction", tx)
 	// link all previous tasks to the commit task that carries the transaction
 	for _, t := range ts.Tasks() {
-		t.Set("commit-task", commitTask.ID())
+		t.Set("tx-task", commitTask.ID())
 	}
 	linkTask(commitTask)
 	ts.MarkEdge(commitTask, commitEdge)
@@ -494,7 +494,7 @@ func GetStoredTransaction(t *state.Task) (tx *Transaction, saveTxChanges func(),
 	}
 
 	var id string
-	err = t.Get("commit-task", &id)
+	err = t.Get("tx-task", &id)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -296,23 +296,14 @@ const (
 )
 
 func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View, callingSnap string) (*state.TaskSet, error) {
-	custodianPlugs, err := getCustodianPlugsForView(st, view)
+	custodians, custodianPlugs, err := getCustodianPlugsForView(st, view)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(custodianPlugs) == 0 {
+	if len(custodians) == 0 {
 		return nil, fmt.Errorf("cannot commit changes to confdb %s/%s: no custodian snap installed", view.Confdb().Account, view.Confdb().Name)
 	}
-
-	custodianNames := make([]string, 0, len(custodianPlugs))
-	for name := range custodianPlugs {
-		custodianNames = append(custodianNames, name)
-	}
-
-	// process the change/save hooks in a deterministic order (useful for testing
-	// and potentially for the snaps themselves)
-	sort.Strings(custodianNames)
 
 	ts := state.NewTaskSet()
 	linkTask := func(t *state.Task) {
@@ -329,7 +320,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 
 	// look for plugs that reference the relevant view and create run-hooks for
 	// them, if the snap has those hooks
-	for _, name := range custodianNames {
+	for _, name := range custodians {
 		plug := custodianPlugs[name]
 		custodian := plug.Snap
 		if _, ok := custodian.Hooks["change-view-"+plug.Name]; !ok {
@@ -342,7 +333,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 		linkTask(chgViewTask)
 	}
 
-	for _, name := range custodianNames {
+	for _, name := range custodians {
 		plug := custodianPlugs[name]
 		custodian := plug.Snap
 		if _, ok := custodian.Hooks["save-view-"+plug.Name]; !ok {
@@ -397,21 +388,25 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 	// clear the ongoing tx from the state and unblock other writers waiting for it
 	clearTxTask := st.NewTask("clear-confdb-tx", "Clears the ongoing confdb transaction from state")
 	linkTask(clearTxTask)
-	clearTxTask.Set("commit-task", commitTask.ID())
+	clearTxTask.Set("tx-task", commitTask.ID())
 	ts.MarkEdge(clearTxTask, clearTxEdge)
 
 	return ts, nil
 }
 
-func getCustodianPlugsForView(st *state.State, view *confdb.View) (map[string]*snap.PlugInfo, error) {
+// getCustodianPlugsForView returns a list of snaps that have connected plugs
+// declaring them as custodians of a confdb view. The list of custodians is
+// sorted. It also returns a map of the snap names to plugs.
+func getCustodianPlugsForView(st *state.State, view *confdb.View) ([]string, map[string]*snap.PlugInfo, error) {
 	repo := ifacerepo.Get(st)
 	plugs := repo.AllPlugs("confdb")
 
-	custodians := make(map[string]*snap.PlugInfo)
+	var custodians []string
+	custodianPlugs := make(map[string]*snap.PlugInfo)
 	for _, plug := range plugs {
 		conns, err := repo.Connected(plug.Snap.InstanceName(), plug.Name)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(conns) == 0 {
 			continue
@@ -423,7 +418,7 @@ func getCustodianPlugsForView(st *state.State, view *confdb.View) (map[string]*s
 
 		account, confdbName, viewName, err := snap.ConfdbPlugAttrs(plug)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if view.Confdb().Account != account || view.Confdb().Name != confdbName ||
@@ -434,10 +429,15 @@ func getCustodianPlugsForView(st *state.State, view *confdb.View) (map[string]*s
 		// TODO: if a snap has more than one plug providing access to a view, then
 		// which plug we're getting here becomes unpredictable. We should check
 		// for this at some point (interface connection?)
-		custodians[plug.Snap.SnapName()] = plug
+		custodianPlugs[plug.Snap.SnapName()] = plug
+		custodians = append(custodians, plug.Snap.InstanceName())
 	}
 
-	return custodians, nil
+	// we want to process these in a deterministic order (useful for testing
+	// and potentially for the snaps themselves)
+	sort.Strings(custodians)
+
+	return custodians, custodianPlugs, nil
 }
 
 func getPlugsAffectedByPaths(st *state.State, confdb *confdb.Confdb, storagePaths []string) (map[string][]*snap.PlugInfo, error) {

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -469,7 +469,8 @@ func (s *confdbTestSuite) TestConfdbTasksUserSetWithCustodianInstalled(c *C) {
 	defer s.state.Unlock()
 
 	// only one custodian snap is installed
-	s.setupConfdbModificationScenario(c, []string{"custodian-snap"}, nil)
+	const noHooks = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, nil)
 
 	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 	c.Assert(err, IsNil)
@@ -525,7 +526,8 @@ func (s *confdbTestSuite) TestConfdbTasksCustodianSnapSet(c *C) {
 	defer s.state.Unlock()
 
 	// only one custodian snap is installed
-	s.setupConfdbModificationScenario(c, []string{"custodian-snap"}, nil)
+	const noHooks = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, nil)
 
 	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 	c.Assert(err, IsNil)
@@ -566,7 +568,8 @@ func (s *confdbTestSuite) TestConfdbTasksObserverSnapSetWithCustodianInstalled(c
 	defer s.state.Unlock()
 
 	// one custodian and several non-custodians are installed
-	s.setupConfdbModificationScenario(c, []string{"custodian-snap"}, []string{"test-snap-1", "test-snap-2"})
+	const noHooks = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, []string{"test-snap-1", "test-snap-2"})
 
 	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 	c.Assert(err, IsNil)
@@ -620,7 +623,8 @@ func (s *confdbTestSuite) TestConfdbTasksDisconnectedCustodianSnap(c *C) {
 	defer s.state.Unlock()
 
 	// mock and installed custodian-snap but disconnect it
-	s.setupConfdbModificationScenario(c, []string{"test-custodian-snap"}, []string{"test-snap"})
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"test-custodian-snap"}, []string{"test-snap"})
 	s.repo.Disconnect("test-custodian-snap", "setup", "core", "confdb-slot")
 	s.testConfdbTasksNoCustodian(c)
 }
@@ -630,7 +634,8 @@ func (s *confdbTestSuite) TestConfdbTasksNoCustodianSnapInstalled(c *C) {
 	defer s.state.Unlock()
 
 	// no custodian snap is installed
-	s.setupConfdbModificationScenario(c, nil, []string{"test-snap"})
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, nil, []string{"test-snap"})
 	s.testConfdbTasksNoCustodian(c)
 }
 
@@ -645,10 +650,10 @@ func (s *confdbTestSuite) testConfdbTasksNoCustodian(c *C) {
 
 	// a non-custodian snap modifies a confdb
 	_, err = confdbstate.CreateChangeConfdbTasks(s.state, tx, view, "test-snap-1")
-	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot commit changes to confdb %s/network: no custodian snap installed", s.devAccID))
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot commit changes to confdb %s/network: no custodian snap connected", s.devAccID))
 }
 
-func (s *confdbTestSuite) setupConfdbModificationScenario(c *C, custodians, nonCustodians []string) {
+func (s *confdbTestSuite) setupConfdbScenario(c *C, noHooks bool, custodians, nonCustodians []string) {
 	s.repo = interfaces.NewRepository()
 	ifacerepo.Replace(s.state, s.repo)
 
@@ -689,10 +694,12 @@ plugs:
 		}
 
 		info := mockInstalledSnap(c, s.state, snapYaml, hooks)
-		for _, hook := range hooks {
-			info.Hooks[hook] = &snap.HookInfo{
-				Name: hook,
-				Snap: info,
+		if !noHooks {
+			for _, hook := range hooks {
+				info.Hooks[hook] = &snap.HookInfo{
+					Name: hook,
+					Snap: info,
+				}
 			}
 		}
 
@@ -710,14 +717,14 @@ plugs:
 	}
 
 	// mock custodians
-	hooks := []string{"change-view-setup", "save-view-setup", "setup-view-changed"}
+	hooks := []string{"change-view-setup", "save-view-setup", "query-view-setup", "load-view-setup", "setup-view-changed"}
 	for _, snap := range custodians {
 		isCustodian := true
 		mockSnap(snap, isCustodian, hooks)
 	}
 
 	// mock non-custodians
-	hooks = []string{"change-view-setup", "save-view-setup", "setup-view-changed", "install"}
+	hooks = []string{"setup-view-changed", "install"}
 	for _, snap := range nonCustodians {
 		isCustodian := false
 		mockSnap(snap, isCustodian, hooks)
@@ -849,7 +856,8 @@ func (s *confdbTestSuite) TestGetTransactionFromUserCreatesNewChange(c *C) {
 	defer s.state.Unlock()
 
 	// only one custodian snap is installed
-	s.setupConfdbModificationScenario(c, []string{"custodian-snap"}, nil)
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, nil)
 
 	view := s.confdb.View("setup-wifi")
 
@@ -897,7 +905,8 @@ func (s *confdbTestSuite) TestGetTransactionFromSnapCreatesNewChange(c *C) {
 	defer s.state.Unlock()
 
 	// only one custodian snap is installed
-	s.setupConfdbModificationScenario(c, []string{"custodian-snap"}, []string{"test-snap"})
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, []string{"test-snap"})
 
 	ctx, err := hookstate.NewContext(nil, s.state, &hookstate.HookSetup{Snap: "test-snap"}, nil, "")
 	c.Assert(err, IsNil)
@@ -956,7 +965,8 @@ func (s *confdbTestSuite) TestGetTransactionFromNonConfdbHookAddsConfdbTx(c *C) 
 	s.state.Lock()
 	defer s.state.Unlock()
 	// only one custodian snap is installed
-	s.setupConfdbModificationScenario(c, []string{"custodian-snap"}, []string{"test-snap"})
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, []string{"test-snap"})
 
 	hookTask := s.state.NewTask("run-hook", "")
 	chg := s.state.NewChange("install", "")
@@ -977,7 +987,7 @@ func (s *confdbTestSuite) TestGetTransactionFromNonConfdbHookAddsConfdbTx(c *C) 
 	select {
 	case <-chg.Ready():
 	case <-time.After(5 * time.Second):
-		c.Fatalf("test timed out")
+		c.Fatal("test timed out")
 	}
 
 	s.state.Lock()
@@ -1076,7 +1086,8 @@ func (s *confdbTestSuite) testGetReadableOngoingTransaction(c *C, hook string) *
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.setupConfdbModificationScenario(c, []string{"custodian-snap"}, []string{"test-snap"})
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, []string{"test-snap"})
 
 	originalTx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 	c.Assert(err, IsNil)
@@ -1144,4 +1155,181 @@ func (s *confdbTestSuite) TestGetDifferentTransactionThanOngoing(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot access confdb foo/bar: ongoing transaction for %s/network`, s.devAccID))
 	c.Assert(tx, IsNil)
 	c.Assert(commitTxFunc, IsNil)
+}
+
+func (s *confdbTestSuite) TestConfdbLoadDisconnectedCustodianSnap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// no connected custodian
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"test-custodian-snap"}, []string{"test-snap"})
+	s.repo.Disconnect("test-custodian-snap", "setup", "core", "confdb-slot")
+	s.testConfdbLoadNoCustodian(c)
+}
+
+func (s *confdbTestSuite) TestConfdbLoadNoCustodianInstalled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// no custodian snap is installed
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, nil, []string{"test-snap"})
+	s.testConfdbLoadNoCustodian(c)
+}
+
+func (s *confdbTestSuite) testConfdbLoadNoCustodian(c *C) {
+	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
+	c.Assert(err, IsNil)
+
+	err = tx.Set("wifi.ssid", "my-ssid")
+	c.Assert(err, IsNil)
+
+	view := s.confdb.View("setup-wifi")
+
+	// a non-custodian snap modifies a confdb
+	_, err = confdbstate.CreateLoadConfdbTasks(s.state, tx, view)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot load confdb %s/network: no custodian snap connected", s.devAccID))
+}
+
+func checkLoadConfdbTasks(c *C, chg *state.Change, taskKinds []string, hooksups []*hookstate.HookSetup) {
+	// check clear-confdb-tx carries the transaction
+	c.Assert(chg.Tasks(), HasLen, len(taskKinds))
+	clearTxTask := findTask(chg, "clear-confdb-tx")
+
+	var tx *confdbstate.Transaction
+	err := clearTxTask.Get("confdb-transaction", &tx)
+	c.Assert(err, IsNil)
+	c.Assert(tx, NotNil)
+
+	t := findTask(chg, "run-hook")
+	var hookIndex int
+	var i int
+loop:
+	for ; t != nil; i++ {
+		c.Assert(t.Kind(), Equals, taskKinds[i])
+		if t.Kind() == "run-hook" {
+			c.Assert(getHookSetup(c, t), DeepEquals, hooksups[hookIndex])
+			hookIndex++
+		}
+
+		// check all other tasks link to it
+		if t.Kind() != "clear-confdb-tx" {
+			var id string
+			err := t.Get("tx-task", &id)
+			c.Assert(err, IsNil)
+			c.Assert(id, Equals, clearTxTask.ID())
+		}
+
+		switch len(t.HaltTasks()) {
+		case 0:
+			break loop
+		case 1:
+			t = t.HaltTasks()[0]
+		}
+	}
+
+	c.Assert(i, Equals, len(taskKinds)-1)
+}
+
+func (s *confdbTestSuite) TestConfdbLoadCustodianInstalled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, nil)
+
+	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
+	c.Assert(err, IsNil)
+
+	err = tx.Set("wifi.ssid", "my-ssid")
+	c.Assert(err, IsNil)
+
+	view := s.confdb.View("setup-wifi")
+	chg := s.state.NewChange("load-confdb", "")
+
+	ts, err := confdbstate.CreateLoadConfdbTasks(s.state, tx, view)
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	cleanupTask, err := ts.Edge(confdbstate.ClearTxEdge)
+	c.Assert(err, IsNil)
+	c.Assert(cleanupTask.Kind(), Equals, "clear-confdb-tx")
+
+	// the custodian snap's hooks are run
+	tasks := []string{"run-hook", "run-hook", "clear-confdb-tx"}
+	hooks := []*hookstate.HookSetup{
+		{
+			Snap:        "custodian-snap",
+			Hook:        "load-view-setup",
+			Optional:    true,
+			IgnoreError: false,
+		},
+		{
+			Snap:        "custodian-snap",
+			Hook:        "query-view-setup",
+			Optional:    true,
+			IgnoreError: false,
+		},
+	}
+
+	checkLoadConfdbTasks(c, chg, tasks, hooks)
+}
+
+func (s *confdbTestSuite) TestConfdbLoadCustodianWithNoHooks(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// only one custodian snap is installed
+	const noHooks bool = true
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, nil)
+
+	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
+	c.Assert(err, IsNil)
+
+	err = tx.Set("wifi.ssid", "my-ssid")
+	c.Assert(err, IsNil)
+
+	view := s.confdb.View("setup-wifi")
+	ts, err := confdbstate.CreateLoadConfdbTasks(s.state, tx, view)
+	c.Assert(err, IsNil)
+	// no hooks, nothing to run
+	c.Assert(ts, IsNil)
+}
+
+func (s *confdbTestSuite) TestConfdbLoadTasks(c *C) {
+	hooks, restore := s.mockConfdbHooks(c)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// only one custodian snap is installed
+	const noHooks bool = false
+	s.setupConfdbScenario(c, noHooks, []string{"custodian-snap"}, nil)
+
+	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
+	c.Assert(err, IsNil)
+
+	err = tx.Set("wifi.ssid", "my-ssid")
+	c.Assert(err, IsNil)
+
+	view := s.confdb.View("setup-wifi")
+	ts, err := confdbstate.CreateLoadConfdbTasks(s.state, tx, view)
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("load-change", "")
+	chg.AddAll(ts)
+
+	s.state.Unlock()
+	s.o.Settle(time.Second)
+	s.state.Lock()
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus)
+	c.Assert(*hooks, DeepEquals, []string{"load-view-setup", "query-view-setup"})
+
+	clearTask := findTask(chg, "clear-confdb-tx")
+	tx, _, err = confdbstate.GetStoredTransaction(clearTask)
+	c.Assert(err, IsNil)
+	c.Assert(tx, NotNil)
 }

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -748,7 +748,7 @@ loop:
 		if t.Kind() != "commit-confdb-tx" {
 			// all tasks (other than the commit) are linked to the commit task
 			var id string
-			err := t.Get("commit-task", &id)
+			err := t.Get("tx-task", &id)
 			c.Assert(err, IsNil)
 			c.Assert(id, Equals, commitTask.ID())
 		}
@@ -795,7 +795,7 @@ func (s *confdbTestSuite) TestGetStoredTransaction(c *C) {
 
 	refTask := s.state.NewTask("links-to-commit", "")
 	chg.AddTask(refTask)
-	refTask.Set("commit-task", commitTask.ID())
+	refTask.Set("tx-task", commitTask.ID())
 
 	for _, t := range []*state.Task{commitTask, refTask} {
 		storedTx, saveChanges, err := confdbstate.GetStoredTransaction(t)
@@ -1093,7 +1093,7 @@ func (s *confdbTestSuite) testGetReadableOngoingTransaction(c *C, hook string) *
 	chg.AddTask(hookTask)
 	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: hook}
 	mockHandler := hooktest.NewMockHandler()
-	hookTask.Set("commit-task", commitTask.ID())
+	hookTask.Set("tx-task", commitTask.ID())
 
 	ctx, err := hookstate.NewContext(hookTask, s.state, setup, mockHandler, "")
 	c.Assert(err, IsNil)
@@ -1122,7 +1122,7 @@ func (s *confdbTestSuite) TestGetDifferentTransactionThanOngoing(c *C) {
 
 	refTask := s.state.NewTask("change-view-setup", "")
 	chg.AddTask(refTask)
-	refTask.Set("commit-task", commitTask.ID())
+	refTask.Set("tx-task", commitTask.ID())
 
 	// make some other confdb to access concurrently
 	confdb, err := confdb.New("foo", "bar", map[string]interface{}{

--- a/overlord/confdbstate/export_test.go
+++ b/overlord/confdbstate/export_test.go
@@ -29,6 +29,7 @@ var (
 	WriteDatabag            = writeDatabag
 	GetPlugsAffectedByPaths = getPlugsAffectedByPaths
 	CreateChangeConfdbTasks = createChangeConfdbTasks
+	CreateLoadConfdbTasks   = createLoadConfdbTasks
 	SetOngoingTransaction   = setOngoingTransaction
 	UnsetOngoingTransaction = unsetOngoingTransaction
 )

--- a/overlord/hookstate/ctlcmd/fail_test.go
+++ b/overlord/hookstate/ctlcmd/fail_test.go
@@ -45,7 +45,7 @@ func (s *confdbSuite) TestFailAbortsConfdbTransaction(c *C) {
 	task := s.state.NewTask("run-hook", "")
 	chg.AddTask(task)
 	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "change-view-plug"}
-	task.Set("commit-task", commitTask.ID())
+	task.Set("tx-task", commitTask.ID())
 	s.state.Unlock()
 
 	mockContext, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
@@ -116,7 +116,7 @@ func (s *confdbSuite) TestFailErrors(c *C) {
 
 	stdout, stderr, err = ctlcmd.Run(s.mockContext, []string{"fail", "reason"}, 0)
 	// this shouldn't happen but check we handle it well anyway
-	c.Assert(err, ErrorMatches, i18n.G("internal error: cannot get confdb transaction to fail: no state entry for key \"commit-task\""))
+	c.Assert(err, ErrorMatches, i18n.G("internal error: cannot get confdb transaction to fail: no state entry for key \"tx-task\""))
 	c.Check(stdout, IsNil)
 	c.Check(stderr, IsNil)
 }

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -41,6 +41,8 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^gate-auto-refresh$")),
 	NewHookType(regexp.MustCompile("^change-view-.+$")),
 	NewHookType(regexp.MustCompile("^save-view-.+$")),
+	NewHookType(regexp.MustCompile("^query-view-.+$")),
+	NewHookType(regexp.MustCompile("^load-view-.+$")),
 	NewHookType(regexp.MustCompile("^.+-view-changed$")),
 }
 


### PR DESCRIPTION
81070b99be08ae23ea5d9896d39a9e16ecc7b6e3 changes the key used to link tasks to the transaction carrying task
c3aca30ebc073e6495cc550f83f44a0f4d55df82 is a small refactor to prevent duplicating some code in the new helper
5490fc10db201a9237ec457b7a2b9eacc5791dab adds support for the query-view and load-view hooks as well as a helper that schedules tasks appropriately