### PR TITLE
debian/rules: change permissions of /var/lib/snapd/void

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -331,6 +331,9 @@ override_dh_install: debian/snapd.install
 	mv debian/snapd/etc/profile.d/snapd.sh debian/snapd/etc/profile.d/apps-bin-path.sh
 
 	$(MAKE) -C cmd install DESTDIR=$(CURDIR)/debian/tmp
+	# Permission 111 breaks deb builds on plucky e.g. "Can't opendir(debian/tmp/var/lib/snapd/void): Permission denied".
+	# The desired permission 111 is re-applied in postinst.
+	chmod 755 $(CURDIR)/debian/tmp/var/lib/snapd/void
 
 	# Rename the apparmor profile, see dh_apparmor call above for an explanation.
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real


### PR DESCRIPTION
Fix snapd deb build on plucky.

Build issue encountered during snapd deb build on plucky as per [build log](https://launchpadlibrarian.net/779864313/buildlog_ubuntu-plucky-amd64.snapd_2.68.2+ubuntu25.04.1_BUILDING.txt.gz):
![image](https://github.com/user-attachments/assets/75ee6b9c-a9aa-4549-b270-3c61e2008b22)

Tested build for plucky: https://launchpad.net/~ernestl/+archive/ubuntu/snapd/+build/30388551

Borrowed fix for similar issue: https://salsa.debian.org/debian/snapd/-/commit/59b0652d7a34c6534616b249d2334c5654e22758