### PR TITLE
o/ifacestate, interfaces: system key mismatch handling

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -2084,6 +2084,13 @@ func (m *InterfaceManager) doRegenerateAllSecurityProfiles(task *state.Task, _ *
 
 	perfTimings := state.TimingsForTask(task)
 	defer perfTimings.Save(task.State())
+
+	// the reported system key change may have an effect on the security
+	// backends, give them a chance to update their view of the system
+	if err := m.reinitializeBackends(perfTimings); err != nil {
+		return err
+	}
+
 	// regenerating and reloading profiles is time consuming, so allow unlocking
 	// of state for the duration of security backend operations
 	const unlockState = true

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -2075,3 +2075,17 @@ func (m *InterfaceManager) doHotplugSeqWait(task *state.Task, _ *tomb.Tomb) erro
 	// no conflicting change for same hotplug key found
 	return nil
 }
+
+func (m *InterfaceManager) doRegenerateAllSecurityProfiles(task *state.Task, _ *tomb.Tomb) error {
+	st := task.State()
+
+	st.Lock()
+	defer st.Unlock()
+
+	perfTimings := state.TimingsForTask(task)
+	defer perfTimings.Save(task.State())
+	// regenerating and reloading profiles is time consuming, so allow unlocking
+	// of state for the duration of security backend operations
+	const unlockState = true
+	return m.regenerateAllSecurityProfiles(perfTimings, unlockState)
+}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -181,7 +181,10 @@ func snapdAppArmorServiceIsDisabledImpl() bool {
 	return err == nil && !isEnabled
 }
 
-// regenerateAllSecurityProfiles will regenerate all security profiles.
+// regenerateAllSecurityProfiles will regenerate all security profiles. This
+// function is expected to be called with the state locked, though in some
+// scenarios one may want to temporarily unlock the state for the duration of
+// security backends executing their setup.
 func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer, unlockState bool) error {
 	// Get all the security backends
 	securityBackends := m.repo.Backends()

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -113,6 +113,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	addHandler("hotplug-update-slot", m.doHotplugUpdateSlot, nil)
 	addHandler("hotplug-remove-slot", m.doHotplugRemoveSlot, nil)
 	addHandler("hotplug-disconnect", m.doHotplugDisconnect, nil)
+	addHandler("regenerate-security-profiles", m.doRegenerateAllSecurityProfiles, nil)
 
 	// don't block on hotplug-seq-wait task
 	runner.AddHandler("hotplug-seq-wait", m.doHotplugSeqWait, nil)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -240,7 +240,8 @@ func (m *InterfaceManager) StartUp() error {
 		}()
 	}
 	if m.profilesNeedRegeneration() {
-		if err := m.regenerateAllSecurityProfiles(perfTimings); err != nil {
+		const unlockState = false
+		if err := m.regenerateAllSecurityProfiles(perfTimings, unlockState); err != nil {
 			return err
 		}
 	}

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/policy"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -627,4 +628,35 @@ func InterfacesRequestsControlHandlerServices(st *state.State) ([]*snap.AppInfo,
 	}
 
 	return handlers, nil
+}
+
+// AdviseReportedSystemKeyMismatch inspects the system key, which is reportedly
+// in a mismatch with the recoded one, and decides to either create a state
+// change for regenerating security profiles, thus returning a change, or do
+// nothing, in which case no change is returned.
+func AdviseReportedSystemKeyMismatch(st *state.State, systemKey any) (*state.Change, error) {
+	action, err := interfaces.SystemKeyMismatchAdvice(systemKey)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("reported system key mismatch action: %v", action)
+
+	if action == interfaces.SystemKeyMismatchActionNone {
+		// nothing to do
+		return nil, nil
+	}
+
+	for _, chg := range st.Changes() {
+		// if we have a change that isn't ready, return it instead
+		if chg.Kind() == "regenerate-security-profiles" && !chg.IsReady() {
+			return chg, nil
+		}
+	}
+
+	chg := st.NewChange("regenerate-security-profiles", "Regenerate security profiles")
+	t := st.NewTask("regenerate-security-profiles", "Regenerate security profiles")
+	chg.AddTask(t)
+
+	return chg, nil
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -11299,3 +11299,176 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesForMultiConnectedPlugConsumer
 	// all slots are considered
 	c.Check(consideredConns, DeepEquals, []string{"consumer:plug producer2:slot", "consumer:plug producer:slot"})
 }
+
+func (s *interfaceManagerSuite) TestDoRegenerateSecurityProfiles(c *C) {
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		"consumer:plug producer:slot": map[string]interface{}{
+			"interface": "test",
+		},
+	})
+	s.state.Unlock()
+
+	s.mockSnap(c, producerYaml)
+	s.mockSnap(c, consumerYaml)
+
+	setupCalls := 0
+	secBackend := &ifacetest.TestSecurityBackendSetupMany{
+		TestSecurityBackend: ifacetest.TestSecurityBackend{
+			BackendName: "test",
+		},
+		SetupManyCallback: func(appSets []*interfaces.SnapAppSet, confinement func(snapName string) interfaces.ConfinementOptions, repo *interfaces.Repository, tm timings.Measurer) []error {
+			setupCalls++
+
+			// expecting 2 calls, first from manager startup, 2nd from handler
+			c.Check(appSets, HasLen, 2)
+			for _, appSet := range appSets {
+				_, err := repo.SnapSpecification("test", appSet, confinement(appSet.InstanceName()))
+				c.Assert(err, IsNil)
+			}
+
+			if setupCalls == 2 {
+				// the handler requests the setup to be called with unlocked
+				// state, so it is possible to lock it
+				c.Logf("-- attempting to lock the state")
+				s.state.Lock()
+				c.Logf("--- state locked\n")
+				defer s.state.Unlock()
+			}
+			return nil
+		},
+	}
+
+	s.mockSecBackend(secBackend)
+	s.mockIfaces(&ifacetest.TestInterface{
+		InterfaceName: "test",
+	})
+
+	// Create the interface manager. This indirectly adds the snaps to the
+	// repository and reloads the connection.
+	s.manager(c)
+
+	// Alter the state to introduce new revision of refreshed snap
+	s.state.Lock()
+	snapstate.Set(s.state, "producer", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{Revision: snap.R(1), RealName: "producer"},
+		}),
+		Current:  snap.R(1),
+		SnapType: string("app"),
+	})
+	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{Revision: snap.R(1), RealName: "consumer"},
+		}),
+		Current:  snap.R(1),
+		SnapType: string("app"),
+	})
+	s.state.Unlock()
+
+	// Setup profiles for refreshed snap v2
+	s.state.Lock()
+	change := s.state.NewChange("regenerate-security-profiles", "")
+	task := s.state.NewTask("regenerate-security-profiles", "")
+	change.AddTask(task)
+	s.state.Unlock()
+
+	// Spin the wheels to run the tasks we added.
+	s.settle(c)
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Logf("change failure: %v", change.Err())
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+	c.Check(setupCalls, Equals, 2)
+}
+
+func (s *interfaceManagerSuite) TestSystemKeyMismatchTrivial(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, "")
+	c.Assert(err, ErrorMatches, "internal error: string is not a system key")
+	c.Check(chg, IsNil)
+
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+	sk, err := interfaces.RecordedSystemKey()
+	c.Assert(err, IsNil)
+
+	// matching system key, no action, no change
+	chg, err = ifacestate.AdviseReportedSystemKeyMismatch(s.state, sk)
+	c.Assert(err, IsNil)
+	c.Check(chg, IsNil)
+
+	// remove system key, we should be able to identify the error
+	c.Assert(interfaces.RemoveSystemKey(), IsNil)
+	chg, err = ifacestate.AdviseReportedSystemKeyMismatch(s.state, sk)
+	c.Assert(err, ErrorMatches, "system-key missing on disk")
+	c.Check(chg, IsNil)
+}
+
+func (s *interfaceManagerSuite) TestSystemKeyMismatch(c *C) {
+	mockedSkS := `{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more-features"]
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+
+	sk, err := interfaces.CurrentSystemKey()
+	c.Assert(err, IsNil)
+
+	mockedSkS = `{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus"]
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, sk)
+	c.Assert(err, IsNil)
+	c.Assert(chg, NotNil)
+
+	c.Check(chg.Kind(), Equals, "regenerate-security-profiles")
+	c.Check(chg.Summary(), Equals, "Regenerate security profiles")
+	tsks := chg.Tasks()
+	c.Assert(tsks, HasLen, 1)
+	c.Check(tsks[0].Kind(), Equals, "regenerate-security-profiles")
+
+	// try again, we should get the exact same change
+	chg2, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, sk)
+	c.Assert(err, IsNil)
+	c.Assert(chg2, NotNil)
+
+	c.Check(chg.ID(), Equals, chg2.ID())
+}
+
+func (s *interfaceManagerSuite) TestSystemKeyMismatchCompat(c *C) {
+	mockedSkS := `{
+"version": 9999,
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus", "more-features"]
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+
+	sk, err := interfaces.CurrentSystemKey()
+	c.Assert(err, IsNil)
+
+	mockedSkS = `{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus"]
+}`
+	s.AddCleanup(interfaces.MockSystemKey(mockedSkS))
+	c.Assert(interfaces.WriteSystemKey(interfaces.SystemKeyExtraData{}), IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, sk)
+	c.Assert(err, ErrorMatches, "system-key version higher than supported")
+	c.Assert(chg, IsNil)
+	// error can be precisely identified
+	c.Check(errors.Is(err, interfaces.ErrSystemKeyMismatchVersionTooHigh), Equals, true)
+}


### PR DESCRIPTION
Handle reported system key mismatch by launching a change to
regenerate all security profiles if needed.

Add a handler for regenerating security profiles, which reinitializes the security backends and recomputes the profiles.

Cherry picked from #15254
Related: [SNAPDENG-34243](https://warthogs.atlassian.net/browse/SNAPDENG-34243)

[SNAPDENG-34243]: https://warthogs.atlassian.net/browse/SNAPDENG-34243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ