### PR TITLE
cmd/snap-confine: handle glibc HWCAPS subdirs

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -22,7 +22,7 @@
     # the .so suffix, eg. ld-linux-aarch64.so.1
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
     # libc, you are funny
-    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,glibc-hwcaps/*/,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libreadline{,-[0-9]*}.so* mr,
     /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}librt{,-[0-9]*}.so* mr,
@@ -514,7 +514,7 @@
         /etc/ld.so.cache r,
         /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
         # libc, you are funny
-        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,glibc-hwcaps/*/,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
         /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
         /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libreadline{,-[0-9]*}.so* mr,
         /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}librt{,-[0-9]*}.so* mr,


### PR DESCRIPTION
Add all known glibc HWCAPS subdirectories to the list of runtime library paths to fix application launch errors like the following:

```
/usr/lib/snapd/snap-confine: error while loading shared libraries: libc.so.6: failed to map segment from shared object
```

As with my 11th Generation Intel laptop, `libc.so.6` matches to:

```
$ ldd /snap/bin/mari0
    linux-vdso.so.1 (0x00007fe51b817000)
    libc.so.6 => /usr/lib/glibc-hwcaps/x86-64-v4/libc.so.6 (0x00007fe51a038000)
    /lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fe51b819000)
```

There are the following known glibc HWCAPS subdirectories:

- /usr/lib/glibc-hwcaps/x86-64-v2
- /usr/lib/glibc-hwcaps/x86-64-v3
- /usr/lib/glibc-hwcaps/x86-64-v4
- /usr/lib/glibc-hwcaps/power9
- /usr/lib/glibc-hwcaps/power10
- /usr/lib/glibc-hwcaps/z13
- /usr/lib/glibc-hwcaps/z14
- /usr/lib/glibc-hwcaps/z15
- /usr/lib/glibc-hwcaps/z16

Handle all above paths to avoid further problems.