### PR TITLE
s/a/notify: simplify the listener

### DIFF
--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -62,7 +62,10 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 	})
 	restoreRun := MockListenerRun(func(l *listener.Listener) error {
 		<-closeChan
-		return listener.ErrClosed
+		// In production, listener.Run() does not return on error, and when
+		// the listener is closed, it returns nil. So it should always return
+		// nil in practice.
+		return nil
 	})
 	restoreReqs := MockListenerReqs(func(l *listener.Listener) <-chan *listener.Request {
 		return reqChan

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -151,17 +151,21 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 // Run is the main run loop for the manager, and must be called using tomb.Go.
 func (m *InterfacesRequestsManager) run() error {
 	m.lock.Lock()
-	// disconnect replaces the listener so keep track of the one we have
-	// right now
+	// disconnect replaces the listener, so keep track of the one we have
+	// right now, even though currently disconnect is only called when this
+	// function returns, so this isn't really necessary.
 	currentListener := m.listener
 	m.lock.Unlock()
 
 	m.tomb.Go(func() error {
 		logger.Debugf("starting prompting listener")
-		if err := listenerRun(currentListener); err != listener.ErrClosed {
-			return err
-		}
-		return nil
+		// listener.Run will return an error if and only if there's a real
+		// error, not if Close() is called. But Close() is called only by
+		// disconnect(), which is itself only called when this run() function
+		// returns, which only occurs when the manager tomb is dying. So we
+		// don't need to worry about the listener returning nil when we don't
+		// already expect to be exiting.
+		return listenerRun(currentListener)
 	})
 
 run_loop:
@@ -170,20 +174,29 @@ run_loop:
 		select {
 		case req, ok := <-listenerReqs(currentListener):
 			if !ok {
-				// Reqs() closed, so either errored or Stop() was called.
-				// In either case, the listener Close() method has already
-				// been called, and the tomb error will be set to the return
+				// Reqs() closed, so an error occurred in the listener. In
+				// production, the listener does not close itself on error, so
+				// this should never actually occur.
+				//
+				// If Stop() were called, it would set the tomb to dying and
+				// the other select case would have occurred, since the
+				// disconnect() method is the only place in the manager where
+				// the listener Close() method is called, and disconnect() is
+				// only called when this function returns.
+				//
+				// The listener Close() method has already been called by the
+				// listener itself, and the tomb error will be set to the error
 				// value of the Run() call from the previous tracked goroutine.
 				logger.Debugf("prompting listener closed requests channel")
 				break run_loop
 			}
 
-			logger.Debugf("received from kernel requests channel: %v", req)
+			logger.Debugf("received from kernel requests channel: %+v", req)
 			if err := m.handleListenerReq(req); err != nil {
 				logger.Noticef("error while handling request: %+v", err)
 			}
 		case <-m.tomb.Dying():
-			logger.Noticef("InterfacesRequestsManager tomb is dying, disconnecting")
+			logger.Debugf("InterfacesRequestsManager tomb is dying with error %v, disconnecting", m.tomb.Err())
 			break run_loop
 		}
 	}

--- a/sandbox/apparmor/notify/ioctl.go
+++ b/sandbox/apparmor/notify/ioctl.go
@@ -109,7 +109,7 @@ func Ioctl(fd uintptr, req IoctlRequest, buf IoctlRequestBuffer) ([]byte, error)
 type IoctlRequest uintptr
 
 // Available ioctl(2) requests for .notify file.
-// Those are not documented beyond the implementeation in the kernel.
+// Those are not documented beyond the implementation in the kernel.
 const (
 	APPARMOR_NOTIF_SET_FILTER  IoctlRequest = 0x4008F800
 	APPARMOR_NOTIF_GET_FILTER  IoctlRequest = 0x8008F801

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -42,10 +42,10 @@ func FakeRequestWithIDVersionClassAllowDeny(id uint64, version notify.ProtocolVe
 	}
 	return &Request{
 		ID:         id,
-		Listener:   listener,
 		Class:      class,
 		Permission: aaDeny,
 		AaAllowed:  aaAllow,
+		listener:   listener,
 	}
 }
 

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -36,10 +36,16 @@ func ExitOnError() (restore func()) {
 	return restore
 }
 
-func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan notify.AppArmorPermission) *Request {
+func FakeRequestWithIDVersionClassAllowDeny(id uint64, version notify.ProtocolVersion, class notify.MediationClass, aaAllow, aaDeny notify.AppArmorPermission) *Request {
+	listener := &Listener{
+		protocolVersion: version,
+	}
 	return &Request{
-		Class:     class,
-		replyChan: replyChan,
+		ID:         id,
+		Listener:   listener,
+		Class:      class,
+		Permission: aaDeny,
+		AaAllowed:  aaAllow,
 	}
 }
 
@@ -92,7 +98,7 @@ func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.Ioct
 // a SEND call via ioctl, the data is instead written to the send channel.
 func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
 	recvChanRW := make(chan []byte)
-	sendChanRW := make(chan []byte)
+	sendChanRW := make(chan []byte, 1) // need to have buffer size 1 since reply is synchronous
 	internalRecvChan := make(chan []byte, 1)
 	epollF := func(l *Listener) ([]epoll.Event, error) {
 		for {
@@ -142,32 +148,25 @@ func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan cha
 	return recvChanRW, sendChanRW, restore
 }
 
+// Return a blocking channel over which a IoctlRequest type will be sent
+// whenever notifyIoctl returns.
+func SynchronizeNotifyIoctl() (ioctlDone <-chan notify.IoctlRequest, restore func()) {
+	ioctlDoneRW := make(chan notify.IoctlRequest)
+	realIoctl := notifyIoctl
+	restore = testutil.Mock(&notifyIoctl, func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		ret, err := realIoctl(fd, req, buf)
+		ioctlDoneRW <- req // synchronize
+		return ret, err
+	})
+	return ioctlDoneRW, restore
+}
+
 func MockEncodeAndSendResponse(f func(l *Listener, resp *notify.MsgNotificationResponse) error) (restore func()) {
 	restore = testutil.Backup(&encodeAndSendResponse)
 	encodeAndSendResponse = f
 	return restore
 }
 
-func (l *Listener) Dead() <-chan struct{} {
-	return l.tomb.Dead()
-}
-
-func (l *Listener) Dying() <-chan struct{} {
-	return l.tomb.Dying()
-}
-
-func (l *Listener) Err() error {
-	return l.tomb.Err()
-}
-
-func (l *Listener) Kill(err error) {
-	l.tomb.Kill(err)
-}
-
 func (l *Listener) EpollIsClosed() bool {
 	return l.poll.IsClosed()
-}
-
-func (l *Listener) WaitAndRespondAaClassFile(req *Request, msg *notify.MsgNotificationFile) error {
-	return l.waitAndRespondAaClassFile(req, msg)
 }

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -98,7 +98,7 @@ func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.Ioct
 // a SEND call via ioctl, the data is instead written to the send channel.
 func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
 	recvChanRW := make(chan []byte)
-	sendChanRW := make(chan []byte, 1) // need to have buffer size 1 since reply is synchronous
+	sendChanRW := make(chan []byte, 1) // need to have buffer size 1 since reply does not run in a goroutine and the test would otherwise block
 	internalRecvChan := make(chan []byte, 1)
 	epollF := func(l *Listener) ([]epoll.Event, error) {
 		for {

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -216,14 +216,16 @@ func (l *Listener) Close() error {
 	// to see whether Close was called or whether a real error occurred.
 	close(l.closeChan)
 
-	// Close the epoll so that if the run loop is waiting on an event, it will
-	// return an error.
-	err1 := l.poll.Close()
-
 	// Closing the notify file signals to the kernel that the listener is
 	// disconnecting, so the kernel will send back denials or pass requests
-	// on to other listeners which connect.
-	err2 := l.notifyFile.Close()
+	// on to other listeners which connect. Do this before closing the epoll
+	// instance so that the kernel does not try to send any further messages
+	// which won't be received.
+	err1 := l.notifyFile.Close()
+
+	// Close the epoll so that if the run loop is waiting on an event, it will
+	// return an error.
+	err2 := l.poll.Close()
 	if err1 != nil {
 		return err1
 	}

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -96,7 +96,7 @@ func (r *Request) Reply(allowedPermission notify.AppArmorPermission) error {
 
 	resp := notify.BuildResponse(r.listener.protocolVersion, r.ID, r.AaAllowed, r.Permission, allowedPermission)
 
-	return encodeAndSendResponse(r.listener, &resp)
+	return encodeAndSendResponse(r.listener, resp)
 }
 
 func expectedResponseTypeForClass(class notify.MediationClass) string {

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -210,18 +210,18 @@ func (l *Listener) Close() error {
 		return ErrAlreadyClosed
 	}
 
-	// Close the close channel so that the the run loop knows to stop trying
-	// to send requests over the request channel, and so that once the epoll
-	// FD is closed (causing the syscall to error), it can check the closeChan
-	// to see whether Close was called or whether a real error occurred.
-	close(l.closeChan)
-
 	// Closing the notify file signals to the kernel that the listener is
 	// disconnecting, so the kernel will send back denials or pass requests
 	// on to other listeners which connect. Do this before closing the epoll
 	// instance so that the kernel does not try to send any further messages
 	// which won't be received.
 	err1 := l.notifyFile.Close()
+
+	// Close the close channel so that the the run loop knows to stop trying
+	// to send requests over the request channel, and so that once the epoll
+	// FD is closed (causing the syscall to error), it can check the closeChan
+	// to see whether Close was called or whether a real error occurred.
+	close(l.closeChan)
 
 	// Close the epoll so that if the run loop is waiting on an event, it will
 	// return an error.

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -56,7 +56,7 @@ type Request struct {
 	// ID is the unique ID of the message notification associated with the request.
 	ID uint64
 	// PID is the identifier of the process which triggered the request.
-	PID uint32
+	PID int32
 	// Label is the apparmor label on the process which triggered the request.
 	Label string
 	// SubjectUID is the UID of the subject which triggered the request.

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -248,6 +248,8 @@ var exitOnError = false
 func (l *Listener) Run() error {
 	var err error
 	l.once.Do(func() {
+		// Run should only be called once, so this once.Do is really only an
+		// extra precaution to ensure that l.reqs is only closed once.
 		defer func() {
 			// When listener run loop ends, close the requests channel.
 			close(l.reqs)
@@ -255,7 +257,7 @@ func (l *Listener) Run() error {
 		for {
 			err = l.handleRequests()
 			if err != nil {
-				if err == ErrClosed {
+				if errors.Is(err, ErrClosed) {
 					// Don't treat the listener closing as a real error
 					err = nil
 					return

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -399,20 +399,20 @@ func parseMsgNotificationFile(buf []byte) (*notify.MsgNotificationFile, error) {
 }
 
 func (l *Listener) newRequest(msg notify.MsgNotificationGeneric) (*Request, error) {
-	aaAllowed, aaDenied, err := msg.MsgAllowedDeniedPermissions()
+	aaAllowed, aaDenied, err := msg.AllowedDeniedPermissions()
 	if err != nil {
 		return nil, err
 	}
 	return &Request{
-		ID:       msg.MsgID(),
+		ID:       msg.ID(),
 		Listener: l,
 
-		PID:        msg.MsgPID(),
-		Label:      msg.MsgLabel(),
-		SubjectUID: msg.MsgSUID(),
+		PID:        msg.PID(),
+		Label:      msg.ProcessLabel(),
+		SubjectUID: msg.SubjectUID(),
 
-		Path:       msg.MsgName(),
-		Class:      msg.MsgClass(),
+		Path:       msg.Name(),
+		Class:      msg.MediationClass(),
 		Permission: aaDenied, // Request permissions which were initially denied
 		AaAllowed:  aaAllowed,
 	}, nil

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -26,9 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync/atomic"
-
-	"gopkg.in/tomb.v2"
+	"sync"
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/epoll"
@@ -40,16 +38,8 @@ var (
 	// ErrClosed indicates that the listener has been closed.
 	ErrClosed = errors.New("listener has been closed")
 
-	// ErrAlreadyRun indicates that the Run() method has already been run.
-	// Each listener must only be run once, so that spawned goroutines can
-	// be safely tracked and terminated.
-	ErrAlreadyRun = errors.New("listener has already been run")
-
 	// ErrAlreadyClosed indicates that the listener has previously been closed.
 	ErrAlreadyClosed = errors.New("listener has already been closed")
-
-	// ErrAlreadyReplied indicates that the request has already received a reply.
-	ErrAlreadyReplied = errors.New("request has already received a reply")
 
 	// ErrNotSupported indicates that the kernel does not support apparmor prompting.
 	ErrNotSupported = errors.New("kernel does not support apparmor notifications")
@@ -61,8 +51,13 @@ var (
 
 // Request is a high-level representation of an apparmor prompting message.
 //
-// Each request must be replied to by writing a boolean to the YesNo channel.
+// A request must be replied to via its Reply method.
 type Request struct {
+	// ID is the unique ID of the message notification associated with the request.
+	ID uint64
+	// Listener is a pointer to the Listener which will handle the reply.
+	Listener *Listener
+
 	// PID is the identifier of the process which triggered the request.
 	PID uint32
 	// Label is the apparmor label on the process which triggered the request.
@@ -76,46 +71,14 @@ type Request struct {
 	Class notify.MediationClass
 	// Permission is the opaque permission that is being requested.
 	Permission notify.AppArmorPermission
-
-	// replyChan is a channel for sending the explicitly allowed permissions.
-	replyChan chan notify.AppArmorPermission
-	// replied indicates whether a reply has already been sent for this request.
-	replied uint32
+	// AaAllowed is the opaque permission mask which was already allowed by
+	// AppArmor rules.
+	AaAllowed notify.AppArmorPermission
 }
 
-func newRequest(msg *notify.MsgNotificationFile) (*Request, error) {
-	var perm notify.AppArmorPermission
-	switch msg.Class {
-	case notify.AA_CLASS_FILE:
-		// DecodeFilePermissions returns:
-		// 1. allow: the permissions which were already allowed by AppArmor profile
-		// 2. deny:  the permissions which were not already allowed by AppArmor profile
-		// 3. err:   an error if the message was not a file permission request
-		_, missingPerms, err := msg.DecodeFilePermissions()
-		if err != nil {
-			return nil, err
-		}
-		// Treat denied permissions as the remaining permissions to request
-		// from the user.
-		perm = missingPerms
-	default:
-		return nil, fmt.Errorf("unsupported mediation class: %v", msg.Class)
-	}
-	return &Request{
-		PID:        msg.Pid,
-		Label:      msg.Label,
-		SubjectUID: msg.SUID,
-
-		Path:       msg.Name,
-		Class:      msg.Class,
-		Permission: perm,
-
-		replyChan: make(chan notify.AppArmorPermission, 1),
-	}, nil
-}
-
-// Reply tells the listener to send back a response to the kernel allowing any
-// of the given permissions which were originally requested.
+// Reply validates that the given permission is of the appropriate type for
+// the mediation class associated with the request, and then constructs a
+// response which allows those permissions and sends it to the kernel.
 func (r *Request) Reply(allowedPermission notify.AppArmorPermission) error {
 	var ok bool
 	switch r.Class {
@@ -130,11 +93,10 @@ func (r *Request) Reply(allowedPermission notify.AppArmorPermission) error {
 		expectedType := expectedResponseTypeForClass(r.Class)
 		return fmt.Errorf("invalid reply: response permission must be of type %s", expectedType)
 	}
-	if !atomic.CompareAndSwapUint32(&r.replied, 0, 1) {
-		return ErrAlreadyReplied
-	}
-	r.replyChan <- allowedPermission
-	return nil
+
+	resp := notify.BuildResponse(r.Listener.protocolVersion, r.ID, r.AaAllowed, r.Permission, allowedPermission)
+
+	return encodeAndSendResponse(r.Listener, &resp)
 }
 
 func expectedResponseTypeForClass(class notify.MediationClass) string {
@@ -151,8 +113,12 @@ func expectedResponseTypeForClass(class notify.MediationClass) string {
 // Listener encapsulates a loop for receiving apparmor notification requests
 // and responding with notification responses, hiding the low-level details.
 type Listener struct {
-	// reqs is a channel with incoming requests. Each request is asynchronous
-	// and needs to be replied to.
+	// once ensures that the Run method is only run once, to avoid closing
+	// a channel multiple times
+	once sync.Once
+
+	// reqs is a channel over which to send requests to the manager.
+	// Only the main run loop may close this channel.
 	reqs chan *Request
 
 	// protocolVersion is the notification protocol version associated with the
@@ -161,27 +127,14 @@ type Listener struct {
 	// socket.
 	protocolVersion notify.ProtocolVersion
 
+	// socketMu guards the notify file, the epoll instance, and the close chan.
+	socketMu   sync.Mutex
 	notifyFile *os.File
 	poll       *epoll.Epoll
-
-	tomb tomb.Tomb
-
-	// status keeps track of whether the listener has been run and/or closed,
-	// both to ensure that Run() and Close() are executed at most once each,
-	// and to ensure that the listener cannot be run after it has been closed.
-	// Must be read/modified atomically, and can only be changed in one of the
-	// following ways:
-	// - statusReady -> statusRunning
-	// - statusReady -> statusClosed
-	// - statusRunning -> statusClosed
-	status uint32
+	// closeChan will be closed by Close to indicate to the run loop that the
+	// listener should be closed.
+	closeChan chan struct{}
 }
-
-const (
-	statusReady uint32 = iota
-	statusRunning
-	statusClosed
-)
 
 // Register opens and configures the apparmor notification interface.
 //
@@ -224,41 +177,49 @@ func Register() (listener *Listener, err error) {
 	}
 
 	listener = &Listener{
-		reqs: make(chan *Request, 1),
+		reqs: make(chan *Request),
 
 		protocolVersion: protoVersion,
 
 		notifyFile: notifyFile,
 		poll:       poll,
+		closeChan:  make(chan struct{}),
 	}
 	return listener, nil
 }
 
+// isClosed returns true if the listener has been closed.
+//
+// Any caller which must ensure that a Close is not in progress should hold the
+// lock while checking isClosed, and continue to hold the lock until it is safe
+// for Close to be run.
+func (l *Listener) isClosed() bool {
+	select {
+	case <-l.closeChan:
+		return true
+	default:
+		return false
+	}
+}
+
 // Close stops the listener and closes the kernel communication file.
-// Returns once all waiting goroutines terminate and the communication file
-// is closed.
 func (l *Listener) Close() error {
-	origStatus := atomic.SwapUint32(&l.status, statusClosed)
-	switch origStatus {
-	case statusReady:
-		// A goroutine was never spawned with the listener tomb.
-		// Spawn one, so the tomb can die.
-		l.tomb.Go(func() error {
-			<-l.tomb.Dying()
-			return nil
-		})
-	case statusRunning:
-	case statusClosed:
-		l.tomb.Wait()
+	l.socketMu.Lock()
+	defer l.socketMu.Unlock()
+	if l.isClosed() {
 		return ErrAlreadyClosed
 	}
-	l.tomb.Kill(ErrClosed)
-	// Close epoll instance to stop the run loop waiting on epoll events
+
+	// Close the close channel so that the the run loop knows to stop trying
+	// to send requests over the request channel, and so that once the epoll
+	// FD is closed (causing the syscall to error), it can check the closeChan
+	// to see whether Close was called or whether a real error occurred.
+	close(l.closeChan)
+
+	// Close the epoll so that if the run loop is waiting on an event, it will
+	// return an error.
 	err1 := l.poll.Close()
-	// Wait for main run loop and waiters to terminate
-	l.tomb.Wait()
-	// l.reqs is only written to by run loop, so it's now safe to close
-	close(l.reqs)
+
 	// Closing the notify file signals to the kernel that the listener is
 	// disconnecting, so the kernel will send back denials or pass requests
 	// on to other listeners which connect.
@@ -281,52 +242,32 @@ var exitOnError = false
 
 // Run reads and dispatches kernel requests until the listener is closed.
 //
-// Run should only be called once per listener object. If called more than once,
-// Run returns an error. Otherwise, waits until the listener stops, and returns
-// the cause as an error. If the listener was intentionally stopped via the
-// Close() method, returns nil.
+// Run should only be called once per listener object, and it runs until the
+// listener is closed or errors (if exitOnError is true), and returns the cause.
+// If the listener was intentionally stopped via the Close() method, returns nil.
 func (l *Listener) Run() error {
-	if !atomic.CompareAndSwapUint32(&l.status, statusReady, statusRunning) {
-		currStatus := atomic.LoadUint32(&l.status)
-		switch currStatus {
-		case statusRunning:
-			return ErrAlreadyRun
-		case statusClosed:
-			return ErrAlreadyClosed
-		default:
-			return fmt.Errorf("listener has unexpected status: %d", currStatus)
-		}
-	}
-	// This is the first and only time calling Run().
-	// Even if Close() kills the tomb before l.tomb.Go() occurs, a panic will
-	// not occur, since this new goroutine will (immediately after l.tomb.Err()
-	// is called) return and close the tomb's dead channel, as it is the last
-	// and only tracked goroutine.
-	l.tomb.Go(func() error {
+	var err error
+	l.once.Do(func() {
+		defer func() {
+			// When listener run loop ends, close the requests channel.
+			close(l.reqs)
+		}()
 		for {
-			if err := l.tomb.Err(); err != tomb.ErrStillAlive {
-				// Do not log error here, as the only error from outside of
-				// runOnce should be when listener was deliberately closed,
-				// and we don't want a log message for that.
-				break
-			}
-			err := l.runOnce()
+			err = l.runOnce()
 			if err != nil {
-				if exitOnError {
-					return err
-				} else {
-					logger.Noticef("error in prompting listener run loop: %v", err)
+				if err == ErrClosed {
+					// Don't treat the listener closing as a real error
+					err = nil
+					return
+				} else if exitOnError {
+					l.Close() // make sure Close is called at least once
+					return
 				}
+				logger.Noticef("error in prompting listener run loop: %v", err)
 			}
 		}
-		return nil
 	})
-	// Wait for an error to occur or the listener to be explicitly closed.
-	<-l.tomb.Dying()
-	// Close the listener, in case an internal error occurred and Close()
-	// was not explicitly called.
-	l.Close()
-	return l.tomb.Err()
+	return err
 }
 
 var listenerEpollWait = func(l *Listener) ([]epoll.Event, error) {
@@ -336,12 +277,21 @@ var listenerEpollWait = func(l *Listener) ([]epoll.Event, error) {
 func (l *Listener) runOnce() error {
 	events, err := listenerEpollWait(l)
 	if err != nil {
-		// If epoll instance is closed, then tomb error status has already
-		// been set. Otherwise, this is a true error. Either way, return it.
+		// The epoll syscall returned an error, so let's see whether it was
+		// because we closed the epoll FD.
+		if l.isClosed() {
+			return ErrClosed
+		}
 		return err
 	}
+
+	// Get the socket FD with the lock held, so we don't break our contract
+	l.socketMu.Lock()
+	socketFd := int(l.notifyFile.Fd())
+	l.socketMu.Unlock() // unlock immediately, we'll lock again later if needed
+
 	for _, event := range events {
-		if event.Fd != int(l.notifyFile.Fd()) {
+		if event.Fd != socketFd {
 			logger.Debugf("unexpected event from fd %v (%v)", event.Fd, event.Readiness)
 			continue
 		}
@@ -352,10 +302,8 @@ func (l *Listener) runOnce() error {
 		// maximum allowed size and will contain one or more kernel requests
 		// upon return.
 		ioctlBuf := notify.NewIoctlRequestBuffer()
-		buf, err := notifyIoctl(l.notifyFile.Fd(), notify.APPARMOR_NOTIF_RECV, ioctlBuf)
+		buf, err := l.doIoctl(notify.APPARMOR_NOTIF_RECV, ioctlBuf)
 		if err != nil {
-			// If epoll instance is closed, then tomb error status has already
-			// been set. Otherwise, this is a true error. Either way, return it.
 			return err
 		}
 		if err := l.decodeAndDispatchRequest(buf); err != nil {
@@ -365,6 +313,22 @@ func (l *Listener) runOnce() error {
 	return nil
 }
 
+// doIoctl locks the mutex guarding the notify socket, checks whether the
+// listener is being closed, and if not, sends an ioctl request with the given
+// request type and buffer.
+func (l *Listener) doIoctl(sendOrRecv notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+	l.socketMu.Lock()
+	defer l.socketMu.Unlock()
+	if l.isClosed() {
+		return nil, ErrClosed
+	}
+	return notifyIoctl(l.notifyFile.Fd(), sendOrRecv, buf)
+}
+
+// decodeAndDispatchRequest reads all messages from the given buffer, decodes
+// each one into a message notification for a particular mediation class,
+// creates a Request from that message, and attempts to send it to the manager
+// via the request channel.
 func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 	for {
 		first, rest, err := notify.ExtractFirstMsg(buf)
@@ -378,7 +342,7 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 		if nmsg.Version != l.protocolVersion {
 			return fmt.Errorf("unexpected protocol version: listener registered with %d, but received %d", l.protocolVersion, nmsg.Version)
 		}
-		// What kind of notification message did we get?
+		// What kind of notification message did we get? (I hope it's an Op)
 		if nmsg.NotificationType != notify.APPARMOR_NOTIF_OP {
 			return fmt.Errorf("unsupported notification type: %v", nmsg.NotificationType)
 		}
@@ -386,15 +350,38 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 		if err := omsg.UnmarshalBinary(first); err != nil {
 			return err
 		}
+
+		var msg notify.MsgNotificationGeneric
 		// What kind of operation notification did we get?
 		switch omsg.Class {
 		case notify.AA_CLASS_FILE:
-			if err := l.handleRequestAaClassFile(first); err != nil {
-				return err
-			}
+			msg, err = parseMsgNotificationFile(first)
 		default:
 			return fmt.Errorf("unsupported mediation class: %v", omsg.Class)
 		}
+		if err != nil {
+			return err
+		}
+
+		// Build request
+		req, err := l.newRequest(msg)
+		if err != nil {
+			return err
+		}
+
+		// Try to send request to manager, or wait for listener to be closed
+		select {
+		case l.reqs <- req:
+			// request received
+		case <-l.closeChan:
+			// XXX: since returning an error causes the request channel to be
+			// closed, the request we received from the kernel will not be
+			// delivered to the manager. It will appear to the kernel that we
+			// have received and processed the request, when in reality, we
+			// have not.
+			return ErrClosed
+		}
+
 		if len(rest) == 0 {
 			return nil
 		}
@@ -402,73 +389,33 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 	}
 }
 
-func (l *Listener) handleRequestAaClassFile(buf []byte) error {
+func parseMsgNotificationFile(buf []byte) (*notify.MsgNotificationFile, error) {
 	var fmsg notify.MsgNotificationFile
 	if err := fmsg.UnmarshalBinary(buf); err != nil {
-		return err
+		return nil, err
 	}
-	logger.Debugf("received prompt request from the kernel: %+v", fmsg)
-	req, err := newRequest(&fmsg)
-	if err != nil {
-		return err
-	}
-	select {
-	case l.reqs <- req:
-		// request received
-	case <-l.tomb.Dying():
-		return l.tomb.Err()
-	}
-	l.tomb.Go(func() error {
-		err := l.waitAndRespondAaClassFile(req, &fmsg)
-		if err != nil {
-			logger.Noticef("error while responding to kernel: %v", err)
-		}
-		return nil
-	})
-	return nil
+	logger.Debugf("received file request from the kernel: %+v", fmsg)
+	return &fmsg, nil
 }
 
-func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotificationFile) error {
-	resp := notify.ResponseForRequest(&msg.MsgNotification)
-	resp.Version = l.protocolVersion
-	resp.MsgNotification.Error = 0 // ignored in responses
-	resp.MsgNotification.NoCache = 1
-
-	var explicitlyAllowed uint32 = 0
-	select {
-	case responsePermission := <-req.replyChan:
-		if responsePermission == nil {
-			// Treat nil as allowing no permission
-			break
-		}
-		perms, ok := responsePermission.(notify.FilePermission)
-		if !ok {
-			// should not occur, Reply() checks that type is correct
-			logger.Debugf("invalid reply from client: %+v; denying request", responsePermission)
-			break
-		}
-		explicitlyAllowed = perms.AsAppArmorOpMask()
-	case <-l.tomb.Dying():
-		// don't bother sending deny response, kernel will auto-deny if needed
-		return nil
+func (l *Listener) newRequest(msg notify.MsgNotificationGeneric) (*Request, error) {
+	aaAllowed, aaDenied, err := msg.MsgAllowedDeniedPermissions()
+	if err != nil {
+		return nil, err
 	}
+	return &Request{
+		ID:       msg.MsgID(),
+		Listener: l,
 
-	// If the same permission appears in both the allow and deny fields,
-	// treat it as initially denied.
-	apparmorAllowed := msg.Allow &^ msg.Deny
+		PID:        msg.MsgPID(),
+		Label:      msg.MsgLabel(),
+		SubjectUID: msg.MsgSUID(),
 
-	// Allow permissions which AppArmor initially allowed, along with those
-	// which the were initially denied but the user explicitly allowed.
-	resp.Allow = apparmorAllowed | (explicitlyAllowed & msg.Deny)
-	// Deny permissions which were initially denied and not explicitly allowed
-	// by the user.
-	resp.Deny = msg.Deny &^ explicitlyAllowed
-	// Any permissions which are omitted from both the allow and deny
-	// fields will be default denied by the kernel.
-	resp.Error = 0
-
-	logger.Debugf("sending request response back to the kernel: %+v", resp)
-	return encodeAndSendResponse(l, &resp)
+		Path:       msg.MsgName(),
+		Class:      msg.MsgClass(),
+		Permission: aaDenied, // Request permissions which were initially denied
+		AaAllowed:  aaAllowed,
+	}, nil
 }
 
 var encodeAndSendResponse = func(l *Listener, resp *notify.MsgNotificationResponse) error {
@@ -481,6 +428,6 @@ func (l *Listener) encodeAndSendResponse(resp *notify.MsgNotificationResponse) e
 		return err
 	}
 	ioctlBuf := notify.IoctlRequestBuffer(buf)
-	_, err = notifyIoctl(l.notifyFile.Fd(), notify.APPARMOR_NOTIF_SEND, ioctlBuf)
+	_, err = l.doIoctl(notify.APPARMOR_NOTIF_SEND, ioctlBuf)
 	return err
 }

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -77,7 +77,7 @@ func (*listenerSuite) TestReply(c *C) {
 	)
 
 	restore := listener.MockEncodeAndSendResponse(func(l *listener.Listener, resp *notify.MsgNotificationResponse) error {
-		c.Check(resp.ID, Equals, id)
+		c.Check(resp.Id, Equals, id)
 		c.Check(resp.Version, Equals, version)
 		c.Check(resp.Allow, Equals, uint32(0b1011))
 		c.Check(resp.Deny, Equals, uint32(0b0100))
@@ -102,7 +102,7 @@ func (*listenerSuite) TestReplyNil(c *C) {
 	)
 
 	restore := listener.MockEncodeAndSendResponse(func(l *listener.Listener, resp *notify.MsgNotificationResponse) error {
-		c.Check(resp.ID, Equals, id)
+		c.Check(resp.Id, Equals, id)
 		c.Check(resp.Version, Equals, version)
 		c.Check(resp.Allow, Equals, aaAllow.AsAppArmorOpMask())
 		c.Check(resp.Deny, Equals, aaDeny.AsAppArmorOpMask())
@@ -271,7 +271,7 @@ func (*listenerSuite) TestReplyPermissions(c *C) {
 		},
 	} {
 		restore := listener.MockEncodeAndSendResponse(func(l *listener.Listener, resp *notify.MsgNotificationResponse) error {
-			c.Check(resp.ID, Equals, id)
+			c.Check(resp.Id, Equals, id)
 			c.Check(resp.Version, Equals, version)
 			c.Check(resp.Allow, Equals, testCase.respAllow, Commentf("testCase: %+v", testCase))
 			c.Check(resp.Deny, Equals, testCase.respDeny, Commentf("testCase: %+v", testCase))
@@ -427,7 +427,7 @@ type msgNotificationFile struct {
 	NotificationType notify.NotificationType
 	Signalled        uint8
 	NoCache          uint8
-	ID               uint64
+	Id               uint64
 	Error            int32
 	// msgNotificationOpKernel
 	Allow uint32
@@ -437,9 +437,9 @@ type msgNotificationFile struct {
 	Class uint16
 	Op    uint16
 	// msgNotificationFileKernel
-	SUID uint32
-	OUID uint32
-	Name uint32
+	SUID     uint32
+	OUID     uint32
+	Filename uint32
 	// msgNotificationFileKernel version 5+
 	Tags         uint32
 	TagsetsCount uint16
@@ -449,7 +449,7 @@ func (msg *msgNotificationFile) MarshalBinary(c *C) []byte {
 	// Check that all the variable-length fields are 0, since we're not packing
 	// strings at the end of the message.
 	c.Assert(msg.Label, Equals, uint32(0))
-	c.Assert(msg.Name, Equals, uint32(0))
+	c.Assert(msg.Filename, Equals, uint32(0))
 	c.Assert(msg.Tags, Equals, uint32(0))
 
 	msgBuf := bytes.NewBuffer(make([]byte, 0, msg.Length))
@@ -850,14 +850,14 @@ func newMsgNotificationFile(protocolVersion notify.ProtocolVersion, id uint64, l
 	msg.Version = protocolVersion
 	msg.NotificationType = notify.APPARMOR_NOTIF_OP
 	msg.NoCache = 1
-	msg.ID = id
+	msg.Id = id
 	msg.Allow = allow
 	msg.Deny = deny
 	msg.Pid = 1234
 	msg.Label = label
 	msg.Class = notify.AA_CLASS_FILE
 	msg.SUID = 1000
-	msg.Name = name
+	msg.Filename = name
 	return &msg
 }
 
@@ -869,7 +869,7 @@ func newMsgNotificationResponse(protocolVersion notify.ProtocolVersion, id uint6
 		MsgHeader:        msgHeader,
 		NotificationType: notify.APPARMOR_NOTIF_RESP,
 		NoCache:          1,
-		ID:               id,
+		Id:               id,
 		Error:            0,
 	}
 	resp := notify.MsgNotificationResponse{
@@ -1110,7 +1110,7 @@ func (*listenerSuite) TestRunConcurrency(c *C) {
 		id := uint64(0)
 		for {
 			id += 1
-			msg.ID = id
+			msg.Id = id
 			buf, err := msg.MarshalBinary()
 			c.Assert(err, IsNil)
 			select {

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -11,12 +11,12 @@ import (
 
 var ErrVersionUnset = errors.New("cannot marshal message without protocol version")
 
-// MsgNotificationGeneric define the methods which the message types for each
+// MsgNotificationGeneric defines the methods which the message types for each
 // mediation class must provide.
 //
 // Many of these methods, including ID, PID, ProcessLabel, and MediationClass,
 // are implemented on MsgNotificationOp, so any struct which embeds a
-// MsgNotificationOp need only implement the remaining methods.
+// MsgNotificationOp needs only to implement the remaining methods.
 type MsgNotificationGeneric interface {
 	// ID returns the unique ID of the notification message.
 	ID() uint64

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -21,7 +21,7 @@ type MsgNotificationGeneric interface {
 	// ID returns the unique ID of the notification message.
 	ID() uint64
 	// PID returns the PID of the process triggering the notification.
-	PID() uint32
+	PID() int32
 	// ProcessLabel returns the AppArmor label of the process triggering the notification.
 	ProcessLabel() string
 	// MediationClass returns the mediation class of the message.
@@ -412,7 +412,7 @@ type msgNotificationOpKernel struct {
 	MsgNotification
 	Allow uint32
 	Deny  uint32
-	Pid   uint32
+	Pid   int32
 	Label uint32
 	Class uint16
 	Op    uint16
@@ -434,7 +434,7 @@ type MsgNotificationOp struct {
 	// the mediation class is AA_CLASS_FILE.
 	Deny uint32
 	// Pid of the process triggering the notification.
-	Pid uint32
+	Pid int32
 	// Label is the apparmor label of the process triggering the notification.
 	Label string
 	// Class of the mediation operation.
@@ -507,7 +507,7 @@ func (msg *MsgNotificationOp) ID() uint64 {
 	return msg.Id
 }
 
-func (msg *MsgNotificationOp) PID() uint32 {
+func (msg *MsgNotificationOp) PID() int32 {
 	return msg.Pid
 }
 

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -346,7 +346,7 @@ type MsgNotificationResponse struct {
 }
 
 // BuildResponse returns a MsgNotificationResponse with the given information.
-func BuildResponse(version ProtocolVersion, id uint64, initiallyAllowed, requested, explicitlyAllowed AppArmorPermission) MsgNotificationResponse {
+func BuildResponse(version ProtocolVersion, id uint64, initiallyAllowed, requested, explicitlyAllowed AppArmorPermission) *MsgNotificationResponse {
 	aaDenyMask := requested.AsAppArmorOpMask()
 	// If permission was originally both allowed and denied in the message,
 	// treat it as initially denied.
@@ -367,7 +367,7 @@ func BuildResponse(version ProtocolVersion, id uint64, initiallyAllowed, request
 	// Any permissions which are omitted from both the allow and deny fields
 	// will be default denied by the kernel.
 
-	return MsgNotificationResponse{
+	return &MsgNotificationResponse{
 		MsgNotification: MsgNotification{
 			MsgHeader: MsgHeader{
 				Version: version,

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -11,6 +11,32 @@ import (
 
 var ErrVersionUnset = errors.New("cannot marshal message without protocol version")
 
+// MsgNotificationGeneric define the methods which the message types for each
+// mediation class must provide.
+//
+// Many of these methods, including ID, PID, ProcessLabel, and MediationClass,
+// are implemented on MsgNotificationOp, so any struct which embeds a
+// MsgNotificationOp need only implement the remaining methods.
+type MsgNotificationGeneric interface {
+	// ID returns the unique ID of the notification message.
+	ID() uint64
+	// PID returns the PID of the process triggering the notification.
+	PID() uint32
+	// ProcessLabel returns the AppArmor label of the process triggering the notification.
+	ProcessLabel() string
+	// MediationClass returns the mediation class of the message.
+	MediationClass() MediationClass
+
+	// AllowedDeniedPermissions returns the AppArmor permission masks which
+	// were originally allowed and originally denied by AppArmor rules.
+	AllowedDeniedPermissions() (AppArmorPermission, AppArmorPermission, error)
+	// SubjectUID returns the UID of the user triggering the notification.
+	SubjectUID() uint32
+	// Name is the identifier of the resource to which access is requested.
+	// For mediation class file, Name is the filepath of the requested file.
+	Name() string
+}
+
 // Message fields are defined as raw sized integer types as the same type may be
 // packed as 16 bit or 32 bit integer, to accommodate other fields in the
 // structure.
@@ -491,39 +517,6 @@ func (msg *MsgNotificationOp) ProcessLabel() string {
 
 func (msg *MsgNotificationOp) MediationClass() MediationClass {
 	return msg.Class
-}
-
-// MsgNotificationGeneric define the methods which the message types for each
-// mediation class must provide.
-//
-// Many (but not all) of these methods are implemented on MsgNotificationOp, so
-// any struct which embeds a MsgNotificationOp need only implement the methods
-// which are specific to the mediation class associated with that message type.
-type MsgNotificationGeneric interface {
-	// The following methods are implemented on MsgNotificationOp, and thus need
-	// not be implemented on any type which embeds a MsgNotificationOp.
-
-	// ID returns the unique ID of the notification message.
-	ID() uint64
-	// PID returns the PID of the process triggering the notification.
-	PID() uint32
-	// ProcessLabel returns the AppArmor label of the process triggering the notification.
-	ProcessLabel() string
-	// MediationClass returns the mediation class of the message.
-	MediationClass() MediationClass
-
-	// The following methods must be implemented on each mediation class-specific
-	// message type which embeds a MsgNotificationOp in order for that message
-	// type to implement MsgNotificationGeneric.
-
-	// AllowedDeniedPermissions returns the AppArmor permission masks which
-	// were originally allowed and originally denied by AppArmor rules.
-	AllowedDeniedPermissions() (AppArmorPermission, AppArmorPermission, error)
-	// SubjectUID returns the UID of the user triggering the notification.
-	SubjectUID() uint32
-	// Name is the identifier of the resource to which access is requested.
-	// For mediation class file, Name is the filepath of the requested file.
-	Name() string
 }
 
 // msgNotificationFileKernelBase (protocol version <5)

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -415,7 +415,7 @@ func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
 		NotificationType: notify.APPARMOR_NOTIF_RESP,
 		Signalled:        1,
 		NoCache:          0,
-		ID:               0x1234,
+		Id:               0x1234,
 		Error:            0xFF,
 	}
 	msg.Version = notify.ProtocolVersion(0xAA)
@@ -454,7 +454,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 		0x0, 0x0, // Op - ???
 		0x0, 0x0, 0x0, 0x0, // SUID
 		0x0, 0x0, 0x0, 0x0, // OUID
-		0x40, 0x0, 0x0, 0x0, // Name at +64 bytes into buffer
+		0x40, 0x0, 0x0, 0x0, // Filename at +64 bytes into buffer
 		0x74, 0x65, 0x73, 0x74, 0x2d, 0x70, 0x72, 0x6f, 0x6d, 0x70, 0x74, 0x0, // "test-prompt\0"
 		0x2f, 0x72, 0x6f, 0x6f, 0x74, 0x2f, 0x2e, 0x73, 0x73, 0x68, 0x2f, 0x0, // "/root/.ssh/\0"
 	}
@@ -471,7 +471,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 					Version: 3,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 4,
@@ -480,7 +480,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 			Label: "test-prompt",
 			Class: notify.AA_CLASS_FILE,
 		},
-		Name: "/root/.ssh/",
+		Filename: "/root/.ssh/",
 	}
 	c.Assert(msg, DeepEquals, expected)
 
@@ -534,7 +534,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C)
 					Version: 5,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 4,
@@ -543,7 +543,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C)
 			Label: "test-prompt",
 			Class: notify.AA_CLASS_FILE,
 		},
-		Name: "/root/.ssh/",
+		Filename: "/root/.ssh/",
 	}
 	c.Assert(msg, DeepEquals, expected)
 
@@ -612,7 +612,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
 					Version: 5,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 0xaaaaaaaa,
@@ -621,9 +621,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
 			Label: "profile",
 			Class: notify.AA_CLASS_FILE,
 		},
-		SUID: 1000,
-		OUID: 1000,
-		Name: "/file",
+		SUID:     1000,
+		OUID:     1000,
+		Filename: "/file",
 		Tagsets: map[notify.AppArmorPermission][]string{
 			notify.FilePermission(0x0103): {
 				"one",
@@ -710,7 +710,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAn
 					Version: 5,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 0xaaaaaaaa,
@@ -719,9 +719,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAn
 			Label: "profile",
 			Class: notify.AA_CLASS_FILE,
 		},
-		SUID: 1000,
-		OUID: 1000,
-		Name: "/file",
+		SUID:     1000,
+		OUID:     1000,
+		Filename: "/file",
 		Tagsets: map[notify.AppArmorPermission][]string{
 			notify.FilePermission(0x01): []string(nil),
 			notify.FilePermission(0x02): {
@@ -932,7 +932,7 @@ func (s *messageSuite) TestBuildResponse(c *C) {
 		c.Check(resp.Version, Equals, protocol)
 		c.Check(resp.NotificationType, Equals, notify.APPARMOR_NOTIF_RESP)
 		c.Check(resp.NoCache, Equals, uint8(1))
-		c.Check(resp.ID, Equals, id)
+		c.Check(resp.Id, Equals, id)
 		c.Check(resp.Allow, Equals, testCase.expectedAllow)
 		c.Check(resp.Deny, Equals, testCase.expectedDeny)
 	}
@@ -950,7 +950,7 @@ func (s *messageSuite) TestMsgNotificationResponseMarshalBinary(c *C) {
 			NotificationType: 0x11,
 			Signalled:        0x22,
 			NoCache:          0x33,
-			ID:               0x44,
+			Id:               0x44,
 			Error:            0x55,
 		},
 		Error: 0x66,
@@ -1001,27 +1001,27 @@ func (*messageSuite) TestDecodeFilePermissionsWrongClass(c *C) {
 
 func (*messageSuite) TestMsgNotificationFileAsGeneric(c *C) {
 	var msg notify.MsgNotificationFile
-	msg.ID = uint64(123)
+	msg.Id = uint64(123)
 	msg.Pid = uint32(456)
 	msg.Label = "hello there"
 	msg.Class = notify.AA_CLASS_FILE
 	msg.Allow = uint32(0xaaaa)
 	msg.Deny = uint32(0xbbbb)
 	msg.SUID = uint32(789)
-	msg.Name = "/foo/bar"
+	msg.Filename = "/foo/bar"
 
-	testMsgNotificationGeneric(c, &msg, msg.ID, msg.Pid, msg.Label, msg.Class, msg.Allow, msg.Deny, msg.SUID, msg.Name)
+	testMsgNotificationGeneric(c, &msg, msg.Id, msg.Pid, msg.Label, msg.Class, msg.Allow, msg.Deny, msg.SUID, msg.Filename)
 }
 
 func testMsgNotificationGeneric(c *C, generic notify.MsgNotificationGeneric, id uint64, pid uint32, label string, class notify.MediationClass, allowed, denied, suid uint32, name string) {
-	c.Check(generic.MsgID(), Equals, id)
-	c.Check(generic.MsgPID(), Equals, pid)
-	c.Check(generic.MsgLabel(), Equals, label)
-	c.Check(generic.MsgClass(), Equals, class)
-	msgAllow, msgDeny, err := generic.MsgAllowedDeniedPermissions()
+	c.Check(generic.ID(), Equals, id)
+	c.Check(generic.PID(), Equals, pid)
+	c.Check(generic.ProcessLabel(), Equals, label)
+	c.Check(generic.MediationClass(), Equals, class)
+	msgAllow, msgDeny, err := generic.AllowedDeniedPermissions()
 	c.Check(err, IsNil)
 	c.Check(msgAllow.AsAppArmorOpMask(), Equals, allowed)
 	c.Check(msgDeny.AsAppArmorOpMask(), Equals, denied)
-	c.Check(generic.MsgSUID(), Equals, suid)
-	c.Check(generic.MsgName(), Equals, name)
+	c.Check(generic.SubjectUID(), Equals, suid)
+	c.Check(generic.Name(), Equals, name)
 }

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -1001,19 +1001,19 @@ func (*messageSuite) TestDecodeFilePermissionsWrongClass(c *C) {
 
 func (*messageSuite) TestMsgNotificationFileAsGeneric(c *C) {
 	var msg notify.MsgNotificationFile
-	msg.Id = uint64(123)
-	msg.Pid = uint32(456)
+	msg.Id = 123
+	msg.Pid = 456
 	msg.Label = "hello there"
 	msg.Class = notify.AA_CLASS_FILE
-	msg.Allow = uint32(0xaaaa)
-	msg.Deny = uint32(0xbbbb)
-	msg.SUID = uint32(789)
+	msg.Allow = 0xaaaa
+	msg.Deny = 0xbbbb
+	msg.SUID = 789
 	msg.Filename = "/foo/bar"
 
 	testMsgNotificationGeneric(c, &msg, msg.Id, msg.Pid, msg.Label, msg.Class, msg.Allow, msg.Deny, msg.SUID, msg.Filename)
 }
 
-func testMsgNotificationGeneric(c *C, generic notify.MsgNotificationGeneric, id uint64, pid uint32, label string, class notify.MediationClass, allowed, denied, suid uint32, name string) {
+func testMsgNotificationGeneric(c *C, generic notify.MsgNotificationGeneric, id uint64, pid int32, label string, class notify.MediationClass, allowed, denied, suid uint32, name string) {
 	c.Check(generic.ID(), Equals, id)
 	c.Check(generic.PID(), Equals, pid)
 	c.Check(generic.ProcessLabel(), Equals, label)

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -412,11 +412,11 @@ func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
 		c.Skip("test only written for little-endian architectures")
 	}
 	msg := notify.MsgNotification{
-		NotificationType: notify.APPARMOR_NOTIF_RESP,
-		Signalled:        1,
-		NoCache:          0,
-		Id:               0x1234,
-		Error:            0xFF,
+		NotificationType:     notify.APPARMOR_NOTIF_RESP,
+		Signalled:            1,
+		NoCache:              0,
+		KernelNotificationID: 0x1234,
+		Error:                0xFF,
 	}
 	msg.Version = notify.ProtocolVersion(0xAA)
 	data, err := msg.MarshalBinary()
@@ -470,9 +470,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 					Length:  76,
 					Version: 3,
 				},
-				NotificationType: notify.APPARMOR_NOTIF_OP,
-				Id:               2,
-				Error:            -13,
+				NotificationType:     notify.APPARMOR_NOTIF_OP,
+				KernelNotificationID: 2,
+				Error:                -13,
 			},
 			Allow: 4,
 			Deny:  4,
@@ -533,9 +533,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C)
 					Length:  82,
 					Version: 5,
 				},
-				NotificationType: notify.APPARMOR_NOTIF_OP,
-				Id:               2,
-				Error:            -13,
+				NotificationType:     notify.APPARMOR_NOTIF_OP,
+				KernelNotificationID: 2,
+				Error:                -13,
 			},
 			Allow: 4,
 			Deny:  4,
@@ -611,9 +611,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
 					Length:  127,
 					Version: 5,
 				},
-				NotificationType: notify.APPARMOR_NOTIF_OP,
-				Id:               2,
-				Error:            -13,
+				NotificationType:     notify.APPARMOR_NOTIF_OP,
+				KernelNotificationID: 2,
+				Error:                -13,
 			},
 			Allow: 0xaaaaaaaa,
 			Deny:  0x55555555,
@@ -709,9 +709,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAn
 					Length:  147,
 					Version: 5,
 				},
-				NotificationType: notify.APPARMOR_NOTIF_OP,
-				Id:               2,
-				Error:            -13,
+				NotificationType:     notify.APPARMOR_NOTIF_OP,
+				KernelNotificationID: 2,
+				Error:                -13,
 			},
 			Allow: 0xaaaaaaaa,
 			Deny:  0x55555555,
@@ -932,7 +932,7 @@ func (s *messageSuite) TestBuildResponse(c *C) {
 		c.Check(resp.Version, Equals, protocol)
 		c.Check(resp.NotificationType, Equals, notify.APPARMOR_NOTIF_RESP)
 		c.Check(resp.NoCache, Equals, uint8(1))
-		c.Check(resp.Id, Equals, id)
+		c.Check(resp.KernelNotificationID, Equals, id)
 		c.Check(resp.Allow, Equals, testCase.expectedAllow)
 		c.Check(resp.Deny, Equals, testCase.expectedDeny)
 	}
@@ -947,11 +947,11 @@ func (s *messageSuite) TestMsgNotificationResponseMarshalBinary(c *C) {
 			MsgHeader: notify.MsgHeader{
 				Version: 43,
 			},
-			NotificationType: 0x11,
-			Signalled:        0x22,
-			NoCache:          0x33,
-			Id:               0x44,
-			Error:            0x55,
+			NotificationType:     0x11,
+			Signalled:            0x22,
+			NoCache:              0x33,
+			KernelNotificationID: 0x44,
+			Error:                0x55,
 		},
 		Error: 0x66,
 		Allow: 0x77,
@@ -1001,7 +1001,7 @@ func (*messageSuite) TestDecodeFilePermissionsWrongClass(c *C) {
 
 func (*messageSuite) TestMsgNotificationFileAsGeneric(c *C) {
 	var msg notify.MsgNotificationFile
-	msg.Id = 123
+	msg.KernelNotificationID = 123
 	msg.Pid = 456
 	msg.Label = "hello there"
 	msg.Class = notify.AA_CLASS_FILE
@@ -1010,7 +1010,7 @@ func (*messageSuite) TestMsgNotificationFileAsGeneric(c *C) {
 	msg.SUID = 789
 	msg.Filename = "/foo/bar"
 
-	testMsgNotificationGeneric(c, &msg, msg.Id, msg.Pid, msg.Label, msg.Class, msg.Allow, msg.Deny, msg.SUID, msg.Filename)
+	testMsgNotificationGeneric(c, &msg, msg.KernelNotificationID, msg.Pid, msg.Label, msg.Class, msg.Allow, msg.Deny, msg.SUID, msg.Filename)
 }
 
 func testMsgNotificationGeneric(c *C, generic notify.MsgNotificationGeneric, id uint64, pid int32, label string, class notify.MediationClass, allowed, denied, suid uint32, name string) {


### PR DESCRIPTION
No more `tomb`, no more waiting goroutines, no more atomics.

The listener run loop is now synchronous, and a `once.Do` ensures that it only runs once, and thus the `reqs` channel is only closed once.

The `Reply` method on `Request` now directly encodes and sends the response to the kernel. As a result, the `Request` struct now contains the ID of the message from which it was derived, a pointer to the listener, and the permission mask which was already allowed by existing AppArmor rules.

A close channel is used to signal to the main loop that the listener has been closed.

A `Mutex` guards the notify file, the epoll instance, and the close channel, ensuring that the listener run loop and any replies cannot race, and that there are no races around checking whether the listener has been closed.

There is a new `MsgNotificationGeneric` interface which the mediation class-specific message structs (e.g. `MsgNotificationFile`) should implement, and which abstracts the behavior required of all mediation classes and means the listener no longer has mediation class-specific functions.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-24605