### PR TITLE
packaging/opensuse: fix setting permissions through permctl

### DIFF
--- a/packaging/opensuse/permissions
+++ b/packaging/opensuse/permissions
@@ -1,1 +1,0 @@
-/usr/lib/snapd/snap-confine                             root:root         4755

--- a/packaging/opensuse/permissions.easy
+++ b/packaging/opensuse/permissions.easy
@@ -1,1 +1,0 @@
-/usr/lib/snapd/snap-confine                             root:root         4755

--- a/packaging/opensuse/permissions.easy.in
+++ b/packaging/opensuse/permissions.easy.in
@@ -1,0 +1,1 @@
+@LIBEXECDIR@/snapd/snap-confine                             root:root         4755

--- a/packaging/opensuse/permissions.in
+++ b/packaging/opensuse/permissions.in
@@ -1,0 +1,1 @@
+@LIBEXECDIR@/snapd/snap-confine                             root:root         4755

--- a/packaging/opensuse/permissions.paranoid
+++ b/packaging/opensuse/permissions.paranoid
@@ -1,1 +1,0 @@
-/usr/lib/snapd/snap-confine                             root:root         755

--- a/packaging/opensuse/permissions.paranoid.in
+++ b/packaging/opensuse/permissions.paranoid.in
@@ -1,0 +1,1 @@
+@LIBEXECDIR@/snapd/snap-confine                             root:root         755

--- a/packaging/opensuse/permissions.secure
+++ b/packaging/opensuse/permissions.secure
@@ -1,1 +1,0 @@
-/usr/lib/snapd/snap-confine                             root:root         4755

--- a/packaging/opensuse/permissions.secure.in
+++ b/packaging/opensuse/permissions.secure.in
@@ -1,0 +1,1 @@
+@LIBEXECDIR@/snapd/snap-confine                             root:root         4755

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -319,8 +319,10 @@ chmod 755 %{buildroot}%{_localstatedir}/lib/snapd/void
 # once snap-confine is added to the permissions package. This is done following
 # the recommendations on
 # https://en.opensuse.org/openSUSE:Package_security_guidelines
-install -pm 644 -D %{indigo_srcdir}/packaging/opensuse/permissions %{buildroot}%{_sysconfdir}/permissions.d/snapd
-install -pm 644 -D %{indigo_srcdir}/packaging/opensuse/permissions.paranoid %{buildroot}%{_sysconfdir}/permissions.d/snapd.paranoid
+sed -e 's,@LIBEXECDIR@,%{_libexecdir},' < %{indigo_srcdir}/packaging/opensuse/permissions.in > permissions
+install -pm 644 -D permissions %{buildroot}%{_sysconfdir}/permissions.d/snapd
+sed -e 's,@LIBEXECDIR@,%{_libexecdir},' < %{indigo_srcdir}/packaging/opensuse/permissions.paranoid.in > permissions.paranoid
+install -pm 644 -D permissions.paranoid %{buildroot}%{_sysconfdir}/permissions.d/snapd.paranoid
 
 # See https://en.opensuse.org/openSUSE:Packaging_checks#suse-missing-rclink for details
 install -d %{buildroot}%{_sbindir}
@@ -462,7 +464,8 @@ fi
 %ghost %{_sharedstatedir}/snapd/state.json
 %ghost %{_sharedstatedir}/snapd/system-key
 %ghost %{snap_mount_dir}/README
-%verify(not user group mode) %attr(04755,root,root) %{_libexecdir}/snapd/snap-confine
+# setuid permissions are set through permctl and set_permissions snippet in post
+%verify(not user group mode) %attr(0755,root,root) %{_libexecdir}/snapd/snap-confine
 %{_bindir}/snap
 %{_bindir}/snapctl
 %{_datadir}/applications/io.snapcraft.SessionAgent.desktop


### PR DESCRIPTION
The permissions file for snapd uses incorrect libexecdir location on
openSUSE Tumbleweed (/usr/lib/snapd instead of /usr/libexec/snapd).
Hence, permissions were never correctly applied through permctl and the
setuid on s-c only worked by accident as we were setting
%attr(4775,root,root).