### PR TITLE
tests: add switch to move executions between google and openstack

### DIFF
--- a/.github/workflows/fundamental-systems.json
+++ b/.github/workflows/fundamental-systems.json
@@ -10,6 +10,7 @@
       {
         "group": "ubuntu-focal (fundamental)",
         "backend": "google",
+        "alternative-backend": "openstack", 
         "systems": "ubuntu-20.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -17,6 +18,7 @@
       {
         "group": "ubuntu-noble (fundamental)",
         "backend": "google",
+        "alternative-backend": "openstack", 
         "systems": "ubuntu-24.04-64",
         "tasks": "tests/...",
         "rules": "main"

--- a/.github/workflows/fundamental-systems.json
+++ b/.github/workflows/fundamental-systems.json
@@ -2,7 +2,8 @@
     "include": [
       {
         "group": "debian-req (fundamental)",
-        "backend": "google-distro-1", 
+        "backend": "google-distro-1",
+        "alternative-backend": "google-distro-1", 
         "systems": "debian-11-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -10,7 +11,7 @@
       {
         "group": "ubuntu-focal (fundamental)",
         "backend": "google",
-        "alternative-backend": "openstack", 
+        "alternative-backend": "openstack",
         "systems": "ubuntu-20.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -18,7 +19,7 @@
       {
         "group": "ubuntu-noble (fundamental)",
         "backend": "google",
-        "alternative-backend": "openstack", 
+        "alternative-backend": "openstack",
         "systems": "ubuntu-24.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -26,6 +27,7 @@
       {
         "group": "ubuntu-interim (fundamental)",
         "backend": "google",
+        "alternative-backend": "google",
         "systems": "ubuntu-24.10-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -33,6 +35,7 @@
       {
         "group": "ubuntu-core-18 (fundamental)",
         "backend": "google-core",
+        "alternative-backend": "google-core",
         "systems": "ubuntu-core-18-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -40,6 +43,7 @@
       {
         "group": "ubuntu-core-20 (fundamental)",
         "backend": "google-core",
+        "alternative-backend": "google-core",
         "systems": "ubuntu-core-20-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -47,6 +51,7 @@
       {
         "group": "ubuntu-core-24 (fundamental)",
         "backend": "google-core",
+        "alternative-backend": "google-core",
         "systems": "ubuntu-core-24-64",
         "tasks": "tests/...",
         "rules": "main"

--- a/.github/workflows/nested-systems.json
+++ b/.github/workflows/nested-systems.json
@@ -3,6 +3,7 @@
       {
         "group": "nested-ubuntu-18.04",
         "backend": "google-nested",
+        "alternative-backend": "google-nested",
         "systems": "ubuntu-18.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
@@ -10,6 +11,7 @@
       {
         "group": "nested-ubuntu-20.04",
         "backend": "google-nested",
+        "alternative-backend": "google-nested",
         "systems": "ubuntu-20.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
@@ -17,6 +19,7 @@
       {
         "group": "nested-ubuntu-22.04",
         "backend": "google-nested",
+        "alternative-backend": "google-nested",
         "systems": "ubuntu-24.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
@@ -24,6 +27,7 @@
       {
         "group": "nested-ubuntu-24.04",
         "backend": "google-nested",
+        "alternative-backend": "google-nested",
         "systems": "ubuntu-24.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -104,6 +104,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
+      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -126,6 +127,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
+      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -147,6 +149,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
+      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}

--- a/.github/workflows/non-fundamental-systems.json
+++ b/.github/workflows/non-fundamental-systems.json
@@ -3,6 +3,7 @@
       {
         "group": "amazon-linux",
         "backend": "google-distro-1",
+        "alternative-backend": "google-distro-1",
         "systems": "amazon-linux-2-64 amazon-linux-2023-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -10,6 +11,7 @@
       {
         "group": "arch-linux",
         "backend": "google-distro-2",
+        "alternative-backend": "google-distro-2",
         "systems": "arch-linux-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -34,6 +36,7 @@
         "group": "fedora",
         "backend": "openstack",
         "systems": "fedora-41-64 fedora-40-64",
+        "alternative-backend": "openstack",
         "tasks": "tests/...",
         "rules": "main"
       },
@@ -48,6 +51,7 @@
       {
         "group": "ubuntu-trusty",
         "backend": "google",
+        "alternative-backend": "google",
         "systems": "ubuntu-14.04-64",
         "tasks": "tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04",
         "rules": "trusty"
@@ -55,6 +59,7 @@
       {
         "group": "ubuntu-xenial-bionic",
         "backend": "google",
+        "alternative-backend": "google",
         "systems": "ubuntu-16.04-64 ubuntu-18.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -62,6 +67,7 @@
       {
         "group": "ubuntu-jammy",
         "backend": "google",
+        "alternative-backend": "openstack",
         "systems": "ubuntu-22.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -69,6 +75,7 @@
       {
         "group": "ubuntu-daily",
         "backend": "google",
+        "alternative-backend": "google",
         "systems": "ubuntu-25.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -76,6 +83,7 @@
       {
         "group": "ubuntu-core-22",
         "backend": "google-core",
+        "alternative-backend": "google-core",
         "systems": "ubuntu-core-22-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -83,6 +91,7 @@
       {
         "group": "ubuntu-arm64",
         "backend": "google-arm",
+        "alternative-backend": "google-arm",
         "systems": "ubuntu-20.04-arm-64 ubuntu-core-22-arm-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -90,6 +99,7 @@
       {
         "group": "ubuntu-secboot",
         "backend": "google",
+        "alternative-backend": "google",
         "systems": "ubuntu-secboot-20.04-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -97,6 +107,7 @@
       {
         "group": "ubuntu-fips",
         "backend": "google-pro",
+        "alternative-backend": "google-pro",
         "systems": "ubuntu-fips-22.04-64",
         "tasks": "tests/fips/...",
         "rules": "fips"

--- a/.github/workflows/non-fundamental-systems.json
+++ b/.github/workflows/non-fundamental-systems.json
@@ -17,6 +17,7 @@
       {
         "group": "centos",
         "backend": "openstack",
+        "alternative-backend": "google-distro-2",
         "systems": "centos-9-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -24,6 +25,7 @@
       {
         "group": "debian-not-req",
         "backend": "openstack",
+        "alternative-backend": "google-distro-1",
         "systems": "debian-12-64 debian-sid-64",
         "tasks": "tests/...",
         "rules": "main"
@@ -37,7 +39,8 @@
       },
       {
         "group": "opensuse",
-        "backend": "openstack", 
+        "backend": "openstack",
+        "alternative-backend": "google-distro-2", 
         "systems": "opensuse-15.6-64 opensuse-tumbleweed-64",
         "tasks": "tests/...",
         "rules": "main"

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -139,8 +139,6 @@ jobs:
 
     - name: Setup run tests variable
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
-      env:
-          USE_ALTERNATIVE_BACKEND: ${{ vars.USE_ALTERNATIVE_BACKEND }}
       run: |
           get_new_tasks() {
             local prefix=$1
@@ -160,8 +158,9 @@ jobs:
           }
 
           # Determine if the alternative backend has to be used for the current group
-          # Alternative backends usage depends on the value stored in the var USE_ALTERNATIVE_BACKEND,
+          # Alternative backends usage depends on the value stored in the file USE_ALTERNATIVE_BACKEND,
           # where it is defined the backend to use when images are ready in both google and openstack.
+          USE_ALTERNATIVE_BACKEND="$(curl -s https://storage.googleapis.com/snapd-spread-tests/snapd-tests/ci/USE_ALTERNATIVE_BACKEND)"
           SPREAD_BACKEND="${{ inputs.backend }}"
           if [ -n "${{ inputs.alternative-backend }}" ] && grep "${{ inputs.group }}: true" <<< "$USE_ALTERNATIVE_BACKEND"  ; then
               SPREAD_BACKEND="${{ inputs.alternative-backend }}"

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -15,7 +15,7 @@ on:
         type: string
       alternative-backend:
         description: 'The spread backend to use when the backend cannot be used'
-        required: true
+        required: false
         type: string
       systems:
         description: 'The spread system(s) to use (for possible values, check spread.yaml). If more than one, separate them with a space. To run all, write ALL. To run none, write NONE'

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -139,6 +139,8 @@ jobs:
 
     - name: Setup run tests variable
       if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread')"
+      env:
+          USE_ALTERNATIVE_BACKEND: ${{ vars.USE_ALTERNATIVE_BACKEND }}
       run: |
           get_new_tasks() {
             local prefix=$1
@@ -161,7 +163,7 @@ jobs:
           # Alternative backends usage depends on the value stored in the var USE_ALTERNATIVE_BACKEND,
           # where it is defined the backend to use when images are ready in both google and openstack.
           SPREAD_BACKEND="${{ inputs.backend }}"
-          if [ -n "${{ inputs.alternative-backend }}" ] && grep "${{ inputs.group }}: true" <<< ${{ vars.USE_ALTERNATIVE_BACKEND }}  ; then
+          if [ -n "${{ inputs.alternative-backend }}" ] && grep "${{ inputs.group }}: true" <<< "$USE_ALTERNATIVE_BACKEND"  ; then
               SPREAD_BACKEND="${{ inputs.alternative-backend }}"
           fi
           echo SPREAD_BACKEND="$SPREAD_BACKEND" >> $GITHUB_ENV

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -13,6 +13,10 @@ on:
         description: 'The spread backend to use (for possible values, check spread.yaml). This cannot be empty'
         required: true
         type: string
+      alternative-backend:
+        description: 'The spread backend to use when the backend cannot be used'
+        required: true
+        type: string
       systems:
         description: 'The spread system(s) to use (for possible values, check spread.yaml). If more than one, separate them with a space. To run all, write ALL. To run none, write NONE'
         required: true
@@ -153,6 +157,15 @@ jobs:
             echo "$TASKS_TO_RUN"
           }
 
+          # Determine if the alternative backend has to be used for the current group
+          # Alternative backends usage depends on the value stored in the var USE_ALTERNATIVE_BACKEND,
+          # where it is defined the backend to use when images are ready in both google and openstack.
+          SPREAD_BACKEND="${{ inputs.backend }}"
+          if [ -n "${{ inputs.alternative-backend }}" ] && grep "${{ inputs.group }}: true" << ${{ vars.USE_ALTERNATIVE_BACKEND }}  ; then
+              SPREAD_BACKEND="${{ inputs.alternative-backend }}"
+          fi
+          echo SPREAD_BACKEND="$SPREAD_BACKEND" >> $GITHUB_ENV
+
           CHANGES_PARAM=""
           for CHANGE in $CHANGED_FILES; do
               CHANGES_PARAM="$CHANGES_PARAM -c $CHANGE"
@@ -162,10 +175,10 @@ jobs:
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
           elif [ "${{ inputs.systems }}" = "ALL" ]; then
-              RUN_TESTS=$(get_new_tasks "${{ inputs.backend }}" "$CHANGES_PARAM")
+              RUN_TESTS=$(get_new_tasks "$SPREAD_BACKEND" "$CHANGES_PARAM")
           elif [ "${{ inputs.systems }}" != "NONE" ]; then
               for SYSTEM in ${{ inputs.systems }}; do
-                NEW_TASKS="$(get_new_tasks "${{ inputs.backend }}:$SYSTEM" "$CHANGES_PARAM")"
+                NEW_TASKS="$(get_new_tasks "$SPREAD_BACKEND:$SYSTEM" "$CHANGES_PARAM")"
                 if [ -z "$RUN_TESTS" ]; then
                     RUN_TESTS="$NEW_TASKS"
                 else
@@ -272,7 +285,7 @@ jobs:
           fi
 
           # Add openstack backend definition to spread.yaml
-          if [ "${{ inputs.backend }}" = openstack ]; then
+          if [ "$SPREAD_BACKEND" = openstack ]; then
               ./tests/lib/spread/add-backend tests/lib/spread/backend.openstack.yaml spread.yaml
           fi
 
@@ -345,7 +358,7 @@ jobs:
               ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json
 
               # Add openstack backend definition to spread.yaml
-              if [ "${{ inputs.backend }}" = openstack ]; then
+              if [ "$SPREAD_BACKEND" = openstack ]; then
                   ./tests/lib/spread/add-backend tests/lib/spread/backend.openstack.yaml spread.yaml
               fi
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -161,7 +161,7 @@ jobs:
           # Alternative backends usage depends on the value stored in the var USE_ALTERNATIVE_BACKEND,
           # where it is defined the backend to use when images are ready in both google and openstack.
           SPREAD_BACKEND="${{ inputs.backend }}"
-          if [ -n "${{ inputs.alternative-backend }}" ] && grep "${{ inputs.group }}: true" << ${{ vars.USE_ALTERNATIVE_BACKEND }}  ; then
+          if [ -n "${{ inputs.alternative-backend }}" ] && grep "${{ inputs.group }}: true" <<< ${{ vars.USE_ALTERNATIVE_BACKEND }}  ; then
               SPREAD_BACKEND="${{ inputs.alternative-backend }}"
           fi
           echo SPREAD_BACKEND="$SPREAD_BACKEND" >> $GITHUB_ENV

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -162,7 +162,7 @@ jobs:
           # where it is defined the backend to use when images are ready in both google and openstack.
           USE_ALTERNATIVE_BACKEND="$(curl -s https://storage.googleapis.com/snapd-spread-tests/snapd-tests/ci/use_alternative_backend.json)"
           SPREAD_BACKEND="${{ inputs.backend }}"
-          if [ -n "${{ inputs.alternative-backend }}" ] && [ $(jq -r '."${{ inputs.group }}"'' <<< "$USE_ALTERNATIVE_BACKEND") == true ]; then
+          if [ -n "${{ inputs.alternative-backend }}" ] && [ $(jq -r ".\"${{ inputs.group }}\"" <<< "$USE_ALTERNATIVE_BACKEND") == true ]; then
               SPREAD_BACKEND="${{ inputs.alternative-backend }}"
           fi
           echo SPREAD_BACKEND="$SPREAD_BACKEND" >> $GITHUB_ENV

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -160,9 +160,9 @@ jobs:
           # Determine if the alternative backend has to be used for the current group
           # Alternative backends usage depends on the value stored in the file USE_ALTERNATIVE_BACKEND,
           # where it is defined the backend to use when images are ready in both google and openstack.
-          USE_ALTERNATIVE_BACKEND="$(curl -s https://storage.googleapis.com/snapd-spread-tests/snapd-tests/ci/USE_ALTERNATIVE_BACKEND)"
+          USE_ALTERNATIVE_BACKEND="$(curl -s https://storage.googleapis.com/snapd-spread-tests/snapd-tests/ci/use_alternative_backend.json)"
           SPREAD_BACKEND="${{ inputs.backend }}"
-          if [ -n "${{ inputs.alternative-backend }}" ] && grep "${{ inputs.group }}: true" <<< "$USE_ALTERNATIVE_BACKEND"  ; then
+          if [ -n "${{ inputs.alternative-backend }}" ] && [ $(jq -r '."${{ inputs.group }}"'' <<< "$USE_ALTERNATIVE_BACKEND") == true ]; then
               SPREAD_BACKEND="${{ inputs.alternative-backend }}"
           fi
           echo SPREAD_BACKEND="$SPREAD_BACKEND" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -321,6 +321,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
+      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -349,6 +350,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
+      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -376,6 +378,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
+      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
@@ -400,6 +403,7 @@ jobs:
       runs-on: '["self-hosted", "spread-enabled"]'
       group: ${{ matrix.group }}
       backend: ${{ matrix.backend }}
+      alternative-backend: ${{ matrix.alternative-backend }}
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}


### PR DESCRIPTION
Through this change it is possible to determine if the alternative backend has to be used for the a group in the ci
Alternative backends usage depends on the value stored in the file USE_ALTERNATIVE_BACKEND, where it is defined the backend to use when images are ready in both google and openstack.

The content for USE_ALTERNATIVE_BACKEND is:
    opensuse: false,
    debian-not-req: false,
    centos: false,
    ubuntu-jammy: false,
    ubuntu-focal (fundamental): false,
    ubuntu-noble (fundamental): false

In case we need to swith a group, we just need to change false by true