### PR TITLE
tests/interfaces-kernel-module-load: switch vmac to wp512 module

### DIFF
--- a/tests/main/interfaces-kernel-module-load/task.yaml
+++ b/tests/main/interfaces-kernel-module-load/task.yaml
@@ -13,7 +13,7 @@ prepare: |
 restore: |
     echo "Ensure snap is removed even if something goes wrong"
     snap remove "$SNAP_NAME"
-    modprobe -r xcbc md4 vmac || true
+    modprobe -r xcbc md4 wp512 || true
 
 execute: |
     echo "When the interface is connected"
@@ -28,7 +28,7 @@ execute: |
     NOMATCH "pcspkr" < "$MODPROBE_CONF"
     MATCH "options md4 something=ok" < "$MODPROBE_CONF"
     # This has the "*" value for the options: no entry should be written:
-    NOMATCH "vmac" < "$MODPROBE_CONF"
+    NOMATCH "wp512" < "$MODPROBE_CONF"
 
     echo "And modules are configured to be auto-loaded"
     MODULES_LOAD_CONF="/etc/modules-load.d/snap.$SNAP_NAME.conf"
@@ -36,23 +36,23 @@ execute: |
     MATCH "arc4" < "$MODULES_LOAD_CONF"
     NOMATCH "mymodule" < "$MODULES_LOAD_CONF"
     NOMATCH "md4" < "$MODULES_LOAD_CONF"
-    NOMATCH "vmac" < "$MODULES_LOAD_CONF"
+    NOMATCH "wp512" < "$MODULES_LOAD_CONF"
 
     echo "Test dynamic loading of kernel modules"
     test-snapd-kernel-module-load.cmd snapctl kmod insert xcbc
     test-snapd-kernel-module-load.cmd snapctl kmod insert md4
-    test-snapd-kernel-module-load.cmd snapctl kmod insert vmac
+    test-snapd-kernel-module-load.cmd snapctl kmod insert wp512
     MATCH "^xcbc " < /proc/modules
     MATCH "^md4 " < /proc/modules
-    MATCH "^vmac " < /proc/modules
+    MATCH "^wp512 " < /proc/modules
 
     echo "Test unloading"
     test-snapd-kernel-module-load.cmd snapctl kmod remove xcbc
     test-snapd-kernel-module-load.cmd snapctl kmod remove md4
-    test-snapd-kernel-module-load.cmd snapctl kmod remove vmac
+    test-snapd-kernel-module-load.cmd snapctl kmod remove wp512
     NOMATCH "^xcbc " < /proc/modules
     NOMATCH "^md4 " < /proc/modules
-    NOMATCH "^vmac " < /proc/modules
+    NOMATCH "^wp512 " < /proc/modules
 
     echo "Test loading with options"
     if test-snapd-kernel-module-load.cmd snapctl kmod insert xcbc option=value; then
@@ -64,8 +64,8 @@ execute: |
         echo "Should not be able to specify parameters for md4 module!"
         exit 1
     fi
-    test-snapd-kernel-module-load.cmd snapctl kmod insert vmac opt1=v1 opt2=v2
-    MATCH "^vmac " < /proc/modules
+    test-snapd-kernel-module-load.cmd snapctl kmod insert wp512 opt1=v1 opt2=v2
+    MATCH "^wp512 " < /proc/modules
 
     echo "Disconnect the interface"
     snap disconnect "$SNAP_NAME:kernel-module-load"

--- a/tests/main/interfaces-kernel-module-load/test-snapd-kernel-module-load/meta/snap.yaml
+++ b/tests/main/interfaces-kernel-module-load/test-snapd-kernel-module-load/meta/snap.yaml
@@ -27,7 +27,7 @@ plugs:
               # The module does not support any options, really, but we still
               # want to test that the module configuration files gets written
               options: something=ok
-            - name: vmac
+            - name: wp512
               load: dynamic
               # Like the above, no options are supported. But let's test "*"
               options: "*"


### PR DESCRIPTION
The 6.14.0-1002-gcp kernel in 25.04 cloud images does not ship the
vmac module anymore.