### PR TITLE
cmd/snap: fix snap validate missing newline

### DIFF
--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -210,7 +210,7 @@ func (cmd *cmdValidate) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(Stdout, fmtValid(vset))
+		fmt.Fprintln(Stdout, fmtValid(vset))
 		// XXX: exit status 1 if invalid?
 	}
 

--- a/cmd/snap/cmd_validate_test.go
+++ b/cmd/snap/cmd_validate_test.go
@@ -186,7 +186,7 @@ func (s *validateSuite) TestValidateQueryOne(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
-	c.Check(s.Stdout(), check.Equals, "valid")
+	c.Check(s.Stdout(), check.Equals, "valid\n")
 }
 
 func (s *validateSuite) TestValidateQueryOneInvalid(c *check.C) {
@@ -199,7 +199,7 @@ func (s *validateSuite) TestValidateQueryOneInvalid(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
-	c.Check(s.Stdout(), check.Equals, "invalid")
+	c.Check(s.Stdout(), check.Equals, "invalid\n")
 }
 
 func (s *validateSuite) TestValidationSetsList(c *check.C) {


### PR DESCRIPTION
Fix `snap validate <specific validation set>` output missing a newline.

![image](https://github.com/user-attachments/assets/1038aa07-38df-46e0-8324-4e10f0719437)

Further considerations:
 - Should we implement suggested exit with error when invalid?
 - Why do we provide less information when inspecting specific validation set VS if there is only a single validation set?

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34714?focusedCommentId=717454