### PR TITLE
tests: account for snapd/kernel incompatibilty warning in prepare-image

### DIFF
--- a/tests/main/prepare-image-classic/task.yaml
+++ b/tests/main/prepare-image-classic/task.yaml
@@ -38,6 +38,9 @@ restore: |
     "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
     rm -rf "$ROOT"
 
+debug: |
+    cat stderr
+
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
@@ -63,8 +66,10 @@ execute: |
 
     # prepare-image ran as user so it warns about the ownership
     MATCH 'WARNING: ensure that the contents under .* are owned by root:root in the \(final\) image' < stderr
+    # check that the snapd/kernel incompatibility check is working
+    MATCH 'WARNING: snapd 2.68\+ is not compatible with a kernel containing snapd prior to 2.68' < stderr
     # But there are not other warnings/errors on stderr
-    wc -l < stderr | MATCH "^1$"
+    wc -l < stderr | MATCH "^2$"
 
     echo Verifying the result
     systemid="$(date +%Y%m%d)"


### PR DESCRIPTION
This warning was added to warn against snapd 2.68+ not being compatible with a kernel containing snapd prior to 2.68 which is useful in the context of FDE installations.

This was introduced by #15106.
