### PR TITLE
tests: make simpleget tool quiet by default

### DIFF
--- a/tests/lib/tools/simpleget
+++ b/tests/lib/tools/simpleget
@@ -13,16 +13,21 @@ from urllib.parse import urlparse
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="simple file getter")
     parser.add_argument("-o", "--output", help="output file name")
+    parser.add_argument("-v", "--verbose", action='store_true', help="set verbose output")
     parser.add_argument("-H", "--header", action="append", help="set a header")
     parser.add_argument("URL", help="download URL")
     return parser.parse_args()
 
 
 def main() -> None:
-    logging.basicConfig(
-        format="%(asctime)s - %(levelname)s - %(message)s", level=logging.DEBUG
-    )
     opts = parse_arguments()
+
+    loglevel=logging.ERROR
+    if opts.verbose:
+        loglevel=logging.DEBUG
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(message)s", level=loglevel
+    )
 
     fromurl = urlparse(opts.URL).path
     output = os.path.basename(fromurl)


### PR DESCRIPTION
Some logs are very hard to read because of the progress reported by the simpleget tool.

The idea of this change is to make it quiet by default but with a new option to display progress.
