### PR TITLE
i/p/requestprompts: restore prompts after snapd restart

### DIFF
--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -23,7 +23,9 @@ package requestprompts
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -34,6 +36,7 @@ import (
 	prompting_errors "github.com/snapcore/snapd/interfaces/prompting/errors"
 	"github.com/snapcore/snapd/interfaces/prompting/internal/maxidmmap"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/strutil"
@@ -365,6 +368,15 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	// Clear all outstanding prompts for the user
 	udb.prompts = nil
 	udb.ids = make(map[prompting.IDType]int) // TODO: clear() once we're on Go 1.21+
+
+	// Remove the request ID mappings now before unlocking the prompt DB
+	for _, p := range expiredPrompts {
+		for _, listenerReq := range p.listenerReqs {
+			delete(pdb.requestIDToPromptID, listenerReq.ID)
+		}
+	}
+	pdb.saveRequestIDPromptIDMapping()
+
 	// Unlock now so we can record notices without holding the prompt DB lock
 	pdb.mutex.Unlock()
 	data := map[string]string{"resolved": "expired"}
@@ -385,6 +397,7 @@ func (udb *userPromptDB) activityResetExpiration() bool {
 // are created with a unique ID.
 type PromptDB struct {
 	// The prompt DB is protected by a RWMutex.
+	// XXX: this should probably just be a Mutex instead.
 	mutex sync.RWMutex
 	// maxIDMmap is the byte slice which is memory mapped to the max ID file in
 	// order to avoid unnecessary syscalls.
@@ -395,6 +408,135 @@ type PromptDB struct {
 	// notifyPrompt is a closure which will be called to record a notice when a
 	// prompt is added, merged, modified, or resolved.
 	notifyPrompt func(userID uint32, promptID prompting.IDType, data map[string]string) error
+
+	requestIDToPromptIDFilepath string
+
+	// requestToPromptID is the mapping from request ID to prompt ID which is
+	// kept updated on disk and re-read when snapd restarts, so that we can
+	// re-associate each request which is re-received with a prompt with the
+	// same ID after snapd restarts.
+	requestIDToPromptID map[uint64]prompting.IDType
+
+	// When the prompt DB is created, any existing mappings are loaded from
+	// disk. Subsequently, whenever a new request is received, it is checked
+	// against the mappings to see if a prompt already existed for the request
+	// with that ID, and if so, ensures that the prompt associated with the
+	// request has the same ID that it previously had.
+	//
+	// TODO: handle tough edge cases:
+	// - Mapping exists for the request ID to a prompt ID, but the prompt
+	//   doesn't currently exist, and there is another prompt which is
+	//   identical in content to the new request.
+	//   - Simple solution: if a mapping exists for the request ID but a prompt
+	//     with that ID doesn't yet exist, create it, and don't bother checking
+	//     whether there are other prompts which match.
+	//     - Worst case, there are duplicate prompts, not the end of the world.
+	//     - XXX: use this solution for now.
+	//   - Medium solution: since the new prompt already exists and is fresher,
+	//     use it and associate the repeated request with it instead, and clean
+	//     up the old prompt by recording a notice that the old prompt has been
+	//     cancelled or merged into the new one.
+	//   - Complex solution: whichever prompt receives a reply first, apply
+	//     that reply to both the original prompt ID and the new prompt ID.
+	//     - TODO: keep a map from prompt ID to other prompt IDs of prompts
+	//       which are known to be identical, and when a reply is received for
+	//       that prompt ID, treat it as a reply to all prompt IDs it maps to.
+	// - Mapping exists for the request ID to a prompt ID, and prompt with that
+	//   ID exists, but the request content doesn't match the prompt content.
+	//   - This should be impossible, since prompt IDs cannot be reused except
+	//     via an existing mapping, and requests themselves are identical when
+	//     they are re-sent, so the re-created prompt should be the same as the
+	//     original.
+	// - A request is received and a prompt is created, then snapd restarts,
+	//   and before the request is re-received and the prompt re-created, a new
+	//   rule is added which matches the request. Then, when the request is
+	//   re-received, it is matched by the rule and a response is sent
+	//   automatically, without ever reaching the prompt DB to clear up the
+	//   prompt ID mapping or record a notice.
+	//   - Simple solution: since the prompt won't ever exist again, any reply
+	//     will be met with an error, as if e.g. another client replied to it.
+	//     The mapping between request ID and prompt ID will continue to exist
+	//     until the machine reboots, then it's cleaned up. No real harm done.
+	//   - Robust solution: explicitly clean up any mapping for the given
+	//     request ID when the request is sent a reply by the manager before
+	//     reaching the requestprompts backend, via a CleanupRequest method of
+	//     some sort. Keep track of how many mappings exist to every given
+	//     prompt ID, and once all the requests mapping to it have been cleaned
+	//     up, record a notice that the prompt has been resolved.
+	//     - TODO: have map from prompt ID to count of request IDs associated
+	//       with it, and have a CleanupRequest method on the prompt DB which
+	//       the manager calls when it sends a response to the kernel without
+	//       creating a prompt through the prompt DB.
+	// - A prompt exists for a given request, then snapd restarts, then a reply
+	//   is received before snapd has re-received the request from the client,
+	//   so there's no prompt yet for the reply to apply to.
+	//   - Bad solution: return an error to the client, since the request could
+	//     have timed out in the kernel. Worst case, the request is re-received
+	//     later and an identical request gets re-sent.
+	//   - Simple partial solution: via the stored mapping, we know the request
+	//     IDs associated with the prompt for which the reply is intended, and
+	//     as long as the listener is registered, we're able to reply to it,
+	//     even before we re-receive the request again.
+	//     - Problem is we don't have the request, so we don't know which
+	//       permissions were exactly requested, so we can't actually send back
+	//       a response safely. And the current mechanism to send a reply is
+	//       calling a method on the Request, which we don't have.
+	//   - Complicated solution: record the notice that the prompt has been
+	//     replied to and store the reply for later, and as every request which
+	//     maps to the prompt is re-received from the kernel, handle it with
+	//     the same reply, and once every request is either replied or cleaned
+	//     up by the manager, then the reply can be dropped.
+	//     - How do we validate that the reply is actually valid, since we know
+	//       nothing about the content of the original request or prompt?
+	//       - Maybe it's fine, if we re-receive the request and it doesn't
+	//         match, then we can re-record a notice for the prompt again and
+	//         tell the client to try again. This should not happen much
+	//         anyway, outside of custom path patterns not being valid or
+	//         matching the originally-requested path, both of which the client
+	//         should probably be able to check before attempting to reply
+	//         anyway?
+	//     - What about if not every request is re-received before snapd
+	//       restarts again? We don't want to persist the reply to disk as
+	//       well.
+	//       - It is exceedingly difficult to end up in this position, so
+	//         probably not worth designing around it. If a request persists
+	//         across two snapd restarts and a reply is received after the
+	//         first, odds are the request has timed out, else it should have
+	//         been re-received in the time during which the reply had time to
+	//         be received.
+	//     - TODO: store a map from prompt ID to allowed permissions (for every
+	//       prompt ID known to be identical, according to the first edge case),
+	//       and when a request is received which maps to that prompt, send
+	//       back the cached response automatically.
+	//     - TODO maybe later: store the response on disk as well, since it's
+	//       possible that the request will not be re-received until after
+	//       snapd restarts again.
+
+	// TODO later
+
+	// Record a map from prompt ID to the IDs of other prompts which have
+	// identical contents. If a request was received and a prompt created, then
+	// snapd restarted, then another request was received which happened to
+	// have the same content as the other request, and a new prompt is created
+	// for that request, then the original request is re-received, which both
+	// matches the new prompt contents and has a previously-assigned prompt.
+	// So record that the prompts are identical, and if a response is received
+	// for either one, send the response for the other one as well, and record
+	// notices that all have received a reply.
+	//identicalPrompts map[prompting.IDType][]prompting.IDType
+
+	// Record the number of outstanding requests for each prompt ID, so that if
+	// old requests are handled by a new rule before being re-sent to the
+	// prompt DB, the manager can still tell the prompt DB to clean up those
+	// requests, and if the final request mapping to a prompt ID is cleaned up,
+	// then a notice can be recorded
+	//promptRequestCounts map[prompting.IDType]int
+
+	// For each prompt which has at least one outstanding request which has not
+	// yet been re-received from the kernel, if that prompt receives a reply,
+	// record the derived allowed permissions from that reply so that if/when
+	// the request is re-received, the reply is already known and can be sent.
+	//cachedResponses map[prompting.IDType]notify.AppArmorPermission
 }
 
 // New creates and returns a new prompt database.
@@ -412,12 +554,84 @@ func New(notifyPrompt func(userID uint32, promptID prompting.IDType, data map[st
 	if err != nil {
 		return nil, err
 	}
+
 	pdb := PromptDB{
 		perUser:      make(map[uint32]*userPromptDB),
 		notifyPrompt: notifyPrompt,
 		maxIDMmap:    maxIDMmap,
+
+		requestIDToPromptIDFilepath: filepath.Join(dirs.SnapRunDir, "request-id-prompt-id-mapping"),
 	}
+
+	// Load the previous ID mappings from disk
+	if err := pdb.loadRequestIDPromptIDMapping(); err != nil {
+		return nil, err
+	}
+
 	return &pdb, nil
+}
+
+// idMappingJSON is the state which is stored on disk, containing the mapping
+// from request ID to prompt ID.
+type idMappingJSON struct {
+	RequestIDToPromptID map[uint64]prompting.IDType `json:"id-mapping"`
+}
+
+// loadRequestIDPromptIDMapping loads from disk the mapping from request ID to
+// prompt ID, and sets the prompt DB's map to the result.
+//
+// This method should only be called once, when the prompt DB is first created.
+//
+// If the existing mapping does not exist, the map is reset to empty, ready
+// for new requests to be added.
+//
+// If the file exists but cannot be read for some reason, returns an error.
+func (pdb *PromptDB) loadRequestIDPromptIDMapping() error {
+	pdb.mutex.Lock()
+	defer pdb.mutex.Unlock()
+
+	defer func() {
+		if pdb.requestIDToPromptID == nil {
+			pdb.requestIDToPromptID = make(map[uint64]prompting.IDType)
+		}
+	}()
+
+	f, err := os.Open(pdb.requestIDToPromptIDFilepath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("cannot open mapping from request ID to prompt ID: %w", err)
+	}
+
+	var savedState idMappingJSON
+	err = json.NewDecoder(f).Decode(&savedState)
+	f.Close() // close now since we're done reading
+	if err != nil {
+		return fmt.Errorf("cannot read stored mapping from request ID to prompt ID: %w", err)
+	}
+
+	pdb.requestIDToPromptID = savedState.RequestIDToPromptID
+
+	return nil
+}
+
+// saveRequestIDPromptIDMapping saves to disk the mapping from request ID to
+// prompt ID.
+//
+// This function should be called whenever the mapping between request ID and
+// prompt ID changes, such as when a prompt is created for a new request or
+// when a prompt receives a reply.
+//
+// The caller must ensure that the database lock is held.
+func (pdb *PromptDB) saveRequestIDPromptIDMapping() error {
+	b, err := json.Marshal(idMappingJSON{RequestIDToPromptID: pdb.requestIDToPromptID})
+	if err != nil {
+		// Should not occur, marshalling should always succeed
+		logger.Noticef("cannot marshal mapping from request ID to prompt ID: %v", err)
+		return fmt.Errorf("cannot marshal mapping from request ID to prompt ID: %w", err)
+	}
+	return osutil.AtomicWriteFile(pdb.requestIDToPromptIDFilepath, b, 0o600, 0)
 }
 
 var timeAfterFunc = func(d time.Duration, f func()) timeutil.Timer {
@@ -471,32 +685,97 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		originalPermissions:    requestedPermissions,
 	}
 
-	// Search for an identical existing prompt, merge if found
-	for _, prompt := range userEntry.prompts {
-		if prompt.Snap == metadata.Snap && prompt.Interface == metadata.Interface && prompt.Constraints.equals(constraints) {
-			prompt.listenerReqs = append(prompt.listenerReqs, listenerReq)
-			// Although the prompt itself has not changed, re-record a notice
-			// to re-notify clients to respond to this request. A client may
-			// have replied with a malformed response and not retried after
-			// receiving the error, so this notice encourages it to try again
-			// if the user retries the operation.
-			pdb.notifyPrompt(metadata.User, prompt.ID, nil)
-			return prompt, true, nil
+	getNewPromptID := true
+
+	// Check whether there's a mapping from the request ID to a prompt ID
+	promptID, ok := pdb.requestIDToPromptID[listenerReq.ID]
+	if ok {
+		// A mapping exists, but does the prompt currently exist?
+		if prompt, err := userEntry.get(promptID); err == nil {
+			// The prompt exists. Confirm that the contents match the request.
+			if prompt.Snap == metadata.Snap && prompt.Interface == metadata.Interface && prompt.Constraints.equals(constraints) {
+				// The prompt matches the request, all is well. Re-add the
+				// request to the prompt, re-record a notice, and return.
+				prompt.listenerReqs = append(prompt.listenerReqs, listenerReq)
+				// Although the prompt itself has not changed, re-record a notice
+				// to re-notify clients to respond to this request. A client may
+				// have replied with a malformed response and not retried after
+				// receiving the error, so this notice encourages it to try again
+				// if the user retries the operation.
+				pdb.notifyPrompt(metadata.User, prompt.ID, nil)
+				return prompt, true, nil
+			}
+			// Contents don't match, which should not occur.
+			//
+			// Remove the mapping, since it's no longer valid, and carry on as
+			// if there was no mapping in the first place.
+			delete(pdb.requestIDToPromptID, listenerReq.ID)
+			// We'll save the new mapping state to disk at the end
+			getNewPromptID = true
+		} else {
+			// The prompt doesn't exist, so we'll have to make a new one, but
+			// use the same ID as before
+			getNewPromptID = false
 		}
 	}
 
-	if len(userEntry.prompts) >= maxOutstandingPromptsPerUser {
-		logger.Noticef("WARNING: too many outstanding prompts for user %d; auto-denying new one", metadata.User)
-		// Deny all permissions which are not already allowed by existing rules
-		allowedPermission := constraints.buildResponse(metadata.Interface, constraints.outstandingPermissions)
-		sendReply(listenerReq, allowedPermission)
-		return nil, false, prompting_errors.ErrTooManyPrompts
+	defer pdb.saveRequestIDPromptIDMapping()
+
+	// Only search for prompts which match the request if we don't already know
+	// the prompt ID which should be associated with the request. This means we
+	// might end up with multiple identical prompts.
+	//
+	// TODO: search for a matching prompt always, and if !getNewPromptID and we
+	// find a matching prompt, then re-associate the request with that prompt's
+	// ID, but don't record a notice that the old prompt was cancelled, since
+	// there may be other requests which map to it which we have yet to
+	// re-receive.
+	// TODO: keep a record of how many request IDs map to each prompt ID, so we
+	// know if this request was the final one, and we can safely record a
+	// notice that it was dropped.
+	// TODO: keep a record of identical prompts, so that when a reply is
+	// received, it can be applied to all identical prompts.
+	// TODO: keep a record of the replies themselves, so that if multiple
+	// requests are associated with a given prompt, but a reply is received
+	// before the requests are re-received, the reply can be used to respond to
+	// those requests.
+	if getNewPromptID {
+		// Search for an identical existing prompt, merge if found
+		for _, prompt := range userEntry.prompts {
+			if prompt.Snap == metadata.Snap && prompt.Interface == metadata.Interface && prompt.Constraints.equals(constraints) {
+				prompt.listenerReqs = append(prompt.listenerReqs, listenerReq)
+				// Although the prompt itself has not changed, re-record a notice
+				// to re-notify clients to respond to this request. A client may
+				// have replied with a malformed response and not retried after
+				// receiving the error, so this notice encourages it to try again
+				// if the user retries the operation.
+				pdb.notifyPrompt(metadata.User, prompt.ID, nil)
+				return prompt, true, nil
+			}
+		}
+
+		// No matching prompt exists, so we must create a new one.
+		// Make sure we don't already have too many.
+		if len(userEntry.prompts) >= maxOutstandingPromptsPerUser {
+			logger.Noticef("WARNING: too many outstanding prompts for user %d; auto-denying new one", metadata.User)
+			// Deny all permissions which are not already allowed by existing rules
+			allowedPermission := constraints.buildResponse(metadata.Interface, constraints.outstandingPermissions)
+			sendReply(listenerReq, allowedPermission)
+			return nil, false, prompting_errors.ErrTooManyPrompts
+		}
+
+		// We'll be creating a new prompt and need a new prompt ID, so get it.
+		promptID, _ = pdb.maxIDMmap.NextID() // err must be nil because maxIDMmap is not nil and lock is held
+
+		// Now that we have the new ID, map the request ID to the prompt ID and
+		// save the mapping to disk.
+		pdb.requestIDToPromptID[listenerReq.ID] = promptID
+		pdb.saveRequestIDPromptIDMapping() // TODO: maybe handle error, but it shouldn't occur
 	}
 
-	id, _ := pdb.maxIDMmap.NextID() // err must be nil because maxIDMmap is not nil and lock is held
 	timestamp := time.Now()
 	prompt := &Prompt{
-		ID:           id,
+		ID:           promptID,
 		Timestamp:    timestamp,
 		Snap:         metadata.Snap,
 		Interface:    metadata.Interface,
@@ -504,7 +783,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		listenerReqs: []*listener.Request{listenerReq},
 	}
 	userEntry.add(prompt)
-	pdb.notifyPrompt(metadata.User, id, nil)
+	pdb.notifyPrompt(metadata.User, promptID, nil)
 	return prompt, false, nil
 }
 
@@ -585,7 +864,14 @@ func (pdb *PromptDB) Reply(user uint32, id prompting.IDType, outcome prompting.O
 	if err = prompt.sendReply(outcome); err != nil {
 		return nil, err
 	}
+
+	for _, listenerReq := range prompt.listenerReqs {
+		delete(pdb.requestIDToPromptID, listenerReq.ID)
+	}
+	pdb.saveRequestIDPromptIDMapping() // error should not occur
+
 	userEntry.remove(id)
+
 	data := map[string]string{"resolved": "replied"}
 	pdb.notifyPrompt(user, id, data)
 	return prompt, nil
@@ -623,6 +909,14 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 	if !ok {
 		return nil, nil
 	}
+
+	needToSave := false
+	defer func() {
+		if needToSave {
+			pdb.saveRequestIDPromptIDMapping()
+		}
+	}()
+
 	var satisfiedPromptIDs []prompting.IDType
 	for _, prompt := range userEntry.prompts {
 		if !(prompt.Snap == metadata.Snap && prompt.Interface == metadata.Interface) {
@@ -670,6 +964,13 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 		// Now that a response has been sent, remove the rule from the rule DB
 		// and record a notice indicating that it has been satisfied.
 		userEntry.remove(prompt.ID)
+
+		// Remove the ID mappings for the requests associated with the prompt.
+		for _, listenerReq := range prompt.listenerReqs {
+			delete(pdb.requestIDToPromptID, listenerReq.ID)
+		}
+		needToSave = true
+
 		satisfiedPromptIDs = append(satisfiedPromptIDs, prompt.ID)
 		data := map[string]string{"resolved": "satisfied"}
 		pdb.notifyPrompt(metadata.User, prompt.ID, data)
@@ -677,10 +978,14 @@ func (pdb *PromptDB) HandleNewRule(metadata *prompting.Metadata, constraints *pr
 	return satisfiedPromptIDs, nil
 }
 
-// Close removes all outstanding prompts and records a notice for each one.
+// Close removes all outstanding prompts and closes the max ID mmap.
 //
-// This should be called when snapd is shutting down, to notify prompt clients
-// that the given prompts are no longer awaiting a reply.
+// This should be called when snapd is shutting down.
+//
+// When snapd restarts, it should re-open the max ID mmap and load the mappings
+// from request ID to prompt ID from disk, so that prompts can be re-created
+// with the same IDs as were previously associated with the requests when they
+// are re-received from the kernel.
 func (pdb *PromptDB) Close() error {
 	pdb.mutex.Lock()
 	defer pdb.mutex.Unlock()
@@ -693,23 +998,8 @@ func (pdb *PromptDB) Close() error {
 		return fmt.Errorf("cannot close max ID mmap: %w", err)
 	}
 
-	// TODO: if in the future we persist prompts across snapd restarts, we do
-	// not want to send {"resolved": "cancelled"} in the notice data.
-	data := map[string]string{"resolved": "cancelled"}
-	for user, userEntry := range pdb.perUser {
-		// No need to explicitly stop the timer, since this is racy with the
-		// timer expiring, and since we've already closed the maxIDMmap with
-		// the lock held, the callback will acquire the lock, see that the DB
-		// has been closed, and immediately return.
-		for id := range userEntry.ids {
-			pdb.notifyPrompt(user, id, data)
-		}
-		// There's no need to explicitly send responses back to the kernel
-		// here, as the listener will send deny responses for all outstanding
-		// listener requests when it is closed, and even if it didn't, the
-		// kernel will automatically reclaim unanswered notifications when
-		// the notify socket FD is closed, and either roll them over to a new
-		// FD or auto-deny them after some time.
+	if err := pdb.saveRequestIDPromptIDMapping(); err != nil {
+		return fmt.Errorf("cannot save mapping from request ID to prompt ID: %w", err)
 	}
 
 	// Clear all outstanding prompts

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -944,9 +944,9 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 
 	pdb.Close()
 
-	// Once notice for each prompt when cleaned up
-	expectedData := map[string]string{"resolved": "cancelled"}
-	s.checkNewNoticesUnorderedSimple(c, expectedPromptIDs, expectedData)
+	// No notices should be recorded when snapd is restarting, so that we can
+	// pick back up where we left off
+	s.checkNewNoticesUnorderedSimple(c, nil, nil)
 
 	// All prompts have been cleared, and all per-user maps deleted
 	c.Check(pdb.PerUser(), HasLen, 0)
@@ -1030,7 +1030,11 @@ func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
 	requestedPermissions := []string{"read", "write", "execute"}
 	outstandingPermissions := []string{"write", "execute"}
 
-	prompt, merged, err := pdb.AddOrMerge(metadata, path, requestedPermissions, outstandingPermissions, nil)
+	fakeRequest := listener.Request{
+		ID: 0x1234,
+	}
+
+	prompt, merged, err := pdb.AddOrMerge(metadata, path, requestedPermissions, outstandingPermissions, &fakeRequest)
 	c.Assert(err, IsNil)
 	c.Assert(merged, Equals, false)
 

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -62,7 +62,10 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 	})
 	restoreRun := MockListenerRun(func(l *listener.Listener) error {
 		<-closeChan
-		return listener.ErrClosed
+		// In production, listener.Run() does not return on error, and when
+		// the listener is closed, it returns nil. So it should always return
+		// nil in practice.
+		return nil
 	})
 	restoreReqs := MockListenerReqs(func(l *listener.Listener) <-chan *listener.Request {
 		return reqChan

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -151,17 +151,21 @@ func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
 // Run is the main run loop for the manager, and must be called using tomb.Go.
 func (m *InterfacesRequestsManager) run() error {
 	m.lock.Lock()
-	// disconnect replaces the listener so keep track of the one we have
-	// right now
+	// disconnect replaces the listener, so keep track of the one we have
+	// right now, even though currently disconnect is only called when this
+	// function returns, so this isn't really necessary.
 	currentListener := m.listener
 	m.lock.Unlock()
 
 	m.tomb.Go(func() error {
 		logger.Debugf("starting prompting listener")
-		if err := listenerRun(currentListener); err != listener.ErrClosed {
-			return err
-		}
-		return nil
+		// listener.Run will return an error if and only if there's a real
+		// error, not if Close() is called. But Close() is called only by
+		// disconnect(), which is itself only called when this run() function
+		// returns, which only occurs when the manager tomb is dying. So we
+		// don't need to worry about the listener returning nil when we don't
+		// already expect to be exiting.
+		return listenerRun(currentListener)
 	})
 
 run_loop:
@@ -170,20 +174,29 @@ run_loop:
 		select {
 		case req, ok := <-listenerReqs(currentListener):
 			if !ok {
-				// Reqs() closed, so either errored or Stop() was called.
-				// In either case, the listener Close() method has already
-				// been called, and the tomb error will be set to the return
+				// Reqs() closed, so an error occurred in the listener. In
+				// production, the listener does not close itself on error, so
+				// this should never actually occur.
+				//
+				// If Stop() were called, it would set the tomb to dying and
+				// the other select case would have occurred, since the
+				// disconnect() method is the only place in the manager where
+				// the listener Close() method is called, and disconnect() is
+				// only called when this function returns.
+				//
+				// The listener Close() method has already been called by the
+				// listener itself, and the tomb error will be set to the error
 				// value of the Run() call from the previous tracked goroutine.
 				logger.Debugf("prompting listener closed requests channel")
 				break run_loop
 			}
 
-			logger.Debugf("received from kernel requests channel: %v", req)
+			logger.Debugf("received from kernel requests channel: %+v", req)
 			if err := m.handleListenerReq(req); err != nil {
 				logger.Noticef("error while handling request: %+v", err)
 			}
 		case <-m.tomb.Dying():
-			logger.Noticef("InterfacesRequestsManager tomb is dying, disconnecting")
+			logger.Debugf("InterfacesRequestsManager tomb is dying with error %v, disconnecting", m.tomb.Err())
 			break run_loop
 		}
 	}

--- a/sandbox/apparmor/notify/ioctl.go
+++ b/sandbox/apparmor/notify/ioctl.go
@@ -109,7 +109,7 @@ func Ioctl(fd uintptr, req IoctlRequest, buf IoctlRequestBuffer) ([]byte, error)
 type IoctlRequest uintptr
 
 // Available ioctl(2) requests for .notify file.
-// Those are not documented beyond the implementeation in the kernel.
+// Those are not documented beyond the implementation in the kernel.
 const (
 	APPARMOR_NOTIF_SET_FILTER  IoctlRequest = 0x4008F800
 	APPARMOR_NOTIF_GET_FILTER  IoctlRequest = 0x8008F801

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -42,10 +42,10 @@ func FakeRequestWithIDVersionClassAllowDeny(id uint64, version notify.ProtocolVe
 	}
 	return &Request{
 		ID:         id,
-		Listener:   listener,
 		Class:      class,
 		Permission: aaDeny,
 		AaAllowed:  aaAllow,
+		listener:   listener,
 	}
 }
 

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -36,10 +36,16 @@ func ExitOnError() (restore func()) {
 	return restore
 }
 
-func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan notify.AppArmorPermission) *Request {
+func FakeRequestWithIDVersionClassAllowDeny(id uint64, version notify.ProtocolVersion, class notify.MediationClass, aaAllow, aaDeny notify.AppArmorPermission) *Request {
+	listener := &Listener{
+		protocolVersion: version,
+	}
 	return &Request{
-		Class:     class,
-		replyChan: replyChan,
+		ID:         id,
+		Listener:   listener,
+		Class:      class,
+		Permission: aaDeny,
+		AaAllowed:  aaAllow,
 	}
 }
 
@@ -92,7 +98,7 @@ func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.Ioct
 // a SEND call via ioctl, the data is instead written to the send channel.
 func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
 	recvChanRW := make(chan []byte)
-	sendChanRW := make(chan []byte)
+	sendChanRW := make(chan []byte, 1) // need to have buffer size 1 since reply is synchronous
 	internalRecvChan := make(chan []byte, 1)
 	epollF := func(l *Listener) ([]epoll.Event, error) {
 		for {
@@ -142,32 +148,25 @@ func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan cha
 	return recvChanRW, sendChanRW, restore
 }
 
+// Return a blocking channel over which a IoctlRequest type will be sent
+// whenever notifyIoctl returns.
+func SynchronizeNotifyIoctl() (ioctlDone <-chan notify.IoctlRequest, restore func()) {
+	ioctlDoneRW := make(chan notify.IoctlRequest)
+	realIoctl := notifyIoctl
+	restore = testutil.Mock(&notifyIoctl, func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		ret, err := realIoctl(fd, req, buf)
+		ioctlDoneRW <- req // synchronize
+		return ret, err
+	})
+	return ioctlDoneRW, restore
+}
+
 func MockEncodeAndSendResponse(f func(l *Listener, resp *notify.MsgNotificationResponse) error) (restore func()) {
 	restore = testutil.Backup(&encodeAndSendResponse)
 	encodeAndSendResponse = f
 	return restore
 }
 
-func (l *Listener) Dead() <-chan struct{} {
-	return l.tomb.Dead()
-}
-
-func (l *Listener) Dying() <-chan struct{} {
-	return l.tomb.Dying()
-}
-
-func (l *Listener) Err() error {
-	return l.tomb.Err()
-}
-
-func (l *Listener) Kill(err error) {
-	l.tomb.Kill(err)
-}
-
 func (l *Listener) EpollIsClosed() bool {
 	return l.poll.IsClosed()
-}
-
-func (l *Listener) WaitAndRespondAaClassFile(req *Request, msg *notify.MsgNotificationFile) error {
-	return l.waitAndRespondAaClassFile(req, msg)
 }

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -248,6 +248,8 @@ var exitOnError = false
 func (l *Listener) Run() error {
 	var err error
 	l.once.Do(func() {
+		// Run should only be called once, so this once.Do is really only an
+		// extra precaution to ensure that l.reqs is only closed once.
 		defer func() {
 			// When listener run loop ends, close the requests channel.
 			close(l.reqs)
@@ -255,7 +257,7 @@ func (l *Listener) Run() error {
 		for {
 			err = l.handleRequests()
 			if err != nil {
-				if err == ErrClosed {
+				if errors.Is(err, ErrClosed) {
 					// Don't treat the listener closing as a real error
 					err = nil
 					return

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -399,20 +399,20 @@ func parseMsgNotificationFile(buf []byte) (*notify.MsgNotificationFile, error) {
 }
 
 func (l *Listener) newRequest(msg notify.MsgNotificationGeneric) (*Request, error) {
-	aaAllowed, aaDenied, err := msg.MsgAllowedDeniedPermissions()
+	aaAllowed, aaDenied, err := msg.AllowedDeniedPermissions()
 	if err != nil {
 		return nil, err
 	}
 	return &Request{
-		ID:       msg.MsgID(),
+		ID:       msg.ID(),
 		Listener: l,
 
-		PID:        msg.MsgPID(),
-		Label:      msg.MsgLabel(),
-		SubjectUID: msg.MsgSUID(),
+		PID:        msg.PID(),
+		Label:      msg.ProcessLabel(),
+		SubjectUID: msg.SubjectUID(),
 
-		Path:       msg.MsgName(),
-		Class:      msg.MsgClass(),
+		Path:       msg.Name(),
+		Class:      msg.MediationClass(),
 		Permission: aaDenied, // Request permissions which were initially denied
 		AaAllowed:  aaAllowed,
 	}, nil

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -26,9 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync/atomic"
-
-	"gopkg.in/tomb.v2"
+	"sync"
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/epoll"
@@ -40,16 +38,8 @@ var (
 	// ErrClosed indicates that the listener has been closed.
 	ErrClosed = errors.New("listener has been closed")
 
-	// ErrAlreadyRun indicates that the Run() method has already been run.
-	// Each listener must only be run once, so that spawned goroutines can
-	// be safely tracked and terminated.
-	ErrAlreadyRun = errors.New("listener has already been run")
-
 	// ErrAlreadyClosed indicates that the listener has previously been closed.
 	ErrAlreadyClosed = errors.New("listener has already been closed")
-
-	// ErrAlreadyReplied indicates that the request has already received a reply.
-	ErrAlreadyReplied = errors.New("request has already received a reply")
 
 	// ErrNotSupported indicates that the kernel does not support apparmor prompting.
 	ErrNotSupported = errors.New("kernel does not support apparmor notifications")
@@ -61,8 +51,13 @@ var (
 
 // Request is a high-level representation of an apparmor prompting message.
 //
-// Each request must be replied to by writing a boolean to the YesNo channel.
+// A request must be replied to via its Reply method.
 type Request struct {
+	// ID is the unique ID of the message notification associated with the request.
+	ID uint64
+	// Listener is a pointer to the Listener which will handle the reply.
+	Listener *Listener
+
 	// PID is the identifier of the process which triggered the request.
 	PID uint32
 	// Label is the apparmor label on the process which triggered the request.
@@ -76,46 +71,14 @@ type Request struct {
 	Class notify.MediationClass
 	// Permission is the opaque permission that is being requested.
 	Permission notify.AppArmorPermission
-
-	// replyChan is a channel for sending the explicitly allowed permissions.
-	replyChan chan notify.AppArmorPermission
-	// replied indicates whether a reply has already been sent for this request.
-	replied uint32
+	// AaAllowed is the opaque permission mask which was already allowed by
+	// AppArmor rules.
+	AaAllowed notify.AppArmorPermission
 }
 
-func newRequest(msg *notify.MsgNotificationFile) (*Request, error) {
-	var perm notify.AppArmorPermission
-	switch msg.Class {
-	case notify.AA_CLASS_FILE:
-		// DecodeFilePermissions returns:
-		// 1. allow: the permissions which were already allowed by AppArmor profile
-		// 2. deny:  the permissions which were not already allowed by AppArmor profile
-		// 3. err:   an error if the message was not a file permission request
-		_, missingPerms, err := msg.DecodeFilePermissions()
-		if err != nil {
-			return nil, err
-		}
-		// Treat denied permissions as the remaining permissions to request
-		// from the user.
-		perm = missingPerms
-	default:
-		return nil, fmt.Errorf("unsupported mediation class: %v", msg.Class)
-	}
-	return &Request{
-		PID:        msg.Pid,
-		Label:      msg.Label,
-		SubjectUID: msg.SUID,
-
-		Path:       msg.Name,
-		Class:      msg.Class,
-		Permission: perm,
-
-		replyChan: make(chan notify.AppArmorPermission, 1),
-	}, nil
-}
-
-// Reply tells the listener to send back a response to the kernel allowing any
-// of the given permissions which were originally requested.
+// Reply validates that the given permission is of the appropriate type for
+// the mediation class associated with the request, and then constructs a
+// response which allows those permissions and sends it to the kernel.
 func (r *Request) Reply(allowedPermission notify.AppArmorPermission) error {
 	var ok bool
 	switch r.Class {
@@ -130,11 +93,10 @@ func (r *Request) Reply(allowedPermission notify.AppArmorPermission) error {
 		expectedType := expectedResponseTypeForClass(r.Class)
 		return fmt.Errorf("invalid reply: response permission must be of type %s", expectedType)
 	}
-	if !atomic.CompareAndSwapUint32(&r.replied, 0, 1) {
-		return ErrAlreadyReplied
-	}
-	r.replyChan <- allowedPermission
-	return nil
+
+	resp := notify.BuildResponse(r.Listener.protocolVersion, r.ID, r.AaAllowed, r.Permission, allowedPermission)
+
+	return encodeAndSendResponse(r.Listener, &resp)
 }
 
 func expectedResponseTypeForClass(class notify.MediationClass) string {
@@ -151,8 +113,12 @@ func expectedResponseTypeForClass(class notify.MediationClass) string {
 // Listener encapsulates a loop for receiving apparmor notification requests
 // and responding with notification responses, hiding the low-level details.
 type Listener struct {
-	// reqs is a channel with incoming requests. Each request is asynchronous
-	// and needs to be replied to.
+	// once ensures that the Run method is only run once, to avoid closing
+	// a channel multiple times
+	once sync.Once
+
+	// reqs is a channel over which to send requests to the manager.
+	// Only the main run loop may close this channel.
 	reqs chan *Request
 
 	// protocolVersion is the notification protocol version associated with the
@@ -161,27 +127,14 @@ type Listener struct {
 	// socket.
 	protocolVersion notify.ProtocolVersion
 
+	// socketMu guards the notify file, the epoll instance, and the close chan.
+	socketMu   sync.Mutex
 	notifyFile *os.File
 	poll       *epoll.Epoll
-
-	tomb tomb.Tomb
-
-	// status keeps track of whether the listener has been run and/or closed,
-	// both to ensure that Run() and Close() are executed at most once each,
-	// and to ensure that the listener cannot be run after it has been closed.
-	// Must be read/modified atomically, and can only be changed in one of the
-	// following ways:
-	// - statusReady -> statusRunning
-	// - statusReady -> statusClosed
-	// - statusRunning -> statusClosed
-	status uint32
+	// closeChan will be closed by Close to indicate to the run loop that the
+	// listener should be closed.
+	closeChan chan struct{}
 }
-
-const (
-	statusReady uint32 = iota
-	statusRunning
-	statusClosed
-)
 
 // Register opens and configures the apparmor notification interface.
 //
@@ -224,41 +177,49 @@ func Register() (listener *Listener, err error) {
 	}
 
 	listener = &Listener{
-		reqs: make(chan *Request, 1),
+		reqs: make(chan *Request),
 
 		protocolVersion: protoVersion,
 
 		notifyFile: notifyFile,
 		poll:       poll,
+		closeChan:  make(chan struct{}),
 	}
 	return listener, nil
 }
 
+// isClosed returns true if the listener has been closed.
+//
+// Any caller which must ensure that a Close is not in progress should hold the
+// lock while checking isClosed, and continue to hold the lock until it is safe
+// for Close to be run.
+func (l *Listener) isClosed() bool {
+	select {
+	case <-l.closeChan:
+		return true
+	default:
+		return false
+	}
+}
+
 // Close stops the listener and closes the kernel communication file.
-// Returns once all waiting goroutines terminate and the communication file
-// is closed.
 func (l *Listener) Close() error {
-	origStatus := atomic.SwapUint32(&l.status, statusClosed)
-	switch origStatus {
-	case statusReady:
-		// A goroutine was never spawned with the listener tomb.
-		// Spawn one, so the tomb can die.
-		l.tomb.Go(func() error {
-			<-l.tomb.Dying()
-			return nil
-		})
-	case statusRunning:
-	case statusClosed:
-		l.tomb.Wait()
+	l.socketMu.Lock()
+	defer l.socketMu.Unlock()
+	if l.isClosed() {
 		return ErrAlreadyClosed
 	}
-	l.tomb.Kill(ErrClosed)
-	// Close epoll instance to stop the run loop waiting on epoll events
+
+	// Close the close channel so that the the run loop knows to stop trying
+	// to send requests over the request channel, and so that once the epoll
+	// FD is closed (causing the syscall to error), it can check the closeChan
+	// to see whether Close was called or whether a real error occurred.
+	close(l.closeChan)
+
+	// Close the epoll so that if the run loop is waiting on an event, it will
+	// return an error.
 	err1 := l.poll.Close()
-	// Wait for main run loop and waiters to terminate
-	l.tomb.Wait()
-	// l.reqs is only written to by run loop, so it's now safe to close
-	close(l.reqs)
+
 	// Closing the notify file signals to the kernel that the listener is
 	// disconnecting, so the kernel will send back denials or pass requests
 	// on to other listeners which connect.
@@ -281,52 +242,32 @@ var exitOnError = false
 
 // Run reads and dispatches kernel requests until the listener is closed.
 //
-// Run should only be called once per listener object. If called more than once,
-// Run returns an error. Otherwise, waits until the listener stops, and returns
-// the cause as an error. If the listener was intentionally stopped via the
-// Close() method, returns nil.
+// Run should only be called once per listener object, and it runs until the
+// listener is closed or errors (if exitOnError is true), and returns the cause.
+// If the listener was intentionally stopped via the Close() method, returns nil.
 func (l *Listener) Run() error {
-	if !atomic.CompareAndSwapUint32(&l.status, statusReady, statusRunning) {
-		currStatus := atomic.LoadUint32(&l.status)
-		switch currStatus {
-		case statusRunning:
-			return ErrAlreadyRun
-		case statusClosed:
-			return ErrAlreadyClosed
-		default:
-			return fmt.Errorf("listener has unexpected status: %d", currStatus)
-		}
-	}
-	// This is the first and only time calling Run().
-	// Even if Close() kills the tomb before l.tomb.Go() occurs, a panic will
-	// not occur, since this new goroutine will (immediately after l.tomb.Err()
-	// is called) return and close the tomb's dead channel, as it is the last
-	// and only tracked goroutine.
-	l.tomb.Go(func() error {
+	var err error
+	l.once.Do(func() {
+		defer func() {
+			// When listener run loop ends, close the requests channel.
+			close(l.reqs)
+		}()
 		for {
-			if err := l.tomb.Err(); err != tomb.ErrStillAlive {
-				// Do not log error here, as the only error from outside of
-				// runOnce should be when listener was deliberately closed,
-				// and we don't want a log message for that.
-				break
-			}
-			err := l.runOnce()
+			err = l.runOnce()
 			if err != nil {
-				if exitOnError {
-					return err
-				} else {
-					logger.Noticef("error in prompting listener run loop: %v", err)
+				if err == ErrClosed {
+					// Don't treat the listener closing as a real error
+					err = nil
+					return
+				} else if exitOnError {
+					l.Close() // make sure Close is called at least once
+					return
 				}
+				logger.Noticef("error in prompting listener run loop: %v", err)
 			}
 		}
-		return nil
 	})
-	// Wait for an error to occur or the listener to be explicitly closed.
-	<-l.tomb.Dying()
-	// Close the listener, in case an internal error occurred and Close()
-	// was not explicitly called.
-	l.Close()
-	return l.tomb.Err()
+	return err
 }
 
 var listenerEpollWait = func(l *Listener) ([]epoll.Event, error) {
@@ -336,12 +277,21 @@ var listenerEpollWait = func(l *Listener) ([]epoll.Event, error) {
 func (l *Listener) runOnce() error {
 	events, err := listenerEpollWait(l)
 	if err != nil {
-		// If epoll instance is closed, then tomb error status has already
-		// been set. Otherwise, this is a true error. Either way, return it.
+		// The epoll syscall returned an error, so let's see whether it was
+		// because we closed the epoll FD.
+		if l.isClosed() {
+			return ErrClosed
+		}
 		return err
 	}
+
+	// Get the socket FD with the lock held, so we don't break our contract
+	l.socketMu.Lock()
+	socketFd := int(l.notifyFile.Fd())
+	l.socketMu.Unlock() // unlock immediately, we'll lock again later if needed
+
 	for _, event := range events {
-		if event.Fd != int(l.notifyFile.Fd()) {
+		if event.Fd != socketFd {
 			logger.Debugf("unexpected event from fd %v (%v)", event.Fd, event.Readiness)
 			continue
 		}
@@ -352,10 +302,8 @@ func (l *Listener) runOnce() error {
 		// maximum allowed size and will contain one or more kernel requests
 		// upon return.
 		ioctlBuf := notify.NewIoctlRequestBuffer()
-		buf, err := notifyIoctl(l.notifyFile.Fd(), notify.APPARMOR_NOTIF_RECV, ioctlBuf)
+		buf, err := l.doIoctl(notify.APPARMOR_NOTIF_RECV, ioctlBuf)
 		if err != nil {
-			// If epoll instance is closed, then tomb error status has already
-			// been set. Otherwise, this is a true error. Either way, return it.
 			return err
 		}
 		if err := l.decodeAndDispatchRequest(buf); err != nil {
@@ -365,6 +313,22 @@ func (l *Listener) runOnce() error {
 	return nil
 }
 
+// doIoctl locks the mutex guarding the notify socket, checks whether the
+// listener is being closed, and if not, sends an ioctl request with the given
+// request type and buffer.
+func (l *Listener) doIoctl(sendOrRecv notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+	l.socketMu.Lock()
+	defer l.socketMu.Unlock()
+	if l.isClosed() {
+		return nil, ErrClosed
+	}
+	return notifyIoctl(l.notifyFile.Fd(), sendOrRecv, buf)
+}
+
+// decodeAndDispatchRequest reads all messages from the given buffer, decodes
+// each one into a message notification for a particular mediation class,
+// creates a Request from that message, and attempts to send it to the manager
+// via the request channel.
 func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 	for {
 		first, rest, err := notify.ExtractFirstMsg(buf)
@@ -378,7 +342,7 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 		if nmsg.Version != l.protocolVersion {
 			return fmt.Errorf("unexpected protocol version: listener registered with %d, but received %d", l.protocolVersion, nmsg.Version)
 		}
-		// What kind of notification message did we get?
+		// What kind of notification message did we get? (I hope it's an Op)
 		if nmsg.NotificationType != notify.APPARMOR_NOTIF_OP {
 			return fmt.Errorf("unsupported notification type: %v", nmsg.NotificationType)
 		}
@@ -386,15 +350,38 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 		if err := omsg.UnmarshalBinary(first); err != nil {
 			return err
 		}
+
+		var msg notify.MsgNotificationGeneric
 		// What kind of operation notification did we get?
 		switch omsg.Class {
 		case notify.AA_CLASS_FILE:
-			if err := l.handleRequestAaClassFile(first); err != nil {
-				return err
-			}
+			msg, err = parseMsgNotificationFile(first)
 		default:
 			return fmt.Errorf("unsupported mediation class: %v", omsg.Class)
 		}
+		if err != nil {
+			return err
+		}
+
+		// Build request
+		req, err := l.newRequest(msg)
+		if err != nil {
+			return err
+		}
+
+		// Try to send request to manager, or wait for listener to be closed
+		select {
+		case l.reqs <- req:
+			// request received
+		case <-l.closeChan:
+			// XXX: since returning an error causes the request channel to be
+			// closed, the request we received from the kernel will not be
+			// delivered to the manager. It will appear to the kernel that we
+			// have received and processed the request, when in reality, we
+			// have not.
+			return ErrClosed
+		}
+
 		if len(rest) == 0 {
 			return nil
 		}
@@ -402,73 +389,33 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 	}
 }
 
-func (l *Listener) handleRequestAaClassFile(buf []byte) error {
+func parseMsgNotificationFile(buf []byte) (*notify.MsgNotificationFile, error) {
 	var fmsg notify.MsgNotificationFile
 	if err := fmsg.UnmarshalBinary(buf); err != nil {
-		return err
+		return nil, err
 	}
-	logger.Debugf("received prompt request from the kernel: %+v", fmsg)
-	req, err := newRequest(&fmsg)
-	if err != nil {
-		return err
-	}
-	select {
-	case l.reqs <- req:
-		// request received
-	case <-l.tomb.Dying():
-		return l.tomb.Err()
-	}
-	l.tomb.Go(func() error {
-		err := l.waitAndRespondAaClassFile(req, &fmsg)
-		if err != nil {
-			logger.Noticef("error while responding to kernel: %v", err)
-		}
-		return nil
-	})
-	return nil
+	logger.Debugf("received file request from the kernel: %+v", fmsg)
+	return &fmsg, nil
 }
 
-func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotificationFile) error {
-	resp := notify.ResponseForRequest(&msg.MsgNotification)
-	resp.Version = l.protocolVersion
-	resp.MsgNotification.Error = 0 // ignored in responses
-	resp.MsgNotification.NoCache = 1
-
-	var explicitlyAllowed uint32 = 0
-	select {
-	case responsePermission := <-req.replyChan:
-		if responsePermission == nil {
-			// Treat nil as allowing no permission
-			break
-		}
-		perms, ok := responsePermission.(notify.FilePermission)
-		if !ok {
-			// should not occur, Reply() checks that type is correct
-			logger.Debugf("invalid reply from client: %+v; denying request", responsePermission)
-			break
-		}
-		explicitlyAllowed = perms.AsAppArmorOpMask()
-	case <-l.tomb.Dying():
-		// don't bother sending deny response, kernel will auto-deny if needed
-		return nil
+func (l *Listener) newRequest(msg notify.MsgNotificationGeneric) (*Request, error) {
+	aaAllowed, aaDenied, err := msg.MsgAllowedDeniedPermissions()
+	if err != nil {
+		return nil, err
 	}
+	return &Request{
+		ID:       msg.MsgID(),
+		Listener: l,
 
-	// If the same permission appears in both the allow and deny fields,
-	// treat it as initially denied.
-	apparmorAllowed := msg.Allow &^ msg.Deny
+		PID:        msg.MsgPID(),
+		Label:      msg.MsgLabel(),
+		SubjectUID: msg.MsgSUID(),
 
-	// Allow permissions which AppArmor initially allowed, along with those
-	// which the were initially denied but the user explicitly allowed.
-	resp.Allow = apparmorAllowed | (explicitlyAllowed & msg.Deny)
-	// Deny permissions which were initially denied and not explicitly allowed
-	// by the user.
-	resp.Deny = msg.Deny &^ explicitlyAllowed
-	// Any permissions which are omitted from both the allow and deny
-	// fields will be default denied by the kernel.
-	resp.Error = 0
-
-	logger.Debugf("sending request response back to the kernel: %+v", resp)
-	return encodeAndSendResponse(l, &resp)
+		Path:       msg.MsgName(),
+		Class:      msg.MsgClass(),
+		Permission: aaDenied, // Request permissions which were initially denied
+		AaAllowed:  aaAllowed,
+	}, nil
 }
 
 var encodeAndSendResponse = func(l *Listener, resp *notify.MsgNotificationResponse) error {
@@ -481,6 +428,6 @@ func (l *Listener) encodeAndSendResponse(resp *notify.MsgNotificationResponse) e
 		return err
 	}
 	ioctlBuf := notify.IoctlRequestBuffer(buf)
-	_, err = notifyIoctl(l.notifyFile.Fd(), notify.APPARMOR_NOTIF_SEND, ioctlBuf)
+	_, err = l.doIoctl(notify.APPARMOR_NOTIF_SEND, ioctlBuf)
 	return err
 }

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -77,7 +77,7 @@ func (*listenerSuite) TestReply(c *C) {
 	)
 
 	restore := listener.MockEncodeAndSendResponse(func(l *listener.Listener, resp *notify.MsgNotificationResponse) error {
-		c.Check(resp.ID, Equals, id)
+		c.Check(resp.Id, Equals, id)
 		c.Check(resp.Version, Equals, version)
 		c.Check(resp.Allow, Equals, uint32(0b1011))
 		c.Check(resp.Deny, Equals, uint32(0b0100))
@@ -102,7 +102,7 @@ func (*listenerSuite) TestReplyNil(c *C) {
 	)
 
 	restore := listener.MockEncodeAndSendResponse(func(l *listener.Listener, resp *notify.MsgNotificationResponse) error {
-		c.Check(resp.ID, Equals, id)
+		c.Check(resp.Id, Equals, id)
 		c.Check(resp.Version, Equals, version)
 		c.Check(resp.Allow, Equals, aaAllow.AsAppArmorOpMask())
 		c.Check(resp.Deny, Equals, aaDeny.AsAppArmorOpMask())
@@ -271,7 +271,7 @@ func (*listenerSuite) TestReplyPermissions(c *C) {
 		},
 	} {
 		restore := listener.MockEncodeAndSendResponse(func(l *listener.Listener, resp *notify.MsgNotificationResponse) error {
-			c.Check(resp.ID, Equals, id)
+			c.Check(resp.Id, Equals, id)
 			c.Check(resp.Version, Equals, version)
 			c.Check(resp.Allow, Equals, testCase.respAllow, Commentf("testCase: %+v", testCase))
 			c.Check(resp.Deny, Equals, testCase.respDeny, Commentf("testCase: %+v", testCase))
@@ -427,7 +427,7 @@ type msgNotificationFile struct {
 	NotificationType notify.NotificationType
 	Signalled        uint8
 	NoCache          uint8
-	ID               uint64
+	Id               uint64
 	Error            int32
 	// msgNotificationOpKernel
 	Allow uint32
@@ -437,9 +437,9 @@ type msgNotificationFile struct {
 	Class uint16
 	Op    uint16
 	// msgNotificationFileKernel
-	SUID uint32
-	OUID uint32
-	Name uint32
+	SUID     uint32
+	OUID     uint32
+	Filename uint32
 	// msgNotificationFileKernel version 5+
 	Tags         uint32
 	TagsetsCount uint16
@@ -449,7 +449,7 @@ func (msg *msgNotificationFile) MarshalBinary(c *C) []byte {
 	// Check that all the variable-length fields are 0, since we're not packing
 	// strings at the end of the message.
 	c.Assert(msg.Label, Equals, uint32(0))
-	c.Assert(msg.Name, Equals, uint32(0))
+	c.Assert(msg.Filename, Equals, uint32(0))
 	c.Assert(msg.Tags, Equals, uint32(0))
 
 	msgBuf := bytes.NewBuffer(make([]byte, 0, msg.Length))
@@ -850,14 +850,14 @@ func newMsgNotificationFile(protocolVersion notify.ProtocolVersion, id uint64, l
 	msg.Version = protocolVersion
 	msg.NotificationType = notify.APPARMOR_NOTIF_OP
 	msg.NoCache = 1
-	msg.ID = id
+	msg.Id = id
 	msg.Allow = allow
 	msg.Deny = deny
 	msg.Pid = 1234
 	msg.Label = label
 	msg.Class = notify.AA_CLASS_FILE
 	msg.SUID = 1000
-	msg.Name = name
+	msg.Filename = name
 	return &msg
 }
 
@@ -869,7 +869,7 @@ func newMsgNotificationResponse(protocolVersion notify.ProtocolVersion, id uint6
 		MsgHeader:        msgHeader,
 		NotificationType: notify.APPARMOR_NOTIF_RESP,
 		NoCache:          1,
-		ID:               id,
+		Id:               id,
 		Error:            0,
 	}
 	resp := notify.MsgNotificationResponse{
@@ -1110,7 +1110,7 @@ func (*listenerSuite) TestRunConcurrency(c *C) {
 		id := uint64(0)
 		for {
 			id += 1
-			msg.ID = id
+			msg.Id = id
 			buf, err := msg.MarshalBinary()
 			c.Assert(err, IsNil)
 			select {

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -11,6 +11,32 @@ import (
 
 var ErrVersionUnset = errors.New("cannot marshal message without protocol version")
 
+// MsgNotificationGeneric define the methods which the message types for each
+// mediation class must provide.
+//
+// Many of these methods, including ID, PID, ProcessLabel, and MediationClass,
+// are implemented on MsgNotificationOp, so any struct which embeds a
+// MsgNotificationOp need only implement the remaining methods.
+type MsgNotificationGeneric interface {
+	// ID returns the unique ID of the notification message.
+	ID() uint64
+	// PID returns the PID of the process triggering the notification.
+	PID() uint32
+	// ProcessLabel returns the AppArmor label of the process triggering the notification.
+	ProcessLabel() string
+	// MediationClass returns the mediation class of the message.
+	MediationClass() MediationClass
+
+	// AllowedDeniedPermissions returns the AppArmor permission masks which
+	// were originally allowed and originally denied by AppArmor rules.
+	AllowedDeniedPermissions() (AppArmorPermission, AppArmorPermission, error)
+	// SubjectUID returns the UID of the user triggering the notification.
+	SubjectUID() uint32
+	// Name is the identifier of the resource to which access is requested.
+	// For mediation class file, Name is the filepath of the requested file.
+	Name() string
+}
+
 // Message fields are defined as raw sized integer types as the same type may be
 // packed as 16 bit or 32 bit integer, to accommodate other fields in the
 // structure.
@@ -491,39 +517,6 @@ func (msg *MsgNotificationOp) ProcessLabel() string {
 
 func (msg *MsgNotificationOp) MediationClass() MediationClass {
 	return msg.Class
-}
-
-// MsgNotificationGeneric define the methods which the message types for each
-// mediation class must provide.
-//
-// Many (but not all) of these methods are implemented on MsgNotificationOp, so
-// any struct which embeds a MsgNotificationOp need only implement the methods
-// which are specific to the mediation class associated with that message type.
-type MsgNotificationGeneric interface {
-	// The following methods are implemented on MsgNotificationOp, and thus need
-	// not be implemented on any type which embeds a MsgNotificationOp.
-
-	// ID returns the unique ID of the notification message.
-	ID() uint64
-	// PID returns the PID of the process triggering the notification.
-	PID() uint32
-	// ProcessLabel returns the AppArmor label of the process triggering the notification.
-	ProcessLabel() string
-	// MediationClass returns the mediation class of the message.
-	MediationClass() MediationClass
-
-	// The following methods must be implemented on each mediation class-specific
-	// message type which embeds a MsgNotificationOp in order for that message
-	// type to implement MsgNotificationGeneric.
-
-	// AllowedDeniedPermissions returns the AppArmor permission masks which
-	// were originally allowed and originally denied by AppArmor rules.
-	AllowedDeniedPermissions() (AppArmorPermission, AppArmorPermission, error)
-	// SubjectUID returns the UID of the user triggering the notification.
-	SubjectUID() uint32
-	// Name is the identifier of the resource to which access is requested.
-	// For mediation class file, Name is the filepath of the requested file.
-	Name() string
 }
 
 // msgNotificationFileKernelBase (protocol version <5)

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -415,7 +415,7 @@ func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
 		NotificationType: notify.APPARMOR_NOTIF_RESP,
 		Signalled:        1,
 		NoCache:          0,
-		ID:               0x1234,
+		Id:               0x1234,
 		Error:            0xFF,
 	}
 	msg.Version = notify.ProtocolVersion(0xAA)
@@ -454,7 +454,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 		0x0, 0x0, // Op - ???
 		0x0, 0x0, 0x0, 0x0, // SUID
 		0x0, 0x0, 0x0, 0x0, // OUID
-		0x40, 0x0, 0x0, 0x0, // Name at +64 bytes into buffer
+		0x40, 0x0, 0x0, 0x0, // Filename at +64 bytes into buffer
 		0x74, 0x65, 0x73, 0x74, 0x2d, 0x70, 0x72, 0x6f, 0x6d, 0x70, 0x74, 0x0, // "test-prompt\0"
 		0x2f, 0x72, 0x6f, 0x6f, 0x74, 0x2f, 0x2e, 0x73, 0x73, 0x68, 0x2f, 0x0, // "/root/.ssh/\0"
 	}
@@ -471,7 +471,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 					Version: 3,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 4,
@@ -480,7 +480,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 			Label: "test-prompt",
 			Class: notify.AA_CLASS_FILE,
 		},
-		Name: "/root/.ssh/",
+		Filename: "/root/.ssh/",
 	}
 	c.Assert(msg, DeepEquals, expected)
 
@@ -534,7 +534,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C)
 					Version: 5,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 4,
@@ -543,7 +543,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C)
 			Label: "test-prompt",
 			Class: notify.AA_CLASS_FILE,
 		},
-		Name: "/root/.ssh/",
+		Filename: "/root/.ssh/",
 	}
 	c.Assert(msg, DeepEquals, expected)
 
@@ -612,7 +612,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
 					Version: 5,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 0xaaaaaaaa,
@@ -621,9 +621,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
 			Label: "profile",
 			Class: notify.AA_CLASS_FILE,
 		},
-		SUID: 1000,
-		OUID: 1000,
-		Name: "/file",
+		SUID:     1000,
+		OUID:     1000,
+		Filename: "/file",
 		Tagsets: map[notify.AppArmorPermission][]string{
 			notify.FilePermission(0x0103): {
 				"one",
@@ -710,7 +710,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAn
 					Version: 5,
 				},
 				NotificationType: notify.APPARMOR_NOTIF_OP,
-				ID:               2,
+				Id:               2,
 				Error:            -13,
 			},
 			Allow: 0xaaaaaaaa,
@@ -719,9 +719,9 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAn
 			Label: "profile",
 			Class: notify.AA_CLASS_FILE,
 		},
-		SUID: 1000,
-		OUID: 1000,
-		Name: "/file",
+		SUID:     1000,
+		OUID:     1000,
+		Filename: "/file",
 		Tagsets: map[notify.AppArmorPermission][]string{
 			notify.FilePermission(0x01): []string(nil),
 			notify.FilePermission(0x02): {
@@ -932,7 +932,7 @@ func (s *messageSuite) TestBuildResponse(c *C) {
 		c.Check(resp.Version, Equals, protocol)
 		c.Check(resp.NotificationType, Equals, notify.APPARMOR_NOTIF_RESP)
 		c.Check(resp.NoCache, Equals, uint8(1))
-		c.Check(resp.ID, Equals, id)
+		c.Check(resp.Id, Equals, id)
 		c.Check(resp.Allow, Equals, testCase.expectedAllow)
 		c.Check(resp.Deny, Equals, testCase.expectedDeny)
 	}
@@ -950,7 +950,7 @@ func (s *messageSuite) TestMsgNotificationResponseMarshalBinary(c *C) {
 			NotificationType: 0x11,
 			Signalled:        0x22,
 			NoCache:          0x33,
-			ID:               0x44,
+			Id:               0x44,
 			Error:            0x55,
 		},
 		Error: 0x66,
@@ -1001,27 +1001,27 @@ func (*messageSuite) TestDecodeFilePermissionsWrongClass(c *C) {
 
 func (*messageSuite) TestMsgNotificationFileAsGeneric(c *C) {
 	var msg notify.MsgNotificationFile
-	msg.ID = uint64(123)
+	msg.Id = uint64(123)
 	msg.Pid = uint32(456)
 	msg.Label = "hello there"
 	msg.Class = notify.AA_CLASS_FILE
 	msg.Allow = uint32(0xaaaa)
 	msg.Deny = uint32(0xbbbb)
 	msg.SUID = uint32(789)
-	msg.Name = "/foo/bar"
+	msg.Filename = "/foo/bar"
 
-	testMsgNotificationGeneric(c, &msg, msg.ID, msg.Pid, msg.Label, msg.Class, msg.Allow, msg.Deny, msg.SUID, msg.Name)
+	testMsgNotificationGeneric(c, &msg, msg.Id, msg.Pid, msg.Label, msg.Class, msg.Allow, msg.Deny, msg.SUID, msg.Filename)
 }
 
 func testMsgNotificationGeneric(c *C, generic notify.MsgNotificationGeneric, id uint64, pid uint32, label string, class notify.MediationClass, allowed, denied, suid uint32, name string) {
-	c.Check(generic.MsgID(), Equals, id)
-	c.Check(generic.MsgPID(), Equals, pid)
-	c.Check(generic.MsgLabel(), Equals, label)
-	c.Check(generic.MsgClass(), Equals, class)
-	msgAllow, msgDeny, err := generic.MsgAllowedDeniedPermissions()
+	c.Check(generic.ID(), Equals, id)
+	c.Check(generic.PID(), Equals, pid)
+	c.Check(generic.ProcessLabel(), Equals, label)
+	c.Check(generic.MediationClass(), Equals, class)
+	msgAllow, msgDeny, err := generic.AllowedDeniedPermissions()
 	c.Check(err, IsNil)
 	c.Check(msgAllow.AsAppArmorOpMask(), Equals, allowed)
 	c.Check(msgDeny.AsAppArmorOpMask(), Equals, denied)
-	c.Check(generic.MsgSUID(), Equals, suid)
-	c.Check(generic.MsgName(), Equals, name)
+	c.Check(generic.SubjectUID(), Equals, suid)
+	c.Check(generic.Name(), Equals, name)
 }


### PR DESCRIPTION
This PR is based on #15178.

Record a map from request ID to prompt ID so that when snapd restarts and requests are re-received from the kernel, prompts can be created which have the same IDs as those which were originally associated with the requests.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-33537

---

Note the TODOs in the comments added in this PR. There are some tough edge cases to handle, and the solutions I have in mind drive up the complexity of this patch quickly.

A few big questions remain, the biggest being how we deal with prompt replies which are received over the API before the requests associated with those prompts are re-received, and thus the prompts may not have been re-created yet. I have ideas for how to address this, but things get complicated fast.

Relatedly, even if at least one request associated with a prompt has been received at the time the reply is received, what if more requests originally associated with the prompt are re-received after the prompt has received a reply? The easy answer is to re-issue a prompt with the same ID, but that's sad for the client/user if it's possible to avoid it.