### PR TITLE
secboot, overlord/fdestate/backend: use primary key from keyring

### DIFF
--- a/overlord/fdestate/backend/export_test.go
+++ b/overlord/fdestate/backend/export_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/snapcore/snapd/secboot"
 )
 
-func MockSecbootResealKeysWithFDESetupHook(f func(keys []secboot.KeyDataLocation, primaryKeyFile string, models []secboot.ModelForSealing, bootModes []string) error) (restore func()) {
+func MockSecbootResealKeysWithFDESetupHook(f func(keys []secboot.KeyDataLocation, primaryKey []byte, models []secboot.ModelForSealing, bootModes []string) error) (restore func()) {
 	old := secbootResealKeysWithFDESetupHook
 	secbootResealKeysWithFDESetupHook = f
 	return func() {

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -370,7 +370,7 @@ func (s *resealTestSuite) TestTPMResealHappy(c *C) {
 	restore = backend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
 		resealCalls++
 
-		c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(params.PrimaryKey, DeepEquals, []byte{1, 2, 3, 4})
 
 		c.Check(params.PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-pcr-profile"`))
 		switch resealCalls {
@@ -426,6 +426,12 @@ func (s *resealTestSuite) TestTPMResealHappy(c *C) {
 			},
 		},
 	}
+
+	defer backend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+		c.Check(fallbackKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(devices, DeepEquals, []string{"/dev/disk/by-uuid/123", "/dev/disk/by-uuid/456"})
+		return []byte{1, 2, 3, 4}, nil
+	})()
 
 	const expectReseal = true
 	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
@@ -713,7 +719,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {
 		// set mock key resealing
 		resealKeysCalls := 0
 		restore = backend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
-			c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+			c.Check(params.PrimaryKey, DeepEquals, []byte{1, 2, 3, 4})
 
 			resealKeysCalls++
 			c.Check(params.PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-pcr-profile"`))
@@ -1028,6 +1034,12 @@ func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {
 			},
 		}
 
+		defer backend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+			c.Check(fallbackKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+			c.Check(devices, DeepEquals, []string{"/dev/disk/by-uuid/123", "/dev/disk/by-uuid/456"})
+			return []byte{1, 2, 3, 4}, nil
+		})()
+
 		const expectReseal = false
 		err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, rootdir, params, expectReseal)
 		if tc.err == "" {
@@ -1161,7 +1173,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsRecoveryKeysForGoodSystemsOn
 	// set mock key resealing
 	resealKeysCalls := 0
 	restore = backend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
-		c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(params.PrimaryKey, DeepEquals, []byte{1, 2, 3, 4})
 
 		resealKeysCalls++
 		c.Check(params.PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-pcr-profile"`))
@@ -1345,6 +1357,12 @@ func (s *resealTestSuite) TestResealKeyForBootchainsRecoveryKeysForGoodSystemsOn
 		},
 	}
 
+	defer backend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+		c.Check(fallbackKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(devices, DeepEquals, []string{"/dev/disk/by-uuid/123", "/dev/disk/by-uuid/456"})
+		return []byte{1, 2, 3, 4}, nil
+	})()
+
 	const expectReseal = false
 	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
 	c.Assert(err, IsNil)
@@ -1502,7 +1520,7 @@ func (s *resealTestSuite) testResealKeyForBootchainsWithTryModel(c *C, shimId, g
 	// set mock key resealing
 	resealKeysCalls := 0
 	restore = backend.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
-		c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(params.PrimaryKey, DeepEquals, []byte{1, 2, 3, 4})
 
 		resealKeysCalls++
 		c.Check(params.PCRProfile, DeepEquals, secboot.SerializedPCRProfile(`"serialized-pcr-profile"`))
@@ -1675,6 +1693,12 @@ func (s *resealTestSuite) testResealKeyForBootchainsWithTryModel(c *C, shimId, g
 			},
 		},
 	}
+
+	defer backend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+		c.Check(fallbackKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(devices, DeepEquals, []string{"/dev/disk/by-uuid/123", "/dev/disk/by-uuid/456"})
+		return []byte{1, 2, 3, 4}, nil
+	})()
 
 	const expectReseal = false
 	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
@@ -1870,6 +1894,12 @@ func (s *resealTestSuite) TestResealKeyForBootchainsFallbackCmdline(c *C) {
 		},
 	}
 
+	defer backend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+		c.Check(fallbackKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(devices, DeepEquals, []string{"/dev/disk/by-uuid/123", "/dev/disk/by-uuid/456"})
+		return []byte{1, 2, 3, 4}, nil
+	})()
+
 	const expectReseal = false
 	err = backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
 	c.Assert(err, IsNil)
@@ -1926,7 +1956,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 	}
 
 	resealCalls := 0
-	restore := backend.MockSecbootResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKeyFile string, models []secboot.ModelForSealing, bootModes []string) error {
+	restore := backend.MockSecbootResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKey []byte, models []secboot.ModelForSealing, bootModes []string) error {
 		resealCalls++
 
 		switch resealCalls {
@@ -1939,7 +1969,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 					KeyFile:    filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"),
 				},
 			})
-			c.Check(primaryKeyFile, Equals, filepath.Join(s.rootdir, "run/mnt/ubuntu-save/device/fde/aux-key"))
+			c.Check(primaryKey, DeepEquals, []byte{1, 2, 3, 4})
 			c.Assert(models, HasLen, 1)
 			c.Check(models[0].Model(), Equals, model.Model())
 			c.Check(bootModes, DeepEquals, []string{"run", "recover"})
@@ -1952,7 +1982,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 					KeyFile:    filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"),
 				},
 			})
-			c.Check(primaryKeyFile, Equals, filepath.Join(s.rootdir, "run/mnt/ubuntu-save/device/fde/aux-key"))
+			c.Check(primaryKey, DeepEquals, []byte{1, 2, 3, 4})
 			c.Assert(models, HasLen, 1)
 			c.Check(models[0].Model(), Equals, model.Model())
 			c.Check(bootModes, DeepEquals, []string{"recover"})
@@ -1965,7 +1995,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 					KeyFile:    filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"),
 				},
 			})
-			c.Check(primaryKeyFile, Equals, filepath.Join(s.rootdir, "run/mnt/ubuntu-save/device/fde/aux-key"))
+			c.Check(primaryKey, DeepEquals, []byte{1, 2, 3, 4})
 			c.Assert(models, HasLen, 1)
 			c.Check(models[0].Model(), Equals, model.Model())
 			c.Check(bootModes, DeepEquals, []string{"recover", "factory-reset"})
@@ -1995,6 +2025,12 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 			},
 		},
 	}
+
+	defer backend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+		c.Check(fallbackKeyFile, Equals, filepath.Join(s.rootdir, "run/mnt/ubuntu-save/device/fde/aux-key"))
+		c.Check(devices, DeepEquals, []string{"/dev/disk/by-uuid/123", "/dev/disk/by-uuid/456"})
+		return []byte{1, 2, 3, 4}, nil
+	})()
 
 	const expectReseal = true
 	err := backend.ResealKeyForBootChains(myState, device.SealingMethodFDESetupHook, s.rootdir, params, expectReseal)
@@ -2153,6 +2189,12 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 			},
 		},
 	}
+
+	defer backend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+		c.Check(fallbackKeyFile, Equals, filepath.Join(dirs.SnapSaveDir, "device/fde", "tpm-policy-auth-key"))
+		c.Check(devices, DeepEquals, []string{"/dev/disk/by-uuid/123", "/dev/disk/by-uuid/456"})
+		return []byte{1, 2, 3, 4}, nil
+	})()
 
 	err = backend.ResealKeysForSignaturesDBUpdate(myState, device.SealingMethodTPM, dirs.GlobalRootDir,
 		params, []byte("dbx-payload"))

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -7643,6 +7643,14 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	})
 	defer restore()
 
+	restore = fdeBackend.MockSecbootGetPrimaryKey(func(devices []string, fallbackKeyFile string) ([]byte, error) {
+		if !encrypted {
+			return nil, fmt.Errorf("unexpected call")
+		}
+		return []byte{1, 2, 3, 4}, nil
+	})
+	defer restore()
+
 	// make sure FDE is initialized
 	fdemgr := s.o.FDEManager()
 	c.Assert(fdemgr, NotNil)

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -182,8 +182,8 @@ type ResealKeysParams struct {
 	PCRProfile SerializedPCRProfile
 	// The locations to the key data
 	Keys []KeyDataLocation
-	// The path to the authorization policy update key file (only relevant for TPM)
-	TPMPolicyAuthKeyFile string
+	// The primary key
+	PrimaryKey []byte
 }
 
 // UnlockVolumeUsingSealedKeyOptions contains options for unlocking encrypted

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -91,7 +91,7 @@ func VerifyPrimaryKeyDigest(devicePath string, alg crypto.Hash, salt []byte, dig
 	return false, errBuildWithoutSecboot
 }
 
-func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, models []ModelForSealing, bootModes []string) error {
+func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKey []byte, models []ModelForSealing, bootModes []string) error {
 	return errBuildWithoutSecboot
 }
 
@@ -123,4 +123,8 @@ func TemporaryNameOldKeys(devicePath string) error {
 
 func DeleteOldKeys(devicePath string) error {
 	return errBuildWithoutSecboot
+}
+
+func GetPrimaryKey(devices []string, fallbackKeyFile string) ([]byte, error) {
+	return nil, errBuildWithoutSecboot
 }

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	sb "github.com/snapcore/secboot"
 	sb_scope "github.com/snapcore/secboot/bootscope"
@@ -141,14 +140,7 @@ var setAuthorizedBootModesOnHooksKeydata = setAuthorizedBootModesOnHooksKeydataI
 
 // ResealKeysWithFDESetupHook updates hook based keydatas for given
 // files with a specific list of models
-func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, models []ModelForSealing, bootModes []string) error {
-	// TODO:FDEM:FIX: load primary key from keyring when available
-	primaryKeyBuf, err := os.ReadFile(primaryKeyFile)
-	if err != nil {
-		return fmt.Errorf("cannot read primary key file: %v", err)
-	}
-	primaryKey := sb.PrimaryKey(primaryKeyBuf)
-
+func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKey []byte, models []ModelForSealing, bootModes []string) error {
 	var sbModels []sb.SnapModel
 	for _, model := range models {
 		sbModels = append(sbModels, model)

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -529,3 +529,24 @@ func sbCopyAndRemoveLUKS2ContainerKeyImpl(devicePath, keyslotName, renameTo stri
 }
 
 var sbCopyAndRemoveLUKS2ContainerKey = sbCopyAndRemoveLUKS2ContainerKeyImpl
+
+// GetPrimaryKey finds the primary from the keyring based on the path of
+// encrypted devices. If it does not find any primary in the keyring,
+// it then tries to read the key from a fallback key file.
+func GetPrimaryKey(devices []string, fallbackKeyFile string) ([]byte, error) {
+	for _, device := range devices {
+		primaryKey, err := findPrimaryKey(device)
+		if err == nil {
+			return primaryKey, nil
+		}
+		if !errors.Is(err, sb.ErrKernelKeyNotFound) {
+			return nil, err
+		}
+	}
+
+	primaryKey, err := os.ReadFile(fallbackKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not find primary in keyring and cannot read fallback primary key file %s: %w", fallbackKeyFile, err)
+	}
+	return primaryKey, nil
+}

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1215,6 +1215,7 @@ func (s *secbootSuite) TestResealKey(c *C) {
 	for idx, tc := range []struct {
 		tpmErr                 error
 		tpmEnabled             bool
+		usePrimaryKeyFile      bool
 		keyDataInFile          bool
 		missingFile            bool
 		addPCRProfileErr       error
@@ -1234,7 +1235,7 @@ func (s *secbootSuite) TestResealKey(c *C) {
 		// happy case
 		{tpmEnabled: true, resealCalls: 1},
 		// happy case with key files
-		{tpmEnabled: true, keyDataInFile: true, resealCalls: 1},
+		{tpmEnabled: true, keyDataInFile: true, usePrimaryKeyFile: true, resealCalls: 1},
 		// happy case with DBX update
 		{tpmEnabled: true, resealCalls: 1, dbxUpdate: []byte("dbx-update")},
 		// happy case, old keys
@@ -1257,8 +1258,20 @@ func (s *secbootSuite) TestResealKey(c *C) {
 
 		mockTPMPolicyAuthKey := []byte{1, 3, 3, 7}
 		mockTPMPolicyAuthKeyFile := filepath.Join(c.MkDir(), "policy-auth-key-file")
-		err := os.WriteFile(mockTPMPolicyAuthKeyFile, mockTPMPolicyAuthKey, 0600)
-		c.Assert(err, IsNil)
+		if tc.usePrimaryKeyFile {
+			err := os.WriteFile(mockTPMPolicyAuthKeyFile, mockTPMPolicyAuthKey, 0600)
+			c.Assert(err, IsNil)
+		}
+		defer secboot.MockSbGetPrimaryKeyFromKernel(func(prefix string, devicePath string, remove bool) (sb.PrimaryKey, error) {
+			c.Check(prefix, Equals, "ubuntu-fde")
+			c.Check(devicePath, Equals, "/dev/somedevice")
+			c.Check(remove, Equals, false)
+			if tc.usePrimaryKeyFile {
+				return nil, sb.ErrKernelKeyNotFound
+			} else {
+				return []byte{1, 3, 3, 7}, nil
+			}
+		})()
 
 		mockEFI := bootloader.NewBootFile("", filepath.Join(c.MkDir(), "file.efi"), bootloader.RoleRecovery)
 		if !tc.missingFile {
@@ -1355,7 +1368,7 @@ func (s *secbootSuite) TestResealKey(c *C) {
 					KeyFile:    keyFile2,
 				},
 			},
-			TPMPolicyAuthKeyFile: mockTPMPolicyAuthKeyFile,
+			PrimaryKey: mockTPMPolicyAuthKey,
 		}
 
 		numMockSealedKeyObjects := len(myParams.Keys)
@@ -2835,9 +2848,6 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookV1(c *C) {
 	key1Fn := filepath.Join(tmpdir, "key1.key")
 	err := os.WriteFile(key1Fn, key1, 0644)
 	c.Assert(err, IsNil)
-	auxKeyFn := filepath.Join(tmpdir, "aux.key")
-	err = os.WriteFile(auxKeyFn, auxKey, 0644)
-	c.Assert(err, IsNil)
 
 	m := &testModel{
 		name: "mytest",
@@ -2849,7 +2859,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookV1(c *C) {
 		KeyFile:    key1Fn,
 	}
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, auxKeyFn, []secboot.ModelForSealing{m}, []string{"run"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, auxKey, []secboot.ModelForSealing{m}, []string{"run"})
 	c.Assert(err, IsNil)
 
 	// Nothing should have happened. But we make sure that they key is still there untouched.
@@ -2866,9 +2876,6 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookV2(c *C) {
 	tmpdir := c.MkDir()
 	key1Fn := filepath.Join(tmpdir, "key1.key")
 	err := os.WriteFile(key1Fn, key1, 0644)
-	c.Assert(err, IsNil)
-	auxKeyFn := filepath.Join(tmpdir, "aux.key")
-	err = os.WriteFile(auxKeyFn, auxKey, 0644)
 	c.Assert(err, IsNil)
 
 	m := &testModel{
@@ -2890,7 +2897,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookV2(c *C) {
 		KeyFile:    key1Fn,
 	}
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, auxKeyFn, []secboot.ModelForSealing{m}, []string{"run"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, auxKey, []secboot.ModelForSealing{m}, []string{"run"})
 	c.Assert(err, IsNil)
 
 	afterReader, err := sb.NewFileKeyDataReader(key1Fn)
@@ -2912,7 +2919,6 @@ func (fakeKeyProtector) ProtectKey(rand io.Reader, cleartext, aad []byte) (ciphe
 func (s *secbootSuite) TestResealKeysWithFDESetupHook(c *C) {
 	tmpdir := c.MkDir()
 	key1Fn := filepath.Join(tmpdir, "key1.key")
-	primaryKeyFn := filepath.Join(tmpdir, "primary.key")
 
 	oldModel := &testModel{
 		name: "oldmodel",
@@ -2923,8 +2929,6 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHook(c *C) {
 	}
 
 	primaryKey := []byte{9, 10, 11, 12}
-	err := os.WriteFile(primaryKeyFn, primaryKey, 0644)
-	c.Assert(err, IsNil)
 
 	params := &sb_hooks.KeyParams{
 		PrimaryKey: primaryKey,
@@ -2979,7 +2983,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHook(c *C) {
 		KeyFile:    key1Fn,
 	}
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, primaryKeyFn, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, primaryKey, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
 	c.Assert(err, IsNil)
 	c.Check(modelSet, Equals, 1)
 	c.Check(bootModesSet, Equals, 1)
@@ -2989,7 +2993,6 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHook(c *C) {
 func (s *secbootSuite) TestResealKeysWithFDESetupHookFromFile(c *C) {
 	tmpdir := c.MkDir()
 	key1Fn := filepath.Join(tmpdir, "key1.key")
-	primaryKeyFn := filepath.Join(tmpdir, "primary.key")
 
 	oldModel := &testModel{
 		name: "oldmodel",
@@ -3000,8 +3003,6 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookFromFile(c *C) {
 	}
 
 	primaryKey := []byte{9, 10, 11, 12}
-	err := os.WriteFile(primaryKeyFn, primaryKey, 0644)
-	c.Assert(err, IsNil)
 
 	params := &sb_hooks.KeyParams{
 		PrimaryKey: primaryKey,
@@ -3053,7 +3054,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookFromFile(c *C) {
 		KeyFile:    key1Fn,
 	}
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, primaryKeyFn, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, primaryKey, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
 	c.Assert(err, IsNil)
 	c.Check(modelSet, Equals, 1)
 	c.Check(bootModesSet, Equals, 1)
@@ -3574,4 +3575,89 @@ func (s *secbootSuite) TestGetPrimaryKeyDigestFallbackDevPath(c *C) {
 	matches, err := secboot.VerifyPrimaryKeyDigest("/dev/other/device", crypto.SHA256, salt, digest)
 	c.Assert(err, IsNil)
 	c.Check(matches, Equals, true)
+}
+
+func (s *secbootSuite) TestGetPrimaryKey(c *C) {
+	defer secboot.MockDisksDevlinks(func(node string) ([]string, error) {
+		switch node {
+		case "/dev/test/device1":
+			return []string{
+				"/dev/test/device1",
+				"/dev/disk/by-partuuid/a9456fe6-9850-41ce-b2ad-cf9b43a34286",
+			}, nil
+		case "/dev/test/device2":
+			return []string{
+				"/dev/test/device2",
+				"/dev/disk/by-partuuid/5b081ac5-2432-48a2-b69b-d1bfb7aec6fe",
+			}, nil
+		default:
+			c.Errorf("unexpected call")
+			return nil, errors.New("unexpected call")
+		}
+	})()
+	defer secboot.MockSbGetPrimaryKeyFromKernel(func(prefix string, devicePath string, remove bool) (sb.PrimaryKey, error) {
+		c.Check(prefix, Equals, "ubuntu-fde")
+		c.Check(remove, Equals, false)
+		switch devicePath {
+		case "/dev/test/device1":
+			return nil, sb.ErrKernelKeyNotFound
+		case "/dev/disk/by-partuuid/a9456fe6-9850-41ce-b2ad-cf9b43a34286":
+			return nil, sb.ErrKernelKeyNotFound
+		case "/dev/test/device2":
+			return []byte{1, 2, 3, 4}, nil
+		default:
+			c.Errorf("unexpected call")
+			return nil, errors.New("unexpected call")
+		}
+	})()
+
+	found, err := secboot.GetPrimaryKey([]string{"/dev/test/device1", "/dev/test/device2"}, "/nonexistant")
+	c.Assert(err, IsNil)
+	c.Check(found, DeepEquals, []byte{1, 2, 3, 4})
+}
+
+func (s *secbootSuite) TestGetPrimaryKeyFallbackFile(c *C) {
+	defer secboot.MockDisksDevlinks(func(node string) ([]string, error) {
+		switch node {
+		case "/dev/test/device1":
+			return []string{
+				"/dev/test/device1",
+				"/dev/disk/by-partuuid/a9456fe6-9850-41ce-b2ad-cf9b43a34286",
+			}, nil
+		case "/dev/test/device2":
+			return []string{
+				"/dev/test/device2",
+				"/dev/disk/by-partuuid/5b081ac5-2432-48a2-b69b-d1bfb7aec6fe",
+			}, nil
+		default:
+			c.Errorf("unexpected call")
+			return nil, errors.New("unexpected call")
+		}
+	})()
+	defer secboot.MockSbGetPrimaryKeyFromKernel(func(prefix string, devicePath string, remove bool) (sb.PrimaryKey, error) {
+		c.Check(prefix, Equals, "ubuntu-fde")
+		c.Check(remove, Equals, false)
+		switch devicePath {
+		case "/dev/test/device1":
+			return nil, sb.ErrKernelKeyNotFound
+		case "/dev/disk/by-partuuid/a9456fe6-9850-41ce-b2ad-cf9b43a34286":
+			return nil, sb.ErrKernelKeyNotFound
+		case "/dev/test/device2":
+			return nil, sb.ErrKernelKeyNotFound
+		case "/dev/disk/by-partuuid/5b081ac5-2432-48a2-b69b-d1bfb7aec6fe":
+			return nil, sb.ErrKernelKeyNotFound
+		default:
+			c.Errorf("unexpected call")
+			return nil, errors.New("unexpected call")
+		}
+	})()
+
+	tmpDir := c.MkDir()
+	keyFile := filepath.Join(tmpDir, "key-file")
+	err := os.WriteFile(keyFile, []byte{1, 2, 3, 4}, 0644)
+	c.Assert(err, IsNil)
+
+	found, err := secboot.GetPrimaryKey([]string{"/dev/test/device1", "/dev/test/device2"}, keyFile)
+	c.Assert(err, IsNil)
+	c.Check(found, DeepEquals, []byte{1, 2, 3, 4})
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -623,12 +623,6 @@ func ResealKeys(params *ResealKeysParams) error {
 		return err
 	}
 
-	// TODO:FDEM:FIX: load primary key from keyring when available
-	authKey, err := os.ReadFile(params.TPMPolicyAuthKeyFile)
-	if err != nil {
-		return fmt.Errorf("cannot read the policy auth key file %s: %w", params.TPMPolicyAuthKeyFile, err)
-	}
-
 	keyDatas := make([]*sb.KeyData, 0, numSealedKeyObjects)
 	sealedKeyObjects := make([]*sb_tpm2.SealedKeyObject, 0, numSealedKeyObjects)
 	writers := make([]sb.KeyDataWriter, 0, numSealedKeyObjects)
@@ -656,7 +650,7 @@ func ResealKeys(params *ResealKeysParams) error {
 	}
 
 	if hasOldSealedKeyObjects {
-		if err := sbUpdateKeyPCRProtectionPolicyMultiple(tpm, sealedKeyObjects, authKey, &pcrProfile); err != nil {
+		if err := sbUpdateKeyPCRProtectionPolicyMultiple(tpm, sealedKeyObjects, params.PrimaryKey, &pcrProfile); err != nil {
 			return fmt.Errorf("cannot update legacy PCR protection policy: %w", err)
 		}
 
@@ -669,12 +663,12 @@ func ResealKeys(params *ResealKeysParams) error {
 		}
 
 		// revoke old policies via the primary key object
-		if err := sbSealedKeyObjectRevokeOldPCRProtectionPolicies(sealedKeyObjects[0], tpm, authKey); err != nil {
+		if err := sbSealedKeyObjectRevokeOldPCRProtectionPolicies(sealedKeyObjects[0], tpm, params.PrimaryKey); err != nil {
 			return fmt.Errorf("cannot revoke old PCR protection policies: %w", err)
 		}
 	} else {
 		// TODO:FDEM:FIX: find out which context when revocation should happen
-		if err := sbUpdateKeyDataPCRProtectionPolicy(tpm, authKey, &pcrProfile, sb_tpm2.NoNewPCRPolicyVersion, keyDatas...); err != nil {
+		if err := sbUpdateKeyDataPCRProtectionPolicy(tpm, params.PrimaryKey, &pcrProfile, sb_tpm2.NoNewPCRPolicyVersion, keyDatas...); err != nil {
 			return fmt.Errorf("cannot update PCR protection policy: %w", err)
 		}
 


### PR DESCRIPTION
We now stop reading primary key files for FDE hooks and TPM. And instead we get them in the keyring. We still try to read the file on reseal if the primary key was not found in the keyring.
