### PR TITLE
daemon,o/state: don't require state lock just to get warnings

### DIFF
--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -450,8 +450,6 @@ func getWarnings(c *Command, r *http.Request, _ *auth.UserState) Response {
 	}
 
 	st := c.d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
 
 	var ws []*state.Warning
 	if all {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -171,9 +171,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rjson.addMaintenanceFromRestartType(rst)
 
 		if rjson.Type != ResponseTypeError {
-			st.Lock()
 			count, stamp := st.WarningsSummary()
-			st.Unlock()
 			rjson.addWarningCount(count, stamp)
 		}
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -410,12 +410,8 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
 	c.Check(mgr.AppArmorPromptingRunning(), Equals, true)
 	c.Check(mgr.InterfacesRequestsManager(), Equals, fakeManager)
 
-	func() {
-		s.state.Lock()
-		defer s.state.Unlock()
-		warns := s.state.AllWarnings()
-		c.Check(warns, HasLen, 0)
-	}()
+	warns := s.state.AllWarnings()
+	c.Check(warns, HasLen, 0)
 
 	c.Check(stopCount, Equals, 0)
 	mgr.Stop()
@@ -457,12 +453,8 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
 	c.Check(mgr.AppArmorPromptingRunning(), Equals, false)
 	c.Check(mgr.InterfacesRequestsManager(), testutil.IsInterfaceNil)
 
-	func() {
-		s.state.Lock()
-		defer s.state.Unlock()
-		warns := s.state.AllWarnings()
-		c.Check(warns, HasLen, 0)
-	}()
+	warns := s.state.AllWarnings()
+	c.Check(warns, HasLen, 0)
 
 	mgr.Stop()
 	c.Check(stopCount, Equals, 0)
@@ -7064,8 +7056,6 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerNoHandlerService(c 
 		c.Check(logStr, Not(testutil.Contains), "failed to start interfaces requests manager")
 	})
 
-	s.state.Lock()
-	defer s.state.Unlock()
 	warns := s.state.AllWarnings()
 	c.Check(warns, HasLen, 1)
 	c.Check(warns[0].String(), Matches, `"apparmor-prompting" feature flag enabled but no prompting client is present; requests will be auto-denied until a prompting client is installed`)
@@ -7110,8 +7100,6 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerHandlerServicePrese
 		c.Check(logbuf.String(), testutil.Contains, "failed to check the presence of a interfaces-requests-control handler service")
 	})
 
-	s.state.Lock()
-	defer s.state.Unlock()
 	warns := s.state.AllWarnings()
 	c.Check(warns, HasLen, 0)
 }
@@ -7150,8 +7138,6 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 		c.Check(logbuf.String(), testutil.Contains, fmt.Sprintf("%v", createError))
 	})
 
-	s.state.Lock()
-	defer s.state.Unlock()
 	warns := s.state.AllWarnings()
 	c.Check(warns, HasLen, 1)
 	c.Check(warns[0].String(), Matches, fmt.Sprintf(`cannot start prompting backend: %v; prompting will be inactive until snapd is restarted`, createError))
@@ -7264,8 +7250,6 @@ func (s *interfaceManagerSuite) TestStartupWarningForDisabledAppArmor(c *C) {
 
 	c.Check(invocationCount, Equals, 1)
 
-	s.state.Lock()
-	defer s.state.Unlock()
 	warns := s.state.AllWarnings()
 	c.Assert(warns, HasLen, 1)
 	c.Check(warns[0].String(), Matches, `the snapd\.apparmor service is disabled.*\nRun .* to correct this\.`)

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -483,13 +483,7 @@ func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Dura
 		readyChangesCount++
 	}
 
-	s.warningsMu.Lock()
-	for k, w := range s.warnings {
-		if w.ExpiredBefore(now) {
-			delete(s.warnings, k)
-		}
-	}
-	s.warningsMu.Unlock()
+	s.pruneWarnings(now)
 
 	for k, n := range s.notices {
 		if n.expired(now) {
@@ -534,6 +528,16 @@ NextChange:
 		if t.Change() == nil && t.SpawnTime().Before(pruneLimit) {
 			s.writing()
 			delete(s.tasks, tid)
+		}
+	}
+}
+
+func (s *State) pruneWarnings(now time.Time) {
+	s.warningsMu.Lock()
+	defer s.warningsMu.Unlock()
+	for k, w := range s.warnings {
+		if w.ExpiredBefore(now) {
+			delete(s.warnings, k)
 		}
 	}
 }

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -772,9 +772,6 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.MarshalJSON() },
 		func() { st.Prune(time.Now(), time.Hour, time.Hour, 100) },
 		func() { st.TaskCount() },
-		func() { st.AllWarnings() },
-		func() { st.PendingWarnings() },
-		func() { st.WarningsSummary() },
 	}
 
 	for i, f := range reads {

--- a/overlord/state/warning.go
+++ b/overlord/state/warning.go
@@ -143,8 +143,12 @@ func (w *Warning) ShowAfter(t time.Time) bool {
 
 // flattenWarning loops over the warnings map, and returns all
 // non-expired warnings therein as a flat list, for serialising.
-// Call with the lock held.
+//
+// State lock does not need to be held, as the warnings mutex ensures
+// warnings can be safely read.
 func (s *State) flattenWarnings() []*Warning {
+	s.warningsMu.RLock()
+	defer s.warningsMu.RUnlock()
 	now := time.Now()
 	flat := make([]*Warning, 0, len(s.warnings))
 	for _, w := range s.warnings {
@@ -158,8 +162,11 @@ func (s *State) flattenWarnings() []*Warning {
 
 // unflattenWarnings takes a flat list of warnings and replaces the
 // warning map with them, ignoring expired warnings in the process.
-// Call with the lock held.
+//
+// Call with the state lock held. Acquires the warnings lock for writing.
 func (s *State) unflattenWarnings(flat []*Warning) {
+	s.warningsMu.Lock()
+	defer s.warningsMu.Unlock()
 	now := time.Now()
 	s.warnings = make(map[string]*Warning, len(flat))
 	for _, w := range flat {
@@ -203,6 +210,8 @@ func (s *State) AddWarning(message string, options *AddWarningOptions) {
 	}
 
 	s.writing()
+	s.warningsMu.Lock()
+	defer s.warningsMu.Unlock()
 
 	now := options.Time
 	if now.IsZero() {
@@ -234,6 +243,8 @@ func (s *State) AddWarning(message string, options *AddWarningOptions) {
 // Returns state.ErrNoState if no warning exists with given message.
 func (s *State) RemoveWarning(message string) error {
 	s.writing()
+	s.warningsMu.Lock()
+	defer s.warningsMu.Unlock()
 	_, ok := s.warnings[message]
 	if !ok {
 		return ErrNoState
@@ -251,9 +262,10 @@ func (a byLastAdded) Less(i, j int) bool { return a[i].lastAdded.Before(a[j].las
 
 // AllWarnings returns all the warnings in the system, whether they're
 // due to be shown or not. They'll be sorted by lastAdded.
+//
+// State lock does not need to be held, as the warnings mutex ensures
+// warnings can be safely read.
 func (s *State) AllWarnings() []*Warning {
-	s.reading()
-
 	all := s.flattenWarnings()
 	sort.Sort(byLastAdded(all))
 
@@ -262,8 +274,10 @@ func (s *State) AllWarnings() []*Warning {
 
 // OkayWarnings marks warnings that were showable at the given time as shown.
 func (s *State) OkayWarnings(t time.Time) int {
-	t = t.UTC()
 	s.writing()
+	s.warningsMu.Lock()
+	defer s.warningsMu.Unlock()
+	t = t.UTC()
 
 	n := 0
 	for _, w := range s.warnings {
@@ -281,8 +295,12 @@ func (s *State) OkayWarnings(t time.Time) int {
 //
 // Warnings to show to the user are those that have not been shown before,
 // or that have been shown earlier than repeatAfter ago.
+//
+// State lock does not need to be held, as the warnings mutex ensures
+// warnings can be safely read.
 func (s *State) PendingWarnings() ([]*Warning, time.Time) {
-	s.reading()
+	s.warningsMu.RLock()
+	defer s.warningsMu.RUnlock()
 	now := time.Now().UTC()
 
 	var toShow []*Warning
@@ -301,8 +319,12 @@ func (s *State) PendingWarnings() ([]*Warning, time.Time) {
 // shown to the user, and the timestamp of the most recently added
 // warning (useful for silencing the warning alerts, and OKing the
 // returned warnings).
+//
+// State lock does not need to be held, as the warnings mutex ensures
+// warnings can be safely read.
 func (s *State) WarningsSummary() (int, time.Time) {
-	s.reading()
+	s.warningsMu.RLock()
+	defer s.warningsMu.RUnlock()
 	now := time.Now().UTC()
 	var last time.Time
 
@@ -323,6 +345,8 @@ func (s *State) WarningsSummary() (int, time.Time) {
 // warnings. For use in debugging.
 func (s *State) UnshowAllWarnings() {
 	s.writing()
+	s.warningsMu.Lock()
+	defer s.warningsMu.Unlock()
 	for _, w := range s.warnings {
 		w.lastShown = time.Time{}
 	}

--- a/overlord/state/warning.go
+++ b/overlord/state/warning.go
@@ -274,10 +274,11 @@ func (s *State) AllWarnings() []*Warning {
 
 // OkayWarnings marks warnings that were showable at the given time as shown.
 func (s *State) OkayWarnings(t time.Time) int {
+	t = t.UTC()
+
 	s.writing()
 	s.warningsMu.Lock()
 	defer s.warningsMu.Unlock()
-	t = t.UTC()
 
 	n := 0
 	for _, w := range s.warnings {

--- a/overlord/state/warning_test.go
+++ b/overlord/state/warning_test.go
@@ -295,3 +295,29 @@ func (stateSuite) TestRemoveWarning(c *check.C) {
 	ws = st.AllWarnings()
 	c.Check(ws, check.HasLen, 0)
 }
+
+func (stateSuite) TestWarningsReadWithoutStateLock(c *check.C) {
+	st := state.New(nil)
+
+	ws := st.AllWarnings()
+	c.Check(ws, check.HasLen, 0)
+	ws, ts := st.PendingWarnings()
+	c.Check(ws, check.HasLen, 0)
+	c.Check(ts.IsZero(), check.Equals, false)
+	count, ts := st.WarningsSummary()
+	c.Check(count, check.Equals, 0)
+	c.Check(ts.IsZero(), check.Equals, true)
+
+	st.Lock()
+	st.Warnf("this warning exists")
+	st.Unlock()
+
+	ws = st.AllWarnings()
+	c.Check(ws, check.HasLen, 1)
+	ws, ts = st.PendingWarnings()
+	c.Check(ws, check.HasLen, 1)
+	c.Check(ts.IsZero(), check.Equals, false)
+	count, ts = st.WarningsSummary()
+	c.Check(count, check.Equals, 1)
+	c.Check(ts.IsZero(), check.Equals, false)
+}


### PR DESCRIPTION
Add a `RWMutex` to guard the state warnings map, and no longer require the state lock to be held just to read warnings.
    
This means that callers of `state.AllWarnings`, `state.PendingWarnings`, and `state.WarningsSummary` no longer need to hold the state lock .

Those callers include `daemon` and tests within `o/ifacestate`.

Some other callers still require state lock for other reasons, so these are left unchanged.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34635