### PR TITLE
tests: set apparmor to complain mode for unshare profile in snap-ns-forward-compat test

### DIFF
--- a/tests/main/snap-ns-forward-compat/task.yaml
+++ b/tests/main/snap-ns-forward-compat/task.yaml
@@ -13,18 +13,11 @@ prepare: |
     mkdir testsnap/import
     "$TESTSTOOLS"/snaps-state install-local testsnap
     if os.query is_ubuntu_ge 25.04; then
-        # TODO remove this when it is no longer needed
+        # FIXME: https://gitlab.com/apparmor/apparmor/-/issues/497
         # Currently the unshare profile also restricts the program shell,
         # which causes the setup_mount_namespace.sh script to fail.
         apparmor_parser --replace --Complain /etc/apparmor.d/unshare-userns-restrict
-    fi
-
-restore: |
-    if os.query is_ubuntu_ge 25.04; then
-        # TODO remove this when it is no longer needed
-        # Currently the unshare profile also restricts the program shell,
-        # which causes the setup_mount_namespace.sh script to fail.
-        apparmor_parser --replace /etc/apparmor.d/unshare-userns-restrict
+        tests.cleanup defer apparmor_parser --replace /etc/apparmor.d/unshare-userns-restrict
     fi
 
 execute: |

--- a/tests/main/snap-ns-forward-compat/task.yaml
+++ b/tests/main/snap-ns-forward-compat/task.yaml
@@ -12,6 +12,20 @@ prepare: |
     echo "Install test snap"
     mkdir testsnap/import
     "$TESTSTOOLS"/snaps-state install-local testsnap
+    if os.query is_ubuntu_ge 25.04; then
+        # TODO remove this when it is no longer needed
+        # Currently the unshare profile also restricts the program shell,
+        # which causes the setup_mount_namespace.sh script to fail.
+        apparmor_parser --replace --Complain /etc/apparmor.d/unshare-userns-restrict
+    fi
+
+restore: |
+    if os.query is_ubuntu_ge 25.04; then
+        # TODO remove this when it is no longer needed
+        # Currently the unshare profile also restricts the program shell,
+        # which causes the setup_mount_namespace.sh script to fail.
+        apparmor_parser --replace /etc/apparmor.d/unshare-userns-restrict
+    fi
 
 execute: |
     echo "Checking if the unshare command supports saving the namespace"


### PR DESCRIPTION
`snap-ns-forward-compat` is failing on 25.04 due to unshare's apparmor profile.

https://warthogs.atlassian.net/browse/SNAPDENG-34643