### PR TITLE
 tests/main/progress: set IO timeout and collect verbose debug log from socat

### DIFF
--- a/tests/main/progress/task.yaml
+++ b/tests/main/progress/task.yaml
@@ -29,8 +29,8 @@ execute: |
   (
   # work around progress.go check for SPREAD_SYSTEM
   unset SPREAD_SYSTEM;
-  socat system:'snap install test-snapd-tools-core24',pty,raw,echo=0 - | tr '\r' '\n' > tty-install.log
-  socat system:'snap remove test-snapd-tools-core24',pty,raw,echo=0 - | tr '\r' '\n' > tty-remove.log
+  socat -dddd -T30 system:'snap install test-snapd-tools-core24',pty,raw,echo=0 - | tr '\r' '\n' > tty-install.log
+  socat -dddd -T30 system:'snap remove test-snapd-tools-core24',pty,raw,echo=0 - | tr '\r' '\n' > tty-remove.log
   )
   # more than one line for each operation
   test "$(wc -l < tty-install.log)" -gt "1"

--- a/tests/main/progress/task.yaml
+++ b/tests/main/progress/task.yaml
@@ -10,6 +10,8 @@ systems:
   # observed to fail randomly?
   # TODO investigate once we can spin up instances in openstack manually
   - -fedora-*
+  # has socat 1.7.4.x which handles timeout in a buggy way
+  - -centos-*
 
 prepare: |
   tests.pkgs install socat


### PR DESCRIPTION
We're trying to identify a failure in spread tests which is manifested
by the following output:

    + tr '\r' '\n'
    + socat 'system:snap install test-snapd-tools-core24,pty,raw,echo=0' -
    2025/02/25 20:01:47 socat[182348] W exiting on signal 15
    + socat 'system:snap remove test-snapd-tools-core24,pty,raw,echo=0' -
    + tr '\r' '\n'

The culprit seems to be the default IO timeout which is set at 0.5s.
Bump the timeout to 30s, but keep debug logs on in case we need them.