### PR TITLE
cmd: drop explicit check for udev pkg-config module, update build dependencies

### DIFF
--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -104,10 +104,9 @@ PKG_CHECK_MODULES([SELINUX], [libselinux], [
 AC_DEFINE([HAVE_SELINUX], [1], [Build with SELinux support])])
 ])
 
-# Check if udev and libudev are available.
-# Those are now used unconditionally even if apparmor is disabled.
+# Check if libudev is available. It is used unconditionally even if apparmor is
+# disabled.
 PKG_CHECK_MODULES([LIBUDEV], [libudev])
-PKG_CHECK_MODULES([UDEV], [udev])
 
 # Check if libcap is available.
 # PKG_CHECK_MODULES([LIBCAP], [libcap])

--- a/packaging/debian-sid/control
+++ b/packaging/debian-sid/control
@@ -56,7 +56,6 @@ Build-Depends: autoconf,
                squashfs-tools,
                systemd-dev,
                tzdata,
-               udev,
                xfslibs-dev
 Standards-Version: 4.6.0
 Homepage: https://github.com/snapcore/snapd

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -221,7 +221,6 @@ BuildRequires:  pkgconfig(libselinux)
 %endif
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(systemd)
-BuildRequires:  pkgconfig(udev)
 BuildRequires:  xfsprogs-devel
 BuildRequires:  glibc-static
 %if ! 0%{?rhel}

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -118,7 +118,6 @@ BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(libseccomp)
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(systemd)
-BuildRequires:  pkgconfig(udev)
 BuildRequires:  systemd-rpm-macros
 %if %{with valgrind}
 BuildRequires:  valgrind

--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -33,7 +33,6 @@ Build-Depends: autoconf,
                python3-docutils,
                python3-markdown,
                squashfs-tools,
-               udev,
                xfslibs-dev
 Recommends: gnupg1 | gnupg
 Suggests: zenity | kdialog

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -40,7 +40,7 @@ Build-Depends: autoconf,
                python3-pytest,
                squashfs-tools,
                tzdata,
-               systemd-dev | udev (< 255),
+               systemd-dev | systemd (< 255),
                xfslibs-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/snapcore/snapd


### PR DESCRIPTION
Drop explicilt check for udev pkg-config module. What we really ever need at this level is libudev.

Based on the discussion around #15210 

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34666

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
