### PR TITLE
sandbox/apparmor: use correct host libexec dir rather than a hardcoded one

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -853,8 +853,7 @@ func systemAppArmorLoadsSnapPolicy() bool {
 }
 
 func snapdAppArmorSupportsReexecImpl() bool {
-	hostInfoDir := filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir)
-	_, flags, err := snapdtool.SnapdVersionFromInfoFile(hostInfoDir)
+	_, flags, err := snapdtool.SnapdVersionFromInfoFile(dirs.DistroLibExecDir)
 	return err == nil && flags["SNAPD_APPARMOR_REEXEC"] == "1"
 }
 

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -920,7 +920,7 @@ func (s *apparmorSuite) TestSnapdAppArmorSupportsReexecImpl(c *C) {
 	// with no info file should indicate it does not support reexec
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, false)
 
-	d := filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir)
+	d := dirs.DistroLibExecDir
 	c.Assert(os.MkdirAll(d, 0755), IsNil)
 	infoFile := filepath.Join(d, "info")
 	c.Assert(os.WriteFile(infoFile, []byte("VERSION=foo"), 0644), IsNil)


### PR DESCRIPTION
Use host libexecdir as identified at runtime, rather than a hardcoded value which is only correct on systems using /usr/lib/snapd.

Related: [SNAPDENG-34646](https://warthogs.atlassian.net/browse/SNAPDENG-34646)

Cherry picked from: #15201 

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-34646]: https://warthogs.atlassian.net/browse/SNAPDENG-34646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ