### PR TITLE
interfaces: fix a number of issues affecting posix-mq

### DIFF
--- a/interfaces/builtin/posix_mq.go
+++ b/interfaces/builtin/posix_mq.go
@@ -301,6 +301,18 @@ func (iface *posixMQInterface) generateSnippet(name, plugOrSlot string, permissi
 	return snippet.String()
 }
 
+func (iface *posixMQInterface) extendPermissions(perms []string) []string {
+	extended := make([]string, len(perms), len(perms)+1)
+	copy(extended, perms)
+
+	// Always allow "open"
+	if !strutil.ListContains(perms, "open") {
+		extended = append(extended, "open")
+	}
+
+	return extended
+}
+
 func (iface *posixMQInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 	if implicitSystemPermanentSlot(slot) {
 		return nil
@@ -329,10 +341,7 @@ func (iface *posixMQInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 		return err
 	}
 
-	// Always allow "open"
-	if !strutil.ListContains(perms, "open") {
-		perms = append(perms, "open")
-	}
+	perms = iface.extendPermissions(perms)
 
 	snippet := iface.generateSnippet(plug.Name(), "plug", perms, paths)
 	spec.AddSnippet(snippet)

--- a/interfaces/builtin/posix_mq.go
+++ b/interfaces/builtin/posix_mq.go
@@ -118,7 +118,7 @@ func (iface *posixMQInterface) checkPosixMQAppArmorSupport() error {
 		return err
 	}
 
-	if !strutil.ListContains(features, "mqueue") {
+	if !strutil.ListContains(features, "mqueue-posix") {
 		return fmt.Errorf("AppArmor does not support POSIX message queues - cannot setup or connect interfaces")
 	}
 
@@ -295,7 +295,7 @@ func (iface *posixMQInterface) generateSnippet(name, plugOrSlot string, permissi
 
 	snippet.WriteString(fmt.Sprintf("  # POSIX Message Queue %s: %s\n", plugOrSlot, name))
 	for _, path := range paths {
-		snippet.WriteString(fmt.Sprintf("  mqueue (%s) \"%s\",\n", aaPerms, path))
+		snippet.WriteString(fmt.Sprintf("  mqueue (%s) type=posix \"%s\",\n", aaPerms, path))
 	}
 
 	return snippet.String()

--- a/interfaces/builtin/posix_mq_test.go
+++ b/interfaces/builtin/posix_mq_test.go
@@ -484,7 +484,7 @@ func (s *PosixMQInterfaceSuite) TestReadWriteMQAppArmor(c *C) {
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
 	c.Check(slotSnippet, testutil.Contains, `# POSIX Message Queue slot: test-rw`)
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-rw",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete getattr setattr) type=posix "/test-rw",`)
 
 	spec = apparmor.NewSpecification(s.testReadOnlyPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testReadWritePlug, s.testReadWriteSlot)
@@ -493,7 +493,7 @@ func (s *PosixMQInterfaceSuite) TestReadWriteMQAppArmor(c *C) {
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
 	c.Check(plugSnippet, testutil.Contains, `# POSIX Message Queue plug: test-rw`)
-	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open) type=posix "/test-rw",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open getattr setattr) type=posix "/test-rw",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestReadWriteMQSeccomp(c *C) {
@@ -531,7 +531,7 @@ func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQAppArmor(c *C) {
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
 	c.Check(slotSnippet, testutil.Contains, `# POSIX Message Queue slot: test-default`)
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-default",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete getattr setattr) type=posix "/test-default",`)
 
 	spec = apparmor.NewSpecification(s.testDefaultPermsPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testDefaultPermsPlug, s.testDefaultPermsSlot)
@@ -540,7 +540,7 @@ func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQAppArmor(c *C) {
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
 	c.Check(plugSnippet, testutil.Contains, `# POSIX Message Queue plug: test-default`)
-	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open) type=posix "/test-default",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open getattr setattr) type=posix "/test-default",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQSeccomp(c *C) {
@@ -576,7 +576,7 @@ func (s *PosixMQInterfaceSuite) TestReadOnlyMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-ro",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete getattr setattr) type=posix "/test-ro",`)
 
 	spec = apparmor.NewSpecification(s.testReadOnlyPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testReadOnlyPlug, s.testReadOnlySlot)
@@ -584,7 +584,7 @@ func (s *PosixMQInterfaceSuite) TestReadOnlyMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
-	c.Check(plugSnippet, testutil.Contains, `mqueue (read open) type=posix "/test-ro",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (read open getattr) type=posix "/test-ro",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestReadOnlyMQSeccomp(c *C) {
@@ -621,9 +621,9 @@ func (s *PosixMQInterfaceSuite) TestPathArrayMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
-	c.Check(slotSnippet, testutil.Contains, `  mqueue (open read write create delete) type=posix "/test-array-1",
-  mqueue (open read write create delete) type=posix "/test-array-2",
-  mqueue (open read write create delete) type=posix "/test-array-3",
+	c.Check(slotSnippet, testutil.Contains, `  mqueue (open read write create delete getattr setattr) type=posix "/test-array-1",
+  mqueue (open read write create delete getattr setattr) type=posix "/test-array-2",
+  mqueue (open read write create delete getattr setattr) type=posix "/test-array-3",
 `)
 
 	spec = apparmor.NewSpecification(s.testPathArrayPlug.AppSet())
@@ -632,9 +632,9 @@ func (s *PosixMQInterfaceSuite) TestPathArrayMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
-	c.Check(plugSnippet, testutil.Contains, `  mqueue (read write open) type=posix "/test-array-1",
-  mqueue (read write open) type=posix "/test-array-2",
-  mqueue (read write open) type=posix "/test-array-3",
+	c.Check(plugSnippet, testutil.Contains, `  mqueue (read write open getattr setattr) type=posix "/test-array-1",
+  mqueue (read write open getattr setattr) type=posix "/test-array-2",
+  mqueue (read write open getattr setattr) type=posix "/test-array-3",
 `)
 }
 
@@ -672,7 +672,7 @@ func (s *PosixMQInterfaceSuite) TestAllPermsMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-all-perms",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete getattr setattr) type=posix "/test-all-perms",`)
 
 	spec = apparmor.NewSpecification(s.testAllPermsPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testAllPermsPlug, s.testAllPermsSlot)
@@ -680,7 +680,7 @@ func (s *PosixMQInterfaceSuite) TestAllPermsMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
-	c.Check(plugSnippet, testutil.Contains, `mqueue (create delete read write open) type=posix "/test-all-perms",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (create delete read write open getattr setattr) type=posix "/test-all-perms",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestAllPermsMQSeccomp(c *C) {

--- a/interfaces/builtin/posix_mq_test.go
+++ b/interfaces/builtin/posix_mq_test.go
@@ -484,7 +484,7 @@ func (s *PosixMQInterfaceSuite) TestReadWriteMQAppArmor(c *C) {
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
 	c.Check(slotSnippet, testutil.Contains, `# POSIX Message Queue slot: test-rw`)
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) "/test-rw",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-rw",`)
 
 	spec = apparmor.NewSpecification(s.testReadOnlyPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testReadWritePlug, s.testReadWriteSlot)
@@ -493,7 +493,7 @@ func (s *PosixMQInterfaceSuite) TestReadWriteMQAppArmor(c *C) {
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
 	c.Check(plugSnippet, testutil.Contains, `# POSIX Message Queue plug: test-rw`)
-	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open) "/test-rw",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open) type=posix "/test-rw",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestReadWriteMQSeccomp(c *C) {
@@ -531,7 +531,7 @@ func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQAppArmor(c *C) {
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
 	c.Check(slotSnippet, testutil.Contains, `# POSIX Message Queue slot: test-default`)
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) "/test-default",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-default",`)
 
 	spec = apparmor.NewSpecification(s.testDefaultPermsPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testDefaultPermsPlug, s.testDefaultPermsSlot)
@@ -540,7 +540,7 @@ func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQAppArmor(c *C) {
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
 	c.Check(plugSnippet, testutil.Contains, `# POSIX Message Queue plug: test-default`)
-	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open) "/test-default",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open) type=posix "/test-default",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQSeccomp(c *C) {
@@ -576,7 +576,7 @@ func (s *PosixMQInterfaceSuite) TestReadOnlyMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) "/test-ro",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-ro",`)
 
 	spec = apparmor.NewSpecification(s.testReadOnlyPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testReadOnlyPlug, s.testReadOnlySlot)
@@ -584,7 +584,7 @@ func (s *PosixMQInterfaceSuite) TestReadOnlyMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
-	c.Check(plugSnippet, testutil.Contains, `mqueue (read open) "/test-ro",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (read open) type=posix "/test-ro",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestReadOnlyMQSeccomp(c *C) {
@@ -621,9 +621,9 @@ func (s *PosixMQInterfaceSuite) TestPathArrayMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
-	c.Check(slotSnippet, testutil.Contains, `  mqueue (open read write create delete) "/test-array-1",
-  mqueue (open read write create delete) "/test-array-2",
-  mqueue (open read write create delete) "/test-array-3",
+	c.Check(slotSnippet, testutil.Contains, `  mqueue (open read write create delete) type=posix "/test-array-1",
+  mqueue (open read write create delete) type=posix "/test-array-2",
+  mqueue (open read write create delete) type=posix "/test-array-3",
 `)
 
 	spec = apparmor.NewSpecification(s.testPathArrayPlug.AppSet())
@@ -632,9 +632,9 @@ func (s *PosixMQInterfaceSuite) TestPathArrayMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
-	c.Check(plugSnippet, testutil.Contains, `  mqueue (read write open) "/test-array-1",
-  mqueue (read write open) "/test-array-2",
-  mqueue (read write open) "/test-array-3",
+	c.Check(plugSnippet, testutil.Contains, `  mqueue (read write open) type=posix "/test-array-1",
+  mqueue (read write open) type=posix "/test-array-2",
+  mqueue (read write open) type=posix "/test-array-3",
 `)
 }
 
@@ -672,7 +672,7 @@ func (s *PosixMQInterfaceSuite) TestAllPermsMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 
 	slotSnippet := spec.SnippetForTag("snap.producer.app")
-	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) "/test-all-perms",`)
+	c.Check(slotSnippet, testutil.Contains, `mqueue (open read write create delete) type=posix "/test-all-perms",`)
 
 	spec = apparmor.NewSpecification(s.testAllPermsPlug.AppSet())
 	err = spec.AddConnectedPlug(s.iface, s.testAllPermsPlug, s.testAllPermsSlot)
@@ -680,7 +680,7 @@ func (s *PosixMQInterfaceSuite) TestAllPermsMQAppArmor(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
-	c.Check(plugSnippet, testutil.Contains, `mqueue (create delete read write open) "/test-all-perms",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (create delete read write open) type=posix "/test-all-perms",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestAllPermsMQSeccomp(c *C) {
@@ -780,7 +780,7 @@ func (s *PosixMQInterfaceSuite) checkPlugPosixMQAttr(c *C, plug *snap.PlugInfo) 
 
 func (s *PosixMQInterfaceSuite) TestSanitizeSlot(c *C) {
 	// Ensure that the mqueue feature is detected
-	restore := apparmor_sandbox.MockFeatures([]string{}, nil, []string{"mqueue"}, nil)
+	restore := apparmor_sandbox.MockFeatures([]string{}, nil, []string{"mqueue-posix"}, nil)
 	defer restore()
 
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testReadWriteSlotInfo), IsNil)
@@ -823,7 +823,7 @@ func (s *PosixMQInterfaceSuite) TestSanitizeSlot(c *C) {
 
 func (s *PosixMQInterfaceSuite) TestSanitizePlug(c *C) {
 	// Ensure that the mqueue feature is detected
-	restore := apparmor_sandbox.MockFeatures([]string{}, nil, []string{"mqueue"}, nil)
+	restore := apparmor_sandbox.MockFeatures([]string{}, nil, []string{"mqueue-posix"}, nil)
 	defer restore()
 
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.testReadWritePlugInfo), IsNil)

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -732,6 +732,11 @@ func probeParserFeatures() ([]string, error) {
 			minVer:  "4.0.1",
 		},
 		{
+			feature: "mqueue-posix",
+			probe:   "mqueue type=posix,",
+			minVer:  "4.0.1",
+		},
+		{
 			feature: "allow-all",
 			probe:   "allow all,",
 			minVer:  "4.0.2",

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -548,6 +548,7 @@ func (s *parserFeatureTestSuite) TestProbeFeature(c *C) {
 	probeOneParserFeature(c, &knownProbes, parserPath, "include-if-exists", `profile snap-test { #include if exists "/foo"}`)
 	probeOneParserFeature(c, &knownProbes, parserPath, "io-uring", `profile snap-test { allow io_uring,}`)
 	probeOneVersionDependentParserFeature(c, &knownProbes, parserPath, "4.0.1", "mqueue", `profile snap-test { mqueue,}`)
+	probeOneVersionDependentParserFeature(c, &knownProbes, parserPath, "4.0.1", "mqueue-posix", `profile snap-test { mqueue type=posix,}`)
 	probeOneParserFeature(c, &knownProbes, parserPath, "prompt", `profile snap-test { prompt /foo r,}`)
 	probeOneParserFeature(c, &knownProbes, parserPath, "qipcrtr-socket", `profile snap-test { network qipcrtr dgram,}`)
 	probeOneParserFeature(c, &knownProbes, parserPath, "unconfined", `profile snap-test flags=(unconfined) { # test unconfined}`)
@@ -625,7 +626,7 @@ func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
 	c.Check(features, DeepEquals, []string{"network", "policy"})
 	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "io-uring", "mqueue", "prompt", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
+	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "io-uring", "mqueue", "mqueue-posix", "prompt", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
 }
 
 func (s *apparmorSuite) TestAppArmorParserMtime(c *C) {
@@ -665,7 +666,7 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	c.Check(features, DeepEquals, []string{"network", "policy"})
 	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "io-uring", "mqueue", "prompt", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
+	c.Check(features, DeepEquals, []string{"cap-audit-read", "cap-bpf", "include-if-exists", "io-uring", "mqueue", "mqueue-posix", "prompt", "qipcrtr-socket", "unconfined", "unsafe", "userns", "xdp"})
 
 	// this makes probing fails but is not done again
 	err = os.RemoveAll(d)


### PR DESCRIPTION
All the patches have detailed descriptions but the main idea is make the interface more precise. The `type=posix` qualifier ensures that the rules talk about POSIX message queues and not sysv queues. The `getattr` and `setattr` changes codify ability to express those permissions and retain the former semantics of automatically providing them by default whenever the `read` or `write` permissions are used.

The penultimate patch in this series fixes a bug that incorrectly clobbered a global variable.