### PR TITLE
tests: new sru validation test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -275,6 +275,12 @@ backends:
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
         location: snapd-spread/us-central1-a
         halt-timeout: 2h
+        environment:
+            SRU_VALIDATION: 1
+            SNAP_REEXEC: 0
+            MODIFY_CORE_SNAP_FOR_REEXEC: 0
+            TRUST_TEST_KEYS: false
+            CORE_CHANNEL: stable
         systems:
             - ubuntu-20.04-64:
                   storage: 12G

--- a/tests/main/sru-validation-check/task.yaml
+++ b/tests/main/sru-validation-check/task.yaml
@@ -1,0 +1,38 @@
+summary: Check snapd deb is used from proposed when running sru validation
+
+details: |
+    When sru validation is being executed, it is needed to check the correct
+    snapd deb is being used and no-reexec policy is applied. 
+
+backends: [google-sru]
+
+environment: 
+    SRU_VALIDATION_VERSION: '$(HOST: echo "${SPREAD_SRU_VALIDATION_VERSION:-}")'
+
+prepare: |
+    cp /etc/apt/sources.list sources.list.back
+    echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -c -s)-proposed restricted main multiverse universe" | tee /etc/apt/sources.list -a
+    apt update
+
+restore: |
+    if [ -e sources.list.back ]; then
+      mv sources.list.back /etc/apt/sources.list
+      apt update
+    fi
+
+execute: |
+    if [ "$SRU_VALIDATION" != "1" ]; then
+        echo "Variable SRU_VALIDATION not set to 1"
+        exit 1
+    fi
+
+    # Check snapd is from proposed
+    apt list snapd | MATCH "snapd/$(lsb_release -c -s)-proposed"
+
+    # Check the snap version being used matches with the expected one
+    if [ -n "$SRU_VALIDATION_VERSION" ]; then
+        apt policy snapd | MATCH "Installed:.*${SRU_VALIDATION_VERSION}+"
+    fi
+
+    # Check re-execution is not being used
+    not tests.info is-reexec-in-use


### PR DESCRIPTION
When sru validation is being executed, it is needed to check the correct snapd deb is being used and no-reexec policy is applied.


The test can be checked once snapd is in proposed running:

SPREAD_SRU_VALIDATION_VERSION=2.68.3 spread google-sru:ubuntu-22.04-64:tests/main/sru-validation-check