### PR TITLE
tests/main/interfaces-system-dbus: ensure snaps are fully removed in restore

### DIFF
--- a/tests/main/interfaces-system-dbus/task.yaml
+++ b/tests/main/interfaces-system-dbus/task.yaml
@@ -16,6 +16,10 @@ prepare: |
         dbus-send --system --print-reply --dest=com.dbustest.HelloWorld /com/dbustest/HelloWorld com.dbustest.HelloWorld.SayHello | MATCH "hello world"
     fi
 
+restore: |
+    snap remove --purge test-snapd-dbus-consumer || true
+    snap remove --purge test-snapd-dbus-provider || true
+
 execute: |
     echo "The dbus consumer plug is disconnected by default"
     snap interfaces -i dbus | MATCH '^- +test-snapd-dbus-consumer:dbus-system-test'


### PR DESCRIPTION
Ensure that snaps are fully removed, such that their cgroups may be cleaned up.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
