### PR TITLE
interfaces: add symlinks backend

### DIFF
--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -216,6 +216,27 @@ type ConfigfilesUser interface {
 	PathPatterns() []string
 }
 
+// SymlinksUser must be implemented by Interfaces that use the symlinks backend.
+type SymlinksUser interface {
+	// TrackedDirectories returns a list of directories that might contain
+	// symlinks under control of snapd. They are understood to be in that
+	// situation if they point to inside snap content or data. These
+	// directories apply to either the rootfs or to the mount namespace of
+	// a snap (the latter is a TODO). AddSymlink from the backend is called
+	// to register symlinks that must be created in these directories.
+	// Non-registered symlinks found in these directories that point to a
+	// snap are removed.
+	//
+	// IMPORTANT when registering directories here from an interface,
+	// remember to also remove them from the snap-mgmt.sh.in script so
+	// removing the snapd package with apt cleans up everything.
+	//
+	// TODO it is possible that we might want to use different paths in the
+	// classic rootfs and in the mount namespace of a snap so the string
+	// could evolve to a type with path + rootfs type.
+	TrackedDirectories() []string
+}
+
 // StaticInfo describes various static-info of a given interface.
 //
 // The Summary must be a one-line string of length suitable for listing views.
@@ -333,6 +354,8 @@ const (
 	SecurityLdconfig SecuritySystem = "ldconfig"
 	// SecurityConfigfiles identifies the configfiles security system.
 	SecurityConfigfiles SecuritySystem = "configfiles"
+	// SecuritySymlinks identifies the symlinks security system.
+	SecuritySymlinks SecuritySystem = "symlinks"
 )
 
 var isValidBusName = regexp.MustCompile(`^[a-zA-Z_-][a-zA-Z0-9_-]*(\.[a-zA-Z_-][a-zA-Z0-9_-]*)+$`).MatchString

--- a/interfaces/symlinks/backend.go
+++ b/interfaces/symlinks/backend.go
@@ -1,0 +1,194 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// symlinks is a backend that ensures that configuration files required by
+// interfaces are present in the system. Currently it works only on classic and
+// modifies the classic rootfs.
+package symlinks
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/timings"
+)
+
+// Backend is responsible for maintaining symlinks cache.
+type Backend struct{}
+
+var _ = interfaces.SecurityBackend(&Backend{})
+
+// Initialize does nothing for this backend.
+func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
+	return nil
+}
+
+// Name returns the name of the backend.
+func (b *Backend) Name() interfaces.SecuritySystem {
+	return interfaces.SecuritySymlinks
+}
+
+// Setup will make the symlinks backend generate the specified symlinks.
+func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) error {
+	symlinkDirs := map[string]bool{}
+	for _, iface := range repo.AllInterfaces() {
+		if symlnIface, ok := iface.(interfaces.SymlinksUser); ok {
+			for _, d := range symlnIface.TrackedDirectories() {
+				symlinkDirs[d] = true
+			}
+		}
+	}
+	snapName := appSet.InstanceName()
+	// Get the spec that applies to this snap
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
+	if err != nil {
+		return fmt.Errorf("cannot obtain symlinks specification for snap %q: %s",
+			snapName, err)
+	}
+
+	return b.ensureSymlinks(spec.(*Specification), symlinkDirs)
+}
+
+// Remove removes modules symlinks files specific to a given snap.
+// This method should be called after removing a snap.
+func (b *Backend) Remove(snapName string) error {
+	// If called for the system (snapd) snap, that is possible only in a
+	// classic scenario when all other snaps in the system must have been
+	// removed already to allow the removal of the snapd snap. In that
+	// case, the config files will have already been removed by a Setup
+	// call, so we do not need to do anything here.
+
+	// TODO but this needs to be revisited for when we start supporting
+	// symlinks plugs in snaps.
+	return nil
+}
+
+// NewSpecification returns a new specification associated with this backend.
+func (b *Backend) NewSpecification(*interfaces.SnapAppSet,
+	interfaces.ConfinementOptions) interfaces.Specification {
+	return &Specification{}
+}
+
+// SandboxFeatures returns the list of features supported by snapd for symlinks.
+func (b *Backend) SandboxFeatures() []string {
+	return []string{"mediated-symlinks"}
+}
+
+func (b *Backend) removeUnwantedInDir(dir string, entries []os.DirEntry, activeLinks SymlinkToTarget) error {
+	// Loop to remove unwanted symlinks
+	for _, node := range entries {
+		if node.Type() != fs.ModeSymlink {
+			continue
+		}
+		path := filepath.Join(dir, node.Name())
+		controlled, err := linkIsSnapdControlled(path)
+		if err != nil {
+			return err
+		}
+		if !controlled {
+			continue
+		}
+		// link is active
+		if _, ok := activeLinks[node.Name()]; ok {
+			continue
+		}
+
+		// link not active, remove
+		if err := os.Remove(path); err != nil {
+			logger.Noticef("symlinks backend cannot remove %q", path)
+		}
+	}
+
+	return nil
+}
+
+func (b *Backend) ensureSymlinks(spec *Specification, symlinkDirs map[string]bool) error {
+	// Setup symlinks only if the snap has plugs that require it. For the
+	// moment this is only the system snap.
+	if len(spec.plugs) == 0 {
+		return nil
+	}
+
+	for lnDir := range spec.dirsToLinkToTarget {
+		if _, ok := symlinkDirs[lnDir]; !ok {
+			return fmt.Errorf("internal error: %s not in any registered symlinks directory", lnDir)
+		}
+	}
+
+	// TODO supported directories apply currently only to a classic rootfs,
+	// not to the rootfs of a snap.
+	for dir := range symlinkDirs {
+		entries, err := os.ReadDir(dir)
+		dirExists := true
+		if err != nil {
+			var pathErr *os.PathError
+			if errors.As(err, &pathErr) {
+				dirExists = false
+			} else {
+				return err
+			}
+		}
+		lnsToTarget := spec.dirsToLinkToTarget[dir]
+
+		// Remove now unwanted symlinks
+		if err := b.removeUnwantedInDir(dir, entries, lnsToTarget); err != nil {
+			return err
+		}
+
+		// Ensure state of the links we want in this directory
+		if len(lnsToTarget) > 0 {
+			if !dirExists {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return err
+				}
+			}
+			for ln, target := range lnsToTarget {
+				lnPath := filepath.Join(dir, ln)
+				logger.Debugf("ensuring symlink %q -> %q", lnPath, target)
+				osutil.EnsureFileState(lnPath, &osutil.SymlinkFileState{Target: target})
+			}
+		}
+	}
+
+	return nil
+}
+
+func linkIsSnapdControlled(symlinkPath string) (bool, error) {
+	dest, err := os.Readlink(symlinkPath)
+	if err != nil {
+		return false, err
+	}
+	// If dest is under $SNAP or points to snaps data snapd owns the
+	// symlink, otherwise it is not under snapd control (these symlinks are
+	// absolute).
+	//
+	// TODO an alternative would be to add trusted extended attributes to
+	// these symlinks (xattr(7)) - adding with the equivalent of "sudo
+	// setfattr -h -n trusted.<snap> -v <val> <symlink>".
+	return strings.HasPrefix(dest, dirs.SnapMountDir+"/") ||
+		strings.HasPrefix(dest, dirs.SnapDataDir+"/"), nil
+}

--- a/interfaces/symlinks/backend_test.go
+++ b/interfaces/symlinks/backend_test.go
@@ -1,0 +1,310 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package symlinks_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type backendSuite struct {
+	Backend         interfaces.SecurityBackend
+	Repo            *interfaces.Repository
+	RootDir         string
+	restoreSanitize func()
+
+	testutil.BaseTest
+}
+
+func (s *backendSuite) SetUpTest(c *C) {
+	// Isolate this test to a temporary directory
+	s.RootDir = c.MkDir()
+	os.Mkdir(filepath.Join(s.RootDir, "/snap"), 0755)
+	dirs.SetRootDir(s.RootDir)
+
+	// Create a fresh repository for each test
+	s.Repo = interfaces.NewRepository()
+
+	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+
+	s.Backend = &symlinks.Backend{}
+	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
+}
+
+func (s *backendSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+	s.restoreSanitize()
+}
+
+var _ = Suite(&backendSuite{})
+
+func (s *backendSuite) TestName(c *C) {
+	c.Check(s.Backend.Name(), Equals, interfaces.SecuritySymlinks)
+}
+
+func (s *backendSuite) mockSlot(c *C, yaml string, slotName string) (*interfaces.SnapAppSet, *snap.SlotInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	if slotInfo, ok := info.Slots[slotName]; ok {
+		return set, slotInfo
+	}
+	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
+}
+
+func (s *backendSuite) mockPlugs(c *C, yaml string, plugNames []string) (*interfaces.SnapAppSet, []*snap.PlugInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	plugInfos := make([]*snap.PlugInfo, 0, len(plugNames))
+	for _, plug := range plugNames {
+		if plugInfo, ok := info.Plugs[plug]; ok {
+			plugInfos = append(plugInfos, plugInfo)
+			continue
+		}
+		panic(fmt.Sprintf("cannot find plug %q in snap %q", plug, info.InstanceName()))
+	}
+	return set, plugInfos
+}
+
+const someProvider1 = `name: some1
+version: 0
+type: app
+slots:
+  some-driver-libs:
+`
+
+const someProvider2 = `name: some2
+version: 0
+type: app
+slots:
+  some-driver-libs:
+`
+
+const otherProvider = `name: other
+version: 0
+type: app
+slots:
+  other-driver-libs:
+`
+
+const someConsumer = `name: snapd
+version: 0
+type: snapd
+apps:
+  app:
+    plugs: [some-driver-libs, other-driver-libs]
+`
+
+func checkSymlink(c *C, target, name string) {
+	t, err := os.Readlink(filepath.Join(dirs.GlobalRootDir, name))
+	c.Assert(err, IsNil)
+	c.Assert(t, Equals, filepath.Join(dirs.GlobalRootDir, target))
+}
+
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"mediated-symlinks"})
+}
+
+func (s *backendSuite) TestConnectDisconnect(c *C) {
+	controlledDir := filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo")
+	// Add callback and register the interface
+	iface := &ifacetest.TestSymlinksInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "some-driver-libs",
+			SymlinksConnectedPlugCallback: func(spec *symlinks.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				switch slot.Snap().InstanceName() {
+				case "some1":
+					return spec.AddSymlink(
+						filepath.Join(dirs.GlobalRootDir, "/snap/somesnap1/1/target.so"),
+						filepath.Join(controlledDir, "bar.so"))
+				case "some2":
+					return spec.AddSymlink(
+						filepath.Join(dirs.GlobalRootDir, "/snap/somesnap2/1/target2.so"),
+						filepath.Join(controlledDir, "bar2.so"))
+				}
+				return errors.New("unexpected snap")
+			},
+		},
+		DirectoriesCallback: func() []string {
+			return []string{controlledDir}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface), IsNil)
+
+	// Create some un-controlled files
+	c.Assert(os.MkdirAll(controlledDir, 0755), IsNil)
+	noSnapdLinkPath := filepath.Join(controlledDir, "nosnapd-link")
+	noSnapdFilePath := filepath.Join(controlledDir, "nosnapd-file")
+	c.Assert(os.Symlink("/var/lib/target", noSnapdLinkPath), IsNil)
+	c.Assert(os.WriteFile(noSnapdFilePath, []byte{}, 0644), IsNil)
+
+	// Mock plug/slots
+	appSet, plugInfos := s.mockPlugs(c, someConsumer, []string{"some-driver-libs"})
+	_, slotInfo1 := s.mockSlot(c, someProvider1, "some-driver-libs")
+	_, slotInfo2 := s.mockSlot(c, someProvider2, "some-driver-libs")
+
+	// Connect them
+	connRef1 := interfaces.NewConnRef(plugInfos[0], slotInfo1)
+	_, err := s.Repo.Connect(connRef1, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	connRef2 := interfaces.NewConnRef(plugInfos[0], slotInfo2)
+	_, err = s.Repo.Connect(connRef2, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Set-up the backend
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), IsNil)
+
+	checkSymlink(c, "/snap/somesnap1/1/target.so", "/usr/lib/foo/bar.so")
+	checkSymlink(c, "/snap/somesnap2/1/target2.so", "/usr/lib/foo/bar2.so")
+
+	// Now disconnect the first slot and set-up backends again
+	c.Assert(s.Repo.Disconnect(plugInfos[0].Snap.InstanceName(), plugInfos[0].Name,
+		slotInfo1.Snap.InstanceName(), slotInfo1.Name), IsNil)
+	s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil)
+
+	// Only symlinks for the connected slots are around
+	c.Check(filepath.Join(controlledDir, "bar.so"), testutil.LFileAbsent)
+	checkSymlink(c, "/snap/somesnap2/1/target2.so", "/usr/lib/foo/bar2.so")
+
+	// Uncontrolled files are around
+	c.Check(noSnapdLinkPath, testutil.LFilePresent)
+	c.Check(noSnapdFilePath, testutil.LFilePresent)
+}
+
+func (s *backendSuite) TestTwoPlugs(c *C) {
+	// Add interfaces
+	iface1 := &ifacetest.TestSymlinksInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "some-driver-libs",
+			SymlinksConnectedPlugCallback: func(spec *symlinks.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				return spec.AddSymlink(
+					filepath.Join(dirs.GlobalRootDir, "/snap/somesnap/1/target.so"),
+					filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo/bar.so"))
+			},
+		},
+		DirectoriesCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface1), IsNil)
+	iface2 := &ifacetest.TestSymlinksInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "other-driver-libs",
+			SymlinksConnectedPlugCallback: func(spec *symlinks.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				return spec.AddSymlink(
+					filepath.Join(dirs.GlobalRootDir, "/snap/somesnap2/1/target2.so"),
+					filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo2/bar2.so"))
+			},
+		},
+		DirectoriesCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo2")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface2), IsNil)
+
+	// Mock plugs/slots
+	appSet, plugInfos := s.mockPlugs(c, someConsumer, []string{"some-driver-libs", "other-driver-libs"})
+	_, slotInfo1 := s.mockSlot(c, someProvider1, "some-driver-libs")
+	_, slotInfo2 := s.mockSlot(c, otherProvider, "other-driver-libs")
+
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), IsNil)
+
+	// Connect them
+	connRef1 := interfaces.NewConnRef(plugInfos[0], slotInfo1)
+	_, err := s.Repo.Connect(connRef1, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	connRef2 := interfaces.NewConnRef(plugInfos[1], slotInfo2)
+	_, err = s.Repo.Connect(connRef2, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Set-up the backend
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), IsNil)
+
+	checkSymlink(c, "/snap/somesnap/1/target.so", "/usr/lib/foo/bar.so")
+	checkSymlink(c, "/snap/somesnap2/1/target2.so", "/usr/lib/foo2/bar2.so")
+
+	// Now disconnect the first slot and set-up backends again
+	c.Assert(s.Repo.Disconnect(plugInfos[0].Snap.InstanceName(), plugInfos[0].Name,
+		slotInfo1.Snap.InstanceName(), slotInfo1.Name), IsNil)
+	s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil)
+
+	// Only symlinks for the connected slots are around
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo/bar.so"), testutil.LFileAbsent)
+	checkSymlink(c, "/snap/somesnap2/1/target2.so", "/usr/lib/foo2/bar2.so")
+}
+
+func (s *backendSuite) TestUnregisteredDirectory(c *C) {
+	// Add callback and register the interface
+	iface := &ifacetest.TestSymlinksInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "some-driver-libs",
+			SymlinksConnectedPlugCallback: func(spec *symlinks.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				return spec.AddSymlink(
+					filepath.Join(dirs.GlobalRootDir, "/snap/somesnap2/1/target2.so"),
+					filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo2/bar2.so"))
+			},
+		},
+		DirectoriesCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface), IsNil)
+
+	// Mock plug/slots
+	appSet, plugInfos := s.mockPlugs(c, someConsumer, []string{"some-driver-libs"})
+	_, slotInfo1 := s.mockSlot(c, someProvider1, "some-driver-libs")
+
+	// Connect
+	connRef1 := interfaces.NewConnRef(plugInfos[0], slotInfo1)
+	_, err := s.Repo.Connect(connRef1, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Set-up the backend
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{}, s.Repo, nil), ErrorMatches,
+		`internal error: .*/usr/lib/foo2 not in any registered symlinks directory`)
+
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo2/bar2.so"), testutil.LFileAbsent)
+}

--- a/interfaces/symlinks/spec.go
+++ b/interfaces/symlinks/spec.go
@@ -1,0 +1,169 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package symlinks
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/snap"
+)
+
+// Specification assists in collecting paths and content associated with an
+// interface.
+//
+// Unlike the Backend itself (which is stateless and non-persistent) this type
+// holds internal state that is used by the symlinks backend during the
+// interface setup process.
+type Specification struct {
+	// plugs is the list of plugs using symlinks for the snap
+	plugs []string
+	// dirsToLinkToTarget is a map from directories to maps of symlink
+	// names to their target file.
+	dirsToLinkToTarget map[string]SymlinkToTarget
+}
+
+type SymlinkToTarget map[string]string
+
+func (spec *Specification) Symlinks() map[string]SymlinkToTarget {
+	return spec.dirsToLinkToTarget
+}
+
+func (spec *Specification) Plugs() []string {
+	return spec.plugs
+}
+
+// Methods called by interfaces
+
+// AddSymlink adds a symlink pointing to target to the specification.
+func (spec *Specification) AddSymlink(target, symlink string) error {
+	for _, path := range []string{target, symlink} {
+		// The interfaces must specify clean paths (this also enforces
+		// non-slash terminated path - we do not allow directories).
+		if path != filepath.Clean(path) {
+			return fmt.Errorf("symlinks internal error: unclean path: %q", path)
+		}
+		// Only support absolute target/symlink
+		if !filepath.IsAbs(path) {
+			return fmt.Errorf("symlinks internal error: relative paths not supported: %q", path)
+		}
+	}
+	if spec.dirsToLinkToTarget == nil {
+		spec.dirsToLinkToTarget = make(map[string]SymlinkToTarget)
+	}
+	dir, link := filepath.Split(symlink)
+	// We do not want the trailing '/'
+	dir = filepath.Clean(dir)
+	var lnsToTarget SymlinkToTarget
+	var ok bool
+	if lnsToTarget, ok = spec.dirsToLinkToTarget[dir]; !ok {
+		lnsToTarget = make(SymlinkToTarget)
+		spec.dirsToLinkToTarget[dir] = lnsToTarget
+	}
+
+	if _, ok := lnsToTarget[link]; ok {
+		return fmt.Errorf("symlinks internal error: already managed symlink: %q", symlink)
+	}
+	lnsToTarget[link] = target
+	return nil
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// ConnectedPlugCallback must be implemented as a minimum by users of this backend.
+type ConnectedPlugCallback interface {
+	SymlinksConnectedPlug(spec *Specification, plug *interfaces.ConnectedPlug,
+		slot *interfaces.ConnectedSlot) error
+}
+
+func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
+	ConnectedPlugCallback, error) {
+	if iface, ok := iface.(ConnectedPlugCallback); ok {
+		if !interfaces.IsTheSystemSnap(instanceName) {
+			return nil, errors.New("internal error: symlinks plugs can be defined only by the system snap")
+		}
+		return iface, nil
+	}
+	return nil, nil
+}
+
+// AddConnectedPlug records symlinks-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap().InstanceName())
+	if err != nil {
+		return err
+	}
+	if connectedPlugCallback != nil {
+		return connectedPlugCallback.SymlinksConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records symlinks-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	type definer interface {
+		SymlinksConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		if !interfaces.IsTheSystemSnap(plug.Snap().InstanceName()) {
+			return errors.New("internal error: symlinks plugs can be defined only by the system snap")
+		}
+		return iface.SymlinksConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records symlinks-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *snap.PlugInfo) error {
+	// Note that ConnectedPlugCallback must be implemented, so we
+	// check for it instead of using SymlinksPermanentPlug.
+	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap.InstanceName())
+	if err != nil {
+		return err
+	}
+	if connectedPlugCallback != nil {
+		// Keep track of interfaces using this backend on the consumer side
+		spec.plugs = append(spec.plugs, plug.Name)
+	}
+
+	type definer interface {
+		SymlinksPermanentPlug(spec *Specification, plug *snap.PlugInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		if !interfaces.IsTheSystemSnap(plug.Snap.InstanceName()) {
+			return errors.New("internal error: symlinks plugs can be defined only by the system snap")
+		}
+		return iface.SymlinksPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records symlinks-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *snap.SlotInfo) error {
+	type definer interface {
+		SymlinksPermanentSlot(spec *Specification, slot *snap.SlotInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.SymlinksPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/symlinks/spec_test.go
+++ b/interfaces/symlinks/spec_test.go
@@ -1,0 +1,151 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package symlinks_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/snap"
+)
+
+type specSuite struct {
+	spec     *symlinks.Specification
+	iface1   *ifacetest.TestInterface
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+}
+
+var _ = Suite(&specSuite{
+	iface1: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		SymlinksConnectedPlugCallback: func(spec *symlinks.Specification,
+			plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			return spec.AddSymlink("/snap/mysnap/1/lib/bar.so", "/usr/lib/foo/bar.so")
+		},
+		SymlinksConnectedSlotCallback: func(spec *symlinks.Specification,
+			plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			return spec.AddSymlink("/snap/mysnap/1/lib2/bar.so", "/usr/lib/foo/bar2.so")
+		},
+		SymlinksPermanentPlugCallback: func(spec *symlinks.Specification,
+			plug *snap.PlugInfo) error {
+			return spec.AddSymlink("/snap/mysnap/1/lib3/bar.so", "/usr/lib/foo2/bar.so")
+		},
+		SymlinksPermanentSlotCallback: func(spec *symlinks.Specification,
+			slot *snap.SlotInfo) error {
+			return spec.AddSymlink("/snap/mysnap/1/lib4/bar.so", "/usr/lib/foo2/bar2.so")
+		},
+	},
+})
+
+func (s *specSuite) SetUpTest(c *C) {
+	s.spec = &symlinks.Specification{}
+	const plugYaml = `name: snapd
+version: 1
+apps:
+  app:
+    plugs: [name]
+`
+	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
+
+	const slotYaml = `name: snap
+version: 1
+slots:
+  name:
+    interface: test
+`
+	s.slot, s.slotInfo = ifacetest.MockConnectedSlot(c, slotYaml, nil, "name")
+}
+
+// The symlinks.Specification can be used through the interfaces.Specification interface
+func (s *specSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(s.spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
+		"/usr/lib/foo": {"bar.so": "/snap/mysnap/1/lib/bar.so"},
+	})
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(s.spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
+		"/usr/lib/foo": {
+			"bar.so":  "/snap/mysnap/1/lib/bar.so",
+			"bar2.so": "/snap/mysnap/1/lib2/bar.so"},
+	})
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), IsNil)
+	c.Assert(s.spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
+		"/usr/lib/foo": {
+			"bar.so":  "/snap/mysnap/1/lib/bar.so",
+			"bar2.so": "/snap/mysnap/1/lib2/bar.so"},
+		"/usr/lib/foo2": {
+			"bar.so": "/snap/mysnap/1/lib3/bar.so"},
+	})
+	c.Assert(s.spec.Plugs(), DeepEquals, []string{"name"})
+	c.Assert(r.AddPermanentSlot(s.iface1, s.slotInfo), IsNil)
+	c.Assert(s.spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
+		"/usr/lib/foo": {
+			"bar.so":  "/snap/mysnap/1/lib/bar.so",
+			"bar2.so": "/snap/mysnap/1/lib2/bar.so"},
+		"/usr/lib/foo2": {
+			"bar.so":  "/snap/mysnap/1/lib3/bar.so",
+			"bar2.so": "/snap/mysnap/1/lib4/bar.so"},
+	})
+}
+
+func (s *specSuite) TestPlugNotFromSystem(c *C) {
+	const plugYaml = `name: notsystem
+version: 1
+apps:
+  app:
+    plugs: [name]
+`
+	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
+
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), ErrorMatches,
+		"internal error: symlinks plugs can be defined only by the system snap")
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), ErrorMatches,
+		"internal error: symlinks plugs can be defined only by the system snap")
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), ErrorMatches,
+		"internal error: symlinks plugs can be defined only by the system snap")
+}
+
+func (s *specSuite) TestAddSymlinkErrors(c *C) {
+	c.Check(s.spec.AddSymlink("/usr/lib/foo4/bar.so", "../../lib4/bar.so"), ErrorMatches,
+		`symlinks internal error: relative paths not supported: "../../lib4/bar.so"`)
+	c.Check(s.spec.AddSymlink("../../foo4/bar.so", "/snap/mysnap/lib4/bar.so"), ErrorMatches,
+		`symlinks internal error: relative paths not supported: "../../foo4/bar.so"`)
+	c.Check(s.spec.AddSymlink("/usr/lib/foo4/bar.so", "/snap/./mysnap/1/lib3/bar.so"), ErrorMatches,
+		`symlinks internal error: unclean path: "/snap/./mysnap/1/lib3/bar.so"`)
+	c.Check(s.spec.AddSymlink("//usr/lib/foo4/bar.so", "/snap/mysnap/1/lib3/bar.so"), ErrorMatches,
+		`symlinks internal error: unclean path: "//usr/lib/foo4/bar.so"`)
+
+	c.Assert(s.spec.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(s.spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
+		"/usr/lib/foo": {"bar.so": "/snap/mysnap/1/lib/bar.so"},
+	})
+	c.Assert(s.spec.AddConnectedPlug(s.iface1, s.plug, s.slot), ErrorMatches,
+		`symlinks internal error: already managed symlink: "/usr/lib/foo/bar.so"`)
+	c.Assert(s.spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
+		"/usr/lib/foo": {"bar.so": "/snap/mysnap/1/lib/bar.so"},
+	})
+}

--- a/testutil/filepresencechecker_test.go
+++ b/testutil/filepresencechecker_test.go
@@ -39,8 +39,25 @@ func (*filePresenceCheckerSuite) TestFilePresent(c *check.C) {
 	testInfo(c, FilePresent, "FilePresent", []string{"filename"})
 	testCheck(c, FilePresent, false, `filename must be a string`, 42)
 	testCheck(c, FilePresent, false, fmt.Sprintf(`file %q is absent but should exist`, filename), filename)
+
+	// Symlink is followed, file not present
+	c.Assert(os.Symlink("bar", filename), check.IsNil)
+	testCheck(c, FilePresent, false, fmt.Sprintf(`file %q is absent but should exist`, filename), filename)
+
+	// Now use regular file
+	c.Assert(os.Remove(filename), check.IsNil)
 	c.Assert(os.WriteFile(filename, nil, 0644), check.IsNil)
 	testCheck(c, FilePresent, true, "", filename)
+}
+
+func (*filePresenceCheckerSuite) TestSymlinkPresent(c *check.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "foo")
+	testInfo(c, LFilePresent, "LFilePresent", []string{"filename"})
+	testCheck(c, LFilePresent, false, `filename must be a string`, 42)
+	testCheck(c, LFilePresent, false, fmt.Sprintf(`file %q is absent but should exist`, filename), filename)
+	c.Assert(os.Symlink("bar", filename), check.IsNil)
+	testCheck(c, LFilePresent, true, "", filename)
 }
 
 func (*filePresenceCheckerSuite) TestFileAbsent(c *check.C) {
@@ -49,6 +66,23 @@ func (*filePresenceCheckerSuite) TestFileAbsent(c *check.C) {
 	testInfo(c, FileAbsent, "FileAbsent", []string{"filename"})
 	testCheck(c, FileAbsent, false, `filename must be a string`, 42)
 	testCheck(c, FileAbsent, true, "", filename)
+
+	// Symlink is followed, still file is absent
+	c.Assert(os.Symlink("bar", filename), check.IsNil)
+	testCheck(c, FileAbsent, true, "", filename)
+
+	// Now use regular file
+	c.Assert(os.Remove(filename), check.IsNil)
 	c.Assert(os.WriteFile(filename, nil, 0644), check.IsNil)
 	testCheck(c, FileAbsent, false, fmt.Sprintf(`file %q is present but should not exist`, filename), filename)
+}
+
+func (*filePresenceCheckerSuite) TestSymlinkAbsent(c *check.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "foo")
+	testInfo(c, LFileAbsent, "LFileAbsent", []string{"filename"})
+	testCheck(c, LFileAbsent, false, `filename must be a string`, 42)
+	testCheck(c, LFileAbsent, true, "", filename)
+	c.Assert(os.Symlink("bar", filename), check.IsNil)
+	testCheck(c, LFileAbsent, false, fmt.Sprintf(`file %q is present but should not exist`, filename), filename)
 }


### PR DESCRIPTION
The symlinks backend maintains symlinks in the rootfs that points inside $SNAP or $SNAP_DATA. It will be useful for interfaces that allow exporting files from a snap to a classic rootfs or, eventually, to the mount namespace of a snap.