### PR TITLE
tests: add test for the posix-mq interface

### DIFF
--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -197,9 +197,6 @@ apps:
   polkit-agent:
     command: bin/run
     plugs: [ polkit-agent ]
-  posix-mq:
-    command: bin/run
-    plugs: [ posix-mq ]
   power-control:
     command: bin/run
     plugs: [ power-control ]

--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -1,0 +1,78 @@
+summary: Ensure that the posix-mq interface works
+
+details: |
+    The posix-mq interface allows access to the POSIX message queues. This test
+    explores a number of features related to distinct sub-permissions implemented
+    in snapd - read, write, create and delete.
+
+systems:
+    # Too old to support this feature entirely.
+    - -ubuntu-14.04-64
+    - -debian-11-64
+    # Distribution AppArmor parser does not support mqueue mediation.
+    # AppArmor parser does not re-execute despite SNAPD_APPARMOR_REEXEC=1 in /usr/lib/snapd/info.
+    - -opensuse-15.6-64
+    # Affected by https://gitlab.com/apparmor/apparmor/-/issues/492
+    - -ubuntu-16.04-64
+    - -ubuntu-18.04-64
+    - -ubuntu-core-16-64
+    - -ubuntu-core-18-64
+    - -ubuntu-core-20-64
+    - -debian-12-64
+    - -debian-13-64
+    - -debian-sid-64
+    - -arch-linux-64
+    - -opensuse-tumbleweed-64
+
+prepare: |
+    # Source code is at https://github.com/canonical/test-snapd-posix-mq
+    snap install test-snapd-posix-mq
+    snap warnings | MATCH 'No further warnings.|No warnings.'
+
+execute: |
+    # We cannot create a queue before connecting the can-create slot.
+    not test-snapd-posix-mq.mqctl create /test read-only 600 max-size=16,max-count=10
+    snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-create
+    # Technically the read permission is required because there's no way to
+    # open an mqueue without any permissions, as O_RDONLY is technically just
+    # zero, so it's not a distinct bit.
+    snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-read
+
+    # Once the can-create slot is connected we can create it.
+    test-snapd-posix-mq.mqctl create /test read-only 600 max-size=16,max-count=10 | MATCH 'mq_open did not fail'
+    test -f /dev/mqueue/test
+
+    # Disconnect the can-read slot for now.
+    snap disconnect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-read
+
+    # We cannot send messages before connecting the can-write slot.
+    # "Hello World" is the message and 5 is the priority.
+    not test-snapd-posix-mq.mqctl send /test write-only "Hello World" 5
+
+    # Once the can-write slot is connected we can send messages.
+    snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-write
+    test-snapd-posix-mq.mqctl send /test write-only "Hello World" 5 | MATCH 'mq_send did not fail'
+
+    # Disconnect the can-write slot for now.
+    snap disconnect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-write
+
+    # We cannot receive messages from the queue before connecting the can-read slot.
+    not test-snapd-posix-mq.mqctl recv /test read-only
+
+    # Once the can-read slot is connected we can receive messages.
+    snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-read
+    test-snapd-posix-mq.mqctl recv /test read-only >msg
+    MATCH 'Received message with priority 5: Hello World' <msg
+
+    # We can also get and set attributes as those are always allowed, as long as we can open the queue.
+    test-snapd-posix-mq.mqctl getattr /test read-only | MATCH 'mq_getattr did not fail'
+    test-snapd-posix-mq.mqctl setattr /test read-only | MATCH 'mq_setattr did not fail'
+    test-snapd-posix-mq.mqctl setattr /test read-only nonblock | MATCH 'mq_setattr did not fail'
+
+    # We cannot delete the queue before connecting the can-delete slot.
+    not test-snapd-posix-mq.mqctl unlink /test
+
+    # Once the can-delete slot is connected we can unlink the queue.
+    snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-delete
+    test-snapd-posix-mq.mqctl unlink /test
+    test ! -f /dev/mqueue/test


### PR DESCRIPTION
The posix-mq interface was merged a while ago without any dedicated tests. Historically there were a number of issues around mediation of mqueue and having this sort of test provided earlier might have saved us some time later.

The test verifies runtime correctness of the read, write, create and delete permissions specific to the posix-mq interface, using the test-snapd-posix-mq snap. The snap has been issued with a snap declaration assertion to use the posix-mq interface slots, which are super-privileged. All slots grant access to the /test POSIX message queue, with the relevant permission, read, write, create or delete.

The tests is skipped on Ubuntu Core 18 and earlier, and equivalent, due to a bug (referenced). Technically the interface apparmor elements require apparmor_parser version 4.0.1 or newer present in snapd snap. The interface does not work with host-provided apparmor as snapd explicitly constrains it to ABI 3.0 which does not support mqueue.

In addition also remove posix-mq plug of test-snapd-policy-app-consumer as that is required by static checker:

  Dedicated test 'tests/main/interfaces-posix-mq' found for 'posix-mq'.
  Please remove 'posix-mq' from 'tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml'.
