### PR TITLE
tests: fixes in after beta validation 2.68.3

### DIFF
--- a/tests/main/aux-info/task.yaml
+++ b/tests/main/aux-info/task.yaml
@@ -12,7 +12,7 @@ environment:
     SNAPD_NO_MEMORY_LIMIT: 1
 
 prepare: |
-  snap install --candidate snap-store
+  snap install --channel 1/stable snap-store
 
 execute: |
   snap_id=$(snap info snap-store | gojq -r --yaml-input '.["snap-id"]')

--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -15,9 +15,8 @@ systems:
     # Affected by https://gitlab.com/apparmor/apparmor/-/issues/492
     - -ubuntu-16.04-64
     - -ubuntu-18.04-64
-    - -ubuntu-core-16-64
-    - -ubuntu-core-18-64
-    - -ubuntu-core-20-64
+    - -ubuntu-core-18-*
+    - -ubuntu-core-20-*
     - -debian-12-64
     - -debian-13-64
     - -debian-sid-64


### PR DESCRIPTION
The change includes:
. use a different channel for snap-store snap  (to make sure it is available in all the architectures)
. skip arm devices too in interfaces-posix-mq for core-18 and core-20
. remove ubuntu-core-16 from interfaces-posix-mq as it is not supported anymore