### PR TITLE
many: make API confdb reads load ephemeral data

### DIFF
--- a/client/confdb.go
+++ b/client/confdb.go
@@ -27,17 +27,12 @@ import (
 	"strings"
 )
 
-func (c *Client) ConfdbGetViaView(viewID string, requests []string) (result map[string]interface{}, err error) {
+func (c *Client) ConfdbGetViaView(viewID string, requests []string) (changeID string, err error) {
 	query := url.Values{}
 	query.Add("fields", strings.Join(requests, ","))
-
 	endpoint := fmt.Sprintf("/v2/confdb/%s", viewID)
-	_, err = c.doSync("GET", endpoint, query, nil, nil, &result)
-	if err != nil {
-		return nil, err
-	}
 
-	return result, nil
+	return c.doAsync("GET", endpoint, query, nil, nil)
 }
 
 func (c *Client) ConfdbSetViaView(viewID string, requestValues map[string]interface{}) (changeID string, err error) {

--- a/client/confdb_test.go
+++ b/client/confdb_test.go
@@ -28,12 +28,16 @@ import (
 )
 
 func (cs *clientSuite) TestConfdbGet(c *C) {
-	cs.rsp = `{"type": "sync", "result":{"foo":"baz","bar":1}}`
+	cs.status = 202
+	cs.rsp = `{
+		"change": "123",
+		"status-code": 202,
+		"type": "async"
+	}`
 
-	res, err := cs.cli.ConfdbGetViaView("a/b/c", []string{"foo", "bar"})
-	c.Check(err, IsNil)
-	c.Check(res, DeepEquals, map[string]interface{}{"foo": "baz", "bar": json.Number("1")})
-	c.Assert(cs.reqs, HasLen, 1)
+	chgID, err := cs.cli.ConfdbGetViaView("a/b/c", []string{"foo", "bar"})
+	c.Assert(err, IsNil)
+	c.Assert(chgID, Equals, "123")
 	c.Check(cs.reqs[0].Method, Equals, "GET")
 	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/confdb/a/b/c")
 	c.Check(cs.reqs[0].URL.Query(), DeepEquals, url.Values{"fields": []string{"foo,bar"}})

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -227,13 +227,6 @@ func (s *SnapSuite) mockGetEmptyConfigServer(c *C) {
 	})
 }
 
-const syncResp = `{
-  "type": "sync",
-  "status-code": 200,
-  "status": "OK",
-  "result": %s
-}`
-
 func (s *confdbSuite) TestConfdbGet(c *C) {
 	restore := snapset.MockIsStdinTTY(true)
 	defer restore()
@@ -252,8 +245,16 @@ func (s *confdbSuite) TestConfdbGet(c *C) {
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
 			c.Check(fields, DeepEquals, []string{"abc"})
 
-			w.WriteHeader(200)
-			fmt.Fprintf(w, syncResp, `{"abc": "cba"}`)
+			w.WriteHeader(202)
+			fmt.Fprintf(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": "cba"}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -289,8 +290,16 @@ func (s *confdbSuite) TestConfdbGetAsDocument(c *C) {
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
 			c.Check(fields, DeepEquals, []string{"abc"})
 
-			w.WriteHeader(200)
-			fmt.Fprintf(w, syncResp, `{"abc": "cba"}`)
+			w.WriteHeader(202)
+			fmt.Fprintf(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": "cba"}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -330,8 +339,16 @@ func (s *confdbSuite) TestConfdbGetMany(c *C) {
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
 			c.Check(fields, DeepEquals, []string{"abc", "xyz"})
 
-			w.WriteHeader(200)
-			fmt.Fprintf(w, syncResp, `{"abc": 1, "xyz": false}`)
+			w.WriteHeader(202)
+			fmt.Fprintf(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": 1, "xyz": false}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -371,8 +388,16 @@ func (s *confdbSuite) TestConfdbGetManyAsDocument(c *C) {
 			fields := strutil.CommaSeparatedList(q.Get("fields"))
 			c.Check(fields, DeepEquals, []string{"abc", "xyz"})
 
-			w.WriteHeader(200)
-			fmt.Fprintf(w, syncResp, `{"abc": 1, "xyz": false}`)
+			w.WriteHeader(202)
+			fmt.Fprintf(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": 1, "xyz": false}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -395,13 +420,13 @@ func (s *confdbSuite) TestConfdbGetManyAsDocument(c *C) {
 	c.Check(s.Stderr(), Equals, "")
 }
 
-func (s *confdbSuite) TestConfdbGetInvalidConfdbID(c *check.C) {
+func (s *confdbSuite) TestConfdbGetInvalidConfdbSchemaID(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"get", "foo//bar", "foo=bar"})
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, "confdb identifier must conform to format: <account-id>/<confdb>/<view>")
+	c.Check(err.Error(), Equals, "confdb-schema view id must conform to format: <account-id>/<confdb-schema>/<view>")
 }
 
 func (s *confdbSuite) TestConfdbGetDisabledFlag(c *check.C) {
@@ -433,11 +458,20 @@ func (s *confdbSuite) TestConfdbGetNoFields(c *check.C) {
 			c.Check(r.Method, Equals, "GET")
 			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
-			fields := r.URL.Query().Get("fields")
-			c.Check(fields, Equals, "")
+			q := r.URL.Query()
+			fields := strutil.CommaSeparatedList(q.Get("fields"))
+			c.Check(fields, HasLen, 0)
 
-			w.WriteHeader(200)
-			fmt.Fprintf(w, syncResp, `{"abc": 1, "xyz": false}`)
+			w.WriteHeader(202)
+			fmt.Fprintf(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": 1, "xyz": false}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -457,4 +491,47 @@ func (s *confdbSuite) TestConfdbGetNoFields(c *check.C) {
 	"xyz": false
 }
 `)
+}
+
+func (s *confdbSuite) TestConfdbGetNoWait(c *check.C) {
+	restore := s.mockConfdbFlag(c)
+	defer restore()
+
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"get", "foo/bar/baz", "--no-wait"})
+	c.Assert(err, ErrorMatches, "cannot use --no-wait when reading confdb")
+}
+
+func (s *confdbSuite) TestConfdbGetNoDataError(c *check.C) {
+	restore := s.mockConfdbFlag(c)
+	defer restore()
+
+	var reqs int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch reqs {
+		case 0:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
+
+			q := r.URL.Query()
+			fields := strutil.CommaSeparatedList(q.Get("fields"))
+			c.Check(fields, DeepEquals, []string{"foo"})
+
+			w.WriteHeader(202)
+			fmt.Fprintf(w, asyncResp)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-error": "some error, no data"}}}`)
+		default:
+			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
+			w.WriteHeader(500)
+			fmt.Fprintf(w, `{"type": "error", "result": {"message": %q}}`, err)
+			c.Error(err)
+		}
+
+		reqs++
+	})
+
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"get", "foo/bar/baz", "foo"})
+	c.Assert(err, ErrorMatches, "some error, no data")
 }

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -498,7 +498,8 @@ func (s *confdbSuite) TestConfdbGetNoWait(c *check.C) {
 	defer restore()
 
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"get", "foo/bar/baz", "--no-wait"})
-	c.Assert(err, ErrorMatches, "cannot use --no-wait when reading confdb")
+	// although a confdb snap get waits for a change, there's no --no-wait option
+	c.Assert(err, ErrorMatches, "unknown flag `no-wait'")
 }
 
 func (s *confdbSuite) TestConfdbGetNoDataError(c *check.C) {

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -139,7 +139,7 @@ func validateConfdbViewID(id string) error {
 	parts := strings.Split(id, "/")
 	for _, part := range parts {
 		if part == "" {
-			return errors.New(i18n.G("confdb identifier must conform to format: <account-id>/<confdb>/<view>"))
+			return errors.New(i18n.G("confdb-schema view id must conform to format: <account-id>/<confdb-schema>/<view>"))
 		}
 	}
 

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -267,7 +267,7 @@ func (s *confdbSuite) TestConfdbSetInvalidAspectID(c *check.C) {
 
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "foo//bar", "foo=bar"})
 	c.Assert(err, check.NotNil)
-	c.Check(err.Error(), check.Equals, "confdb identifier must conform to format: <account-id>/<confdb>/<view>")
+	c.Check(err.Error(), check.Equals, "confdb-schema view id must conform to format: <account-id>/<confdb-schema>/<view>")
 }
 
 func (s *confdbSuite) TestConfdbSetNoWait(c *check.C) {

--- a/cmd/snap/cmd_unset_test.go
+++ b/cmd/snap/cmd_unset_test.go
@@ -97,7 +97,7 @@ func (s *confdbSuite) TestConfdbUnsetInvalidConfdbID(c *check.C) {
 
 	_, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "foo//bar", "abc"})
 	c.Assert(err, check.NotNil)
-	c.Check(err.Error(), check.Equals, "confdb identifier must conform to format: <account-id>/<confdb>/<view>")
+	c.Check(err.Error(), check.Equals, "confdb-schema view id must conform to format: <account-id>/<confdb-schema>/<view>")
 }
 
 func (s *confdbSuite) TestUnsetEmptyKey(c *check.C) {

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -1024,7 +1024,7 @@ func (v *View) Get(databag Databag, request string) (interface{}, error) {
 			reqStr = fmt.Sprintf(" %q through", request)
 		}
 
-		return nil, NewNotFoundError(i18n.G("cannot get%s %s/%s/%s: no view data"), reqStr, v.schema.Account, v.schema.Name, v.Name)
+		return nil, NewNotFoundError(i18n.G("cannot get%s %s/%s/%s: no data"), reqStr, v.schema.Account, v.schema.Name, v.Name)
 	}
 
 	return merged, nil

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -349,11 +349,11 @@ func (s *viewSuite) TestConfdbNotFound(c *C) {
 
 	_, err = view.Get(databag, "top-level")
 	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "top-level" through acc/foo/bar: no view data`)
+	c.Assert(err, ErrorMatches, `cannot get "top-level" through acc/foo/bar: no data`)
 
 	_, err = view.Get(databag, "")
 	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get acc/foo/bar: no view data`)
+	c.Assert(err, ErrorMatches, `cannot get acc/foo/bar: no data`)
 
 	err = view.Set(databag, "nested", "thing")
 	c.Assert(err, IsNil)
@@ -363,7 +363,7 @@ func (s *viewSuite) TestConfdbNotFound(c *C) {
 
 	_, err = view.Get(databag, "other-nested")
 	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "other-nested" through acc/foo/bar: no view data`)
+	c.Assert(err, ErrorMatches, `cannot get "other-nested" through acc/foo/bar: no data`)
 }
 
 func (s *viewSuite) TestViewBadRead(c *C) {
@@ -402,7 +402,7 @@ func (s *viewSuite) TestViewAccessControl(c *C) {
 		{
 			access: "read",
 			// non-access control error, access ok
-			getErr: `cannot get "foo" through acc/confdb/foo: no view data`,
+			getErr: `cannot get "foo" through acc/confdb/foo: no data`,
 			setErr: `cannot set "foo" through acc/confdb/foo: no matching rule`,
 		},
 		{
@@ -1906,7 +1906,7 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderLast(c *C) {
 
 	_, err = view.Get(databag, "foo")
 	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "foo" through acc/confdb/foo: no view data`)
+	c.Assert(err, ErrorMatches, `cannot get "foo" through acc/confdb/foo: no data`)
 }
 
 func (s *viewSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -173,10 +173,10 @@ var (
 	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking
 	assertstateFetchAllValidationSets        = assertstate.FetchAllValidationSets
 
-	confdbstateGetView        = confdbstate.GetView
-	confdbstateGetTransaction = confdbstate.GetTransactionToSet
-	confdbstateGet            = confdbstate.Get
-	confdbstateSetViaView     = confdbstate.SetViaView
+	confdbstateGetView             = confdbstate.GetView
+	confdbstateGetTransactionToSet = confdbstate.GetTransactionToSet
+	confdbstateSetViaView          = confdbstate.SetViaView
+	confdbstateLoadConfdbAsync     = confdbstate.LoadConfdbAsync
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -387,12 +387,8 @@ var (
 	MaxReadBuflen = maxReadBuflen
 )
 
-func MockConfdbstateGet(f func(_ *state.State, _, _, _ string, _ []string) (interface{}, error)) (restore func()) {
-	return testutil.Mock(&confdbstateGet, f)
-}
-
 func MockConfdbstateGetTransaction(f func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error)) (restore func()) {
-	return testutil.Mock(&confdbstateGetTransaction, f)
+	return testutil.Mock(&confdbstateGetTransactionToSet, f)
 }
 
 func MockRebootNoticeWait(d time.Duration) (restore func()) {
@@ -431,4 +427,8 @@ func MockConfdbstateSetViaView(f func(confdb.Databag, *confdb.View, map[string]i
 
 func MockAssertstateFetchAllValidationSets(f func(*state.State, int, *assertstate.RefreshAssertionsOptions) error) (restore func()) {
 	return testutil.Mock(&assertstateFetchAllValidationSets, f)
+}
+
+func MockConfdbstateLoadConfdbAsync(f func(_ *state.State, _ *confdb.View, _ []string) (string, error)) (restore func()) {
+	return testutil.Mock(&confdbstateLoadConfdbAsync, f)
 }

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -54,6 +55,7 @@ func Manager(st *state.State, hookMgr *hookstate.HookManager, runner *state.Task
 	// unblock others who may be waiting for it
 	runner.AddHandler("clear-confdb-tx-on-error", m.noop, m.clearOngoingTransaction)
 	runner.AddHandler("clear-confdb-tx", m.clearOngoingTransaction, nil)
+	runner.AddHandler("load-confdb-change", m.doLoadDataIntoChange, nil)
 
 	hookMgr.Register(regexp.MustCompile("^change-view-.+$"), func(context *hookstate.Context) hookstate.Handler {
 		return &changeViewHandler{ctx: context}
@@ -111,6 +113,58 @@ func (m *ConfdbManager) clearOngoingTransaction(t *state.Task, _ *tomb.Tomb) err
 	}
 
 	// TODO: unblock next waiting confdb writer once we add the blocking logic
+	return nil
+}
+
+func (m *ConfdbManager) doLoadDataIntoChange(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	tx, _, _, err := GetStoredTransaction(t)
+	if err != nil {
+		return err
+	}
+
+	var viewName string
+	err = t.Get("view-name", &viewName)
+	if err != nil {
+		return fmt.Errorf(`internal error: cannot get "view-name" from task: %w`, err)
+	}
+
+	var requests []string
+	err = t.Get("requests", &requests)
+	if err != nil {
+		return fmt.Errorf(`internal error: cannot get "requests" from task: %w`, err)
+	}
+
+	view, err := GetView(st, tx.ConfdbAccount, tx.ConfdbName, viewName)
+	if err != nil {
+		return fmt.Errorf("internal error: cannot get view: %w", err)
+	}
+
+	var apiData map[string]interface{}
+	err = t.Change().Get("api-data", &apiData)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
+	if apiData == nil {
+		apiData = make(map[string]interface{})
+	}
+
+	result, err := GetViaView(tx, view, requests)
+	if err != nil {
+		if errors.Is(err, &confdb.NotFoundError{}) {
+			apiData["confdb-error"] = err.Error()
+			t.Change().Set("api-data", apiData)
+			return nil
+		}
+		return fmt.Errorf("cannot read confdb %s/%s: %w", tx.ConfdbAccount, tx.ConfdbName, err)
+	}
+
+	apiData["confdb-data"] = result
+	t.Change().Set("api-data", apiData)
 	return nil
 }
 

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -155,7 +155,7 @@ func GetViaView(bag confdb.Databag, view *confdb.View, fields []string) (interfa
 			reqStr = fmt.Sprintf(i18n.G(" %s through"), strutil.Quoted(fields))
 		}
 
-		return nil, confdb.NewNotFoundError(i18n.G("cannot get%s %s/%s/%s: no view data"), reqStr, view.Schema().Account, view.Schema().Name, view.Name)
+		return nil, confdb.NewNotFoundError(i18n.G("cannot get%s %s/%s/%s: no data"), reqStr, view.Schema().Account, view.Schema().Name, view.Name)
 	}
 
 	return results, nil
@@ -617,6 +617,69 @@ func GetTransactionForSnapctlGet(ctx *hookstate.Context, view *confdb.View) (*Tr
 		return nil, err
 	}
 	return tx, nil
+}
+
+// LoadConfdbAsync schedules a change to load a confdb, running any appropriate
+// hooks and fulfilling the requests by reading the view and placing the resulting
+// data in the change's data (so it can be read by the client).
+func LoadConfdbAsync(st *state.State, view *confdb.View, requests []string) (changeID string, err error) {
+	account, schemaName := view.Schema().Account, view.Schema().Name
+
+	tx, err := NewTransaction(st, account, schemaName)
+	if err != nil {
+		return "", fmt.Errorf("cannot access confdb view %s/%s/%s: cannot create transaction: %v", account, schemaName, view.Name, err)
+	}
+
+	ts, err := createLoadConfdbTasks(st, tx, view)
+	if err != nil {
+		return "", err
+	}
+
+	chg := st.NewChange("get-confdb", fmt.Sprintf(`Get confdb through "%s/%s/%s"`, account, schemaName, view.Name))
+	if ts != nil {
+		// if there are hooks to run, link the read-confdb task to those tasks
+		clearTxTask, err := ts.Edge(clearTxEdge)
+		if err != nil {
+			return "", err
+		}
+
+		// schedule a task to read the tx after the hook and add the data to the
+		// change so it can be read by the client
+		loadConfdbTask := st.NewTask("load-confdb-change", "Load confdb data into the change")
+		loadConfdbTask.Set("requests", requests)
+		loadConfdbTask.Set("view-name", view.Name)
+
+		loadConfdbTask.Set("tx-task", clearTxTask.ID())
+		loadConfdbTask.WaitFor(clearTxTask)
+		chg.AddAll(ts)
+
+		err = addReadTransaction(st, account, schemaName, clearTxTask.ID())
+		if err != nil {
+			return "", err
+		}
+		chg.AddTask(loadConfdbTask)
+	} else {
+		// no hooks to run so we can just load the values directly into the change
+		// (we still need the change because the API is async)
+		result, err := GetViaView(tx, view, requests)
+		if err != nil {
+			if errors.Is(err, &confdb.NotFoundError{}) {
+				chg.Set("api-data", map[string]interface{}{
+					"confdb-error": err.Error(),
+				})
+				chg.SetStatus(state.DoneStatus)
+				return chg.ID(), nil
+			}
+			return "", fmt.Errorf("cannot read confdb %s/%s: %w", tx.ConfdbAccount, tx.ConfdbName, err)
+		}
+
+		chg.Set("api-data", map[string]interface{}{
+			"confdb-data": result,
+		})
+		chg.SetStatus(state.DoneStatus)
+	}
+
+	return chg.ID(), nil
 }
 
 // createLoadConfdbTasks returns a taskset with the hooks and tasks required to

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -893,7 +893,7 @@ func (s *confdbSuite) TestConfdbGetDifferentViewThanOngoingTx(c *C) {
 
 	stdout, stderr, err := ctlcmd.Run(ctx, []string{"get", "--view", ":other", "ssid"}, 0)
 	// error is for no stored value, meaning we read the right confdb
-	c.Assert(err, ErrorMatches, `.*: no view data`)
+	c.Assert(err, ErrorMatches, `.*: no data`)
 	c.Check(stdout, IsNil)
 	c.Check(stderr, IsNil)
 }

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -246,8 +246,7 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, requests map[strin
 		return err
 	}
 
-	if confdbstate.IsConfdbHook(ctx) && !strings.HasPrefix(ctx.HookName(), "change-view-") &&
-		!strings.HasPrefix(ctx.HookName(), "load-view-") {
+	if confdbstate.IsConfdbHook(ctx) && !confdbstate.IsModifyConfdbHook(ctx) {
 		return fmt.Errorf("cannot modify confdb in %q hook", ctx.HookName())
 	}
 

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -246,7 +246,8 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, requests map[strin
 		return err
 	}
 
-	if confdbstate.IsConfdbHook(ctx) && !strings.HasPrefix(ctx.HookName(), "change-view-") {
+	if confdbstate.IsConfdbHook(ctx) && !strings.HasPrefix(ctx.HookName(), "change-view-") &&
+		!strings.HasPrefix(ctx.HookName(), "load-view-") {
 		return fmt.Errorf("cannot modify confdb in %q hook", ctx.HookName())
 	}
 

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -190,7 +190,7 @@ func (s *confdbSuite) TestConfdbUnsetManyViews(c *C) {
 	s.state.Lock()
 	_, err = confdbstate.Get(s.state, s.devAccID, "network", "write-wifi", []string{"ssid", "password"})
 	s.state.Unlock()
-	c.Assert(err, ErrorMatches, `cannot get "ssid", "password" .*: no view data`)
+	c.Assert(err, ErrorMatches, `cannot get "ssid", "password" .*: no data`)
 }
 
 func (s *confdbSuite) TestConfdbUnsetInvalid(c *C) {

--- a/tests/main/confdb/task.yaml
+++ b/tests/main/confdb/task.yaml
@@ -26,7 +26,7 @@ execute: |
   # hook was called
   MATCH "canonical" < /var/snap/test-custodian-snap/common/manage-wifi-view-changed-ran
   snap set developer1/network/wifi-setup ssid!
-  snap get developer1/network/wifi-setup ssid 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "ssid" through developer1/network/wifi-setup: no view data'
+  snap get developer1/network/wifi-setup ssid 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "ssid" through developer1/network/wifi-setup: no data'
 
   # check writing, reading and unsetting using placeholders
   snap set -t developer1/network/wifi-setup private.my-company=\"my-config\" private.your-company=\"your-config\"
@@ -34,7 +34,7 @@ execute: |
   snap get developer1/network/wifi-setup private.your-company | MATCH "your-config"
 
   snap set developer1/network/wifi-setup private.my-company!
-  snap get developer1/network/wifi-setup private.my-company 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "private.my-company" through developer1/network/wifi-setup: no view data'
+  snap get developer1/network/wifi-setup private.my-company 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "private.my-company" through developer1/network/wifi-setup: no data'
 
   snap get developer1/network/wifi-setup private.your-company | MATCH "your-config"
   snap set developer1/network/wifi-setup private.your-company!


### PR DESCRIPTION
Load ephemeral confdb data when reading from the API (for snap get). This requires making the read side of the API async, since it might be necessary to run hooks. The result in then transmitted through the change to the client. In case there are no custodian hooks to run, no tasks are run and the result is just directly placed into a "done" change.
This change turned out to be larger than I thought due to the API changes. The changes to the API are relatively simple but they required basically a re-write of the tests which blew up the diff. I can split the changes, if needed