### PR TITLE
s/a/notify: fix URESPONSE_NO_CACHE flag which should be 1

### DIFF
--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -241,7 +241,7 @@ func (msg *MsgNotificationFilter) Validate() error {
 // Flags for MsgNotification.
 const (
 	// URESPONSE_NO_CACHE tells the kernel not to cache the response.
-	URESPONSE_NO_CACHE = iota
+	URESPONSE_NO_CACHE = 1 << iota
 	// Other flags which are not currently needed by snapd:
 	// URESPONSE_LOOKUP
 	// URESPONSE_PROFILE


### PR DESCRIPTION
This fixes a bug introduced in f04f00b2bb78b8f04f468b2a5765927d73136c9a from #15089.

That bug the potential to break `"lifespan": "single"` since the kernel would cache the response at the profile level.
