### PR TITLE
kernel: workaround for wrong model base in 24.04/24.10

### DIFF
--- a/kernel/kernel_drivers.go
+++ b/kernel/kernel_drivers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -422,9 +423,23 @@ func NeedsKernelDriversTree(mod *asserts.Model) bool {
 	// TODO this won't work for a UC2{0,2} -> UC24+ remodel as we need the
 	// new model here. Get to this ASAP after snapd 2.62 release.
 	switch mod.Base() {
-	case "core20", "core22", "core22-desktop":
+	case "core22":
+		if mod.Classic() {
+			// This is a workaround for LP#2104933. The base should
+			// never have been core22 in 24.04/24.10.
+			return classic24ModelWithWrongBase()
+		}
+		return false
+	case "core20", "core22-desktop":
 		return false
 	default:
 		return true
 	}
+}
+
+// This is a workaround for LP#2104933. The base should never have been core22
+// in classic 24.04/24.10.
+func classic24ModelWithWrongBase() bool {
+	return release.ReleaseInfo.ID == "ubuntu" &&
+		(release.ReleaseInfo.VersionID == "24.04" || release.ReleaseInfo.VersionID == "24.10")
 }

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/kernel"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -711,6 +712,26 @@ func (s *kernelDriversTestSuite) TestNeedsKernelDriversTree(c *C) {
 	c.Assert(kernel.NeedsKernelDriversTree(uc16model), Equals, false)
 	uc20model := mockModel20plus(nil)
 	c.Assert(kernel.NeedsKernelDriversTree(uc20model), Equals, false)
+	uc22model := mockModel20plus(map[string]interface{}{"base": "core22"})
+	c.Assert(kernel.NeedsKernelDriversTree(uc22model), Equals, false)
 	uc24model := mockModel20plus(map[string]interface{}{"base": "core24"})
 	c.Assert(kernel.NeedsKernelDriversTree(uc24model), Equals, true)
+}
+
+func (s *kernelDriversTestSuite) TestNeedsKernelDriversTreeClassicWithWrongBase(c *C) {
+	for _, tc := range []struct {
+		version string
+		result  bool
+	}{
+		{"23.10", false},
+		{"24.04", true},
+		{"24.10", true},
+		{"25.04", false},
+	} {
+		defer release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: tc.version})()
+
+		uc22model := mockModel20plus(map[string]interface{}{"base": "core22",
+			"classic": "true", "distribution": "ubuntu"})
+		c.Assert(kernel.NeedsKernelDriversTree(uc22model), Equals, tc.result)
+	}
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7320,8 +7320,15 @@ func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnUCKernelRefreshHybrid(c *C
 }
 
 func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnUCKernelRefreshHybridOldBase(c *C) {
+	defer release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "22.04"})()
 	s.testGadgetUpdateTaskAddedOnUCKernelRefreshHybrid(c, "core22",
 		doesReRefresh|isHybrid)
+}
+
+func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnUCKernelRefreshHybridWrongBase(c *C) {
+	defer release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "24.04"})()
+	s.testGadgetUpdateTaskAddedOnUCKernelRefreshHybrid(c, "core22",
+		doesReRefresh|needsKernelSetup|isHybrid)
 }
 
 func (s *snapmgrTestSuite) testGadgetUpdateTaskAddedOnUCKernelRefreshHybrid(c *C, base string, opts int) {


### PR DESCRIPTION
Models in in classic 24.04/24.10 are base core22 while should have been core24. We check the model base to know if we need a drivers tree or not. Special-case these models so the kernel can be safely refreshed, workarounding LP#2104933.