### PR TITLE
tests/muinstaller: move to 24.04.2 release

### DIFF
--- a/tests/lib/muinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/muinstaller/mk-classic-rootfs.sh
@@ -110,7 +110,7 @@ else
             pointrel=.4
             ;;
         24.04)
-            pointrel=.1
+            pointrel=.2
             ;;
         *)
             pointrel=


### PR DESCRIPTION
https://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.1-base-amd64.tar.gz now gives 404, move to 24.04.2 release
