### PR TITLE
daemon: fake fde state in tests to avoid warnings initializing it

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -336,8 +336,10 @@ func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *
 	c.Assert(err, check.IsNil)
 
 	st := d.Overlord().State()
-	// mark as already seeded
 	st.Lock()
+	// set a fake fde state
+	st.Set("fde", &struct{}{})
+	// mark as already seeded
 	st.Set("seeded", true)
 	// and registered
 	s.mockModel(st, nil)

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -829,6 +829,13 @@ defaults:
 	// this overlord will use the proper EarlyConfig implementation
 	o, err := overlord.New(nil)
 	c.Assert(err, IsNil)
+	func() {
+		st := o.State()
+		st.Lock()
+		defer st.Unlock()
+		// set a fake fde state to avoid failure in initialization
+		st.Set("fde", &struct{}{})
+	}()
 	o.InterfaceManager().DisableUDevMonitor()
 	c.Assert(o.StartUp(), IsNil)
 
@@ -865,6 +872,13 @@ defaults:
 	// this overlord will use the proper EarlyConfig implementation
 	o, err := overlord.New(nil)
 	c.Assert(err, IsNil)
+	func() {
+		st := o.State()
+		st.Lock()
+		defer st.Unlock()
+		// set a fake fde state to avoid failure in initialization
+		st.Set("fde", &struct{}{})
+	}()
 	o.InterfaceManager().DisableUDevMonitor()
 	c.Assert(o.StartUp(), IsNil)
 

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -135,6 +135,14 @@ func (t *firstBootBaseTest) setupBaseTest(c *C, s *seedtest.SeedSnaps) {
 // your own before calling this again
 func (t *firstBootBaseTest) startOverlord(c *C) {
 	ovld, err := overlord.New(nil)
+	func() {
+		st := ovld.State()
+		st.Lock()
+		defer st.Unlock()
+		// set a fake fde state to avoid failure in initialization
+		st.Set("fde", &struct{}{})
+	}()
+
 	c.Assert(err, IsNil)
 	ovld.InterfaceManager().DisableUDevMonitor()
 	// avoid gadget preload in the general tests cases


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
