### PR TITLE
i/builtin: allow accessing scaling_governor in cpu-control through symlink

### DIFF
--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -38,6 +38,7 @@ const cpuControlConnectedPlugAppArmor = `
 
 /sys/module/cpu_boost/parameters/input_boost_freq rw,
 /sys/module/cpu_boost/parameters/input_boost_ms rw,
+/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor rw,
 /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_min_freq rw,
 /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_max_freq rw,
 /sys/devices/system/cpu/cpu[0-9]*/core_ctl/min_cpus rw,


### PR DESCRIPTION
According to https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html#policy-interface-in-sysfs Each policyX directory is pointed to by cpufreq symbolic links under `/sys/devices/system/cpu/cpuY/`. The interface gave access to `/sys/devices/system/cpu/cpufreq/policy*/scaling_governor` but not `/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor`.
