### PR TITLE
dirs, snapdtool: support reexec when using /usr/libexec/snapd on the host

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -165,6 +165,12 @@ const (
 	DefaultSnapMountDir = "/snap"
 	AltSnapMountDir     = "/var/lib/snapd/snap"
 
+	// DefaultDistroLibexecDir is a default libexecdir used on most
+	// distributions
+	DefaultDistroLibexecDir = "/usr/lib/snapd"
+	// AltDistroLibexecDir is an anterlative libexec dir used on some distributions
+	AltDistroLibexecDir = "/usr/libexec/snapd"
+
 	// These are directories which are static inside the core snap and
 	// can never be prefixed as they will be always absolute once we
 	// are in the snap confinement environment.
@@ -669,9 +675,9 @@ func SetRootDir(rootdir string) {
 		// RHEL, CentOS, Fedora and derivatives, some more recent
 		// snapshots of openSUSE Tumbleweed and Slowroll;
 		// both RHEL and CentOS list "fedora" in ID_LIKE
-		DistroLibExecDir = filepath.Join(rootdir, "/usr/libexec/snapd")
+		DistroLibExecDir = filepath.Join(rootdir, AltDistroLibexecDir)
 	} else {
-		DistroLibExecDir = filepath.Join(rootdir, "/usr/lib/snapd")
+		DistroLibExecDir = filepath.Join(rootdir, DefaultDistroLibexecDir)
 	}
 
 	XdgRuntimeDirBase = filepath.Join(rootdir, "/run/user")


### PR DESCRIPTION
Two patches needed for supporting reexec when the host uses /usr/libexec/snapd instead of /usr/lib/snapd. This happens on Fedora/Amazon Linux and Tumbleweed.

Related: [SNAPDENG-34646](https://warthogs.atlassian.net/browse/SNAPDENG-34646)

Cherry picked from: #15201 

[SNAPDENG-34646]: https://warthogs.atlassian.net/browse/SNAPDENG-34646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ