### PR TITLE
interfaces/opengl: Fix GLX on NVIDIA when Xorg is confined by AppArmor

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -108,6 +108,10 @@ const openglConnectedPlugAppArmor = `
 @{PROC}/modules r,
 /dev/nvidia* rw,
 unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
+# A socketpair with the NVIDIA DDX is needed for GLX.
+# When Xorg is not confined, then a special-case object delegation allows this automatically.
+# When Xorg is confined, object delegation is not implemented yet and we need a rule on our side to allow this.
+unix (send, receive) type=stream peer=(label="Xorg"),
 # driver profiles
 /usr/share/nvidia/ r,
 /usr/share/nvidia/** r,


### PR DESCRIPTION
> apparmor="DENIED" operation="file_receive" class="net" profile="snap.graphics-test-tools.glxinfo" pid=2801 comm="Xorg" family="unix" sock_type="stream" protocol=0 requested="send receive" denied="send receive" addr=none peer_addr=none peer="Xorg"

Since oracular Xorg has a new AppArmor profile, in complain mode.
The snap's AppArmor profile is now blocking communication on an unnamed stream
socket, breaking GLX on NVIDIA only.

`addr=none, peer_addr=none` is a socket_pair.
`file_receive` indicates one end of the pair is being passed over SCM rights.

The reason there was no denial or message previously, is that unconfined does
object delegation of open descriptors.
Object delegation is not currently available to confined applications (WIP),
so a rule is needed.

Fixes LP#2088456.