### PR TITLE
packaging/ubuntu-16.04: fix ifneq in debian/rules

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -18,7 +18,7 @@ export DH_GOLANG_GO_GENERATE=1
 
 VERSION := $(shell dpkg-parsechangelog -S Version)
 
-ifneq (,$(findstring +fips,$(VERSION))))
+ifneq (,$(findstring +fips,$(VERSION)))
 	# the version has +fips tag, we're building a FIPS variant
 	FIPSBUILD = 1
 else


### PR DESCRIPTION
Drop extra bracket.

During release 2.68.2, the LP deb build for plucky failed.
![image](https://github.com/user-attachments/assets/e8246696-ecd3-4e93-9f81-bb3c7729a618)

This was broken since commit commit 9f6a29a2d11d75d96de278288c444102decb3ec6, but became problematic after plucky started using make 4.4.