### PR TITLE
tests: use sha commit instead of version tag in changed-files

### DIFF
--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
 
       - name: woke
         uses: get-woke/woke-action-reviewdog@v0

--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -11,8 +11,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tj-actions/changed-files@v41.0.0
-        id: files
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
 
       - name: woke
         uses: get-woke/woke-action-reviewdog@v0
@@ -20,4 +21,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
           fail-on-error: true
-          woke-args: ${{ steps.files.outputs.all_changed_files }}
+          woke-args: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -117,7 +117,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v45.0.6
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
 
     - name: Save changes files
       run: |

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -117,7 +117,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
 
     - name: Save changes files
       run: |

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
 
     - name: Save changes files
       run: |

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -61,9 +61,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v41.0.0
-      with:
-        path: ./
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
 
     - name: Save changes files
       run: |


### PR DESCRIPTION
This is proposed solution to avoid a security issue in change-files action used in snapd workflows raised in https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
