### PR TITLE
tests: fix snap-user-service-socket-activation with confined nc

### DIFF
--- a/tests/main/snap-user-service-socket-activation/task.yaml
+++ b/tests/main/snap-user-service-socket-activation/task.yaml
@@ -33,6 +33,14 @@ execute: |
 
     echo "And the user mode systemd instance is started"
     tests.session -u test prepare
+    # Staring with Ubuntu 25.04, many programs gain dedicated apparmor
+    # profiles.  This includes the nc program which is now confined and does
+    # not allow for cap_dac_override required to traverse /run/user/$(id -u
+    # test)/ or /home/test, which do not have o+x permission.  As such, poke a
+    # small hole to allow that.
+    chmod +x /run/user/"$(id -u test)" ~test
+    # The runtime directory will be removed by now.
+    tests.cleanup defer chmod -x ~test
 
     echo "It's sockets are created in the test user's directories and activate the service"
     [ -S ~test/snap/test-snapd-user-service-sockets/common/common.sock ]


### PR DESCRIPTION
AppArmor is undergoing a flurry of activity, with dozens of new confinement profiles for previously unconfined applications. In Ubuntu 25.04 and newer, the nc program is now sandboxed and the sandbox does not allow cap_dac_override. As such the test running as root, no longer has the ability to traverse /home/test or /run/user/12345/ which ordinarily lack the o+x permission.