### PR TITLE
many: make state cache lock-free using sync.Map

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -138,8 +138,6 @@ var muxVars = mux.Vars
 
 func storeFrom(d *Daemon) snapstate.StoreService {
 	st := d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
 
 	return snapstate.Store(st, nil)
 }

--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -135,9 +135,7 @@ func assertsFindOneRemote(c *Command, at *asserts.AssertionType, headers map[str
 
 func assertsFindManyInState(c *Command, at *asserts.AssertionType, headers map[string]string, opts *daemonAssertOptions) ([]asserts.Assertion, error) {
 	state := c.d.overlord.State()
-	state.Lock()
 	db := assertstate.DB(state)
-	state.Unlock()
 
 	return db.FindMany(at, opts.headers)
 }

--- a/daemon/api_asserts_test.go
+++ b/daemon/api_asserts_test.go
@@ -86,8 +86,6 @@ func (s *assertsSuite) TestAssertOK(c *check.C) {
 	// Verify (external)
 	c.Check(rsp.Status, check.Equals, 200)
 	// Verify (internal)
-	st.Lock()
-	defer st.Unlock()
 	_, err = assertstate.DB(st).Find(asserts.AccountType, map[string]string{
 		"account-id": acct.AccountID(),
 	})
@@ -112,8 +110,6 @@ func (s *assertsSuite) TestAssertStreamOK(c *check.C) {
 	// Verify (external)
 	c.Check(rsp.Status, check.Equals, 200)
 	// Verify (internal)
-	st.Lock()
-	defer st.Unlock()
 	_, err = assertstate.DB(st).Find(asserts.AccountType, map[string]string{
 		"account-id": acct.AccountID(),
 	})

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -344,8 +344,6 @@ func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *
 	st.Unlock()
 	c.Assert(d.Overlord().StartUp(), check.IsNil)
 
-	st.Lock()
-	defer st.Unlock()
 	snapstate.ReplaceStore(st, sto)
 
 	// don't actually try to talk to the store on snapstate.Ensure
@@ -389,8 +387,6 @@ func (s *apiBaseSuite) daemonWithOverlordMockAndStore() *daemon.Daemon {
 	st := d.Overlord().State()
 	// adds an assertion db
 	assertstate.Manager(st, o.TaskRunner())
-	st.Lock()
-	defer st.Unlock()
 	snapstate.ReplaceStore(st, s)
 
 	s.d = d

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -623,7 +623,6 @@ func (s *confdbControlSuite) TestConfdbControlActionOK(c *C) {
 	c.Assert(rsp.Status, Equals, 200)
 	c.Check(rsp.Result, DeepEquals, nil)
 
-	s.st.Lock()
 	a, err := assertstate.DB(s.st).Find(
 		asserts.ConfdbControlType,
 		map[string]string{"brand-id": "can0nical", "model": "generic-classic", "serial": "serial-serial"},
@@ -632,7 +631,6 @@ func (s *confdbControlSuite) TestConfdbControlActionOK(c *C) {
 	cc := a.(*asserts.ConfdbControl)
 	ctrl := cc.Control()
 	c.Check(ctrl.Groups(), DeepEquals, []interface{}{jane})
-	s.st.Unlock()
 }
 
 func (s *confdbControlSuite) TestConfdbControlActionSigningErr(c *C) {

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -74,8 +74,6 @@ func getBaseDeclaration(st *state.State) Response {
 
 func checkConnectivity(st *state.State) Response {
 	theStore := snapstate.Store(st, nil)
-	st.Unlock()
-	defer st.Lock()
 	checkResult, err := theStore.ConnectivityCheck()
 	if err != nil {
 		return InternalError("cannot run connectivity check: %v", err)
@@ -342,14 +340,14 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 	query := r.URL.Query()
 	aspect := query.Get("aspect")
 	st := c.d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
 	switch aspect {
 	case "base-declaration":
 		return getBaseDeclaration(st)
 	case "connectivity":
 		return checkConnectivity(st)
 	case "model":
+		st.Lock()
+		defer st.Unlock()
 		model, err := c.d.overlord.DeviceManager().Model()
 		if err != nil {
 			return InternalError("cannot get model: %v", err)
@@ -363,10 +361,16 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		ensureTag := query.Get("ensure")
 		startupTag := query.Get("startup")
 		all := query.Get("all")
+		st.Lock()
+		defer st.Unlock()
 		return getChangeTimings(st, chgID, ensureTag, startupTag, all == "true")
 	case "seeding":
+		st.Lock()
+		defer st.Unlock()
 		return getSeedingInfo(st)
 	case "gadget-disk-mapping":
+		st.Lock()
+		defer st.Unlock()
 		return getGadgetDiskMapping(st)
 	case "disks":
 		return getDisks(st)

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1441,10 +1441,10 @@ func (s *snapsSuite) TestSnapInfoReturnsRefreshInhibitProceedTime(c *check.C) {
 	snapstate.Set(st, "foo", &snapst)
 	// Get expected proceed time while we have the lock.
 	expectedProceedTime := snapst.RefreshInhibitProceedTime(st)
+	st.Unlock()
 
 	monitored := map[string]context.CancelFunc{"foo": func() {}}
 	st.Cache("monitored-snaps", monitored)
-	st.Unlock()
 
 	req, err := http.NewRequest("GET", "/v2/snaps/foo", nil)
 	c.Assert(err, check.IsNil)
@@ -1465,11 +1465,9 @@ func (s *snapsSuite) TestSnapInfoRefreshInhibitProceedTimeLP2089195(c *check.C) 
 	s.mkInstalledInState(c, d, "foo", "bar", "v0", snap.R(5), true, "")
 
 	st := d.Overlord().State()
-	st.Lock()
 	// Mark monitored while RefreshInhibitedTime is nil
 	monitored := map[string]context.CancelFunc{"foo": func() {}}
 	st.Cache("monitored-snaps", monitored)
-	st.Unlock()
 
 	req, err := http.NewRequest("GET", "/v2/snaps/foo", nil)
 	c.Assert(err, check.IsNil)
@@ -1508,6 +1506,8 @@ func (s *snapsSuite) TestSnapManyInfosReturnsRefreshInhibitProceedTime(c *check.
 	// Get expected proceed time for snap-b while we have the lock.
 	expectedProceedTimeB := snapst.RefreshInhibitProceedTime(st)
 
+	st.Unlock()
+
 	monitored := map[string]context.CancelFunc{
 		"snap-a": func() {},
 		// Simulate a scenario where a refresh is continued (i.e. snap is
@@ -1515,8 +1515,6 @@ func (s *snapsSuite) TestSnapManyInfosReturnsRefreshInhibitProceedTime(c *check.
 		"snap-b": nil,
 	}
 	st.Cache("monitored-snaps", monitored)
-
-	st.Unlock()
 
 	req, err := http.NewRequest("GET", "/v2/snaps", nil)
 	c.Assert(err, check.IsNil)
@@ -1573,14 +1571,14 @@ func (s *snapsSuite) TestSnapManyInfosSelectRefreshInhibited(c *check.C) {
 	// Get expected proceed time for snap-a while we have the lock.
 	expectedProceedTimeB := snapst.RefreshInhibitProceedTime(st)
 
+	st.Unlock()
+
 	monitored := map[string]context.CancelFunc{
 		"snap-a": func() {},
 		// Snap monitored should show as inhibited even when proceed-time is in the past
 		"snap-b": func() {},
 	}
 	st.Cache("monitored-snaps", monitored)
-
-	st.Unlock()
 
 	req, err := http.NewRequest("GET", "/v2/snaps?select=refresh-inhibited", nil)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -608,9 +608,7 @@ type encryptionSupportInfoKey struct{ systemLabel string }
 //
 // Note that the cached value is never cleared as system seeds are assumed to be immutable.
 func cachedEncryptionSupportInfoByLabel(c *Command, systemLabel string) (*install.EncryptionSupportInfo, error) {
-	c.d.state.Lock()
 	cached := c.d.state.Cached(encryptionSupportInfoKey{systemLabel})
-	c.d.state.Unlock()
 	if cached != nil {
 		encryptionSupportInfo, ok := cached.(*install.EncryptionSupportInfo)
 		if ok {
@@ -623,9 +621,7 @@ func cachedEncryptionSupportInfoByLabel(c *Command, systemLabel string) (*instal
 	if err != nil {
 		return nil, err
 	}
-	c.d.state.Lock()
 	c.d.state.Cache(encryptionSupportInfoKey{systemLabel}, encryptionInfo)
-	c.d.state.Unlock()
 	return encryptionInfo, nil
 }
 

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1470,10 +1470,7 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 		})
 		defer restore()
 
-		st := d.Overlord().State()
-		st.Lock()
 		daemon.ClearCachedEncryptionSupportInfoForLabel(d.Overlord().State(), "20250122")
-		st.Unlock()
 
 		b, err := json.Marshal(body)
 		c.Assert(err, check.IsNil)
@@ -1564,9 +1561,7 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 		})
 		defer restore()
 
-		st.Lock()
 		daemon.ClearCachedEncryptionSupportInfoForLabel(d.Overlord().State(), "20250122")
-		st.Unlock()
 
 		b, err := json.Marshal(body)
 		c.Assert(err, check.IsNil)

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1703,10 +1703,8 @@ func (s *systemsCreateSuite) SetUpTest(c *check.C) {
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 
 	st := d.Overlord().State()
-	st.Lock()
 	snapstate.ReplaceStore(st, s)
 	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	st.Unlock()
 
 	s.dev1acct = assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
 	c.Assert(s.storeSigning.Add(s.dev1acct), check.IsNil)

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -386,8 +386,6 @@ func (s *themesSuite) daemonWithIfaceMgr(c *C) *daemon.Daemon {
 	overlord.AddManager(runner)
 	c.Assert(overlord.StartUp(), IsNil)
 
-	st.Lock()
-	defer st.Unlock()
 	snapstate.ReplaceStore(st, s)
 	return d
 }

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -77,10 +77,8 @@ func (s *apiValidationSetsSuite) SetUpTest(c *check.C) {
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 
 	st := d.Overlord().State()
-	st.Lock()
 	snapstate.ReplaceStore(st, s)
 	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
-	st.Unlock()
 
 	s.dev1acct = assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
 	c.Assert(s.storeSigning.Add(s.dev1acct), check.IsNil)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -166,9 +166,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if srsp, ok := rsp.(StructuredResponse); ok {
 		rjson := srsp.JSON()
 
-		st.Lock()
 		_, rst := restart.Pending(st)
-		st.Unlock()
 		rjson.addMaintenanceFromRestartType(rst)
 
 		if rjson.Type != ResponseTypeError {
@@ -541,9 +539,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		// stop running hooks first
 		// and do it more gracefully if we are restarting
 		hookMgr := d.overlord.HookManager()
-		d.state.Lock()
 		ok, _ := restart.Pending(d.state)
-		d.state.Unlock()
 		if ok {
 			logger.Noticef("gracefully waiting for running hooks")
 			hookMgr.GracefullyWaitRunningHooks()

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -50,9 +50,7 @@ func Manager(s *state.State, runner *state.TaskRunner) (*AssertManager, error) {
 		return nil, err
 	}
 
-	s.Lock()
 	ReplaceDB(s, db)
-	s.Unlock()
 
 	return &AssertManager{}, nil
 }

--- a/overlord/configstate/configcore/kernel_test.go
+++ b/overlord/configstate/configcore/kernel_test.go
@@ -131,8 +131,8 @@ func (s *kernelSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.state.Lock()
 	s.state.Set("seeded", true)
-	assertstate.ReplaceDB(s.state, db)
 	s.state.Unlock()
+	assertstate.ReplaceDB(s.state, db)
 
 	s.mockEarlyConfig()
 

--- a/overlord/configstate/configcore/netplan.go
+++ b/overlord/configstate/configcore/netplan.go
@@ -64,9 +64,7 @@ var snapstateStore = func(st *state.State, deviceCtx snapstate.DeviceContext) co
 }
 
 func storeReachable(st *state.State) error {
-	st.Lock()
 	sto := snapstateStore(st, nil)
-	st.Unlock()
 	status, err := sto.ConnectivityCheck()
 	if err != nil {
 		return err

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -98,8 +98,6 @@ func (s *promptingSuite) SetUpTest(c *C) {
 		c.Assert(s.repo.AddInterface(iface), IsNil)
 	}
 
-	s.state.Lock()
-	defer s.state.Unlock()
 	ifacerepo.Replace(s.state, s.repo)
 }
 

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -64,9 +64,7 @@ func (s *proxySuite) SetUpTest(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s.state.Lock()
 	assertstate.ReplaceDB(s.state, db)
-	s.state.Unlock()
 
 	err = db.Add(s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -185,9 +185,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 		}
 	}
 
-	s.Lock()
 	s.Cache(deviceMgrKey{}, m)
-	s.Unlock()
 
 	if err := m.confirmRegistered(); err != nil {
 		return nil, err

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -229,13 +229,9 @@ func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 	})
 	c.Assert(err, IsNil)
 
-	s.state.Lock()
 	assertstate.ReplaceDB(s.state, db)
-	s.state.Unlock()
 	s.AddCleanup(func() {
-		s.state.Lock()
 		assertstate.ReplaceDB(s.state, nil)
-		s.state.Unlock()
 	})
 
 	err = db.Add(s.storeSigning.StoreAccountKey(""))

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -263,12 +263,10 @@ func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 
 	c.Assert(s.o.StartUp(), IsNil)
 
-	s.state.Lock()
 	snapstate.ReplaceStore(s.state, &fakeStore{
 		state: s.state,
 		db:    s.storeSigning,
 	})
-	s.state.Unlock()
 
 	s.restoreCloudInitStatusRestore = devicestate.MockCloudInitStatus(func() (sysconfig.CloudInitState, error) {
 		return sysconfig.CloudInitRestrictedBySnapd, nil

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -89,9 +89,7 @@ func (s *usersSuite) SetUpTest(c *check.C) {
 	s.trivialUserLookup = mkUserLookup(s.mockUserHome)
 	s.AddCleanup(devicestate.MockUserLookup(s.trivialUserLookup))
 
-	s.state.Lock()
 	snapstate.ReplaceStore(s.state, s)
-	s.state.Unlock()
 
 	// make sure we don't call these by accident
 	s.AddCleanup(devicestate.MockOsutilAddUser(func(name string, opts *osutil.AddUserOptions) error {

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -500,8 +500,8 @@ func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 
 	s.state.Lock()
 	model, err := s.mgr.Model()
-	db := assertstate.DB(s.state)
 	s.state.Unlock()
+	db := assertstate.DB(s.state)
 	c.Assert(err, check.IsNil)
 
 	// ensure that if we query the details from the assert DB we get

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -573,8 +573,7 @@ func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, asser
 }
 
 func MockEncryptionSetupDataInCache(st *state.State, label string, volumesAuth *device.VolumesAuthOptions) (restore func()) {
-	st.Lock()
-	defer st.Unlock()
+	// state cache is thread safe without holding state lock
 	var esd *install.EncryptionSetupData
 	labelToEncData := map[string]*install.MockEncryptedDeviceAndRole{
 		"ubuntu-save": {
@@ -603,8 +602,7 @@ func CheckEncryptionSetupDataFromCache(st *state.State, label string) error {
 }
 
 func CleanUpEncryptionSetupDataInCache(st *state.State, label string) {
-	st.Lock()
-	defer st.Unlock()
+	// state cache is thread safe without holding state lock
 	key := encryptionSetupDataKey{label}
 	st.Cache(key, nil)
 }

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -694,9 +694,6 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20(c *C) {
 	c.Assert(err, IsNil)
 	st := o.State()
 
-	st.Lock()
-	defer st.Unlock()
-
 	deviceSeed, err := devicestate.LoadDeviceSeed(st, m.RecoverySystem)
 	c.Assert(err, IsNil)
 

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -690,9 +690,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedHappy(c *C) {
 func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	s.startOverlord(c)
 	st0 := s.overlord.State()
-	st0.Lock()
 	db := assertstate.DB(st0)
-	st0.Unlock()
 
 	// we run only with the relevant managers to produce the error
 	// situation
@@ -713,9 +711,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	c.Assert(err, IsNil)
 	o.AddManager(deviceMgr)
 
-	st.Lock()
 	assertstate.ReplaceDB(st, db.(*asserts.Database))
-	st.Unlock()
 
 	o.AddManager(o.TaskRunner())
 

--- a/overlord/fdestate/dbx_test.go
+++ b/overlord/fdestate/dbx_test.go
@@ -1111,14 +1111,10 @@ func (s *fdeMgrSuite) TestEFIDBXOperationAddWait(c *C) {
 
 	go func() {
 		<-syncC
-		st.Lock()
 		fdestate.NotifyDBXUpdatePrepareDoneOK(st, op1.ChangeID)
-		st.Unlock()
 
 		<-syncC
-		st.Lock()
 		fdestate.NotifyDBXUpdatePrepareDoneOK(st, op2.ChangeID)
-		st.Unlock()
 
 		close(doneC)
 	}()

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -82,10 +82,8 @@ func (s *fdeMgrSuite) SetUpTest(c *C) {
 	s.st = s.o.State()
 	s.runner = s.o.TaskRunner()
 
-	s.st.Lock()
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.st, repo)
-	s.st.Unlock()
 
 	buf, restore := logger.MockLogger()
 	s.AddCleanup(restore)

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -46,7 +46,7 @@ type Context struct {
 	id      string
 	handler Handler
 
-	cache  map[interface{}]interface{}
+	cache  map[interface{}]interface{} // TODO: replace with sync.Map ?
 	onDone []func() error
 
 	mutex        sync.Mutex

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -775,9 +775,7 @@ func (s *confdbSuite) TestConfdbGetAndSetAssertionNotFound(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(db.Add(storeSigning.StoreAccountKey("")), IsNil)
 
-	s.state.Lock()
 	assertstate.ReplaceDB(s.state, db)
-	s.state.Unlock()
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"get", "--view", ":read-wifi"}, 0)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot find confdb schema %s/network: assertion not found", s.devAccID))

--- a/overlord/hookstate/ctlcmd/model_test.go
+++ b/overlord/hookstate/ctlcmd/model_test.go
@@ -144,12 +144,10 @@ func (s *modelSuite) SetUpTest(c *C) {
 	s.o.AddManager(s.mgr)
 	s.o.AddManager(s.o.TaskRunner())
 
-	s.state.Lock()
 	snapstate.ReplaceStore(s.state, &fakeSnapStore{
 		state: s.state,
 		db:    s.storeSigning,
 	})
-	s.state.Unlock()
 
 	s.AddCleanup(func() { s.newFakeStore = nil })
 }

--- a/overlord/hookstate/ctlcmd/model_test.go
+++ b/overlord/hookstate/ctlcmd/model_test.go
@@ -118,13 +118,9 @@ func (s *modelSuite) SetUpTest(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s.state.Lock()
 	assertstate.ReplaceDB(s.state, db)
-	s.state.Unlock()
 	s.AddCleanup(func() {
-		s.state.Lock()
 		assertstate.ReplaceDB(s.state, nil)
-		s.state.Unlock()
 	})
 
 	err = db.Add(s.storeSigning.StoreAccountKey(""))

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -70,8 +70,6 @@ func (s *refreshSuite) SetUpTest(c *C) {
 	// snapstate.AffectedByRefreshCandidates needs a cached iface repo
 	repo := interfaces.NewRepository()
 	// no interfaces needed for this test suite
-	s.st.Lock()
-	defer s.st.Unlock()
 	ifacerepo.Replace(s.st, repo)
 }
 

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -334,6 +334,9 @@ func (m *HookManager) runHookForTask(task *state.Task, tomb *tomb.Tomb, snapst *
 func (m *HookManager) runHookGuardForRestarting(context *Context) error {
 	context.Lock()
 	defer context.Unlock()
+	// XXX: restart.Pending() no longer requires state lock, but is this
+	// context lock required to ensure nothing changes between pending check
+	// and incrementing running hooks?
 	if ok, _ := restart.Pending(m.state); ok {
 		return &state.Retry{}
 	}

--- a/overlord/ifacestate/ifacerepo/repo.go
+++ b/overlord/ifacestate/ifacerepo/repo.go
@@ -27,11 +27,15 @@ import (
 type interfacesRepoKey struct{}
 
 // Replace replaces the interface repository used by the managers.
+//
+// Since state cache is thread safe, it is not necessary to hold the state lock.
 func Replace(st *state.State, repo *interfaces.Repository) {
 	st.Cache(interfacesRepoKey{}, repo)
 }
 
 // Get returns the interface repository used by the managers.
+//
+// Since state cache is thread safe, it is not necessary to hold the state lock.
 func Get(st *state.State) *interfaces.Repository {
 	repo := st.Cached(interfacesRepoKey{})
 	if repo == nil {

--- a/overlord/ifacestate/ifacerepo/repo_test.go
+++ b/overlord/ifacestate/ifacerepo/repo_test.go
@@ -45,8 +45,6 @@ func (s *ifaceRepoSuite) SetUpTest(c *C) {
 
 func (s *ifaceRepoSuite) TestHappy(c *C) {
 	st := s.o.State()
-	st.Lock()
-	defer st.Unlock()
 
 	ifacerepo.Replace(st, s.repo)
 
@@ -56,8 +54,6 @@ func (s *ifaceRepoSuite) TestHappy(c *C) {
 
 func (s *ifaceRepoSuite) TestGetPanics(c *C) {
 	st := s.o.State()
-	st.Lock()
-	defer st.Unlock()
 
 	c.Check(func() { ifacerepo.Get(st) }, PanicMatches, `internal error: cannot find cached interfaces repository, interface manager not initialized\?`)
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -92,9 +92,7 @@ func (am *AssertsMock) SetupAsserts(c *C, st *state.State, cleaner cleaner) {
 	err = db.Add(am.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)
 
-	st.Lock()
 	assertstate.ReplaceDB(st, am.Db)
-	st.Unlock()
 }
 
 func (am *AssertsMock) mockModel(extraHeaders map[string]interface{}) *asserts.Model {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -468,8 +468,6 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
 
 func (s *interfaceManagerSuite) TestRepoAvailable(c *C) {
 	_ = s.manager(c)
-	s.state.Lock()
-	defer s.state.Unlock()
 	repo := ifacerepo.Get(s.state)
 	c.Check(repo, FitsTypeOf, &interfaces.Repository{})
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1313,10 +1313,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 	}
 
 	mStore := store.New(&storeCfg, nil)
-	st := s.o.State()
-	st.Lock()
 	snapstate.ReplaceStore(s.o.State(), mStore)
-	st.Unlock()
 
 	// this will be used by remodeling cases
 	storeNew := func(cfg *store.Config, dac store.DeviceAndAuthContext) *store.Store {

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -199,8 +199,6 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)
 
-	s.Lock()
-	defer s.Unlock()
 	// setting up the store
 	o.proxyConf = proxyconf.New(s).Conf
 	storeCtx := storecontext.New(s, o.deviceMgr.StoreContextBackend())

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -82,15 +82,15 @@ func (s *restartSuite) TestManager(c *C) {
 func (s *restartSuite) TestRequestRestartDaemon(c *C) {
 	st := state.New(nil)
 
-	st.Lock()
-	defer st.Unlock()
-
 	// uninitialized
 	ok, t := restart.Pending(st)
 	c.Check(ok, Equals, false)
 	c.Check(t, Equals, restart.RestartUnset)
 
 	h := &testHandler{}
+
+	st.Lock()
+	defer st.Unlock()
 
 	_, err := restart.Manager(st, "boot-id-1", h)
 	c.Assert(err, IsNil)
@@ -113,12 +113,13 @@ func (s *restartSuite) TestRequestRestartDaemonNoHandler(c *C) {
 	st := state.New(nil)
 
 	st.Lock()
-	defer st.Unlock()
 
 	_, err := restart.Manager(st, "boot-id-1", nil)
 	c.Assert(err, IsNil)
 
 	restart.Request(st, restart.RestartDaemon, nil)
+
+	st.Unlock()
 
 	ok, t := restart.Pending(st)
 	c.Check(ok, Equals, true)

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -121,13 +121,13 @@ func (s *autoRefreshTestSuite) SetUpTest(c *C) {
 
 	s.AddCleanup(func() { s.store.snapActionOpsFunc = nil })
 
-	s.state.Lock()
-	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.store)
 
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.state, repo)
 
+	s.state.Lock()
+	defer s.state.Unlock()
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -104,10 +104,8 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	}
 	bs.restore = snapstatetest.MockDeviceModel(DefaultModel())
 
-	bs.state.Lock()
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(bs.state, repo)
-	bs.state.Unlock()
 
 	oldSnapServiceOptions := snapstate.SnapServiceOptions
 	snapstate.SnapServiceOptions = servicestate.SnapServiceOptions

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -116,7 +116,6 @@ var (
 	CheckSnap              = checkSnap
 	CanRemove              = canRemove
 	CanDisable             = canDisable
-	CachedStore            = cachedStore
 	DefaultRefreshSchedule = defaultRefreshScheduleStr
 	DoInstall              = doInstall
 	UserFromUserID         = userFromUserID

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -41,8 +41,6 @@ var _ = Suite(&discardSnapSuite{})
 func (s *discardSnapSuite) SetUpTest(c *C) {
 	s.baseHandlerSuite.SetUpTest(c)
 
-	s.state.Lock()
-	defer s.state.Unlock()
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.state, repo)
 	oldSnapStateEnsureSnapAbsentFromQuotaGroup := snapstate.EnsureSnapAbsentFromQuotaGroup

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -394,8 +394,6 @@ func (s *downloadSnapSuite) TestDoDownloadSnapNormal(c *C) {
 }
 
 func (s *downloadSnapSuite) TestDoDownloadSnapWithDeviceContext(c *C) {
-	s.state.Lock()
-
 	// unset the global store, it will need to come via the device context
 	// CtxStore
 	snapstate.ReplaceStore(s.state, nil)
@@ -411,6 +409,8 @@ func (s *downloadSnapSuite) TestDoDownloadSnapWithDeviceContext(c *C) {
 		Revision: snap.R(11),
 		Channel:  "my-channel",
 	}
+
+	s.state.Lock()
 
 	// download, ensure the store does not query
 	t := s.state.NewTask("download-snap", "test")

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -59,13 +59,13 @@ func (s *prereqSuite) SetUpTest(c *C) {
 		state:       s.state,
 		fakeBackend: s.fakeBackend,
 	}
-	s.state.Lock()
-	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
 
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.state, repo)
 
+	s.state.Lock()
+	defer s.state.Unlock()
 	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "privacy-key")
 	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -475,9 +475,6 @@ func (s *snapmgrTestSuite) TestCleanSnapStateGet(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestStore(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	sto := &store.Store{}
 	snapstate.ReplaceStore(s.state, sto)
 	store1 := snapstate.Store(s.state, nil)
@@ -489,9 +486,6 @@ func (s *snapmgrTestSuite) TestStore(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestStoreWithDeviceContext(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	stoA := &store.Store{}
 	snapstate.ReplaceStore(s.state, stoA)
 	store1 := snapstate.Store(s.state, nil)

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1784,9 +1784,6 @@ func (s *snapmgrTestSuite) TestUpdateWithAlreadyInstalledBase(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.state, repo)
@@ -1797,6 +1794,10 @@ func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 		Revision: snap.R(7),
 	}
 	snaptest.MockSnap(c, `name: snap-content-plug`, si)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	snapstate.Set(s.state, "snap-content-plug", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
@@ -1819,9 +1820,6 @@ func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	snapstate.ReplaceStore(s.state, contentStore{fakeStore: s.fakeStore, state: s.state})
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.state, repo)
@@ -1832,6 +1830,10 @@ func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
 		Revision: snap.R(7),
 	}
 	snaptest.MockSnap(c, `name: snap-content-plug`, si)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	snapstate.Set(s.state, "snap-content-plug", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
@@ -3045,9 +3047,6 @@ func (n noResultsStore) SnapAction(ctx context.Context, currentSnaps []*store.Cu
 }
 
 func (s *snapmgrTestSuite) TestUpdateNoStoreResults(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	snapstate.ReplaceStore(s.state, noResultsStore{fakeStore: s.fakeStore})
 
 	// this is an atypical case in which the store didn't return
@@ -3058,6 +3057,9 @@ func (s *snapmgrTestSuite) TestUpdateNoStoreResults(c *C) {
 		SnapID:   "some-snap-id",
 		Revision: snap.R(7),
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -3071,9 +3073,6 @@ func (s *snapmgrTestSuite) TestUpdateNoStoreResults(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateNoStoreResultsWithChannelChange(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	snapstate.ReplaceStore(s.state, noResultsStore{fakeStore: s.fakeStore})
 
 	// this is an atypical case in which the store didn't return
@@ -3084,6 +3083,9 @@ func (s *snapmgrTestSuite) TestUpdateNoStoreResultsWithChannelChange(c *C) {
 		SnapID:   "some-snap-id",
 		Revision: snap.R(7),
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -4631,9 +4633,6 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContextSameRevisionSwitchesChanne
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithDeviceContext(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
@@ -4641,6 +4640,9 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContext(c *C) {
 		DeviceModel: DefaultModel(),
 		CtxStore:    s.fakeStore,
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -4688,9 +4690,6 @@ func (prqt *testPrereqTracker) MissingProviderContentTags(*snap.Info, snap.Inter
 }
 
 func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContext(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
@@ -4698,6 +4697,9 @@ func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContext(c *C) {
 		DeviceModel: DefaultModel(),
 		CtxStore:    s.fakeStore,
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -4724,9 +4726,6 @@ epoch: 1*
 }
 
 func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextSwitchChannel(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
@@ -4734,6 +4733,9 @@ func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextSwitchChannel(c *C) {
 		DeviceModel: DefaultModel(),
 		CtxStore:    s.fakeStore,
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -4756,9 +4758,6 @@ epoch: 1*
 }
 
 func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextBadFile(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
@@ -4766,6 +4765,9 @@ func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextBadFile(c *C) {
 		DeviceModel: DefaultModel(),
 		CtxStore:    s.fakeStore,
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
@@ -4806,9 +4808,6 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContextDefaultsToTracked(c *C) {
 }
 
 func (s *snapmgrTestSuite) testUpdateWithDeviceContext(c *C, revision snap.Revision, channel string) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
@@ -4816,6 +4815,9 @@ func (s *snapmgrTestSuite) testUpdateWithDeviceContext(c *C, revision snap.Revis
 		DeviceModel: DefaultModel(),
 		CtxStore:    s.fakeStore,
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	const trackedChannel = "tracked-channel/stable"
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -14153,9 +14155,6 @@ func (s hybridContentStore) SnapAction(ctx context.Context, currentSnaps []*stor
 }
 
 func (s *snapmgrTestSuite) TestSplitRefreshWithDefaultProviderDependingOnModelBase(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	snapstate.ReplaceStore(s.state, hybridContentStore{fakeStore: s.fakeStore, state: s.state})
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.state, repo)
@@ -14182,6 +14181,9 @@ func (s *snapmgrTestSuite) TestSplitRefreshWithDefaultProviderDependingOnModelBa
 		"kernel":            "kernel-id",
 		"snap-content-plug": "snap-content-plug-id",
 	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
 
 	for _, sn := range snaps {
 		yaml := fmt.Sprintf("name: %s\nversion: 1.0\nepoch: 1\ntype: %s", sn, types[sn])

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -12414,9 +12414,9 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 	monitorSignal <- "foo"
 	waitForMonitoringEnd(s.state, c)
 
-	s.state.Lock()
 	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
 
+	s.state.Lock()
 	// start a 2nd task that checks the state for the map of monitored snap
 	preDlChg = s.state.NewChange("pre-download", "pre-download change")
 	preDlTask = s.state.NewTask("pre-download-snap", "pre-download task")
@@ -12505,11 +12505,9 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeletedAfterRefresh
 		return s.state.Cached("monitored-snaps") == nil
 	})
 
-	s.state.Lock()
 	// monitoring removal is robust and doesn't fail when corresponding
 	// refresh candidate is not available.
 	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
-	s.state.Unlock()
 }
 
 func waitFor(st *state.State, c *C, cond func() bool) {
@@ -12768,10 +12766,8 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 	c.Assert(stopMonitor, NotNil)
 	c.Assert(notified, Equals, false)
 
-	s.state.Lock()
 	aborts := s.state.Cached("monitored-snaps").(map[string]context.CancelFunc)
 	abort := aborts["some-snap"]
-	s.state.Unlock()
 	c.Assert(abort, NotNil)
 
 	stopMonitor <- "some-snap"

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -191,8 +191,6 @@ func (ss *stateSuite) TestGetUnmarshalProblem(c *C) {
 
 func (ss *stateSuite) TestCache(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
 	type key1 struct{}
 	type key2 struct{}
@@ -577,7 +575,6 @@ func (ss *stateSuite) TestEmptyStateDataAndCheckpointReadAndSet(c *C) {
 		"tasks",
 		"warnings",
 		"notices",
-		"cache",
 		"pendingChangeByAttr",
 		"taskHandlers",
 		"changeHandlers",
@@ -763,8 +760,6 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 
 	reads := []func(){
 		func() { st.Get("foo", nil) },
-		func() { st.Cached("foo") },
-		func() { st.Cache("foo", 1) },
 		func() { st.Changes() },
 		func() { st.Change("foo") },
 		func() { st.Tasks() },
@@ -1081,11 +1076,11 @@ func (ss *stateSuite) TestPruneHonorsStartOperationTime(c *C) {
 func (ss *stateSuite) TestReadStateInitsTransientMapFields(c *C) {
 	st, err := state.ReadState(nil, bytes.NewBufferString("{}"))
 	c.Assert(err, IsNil)
-	st.Lock()
-	defer st.Unlock()
 
 	st.Cache("key", "value")
 	c.Assert(st.Cached("key"), Equals, "value")
+	st.Lock()
+	defer st.Unlock()
 	st.RegisterPendingChangeByAttr("attr", func(*state.Change) bool { return false })
 }
 


### PR DESCRIPTION
We want the daemon to avoid taking the state lock whenever possible. At the moment, `ServeHTTP()` in `daemon/daemon.go` acquires the state lock to check `restart.Pending()`, since `restart.Pending` calls `state.Cached()` to retrieve any cached restart setting.

By making `state.Cached()` and `state.Cache()` not require state lock, we make `restart.Pending()` and all the other places which call it not require the state lock, unless they want to acquire it for their own synchronization purposes.

If we use a `sync.Map` instead of the state-lock-guarded `map[interface{}]interface{}`, calls to `state.Cached()` and `state.Cache()` can be inherently thread safe without requiring state lock.

This PR is an attempt to make that change, and clean up all places which acquire state lock for the sole purpose of accessing the state cache, without other synchronization requirements.

This work is tracked by https://warthogs.atlassian.net/browse/SNAPDENG-34635