### PR TITLE
spread: Revert "spread: arch: workaround for dropped community repository (#15160)"

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -797,9 +797,6 @@ prepare: |
         else
             exit 1
         fi
-        # workaround for https://warthogs.atlassian.net/browse/SNAPDENG-34591
-        awk '/\[community\]/ {print "#" $0; getline; print "#" $0; next} {print}' < /etc/pacman.conf > /etc/pacman.conf.spread
-        mv /etc/pacman.conf.spread /etc/pacman.conf
     fi
 
     if [[ "$SPREAD_SYSTEM" == debian-* ]]; then


### PR DESCRIPTION
This reverts commit 513d788c376dfe7309a6bf6bcc2bfcc1787572c1.

The arch linux base images was updated here https://github.com/canonical/spread-images/pull/26