### PR TITLE
github, build-aux, logger: add structured logger with build tag and new trace logger method

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -240,6 +240,7 @@ jobs:
           - { go-build-tags: faultinject,           skip-coverage: false, snapd-debug: false, go-test-race: false}
           - { go-build-tags: statelocktrace,        skip-coverage: true,  snapd-debug: false, go-test-race: false}
           - { go-build-tags: snapdusergo,           skip-coverage: false, snapd-debug: false, go-test-race: false}
+          - { go-build-tags: structuredlogging,     skip-coverage: true,  snapd-debug: false, go-test-race: false}
           - { go-build-tags: "",                    skip-coverage: true,  snapd-debug: false, go-test-race: true }
 
   unit-tests-special-not-required:

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -380,14 +380,14 @@ parts:
             TAGS+=(nomanagers)
             case "${VERSION}" in
               1337.*)
-                TAGS+=(withtestkeys faultinject statelocktrace)
+                TAGS+=(withtestkeys faultinject statelocktrace structuredlogging)
                 ;;
             esac
             ;;
           *)
             case "${VERSION}" in
               1337.*)
-                TAGS+=(withtestkeys withbootassetstesting faultinject statelocktrace)
+                TAGS+=(withtestkeys withbootassetstesting faultinject statelocktrace structuredlogging)
                 ;;
             esac
             ;;

--- a/cmd/snap-failure/main.go
+++ b/cmd/snap-failure/main.go
@@ -47,10 +47,7 @@ reverts if appropriate.
 )
 
 func init() {
-	err := logger.SimpleSetup(nil)
-	if err != nil {
-		fmt.Fprintf(Stderr, "WARNING: failed to activate logging: %v\n", err)
-	}
+	logger.SimpleSetup(nil)
 }
 
 func main() {

--- a/cmd/snap-fde-keymgr/main.go
+++ b/cmd/snap-fde-keymgr/main.go
@@ -244,9 +244,7 @@ func run(osArgs1 []string) error {
 }
 
 func main() {
-	if err := logger.SimpleSetup(nil); err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %v\n", err)
-	}
+	logger.SimpleSetup(nil)
 
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/snap-recovery-chooser/main.go
+++ b/cmd/snap-recovery-chooser/main.go
@@ -203,17 +203,14 @@ func loggerWithSyslogMaybe() error {
 		if err != nil {
 			return err
 		}
-		l, err := logger.New(syslogWriter, logger.DefaultFlags, nil)
-		if err != nil {
-			return err
-		}
+		l := logger.New(syslogWriter, logger.DefaultFlags, nil)
 		logger.SetLogger(l)
 		return nil
 	}
 
 	if err := maybeSyslog(); err != nil {
 		// try simple setup
-		return logger.SimpleSetup(nil)
+		logger.SimpleSetup(nil)
 	}
 	return nil
 }

--- a/cmd/snap-repair/main.go
+++ b/cmd/snap-repair/main.go
@@ -50,10 +50,7 @@ which are used to do emergency repairs on the device.
 )
 
 func init() {
-	err := logger.SimpleSetup(nil)
-	if err != nil {
-		fmt.Fprintf(Stderr, "WARNING: failed to activate logging: %v\n", err)
-	}
+	logger.SimpleSetup(nil)
 }
 
 var errOnClassic = fmt.Errorf("cannot use snap-repair on a classic system")

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -402,10 +402,7 @@ This command has been left available for documentation purposes only.
 }
 
 func init() {
-	err := logger.SimpleSetup(nil)
-	if err != nil {
-		fmt.Fprintf(Stderr, i18n.G("WARNING: failed to activate logging: %v\n"), err)
-	}
+	logger.SimpleSetup(nil)
 }
 
 func resolveApp(snapApp string) (string, error) {

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -160,9 +160,7 @@ func validateArgs(args []string) error {
 }
 
 func init() {
-	if err := logger.SimpleSetup(nil); err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %v\n", err)
-	}
+	logger.SimpleSetup(nil)
 }
 
 func main() {

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -44,10 +44,7 @@ var (
 )
 
 func init() {
-	err := logger.SimpleSetup(nil)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %s\n", err)
-	}
+	logger.SimpleSetup(nil)
 }
 
 func main() {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -110,6 +110,7 @@ func Debug(msg string) {
 	logger.Debug(msg)
 }
 
+// Trace records something in the trace log
 func Trace(msg string, attrs ...any) {
 	lock.Lock()
 	defer lock.Unlock()
@@ -196,6 +197,7 @@ func (l *Log) Notice(msg string) {
 	}
 }
 
+// Trace only prints if SNAPD_TRACE is set and the structured logger is used
 func (l *Log) Trace(string, ...any) {}
 
 // NoGuardDebug always prints the message, w/o gating it based on environment

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -22,6 +22,7 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -110,6 +111,9 @@ func Debug(msg string) {
 }
 
 func Trace(msg string, attrs ...any) {
+	lock.Lock()
+	defer lock.Unlock()
+
 	logger.Trace(msg, attrs...)
 }
 
@@ -203,6 +207,15 @@ func (l *Log) NoGuardDebug(msg string) {
 	// this frame + single package level API func() + actual caller
 	calldepth := 1 + 1 + 1
 	l.log.Output(calldepth, "DEBUG: "+msg)
+}
+
+func newLog(w io.Writer, flag int, opts *LoggerOptions) (Logger, error) {
+	logger := &Log{
+		log:   log.New(w, "", flag),
+		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
+		flags: flag,
+	}
+	return logger, nil
 }
 
 type LoggerOptions struct {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,11 +17,12 @@
  *
  */
 
-// The logger package, when built with the structuredlogging build tag,
-// offers the ability to use structured JSON for log entries and to turn
-// on trace logging. To activate JSON logging, the SNAPD_JSON_LOGGING
-// environment variable should be set at the time of logger creation.
-// Trace logging can be activated by setting the SNAPD_TRACE env variable.
+// The logger package implements logging facilities for snapd.
+// When built with the structuredlogging build tag, it offers the ability
+// to use structured JSON for log entries and to turn on trace logging.
+// To activate JSON logging, the SNAPD_JSON_LOGGING environment variable
+// should be set at the time of logger creation. Trace logging can be
+// activated by setting the SNAPD_TRACE env variable.
 //
 // When built without the structuredlogging build tag, the logger package
 // offers only the simple logger and will not activate trace logging even

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -142,10 +142,7 @@ func MockDebugLogger() (buf *bytes.Buffer, restore func()) {
 func mockLogger(opts *LoggerOptions) (buf *bytes.Buffer, restore func()) {
 	buf = &bytes.Buffer{}
 	oldLogger := logger
-	l, err := New(buf, DefaultFlags, opts)
-	if err != nil {
-		panic(err)
-	}
+	l := New(buf, DefaultFlags, opts)
 	SetLogger(l)
 	return buf, func() {
 		SetLogger(oldLogger)
@@ -209,13 +206,13 @@ func (l *Log) NoGuardDebug(msg string) {
 	l.log.Output(calldepth, "DEBUG: "+msg)
 }
 
-func newLog(w io.Writer, flag int, opts *LoggerOptions) (Logger, error) {
+func newLog(w io.Writer, flag int, opts *LoggerOptions) Logger {
 	logger := &Log{
 		log:   log.New(w, "", flag),
 		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
 		flags: flag,
 	}
-	return logger, nil
+	return logger
 }
 
 type LoggerOptions struct {
@@ -234,13 +231,10 @@ func buildFlags() int {
 }
 
 // SimpleSetup creates the default (console) logger
-func SimpleSetup(opts *LoggerOptions) error {
+func SimpleSetup(opts *LoggerOptions) {
 	flags := buildFlags()
-	l, err := New(os.Stderr, flags, opts)
-	if err == nil {
-		SetLogger(l)
-	}
-	return err
+	l := New(os.Stderr, flags, opts)
+	SetLogger(l)
 }
 
 // BootSetup creates a logger meant to be used when running from

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,6 +17,15 @@
  *
  */
 
+// The logger package, when built with the structuredlogging build tag,
+// offers the ability to use structured JSON for log entries and to turn
+// on trace logging. To activate JSON logging, the SNAPD_JSON_LOGGING
+// environment variable should be set at the time of logger creation.
+// Trace logging can be activated by setting the SNAPD_TRACE env variable.
+//
+// When built without the structuredlogging build tag, the logger package
+// offers only the simple logger and will not activate trace logging even
+// if the SNAPD_TRACE env variable is set.
 package logger
 
 import (

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -110,8 +110,6 @@ func Debug(msg string) {
 }
 
 func Trace(msg string, attrs ...any) {
-	lock.Lock()
-	defer lock.Unlock()
 	logger.Trace(msg, attrs...)
 }
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -77,14 +77,12 @@ func (s *LogSuite) TestDefault(c *C) {
 	c.Check(logger.GetLogger(), IsNil)
 
 	os.Setenv("TERM", "dumb")
-	err := logger.SimpleSetup(nil)
-	c.Assert(err, IsNil)
+	logger.SimpleSetup(nil)
 	c.Check(logger.GetLogger(), NotNil)
 	c.Check(logger.GetLoggerFlags(), Equals, logger.DefaultFlags)
 
 	os.Unsetenv("TERM")
-	err = logger.SimpleSetup(nil)
-	c.Assert(err, IsNil)
+	logger.SimpleSetup(nil)
 	c.Check(logger.GetLogger(), NotNil)
 	c.Check(logger.GetLoggerFlags(), Equals, log.Lshortfile)
 }
@@ -135,8 +133,7 @@ func (s *LogSuite) TestBootSetup(c *C) {
 
 func (s *LogSuite) TestNew(c *C) {
 	var buf bytes.Buffer
-	l, err := logger.New(&buf, logger.DefaultFlags, nil)
-	c.Assert(err, IsNil)
+	l := logger.New(&buf, logger.DefaultFlags, nil)
 	c.Assert(l, NotNil)
 }
 
@@ -202,8 +199,7 @@ func (s *LogSuite) TestIntegrationDebugFromKernelCmdline(c *C) {
 	defer restore()
 
 	var buf bytes.Buffer
-	l, err := logger.New(&buf, logger.DefaultFlags, nil)
-	c.Assert(err, IsNil)
+	l := logger.New(&buf, logger.DefaultFlags, nil)
 	l.Debug("xyzzy")
 	c.Check(buf.String(), testutil.Contains, `DEBUG: xyzzy`)
 }
@@ -239,8 +235,7 @@ func (s *LogSuite) TestStartupTimestampMsg(c *C) {
 
 func (s *LogSuite) TestForceDebug(c *C) {
 	var buf bytes.Buffer
-	l, err := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{ForceDebug: true})
-	c.Assert(err, IsNil)
+	l := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{ForceDebug: true})
 	l.Debug("xyzzy")
 	c.Check(buf.String(), testutil.Contains, `DEBUG: xyzzy`)
 }

--- a/logger/simple_logger.go
+++ b/logger/simple_logger.go
@@ -22,7 +22,6 @@ package logger
 
 import (
 	"io"
-	"log"
 )
 
 // New creates a log.Logger using the given io.Writer and flag, using the
@@ -31,10 +30,5 @@ func New(w io.Writer, flag int, opts *LoggerOptions) (Logger, error) {
 	if opts == nil {
 		opts = &LoggerOptions{}
 	}
-	logger := &Log{
-		log:   log.New(w, "", flag),
-		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
-		flags: flag,
-	}
-	return logger, nil
+	return newLog(w, flag, opts)
 }

--- a/logger/simple_logger.go
+++ b/logger/simple_logger.go
@@ -26,7 +26,7 @@ import (
 
 // New creates a log.Logger using the given io.Writer and flag, using the
 // options from opts.
-func New(w io.Writer, flag int, opts *LoggerOptions) (Logger, error) {
+func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 	if opts == nil {
 		opts = &LoggerOptions{}
 	}

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -106,7 +106,7 @@ func (l *StructuredLog) Trace(msg string, attrs ...any) {
 
 // // New creates a log.Logger using the given io.Writer and flag, using the
 // // options from opts.
-func New(w io.Writer, flag int, opts *LoggerOptions) (Logger, error) {
+func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 	if opts == nil {
 		opts = &LoggerOptions{}
 	}
@@ -151,5 +151,5 @@ func New(w io.Writer, flag int, opts *LoggerOptions) (Logger, error) {
 		flags: flag,
 		trace: false,
 	}
-	return logger, nil
+	return logger
 }

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -18,6 +18,11 @@
  *
  */
 
+// The logger package, when built with the structuredlogging build tag,
+// offers the ability to use structured JSON for log entries and to turn
+// on trace logging. To activate JSON logging, the SNAPD_JSON_LOGGING
+// environment variable should be set at the time of logger creation.
+// Trace logging can be activated by setting the SNAPD_TRACE env variable.
 package logger
 
 import (
@@ -94,6 +99,7 @@ func (l *StructuredLog) traceEnabled() bool {
 	return false
 }
 
+// Trace only prints if SNAPD_TRACE is set and structured logging is active
 func (l *StructuredLog) Trace(msg string, attrs ...any) {
 	if l.traceEnabled() {
 		var pcs [1]uintptr

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -44,7 +44,7 @@ const (
 	LevelNotice = slog.Level(2)
 )
 
-var LevelNames = map[slog.Leveler]string{
+var LevelNames = map[slog.Level]string{
 	LevelTrace:  "TRACE",
 	LevelNotice: "NOTICE",
 }

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -18,11 +18,6 @@
  *
  */
 
-// The logger package, when built with the structuredlogging build tag,
-// offers the ability to use structured JSON for log entries and to turn
-// on trace logging. To activate JSON logging, the SNAPD_JSON_LOGGING
-// environment variable should be set at the time of logger creation.
-// Trace logging can be activated by setting the SNAPD_TRACE env variable.
 package logger
 
 import (

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -1,0 +1,143 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build structuredlogging
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package logger
+
+import (
+	"context"
+	"io"
+	"log"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type StructuredLog struct {
+	log   *slog.Logger
+	debug bool
+	quiet bool
+	flags int
+}
+
+const (
+	LevelTrace  = slog.Level(-8)
+	LevelNotice = slog.Level(2)
+)
+
+var LevelNames = map[slog.Leveler]string{
+	LevelTrace:  "TRACE",
+	LevelNotice: "NOTICE",
+}
+
+func (l *StructuredLog) debugEnabled() bool {
+	return l.debug || osutil.GetenvBool("SNAPD_DEBUG") || osutil.GetenvBool("SNAPD_TRACE")
+}
+
+// Debug only prints if SNAPD_DEBUG or SNAPD_TRACE is set
+func (l *StructuredLog) Debug(msg string) {
+	if l.debugEnabled() {
+		var pcs [1]uintptr
+		runtime.Callers(3, pcs[:])
+		r := slog.NewRecord(time.Now(), slog.LevelDebug, msg, pcs[0])
+		l.log.Handler().Handle(context.Background(), r)
+	}
+}
+
+// Notice alerts the user about something, as well as putting in syslog
+func (l *StructuredLog) Notice(msg string) {
+	if !l.quiet {
+		var pcs [1]uintptr
+		runtime.Callers(3, pcs[:])
+		r := slog.NewRecord(time.Now(), LevelNotice, msg, pcs[0])
+		l.log.Handler().Handle(context.Background(), r)
+	}
+}
+
+// NoGuardDebug always prints the message, w/o gating it based on environment
+// variables or other configurations.
+func (l *StructuredLog) NoGuardDebug(msg string) {
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:])
+	r := slog.NewRecord(time.Now(), slog.LevelDebug, msg, pcs[0])
+	l.log.Handler().Handle(context.Background(), r)
+}
+
+// Trace only prints if SNAPD_TRACE is set
+func (l *StructuredLog) Trace(msg string, attrs ...any) {
+	if osutil.GetenvBool("SNAPD_TRACE") {
+		var pcs [1]uintptr
+		runtime.Callers(3, pcs[:])
+		r := slog.NewRecord(time.Now(), LevelTrace, msg, pcs[0])
+		r.Add(attrs...)
+		l.log.Handler().Handle(context.Background(), r)
+	}
+}
+
+// // New creates a log.Logger using the given io.Writer and flag, using the
+// // options from opts.
+func New(w io.Writer, flag int, opts *LoggerOptions) (Logger, error) {
+	if opts == nil {
+		opts = &LoggerOptions{}
+	}
+	if !osutil.GetenvBool("SNAPD_JSON_LOGGING") {
+		logger := &Log{
+			log:   log.New(w, "", flag),
+			debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
+			flags: flag,
+		}
+		return logger, nil
+	}
+	options := &slog.HandlerOptions{
+		AddSource: true,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey && (flag&log.Ldate) != log.Ldate {
+				// Remove timestamp
+				return slog.Attr{}
+			}
+			if a.Key == slog.SourceKey && (flag&log.Lshortfile) == log.Lshortfile {
+				// Remove all but the file name of the source file
+				source, _ := a.Value.Any().(*slog.Source)
+				if source != nil {
+					source.File = filepath.Base(source.File)
+				}
+				return a
+			}
+			if a.Key == slog.LevelKey {
+				// Add TRACE and NOTICE level names
+				level := a.Value.Any().(slog.Level)
+				levelLabel, exists := LevelNames[level]
+				if !exists {
+					levelLabel = level.String()
+				}
+				a.Value = slog.StringValue(levelLabel)
+			}
+			return a
+		},
+	}
+	logger := &StructuredLog{
+		log:   slog.New(slog.NewJSONHandler(w, options)),
+		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
+		flags: flag,
+	}
+	return logger, nil
+}

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -102,7 +102,7 @@ func (s *LogStructuredSuite) TestTraceEnvStructured(c *C) {
 	err := json.Unmarshal(s.logbuf.Bytes(), &data)
 	c.Check(err, IsNil)
 	c.Check(data.Msg, Equals, "xyzzy")
-	c.Check(data.Level, Equals, logger.LevelNames[logger.LevelTrace])
+	c.Check(data.Level, Equals, "TRACE")
 	c.Check(data.Attr, Equals, "val")
 	c.Check(data.Source.File, Equals, "structured_logger_test.go")
 }
@@ -127,7 +127,7 @@ func (s *LogStructuredSuite) TestNoticeStructured(c *C) {
 	err := json.Unmarshal(s.logbuf.Bytes(), &data)
 	c.Check(err, IsNil)
 	c.Check(data.Msg, Equals, "xyzzy")
-	c.Check(data.Level, Equals, logger.LevelNames[logger.LevelNotice])
+	c.Check(data.Level, Equals, "NOTICE")
 	c.Check(data.Attr, Equals, "")
 	c.Check(data.Source.File, Equals, "structured_logger_test.go")
 }
@@ -160,7 +160,7 @@ func (s *LogStructuredSuite) TestPanicfStructured(c *C) {
 	err := json.Unmarshal(s.logbuf.Bytes(), &data)
 	c.Check(err, IsNil)
 	c.Check(data.Msg, Equals, "PANIC xyzzy")
-	c.Check(data.Level, Equals, logger.LevelNames[logger.LevelNotice])
+	c.Check(data.Level, Equals, "NOTICE")
 	c.Check(data.Attr, Equals, "")
 }
 
@@ -174,7 +174,7 @@ func (s *LogStructuredSuite) TestWithLoggerLockStructured(c *C) {
 		err := json.Unmarshal(s.logbuf.Bytes(), &data)
 		c.Check(err, IsNil)
 		c.Check(data.Msg, Equals, "xyzzy")
-		c.Check(data.Level, Equals, logger.LevelNames[logger.LevelNotice])
+		c.Check(data.Level, Equals, "NOTICE")
 		c.Check(data.Attr, Equals, "")
 		c.Check(data.Source.File, Equals, "structured_logger_test.go")
 	})

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -78,8 +78,7 @@ func (s *LogStructuredSuite) TestNewStructured(c *C) {
 	os.Setenv("SNAPD_JSON_LOGGING", "1")
 	defer os.Unsetenv("SNAPD_JSON_LOGGING")
 	var buf bytes.Buffer
-	l, err := logger.New(&buf, logger.DefaultFlags, nil)
-	c.Assert(err, IsNil)
+	l := logger.New(&buf, logger.DefaultFlags, nil)
 	c.Assert(l, NotNil)
 }
 
@@ -137,12 +136,11 @@ func (s *LogStructuredSuite) TestNoTimestamp(c *C) {
 	defer os.Unsetenv("SNAPD_JSON_LOGGING")
 
 	var buf bytes.Buffer
-	l, err := logger.New(&buf, log.Lshortfile, nil)
-	c.Check(err, IsNil)
+	l := logger.New(&buf, log.Lshortfile, nil)
 	l.Notice("xyzzy")
 
 	var data map[string]any
-	err = json.Unmarshal(buf.Bytes(), &data)
+	err := json.Unmarshal(buf.Bytes(), &data)
 	c.Check(err, IsNil)
 	_, ok := data["time"]
 	c.Check(ok, Equals, false)
@@ -182,7 +180,6 @@ func (s *LogStructuredSuite) TestWithLoggerLockStructured(c *C) {
 }
 
 func (s *LogStructuredSuite) TestNoGuardDebugStructured(c *C) {
-
 	debugValue, ok := os.LookupEnv("SNAPD_DEBUG")
 	if ok {
 		defer func() {
@@ -218,8 +215,7 @@ func (s *LogStructuredSuite) TestIntegrationDebugFromKernelCmdlineStructured(c *
 	defer restore()
 
 	var buf bytes.Buffer
-	l, err := logger.New(&buf, logger.DefaultFlags, nil)
-	c.Assert(err, IsNil)
+	l := logger.New(&buf, logger.DefaultFlags, nil)
 	l.Debug("xyzzy")
 	data := TestLogEntry{}
 	err = json.Unmarshal(buf.Bytes(), &data)
@@ -266,11 +262,10 @@ func (s *LogStructuredSuite) TestForceDebugStructured(c *C) {
 	defer os.Unsetenv("SNAPD_JSON_LOGGING")
 
 	var buf bytes.Buffer
-	l, err := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{ForceDebug: true})
-	c.Assert(err, IsNil)
+	l := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{ForceDebug: true})
 	l.Debug("xyzzy")
 	data := TestLogEntry{}
-	err = json.Unmarshal(buf.Bytes(), &data)
+	err := json.Unmarshal(buf.Bytes(), &data)
 	c.Check(err, IsNil)
 	c.Check(data.Level, Equals, "DEBUG")
 	c.Check(data.Msg, Equals, "xyzzy")

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -1,0 +1,291 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build structuredlogging
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package logger_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil/kcmdline"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func TestStructured(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&LogStructuredSuite{})
+
+type LogStructuredSuite struct {
+	testutil.BaseTest
+	logbuf        *bytes.Buffer
+	restoreLogger func()
+}
+
+func (s *LogStructuredSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+	s.logbuf, s.restoreLogger = logger.MockLogger()
+}
+
+func (s *LogStructuredSuite) TearDownTest(c *C) {
+	s.restoreLogger()
+}
+
+var _ = Suite(&LogStructuredSuite{})
+
+type TestSourceLogEntry struct {
+	File     string
+	Line     int32
+	Function string
+}
+
+type TestLogEntry struct {
+	Msg    string
+	Level  string
+	Attr   string
+	Time   string
+	Source TestSourceLogEntry
+}
+
+func (s *LogStructuredSuite) TestNewStructured(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+	var buf bytes.Buffer
+	l, err := logger.New(&buf, logger.DefaultFlags, nil)
+	c.Assert(err, IsNil)
+	c.Assert(l, NotNil)
+}
+
+func (s *LogStructuredSuite) TestDebugfStructured(c *C) {
+	logger.Debug("xyzzy")
+	c.Check(s.logbuf.String(), Equals, "")
+}
+
+func (s *LogStructuredSuite) TestTrace(c *C) {
+	logger.Trace("xyzzy")
+	c.Check(s.logbuf.String(), Equals, "")
+}
+
+func (s *LogStructuredSuite) TestTraceEnvStructured(c *C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	logger.Trace("xyzzy", "attr", "val")
+	data := TestLogEntry{}
+	err := json.Unmarshal(s.logbuf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Msg, Equals, "xyzzy")
+	c.Check(data.Level, Equals, logger.LevelNames[logger.LevelTrace])
+	c.Check(data.Attr, Equals, "val")
+	c.Check(data.Source.File, Equals, "structured_logger_test.go")
+}
+
+func (s *LogStructuredSuite) TestTraceEnvDebugStructured(c *C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	logger.Debug("xyzzy")
+	data := TestLogEntry{}
+	err := json.Unmarshal(s.logbuf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Msg, Equals, "xyzzy")
+	c.Check(data.Level, Equals, "DEBUG")
+	c.Check(data.Attr, Equals, "")
+	c.Check(data.Source.File, Equals, "structured_logger_test.go")
+}
+
+func (s *LogStructuredSuite) TestNoticeStructured(c *C) {
+	logger.Notice("xyzzy")
+	data := TestLogEntry{}
+	err := json.Unmarshal(s.logbuf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Msg, Equals, "xyzzy")
+	c.Check(data.Level, Equals, logger.LevelNames[logger.LevelNotice])
+	c.Check(data.Attr, Equals, "")
+	c.Check(data.Source.File, Equals, "structured_logger_test.go")
+}
+
+func (s *LogStructuredSuite) TestNoTimestamp(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+
+	var buf bytes.Buffer
+	l, err := logger.New(&buf, log.Lshortfile, nil)
+	c.Check(err, IsNil)
+	l.Notice("xyzzy")
+
+	var data map[string]any
+	err = json.Unmarshal(buf.Bytes(), &data)
+	c.Check(err, IsNil)
+	_, ok := data["time"]
+	c.Check(ok, Equals, false)
+	_, ok = data["source"]
+	c.Check(ok, Equals, true)
+	_, ok = data["msg"]
+	c.Check(ok, Equals, true)
+	_, ok = data["level"]
+	c.Check(ok, Equals, true)
+}
+
+func (s *LogStructuredSuite) TestPanicfStructured(c *C) {
+	c.Check(func() { logger.Panicf("xyzzy") }, Panics, "xyzzy")
+	data := TestLogEntry{}
+	err := json.Unmarshal(s.logbuf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Msg, Equals, "PANIC xyzzy")
+	c.Check(data.Level, Equals, logger.LevelNames[logger.LevelNotice])
+	c.Check(data.Attr, Equals, "")
+}
+
+func (s *LogStructuredSuite) TestWithLoggerLockStructured(c *C) {
+
+	logger.Noticef("xyzzy")
+	called := false
+	logger.WithLoggerLock(func() {
+		called = true
+		data := TestLogEntry{}
+		err := json.Unmarshal(s.logbuf.Bytes(), &data)
+		c.Check(err, IsNil)
+		c.Check(data.Msg, Equals, "xyzzy")
+		c.Check(data.Level, Equals, logger.LevelNames[logger.LevelNotice])
+		c.Check(data.Attr, Equals, "")
+		c.Check(data.Source.File, Equals, "structured_logger_test.go")
+	})
+	c.Check(called, Equals, true)
+}
+
+func (s *LogStructuredSuite) TestNoGuardDebugStructured(c *C) {
+
+	debugValue, ok := os.LookupEnv("SNAPD_DEBUG")
+	if ok {
+		defer func() {
+			os.Setenv("SNAPD_DEBUG", debugValue)
+		}()
+		os.Unsetenv("SNAPD_DEBUG")
+	}
+
+	logger.NoGuardDebugf("xyzzy")
+	data := TestLogEntry{}
+	err := json.Unmarshal(s.logbuf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Msg, Equals, "xyzzy")
+	c.Check(data.Level, Equals, "DEBUG")
+	c.Check(data.Attr, Equals, "")
+	c.Check(data.Source.File, Equals, "structured_logger_test.go")
+}
+
+func (s *LogStructuredSuite) TestIntegrationDebugFromKernelCmdlineStructured(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+	// must enable actually checking the command line, because by default the
+	// logger package will skip checking for the kernel command line parameter
+	// if it detects it is in a test because otherwise we would have to mock the
+	// cmdline in many many many more tests that end up using a logger
+	restore := logger.ProcCmdlineMustMock(false)
+	defer restore()
+
+	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
+	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 snapd.debug=1\n"), 0644)
+	c.Assert(err, IsNil)
+	restore = kcmdline.MockProcCmdline(mockProcCmdline)
+	defer restore()
+
+	var buf bytes.Buffer
+	l, err := logger.New(&buf, logger.DefaultFlags, nil)
+	c.Assert(err, IsNil)
+	l.Debug("xyzzy")
+	data := TestLogEntry{}
+	err = json.Unmarshal(buf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Msg, Equals, "xyzzy")
+	c.Check(data.Level, Equals, "DEBUG")
+	c.Check(data.Attr, Equals, "")
+}
+
+func (s *LogStructuredSuite) TestStartupTimestampMsgStructured(c *C) {
+	os.Setenv("SNAPD_DEBUG", "1")
+	defer os.Unsetenv("SNAPD_DEBUG")
+
+	type msgTimestamp struct {
+		Stage string `json:"stage"`
+		Time  string `json:"time"`
+	}
+
+	now := time.Date(2022, time.May, 16, 10, 43, 12, 22312000, time.UTC)
+	logger.MockTimeNow(func() time.Time {
+		return now
+	})
+	logger.StartupStageTimestamp("foo to bar")
+	data := TestLogEntry{}
+	err := json.Unmarshal(s.logbuf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Level, Equals, "DEBUG")
+	c.Check(data.Msg, Equals, `-- snap startup {"stage":"foo to bar", "time":"1652697792.022312"}`)
+
+	var m msgTimestamp
+	start := strings.LastIndex(data.Msg, "{")
+	c.Assert(start, Not(Equals), -1)
+	stamp := data.Msg[start:]
+	err = json.Unmarshal([]byte(stamp), &m)
+	c.Assert(err, IsNil)
+	c.Check(m, Equals, msgTimestamp{
+		Stage: "foo to bar",
+		Time:  "1652697792.022312",
+	})
+}
+
+func (s *LogStructuredSuite) TestForceDebugStructured(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+
+	var buf bytes.Buffer
+	l, err := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{ForceDebug: true})
+	c.Assert(err, IsNil)
+	l.Debug("xyzzy")
+	data := TestLogEntry{}
+	err = json.Unmarshal(buf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Level, Equals, "DEBUG")
+	c.Check(data.Msg, Equals, "xyzzy")
+}
+
+func (s *LogStructuredSuite) TestMockDebugLoggerStructured(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+
+	logbuf, restore := logger.MockDebugLogger()
+	defer restore()
+	logger.Debugf("xyzzy")
+	data := TestLogEntry{}
+	err := json.Unmarshal(logbuf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Level, Equals, "DEBUG")
+	c.Check(data.Msg, Equals, "xyzzy")
+}

--- a/overlord/configstate/configcore/debug.go
+++ b/overlord/configstate/configcore/debug.go
@@ -95,9 +95,7 @@ func handleDebugSnapdLogConfiguration(tr RunTransaction, opts *fsOnlyContext) er
 	}
 
 	// Enable/disable debug logging for current snapd instance
-	if err := loggerSimpleSetup(&logger.LoggerOptions{ForceDebug: enableDebug}); err != nil {
-		return err
-	}
+	loggerSimpleSetup(&logger.LoggerOptions{ForceDebug: enableDebug})
 
 	return nil
 }

--- a/overlord/configstate/configcore/debug_test.go
+++ b/overlord/configstate/configcore/debug_test.go
@@ -59,9 +59,8 @@ func (s *debugSuite) SetUpTest(c *C) {
 
 func (s *debugSuite) testConfigureDebugSnapdLogGoodVals(c *C, valChanges bool) {
 	var loggerOpts *logger.LoggerOptions
-	r := configcore.MockLoggerSimpleSetup(func(opts *logger.LoggerOptions) error {
+	r := configcore.MockLoggerSimpleSetup(func(opts *logger.LoggerOptions) {
 		loggerOpts = opts
-		return nil
 	})
 	defer r()
 
@@ -104,9 +103,8 @@ func (s *debugSuite) TestConfigureDebugSnapdLogGoodValsNoChange(c *C) {
 }
 
 func (s *debugSuite) TestConfigureDebugSnapdLogBadVals(c *C) {
-	r := configcore.MockLoggerSimpleSetup(func(opts *logger.LoggerOptions) error {
+	r := configcore.MockLoggerSimpleSetup(func(opts *logger.LoggerOptions) {
 		c.Error("loggerSimpleSetup should not have been called")
-		return nil
 	})
 	defer r()
 

--- a/overlord/configstate/configcore/export_test.go
+++ b/overlord/configstate/configcore/export_test.go
@@ -86,7 +86,7 @@ func MockApparmorReloadAllSnapProfiles(f func() error) func() {
 	return testutil.Mock(&apparmorReloadAllSnapProfiles, f)
 }
 
-func MockLoggerSimpleSetup(f func(opts *logger.LoggerOptions) error) func() {
+func MockLoggerSimpleSetup(f func(opts *logger.LoggerOptions)) func() {
 	return testutil.Mock(&loggerSimpleSetup, f)
 }
 

--- a/tests/lib/fakestore/cmd/fakestore/main.go
+++ b/tests/lib/fakestore/cmd/fakestore/main.go
@@ -33,10 +33,7 @@ type Options struct{}
 var parser = flags.NewParser(&Options{}, flags.HelpFlag|flags.PassDoubleDash)
 
 func main() {
-	if err := logger.SimpleSetup(nil); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to activate logging: %v\n", err)
-		os.Exit(1)
-	}
+	logger.SimpleSetup(nil)
 	logger.Debugf("fakestore starting")
 
 	if err := run(); err != nil {

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -29,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/gadget/install"
-	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -66,9 +64,7 @@ func (c uc20Constraints) Classic() bool             { return false }
 func (c uc20Constraints) Grade() asserts.ModelGrade { return asserts.ModelSigned }
 
 func main() {
-	if err := logger.SimpleSetup(nil); err != nil {
-		fmt.Fprintf(os.Stderr, i18n.G("WARNING: failed to activate logging: %v\n"), err)
-	}
+	logger.SimpleSetup(nil)
 
 	args := &cmdCreatePartitions{}
 	if _, err := flags.ParseArgs(args, os.Args[1:]); err != nil {


### PR DESCRIPTION
This adds a new trace method for logging as well as `slog`'s json logger for builds with the `structuredlogger` tag. The json logging will only be used if the `SNAPD_USE_JSON_LOGGING` environment variable is set. The trace logging will only happen when `SNAPD_TRACE` is activated and only when the `structuredlogger` build tag is present.

Note: `slog` uses log levels inside its higher-order logging functions to determine what actually gets logged (e.g. if the level is set a debug, then it logs debug, info, and error). Properly showing the correct source file in the log entry required directly creating a record, which bypasses the level-checking mechanism. Rather than include those checks, I opted to simplify and use the same method already present in the other logger.