### PR TITLE
cmd/snap-confine: workaround time_t size differences between architectures

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <glob.h>
+#include <inttypes.h>
 #include <sched.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -274,8 +275,8 @@ static void log_startup_stage(const char *stage) {
     }
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lld.%06lld\"}", stage, (long long int)tv.tv_sec,
-          (long long int)tv.tv_usec);
+    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%" PRId64 ".%06" PRId64 "\"}", stage, (int64_t)tv.tv_sec,
+          (int64_t)tv.tv_usec);
 }
 
 /**


### PR DESCRIPTION
The following error was observed when building for armhf:

```
snap-confine/snap-confine.c: In function ‘log_startup_stage’: snap-confine/snap-confine.c:280:60: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘__time64_t’ {aka ‘long long int’} [-Werror=format=]
  280 |     debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lu.%06lu\"}", stage, tv.tv_sec, tv.tv_usec);
      |                                                          ~~^                   ~~~~~~~~~
      |                                                            |                     |
      |                                                            long unsigned int     __time64_t {aka long long int}
      |                                                          %llu
snap-confine/snap-confine.c:280:66: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 4 has type ‘__suseconds64_t’ {aka ‘long long int’} [-Werror=format=]
  280 |     debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lu.%06lu\"}", stage, tv.tv_sec, tv.tv_usec);
      |                                                              ~~~~^                        ~~~~~~~~~~
      |                                                                  |                          |
      |                                                                  long unsigned int          __suseconds64_t {aka long long int}
      |                                                              %06llu
cc1: all warnings being treated as errors
```

Use proper formatting macros and check for time_t size.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
