### PR TITLE
o/h/ctlcmd: snapctl get loads ephemeral data

### DIFF
--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -496,6 +496,7 @@ func IsConfdbHook(ctx *hookstate.Context) bool {
 func IsModifyConfdbHook(ctx *hookstate.Context) bool {
 	return ctx != nil && !ctx.IsEphemeral() &&
 		(strings.HasPrefix(ctx.HookName(), "change-view-") ||
+			strings.HasPrefix(ctx.HookName(), "query-view-") ||
 			strings.HasPrefix(ctx.HookName(), "load-view-"))
 }
 

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -38,26 +38,6 @@ import (
 
 var assertstateConfdbSchema = assertstate.ConfdbSchema
 
-// Set finds the view identified by the account, confdb schema and view names
-// and sets the request fields to their respective values.
-func Set(st *state.State, account, dbSchemaName, viewName string, requests map[string]interface{}) error {
-	view, err := GetView(st, account, dbSchemaName, viewName)
-	if err != nil {
-		return err
-	}
-
-	tx, err := NewTransaction(st, account, dbSchemaName)
-	if err != nil {
-		return err
-	}
-
-	if err := SetViaView(tx, view, requests); err != nil {
-		return err
-	}
-
-	return tx.Commit(st, view.Schema().DatabagSchema)
-}
-
 // SetViaView uses the view to set the requests in the transaction's databag.
 func SetViaView(bag confdb.Databag, view *confdb.View, requests map[string]interface{}) error {
 	for field, value := range requests {
@@ -95,24 +75,6 @@ func GetView(st *state.State, account, dbSchemaName, viewName string) (*confdb.V
 	}
 
 	return view, nil
-}
-
-// Get finds the view identified by the account, confdb schema and view names and
-// uses it to get the values for the specified fields. The results are returned
-// in a map of fields to their values, unless there are no fields in which case
-// case all views are returned.
-func Get(st *state.State, account, dbSchemaName, viewName string, fields []string) (interface{}, error) {
-	view, err := GetView(st, account, dbSchemaName, viewName)
-	if err != nil {
-		return nil, err
-	}
-
-	bag, err := readDatabag(st, account, dbSchemaName)
-	if err != nil {
-		return nil, err
-	}
-
-	return GetViaView(bag, view, fields)
 }
 
 // GetViaView uses the view to get values for the fields from the databag in

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -181,11 +181,11 @@ func MockNewStatusDecorator(f func(ctx context.Context, isGlobal bool, uid strin
 	return restore
 }
 
-func MockConfdbstateGetTransaction(f func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error)) (restore func()) {
-	old := confdbstateGetTransaction
-	confdbstateGetTransaction = f
+func MockConfdbstateTransactionForSet(f func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error)) (restore func()) {
+	old := confdbstateTransactionForSet
+	confdbstateTransactionForSet = f
 	return func() {
-		confdbstateGetTransaction = old
+		confdbstateTransactionForSet = old
 	}
 }
 
@@ -197,18 +197,10 @@ func MockConfdbstateGetView(f func(st *state.State, account, confdbName, viewNam
 	}
 }
 
-func MockConfdbstateNewTransaction(f func(*state.State, string, string) (*confdbstate.Transaction, error)) (restore func()) {
-	old := confdbstateNewTransaction
-	confdbstateNewTransaction = f
+func MockConfdbstateTransactionForGet(f func(*hookstate.Context, *confdb.View) (*confdbstate.Transaction, error)) (restore func()) {
+	old := confdbstateTransactionForGet
+	confdbstateTransactionForGet = f
 	return func() {
-		confdbstateNewTransaction = old
-	}
-}
-
-func MockConfdbstateGetStoredTransaction(f func(*state.Task) (*confdbstate.Transaction, *state.Task, func(), error)) (restore func()) {
-	old := confdbstateGetStoredTransaction
-	confdbstateGetStoredTransaction = f
-	return func() {
-		confdbstateGetStoredTransaction = old
+		confdbstateTransactionForGet = old
 	}
 }

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -34,7 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 )
 
-var confdbstateGetTransaction = confdbstate.GetTransactionToSet
+var confdbstateTransactionForSet = confdbstate.GetTransactionToSet
 
 type setCommand struct {
 	baseCommand
@@ -250,7 +250,7 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, requests map[strin
 		return fmt.Errorf("cannot modify confdb in %q hook", ctx.HookName())
 	}
 
-	tx, commitTxFunc, err := confdbstateGetTransaction(ctx, ctx.State(), view)
+	tx, commitTxFunc, err := confdbstateTransactionForSet(ctx, ctx.State(), view)
 	if err != nil {
 		return err
 	}

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -411,7 +411,7 @@ func (s *confdbSuite) TestConfdbSetSingleView(c *C) {
 	s.state.Unlock()
 	c.Assert(err, IsNil)
 
-	restore := ctlcmd.MockConfdbstateGetTransaction(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForSet(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
 		return tx, nil, nil
 	})
 	defer restore()
@@ -436,7 +436,7 @@ func (s *confdbSuite) TestConfdbSetSingleViewNewTransaction(c *C) {
 	c.Assert(err, IsNil)
 
 	var called bool
-	restore := ctlcmd.MockConfdbstateGetTransaction(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForSet(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
 		return tx, func() (string, <-chan struct{}, error) {
 			called = true
 			waitChan := make(chan struct{})
@@ -464,7 +464,7 @@ func (s *confdbSuite) TestConfdbSetManyViews(c *C) {
 	s.state.Unlock()
 	c.Assert(err, IsNil)
 
-	restore := ctlcmd.MockConfdbstateGetTransaction(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForSet(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
 		return tx, nil, nil
 	})
 	defer restore()
@@ -520,7 +520,7 @@ func (s *confdbSuite) TestConfdbSetExclamationMark(c *C) {
 	err = tx.Set("wifi.psk", "bar")
 	c.Assert(err, IsNil)
 
-	restore := ctlcmd.MockConfdbstateGetTransaction(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForSet(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
 		return tx, nil, nil
 	})
 	defer restore()
@@ -550,7 +550,7 @@ func (s *confdbSuite) TestConfdbOnlyChangeViewCanSet(c *C) {
 	tx, err := confdbstate.NewTransaction(s.state, s.devAccID, "network")
 	c.Assert(err, IsNil)
 
-	restore := ctlcmd.MockConfdbstateGetTransaction(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForSet(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
 		return tx, nil, nil
 	})
 	defer restore()

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -175,7 +175,7 @@ func (s *confdbSuite) TestConfdbUnsetManyViews(c *C) {
 	err = tx.Set("wifi.psk", "bar")
 	c.Assert(err, IsNil)
 
-	ctlcmd.MockConfdbstateGetTransaction(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
+	ctlcmd.MockConfdbstateTransactionForSet(func(*hookstate.Context, *state.State, *confdb.View) (*confdbstate.Transaction, confdbstate.CommitTxFunc, error) {
 		return tx, nil, nil
 	})
 

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -187,10 +187,8 @@ func (s *confdbSuite) TestConfdbUnsetManyViews(c *C) {
 	_, err = tx.Get("wifi.ssid")
 	c.Assert(err, ErrorMatches, `no value was found under path "wifi.ssid"`)
 
-	s.state.Lock()
-	_, err = confdbstate.Get(s.state, s.devAccID, "network", "write-wifi", []string{"ssid", "password"})
-	s.state.Unlock()
-	c.Assert(err, ErrorMatches, `cannot get "ssid", "password" .*: no data`)
+	_, err = tx.Get("wifi.psk")
+	c.Assert(err, ErrorMatches, `no value was found under path "wifi.psk"`)
 }
 
 func (s *confdbSuite) TestConfdbUnsetInvalid(c *C) {


### PR DESCRIPTION
Use the previously added helpers to load ephemeral data in `snapctl get`. Since we no longer use the general confdbstate.Get/Set functions that directly accessed the databags, these are also removed and any tests using them are changed to use the new way of accessing confdb.