### PR TITLE
cmd/libsnap-confine-private,snap-confine: helper for no-change identity, booleans with sc_identity

### DIFF
--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -116,10 +116,7 @@ void sc_call_snap_update_ns_as_user(int snap_update_ns_fd, const char *snap_name
                      * for details. */
                     "SNAPD_DEBUG=x", xdg_runtime_dir_env, snap_real_home_env, NULL};
     /* keep the current identity */
-    sc_identity no_change_identity = {
-        .change_gid = false,
-        .change_uid = false,
-    };
+    sc_identity no_change_identity = sc_no_change_identity();
     sc_call_snapd_tool_with_apparmor(snap_update_ns_fd, "snap-update-ns", apparmor, aa_profile, no_change_identity,
                                      argv, envp);
 }

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <regex.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -124,13 +125,13 @@ sc_identity sc_set_effective_identity(sc_identity identity) {
     /* We are being careful not to return a value instructing us to change GID
      * or UID by accident. */
     sc_identity old = {
-        .change_gid = 0,
-        .change_uid = 0,
+        .change_gid = false,
+        .change_uid = false,
     };
 
     if (identity.change_gid) {
         old.gid = getegid();
-        old.change_gid = 1;
+        old.change_gid = true;
         if (setegid(identity.gid) < 0) {
             die("cannot set effective group to %d", identity.gid);
         }
@@ -140,7 +141,7 @@ sc_identity sc_set_effective_identity(sc_identity identity) {
     }
     if (identity.change_uid) {
         old.uid = geteuid();
-        old.change_uid = 1;
+        old.change_uid = true;
         if (seteuid(identity.uid) < 0) {
             die("cannot set effective user to %d", identity.uid);
         }

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -83,6 +83,21 @@ static inline sc_identity sc_root_group_identity(void) {
 }
 
 /**
+ * Produce value indicating no change in current identity.
+ *
+ * Produce a value of sc_identity which indicates no change in the identity of
+ * the current process.
+ **/
+static inline sc_identity sc_no_change_identity(void) {
+    sc_identity id = {
+        /* Explicit no change in either uid or gid. */
+        .change_uid = false,
+        .change_gid = false,
+    };
+    return id;
+}
+
+/**
  * Set the effective user and group IDs to given values.
  *
  * Effective user and group identifiers are applied to the system. The

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -428,8 +428,8 @@ int main(int argc, char **argv) {
     sc_identity real_user_identity = {
         .uid = real_uid,
         .gid = real_gid,
-        .change_uid = 1,
-        .change_gid = 1,
+        .change_uid = true,
+        .change_gid = true,
     };
     sc_set_effective_identity(real_user_identity);
     // Ensure that the user data path exists. When creating it use the identity


### PR DESCRIPTION
A followup to #15100, which adds a helper suggested by @alexmurray and updates all sites where change_uid/gid is used to pass bools.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
