### PR TITLE
snapcraft.yaml: build snap-bootstrap with nomanagers

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -384,6 +384,14 @@ parts:
                 ;;
             esac
             ;;
+          lib/snapd/snap-bootstrap)
+            TAGS+=(nomanagers)
+            case "${VERSION}" in
+              1337.*)
+                TAGS+=(withtestkeys withbootassetstesting faultinject statelocktrace)
+                ;;
+            esac
+            ;;
           *)
             case "${VERSION}" in
               1337.*)


### PR DESCRIPTION
That saves 1MB on the snapd snap after compression.