### PR TITLE
spread, arch: workaround for dropped community repository

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -797,6 +797,9 @@ prepare: |
         else
             exit 1
         fi
+        # workaround for https://warthogs.atlassian.net/browse/SNAPDENG-34591
+        awk '/\[community\]/ {print "#" $0; getline; print "#" $0; next} {print}' < /etc/pacman.conf > /etc/pacman.conf.spread
+        mv /etc/pacman.conf.spread /etc/pacman.conf
     fi
 
     if [[ "$SPREAD_SYSTEM" == debian-* ]]; then


### PR DESCRIPTION
On 01-03-2025 Arch project has finally turned off the [community] repository mirrors. This ends a 2 year grace period period since the change was first announced. While we have a task to fix and update spread images, the patch adds a temporary workaround.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
