### PR TITLE
core-initrd: changelog update after CVM fix

### DIFF
--- a/core-initrd/24.04/debian/changelog
+++ b/core-initrd/24.04/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (69+2.68.2+g116.194fb1d+24.04) noble; urgency=medium
+
+  * Update to snapd version 2.68.2+g116.194fb1d
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Fri, 07 Mar 2025 17:01:51 -0500
+
 ubuntu-core-initramfs (69+2.68.2+24.04) noble; urgency=medium
 
   * Update to snapd version 2.68.2

--- a/core-initrd/24.10/debian/changelog
+++ b/core-initrd/24.10/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (70+2.68.2+g116.194fb1d+24.10) oracular; urgency=medium
+
+  * Update to snapd version 2.68.2+g116.194fb1d
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Fri, 07 Mar 2025 17:02:21 -0500
+
 ubuntu-core-initramfs (70+2.68.2+24.10) oracular; urgency=medium
 
   * Update to snapd version 2.68.2

--- a/core-initrd/latest/debian/changelog
+++ b/core-initrd/latest/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (71+2.68.2+g116.194fb1d+25.04) plucky; urgency=medium
+
+  * Update to snapd version 2.68.2+g116.194fb1d
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Fri, 07 Mar 2025 17:02:35 -0500
+
 ubuntu-core-initramfs (71+2.68.2+25.04) plucky; urgency=medium
 
   * Update to snapd version 2.68.2


### PR DESCRIPTION
New packages had to be uploaded after mreging
https://github.com/canonical/snapd/pull/15168.