### PR TITLE
tests: remove confdb docs exclusion

### DIFF
--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -45,8 +45,6 @@ execute: |
     # The expiry date is <expiration year>/<expiration month>      
     
     declare -A exclusion_map
-    # confdb are still in the experimental phase so its page is not exposed yet
-    exclusion_map["confdb"]="2025/06"
     # gpio-chardev is still in the experimental phase so its page is not exposed yet
     exclusion_map["gpio-chardev"]="2025/06"
     # need to add https://snapcraft.io/docs/checkbox-support-interface


### PR DESCRIPTION
We don't need the confdb exclusion for document-interfaces-url, since the docs https://snapcraft.io/docs/confdb-interface were created last year