### PR TITLE
cmd/snap-confine: fix type specifier type mismatches on armhf

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -277,7 +277,7 @@ static void log_startup_stage(const char *stage) {
     }
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lu.%06lu\"}", stage, tv.tv_sec, tv.tv_usec);
+    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lld.%06lld\"}", stage, (long long int)tv.tv_sec, (long long int)tv.tv_usec);
 }
 
 /**

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -277,7 +277,8 @@ static void log_startup_stage(const char *stage) {
     }
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lld.%06lld\"}", stage, (long long int)tv.tv_sec, (long long int)tv.tv_usec);
+    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lld.%06lld\"}", stage, (long long int)tv.tv_sec,
+          (long long int)tv.tv_usec);
 }
 
 /**


### PR DESCRIPTION
Fix type mismatch warnings due to incorrect debug() type specifier that's escalated to errors when build in LP. 

The mismatches that shows in noble, oracular and plucky happens because of armhf definition type changes in  sys/time.h
tv.sec:        `long int`     ->    `__int64_t`
tv.usec:      `long int`     ->    `__int64_t`

Example: https://launchpadlibrarian.net/777801433/buildlog_ubuntu-plucky-armhf.snapd_2.68+ubuntu25.04_BUILDING.txt.gz (look for `snap-confine/snap-confine.c: In function`)

Currently affects armhf (32 bit) on: [2.68 | 25.04](https://launchpad.net/~snappy-dev/+archive/ubuntu/image/+sourcepub/16993872/+listing-archive-extra), [2.68 | 24.10](https://launchpad.net/~snappy-dev/+archive/ubuntu/image/+sourcepub/16993850/+listing-archive-extra), [2.68 | 24.04](https://launchpad.net/~snappy-dev/+archive/ubuntu/image/+sourcepub/16993847/+listing-archive-extra)