### PR TITLE
tests/main/remote-home: enable 20.04, require linux-modules, no skipping

### DIFF
--- a/tests/main/remote-home/task.yaml
+++ b/tests/main/remote-home/task.yaml
@@ -15,6 +15,7 @@ details: |
 # unit tests and is relatively useless in the field, where way more elaborate
 # logic is used in practice (e.g. PAM modules), that snapd has no support for.
 systems:
+  - ubuntu-20.04-*
   - ubuntu-22.04-*
   - ubuntu-24.04-*
 

--- a/tests/main/remote-home/task.yaml
+++ b/tests/main/remote-home/task.yaml
@@ -44,12 +44,9 @@ prepare: |
     tests.cleanup defer rm -rf /var/home/test-remote
 
     # Install a package with additional kernel modules, so that we can mount cifs/nfs.
-    if ! tests.pkgs install "linux-modules-extra-$(uname -r)"; then
-      echo "SKIP: Kernel version and extras module mismatch"
-      # TODO: figure out something better. This sort of skew can happen at any time,
-      # and we have no good way of solving the problem apart from a real SKIP command
-      # in spread.
-      exit 0
+    if ! tests.pkgs install "linux-modules-$(uname -r)"; then
+      echo "Kernel version and modules mismatch"
+      exit 1
     fi
 
     case "$FS" in


### PR DESCRIPTION
Update the test to run on 20.04, as it's still fully supported. While at it, install linux-modules (which carries cifs.ko/nfs.ko), and not linux-modules-extra and stop skipping the test.