### PR TITLE
cmd/snap-bootstrap: create sysroot.mount for CVMs

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_cvm.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_cvm.go
@@ -22,6 +22,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -305,6 +306,20 @@ func generateMountsModeRunCVM(mst *initramfsMountsState) error {
 			if err := createOverlayDirs(pm.Where); err != nil {
 				return err
 			}
+		}
+	}
+
+	if createSysrootMount() {
+		// Create unit for sysroot. We restrict this to Ubuntu 24+ for
+		// the moment, until we backport necessary changes to the
+		// UC20/22 initramfs. Note that a transient unit is not used as
+		// it tries to be restarted after the switch root, and fails.
+		rootfsDir := boot.InitramfsDataDir
+		if err := writeSysrootMountUnit(rootfsDir, ""); err != nil {
+			return fmt.Errorf("cannot write sysroot.mount (what: %s): %w", rootfsDir, err)
+		}
+		if err := recalculateRootfsTarget(); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
The sysroot.mount is now dynamically created by snap-bootstrap instead of being a static file in the initramfs, but that was being done only for UC/hybrid. Make sure that this happens also for CVMs.