### PR TITLE
core-initrd: load modules required by systemd

### DIFF
--- a/core-initrd/latest/factory/usr/lib/modules-load.d/broken-kernel-modules-work-around.conf
+++ b/core-initrd/latest/factory/usr/lib/modules-load.d/broken-kernel-modules-work-around.conf
@@ -1,0 +1,13 @@
+# systemd normally loads those but because we have a broken boot that
+# does not provide modules right on boot, we have to load them while
+# we are in initrd.
+# see src/core/kmod-setup.c
+autofs4
+dmi_sysfs
+ip_tables
+ipv6
+qemu_fw_cfg
+unix
+virtio_console
+virtio_rng
+vmw_vsock_virtio_transport

--- a/kernel/kernel_drivers.go
+++ b/kernel/kernel_drivers.go
@@ -176,6 +176,11 @@ func createModulesSubtree(kMntPts MountPoints, kernelTree, kversion string, comp
 }
 
 func createKernelModulesSymlinks(modsRoot, kMntPt string) error {
+	// FIXME: having a symlink for something not yet mounted is
+	// not enough. During boot after the switch root, the kernel
+	// might request modules for algorithms (like encryption or
+	// compression). These can happen any time during the boot,
+	// even before udevd is started.
 	for _, d := range []string{"kernel", "vdso"} {
 		lname := filepath.Join(modsRoot, d)
 		to := filepath.Join(kMntPt, d)


### PR DESCRIPTION
At this point UC24, does not have modules available in the start of the main boot. This is a bug because modules could be loaded at any time by the kernel.

Until this is fixed, we pre-load the kernel modules expected by systemd to be loaded at start.

See https://github.com/systemd/systemd/blob/main/src/core/kmod-setup.c
