### PR TITLE
tests/main/document-interfaces-url: remove confdb exemption

### DIFF
--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -45,8 +45,6 @@ execute: |
     # The expiry date is <expiration year>/<expiration month>      
     
     declare -A exclusion_map
-    # confdb are still in the experimental phase so its page is not exposed yet
-    exclusion_map["confdb"]="2025/06"
     # gpio-chardev is still in the experimental phase so its page is not exposed yet
     exclusion_map["gpio-chardev"]="2025/06"
     # need to add https://snapcraft.io/docs/checkbox-support-interface


### PR DESCRIPTION
I've removed the interfaces that now have documentation pages:

- [confdb](https://snapcraft.io/docs/confdb-interface)
- ~~[nomad-support](https://snapcraft.io/docs/nomad-support-interface)~~ (fixed  in #15277)

~~And bumped `checkbox-support` by a month since it's exemption has now expired and causing [PR tests to fail elsewhere](https://github.com/canonical/snapd/actions/runs/14188583880/job/39748766850)... #15104~~ (fixed  in #15277)

@ernestl 