### PR TITLE
interfaces/system_key: system key mismatch policy

### DIFF
--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -391,3 +391,73 @@ func MockSystemKey(s string) func() {
 	mockedSystemKey = sk.(*systemKey)
 	return func() { mockedSystemKey = nil }
 }
+
+type SystemKeyMismatchAction int
+
+const (
+	SystemKeyMismatchActionUndefined SystemKeyMismatchAction = iota
+	SystemKeyMismatchActionNone
+	SystemKeyMismatchActionRegenerateProfiles
+)
+
+func (s SystemKeyMismatchAction) String() string {
+	switch s {
+	case SystemKeyMismatchActionNone:
+		return "none"
+	case SystemKeyMismatchActionRegenerateProfiles:
+		return "regenerate-profiles"
+	default:
+		return fmt.Sprintf("SystemKeyMismatchAction(%d)", int(s))
+	}
+}
+
+var (
+	ErrSystemKeyMismatchVersionTooHigh = errors.New("system-key version higher than supported")
+)
+
+// SystemKeyMismatchAdvice checks the provided and currently saved system keys
+// to advise whether security profiles should be regenerated. Returns
+// ErrSystemKeyMismatchVersionTooHigh when the provided system key is newer than
+// one supported by the current process.
+func SystemKeyMismatchAdvice(maybeOther any) (SystemKeyMismatchAction, error) {
+	other, ok := maybeOther.(*systemKey)
+	if !ok {
+		return SystemKeyMismatchActionUndefined, fmt.Errorf("internal error: %T is not a system key", maybeOther)
+	}
+
+	// system-key is regeneraterd on startup of snapd, so anything read back
+	// from disk should match what currently exeuting snapd supports
+	my, err := readSystemKey()
+	if err != nil {
+		return SystemKeyMismatchActionUndefined, err
+	}
+
+	if other.Version == my.Version {
+		// same version as our key, let's double check the mismatch, as the
+		// client may have generated a system key right right before snapd
+		// startup, so they did not observe the latest content of the key
+		match, err := SystemKeysMatch(my, other)
+		if err != nil {
+			// unreachable
+			return SystemKeyMismatchActionUndefined, err
+		}
+
+		if match {
+			return SystemKeyMismatchActionNone, nil
+		}
+	} else if other.Version < systemKeyVersion {
+		// fallback behavior for lower versions of system key observed by the
+		// client, most likely the client is older than the current snapd
+		// process, selectively compare keys that have special meaning
+		if other.NFSHome == my.NFSHome {
+			// client's view of NFS home is same as ours, let the client proceed
+			return SystemKeyMismatchActionNone, nil
+		}
+	} else {
+		// client is likely newer than the current snapd process, we don't know
+		// how to interpret, let the caller decide
+		return SystemKeyMismatchActionUndefined, ErrSystemKeyMismatchVersionTooHigh
+	}
+
+	return SystemKeyMismatchActionRegenerateProfiles, nil
+}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -92,6 +92,12 @@ var (
 	_ fmt.Stringer = (*systemKey)(nil)
 )
 
+// SystemKeyFromString unpacks the system key from a string obtained previously
+// by using the system key's Stringer interface.
+func SystemKeyFromString(s string) (any, error) {
+	return UnmarshalJSONSystemKey(strings.NewReader(s))
+}
+
 // IMPORTANT: when adding/removing/changing inputs bump this
 const systemKeyVersion = 11
 
@@ -173,7 +179,7 @@ func generateSystemKey() (*systemKey, error) {
 
 // UnmarshalJSONSystemKey unmarshalls the data from the reader as JSON into a
 // system key usable with SystemKeysMatch.
-func UnmarshalJSONSystemKey(r io.Reader) (interface{}, error) {
+func UnmarshalJSONSystemKey(r io.Reader) (any, error) {
 	sk := &systemKey{}
 	err := json.NewDecoder(r).Decode(sk)
 	if err != nil {
@@ -378,11 +384,10 @@ func RemoveSystemKey() error {
 }
 
 func MockSystemKey(s string) func() {
-	var sk systemKey
-	err := json.Unmarshal([]byte(s), &sk)
+	sk, err := SystemKeyFromString(s)
 	if err != nil {
 		panic(err)
 	}
-	mockedSystemKey = &sk
+	mockedSystemKey = sk.(*systemKey)
 	return func() { mockedSystemKey = nil }
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -22,6 +22,7 @@ package interfaces_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -633,4 +634,147 @@ func (s *systemKeySuite) TestRemoveSystemKey(c *C) {
 	// when it does not exist in the first place
 	err = interfaces.RemoveSystemKey()
 	c.Assert(err, IsNil)
+}
+
+func (s *systemKeySuite) TestSystemKeyMismatchAdviceTrivial(c *C) {
+	mockedSkS := `
+{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"]
+}
+`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+
+	mockedSk, err := interfaces.SystemKeyFromString(mockedSkS)
+	c.Assert(err, IsNil)
+
+	// comparing with self, so nothing to regenerate
+	act, err := interfaces.SystemKeyMismatchAdvice(mockedSk)
+	c.Assert(err, IsNil)
+	c.Check(act, Equals, interfaces.SystemKeyMismatchActionNone)
+}
+
+func (s *systemKeySuite) TestSystemKeyMismatchAdviceNFSHome(c *C) {
+	mockedSkS := `{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": false
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+
+	mockedSk, err := interfaces.SystemKeyFromString(`{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": true
+}`)
+	c.Assert(err, IsNil)
+
+	// nfs-home differs, need to regenerate
+	act, err := interfaces.SystemKeyMismatchAdvice(mockedSk)
+	c.Assert(err, IsNil)
+	c.Check(act, Equals, interfaces.SystemKeyMismatchActionRegenerateProfiles)
+}
+
+func (s *systemKeySuite) TestSystemKeyMismatchAdviceTypeCheck(c *C) {
+	_, err := interfaces.SystemKeyMismatchAdvice("not-a-system-key")
+	c.Assert(err, ErrorMatches, "internal error: string is not a system key")
+}
+
+func (s *systemKeySuite) TestSystemKeyMismatchAdviceNoDiskSystemKey(c *C) {
+	sk, err := interfaces.SystemKeyFromString(`{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": true
+}`)
+	c.Assert(err, IsNil)
+
+	_, err = interfaces.SystemKeyMismatchAdvice(sk)
+	c.Assert(err, ErrorMatches, "system-key missing on disk")
+}
+
+func (s *systemKeySuite) TestSystemKeyMismatchAdviceVersion10NFSHome(c *C) {
+	// first NFS home is false in snapd's system-key
+	mockedSkS := `{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": false
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+
+	// client observed home on NFS like fs
+	skWithNFSHome, err := interfaces.SystemKeyFromString(fmt.Sprintf(`{
+"version": %d,
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": true
+}`, interfaces.SystemKeyVersion-1))
+	c.Assert(err, IsNil)
+
+	act, err := interfaces.SystemKeyMismatchAdvice(skWithNFSHome)
+	c.Assert(err, IsNil)
+	c.Check(act, Equals, interfaces.SystemKeyMismatchActionRegenerateProfiles)
+
+	// client home not on NFS like system, which matches what snapd has observed
+	skNoNFSHome, err := interfaces.SystemKeyFromString(fmt.Sprintf(`{
+"version": %d,
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": false
+}`, interfaces.SystemKeyVersion-1))
+	c.Assert(err, IsNil)
+
+	act, err = interfaces.SystemKeyMismatchAdvice(skNoNFSHome)
+	c.Assert(err, IsNil)
+	// client can proceed
+	c.Check(act, Equals, interfaces.SystemKeyMismatchActionNone)
+
+	// snapd observes the same value of nfs home as the client
+	mockedSkS = `{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": true
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+
+	act, err = interfaces.SystemKeyMismatchAdvice(skNoNFSHome)
+	c.Assert(err, IsNil)
+	c.Check(act, Equals, interfaces.SystemKeyMismatchActionRegenerateProfiles)
+}
+
+func (s *systemKeySuite) TestSystemKeyMismatchAdviceVersionNewer(c *C) {
+	// first NFS home is false in snapd's system-key
+	mockedSkS := `{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": false
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+
+	// client observed home on NFS like fs
+	skNewer, err := interfaces.SystemKeyFromString(fmt.Sprintf(`{
+"version": %d,
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more", "and", "more"],
+"nfs-home": true
+}`, interfaces.SystemKeyVersion+1))
+	c.Assert(err, IsNil)
+
+	act, err := interfaces.SystemKeyMismatchAdvice(skNewer)
+	c.Assert(errors.Is(err, interfaces.ErrSystemKeyMismatchVersionTooHigh), Equals, true)
+	c.Check(act, Equals, interfaces.SystemKeyMismatchActionUndefined)
+}
+
+func (s *systemKeySuite) TestSystemKeyMismatchActionStringer(c *C) {
+	c.Check(interfaces.SystemKeyMismatchActionNone.String(), Equals, "none")
+	c.Check(interfaces.SystemKeyMismatchActionRegenerateProfiles.String(),
+		Equals, "regenerate-profiles")
+	c.Check(interfaces.SystemKeyMismatchActionUndefined.String(), Equals, "SystemKeyMismatchAction(0)")
+	c.Check(interfaces.SystemKeyMismatchAction(99).String(), Equals, "SystemKeyMismatchAction(99)")
 }


### PR DESCRIPTION
A helper implementing a policy for dealing with system key mismatch.

Related: [SNAPDENG-34243](https://warthogs.atlassian.net/browse/SNAPDENG-34243)
Cherry picked from: #15254 

[SNAPDENG-34243]: https://warthogs.atlassian.net/browse/SNAPDENG-34243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ