### PR TITLE
cmd/snap-bootstrap: mount /lib/{modules,firmware} from snap as fallback

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_classic_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_classic_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -637,6 +638,13 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsSystemDiskParamPath(c *
 func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeWithComponentsHappyClassic(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
+	defer main.MockOsGetenv(func(envVar string) string {
+		if envVar == "CORE24_PLUS_INITRAMFS" {
+			return "1"
+		}
+		return ""
+	})()
+
 	restore := disks.MockMountPointDisksToPartitionMapping(
 		map[disks.Mountpoint]*disks.MockDiskMapping{
 			{Mountpoint: boot.InitramfsUbuntuSeedDir}: defaultBootWithSaveDisk,
@@ -707,6 +715,117 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeWithComponentsHa
 
 	checkKernelMounts(c, "/run/mnt/data", "/sysroot",
 		[]string{"comp1", "comp2", "comp3"}, []string{"11", "22", "33"}, nil, nil)
+	checkClassicSysrootMount(c)
+}
+
+func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunMode24KernelClassicNoDriversTree(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
+
+	defer main.MockOsGetenv(func(envVar string) string {
+		if envVar == "CORE24_PLUS_INITRAMFS" {
+			return "1"
+		}
+		return ""
+	})()
+
+	restore := disks.MockMountPointDisksToPartitionMapping(
+		map[disks.Mountpoint]*disks.MockDiskMapping{
+			{Mountpoint: boot.InitramfsUbuntuSeedDir}: defaultBootWithSaveDisk,
+			{Mountpoint: boot.InitramfsUbuntuBootDir}: defaultBootWithSaveDisk,
+			{Mountpoint: boot.InitramfsDataDir}:       defaultBootWithSaveDisk,
+			{Mountpoint: boot.InitramfsUbuntuSaveDir}: defaultBootWithSaveDisk,
+		},
+	)
+	defer restore()
+
+	restore = s.mockSystemdMountSequence(c, []systemdMount{
+		s.ubuntuLabelMount("ubuntu-boot", "run"),
+		s.ubuntuPartUUIDMount("ubuntu-seed-partuuid", "run"),
+		s.ubuntuPartUUIDMount("ubuntu-data-partuuid", "run"),
+		s.ubuntuPartUUIDMount("ubuntu-save-partuuid", "run"),
+		s.makeRunSnapSystemdMount(snap.TypeGadget, s.gadget),
+		s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
+	}, nil)
+	defer restore()
+
+	// mock a bootloader
+	bloader := boottest.MockUC20RunBootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
+	// set the current kernel
+	restore = bloader.SetEnabledKernel(s.kernel)
+	defer restore()
+
+	s.makeSnapFilesOnEarlyBootUbuntuData(c, s.kernel, s.core20, s.gadget)
+
+	// write modeenv
+	modeEnv := boot.Modeenv{
+		Mode:           "run",
+		Base:           s.core20.Filename(),
+		Gadget:         s.gadget.Filename(),
+		CurrentKernels: []string{s.kernel.Filename()},
+	}
+	err := modeEnv.WriteTo(boot.InitramfsDataDir)
+	c.Assert(err, IsNil)
+
+	// write gadget.yaml, which is checked for classic
+	writeGadget(c, "ubuntu-seed", "system-seed", "")
+
+	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+
+	// Check /lib/{modules,firmware} mounts
+	unitsPath := filepath.Join(dirs.GlobalRootDir, "run/systemd/system")
+	for _, subdir := range []string{"modules", "firmware"} {
+		what := filepath.Join("/run/mnt/kernel", subdir)
+		where := filepath.Join("/sysroot/usr/lib", subdir)
+		unit := systemd.EscapeUnitNamePath(where) + ".mount"
+		c.Check(filepath.Join(unitsPath, unit), testutil.FileEquals, fmt.Sprintf(`[Unit]
+Description=Mount of kernel drivers tree
+DefaultDependencies=no
+After=initrd-parse-etc.service
+Before=initrd-fs.target
+Before=umount.target
+Conflicts=umount.target
+
+[Mount]
+What=%s
+Where=%s
+Options=bind,shared
+`, what, where))
+
+		symlinkPath := filepath.Join(unitsPath, "initrd-fs.target.wants", unit)
+		target, err := os.Readlink(symlinkPath)
+		c.Assert(err, IsNil)
+		c.Assert(target, Equals, "../"+unit)
+	}
+
+	checkClassicSysrootMount(c)
+}
+
+func checkClassicSysrootMount(c *C) {
+	unitsPath := filepath.Join(dirs.GlobalRootDir, "run/systemd/system")
+	unitDir := dirs.SnapRuntimeServicesDirUnder(dirs.GlobalRootDir)
+	baseUnitPath := filepath.Join(unitDir, "sysroot.mount")
+	c.Assert(baseUnitPath, testutil.FileEquals, `[Unit]
+DefaultDependencies=no
+Before=initrd-root-fs.target
+After=snap-initramfs-mounts.service
+Before=umount.target
+Conflicts=umount.target
+
+[Mount]
+What=/run/mnt/data
+Where=/sysroot
+Type=none
+Options=bind
+`)
+
+	symlinkPath := filepath.Join(unitsPath, "initrd-root-fs.target.wants", "sysroot.mount")
+	target, err := os.Readlink(symlinkPath)
+	c.Assert(err, IsNil)
+	c.Assert(target, Equals, "../sysroot.mount")
 }
 
 func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeWithDriversTreeHappyClassic(c *C) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -362,6 +362,11 @@ What=%s
 Where=%s
 Options=bind,shared
 `, what, where))
+
+		symlinkPath := filepath.Join(unitsPath, "initrd-fs.target.wants", unit)
+		target, err := os.Readlink(symlinkPath)
+		c.Assert(err, IsNil)
+		c.Assert(target, Equals, "../"+unit)
 	}
 }
 

--- a/tests/lib/assertions/developer1-22-kernel-24-classic-dangerous.json
+++ b/tests/lib/assertions/developer1-22-kernel-24-classic-dangerous.json
@@ -1,0 +1,42 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "developer1-22-kernel-24-classic-dangerous",
+    "architecture": "amd64",
+    "timestamp": "2025-04-02T22:00:00+00:00",
+    "grade": "dangerous",
+    "base": "core22",
+    "classic": "true",
+    "distribution": "ubuntu",
+    "serial-authority": [
+        "generic"
+    ],
+    "snaps": [
+        {
+            "default-channel": "22/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+            "name": "core22",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        }
+    ]
+}

--- a/tests/nested/manual/muinstaller-oldbasenewkernel/task.yaml
+++ b/tests/nested/manual/muinstaller-oldbasenewkernel/task.yaml
@@ -1,0 +1,117 @@
+summary: Check for hybrid models using core22 with 24 kernel
+
+details: Check for hybrid models using core22 with 24 kernel
+
+systems: [ubuntu-24*]
+
+environment:
+  NESTED_ENABLE_TPM: true
+  NESTED_ENABLE_SECURE_BOOT: true
+
+  # ensure we use our latest code
+  NESTED_BUILD_SNAPD_FROM_CURRENT: true
+  NESTED_REPACK_KERNEL_SNAP: true
+  NESTED_ENABLE_OVMF: true
+  # store related setup
+  STORE_ADDR: localhost:11028
+  STORE_DIR: $(pwd)/fake-store-blobdir
+  # image
+  IMAGE_MOUNTPOINT: /mnt/cloudimg
+
+prepare: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+  "$TESTSTOOLS"/store-state setup-fake-store "$STORE_DIR"
+
+restore: |
+  "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
+  rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
+
+execute: |
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB/prepare.sh"
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB"/nested.sh
+
+  echo "Expose the needed assertions through the fakestore"
+  cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$STORE_DIR/asserts"
+  export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
+
+  core_version=22
+  kernel_version="$(nested_get_version)"
+
+  # Retrieve the gadget
+  snap download --basename=pc --channel="$core_version/edge" pc
+  # the fakestore needs the assertion
+  snap ack pc.assert
+  # keep original blob just so we can find the assertion later
+  cp pc.snap pc.snap.orig
+
+  # New modified gadget
+  unsquashfs -d pc-gadget pc.snap
+  echo 'console=ttyS0 systemd.journald.forward_to_console=1' > pc-gadget/cmdline.extra
+  echo "Sign the shim binary"
+  KEY_NAME=$(tests.nested download snakeoil-key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+  tests.nested secboot-sign gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  snap pack --filename=pc.snap pc-gadget/
+
+  # Retrieve kernel
+  snap download --basename=pc-kernel-from-store --channel="$kernel_version/edge" pc-kernel
+  # the fakestore needs this assertion
+  snap ack pc-kernel-from-store.assert
+  # Build kernel with initramfs with the compiled snap-bootstrap
+  uc24_build_initramfs_kernel_snap "$PWD/pc-kernel-from-store.snap" "$NESTED_ASSETS_DIR"
+  mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel-repacked.snap
+
+  gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-22-kernel-24-classic-dangerous.json > classic.model
+
+  # create new disk for the installer to work on and attach to VM
+  truncate --size=6G disk.img
+
+  # setup_nested_hybrid_system.sh runs the muinstaller to install a hybrid
+  # system
+  # shellcheck disable=SC2086
+  "${TESTSTOOLS}"/setup_nested_hybrid_system.sh \
+     --model classic.model \
+     --store-dir "${STORE_DIR}" \
+     --gadget pc.snap \
+     --gadget-assertion pc.assert \
+     --kernel pc-kernel-repacked.snap \
+     --kernel-assertion pc-kernel-from-store.assert \
+     --disk disk.img
+
+  # basic things look fine
+  remote.exec "cat /etc/os-release" | MATCH 'NAME="Ubuntu"'
+  remote.exec "snap changes" | MATCH "Done.* Initialize system state"
+  remote.exec "snap list" | MATCH pc-kernel
+
+  # Check the model is as expected
+  remote.exec snap known model | MATCH '^base: core22'
+
+  # Check that a drivers tree was created
+  krel=$(remote.exec uname -r)
+  drivers_tree=/var/lib/snapd/kernel/pc-kernel/x1/lib/modules/"$krel"/
+  remote.exec stat "$drivers_tree"
+  # Must be a symlink
+  remote.exec readlink /lib/modules/"$krel"/kernel | MATCH /snap/pc-kernel/x1/modules/"$krel"/kernel
+  remote.exec lsmod | MATCH efi_pstore
+
+  # Now forcibly remove the drivers tree
+  remote.exec sudo rm -rf /var/lib/snapd/kernel/
+
+  # Reboot
+  boot_id=$(tests.nested boot-id)
+  remote.exec sudo reboot || true
+  tests.nested wait-for reboot "$boot_id"
+
+  # We still get modules, but mounted directly from the kernel snap
+  remote.exec mountpoint /run/mnt/kernel
+  remote.exec mount | MATCH 'pc-kernel_.*.snap on /usr/lib/modules'
+  remote.exec mount | MATCH 'pc-kernel_.*.snap on /usr/lib/firmware'
+  remote.exec lsmod | MATCH efi_pstore


### PR DESCRIPTION
In case we do not have a drivers tree on 24+, mount /lib/{modules,firmware} from the kernel snap as a fallback. This should not really happen and we do not support fully this scenario, but there are cases where this might be necessary, like if somebody uses a core22 model but install a 24+ kernel.