### PR TITLE
cmd/libsnap-confine-private, cmd: introduce SC_ARRAY_SIZE macro and use where applicable

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support-test.c
+++ b/cmd/libsnap-confine-private/cgroup-support-test.c
@@ -77,7 +77,7 @@ static void _test_sc_cgroupv2_is_tracking_happy(cgroupv2_is_tracking_fixture *fi
         "/user/slice/other/app",
     };
 
-    for (size_t i = 0; i < sizeof dirs / sizeof dirs[0]; i++) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(dirs); i++) {
         char *np = g_build_filename(fixture->root, dirs[i], NULL);
         int ret = g_mkdir_with_parents(np, 0755);
         g_assert_cmpint(ret, ==, 0);
@@ -112,7 +112,7 @@ static void test_sc_cgroupv2_is_tracking_just_own_group(cgroupv2_is_tracking_fix
         "/user/slice/other/app",
     };
 
-    for (size_t i = 0; i < sizeof dirs / sizeof dirs[0]; i++) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(dirs); i++) {
         char *np = g_build_filename(fixture->root, dirs[i], NULL);
         int ret = g_mkdir_with_parents(np, 0755);
         g_assert_cmpint(ret, ==, 0);
@@ -135,7 +135,7 @@ static void test_sc_cgroupv2_is_tracking_other_snaps(cgroupv2_is_tracking_fixtur
         "/user/slice/other/app",
     };
 
-    for (size_t i = 0; i < sizeof dirs / sizeof dirs[0]; i++) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(dirs); i++) {
         char *np = g_build_filename(fixture->root, dirs[i], NULL);
         int ret = g_mkdir_with_parents(np, 0755);
         g_assert_cmpint(ret, ==, 0);
@@ -202,7 +202,7 @@ static void test_sc_cgroupv2_is_tracking_dir_permissions(cgroupv2_is_tracking_fi
         "/foo/bar/bad",
         "/foo/bar/bad/badperm",
     };
-    for (size_t i = 0; i < sizeof dirs / sizeof dirs[0]; i++) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(dirs); i++) {
         int mode = 0755;
         if (g_str_has_suffix(dirs[i], "/badperm")) {
             mode = 0000;

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -2,6 +2,7 @@
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/infofile.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
 #include "config.h"
 
 #include <stdbool.h>
@@ -63,7 +64,7 @@ bool sc_is_debian_like(void) {
         "ID",      /* actual debian only sets ID */
         "ID_LIKE", /* distros based on debian */
     };
-    size_t id_keys_to_try_len = sizeof id_keys_to_try / sizeof *id_keys_to_try;
+    size_t id_keys_to_try_len = SC_ARRAY_SIZE(id_keys_to_try);
     for (size_t i = 0; i < id_keys_to_try_len; i++) {
         if (fseek(f, 0L, SEEK_SET) == -1) {
             return false;

--- a/cmd/libsnap-confine-private/device-cgroup-support.c
+++ b/cmd/libsnap-confine-private/device-cgroup-support.c
@@ -239,8 +239,7 @@ static int load_devcgroup_prog(int map_fd) {
 
     char log_buf[4096] = {0};
 
-    int prog_fd =
-        bpf_load_prog(BPF_PROG_TYPE_CGROUP_DEVICE, prog, sizeof(prog) / sizeof(prog[0]), log_buf, sizeof(log_buf));
+    int prog_fd = bpf_load_prog(BPF_PROG_TYPE_CGROUP_DEVICE, prog, SC_ARRAY_SIZE(prog), log_buf, sizeof(log_buf));
     if (prog_fd < 0) {
         die("cannot load program:\n%s\n", log_buf);
     }

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -206,7 +206,7 @@ static void test_sc_snap_or_instance_name_validate(gconstpointer data) {
 
     const char *valid_names[] = {"aa",    "aaa", "aaaa", "a-a",  "aa-a",   "a-aa",
                                  "a-b-c", "a0",  "a-0",  "a-0a", "01game", "1-or-2"};
-    for (size_t i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(valid_names); ++i) {
         g_test_message("checking valid snap name: %s", valid_names[i]);
         validate(valid_names[i], &err);
         g_assert_null(err);
@@ -242,7 +242,7 @@ static void test_sc_snap_or_instance_name_validate(gconstpointer data) {
         "한글",
         "ру́сский язы́к",
     };
-    for (size_t i = 0; i < sizeof invalid_names / sizeof *invalid_names; ++i) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(invalid_names); ++i) {
         g_test_message("checking invalid snap name: >%s<", invalid_names[i]);
         validate(invalid_names[i], &err);
         g_assert_nonnull(err);
@@ -332,7 +332,7 @@ static void test_sc_instance_name_validate(void) {
     const char *valid_names[] = {
         "aa", "aaa", "aaaa", "aa_a", "aa_1", "aa_123", "aa_0123456789",
     };
-    for (size_t i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(valid_names); ++i) {
         g_test_message("checking valid instance name: %s", valid_names[i]);
         sc_instance_name_validate(valid_names[i], &err);
         g_assert_null(err);
@@ -358,7 +358,7 @@ static void test_sc_instance_name_validate(void) {
         "foobar_baz_zed_daz",
         "foobar______",
     };
-    for (size_t i = 0; i < sizeof invalid_names / sizeof *invalid_names; ++i) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(invalid_names); ++i) {
         g_test_message("checking invalid instance name: >%s<", invalid_names[i]);
         sc_instance_name_validate(invalid_names[i], &err);
         g_assert_nonnull(err);
@@ -509,7 +509,7 @@ static void test_sc_snap_component_validate(void) {
         "snap-name+loooooooooooooooooooooooooooong-comp-name",
     };
 
-    for (size_t i = 0; i < sizeof cases / sizeof *cases; ++i) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(cases); ++i) {
         g_test_message("checking invalid snap name: %s", cases[i]);
         sc_snap_component_validate(cases[i], NULL, &err);
         g_assert_nonnull(err);

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -51,7 +51,7 @@ bool sc_security_tag_validate(const char *security_tag, const char *snap_instanc
         die("internal error: all regex capture groups not fully accounted for");
     }
 
-    int status = regexec(&re, security_tag, sizeof matches / sizeof *matches, matches, 0);
+    int status = regexec(&re, security_tag, SC_ARRAY_SIZE(matches), matches, 0);
     regfree(&re);
 
     // Fail if no match or if snap name wasn't captured in the 2nd match group

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -243,6 +243,19 @@ static void test_sc_is_container__no_file(void) {
     g_assert_false(_sc_is_in_container("container"));
 }
 
+static void test_sc_array_size(void) {
+    char a1[] = {1, 2, 3, 4, 5};
+    char a_empty[] = {};
+    g_assert_cmpint(SC_ARRAY_SIZE(a1), ==, 5);
+    g_assert_cmpint(SC_ARRAY_SIZE(a_empty), ==, 0);
+
+#if 0
+    /* DOES NOT COMPILE due to static assert */
+    char *a_bad = "foobar";
+    g_assert_cmpint(SC_ARRAY_SIZE(a_bad), ==, 0);
+#endif
+}
+
 static void __attribute__((constructor)) init(void) {
     g_test_add_func("/utils/parse_bool", test_parse_bool);
     g_test_add_func("/utils/sc_is_expected_path", test_sc_is_expected_path);
@@ -254,4 +267,5 @@ static void __attribute__((constructor)) init(void) {
     g_test_add_func("/utils/sc_is_in_container/no_file", test_sc_is_container__no_file);
     g_test_add_func("/utils/sc_is_in_container/lxc", test_sc_is_container__lxc);
     g_test_add_func("/utils/sc_is_in_container/lxc_newline", test_sc_is_container__lxc_with_newline);
+    g_test_add_func("/utils/sc_array_size", test_sc_array_size);
 }

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -95,7 +95,7 @@ static void test_sc_is_expected_path(void) {
         {"/var/lib/snapd/snap/snapd/23374/usr/lib/snapd/snap-confine", true},
     };
     size_t i;
-    for (i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+    for (i = 0; i < SC_ARRAY_SIZE(test_cases); i++) {
         bool result = sc_is_expected_path(test_cases[i].path);
         g_assert_cmpint(result, ==, test_cases[i].expected);
     }
@@ -246,8 +246,14 @@ static void test_sc_is_container__no_file(void) {
 static void test_sc_array_size(void) {
     char a1[] = {1, 2, 3, 4, 5};
     char a_empty[] = {};
+    char *a_strings[] = {
+        "foo",
+        "bar",
+    };
+
     g_assert_cmpint(SC_ARRAY_SIZE(a1), ==, 5);
     g_assert_cmpint(SC_ARRAY_SIZE(a_empty), ==, 0);
+    g_assert_cmpint(SC_ARRAY_SIZE(a_strings), ==, 2);
 
 #if 0
     /* DOES NOT COMPILE due to static assert */

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -62,7 +62,7 @@ static int parse_bool(const char *text, bool *value, bool default_value) {
         *value = default_value;
         return 0;
     }
-    for (size_t i = 0; i < sizeof sc_bool_names / sizeof *sc_bool_names; ++i) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(sc_bool_names); ++i) {
         if (strcmp(text, sc_bool_names[i].text) == 0) {
             *value = sc_bool_names[i].value;
             return 0;

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -20,6 +20,17 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+/**
+ * Macro which calculates array size.
+ *
+ * Based on ARRAY_SIZE from the Linux kernel, see
+ * https://elixir.bootlin.com/linux/v6.13.3/source/include/linux/array_size.h#L11
+ */
+#define SC_ARRAY_SIZE(arr)                                                                                  \
+    (sizeof(arr) / sizeof((arr)[0]) + ((int)sizeof(struct {                                                 \
+         _Static_assert(!__builtin_types_compatible_p(typeof(arr), typeof(&(arr)[0])), "must be an array"); \
+     })))
+
 __attribute__((noreturn)) __attribute__((format(printf, 1, 2))) void die(const char *fmt, ...);
 
 __attribute__((format(printf, 1, 2))) void debug(const char *fmt, ...);

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -52,14 +52,14 @@ static const char *vulkan_globs[] = {
     "icd.d/*nvidia*.json",
 };
 
-static const size_t vulkan_globs_len = sizeof vulkan_globs / sizeof *vulkan_globs;
+static const size_t vulkan_globs_len = SC_ARRAY_SIZE(vulkan_globs);
 
 // Location of EGL vendor files
 static const char *egl_vendor_globs[] = {
     "egl_vendor.d/*nvidia*.json",
 };
 
-static const size_t egl_vendor_globs_len = sizeof egl_vendor_globs / sizeof *egl_vendor_globs;
+static const size_t egl_vendor_globs_len = SC_ARRAY_SIZE(egl_vendor_globs);
 
 #if defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 
@@ -162,14 +162,14 @@ static const char *nvidia_globs[] = {
     "libcudnn_ops_train*",
 };
 
-static const size_t nvidia_globs_len = sizeof nvidia_globs / sizeof *nvidia_globs;
+static const size_t nvidia_globs_len = SC_ARRAY_SIZE(nvidia_globs);
 
 static const char *glvnd_globs[] = {
     "libEGL.so*",          "libGL.so*",  "libOpenGL.so*",     "libGLESv1_CM.so*", "libGLESv2.so*",
     "libGLX_indirect.so*", "libGLX.so*", "libGLdispatch.so*", "libGLU.so*",
 };
 
-static const size_t glvnd_globs_len = sizeof glvnd_globs / sizeof *glvnd_globs;
+static const size_t glvnd_globs_len = SC_ARRAY_SIZE(glvnd_globs);
 
 #endif  // defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 
@@ -331,7 +331,7 @@ static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir, const char **g
         NATIVE_LIBDIR,
         NATIVE_LIBDIR "/nvidia*",
     };
-    const size_t native_sources_len = sizeof native_sources / sizeof *native_sources;
+    const size_t native_sources_len = SC_ARRAY_SIZE(native_sources);
 
 #if UINTPTR_MAX == 0xffffffffffffffff
     // Alternative 32-bit support
@@ -339,7 +339,7 @@ static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir, const char **g
         LIB32_DIR,
         LIB32_DIR "/nvidia*",
     };
-    const size_t lib32_sources_len = sizeof lib32_sources / sizeof *lib32_sources;
+    const size_t lib32_sources_len = SC_ARRAY_SIZE(lib32_sources);
 #endif
 
     // Primary arch
@@ -470,7 +470,7 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir, const char 
         // initialize native_sources accordingly, but calculate the array length
         // dynamically to make adjustments to native_sources easier.
         const char *native_sources[] = {native_libdir};
-        const size_t native_sources_len = sizeof native_sources / sizeof *native_sources;
+        const size_t native_sources_len = SC_ARRAY_SIZE(native_sources);
         // Primary arch
         sc_mkdir_and_mount_and_glob_files(rootfs_dir, native_sources, native_sources_len, SC_LIBGL_DIR, globs,
                                           globs_len);
@@ -481,7 +481,7 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir, const char 
             // initialize lib32_sources accordingly, but calculate the array length
             // dynamically to make adjustments to lib32_sources easier.
             const char *lib32_sources[] = {lib32_libdir};
-            const size_t lib32_sources_len = sizeof lib32_sources / sizeof *lib32_sources;
+            const size_t lib32_sources_len = SC_ARRAY_SIZE(lib32_sources);
             sc_mkdir_and_mount_and_glob_files(rootfs_dir, lib32_sources, lib32_sources_len, SC_LIBGL32_DIR, globs,
                                               globs_len);
         }
@@ -499,7 +499,7 @@ static void sc_mount_vulkan(const char *rootfs_dir) {
     const char *vulkan_sources[] = {
         SC_VULKAN_SOURCE_DIR,
     };
-    const size_t vulkan_sources_len = sizeof vulkan_sources / sizeof *vulkan_sources;
+    const size_t vulkan_sources_len = SC_ARRAY_SIZE(vulkan_sources);
 
     sc_mkdir_and_mount_and_glob_files(rootfs_dir, vulkan_sources, vulkan_sources_len, SC_VULKAN_DIR, vulkan_globs,
                                       vulkan_globs_len);
@@ -507,7 +507,7 @@ static void sc_mount_vulkan(const char *rootfs_dir) {
 
 static void sc_mount_egl(const char *rootfs_dir) {
     const char *egl_vendor_sources[] = {SC_EGL_VENDOR_SOURCE_DIR};
-    const size_t egl_vendor_sources_len = sizeof egl_vendor_sources / sizeof *egl_vendor_sources;
+    const size_t egl_vendor_sources_len = SC_ARRAY_SIZE(egl_vendor_sources);
 
     sc_mkdir_and_mount_and_glob_files(rootfs_dir, egl_vendor_sources, egl_vendor_sources_len, SC_GLVND_DIR,
                                       egl_vendor_globs, egl_vendor_globs_len);

--- a/cmd/snap-device-helper/snap-device-helper-test.c
+++ b/cmd/snap-device-helper/snap-device-helper-test.c
@@ -220,7 +220,7 @@ static void test_sdh_action_nvme(sdh_test_fixture *fixture, gconstpointer test_d
 
     int bogus = 0;
 
-    for (size_t i = 0; i < sizeof(tcs) / sizeof(tcs[0]); i++) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(tcs); i++) {
         mocks_reset();
         /* make cgroup_device_new return a non-NULL */
         mocks.new_ret = &bogus;
@@ -308,7 +308,7 @@ static void test_sdh_action_remove_fallback_devtype(sdh_test_fixture *fixture, g
 
     int bogus = 0;
 
-    for (size_t i = 0; i < sizeof(tcs) / sizeof(tcs[0]); i++) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(tcs); i++) {
         mocks_reset();
         /* make cgroup_device_new return a non-NULL */
         mocks.new_ret = &bogus;

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
             {.pattern = usr_fstab_pattern},
             {.pattern = sys_info_pattern},
         };
-        for (size_t i = 0; i < sizeof variants / sizeof *variants; ++i) {
+        for (size_t i = 0; i < SC_ARRAY_SIZE(variants); ++i) {
             struct variant* v = &variants[i];
             debug("checking if %s matches %s", dname, v->pattern);
             int match_result = fnmatch(v->pattern, dname, 0);

--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -30,6 +30,7 @@
 #include "../libsnap-confine-private/infofile.h"
 #include "../libsnap-confine-private/mountinfo.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
 
 static sc_mountinfo_entry *find_dir_mountinfo(sc_mountinfo *mounts, const char *mnt_dir) {
     sc_mountinfo_entry *cur, *root = NULL;
@@ -123,7 +124,7 @@ static int ensure_kernel_drivers_mounts(const char *normal_dir) {
     // complains, and older initramfs won't come in a kernel snap with
     // support for components anyway.
     const char *const kern_mntpts[] = {FIRMWARE_MNTPOINT, MODULES_MNTPOINT};
-    for (size_t i = 0; i < sizeof kern_mntpts / sizeof(char *); ++i) {
+    for (size_t i = 0; i < SC_ARRAY_SIZE(kern_mntpts); ++i) {
         sc_mountinfo_entry *minfo = find_dir_mountinfo(mounts, kern_mntpts[i]);
         // If the mounts already exist (old initramfs), do not create them -
         // note that we additionally check for SNAPD_DRIVERS_TREE_DIR in the


### PR DESCRIPTION
Introduce a macro SC_ARRAY_SIZE derived from Linux' ARRAY_SIZE. See https://elixir.bootlin.com/linux/v6.13.3/source/include/linux/array_size.h#L11 for reference.

And yes, the static check actually raises an error when trying with non 'array' types. This is obtained after enabling the snippet in utils-test.c which should fail during compilation:

```
libsnap-confine-private/utils-test.c: In function ‘test_sc_array_size’:
libsnap-confine-private/utils.h:30:18: error: division ‘sizeof (char *) / sizeof (char)’ does not compute the number of array elements [-Werror=sizeof-pointer-div]
   30 |     (sizeof(arr) / sizeof((arr)[0]) + ((int)sizeof(struct {                                                 \
      |                  ^
/usr/include/glib-2.0/glib/gtestutils.h:54:61: note: in definition of macro ‘g_assert_cmpint’
   54 |                                              gint64 __n1 = (n1), __n2 = (n2); \
      |                                                             ^~
libsnap-confine-private/utils-test.c:261:21: note: in expansion of macro ‘SC_ARRAY_SIZE’
  261 |     g_assert_cmpint(SC_ARRAY_SIZE(a_bad), ==, 0);
      |                     ^~~~~~~~~~~~~
libsnap-confine-private/utils-test.c:260:11: note: first ‘sizeof’ operand was declared here
  260 |     char *a_bad = "foobar";
      |           ^~~~~
libsnap-confine-private/utils.h:31:10: error: static assertion failed: "must be an array"
   31 |          _Static_assert(!__builtin_types_compatible_p(typeof(arr), typeof(&(arr)[0])), "must be an array"); \
      |          ^~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gtestutils.h:54:61: note: in definition of macro ‘g_assert_cmpint’
   54 |                                              gint64 __n1 = (n1), __n2 = (n2); \
      |                                                             ^~
libsnap-confine-private/utils-test.c:261:21: note: in expansion of macro ‘SC_ARRAY_SIZE’
  261 |     g_assert_cmpint(SC_ARRAY_SIZE(a_bad), ==, 0);
      |                     ^~~~~~~~~~~~~
```

cherry picked from #15094 

Related: [SNAPDENG-34419](https://warthogs.atlassian.net/browse/SNAPDENG-34419)

[SNAPDENG-34419]: https://warthogs.atlassian.net/browse/SNAPDENG-34419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ