### PR TITLE
tests: fix not running nested-ubuntu-22.04

### DIFF
--- a/.github/workflows/nested-systems.json
+++ b/.github/workflows/nested-systems.json
@@ -20,7 +20,7 @@
         "group": "nested-ubuntu-22.04",
         "backend": "google-nested",
         "alternative-backend": "google-nested",
-        "systems": "ubuntu-24.04-64",
+        "systems": "ubuntu-22.04-64",
         "tasks": "tests/nested/...",
         "rules": "nested"
       },


### PR DESCRIPTION
Fix small typo that caused never running nested tests on ubuntu-22.04, instead running on 24.04 twice.