### PR TITLE
cmd/snap: fix snap validate refresh without enforce

### DIFF
--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -106,6 +106,10 @@ func (cmd *cmdValidate) Execute(args []string) error {
 		}
 	}
 
+	if cmd.Refresh && !cmd.Enforce {
+		return fmt.Errorf("--refresh can only be used together with --enforce")
+	}
+
 	if cmd.Positional.ValidationSet == "" && action != "" {
 		return fmt.Errorf("missing validation set argument")
 	}
@@ -121,10 +125,6 @@ func (cmd *cmdValidate) Execute(args []string) error {
 	}
 
 	if action != "" {
-		if cmd.Refresh && action != "enforce" {
-			return fmt.Errorf("--refresh can only be used together with --enforce")
-		}
-
 		if cmd.Refresh {
 			changeID, err := cmd.client.RefreshMany(nil, nil, &client.SnapOptions{
 				ValidationSets: []string{cmd.Positional.ValidationSet},

--- a/cmd/snap/cmd_validate_test.go
+++ b/cmd/snap/cmd_validate_test.go
@@ -240,6 +240,12 @@ func (s *validateSuite) TestValidateRefreshOnlyUsedWithEnforce(c *check.C) {
 	c.Check(rest, check.HasLen, 1)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, "")
+
+	rest, err = main.Parser(main.Client()).ParseArgs([]string{"validate", "--refresh", "foo/bar"})
+	c.Assert(err, check.ErrorMatches, "--refresh can only be used together with --enforce")
+	c.Check(rest, check.HasLen, 1)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "")
 }
 
 func (s *validateSuite) TestValidationSetsRefreshEnforce(c *check.C) {


### PR DESCRIPTION
Fix snap validate --refresh <specific validation set> outputs valid/invalid state instead of error

![image](https://github.com/user-attachments/assets/edb73de1-dbd1-4e9e-948f-6cca27724457)

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34714?focusedCommentId=717365
Builds on: https://github.com/canonical/snapd/pull/15288