### PR TITLE
daemon,o/restart: add method to check pending restart without state lock

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -515,7 +515,11 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		// stop running hooks first
 		// and do it more gracefully if we are restarting
 		hookMgr := d.overlord.HookManager()
+		// Don't proceed before the state lock has been released by the code
+		// path which may request a restart.
+		d.state.Lock()
 		ok, _ := d.overlord.RestartManager().Pending()
+		d.state.Unlock()
 		if ok {
 			logger.Noticef("gracefully waiting for running hooks")
 			hookMgr.GracefullyWaitRunningHooks()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -164,9 +164,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if srsp, ok := rsp.(StructuredResponse); ok {
 		rjson := srsp.JSON()
 
-		st.Lock()
-		_, rst := restart.Pending(st)
-		st.Unlock()
+		_, rst := c.d.overlord.RestartManager().Pending()
 		rjson.addMaintenanceFromRestartType(rst)
 
 		if rjson.Type != ResponseTypeError {
@@ -517,9 +515,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		// stop running hooks first
 		// and do it more gracefully if we are restarting
 		hookMgr := d.overlord.HookManager()
-		d.state.Lock()
-		ok, _ := restart.Pending(d.state)
-		d.state.Unlock()
+		ok, _ := d.overlord.RestartManager().Pending()
 		if ok {
 			logger.Noticef("gracefully waiting for running hooks")
 			hookMgr.GracefullyWaitRunningHooks()

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -286,10 +286,7 @@ func (s *daemonSuite) TestCommandRestartingState(c *check.C) {
 	}
 
 	for _, t := range tests {
-		st := d.overlord.State()
-		st.Lock()
-		restart.MockPending(st, t.rst)
-		st.Unlock()
+		d.overlord.RestartManager().MockPending(t.rst)
 		rec = httptest.NewRecorder()
 		cmd.ServeHTTP(rec, req)
 		c.Check(rec.Code, check.Equals, 200)

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -30,6 +30,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
@@ -39,7 +40,7 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
-type RestartType int
+type RestartType int32
 
 const (
 	RestartUnset RestartType = iota
@@ -123,7 +124,7 @@ type restartManagerKey struct{}
 // RestartManager takes care of restart-related state.
 type RestartManager struct {
 	state            *state.State
-	restarting       RestartType
+	restarting       int32 // really of type RestartType -- TODO: use atomic.Int32 once on go 1.19+
 	h                Handler
 	bootID           string
 	changeCallbackID int
@@ -344,7 +345,7 @@ func Request(st *state.State, t RestartType, rebootInfo *boot.RebootInfo) {
 	case RestartSystem, RestartSystemNow, RestartSystemHaltNow, RestartSystemPoweroffNow:
 		st.Set("system-restart-from-boot-id", rm.bootID)
 	}
-	rm.restarting = t
+	atomic.StoreInt32(&rm.restarting, int32(t))
 	rm.handleRestart(t, rebootInfo)
 }
 
@@ -394,13 +395,27 @@ func Pending(st *state.State) (bool, RestartType) {
 		return false, RestartUnset
 	}
 	rm := cached.(*RestartManager)
-	return rm.restarting != RestartUnset, rm.restarting
+	return rm.Pending()
+}
+
+// Pending returns whether a restart was requested with Request and of which type.
+// NOTE: the state does not need to be locked to fetch this information.
+func (rm *RestartManager) Pending() (bool, RestartType) {
+	if rm == nil {
+		return false, RestartUnset
+	}
+	restarting := RestartType(atomic.LoadInt32(&rm.restarting))
+	return restarting != RestartUnset, restarting
 }
 
 func MockPending(st *state.State, restarting RestartType) RestartType {
 	rm := restartManager(st, "internal error: cannot mock a restart request before RestartManager initialization")
-	old := rm.restarting
-	rm.restarting = restarting
+	return rm.MockPending(restarting)
+}
+
+// NOTE: the state does not need to be locked to set this information.
+func (rm *RestartManager) MockPending(restarting RestartType) RestartType {
+	old := RestartType(atomic.SwapInt32(&rm.restarting, int32(restarting)))
 	return old
 }
 

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -402,6 +402,8 @@ func Pending(st *state.State) (bool, RestartType) {
 // NOTE: the state does not need to be locked to fetch this information.
 func (rm *RestartManager) Pending() (bool, RestartType) {
 	if rm == nil {
+		// This check is here because some tests don't set a RestartManager.
+		// This should generally not occur in production.
 		return false, RestartUnset
 	}
 	restarting := RestartType(atomic.LoadInt32(&rm.restarting))

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -92,11 +92,14 @@ func (s *restartSuite) TestRequestRestartDaemon(c *C) {
 
 	h := &testHandler{}
 
-	_, err := restart.Manager(st, "boot-id-1", h)
+	manager, err := restart.Manager(st, "boot-id-1", h)
 	c.Assert(err, IsNil)
 	c.Check(h.rebootAsExpected, Equals, true)
 
 	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+	ok, t = manager.Pending()
 	c.Check(ok, Equals, false)
 	c.Check(t, Equals, restart.RestartUnset)
 
@@ -105,6 +108,9 @@ func (s *restartSuite) TestRequestRestartDaemon(c *C) {
 	c.Check(h.restartRequested, Equals, true)
 
 	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartDaemon)
+	ok, t = manager.Pending()
 	c.Check(ok, Equals, true)
 	c.Check(t, Equals, restart.RestartDaemon)
 }
@@ -115,12 +121,15 @@ func (s *restartSuite) TestRequestRestartDaemonNoHandler(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	_, err := restart.Manager(st, "boot-id-1", nil)
+	manager, err := restart.Manager(st, "boot-id-1", nil)
 	c.Assert(err, IsNil)
 
 	restart.Request(st, restart.RestartDaemon, nil)
 
 	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartDaemon)
+	ok, t = manager.Pending()
 	c.Check(ok, Equals, true)
 	c.Check(t, Equals, restart.RestartDaemon)
 }
@@ -131,11 +140,14 @@ func (s *restartSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
 	defer st.Unlock()
 
 	h := &testHandler{}
-	_, err := restart.Manager(st, "boot-id-1", h)
+	manager, err := restart.Manager(st, "boot-id-1", h)
 	c.Assert(err, IsNil)
 	c.Check(h.rebootAsExpected, Equals, true)
 
 	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+	ok, t = manager.Pending()
 	c.Check(ok, Equals, false)
 	c.Check(t, Equals, restart.RestartUnset)
 
@@ -144,6 +156,9 @@ func (s *restartSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
 	c.Check(h.restartRequested, Equals, true)
 
 	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartSystem)
+	ok, t = manager.Pending()
 	c.Check(ok, Equals, true)
 	c.Check(t, Equals, restart.RestartSystem)
 
@@ -173,11 +188,14 @@ func (s *restartSuite) TestRequestRestartSystemWithRebootInfo(c *C) {
 	defer st.Unlock()
 
 	h := &testHandler{}
-	_, err := restart.Manager(st, "boot-id-1", h)
+	manager, err := restart.Manager(st, "boot-id-1", h)
 	c.Assert(err, IsNil)
 	c.Check(h.rebootAsExpected, Equals, true)
 
 	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+	ok, t = manager.Pending()
 	c.Check(ok, Equals, false)
 	c.Check(t, Equals, restart.RestartUnset)
 
@@ -191,6 +209,9 @@ func (s *restartSuite) TestRequestRestartSystemWithRebootInfo(c *C) {
 	c.Check(h.rebootInfo.BootloaderOptions, NotNil)
 
 	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartSystem)
+	ok, t = manager.Pending()
 	c.Check(ok, Equals, true)
 	c.Check(t, Equals, restart.RestartSystem)
 


### PR DESCRIPTION
~~This PR is based on #15309~~

In places such as the daemon, we acquire state lock just to check whether a restart is pending. This increases state lock contention and slows down API replies.

Thus, make the restart value atomic, allowing it to be checked via a method on the `RestartManager` without needing to lock snapd state.

This is an adaptation of a similar change from pebble:

https://github.com/canonical/pebble/pull/451

Because many other places do not have a reference to an overlord from which they call `RestartManager()` to get access to the manager, we also preserve the existing `restart.Pending()` function, which differs from the change in pebble.

Snapd is still on go 1.18, so we cannot yet use `atomic.Int32` as pebble does. Instead, we use `atomic.{Load,Store,Swap}` on an `int32`, but we should switch to the atomic types once snapd's go version is advanced.

Lastly, there are a few other drive-by changes identified in snapd which were not previously included in pebble. The following PR ports them back to pebble: https://github.com/canonical/pebble/pull/597

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34635
