### PR TITLE
Add --update-timestamp flag to update JSON timestamp before signing

### DIFF
--- a/asserts/signtool/sign.go
+++ b/asserts/signtool/sign.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/snapcore/snapd/asserts"
 )
@@ -55,6 +56,10 @@ type Options struct {
 	// instead to match if present. Pseudo-header "body" can also
 	// be specified here.
 	Complement map[string]interface{}
+
+	// UpdateTimestamp is used to update the JSON input's timestamp
+	// to the current time before signing.
+	UpdateTimestamp bool
 }
 
 // Sign produces the text of a signed assertion as specified by opts.
@@ -120,6 +125,11 @@ func Sign(opts *Options, keypairMgr asserts.KeypairManager) ([]byte, error) {
 		if accKey.ConstraintsPrecheck(typ, headers) != nil {
 			return nil, fmt.Errorf("the assertion headers do not match the constraints of the signing account-key")
 		}
+	}
+
+	if opts.UpdateTimestamp {
+		// Update the "timestamp" field with the current time in RFC3339 format.
+		headers["timestamp"] = time.Now().Format(time.RFC3339)
 	}
 
 	a, err := adb.Sign(typ, headers, body, opts.KeyID)

--- a/asserts/signtool/sign_test.go
+++ b/asserts/signtool/sign_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -318,4 +319,49 @@ func (s *signSuite) TestSignErrors(c *C) {
 		_, err := signtool.Sign(&fresh, s.keypairMgr)
 		c.Check(err, ErrorMatches, t.expError)
 	}
+}
+
+func (s *signSuite) TestSignJSONWithUpdateTimestamp(c *C) {
+	opts := signtool.Options{
+		KeyID: s.testKeyID,
+
+		Statement:       exampleJSON(nil),
+		UpdateTimestamp: true,
+	}
+
+	assertText, err := signtool.Sign(&opts, s.keypairMgr)
+	c.Assert(err, IsNil)
+
+	a, err := asserts.Decode(assertText)
+	c.Assert(err, IsNil)
+
+	c.Check(a.Type(), Equals, asserts.ModelType)
+	c.Check(a.Revision(), Equals, 0)
+
+	// Retrieve the header "timestamp" from the assertion.
+	header := a.Headers()
+	tsValue, ok := header["timestamp"].(string)
+	c.Assert(ok, Equals, true)
+
+	// The original expected timestamp from expectedModelHeaders is "2015-11-25T20:00:00Z".
+	// Verify that the timestamp was indeed updated.
+	c.Check(tsValue, Not(Equals), "2015-11-25T20:00:00Z")
+
+	// Parse the updated timestamp and verify it is a valid RFC3339 timestamp near the current time.
+	updatedTime, err := time.Parse(time.RFC3339, tsValue)
+	c.Assert(err, IsNil)
+	now := time.Now()
+	diff := now.Sub(updatedTime)
+	if diff < 0 {
+		diff = -diff
+	}
+	// Allow a difference of up to 5 minutes.
+	c.Check(diff < 5*time.Minute, Equals, true)
+
+	// For a deep equality check, build the expected headers and replace the "timestamp" field
+	expectedHeaders := expectedModelHeaders(a)
+	expectedHeaders["timestamp"] = tsValue
+	c.Check(header, DeepEquals, expectedHeaders)
+
+	c.Check(a.Body(), IsNil)
 }

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -44,8 +44,9 @@ type cmdSign struct {
 		Filename flags.Filename
 	} `positional-args:"yes"`
 
-	KeyName keyName `short:"k" default:"default"`
-	Chain   bool    `long:"chain"`
+	KeyName         keyName `short:"k" default:"default"`
+	Chain           bool    `long:"chain"`
+	UpdateTimestamp bool    `long:"update-timestamp"`
 }
 
 func init() {
@@ -56,6 +57,8 @@ func init() {
 		"k": i18n.G("Name of the key to use, otherwise use the default key"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"chain": i18n.G("Append the account and account-key assertions necessary to allow any device to validate the signed assertion."),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"update-timestamp": i18n.G("Update the JSON input's timestamp to the current time before signing."),
 	}, []argDesc{{
 		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<filename>"),
@@ -100,9 +103,10 @@ func (x *cmdSign) Execute(args []string) error {
 	accountKey, _ := ak.(*asserts.AccountKey)
 
 	signOpts := signtool.Options{
-		KeyID:      privKey.PublicKey().ID(),
-		AccountKey: accountKey,
-		Statement:  statement,
+		KeyID:           privKey.PublicKey().ID(),
+		AccountKey:      accountKey,
+		Statement:       statement,
+		UpdateTimestamp: x.UpdateTimestamp,
 	}
 
 	encodedAssert, err := signtool.Sign(&signOpts, keypairMgr)


### PR DESCRIPTION
Users often encounter issues when the timestamp in the JSON input is not later than the key generation time, leading to invalid assertions and prolonged troubleshooting. This change introduces a new --update-timestamp flag to the snap sign command that updates the "timestamp" field to the current time (in RFC3339 format) prior to signing.

This enhancement aims to reduce user confusion and improve the signing workflow by automating the necessary timestamp update.

