### PR TITLE
tests/core20-remodel: increase further the seed partition size

### DIFF
--- a/tests/nested/manual/core20-remodel/task.yaml
+++ b/tests/nested/manual/core20-remodel/task.yaml
@@ -15,7 +15,7 @@ environment:
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
-  NESTED_UBUNTU_SEED_SIZE: 1500M
+  NESTED_UBUNTU_SEED_SIZE: 2000M
 
 prepare: |
     tests.nested build-image core


### PR DESCRIPTION
After the 3rd remodel we are slightly ahead of 1500M.