### PR TITLE
o/confdbstate: add helper for snapctl confdb load

### DIFF
--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -81,7 +81,7 @@ func (m *ConfdbManager) doCommitTransaction(t *state.Task, _ *tomb.Tomb) (err er
 	st.Lock()
 	defer st.Unlock()
 
-	tx, _, err := GetStoredTransaction(t)
+	tx, _, _, err := GetStoredTransaction(t)
 	if err != nil {
 		return err
 	}
@@ -100,12 +100,12 @@ func (m *ConfdbManager) clearOngoingTransaction(t *state.Task, _ *tomb.Tomb) err
 	st.Lock()
 	defer st.Unlock()
 
-	tx, _, err := GetStoredTransaction(t)
+	tx, txTask, _, err := GetStoredTransaction(t)
 	if err != nil {
 		return err
 	}
 
-	err = unsetOngoingTransaction(st, tx.ConfdbAccount, tx.ConfdbName)
+	err = unsetOngoingTransaction(st, tx.ConfdbAccount, tx.ConfdbName, txTask.ID())
 	if err != nil {
 		return err
 	}
@@ -114,52 +114,109 @@ func (m *ConfdbManager) clearOngoingTransaction(t *state.Task, _ *tomb.Tomb) err
 	return nil
 }
 
-func setOngoingTransaction(st *state.State, account, confdbName, commitTaskID string) error {
-	var commitTasks map[string]string
-	err := st.Get("confdb-commit-tasks", &commitTasks)
-	if err != nil {
-		if !errors.Is(err, &state.NoStateError{}) {
-			return err
-		}
-
-		commitTasks = make(map[string]string, 1)
-	}
-
-	confdbRef := account + "/" + confdbName
-	if taskID, ok := commitTasks[confdbRef]; ok {
-		return fmt.Errorf("internal error: cannot set task %q as ongoing commit task for confdb %s: already have %q", commitTaskID, confdbRef, taskID)
-	}
-
-	commitTasks[confdbRef] = commitTaskID
-	st.Set("confdb-commit-tasks", commitTasks)
-	return nil
+type confdbTransactions struct {
+	ReadTxIDs []string `json:"read-tx-ids,omitempty"`
+	WriteTxID string   `json:"write-tx-id,omitempty"`
 }
 
-func unsetOngoingTransaction(st *state.State, account, confdbName string) error {
-	var commitTasks map[string]string
-	err := st.Get("confdb-commit-tasks", &commitTasks)
+// addReadTransaction adds a read transaction for the specified confdb, if no
+// write transactions is ongoing.
+func addReadTransaction(st *state.State, account, confdbName, id string) error {
+	txs, updateFunc, err := getOngoingTxs(st, account, confdbName)
 	if err != nil {
-		if errors.Is(err, &state.NoStateError{}) {
-			// already unset, nothing to do
-			return nil
-		}
 		return err
 	}
 
-	confdbRef := account + "/" + confdbName
-	if _, ok := commitTasks[confdbRef]; !ok {
-		// already unset, nothing to do
+	if txs == nil {
+		txs = &confdbTransactions{}
+	}
+
+	if txs.WriteTxID != "" {
+		return fmt.Errorf("cannot read confdb (%s/%s): a write transaction is ongoing", account, confdbName)
+	}
+
+	txs.ReadTxIDs = append(txs.ReadTxIDs, id)
+	updateFunc(txs)
+	return nil
+}
+
+// setWriteTransaction sets a write transaction for the specified confdb schema,
+// if no other transactions (read or write) are ongoing.
+func setWriteTransaction(st *state.State, account, schemaName, id string) error {
+	txs, updateFunc, err := getOngoingTxs(st, account, schemaName)
+	if err != nil {
+		return err
+	}
+
+	if txs == nil {
+		txs = &confdbTransactions{}
+	}
+
+	if txs.WriteTxID != "" || len(txs.ReadTxIDs) != 0 {
+		op := "read"
+		if txs.WriteTxID != "" {
+			op = "write"
+		}
+
+		return fmt.Errorf("cannot write confdb (%s/%s): a %s transaction is ongoing", account, schemaName, op)
+	}
+
+	txs.WriteTxID = id
+	updateFunc(txs)
+	return nil
+}
+
+func getOngoingTxs(st *state.State, account, schemaName string) (*confdbTransactions, func(*confdbTransactions), error) {
+	var confdbTxs map[string]*confdbTransactions
+	err := st.Get("confdb-ongoing-txs", &confdbTxs)
+	if err != nil {
+		if !errors.Is(err, &state.NoStateError{}) {
+			return nil, nil, err
+		}
+
+		confdbTxs = make(map[string]*confdbTransactions, 1)
+	}
+
+	ref := account + "/" + schemaName
+	updateFunc := func(ongoingTxs *confdbTransactions) {
+		if ongoingTxs == nil || (ongoingTxs.WriteTxID == "" && len(ongoingTxs.ReadTxIDs) == 0) {
+			delete(confdbTxs, ref)
+		} else {
+			confdbTxs[ref] = ongoingTxs
+		}
+
+		if len(confdbTxs) == 0 {
+			st.Set("confdb-ongoing-txs", nil)
+		} else {
+			st.Set("confdb-ongoing-txs", confdbTxs)
+		}
+	}
+	return confdbTxs[ref], updateFunc, nil
+}
+
+func unsetOngoingTransaction(st *state.State, account, schemaName, id string) error {
+	txs, updateFunc, err := getOngoingTxs(st, account, schemaName)
+	if err != nil {
+		return err
+	}
+
+	if txs == nil {
+		// no ongoing txs, nothing to unset
 		return nil
 	}
 
-	delete(commitTasks, confdbRef)
-
-	if len(commitTasks) == 0 {
-		st.Set("confdb-commit-tasks", nil)
+	if txs.WriteTxID == id {
+		txs.WriteTxID = ""
 	} else {
-		st.Set("confdb-commit-tasks", commitTasks)
+		for i, txID := range txs.ReadTxIDs {
+			if txID == id {
+				txs.ReadTxIDs = append(txs.ReadTxIDs[:i], txs.ReadTxIDs[i+1:]...)
+				break
+			}
+		}
 	}
 
+	updateFunc(txs)
 	return nil
 }
 
@@ -177,7 +234,7 @@ func (h *changeViewHandler) Done() error {
 	defer h.ctx.Unlock()
 
 	t, _ := h.ctx.Task()
-	tx, _, err := GetStoredTransaction(t)
+	tx, _, _, err := GetStoredTransaction(t)
 	if err != nil {
 		return fmt.Errorf("cannot get transaction in change-confdb handler: %v", err)
 	}
@@ -246,7 +303,7 @@ func (h *saveViewHandler) Error(origErr error) (ignoreErr bool, err error) {
 	// save the original error so we can return that once the rollback is done
 	last.Set("original-error", origErr.Error())
 
-	tx, saveChanges, err := GetStoredTransaction(t)
+	tx, _, saveChanges, err := GetStoredTransaction(t)
 	if err != nil {
 		return false, fmt.Errorf("cannot rollback failed save-view: cannot get transaction: %v", err)
 	}

--- a/overlord/confdbstate/confdbmgr_test.go
+++ b/overlord/confdbstate/confdbmgr_test.go
@@ -230,7 +230,7 @@ func (s *hookHandlerSuite) TestSaveViewHookErrorRollsBackSaves(c *C) {
 
 	s.state.Lock()
 	// the transaction has been cleared
-	tx, _, err = confdbstate.GetStoredTransaction(secondTask)
+	tx, _, _, err = confdbstate.GetStoredTransaction(secondTask)
 	c.Assert(err, IsNil)
 	_, err = tx.Get("foo")
 	c.Assert(err, ErrorMatches, "no value was found under path \"foo\"")
@@ -359,43 +359,69 @@ func (s *confdbTestSuite) TestSetAndUnsetOngoingTransactionHelpers(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var commitTasks map[string]string
-	err := s.state.Get("confdb-commit-tasks", &commitTasks)
+	var ongoingTxs map[string]*confdbstate.ConfdbTransactions
+	err := s.state.Get("confdb-ongoing-txs", &ongoingTxs)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 
-	err = confdbstate.SetOngoingTransaction(s.state, "my-acc", "my-confdb", "1")
+	err = confdbstate.SetWriteTransaction(s.state, "my-acc", "my-confdb", "1")
 	c.Assert(err, IsNil)
 
-	// can't overwrite an ongoing commit task, since that could hide errors
-	err = confdbstate.SetOngoingTransaction(s.state, "my-acc", "my-confdb", "3")
-	c.Assert(err, ErrorMatches, `internal error: cannot set task "3" as ongoing commit task for confdb my-acc/my-confdb: already have "1"`)
-
-	err = confdbstate.SetOngoingTransaction(s.state, "other-acc", "other-confdb", "2")
+	err = confdbstate.SetWriteTransaction(s.state, "other-acc", "other-confdb", "2")
 	c.Assert(err, IsNil)
 
-	err = s.state.Get("confdb-commit-tasks", &commitTasks)
+	err = s.state.Get("confdb-ongoing-txs", &ongoingTxs)
 	c.Assert(err, IsNil)
-	c.Assert(commitTasks["my-acc/my-confdb"], Equals, "1")
+	c.Assert(ongoingTxs["my-acc/my-confdb"].WriteTxID, Equals, "1")
 
-	err = confdbstate.UnsetOngoingTransaction(s.state, "my-acc", "my-confdb")
+	err = confdbstate.UnsetOngoingTransaction(s.state, "my-acc", "my-confdb", "1")
 	c.Assert(err, IsNil)
 
 	// unsetting non-existing key is fine
-	err = confdbstate.UnsetOngoingTransaction(s.state, "my-acc", "my-confdb")
+	err = confdbstate.UnsetOngoingTransaction(s.state, "my-acc", "my-confdb", "1")
 	c.Assert(err, IsNil)
 
-	err = s.state.Get("confdb-commit-tasks", &commitTasks)
+	err = s.state.Get("confdb-ongoing-txs", &ongoingTxs)
 	c.Assert(err, IsNil)
-	c.Assert(commitTasks["other-acc/other-confdb"], Equals, "2")
+	c.Assert(ongoingTxs["other-acc/other-confdb"].WriteTxID, Equals, "2")
 
-	err = confdbstate.UnsetOngoingTransaction(s.state, "other-acc", "other-confdb")
+	err = confdbstate.UnsetOngoingTransaction(s.state, "other-acc", "other-confdb", "2")
 	c.Assert(err, IsNil)
 
-	err = s.state.Get("confdb-commit-tasks", &commitTasks)
+	err = s.state.Get("confdb-ongoing-txs", &ongoingTxs)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 
 	// unsetting non-existing key is still fine when there's no map at all
-	err = confdbstate.UnsetOngoingTransaction(s.state, "my-acc", "my-confdb")
+	err = confdbstate.UnsetOngoingTransaction(s.state, "my-acc", "my-confdb", "1")
+	c.Assert(err, IsNil)
+}
+
+func (s *confdbTestSuite) TestConflictingOngoingTransactions(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	err := confdbstate.SetWriteTransaction(s.state, "my-acc", "my-confdb", "1")
+	c.Assert(err, IsNil)
+
+	// can't set write due to ongoing write
+	err = confdbstate.SetWriteTransaction(s.state, "my-acc", "my-confdb", "2")
+	c.Assert(err, ErrorMatches, `cannot write confdb \(my-acc/my-confdb\): a write transaction is ongoing`)
+
+	// can't add read due to ongoing write
+	err = confdbstate.AddReadTransaction(s.state, "my-acc", "my-confdb", "2")
+	c.Assert(err, ErrorMatches, `cannot read confdb \(my-acc/my-confdb\): a write transaction is ongoing`)
+
+	err = confdbstate.UnsetOngoingTransaction(s.state, "my-acc", "my-confdb", "1")
+	c.Assert(err, IsNil)
+
+	err = confdbstate.AddReadTransaction(s.state, "my-acc", "my-confdb", "1")
+	c.Assert(err, IsNil)
+
+	// can't set write due to ongoing read
+	err = confdbstate.SetWriteTransaction(s.state, "my-acc", "my-confdb", "2")
+	c.Assert(err, ErrorMatches, `cannot write confdb \(my-acc/my-confdb\): a read transaction is ongoing`)
+
+	// many reads are fine
+	err = confdbstate.AddReadTransaction(s.state, "my-acc", "my-confdb", "2")
 	c.Assert(err, IsNil)
 }
 
@@ -423,7 +449,7 @@ func (s *confdbTestSuite) TestCommitTransaction(c *C) {
 
 	c.Assert(t.Status(), Equals, state.DoneStatus, Commentf(strings.Join(t.Log(), "\n")))
 
-	tx, _, err = confdbstate.GetStoredTransaction(t)
+	tx, _, _, err = confdbstate.GetStoredTransaction(t)
 	c.Assert(err, IsNil)
 
 	// clearing would remove non-committed changes, so if we read the set value
@@ -453,10 +479,11 @@ func (s *confdbTestSuite) TestClearOngoingTransaction(c *C) {
 	chg.AddTask(t)
 	t.Set("tx-task", commitTask.ID())
 
-	confdbstate.SetOngoingTransaction(s.state, s.devAccID, "network", commitTask.ID())
+	confdbstate.SetWriteTransaction(s.state, s.devAccID, "network", commitTask.ID())
+	c.Assert(err, IsNil)
 
-	var commitTasks map[string]string
-	err = s.state.Get("confdb-commit-tasks", &commitTasks)
+	var confdbTxs map[string]*confdbstate.ConfdbTransactions
+	err = s.state.Get("confdb-ongoing-txs", &confdbTxs)
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()
@@ -465,8 +492,8 @@ func (s *confdbTestSuite) TestClearOngoingTransaction(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(t.Status(), Equals, state.DoneStatus, Commentf(strings.Join(t.Log(), "\n")))
 
-	commitTasks = nil
-	err = s.state.Get("confdb-commit-tasks", &commitTasks)
+	confdbTxs = nil
+	err = s.state.Get("confdb-ongoing-txs", &confdbTxs)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 }
 
@@ -492,7 +519,8 @@ func (s *confdbTestSuite) TestClearTransactionOnError(c *C) {
 	setTransaction(commitTask, tx)
 
 	// add this transaction to the state
-	confdbstate.SetOngoingTransaction(s.state, s.devAccID, "network", commitTask.ID())
+	err = confdbstate.SetWriteTransaction(s.state, s.devAccID, "network", commitTask.ID())
+	c.Assert(err, IsNil)
 
 	s.state.Unlock()
 	err = s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
@@ -505,7 +533,7 @@ func (s *confdbTestSuite) TestClearTransactionOnError(c *C) {
 	c.Assert(strings.Join(commitTask.Log(), "\n"), Matches, ".*ERROR cannot accept top level element: map contains unexpected key \"foo\"")
 
 	// no ongoing confdb transaction
-	var commitTasks map[string]string
-	err = s.state.Get("confdb-commit-tasks", &commitTasks)
+	var ongoingTxs map[string]*confdbstate.ConfdbTransactions
+	err = s.state.Get("confdb-ongoing-txs", &ongoingTxs)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 }

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -530,10 +530,10 @@ func IsConfdbHook(ctx *hookstate.Context) bool {
 			strings.HasSuffix(ctx.HookName(), "-view-changed"))
 }
 
-// LoadConfdbFromSnapctl gets a transaction to read the view's confdb. It schedules
-// tasks to load the confdb as needed, unless no custodian defined relevant hooks.
-// Blocks until the confdb has been loaded into the Transaction. If no tasks need
-// to execute to load the confdb, returns without blocking.
+// GetTransactionForSnapctlGet gets a transaction to read the view's confdb. It
+// schedules tasks to load the confdb as needed, unless no custodian defined
+// relevant hooks. Blocks until the confdb has been loaded into the Transaction.
+// If no tasks need to run to load the confdb, returns without blocking.
 func GetTransactionForSnapctlGet(ctx *hookstate.Context, view *confdb.View) (*Transaction, error) {
 	st := ctx.State()
 	account, schemaName := view.Schema().Account, view.Schema().Name

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/confdb"
@@ -194,12 +195,13 @@ var writeDatabag = func(st *state.State, databag confdb.JSONDatabag, account, db
 
 type CommitTxFunc func() (changeID string, waitChan <-chan struct{}, err error)
 
-// GetTransactionToSet retrieves or creates a transaction to change confdb
-// through the view. The state must be locked by the caller. Takes a hookstate.Context
-// if invoked in a hook. If a new transaction was created, also returns a
-// CommitTxFunc to be called to start committing (which in turn returns a change
-// ID and a wait channel that will be closed on the commit is done). If a transaction
-// already existed, changes to it will be saved on ctx.Done().
+// GetTransactionToSet gets a transaction to change the confdb through the view.
+// The state must be locked by the caller. Returns a transaction through which
+// the confdb can be modified and a CommitTxFunc. The latter is called once the
+// modifications are made to commit them. It will return a changeID and a channel,
+// allowing the caller to block until commit. If a transaction was already ongoing,
+// CommitTxFunc simply returns that without blocking (changes to it will be
+// saved on ctx.Done()).
 func GetTransactionToSet(ctx *hookstate.Context, st *state.State, view *confdb.View) (*Transaction, CommitTxFunc, error) {
 	account, dbSchemaName := view.Schema().Account, view.Schema().Name
 
@@ -208,7 +210,7 @@ func GetTransactionToSet(ctx *hookstate.Context, st *state.State, view *confdb.V
 		// running in the context of a transaction, so if the referenced confdb schema
 		// doesn't match that tx, we only allow the caller to read through the other confdb schema
 		t, _ := ctx.Task()
-		tx, saveTxChanges, err := GetStoredTransaction(t)
+		tx, _, saveTxChanges, err := GetStoredTransaction(t)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot access confdb through view %s/%s/%s: cannot get transaction: %v", account, dbSchemaName, view.Name, err)
 		}
@@ -225,7 +227,7 @@ func GetTransactionToSet(ctx *hookstate.Context, st *state.State, view *confdb.V
 
 		return tx, nil, nil
 	}
-	// TODO: add concurrency checks
+	// TODO: add early concurrency checks
 
 	// not running in an existing confdb hook context, so create a transaction
 	// and a change to verify its changes and commit
@@ -265,7 +267,7 @@ func GetTransactionToSet(ctx *hookstate.Context, st *state.State, view *confdb.V
 			return "", nil, err
 		}
 
-		err = setOngoingTransaction(st, account, dbSchemaName, commitTask.ID())
+		err = setWriteTransaction(st, account, dbSchemaName, commitTask.ID())
 		if err != nil {
 			return "", nil, err
 		}
@@ -286,9 +288,13 @@ func GetTransactionToSet(ctx *hookstate.Context, st *state.State, view *confdb.V
 	return tx, commitTx, nil
 }
 
-var ensureNow = func(st *state.State) {
-	st.EnsureBefore(0)
-}
+var (
+	ensureNow = func(st *state.State) {
+		st.EnsureBefore(0)
+	}
+
+	transactionTimeout = 2 * time.Minute
+)
 
 const (
 	commitEdge  = state.TaskSetEdge("commit-edge")
@@ -481,37 +487,37 @@ func getPlugsAffectedByPaths(st *state.State, dbSchema *confdb.Schema, storagePa
 
 // GetStoredTransaction returns the transaction associated with the task
 // (even if indirectly) and a callback to persist changes made to it.
-func GetStoredTransaction(t *state.Task) (tx *Transaction, saveTxChanges func(), err error) {
+func GetStoredTransaction(t *state.Task) (tx *Transaction, txTask *state.Task, saveTxChanges func(), err error) {
 	err = t.Get("confdb-transaction", &tx)
 	if err == nil {
 		saveTxChanges = func() {
 			t.Set("confdb-transaction", tx)
 		}
 
-		return tx, saveTxChanges, nil
+		return tx, t, saveTxChanges, nil
 	} else if !errors.Is(err, &state.NoStateError{}) {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var id string
 	err = t.Get("tx-task", &id)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	ct := t.State().Task(id)
 	if ct == nil {
-		return nil, nil, fmt.Errorf("cannot find task %s", id)
+		return nil, nil, nil, fmt.Errorf("cannot find task %s", id)
 	}
 
 	if err := ct.Get("confdb-transaction", &tx); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	saveTxChanges = func() {
 		ct.Set("confdb-transaction", tx)
 	}
-	return tx, saveTxChanges, nil
+	return tx, ct, saveTxChanges, nil
 }
 
 // IsConfdbHook returns whether the hook context belongs to a confdb hook.
@@ -519,7 +525,98 @@ func IsConfdbHook(ctx *hookstate.Context) bool {
 	return ctx != nil && !ctx.IsEphemeral() &&
 		(strings.HasPrefix(ctx.HookName(), "change-view-") ||
 			strings.HasPrefix(ctx.HookName(), "save-view-") ||
+			strings.HasPrefix(ctx.HookName(), "load-view-") ||
+			strings.HasPrefix(ctx.HookName(), "query-view-") ||
 			strings.HasSuffix(ctx.HookName(), "-view-changed"))
+}
+
+// LoadConfdbFromSnapctl gets a transaction to read the view's confdb. It schedules
+// tasks to load the confdb as needed, unless no custodian defined relevant hooks.
+// Blocks until the confdb has been loaded into the Transaction. If no tasks need
+// to execute to load the confdb, returns without blocking.
+func GetTransactionForSnapctlGet(ctx *hookstate.Context, view *confdb.View) (*Transaction, error) {
+	st := ctx.State()
+	account, schemaName := view.Schema().Account, view.Schema().Name
+	if IsConfdbHook(ctx) {
+		// running in the context of a transaction, so if the referenced confdb
+		// doesn't match that tx, we only allow the caller to read the other confdb
+		t, _ := ctx.Task()
+		tx, _, _, err := GetStoredTransaction(t)
+		if err != nil {
+			return nil, fmt.Errorf("cannot load confdb view %s/%s/%s: cannot get transaction: %v", account, schemaName, view.Name, err)
+		}
+
+		if tx.ConfdbAccount != account || tx.ConfdbName != schemaName {
+			// TODO: this should be enabled at some point
+			return nil, fmt.Errorf("cannot load confdb %s/%s: ongoing transaction for %s/%s", account, schemaName, tx.ConfdbAccount, tx.ConfdbName)
+		}
+
+		// we're reading the tx that this hook is modifying, just return that
+		return tx, nil
+	}
+
+	// not running in an existing confdb hook context, so create a transaction
+	// and a change to load/modify data
+	tx, err := NewTransaction(st, account, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load confdb view %s/%s/%s: cannot create transaction: %v", account, schemaName, view.Name, err)
+	}
+
+	ts, err := createLoadConfdbTasks(st, tx, view)
+	if err != nil {
+		return nil, err
+	}
+
+	if ts == nil {
+		// no hooks or tasks to run, transaction can read databag directly
+		return tx, nil
+	}
+
+	var chg *state.Change
+	if ctx.IsEphemeral() {
+		chg = st.NewChange("get-confdb", fmt.Sprintf("Get confdb through \"%s/%s/%s\"", account, schemaName, view.Name))
+	} else {
+		// we're running in the context of a non-confdb hook, add the tasks to that change
+		task, _ := ctx.Task()
+		chg = task.Change()
+	}
+
+	chg.AddAll(ts)
+
+	clearTxTask, err := ts.Edge(clearTxEdge)
+	if err != nil {
+		return nil, err
+	}
+
+	waitChan := make(chan struct{})
+	st.AddTaskStatusChangedHandler(func(t *state.Task, old, new state.Status) (remove bool) {
+		if t.ID() == clearTxTask.ID() && new.Ready() {
+			close(waitChan)
+			return true
+		}
+		return false
+	})
+
+	err = addReadTransaction(st, account, schemaName, clearTxTask.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	ensureNow(st)
+	ctx.Unlock()
+
+	select {
+	case <-waitChan:
+	case <-time.After(transactionTimeout):
+		ctx.Lock()
+		return nil, fmt.Errorf("cannot load confdb %s/%s in change %s: timed out after %s", account, schemaName, chg.ID(), transactionTimeout)
+	}
+
+	ctx.Lock()
+	if err := clearTxTask.Get("confdb-transaction", &tx); err != nil {
+		return nil, err
+	}
+	return tx, nil
 }
 
 // createLoadConfdbTasks returns a taskset with the hooks and tasks required to

--- a/overlord/confdbstate/export_test.go
+++ b/overlord/confdbstate/export_test.go
@@ -19,6 +19,8 @@
 package confdbstate
 
 import (
+	"time"
+
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -30,8 +32,13 @@ var (
 	GetPlugsAffectedByPaths = getPlugsAffectedByPaths
 	CreateChangeConfdbTasks = createChangeConfdbTasks
 	CreateLoadConfdbTasks   = createLoadConfdbTasks
-	SetOngoingTransaction   = setOngoingTransaction
+	SetWriteTransaction     = setWriteTransaction
+	AddReadTransaction      = addReadTransaction
 	UnsetOngoingTransaction = unsetOngoingTransaction
+)
+
+type (
+	ConfdbTransactions = confdbTransactions
 )
 
 const (
@@ -68,5 +75,13 @@ func MockEnsureNow(f func(*state.State)) func() {
 	ensureNow = f
 	return func() {
 		ensureNow = old
+	}
+}
+
+func MockTransactionTimeout(dur time.Duration) func() {
+	old := transactionTimeout
+	transactionTimeout = dur
+	return func() {
+		transactionTimeout = old
 	}
 }

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -205,7 +205,7 @@ func MockConfdbstateNewTransaction(f func(*state.State, string, string) (*confdb
 	}
 }
 
-func MockConfdbstateGetStoredTransaction(f func(*state.Task) (*confdbstate.Transaction, func(), error)) (restore func()) {
+func MockConfdbstateGetStoredTransaction(f func(*state.Task) (*confdbstate.Transaction, *state.Task, func(), error)) (restore func()) {
 	old := confdbstateGetStoredTransaction
 	confdbstateGetStoredTransaction = f
 	return func() {

--- a/overlord/hookstate/ctlcmd/fail.go
+++ b/overlord/hookstate/ctlcmd/fail.go
@@ -68,7 +68,7 @@ func (c *failCommand) Execute(args []string) error {
 	}
 
 	t, _ := ctx.Task()
-	tx, saveChanges, err := confdbstate.GetStoredTransaction(t)
+	tx, _, saveChanges, err := confdbstate.GetStoredTransaction(t)
 	if err != nil {
 		return fmt.Errorf(i18n.G("internal error: cannot get confdb transaction to fail: %v"), err)
 	}

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -409,7 +409,7 @@ func (c *getCommand) getDatabag(ctx *hookstate.Context, view *confdb.View, prist
 		// running in the context of a transaction, so if the referenced confdb schema
 		// doesn't match that tx, we only allow the caller to read through other confdb schema
 		t, _ := ctx.Task()
-		tx, _, err = confdbstateGetStoredTransaction(t)
+		tx, _, _, err = confdbstateGetStoredTransaction(t)
 		if err != nil {
 			return nil, fmt.Errorf("cannot access confdb through view %s/%s/%s: cannot get transaction: %v", account, dbSchemaName, view.Name, err)
 		}

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -826,13 +826,13 @@ func (s *confdbSuite) TestConfdbGetAndSetViewNotFound(c *C) {
 }
 
 func (s *confdbSuite) TestConfdbGetPristine(c *C) {
-	restore := ctlcmd.MockConfdbstateGetStoredTransaction(func(*state.Task) (*confdbstate.Transaction, func(), error) {
+	restore := ctlcmd.MockConfdbstateGetStoredTransaction(func(*state.Task) (*confdbstate.Transaction, *state.Task, func(), error) {
 		tx, _ := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 		c.Assert(tx.Set("wifi.ssid", "foo"), IsNil)
 		c.Assert(tx.Commit(s.state, confdb.NewJSONSchema()), IsNil)
 
 		c.Assert(tx.Set("wifi.ssid", "bar"), IsNil)
-		return tx, func() {}, nil
+		return tx, nil, func() {}, nil
 	})
 	defer restore()
 


### PR DESCRIPTION
Adds a GetTransactionForSnapctlGet helper that returns a Transaction for `snapctl get` to read a confdb. If there are hooks to run, it schedules the right tasks and tracks the transaction. This is meant only for snapctl, the API will use a different helper since the circumstances there differ quite a bit.
Also changes the tracking of the transaction to distinguish between read and write transactions, since there can be many concurrent read transaction but not write. A follow-up PR will use that to check for conflicts earlier in the read/write.
