### PR TITLE
tests/main/snap-quota: explicitly remove all created groups during restore

### DIFF
--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -12,6 +12,19 @@ prepare: |
 
 restore: |
   snap remove-quota group-one || true
+  snap remove-quota group-two || true
+  snap remove-quota group-sub-one || true
+  snap remove-quota group-one || true
+  snap remove-quota group-sub-sub-three || true
+  snap remove-quota group-sub-three || true
+  snap remove-quota group-three || true
+  snap remove-quota group-top1 || true
+  snap remove-quota group-top2 || true
+  # no groups remain
+  test "$(find /sys/fs/cgroup/ -name 'snap.group*' | wc -l)" = "0"
+
+debug: |
+  find /sys/fs/cgroup/ -name 'snap.group*' -ls || true
 
 execute: |
   if os.query is-trusty || os.query is-amazon-linux 2 || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then


### PR DESCRIPTION
Despite groups not being assigned to any snaps, there are quota groups related files created by system under /sys/fs/cgroup/. Make sure to remove all groups and check that no files are left behind.

Cherry picked from #15094 