### PR TITLE
interfaces: add accel interface

### DIFF
--- a/interfaces/builtin/accel.go
+++ b/interfaces/builtin/accel.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const accelSummary = `allows access to devices in the compute accelerators subsystem`
+
+const accelBaseDeclarationSlots = `
+  accel:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const accelConnectedPlugAppArmor = `
+# Description: Provide permissions for accessing devices and files of the compute accelerator subsystem
+
+# Access to accel character devices such as /dev/accel/accel0
+#
+# https://docs.kernel.org/accel/introduction.html
+#
+/dev/accel/accel* rw,
+`
+
+var accelConnectedPlugUDev = []string{
+	`SUBSYSTEM=="accel", KERNEL=="accel*"`,
+}
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "accel",
+		summary:               accelSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  accelBaseDeclarationSlots,
+		connectedPlugAppArmor: accelConnectedPlugAppArmor,
+		connectedPlugUDev:     accelConnectedPlugUDev,
+	})
+}

--- a/interfaces/builtin/accel_test.go
+++ b/interfaces/builtin/accel_test.go
@@ -1,0 +1,138 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type accelSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+const accelMockPlugSnapInfoYaml = `name: accel
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [accel]
+`
+
+const accelCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  accel:
+`
+
+var _ = Suite(&accelSuite{
+	iface: builtin.MustInterface("accel"),
+})
+
+func (s *accelSuite) SetUpTest(c *C) {
+	s.slot, s.slotInfo = MockConnectedSlot(c, accelCoreYaml, nil, "accel")
+	s.plug, s.plugInfo = MockConnectedPlug(c, accelMockPlugSnapInfoYaml, nil, "accel")
+}
+
+func (s *accelSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "accel")
+}
+
+func (s *accelSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
+
+	// connected plugs have a nil security snippet for seccomp
+	appSet, err = interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	seccompSpec := seccomp.NewSpecification(appSet)
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.Snippets(), HasLen, 0)
+}
+
+func (s *accelSuite) TestConnectedPlugSnippet(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.accel.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.accel.app"), testutil.Contains, "/dev/accel/accel* rw,\n")
+
+	appSet, err = interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	seccompSpec := seccomp.NewSpecification(appSet)
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string(nil))
+}
+
+func (s *accelSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *accelSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *accelSuite) TestUDevConnectedPlug(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := udev.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# accel
+SUBSYSTEM=="accel", KERNEL=="accel*", TAG+="snap_accel_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
+		`TAG=="snap_accel_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_accel_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *accelSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to devices in the compute accelerators subsystem`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *accelSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -5,6 +5,9 @@ description: Test policy app matching snapd version
 confinement: strict
 
 apps:
+  accel:
+    command: bin/run
+    plugs: [ accel ]
   acrn-support:
     command: bin/run
     plugs: [ acrn-support ]


### PR DESCRIPTION
This adds a simple interface for accessing char device nodes managed by the relatively new [accel kernel subsystem](https://docs.kernel.org/accel/introduction.html). This subsystem is in active use by Intel NPUs (neural processing units) and Intel Gaudi SoCs, and is expected to be adopted by other vendors in the future as well.

I've tested this new interface with a validation app that ships with the [`intel-npu-driver` snap](https://github.com/canonical/intel-npu-driver-snap) and it works as expected. Currently this snap (and a handful of others that our team manages for Intel) relies on the `custom-device` interface for accessing the accel device nodes, which also works fine, but a dedicated interface will be simpler to work with for snap creators and maintainers, especially as usage of the accel subsystem becomes more widespread. 


