### PR TITLE
tests: switch to github-hosted arm runners

### DIFF
--- a/.github/workflows/snap-builds.yaml
+++ b/.github/workflows/snap-builds.yaml
@@ -27,7 +27,7 @@ jobs:
       id: set_artifact_name
       run: |
         postfix="${{ inputs.toolchain }}-${{ inputs.variant }}"
-        if grep -iq "arm64" <<<"${{ inputs.runs-on }}"; then
+        if grep -iq "arm" <<<"${{ inputs.runs-on }}"; then
           echo "artifact_name=snap-files-arm64-${postfix}" >> $GITHUB_OUTPUT
         else
           echo "artifact_name=snap-files-amd64-${postfix}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,10 +36,7 @@ jobs:
       matrix:
         runs-on:
           - '["ubuntu-22.04"]'
-          # Tags to identify the self-hosted runners to use from
-          # internal runner collection. See internal self-hosted
-          # runners doc for the complete list of options.
-          - '["self-hosted", "Linux", "jammy", "ARM64", "large"]'
+          - '["ubuntu-22.04-arm"]'
         toolchain:
           - default
           - FIPS
@@ -53,9 +50,9 @@ jobs:
         # to keep the number of builds down as we currently don't have a
         # clear need for these excluded builds.
         exclude:
-          - runs-on: '["self-hosted", "Linux", "jammy", "ARM64", "large"]'
+          - runs-on: '["ubuntu-22.04-arm"]'
             toolchain: FIPS
-          - runs-on: '["self-hosted", "Linux", "jammy", "ARM64", "large"]'
+          - runs-on: '["ubuntu-22.04-arm"]'
             variant: pristine
 
   cache-build-deps:


### PR DESCRIPTION
Changing to github hosted arm runners due to self-hosted arm runners giving problems that is blocking merging the release content. This can be reverted back once the self-hosted runners are back in action.