### PR TITLE
interfaces/apparmor: make AppArmor backend reinitializable

### DIFF
--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -122,6 +122,13 @@ type SecurityBackend interface {
 	SandboxFeatures() []string
 }
 
+// ReinitializableSecurityBackend is a backend which can be dynamically
+// reinitialized at runtime in response to changes in the system state,
+// typically ones that are observable in system-key.
+type ReinitializableSecurityBackend interface {
+	Reinitialize() error
+}
+
 // SecurityBackendSetupMany interface may be implemented by backends that can optimize their operations
 // when setting up multiple snaps at once.
 type SecurityBackendSetupMany interface {

--- a/interfaces/ifacetest/backend.go
+++ b/interfaces/ifacetest/backend.go
@@ -129,3 +129,25 @@ func (b *TestSecurityBackendDiscardingLate) RemoveLate(snapName string, rev snap
 	}
 	return b.RemoveLateCallback(snapName, rev, typ)
 }
+
+// TestSecurityBackendReinitializable implements Reinitialize on top of
+// TestSecurityBackend.
+type TestSecurityBackendReinitializable struct {
+	TestSecurityBackend
+
+	ReinitializeCalls int
+
+	ReinitializeCallback func() error
+}
+
+var (
+	_ interfaces.ReinitializableSecurityBackend = (*TestSecurityBackendReinitializable)(nil)
+)
+
+func (b *TestSecurityBackendReinitializable) Reinitialize() error {
+	b.ReinitializeCalls++
+	if b.ReinitializeCallback == nil {
+		return nil
+	}
+	return b.ReinitializeCallback()
+}


### PR DESCRIPTION
Add support for reinitialization in AppArmor security backend.

Cherry picked from #15254
Related: [SNAPDENG-34243](https://warthogs.atlassian.net/browse/SNAPDENG-34243)

[SNAPDENG-34243]: https://warthogs.atlassian.net/browse/SNAPDENG-34243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ