### PR TITLE
secboot/keymgr: fallback to old keyring path for keys

### DIFF
--- a/cmd/snap-fde-keymgr/main.go
+++ b/cmd/snap-fde-keymgr/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot/keymgr"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -243,6 +244,10 @@ func run(osArgs1 []string) error {
 }
 
 func main() {
+	if err := logger.SimpleSetup(nil); err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %v\n", err)
+	}
+
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/secboot/keymgr/export_test.go
+++ b/secboot/keymgr/export_test.go
@@ -31,3 +31,9 @@ func MockGetDiskUnlockKeyFromKernel(f func(prefix, devicePath string, remove boo
 }
 
 var RecoveryKDF = recoveryKDF
+
+func MockDisksDevlinks(f func(devPath string) ([]string, error)) (restore func()) {
+	restore = testutil.Backup(&disksDevlinks)
+	disksDevlinks = f
+	return restore
+}


### PR DESCRIPTION
When using snapd 2.68+ along with snap-boostrap <2.68, then the path in keyring is still using the old by-partuuid path, but the old keymgr tries to find it with the new path. So we need to look for the old path if we cannot find the new one.

SF00406468
