### PR TITLE
secboot/secboot_hooks.go: remove an implemented TODO

### DIFF
--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -186,7 +186,6 @@ func ResealKeysWithFDESetupHook(keys []KeyDataLocation, primaryKeyFile string, m
 				return err
 			}
 		} else {
-			// TODO:FDEM:FIX: also set the run modes
 			hooksKeyData, err := sb_hooks.NewKeyData(keyData)
 			if err != nil {
 				return err


### PR DESCRIPTION
This was done in 041e705792b06f44d7d87b004fed17ab34d89f1f #15049

