### PR TITLE
tests/lib/prepare-restore: use /etc/sudoers.d where possible

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -53,11 +53,17 @@ create_test_user(){
     fi
     unset owner
 
-    # Add a new line first to prevent an error which happens when
-    # the file has not new line, and we see this:
-    # syntax error, unexpected WORD, expecting END or ':' or '\n'
-    echo >> /etc/sudoers
-    echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+    if [ -d /etc/sudoers.d ]; then
+        # this also works around systems where /etc/sudo is empty and /etc could
+        # be ephemeral, eg. openSUSE Tumbleweed which keeps /usr/etc/sudoers
+        echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/99-test-user
+    else
+        # Add a new line first to prevent an error which happens when
+        # the file has not new line, and we see this:
+        # syntax error, unexpected WORD, expecting END or ':' or '\n'
+        echo >> /etc/sudoers
+        echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+    fi
 
     chown test:test -R "$SPREAD_PATH"
     chown test:test "$SPREAD_PATH/../"


### PR DESCRIPTION
Modern sudo setups use /etc/sudoers.d/ for local configuration. Some even take it a step further and use /usr/etc/sudoers which includes /etc/sudo, but in this case the latter needs to be properly built so that it doesn't break the configuration. To make all setups happy, try to use /etc/sudoers.d where possible.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
