### PR TITLE
tests: revert account for snapd/kernel incompatibilty warning in prepare-image

### DIFF
--- a/tests/main/prepare-image-classic/task.yaml
+++ b/tests/main/prepare-image-classic/task.yaml
@@ -38,9 +38,6 @@ restore: |
     "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
     rm -rf "$ROOT"
 
-debug: |
-    cat stderr
-
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
@@ -66,10 +63,8 @@ execute: |
 
     # prepare-image ran as user so it warns about the ownership
     MATCH 'WARNING: ensure that the contents under .* are owned by root:root in the \(final\) image' < stderr
-    # check that the snapd/kernel incompatibility check is working
-    MATCH 'WARNING: snapd 2.68\+ is not compatible with a kernel containing snapd prior to 2.68' < stderr
     # But there are not other warnings/errors on stderr
-    wc -l < stderr | MATCH "^2$"
+    wc -l < stderr | MATCH "^1$"
 
     echo Verifying the result
     systemid="$(date +%Y%m%d)"


### PR DESCRIPTION
This reverts commit d086b44163dc3c93df8dec914481f6ca9e559617.

The `prepare-image-classic` test is failing, blocking other PRs from being merged. It only runs on jammy, which is required.

It seems the warning added by that commit is no longer occurring, likely because the kernel has been updated. Is this warning likely to be resolved permanently for this test, or do we expect it to recur later? If the latter, perhaps we need a more dynamic check.