### PR TITLE
tests/main/document-interfaces-url: updated expiration dates and removed nomad-support

### DIFF
--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -46,14 +46,12 @@ execute: |
     
     declare -A exclusion_map
     # confdb are still in the experimental phase so its page is not exposed yet
-    exclusion_map["confdb"]="2025/04"
+    exclusion_map["confdb"]="2025/06"
     # gpio-chardev is still in the experimental phase so its page is not exposed yet
-    exclusion_map["gpio-chardev"]="2025/04"
-    # we're actually missing this page but can't add it yet due to the same Discourse issues
-    exclusion_map["nomad-support"]="2024/12"
+    exclusion_map["gpio-chardev"]="2025/06"
     # need to add https://snapcraft.io/docs/checkbox-support-interface
     # as well as a link to it on https://snapcraft.io/docs/supported-interfaces
-    exclusion_map["checkbox-support"]="2025/03"
+    exclusion_map["checkbox-support"]="2025/06"
 
     # If the interface is in the exclusion_map and it is currently sooner
     # than its specified expiration date, then return true


### PR DESCRIPTION
Fixed document-interfaces-url check issue that is now showing in tests [during testing](https://github.com/canonical/snapd/actions/runs/14208273236/job/39810952635?pr=15276) because of expired exclusion date. Also moved forward dates for others that will expire soon.

![image](https://github.com/user-attachments/assets/80dd9635-5618-4a20-b454-f1106337b48c)
