### PR TITLE
debian/control: replace invalid operator

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -40,7 +40,7 @@ Build-Depends: autoconf,
                python3-pytest,
                squashfs-tools,
                tzdata,
-               systemd-dev | systemd (< 255),
+               systemd-dev | systemd (<< 255),
                xfslibs-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/snapcore/snapd


### PR DESCRIPTION
`<` is not a valid operator and needs to be replaced with `<<`

Inspired by [LP#2106009](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2106009), but does not solve the issue directly for 2.68.3 SRU review, so this PR should not be linked to the SF ticket.

Went back my [test build](https://launchpadlibrarian.net/782343129/buildlog_ubuntu-plucky-amd64.snapd_2.68.3+ubuntu25.04.2_BUILDING.txt.gz), and noticed a similar warning in build log as well: 
`dpkg-source: warning: relation < is deprecated: use << or <=`

IMPORTANT: Need to be cherry-picked for 2.68.4 and 2.69
