### PR TITLE
Release: 2.68.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# New in snapd 2.68.1
+* Fix snap-confine type specifier type mismatch on armhf
+
 # New in snapd 2.68
 * FDE: add support for new and more extensible key format that is unified between TPM and FDE hook
 * FDE: add support for adding passphrases during installation

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -277,7 +277,8 @@ static void log_startup_stage(const char *stage) {
     }
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lu.%06lu\"}", stage, tv.tv_sec, tv.tv_usec);
+    debug("-- snap startup {\"stage\":\"%s\", \"time\":\"%lld.%06lld\"}", stage, (long long int)tv.tv_sec,
+          (long long int)tv.tv_usec);
 }
 
 /**

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.68
+pkgver=2.68.1
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,10 @@
+snapd (2.68.1-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2098137
+    - Fix snap-confine type specifier type mismatch on armhf
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Mon, 24 Feb 2025 10:31:49 +0200
+
 snapd (2.68-1) unstable; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.68
+Version:        2.68.1
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPL-3.0-only
@@ -1003,6 +1003,10 @@ fi
 
 
 %changelog
+* Mon Feb 24 2025 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.68.1
+ - Fix snap-confine type specifier type mismatch on armhf
+
 * Thu Feb 13 2025 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.68
  - FDE: add support for new and more extensible key format that is

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb 24 08:31:49 UTC 2025 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.68.1
+
+-------------------------------------------------------------------
 Thu Feb 13 10:42:09 UTC 2025 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.68

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -91,7 +91,7 @@
 
 
 Name:           snapd
-Version:        2.68
+Version:        2.68.1
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.68.1~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2098137
+    - Fix snap-confine type specifier type mismatch on armhf
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Mon, 24 Feb 2025 10:31:49 +0200
+
 snapd (2.68~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.68.1) xenial; urgency=medium
+
+  * New upstream release, LP: #2098137
+    - Fix snap-confine type specifier type mismatch on armhf
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Mon, 24 Feb 2025 10:31:49 +0200
+
 snapd (2.68) xenial; urgency=medium
 
   * New upstream release, LP: #2098137


### PR DESCRIPTION
This is a deb only dot release that fixes a type warning that gets escalated to error preventing armhf builds for newer releases. 

**VERIFICATION:** Current automated tests does not cover building for armhf or any other 32 bit system. Verified the fix by uploading on LP PPA: [LP builds to verify the fix](https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+build/30362382)

Generated changelogs with:
DEBEMAIL="Ernest Lotter [ernest.lotter@canonical.com](mailto:ernest.lotter@canonical.com)" release-tools/changelog.py 2.68.1 2098137 NEWS.md

Cherry picks:
- https://github.com/canonical/snapd/pull/15111

SRU Bug: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2098137
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34552

Requires rebase merge

