### PR TITLE
core-initrd: make Azure kernels reboot upon panic

### DIFF
--- a/core-initrd/latest/postinst.d/ubuntu-core-initramfs
+++ b/core-initrd/latest/postinst.d/ubuntu-core-initramfs
@@ -24,7 +24,7 @@ case $(dpkg --print-architecture) in
 	case $version in
 	    *-azure | *-azure-fde)
 		# Currently nullboot doesn't seal cmdline, thus it must be baked in for azure
-		ubuntu-core-initramfs create-efi --unsigned --kernelver "$version" --cmdline "snapd_recovery_mode=cloudimg-rootfs console=tty1 console=ttyS0 earlyprintk=ttyS0"
+		ubuntu-core-initramfs create-efi --unsigned --kernelver "$version" --cmdline "snapd_recovery_mode=cloudimg-rootfs console=tty1 console=ttyS0 earlyprintk=ttyS0 panic=60"
 		;;
 	    *)
 		ubuntu-core-initramfs create-efi --unsigned --kernelver "$version"


### PR DESCRIPTION
Add the "panic=60" kernel cmdline option for Azure kernels in order to make them reboot after 60s upon a panic during boot. This will be relevant for implementing a fallback mechanism in nullboot, allowing rollbacks in the event of a faulty kernel upgrade. The 60s timeout is chosen to allow easier collection of console logs during troubleshooting.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
