### PR TITLE
secboot: use new auth requestor without text/template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/canonical/go-efilib v1.4.1
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 // indirect
-	github.com/canonical/go-tpm2 v1.11.1
+	github.com/canonical/go-tpm2 v1.12.2
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2
 	github.com/gorilla/mux v1.8.0
@@ -21,7 +21,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250225135840-e07f4ae48e98
+	github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9 h1:Twk1ZSTWRClf
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9/go.mod h1:IneQ5/yQcfPXrGekEXpR6yeea55ZD24N5+kHzeDseOM=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=
-github.com/canonical/go-tpm2 v1.11.1 h1:RivdSXfBWWW+eFaFNYQby5+kVgY4km9eEayot1wX/qU=
-github.com/canonical/go-tpm2 v1.11.1/go.mod h1:zK+qESVwu78XyX+NPhiBdN+zwPPDoKk4rYlQ7VUsRp4=
+github.com/canonical/go-tpm2 v1.12.2 h1:7sWef6xVlWwBAn7hsY+3j62ANzoAO+GZvrltMHXq9RQ=
+github.com/canonical/go-tpm2 v1.12.2/go.mod h1:zK+qESVwu78XyX+NPhiBdN+zwPPDoKk4rYlQ7VUsRp4=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981 h1:vrUzSfbhl8mzdXPzjxq4jXZPCCNLv18jy6S7aVTS2tI=
 github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981/go.mod h1:ywdPBqUGkuuiitPpVWCfilf2/gq+frhq4CNiNs9KyHU=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
@@ -49,8 +49,8 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraK
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20250225135840-e07f4ae48e98 h1:slmWDMFeSWUX1F0C2C8VI9IW2kqejGZB/p7ECsq7HkA=
-github.com/snapcore/secboot v0.0.0-20250225135840-e07f4ae48e98/go.mod h1:2cqUsx8AzOpyo7IAkeAln8SEr9ymC/GVOrFEYNL0RrI=
+github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4 h1:ECxlsvtHL7HOv8wIsnF95kUkQrtE86cY/cylWVt2n0M=
+github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4/go.mod h1:Y3APoLyInDvY8mVP1qDQd/t9bPuNp2itYPCGrltRQoQ=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -169,11 +169,7 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, sealedE
 
 	const allowPassphrase = true
 	options := activateVolOpts(opts.AllowRecoveryKey, allowPassphrase, partDevice)
-	authRequestor, err := newAuthRequestor()
-	if err != nil {
-		res.UnlockMethod = NotUnlocked
-		return res, fmt.Errorf("internal error: cannot build an auth requestor: %v", err)
-	}
+	authRequestor := newAuthRequestor()
 
 	// Non-nil FDEHookKeyV1 indicates that V1 hook key is used
 	if loadedKey.FDEHookKeyV1 != nil {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -239,10 +239,10 @@ func activateVolOpts(allowRecoveryKey bool, allowPassphrase bool, legacyPaths ..
 	return &options
 }
 
-func newAuthRequestor() (sb.AuthRequestor, error) {
+func newAuthRequestor() sb.AuthRequestor {
 	return sb.NewSystemdAuthRequestor(
-		"Please enter the passphrase for volume {{.VolumeName}} for device {{.SourceDevicePath}}",
-		"Please enter the recovery key for volume {{.VolumeName}} for device {{.SourceDevicePath}}",
+		"Please enter the passphrase for volume %[1]s for device %[2]s",
+		"Please enter the recovery key for volume %[1]s for device %[2]s",
 	)
 }
 


### PR DESCRIPTION
See https://github.com/canonical/snapd/pull/15226 and https://github.com/canonical/secboot/pull/390

LP#2102456

~~IMPORTANT: This is dependent on https://github.com/canonical/snapd/pull/15226~~ Not really. Just not much point without it.