### PR TITLE
tests: test ephemeral data loading

### DIFF
--- a/tests/lib/assertions/developer1-network-ephemeral-confdb.json
+++ b/tests/lib/assertions/developer1-network-ephemeral-confdb.json
@@ -1,0 +1,18 @@
+{
+	"type": "confdb-schema",
+	"account-id": "developer1",
+	"authority-id": "developer1",
+	"name": "network-ephemeral",
+	"views": {
+		"wifi-setup": {
+			"rules": [
+				{"request": "ssids", "storage": "wifi.ssids"},
+				{"request": "ssid", "storage": "wifi.ssid"},
+				{"request": "password", "storage": "wifi.psk"},
+				{"request": "status", "storage": "wifi.status"}
+			]
+		}
+	},
+	"body": "{\n  \"storage\": {\n    \"schema\": {\n      \"wifi\": {\n        \"schema\": {\n          \"psk\": {\n            \"ephemeral\": true,\n            \"type\": \"string\"\n          },\n          \"ssid\": \"string\",\n          \"ssids\": {\n            \"type\": \"array\",\n            \"unique\": true,\n            \"values\": \"string\"\n          },\n          \"status\": {\n            \"choices\": [\n              \"on\",\n              \"off\"\n            ],\n            \"type\": \"string\"\n          }\n        }\n      }\n    }\n  }\n}",
+	"timestamp": "2025-03-21T11:51:32Z"
+}

--- a/tests/lib/assertions/network-ephemeral.confdb
+++ b/tests/lib/assertions/network-ephemeral.confdb
@@ -1,0 +1,61 @@
+type: confdb-schema
+authority-id: developer1
+account-id: developer1
+name: network-ephemeral
+timestamp: 2025-03-21T11:51:32Z
+views:
+  wifi-setup:
+    rules:
+      -
+        request: ssids
+        storage: wifi.ssids
+      -
+        request: ssid
+        storage: wifi.ssid
+      -
+        request: password
+        storage: wifi.psk
+      -
+        request: status
+        storage: wifi.status
+body-length: 483
+sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+
+{
+  "storage": {
+    "schema": {
+      "wifi": {
+        "schema": {
+          "psk": {
+            "ephemeral": true,
+            "type": "string"
+          },
+          "ssid": "string",
+          "ssids": {
+            "type": "array",
+            "unique": true,
+            "values": "string"
+          },
+          "status": {
+            "choices": [
+              "on",
+              "off"
+            ],
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+
+AcLBUgQAAQoABgUCZ91TJAAAQ50QAFZ0FClC8Agmcs/p+wyZ/2O79fs1ojmHFPR2GkS+Rqoq9+RO
+Buy10/vGIDb8PdNQ0+b6d/prstvsuvEC9s5XJY34hDPdJyiTBYSfkyaDQT0NSyMt2KUcbnzdLj1L
+RA7HvMyX1miqmQBwK80XC3mmpjMUY8pQqXmPGkwYyaWp+naBDMVTDZMZmB36sBI6bU2mXMdg9BAS
+iDAosU4HnjDnbJOwyyF8mrrhrohrSYU8/AH7vIpP/56Up+WfV5wapmFE5j0kvcUKU44JRNNvnpF0
+FnJgRDidE9mzqPsgRO8DZVvqqx3MK+C3Np6Uc/zQBclgkhRrO5MC9ApVK3V7kkRSrfoKQzePxKLH
+JPGDw2lQfqdnyfVcTfSAsKDbD85M1wTLwcEIzg5y2+4+rJqM8KgQQ16smWv+N0m4vMNzpYRoRcju
+Pox9Qao4aVT6ffjS59Cm+6/JTJdjv7DReVG5WANc/HIRExxWwwHzjAu4KmCn+FXZUDrtL4LPNGPn
+jrdyZS2pUDZDqeU/j0bJhOX7WuBBoaq1shAGsoWmLFVU6eNo1nxiYg4x68Aervq9/rieF+aHjAXR
+EOnmmYbFAoYCxhpo4G82iXraIBmH1K7S/InCZEdI9sddBRYZGGNX+FaI17fIwB80f2yBNx0Qa3Qz
+7TNpKaAng8ogI2/oh2fXV0bFzL7Z

--- a/tests/main/confdb-cross-config/eph-schema.json
+++ b/tests/main/confdb-cross-config/eph-schema.json
@@ -1,0 +1,24 @@
+{
+	"storage": {
+		"schema": {
+			"wifi": {
+				"schema": {
+					"ssids": {
+						"type": "array",
+						"values": "string",
+						"unique": true
+					},
+					"ssid": "string",
+					"psk": {
+						"type": "string",
+						"ephemeral": true
+					},
+					"status": {
+						"type": "string",
+						"choices": ["on", "off"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/main/confdb-cross-config/loading-custodian/bin/sh
+++ b/tests/main/confdb-cross-config/loading-custodian/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/confdb-cross-config/loading-custodian/meta/hooks/change-view-manage-wifi
+++ b/tests/main/confdb-cross-config/loading-custodian/meta/hooks/change-view-manage-wifi
@@ -1,0 +1,8 @@
+#!/bin/sh -xe
+
+# save the original value so we can check it in the test
+value=$(snapctl get --view :manage-wifi password)
+echo "$value" >> "$SNAP_COMMON"/change-view-manage-wifi-ran
+
+# check we can modify it
+snapctl set --view :manage-wifi password="$value-changed"

--- a/tests/main/confdb-cross-config/loading-custodian/meta/hooks/load-view-manage-wifi
+++ b/tests/main/confdb-cross-config/loading-custodian/meta/hooks/load-view-manage-wifi
@@ -1,0 +1,8 @@
+#!/bin/sh -xe
+
+# save the existing value
+value=$(snapctl get --view :manage-wifi password 2>&1 || :)
+echo "$value" >> "$SNAP_COMMON"/load-view-manage-wifi-ran
+
+# load the ephemeral data
+snapctl set --view :manage-wifi password="loaded-secret"

--- a/tests/main/confdb-cross-config/loading-custodian/meta/hooks/query-view-manage-wifi
+++ b/tests/main/confdb-cross-config/loading-custodian/meta/hooks/query-view-manage-wifi
@@ -1,0 +1,8 @@
+#!/bin/sh -xe
+
+# save the previous value for test validation
+value=$(snapctl get --view :manage-wifi password)
+echo "$value" >> "$SNAP_COMMON"/query-view-manage-wifi-ran
+
+# add a suffix so we can check query-view can modify values
+snapctl set --view :manage-wifi password="$value-queried"

--- a/tests/main/confdb-cross-config/loading-custodian/meta/hooks/save-view-manage-wifi
+++ b/tests/main/confdb-cross-config/loading-custodian/meta/hooks/save-view-manage-wifi
@@ -1,0 +1,5 @@
+#!/bin/sh -xe
+
+# check that we save the right value
+value=$(snapctl get --view :manage-wifi password)
+echo "$value" >> "$SNAP_COMMON"/save-view-manage-wifi-ran

--- a/tests/main/confdb-cross-config/loading-custodian/meta/snap.yaml
+++ b/tests/main/confdb-cross-config/loading-custodian/meta/snap.yaml
@@ -1,0 +1,13 @@
+name: loading-custodian
+version: 1.0
+apps:
+  sh:
+    command: /bin/sh
+base: core24
+
+plugs:
+  manage-wifi:
+    interface: confdb
+    account: developer1
+    view: network-ephemeral/wifi-setup
+    role: custodian

--- a/tests/main/confdb-cross-config/task.yaml
+++ b/tests/main/confdb-cross-config/task.yaml
@@ -34,6 +34,7 @@ execute: |
     rm -f /var/snap/test-custodian-snap/common/*
     rm -f /var/snap/test-failing-custodian-snap/common/*
     rm -f /var/snap/test-snap/common/*
+    rm -f /var/snap/loading-custodian/common/*
   }
 
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -99,10 +100,51 @@ execute: |
   test "2" = "$(wc -l /var/snap/test-custodian-snap/common/save-view-manage-wifi-ran | awk '{printf $1}')"
   head -n 1 /var/snap/test-custodian-snap/common/save-view-manage-wifi-ran | MATCH "third-custodian-rollback"
   tail -n 1 /var/snap/test-custodian-snap/common/save-view-manage-wifi-ran | MATCH "second-custodian"
-  # check no other hooks were called (don't call view-change since the change failed)
+  # check no other hooks were called (don't call observe-view since the change failed)
   test "2" = "$(find /var/snap/test-custodian-snap/common/* -maxdepth 1 | wc -l)"
   test "1" = "$(find /var/snap/test-failing-custodian-snap/common/* -maxdepth 1 | wc -l)"
   test "0" = "$(find /var/snap/test-snap/common/* -maxdepth 1 | wc -l)"
   # still the same value
   snap get developer1/network/wifi-setup ssid | MATCH "second-custodian"
   resetTestState
+
+  # install a sole custodian that saves and loads data
+  snap remove --purge test-custodian-snap test-failing-custodian-snap test-snap
+  "$TESTSTOOLS"/snaps-state install-local loading-custodian
+  snap ack "$TESTSLIB/assertions/network-ephemeral.confdb"
+  snap connect loading-custodian:manage-wifi
+
+  # write some ephemeral data (i.e., password)
+  OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+  loading-custodian.sh -c 'snapctl set --view :manage-wifi ssid=my-ssid password=written-secret'
+  changeAfterID "$OLD_CHANGE"
+  retry -n 5 --wait 1 sh -c 'snap changes | tail -n 2 | grep "Done.*Set confdb through \"developer1/network-ephemeral/wifi-setup\""'
+
+  # the hooks get the expected data
+  MATCH 'written-secret' < /var/snap/loading-custodian/common/change-view-manage-wifi-ran
+  MATCH 'written-secret-changed' < /var/snap/loading-custodian/common/save-view-manage-wifi-ran
+  # snapd caches the written value
+  gojq -c '.data."confdb-databags".developer1."network-ephemeral".wifi.psk' < /var/lib/snapd/state.json | MATCH "written-secret-changed"
+
+  OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+  # we load the most up to date value from the custodian snap
+  loading-custodian.sh -c 'snapctl get --view :manage-wifi password' | MATCH "loaded-secret-queried"
+  changeAfterID "$OLD_CHANGE"
+  retry -n 5 --wait 1 sh -c 'snap changes | tail -n 2 | grep "Done.*Get confdb through \"developer1/network-ephemeral/wifi-setup\""'
+
+  # check that before loading we read the cached version from snapd and the load-view hook gets this
+  MATCH 'written-secret-changed' < /var/snap/loading-custodian/common/load-view-manage-wifi-ran
+  # but query-view gets the value load-view sets
+  MATCH "loaded-secret" < /var/snap/loading-custodian/common/query-view-manage-wifi-ran
+
+  # check that triggering the change from the API has the same effect
+  resetTestState
+  OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+  snap get developer1/network-ephemeral/wifi-setup password | MATCH "loaded-secret-queried"
+  changeAfterID "$OLD_CHANGE"
+  retry -n 5 --wait 1 sh -c 'snap changes | tail -n 2 | grep "Done.*Get confdb through \"developer1/network-ephemeral/wifi-setup\""'
+
+  # check we read the cached version before running any hooks (and load-view sees that)
+  MATCH 'written-secret-changed' < /var/snap/loading-custodian/common/load-view-manage-wifi-ran
+  # but query-view gets the value load-view sets
+  MATCH "loaded-secret" < /var/snap/loading-custodian/common/query-view-manage-wifi-ran


### PR DESCRIPTION
Adds checks to the confdb-cross-config test to check that custodians can save and load ephemeral data.
~~Based on https://github.com/canonical/snapd/pull/15228 so only commit [3414c29](https://github.com/canonical/snapd/pull/15245/commits/3414c2940f587dc330b140daf98c05356c34ddc4) is relevant to this PR~~