### PR TITLE
tests: fix using master snap flag on nightly

### DIFF
--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -108,6 +108,7 @@ jobs:
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
       is-fundamental: true
+      use-snapd-snap-from-master: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.fundamental-systems) }}
@@ -128,6 +129,7 @@ jobs:
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
+      use-snapd-snap-from-master: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}
@@ -148,6 +150,7 @@ jobs:
       systems: ${{ matrix.systems }}
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
+      use-snapd-snap-from-master: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.nested-systems) }}

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -215,7 +215,7 @@ jobs:
         path: "${{ github.workspace }}/built-snap"
 
     - name: Download built snap (arm64)
-      if: "contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips')"
+      if: "${{ !inputs.use-snapd-snap-from-master && contains(inputs.group, '-arm64') && !endsWith(inputs.group, '-fips') }}"
       uses: actions/download-artifact@v4
       with:
         name: snap-files-arm64-default-test


### PR DESCRIPTION
The nightly tests were missing the flag to use the snapd snap from master and the arm snap download was missing a check on that flag.