### PR TITLE
tests: fixes for errors found in snapd  2.68.2 validation

### DIFF
--- a/tests/core/snapd-refresh-undo/task.yaml
+++ b/tests/core/snapd-refresh-undo/task.yaml
@@ -34,8 +34,10 @@ execute: |
   fi
 
   revision=""
-  if os.query is_arm; then
+  if os.query is-arm64; then
     revision=18363
+  elif os.query is-armhf; then
+    revision=18359
   else
     revision=18357
   fi

--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -12,7 +12,7 @@ environment:
     SNAPD_NO_MEMORY_LIMIT: 1
 
 prepare: |
-  snap install snap-store
+  snap install --candidate snap-store
 
 execute: |
   snap_id=$(snap info snap-store | gojq -r --yaml-input '.["snap-id"]')

--- a/tests/main/snap-icons-fallback/task.yaml
+++ b/tests/main/snap-icons-fallback/task.yaml
@@ -25,10 +25,10 @@ execute: |
     test ! -e "/var/cache/snapd/icons/${SNAP_FALLBACK_ID}.icon"
 
     echo "Install a snap which has a local icon and a store icon"
-    snap install "$SNAP_LOCAL"
+    snap install --edge "$SNAP_LOCAL"
 
     echo "Install a snap which has a store icon but no local icon"
-    snap install "$SNAP_FALLBACK"
+    snap install --edge "$SNAP_FALLBACK"
 
     SNAP_DIR="/snap"
     if [ ! -d "/snap" ] ; then

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -6,12 +6,9 @@ details: |
   single service. Check that systemd reports the services as belonging to the
   expected slices.
 
-# memory cgroup is disabled on external devices like rpi3
-backends:
-  - -external
-
 # these systems do not support journal quota groups due to their old systemd versions.
 # requires systemd v245+
+# memory cgroup is disabled on arm devices like rpi3
 systems:
   - -amazon-linux-2-*
   - -ubuntu-14.04-*
@@ -19,6 +16,7 @@ systems:
   - -ubuntu-18.04-*
   - -ubuntu-core-16-*
   - -ubuntu-core-18-*
+  - -ubuntu-core-*-arm-*
 
 prepare: |
   snap install test-snapd-stressd --edge --devmode


### PR DESCRIPTION
Using edge channel for test snaps and skipping arm devices doe quota-services test.
