### PR TITLE
cmd/libsnap-confine-private: simplify sc_ensure_mkdir(), reset errno in fchmodat() fallback path

### DIFF
--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -301,17 +301,5 @@ int sc_ensure_mkdirat(int fd, const char *name, mode_t mode, uid_t uid, uid_t gi
 }
 
 int sc_ensure_mkdir(const char *path, mode_t mode, uid_t uid, uid_t gid) {
-    /* Using 0000 permissions to avoid a race condition; we'll set the right
-     * permissions after chown. */
-    if (mkdir(path, 0000) < 0) {
-        if (errno != EEXIST) {
-            return -1;
-        }
-    } else {
-        // new directory: set the right permissions and mode
-        if (chown(path, uid, gid) < 0 || chmod(path, mode)) {
-            return -1;
-        }
-    }
-    return 0;
+    return sc_ensure_mkdirat(AT_FDCWD, path, mode, uid, gid);
 }

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -275,6 +275,8 @@ static int compat_fchmodat_symlink_nofollow(int fd, const char *name, mode_t mod
      * on AMZN2 does not), attempt to handle that gracefully */
     int ret = fchmodat(fd, name, mode, AT_SYMLINK_NOFOLLOW);
     if (ret != 0 && errno == ENOTSUP) {
+        /* reset errno */
+        errno = 0;
         /* AT_SYMLINK_NOFOLLOW is not supported by the kernel */
         ret = fchmodat(fd, name, mode, 0);
     }


### PR DESCRIPTION
Two commits cherry picked from #15094 

```
cmd/libsnap-confine-private: simplify sc_ensure_mkdir()
    Simplify sc_ensure_mkdir() by calling sc_ensure_mkdirat(AT_FDCWD,...).

cmd/libsnap-confine-private: reset errno when trying fchmodat() compatibility fallback
    Make sure to reset the errno when going through fchmodat() compatibility
    fallback path.
```