### PR TITLE
s/a/notify{,/listener}: register listener id and resend notifications

### DIFF
--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -35,6 +35,10 @@ func MockListenerRun(f func(l *listener.Listener) error) (restore func()) {
 	return testutil.Mock(&listenerRun, f)
 }
 
+func MockListenerReady(f func(l *listener.Listener) <-chan struct{}) (restore func()) {
+	return testutil.Mock(&listenerReady, f)
+}
+
 func MockListenerReqs(f func(l *listener.Listener) <-chan *listener.Request) (restore func()) {
 	return testutil.Mock(&listenerReqs, f)
 }
@@ -48,7 +52,10 @@ type RequestResponse struct {
 	AllowedPermission notify.AppArmorPermission
 }
 
-func MockListener() (reqChan chan *listener.Request, replyChan chan RequestResponse, restore func()) {
+func MockListener() (readyChan chan struct{}, reqChan chan *listener.Request, replyChan chan RequestResponse, restore func()) {
+	// The readyChan should be closed once all pending previously-sent requests
+	// have been re-sent.
+	readyChan = make(chan struct{})
 	// Since the manager run loop is in a tracked goroutine, shouldn't block.
 	reqChan = make(chan *listener.Request)
 	// Replies would be sent synchronously to an async listener, but it's
@@ -67,6 +74,9 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 		// nil in practice.
 		return nil
 	})
+	restoreReady := MockListenerReady(func(l *listener.Listener) <-chan struct{} {
+		return readyChan
+	})
 	restoreReqs := MockListenerReqs(func(l *listener.Listener) <-chan *listener.Request {
 		return reqChan
 	})
@@ -78,6 +88,12 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 			close(reqChan)
 			close(replyChan)
 			close(closeChan)
+		}
+		select {
+		case <-readyChan:
+			// already closed
+		default:
+			close(readyChan)
 		}
 		return nil
 	})
@@ -93,10 +109,11 @@ func MockListener() (reqChan chan *listener.Request, replyChan chan RequestRespo
 		restoreReply()
 		restoreClose()
 		restoreReqs()
+		restoreReady()
 		restoreRun()
 		restoreRegister()
 	}
-	return reqChan, replyChan, restore
+	return readyChan, reqChan, replyChan, restore
 }
 
 func MockRequestReply(f func(req *listener.Request, allowedPermission notify.AppArmorPermission) error) (restore func()) {

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -542,6 +542,10 @@ func (m *InterfacesRequestsManager) AddRule(userID uint32, snap string, iface st
 // RemoveRules removes all rules for the user with the given user ID and the
 // given snap and/or interface. Snap and iface can't both be unspecified.
 func (m *InterfacesRequestsManager) RemoveRules(userID uint32, snap string, iface string) ([]*requestrules.Rule, error) {
+	// Wait until the listener has re-sent pending requests and prompts have
+	// been re-created.
+	<-m.ready
+
 	// The lock need only be held for reading, since no synchronization is
 	// required between the rules and prompts backends, and the rules backend
 	// has an internal mutex.
@@ -591,6 +595,10 @@ func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.ID
 }
 
 func (m *InterfacesRequestsManager) RemoveRule(userID uint32, ruleID prompting.IDType) (*requestrules.Rule, error) {
+	// Wait until the listener has re-sent pending requests and prompts have
+	// been re-created.
+	<-m.ready
+
 	// The lock need only be held for reading, since no synchronization is
 	// required between the rules and prompts backends, and the rules backend
 	// has an internal mutex.

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -177,6 +177,18 @@ func (m *InterfacesRequestsManager) run() error {
 		return listenerRun(m.listener)
 	})
 
+	defer func() {
+		// Ensure that m.ready ends up closed, since we'll never have the
+		// opportunity to close it again after this function returns, and we
+		// don't want to leave method calls blocked forever.
+		select {
+		case <-m.ready:
+			// is already closed
+		default:
+			close(m.ready)
+		}
+	}()
+
 run_loop:
 	for {
 		logger.Debugf("waiting prompt loop")

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -234,8 +234,8 @@ func (m *InterfacesRequestsManager) listenerReadyForTheFirstTime() <-chan struct
 	select {
 	case <-m.ready:
 		// We already closed m.ready, so the listener previously readied and we
-		// we handled it. So return something which will never signal.
-		return make(chan struct{})
+		// handled it. So return something which will never signal.
+		return nil
 	default:
 		// We haven't handled a ready signal yet, so return the real thing.
 		return listenerReady(m.listener)

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -1570,8 +1570,19 @@ func (s *apparmorpromptingSuite) TestListenerReadyBlocksRepliesNewRules(c *C) {
 	})
 
 	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		rules, err := mgr.RemoveRules(1000, "foo", "bar")
+		c.Check(err, IsNil)
+		c.Check(rules, HasLen, 0)
+	})
+
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
 		_, err := mgr.PatchRule(1000, 0, nil)
 		c.Check(err, Equals, prompting_errors.ErrRuleNotFound)
+	})
+
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		_, err := mgr.RemoveRule(1000, 0)
+		c.Check(err, NotNil)
 	})
 }
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -68,7 +68,7 @@ func (s *apparmorpromptingSuite) SetUpTest(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestNew(c *C) {
-	_, _, restore := apparmorprompting.MockListener()
+	_, _, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
@@ -91,7 +91,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
-	reqChan, _, restore := apparmorprompting.MockListener()
+	_, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	// Prevent prompt backend from opening successfully
@@ -120,7 +120,7 @@ func checkListenerClosed(c *C, reqChan <-chan *listener.Request) {
 }
 
 func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
-	reqChan, _, restore := apparmorprompting.MockListener()
+	_, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	// Prevent rule backend from opening successfully
@@ -144,7 +144,7 @@ func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestStop(c *C) {
-	reqChan, _, restore := apparmorprompting.MockListener()
+	_, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
@@ -185,7 +185,7 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestHandleListenerRequestInterfaceSelection(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	logbuf, restore := logger.MockLogger()
@@ -193,6 +193,9 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestInterfaceSelection(c *
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// Close readyChan so we can add rules
+	close(readyChan)
 
 	clientActivity := true
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
@@ -266,7 +269,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestInterfaceSelection(c *
 }
 
 func (s *apparmorpromptingSuite) TestHandleListenerRequestDenyRoot(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	_, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
@@ -288,7 +291,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestDenyRoot(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	logbuf, restore := logger.MockLogger()
@@ -296,6 +299,9 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// Close readyChan so we can check mgr.Prompts
+	close(readyChan)
 
 	clientActivity := true
 	prompts, err := mgr.Prompts(s.defaultUser, clientActivity)
@@ -350,6 +356,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 		reqChan <- req
 	}
 	time.Sleep(10 * time.Millisecond)
+
 	prompts, err = mgr.Prompts(s.defaultUser, clientActivity)
 	c.Assert(err, IsNil)
 	c.Assert(len(prompts), Equals, maxOutstandingPromptsPerUser)
@@ -378,11 +385,14 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestHandleReplySimple(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	req, prompt := s.simulateRequest(c, reqChan, mgr, &listener.Request{}, false)
 
@@ -522,11 +532,14 @@ func waitForReply(replyChan chan apparmorprompting.RequestResponse) (*apparmorpr
 }
 
 func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	_, prompt := s.simulateRequest(c, reqChan, mgr, &listener.Request{}, false)
 
@@ -601,11 +614,14 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// pretend that there are no pending requests to be re-sent
+	close(readyChan)
 
 	// Add allow rule to match read permission
 	constraints := &prompting.Constraints{
@@ -683,11 +699,14 @@ func (s *apparmorpromptingSuite) checkRecordedRuleUpdateNotices(c *C, since time
 }
 
 func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) {
-	reqChan, _, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// pretend that there are no pending requests to be re-sent
+	close(readyChan)
 
 	// Add rule to match read permission
 	constraints := &prompting.Constraints{
@@ -717,11 +736,14 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 }
 
 func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// pretend that there are no pending requests to be re-sent
+	close(readyChan)
 
 	// Add deny rule to match read permission
 	constraints := &prompting.Constraints{
@@ -766,11 +788,14 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 }
 
 func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// pretend that there are no pending requests to be re-sent
+	close(readyChan)
 
 	// Add deny rule to match read permission
 	constraints := &prompting.Constraints{
@@ -833,11 +858,14 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 }
 
 func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	// Add read request
 	readReq := &listener.Request{
@@ -912,11 +940,14 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	// Add read request
 	readReq := &listener.Request{
@@ -983,7 +1014,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
@@ -992,6 +1023,9 @@ func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
 	// works correctly, so now just need to test that if reply creates a rule,
 	// that rule applies to existing prompts.
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	// Add read request
 	readReq := &listener.Request{
@@ -1078,7 +1112,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 		duration = "10m"
 	}
 
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
@@ -1087,6 +1121,9 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
 	// works correctly, so now just need to test that if reply creates a rule,
 	// that rule applies to existing prompts.
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	// Add read request
 	readReq := &listener.Request{
@@ -1176,7 +1213,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 }
 
 func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
-	reqChan, _, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
@@ -1184,6 +1221,9 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 
 	// Requests with identical *original* abstract permissions are merged into
 	// the existing prompt
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	// Create request for read and write
 	partialReq := &listener.Request{
@@ -1228,8 +1268,11 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestRules(c *C) {
-	_, _, restore := apparmorprompting.MockListener()
+	readyChan, _, _, restore := apparmorprompting.MockListener()
 	defer restore()
+
+	// Close readyChan so we can add rules
+	close(readyChan)
 
 	mgr, rules := s.prepManagerWithRules(c)
 
@@ -1329,8 +1372,11 @@ func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompt
 }
 
 func (s *apparmorpromptingSuite) TestRemoveRulesInterface(c *C) {
-	_, _, restore := apparmorprompting.MockListener()
+	readyChan, _, _, restore := apparmorprompting.MockListener()
 	defer restore()
+
+	// Close readyChan so we can add rules
+	close(readyChan)
 
 	mgr, rules := s.prepManagerWithRules(c)
 
@@ -1352,8 +1398,11 @@ func (s *apparmorpromptingSuite) TestRemoveRulesInterface(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestRemoveRulesSnap(c *C) {
-	_, _, restore := apparmorprompting.MockListener()
+	readyChan, _, _, restore := apparmorprompting.MockListener()
 	defer restore()
+
+	// Close readyChan so we can add rules
+	close(readyChan)
 
 	mgr, rules := s.prepManagerWithRules(c)
 
@@ -1375,8 +1424,11 @@ func (s *apparmorpromptingSuite) TestRemoveRulesSnap(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestRemoveRulesSnapInterface(c *C) {
-	_, _, restore := apparmorprompting.MockListener()
+	readyChan, _, _, restore := apparmorprompting.MockListener()
 	defer restore()
+
+	// Close readyChan so we can add rules
+	close(readyChan)
 
 	mgr, rules := s.prepManagerWithRules(c)
 
@@ -1398,11 +1450,14 @@ func (s *apparmorpromptingSuite) TestRemoveRulesSnapInterface(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
-	reqChan, replyChan, restore := apparmorprompting.MockListener()
+	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
 	mgr, err := apparmorprompting.New(s.st)
 	c.Assert(err, IsNil)
+
+	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
+	close(readyChan)
 
 	// Add read request
 	req := &listener.Request{
@@ -1490,4 +1545,63 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 	c.Assert(rules, HasLen, 0)
 
 	c.Assert(mgr.Stop(), IsNil)
+}
+
+func (s *apparmorpromptingSuite) TestListenerReadyBlocksRepliesNewRules(c *C) {
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		prompts, err := mgr.Prompts(1000, false)
+		c.Check(err, IsNil)
+		c.Check(prompts, HasLen, 0)
+	})
+
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		_, err := mgr.PromptWithID(1000, 0, false)
+		c.Check(err, Equals, prompting_errors.ErrPromptNotFound)
+	})
+
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		_, err := mgr.PromptWithID(1000, 0, false)
+		c.Check(err, Equals, prompting_errors.ErrPromptNotFound)
+	})
+
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		_, err := mgr.HandleReply(1000, 0, nil, prompting.OutcomeAllow, prompting.LifespanSingle, "", false)
+		c.Check(err, Equals, prompting_errors.ErrPromptNotFound)
+	})
+
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		_, err := mgr.AddRule(1000, "foo", "bar", &prompting.Constraints{})
+		c.Check(err, NotNil)
+	})
+
+	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
+		_, err := mgr.PatchRule(1000, 0, nil)
+		c.Check(err, Equals, prompting_errors.ErrRuleNotFound)
+	})
+}
+
+func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorprompting.InterfacesRequestsManager)) {
+	readyChan, _, _, restore := apparmorprompting.MockListener()
+	defer restore()
+
+	mgr, err := apparmorprompting.New(s.st)
+	c.Assert(err, IsNil)
+
+	startChan := make(chan time.Time)
+	doneChan := make(chan time.Time)
+	go func() {
+		startChan <- time.Now()
+		f(mgr)
+		doneChan <- time.Now()
+	}()
+	// Wait for function to start
+	<-startChan
+	// Wait another few milliseconds
+	<-time.NewTimer(10 * time.Millisecond).C
+	// Record the current time before readying
+	now := time.Now()
+	close(readyChan)
+	finished := <-doneChan
+	// Check that the finished time was after the ready time
+	c.Check(finished.After(now), Equals, true, Commentf("finish time failed to be after ready time"))
 }

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -1560,11 +1560,6 @@ func (s *apparmorpromptingSuite) TestListenerReadyBlocksRepliesNewRules(c *C) {
 	})
 
 	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
-		_, err := mgr.PromptWithID(1000, 0, false)
-		c.Check(err, Equals, prompting_errors.ErrPromptNotFound)
-	})
-
-	s.testReadyBlocks(c, func(mgr *apparmorprompting.InterfacesRequestsManager) {
 		_, err := mgr.HandleReply(1000, 0, nil, prompting.OutcomeAllow, prompting.LifespanSingle, "", false)
 		c.Check(err, Equals, prompting_errors.ErrPromptNotFound)
 	})
@@ -1604,4 +1599,9 @@ func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorpromp
 	finished := <-doneChan
 	// Check that the finished time was after the ready time
 	c.Check(finished.After(now), Equals, true, Commentf("finish time failed to be after ready time"))
+
+	// restore races with listenerRun and listenerReqs, so wait for everything
+	// to stop before restoring.
+	err = mgr.Stop()
+	c.Check(err, IsNil)
 }

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -21,6 +21,7 @@ package listener
 
 import (
 	"os"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -28,6 +29,11 @@ import (
 	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timeutil"
+)
+
+var (
+	ReadyTimeout = readyTimeout
 )
 
 func ExitOnError() (restore func()) {
@@ -175,4 +181,8 @@ func MockEncodeAndSendResponse(f func(l *Listener, resp *notify.MsgNotificationR
 
 func (l *Listener) EpollIsClosed() bool {
 	return l.poll.IsClosed()
+}
+
+func MockTimeAfterFunc(f func(d time.Duration, callback func()) timeutil.Timer) (restore func()) {
+	return testutil.Mock(&timeAfterFunc, f)
 }

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -96,7 +96,7 @@ func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.Ioct
 // call), it triggers an epoll event with the listener's notify socket fd, and
 // then passes the data on to the next ioctl RECV call. When the listener makes
 // a SEND call via ioctl, the data is instead written to the send channel.
-func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
+func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion, pendingCount int) (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
 	recvChanRW := make(chan []byte)
 	sendChanRW := make(chan []byte, 1) // need to have buffer size 1 since reply does not run in a goroutine and the test would otherwise block
 	internalRecvChan := make(chan []byte, 1)
@@ -138,8 +138,6 @@ func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan cha
 		return buf, nil
 	}
 	rfdF := func(fd uintptr) (notify.ProtocolVersion, int, error) {
-		pendingCount := 0
-		// TODO: set pendingCount to something interesting
 		return protoVersion, pendingCount, nil
 	}
 	restoreEpoll := testutil.Mock(&listenerEpollWait, epollF)

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -76,7 +76,7 @@ func MockEpollWait(f func(l *Listener) ([]epoll.Event, error)) (restore func()) 
 	return restore
 }
 
-func MockNotifyRegisterFileDescriptor(f func(fd uintptr) (notify.ProtocolVersion, error)) (restore func()) {
+func MockNotifyRegisterFileDescriptor(f func(fd uintptr) (notify.ProtocolVersion, int, error)) (restore func()) {
 	restore = testutil.Backup(&notifyRegisterFileDescriptor)
 	notifyRegisterFileDescriptor = f
 	return restore
@@ -137,8 +137,10 @@ func MockEpollWaitNotifyIoctl(protoVersion notify.ProtocolVersion) (recvChan cha
 		}
 		return buf, nil
 	}
-	rfdF := func(fd uintptr) (notify.ProtocolVersion, error) {
-		return protoVersion, nil
+	rfdF := func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 0
+		// TODO: set pendingCount to something interesting
+		return protoVersion, pendingCount, nil
 	}
 	restoreEpoll := testutil.Mock(&listenerEpollWait, epollF)
 	restoreIoctl := testutil.Mock(&notifyIoctl, ioctlF)

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -462,15 +462,17 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 		// can signal ready.
 		isFinalPendingReq := false
 
-		// Before sending the request, check if it is resent. The kernel is
+		// Before forwarding the request, check if it is resent. The kernel is
 		// guaranteed to resend all previously-pending messages before it sends
 		// any new messages, so if it's NOT resent, then we know the kernel is
-		// done sending pending messages.
+		// done sending pending messages. Regardless, all requests are forwarded
+		// over the reqs channel.
 		if msg.Resent() {
 			// Message was previously sent, see if it was the last one we're
 			// waiting for. Also ensure the pending count is decremented before
 			// waiting for the request to be received, so the pending count in
-			// case of a timeout is reported correctly.
+			// case of a timeout is reported correctly. If the listener is
+			// already ready, this check will will return false.
 			isFinalPendingReq = l.decrementPendingCheckFinal()
 		} else {
 			// It is not resent, so there are no more resent messages, and we

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -156,13 +156,6 @@ type Listener struct {
 	// expected to be re-received from the kernel. When the listener becomes
 	// ready, this count must be sent to 0, as it's used as the internal check
 	// for whether a non-RESENT message should be queued.
-	//
-	// XXX: In order for this count to be accurate, it is important that the
-	// pending messages at time of registration are only re-sent by the kernel
-	// once, and that no messages which were first sent this listener was
-	// registered are resent. If, however, we are able to reset this count
-	// based on the result of the resend command, and the ready channel has not
-	// yet been closed, this is okay.
 	pendingCount int
 	// readyQueue is the queue of "ready" (not UNOTIF_RESENT) requests from the
 	// kernel which were received before either all remaining pending requests

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -135,38 +135,20 @@ type Listener struct {
 
 	// ready is a channel which is closed once all requests which were pending
 	// at time of registration have been re-received from the kernel and sent
-	// over the reqs channel. This occurs once pendingCount reaches 0 or the
+	// over the reqs channel. This occurs once pendingCount reaches 0, snapd
+	// receives a message which does not have the UNOTIF_RESENT flag, or the
 	// ready timer times out. This channel must only be closed by the
-	// signalReadyAndFlushQueue method.
-	//
-	// Until this occurs, other new (not NOTF_RESENT) requests will be queued
-	// up by the listener, and only sent once all UNOTIF_RESENT requests have
-	// been sent over the reqs channel.
+	// signalReady method.
 	ready chan struct{}
-	// doneReadying is a channel which is closed once signalReadyAndFlushQueue
-	// has finished writing queued requests to l.reqs. This channel is used so
-	// that the run loop can safely close l.reqs.
-	doneReadying chan struct{}
-	// readyTimer is a timer which will call signalReadyAndFlushQueue if the
-	// listener times out waiting for pending requests to be received.
+	// readyTimer is a timer which will call signalReady if the listener times
+	// out waiting for pending requests to be received.
 	readyTimer timeutil.Timer
-	// pendingMu is a mutex which protects pendingCount and readyQueue.
+	// pendingMu is a mutex which protects pendingCount.
 	pendingMu sync.Mutex
 	// pendingCount is the number of "pending" (UNOTIF_RESENT) messages still
 	// expected to be re-received from the kernel. When the listener becomes
-	// ready, this count must be sent to 0, as it's used as the internal check
-	// for whether a non-RESENT message should be queued.
+	// ready, this count must be sent to 0.
 	pendingCount int
-	// readyQueue is the queue of "ready" (not UNOTIF_RESENT) requests from the
-	// kernel which were received before either all remaining pending requests
-	// were re-received or the ready timer timed out. Once one of these occurs,
-	// all requests in this queue should be sent by signalReadyAndFlushQueue in
-	// the order in which they were received, and the queue should be discarded.
-	//
-	// The motivation for queueing non-resent requests until the listener is
-	// ready is so that consumers of the listener requests can re-create their
-	// state (i.e. prompts) fully before any new requests are received.
-	readyQueue []*Request
 
 	// protocolVersion is the notification protocol version associated with the
 	// listener's notify socket. Once registered with a particular version,
@@ -227,7 +209,6 @@ func Register() (listener *Listener, err error) {
 		reqs: make(chan *Request),
 
 		ready:        make(chan struct{}),
-		doneReadying: make(chan struct{}),
 		readyTimer:   timeutil.NewTimer(0), // initialize placeholder non-nil timer
 		pendingCount: pendingCount,
 
@@ -240,7 +221,7 @@ func Register() (listener *Listener, err error) {
 	// If there are no pending requests waiting to be re-sent, ready
 	// immediately, otherwise start the ready timer when Run is called.
 	if listener.pendingCount == 0 {
-		listener.signalReadyAndFlushQueue()
+		listener.signalReady()
 	}
 	return listener, nil
 }
@@ -331,18 +312,15 @@ func (l *Listener) Run() error {
 		// If there were pending requests at time of registration, then Register
 		// didn't set a real ready timer with callback, so do so now.
 		if l.pendingCount != 0 {
-			l.readyTimer = timeAfterFunc(readyTimeout, l.signalReadyAndFlushQueue)
+			l.readyTimer = timeAfterFunc(readyTimeout, l.signalReady)
 		}
 		defer func() {
-			if !l.readyTimer.Stop() {
-				// Already fired or stopped (which in both cases should result
-				// in signalReadyAndFlushQueue() being called), so ensure it
-				// won't try to write to l.reqs by waiting for l.doneReadying.
-				<-l.doneReadying
+			if l.readyTimer.Stop() {
+				// The timer was still active, so the listener was not ready.
+				// The manager is closing the listener, so if the listener isn't
+				// ready by now, it doesn't matter, the manager has stopped
+				// receiving requests by now anyway.
 			}
-			// The manager is closing the listener, so if the listener isn't
-			// ready by now, it doesn't matter, the manager has stopped
-			// receiving requests by now anyway.
 
 			// When listener run loop ends, close the requests channel.
 			close(l.reqs)
@@ -476,14 +454,17 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 			return err
 		}
 
-		// Before sending the request, check if it should instead be queued.
+		// Before sending the request, check if it is resent. The kernel is
+		// guaranteed to resend all previously-pending messages before it sends
+		// any new messages, so if it's NOT resent, then we know the kernel is
+		// done sending pending messages.
 		if !msg.Resent() {
-			// This is a new message, not one we're re-receiving, so if the
-			// listener is not yet ready, queue it up for later instead.
-			if l.queueRequestIfNotReady(req) {
-				continue
+			// It is not resent, so there are no more resent messages, and we
+			// should ensure that we're ready.
+			if l.readyTimer.Stop() {
+				// Timer was active so we weren't yet ready. Ready up now.
+				l.signalReady()
 			}
-			// The listener is ready, so carry on sending this request
 		}
 
 		// Try to send request to manager, or wait for listener to be closed
@@ -494,9 +475,9 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 			// The listener is being closed, so stop trying to deliver the
 			// message up to the manager. It will appear to the kernel that we
 			// have received and processed the request, when in reality, we
-			// have not. The higher-level restart handling logic will ensure
-			// that the request will be re-sent to snapd when it restarts and
-			// registers a new listener.
+			// have not. The higher-level restart handling logic ensures that
+			// the request will be re-sent to snapd when it restarts and
+			// re-registers the listener.
 			return ErrClosed
 		}
 
@@ -511,7 +492,7 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte) error {
 		if l.readyTimer.Stop() {
 			// We stopped the timer before it fired, so we can signal
 			// ready. Otherwise, the timer already signalled for us.
-			l.signalReadyAndFlushQueue()
+			l.signalReady()
 		}
 	}
 	return nil
@@ -547,22 +528,6 @@ func (l *Listener) newRequest(msg notify.MsgNotificationGeneric) (*Request, erro
 	}, nil
 }
 
-// queueRequestIfNotReady queues the given request if the listener is not yet
-// ready, which is indicated by there being pending requests which are still
-// expected to be re-received. Returns true if the request is queued.
-//
-// The caller should only call this method if the message associated with the
-// given request was *not* marked by the kernel as having been previously sent.
-func (l *Listener) queueRequestIfNotReady(req *Request) (queued bool) {
-	l.pendingMu.Lock()
-	defer l.pendingMu.Unlock()
-	if l.pendingCount == 0 {
-		return false
-	}
-	l.readyQueue = append(l.readyQueue, req)
-	return true
-}
-
 // decrementPendingCheckFinal decrements the pending count if it's not already
 // 0, and returns whether this was the final pending request.
 //
@@ -581,30 +546,16 @@ func (l *Listener) decrementPendingCheckFinal() (isFinal bool) {
 	return false
 }
 
-// signalReadyAndFlushQueue is responsible for closing the ready channel,
-// setting pendingCount to 0, and sending any requests which were queued in the
-// ready queue. When it's done, it closes doneReadying so that waiters know
-// it's safe to close l.reqs.
+// signalReady is responsible for closing the ready channel and ensuring that
+// pendingCount is set to 0.
 //
 // Potential callers must ensure that this method is only called once per
 // listener.
-func (l *Listener) signalReadyAndFlushQueue() {
+func (l *Listener) signalReady() {
 	l.pendingMu.Lock()
 	defer l.pendingMu.Unlock()
-	defer close(l.doneReadying)
-	l.pendingCount = 0 // if timed out, tell the run loop we're ready, stop queueing
+	l.pendingCount = 0 // if timed out, tell the run loop we're ready
 	close(l.ready)
-	for _, req := range l.readyQueue {
-		// Try to send request to manager, or wait for listener to be closed
-		select {
-		case l.reqs <- req:
-			// request received
-		case <-l.closeChan:
-			// Break rather than return so we're sure to close l.doneReadying
-			break
-		}
-	}
-	l.readyQueue = nil
 }
 
 var encodeAndSendResponse = func(l *Listener, resp *notify.MsgNotificationResponse) error {

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -175,10 +175,14 @@ func Register() (listener *Listener, err error) {
 		return nil, fmt.Errorf("cannot register epoll on %q: %v", path, err)
 	}
 
-	protoVersion, err := notifyRegisterFileDescriptor(notifyFile.Fd())
+	protoVersion, _, err := notifyRegisterFileDescriptor(notifyFile.Fd())
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: use pendingCount from notifyRegisterFileDescriptor to ensure that
+	// all pending requests are handled before any new requests, replies, or
+	// rules are accepted
 
 	listener = &Listener{
 		reqs: make(chan *Request),

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -162,11 +162,6 @@ func Register() (listener *Listener, err error) {
 		}
 	}()
 
-	protoVersion, err := notifyRegisterFileDescriptor(notifyFile.Fd())
-	if err != nil {
-		return nil, err
-	}
-
 	poll, err := epoll.Open()
 	if err != nil {
 		return nil, fmt.Errorf("cannot open epoll file descriptor: %v", err)
@@ -178,6 +173,11 @@ func Register() (listener *Listener, err error) {
 	}()
 	if err = poll.Register(int(notifyFile.Fd()), epoll.Readable); err != nil {
 		return nil, fmt.Errorf("cannot register epoll on %q: %v", path, err)
+	}
+
+	protoVersion, err := notifyRegisterFileDescriptor(notifyFile.Fd())
+	if err != nil {
+		return nil, err
 	}
 
 	listener = &Listener{

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -784,7 +784,7 @@ func (*listenerSuite) TestRunWithPendingReadyTimeout(c *C) {
 	aBits := uint32(0b1010)
 	dBits := uint32(0b0101)
 
-	msg := newMsgNotificationFile(protoVersion, 0, label, path, aBits, dBits)
+	msg := newMsgNotificationFile(protoVersion, 0, label, path, aBits, dBits, nil)
 
 	// Send first message, no flags
 	msg.KernelNotificationID = 0xf00
@@ -801,9 +801,9 @@ func (*listenerSuite) TestRunWithPendingReadyTimeout(c *C) {
 		// all good
 	}
 
-	// Send second message, this time with NOTIF_RESENT flag
+	// Send second message, this time with UNOTIF_RESENT flag
 	msg.KernelNotificationID = 0xba4
-	msg.Flags = notify.NOTIF_RESENT
+	msg.Flags = notify.UNOTIF_RESENT
 	buf, err = msg.MarshalBinary()
 	c.Assert(err, IsNil)
 	recvChan <- buf
@@ -813,7 +813,7 @@ func (*listenerSuite) TestRunWithPendingReadyTimeout(c *C) {
 	case req := <-l.Reqs():
 		c.Assert(req.ID, Equals, msg.KernelNotificationID)
 	case <-time.NewTimer(10 * time.Millisecond).C:
-		c.Fatalf("failed to receive request with NOTIF_RESENT")
+		c.Fatalf("failed to receive request with UNOTIF_RESENT")
 	}
 
 	// Send third message, no flags
@@ -831,9 +831,9 @@ func (*listenerSuite) TestRunWithPendingReadyTimeout(c *C) {
 		// all good
 	}
 
-	// Send fourth message, this time with NOTIF_RESENT flag again
+	// Send fourth message, this time with UNOTIF_RESENT flag again
 	msg.KernelNotificationID = 0xdef
-	msg.Flags = notify.NOTIF_RESENT
+	msg.Flags = notify.UNOTIF_RESENT
 	buf, err = msg.MarshalBinary()
 	c.Assert(err, IsNil)
 	recvChan <- buf
@@ -843,7 +843,7 @@ func (*listenerSuite) TestRunWithPendingReadyTimeout(c *C) {
 	case req := <-l.Reqs():
 		c.Assert(req.ID, Equals, msg.KernelNotificationID)
 	case <-time.NewTimer(10 * time.Millisecond).C:
-		c.Fatalf("failed to receive request with NOTIF_RESENT")
+		c.Fatalf("failed to receive request with UNOTIF_RESENT")
 	}
 
 	c.Assert(timer.Active(), Equals, true)
@@ -852,7 +852,7 @@ func (*listenerSuite) TestRunWithPendingReadyTimeout(c *C) {
 	c.Assert(timer.Active(), Equals, false)
 	c.Assert(timer.FireCount(), Equals, 1)
 	// Expect the callback to first mark the listener as ready, and then send
-	// the previous non-NOTIF_RESENT requests which were queued.
+	// the previous non-UNOTIF_RESENT requests which were queued.
 	checkListenerReadyWithTimeout(c, l, true, 10*time.Millisecond)
 	for _, id := range []uint64{0xf00, 0xabc} {
 		select {
@@ -878,10 +878,10 @@ func (*listenerSuite) TestRunWithPendingReadyTimeout(c *C) {
 		c.Fatalf("failed to receive request with IX 0x%x after listener ready", msg.ID())
 	}
 
-	// Send sixth message, this time with NOTIF_RESENT flag again, the last one
+	// Send sixth message, this time with UNOTIF_RESENT flag again, the last one
 	// the listener would be waiting for if it weren't already ready
 	msg.KernelNotificationID = 0x456
-	msg.Flags = notify.NOTIF_RESENT
+	msg.Flags = notify.UNOTIF_RESENT
 	buf, err = msg.MarshalBinary()
 	c.Assert(err, IsNil)
 	recvChan <- buf
@@ -1303,7 +1303,7 @@ func (*listenerSuite) TestRunNoReceiverWithPendingTimeout(c *C) {
 	aBits := uint32(0b1010)
 	dBits := uint32(0b0101)
 
-	msg := newMsgNotificationFile(protoVersion, id, label, path, aBits, dBits)
+	msg := newMsgNotificationFile(protoVersion, id, label, path, aBits, dBits, nil)
 	// no flags set
 	buf, err := msg.MarshalBinary()
 	c.Check(err, IsNil)

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -1059,8 +1059,8 @@ func (*listenerSuite) TestRunNoReceiverWithPending(c *C) {
 
 	c.Check(l.Close(), IsNil)
 
-	// Close() should call listener to become ready
-	checkListenerReadyWithTimeout(c, l, true, 10*time.Millisecond)
+	// Close() doesn't cause the listener to signal that it's ready
+	checkListenerReadyWithTimeout(c, l, false, 10*time.Millisecond)
 
 	c.Check(t.Wait(), IsNil)
 }

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -294,8 +294,9 @@ func (*listenerSuite) TestRegisterClose(c *C) {
 	restoreOpen := listener.MockOsOpenWithSocket()
 	defer restoreOpen()
 
-	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return notify.ProtocolVersion(12345), nil
+	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 5
+		return notify.ProtocolVersion(12345), pendingCount, nil
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -324,8 +325,9 @@ func (*listenerSuite) TestRegisterOverridePath(c *C) {
 	})
 	defer restoreOpen()
 
-	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return notify.ProtocolVersion(12345), nil
+	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 1
+		return notify.ProtocolVersion(12345), pendingCount, nil
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -389,8 +391,8 @@ func (*listenerSuite) TestRegisterErrors(c *C) {
 	})
 	defer restoreOpen()
 
-	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return 0, customError
+	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		return 0, 0, customError
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -411,8 +413,9 @@ func (*listenerSuite) TestRegisterErrors(c *C) {
 	})
 	defer restoreOpen()
 
-	restoreRegisterFileDescriptor = listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return notify.ProtocolVersion(12345), nil
+	restoreRegisterFileDescriptor = listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 0
+		return notify.ProtocolVersion(12345), pendingCount, nil
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -682,8 +685,9 @@ func (*listenerSuite) TestRunEpoll(c *C) {
 
 	protoVersion := notify.ProtocolVersion(12345)
 
-	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return protoVersion, nil
+	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 0 // TODO: set to 1, send 2 messages, with second one NOTIF_RESENT, and check that the second is received first
+		return protoVersion, pendingCount, nil
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -751,8 +755,9 @@ func (*listenerSuite) TestRunNoEpoll(c *C) {
 	})
 	defer restoreEpoll()
 
-	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return notify.ProtocolVersion(12345), nil
+	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 1
+		return notify.ProtocolVersion(12345), pendingCount, nil
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -1006,8 +1011,9 @@ func (*listenerSuite) TestRunMultipleTimes(c *C) {
 	})
 	defer restoreEpoll()
 
-	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return notify.ProtocolVersion(12345), nil
+	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 0
+		return notify.ProtocolVersion(12345), pendingCount, nil
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -1060,8 +1066,9 @@ func (*listenerSuite) TestCloseThenRun(c *C) {
 	restoreOpen := listener.MockOsOpenWithSocket()
 	defer restoreOpen()
 
-	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return notify.ProtocolVersion(12345), nil
+	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, int, error) {
+		pendingCount := 3
+		return notify.ProtocolVersion(12345), pendingCount, nil
 	})
 	defer restoreRegisterFileDescriptor()
 

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -69,6 +69,13 @@ func RegisterFileDescriptor(fd uintptr) (version ProtocolVersion, pendingCount i
 		if err := setFilterForListener(fd, protocolVersion); err != nil {
 			if errors.Is(err, unix.EPROTONOSUPPORT) {
 				unsupported[protocolVersion] = true
+				// XXX: pendingCount may still be set, if the current protocol
+				// version supports registration but not setting filter. This
+				// should never happen in the real world. If the next protocol
+				// version we try supports setting filter but not registration,
+				// then we will leak the pendingCount from this previous
+				// version, though technically this registration and the
+				// pendingCount are still valid, so this is... not incorrect.
 				continue
 			}
 			return 0, 0, err

--- a/sandbox/apparmor/notify/notify_test.go
+++ b/sandbox/apparmor/notify/notify_test.go
@@ -30,15 +30,7 @@ func (s *notifySuite) SetUpTest(c *C) {
 
 var fakeNotifyVersions = []notify.VersionAndCheck{
 	{
-		Version: 2,
-		Check:   func() bool { return false },
-	},
-	{
-		Version: 3,
-		Check:   func() bool { return true },
-	},
-	{
-		Version: 5,
+		Version: 11,
 		Check:   func() bool { return false },
 	},
 	{
@@ -46,7 +38,15 @@ var fakeNotifyVersions = []notify.VersionAndCheck{
 		Check:   func() bool { return true },
 	},
 	{
-		Version: 11,
+		Version: 5,
+		Check:   func() bool { return false },
+	},
+	{
+		Version: 3,
+		Check:   func() bool { return true },
+	},
+	{
+		Version: 2,
 		Check:   func() bool { return false },
 	},
 }
@@ -60,18 +60,32 @@ func (s *notifySuite) TestRegisterFileDescriptor(c *C) {
 	ioctlCalls := 0
 	restoreSyscall := notify.MockIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
 		c.Assert(fd, Equals, fakeFD)
-		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
 
 		ioctlCalls++
 
-		// First expect check for version 3, then for version 7
+		// First expect check for version 7, then for version 3
 		switch ioctlCalls {
 		case 1:
-			checkIoctlBuffer(c, buf, notify.ProtocolVersion(3))
-			return buf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EPROTONOSUPPORT, unix.ErrnoName(unix.EPROTONOSUPPORT))
+			// v7 APPARMOR_NOTIF_REGISTER
+			c.Check(req, Equals, notify.APPARMOR_NOTIF_REGISTER)
+			// Expect listener ID 0, set some arbitrary values
+			respBuf := checkIoctlBufferRegister(c, buf, notify.ProtocolVersion(7), 0, 123, 456, 789)
+			return respBuf, nil
 		case 2:
-			checkIoctlBuffer(c, buf, notify.ProtocolVersion(7))
-			return buf, nil
+			// v7 APPARMOR_NOTIF_RESEND
+			c.Check(req, Equals, notify.APPARMOR_NOTIF_RESEND)
+			respBuf := checkIoctlBufferResend(c, buf, notify.ProtocolVersion(7))
+			return respBuf, nil
+		case 3:
+			// v7 APPARMOR_NOTIF_SET_FILTER
+			c.Check(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+			respBuf := checkIoctlBufferSetFilter(c, buf, notify.ProtocolVersion(7))
+			// Here we return error, so that we're forced to try again with v3.
+			return respBuf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EPROTONOSUPPORT, unix.ErrnoName(unix.EPROTONOSUPPORT))
+		case 4:
+			// v3 APPARNOR_NOTIF_SET_FILTER (v3 doesn't support reregistration)
+			respBuf := checkIoctlBufferSetFilter(c, buf, notify.ProtocolVersion(3))
+			return respBuf, nil
 		default:
 			c.Fatal("called Ioctl more than twice")
 			return buf, nil
@@ -81,11 +95,54 @@ func (s *notifySuite) TestRegisterFileDescriptor(c *C) {
 
 	receivedVersion, pendingCount, err := notify.RegisterFileDescriptor(fakeFD)
 	c.Check(err, IsNil)
-	c.Check(receivedVersion, Equals, notify.ProtocolVersion(7))
-	c.Check(pendingCount, Equals, 0) // TODO: set to something interesting and check it here
+	c.Check(receivedVersion, Equals, notify.ProtocolVersion(3))
+	// Technically, if the protocol supports re-registration, it should always
+	// support setting filter. We registered the notify FD with a listener
+	// which set the pending count (though this would only really happen if we
+	// were re-registering an existing listener with non-zero ID), and we never
+	// retried re-registering it again with protocol version 3, since it
+	// doesn't support (re-)registration, so the initial registration is still
+	// valid, and the associated pendingCount is valid as well. Check that it
+	// was returned correctly, though in practice we're testing an edge case
+	// which leaks pendingCount.
+	c.Check(pendingCount, Equals, 789)
 }
 
-func checkIoctlBuffer(c *C, receivedBuf notify.IoctlRequestBuffer, expectedVersion notify.ProtocolVersion) {
+func checkIoctlBufferRegister(c *C, receivedBuf notify.IoctlRequestBuffer, expectedVersion notify.ProtocolVersion, expectedListenerID, setListenerID uint64, ready uint32, pending uint32) []byte {
+	expectedMsg := notify.MsgNotificationResend{
+		MsgHeader: notify.MsgHeader{
+			Version: expectedVersion,
+		},
+		KernelListenerID: expectedListenerID,
+	}
+	expectedBuf, err := expectedMsg.MarshalBinary()
+	c.Assert(err, IsNil)
+	ioctlBuf := notify.IoctlRequestBuffer(expectedBuf)
+
+	c.Check(receivedBuf, DeepEquals, ioctlBuf, Commentf("received incorrect buffer on Ioctl call; expected: %+v", expectedMsg))
+
+	responseMsg := notify.MsgNotificationResend{
+		MsgHeader: notify.MsgHeader{
+			Version: expectedVersion,
+		},
+		KernelListenerID: setListenerID,
+		Ready:            ready,
+		Pending:          pending,
+	}
+	responseBuf, err := responseMsg.MarshalBinary()
+	c.Assert(err, IsNil)
+	return responseBuf
+}
+
+func checkIoctlBufferResend(c *C, receivedBuf notify.IoctlRequestBuffer, expectedVersion notify.ProtocolVersion) []byte {
+	ioctlBuf := notify.NewIoctlRequestBuffer(expectedVersion)
+
+	c.Check(receivedBuf, DeepEquals, ioctlBuf, Commentf("received incorrect buffer on Ioctl call; expected empty buffer with header version %d", expectedVersion))
+
+	return receivedBuf
+}
+
+func checkIoctlBufferSetFilter(c *C, receivedBuf notify.IoctlRequestBuffer, expectedVersion notify.ProtocolVersion) []byte {
 	expectedMsg := notify.MsgNotificationFilter{
 		MsgHeader: notify.MsgHeader{
 			Version: expectedVersion,
@@ -96,7 +153,9 @@ func checkIoctlBuffer(c *C, receivedBuf notify.IoctlRequestBuffer, expectedVersi
 	c.Assert(err, IsNil)
 	ioctlBuf := notify.IoctlRequestBuffer(expectedBuf)
 
-	c.Check(receivedBuf, DeepEquals, ioctlBuf, Commentf("received incorrect buffer on Ioctl call, which expected version %d", expectedVersion))
+	c.Check(receivedBuf, DeepEquals, ioctlBuf, Commentf("received incorrect buffer on Ioctl call; expected: %+v", expectedMsg))
+
+	return receivedBuf
 }
 
 func (s *notifySuite) TestRegisterFileDescriptorErrors(c *C) {
@@ -108,21 +167,25 @@ func (s *notifySuite) TestRegisterFileDescriptorErrors(c *C) {
 	ioctlCalls := 0
 	restoreSyscall := notify.MockIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
 		c.Assert(fd, Equals, fakeFD)
-		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
 
 		ioctlCalls++
 
-		// First expect check for version 3, then for version 7
+		// First expect check for version 7, then for version 3
 		switch ioctlCalls {
 		case 1:
-			checkIoctlBuffer(c, buf, notify.ProtocolVersion(3))
+			c.Check(req, Equals, notify.APPARMOR_NOTIF_REGISTER)
+			// Expect listener ID 0, set arbitrary ID/ready/pending
+			respBuf := checkIoctlBufferRegister(c, buf, notify.ProtocolVersion(7), 0, 123, 456, 789)
+			// On v7, return an error on the APPARMOR_NOTIF_REGISTER
+			return respBuf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EINVAL, unix.ErrnoName(unix.EINVAL))
 		case 2:
-			checkIoctlBuffer(c, buf, notify.ProtocolVersion(7))
+			c.Check(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+			respBuf := checkIoctlBufferSetFilter(c, buf, notify.ProtocolVersion(3))
+			return respBuf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EPROTONOSUPPORT, unix.ErrnoName(unix.EPROTONOSUPPORT))
 		default:
 			c.Fatal("called Ioctl more than twice")
+			return buf, fmt.Errorf("called Ioctl more than twice")
 		}
-		// Always return EPROTONOSUPPORT
-		return buf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EPROTONOSUPPORT, unix.ErrnoName(unix.EPROTONOSUPPORT))
 	})
 	defer restoreSyscall()
 
@@ -131,15 +194,83 @@ func (s *notifySuite) TestRegisterFileDescriptorErrors(c *C) {
 	c.Check(receivedVersion, Equals, notify.ProtocolVersion(0))
 	c.Check(pendingCount, Equals, 0)
 
+	// A non-recoverable error occurs during REGISTER
 	calledIoctl := false
 	restoreSyscallError := notify.MockIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
 		c.Assert(fd, Equals, fakeFD)
-		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
 
-		checkIoctlBuffer(c, buf, notify.ProtocolVersion(3))
 		c.Assert(calledIoctl, Equals, false, Commentf("called ioctl more than once after first returned error"))
 		calledIoctl = true
-		return buf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EINVAL, unix.ErrnoName(unix.EINVAL))
+
+		c.Assert(req, Equals, notify.APPARMOR_NOTIF_REGISTER)
+		// Expect listener ID 0, reply with arbitrary values
+		respBuf := checkIoctlBufferRegister(c, buf, notify.ProtocolVersion(7), 0, 123, 456, 789)
+		return respBuf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EPERM, unix.ErrnoName(unix.EPERM))
+	})
+	defer restoreSyscallError()
+
+	receivedVersion, pendingCount, err = notify.RegisterFileDescriptor(fakeFD)
+	c.Check(err, ErrorMatches, `cannot perform IOCTL request APPARMOR_NOTIF_REGISTER: operation not permitted \(EPERM\)`)
+	c.Check(receivedVersion, Equals, notify.ProtocolVersion(0))
+	c.Check(pendingCount, Equals, 0)
+
+	// REGISTER succeeds but a non-recoverable error occurs during RESEND
+	ioctlCount := 0
+	restoreSyscallError = notify.MockIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		c.Assert(fd, Equals, fakeFD)
+
+		ioctlCount++
+
+		switch ioctlCount {
+		case 1:
+			c.Assert(req, Equals, notify.APPARMOR_NOTIF_REGISTER)
+			respBuf := checkIoctlBufferRegister(c, buf, notify.ProtocolVersion(7), 0, 123, 456, 789)
+			// Since REGISTER succeeds, we actually save listener ID 123 to disk, so expect it next time
+			return respBuf, nil
+		case 2:
+			// Throw an error on RESEND
+			c.Assert(req, Equals, notify.APPARMOR_NOTIF_RESEND)
+			respBuf := checkIoctlBufferResend(c, buf, notify.ProtocolVersion(7))
+			return respBuf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EINVAL, unix.ErrnoName(unix.EINVAL))
+		default:
+			c.Fatal("called Ioctl more than twice")
+			return buf, nil
+		}
+	})
+	defer restoreSyscallError()
+
+	receivedVersion, pendingCount, err = notify.RegisterFileDescriptor(fakeFD)
+	c.Check(err, ErrorMatches, `cannot perform IOCTL request APPARMOR_NOTIF_RESEND: invalid argument \(EINVAL\)`)
+	c.Check(receivedVersion, Equals, notify.ProtocolVersion(0))
+	c.Check(pendingCount, Equals, 0)
+
+	// REGISTER and RESEND succeed but a non-recoverable error occurs during SET_FILTER
+	ioctlCount = 0
+	restoreSyscallError = notify.MockIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		c.Assert(fd, Equals, fakeFD)
+
+		ioctlCount++
+
+		switch ioctlCount {
+		case 1:
+			c.Assert(req, Equals, notify.APPARMOR_NOTIF_REGISTER)
+			// The previous test successfully finished REGISTER, so listener ID
+			// 123 was stored to disk. Expect it, and reply with the same ID.
+			respBuf := checkIoctlBufferRegister(c, buf, notify.ProtocolVersion(7), 123, 123, 456, 789)
+			return respBuf, nil
+		case 2:
+			c.Assert(req, Equals, notify.APPARMOR_NOTIF_RESEND)
+			respBuf := checkIoctlBufferResend(c, buf, notify.ProtocolVersion(7))
+			return respBuf, nil
+		case 3:
+			// Throw an error on SET_FILTER
+			c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+			respBuf := checkIoctlBufferSetFilter(c, buf, notify.ProtocolVersion(7))
+			return respBuf, fmt.Errorf("cannot perform IOCTL request %v: %w (%s)", req, unix.EINVAL, unix.ErrnoName(unix.EINVAL))
+		default:
+			c.Fatal("called Ioctl more than thrice")
+			return buf, nil
+		}
 	})
 	defer restoreSyscallError()
 


### PR DESCRIPTION
~~This PR is based on #15178~~

TODO:
- [x] Fix tests
- [x] Add explicit test(s) for listener ID saving behavior
- [x] Send `APPARMOR_NOTIF_RESEND` command after `APPARMOR_NOTIF_REGISTER`
  - [x] Confirm with @jjohansen whether this should be done iff listener FD was nonzero
- [x] Get real values of `APPARMOR_NOTIF_REGISTER`, `APPARMOR_NOTIF_RESEND`, and `NOTIF_RESENT` from @jjohansen
- [x] Confirm struct values and usage with @jjohansen
- [x] Ensure that the apparmorprompting manager is able to ensure that all pending requests are re-received before accepting any new requests from the kernel or any new replies or rules from the API
- [x] Add timeout for the listener signalling that it is ready
- [x] Confirm whether the number of pending notifications at time of re-registration is the number of notifications with `UNOTIF_RESENT` we're guaranteed to re-receive from the kernel before any of them time out
  - [x] Get pending count from `RESEND` command (rather than `REGISTER`) so no requests can time out between registration and the resend command
  - [x] If not (or perhaps regardless), add a means to override the listener `Ready` state if the kernel is taking too long to re-send all the notifications
  - [x] ~~Potentially bolster the checks around count/uniqueness of re-received notifications~~
- [x] Worry about nil-pointer dereferences on listener/prompts/rules backends from the manager (this wasn't handled previously at all, but is exacerbated by some API endpoints waiting for the listener to be ready) -- handled in #15320
- [X] Ask JJ to ensure that the kernel pending queue is inserted before the ready queue after the kernel receives the `RESEND` command, so the listener can guarantee that any resent requests are re-received before any new requests.

The spec for restarts support can be found here: https://docs.google.com/document/d/1ODuvREJXCuTBWFaoj_k_bHJuoVcnG5WSz850j2ks15Y

The current struct definitions from JJ here: https://pastebin.canonical.com/p/2qbKQ8NFWz/

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34637