### PR TITLE
run-checks, cmd: multiple run-check improvements

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -78,18 +78,3 @@ jobs:
           fi
           sudo apt-get install -y python3-yamlordereddictloader
           ./run-checks --static
-
-    - name: Check C source code formatting
-      run: |
-          set -x
-          cd cmd/
-          ./autogen.sh
-          # apply formatting
-          make fmt
-          set +x
-          if [ -n "$(git diff --stat)" ]; then
-              git diff
-              echo "C files are not fomratted correctly, run 'make fmt'"
-              echo "make sure to have clang-format installed"
-              exit 1
-          fi

--- a/.github/workflows/unit-tests-cross-distro.yaml
+++ b/.github/workflows/unit-tests-cross-distro.yaml
@@ -38,10 +38,24 @@ jobs:
             # TODO these are needed only by cmd/snap-seccomp unit tests, and
             # should be added to BuildRequires
             dnf install -y glibc-devel.i686 glibc-static.i686
+            dnf install -y clang-tools-extra # required by run-checks
+            dnf install -y python3-pytest # required by run-checks
+            dnf install -y python3-markdown # required by release-tools
+            dnf install -y python3-beautifulsoup4 # required by release-tools
+            dnf install -y python3-debian # required by release-tools
+            dnf install -y python3-flake8 # required by release-tools
             ;;
         opensuse/*)
             zypper --non-interactive install -y rpmdevtools rpm-build git
             zypper --non-interactive install -y $(rpmspec -q --buildrequires "./packaging/$distroname/snapd.spec")
+            zypper --non-interactive install -y llvm-clang # required by run-checks
+            zypper --non-interactive install -y python3-pytest # required by run-checks
+            zypper --non-interactive install -y ShellCheck # required by run-checks
+            ln -s "$(command -v pytest)"-3* /usr/local/bin/pytest-3 # run-checks expects pytest-3
+            zypper --non-interactive install -y python3-Markdown # required by release-tools (note: https://github.com/jamiemcg/Remarkable/issues/22)
+            zypper --non-interactive install -y python3-beautifulsoup4 # required by release-tools
+            zypper --non-interactive install -y python3-debian # required by release-tools
+            zypper --non-interactive install -y python3-flake8 # required by release-tools
             ;;
         *)
             echo "Unsupported distribution variant ${{ inputs.distro }}"

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -53,12 +53,12 @@ endif
 
 # NOTE: clang-format is using project-wide .clang-format file.
 .PHONY: fmt
-fmt:: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
+fmt:: $(wildcard $(addsuffix /*.[ch],$(addprefix $(srcdir)/,$(subdirs))))
 	clang-format -i $^
 
 # fmt-check is intended for use by tests
 .PHONY: fmt-check
-fmt-check:: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
+fmt-check:: $(wildcard $(addsuffix /*.[ch],$(addprefix $(srcdir)/,$(subdirs))))
 	clang-format --dry-run --Werror $^
 
 # The hack target helps developers work on snap-confine on their live system by

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -56,6 +56,11 @@ endif
 fmt:: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
 	clang-format -i $^
 
+# fmt-check is intended for use by tests
+.PHONY: fmt-check
+fmt-check:: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
+	clang-format --dry-run --Werror $^
+
 # The hack target helps developers work on snap-confine on their live system by
 # installing a fresh copy of snap confine and the appropriate apparmor profile.
 .PHONY: hack

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -110,7 +110,7 @@ check() {
       fi
   done
 
-  SKIP_UNCLEAN=1 ./run-checks --unit
+  SKIP_UNCLEAN=1 IGNORE_MISSING=1 ./run-checks --unit
   # XXX: Static checks choke on autotools generated cruft. Let's not run them
   # here as they are designed to pass on a clean tree, before anything else is
   # done, not after building the tree.

--- a/run-checks
+++ b/run-checks
@@ -56,15 +56,6 @@ tool_configure() {
     local tool=$1
     case "$tool" in
     go)
-        # add workaround for https://github.com/golang/go/issues/24449
-        if [ "$(uname -m)" = "s390x" ]; then
-            if go version | grep -q go1.10; then
-                echo "covermode 'atomic' crashes on s390x with go1.10, reseting"
-                echo "to 'set'. see https://github.com/golang/go/issues/24449"
-                COVERMODE="set"
-            fi
-        fi
-
         # If GOPATH is set in the shell environment, the path will be reflected
         # in $(go env GOPATH). If no shell path was set, Go will default the internal
         # GOPATH to $HOME/go. Note that GOPATH may contain a colon delimited set
@@ -74,8 +65,9 @@ tool_configure() {
         export PATH="$PATH:$GOBINS"
 
         # when *not* running inside github, and go-1.18 is available, use it
-        if [ -z "${GITHUB_WORKFLOW:-}" ] && [ -e "/usr/lib/go-1.18/bin" ]; then
+        if [ "${CI:-}" != "true" ] && [ -e "/usr/lib/go-1.18/bin" ]; then
             export PATH=/usr/lib/go-1.18/bin:"${PATH}"
+	    echo "WARNING: Forcing the use of Go 1.18 (preferred version for this project)" >&2
         fi
         ;;
     shellcheck) ;&    # fallthrough
@@ -96,27 +88,27 @@ install_conf_show_tool() {
 
     echo ">> Depends on \"$tool\""
 
-    if [ "$auto_install" = "1" ] && ! command -v "$tool" >/dev/null; then # ignore-tool
+    if [ "$auto_install" -eq 1 ] && ! command -v "$tool" >/dev/null; then # ignore-tool
         if ! tool_install "$tool"; then
-            echo "WARNING: Cannot install tool $tool"
+            echo "WARNING: Cannot install tool $tool" >&2
         fi
     fi
 
     if ! executable=$(command -v "$tool"); then # ignore-tool
-        if [ "$ignore_missing" != "1" ]; then
-            echo "ERROR: Tool $tool is not available"
+        if [ "$ignore_missing" -ne 1 ]; then
+            echo "ERROR: Tool $tool is not available" >&2
             return 1
         else
-            echo "WARNING: Tool $tool is not available"
+            echo "WARNING: Tool $tool is not available" >&2
         fi
     else
         if ! tool_configure "$tool"; then
-            echo "ERROR: Cannot configure $tool"
+            echo "ERROR: Cannot configure $tool" >&2
             return 1
         fi
 
         if ! version=$(tool_version "$tool"); then
-            echo "ERROR: Cannot retrieve version of $tool"
+            echo "ERROR: Cannot retrieve version of $tool" >&2
             return 1
         else
             echo "Version: $version"
@@ -130,7 +122,7 @@ verify_tools() {
     local ignore_missing=$2
 
     # find tool dependencies but ignore those marked with `# check-tools-ignore`
-    tools=$(grep -v '# ignore-tool' "$this_file" | grep -oP 'command -v \K[\w-]+' | sort | uniq)
+    tools=$(grep -v '# ignore-tool' "$this_file" | grep -oP 'command -v \K[\w-]+' | sort -u)
 
     # check go first that includes setting up go paths required to find or install
     # other go based tools, error early when missing
@@ -170,8 +162,8 @@ missing_interface_spread_test() {
         dedicated_test=$(find tests/main/ -maxdepth 1 -name "interfaces-$iface")
         if [ -n "$dedicated_test" ]; then
             if grep -q "$search" "$snap_yaml"; then
-                echo "Dedicated test '$dedicated_test' found for '$iface'."
-                echo "Please remove '$iface' from '$snap_yaml'."
+                echo "Dedicated test '$dedicated_test' found for '$iface'." >&2
+                echo "Please remove '$iface' from '$snap_yaml'." >&2
                 exit 1
             fi
             # dedicated test already exists, skip high-level test check below
@@ -180,10 +172,10 @@ missing_interface_spread_test() {
 
         # check if high-level minimal test exists for interface
         if ! grep -q "$search" "$snap_yaml"; then
-            echo "Missing high-level test for interface '$iface'. Please add to:"
-            echo "* $snap_yaml"
-            echo "* $core_snap_yaml (if needed)"
-            echo "* $classic_snap_yaml (if needed)"
+            echo "Missing high-level test for interface '$iface'. Please add to:" >&2
+            echo "* $snap_yaml" >&2
+            echo "* $core_snap_yaml (if needed)" >&2
+            echo "* $classic_snap_yaml (if needed)" >&2
             exit 1
         fi
     done
@@ -299,8 +291,8 @@ if [ "$STATIC" = 1 ]; then
     done
 
     if [ -n "$got" ]; then
-        echo 'Usages of http.Status*, we prefer the numeric values directly:'
-        echo "$got"
+        echo 'Usages of http.Status*, we prefer the numeric values directly:' >&2
+        echo "$got" >&2
         exit 1
     fi
 
@@ -315,8 +307,8 @@ if [ "$STATIC" = 1 ]; then
     done
 
     if [ -n "$got" ]; then
-        echo 'Direct usages of math/rand, we prefer randutil:'
-        echo "$got"
+        echo 'Direct usages of math/rand, we prefer randutil:' >&2
+        echo "$got" >&2
         exit 1
     fi
 
@@ -331,8 +323,8 @@ if [ "$STATIC" = 1 ]; then
     done
 
     if [ -n "$got" ]; then
-        echo 'Found usages of deprecated io/ioutil, please use "io" or "os" equivalents'
-        echo "$got"
+        echo 'Found usages of deprecated io/ioutil, please use "io" or "os" equivalents' >&2
+        echo "$got" >&2
         exit 1
     fi
 
@@ -366,9 +358,9 @@ if [ "$STATIC" = 1 ]; then
 
         regexp='GOPATH(?!%%:\*)(?!:)[^= ]*/'
         if grep -qPr --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"; then
-            echo "Using GOPATH as if it were a single entry and not a list:"
+            echo "Using GOPATH as if it were a single entry and not a list:" >&2
             grep -PHrn -C1 --color=auto --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"
-            echo "Use GOHOME, or {GOPATH%%:*}, instead."
+            echo "Use GOHOME, or {GOPATH%%:*}, instead." >&2
             exit 1
         fi
         unset regexp
@@ -399,8 +391,8 @@ if [ "$STATIC" = 1 ]; then
     badmultiline=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 |
         xargs -0 grep -R -n -E '(restore*|prepare*|execute|debug):\s*$' || true)
     if [ -n "$badmultiline" ]; then
-        echo "Incorrect multiline strings at the following locations:"
-        echo "$badmultiline"
+        echo "Incorrect multiline strings at the following locations:" >&2
+        echo "$badmultiline" >&2
         exit 1
     fi
 
@@ -408,8 +400,8 @@ if [ "$STATIC" = 1 ]; then
     badMATCH=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 |
         xargs -0 grep -R -n -E 'MATCH +-v' || true)
     if [ -n "$badMATCH" ]; then
-        echo "Potentially incorrect use of MATCH -v at the following locations:"
-        echo "$badMATCH"
+        echo "Potentially incorrect use of MATCH -v at the following locations:" >&2
+        echo "$badMATCH" >&2
         exit 1
     fi
 
@@ -448,8 +440,8 @@ if [ "$STATIC" = 1 ]; then
 
     echo ">> [Go] Checking for usages of !=, == or Equals with ErrNoState"
     if got=$(grep -n -R -E "(\!=|==|Equals,) (state\.)?ErrNoState" --include=*.go); then
-        echo "Don't use equality checks with ErrNoState, use errors.Is() instead"
-        echo "$got"
+        echo "Don't use equality checks with ErrNoState, use errors.Is() instead" >&2
+        echo "$got" >&2
         exit 1
     fi
 
@@ -458,10 +450,10 @@ if [ "$STATIC" = 1 ]; then
         if echo "$gcil" | grep -q '/snap/bin/'; then
             # golangci-lint was installed from the snap
             if snap refresh --list | grep -q golangci-lint; then
-                echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours."
+                echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours." >&2
             fi
             if ! snap list golangci-lint | grep -q latest; then
-                echo "WARNING: your golangci-lint snap is not installed from the latest/* channel."
+                echo "WARNING: your golangci-lint snap is not installed from the latest/* channel." >&2
             fi
         fi
 
@@ -507,7 +499,7 @@ if [ "$STATIC" = 1 ]; then
         cd cmd/
         ./autogen.sh
         if ! make fmt-check; then
-            echo "C files are not formatted correctly, run 'make fmt'"
+            echo "C files are not formatted correctly, run 'make fmt'" >&2
             exit 1
         fi
         cd "$current"
@@ -572,7 +564,7 @@ else
     echo "> [Git] Checking for leftover files in git tree"
     UNCLEAN="$(git status -s | grep '^??')" || true
     if [ -n "$UNCLEAN" ]; then
-        cat <<EOF
+        cat >&2 <<EOF
 
 There are files left in the git tree after the tests:
 
@@ -588,7 +580,7 @@ if [ -n "${SKIP_DIRTY_CHECK:-}" ]; then
 fi
 echo "> [Git] Checking for dirty build tree"
 if git describe --always --dirty | grep -q dirty; then
-    echo "Build tree is dirty"
-    git diff
+    echo "Build tree is dirty" >&2
+    git diff >&2
     exit 1
 fi

--- a/run-checks
+++ b/run-checks
@@ -264,7 +264,7 @@ endmsg() {
 }
 addtrap endmsg
 
-short=:-
+short=
 STATIC=
 UNIT=
 
@@ -324,7 +324,7 @@ if [ "$STATIC" = 1 ]; then
         if [ -n "$fmt" ]; then
             echo "Formatting wrong in following files:"
             # shellcheck disable=SC2001
-            :- echo "$fmt" | sed -e 's/\\n/\n/g'
+            echo "$fmt" | sed -e 's/\\n/\n/g'
             exit 1
         fi
     else
@@ -414,7 +414,7 @@ if [ "$STATIC" = 1 ]; then
         if grep -qPr --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"; then
             echo "Using GOPATH as if it were a single entry and not a list:"
             grep -PHrn -C1 --color=auto --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"
-            :-echo "Use GOHOME, or {GOPATH%%:*}, instead."
+            echo "Use GOHOME, or {GOPATH%%:*}, instead."
             exit 1
         fi
         unset regexp
@@ -479,7 +479,7 @@ if [ "$STATIC" = 1 ]; then
     badmultiline=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 |
         xargs -0 grep -R -n -E '(restore*|prepare*|execute|debug):\s*$' || true)
     if [ -n "$badmultiline" ]; then
-        echo "In:-correct multiline strings at the following locations:"
+        echo "Incorrect multiline strings at the following locations:"
         echo "$badmultiline"
         exit 1
     fi

--- a/run-checks
+++ b/run-checks
@@ -13,16 +13,16 @@ AUTO_INSTALL=${AUTO_INSTALL:-1}     # Automatically install supported tool depen
 IGNORE_MISSING=${IGNORE_MISSING:-0} # Do not error on missing tool dependencies (default: error)
 
 goinstall() {
-    pkg="$1"
-    version="${2:-}"
+    local pkg="$1"
+    local version="${2:-latest}"
     # go1.18+ will no longer build/install packages. Here "go install"
     # must be used but it will only fetch remote packages if the @latest
     # (or similar syntax is used). Instead of checking the version we
     # check if the "go install" help mentions this new feature.
     if go help install | grep -q @latest; then
-        go install "${pkg}"@"${version:=latest}"
+        go install "${pkg}"@"${version}"
     else
-        go get -u "${pkg}"@"${version:=latest}"
+        go get -u "${pkg}"@"${version}"
     fi
 }
 

--- a/run-checks
+++ b/run-checks
@@ -297,9 +297,8 @@ if [ "$STATIC" = 1 ]; then
     if [ -z "${SKIP_GOFMT:-}" ]; then
         echo ">> [Go] Checking go formatting"
         fmt=""
-        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/\(c-\)\?vendor/'); do
-            # skip vendor packages
-            s="$(${GOFMT:-gofmt} -s -d "$dir" || true)"
+        for dir in $(go list -f '{{.Dir}}' ./...); do
+            s="$(gofmt -s -d "$dir" || true)"
             if [ -n "$s" ]; then
                 fmt="$s\\n$fmt"
             fi
@@ -320,7 +319,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo '>> [Go] Checking for usages of http.Status*'
     got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
+    for dir in $(go list -f '{{.Dir}}' ./...); do
         s="$(grep -nP 'http\.Status(?!Text)' "$dir"/*.go || true)"
         if [ -n "$s" ]; then
             got="$s\\n$got"
@@ -335,7 +334,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo ">> [Go] Checking for direct usages of math/rand"
     got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
+    for dir in $(go list -f '{{.Dir}}' ./...); do
         # shellcheck disable=SC2063
         s="$(grep -nP --exclude '*_test.go' --exclude 'randutil/*.go' math/rand "$dir"/*.go || true)"
         if [ -n "$s" ]; then
@@ -351,7 +350,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo ">> [Go] Checking for usages of deprecated io/ioutil"
     got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
+    for dir in $(go list -f '{{.Dir}}' ./...); do
         # shellcheck disable=SC2063
         s="$(grep -nP io/ioutil "$dir"/*.go || true)"
         if [ -n "$s" ]; then
@@ -446,7 +445,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo ">> [Go] Checking for naked returns"
     if [ -z "${SKIP_NAKEDRET:-}" ] && command -v nakedret >/dev/null; then
-        got=$(go list ./... | grep -v '/osutil/udev/' | grep -v '/vendor/' | xargs nakedret 2>&1)
+        got=$(go list ./... | grep -v '/osutil/udev/' | xargs nakedret 2>&1)
         if [ -n "$got" ]; then
             echo "$got"
             exit 1

--- a/run-checks
+++ b/run-checks
@@ -438,7 +438,7 @@ if [ "$STATIC" = 1 ]; then
         echo ">> [Bash] Skipping shellcheck check"
     fi
 
-    if [ -z "${SKIP_MISSPELL:-}" ] || ! command -v misspell >/dev/null; then
+    if [ -z "${SKIP_MISSPELL:-}" ] && command -v misspell >/dev/null; then
         echo ">> Checking spelling"
         # FIXME: author is only misspelled in the changelog so we should fix there
         # PROCES is used in the seccomp tests (PRIO_PROCES{,S,SS})
@@ -451,7 +451,7 @@ if [ "$STATIC" = 1 ]; then
         echo ">> Skipping spelling check"
     fi
 
-    if [ -z "${SKIP_INEFFASSIGN:-}" ] || ! command -v ineffassign >/dev/null; then
+    if [ -z "${SKIP_INEFFASSIGN:-}" ] && command -v ineffassign >/dev/null; then
         if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
             echo ">> [Go] Checking for ineffective assignments"
             # ineffassign knows about ignoring vendor/ \o/
@@ -462,7 +462,7 @@ if [ "$STATIC" = 1 ]; then
     fi
 
     echo ">> [Go] Checking for naked returns"
-    if [ -z "${SKIP_NAKEDRET:-}" ] || ! command -v nakedret >/dev/null; then
+    if [ -z "${SKIP_NAKEDRET:-}" ] && command -v nakedret >/dev/null; then
         got=$(go list ./... | grep -v '/osutil/udev/' | grep -v '/vendor/' | xargs nakedret 2>&1)
         if [ -n "$got" ]; then
             echo "$got"

--- a/run-checks
+++ b/run-checks
@@ -57,7 +57,7 @@ tool_install() {
     golangci-lint)
         # Decided to start using latest instead of pinning specific version, if this approach
         # introduces too much instability, revert back to pinning a working version.
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest >/dev/null
+        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2 >/dev/null
         ;;
     go) ;&         # fallthrough
     shellcheck) ;& # fallthrough

--- a/run-checks
+++ b/run-checks
@@ -18,9 +18,6 @@ tool_version() {
     go)
         $tool version
         ;;
-    misspell)
-        $tool -v
-        ;;
     shellcheck)
         $tool --version | grep version
         ;;
@@ -44,9 +41,6 @@ tool_install() {
     case "$tool" in
     nakedret)
         go install github.com/alexkohler/nakedret@v1.0.1 >/dev/null
-        ;;
-    misspell)
-        go install github.com/client9/misspell/cmd/misspell@latest >/dev/null
         ;;
     golangci-lint)
         # Decided to start using latest instead of pinning specific version, if this approach
@@ -91,7 +85,6 @@ tool_configure() {
         fi
         ;;
     nakedret) ;&      # fallthrough
-    misspell) ;&      # fallthrough
     shellcheck) ;&    # fallthrough
     golangci-lint) ;& # fallthrough
     python3) ;&       # fallthrough
@@ -404,19 +397,6 @@ if [ "$STATIC" = 1 ]; then
         ./tests/lib/external/snapd-testing-tools/utils/spread-shellcheck $FILTERED_FILES --exclude "$exclude_tools_path" --exclude "tests/nested/manual/core20-preseed"
     else
         echo ">> [Bash] Skipping shellcheck check"
-    fi
-
-    if [ -z "${SKIP_MISSPELL:-}" ] && command -v misspell >/dev/null; then
-        echo ">> Checking spelling"
-        # FIXME: author is only misspelled in the changelog so we should fix there
-        # PROCES is used in the seccomp tests (PRIO_PROCES{,S,SS})
-        # exportfs is used in the nfs-support test
-        # becuase because of misspell in upstream steam rules (PR#12657)
-        MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs,becuase"
-        git ls-files -z -- . ':!:./po' ':!:./vendor' ':!:./c-vendor' ':!:./cmd/libsnap-confine-private/bpf/vendor' ':!:./build-aux/snap/local/apparmor' |
-            xargs -0 misspell -error -i "$MISSPELL_IGNORE"
-    else
-        echo ">> Skipping spelling check"
     fi
 
     echo ">> [Go] Checking for naked returns"

--- a/run-checks
+++ b/run-checks
@@ -18,9 +18,6 @@ tool_version() {
     go)
         $tool version
         ;;
-    ineffassign)
-        $tool -version 2>&1
-        ;;
     misspell)
         $tool -v
         ;;
@@ -45,9 +42,6 @@ tool_version() {
 tool_install() {
     local tool=$1
     case "$tool" in
-    ineffassign)
-        go install github.com/gordonklaus/ineffassign@latest >/dev/null
-        ;;
     nakedret)
         go install github.com/alexkohler/nakedret@v1.0.1 >/dev/null
         ;;
@@ -96,7 +90,6 @@ tool_configure() {
             export PATH=/usr/lib/go-1.18/bin:"${PATH}"
         fi
         ;;
-    ineffassign) ;&   # fallthrough
     nakedret) ;&      # fallthrough
     misspell) ;&      # fallthrough
     shellcheck) ;&    # fallthrough
@@ -424,16 +417,6 @@ if [ "$STATIC" = 1 ]; then
             xargs -0 misspell -error -i "$MISSPELL_IGNORE"
     else
         echo ">> Skipping spelling check"
-    fi
-
-    if [ -z "${SKIP_INEFFASSIGN:-}" ] && command -v ineffassign >/dev/null; then
-        if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
-            echo ">> [Go] Checking for ineffective assignments"
-            # ineffassign knows about ignoring vendor/ \o/
-            ineffassign ./...
-        fi
-    else
-        echo ">> [Go] Skipping ineffective assignments check"
     fi
 
     echo ">> [Go] Checking for naked returns"

--- a/run-checks
+++ b/run-checks
@@ -281,7 +281,7 @@ all)
     ;;
 --short-unit)
     UNIT=1
-    short=1
+    short="-short"
     ;;
 *)
     echo "Wrong flag ${1}. To run a single suite use --static, --unit."
@@ -603,10 +603,10 @@ if [ "$UNIT" = 1 ]; then
 
     # tests
     echo ">> [Go] Running go unit tests from $PWD"
-    if [ "$short" = 1 ] || [ -n "${SKIP_COVERAGE:-}" ]; then
+    if [ "$short" = "-short" ] || [ -n "${SKIP_COVERAGE:-}" ]; then
         echo ">> [Go] Skipping coverage"
         # shellcheck disable=SC2046,SC2086
-        GOTRACEBACK=1 $goctest $tags $race -short -timeout $timeout
+        GOTRACEBACK=1 $goctest $tags $race $short -timeout $timeout
     else
         coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
         echo ">> [Go] Checking coverage with params: $coverage"

--- a/run-checks
+++ b/run-checks
@@ -37,8 +37,6 @@ tool_install() {
     local tool=$1
     case "$tool" in
     golangci-lint)
-        # Decided to start using latest instead of pinning specific version, if this approach
-        # introduces too much instability, revert back to pinning a working version.
         go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2 >/dev/null
         ;;
     go) ;&         # fallthrough

--- a/run-checks
+++ b/run-checks
@@ -3,33 +3,184 @@
 export LANG=C.UTF-8
 export LANGUAGE=en
 
+this_file="$0"
 COVERMODE=${COVERMODE:-atomic}
 COVERAGE_SUFFIX=${GO_BUILD_TAGS:-notags}
 COVERAGE_OUT=${COVERAGE_OUT:-.coverage/coverage-$COVERAGE_SUFFIX.cov}
 CHANGED_FILES=${CHANGED_FILES:-""}
 TIMEOUT=${TIMEOUT:-15}
+AUTO_INSTALL=${AUTO_INSTALL:-1}     # Automatically install supported tool dependencies (default: install)
+IGNORE_MISSING=${IGNORE_MISSING:-0} # Do not error on missing tool dependencies (default: error)
 
-if [ -z "${GITHUB_WORKFLOW:-}" ]; then
-    # when *not* running inside github, ensure we use go-1.18 by default
-    export PATH=/usr/lib/go-1.18/bin:"${PATH}"
-fi
-
-# add workaround for https://github.com/golang/go/issues/24449
-if [ "$(uname -m)" = "s390x" ]; then
-    if go version | grep -q go1.10; then
-        echo "covermode 'atomic' crashes on s390x with go1.10, reseting "
-        echo "to 'set'. see https://github.com/golang/go/issues/24449"
-        COVERMODE="set"
+goinstall() {
+    pkg="$1"
+    version="${2:-}"
+    # go1.18+ will no longer build/install packages. Here "go install"
+    # must be used but it will only fetch remote packages if the @latest
+    # (or similar syntax is used). Instead of checking the version we
+    # check if the "go install" help mentions this new feature.
+    if go help install | grep -q @latest; then
+        go install "${pkg}"@"${version:=latest}"
+    else
+        go get -u "${pkg}"@"${version:=latest}"
     fi
-fi
+}
 
-# If GOPATH is set in the shell environment, the path will be reflected
-# in $(go env GOPATH). If no shell path was set, Go will default the internal
-# GOPATH to $HOME/go. Note that GOPATH may contain a colon delimited set
-# of paths, so in order to run any binary from any of the installed GOPATHs
-# we must add all the possible bin locations.
-GOBINS=$(go env GOPATH | sed 's|:|/bin:|g' | sed 's|.*|\0/bin|g')
-export PATH="$PATH:$GOBINS"
+tool_version() {
+    local tool=$1
+    case "$tool" in
+    go)
+        $tool version
+        ;;
+    ineffassign)
+        $tool -version 2>&1
+        ;;
+    misspell)
+        $tool -v
+        ;;
+    shellcheck)
+        $tool --version | grep version
+        ;;
+    golangci-lint) ;& # fallthrough
+    python2) ;&       # fallthrough
+    python3) ;&       # fallthrough
+    pytest-3) ;&      # fallthrough
+    goctest) ;&       # fallthrough
+    clang-format)
+        $tool --version
+        ;;
+    nakedret)
+        echo "unknown"
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+tool_install() {
+    local tool=$1
+    case "$tool" in
+    ineffassign)
+        goinstall github.com/gordonklaus/ineffassign >/dev/null
+        ;;
+    nakedret)
+        goinstall github.com/alexkohler/nakedret v1.0.1 >/dev/null
+        ;;
+    misspell)
+        goinstall github.com/client9/misspell/cmd/misspell >/dev/null
+        ;;
+    golangci-lint)
+        goinstall github.com/golangci/golangci-lint/cmd/golangci-lint v1.64.5 >/dev/null
+        ;;
+    go) ;&         # fallthrough
+    shellcheck) ;& # fallthrough
+    python2) ;&    # fallthrough
+    python3) ;&    # fallthrough
+    pytest-3) ;&   # fallthrough
+    goctest) ;&    # fallthrough
+    clang-format) ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+tool_configure() {
+    local tool=$1
+    case "$tool" in
+    go)
+        # add workaround for https://github.com/golang/go/issues/24449
+        if [ "$(uname -m)" = "s390x" ]; then
+            if go version | grep -q go1.10; then
+                echo "covermode 'atomic' crashes on s390x with go1.10, reseting"
+                echo "to 'set'. see https://github.com/golang/go/issues/24449"
+                COVERMODE="set"
+            fi
+        fi
+
+        # If GOPATH is set in the shell environment, the path will be reflected
+        # in $(go env GOPATH). If no shell path was set, Go will default the internal
+        # GOPATH to $HOME/go. Note that GOPATH may contain a colon delimited set
+        # of paths, so in order to run any binary from any of the installed GOPATHs
+        # we must add all the possible bin locations.
+        GOBINS=$(go env GOPATH | sed 's|:|/bin:|g' | sed 's|.*|\0/bin|g')
+        export PATH="$PATH:$GOBINS"
+
+        # when *not* running inside github, and go-1.18 is available, use it
+        if [ -z "${GITHUB_WORKFLOW:-}" ] && [ -e "/usr/lib/go-1.18/bin" ]; then
+            export PATH=/usr/lib/go-1.18/bin:"${PATH}"
+        fi
+        ;;
+    ineffassign) ;&   # fallthrough
+    nakedret) ;&      # fallthrough
+    misspell) ;&      # fallthrough
+    shellcheck) ;&    # fallthrough
+    golangci-lint) ;& # fallthrough
+    python2) ;&       # fallthrough
+    python3) ;&       # fallthrough
+    pytest-3) ;&      # fallthrough
+    goctest) ;&       # fallthrough
+    clang-format) ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+install_conf_show_tool() {
+    local tool=$1
+    local auto_install=$2
+    local ignore_missing=$3
+
+    echo ">> Depends on \"$tool\""
+
+    if [ "$auto_install" = "1" ] && ! command -v "$tool" >/dev/null; then # ignore-tool
+        if ! tool_install "$tool"; then
+            echo "WARNING: Cannot install tool $tool"
+        fi
+    fi
+
+    if ! executable=$(command -v "$tool"); then # ignore-tool
+        if [ "$ignore_missing" != "1" ] && [ "$tool" != "python2" ] && [ "$tool" != "goctest" ]; then
+            echo "ERROR: Tool $tool is not available"
+            return 1
+        else
+            echo "WARNING: Tool $tool is not available"
+        fi
+    else
+        if ! tool_configure "$tool"; then
+            echo "ERROR: Cannot configure $tool"
+            return 1
+        fi
+
+        if ! version=$(tool_version "$tool"); then
+            echo "ERROR: Cannot retrieve version of $tool"
+            return 1
+        else
+            echo "Version: $version"
+            echo "Executable: $executable"
+        fi
+    fi
+}
+
+verify_tools() {
+    local auto_install=$1
+    local ignore_missing=$2
+
+    # find tool dependencies but ignore those marked with `# check-tools-ignore`
+    tools=$(grep -v '# ignore-tool' "$this_file" | grep -oP 'command -v \K[\w-]+' | sort | uniq)
+
+    # check go first that includes setting up go paths required to find or install
+    # other go based tools, error early when missing
+    tool="go"
+    install_conf_show_tool "$tool" "$auto_install" "0"
+
+    # check other tools
+    for tool in $tools; do
+        install_conf_show_tool "$tool" "$auto_install" "$ignore_missing"
+    done
+}
 
 missing_interface_spread_test() {
     snap_yaml="tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml"
@@ -40,6 +191,10 @@ missing_interface_spread_test() {
         case "$iface" in
         bool-file | gpio | pwm | dsp | netlink-driver | hidraw | i2c | iio | serial-port | spi | confdb)
             # skip gadget provided interfaces for now
+            continue
+            ;;
+        cuda-driver-libs)
+            # skip interfaces with plug side only in rootfs for now
             continue
             ;;
         dbus | content)
@@ -91,20 +246,6 @@ addtrap() {
     trap "store_exit_code; $CURRENTTRAP ; exit_with_exit_code" EXIT
 }
 
-goinstall() {
-    pkg="$1"
-    version="${2:-}"
-    # go1.18+ will no longer build/install packages. Here "go install"
-    # must be used but it will only fetch remote packages if the @latest
-    # (or similar syntax is used). Instead of checking the version we
-    # check if the "go install" help mentions this new feature.
-    if go help install | grep -q @latest; then
-        go install "${pkg}"@"${version:=latest}"
-    else
-        go get -u "${pkg}"@"${version:=latest}"
-    fi
-}
-
 endmsg() {
     if [ $EXIT_CODE -eq 0 ]; then
         p="success.txt"
@@ -122,7 +263,7 @@ endmsg() {
 }
 addtrap endmsg
 
-short=
+short=:-
 STATIC=
 UNIT=
 
@@ -147,27 +288,30 @@ all)
     ;;
 esac
 
+echo "> Verify tool dependencies"
+verify_tools "$AUTO_INSTALL" "$IGNORE_MISSING"
+
 if [ "$STATIC" = 1 ]; then
     ./get-deps.sh
+    echo "> Running static tests"
 
-    # Run static tests.
-    echo Checking docs
+    echo ">> Checking docs"
     ./mdlint.py ./*.md ./**/*.md
 
     # XXX: remove once we can use an action, see workflows/test.yaml for
     #      details why we still use this script
     if [ -n "${GITHUB_PULL_REQUEST_TITLE:-}" ]; then
-        echo Checking pull request summary
+        echo ">> Checking pull request summary"
         ./check-pr-title.py "${GITHUB_PULL_REQUEST_TITLE}"
     else
-        echo Skipping pull request summary check: not a pull request
+        echo ">> Skipping pull request summary check: not a pull request"
     fi
 
-    # check commit author/committer name for unicode
+    echo ">> [Git] Checking commit author/committer name for unicode"
     ./check-commit-email.py
 
     if [ -z "${SKIP_GOFMT:-}" ]; then
-        echo Checking formatting
+        echo ">> [Go] Checking go formatting"
         fmt=""
         for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/\(c-\)\?vendor/'); do
             # skip vendor packages
@@ -179,16 +323,18 @@ if [ "$STATIC" = 1 ]; then
         if [ -n "$fmt" ]; then
             echo "Formatting wrong in following files:"
             # shellcheck disable=SC2001
-            echo "$fmt" | sed -e 's/\\n/\n/g'
+            :- echo "$fmt" | sed -e 's/\\n/\n/g'
             exit 1
         fi
+    else
+        echo ">> [Go] Skipping go formatting check"
     fi
 
     # go vet
-    echo Running vet
+    echo ">> [Go] Running go vet"
     go list ./... | grep -v '/vendor/' | xargs go vet
 
-    echo 'Checking for usages of http.Status*'
+    echo '>> [Go] Checking for usages of http.Status*'
     got=""
     for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
         s="$(grep -nP 'http\.Status(?!Text)' "$dir"/*.go || true)"
@@ -203,7 +349,7 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
-    echo "Checking for direct usages of math/rand"
+    echo ">> [Go] Checking for direct usages of math/rand"
     got=""
     for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
         # shellcheck disable=SC2063
@@ -219,7 +365,7 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
-    echo "Checking for usages of deprecated io/ioutil"
+    echo ">> [Go] Checking for usages of deprecated io/ioutil"
     got=""
     for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
         # shellcheck disable=SC2063
@@ -237,7 +383,7 @@ if [ "$STATIC" = 1 ]; then
 
     if command -v shellcheck >/dev/null; then
         exclude_tools_path=tests/lib/external/snapd-testing-tools
-        echo "Checking shell scripts..."
+        echo ">> [Bash] Checking shell scripts"
         if [ -n "$CHANGED_FILES" ]; then
             echo "Checking just the changed bash files"
             echo "Changed files: $CHANGED_FILES"
@@ -267,7 +413,7 @@ if [ "$STATIC" = 1 ]; then
         if grep -qPr --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"; then
             echo "Using GOPATH as if it were a single entry and not a list:"
             grep -PHrn -C1 --color=auto --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"
-            echo "Use GOHOME, or {GOPATH%%:*}, instead."
+            :-echo "Use GOHOME, or {GOPATH%%:*}, instead."
             exit 1
         fi
         unset regexp
@@ -287,60 +433,57 @@ if [ "$STATIC" = 1 ]; then
         # XXX: exclude core20-preseed test as its environment block confuses shellcheck, and it's not possible to disable shellcheck there.
         # shellcheck disable=SC2086
         ./tests/lib/external/snapd-testing-tools/utils/spread-shellcheck $FILTERED_FILES --exclude "$exclude_tools_path" --exclude "tests/nested/manual/core20-preseed"
+    else
+        echo ">> [Bash] Skipping shellcheck check"
     fi
 
-    if [ -z "${SKIP_MISSPELL:-}" ]; then
-        echo "Checking spelling errors"
-        if ! command -v misspell >/dev/null; then
-            goinstall github.com/client9/misspell/cmd/misspell
-        fi
-        # FIXME: auter is only misspelled in the changelog so we should fix there
+    if [ -z "${SKIP_MISSPELL:-}" ] || ! command -v misspell >/dev/null; then
+        echo ">> Checking spelling"
+        # FIXME: author is only misspelled in the changelog so we should fix there
         # PROCES is used in the seccomp tests (PRIO_PROCES{,S,SS})
         # exportfs is used in the nfs-support test
         # becuase because of misspell in upstream steam rules (PR#12657)
         MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs,becuase"
         git ls-files -z -- . ':!:./po' ':!:./vendor' ':!:./c-vendor' ':!:./cmd/libsnap-confine-private/bpf/vendor' ':!:./build-aux/snap/local/apparmor' |
             xargs -0 misspell -error -i "$MISSPELL_IGNORE"
+    else
+        echo ">> Skipping spelling check"
     fi
 
-    if [ -z "${SKIP_INEFFASSIGN:-}" ]; then
+    if [ -z "${SKIP_INEFFASSIGN:-}" ] || ! command -v ineffassign >/dev/null; then
         if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
-            echo "Checking for ineffective assignments"
-            if ! command -v ineffassign >/dev/null; then
-                goinstall github.com/gordonklaus/ineffassign
-            fi
+            echo ">> [Go] Checking for ineffective assignments"
             # ineffassign knows about ignoring vendor/ \o/
             ineffassign ./...
         fi
+    else
+        echo ">> [Go] Skipping ineffective assignments check"
     fi
 
-    echo "Checking for naked returns"
-    if ! command -v nakedret >/dev/null; then
-        goinstall github.com/alexkohler/nakedret v1.0.1
-    fi
-    got=$(go list ./... | grep -v '/osutil/udev/' | grep -v '/vendor/' | xargs nakedret 2>&1)
-    if [ -n "$got" ]; then
-        echo "$got"
-        if [ -z "${SKIP_NAKEDRET:-}" ]; then
+    echo ">> [Go] Checking for naked returns"
+    if [ -z "${SKIP_NAKEDRET:-}" ] || ! command -v nakedret >/dev/null; then
+        got=$(go list ./... | grep -v '/osutil/udev/' | grep -v '/vendor/' | xargs nakedret 2>&1)
+        if [ -n "$got" ]; then
+            echo "$got"
             exit 1
-        else
-            echo "Ignoring nakedret errors as requested"
         fi
+    else
+        echo "[Go] Skipping naked returns check"
     fi
 
-    echo "Checking all interfaces have a spread test"
+    echo ">> [Spread] Checking all interfaces have a spread test"
     missing_interface_spread_test
 
-    echo "Checking for incorrect multiline strings in spread tests"
+    echo ">> [Spread] Checking for incorrect multiline strings in spread tests"
     badmultiline=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 |
         xargs -0 grep -R -n -E '(restore*|prepare*|execute|debug):\s*$' || true)
     if [ -n "$badmultiline" ]; then
-        echo "Incorrect multiline strings at the following locations:"
+        echo "In:-correct multiline strings at the following locations:"
         echo "$badmultiline"
         exit 1
     fi
 
-    echo "Checking for potentially incorrect use of MATCH -v"
+    echo ">> [Spread] Checking for potentially incorrect use of MATCH -v"
     badMATCH=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 |
         xargs -0 grep -R -n -E 'MATCH +-v' || true)
     if [ -n "$badMATCH" ]; then
@@ -352,6 +495,7 @@ if [ "$STATIC" = 1 ]; then
     # FIXME: re-add staticcheck with a matching version for the used go-version
 
     if [ -z "${SKIP_TESTS_FORMAT_CHECK:-}" ] || [ "$SKIP_TESTS_FORMAT_CHECK" = 0 ]; then
+        echo ">> [Spread] Checking tests formatting"
         CHANGED_TESTS=""
         FILTERED_TESTS=""
         EXCLUDE_PATH=tests/lib/external/snapd-testing-tools
@@ -373,30 +517,23 @@ if [ "$STATIC" = 1 ]; then
                 fi
             fi
         done
-
-        echo "Checking tests formatting"
         if [ -n "$FILTERED_TESTS" ]; then
             # shellcheck disable=SC2086
             ./tests/lib/external/snapd-testing-tools/utils/check-test-format --tests $FILTERED_TESTS
         fi
+    else
+        echo ">> [Spread] Skipping tests formatting check"
     fi
 
-    echo "Checking for usages of !=, == or Equals with ErrNoState"
+    echo ">> [Go] Checking for usages of !=, == or Equals with ErrNoState"
     if got=$(grep -n -R -E "(\!=|==|Equals,) (state\.)?ErrNoState" --include=*.go); then
         echo "Don't use equality checks with ErrNoState, use errors.Is() instead"
         echo "$got"
         exit 1
     fi
 
-    if [ -z "${SKIP_GOLANGCI_LINT:-}" ]; then
-
-        echo "Checking installation of golangci-lint"
-        gcil="$(command -v golangci-lint || true)"
-        if [ -z "$gcil" ]; then
-            echo "ERROR: Cannot find golangci-lint. You need to first install the golangci-lint"
-            exit 1
-        fi
-
+    if gcil=$(command -v golangci-lint) || [ -z "${SKIP_GOLANGCI_LINT:-}" ]; then
+        echo ">> [Go] Checking golangci-lint"
         if echo "$gcil" | grep -q '/snap/bin/'; then
             # golangci-lint was installed from the snap
             if snap refresh --list | grep -q golangci-lint; then
@@ -417,9 +554,11 @@ if [ "$STATIC" = 1 ]; then
         # don't run with --new-from-rev as the diff might not be enough to tell
         # the change introduces problems (e.g., removing the last call to a function)
         golangci-lint --path-prefix= run
+    else
+        echo ">> [Go] Skipping golangci-lint check"
     fi
 
-    echo "Checking C source code formatting"
+    echo ">> [C] Checking C source code formatting"
     if command -v clang-format >/dev/null; then
         current=$(pwd)
         cd cmd/
@@ -429,15 +568,14 @@ if [ "$STATIC" = 1 ]; then
             exit 1
         fi
         cd "$current"
+    else
+        echo ">> [C] Skipping C source code formatting check"
     fi
 fi
 
 if [ "$UNIT" = 1 ]; then
     ./get-deps.sh
-
-    echo "Show go version"
-    command -v go
-    go version
+    echo "> Running unit tests"
 
     tags=
     race=
@@ -463,50 +601,62 @@ if [ "$UNIT" = 1 ]; then
     fi
 
     # tests
-    echo Running tests from "$PWD"
-    if [ "$short" = 1 ]; then
-        echo "Running without test coverage"
+    echo ">> [Go] Running go unit tests from $PWD"
+    if [ "$short" = 1 ] || [ -n "${SKIP_COVERAGE:-}" ]; then
+        echo ">> [Go] Skipping coverage"
         # shellcheck disable=SC2046,SC2086
         GOTRACEBACK=1 $goctest $tags $race -short -timeout $timeout
     else
-        coverage=""
-        if [ -z "${SKIP_COVERAGE:-}" ]; then
-            coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
-            # Prepare the coverage output profile.
-            mkdir -p "$(dirname "$COVERAGE_OUT")"
-            echo "Using coverage params: $coverage"
-        else
-            echo "Skipping test coverage"
-        fi
-
+        coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
+        echo ">> [Go] Checking coverage with params: $coverage"
+        mkdir -p "$(dirname "$COVERAGE_OUT")"
         # shellcheck disable=SC2046,SC2086
         GOTRACEBACK=1 $goctest $tags $race -timeout $timeout $coverage
     fi
-
     # python unit test for mountinfo.query and version-compare
-    command -v python2 && python2 ./tests/lib/tools/mountinfo.query --run-unit-tests
-    command -v python3 && python3 ./tests/lib/tools/mountinfo.query --run-unit-tests
-    command -v python2 && python2 ./tests/lib/tools/version-compare --run-unit-tests
-    command -v python3 && python3 ./tests/lib/tools/version-compare --run-unit-tests
-    command -v pytest-3 && PYTHONDONTWRITEBYTECODE=1 pytest-3 ./release-tools
+    if command -v python2; then
+        echo ">> [Python] Running python2 unit tests for mountinfo.query and version-compare"
+        python2 ./tests/lib/tools/mountinfo.query --run-unit-tests
+        python2 ./tests/lib/tools/version-compare --run-unit-tests
+    else
+        echo ">> [Python] Skipping python2 unit tests for mountinfo.query and version-compare"
+    fi
+    if command -v python3; then
+        echo ">> [Python] Running python3 unit tests for mountinfo.query and version-compare"
+        python3 ./tests/lib/tools/mountinfo.query --run-unit-tests
+        python3 ./tests/lib/tools/version-compare --run-unit-tests
+    else
+        echo ">> [Python] Skipping python3 unit tests for mountinfo.query and version-compare"
+    fi
+    if command -v pytest-3; then
+        echo ">> [Python] Running pytest-3 test for release-tools"
+        PYTHONDONTWRITEBYTECODE=1 pytest-3 ./release-tools
+    else
+        echo ">> [Python] Skipping pytest-3 test for release-tools"
+    fi
 fi
 
-UNCLEAN="$(git status -s | grep '^??')" || true
-SKIP_UNCLEAN=${SKIP_UNCLEAN=}
-if [ -n "$UNCLEAN" ] && [ -z "$SKIP_UNCLEAN" ]; then
-    cat <<EOF
+if [ -n "${SKIP_UNCLEAN:-}" ]; then
+    echo "> [Git] Skipping leftover files in git tree check"
+else
+    echo "> [Git] Checking for leftover files in git tree"
+    UNCLEAN="$(git status -s | grep '^??')" || true
+    if [ -n "$UNCLEAN" ]; then
+        cat <<EOF
 
 There are files left in the git tree after the tests:
 
 $UNCLEAN
 EOF
-    exit 1
+        exit 1
+    fi
 fi
 
 if [ -n "${SKIP_DIRTY_CHECK:-}" ]; then
+    echo "> [Git] Skipping dirty check"
     exit 0
 fi
-
+echo "> [Git] Checking for dirty build tree"
 if git describe --always --dirty | grep -q dirty; then
     echo "Build tree is dirty"
     git diff

--- a/run-checks
+++ b/run-checks
@@ -42,23 +42,24 @@ STATIC=
 UNIT=
 
 case "${1:-all}" in
-    all)
-        STATIC=1
-        UNIT=1
-        ;;
-    --static)
-        STATIC=1
-        ;;
-    --unit)
-        UNIT=1
-        ;;
-    --short-unit)
-        UNIT=1
-        short=1
-        ;;
-    *)
-        echo "Wrong flag ${1}. To run a single suite use --static, --unit."
-        exit 1
+all)
+    STATIC=1
+    UNIT=1
+    ;;
+--static)
+    STATIC=1
+    ;;
+--unit)
+    UNIT=1
+    ;;
+--short-unit)
+    UNIT=1
+    short=1
+    ;;
+*)
+    echo "Wrong flag ${1}. To run a single suite use --static, --unit."
+    exit 1
+    ;;
 esac
 
 CURRENTTRAP="true"
@@ -113,30 +114,30 @@ missing_interface_spread_test() {
     snap_yaml="tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml"
     core_snap_yaml="tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-core/meta/snap.yaml"
     classic_snap_yaml="tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-classic/meta/snap.yaml"
-    for iface in $(go run ./tests/lib/list-interfaces.go) ; do
+    for iface in $(go run ./tests/lib/list-interfaces.go); do
         search="plugs: \\[ $iface \\]"
         case "$iface" in
-            bool-file|gpio|pwm|dsp|netlink-driver|hidraw|i2c|iio|serial-port|spi|confdb)
-                # skip gadget provided interfaces for now
-                continue
-                ;;
+        bool-file | gpio | pwm | dsp | netlink-driver | hidraw | i2c | iio | serial-port | spi | confdb)
+            # skip gadget provided interfaces for now
+            continue
+            ;;
             cuda-driver-libs|egl-driver-libs)
-                # skip interfaces with plug side only in rootfs for now
-                continue
-                ;;
-            dbus|content)
-                search="interface: $iface"
-                ;;
-            autopilot)
-                search='plugs: \[ autopilot-introspection \]'
-                ;;
+            # skip interfaces with plug side only in rootfs for now
+            continue
+            ;;
+        dbus | content)
+            search="interface: $iface"
+            ;;
+        autopilot)
+            search='plugs: \[ autopilot-introspection \]'
+            ;;
         esac
 
         # check if a standalone test already exists and that it at least
         # connects and disconnects the interface
         dedicated_test=$(find tests/main/ -maxdepth 1 -name "interfaces-$iface")
         if [ -n "$dedicated_test" ]; then
-            if grep -q "$search" "$snap_yaml" ; then
+            if grep -q "$search" "$snap_yaml"; then
                 echo "Dedicated test '$dedicated_test' found for '$iface'."
                 echo "Please remove '$iface' from '$snap_yaml'."
                 exit 1
@@ -146,7 +147,7 @@ missing_interface_spread_test() {
         fi
 
         # check if high-level minimal test exists for interface
-        if ! grep -q "$search" "$snap_yaml" ; then
+        if ! grep -q "$search" "$snap_yaml"; then
             echo "Missing high-level test for interface '$iface'. Please add to:"
             echo "* $snap_yaml"
             echo "* $core_snap_yaml (if needed)"
@@ -155,7 +156,6 @@ missing_interface_spread_test() {
         fi
     done
 }
-
 
 if [ "$STATIC" = 1 ]; then
     ./get-deps.sh
@@ -179,7 +179,7 @@ if [ "$STATIC" = 1 ]; then
     if [ -z "${SKIP_GOFMT:-}" ]; then
         echo Checking formatting
         fmt=""
-        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/\(c-\)\?vendor/' ); do
+        for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/\(c-\)\?vendor/'); do
             # skip vendor packages
             s="$(${GOFMT:-gofmt} -s -d "$dir" || true)"
             if [ -n "$s" ]; then
@@ -200,7 +200,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo 'Checking for usages of http.Status*'
     got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
+    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
         s="$(grep -nP 'http\.Status(?!Text)' "$dir"/*.go || true)"
         if [ -n "$s" ]; then
             got="$s\\n$got"
@@ -215,7 +215,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo "Checking for direct usages of math/rand"
     got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
+    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
         # shellcheck disable=SC2063
         s="$(grep -nP --exclude '*_test.go' --exclude 'randutil/*.go' math/rand "$dir"/*.go || true)"
         if [ -n "$s" ]; then
@@ -231,7 +231,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo "Checking for usages of deprecated io/ioutil"
     got=""
-    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
+    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/'); do
         # shellcheck disable=SC2063
         s="$(grep -nP io/ioutil "$dir"/*.go || true)"
         if [ -n "$s" ]; then
@@ -252,10 +252,10 @@ if [ "$STATIC" = 1 ]; then
             echo "Checking just the changed bash files"
             echo "Changed files: $CHANGED_FILES"
             # shellcheck disable=SC2086
-            INITIAL_FILES="$( file -N $CHANGED_FILES | awk -F": " '$2~/shell.script/{print $1}' )"
+            INITIAL_FILES="$(file -N $CHANGED_FILES | awk -F": " '$2~/shell.script/{print $1}')"
         else
             echo "Checking all the bash files"
-            INITIAL_FILES="$( ( git ls-files -z 2>/dev/null || find . \( -name .git -o -name vendor -o -name c-vendor \) -prune -o -print0) | xargs -0 file -N | awk -F": " '$2~/shell.script/{print $1}' )"
+            INITIAL_FILES="$( (git ls-files -z 2>/dev/null || find . \( -name .git -o -name vendor -o -name c-vendor \) -prune -o -print0) | xargs -0 file -N | awk -F": " '$2~/shell.script/{print $1}')"
         fi
 
         echo "Filtering files"
@@ -274,7 +274,7 @@ if [ "$STATIC" = 1 ]; then
         fi
 
         regexp='GOPATH(?!%%:\*)(?!:)[^= ]*/'
-        if  grep -qPr                   --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"; then
+        if grep -qPr --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"; then
             echo "Using GOPATH as if it were a single entry and not a list:"
             grep -PHrn -C1 --color=auto --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"
             echo "Use GOHOME, or {GOPATH%%:*}, instead."
@@ -309,7 +309,7 @@ if [ "$STATIC" = 1 ]; then
         # exportfs is used in the nfs-support test
         # becuase because of misspell in upstream steam rules (PR#12657)
         MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs,becuase"
-        git ls-files -z -- . ':!:./po' ':!:./vendor' ':!:./c-vendor' ':!:./cmd/libsnap-confine-private/bpf/vendor' ':!:./build-aux/snap/local/apparmor'|
+        git ls-files -z -- . ':!:./po' ':!:./vendor' ':!:./c-vendor' ':!:./cmd/libsnap-confine-private/bpf/vendor' ':!:./build-aux/snap/local/apparmor' |
             xargs -0 misspell -error -i "$MISSPELL_IGNORE"
     fi
 
@@ -342,8 +342,8 @@ if [ "$STATIC" = 1 ]; then
     missing_interface_spread_test
 
     echo "Checking for incorrect multiline strings in spread tests"
-    badmultiline=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 | \
-                       xargs -0 grep -R -n -E '(restore*|prepare*|execute|debug):\s*$' || true)
+    badmultiline=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 |
+        xargs -0 grep -R -n -E '(restore*|prepare*|execute|debug):\s*$' || true)
     if [ -n "$badmultiline" ]; then
         echo "Incorrect multiline strings at the following locations:"
         echo "$badmultiline"
@@ -351,8 +351,8 @@ if [ "$STATIC" = 1 ]; then
     fi
 
     echo "Checking for potentially incorrect use of MATCH -v"
-    badMATCH=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 | \
-                       xargs -0 grep -R -n -E 'MATCH +-v' || true)
+    badMATCH=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 |
+        xargs -0 grep -R -n -E 'MATCH +-v' || true)
     if [ -n "$badMATCH" ]; then
         echo "Potentially incorrect use of MATCH -v at the following locations:"
         echo "$badMATCH"
@@ -392,10 +392,10 @@ if [ "$STATIC" = 1 ]; then
     fi
 
     echo "Checking for usages of !=, == or Equals with ErrNoState"
-    if got=$(grep -n -R -E "(\!=|==|Equals,) (state\.)?ErrNoState" --include=*.go) ; then
-      echo "Don't use equality checks with ErrNoState, use errors.Is() instead"
-      echo "$got"
-      exit 1
+    if got=$(grep -n -R -E "(\!=|==|Equals,) (state\.)?ErrNoState" --include=*.go); then
+        echo "Don't use equality checks with ErrNoState, use errors.Is() instead"
+        echo "$got"
+        exit 1
     fi
 
     if [ -z "${SKIP_GOLANGCI_LINT:-}" ]; then
@@ -407,7 +407,7 @@ if [ "$STATIC" = 1 ]; then
             exit 1
         fi
 
-        if echo "$gcil" | grep -q '/snap/bin/' ; then
+        if echo "$gcil" | grep -q '/snap/bin/'; then
             # golangci-lint was installed from the snap
             if snap refresh --list | grep -q golangci-lint; then
                 echo "WARNING: your golangci-lint snap is out of date. The CI will install a fresh version, which may differ from yours."
@@ -421,7 +421,7 @@ if [ "$STATIC" = 1 ]; then
         gcil_go_ver=$(golangci-lint --version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
         go_ver=$(go version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
         if [ "$(printf '%s\n' "$go_ver" "$gcil_go_ver" | sort -V | head -n1)" != "$go_ver" ]; then
-           echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lint was built with ($gcil_go_ver)."
+            echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lint was built with ($gcil_go_ver)."
         fi
 
         # don't run with --new-from-rev as the diff might not be enough to tell
@@ -447,7 +447,7 @@ if [ "$UNIT" = 1 ]; then
     if [ -n "${GO_TEST_RACE:-}" ]; then
         echo "Using go test -race"
         race="-race"
-        timeout="$((TIMEOUT*2))m"
+        timeout="$((TIMEOUT * 2))m"
     fi
 
     echo Building
@@ -457,9 +457,9 @@ if [ "$UNIT" = 1 ]; then
     # tests
     echo Running tests from "$PWD"
     if [ "$short" = 1 ]; then
-            echo "Running without test coverage"
-            # shellcheck disable=SC2046,SC2086
-            GOTRACEBACK=1 $goctest $tags $race -short -timeout $timeout
+        echo "Running without test coverage"
+        # shellcheck disable=SC2046,SC2086
+        GOTRACEBACK=1 $goctest $tags $race -short -timeout $timeout
     else
         coverage=""
         if [ -z "${SKIP_COVERAGE:-}" ]; then
@@ -483,7 +483,7 @@ if [ "$UNIT" = 1 ]; then
     command -v pytest-3 && PYTHONDONTWRITEBYTECODE=1 pytest-3 ./release-tools
 fi
 
-UNCLEAN="$(git status -s|grep '^??')" || true
+UNCLEAN="$(git status -s | grep '^??')" || true
 SKIP_UNCLEAN=${SKIP_UNCLEAN=}
 if [ -n "$UNCLEAN" ] && [ -z "$SKIP_UNCLEAN" ]; then
     cat <<EOF

--- a/run-checks
+++ b/run-checks
@@ -319,7 +319,7 @@ if [ "$STATIC" = 1 ]; then
 
     # go vet
     echo ">> [Go] Running go vet"
-    go list ./... | grep -v '/vendor/' | xargs go vet
+    go vet ./...
 
     echo '>> [Go] Checking for usages of http.Status*'
     got=""

--- a/run-checks
+++ b/run-checks
@@ -71,8 +71,8 @@ tool_install() {
         goinstall github.com/client9/misspell/cmd/misspell >/dev/null
         ;;
     golangci-lint)
-	# Decided to start using latest instead of pinning specific version, if this approach
-	# introduces too much instability, revert back to pinning a working version.
+        # Decided to start using latest instead of pinning specific version, if this approach
+        # introduces too much instability, revert back to pinning a working version.
         goinstall github.com/golangci/golangci-lint/cmd/golangci-lint >/dev/null
         ;;
     go) ;&         # fallthrough
@@ -194,7 +194,7 @@ missing_interface_spread_test() {
             # skip gadget provided interfaces for now
             continue
             ;;
-        cuda-driver-libs)
+        cuda-driver-libs | egl-driver-libs)
             # skip interfaces with plug side only in rootfs for now
             continue
             ;;

--- a/run-checks
+++ b/run-checks
@@ -310,10 +310,6 @@ if [ "$STATIC" = 1 ]; then
         echo ">> [Go] Skipping go formatting check"
     fi
 
-    # go vet
-    echo ">> [Go] Running go vet"
-    go vet ./...
-
     echo '>> [Go] Checking for usages of http.Status*'
     got=""
     for dir in $(go list -f '{{.Dir}}' ./...); do

--- a/run-checks
+++ b/run-checks
@@ -28,7 +28,6 @@ tool_version() {
         $tool --version | grep version
         ;;
     golangci-lint) ;& # fallthrough
-    python2) ;&       # fallthrough
     python3) ;&       # fallthrough
     pytest-3) ;&      # fallthrough
     goctest) ;&       # fallthrough
@@ -63,7 +62,6 @@ tool_install() {
         ;;
     go) ;&         # fallthrough
     shellcheck) ;& # fallthrough
-    python2) ;&    # fallthrough
     python3) ;&    # fallthrough
     pytest-3) ;&   # fallthrough
     goctest) ;&    # fallthrough
@@ -105,7 +103,6 @@ tool_configure() {
     misspell) ;&      # fallthrough
     shellcheck) ;&    # fallthrough
     golangci-lint) ;& # fallthrough
-    python2) ;&       # fallthrough
     python3) ;&       # fallthrough
     pytest-3) ;&      # fallthrough
     goctest) ;&       # fallthrough
@@ -130,7 +127,7 @@ install_conf_show_tool() {
     fi
 
     if ! executable=$(command -v "$tool"); then # ignore-tool
-        if [ "$ignore_missing" != "1" ] && [ "$tool" != "python2" ] && [ "$tool" != "goctest" ]; then
+        if [ "$ignore_missing" != "1" ] && [ "$tool" != "goctest" ]; then
             echo "ERROR: Tool $tool is not available"
             return 1
         else
@@ -601,13 +598,6 @@ if [ "$UNIT" = 1 ]; then
         GOTRACEBACK=1 $goctest $tags $race -timeout $timeout $coverage
     fi
     # python unit test for mountinfo.query and version-compare
-    if command -v python2; then
-        echo ">> [Python] Running python2 unit tests for mountinfo.query and version-compare"
-        python2 ./tests/lib/tools/mountinfo.query --run-unit-tests
-        python2 ./tests/lib/tools/version-compare --run-unit-tests
-    else
-        echo ">> [Python] Skipping python2 unit tests for mountinfo.query and version-compare"
-    fi
     if command -v python3; then
         echo ">> [Python] Running python3 unit tests for mountinfo.query and version-compare"
         python3 ./tests/lib/tools/mountinfo.query --run-unit-tests

--- a/run-checks
+++ b/run-checks
@@ -3,11 +3,6 @@
 export LANG=C.UTF-8
 export LANGUAGE=en
 
-if command -v goctest >/dev/null; then
-    goctest="goctest ./..."
-else
-    goctest="go test ./..."
-fi
 COVERMODE=${COVERMODE:-atomic}
 COVERAGE_SUFFIX=${GO_BUILD_TAGS:-notags}
 COVERAGE_OUT=${COVERAGE_OUT:-.coverage/coverage-$COVERAGE_SUFFIX.cov}
@@ -36,31 +31,48 @@ fi
 GOBINS=$(go env GOPATH | sed 's|:|/bin:|g' | sed 's|.*|\0/bin|g')
 export PATH="$PATH:$GOBINS"
 
-short=
+missing_interface_spread_test() {
+    snap_yaml="tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml"
+    core_snap_yaml="tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-core/meta/snap.yaml"
+    classic_snap_yaml="tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-classic/meta/snap.yaml"
+    for iface in $(go run ./tests/lib/list-interfaces.go); do
+        search="plugs: \\[ $iface \\]"
+        case "$iface" in
+        bool-file | gpio | pwm | dsp | netlink-driver | hidraw | i2c | iio | serial-port | spi | confdb)
+            # skip gadget provided interfaces for now
+            continue
+            ;;
+        dbus | content)
+            search="interface: $iface"
+            ;;
+        autopilot)
+            search='plugs: \[ autopilot-introspection \]'
+            ;;
+        esac
 
-STATIC=
-UNIT=
+        # check if a standalone test already exists and that it at least
+        # connects and disconnects the interface
+        dedicated_test=$(find tests/main/ -maxdepth 1 -name "interfaces-$iface")
+        if [ -n "$dedicated_test" ]; then
+            if grep -q "$search" "$snap_yaml"; then
+                echo "Dedicated test '$dedicated_test' found for '$iface'."
+                echo "Please remove '$iface' from '$snap_yaml'."
+                exit 1
+            fi
+            # dedicated test already exists, skip high-level test check below
+            continue
+        fi
 
-case "${1:-all}" in
-all)
-    STATIC=1
-    UNIT=1
-    ;;
---static)
-    STATIC=1
-    ;;
---unit)
-    UNIT=1
-    ;;
---short-unit)
-    UNIT=1
-    short=1
-    ;;
-*)
-    echo "Wrong flag ${1}. To run a single suite use --static, --unit."
-    exit 1
-    ;;
-esac
+        # check if high-level minimal test exists for interface
+        if ! grep -q "$search" "$snap_yaml"; then
+            echo "Missing high-level test for interface '$iface'. Please add to:"
+            echo "* $snap_yaml"
+            echo "* $core_snap_yaml (if needed)"
+            echo "* $classic_snap_yaml (if needed)"
+            exit 1
+        fi
+    done
+}
 
 CURRENTTRAP="true"
 EXIT_CODE=99
@@ -110,52 +122,30 @@ endmsg() {
 }
 addtrap endmsg
 
-missing_interface_spread_test() {
-    snap_yaml="tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml"
-    core_snap_yaml="tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-core/meta/snap.yaml"
-    classic_snap_yaml="tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-classic/meta/snap.yaml"
-    for iface in $(go run ./tests/lib/list-interfaces.go); do
-        search="plugs: \\[ $iface \\]"
-        case "$iface" in
-        bool-file | gpio | pwm | dsp | netlink-driver | hidraw | i2c | iio | serial-port | spi | confdb)
-            # skip gadget provided interfaces for now
-            continue
-            ;;
-            cuda-driver-libs|egl-driver-libs)
-            # skip interfaces with plug side only in rootfs for now
-            continue
-            ;;
-        dbus | content)
-            search="interface: $iface"
-            ;;
-        autopilot)
-            search='plugs: \[ autopilot-introspection \]'
-            ;;
-        esac
+short=
+STATIC=
+UNIT=
 
-        # check if a standalone test already exists and that it at least
-        # connects and disconnects the interface
-        dedicated_test=$(find tests/main/ -maxdepth 1 -name "interfaces-$iface")
-        if [ -n "$dedicated_test" ]; then
-            if grep -q "$search" "$snap_yaml"; then
-                echo "Dedicated test '$dedicated_test' found for '$iface'."
-                echo "Please remove '$iface' from '$snap_yaml'."
-                exit 1
-            fi
-            # dedicated test already exists, skip high-level test check below
-            continue
-        fi
-
-        # check if high-level minimal test exists for interface
-        if ! grep -q "$search" "$snap_yaml"; then
-            echo "Missing high-level test for interface '$iface'. Please add to:"
-            echo "* $snap_yaml"
-            echo "* $core_snap_yaml (if needed)"
-            echo "* $classic_snap_yaml (if needed)"
-            exit 1
-        fi
-    done
-}
+case "${1:-all}" in
+all)
+    STATIC=1
+    UNIT=1
+    ;;
+--static)
+    STATIC=1
+    ;;
+--unit)
+    UNIT=1
+    ;;
+--short-unit)
+    UNIT=1
+    short=1
+    ;;
+*)
+    echo "Wrong flag ${1}. To run a single suite use --static, --unit."
+    exit 1
+    ;;
+esac
 
 if [ "$STATIC" = 1 ]; then
     ./get-deps.sh
@@ -465,6 +455,12 @@ if [ "$UNIT" = 1 ]; then
     echo Building
     # shellcheck disable=SC2086
     go build -v $tags $race github.com/snapcore/snapd/...
+
+    if command -v goctest >/dev/null; then
+        goctest="goctest ./..."
+    else
+        goctest="go test ./..."
+    fi
 
     # tests
     echo Running tests from "$PWD"

--- a/run-checks
+++ b/run-checks
@@ -12,20 +12,6 @@ TIMEOUT=${TIMEOUT:-15}
 AUTO_INSTALL=${AUTO_INSTALL:-1}     # Automatically install supported tool dependencies (default: install)
 IGNORE_MISSING=${IGNORE_MISSING:-0} # Do not error on missing tool dependencies (default: error)
 
-goinstall() {
-    local pkg="$1"
-    local version="${2:-latest}"
-    # go1.18+ will no longer build/install packages. Here "go install"
-    # must be used but it will only fetch remote packages if the @latest
-    # (or similar syntax is used). Instead of checking the version we
-    # check if the "go install" help mentions this new feature.
-    if go help install | grep -q @latest; then
-        go install "${pkg}"@"${version}"
-    else
-        go get -u "${pkg}"@"${version}"
-    fi
-}
-
 tool_version() {
     local tool=$1
     case "$tool" in
@@ -62,18 +48,18 @@ tool_install() {
     local tool=$1
     case "$tool" in
     ineffassign)
-        goinstall github.com/gordonklaus/ineffassign >/dev/null
+        go install github.com/gordonklaus/ineffassign@latest >/dev/null
         ;;
     nakedret)
-        goinstall github.com/alexkohler/nakedret v1.0.1 >/dev/null
+        go install github.com/alexkohler/nakedret@v1.0.1 >/dev/null
         ;;
     misspell)
-        goinstall github.com/client9/misspell/cmd/misspell >/dev/null
+        go install github.com/client9/misspell/cmd/misspell@latest >/dev/null
         ;;
     golangci-lint)
         # Decided to start using latest instead of pinning specific version, if this approach
         # introduces too much instability, revert back to pinning a working version.
-        goinstall github.com/golangci/golangci-lint/cmd/golangci-lint >/dev/null
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest >/dev/null
         ;;
     go) ;&         # fallthrough
     shellcheck) ;& # fallthrough
@@ -230,7 +216,7 @@ missing_interface_spread_test() {
     done
 }
 
-CURRENTTRAP="true"
+CURRENT_TRAP="true"
 EXIT_CODE=99
 
 store_exit_code() {
@@ -242,9 +228,9 @@ exit_with_exit_code() {
 }
 
 addtrap() {
-    CURRENTTRAP="$CURRENTTRAP ; $1"
+    CURRENT_TRAP="$CURRENT_TRAP ; $1"
     # shellcheck disable=SC2064
-    trap "store_exit_code; $CURRENTTRAP ; exit_with_exit_code" EXIT
+    trap "store_exit_code; $CURRENT_TRAP ; exit_with_exit_code" EXIT
 }
 
 endmsg() {

--- a/run-checks
+++ b/run-checks
@@ -30,7 +30,6 @@ tool_version() {
     golangci-lint) ;& # fallthrough
     python3) ;&       # fallthrough
     pytest-3) ;&      # fallthrough
-    goctest) ;&       # fallthrough
     clang-format)
         $tool --version
         ;;
@@ -64,7 +63,6 @@ tool_install() {
     shellcheck) ;& # fallthrough
     python3) ;&    # fallthrough
     pytest-3) ;&   # fallthrough
-    goctest) ;&    # fallthrough
     clang-format) ;;
     *)
         return 1
@@ -105,7 +103,6 @@ tool_configure() {
     golangci-lint) ;& # fallthrough
     python3) ;&       # fallthrough
     pytest-3) ;&      # fallthrough
-    goctest) ;&       # fallthrough
     clang-format) ;;
     *)
         return 1
@@ -127,7 +124,7 @@ install_conf_show_tool() {
     fi
 
     if ! executable=$(command -v "$tool"); then # ignore-tool
-        if [ "$ignore_missing" != "1" ] && [ "$tool" != "goctest" ]; then
+        if [ "$ignore_missing" != "1" ]; then
             echo "ERROR: Tool $tool is not available"
             return 1
         else
@@ -577,24 +574,18 @@ if [ "$UNIT" = 1 ]; then
     # shellcheck disable=SC2086
     go build -v $tags $race github.com/snapcore/snapd/...
 
-    if command -v goctest >/dev/null; then
-        goctest="goctest ./..."
-    else
-        goctest="go test ./..."
-    fi
-
     # tests
     echo ">> [Go] Running go unit tests from $PWD"
     if [ "$short" = "-short" ] || [ -n "${SKIP_COVERAGE:-}" ]; then
         echo ">> [Go] Skipping coverage"
         # shellcheck disable=SC2046,SC2086
-        GOTRACEBACK=1 $goctest $tags $race $short -timeout $timeout
+        GOTRACEBACK=1 go test ./... $tags $race $short -timeout $timeout
     else
         coverage="-coverprofile=$COVERAGE_OUT -covermode=$COVERMODE"
         echo ">> [Go] Checking coverage with params: $coverage"
         mkdir -p "$(dirname "$COVERAGE_OUT")"
         # shellcheck disable=SC2046,SC2086
-        GOTRACEBACK=1 $goctest $tags $race -timeout $timeout $coverage
+        GOTRACEBACK=1 go test ./... $tags $race -timeout $timeout $coverage
     fi
     # python unit test for mountinfo.query and version-compare
     if command -v python3; then

--- a/run-checks
+++ b/run-checks
@@ -27,9 +27,6 @@ tool_version() {
     clang-format)
         $tool --version
         ;;
-    nakedret)
-        echo "unknown"
-        ;;
     *)
         return 1
         ;;
@@ -39,9 +36,6 @@ tool_version() {
 tool_install() {
     local tool=$1
     case "$tool" in
-    nakedret)
-        go install github.com/alexkohler/nakedret@v1.0.1 >/dev/null
-        ;;
     golangci-lint)
         # Decided to start using latest instead of pinning specific version, if this approach
         # introduces too much instability, revert back to pinning a working version.
@@ -84,7 +78,6 @@ tool_configure() {
             export PATH=/usr/lib/go-1.18/bin:"${PATH}"
         fi
         ;;
-    nakedret) ;&      # fallthrough
     shellcheck) ;&    # fallthrough
     golangci-lint) ;& # fallthrough
     python3) ;&       # fallthrough
@@ -397,17 +390,6 @@ if [ "$STATIC" = 1 ]; then
         ./tests/lib/external/snapd-testing-tools/utils/spread-shellcheck $FILTERED_FILES --exclude "$exclude_tools_path" --exclude "tests/nested/manual/core20-preseed"
     else
         echo ">> [Bash] Skipping shellcheck check"
-    fi
-
-    echo ">> [Go] Checking for naked returns"
-    if [ -z "${SKIP_NAKEDRET:-}" ] && command -v nakedret >/dev/null; then
-        got=$(go list ./... | grep -v '/osutil/udev/' | xargs nakedret 2>&1)
-        if [ -n "$got" ]; then
-            echo "$got"
-            exit 1
-        fi
-    else
-        echo "[Go] Skipping naked returns check"
     fi
 
     echo ">> [Spread] Checking all interfaces have a spread test"

--- a/run-checks
+++ b/run-checks
@@ -71,7 +71,9 @@ tool_install() {
         goinstall github.com/client9/misspell/cmd/misspell >/dev/null
         ;;
     golangci-lint)
-        goinstall github.com/golangci/golangci-lint/cmd/golangci-lint v1.64.5 >/dev/null
+	# Decided to start using latest instead of pinning specific version, if this approach
+	# introduces too much instability, revert back to pinning a working version.
+        goinstall github.com/golangci/golangci-lint/cmd/golangci-lint >/dev/null
         ;;
     go) ;&         # fallthrough
     shellcheck) ;& # fallthrough

--- a/run-checks
+++ b/run-checks
@@ -173,8 +173,7 @@ verify_tools() {
 
     # check go first that includes setting up go paths required to find or install
     # other go based tools, error early when missing
-    tool="go"
-    install_conf_show_tool "$tool" "$auto_install" "0"
+    install_conf_show_tool "go" "$auto_install" "0"
 
     # check other tools
     for tool in $tools; do

--- a/run-checks
+++ b/run-checks
@@ -465,16 +465,38 @@ if [ "$STATIC" = 1 ]; then
             fi
         fi
 
-        # Check whether golangci-lint was built with go version >= the installed go version
-        gcil_go_ver=$(golangci-lint --version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
-        go_ver=$(go version | grep -o 'go[0-9]*\.[0-9]*\.[0-9]*' | cut -c 3-)
-        if [ "$(printf '%s\n' "$go_ver" "$gcil_go_ver" | sort -V | head -n1)" != "$go_ver" ]; then
-            echo "WARNING: Your go version ($go_ver) is greater than the version of go that golangci-lint was built with ($gcil_go_ver)."
+        # only linters can be disabled, formatters require configuration change
+        disable=""
+        if [ -n "${SKIP_INEFFASSIGN:-}" ]; then
+            disable+=" ineffassign"
+        fi
+        if [ -n "${SKIP_MISSPELL:-}" ]; then
+            disable+=" misspell"
+        fi
+        if [ -n "${SKIP_NAKEDRET:-}" ]; then
+            disable+=" nakedret"
         fi
 
-        # don't run with --new-from-rev as the diff might not be enough to tell
-        # the change introduces problems (e.g., removing the last call to a function)
-        golangci-lint --path-prefix= run
+        enabled=$(golangci-lint linters | awk '
+        /^Enabled by your configuration linters:/ { in_section=1; next }
+        /^Disabled by your configuration linters:/ { in_section=0 }
+        in_section && NF {
+        sub(/:.*/, "", $1)
+        linters = linters ? linters "," $1 : $1
+        }
+        END { print linters }')
+
+        echo ">> [Go] Enabled golangci-lint linters: $enabled"
+
+        if [ -n "${disable:-}" ]; then
+            disable="$(echo "$disable" | sed 's/^ *//' | tr ' ' ',')"
+            echo ">> [Go] Disabling the following golangci-lint linters on request: $disable"
+            golangci-lint --path-prefix= run --disable "$disable"
+        else
+            # don't run with --new-from-rev as the diff might not be enough to tell
+            # the change introduces problems (e.g., removing the last call to a function)
+            golangci-lint --path-prefix= run
+        fi
     else
         echo ">> [Go] Skipping golangci-lint check"
     fi

--- a/run-checks
+++ b/run-checks
@@ -507,9 +507,8 @@ if [ -n "${SKIP_DIRTY_CHECK:-}" ]; then
     exit 0
 fi
 
-# XXX: re-enable after vendor/vendor.json is removed
-# if git describe --always --dirty | grep -q dirty; then
-#     echo "Build tree is dirty"
-#     git diff
-#     exit 1
-# fi
+if git describe --always --dirty | grep -q dirty; then
+    echo "Build tree is dirty"
+    git diff
+    exit 1
+fi

--- a/run-checks
+++ b/run-checks
@@ -428,6 +428,18 @@ if [ "$STATIC" = 1 ]; then
         # the change introduces problems (e.g., removing the last call to a function)
         golangci-lint --path-prefix= run
     fi
+
+    echo "Checking C source code formatting"
+    if command -v clang-format >/dev/null; then
+        current=$(pwd)
+        cd cmd/
+        ./autogen.sh
+        if ! make fmt-check; then
+            echo "C files are not formatted correctly, run 'make fmt'"
+            exit 1
+        fi
+        cd "$current"
+    fi
 fi
 
 if [ "$UNIT" = 1 ]; then

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -48,10 +48,6 @@ execute: |
         skip='SKIP_GOFMT=1'
     fi
 
-    if [[ -n "${SKIP_NAKEDRET:-}" ]]; then
-        skip="${skip:-} SKIP_NAKEDRET=1"
-    fi
-
     # golangci-lint checks are system agnostic and were already checked in the github
     # test workflow static checks. They can therefore be safely skipped here.
     skip="${skip:-} SKIP_GOLANGCI_LINT=1"

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -76,6 +76,7 @@ execute: |
                 $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
+                IGNORE_MISSING=1 \
                 ./run-checks --static"
         else
             tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
@@ -84,6 +85,7 @@ execute: |
                 $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
+                IGNORE_MISSING=1 \
                 ./run-checks --unit"
         fi
     else
@@ -111,6 +113,7 @@ execute: |
                 $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
+                IGNORE_MISSING=1 \
                 ./run-checks --static" test
         else
             su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
@@ -119,6 +122,7 @@ execute: |
                 $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
+                IGNORE_MISSING=1 \
                 ./run-checks --unit" test
         fi
     fi

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -48,6 +48,14 @@ execute: |
         skip='SKIP_GOFMT=1'
     fi
 
+    if os.query is-xenial || os.query is-trusty || os.query is-bionic || os.query is-focal || ! os.query is-ubuntu; then
+        skip="${skip:-} SKIP_MISSPELL=1 SKIP_INEFFASSIGN=1"
+    fi
+
+    if [[ -n "${SKIP_NAKEDRET:-}" ]]; then
+        skip="${skip:-} SKIP_NAKEDRET=1"
+    fi
+
     # golangci-lint checks are system agnostic and were already checked in the github
     # test workflow static checks. They can therefore be safely skipped here.
     skip="${skip:-} SKIP_GOLANGCI_LINT=1"

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -49,7 +49,7 @@ execute: |
     fi
 
     if os.query is-xenial || os.query is-trusty || os.query is-bionic || os.query is-focal || ! os.query is-ubuntu; then
-        skip="${skip:-} SKIP_MISSPELL=1 SKIP_INEFFASSIGN=1"
+        skip="${skip:-} SKIP_MISSPELL=1"
     fi
 
     if [[ -n "${SKIP_NAKEDRET:-}" ]]; then

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -48,10 +48,6 @@ execute: |
         skip='SKIP_GOFMT=1'
     fi
 
-    if os.query is-xenial || os.query is-trusty || os.query is-bionic || os.query is-focal || ! os.query is-ubuntu; then
-        skip="${skip:-} SKIP_MISSPELL=1"
-    fi
-
     if [[ -n "${SKIP_NAKEDRET:-}" ]]; then
         skip="${skip:-} SKIP_NAKEDRET=1"
     fi


### PR DESCRIPTION
Proposing changes to run-check with the goal of boosting verbosity around what is run/skipped and early warning when tool dependency is missing that will, perhaps unexpectedly, cause lower coverage.

**Overview:**
 - format run-checks with shfmt
 - add C format check based on clang-format
 - install required packages that is now flagged as missing on fedora and opensuse
 - remove independent step for similar check in static-checks.yaml (now covered by previous step "run checks --static")
 - re-enabled build tree dirty check (TODO with conditions met)
 - add tool dependency precheck, that will fail on missing dependency if not instructed otherwise
    - ability to IGNORE_MISSING (default=0): override default behavior to error on missing dependency (for development)
    - ability to AUTO_INSTALL (default=1): install supported tools if supported, currently go packages (same as before)
 - changed printout to be consistent, indicating test sections and subsections (">" and ">>") and always explicitly state if test was run or skipped (either tool not available, or due to ENV var).
 - install golangci-lint v2 when  missing
 - removed duplicate linters covered by golangci-lint, while also enabling golangci-ling support for env VARS based skip requested for linting tools.

NOTE: golangci-lint does not have a trivial way to disabling formatters, therefore gofmt for golangci-lint is not used. Improving this is outside the scope of this task.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34573