### PR TITLE
cmd/snap-discard-ns: assert process capabilities

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -457,6 +457,11 @@ snap_discard_ns_snap_discard_ns_SOURCES = \
 snap_discard_ns_snap_discard_ns_LDFLAGS = $(AM_LDFLAGS) $(SANITIZE_LDFLAGS)
 snap_discard_ns_snap_discard_ns_LDADD = libsnap-confine-private.a
 snap_discard_ns_snap_discard_ns_STATIC =
+if STATIC_LIBCAP
+snap_discard_ns_snap_discard_ns_STATIC += -lcap
+else
+snap_discard_ns_snap_discard_ns_LDADD += -lcap
+endif  # STATIC_LIBCAP
 
 # Use a hacked rule if we're doing static build. This allows us to inject the LIBS += .. rule below.
 snap-discard-ns/snap-discard-ns$(EXEEXT): $(snap_discard_ns_snap_discard_ns_OBJECTS) $(snap_discard_ns_snap_discard_ns_DEPENDENCIES) $(EXTRA_snap_discard_ns_snap_discard_ns_DEPENDENCIES) snap-discard-ns/$(am__dirstamp)

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -24,12 +24,14 @@
 #include <limits.h>
 #include <linux/magic.h>
 #include <stdio.h>
+#include <sys/capability.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/vfs.h>
 #include <unistd.h>
 
+#include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/error.h"
 #include "../libsnap-confine-private/locking.h"
 #include "../libsnap-confine-private/snap.h"
@@ -39,6 +41,32 @@
 #ifndef NSFS_MAGIC
 #define NSFS_MAGIC 0x6e736673
 #endif
+
+// Asserts the proces has sufficient capabilities being either run directly by root user or
+// through snap-confine.
+static void assert_caps(void) {
+    cap_t current SC_CLEANUP(cap_free) = cap_get_proc();
+
+    cap_value_t expected_caps[] = {
+        CAP_SYS_ADMIN,    /* umount */
+        CAP_DAC_OVERRIDE, /* for poking around /run/snapd */
+        CAP_CHOWN,        /* for lock file and directory */
+    };
+
+    for (size_t i = 0; i < SC_ARRAY_SIZE(expected_caps); i++) {
+        cap_value_t cap = expected_caps[i];
+        const char* cap_name SC_CLEANUP(cap_free) = cap_to_name(cap);
+
+        cap_flag_value_t set = CAP_CLEAR;
+        if (cap_get_flag(current, cap, CAP_EFFECTIVE, &set) != 0) {
+            die("cannot assert %s state", cap_name);
+        }
+
+        if (set != CAP_SET) {
+            die("missing capability %s", cap_name);
+        }
+    }
+}
 
 int main(int argc, char** argv) {
     if (argc != 2 && argc != 3) {
@@ -62,6 +90,11 @@ int main(int argc, char** argv) {
     sc_error* err = NULL;
     sc_instance_name_validate(snap_instance_name, &err);
     sc_die_on_error(err);
+
+    /* time to asssert we have the right capabilities to perform the job */
+    assert_caps();
+    /* TODO: drop superfluous capabilities and keep only the ones that are
+     * explicitly needed */
 
     int snap_lock_fd = -1;
     if (from_snap_confine) {


### PR DESCRIPTION
Assert process capabilities, to ensure correctness when invoked from snap-confine.

Cherry picked from #15094. This is a preparatory step for having snap-discard-ns be invoked by a user with privileges carried by capabilities.

Related: [SNAPDENG-34419](https://warthogs.atlassian.net/browse/SNAPDENG-34419)


[SNAPDENG-34419]: https://warthogs.atlassian.net/browse/SNAPDENG-34419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ