### PR TITLE
tests/nested/manual: free some space in restore stanza

### DIFF
--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -57,7 +57,7 @@ prepare: |
   fi
 
 restore: |
-  rm -rf ./classic-root
+  rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
 
 execute: |
   # shellcheck source=tests/lib/prepare.sh

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -43,7 +43,7 @@ prepare: |
 
 restore: |
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
-  rm -rf ./classic-root
+  rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
 
 execute: |
   # shellcheck source=tests/lib/prepare.sh

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -44,7 +44,7 @@ restore: |
       mv /var/lib/snapd/seed.orig /var/lib/snapd/seed
   fi
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
-  rm -rf ./classic-root
+  rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
 
 execute: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
@@ -40,7 +40,7 @@ prepare: |
 
 restore: |
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
-  rm -rf ./classic-root
+  rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
 
 execute: |
   # shellcheck source=tests/lib/prepare.sh

--- a/tests/nested/manual/split-refresh/task.yaml
+++ b/tests/nested/manual/split-refresh/task.yaml
@@ -39,7 +39,7 @@ restore: |
       mv /var/lib/snapd/seed.orig /var/lib/snapd/seed
   fi
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
-  rm -rf ./classic-root
+  rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
 
 debug: |
   if remote.exec true; then


### PR DESCRIPTION
Most hybrid tests take a lot of extra space in the test folder, clean up things to avoid failures due to lack of space when doing full runs of the test suite.