### PR TITLE
tests: use sha commit instead of version tag in woke-action-reviewdog

### DIFF
--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -15,7 +15,7 @@ jobs:
         id: files
 
       - name: woke
-        uses: get-woke/woke-action-reviewdog@v0
+        uses: get-woke/woke-action-reviewdog@d71fd0115146a01c3181439ce714e21a69d75e31
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check

--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -15,7 +15,7 @@ jobs:
         id: files
 
       - name: woke
-        uses: get-woke/woke-action-reviewdog@d71fd0115146a01c3181439ce714e21a69d75e31
+        uses: get-woke/woke-action-reviewdog@d71fd0115146a01c3181439ce714e21a69d75e31 # v0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check


### PR DESCRIPTION
Use commit sha instead og version tag for woke-action-reviewdog as those tags could be insecure.

This need to be addressed too after the security issue raised with the changed-files action.
