### PR TITLE
boot: have a separate mutex for the sections writing a fresh modeenv 

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -50,7 +50,6 @@ func newBootState20(typ snap.Type, dev snap.Device) bootState {
 
 // modeenvMu is used to protect sections doing:
 //   - read moddeenv/modify it(/reseal from it)
-//   - write modeenv/seal from it
 //
 // while we might want to release the global state lock as seal/reseal are slow
 // (see Unlocker for that)
@@ -58,6 +57,10 @@ var (
 	modeenvMu     sync.Mutex
 	modeenvLocked int32
 )
+
+// TODO: we need to rethink the modeenv mutexes as naively releasing the state
+// lock while holding them can create deadlocks when we try to reacquire the
+// former
 
 func modeenvLock() {
 	modeenvMu.Lock()

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -69,12 +69,12 @@ func modeenvUnlock() {
 	modeenvMu.Unlock()
 }
 
-func isModeeenvLocked() bool {
+func isModeenvLocked() bool {
 	return atomic.LoadInt32(&modeenvLocked) == 1
 }
 
 func loadModeenv() (*Modeenv, error) {
-	if !isModeeenvLocked() {
+	if !isModeenvLocked() {
 		return nil, fmt.Errorf("internal error: cannot read modeenv without the lock")
 	}
 	modeenv, err := ReadModeenv("")
@@ -184,7 +184,7 @@ func newBootStateUpdate20(m *Modeenv) (*bootStateUpdate20, error) {
 
 // commit will write out boot state persistently to disk.
 func (u20 *bootStateUpdate20) commit() error {
-	if !isModeeenvLocked() {
+	if !isModeenvLocked() {
 		return fmt.Errorf("internal error: cannot commit modeenv without the lock")
 	}
 

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -199,6 +199,13 @@ func MockModeenvLocked() (restore func()) {
 	}
 }
 
+func MockSealModeenvLocked() (restore func()) {
+	atomic.AddInt32(&sealModeenvLocked, 1)
+	return func() {
+		atomic.AddInt32(&sealModeenvLocked, -1)
+	}
+}
+
 func MockAdditionalBootFlags(bootFlags []string) (restore func()) {
 	old := understoodBootFlags
 	understoodBootFlags = append(understoodBootFlags, bootFlags...)

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -115,8 +115,8 @@ func sealKeyToModeenvImpl(
 	modeenv *Modeenv,
 	flags sealKeyToModeenvFlags,
 ) error {
-	if !isModeenvLocked() {
-		return fmt.Errorf("internal error: cannot seal without the modeenv lock")
+	if !isSealModeenvLocked() {
+		return fmt.Errorf("internal error: cannot seal without the seal modeenv lock")
 	}
 
 	// make sure relevant locations exist

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -115,7 +115,7 @@ func sealKeyToModeenvImpl(
 	modeenv *Modeenv,
 	flags sealKeyToModeenvFlags,
 ) error {
-	if !isModeeenvLocked() {
+	if !isModeenvLocked() {
 		return fmt.Errorf("internal error: cannot seal without the modeenv lock")
 	}
 
@@ -265,7 +265,7 @@ var resealKeyToModeenv = resealKeyToModeenvImpl
 // transient/in-memory information with the risk that successive
 // reseals during in-progress operations produce diverging outcomes.
 func resealKeyToModeenvImpl(rootdir string, modeenv *Modeenv, expectReseal bool, unlocker Unlocker) error {
-	if !isModeeenvLocked() {
+	if !isModeenvLocked() {
 		return fmt.Errorf("internal error: cannot reseal without the modeenv lock")
 	}
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -74,7 +74,7 @@ func mockGadgetSeedSnap(c *C, files [][]string) *seed.Snap {
 }
 
 func (s *sealSuite) TestSealKeyToModeenv(c *C) {
-	defer boot.MockModeenvLocked()()
+	defer boot.MockSealModeenvLocked()()
 
 	for idx, tc := range []struct {
 		sealErr       error
@@ -1638,7 +1638,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 	})
 	defer restore()
 
-	defer boot.MockModeenvLocked()()
+	defer boot.MockSealModeenvLocked()()
 
 	err := boot.SealKeyToModeenv(myKey, myKey2, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{HasFDESetupHook: true, UseTokens: true})
 	c.Assert(err, IsNil)
@@ -1671,7 +1671,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	key := secboot.CreateMockBootstrappedContainer()
 	saveKey := secboot.CreateMockBootstrappedContainer()
 
-	defer boot.MockModeenvLocked()()
+	defer boot.MockSealModeenvLocked()()
 
 	err := boot.SealKeyToModeenv(key, saveKey, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{HasFDESetupHook: true})
 	c.Assert(err, ErrorMatches, `seal key failed`)


### PR DESCRIPTION
when we write a fresh modeenv and seal we are operating on the modeenv
of not the current system, so it was wrong to use the same mutext

this now mostly avoid overlapping operations of this kind, which shouldn't
happen, but is the most conservative change

we need to rethink the modeenv mutexes as naively releasing the
state lock while holding them can create deadlocks when we try
to reacquire the former