### PR TITLE
s/a/notify: properly set protocol version in ioctl request buffer

### DIFF
--- a/sandbox/apparmor/notify/ioctl.go
+++ b/sandbox/apparmor/notify/ioctl.go
@@ -44,10 +44,10 @@ type IoctlRequestBuffer []byte
 // NewIoctlRequestBuffer returns a new buffer for communication with the kernel.
 //
 // The buffer contains encoded information about its size and protocol version.
-func NewIoctlRequestBuffer() IoctlRequestBuffer {
+func NewIoctlRequestBuffer(version ProtocolVersion) IoctlRequestBuffer {
 	bufSize := 0xFFFF
 	buf := bytes.NewBuffer(make([]byte, 0, bufSize))
-	header := MsgHeader{Version: 3, Length: uint16(bufSize)}
+	header := MsgHeader{Version: version, Length: uint16(bufSize)}
 	order := arch.Endian()
 	binary.Write(buf, order, &header)
 	buf.Write(make([]byte, bufSize-buf.Len()))

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -305,7 +305,7 @@ func (l *Listener) handleRequests() error {
 		// Prepare a receive buffer for incoming request. The buffer is of the
 		// maximum allowed size and will contain one or more kernel requests
 		// upon return.
-		ioctlBuf := notify.NewIoctlRequestBuffer()
+		ioctlBuf := notify.NewIoctlRequestBuffer(l.protocolVersion)
 		buf, err := l.doIoctl(notify.APPARMOR_NOTIF_RECV, ioctlBuf)
 		if err != nil {
 			return err

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -662,8 +662,10 @@ func (*listenerSuite) TestRunEpoll(c *C) {
 	})
 	defer restoreOpen()
 
+	protoVersion := notify.ProtocolVersion(12345)
+
 	restoreRegisterFileDescriptor := listener.MockNotifyRegisterFileDescriptor(func(fd uintptr) (notify.ProtocolVersion, error) {
-		return notify.ProtocolVersion(12345), nil
+		return protoVersion, nil
 	})
 	defer restoreRegisterFileDescriptor()
 
@@ -673,7 +675,7 @@ func (*listenerSuite) TestRunEpoll(c *C) {
 		case notify.APPARMOR_NOTIF_SET_FILTER:
 			c.Fatalf("unexpectedly called notifyIoctl directly: req: %v, buf: %v", req, buf)
 		case notify.APPARMOR_NOTIF_RECV:
-			buf := notify.NewIoctlRequestBuffer()
+			buf := notify.NewIoctlRequestBuffer(protoVersion)
 			n, err := unix.Read(int(fd), buf)
 			c.Assert(err, IsNil)
 			return buf[:n], nil
@@ -684,7 +686,6 @@ func (*listenerSuite) TestRunEpoll(c *C) {
 	})
 	defer restoreIoctl()
 
-	protoVersion := notify.ProtocolVersion(12345)
 	id := uint64(0x1234)
 	label := "snap.foo.bar"
 	path := "/home/Documents/foo/bar"


### PR DESCRIPTION
This is a follow-up to f04f00b2bb78b8f04f468b2a5765927d73136c9a (#15089) which fixes a place where the protocol version was erroneously left hard-coded.
