### PR TITLE
client: relax timeout err check

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -674,14 +674,14 @@ func (cs *integrationSuite) TestClientTimeoutLP1837804(c *C) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		time.Sleep(25 * time.Millisecond)
 	}))
-	defer func() { testServer.Close() }()
+	defer testServer.Close()
 
 	cli := client.New(&client.Config{BaseURL: testServer.URL})
 	_, err := cli.Do("GET", "/", nil, nil, nil, nil)
-	c.Assert(err, ErrorMatches, `.* timeout exceeded while waiting for response`)
+	c.Assert(err, ErrorMatches, `.*timeout.*`)
 
 	_, err = cli.Do("POST", "/", nil, nil, nil, nil)
-	c.Assert(err, ErrorMatches, `.* timeout exceeded while waiting for response`)
+	c.Assert(err, ErrorMatches, `.*timeout.*`)
 }
 
 func (cs *clientSuite) TestClientSystemRecoveryKeys(c *C) {


### PR DESCRIPTION
The test was failing due to a different timeout message thane expected. This relaxes the check a little bit to succeed on different timeout messages

```
client_test.go:684:
    c.Assert(err, ErrorMatches, `.* timeout exceeded while waiting for response`)
... error string = "cannot communicate with server: Post \"http://127.0.0.1:34801\": dial tcp 127.0.0.1:34801: i/o timeout"
... regex string = ".* timeout exceeded while waiting for response"
```