### PR TITLE
interfaces/system_key, many: return generated system key on mismatch

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -156,7 +156,7 @@ func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 	}
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
-	mismatch, err := interfaces.SystemKeyMismatch(extraData)
+	mismatch, _, err := interfaces.SystemKeyMismatch(extraData)
 	if err == nil && !mismatch {
 		return nil
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -154,7 +154,7 @@ var profilesNeedRegenerationImpl = func(m *InterfaceManager) bool {
 	extraData := interfaces.SystemKeyExtraData{
 		AppArmorPrompting: m.useAppArmorPrompting,
 	}
-	mismatch, err := interfaces.SystemKeyMismatch(extraData)
+	mismatch, _, err := interfaces.SystemKeyMismatch(extraData)
 	if err != nil {
 		logger.Noticef("error trying to compare the snap system key: %v", err)
 		return true


### PR DESCRIPTION
Since we will need to transfer the system key from snap client to snapd, return generated system key when a mismatch is detected.

Related: [SNAPDENG-34243](https://warthogs.atlassian.net/browse/SNAPDENG-34243)



[SNAPDENG-34243]: https://warthogs.atlassian.net/browse/SNAPDENG-34243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ