### PR TITLE
tests/lib/tools/build_kernel_with_comps.sh: fix failure when lib already exists

### DIFF
--- a/tests/lib/assertions/developer1-24-classic-dangerous.json
+++ b/tests/lib/assertions/developer1-24-classic-dangerous.json
@@ -21,7 +21,7 @@
             "type": "gadget"
         },
         {
-            "default-channel": "24/edge",
+            "default-channel": "24/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
             "name": "pc-kernel",
             "type": "kernel"

--- a/tests/lib/assertions/developer1-24-classic-dangerous.model
+++ b/tests/lib/assertions/developer1-24-classic-dangerous.model
@@ -17,7 +17,7 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 24/edge
+    default-channel: 24/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
@@ -34,13 +34,13 @@ snaps:
 timestamp: 2024-04-09T22:00:00+00:00
 sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
 
-AcLBUgQAAQoABgUCZhWeVwAAqQ8QAANqBf4lwDRXCxDBgWLKpA5HblmFyisUJHSOt/sdBdUy1icu
-vw/48tJljAmEu8XOesAa97NZiHU2UU8d0cKGsGHS9wgdVxCjACZVQaDEbNdX4455xY+aDQYxBwJ6
-R/2T29XIMffXjr7d+PeRb7s1PbrfHktH3D3fnJsQHPGF7Y6Tj9e0H6wx4gKkU9kkmhYTiHSVa8PS
-s+zi7NZhlfpQVkA49/KTjlmA7uH4oit47gjl32SHGiq/V70Yn2fuADKjJzJFN50Ld7uOtUqmNo58
-KBv+drdoP9krOxTjU9o2Jl0wzOKYste8QiiGSPI3l7hFEVQEqzHjVVEr+9zxlaf4dyxEhT7JeFDy
-z8uDG0AOTgGtw/Uo8QfGm91VHZSHR0+sqaDtizigtp0AvXRNLiiliR0dT4AhFwHmCOlxeaiT5fNL
-Rz9XGeT4Zjl+QHP6GL+0WpcdUKlIUey99Zhdky/t+z0boDN2JUnhL0GoFWMF9kxqtnDvUBsk2j2X
-xex4wCL5eQYooIk+KE7f2+7xlzK3HDvxmyjt6RytY3XlbqucakfiSERFYGWeEC2CZvwlPzHy+moC
-VSiXsCkNhV1A/pwXxtOsvaNVxJhgrvYsSB3dNTEA2qHgTML9PzCsKco+Te7XjRz+Lb455QVvrk+6
-W4vx2ge+itU29cdzCYcyWX4WT8ut
+AcLBUgQAAQoABgUCZ+bMpgAAeyAQAEHRlSdsW6apGSK6eEgfNNQjyi+ZCcCRD4OU/ZnBvG5p6Yjb
+VQv0PpxoNaoVVRdl7uSWxRFwroq5IA+hf3VaVjtl3dF7rH9vkfF/SU+NTUxrN0h4TNw4hzeu+X/K
+TTCbNBpTHwMoK5jMZBsPnDEPMRitvzsgzijtOIg3pI5sqJtFeQF3K+JpIrdTziestmGQHbBLJZcx
+R8TD62XGlug1ewwSTHDKP+PsxqmBEUpHGODdCO38bA+QBUbn/a5KcE1AQzu3uFrVusfOSIOFqMs/
+33fczszN+v4gZCju9/GrRMxtA8OXXlPhpHzD5SvetyVjgSMJZUJWg8jdDDAsLSTh9OCoKO4hze0s
+s1WgepHC53/w0s+Ngb8MVVwQQdWHT1V5LDsGyBj1vlGinJyK7xNzqSzIUhhvYSgr+/Y2LuHuPO6Y
+DT7BgdeN8/b/j9t5fmSjyoLivu9vQ/+rq1Takck+W+FWNmF5f6exLecgh9CgCHmvY4+EsQ8d7LTL
+bFSnHZ10xYalGGtbtpYII7jPeCOUKJTjNmvebUnno93vU3kmbqPv90vc7jFFU4qiGR+r0jbuPamU
+0mHIaX0PTdsCBCMP0qokXqGNj0pRlLL2G4H+RVvdiYefpU2m2kjv32e54w9g7TkYgomSxQ2WAZwW
+2/nofmmn3OaK96VJh2CgHnpme6l7

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -967,13 +967,14 @@ EOF
 
     # remove the kernel module from the kernel snap
     rm "$module_path"
-    # depmod wants a lib subdir, fake it and remove after invocation
-    mkdir pc-kernel/lib
+    # depmod wants a lib subdir
+    mkdir -p pc-kernel/lib
     ln -s ../modules pc-kernel/lib/modules
     depmod -b pc-kernel/ "$kern_ver"
-    rm -rf pc-kernel/lib
     # append component meta-information
-    printf 'components:\n  %s:\n    type: kernel-modules\n' "$comp_name" >> pc-kernel/meta/snap.yaml
+    #shellcheck disable=SC2016
+    gojq --arg COMP_NAME "${comp_name}" '.components = {$COMP_NAME:{"type":"kernel-modules"}}' --yaml-input pc-kernel/meta/snap.yaml --yaml-output >pc-kernel/meta/snap.yaml.new
+    mv pc-kernel/meta/snap.yaml.new pc-kernel/meta/snap.yaml
 }
 
 uc24_build_initramfs_kernel_snap() {

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1027,6 +1027,14 @@ uc24_build_initramfs_kernel_snap() {
         cp -a ./extra-kernel-snap/* ./pc-kernel
     fi
 
+    if [ -n "${NESTED_KERNEL_REMOVE_COMPONENTS-}" ]; then
+        #shellcheck disable=SC2016
+        gojq 'del(.components)' --yaml-input pc-kernel/meta/snap.yaml --yaml-output >pc-kernel/meta/snap.yaml.new
+        mv pc-kernel/meta/snap.yaml.new pc-kernel/meta/snap.yaml
+        gojq 'del(.slots)' --yaml-input pc-kernel/meta/snap.yaml --yaml-output >pc-kernel/meta/snap.yaml.new
+        mv pc-kernel/meta/snap.yaml.new pc-kernel/meta/snap.yaml
+    fi
+
     if [ -n "$NESTED_KERNEL_MODULES_COMP" ] && is_test_target_core_ge 24; then
         # "split" kernel in kernel-modules component and kernel
         move_module_to_component "$NESTED_COMP_KERNEL_MODULE_NAME" "$NESTED_KERNEL_MODULES_COMP"

--- a/tests/lib/tools/build_kernel_with_comps.sh
+++ b/tests/lib/tools/build_kernel_with_comps.sh
@@ -51,7 +51,9 @@ EOF
     depmod -b kernel/ "$kern_ver"
     rm "${kernel_snap_file}"
     # append component meta-information
-    printf 'components:\n  %s:\n    type: kernel-modules\n' "$comp_name" >> kernel/meta/snap.yaml
+    #shellcheck disable=SC2016
+    gojq --arg COMP_NAME "${comp_name}" '.components = {$COMP_NAME:{"type":"kernel-modules"}}' --yaml-input kernel/meta/snap.yaml --yaml-output >kernel/meta/snap.yaml.new
+    mv kernel/meta/snap.yaml.new kernel/meta/snap.yaml
     snap pack --filename="${kernel_snap_file}" kernel
 
     if [ "${use_provided_kernel}" = false ]; then

--- a/tests/lib/tools/build_kernel_with_comps.sh
+++ b/tests/lib/tools/build_kernel_with_comps.sh
@@ -45,11 +45,10 @@ EOF
 
     # Create kernel without the kernel module
     rm "$module_path"
-    # depmod wants a lib subdir, fake it and remove after invocation
-    mkdir kernel/lib
+    # depmod wants a lib subdir
+    mkdir -p kernel/lib
     ln -s ../modules kernel/lib/modules
     depmod -b kernel/ "$kern_ver"
-    rm -rf kernel/lib
     rm "${kernel_snap_file}"
     # append component meta-information
     printf 'components:\n  %s:\n    type: kernel-modules\n' "$comp_name" >> kernel/meta/snap.yaml

--- a/tests/nested/manual/core-factory-reset-new-secboot/task.yaml
+++ b/tests/nested/manual/core-factory-reset-new-secboot/task.yaml
@@ -24,6 +24,8 @@ environment:
     NESTED_ENABLE_TPM/tpm: true
     NESTED_ENABLE_SECURE_BOOT/tpm: true
 
+    NESTED_KERNEL_REMOVE_COMPONENTS: true
+
 prepare: |
     if [ "${ENCRYPTION}" = hook ]; then
        mkdir -p ./extra-initrd/usr/bin/

--- a/tests/nested/manual/core20-fault-inject-on-install-component/task.yaml
+++ b/tests/nested/manual/core20-fault-inject-on-install-component/task.yaml
@@ -30,11 +30,10 @@ prepare: |
 
     # Create kernel without the kernel module
     rm "$hwsim_path"
-    # depmod wants a lib subdir, fake it and remove after invocation
-    mkdir kernel/lib
+    # depmod wants a lib subdir
+    mkdir -p kernel/lib
     ln -s ../modules kernel/lib/modules
     depmod -b kernel/ "$kern_ver"
-    rm -rf kernel/lib
     # append component meta-information
     printf 'components:\n  wifi-comp:\n    type: kernel-modules\n' >> kernel/meta/snap.yaml
     snap pack kernel

--- a/tests/nested/manual/hybrid-fde-dbx/task.yaml
+++ b/tests/nested/manual/hybrid-fde-dbx/task.yaml
@@ -57,7 +57,7 @@ prepare: |
   snap pack --filename=pc.snap pc-gadget/
 
   # Retrieve kernel
-  snap download --basename=pc-kernel-from-store --channel="$version/edge" pc-kernel
+  snap download --basename=pc-kernel-from-store --channel="$version/${KERNEL_CHANNEL}" pc-kernel
   # the fakestore needs this assertion
   snap ack pc-kernel-from-store.assert
   # Build kernel with initramfs with the compiled snap-bootstrap

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -73,7 +73,7 @@ execute: |
   version="$(nested_get_version)"
 
   # Retrieve the gadget
-  snap download --basename=pc --channel="$version/edge" pc
+  snap download --basename=pc --channel="$version/${KERNEL_CHANNEL}" pc
 
   # Modify gadget, making sure we can access the device (we are not building
   # the image in the usual way in snapd spread tests).
@@ -101,7 +101,7 @@ execute: |
   snap pack --filename=pc.snap pc-gadget/
 
   # Retrieve kernel
-  snap download --basename=pc-kernel --channel="$version/edge" pc-kernel
+  snap download --basename=pc-kernel --channel="$version/${KERNEL_CHANNEL}" pc-kernel
 
   # THIS IS A HACK
   # TODO: Remove when pc-kernel snapd-info includes snap-bootstrap from snapd 2.68+

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -74,7 +74,7 @@ execute: |
   . "$TESTSLIB"/nested.sh
   version="$(nested_get_version)"
   # get an updated kernel
-  snap download --basename=pc-kernel --channel="$version/edge" pc-kernel
+  snap download --basename=pc-kernel --channel="$version/${KERNEL_CHANNEL}" pc-kernel
   if os.query is-ubuntu-ge 24.04; then
     uc24_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   else

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -180,12 +180,12 @@ execute: |
 
   remote.exec "snap download --basename=snapd-edge --channel=latest/edge snapd"
   remote.exec "snap download --basename=core22-edge --channel=latest/edge core22"
-  remote.exec "snap download --basename=pc-kernel-edge --channel=\"$version/edge\" pc-kernel"
+  remote.exec "snap download --basename=pc-kernel-channel --channel=\"$version/${KERNEL_CHANNEL}\" pc-kernel"
   remote.exec "snap download --basename=test-snapd-sh-edge --channel=latest/edge test-snapd-sh"
   remote.exec "snap download --basename=test-snapd-tools-core22-edge --channel=latest/edge test-snapd-tools-core22"
 
   echo "Update all snaps at once"
-  remote.exec "sudo snap install --dangerous ./snapd-edge.snap ./pc-kernel-edge.snap ./pc-edge.snap ./core22-edge.snap ./test-snapd-sh-edge.snap ./test-snapd-tools-core22-edge.snap"
+  remote.exec "sudo snap install --dangerous ./snapd-edge.snap ./pc-kernel-channel.snap ./pc-edge.snap ./core22-edge.snap ./test-snapd-sh-edge.snap ./test-snapd-tools-core22-edge.snap"
   CHG_ID=$(remote.exec snap changes | grep "Install.*from files" | awk '{print $1}')
 
   echo "Check that the essential snaps' refresh is pending on a reboot"

--- a/tests/nested/manual/update-snapd-seed-and-factory-reset/task.yaml
+++ b/tests/nested/manual/update-snapd-seed-and-factory-reset/task.yaml
@@ -27,6 +27,8 @@ environment:
   OLD_SNAPD_REVISION: 21759
   OLD_SNAPD_COMMIT: 40efd81c2f35213eabf2df83fb9efabe88fa124e
 
+  NESTED_KERNEL_REMOVE_COMPONENTS: true
+
 prepare: |
     # Install what is needed before using the fake store
     snap install test-snapd-swtpm --edge


### PR DESCRIPTION
That fixes some of the nested tests failures.