### PR TITLE
many: create notify.AppArmorPermission interface

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -498,7 +498,7 @@ func AvailablePermissions(iface string) ([]string, error) {
 
 // AbstractPermissionsFromAppArmorPermissions returns the list of permissions
 // corresponding to the given AppArmor permissions for the given interface.
-func AbstractPermissionsFromAppArmorPermissions(iface string, permissions any) ([]string, error) {
+func AbstractPermissionsFromAppArmorPermissions(iface string, permissions notify.AppArmorPermission) ([]string, error) {
 	filePerms, ok := permissions.(notify.FilePermission)
 	if !ok {
 		return nil, fmt.Errorf("cannot parse the given permissions as file permissions: %v", permissions)
@@ -543,7 +543,7 @@ func AbstractPermissionsFromAppArmorPermissions(iface string, permissions any) (
 
 // AbstractPermissionsToAppArmorPermissions returns AppArmor permissions
 // corresponding to the given permissions for the given interface.
-func AbstractPermissionsToAppArmorPermissions(iface string, permissions []string) (any, error) {
+func AbstractPermissionsToAppArmorPermissions(iface string, permissions []string) (notify.AppArmorPermission, error) {
 	// permissions may be empty, e.g. if we're constructing allowed permissions
 	// and denying all of them.
 	filePermsMap, exists := interfaceFilePermissionsMaps[iface]

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -970,12 +970,12 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 	}
 }
 
-func constructPermissionsMaps() []map[string]map[string]any {
-	var permissionsMaps []map[string]map[string]any
+func constructPermissionsMaps() []map[string]map[string]notify.AppArmorPermission {
+	var permissionsMaps []map[string]map[string]notify.AppArmorPermission
 	// interfaceFilePermissionsMaps
-	filePermissionsMaps := make(map[string]map[string]any)
+	filePermissionsMaps := make(map[string]map[string]notify.AppArmorPermission)
 	for iface, permsMap := range prompting.InterfaceFilePermissionsMaps {
-		filePermissionsMaps[iface] = make(map[string]any, len(permsMap))
+		filePermissionsMaps[iface] = make(map[string]notify.AppArmorPermission, len(permsMap))
 		for perm, val := range permsMap {
 			filePermissionsMaps[iface][perm] = val
 		}
@@ -1046,7 +1046,7 @@ func (s *constraintsSuite) TestAvailablePermissions(c *C) {
 func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsHappy(c *C) {
 	cases := []struct {
 		iface string
-		perms any
+		perms notify.AppArmorPermission
 		list  []string
 	}{
 		{
@@ -1087,15 +1087,21 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsHappy(c
 	}
 }
 
+type fakeAaPerm string
+
+func (p fakeAaPerm) AsAppArmorOpMask() uint32 {
+	return uint32(len(p))
+}
+
 func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy(c *C) {
 	for _, testCase := range []struct {
 		iface  string
-		perms  any
+		perms  notify.AppArmorPermission
 		errStr string
 	}{
 		{
 			"home",
-			"not a file permission",
+			fakeAaPerm("not a file permission"),
 			"cannot parse the given permissions as file permissions.*",
 		},
 		{
@@ -1115,7 +1121,7 @@ func (s *constraintsSuite) TestAbstractPermissionsFromAppArmorPermissionsUnhappy
 	}
 	for _, testCase := range []struct {
 		iface    string
-		perms    any
+		perms    notify.AppArmorPermission
 		abstract []string
 		errStr   string
 	}{
@@ -1145,7 +1151,7 @@ func (s *constraintsSuite) TestAbstractPermissionsToAppArmorPermissionsHappy(c *
 	cases := []struct {
 		iface string
 		list  []string
-		perms any
+		perms notify.AppArmorPermission
 	}{
 		{
 			"home",

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -81,7 +81,7 @@ func (s *requestpromptsSuite) SetUpTest(c *C) {
 }
 
 func (s *requestpromptsSuite) TestNew(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -101,7 +101,7 @@ func (s *requestpromptsSuite) TestNew(c *C) {
 }
 
 func (s *requestpromptsSuite) TestNewValidMaxID(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -151,7 +151,7 @@ func (s *requestpromptsSuite) TestNewValidMaxID(c *C) {
 }
 
 func (s *requestpromptsSuite) TestNewInvalidMaxID(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -193,7 +193,7 @@ func (s *requestpromptsSuite) TestNewInvalidMaxID(c *C) {
 }
 
 func (s *requestpromptsSuite) TestNewNextIDUniqueIDs(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -255,7 +255,7 @@ func (s *requestpromptsSuite) checkWrittenMaxID(c *C, id uint64) {
 }
 
 func (s *requestpromptsSuite) TestAddOrMerge(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -385,7 +385,7 @@ func sortSliceParams(list []*noticeInfo) ([]*noticeInfo, func(i, j int) bool) {
 }
 
 func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -419,7 +419,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 	path := fmt.Sprintf("/home/test/Documents/%d.txt", requestprompts.MaxOutstandingPromptsPerUser)
 	lr := &listener.Request{}
 
-	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Assert(listenerReq, Equals, lr)
 		c.Assert(allowedPermission, DeepEquals, notify.FilePermission(0))
 		return nil
@@ -456,7 +456,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 }
 
 func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -501,8 +501,8 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 
 func (s *requestpromptsSuite) TestReply(c *C) {
 	listenerReqChan := make(chan *listener.Request, 2)
-	replyChan := make(chan any, 2)
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	replyChan := make(chan notify.AppArmorPermission, 2)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		listenerReqChan <- listenerReq
 		replyChan <- allowedPermission
 		return nil
@@ -569,7 +569,7 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 	}
 }
 
-func (s *requestpromptsSuite) waitForListenerReqAndReply(c *C, listenerReqChan <-chan *listener.Request, replyChan <-chan any) (req *listener.Request, allowedPermission any, err error) {
+func (s *requestpromptsSuite) waitForListenerReqAndReply(c *C, listenerReqChan <-chan *listener.Request, replyChan <-chan notify.AppArmorPermission) (req *listener.Request, allowedPermission notify.AppArmorPermission, err error) {
 	select {
 	case req = <-listenerReqChan:
 	case <-time.NewTimer(10 * time.Second).C:
@@ -585,7 +585,7 @@ func (s *requestpromptsSuite) waitForListenerReqAndReply(c *C, listenerReqChan <
 
 func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 	fakeError := fmt.Errorf("fake reply error")
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		return fakeError
 	})
 	defer restore()
@@ -628,8 +628,8 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 
 func (s *requestpromptsSuite) TestHandleNewRule(c *C) {
 	listenerReqChan := make(chan *listener.Request, 2)
-	replyChan := make(chan any, 2)
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	replyChan := make(chan notify.AppArmorPermission, 2)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		listenerReqChan <- listenerReq
 		replyChan <- allowedPermission
 		return nil
@@ -764,8 +764,8 @@ func promptIDListContains(haystack []prompting.IDType, needle prompting.IDType) 
 
 func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	listenerReqChan := make(chan *listener.Request, 1)
-	replyChan := make(chan any, 1)
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	replyChan := make(chan notify.AppArmorPermission, 1)
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		listenerReqChan <- listenerReq
 		replyChan <- allowedPermission
 		return nil
@@ -902,7 +902,7 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 	})
 	defer restore()
 
-	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -967,7 +967,7 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 }
 
 func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -1011,7 +1011,7 @@ func (s *requestpromptsSuite) TestCloseThenOperate(c *C) {
 }
 
 func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
-	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
 	})
@@ -1059,7 +1059,7 @@ func (s *requestpromptsSuite) TestPromptExpiration(c *C) {
 	defer restore()
 
 	replyChan := make(chan notify.FilePermission, 1)
-	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		allowedFilePermission, ok := allowedPermission.(notify.FilePermission)
 		c.Assert(ok, Equals, true)
 		replyChan <- allowedFilePermission
@@ -1205,7 +1205,7 @@ func (s *requestpromptsSuite) TestPromptExpirationRace(c *C) {
 	defer restore()
 
 	replyChan := make(chan notify.FilePermission, 1)
-	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission any) error {
+	restore = requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		allowedFilePermission, ok := allowedPermission.(notify.FilePermission)
 		c.Assert(ok, Equals, true)
 		replyChan <- allowedFilePermission

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -22,6 +22,7 @@ package apparmorprompting
 import (
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -44,7 +45,7 @@ func MockListenerClose(f func(l *listener.Listener) error) (restore func()) {
 
 type RequestResponse struct {
 	Request           *listener.Request
-	AllowedPermission any
+	AllowedPermission notify.AppArmorPermission
 }
 
 func MockListener() (reqChan chan *listener.Request, replyChan chan RequestResponse, restore func()) {
@@ -77,7 +78,7 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 		}
 		return nil
 	})
-	restoreReply := MockRequestReply(func(req *listener.Request, allowedPermission any) error {
+	restoreReply := MockRequestReply(func(req *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		reqResp := RequestResponse{
 			Request:           req,
 			AllowedPermission: allowedPermission,
@@ -95,7 +96,7 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 	return reqChan, replyChan, restore
 }
 
-func MockRequestReply(f func(req *listener.Request, allowedPermission any) error) (restore func()) {
+func MockRequestReply(f func(req *listener.Request, allowedPermission notify.AppArmorPermission) error) (restore func()) {
 	restoreRequestReply := testutil.Backup(&requestReply)
 	requestReply = f
 	restoreRequestpromptsSendReply := requestprompts.MockSendReply(f)

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/strutil"
@@ -43,7 +44,9 @@ var (
 	listenerRun      = func(l *listener.Listener) error { return l.Run() }
 	listenerReqs     = func(l *listener.Listener) <-chan *listener.Request { return l.Reqs() }
 
-	requestReply = func(req *listener.Request, allowedPermission any) error { return req.Reply(allowedPermission) }
+	requestReply = func(req *listener.Request, allowedPermission notify.AppArmorPermission) error {
+		return req.Reply(allowedPermission)
+	}
 )
 
 // A Manager holds outstanding prompts and mediates their replies, further it

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -988,7 +988,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	resp, err := waitForReply(replyChan)
 	c.Assert(err, IsNil)
 	c.Check(resp.Request, Equals, readReq)
-	var expectedPermission any
+	var expectedPermission notify.AppArmorPermission
 	switch outcome {
 	case prompting.OutcomeAllow:
 		expectedPermission, err = prompting.AbstractPermissionsToAppArmorPermissions("home", []string{"read"})
@@ -1035,7 +1035,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	for i := 0; i < 2; i++ {
 		resp, err := waitForReply(replyChan)
 		c.Assert(err, IsNil)
-		var expectedPermission any
+		var expectedPermission notify.AppArmorPermission
 		switch outcome {
 		case prompting.OutcomeAllow:
 			// Round-trip to abstract permissions and back to get full permission mask

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -36,7 +36,7 @@ func ExitOnError() (restore func()) {
 	return restore
 }
 
-func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan any) *Request {
+func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan notify.AppArmorPermission) *Request {
 	return &Request{
 		Class:     class,
 		replyChan: replyChan,

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -75,16 +75,16 @@ type Request struct {
 	// Class is the mediation class corresponding to this request.
 	Class notify.MediationClass
 	// Permission is the opaque permission that is being requested.
-	Permission any
+	Permission notify.AppArmorPermission
 
 	// replyChan is a channel for sending the explicitly allowed permissions.
-	replyChan chan any
+	replyChan chan notify.AppArmorPermission
 	// replied indicates whether a reply has already been sent for this request.
 	replied uint32
 }
 
 func newRequest(msg *notify.MsgNotificationFile) (*Request, error) {
-	var perm any
+	var perm notify.AppArmorPermission
 	switch msg.Class {
 	case notify.AA_CLASS_FILE:
 		// DecodeFilePermissions returns:
@@ -110,13 +110,13 @@ func newRequest(msg *notify.MsgNotificationFile) (*Request, error) {
 		Class:      msg.Class,
 		Permission: perm,
 
-		replyChan: make(chan any, 1),
+		replyChan: make(chan notify.AppArmorPermission, 1),
 	}, nil
 }
 
 // Reply tells the listener to send back a response to the kernel allowing any
 // of the given permissions which were originally requested.
-func (r *Request) Reply(allowedPermission any) error {
+func (r *Request) Reply(allowedPermission notify.AppArmorPermission) error {
 	var ok bool
 	switch r.Class {
 	case notify.AA_CLASS_FILE:
@@ -447,7 +447,7 @@ func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotifi
 			logger.Debugf("invalid reply from client: %+v; denying request", responsePermission)
 			break
 		}
-		explicitlyAllowed = uint32(perms)
+		explicitlyAllowed = perms.AsAppArmorOpMask()
 	case <-l.tomb.Dying():
 		// don't bother sending deny response, kernel will auto-deny if needed
 		return nil

--- a/sandbox/apparmor/notify/permission.go
+++ b/sandbox/apparmor/notify/permission.go
@@ -5,9 +5,17 @@ import (
 	"strings"
 )
 
+type AppArmorPermission interface {
+	AsAppArmorOpMask() uint32
+}
+
 // FilePermission is a bit-mask of apparmor permissions in relation to files.
 // It is applicable to messages with the class of AA_CLASS_FILE.
 type FilePermission uint32
+
+func (fp FilePermission) AsAppArmorOpMask() uint32 {
+	return uint32(fp)
+}
 
 const (
 	// AA_MAY_EXEC implies that a process has a permission to execute another

--- a/sandbox/apparmor/notify/permission.go
+++ b/sandbox/apparmor/notify/permission.go
@@ -5,7 +5,12 @@ import (
 	"strings"
 )
 
+// AppArmorPermission defines the requirements common to the permission types
+// for all mediation classes, so that functions and helpers can be safely used
+// for all AppArmor permission types.
 type AppArmorPermission interface {
+	// AsAppArmorOpMask returns the receiver as an AppArmor operation mask, as
+	// found in MsgNotificationOp and MsgNotificationResponse.
 	AsAppArmorOpMask() uint32
 }
 


### PR DESCRIPTION
Rather than using `any` to store and pass around generic AppArmor permission masks (which are usually `notify.FilePermission`), instead create a dedicated interface with a `AsAppArmorOpMask` method which returns the corresponding `uint32` permission mask for the AppArmor `MsgNotificationOp`. This way, we can enforce that only appropriate types are passed into replies, and the reply code itself can use the be simplified by using the new method without requiring additional validation.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-30466
