### PR TITLE
many: move notify.SysPath to apparmor.NotifySocketPath

### DIFF
--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
@@ -70,7 +69,7 @@ func (s *promptingSuite) SetUpTest(c *C) {
 		[]string{"prompt"}, nil,
 	))
 	// mock the presence of the notification socket
-	os.MkdirAll(notify.SysPath, 0o755)
+	os.MkdirAll(apparmor.NotifySocketPath, 0o755)
 	// mock the presence of permstable32_version with supported version
 	s.AddCleanup(apparmor.MockFsRootPath(dirs.GlobalRootDir))
 	os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "sys/kernel/security/apparmor/features/policy"), 0o755)

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -305,11 +305,19 @@ const (
 )
 
 var (
-	ConfDir                string
-	CacheDir               string
-	SystemCacheDir         string
+	// ConfDir is the path to the directory holding AppArmor configuration.
+	ConfDir string
+	// CacheDir is the path to the cache directory for AppArmor.
+	CacheDir string
+	// SystemCacheDir is the path to the system cache directory for AppArmor,
+	// which may or may not be different from CacheDir.
+	SystemCacheDir string
+	// SnapConfineAppArmorDir is the path to the AppArmor snap confine
+	// directory.
 	SnapConfineAppArmorDir string
-	NotifySocketPath       string
+	// NotifySocketPath is the path to the socket over which listeners can
+	// communicate with AppArmor in the kernel.
+	NotifySocketPath string
 )
 
 func setupConfCacheDirs(newrootdir string) {

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -904,6 +904,10 @@ func (s *apparmorSuite) TestSetupConfCacheDirsWithInternalApparmor(c *C) {
 func (s *apparmorSuite) TestSetupNotifySocketPath(c *C) {
 	apparmor.SetupNotifySocketPath("/newdir")
 	c.Check(apparmor.NotifySocketPath, Equals, "/newdir/sys/kernel/security/apparmor/.notify")
+
+	newRoot := c.MkDir()
+	dirs.SetRootDir(newRoot)
+	c.Check(apparmor.NotifySocketPath, Equals, filepath.Join(newRoot, "/sys/kernel/security/apparmor/.notify"))
 }
 
 func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicyErr(c *C) {

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -765,7 +764,7 @@ func (s *apparmorSuite) TestPromptingSupported(c *C) {
 
 	// Create a file at the notify path, doesn't matter what kind of file.
 	// The actual file is a socket, but a directory will do here for convenience.
-	c.Assert(os.MkdirAll(notify.SysPath, 0o755), IsNil)
+	c.Assert(os.MkdirAll(apparmor.NotifySocketPath, 0o755), IsNil)
 	restore = apparmor.MockFeatures(goodKernelFeatures, nil, goodParserFeatures, nil)
 	defer restore()
 
@@ -900,6 +899,11 @@ func (s *apparmorSuite) TestSetupConfCacheDirsWithInternalApparmor(c *C) {
 
 	apparmor.SetupConfCacheDirs("/newdir")
 	c.Check(apparmor.SnapConfineAppArmorDir, Equals, "/newdir/var/lib/snapd/apparmor/snap-confine.internal")
+}
+
+func (s *apparmorSuite) TestSetupNotifySocketPath(c *C) {
+	apparmor.SetupNotifySocketPath("/newdir")
+	c.Check(apparmor.NotifySocketPath, Equals, "/newdir/sys/kernel/security/apparmor/.notify")
 }
 
 func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicyErr(c *C) {

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -28,8 +28,9 @@ import (
 )
 
 var (
-	NumberOfJobsParam  = numberOfJobsParam
-	SetupConfCacheDirs = setupConfCacheDirs
+	NumberOfJobsParam     = numberOfJobsParam
+	SetupConfCacheDirs    = setupConfCacheDirs
+	SetupNotifySocketPath = setupNotifySocketPath
 )
 
 func MockRuntimeNumCPU(new func() int) (restore func()) {

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/snapcore/snapd/osutil/epoll"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -56,7 +57,7 @@ func MockOsOpenWithSocket() (restore func()) {
 		if err != nil {
 			return nil, err
 		}
-		notifyFile := os.NewFile(uintptr(socket), notify.SysPath)
+		notifyFile := os.NewFile(uintptr(socket), apparmor.NotifySocketPath)
 		return notifyFile, nil
 	}
 	restore = MockOsOpen(f)

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/epoll"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 )
 
@@ -186,7 +187,7 @@ const (
 //
 // If the kernel does not support the notification mechanism the error is ErrNotSupported.
 func Register() (listener *Listener, err error) {
-	path := notify.SysPath
+	path := apparmor.NotifySocketPath
 	if override := os.Getenv("PROMPT_NOTIFY_PATH"); override != "" {
 		path = override
 	}

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -4,21 +4,9 @@ package notify
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	"golang.org/x/sys/unix"
-
-	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
 )
-
-var SysPath string
-
-// SupportAvailable returns true if SysPath exists, indicating that apparmor
-// prompting messages may be received from SysPath.
-func SupportAvailable() bool {
-	return osutil.FileExists(SysPath)
-}
 
 var doIoctl = Ioctl
 
@@ -55,13 +43,4 @@ func RegisterFileDescriptor(fd uintptr) (ProtocolVersion, error) {
 		}
 		return protocolVersion, nil
 	}
-}
-
-func setupSysPath(newrootdir string) {
-	SysPath = filepath.Join(newrootdir, "/sys/kernel/security/apparmor/.notify")
-}
-
-func init() {
-	dirs.AddRootDirCallback(setupSysPath)
-	setupSysPath(dirs.GlobalRootDir)
 }

--- a/sandbox/apparmor/notify/notify_test.go
+++ b/sandbox/apparmor/notify/notify_test.go
@@ -2,8 +2,6 @@ package notify_test
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -28,25 +26,6 @@ func (s *notifySuite) SetUpTest(c *C) {
 
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
-}
-
-func (*notifySuite) TestSysPathBehavior(c *C) {
-	newRoot := c.MkDir()
-	newSysPath := filepath.Join(newRoot, "/sys/kernel/security/apparmor/.notify")
-	dirs.SetRootDir(newRoot)
-	c.Assert(notify.SysPath, Equals, newSysPath)
-}
-
-func (*notifySuite) TestSupportAvailable(c *C) {
-	newRoot := c.MkDir()
-	dirs.SetRootDir(newRoot)
-	c.Assert(notify.SupportAvailable(), Equals, false)
-	err := os.MkdirAll(filepath.Dir(notify.SysPath), 0755)
-	c.Assert(err, IsNil)
-	c.Assert(notify.SupportAvailable(), Equals, false)
-	_, err = os.Create(notify.SysPath)
-	c.Assert(err, IsNil)
-	c.Assert(notify.SupportAvailable(), Equals, true)
 }
 
 var fakeNotifyVersions = []notify.VersionAndCheck{

--- a/sandbox/apparmor/notify/version.go
+++ b/sandbox/apparmor/notify/version.go
@@ -41,7 +41,11 @@ var (
 	// on the notify socket with that version, in which case we'll need to try
 	// the next version in the list.
 	versionLikelySupportedChecks = map[ProtocolVersion]func() bool{
-		3: SupportAvailable,
+		3: func() bool {
+			// If prompting is supported, version 3 is always assumed to be
+			// supported.
+			return true
+		},
 	}
 
 	// versionKnown returns true if the given protocol version is known by


### PR DESCRIPTION
Move the definition of the notify socket path from the notify package into the apparmor package. This means that the apparmor package no longer needs to import the notify package, so the notify package can import the apparmor package in the future without a circular import.

This is required for #15089 so that it can check the supported AppArmor kernel features by importing the `apparmor` package.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34598