### PR TITLE
i/prompting: use omitzero when encoding expiration

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -412,7 +412,7 @@ func (e *PermissionEntry) toRulePermissionEntry(currTime time.Time) (*RulePermis
 type RulePermissionEntry struct {
 	Outcome    OutcomeType  `json:"outcome"`
 	Lifespan   LifespanType `json:"lifespan"`
-	Expiration time.Time    `json:"expiration,omitempty"`
+	Expiration time.Time    `json:"expiration,omitzero"`
 }
 
 // Expired returns true if the receiving permission entry has expired and

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -20,7 +20,9 @@
 package prompting_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"runtime"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -983,6 +985,37 @@ func constructPermissionsMaps() []map[string]map[string]any {
 	permissionsMaps = append(permissionsMaps, filePermissionsMaps)
 	// TODO: do the same for other maps of permissions maps in the future
 	return permissionsMaps
+}
+
+func (s *constraintsSuite) TestMarshalRulePermissionEntry(c *C) {
+	if runtime.Version() < "go1.24" {
+		c.Skip("omitzero requires go version 1.24 or higher")
+	}
+	timeNow := time.Date(2025, time.February, 20, 16, 0, 27, 913561089, time.UTC)
+	for _, testCase := range []struct {
+		entry    prompting.RulePermissionEntry
+		expected string
+	}{
+		{
+			entry: prompting.RulePermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+			expected: `{"outcome":"allow","lifespan":"forever"}`,
+		},
+		{
+			entry: prompting.RulePermissionEntry{
+				Outcome:    prompting.OutcomeDeny,
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: timeNow,
+			},
+			expected: `{"outcome":"deny","lifespan":"timespan","expiration":"2025-02-20T16:00:27.913561089Z"}`,
+		},
+	} {
+		marshalled, err := json.Marshal(testCase.entry)
+		c.Check(err, IsNil, Commentf("testCase: %+v", testCase))
+		c.Check(string(marshalled), Equals, testCase.expected, Commentf("testCase: %+v", testCase))
+	}
 }
 
 func (s *constraintsSuite) TestInterfacesAndPermissionsCompleteness(c *C) {


### PR DESCRIPTION
Go 1.24 brings a new `omitzero` keyword: https://go.dev/doc/go1.24#encodingjsonpkgencodingjson

> When marshaling, a struct field with the new `omitzero` option in the struct field tag will be omitted if its value is zero. If the field type has an `IsZero() bool` method, that will be used to determine whether the value is zero. Otherwise, the value is zero if it is [the zero value for its type](https://go.dev/ref/spec#The_zero_value). The `omitzero` field tag is clearer and less error-prone than `omitempty` when the intent is to omit zero values. In particular, unlike `omitempty`, `omitzero` omits zero-valued [`time.Time`](https://go.dev/pkg/time#Time) values, which is a common source of friction.
>
> If both `omitempty` and `omitzero` are specified, the field will be omitted if the value is either empty or zero (or both).

Previously, use of `omitempty` had resulted in a zero time being encoded as the explicit expiration, when the intention was for expiration to be omitted if it's not specified (and always non-zero if it is specified). This should solve the problem, at least once snapd uses go version 1.24 or higher.

If the go version does not recognize `omitzero`, it ignores it, and there's no harm done. `omitempty` never worked for expiration anyway.