### PR TITLE
tests: speed up the prepare-each phase

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -680,16 +680,6 @@ prepare_suite_each() {
 
     # Save all the installed packages
     if os.query is-classic; then
-        # lxd-installer is in cloud images starting from 24.04. This package
-        # installs lxd when any lxc command is run. This caused problems
-        # because if we install snapcraft & lxd, in the restore step lxd is
-        # removed, and after that snapcraft is removed. However, snapcraft's
-        # remove hook calls lxd and triggers a new installation of lxd, and in
-        # turn when we try to remove core22, it fails as lxd has been
-        # re-installed and depends on that base. Therefore, we remove it to
-        # prevent these issues, and we do that before we get the list of
-        # installed packages to make sure we do not re-install it again.
-        apt remove -y --purge lxd-installer || true
         tests.pkgs list-installed > installed-initial.pkgs
     fi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -478,6 +478,19 @@ prepare_classic() {
             fi
         fi
 
+        # lxd-installer is in cloud images starting from 24.04. This package
+        # installs lxd when any lxc command is run. This caused problems
+        # because if we install snapcraft & lxd, in the restore step lxd is
+        # removed, and after that snapcraft is removed. However, snapcraft's
+        # remove hook calls lxd and triggers a new installation of lxd, and in
+        # turn when we try to remove core22, it fails as lxd has been
+        # re-installed and depends on that base. Therefore, we remove it to
+        # prevent these issues, and we do that before we get the list of
+        # installed packages to make sure we do not re-install it again.
+        if ( os.query is-ubuntu || os.query is-debian ) && tests.pkgs is-installed lxd-installer; then
+            apt remove -y --purge lxd-installer
+        fi
+
         setup_experimental_features
 
         systemctl stop snapd.{service,socket}

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -80,40 +80,34 @@ check_lxcfs_mounted() {
 
 check_stray_dbus_daemon() {
 	n="$1" # invariant name
-	wait_for_dbus_daemon=5
 	failed=()
-	while [ "${wait_for_dbus_daemon}" -gt 0 ]; do
-		failed=()
-		skipped_system=0
-		skipped_root_session=0
-		for pid in $(pgrep -x dbus-daemon); do
-			cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline")"
-			# Ignore one dbus-daemon responsible for the system bus.
-			if echo "$cmdline" | grep -q 'dbus-daemon --system' && [ "$skipped_system" -eq 0 ]; then
-				skipped_system=1
-				continue
-			fi
-			if echo "$cmdline" | grep -q 'dbus-daemon --session' && [ "$(stat -c %u "/proc/$pid")" -eq 0 ] && [ "$skipped_root_session" -eq 0 ]; then
-				skipped_root_session=1
-				continue
-			fi
-			# Ignore dbus-daemon running the session of the "external" user.
-			# This may happen when testing a core device using the ad-hoc
-			# backend. This user is never used by tests explicitly.
-			user="$(stat -c %U "/proc/$pid")"
-			if [ "$user" = "external" ]; then
-				continue
-			fi
-                        # On qemu backend, sudo from user "ubuntu" is used. So the session
-                        # for user "ubuntu" is expected to exist.
-			if [ "$user" = "ubuntu" ]; then
-				continue
-			fi
-			# Report stray dbus-daemon.
-			failed+=("pid:$pid user:$user cmdline:$cmdline")
-		done
-		: $((wait_for_dbus_daemon--))
-		sleep 1
+	skipped_system=0
+	skipped_root_session=0
+	for pid in $(pgrep -x dbus-daemon); do
+		cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline")"
+		# Ignore one dbus-daemon responsible for the system bus.
+		if echo "$cmdline" | grep -q 'dbus-daemon --system' && [ "$skipped_system" -eq 0 ]; then
+			skipped_system=1
+			continue
+		fi
+		if echo "$cmdline" | grep -q 'dbus-daemon --session' && [ "$(stat -c %u "/proc/$pid")" -eq 0 ] && [ "$skipped_root_session" -eq 0 ]; then
+			skipped_root_session=1
+			continue
+		fi
+		# Ignore dbus-daemon running the session of the "external" user.
+		# This may happen when testing a core device using the ad-hoc
+		# backend. This user is never used by tests explicitly.
+		user="$(stat -c %U "/proc/$pid")"
+		if [ "$user" = "external" ]; then
+			continue
+		fi
+		# On qemu backend, sudo from user "ubuntu" is used. So the session
+		# for user "ubuntu" is expected to exist.
+		if [ "$user" = "ubuntu" ]; then
+			continue
+		fi
+		# Report stray dbus-daemon.
+		failed+=("pid:$pid user:$user cmdline:$cmdline")
 	done
 
 	if [ "${#failed[@]}" -ne 0 ]; then


### PR DESCRIPTION
This change introduces 2 improvements while preparing each task:

1. Reduces the invariant check check_stray_dbus_daemon from 5 seconds to 1 (https://pastebin.canonical.com/p/mT5m6qqDwj/)

2. Moves the removal of lxd-installer to the suite preparation, which takes almost 2 seconds (https://pastebin.canonical.com/p/qfkT6hvcmp/)
