### PR TITLE
interfaces: inject dependency into snap services that have a gpio-chardev plug

### DIFF
--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -90,7 +90,7 @@ type commonInterface struct {
 
 	controlsDeviceCgroup bool
 
-	serviceSnippets []string
+	serviceSnippets []interfaces.PlugServiceSnippet
 }
 
 // Name returns the interface name.
@@ -116,7 +116,7 @@ func (iface *commonInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
-func (iface *commonInterface) ServicePermanentPlug(plug *snap.PlugInfo) []string {
+func (iface *commonInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
 	return iface.serviceSnippets
 }
 

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -90,7 +90,7 @@ type commonInterface struct {
 
 	controlsDeviceCgroup bool
 
-	serviceSnippets []interfaces.PlugServiceSnippet
+	serviceSnippets []interfaces.PlugServicesSnippet
 }
 
 // Name returns the interface name.
@@ -116,7 +116,7 @@ func (iface *commonInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
-func (iface *commonInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
+func (iface *commonInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServicesSnippet {
 	return iface.serviceSnippets
 }
 

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -731,10 +731,7 @@ const dockerSupportPrivilegedSecComp = `
 @unrestricted
 `
 
-var dockerSupportServiceSnippet = interfaces.PlugServiceSnippet{
-	Section: interfaces.PlugServiceSnippetServiceSection,
-	Content: "Delegate=true",
-}
+const dockerSupportServiceSnippet = interfaces.PlugServicesServiceSectionSnippet(`Delegate=true`)
 
 type dockerSupportInterface struct {
 	commonInterface
@@ -882,7 +879,7 @@ func init() {
 		baseDeclarationPlugs: dockerSupportBaseDeclarationPlugs,
 		baseDeclarationSlots: dockerSupportBaseDeclarationSlots,
 		controlsDeviceCgroup: true,
-		serviceSnippets:      []interfaces.PlugServiceSnippet{dockerSupportServiceSnippet},
+		serviceSnippets:      []interfaces.PlugServicesSnippet{dockerSupportServiceSnippet},
 		// docker-support also uses ptrace(trace), but it already declares this in
 		// the AppArmorConnectedPlug method
 	}})

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -731,7 +731,10 @@ const dockerSupportPrivilegedSecComp = `
 @unrestricted
 `
 
-const dockerSupportServiceSnippet = `Delegate=true`
+var dockerSupportServiceSnippet = interfaces.PlugServiceSnippet{
+	Section: interfaces.PlugServiceSnippetServiceSection,
+	Content: "Delegate=true",
+}
 
 type dockerSupportInterface struct {
 	commonInterface
@@ -879,7 +882,7 @@ func init() {
 		baseDeclarationPlugs: dockerSupportBaseDeclarationPlugs,
 		baseDeclarationSlots: dockerSupportBaseDeclarationSlots,
 		controlsDeviceCgroup: true,
-		serviceSnippets:      []string{dockerSupportServiceSnippet},
+		serviceSnippets:      []interfaces.PlugServiceSnippet{dockerSupportServiceSnippet},
 		// docker-support also uses ptrace(trace), but it already declares this in
 		// the AppArmorConnectedPlug method
 	}})

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -309,7 +309,7 @@ func (s *DockerSupportInterfaceSuite) TestUdevTaggingDisablingRemoveFirst(c *C) 
 func (s *DockerSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
-	c.Check(snips, DeepEquals, []string{"Delegate=true"})
+	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
 
 	// check that a malformed plug with bad attribute returns non-nil error
 	// from PermanentPlugServiceSnippets, thereby ensuring that function

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -309,7 +309,7 @@ func (s *DockerSupportInterfaceSuite) TestUdevTaggingDisablingRemoveFirst(c *C) 
 func (s *DockerSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
-	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
+	c.Check(snips, DeepEquals, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")})
 
 	// check that a malformed plug with bad attribute returns non-nil error
 	// from PermanentPlugServiceSnippets, thereby ensuring that function

--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -64,9 +64,9 @@ var gpioChardevConnectedSlotKmod = []string{
 	"gpio-aggregator",
 }
 
-var gpioChardevPlugServiceSnippets = []interfaces.PlugServiceSnippet{
-	{Section: interfaces.PlugServiceSnippetUnitSection, Content: "After=snapd.gpio-chardev-setup.target"},
-	{Section: interfaces.PlugServiceSnippetUnitSection, Content: "Wants=snapd.gpio-chardev-setup.target"},
+var gpioChardevPlugServiceSnippets = []interfaces.PlugServicesSnippet{
+	interfaces.PlugServicesUnitSectionSnippet(`After=snapd.gpio-chardev-setup.target`),
+	interfaces.PlugServicesUnitSectionSnippet(`Wants=snapd.gpio-chardev-setup.target`),
 }
 
 type gpioChardevInterface struct {

--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -64,6 +64,11 @@ var gpioChardevConnectedSlotKmod = []string{
 	"gpio-aggregator",
 }
 
+var gpioChardevPlugServiceSnippets = []interfaces.PlugServiceSnippet{
+	{Section: interfaces.PlugServiceSnippetUnitSection, Content: "After=snapd.gpio-chardev-setup.target"},
+	{Section: interfaces.PlugServiceSnippetUnitSection, Content: "Wants=snapd.gpio-chardev-setup.target"},
+}
+
 type gpioChardevInterface struct {
 	commonInterface
 }
@@ -208,6 +213,7 @@ func init() {
 			summary:                  gpioChardevSummary,
 			baseDeclarationSlots:     gpioChardevBaseDeclarationSlots,
 			connectedSlotKModModules: gpioChardevConnectedSlotKmod,
+			serviceSnippets:          gpioChardevPlugServiceSnippets,
 		},
 	})
 }

--- a/interfaces/builtin/gpio_chardev_test.go
+++ b/interfaces/builtin/gpio_chardev_test.go
@@ -271,10 +271,11 @@ TAG=="snap_my-device_interface_gpio_chardev_gpio-chardev-good-slot", TAG+="snap_
 func (s *GpioChardevInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
-	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{
-		{Section: "unit", Content: "After=snapd.gpio-chardev-setup.target"},
-		{Section: "unit", Content: "Wants=snapd.gpio-chardev-setup.target"},
-	})
+	c.Assert(snips, HasLen, 2)
+	c.Check(string(snips[0].Section()), Equals, "unit")
+	c.Check(snips[0].String(), Equals, "After=snapd.gpio-chardev-setup.target")
+	c.Check(string(snips[1].Section()), Equals, "unit")
+	c.Check(snips[1].String(), Equals, "Wants=snapd.gpio-chardev-setup.target")
 }
 
 func (s *GpioChardevInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/gpio_chardev_test.go
+++ b/interfaces/builtin/gpio_chardev_test.go
@@ -268,6 +268,15 @@ func (s *GpioChardevInterfaceSuite) TestUDevConnectedPlug(c *C) {
 TAG=="snap_my-device_interface_gpio_chardev_gpio-chardev-good-slot", TAG+="snap_consumer_app"`)
 }
 
+func (s *GpioChardevInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
+	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
+	c.Assert(err, IsNil)
+	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{
+		{Section: "unit", Content: "After=snapd.gpio-chardev-setup.target"},
+		{Section: "unit", Content: "Wants=snapd.gpio-chardev-setup.target"},
+	})
+}
+
 func (s *GpioChardevInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)

--- a/interfaces/builtin/gpio_chardev_test.go
+++ b/interfaces/builtin/gpio_chardev_test.go
@@ -272,9 +272,9 @@ func (s *GpioChardevInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
 	c.Assert(snips, HasLen, 2)
-	c.Check(string(snips[0].Section()), Equals, "Unit")
+	c.Check(string(snips[0].SystemdConfSection()), Equals, "Unit")
 	c.Check(snips[0].String(), Equals, "After=snapd.gpio-chardev-setup.target")
-	c.Check(string(snips[1].Section()), Equals, "Unit")
+	c.Check(string(snips[1].SystemdConfSection()), Equals, "Unit")
 	c.Check(snips[1].String(), Equals, "Wants=snapd.gpio-chardev-setup.target")
 }
 

--- a/interfaces/builtin/gpio_chardev_test.go
+++ b/interfaces/builtin/gpio_chardev_test.go
@@ -272,9 +272,9 @@ func (s *GpioChardevInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
 	c.Assert(snips, HasLen, 2)
-	c.Check(string(snips[0].Section()), Equals, "unit")
+	c.Check(string(snips[0].Section()), Equals, "Unit")
 	c.Check(snips[0].String(), Equals, "After=snapd.gpio-chardev-setup.target")
-	c.Check(string(snips[1].Section()), Equals, "unit")
+	c.Check(string(snips[1].Section()), Equals, "Unit")
 	c.Check(snips[1].String(), Equals, "Wants=snapd.gpio-chardev-setup.target")
 }
 

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -400,7 +400,7 @@ mknod - |S_IFCHR -
 mknodat - - |S_IFCHR -
 `
 
-func (iface *greengrassSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []string {
+func (iface *greengrassSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
 	var flavor string
 	_ = plug.Attr("flavor", &flavor)
 
@@ -412,7 +412,10 @@ func (iface *greengrassSupportInterface) ServicePermanentPlug(plug *snap.PlugInf
 		return nil
 	}
 
-	return []string{"Delegate=true"}
+	return []interfaces.PlugServiceSnippet{{
+		Section: interfaces.PlugServiceSnippetServiceSection,
+		Content: "Delegate=true",
+	}}
 }
 
 func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -400,7 +400,7 @@ mknod - |S_IFCHR -
 mknodat - - |S_IFCHR -
 `
 
-func (iface *greengrassSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
+func (iface *greengrassSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServicesSnippet {
 	var flavor string
 	_ = plug.Attr("flavor", &flavor)
 
@@ -412,10 +412,9 @@ func (iface *greengrassSupportInterface) ServicePermanentPlug(plug *snap.PlugInf
 		return nil
 	}
 
-	return []interfaces.PlugServiceSnippet{{
-		Section: interfaces.PlugServiceSnippetServiceSection,
-		Content: "Delegate=true",
-	}}
+	return []interfaces.PlugServicesSnippet{
+		interfaces.PlugServicesServiceSectionSnippet("Delegate=true"),
+	}
 }
 
 func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -263,10 +263,10 @@ func (s *GreengrassSupportInterfaceSuite) TestPermanentSlotAppArmorSessionClassi
 func (s *GreengrassSupportInterfaceSuite) TestPermanentPlugServiceSnippets(c *C) {
 	for _, t := range []struct {
 		plug *snap.PlugInfo
-		exp  []interfaces.PlugServiceSnippet
+		exp  []interfaces.PlugServicesSnippet
 	}{
-		{s.plugInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
-		{s.containerModePlugInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
+		{s.plugInfo, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")}},
+		{s.containerModePlugInfo, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")}},
 		// the process-mode or no-container plug doesn't get Delegate=true
 		{s.processModePlugInfo, nil},
 	} {

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -263,10 +263,10 @@ func (s *GreengrassSupportInterfaceSuite) TestPermanentSlotAppArmorSessionClassi
 func (s *GreengrassSupportInterfaceSuite) TestPermanentPlugServiceSnippets(c *C) {
 	for _, t := range []struct {
 		plug *snap.PlugInfo
-		exp  []string
+		exp  []interfaces.PlugServiceSnippet
 	}{
-		{s.plugInfo, []string{"Delegate=true"}},
-		{s.containerModePlugInfo, []string{"Delegate=true"}},
+		{s.plugInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
+		{s.containerModePlugInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
 		// the process-mode or no-container plug doesn't get Delegate=true
 		{s.processModePlugInfo, nil},
 	} {

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -293,7 +293,7 @@ type kubernetesSupportInterface struct {
 	commonInterface
 }
 
-func (iface *kubernetesSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []string {
+func (iface *kubernetesSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
 	// only autobind-unix flavor does not get Delegate=true, all other flavors
 	// are usable to manage control groups of processes/containers, and thus
 	// need Delegate=true
@@ -302,7 +302,10 @@ func (iface *kubernetesSupportInterface) ServicePermanentPlug(plug *snap.PlugInf
 		return nil
 	}
 
-	return []string{"Delegate=true"}
+	return []interfaces.PlugServiceSnippet{{
+		Section: interfaces.PlugServiceSnippetServiceSection,
+		Content: "Delegate=true",
+	}}
 }
 
 func k8sFlavor(plug interfaces.Attrer) string {

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -293,7 +293,7 @@ type kubernetesSupportInterface struct {
 	commonInterface
 }
 
-func (iface *kubernetesSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
+func (iface *kubernetesSupportInterface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServicesSnippet {
 	// only autobind-unix flavor does not get Delegate=true, all other flavors
 	// are usable to manage control groups of processes/containers, and thus
 	// need Delegate=true
@@ -302,10 +302,9 @@ func (iface *kubernetesSupportInterface) ServicePermanentPlug(plug *snap.PlugInf
 		return nil
 	}
 
-	return []interfaces.PlugServiceSnippet{{
-		Section: interfaces.PlugServiceSnippetServiceSection,
-		Content: "Delegate=true",
-	}}
+	return []interfaces.PlugServicesSnippet{
+		interfaces.PlugServicesServiceSectionSnippet("Delegate=true"),
+	}
 }
 
 func k8sFlavor(plug interfaces.Attrer) string {

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -284,11 +284,11 @@ func (s *KubernetesSupportInterfaceSuite) TestInterfaces(c *C) {
 func (s *KubernetesSupportInterfaceSuite) TestPermanentPlugServiceSnippets(c *C) {
 	for _, t := range []struct {
 		plug *snap.PlugInfo
-		exp  []string
+		exp  []interfaces.PlugServiceSnippet
 	}{
-		{s.plugInfo, []string{"Delegate=true"}},
-		{s.plugKubeletInfo, []string{"Delegate=true"}},
-		{s.plugKubeproxyInfo, []string{"Delegate=true"}},
+		{s.plugInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
+		{s.plugKubeletInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
+		{s.plugKubeproxyInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
 		// only autobind-unix flavor does not get Delegate=true
 		{s.plugKubeAutobindInfo, nil},
 	} {

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -284,11 +284,11 @@ func (s *KubernetesSupportInterfaceSuite) TestInterfaces(c *C) {
 func (s *KubernetesSupportInterfaceSuite) TestPermanentPlugServiceSnippets(c *C) {
 	for _, t := range []struct {
 		plug *snap.PlugInfo
-		exp  []interfaces.PlugServiceSnippet
+		exp  []interfaces.PlugServicesSnippet
 	}{
-		{s.plugInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
-		{s.plugKubeletInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
-		{s.plugKubeproxyInfo, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}}},
+		{s.plugInfo, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")}},
+		{s.plugKubeletInfo, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")}},
+		{s.plugKubeproxyInfo, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")}},
 		// only autobind-unix flavor does not get Delegate=true
 		{s.plugKubeAutobindInfo, nil},
 	} {

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -68,7 +68,10 @@ const lxdSupportConnectedPlugSecComp = `
 @unrestricted
 `
 
-const lxdSupportServiceSnippet = `Delegate=true`
+var lxdSupportServiceSnippet = interfaces.PlugServiceSnippet{
+	Section: interfaces.PlugServiceSnippetServiceSection,
+	Content: "Delegate=true",
+}
 
 type lxdSupportInterface struct {
 	commonInterface
@@ -129,6 +132,6 @@ func init() {
 		controlsDeviceCgroup:    true,
 		baseDeclarationSlots:    lxdSupportBaseDeclarationSlots,
 		baseDeclarationPlugs:    lxdSupportBaseDeclarationPlugs,
-		serviceSnippets:         []string{lxdSupportServiceSnippet}},
+		serviceSnippets:         []interfaces.PlugServiceSnippet{lxdSupportServiceSnippet}},
 	})
 }

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -68,10 +68,7 @@ const lxdSupportConnectedPlugSecComp = `
 @unrestricted
 `
 
-var lxdSupportServiceSnippet = interfaces.PlugServiceSnippet{
-	Section: interfaces.PlugServiceSnippetServiceSection,
-	Content: "Delegate=true",
-}
+const lxdSupportServiceSnippet = interfaces.PlugServicesServiceSectionSnippet(`Delegate=true`)
 
 type lxdSupportInterface struct {
 	commonInterface
@@ -132,6 +129,6 @@ func init() {
 		controlsDeviceCgroup:    true,
 		baseDeclarationSlots:    lxdSupportBaseDeclarationSlots,
 		baseDeclarationPlugs:    lxdSupportBaseDeclarationPlugs,
-		serviceSnippets:         []interfaces.PlugServiceSnippet{lxdSupportServiceSnippet}},
+		serviceSnippets:         []interfaces.PlugServicesSnippet{lxdSupportServiceSnippet}},
 	})
 }

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -181,6 +181,6 @@ func (s *LxdSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
 	c.Assert(snips, HasLen, 1)
-	c.Check(string(snips[0].Section()), Equals, "Service")
+	c.Check(string(snips[0].SystemdConfSection()), Equals, "Service")
 	c.Check(snips[0].String(), Equals, "Delegate=true")
 }

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -180,5 +180,7 @@ func (s *LxdSupportInterfaceSuite) TestInterfaces(c *C) {
 func (s *LxdSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
-	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
+	c.Assert(snips, HasLen, 1)
+	c.Check(string(snips[0].Section()), Equals, "service")
+	c.Check(snips[0].String(), Equals, "Delegate=true")
 }

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -180,5 +180,5 @@ func (s *LxdSupportInterfaceSuite) TestInterfaces(c *C) {
 func (s *LxdSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
-	c.Check(snips, DeepEquals, []string{"Delegate=true"})
+	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
 }

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -181,6 +181,6 @@ func (s *LxdSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
 	c.Assert(snips, HasLen, 1)
-	c.Check(string(snips[0].Section()), Equals, "service")
+	c.Check(string(snips[0].Section()), Equals, "Service")
 	c.Check(snips[0].String(), Equals, "Delegate=true")
 }

--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -227,10 +227,7 @@ mknod - |S_IFBLK -
 mknodat - - |S_IFBLK -
 `
 
-var microstackSupportServiceSnippet = interfaces.PlugServiceSnippet{
-	Section: interfaces.PlugServiceSnippetServiceSection,
-	Content: "Delegate=true",
-}
+const microstackSupportServiceSnippet = interfaces.PlugServicesServiceSectionSnippet(`Delegate=true`)
 
 type microStackInterface struct {
 	commonInterface
@@ -264,6 +261,6 @@ func init() {
 		connectedPlugAppArmor:    microStackSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:     microStackSupportConnectedPlugSecComp,
 		connectedPlugKModModules: microStackSupportConnectedPlugKmod,
-		serviceSnippets:          []interfaces.PlugServiceSnippet{microstackSupportServiceSnippet},
+		serviceSnippets:          []interfaces.PlugServicesSnippet{microstackSupportServiceSnippet},
 	}})
 }

--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+import "github.com/snapcore/snapd/interfaces"
+
 /*
  * Microstack is a full OpenStack in a single snap package.
  * Virtual machines are spawned as QEMU processes with libvirt acting as a management
@@ -225,6 +227,11 @@ mknod - |S_IFBLK -
 mknodat - - |S_IFBLK -
 `
 
+var microstackSupportServiceSnippet = interfaces.PlugServiceSnippet{
+	Section: interfaces.PlugServiceSnippetServiceSection,
+	Content: "Delegate=true",
+}
+
 type microStackInterface struct {
 	commonInterface
 }
@@ -257,6 +264,6 @@ func init() {
 		connectedPlugAppArmor:    microStackSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:     microStackSupportConnectedPlugSecComp,
 		connectedPlugKModModules: microStackSupportConnectedPlugKmod,
-		serviceSnippets:          []string{`Delegate=true`},
+		serviceSnippets:          []interfaces.PlugServiceSnippet{microstackSupportServiceSnippet},
 	}})
 }

--- a/interfaces/builtin/microstack_support_test.go
+++ b/interfaces/builtin/microstack_support_test.go
@@ -145,6 +145,12 @@ func (s *microStackSupportInterfaceSuite) TestUDevConnectedPlug(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 0)
 }
 
+func (s *microStackSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
+	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
+	c.Assert(err, IsNil)
+	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
+}
+
 func (s *microStackSupportInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }

--- a/interfaces/builtin/microstack_support_test.go
+++ b/interfaces/builtin/microstack_support_test.go
@@ -148,7 +148,7 @@ func (s *microStackSupportInterfaceSuite) TestUDevConnectedPlug(c *C) {
 func (s *microStackSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
-	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
+	c.Check(snips, DeepEquals, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")})
 }
 
 func (s *microStackSupportInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/nomad_support.go
+++ b/interfaces/builtin/nomad_support.go
@@ -88,10 +88,7 @@ lchown
 lchownat
 `
 
-var nomadSupportServiceSnippet = interfaces.PlugServiceSnippet{
-	Section: interfaces.PlugServiceSnippetServiceSection,
-	Content: "Delegate=true",
-}
+const nomadSupportServiceSnippet = interfaces.PlugServicesServiceSectionSnippet(`Delegate=true`)
 
 type nomadSupportInterface struct {
 	commonInterface
@@ -108,6 +105,6 @@ func init() {
 		baseDeclarationSlots:  nomadSupportBaseDeclarationSlots,
 		connectedPlugAppArmor: nomadSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  nomadSupportConnectedPlugSecComp,
-		serviceSnippets:       []interfaces.PlugServiceSnippet{nomadSupportServiceSnippet},
+		serviceSnippets:       []interfaces.PlugServicesSnippet{nomadSupportServiceSnippet},
 	}})
 }

--- a/interfaces/builtin/nomad_support.go
+++ b/interfaces/builtin/nomad_support.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+import "github.com/snapcore/snapd/interfaces"
+
 // The nomad-support interface enables running Hashicorp Nomad within
 // a strictly confined snap
 // https://www.nomadproject.io/
@@ -86,6 +88,11 @@ lchown
 lchownat
 `
 
+var nomadSupportServiceSnippet = interfaces.PlugServiceSnippet{
+	Section: interfaces.PlugServiceSnippetServiceSection,
+	Content: "Delegate=true",
+}
+
 type nomadSupportInterface struct {
 	commonInterface
 }
@@ -101,6 +108,6 @@ func init() {
 		baseDeclarationSlots:  nomadSupportBaseDeclarationSlots,
 		connectedPlugAppArmor: nomadSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  nomadSupportConnectedPlugSecComp,
-		serviceSnippets:       []string{`Delegate=true`},
+		serviceSnippets:       []interfaces.PlugServiceSnippet{nomadSupportServiceSnippet},
 	}})
 }

--- a/interfaces/builtin/nomad_support_test.go
+++ b/interfaces/builtin/nomad_support_test.go
@@ -101,7 +101,7 @@ func (s *nomadSupportInterfaceSuite) TestUdevSpec(c *C) {
 func (s *nomadSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
 	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
 	c.Assert(err, IsNil)
-	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
+	c.Check(snips, DeepEquals, []interfaces.PlugServicesSnippet{interfaces.PlugServicesServiceSectionSnippet("Delegate=true")})
 }
 
 func (s *nomadSupportInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/nomad_support_test.go
+++ b/interfaces/builtin/nomad_support_test.go
@@ -98,6 +98,12 @@ func (s *nomadSupportInterfaceSuite) TestUdevSpec(c *C) {
 	c.Assert(spec.ControlsDeviceCgroup(), Equals, true)
 }
 
+func (s *nomadSupportInterfaceSuite) TestServicePermanentPlugSnippets(c *C) {
+	snips, err := interfaces.PermanentPlugServiceSnippets(s.iface, s.plugInfo)
+	c.Assert(err, IsNil)
+	c.Check(snips, DeepEquals, []interfaces.PlugServiceSnippet{{Section: "service", Content: "Delegate=true"}})
+}
+
 func (s *nomadSupportInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, true)

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -286,12 +286,29 @@ type StaticInfo struct {
 	AppArmorUnconfinedSlots bool
 }
 
+type PlugServiceSnippetSection string
+
+const (
+	PlugServiceSnippetUnitSection    PlugServiceSnippetSection = "unit"
+	PlugServiceSnippetServiceSection PlugServiceSnippetSection = "service"
+)
+
+// PlugServiceSnippet describes a systemd service snippet to be generated
+// for a snap with a plug whose interface implements ServicePermanentPlug.
+type PlugServiceSnippet struct {
+	// Section is the target unit file section for the snippet to be
+	// injected in (i.e. [Unit], [Service]).
+	Section PlugServiceSnippetSection
+	// Content is the actual snippet to be injected.
+	Content string
+}
+
 // PermanentPlugServiceSnippets will return the set of snippets for the systemd
 // service unit that should be generated for a snap with the specified plug.
 // The list returned is not unique, callers must de-duplicate themselves.
 // The plug is provided because the snippet may depend on plug attributes for
 // example. The plug is sanitized before the snippets are returned.
-func PermanentPlugServiceSnippets(iface Interface, plug *snap.PlugInfo) (snips []string, err error) {
+func PermanentPlugServiceSnippets(iface Interface, plug *snap.PlugInfo) (snips []PlugServiceSnippet, err error) {
 	// sanitize the plug first
 	err = BeforePreparePlug(iface, plug)
 	if err != nil {
@@ -299,7 +316,7 @@ func PermanentPlugServiceSnippets(iface Interface, plug *snap.PlugInfo) (snips [
 	}
 
 	type serviceSnippetPlugger interface {
-		ServicePermanentPlug(plug *snap.PlugInfo) []string
+		ServicePermanentPlug(plug *snap.PlugInfo) []PlugServiceSnippet
 	}
 	if iface, ok := iface.(serviceSnippetPlugger); ok {
 		snips = iface.ServicePermanentPlug(plug)

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -289,8 +289,8 @@ type StaticInfo struct {
 type PlugServicesSnippetSection string
 
 const (
-	PlugServicesSnippetUnitSection    PlugServicesSnippetSection = "unit"
-	PlugServicesSnippetServiceSection PlugServicesSnippetSection = "service"
+	PlugServicesSnippetUnitSection    PlugServicesSnippetSection = "Unit"
+	PlugServicesSnippetServiceSection PlugServicesSnippetSection = "Service"
 )
 
 // PlugServiceSnippet describes a systemd service snippet to be generated

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -286,19 +286,25 @@ type StaticInfo struct {
 	AppArmorUnconfinedSlots bool
 }
 
+// PlugServicesSnippetSection is the target systemd unit section for
+// a plug service snippet.
 type PlugServicesSnippetSection string
 
 const (
-	PlugServicesSnippetUnitSection    PlugServicesSnippetSection = "Unit"
+	// PlugServicesSnippetUnitSection indicates that the target systemd
+	// unit section for a plug service snippet is [Unit].
+	PlugServicesSnippetUnitSection PlugServicesSnippetSection = "Unit"
+	// PlugServicesSnippetServiceSection indicates that the target systemd
+	// unit section for a plug service snippet is [Service].
 	PlugServicesSnippetServiceSection PlugServicesSnippetSection = "Service"
 )
 
 // PlugServiceSnippet describes a systemd service snippet to be generated
 // for a snap with a plug whose interface implements ServicePermanentPlug.
 type PlugServicesSnippet interface {
-	// Section is the target unit file section for the snippet to be
+	// SystemdConfSection is the target unit file section for the snippet to be
 	// injected in (i.e. [Unit], [Service]).
-	Section() PlugServicesSnippetSection
+	SystemdConfSection() PlugServicesSnippetSection
 	// This is the actual snippet content to be injected.
 	String() string
 }
@@ -308,7 +314,7 @@ type PlugServicesSnippet interface {
 // implements ServicePermanentPlug.
 type PlugServicesUnitSectionSnippet string
 
-func (s PlugServicesUnitSectionSnippet) Section() PlugServicesSnippetSection {
+func (s PlugServicesUnitSectionSnippet) SystemdConfSection() PlugServicesSnippetSection {
 	return PlugServicesSnippetUnitSection
 }
 func (s PlugServicesUnitSectionSnippet) String() string { return string(s) }
@@ -318,7 +324,7 @@ func (s PlugServicesUnitSectionSnippet) String() string { return string(s) }
 // implements ServicePermanentPlug.
 type PlugServicesServiceSectionSnippet string
 
-func (s PlugServicesServiceSectionSnippet) Section() PlugServicesSnippetSection {
+func (s PlugServicesServiceSectionSnippet) SystemdConfSection() PlugServicesSnippetSection {
 	return PlugServicesSnippetServiceSection
 }
 func (s PlugServicesServiceSectionSnippet) String() string { return string(s) }

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -172,14 +172,14 @@ type serviceSnippetIface struct {
 
 	sanitizerErr error
 
-	snips []interfaces.PlugServiceSnippet
+	snips []interfaces.PlugServicesSnippet
 }
 
 func (ssi serviceSnippetIface) BeforePreparePlug(plug *snap.PlugInfo) error {
 	return ssi.sanitizerErr
 }
 
-func (ssi serviceSnippetIface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
+func (ssi serviceSnippetIface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServicesSnippet {
 	return ssi.snips
 }
 
@@ -188,9 +188,9 @@ func (s *CoreSuite) TestPermanentPlugServiceSnippets(c *C) {
 	// builtin package which set ByName to a real implementation
 	ssi := serviceSnippetIface{
 		simpleIface: simpleIface{name: "mock-service-snippets"},
-		snips: []interfaces.PlugServiceSnippet{
-			{interfaces.PlugServiceSnippetServiceSection, "foo1"},
-			{interfaces.PlugServiceSnippetUnitSection, "foo2"},
+		snips: []interfaces.PlugServicesSnippet{
+			interfaces.PlugServicesServiceSectionSnippet("foo1"),
+			interfaces.PlugServicesUnitSectionSnippet("foo2"),
 		},
 	}
 	r := builtin.MockInterface(ssi)
@@ -211,10 +211,11 @@ plugs:
 
 	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
 	c.Assert(err, IsNil)
-	c.Assert(snips, DeepEquals, []interfaces.PlugServiceSnippet{
-		{interfaces.PlugServiceSnippetServiceSection, "foo1"},
-		{interfaces.PlugServiceSnippetUnitSection, "foo2"},
-	})
+	c.Assert(snips, HasLen, 2)
+	c.Check(string(snips[0].Section()), Equals, "service")
+	c.Check(snips[0].String(), Equals, "foo1")
+	c.Check(string(snips[1].Section()), Equals, "unit")
+	c.Check(snips[1].String(), Equals, "foo2")
 }
 
 func (s *CoreSuite) TestPermanentPlugServiceSnippetsSanitizesPlugs(c *C) {

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -212,9 +212,9 @@ plugs:
 	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
 	c.Assert(err, IsNil)
 	c.Assert(snips, HasLen, 2)
-	c.Check(string(snips[0].Section()), Equals, "service")
+	c.Check(string(snips[0].Section()), Equals, "Service")
 	c.Check(snips[0].String(), Equals, "foo1")
-	c.Check(string(snips[1].Section()), Equals, "unit")
+	c.Check(string(snips[1].Section()), Equals, "Unit")
 	c.Check(snips[1].String(), Equals, "foo2")
 }
 

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -172,14 +172,14 @@ type serviceSnippetIface struct {
 
 	sanitizerErr error
 
-	snips []string
+	snips []interfaces.PlugServiceSnippet
 }
 
 func (ssi serviceSnippetIface) BeforePreparePlug(plug *snap.PlugInfo) error {
 	return ssi.sanitizerErr
 }
 
-func (ssi serviceSnippetIface) ServicePermanentPlug(plug *snap.PlugInfo) []string {
+func (ssi serviceSnippetIface) ServicePermanentPlug(plug *snap.PlugInfo) []interfaces.PlugServiceSnippet {
 	return ssi.snips
 }
 
@@ -188,7 +188,10 @@ func (s *CoreSuite) TestPermanentPlugServiceSnippets(c *C) {
 	// builtin package which set ByName to a real implementation
 	ssi := serviceSnippetIface{
 		simpleIface: simpleIface{name: "mock-service-snippets"},
-		snips:       []string{"foo1", "foo2"},
+		snips: []interfaces.PlugServiceSnippet{
+			{interfaces.PlugServiceSnippetServiceSection, "foo1"},
+			{interfaces.PlugServiceSnippetUnitSection, "foo2"},
+		},
 	}
 	r := builtin.MockInterface(ssi)
 	defer r()
@@ -208,7 +211,10 @@ plugs:
 
 	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
 	c.Assert(err, IsNil)
-	c.Assert(snips, DeepEquals, []string{"foo1", "foo2"})
+	c.Assert(snips, DeepEquals, []interfaces.PlugServiceSnippet{
+		{interfaces.PlugServiceSnippetServiceSection, "foo1"},
+		{interfaces.PlugServiceSnippetUnitSection, "foo2"},
+	})
 }
 
 func (s *CoreSuite) TestPermanentPlugServiceSnippetsSanitizesPlugs(c *C) {

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -212,9 +212,9 @@ plugs:
 	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
 	c.Assert(err, IsNil)
 	c.Assert(snips, HasLen, 2)
-	c.Check(string(snips[0].Section()), Equals, "Service")
+	c.Check(string(snips[0].SystemdConfSection()), Equals, "Service")
 	c.Check(snips[0].String(), Equals, "foo1")
-	c.Check(string(snips[1].Section()), Equals, "Unit")
+	c.Check(string(snips[1].SystemdConfSection()), Equals, "Unit")
 	c.Check(snips[1].String(), Equals, "foo2")
 }
 

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -105,13 +105,13 @@ func GenerateSnapServiceUnitFile(appInfo *snap.AppInfo, opts *SnapServicesUnitOp
 			return nil, fmt.Errorf("error processing plugs while generating service unit for %v: %v", appInfo.SecurityTag(), err)
 		}
 		for _, snip := range snips {
-			switch snip.Section() {
+			switch snip.SystemdConfSection() {
 			case interfaces.PlugServicesSnippetUnitSection:
 				ifaceUnitSnippets.Put(snip.String())
 			case interfaces.PlugServicesSnippetServiceSection:
 				ifaceServiceSnippets.Put(snip.String())
 			default:
-				return nil, fmt.Errorf("internal error: unknown plug service snippet section %q", snip.Section())
+				return nil, fmt.Errorf("internal error: unknown plug service snippet section %q", snip.SystemdConfSection())
 			}
 		}
 	}

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -105,13 +105,13 @@ func GenerateSnapServiceUnitFile(appInfo *snap.AppInfo, opts *SnapServicesUnitOp
 			return nil, fmt.Errorf("error processing plugs while generating service unit for %v: %v", appInfo.SecurityTag(), err)
 		}
 		for _, snip := range snips {
-			switch snip.Section {
-			case interfaces.PlugServiceSnippetUnitSection:
-				ifaceUnitSnippets.Put(snip.Content)
-			case interfaces.PlugServiceSnippetServiceSection:
-				ifaceServiceSnippets.Put(snip.Content)
+			switch snip.Section() {
+			case interfaces.PlugServicesSnippetUnitSection:
+				ifaceUnitSnippets.Put(snip.String())
+			case interfaces.PlugServicesSnippetServiceSection:
+				ifaceServiceSnippets.Put(snip.String())
 			default:
-				return nil, fmt.Errorf("internal error: unknown plug service snippet section %q", snip.Section)
+				return nil, fmt.Errorf("internal error: unknown plug service snippet section %q", snip.Section())
 			}
 		}
 	}

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -93,6 +93,7 @@ func GenerateSnapServiceUnitFile(appInfo *snap.AppInfo, opts *SnapServicesUnitOp
 	// value, but for some directives, systemd combines their values into a
 	// list.
 	ifaceServiceSnippets := &strutil.OrderedSet{}
+	ifaceUnitSnippets := &strutil.OrderedSet{}
 
 	for _, plug := range appInfo.Plugs {
 		iface, err := interfaces.ByName(plug.Interface)
@@ -104,13 +105,21 @@ func GenerateSnapServiceUnitFile(appInfo *snap.AppInfo, opts *SnapServicesUnitOp
 			return nil, fmt.Errorf("error processing plugs while generating service unit for %v: %v", appInfo.SecurityTag(), err)
 		}
 		for _, snip := range snips {
-			ifaceServiceSnippets.Put(snip)
+			switch snip.Section {
+			case interfaces.PlugServiceSnippetUnitSection:
+				ifaceUnitSnippets.Put(snip.Content)
+			case interfaces.PlugServiceSnippetServiceSection:
+				ifaceServiceSnippets.Put(snip.Content)
+			default:
+				return nil, fmt.Errorf("internal error: unknown plug service snippet section %q", snip.Section)
+			}
 		}
 	}
 
 	// join the service snippets into one string to be included in the
 	// template
 	ifaceSpecifiedServiceSnippet := strings.Join(ifaceServiceSnippets.Items(), "\n")
+	ifaceSpecifiedUnitSnippet := strings.Join(ifaceUnitSnippets.Items(), "\n")
 
 	serviceTemplate := `[Unit]
 # Auto-generated, DO NOT EDIT
@@ -130,6 +139,9 @@ Before={{ stringsJoin .Before " "}}
 {{- if .CoreMountedSnapdSnapDep}}
 Wants={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
 After={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
+{{- end}}
+{{- if .InterfaceUnitSnippets}}
+{{.InterfaceUnitSnippets}}
 {{- end}}
 X-Snappy=yes
 
@@ -256,6 +268,7 @@ WantedBy={{.ServicesTarget}}
 		Before                   []string
 		After                    []string
 		InterfaceServiceSnippets string
+		InterfaceUnitSnippets    string
 		SliceUnit                string
 		LogNamespace             string
 
@@ -267,6 +280,7 @@ WantedBy={{.ServicesTarget}}
 		App: appInfo,
 
 		InterfaceServiceSnippets: ifaceSpecifiedServiceSnippet,
+		InterfaceUnitSnippets:    ifaceSpecifiedUnitSnippet,
 
 		Restart:        restartCond,
 		StopTimeout:    serviceStopTimeout(appInfo),

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -919,7 +919,7 @@ WantedBy=multi-user.target
 
 type mockBadPlugSnippetSection string
 
-func (s mockBadPlugSnippetSection) Section() interfaces.PlugServicesSnippetSection {
+func (s mockBadPlugSnippetSection) SystemdConfSection() interfaces.PlugServicesSnippetSection {
 	return "bad"
 }
 func (s mockBadPlugSnippetSection) String() string { return string(s) }


### PR DESCRIPTION
This PR extends plug service snippets to allow specifying target section as originally it implicitly injected the snippets into the `[Serivce]` section. Using the new mechanism, it injects a Wants/After relation into consumer services that reference a plug of gpio-chardev so that they are ordered after gpio setup is completed.