### PR TITLE
snap: fix non-octal os.FileMode in TestPackConfigureHooksPermissionsError

### DIFF
--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -252,7 +252,7 @@ apps:
 		c.Check(err, testutil.ErrorIs, snap.ErrBadModes)
 		c.Check(err, ErrorMatches, fmt.Sprintf(`snap is unusable due to bad permissions: "meta/hooks/%s" should be executable, and isn't: -rw-r--r--`, hook))
 		// Fix hook error to catch next hook's error
-		c.Assert(os.Chmod(filepath.Join(sourceDir, "meta", "hooks", hook), 755), IsNil)
+		c.Assert(os.Chmod(filepath.Join(sourceDir, "meta", "hooks", hook), 0755), IsNil)
 	}
 }
 


### PR DESCRIPTION
This PR fixes the usage of non-octal file modes in [TestPackConfigureHooksPermissionsError](https://github.com/canonical/snapd/blob/1a7948f401f4c37df6ad39ad07d268cba60fc6ac/snap/pack/pack_test.go#L255)