### PR TITLE
daemon: avoid locking state until necessary in userFromRequest

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -52,9 +52,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 func (s *apiSuite) TestserFromRequestNoHeader(c *check.C) {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 
-	s.st.Lock()
 	user, err := daemon.UserFromRequest(s.st, req)
-	s.st.Unlock()
 
 	c.Check(err, check.Equals, auth.ErrInvalidAuth)
 	c.Check(user, check.IsNil)
@@ -64,9 +62,7 @@ func (s *apiSuite) TestUserFromRequestHeaderNoMacaroons(c *check.C) {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 	req.Header.Set("Authorization", "Invalid")
 
-	s.st.Lock()
 	user, err := daemon.UserFromRequest(s.st, req)
-	s.st.Unlock()
 
 	c.Check(err, check.ErrorMatches, "authorization header misses Macaroon prefix")
 	c.Check(user, check.IsNil)
@@ -76,9 +72,7 @@ func (s *apiSuite) TestUserFromRequestHeaderIncomplete(c *check.C) {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 	req.Header.Set("Authorization", `Macaroon root=""`)
 
-	s.st.Lock()
 	user, err := daemon.UserFromRequest(s.st, req)
-	s.st.Unlock()
 
 	c.Check(err, check.ErrorMatches, "invalid authorization header")
 	c.Check(user, check.IsNil)
@@ -88,9 +82,7 @@ func (s *apiSuite) TestUserFromRequestHeaderCorrectMissingUser(c *check.C) {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 	req.Header.Set("Authorization", `Macaroon root="macaroon", discharge="discharge"`)
 
-	s.st.Lock()
 	user, err := daemon.UserFromRequest(s.st, req)
-	s.st.Unlock()
 
 	c.Check(err, check.Equals, auth.ErrInvalidAuth)
 	c.Check(user, check.IsNil)
@@ -110,9 +102,7 @@ func (s *apiSuite) TestUserFromRequestHeaderValidUser(c *check.C) {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 	req.Header.Set("Authorization", fmt.Sprintf(`Macaroon root="%s"`, expectedUser.Macaroon))
 
-	s.st.Lock()
 	user, err := daemon.UserFromRequest(s.st, req)
-	s.st.Unlock()
 
 	c.Check(err, check.IsNil)
 	c.Check(user, check.DeepEquals, expectedUser)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -115,10 +115,8 @@ type Command struct {
 
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	st := c.d.state
-	st.Lock()
 	// TODO Look at the error and fail if there's an attempt to authenticate with invalid data.
 	user, _ := userFromRequest(st, r)
-	st.Unlock()
 
 	// check if we are in degradedMode
 	if c.d.degradedErr != nil && r.Method != "GET" {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -115,6 +115,7 @@ type Command struct {
 
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	st := c.d.state
+	// userFromRequest locks the state internally when checking authentication.
 	// TODO Look at the error and fail if there's an attempt to authenticate with invalid data.
 	user, _ := userFromRequest(st, r)
 


### PR DESCRIPTION
This is the first piece of avoiding taking state lock within `Command.ServeHTTP()`.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34635