### PR TITLE
interfaces/builtin/network_control: allow removing created network namespaces

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -330,6 +330,7 @@ network netlink raw,
 mount options=(rw, rshared) -> /run/netns/,
 mount options=(rw, bind) /run/netns/ -> /run/netns/,
 mount options=(rw, bind) / -> /run/netns/*,
+umount /run/netns/*,
 umount /,
 
 # 'ip netns identify <pid>' and 'ip netns pids foo'. Intenionally omit 'ptrace

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -85,6 +85,13 @@ execute: |
     echo "A network namespace can be created"
     network-control-consumer.cmd ip netns add test-ns
     ip netns list | MATCH test-ns
+    echo "Listed"
+    network-control-consumer.cmd ip netns list | MATCH test-ns
+    echo "And removed"
+    network-control-consumer.cmd ip netns delete test-ns
+
+    # re-add to continue with the test
+    network-control-consumer.cmd ip netns add test-ns
 
     echo "And a veth interface can be added to the namespace"
 


### PR DESCRIPTION
Trying to delete a network namespace raises a denial:

    audit: type=1400 audit(1741169474.109:5051): apparmor="DENIED"
    operation="umount" class="mount"
    profile="snap.network-control-consumer.cmd"
    name="/run/netns/foo" pid=2490600 comm="ip"

Issue reported by customer.