### PR TITLE
tests/nested/manual/recovery-system-reboot: reenable encryption

### DIFF
--- a/tests/nested/manual/recovery-system-reboot/task.yaml
+++ b/tests/nested/manual/recovery-system-reboot/task.yaml
@@ -8,15 +8,8 @@ systems: [ubuntu-22.04-64, ubuntu-24.04-64]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/test-snapd-recovery-system-reboot-pc-{VERSION}.model
-  # TODO:FDEM:FIX: we should use NESTED_BUILD_SNAPD_FROM_CURRENT=true with
-  # NESTED_REPACK_KERNEL_SNAP=false and enable encryption. For now we
-  # disable it until since snap-bootstrap will not be new enough in
-  # the store. A more robust approach is to use the fakestore to
-  # provide/sign a repacked kernel.
-  # NESTED_ENABLE_TPM: true
-  # NESTED_ENABLE_SECURE_BOOT: true
-  NESTED_ENABLE_TPM: false
-  NESTED_ENABLE_SECURE_BOOT: false
+  NESTED_ENABLE_TPM: true
+  NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
   NESTED_REPACK_GADGET_SNAP: false
   NESTED_REPACK_KERNEL_SNAP: false


### PR DESCRIPTION
This reverts 525196558639a05fc320c969391e1d808e3d4b33
