### PR TITLE
cmd: enforce application tracking for snaps using core24+

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1462,11 +1462,21 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 			if err != cgroup.ErrCannotTrackProcess {
 				return err
 			}
-			// If we cannot track the process then log a debug message.
-			// TODO: if we could, create a warning. Currently this is not possible
-			// because only snapd can create warnings, internally.
-			logger.Debugf("snapd cannot track the started application")
-			logger.Debugf("snap refreshes will not be postponed by this process")
+			switch runner.info.Base {
+			case "", "core", "core18", "core20", "core22":
+				// If we cannot track the process then log a debug message.
+				// TODO: if we could, create a warning. Currently this is not possible
+				// because only snapd can create warnings, internally.
+				logger.Debugf("snapd cannot track the started application")
+				logger.Debugf("snap refreshes will not be postponed by this process")
+			default:
+				// For apps using core24+, fail hard.
+				if usr, err := userCurrent(); err == nil {
+					logger.Noticef("The user %s cannot run snap applications on this system.\n"+
+						"See https://forum.snapcraft.io/t/46210 for more details.", usr.Username)
+				}
+				return err
+			}
 		}
 	}
 

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -60,6 +60,19 @@ hooks:
  configure:
 `)
 
+var mockYamlCore24 = []byte(`name: snapname
+version: 1.0
+base: core24
+apps:
+ app:
+  command: run-app
+ svc:
+  command: run-svc
+  daemon: simple
+hooks:
+ configure:
+`)
+
 var mockYamlWithComponent = []byte(`name: snapname
 version: 1.0
 components:
@@ -2564,6 +2577,51 @@ func (s *RunSuite) TestSnapRunTrackingFailure(c *check.C) {
 
 	// Ensure that the debug message is printed.
 	c.Assert(logbuf.String(), testutil.Contains, "snapd cannot track the started application\n")
+}
+
+func (s *RunSuite) TestSnapRunTrackingFailureCore24(c *check.C) {
+	restore := mockSnapConfine(filepath.Join(dirs.SnapMountDir, "core", "111", dirs.CoreLibExecDir))
+	defer restore()
+
+	// mock installed snap
+	snaptest.MockSnapCurrent(c, string(mockYamlCore24), &snap.SideInfo{
+		Revision: snap.R("x2"),
+	})
+
+	// pretend to be running from core
+	restore = snaprun.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+	})
+	defer restore()
+
+	restore = snaprun.MockCreateTransientScopeForTracking(func(securityTag string, opts *cgroup.TrackingOptions) error {
+		c.Assert(securityTag, check.Equals, "snap.snapname.app")
+		c.Assert(opts, check.NotNil)
+		c.Assert(opts.AllowSessionBus, check.Equals, true)
+		// Pretend that the tracking system was unable to track this application.
+		return cgroup.ErrCannotTrackProcess
+	})
+	defer restore()
+
+	restore = snaprun.MockConfirmSystemdServiceTracking(func(securityTag string) error {
+		panic("apps need to create a scope and do not use systemd service tracking")
+	})
+	defer restore()
+
+	// redirect exec
+	restore = snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		panic("did not expect to run through exec")
+	})
+	defer restore()
+
+	// Capture the non-debug log that is printed by this test.
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	// Ensure that the error message is printed.
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
+	c.Assert(err, check.ErrorMatches, "cannot track application process")
+	c.Assert(logbuf.String(), testutil.Contains, "See https://forum.snapcraft.io/t/46210 for more details.\n")
 }
 
 var mockKernelYaml = []byte(`name: pc-kernel


### PR DESCRIPTION
When snap applications or hooks are launched, they are tracked using a systemd facility that requires cooperation from systemd running either as root, or from systemd running as user (talking to systemd running as root).

Since this feature was introduced, snapd had allowed for the tracking functionality to fail silently. Now, when a snap application is using core, core18, core20 or core22 this behavior is retained, but for snap applications based on core24 or newer, the failure is now blocking application startup.

A message is printed to the user to inform them of this situation. The message uses an abbreviated URL to the forum so that the message can be edited and stay relevant over time.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34299
