### PR TITLE
spread: enable cross distro reexec test suite on openSUSE

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1485,8 +1485,9 @@ suites:
         summary: Cross-distro reeexec
         systems:
           - arch-linux-*
+          # will only for work for AppArmor setups
+          - opensuse-*
           # TODO: enable the following:
-          # - opensuse-*
           # - fedora-*
           # - amazon-linux-*
         environment:

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -805,8 +805,10 @@ pkg_dependencies_opensuse(){
         nss-mdns
         osc
         PackageKit
+        procps
         python3-yaml
         strace
+        sysvinit-tools
         netcat-openbsd
         rpm-build
         udisks2


### PR DESCRIPTION
Add openSUSE to set of systems on which we run cross distro with snapd
reexec test suite.

Depends on #15197 

Related: [SNAPDENG-34646](https://warthogs.atlassian.net/browse/SNAPDENG-34646)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-34646]: https://warthogs.atlassian.net/browse/SNAPDENG-34646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ