### PR TITLE
o/confdbstate: rework --pristine into --previous

### DIFF
--- a/overlord/confdbstate/transaction_test.go
+++ b/overlord/confdbstate/transaction_test.go
@@ -435,7 +435,7 @@ func (s *transactionTestSuite) TestAbortPreventsReadsAndWrites(c *C) {
 	c.Assert(err, ErrorMatches, "cannot commit aborted transaction")
 }
 
-func (s *transactionTestSuite) TestTransactionPristine(c *C) {
+func (s *transactionTestSuite) TestTransactionPrevious(c *C) {
 	bag := confdb.NewJSONDatabag()
 	err := bag.Set("foo", "bar")
 	c.Assert(err, IsNil)
@@ -449,16 +449,16 @@ func (s *transactionTestSuite) TestTransactionPristine(c *C) {
 	err = tx.Set("foo", "baz")
 	c.Assert(err, IsNil)
 
-	checkPristine := func(key, expected string) {
-		pristineBag := tx.Pristine()
-		val, err := pristineBag.Get(key)
+	checkPrevious := func() {
+		previousBag := tx.Previous()
+		val, err := previousBag.Get("foo")
 		c.Assert(err, IsNil)
-		c.Check(val, Equals, expected)
+		c.Check(val, Equals, "bar")
 	}
-	checkPristine("foo", "bar")
+	checkPrevious()
 
 	err = tx.Commit(s.state, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 
-	checkPristine("foo", "baz")
+	checkPrevious()
 }

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -50,7 +50,7 @@ type getCommand struct {
 	ForceSlotSide bool `long:"slot" description:"return attribute values from the slot side of the connection"`
 	ForcePlugSide bool `long:"plug" description:"return attribute values from the plug side of the connection"`
 	View          bool `long:"view" description:"return confdb values from the view declared in the plug"`
-	Pristine      bool `long:"pristine" description:"return confdb values disregarding changes from the current transaction"`
+	Previous      bool `long:"previous" description:"return confdb values disregarding changes from the current transaction"`
 
 	Positional struct {
 		PlugOrSlotSpec string   `positional-args:"true" positional-arg-name:":<plug|slot>"`
@@ -164,8 +164,8 @@ func (c *getCommand) Execute(args []string) error {
 	if c.Typed && c.Document {
 		return fmt.Errorf("cannot use -d and -t together")
 	}
-	if c.Pristine && !c.View {
-		return fmt.Errorf("cannot use --pristine without --view")
+	if c.Previous && !c.View {
+		return fmt.Errorf("cannot use --previous without --view")
 	}
 
 	if strings.Contains(c.Positional.PlugOrSlotSpec, ":") {
@@ -184,7 +184,7 @@ func (c *getCommand) Execute(args []string) error {
 			}
 
 			requests := c.Positional.Keys
-			return c.getConfdbValues(context, name, requests, c.Pristine)
+			return c.getConfdbValues(context, name, requests, c.Previous)
 		}
 
 		if len(c.Positional.Keys) == 0 {
@@ -370,7 +370,7 @@ func (c *getCommand) getInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	})
 }
 
-func (c *getCommand) getConfdbValues(ctx *hookstate.Context, plugName string, requests []string, pristine bool) error {
+func (c *getCommand) getConfdbValues(ctx *hookstate.Context, plugName string, requests []string, previous bool) error {
 	if c.ForcePlugSide || c.ForceSlotSide {
 		return errors.New(i18n.G("cannot use --plug or --slot with --view"))
 	}
@@ -393,8 +393,8 @@ func (c *getCommand) getConfdbValues(ctx *hookstate.Context, plugName string, re
 	}
 
 	var bag confdb.Databag = tx
-	if pristine {
-		bag = tx.Pristine()
+	if previous {
+		bag = tx.Previous()
 	}
 
 	res, err := confdbstate.GetViaView(bag, view, requests)


### PR DESCRIPTION
In order to make --pristine consistent with the features required for clustering, we need to rework into a --previous. This isn't semantically the same since --pristine ignored uncommitted changes but --previous ignores all of the transaction's changes (even committed) so the behaviour in `observe-view-<plug>` hooks will differ.
