### PR TITLE
packaging/ubuntu-16.04: install systemd-dev if pkg-config udev not satisfied

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -40,7 +40,7 @@ Build-Depends: autoconf,
                python3-pytest,
                squashfs-tools,
                tzdata,
-               udev,
+               systemd-dev | udev (< 255),
                xfslibs-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/snapcore/snapd

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -197,6 +197,19 @@ override_dh_clean:
 	# XXX: hacky^2
 	(cd c-vendor/squashfuse && rm -f snapfuse && make distclean || true )
 
+
+override_dh_auto_configure:
+	# The package udev is a build dependency used to satisfy the pkg-config
+	# dependency on udev (udev.pc). Starting from Ubuntu Noble (24.04+),
+	# udev.pc is provided by package systemd-dev instead of udev. This step
+	# attempts to install systemd-dev when the pkg-config dependency on udev
+	# is not yet resolved.
+	if ! pkg-config udev; then \
+		echo "pkg-config dependency udev missing, installing systemd-dev"; \
+		apt-get install -y systemd-dev > /dev/null 2>&1 || echo "warning: failed to install systemd-dev"; \
+	fi; \
+	dh_auto_configure
+
 override_dh_auto_build:
 	# very ugly test for FIPS variant of a toolchain
 	# see https://warthogs.atlassian.net/browse/FR-8860

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -197,19 +197,6 @@ override_dh_clean:
 	# XXX: hacky^2
 	(cd c-vendor/squashfuse && rm -f snapfuse && make distclean || true )
 
-
-override_dh_auto_configure:
-	# The package udev is a build dependency used to satisfy the pkg-config
-	# dependency on udev (udev.pc). Starting from Ubuntu Noble (24.04+),
-	# udev.pc is provided by package systemd-dev instead of udev. This step
-	# attempts to install systemd-dev when the pkg-config dependency on udev
-	# is not yet resolved.
-	if ! pkg-config udev; then \
-		echo "pkg-config dependency udev missing, installing systemd-dev"; \
-		apt-get install -y systemd-dev > /dev/null 2>&1 || echo "warning: failed to install systemd-dev"; \
-	fi; \
-	dh_auto_configure
-
 override_dh_auto_build:
 	# very ugly test for FIPS variant of a toolchain
 	# see https://warthogs.atlassian.net/browse/FR-8860


### PR DESCRIPTION
Dix deb build failures for plucky caused by missing pkg-config dependency udev that looks for package providing udev.pc

- In Xenial, Bionic, Focal and Jammy udev.pc used to be provided by package udev (systemd-dev is not available)
- In Noble onward package systemd-dev was introduced and provided udev.pc while udev was still available but no longer providing udev.pc (see http://archive.ubuntu.com/ubuntu/pool/main/s/systemd/)

Approach:
Changed build dependency so that at the point where systemd-dev replaced udev with providing udev.pc, udev >= 255 (noble, oracular, plucky), we require systemd-dev. 

Tests:
- Plucky |  https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17064219/+listing-archive-extra
- Oracular | https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17064236/+listing-archive-extra
- Noble | https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17064237/+listing-archive-extra
- Jammy | https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17064238/+listing-archive-extra
- Focal | https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17064239/+listing-archive-extra
- Bionic | https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17064240/+listing-archive-extra
-  Xenial  | https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17064247/+listing-archive-extra

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34584