### PR TITLE
many: rename view-changed confdb hook to observe-view

### DIFF
--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -61,7 +61,7 @@ func Manager(st *state.State, hookMgr *hookstate.HookManager, runner *state.Task
 	hookMgr.Register(regexp.MustCompile("^save-view-.+$"), func(context *hookstate.Context) hookstate.Handler {
 		return &saveViewHandler{ctx: context}
 	})
-	hookMgr.Register(regexp.MustCompile("^.+-view-changed$"), func(context *hookstate.Context) hookstate.Handler {
+	hookMgr.Register(regexp.MustCompile("^observe-view-.+$"), func(context *hookstate.Context) hookstate.Handler {
 		return &hookstate.SnapHookHandler{}
 	})
 	hookMgr.Register(regexp.MustCompile("^query-view-.+$"), func(context *hookstate.Context) hookstate.Handler {

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -353,7 +353,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 		linkTask(saveViewTask)
 	}
 
-	// run view-changed hooks for any plug that references a view that could have
+	// run observe-view hooks for any plug that references a view that could have
 	// changed with this data modification
 	paths := tx.AlteredPaths()
 	affectedPlugs, err := getPlugsAffectedByPaths(st, view.Schema(), paths)
@@ -376,7 +376,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 		for _, plug := range affectedPlugs[snapName] {
 			// TODO: run these concurrently or keep sequential for predictability?
 			const ignoreError = true
-			task := setupConfdbHook(st, snapName, plug.Name+"-view-changed", ignoreError)
+			task := setupConfdbHook(st, snapName, "observe-view-"+plug.Name, ignoreError)
 			linkTask(task)
 		}
 	}
@@ -527,7 +527,7 @@ func IsConfdbHook(ctx *hookstate.Context) bool {
 			strings.HasPrefix(ctx.HookName(), "save-view-") ||
 			strings.HasPrefix(ctx.HookName(), "load-view-") ||
 			strings.HasPrefix(ctx.HookName(), "query-view-") ||
-			strings.HasSuffix(ctx.HookName(), "-view-changed"))
+			strings.HasPrefix(ctx.HookName(), "observe-view-"))
 }
 
 // GetTransactionForSnapctlGet gets a transaction to read the view's confdb. It

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -512,7 +512,7 @@ func (s *confdbTestSuite) TestConfdbTasksUserSetWithCustodianInstalled(c *C) {
 		},
 		{
 			Snap:        "custodian-snap",
-			Hook:        "setup-view-changed",
+			Hook:        "observe-view-setup",
 			Optional:    true,
 			IgnoreError: true,
 		},
@@ -585,7 +585,7 @@ func (s *confdbTestSuite) TestConfdbTasksObserverSnapSetWithCustodianInstalled(c
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	// we trigger hooks for the custodian snap and for the -view-changed for the
+	// we trigger hooks for the custodian snap and for the observe-view- for the
 	// observer snap that didn't trigger the change
 	tasks := []string{"clear-confdb-tx-on-error", "run-hook", "run-hook", "run-hook", "run-hook", "commit-confdb-tx", "clear-confdb-tx"}
 	hooks := []*hookstate.HookSetup{
@@ -603,13 +603,13 @@ func (s *confdbTestSuite) TestConfdbTasksObserverSnapSetWithCustodianInstalled(c
 		},
 		{
 			Snap:        "custodian-snap",
-			Hook:        "setup-view-changed",
+			Hook:        "observe-view-setup",
 			Optional:    true,
 			IgnoreError: true,
 		},
 		{
 			Snap:        "test-snap-2",
-			Hook:        "setup-view-changed",
+			Hook:        "observe-view-setup",
 			Optional:    true,
 			IgnoreError: true,
 		},
@@ -717,14 +717,14 @@ plugs:
 	}
 
 	// mock custodians
-	hooks := []string{"change-view-setup", "save-view-setup", "query-view-setup", "load-view-setup", "setup-view-changed"}
+	hooks := []string{"change-view-setup", "save-view-setup", "query-view-setup", "load-view-setup", "observe-view-setup"}
 	for _, snap := range custodians {
 		isCustodian := true
 		mockSnap(snap, isCustodian, hooks)
 	}
 
 	// mock non-custodians
-	hooks = []string{"setup-view-changed", "install"}
+	hooks = []string{"observe-view-setup", "install"}
 	for _, snap := range nonCustodians {
 		isCustodian := false
 		mockSnap(snap, isCustodian, hooks)
@@ -1017,7 +1017,7 @@ func (s *confdbTestSuite) mockConfdbHooks(c *C) (*[]string, func()) {
 
 func (s *confdbTestSuite) checkSetConfdbChange(c *C, chg *state.Change, hooks *[]string) {
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
-	c.Assert(*hooks, DeepEquals, []string{"change-view-setup", "save-view-setup", "setup-view-changed"})
+	c.Assert(*hooks, DeepEquals, []string{"change-view-setup", "save-view-setup", "observe-view-setup"})
 
 	commitTask := findTask(chg, "commit-confdb-tx")
 	tx, _, _, err := confdbstate.GetStoredTransaction(commitTask)
@@ -1074,11 +1074,11 @@ func (s *confdbTestSuite) TestGetTransactionFromSaveViewHook(c *C) {
 }
 
 func (s *confdbTestSuite) TestGetTransactionFromViewChangedHook(c *C) {
-	ctx := s.testGetReadableOngoingTransaction(c, "setup-view-changed")
+	ctx := s.testGetReadableOngoingTransaction(c, "observe-view-setup")
 
 	// non change-view hooks cannot modify the transaction
 	stdout, stderr, err := ctlcmd.Run(ctx, []string{"set", "--view", ":setup", "ssid=bar"}, 0)
-	c.Assert(err, ErrorMatches, `cannot modify confdb in "setup-view-changed" hook`)
+	c.Assert(err, ErrorMatches, `cannot modify confdb in "observe-view-setup" hook`)
 	c.Assert(stdout, IsNil)
 	c.Assert(stderr, IsNil)
 }

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -43,7 +43,7 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^save-view-.+$")),
 	NewHookType(regexp.MustCompile("^query-view-.+$")),
 	NewHookType(regexp.MustCompile("^load-view-.+$")),
-	NewHookType(regexp.MustCompile("^.+-view-changed$")),
+	NewHookType(regexp.MustCompile("^observe-view-.+$")),
 }
 
 var supportedComponentHooks = []*HookType{

--- a/tests/main/confdb-cross-config/task.yaml
+++ b/tests/main/confdb-cross-config/task.yaml
@@ -58,7 +58,7 @@ execute: |
   MATCH "first" < /var/snap/test-custodian-snap/common/change-view-manage-wifi-ran
   # the value was modified by change-confdb
   MATCH "first-custodian" < /var/snap/test-custodian-snap/common/save-view-manage-wifi-ran
-  MATCH "first-custodian" < /var/snap/test-snap/common/setup-wifi-view-changed-ran
+  MATCH "first-custodian" < /var/snap/test-snap/common/observe-view-setup-wifi-ran
 
   # check no other hooks were called
   test "2" = "$(find /var/snap/test-custodian-snap/common/* -maxdepth 1 | wc -l)"
@@ -75,7 +75,7 @@ execute: |
   MATCH "second" < /var/snap/test-custodian-snap/common/change-view-manage-wifi-ran
   # the value was modified by the custodian snap
   MATCH "second-custodian" < /var/snap/test-custodian-snap/common/save-view-manage-wifi-ran
-  MATCH "second-custodian" < /var/snap/test-custodian-snap/common/manage-wifi-view-changed-ran
+  MATCH "second-custodian" < /var/snap/test-custodian-snap/common/observe-view-manage-wifi-ran
   # check no other hooks were called
   test "3" = "$(find /var/snap/test-custodian-snap/common/* -maxdepth 1 | wc -l)"
   test "0" = "$(find /var/snap/test-snap/common/* -maxdepth 1 | wc -l)"

--- a/tests/main/confdb-cross-config/test-custodian-snap/meta/hooks/observe-view-manage-wifi
+++ b/tests/main/confdb-cross-config/test-custodian-snap/meta/hooks/observe-view-manage-wifi
@@ -1,4 +1,4 @@
 #!/bin/sh -xe
 
 value=$(snapctl get --view :manage-wifi ssid)
-echo "$value" > "$SNAP_COMMON"/manage-wifi-view-changed-ran
+echo "$value" > "$SNAP_COMMON"/observe-view-manage-wifi-ran

--- a/tests/main/confdb-cross-config/test-snap/meta/hooks/observe-view-setup-wifi
+++ b/tests/main/confdb-cross-config/test-snap/meta/hooks/observe-view-setup-wifi
@@ -1,4 +1,4 @@
 #!/bin/sh -xe
 
 value=$(snapctl get --view :setup-wifi ssid)
-echo "$value" > "$SNAP_COMMON"/setup-wifi-view-changed-ran
+echo "$value" > "$SNAP_COMMON"/observe-view-setup-wifi-ran

--- a/tests/main/confdb/task.yaml
+++ b/tests/main/confdb/task.yaml
@@ -24,7 +24,7 @@ execute: |
   snap set developer1/network/wifi-setup ssid=canonical
   snap get developer1/network/wifi-setup ssid | MATCH "canonical"
   # hook was called
-  MATCH "canonical" < /var/snap/test-custodian-snap/common/manage-wifi-view-changed-ran
+  MATCH "canonical" < /var/snap/test-custodian-snap/common/observe-view-manage-wifi-ran
   snap set developer1/network/wifi-setup ssid!
   snap get developer1/network/wifi-setup ssid 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH $'cannot get "ssid" through developer1/network/wifi-setup: no view data'
 

--- a/tests/main/confdb/test-custodian-snap/meta/hooks/observe-view-manage-wifi
+++ b/tests/main/confdb/test-custodian-snap/meta/hooks/observe-view-manage-wifi
@@ -1,4 +1,4 @@
 #!/bin/sh -xe
 
 value=$(snapctl get --view :manage-wifi ssid)
-echo "$value" > "$SNAP_COMMON"/manage-wifi-view-changed-ran
+echo "$value" > "$SNAP_COMMON"/observe-view-manage-wifi-ran


### PR DESCRIPTION
The `<plug>-view-changed` needs to be renamed to `observe-view-<plug>` in the context of the clustering sprint so it matches the `observe-cluster-*` hooks. 