### PR TITLE
many: apply changes of go's new 'modernize' tool (swap interface{} for any)

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -42,7 +42,7 @@ type sinceUntil struct {
 	until time.Time
 }
 
-func checkSinceUntilWhat(m map[string]interface{}, what string) (*sinceUntil, error) {
+func checkSinceUntilWhat(m map[string]any, what string) (*sinceUntil, error) {
 	since, err := checkRFC3339DateWhat(m, "since", what)
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func (ak *AccountKey) publicKey() PublicKey {
 }
 
 // ConstraintsPrecheck checks whether the given type and headers match the signing constraints of the account key.
-func (ak *AccountKey) ConstraintsPrecheck(assertType *AssertionType, headers map[string]interface{}) error {
+func (ak *AccountKey) ConstraintsPrecheck(assertType *AssertionType, headers map[string]any) error {
 	headersWithType := copyHeaders(headers)
 	headersWithType["type"] = assertType.Name
 	if !ak.matchAgainstConstraints(headersWithType) {
@@ -139,7 +139,7 @@ func (ak *AccountKey) ConstraintsPrecheck(assertType *AssertionType, headers map
 	return nil
 }
 
-func (ak *AccountKey) matchAgainstConstraints(headers map[string]interface{}) bool {
+func (ak *AccountKey) matchAgainstConstraints(headers map[string]any) bool {
 	matchers := ak.constraintMatchers
 	// no constraints, everything is allowed
 	if len(matchers) == 0 {
@@ -265,8 +265,8 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 	}, nil
 }
 
-func checkAKConstraints(cs interface{}) ([]attrMatcher, error) {
-	csmaps, ok := cs.([]interface{})
+func checkAKConstraints(cs any) ([]attrMatcher, error) {
+	csmaps, ok := cs.([]any)
 	if !ok {
 		return nil, fmt.Errorf("assertions constraints must be a list of maps")
 	}
@@ -276,7 +276,7 @@ func checkAKConstraints(cs interface{}) ([]attrMatcher, error) {
 	}
 	matchers := make([]attrMatcher, 0, len(csmaps))
 	for _, csmap := range csmaps {
-		m, ok := csmap.(map[string]interface{})
+		m, ok := csmap.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("assertions constraints must be a list of maps")
 		}
@@ -310,7 +310,7 @@ func checkAKConstraints(cs interface{}) ([]attrMatcher, error) {
 	return matchers, nil
 }
 
-func accountKeyFormatAnalyze(headers map[string]interface{}, body []byte) (formatnum int, err error) {
+func accountKeyFormatAnalyze(headers map[string]any, body []byte) (formatnum int, err error) {
 	formatnum = 0
 	if _, ok := headers["constraints"]; ok {
 		formatnum = 1

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -265,7 +265,7 @@ func (aks *accountKeySuite) openDB(c *C) *asserts.Database {
 func (aks *accountKeySuite) prereqAccount(c *C, db *asserts.Database) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"display-name": "Acct1",
 		"account-id":   "acc-id1",
@@ -283,7 +283,7 @@ func (aks *accountKeySuite) prereqAccount(c *C, db *asserts.Database) {
 func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "acc-id1",
 		"name":                "default",
@@ -305,7 +305,7 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 func (aks *accountKeySuite) TestAccountKeyCheckNoAccount(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "acc-id1",
 		"name":                "default",
@@ -329,7 +329,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckUntrustedAuthority(c *C) {
 	storeDB := assertstest.NewSigningDB("canonical", trustedKey)
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"account-id":          "acc-id1",
 		"name":                "default",
 		"public-key-sha3-384": aks.keyID,
@@ -346,7 +346,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckUntrustedAuthority(c *C) {
 func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndNewRevision(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "acc-id1",
 		"name":                "default",
@@ -374,7 +374,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndNewRevision(c *C) {
 func (aks *accountKeySuite) TestAccountKeyCheckSameAccountAndDifferentName(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "acc-id1",
 		"name":                "default",
@@ -411,7 +411,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameAccountAndDifferentName(c *C)
 func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndDifferentAccount(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "acc-id1",
 		"name":                "default",
@@ -438,7 +438,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndDifferentAccount(c *C)
 	newPubKeyEncoded, err := asserts.EncodePublicKey(newPubKey)
 	c.Assert(err, IsNil)
 
-	acct2 := assertstest.NewAccount(db, "acc-id2", map[string]interface{}{
+	acct2 := assertstest.NewAccount(db, "acc-id2", map[string]any{
 		"authority-id": "canonical",
 		"account-id":   "acc-id2",
 	}, trustedKey.PublicKey().ID())
@@ -457,7 +457,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndDifferentAccount(c *C)
 func (aks *accountKeySuite) TestAccountKeyCheckNameClash(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "acc-id1",
 		"name":                "default",
@@ -494,7 +494,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckNameClash(c *C) {
 func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "acc-id1",
 		"name":                "default",
@@ -799,7 +799,7 @@ func (aks *accountKeySuite) TestPrerequisites(c *C) {
 
 func (aks *accountKeySuite) TestAccountKeyRequestHappy(c *C) {
 	akr, err := asserts.SignWithoutAuthority(asserts.AccountKeyRequestType,
-		map[string]interface{}{
+		map[string]any{
 			"account-id":          "acc-id1",
 			"name":                "default",
 			"public-key-sha3-384": aks.keyID,
@@ -841,7 +841,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestUntil(c *C) {
 
 	for _, test := range tests {
 		c.Log(test)
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"account-id":          "acc-id1",
 			"name":                "default",
 			"public-key-sha3-384": aks.keyID,
@@ -863,7 +863,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestUntil(c *C) {
 
 func (aks *accountKeySuite) TestAccountKeyRequestAddAndFind(c *C) {
 	akr, err := asserts.SignWithoutAuthority(asserts.AccountKeyRequestType,
-		map[string]interface{}{
+		map[string]any{
 			"account-id":          "acc-id1",
 			"name":                "default",
 			"public-key-sha3-384": aks.keyID,
@@ -977,7 +977,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestDecodeKeyIDMismatch(c *C) {
 }
 
 func (aks *accountKeySuite) TestAccountKeyRequestNoAccount(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"account-id":          "acc-id1",
 		"name":                "default",
 		"public-key-sha3-384": aks.keyID,
@@ -1063,8 +1063,8 @@ func (s *accountKeySuite) TestSuggestedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 0)
 
-	headers := map[string]interface{}{
-		"constraints": []interface{}{map[string]interface{}{"headers": nil}},
+	headers := map[string]any{
+		"constraints": []any{map[string]any{"headers": nil}},
 	}
 	fmtnum, err = asserts.SuggestFormat(asserts.AccountKeyType, headers, nil)
 	c.Assert(err, IsNil)
@@ -1095,7 +1095,7 @@ func (aks *accountKeySuite) TestCanSignAndConstraintsPrecheck(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.AccountKeyType)
 	accKey := a.(*asserts.AccountKey)
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"brand-id":     "my-brand",
@@ -1106,7 +1106,7 @@ func (aks *accountKeySuite) TestCanSignAndConstraintsPrecheck(c *C) {
 	c.Check(accKey.ConstraintsPrecheck(asserts.ModelType, headers), IsNil)
 	mfoo := assertstest.FakeAssertion(headers)
 	c.Check(accKey.CanSign(mfoo), Equals, true)
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"brand-id":     "my-brand",
@@ -1117,20 +1117,20 @@ func (aks *accountKeySuite) TestCanSignAndConstraintsPrecheck(c *C) {
 	c.Check(accKey.ConstraintsPrecheck(asserts.ModelType, headers), ErrorMatches, `headers do not match the account-key constraints`)
 	mnotfoo := assertstest.FakeAssertion(headers)
 	c.Check(accKey.CanSign(mnotfoo), Equals, false)
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"type":              "preseed",
 		"authority-id":      "my-brand",
 		"series":            "16",
 		"brand-id":          "my-brand",
 		"model":             "goo-200",
 		"system-label":      "2023-07-17",
-		"snaps":             []interface{}{},
+		"snaps":             []any{},
 		"artifact-sha3-384": "KPIl7M4vQ9d4AUjkoU41TGAwtOMLc_bWUCeW8AvdRWD4_xcP60Oo4ABs1No7BtXj",
 	}
 	c.Check(accKey.ConstraintsPrecheck(asserts.PreseedType, headers), IsNil)
 	pr := assertstest.FakeAssertion(headers)
 	c.Check(accKey.CanSign(pr), Equals, true)
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"type":         "snap-declaration",
 		"authority-id": "my-brand",
 		"series":       "16",

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -249,7 +249,7 @@ func MockOptionalPrimaryKey(assertType *AssertionType, key, defaultValue string)
 	}
 }
 
-var formatAnalyzer = map[*AssertionType]func(headers map[string]interface{}, body []byte) (formatnum int, err error){
+var formatAnalyzer = map[*AssertionType]func(headers map[string]any, body []byte) (formatnum int, err error){
 	AccountKeyType:      accountKeyFormatAnalyze,
 	SnapDeclarationType: snapDeclarationFormatAnalyze,
 	SystemUserType:      systemUserFormatAnalyze,
@@ -274,7 +274,7 @@ func MaxSupportedFormats(min int) (maxFormats map[string]int) {
 }
 
 // SuggestFormat returns a minimum format that supports the features that would be used by an assertion with the given components.
-func SuggestFormat(assertType *AssertionType, headers map[string]interface{}, body []byte) (formatnum int, err error) {
+func SuggestFormat(assertType *AssertionType, headers map[string]any, body []byte) (formatnum int, err error) {
 	analyzer := formatAnalyzer[assertType]
 	if analyzer == nil {
 		// no analyzer, format 0 is all there is
@@ -531,10 +531,10 @@ type Assertion interface {
 	AuthorityID() string
 
 	// Header retrieves the header with name
-	Header(name string) interface{}
+	Header(name string) any
 
 	// Headers returns the complete headers
-	Headers() map[string]interface{}
+	Headers() map[string]any
 
 	// HeaderString retrieves the string value of header with name or ""
 	HeaderString(name string) string
@@ -577,7 +577,7 @@ const MediaType = "application/x.ubuntu.assertion"
 
 // assertionBase is the concrete base to hold representation data for actual assertions.
 type assertionBase struct {
-	headers map[string]interface{}
+	headers map[string]any
 	body    []byte
 	// parsed format iteration
 	format int
@@ -623,7 +623,7 @@ func (ab *assertionBase) AuthorityID() string {
 }
 
 // Header returns the value of an header by name.
-func (ab *assertionBase) Header(name string) interface{} {
+func (ab *assertionBase) Header(name string) any {
 	v := ab.headers[name]
 	if v == nil {
 		return nil
@@ -632,7 +632,7 @@ func (ab *assertionBase) Header(name string) interface{} {
 }
 
 // Headers returns the complete headers.
-func (ab *assertionBase) Headers() map[string]interface{} {
+func (ab *assertionBase) Headers() map[string]any {
 	return copyHeaders(ab.headers)
 }
 
@@ -958,7 +958,7 @@ func (d *Decoder) Decode() (Assertion, error) {
 	return assemble(headers, finalBody, finalContent, finalSig)
 }
 
-func checkIteration(headers map[string]interface{}, name string) (int, error) {
+func checkIteration(headers map[string]any, name string) (int, error) {
 	iternum, err := checkIntWithDefault(headers, name, 0)
 	if err != nil {
 		return -1, err
@@ -969,16 +969,16 @@ func checkIteration(headers map[string]interface{}, name string) (int, error) {
 	return iternum, nil
 }
 
-func checkFormat(headers map[string]interface{}) (int, error) {
+func checkFormat(headers map[string]any) (int, error) {
 	return checkIteration(headers, "format")
 }
 
-func checkRevision(headers map[string]interface{}) (int, error) {
+func checkRevision(headers map[string]any) (int, error) {
 	return checkIteration(headers, "revision")
 }
 
 // Assemble assembles an assertion from its components.
-func Assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
+func Assemble(headers map[string]any, body, content, signature []byte) (Assertion, error) {
 	err := checkHeaders(headers)
 	if err != nil {
 		return nil, err
@@ -986,14 +986,14 @@ func Assemble(headers map[string]interface{}, body, content, signature []byte) (
 	return assemble(headers, body, content, signature)
 }
 
-func checkAuthority(_ *AssertionType, headers map[string]interface{}) error {
+func checkAuthority(_ *AssertionType, headers map[string]any) error {
 	if _, err := checkNotEmptyString(headers, "authority-id"); err != nil {
 		return err
 	}
 	return nil
 }
 
-func checkNoAuthority(assertType *AssertionType, headers map[string]interface{}) error {
+func checkNoAuthority(assertType *AssertionType, headers map[string]any) error {
 	if _, ok := headers["authority-id"]; ok {
 		return fmt.Errorf("%q assertion cannot have authority-id set", assertType.Name)
 	}
@@ -1011,7 +1011,7 @@ func checkJSON(assertType *AssertionType, body []byte) (err error) {
 		return fmt.Errorf(`body must contain JSON`)
 	}
 
-	var val interface{}
+	var val any
 	if err := json.Unmarshal(body, &val); err != nil {
 		return fmt.Errorf("invalid JSON in body: %v", err)
 	}
@@ -1029,7 +1029,7 @@ func checkJSON(assertType *AssertionType, body []byte) (err error) {
 }
 
 // assemble is the internal variant of Assemble, assumes headers are already checked for supported types
-func assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
+func assemble(headers map[string]any, body, content, signature []byte) (Assertion, error) {
 	length, err := checkIntWithDefault(headers, "body-length", 0)
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
@@ -1110,11 +1110,11 @@ func assemble(headers map[string]interface{}, body, content, signature []byte) (
 	return assert, nil
 }
 
-func writeHeader(buf *bytes.Buffer, headers map[string]interface{}, name string) {
+func writeHeader(buf *bytes.Buffer, headers map[string]any, name string) {
 	appendEntry(buf, fmt.Sprintf("%s:", name), headers[name], 0)
 }
 
-func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, body []byte, privKey PrivateKey) (Assertion, error) {
+func assembleAndSign(assertType *AssertionType, headers map[string]any, body []byte, privKey PrivateKey) (Assertion, error) {
 	err := checkAssertType(assertType)
 	if err != nil {
 		return nil, err
@@ -1279,7 +1279,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 }
 
 // SignWithoutAuthority assembles an assertion without a set authority with the provided information and signs it with the given private key.
-func SignWithoutAuthority(assertType *AssertionType, headers map[string]interface{}, body []byte, privKey PrivateKey) (Assertion, error) {
+func SignWithoutAuthority(assertType *AssertionType, headers map[string]any, body []byte, privKey PrivateKey) (Assertion, error) {
 	if assertType.flags&noAuthority == 0 {
 		return nil, fmt.Errorf("cannot sign assertions needing a definite authority with SignWithoutAuthority")
 	}

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -864,7 +864,7 @@ func (as *assertsSuite) TestEncoderSingleDecodeOK(c *C) {
 }
 
 func (as *assertsSuite) TestSignFormatValidityEmptyBody(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
@@ -876,7 +876,7 @@ func (as *assertsSuite) TestSignFormatValidityEmptyBody(c *C) {
 }
 
 func (as *assertsSuite) TestSignFormatValidityNonEmptyBody(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
@@ -891,7 +891,7 @@ func (as *assertsSuite) TestSignFormatValidityNonEmptyBody(c *C) {
 }
 
 func (as *assertsSuite) TestSignFormatValiditySupportMultilineHeaderValues(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
@@ -922,7 +922,7 @@ func (as *assertsSuite) TestSignFormatValiditySupportMultilineHeaderValues(c *C)
 }
 
 func (as *assertsSuite) TestSignFormatAndRevision(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 		"format":       "1",
@@ -948,7 +948,7 @@ func (as *assertsSuite) TestSignFormatOptionalPrimaryKeys(c *C) {
 	r := asserts.MockOptionalPrimaryKey(asserts.TestOnlyType, "opt1", "o1-defl")
 	defer r()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "k1",
 		"header1":      "a",
@@ -967,7 +967,7 @@ header1:`)), Equals, true)
 	c.Check(err, IsNil)
 
 	// defaults are always normalized away
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "k1",
 		"opt1":         "o1-defl",
@@ -986,7 +986,7 @@ header1:`)), Equals, true)
 	_, err = asserts.Decode(b)
 	c.Check(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "k1",
 		"opt1":         "A",
@@ -1008,7 +1008,7 @@ header1:`)), Equals, true)
 }
 
 func (as *assertsSuite) TestSignBodyIsUTF8Text(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
@@ -1032,7 +1032,7 @@ func (as *assertsSuite) TestHeaders(c *C) {
 	c.Assert(err, IsNil)
 
 	hs := a.Headers()
-	c.Check(hs, DeepEquals, map[string]interface{}{
+	c.Check(hs, DeepEquals, map[string]any{
 		"type":              "test-only",
 		"authority-id":      "auth-id2",
 		"primary-key":       "abc",
@@ -1093,7 +1093,7 @@ func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
 }
 
 func (as *assertsSuite) TestSignKeyID(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
@@ -1105,7 +1105,7 @@ func (as *assertsSuite) TestSignKeyID(c *C) {
 }
 
 func (as *assertsSuite) TestSelfRef(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
@@ -1125,7 +1125,7 @@ func (as *assertsSuite) TestSelfRef(c *C) {
 		Revision: 0,
 	})
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "auth-id1",
 		"pk1":          "a",
 		"pk2":          "b",
@@ -1153,7 +1153,7 @@ func (as *assertsSuite) TestAssembleHeadersCheck(c *C) {
 		"authority-id: auth-id2\n" +
 		"primary-key: abc\n" +
 		"revision: 5")
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "test-only",
 		"authority-id": "auth-id2",
 		"primary-key":  "abc",
@@ -1169,7 +1169,7 @@ func (as *assertsSuite) TestSignWithoutAuthorityMisuse(c *C) {
 	c.Check(err, ErrorMatches, `cannot sign assertions needing a definite authority with SignWithoutAuthority`)
 
 	_, err = asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityType,
-		map[string]interface{}{
+		map[string]any{
 			"authority-id": "auth-id1",
 			"hdr":          "FOO",
 		}, nil, testPrivKey1)
@@ -1178,7 +1178,7 @@ func (as *assertsSuite) TestSignWithoutAuthorityMisuse(c *C) {
 
 func (ss *serialSuite) TestSignatureCheckError(c *C) {
 	sreq, err := asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityType,
-		map[string]interface{}{
+		map[string]any{
 			"hdr": "FOO",
 		}, nil, testPrivKey1)
 	c.Assert(err, IsNil)

--- a/asserts/assertstest/assertstest_test.go
+++ b/asserts/assertstest/assertstest_test.go
@@ -168,7 +168,7 @@ func (s *helperSuite) TestSigningAccounts(c *C) {
 	store := assertstest.NewStoreStack("super", nil)
 
 	sa := assertstest.NewSigningAccounts(store)
-	sa.Register("my-brand", brandKey, map[string]interface{}{
+	sa.Register("my-brand", brandKey, map[string]any{
 		"validation": "verified",
 	})
 
@@ -180,7 +180,7 @@ func (s *helperSuite) TestSigningAccounts(c *C) {
 
 	c.Check(sa.PublicKey("my-brand").ID(), Equals, brandKey.PublicKey().ID())
 
-	model := sa.Model("my-brand", "my-model", map[string]interface{}{
+	model := sa.Model("my-brand", "my-model", map[string]any{
 		"classic": "true",
 	})
 	c.Check(model.BrandID(), Equals, "my-brand")
@@ -188,7 +188,7 @@ func (s *helperSuite) TestSigningAccounts(c *C) {
 	c.Check(model.Classic(), Equals, true)
 
 	// can also sign models for store account-id
-	model = sa.Model("super", "pc", map[string]interface{}{
+	model = sa.Model("super", "pc", map[string]any{
 		"classic": "true",
 	})
 	c.Check(model.BrandID(), Equals, "super")
@@ -201,7 +201,7 @@ func (s *helperSuite) TestSigningAccountsAccountsAndKeysPlusAddMany(c *C) {
 	store := assertstest.NewStoreStack("super", nil)
 
 	sa := assertstest.NewSigningAccounts(store)
-	sa.Register("my-brand", brandKey, map[string]interface{}{
+	sa.Register("my-brand", brandKey, map[string]any{
 		"validation": "verified",
 	})
 

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -55,8 +55,8 @@ func (s *batchSuite) SetUpTest(c *C) {
 	s.db = db
 }
 
-func (s *batchSuite) snapDecl(c *C, name string, extraHeaders map[string]interface{}) *asserts.SnapDeclaration {
-	headers := map[string]interface{}{
+func (s *batchSuite) snapDecl(c *C, name string, extraHeaders map[string]any) *asserts.SnapDeclaration {
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      name + "-id",
 		"snap-name":    name,
@@ -212,7 +212,7 @@ func (s *batchSuite) TestCommitRefusesSelfSignedKey(c *C) {
 	aKeyEncoded, err := asserts.EncodePublicKey(aKey.PublicKey())
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "can0nical",
 		"account-id":          "can0nical",
 		"public-key-sha3-384": aKey.PublicKey().ID(),
@@ -222,7 +222,7 @@ func (s *batchSuite) TestCommitRefusesSelfSignedKey(c *C) {
 	acctKey, err := aSignDB.Sign(asserts.AccountKeyType, headers, aKeyEncoded, "")
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "can0nical",
 		"brand-id":     "can0nical",
 		"repair-id":    "2",
@@ -255,7 +255,7 @@ func (s *batchSuite) TestAddUnsupported(c *C) {
 	(func() {
 		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
 		defer restore()
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"format":       "999",
 			"revision":     "1",
 			"series":       "16",
@@ -289,7 +289,7 @@ func (s *batchSuite) TestAddUnsupportedIgnore(c *C) {
 	(func() {
 		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
 		defer restore()
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"format":       "999",
 			"revision":     "1",
 			"series":       "16",
@@ -329,7 +329,7 @@ func (s *batchSuite) TestCommitPartial(c *C) {
 
 	// too old
 	rev := 1
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "foo-id",
 		"snap-sha3-384": makeDigest(rev),
 		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
@@ -386,7 +386,7 @@ func (s *batchSuite) TestPrecheckPartial(c *C) {
 
 	// too old
 	rev := 1
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "foo-id",
 		"snap-sha3-384": makeDigest(rev),
 		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
@@ -427,7 +427,7 @@ func (s *batchSuite) TestPrecheckHappy(c *C) {
 
 	rev := 1
 	revDigest := makeDigest(rev)
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "foo-id",
 		"snap-sha3-384": revDigest,
 		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
@@ -470,7 +470,7 @@ func (s *batchSuite) TestFetch(c *C) {
 
 	rev := 10
 	revDigest := makeDigest(rev)
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "foo-id",
 		"snap-sha3-384": revDigest,
 		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -199,12 +199,12 @@ func assembleConfdbControl(assert assertionBase) (Assertion, error) {
 	}, nil
 }
 
-func parseConfdbControlGroups(rawGroups []interface{}) (*confdb.Control, error) {
+func parseConfdbControlGroups(rawGroups []any) (*confdb.Control, error) {
 	cc := &confdb.Control{}
 	for i, rawGroup := range rawGroups {
 		errPrefix := fmt.Sprintf("cannot parse group at position %d", i+1)
 
-		group, ok := rawGroup.(map[string]interface{})
+		group, ok := rawGroup.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("%s: must be a map", errPrefix)
 		}

--- a/asserts/confdb_test.go
+++ b/asserts/confdb_test.go
@@ -150,14 +150,14 @@ func (s *confdbSuite) TestDecodeInvalid(c *C) {
 }
 
 func (s *confdbSuite) TestAssembleAndSignChecksSchemaFormatOK(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "brand-id1",
 		"account-id":   "brand-id1",
 		"name":         "my-network",
-		"views": map[string]interface{}{
-			"foo": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "wifi", "storage": "wifi"},
+		"views": map[string]any{
+			"foo": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "wifi", "storage": "wifi"},
 				},
 			},
 		},
@@ -181,14 +181,14 @@ func (s *confdbSuite) TestAssembleAndSignChecksSchemaFormatOK(c *C) {
 }
 
 func (s *confdbSuite) TestAssembleAndSignChecksSchemaFormatFail(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "brand-id1",
 		"account-id":   "brand-id1",
 		"name":         "my-network",
-		"views": map[string]interface{}{
-			"foo": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "wifi", "storage": "wifi"},
+		"views": map[string]any{
+			"foo": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "wifi", "storage": "wifi"},
 				},
 			},
 		},
@@ -272,7 +272,7 @@ func (s *confdbCtrlSuite) addSerial(c *C) {
 	encodedPubKey, err := asserts.EncodePublicKey(pubKey)
 	c.Assert(err, IsNil)
 
-	serial, err := asserts.AssembleAndSignInTest(asserts.SerialType, map[string]interface{}{
+	serial, err := asserts.AssembleAndSignInTest(asserts.SerialType, map[string]any{
 		"authority-id":        "canonical",
 		"brand-id":            "canonical",
 		"model":               "pc",
@@ -407,8 +407,8 @@ func (s *confdbCtrlSuite) TestPrerequisites(c *C) {
 }
 
 func (s *confdbCtrlSuite) TestAckAssertionNoSerial(c *C) {
-	headers := map[string]interface{}{
-		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []interface{}{},
+	headers := map[string]any{
+		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []any{},
 	}
 	a, err := asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey0)
 	c.Assert(err, IsNil)
@@ -424,8 +424,8 @@ func (s *confdbCtrlSuite) TestAckAssertionNoSerial(c *C) {
 func (s *confdbCtrlSuite) TestAckAssertionKeysMismatch(c *C) {
 	s.addSerial(c)
 
-	headers := map[string]interface{}{
-		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []interface{}{},
+	headers := map[string]any{
+		"brand-id": "canonical", "model": "pc", "serial": "42", "groups": []any{},
 	}
 	a, err := asserts.AssembleAndSignInTest(asserts.ConfdbControlType, headers, nil, testPrivKey2)
 	c.Assert(err, IsNil)
@@ -441,15 +441,15 @@ func (s *confdbCtrlSuite) TestAckAssertionKeysMismatch(c *C) {
 func (s *confdbCtrlSuite) TestAckAssertionOK(c *C) {
 	s.addSerial(c)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"brand-id": "canonical",
 		"model":    "pc",
 		"serial":   "42",
-		"groups": []interface{}{
-			map[string]interface{}{
-				"operators":       []interface{}{"aa", "cc"},
-				"authentications": []interface{}{"operator-key"},
-				"views":           []interface{}{"pp/qq/rr"},
+		"groups": []any{
+			map[string]any{
+				"operators":       []any{"aa", "cc"},
+				"authentications": []any{"operator-key"},
+				"views":           []any{"pp/qq/rr"},
 			},
 		},
 	}

--- a/asserts/constraint_test.go
+++ b/asserts/constraint_test.go
@@ -38,8 +38,8 @@ type attrMatcherSuite struct {
 
 var _ = Suite(&attrMatcherSuite{})
 
-func vals(yml string) map[string]interface{} {
-	var vs map[string]interface{}
+func vals(yml string) map[string]any {
+	var vs map[string]any
 	err := yaml.Unmarshal([]byte(yml), &vs)
 	if err != nil {
 		panic(err)
@@ -48,7 +48,7 @@ func vals(yml string) map[string]interface{} {
 	if err != nil {
 		panic(err)
 	}
-	return v.(map[string]interface{})
+	return v.(map[string]any)
 }
 
 func (s *attrMatcherSuite) SetUpTest(c *C) {
@@ -62,10 +62,10 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
   bar: BAR`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"foo": "FOO",
 		"bar": "BAR",
 		"baz": "BAZ",
@@ -73,7 +73,7 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"bar": "BAZ",
 		"baz": "BAZ",
@@ -81,7 +81,7 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BAZ" does not match \^\(BAR\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"baz": "BAZ",
 	}
@@ -94,34 +94,34 @@ func (s *attrMatcherSuite) TestSimpleAnchorsVsRegexpAlt(c *C) {
   bar: BAR|BAZ`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"bar": "BAR",
 	}
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BARR",
 	}
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BARR" does not match \^\(BAR|BAZ\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BBAZ",
 	}
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BAZZ" does not match \^\(BAR|BAZ\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BABAZ",
 	}
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BABAZ" does not match \^\(BAR|BAZ\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BARAZ",
 	}
 	err = domatch(values, nil)
@@ -136,7 +136,7 @@ func (s *attrMatcherSuite) TestNested(c *C) {
     bar2: BAR2`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -191,7 +191,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
 	domatch, err := asserts.CompileAttrMatcher(m["attrs"], nil, nil)
 	c.Assert(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"foo": "FOO",
 		"bar": "BAR",
 		"baz": "BAZ",
@@ -199,7 +199,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"bar": "BAZ",
 		"baz": "BAZ",
@@ -207,7 +207,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"bar": "BARR",
 		"baz": "BAR",
@@ -226,7 +226,7 @@ func (s *attrMatcherSuite) TestNestedAlternative(c *C) {
       - BAR22`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -264,7 +264,7 @@ write:
   write: /var/(tmp|lib/snapd/snapshots)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -276,7 +276,7 @@ write:
     - /var/lib/snapd/snapshots`))
 	c.Assert(err, IsNil)
 
-	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatchLst(toMatch, nil)
@@ -296,7 +296,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
       options: rw|bind|nodev`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -318,7 +318,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensive(toMatch, nil)
@@ -340,7 +340,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensiveNoMatch(toMatch, nil)
@@ -353,7 +353,7 @@ func (s *attrMatcherSuite) TestOtherScalars(c *C) {
   bar: true`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -362,7 +362,7 @@ bar: true
 `), nil)
 	c.Check(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"foo": int64(1),
 		"bar": true,
 	}
@@ -374,33 +374,33 @@ func (s *attrMatcherSuite) TestCompileErrors(c *C) {
 	_, err := asserts.CompileAttrMatcher(1, nil, nil)
 	c.Check(err, ErrorMatches, `top constraint must be a key-value map, regexp or a list of alternative constraints: 1`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+	_, err = asserts.CompileAttrMatcher(map[string]any{
 		"foo": 1,
 	}, nil, nil)
 	c.Check(err, ErrorMatches, `constraint "foo" must be a key-value map, regexp or a list of alternative constraints: 1`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+	_, err = asserts.CompileAttrMatcher(map[string]any{
 		"foo": "[",
 	}, nil, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
-		"foo": []interface{}{"foo", "["},
+	_, err = asserts.CompileAttrMatcher(map[string]any{
+		"foo": []any{"foo", "["},
 	}, nil, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo/alt#2/" constraint "\[": error parsing regexp:.*`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
-		"foo": []interface{}{"foo", []interface{}{"bar", "baz"}},
+	_, err = asserts.CompileAttrMatcher(map[string]any{
+		"foo": []any{"foo", []any{"bar", "baz"}},
 	}, nil, nil)
 	c.Check(err, ErrorMatches, `cannot nest alternative constraints directly at "foo/alt#2/"`)
 
 	_, err = asserts.CompileAttrMatcher("FOO", nil, nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value constraints`)
 
-	_, err = asserts.CompileAttrMatcher([]interface{}{"FOO"}, nil, nil)
+	_, err = asserts.CompileAttrMatcher([]any{"FOO"}, nil, nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value constraints`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+	_, err = asserts.CompileAttrMatcher(map[string]any{
 		"foo": "$FOO()",
 	}, nil, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\$FOO\(\)": no \$OP\(\) or \$REF constraints supported`)
@@ -415,7 +415,7 @@ func (s *attrMatcherSuite) TestCompileErrors(c *C) {
 	}
 
 	for _, wrong := range wrongDollarConstraints {
-		_, err := asserts.CompileAttrMatcher(map[string]interface{}{
+		_, err := asserts.CompileAttrMatcher(map[string]any{
 			"foo": wrong,
 		}, []string{"SLOT", "OP"}, []string{"PLUG_PUBLISHER_ID"})
 		if wrong != "$SLOT(x,y)" {
@@ -432,7 +432,7 @@ func (s *attrMatcherSuite) TestMatchingListsSimple(c *C) {
   foo: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -451,7 +451,7 @@ func (s *attrMatcherSuite) TestMissingCheck(c *C) {
   foo: $MISSING`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -472,7 +472,7 @@ func (s *attrMatcherSuite) TestEvalCheck(c *C) {
   bar: $PLUG(bar.baz)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), []string{"SLOT", "PLUG"}, []string{"PLUG_PUBLISHER_ID"})
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), []string{"SLOT", "PLUG"}, []string{"PLUG_PUBLISHER_ID"})
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -482,7 +482,7 @@ bar: bar
 	c.Check(err, ErrorMatches, `field "(foo|bar)" cannot be matched without context`)
 
 	calls := make(map[[2]string]bool)
-	comp1 := func(op string, arg string) (interface{}, error) {
+	comp1 := func(op string, arg string) (any, error) {
 		calls[[2]string{op, arg}] = true
 		return arg, nil
 	}
@@ -498,7 +498,7 @@ bar: bar.baz
 		{"plug", "bar.baz"}: true,
 	})
 
-	comp2 := func(op string, arg string) (interface{}, error) {
+	comp2 := func(op string, arg string) (any, error) {
 		if op == "plug" {
 			return nil, fmt.Errorf("boom")
 		}
@@ -511,7 +511,7 @@ bar: bar.baz
 `), testEvalAttr{comp: comp2})
 	c.Check(err, ErrorMatches, `field "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
 
-	comp3 := func(op string, arg string) (interface{}, error) {
+	comp3 := func(op string, arg string) (any, error) {
 		if op == "slot" {
 			return "other-value", nil
 		}
@@ -531,7 +531,7 @@ func (s *attrMatcherSuite) TestMatchingListsMap(c *C) {
     p: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil, nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil, nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -553,19 +553,19 @@ var _ = Suite(&deviceScopeConstraintSuite{})
 
 func (s *deviceScopeConstraintSuite) TestCompile(c *C) {
 	tests := []struct {
-		m   map[string]interface{}
+		m   map[string]any
 		exp *asserts.DeviceScopeConstraint
 		err string
 	}{
 		{m: nil, exp: nil},
-		{m: map[string]interface{}{"on-store": []interface{}{"foo", "bar"}}, exp: &asserts.DeviceScopeConstraint{Store: []string{"foo", "bar"}}},
-		{m: map[string]interface{}{"on-brand": []interface{}{"foo", "bar"}}, exp: &asserts.DeviceScopeConstraint{Brand: []string{"foo", "bar"}}},
-		{m: map[string]interface{}{"on-model": []interface{}{"foo/model1", "bar/model-2"}}, exp: &asserts.DeviceScopeConstraint{Model: []string{"foo/model1", "bar/model-2"}}},
+		{m: map[string]any{"on-store": []any{"foo", "bar"}}, exp: &asserts.DeviceScopeConstraint{Store: []string{"foo", "bar"}}},
+		{m: map[string]any{"on-brand": []any{"foo", "bar"}}, exp: &asserts.DeviceScopeConstraint{Brand: []string{"foo", "bar"}}},
+		{m: map[string]any{"on-model": []any{"foo/model1", "bar/model-2"}}, exp: &asserts.DeviceScopeConstraint{Model: []string{"foo/model1", "bar/model-2"}}},
 		{
-			m: map[string]interface{}{
-				"on-brand": []interface{}{"foo", "bar"},
-				"on-model": []interface{}{"foo/model1", "bar/model-2"},
-				"on-store": []interface{}{"foo", "bar"},
+			m: map[string]any{
+				"on-brand": []any{"foo", "bar"},
+				"on-model": []any{"foo/model1", "bar/model-2"},
+				"on-store": []any{"foo", "bar"},
 			},
 			exp: &asserts.DeviceScopeConstraint{
 				Store: []string{"foo", "bar"},
@@ -573,9 +573,9 @@ func (s *deviceScopeConstraintSuite) TestCompile(c *C) {
 				Model: []string{"foo/model1", "bar/model-2"},
 			},
 		},
-		{m: map[string]interface{}{"on-store": ""}, err: `on-store in constraint must be a list of strings`},
-		{m: map[string]interface{}{"on-brand": "foo"}, err: `on-brand in constraint must be a list of strings`},
-		{m: map[string]interface{}{"on-model": map[string]interface{}{"brand": "x"}}, err: `on-model in constraint must be a list of strings`},
+		{m: map[string]any{"on-store": ""}, err: `on-store in constraint must be a list of strings`},
+		{m: map[string]any{"on-brand": "foo"}, err: `on-brand in constraint must be a list of strings`},
+		{m: map[string]any{"on-model": map[string]any{"brand": "x"}}, err: `on-model in constraint must be a list of strings`},
 	}
 
 	for _, t := range tests {
@@ -640,8 +640,8 @@ func (s *deviceScopeConstraintSuite) TestValidOnStoreBrandModel(c *C) {
 	}
 
 	check := func(constr, value string, valid bool) {
-		cMap := map[string]interface{}{
-			constr: []interface{}{value},
+		cMap := map[string]any{
+			constr: []any{value},
 		}
 
 		_, err := asserts.CompileDeviceScopeConstraint(cMap, "constraint")
@@ -728,73 +728,73 @@ AXNpZw==`))
 	substore1 := a.(*asserts.Store)
 
 	tests := []struct {
-		m                 map[string]interface{}
+		m                 map[string]any
 		model             *asserts.Model
 		store             *asserts.Store
 		useFriendlyStores bool
 		err               string
 	}{
-		{m: map[string]interface{}{"on-store": []interface{}{"store1"}}, model: myModel1},
-		{m: map[string]interface{}{"on-store": []interface{}{"a-store", "store1"}}, model: myModel1},
-		{m: map[string]interface{}{"on-store": []interface{}{"store1"}}, model: myModel2, err: "on-store mismatch"},
-		{m: map[string]interface{}{"on-store": []interface{}{"store1"}}, model: myModel3, store: substore1, useFriendlyStores: true},
-		{m: map[string]interface{}{"on-store": []interface{}{"store1"}}, model: myModel3, store: substore1, useFriendlyStores: false, err: "on-store mismatch"},
-		{m: map[string]interface{}{"on-store": []interface{}{"store1"}}, model: nil, err: `cannot match on-store/on-brand/on-model without model`},
-		{m: map[string]interface{}{"on-store": []interface{}{"store1"}}, model: myModel2, store: substore1, err: `store assertion and model store must match`, useFriendlyStores: true},
-		{m: map[string]interface{}{"on-store": []interface{}{"other-store"}}, model: myModel3, store: substore1, err: "on-store mismatch"},
-		{m: map[string]interface{}{"on-brand": []interface{}{"my-brand"}}, model: myModel1},
-		{m: map[string]interface{}{"on-brand": []interface{}{"my-brand", "my-brand-subbrand"}}, model: myModel2},
-		{m: map[string]interface{}{"on-brand": []interface{}{"other-brand"}}, model: myModel2, err: "on-brand mismatch"},
-		{m: map[string]interface{}{"on-model": []interface{}{"my-brand/my-model1"}}, model: myModel1},
-		{m: map[string]interface{}{"on-model": []interface{}{"my-brand/other-model"}}, model: myModel1, err: "on-model mismatch"},
-		{m: map[string]interface{}{"on-model": []interface{}{"my-brand/my-model", "my-brand-subbrand/my-model2", "other-brand/other-model"}}, model: myModel2},
+		{m: map[string]any{"on-store": []any{"store1"}}, model: myModel1},
+		{m: map[string]any{"on-store": []any{"a-store", "store1"}}, model: myModel1},
+		{m: map[string]any{"on-store": []any{"store1"}}, model: myModel2, err: "on-store mismatch"},
+		{m: map[string]any{"on-store": []any{"store1"}}, model: myModel3, store: substore1, useFriendlyStores: true},
+		{m: map[string]any{"on-store": []any{"store1"}}, model: myModel3, store: substore1, useFriendlyStores: false, err: "on-store mismatch"},
+		{m: map[string]any{"on-store": []any{"store1"}}, model: nil, err: `cannot match on-store/on-brand/on-model without model`},
+		{m: map[string]any{"on-store": []any{"store1"}}, model: myModel2, store: substore1, err: `store assertion and model store must match`, useFriendlyStores: true},
+		{m: map[string]any{"on-store": []any{"other-store"}}, model: myModel3, store: substore1, err: "on-store mismatch"},
+		{m: map[string]any{"on-brand": []any{"my-brand"}}, model: myModel1},
+		{m: map[string]any{"on-brand": []any{"my-brand", "my-brand-subbrand"}}, model: myModel2},
+		{m: map[string]any{"on-brand": []any{"other-brand"}}, model: myModel2, err: "on-brand mismatch"},
+		{m: map[string]any{"on-model": []any{"my-brand/my-model1"}}, model: myModel1},
+		{m: map[string]any{"on-model": []any{"my-brand/other-model"}}, model: myModel1, err: "on-model mismatch"},
+		{m: map[string]any{"on-model": []any{"my-brand/my-model", "my-brand-subbrand/my-model2", "other-brand/other-model"}}, model: myModel2},
 		{
-			m: map[string]interface{}{
-				"on-store": []interface{}{"store2"},
-				"on-brand": []interface{}{"my-brand", "my-brand-subbrand"},
-				"on-model": []interface{}{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
+			m: map[string]any{
+				"on-store": []any{"store2"},
+				"on-brand": []any{"my-brand", "my-brand-subbrand"},
+				"on-model": []any{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
 			},
 			model: myModel2,
 		}, {
-			m: map[string]interface{}{
-				"on-store": []interface{}{"store2"},
-				"on-brand": []interface{}{"my-brand", "my-brand-subbrand"},
-				"on-model": []interface{}{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
+			m: map[string]any{
+				"on-store": []any{"store2"},
+				"on-brand": []any{"my-brand", "my-brand-subbrand"},
+				"on-model": []any{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
 			},
 			model: myModel3, store: substore1,
 			useFriendlyStores: true,
 		}, {
-			m: map[string]interface{}{
-				"on-store": []interface{}{"other-store"},
-				"on-brand": []interface{}{"my-brand", "my-brand-subbrand"},
-				"on-model": []interface{}{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
+			m: map[string]any{
+				"on-store": []any{"other-store"},
+				"on-brand": []any{"my-brand", "my-brand-subbrand"},
+				"on-model": []any{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
 			},
 			model: myModel3, store: substore1,
 			useFriendlyStores: true,
 			err:               "on-store mismatch",
 		}, {
-			m: map[string]interface{}{
-				"on-store": []interface{}{"store2"},
-				"on-brand": []interface{}{"other-brand", "my-brand-subbrand"},
-				"on-model": []interface{}{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
+			m: map[string]any{
+				"on-store": []any{"store2"},
+				"on-brand": []any{"other-brand", "my-brand-subbrand"},
+				"on-model": []any{"my-brand/my-model3", "my-brand-subbrand/my-model2"},
 			},
 			model: myModel3, store: substore1,
 			useFriendlyStores: true,
 			err:               "on-brand mismatch",
 		}, {
-			m: map[string]interface{}{
-				"on-store": []interface{}{"store2"},
-				"on-brand": []interface{}{"my-brand", "my-brand-subbrand"},
-				"on-model": []interface{}{"my-brand/my-model1", "my-brand-subbrand/my-model2"},
+			m: map[string]any{
+				"on-store": []any{"store2"},
+				"on-brand": []any{"my-brand", "my-brand-subbrand"},
+				"on-model": []any{"my-brand/my-model1", "my-brand-subbrand/my-model2"},
 			},
 			model: myModel3, store: substore1,
 			useFriendlyStores: true,
 			err:               "on-model mismatch",
 		}, {
-			m: map[string]interface{}{
-				"on-store": []interface{}{"store2"},
-				"on-brand": []interface{}{"my-brand", "my-brand-subbrand"},
-				"on-model": []interface{}{"my-brand/my-model1", "my-brand-subbrand/my-model2"},
+			m: map[string]any{
+				"on-store": []any{"store2"},
+				"on-brand": []any{"my-brand", "my-brand-subbrand"},
+				"on-model": []any{"my-brand/my-model1", "my-brand-subbrand/my-model2"},
 			},
 			model: myModel3, store: substore1,
 			useFriendlyStores: false,

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -383,7 +383,7 @@ func (db *Database) PublicKey(keyID string) (PublicKey, error) {
 
 // Sign assembles an assertion with the provided information and signs it
 // with the private key from `headers["authority-id"]` that has the provided key id.
-func (db *Database) Sign(assertType *AssertionType, headers map[string]interface{}, body []byte, keyID string) (Assertion, error) {
+func (db *Database) Sign(assertType *AssertionType, headers map[string]any, body []byte, keyID string) (Assertion, error) {
 	privKey, err := db.safeGetPrivateKey(keyID)
 	if err != nil {
 		return nil, err

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -59,7 +59,7 @@ func (opens *openSuite) TestOpenDatabaseOK(c *C) {
 }
 
 func (opens *openSuite) TestOpenDatabaseTrustedAccount(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"account-id":   "trusted",
 		"display-name": "Trusted",
@@ -92,7 +92,7 @@ func (opens *openSuite) TestOpenDatabaseTrustedAccount(c *C) {
 }
 
 func (opens *openSuite) TestOpenDatabaseTrustedWrongType(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
@@ -229,7 +229,7 @@ func (chks *checkSuite) SetUpTest(c *C) {
 	chks.bs, err = asserts.OpenFSBackstore(topDir)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
@@ -351,7 +351,7 @@ func (chks *checkSuite) TestCheckUnsupportedFormat(c *C) {
 		defer restore()
 		var err error
 
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"authority-id": "canonical",
 			"primary-key":  "0",
 			"format":       "77",
@@ -375,7 +375,7 @@ func (chks *checkSuite) TestCheckMismatchedAccountIDandKey(c *C) {
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "random",
 		"primary-key":  "0",
 	}
@@ -401,7 +401,7 @@ func (chks *checkSuite) TestCheckAndSetEarliestTime(c *C) {
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
@@ -467,7 +467,7 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 	bs, err := asserts.OpenFSBackstore(topDir)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "account",
 		"authority-id": "canonical",
 		"account-id":   "predefined",
@@ -495,7 +495,7 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSign(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -507,7 +507,7 @@ func (safs *signAddFindSuite) TestSign(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignEmptyKeyID(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -517,7 +517,7 @@ func (safs *signAddFindSuite) TestSignEmptyKeyID(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignMissingAuthorityId(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"primary-key": "a",
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
@@ -526,7 +526,7 @@ func (safs *signAddFindSuite) TestSignMissingAuthorityId(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignMissingPrimaryKey(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
@@ -535,7 +535,7 @@ func (safs *signAddFindSuite) TestSignMissingPrimaryKey(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignPrimaryKeyWithSlash(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "baz/9000",
 	}
@@ -545,7 +545,7 @@ func (safs *signAddFindSuite) TestSignPrimaryKeyWithSlash(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignNoPrivateKey(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -555,7 +555,7 @@ func (safs *signAddFindSuite) TestSignNoPrivateKey(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignUnknownType(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "xyz", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
@@ -564,7 +564,7 @@ func (safs *signAddFindSuite) TestSignUnknownType(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignNonPredefinedType(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "test-only", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
@@ -573,7 +573,7 @@ func (safs *signAddFindSuite) TestSignNonPredefinedType(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"revision":     "zzz",
@@ -584,7 +584,7 @@ func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignBadFormat(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"format":       "zzz",
@@ -595,10 +595,10 @@ func (safs *signAddFindSuite) TestSignBadFormat(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignHeadersCheck(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
-		"extra":        []interface{}{1, 2},
+		"extra":        []any{1, 2},
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Check(err, ErrorMatches, `header "extra": header values must be strings or nested lists or maps with strings as the only scalars: 1`)
@@ -606,10 +606,10 @@ func (safs *signAddFindSuite) TestSignHeadersCheck(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignHeadersCheckMap(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
-		"extra":        map[string]interface{}{"a": "a", "b": 1},
+		"extra":        map[string]any{"a": "a", "b": 1},
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Check(err, ErrorMatches, `header "extra": header values must be strings or nested lists or maps with strings as the only scalars: 1`)
@@ -617,7 +617,7 @@ func (safs *signAddFindSuite) TestSignHeadersCheckMap(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignAssemblerError(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"count":        "zzz",
@@ -628,7 +628,7 @@ func (safs *signAddFindSuite) TestSignAssemblerError(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignUnsupportedFormat(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"format":       "77",
@@ -639,7 +639,7 @@ func (safs *signAddFindSuite) TestSignUnsupportedFormat(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignInadequateFormat(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":     "canonical",
 		"primary-key":      "a",
 		"format-1-feature": "true",
@@ -656,7 +656,7 @@ func (safs *signAddFindSuite) TestAddRefusesSelfSignedKey(c *C) {
 	c.Assert(err, IsNil)
 
 	now := time.Now().UTC()
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "canonical",
 		"public-key-sha3-384": aKey.PublicKey().ID(),
@@ -672,7 +672,7 @@ func (safs *signAddFindSuite) TestAddRefusesSelfSignedKey(c *C) {
 }
 
 func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -709,7 +709,7 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 }
 
 func (safs *signAddFindSuite) TestAddNoAuthorityNoPrimaryKey(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"hdr": "FOO",
 	}
 	a, err := asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityType, headers, nil, testPrivKey0)
@@ -720,7 +720,7 @@ func (safs *signAddFindSuite) TestAddNoAuthorityNoPrimaryKey(c *C) {
 }
 
 func (safs *signAddFindSuite) TestAddNoAuthorityButPrimaryKey(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"pk": "primary",
 	}
 	a, err := asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityPKType, headers, nil, testPrivKey0)
@@ -749,7 +749,7 @@ func (safs *signAddFindSuite) TestAddUnsupportedFormat(c *C) {
 	c.Check(err, ErrorMatches, `proposed "test-only" assertion has format 77 but 1 is latest supported`)
 	c.Check(asserts.IsUnaccceptedUpdate(err), Equals, false)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"format":       "1",
@@ -787,7 +787,7 @@ func (safs *signAddFindSuite) TestNotFoundError(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindNotFound(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -827,7 +827,7 @@ func (safs *signAddFindSuite) TestFindPrimaryLeftOut(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindMany(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"other":        "other-x",
@@ -837,7 +837,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	err = safs.db.Add(aa)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "b",
 		"other":        "other-y",
@@ -847,7 +847,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	err = safs.db.Add(ab)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "c",
 		"other":        "other-x",
@@ -899,11 +899,11 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 func (safs *signAddFindSuite) TestFindFindsPredefined(c *C) {
 	pk1 := testPrivKey1
 
-	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]interface{}{
+	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]any{
 		"authority-id": "canonical",
 	}, safs.signingKeyID)
 
-	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
+	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]any{
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
@@ -942,11 +942,11 @@ func (safs *signAddFindSuite) TestFindFindsPredefined(c *C) {
 func (safs *signAddFindSuite) TestFindTrusted(c *C) {
 	pk1 := testPrivKey1
 
-	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]interface{}{
+	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]any{
 		"authority-id": "canonical",
 	}, safs.signingKeyID)
 
-	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
+	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]any{
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
@@ -1000,11 +1000,11 @@ func (safs *signAddFindSuite) TestFindTrusted(c *C) {
 func (safs *signAddFindSuite) TestFindPredefined(c *C) {
 	pk1 := testPrivKey1
 
-	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]interface{}{
+	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]any{
 		"authority-id": "canonical",
 	}, safs.signingKeyID)
 
-	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
+	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]any{
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
@@ -1059,7 +1059,7 @@ func (safs *signAddFindSuite) TestFindPredefined(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindManyPredefined(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "account",
 		"authority-id": "canonical",
 		"account-id":   "predefined",
@@ -1088,11 +1088,11 @@ func (safs *signAddFindSuite) TestFindManyPredefined(c *C) {
 
 	pk1 := testPrivKey2
 
-	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]interface{}{
+	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]any{
 		"authority-id": "canonical",
 	}, safs.signingKeyID)
 
-	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
+	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]any{
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
@@ -1158,7 +1158,7 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithTrus
 	c.Assert(err, IsNil)
 
 	now := time.Now().UTC()
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "canonical",
 		"public-key-sha3-384": safs.signingKeyID,
@@ -1174,7 +1174,7 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithTrus
 }
 
 func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithPredefinedOnes(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "account",
 		"authority-id": "canonical",
 		"account-id":   "predefined",
@@ -1190,7 +1190,7 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithPred
 }
 
 func (safs *signAddFindSuite) TestFindAndRefResolve(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"pk1":          "ka",
 		"pk2":          "kb",
@@ -1208,7 +1208,7 @@ func (safs *signAddFindSuite) TestFindAndRefResolve(c *C) {
 
 	resolved, err := ref.Resolve(safs.db.Find)
 	c.Assert(err, IsNil)
-	c.Check(resolved.Headers(), DeepEquals, map[string]interface{}{
+	c.Check(resolved.Headers(), DeepEquals, map[string]any{
 		"type":              "test-only-2",
 		"authority-id":      "canonical",
 		"pk1":               "ka",
@@ -1231,7 +1231,7 @@ func (safs *signAddFindSuite) TestFindAndRefResolve(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindMaxFormat(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "foo",
 	}
@@ -1241,7 +1241,7 @@ func (safs *signAddFindSuite) TestFindMaxFormat(c *C) {
 	err = safs.db.Add(af0)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "foo",
 		"format":       "1",
@@ -1276,7 +1276,7 @@ func (safs *signAddFindSuite) TestFindOptionalPrimaryKeys(c *C) {
 	r := asserts.MockOptionalPrimaryKey(asserts.TestOnlyType, "opt1", "o1-defl")
 	defer r()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "k1",
 	}
@@ -1286,7 +1286,7 @@ func (safs *signAddFindSuite) TestFindOptionalPrimaryKeys(c *C) {
 	err = safs.db.Add(a1)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "k2",
 		"opt1":         "A",
@@ -1366,7 +1366,7 @@ func (safs *signAddFindSuite) TestFindOptionalPrimaryKeys(c *C) {
 }
 
 func (safs *signAddFindSuite) TestWithStackedBackstore(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "one",
 	}
@@ -1376,7 +1376,7 @@ func (safs *signAddFindSuite) TestWithStackedBackstore(c *C) {
 	err = safs.db.Add(a1)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "two",
 	}
@@ -1424,7 +1424,7 @@ func (safs *signAddFindSuite) TestWithStackedBackstoreSafety(c *C) {
 	c.Assert(err, IsNil)
 
 	now := time.Now().UTC()
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "canonical",
 		"public-key-sha3-384": safs.signingKeyID,
@@ -1439,14 +1439,14 @@ func (safs *signAddFindSuite) TestWithStackedBackstoreSafety(c *C) {
 	c.Check(err, ErrorMatches, `cannot add "account-key" assertion with primary key clashing with a trusted assertion: .*`)
 
 	// cannot go back to old revisions
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "one",
 	}
 	a0, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"primary-key":  "one",
 		"revision":     "1",
@@ -1465,7 +1465,7 @@ func (safs *signAddFindSuite) TestWithStackedBackstoreSafety(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindSequence(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "canonical",
 		"n":            "s1",
 		"sequence":     "1",
@@ -1473,7 +1473,7 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 	sq1f0, err := safs.signingDB.Sign(asserts.TestOnlySeqType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"n":            "s1",
 		"sequence":     "2",
@@ -1481,7 +1481,7 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 	sq2f0, err := safs.signingDB.Sign(asserts.TestOnlySeqType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"format":       "1",
 		"n":            "s1",
@@ -1491,7 +1491,7 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 	sq2f1, err := safs.signingDB.Sign(asserts.TestOnlySeqType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"format":       "1",
 		"n":            "s1",
@@ -1500,7 +1500,7 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 	sq3f1, err := safs.signingDB.Sign(asserts.TestOnlySeqType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id": "canonical",
 		"format":       "2",
 		"n":            "s1",
@@ -1576,7 +1576,7 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 }
 
 func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "account",
 		"authority-id": "canonical",
 		"account-id":   "my-brand",
@@ -1595,7 +1595,7 @@ func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
 	c.Assert(err, IsNil)
 
 	now := time.Now().UTC()
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id":        "canonical",
 		"format":              "1",
 		"account-id":          "my-brand",
@@ -1603,9 +1603,9 @@ func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
 		"name":                "default",
 		"since":               now.Format(time.RFC3339),
 		"until":               now.AddDate(1, 0, 0).Format(time.RFC3339),
-		"constraints": []interface{}{
-			map[string]interface{}{
-				"headers": map[string]interface{}{
+		"constraints": []any{
+			map[string]any{
+				"headers": map[string]any{
 					"type":  "model",
 					"model": "foo-.*",
 				},
@@ -1618,7 +1618,7 @@ func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
 	err = safs.db.Add(accKey)
 	c.Check(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"brand-id":     "my-brand",
@@ -1633,7 +1633,7 @@ func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
 	err = safs.db.Add(mfoo)
 	c.Check(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"brand-id":     "my-brand",

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -58,7 +58,7 @@ func NewDecoderStressed(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSi
 func BootstrapAccountForTest(authorityID string) *Account {
 	return &Account{
 		assertionBase: assertionBase{
-			headers: map[string]interface{}{
+			headers: map[string]any{
 				"type":         "account",
 				"authority-id": authorityID,
 				"account-id":   authorityID,
@@ -76,7 +76,7 @@ func MakeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, since ti
 func MakeAccountKeyForTestWithUntil(authorityID string, openPGPPubKey PublicKey, since, until time.Time, validYears int) *AccountKey {
 	return &AccountKey{
 		assertionBase: assertionBase{
-			headers: map[string]interface{}{
+			headers: map[string]any{
 				"type":                "account-key",
 				"authority-id":        authorityID,
 				"account-id":          authorityID,
@@ -248,7 +248,7 @@ func init() {
 	typeRegistry[TestOnly2Type.Name] = TestOnly2Type
 	typeRegistry[TestOnlyNoAuthorityType.Name] = TestOnlyNoAuthorityType
 	typeRegistry[TestOnlyNoAuthorityPKType.Name] = TestOnlyNoAuthorityPKType
-	formatAnalyzer[TestOnlyType] = func(headers map[string]interface{}, _ []byte) (int, error) {
+	formatAnalyzer[TestOnlyType] = func(headers map[string]any, _ []byte) (int, error) {
 		if _, ok := headers["format-1-feature"]; ok {
 			return 1, nil
 		}
@@ -310,7 +310,7 @@ func (gkm *GPGKeypairManager) ParametersForGenerate(passphrase string, name stri
 
 // constraint tests
 
-func CompileAttrMatcher(constraints interface{}, allowedOperations, allowedRefs []string) (func(attrs map[string]interface{}, helper AttrMatchContext) error, error) {
+func CompileAttrMatcher(constraints any, allowedOperations, allowedRefs []string) (func(attrs map[string]any, helper AttrMatchContext) error, error) {
 	// XXX adjust
 	cc := compileContext{
 		opts: &compileAttrMatcherOptions{
@@ -322,7 +322,7 @@ func CompileAttrMatcher(constraints interface{}, allowedOperations, allowedRefs 
 	if err != nil {
 		return nil, err
 	}
-	domatch := func(attrs map[string]interface{}, helper AttrMatchContext) error {
+	domatch := func(attrs map[string]any, helper AttrMatchContext) error {
 		return matcher.match("", attrs, &attrMatchingContext{
 			attrWord: "field",
 			helper:   helper,

--- a/asserts/extkeypairmgr.go
+++ b/asserts/extkeypairmgr.go
@@ -60,7 +60,7 @@ func NewExternalKeypairManager(keyMgrPath string) (*ExternalKeypairManager, erro
 	return em, nil
 }
 
-func (em *ExternalKeypairManager) keyMgr(op string, args []string, in []byte, out interface{}) error {
+func (em *ExternalKeypairManager) keyMgr(op string, args []string, in []byte, out any) error {
 	args = append([]string{op}, args...)
 	cmd := exec.Command(em.keyMgrPath, args...)
 	var outBuf bytes.Buffer

--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -204,7 +204,7 @@ func (s *extKeypairMgrSuite) TestSignFlow(c *C) {
 
 	store := assertstest.NewStoreStack("trusted", nil)
 
-	brandAcct := assertstest.NewAccount(store, "brand", map[string]interface{}{
+	brandAcct := assertstest.NewAccount(store, "brand", map[string]any{
 		"account-id": "brand-id",
 	}, "")
 	brandAccKey := assertstest.NewAccountKey(store, brandAcct, nil, pk.PublicKey(), "")
@@ -228,7 +228,7 @@ func (s *extKeypairMgrSuite) TestSignFlow(c *C) {
 	err = checkDB.Add(brandAccKey)
 	c.Assert(err, IsNil)
 
-	modelHdsrs := map[string]interface{}{
+	modelHdsrs := map[string]any{
 		"authority-id": "brand-id",
 		"brand-id":     "brand-id",
 		"model":        "model",

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -65,7 +65,7 @@ func (s *fetcherSuite) prereqSnapAssertions(c *C, revisions ...int) {
 	err := s.storeSigning.Add(dev1Acct)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -78,7 +78,7 @@ func (s *fetcherSuite) prereqSnapAssertions(c *C, revisions ...int) {
 	c.Assert(err, IsNil)
 
 	for _, rev := range revisions {
-		headers = map[string]interface{}{
+		headers = map[string]any{
 			"series":        "16",
 			"snap-id":       "snap-id-1",
 			"snap-sha3-384": makeDigest(rev),
@@ -197,15 +197,15 @@ func (s *fetcherSuite) TestSave(c *C) {
 }
 
 func (s *fetcherSuite) prereqValidationSetAssertion(c *C) {
-	vs, err := s.storeSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	vs, err := s.storeSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "base-set",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       "123456ididididididididididididid",
 				"presence": "required",

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -93,7 +93,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	devKey, err := gkms.keypairMgr.Get(assertstest.DevKeyID)
 	c.Assert(err, IsNil)
 
-	devAcct := assertstest.NewAccount(store, "devel1", map[string]interface{}{
+	devAcct := assertstest.NewAccount(store, "devel1", map[string]any{
 		"account-id": "dev1-id",
 	}, "")
 	devAccKey := assertstest.NewAccountKey(store, devAcct, nil, devKey.PublicKey(), "")
@@ -117,7 +117,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	err = checkDB.Add(devAccKey)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  "dev1-id",
 		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",
@@ -198,7 +198,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningBrokenSignature(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  "dev1-id",
 		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",
@@ -246,7 +246,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  "dev1-id",
 		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",
@@ -301,7 +301,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningKeyTooShort(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  "dev1-id",
 		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -31,11 +31,11 @@ import (
 
 // common checks used when decoding/assembling assertions
 
-func checkExistsString(headers map[string]interface{}, name string) (string, error) {
+func checkExistsString(headers map[string]any, name string) (string, error) {
 	return checkExistsStringWhat(headers, name, "header")
 }
 
-func checkExistsStringWhat(m map[string]interface{}, name, what string) (string, error) {
+func checkExistsStringWhat(m map[string]any, name, what string) (string, error) {
 	value, ok := m[name]
 	if !ok {
 		return "", fmt.Errorf("%q %s is mandatory", name, what)
@@ -47,11 +47,11 @@ func checkExistsStringWhat(m map[string]interface{}, name, what string) (string,
 	return s, nil
 }
 
-func checkNotEmptyString(headers map[string]interface{}, name string) (string, error) {
+func checkNotEmptyString(headers map[string]any, name string) (string, error) {
 	return checkNotEmptyStringWhat(headers, name, "header")
 }
 
-func checkNotEmptyStringWhat(m map[string]interface{}, name, what string) (string, error) {
+func checkNotEmptyStringWhat(m map[string]any, name, what string) (string, error) {
 	s, err := checkExistsStringWhat(m, name, what)
 	if err != nil {
 		return "", err
@@ -62,7 +62,7 @@ func checkNotEmptyStringWhat(m map[string]interface{}, name, what string) (strin
 	return s, nil
 }
 
-func checkOptionalStringWhat(headers map[string]interface{}, name, what string) (string, error) {
+func checkOptionalStringWhat(headers map[string]any, name, what string) (string, error) {
 	value, ok := headers[name]
 	if !ok {
 		return "", nil
@@ -74,11 +74,11 @@ func checkOptionalStringWhat(headers map[string]interface{}, name, what string) 
 	return s, nil
 }
 
-func checkOptionalString(headers map[string]interface{}, name string) (string, error) {
+func checkOptionalString(headers map[string]any, name string) (string, error) {
 	return checkOptionalStringWhat(headers, name, "header")
 }
 
-func checkPrimaryKey(headers map[string]interface{}, primKey string) (string, error) {
+func checkPrimaryKey(headers map[string]any, primKey string) (string, error) {
 	value, err := checkNotEmptyString(headers, primKey)
 	if err != nil {
 		return "", err
@@ -107,7 +107,7 @@ func checkAssertType(assertType *AssertionType) error {
 }
 
 // use 'defl' default if missing
-func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
+func checkIntWithDefault(headers map[string]any, name string, defl int) (int, error) {
 	value, ok := headers[name]
 	if !ok {
 		return defl, nil
@@ -123,11 +123,11 @@ func checkIntWithDefault(headers map[string]interface{}, name string, defl int) 
 	return m, nil
 }
 
-func checkInt(headers map[string]interface{}, name string) (int, error) {
+func checkInt(headers map[string]any, name string) (int, error) {
 	return checkIntWhat(headers, name, "header")
 }
 
-func checkIntWhat(headers map[string]interface{}, name, what string) (int, error) {
+func checkIntWhat(headers map[string]any, name, what string) (int, error) {
 	valueStr, err := checkNotEmptyStringWhat(headers, name, what)
 	if err != nil {
 		return -1, err
@@ -145,7 +145,7 @@ func (e intSyntaxError) Error() string {
 	return string(e)
 }
 
-func atoi(valueStr, whichFmt string, whichArgs ...interface{}) (int, error) {
+func atoi(valueStr, whichFmt string, whichArgs ...any) (int, error) {
 	value, err := strconv.Atoi(valueStr)
 	if err != nil {
 		which := fmt.Sprintf(whichFmt, whichArgs...)
@@ -164,11 +164,11 @@ func prefixZeros(s string) bool {
 	return strings.HasPrefix(s, "0") && s != "0"
 }
 
-func checkRFC3339Date(headers map[string]interface{}, name string) (time.Time, error) {
+func checkRFC3339Date(headers map[string]any, name string) (time.Time, error) {
 	return checkRFC3339DateWhat(headers, name, "header")
 }
 
-func checkRFC3339DateWhat(m map[string]interface{}, name, what string) (time.Time, error) {
+func checkRFC3339DateWhat(m map[string]any, name, what string) (time.Time, error) {
 	dateStr, err := checkNotEmptyStringWhat(m, name, what)
 	if err != nil {
 		return time.Time{}, err
@@ -180,7 +180,7 @@ func checkRFC3339DateWhat(m map[string]interface{}, name, what string) (time.Tim
 	return date, nil
 }
 
-func checkRFC3339DateWithDefaultWhat(m map[string]interface{}, name, what string, defl time.Time) (time.Time, error) {
+func checkRFC3339DateWithDefaultWhat(m map[string]any, name, what string, defl time.Time) (time.Time, error) {
 	value, ok := m[name]
 	if !ok {
 		return defl, nil
@@ -196,11 +196,11 @@ func checkRFC3339DateWithDefaultWhat(m map[string]interface{}, name, what string
 	return date, nil
 }
 
-func checkUint(headers map[string]interface{}, name string, bitSize int) (uint64, error) {
+func checkUint(headers map[string]any, name string, bitSize int) (uint64, error) {
 	return checkUintWhat(headers, name, bitSize, "header")
 }
 
-func checkUintWhat(headers map[string]interface{}, name string, bitSize int, what string) (uint64, error) {
+func checkUintWhat(headers map[string]any, name string, bitSize int, what string) (uint64, error) {
 	valueStr, err := checkNotEmptyStringWhat(headers, name, what)
 	if err != nil {
 		return 0, err
@@ -218,11 +218,11 @@ func checkUintWhat(headers map[string]interface{}, name string, bitSize int, wha
 	return value, nil
 }
 
-func checkDigest(headers map[string]interface{}, name string, h crypto.Hash) (string, error) {
+func checkDigest(headers map[string]any, name string, h crypto.Hash) (string, error) {
 	return checkDigestDecWhat(headers, name, h, base64.RawURLEncoding.DecodeString, "header")
 }
 
-func checkDigestDecWhat(headers map[string]interface{}, name string, h crypto.Hash, decode func(string) ([]byte, error), what string) (string, error) {
+func checkDigestDecWhat(headers map[string]any, name string, h crypto.Hash, decode func(string) ([]byte, error), what string) (string, error) {
 	digestStr, err := checkNotEmptyStringWhat(headers, name, what)
 	if err != nil {
 		return "", err
@@ -242,12 +242,12 @@ func checkDigestDecWhat(headers map[string]interface{}, name string, h crypto.Ha
 // if `m` has an entry for `name` and it isn't a `[]string`, an error is returned
 // if pattern is not nil, all the strings must match that pattern, otherwise an error is returned
 // `what` is a descriptor, used for error messages
-func checkStringListInMap(m map[string]interface{}, name, what string, pattern *regexp.Regexp) ([]string, error) {
+func checkStringListInMap(m map[string]any, name, what string, pattern *regexp.Regexp) ([]string, error) {
 	value, ok := m[name]
 	if !ok {
 		return nil, nil
 	}
-	lst, ok := value.([]interface{})
+	lst, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf("%s must be a list of strings", what)
 	}
@@ -268,19 +268,19 @@ func checkStringListInMap(m map[string]interface{}, name, what string, pattern *
 	return res, nil
 }
 
-func checkStringList(headers map[string]interface{}, name string) ([]string, error) {
+func checkStringList(headers map[string]any, name string) ([]string, error) {
 	return checkStringListMatches(headers, name, nil)
 }
 
-func checkStringListMatches(headers map[string]interface{}, name string, pattern *regexp.Regexp) ([]string, error) {
+func checkStringListMatches(headers map[string]any, name string, pattern *regexp.Regexp) ([]string, error) {
 	return checkStringListInMap(headers, name, fmt.Sprintf("%q header", name), pattern)
 }
 
-func checkStringMatches(headers map[string]interface{}, name string, pattern *regexp.Regexp) (string, error) {
+func checkStringMatches(headers map[string]any, name string, pattern *regexp.Regexp) (string, error) {
 	return checkStringMatchesWhat(headers, name, "header", pattern)
 }
 
-func checkStringMatchesWhat(headers map[string]interface{}, name, what string, pattern *regexp.Regexp) (string, error) {
+func checkStringMatchesWhat(headers map[string]any, name, what string, pattern *regexp.Regexp) (string, error) {
 	s, err := checkNotEmptyStringWhat(headers, name, what)
 	if err != nil {
 		return "", err
@@ -291,11 +291,11 @@ func checkStringMatchesWhat(headers map[string]interface{}, name, what string, p
 	return s, nil
 }
 
-func checkOptionalBool(headers map[string]interface{}, name string) (bool, error) {
+func checkOptionalBool(headers map[string]any, name string) (bool, error) {
 	return checkOptionalBoolWhat(headers, name, "header")
 }
 
-func checkOptionalBoolWhat(headers map[string]interface{}, name, what string) (bool, error) {
+func checkOptionalBoolWhat(headers map[string]any, name, what string) (bool, error) {
 	value, ok := headers[name]
 	if !ok {
 		return false, nil
@@ -307,33 +307,33 @@ func checkOptionalBoolWhat(headers map[string]interface{}, name, what string) (b
 	return s == "true", nil
 }
 
-func checkMap(headers map[string]interface{}, name string) (map[string]interface{}, error) {
+func checkMap(headers map[string]any, name string) (map[string]any, error) {
 	return checkMapWhat(headers, name, "header")
 }
 
-func checkMapWhat(m map[string]interface{}, name, what string) (map[string]interface{}, error) {
+func checkMapWhat(m map[string]any, name, what string) (map[string]any, error) {
 	value, ok := m[name]
 	if !ok {
 		return nil, nil
 	}
-	mv, ok := value.(map[string]interface{})
+	mv, ok := value.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%q %s must be a map", name, what)
 	}
 	return mv, nil
 }
 
-func checkList(headers map[string]interface{}, name string) ([]interface{}, error) {
+func checkList(headers map[string]any, name string) ([]any, error) {
 	return checkListWhat(headers, name, "header")
 }
 
-func checkListWhat(m map[string]interface{}, name, what string) ([]interface{}, error) {
+func checkListWhat(m map[string]any, name, what string) ([]any, error) {
 	value, ok := m[name]
 	if !ok {
 		return nil, nil
 	}
 
-	list, ok := value.([]interface{})
+	list, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf("%q %s must be a list", name, what)
 	}

--- a/asserts/headers_test.go
+++ b/asserts/headers_test.go
@@ -35,7 +35,7 @@ func (s *headersSuite) TestParseHeadersSimple(c *C) {
 	m, err := asserts.ParseHeaders([]byte(`foo: 1
 bar: baz`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz",
 	})
@@ -47,7 +47,7 @@ func (s *headersSuite) TestParseHeadersMultiline(c *C) {
     
 bar: baz`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"foo": "abc\n",
 		"bar": "baz",
 	})
@@ -56,7 +56,7 @@ bar: baz`))
 bar:
     baz`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz",
 	})
@@ -66,7 +66,7 @@ bar:
     baz
     `))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz\n",
 	})
@@ -77,7 +77,7 @@ bar:
     
     baz2`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz\n\nbaz2",
 	})
@@ -90,8 +90,8 @@ func (s *headersSuite) TestParseHeadersSimpleList(c *C) {
   - z
 bar: baz`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"foo": []interface{}{"x", "y", "z"},
+	c.Check(m, DeepEquals, map[string]any{
+		"foo": []any{"x", "y", "z"},
 		"bar": "baz",
 	})
 }
@@ -106,8 +106,8 @@ func (s *headersSuite) TestParseHeadersListNestedMultiline(c *C) {
   - z
 bar: baz`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"foo": []interface{}{"x", "y1\ny2\n", "z"},
+	c.Check(m, DeepEquals, map[string]any{
+		"foo": []any{"x", "y1\ny2\n", "z"},
 		"bar": "baz",
 	})
 
@@ -121,8 +121,8 @@ foo:
       y2
       `))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"foo": []interface{}{[]interface{}{"u1", "u2"}, "y1\ny2\n"},
+	c.Check(m, DeepEquals, map[string]any{
+		"foo": []any{[]any{"u1", "u2"}, "y1\ny2\n"},
 		"bar": "baz",
 	})
 }
@@ -134,8 +134,8 @@ func (s *headersSuite) TestParseHeadersSimpleMap(c *C) {
   z5: 
 bar: baz`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"x":  "X",
 			"yy": "YY",
 			"z5": "",
@@ -155,11 +155,11 @@ func (s *headersSuite) TestParseHeadersMapNestedMultiline(c *C) {
     - u2
 bar: baz`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"x":  "X",
 			"yy": "YY1\nYY2",
-			"u":  []interface{}{"u1", "u2"},
+			"u":  []any{"u1", "u2"},
 		},
 		"bar": "baz",
 	})
@@ -168,9 +168,9 @@ bar: baz`))
   two:
     three: `))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"one": map[string]interface{}{
-			"two": map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
+		"one": map[string]any{
+			"two": map[string]any{
 				"three": "",
 			},
 		},
@@ -180,8 +180,8 @@ bar: baz`))
   two:
       three`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"one": map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
+		"one": map[string]any{
 			"two": "three",
 		},
 	})
@@ -190,9 +190,9 @@ bar: baz`))
   lev1:
     lev2: x`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"map-within-map": map[string]interface{}{
-			"lev1": map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
+		"map-within-map": map[string]any{
+			"lev1": map[string]any{
 				"lev2": "x",
 			},
 		},
@@ -205,13 +205,13 @@ bar: baz`))
   -
     entry: bar`))
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
-		"list-of-maps": []interface{}{
-			map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
+		"list-of-maps": []any{
+			map[string]any{
 				"entry": "foo",
 				"bar":   "baz",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"entry": "bar",
 			},
 		},
@@ -262,7 +262,7 @@ func (s *headersSuite) TestAppendEntrySimple(c *C) {
 
 	m, err := asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
 		"bar":   "baz",
 	})
@@ -284,7 +284,7 @@ func (s *headersSuite) TestAppendEntryMultiline(c *C) {
 
 		m, err := asserts.ParseHeaders(buf.Bytes())
 		c.Assert(err, IsNil)
-		c.Check(m, DeepEquals, map[string]interface{}{
+		c.Check(m, DeepEquals, map[string]any{
 			"start": ".",
 			"bar":   multiline,
 		})
@@ -292,7 +292,7 @@ func (s *headersSuite) TestAppendEntryMultiline(c *C) {
 }
 
 func (s *headersSuite) TestAppendEntrySimpleList(c *C) {
-	lst := []interface{}{"x", "y", "z"}
+	lst := []any{"x", "y", "z"}
 
 	buf := bytes.NewBufferString("start: .")
 
@@ -300,14 +300,14 @@ func (s *headersSuite) TestAppendEntrySimpleList(c *C) {
 
 	m, err := asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
 		"bar":   lst,
 	})
 }
 
 func (s *headersSuite) TestAppendEntryListNested(c *C) {
-	lst := []interface{}{"x", "a\nb\n", "", []interface{}{"u1", []interface{}{"w1", "w2"}}}
+	lst := []any{"x", "a\nb\n", "", []any{"u1", []any{"w1", "w2"}}}
 
 	buf := bytes.NewBufferString("start: .")
 
@@ -315,14 +315,14 @@ func (s *headersSuite) TestAppendEntryListNested(c *C) {
 
 	m, err := asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
 		"bar":   lst,
 	})
 }
 
 func (s *headersSuite) TestAppendEntrySimpleMap(c *C) {
-	mp := map[string]interface{}{
+	mp := map[string]any{
 		"x":  "X",
 		"yy": "YY",
 		"z5": "",
@@ -334,18 +334,18 @@ func (s *headersSuite) TestAppendEntrySimpleMap(c *C) {
 
 	m, err := asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
 		"bar":   mp,
 	})
 }
 
 func (s *headersSuite) TestAppendEntryNestedMap(c *C) {
-	mp := map[string]interface{}{
+	mp := map[string]any{
 		"x":  "X",
-		"u":  []interface{}{"u1", "u2"},
+		"u":  []any{"u1", "u2"},
 		"yy": "YY1\nYY2",
-		"m":  map[string]interface{}{"a": "A", "b": map[string]interface{}{"x": "X", "y": "Y"}},
+		"m":  map[string]any{"a": "A", "b": map[string]any{"x": "X", "y": "Y"}},
 	}
 
 	buf := bytes.NewBufferString("start: .")
@@ -354,7 +354,7 @@ func (s *headersSuite) TestAppendEntryNestedMap(c *C) {
 
 	m, err := asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
 		"bar":   mp,
 	})
@@ -363,15 +363,15 @@ func (s *headersSuite) TestAppendEntryNestedMap(c *C) {
 func (s *headersSuite) TestAppendEntryOmitting(c *C) {
 	buf := bytes.NewBufferString("start: .")
 
-	asserts.AppendEntry(buf, "bar:", []interface{}{}, 0)
+	asserts.AppendEntry(buf, "bar:", []any{}, 0)
 
 	m, err := asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
 	})
 
-	lst := []interface{}{nil, []interface{}{}, "z"}
+	lst := []any{nil, []any{}, "z"}
 
 	buf = bytes.NewBufferString("start: .")
 
@@ -379,18 +379,18 @@ func (s *headersSuite) TestAppendEntryOmitting(c *C) {
 
 	m, err = asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
-		"bar":   []interface{}{"z"},
+		"bar":   []any{"z"},
 	})
 
 	buf = bytes.NewBufferString("start: .")
 
-	asserts.AppendEntry(buf, "bar:", map[string]interface{}{}, 0)
+	asserts.AppendEntry(buf, "bar:", map[string]any{}, 0)
 
 	m, err = asserts.ParseHeaders(buf.Bytes())
 	c.Assert(err, IsNil)
-	c.Check(m, DeepEquals, map[string]interface{}{
+	c.Check(m, DeepEquals, map[string]any{
 		"start": ".",
 	})
 }

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -113,10 +113,10 @@ var (
 	defaultModes       = []string{"run"}
 )
 
-func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade, modelIsClassic bool) (*modelSnaps, error) {
+func checkExtendedSnaps(extendedSnaps any, base string, grade ModelGrade, modelIsClassic bool) (*modelSnaps, error) {
 	const wrongHeaderType = `"snaps" header must be a list of maps`
 
-	entries, ok := extendedSnaps.([]interface{})
+	entries, ok := extendedSnaps.([]any)
 	if !ok {
 		return nil, fmt.Errorf(wrongHeaderType)
 	}
@@ -126,7 +126,7 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 	seenIDs := make(map[string]string, len(entries))
 
 	for _, entry := range entries {
-		snap, ok := entry.(map[string]interface{})
+		snap, ok := entry.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(wrongHeaderType)
 		}
@@ -197,7 +197,7 @@ func isEssentialSnap(snapName, snapType, modelBase string) bool {
 	return false
 }
 
-func checkModesForSnap(snap map[string]interface{}, isEssential bool, what string) ([]string, error) {
+func checkModesForSnap(snap map[string]any, isEssential bool, what string) ([]string, error) {
 	modes, err := checkStringListInMap(snap, "modes", fmt.Sprintf("%q %s", "modes", what),
 		validSnapMode)
 	if err != nil {
@@ -217,7 +217,7 @@ func checkModesForSnap(snap map[string]interface{}, isEssential bool, what strin
 	return modes, nil
 }
 
-func checkModelSnap(snap map[string]interface{}, modelBase string, grade ModelGrade, modelIsClassic bool) (*ModelSnap, error) {
+func checkModelSnap(snap map[string]any, modelBase string, grade ModelGrade, modelIsClassic bool) (*ModelSnap, error) {
 	name, err := checkNotEmptyStringWhat(snap, "name", "of snap")
 	if err != nil {
 		return nil, err
@@ -338,13 +338,13 @@ snaps:
                                       # as the snap
       <component-name-2>: "required"|"optional" # presence, shortcut syntax
 **/
-func checkComponentsForMaps(m map[string]interface{}, validModes []string, what string) (map[string]ModelComponent, error) {
+func checkComponentsForMaps(m map[string]any, validModes []string, what string) (map[string]ModelComponent, error) {
 	const compsField = "components"
 	value, ok := m[compsField]
 	if !ok {
 		return nil, nil
 	}
-	comps, ok := value.(map[string]interface{})
+	comps, ok := value.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%q %s must be a map from strings to components",
 			compsField, what)
@@ -370,7 +370,7 @@ func checkComponentsForMaps(m map[string]interface{}, validModes []string, what 
 		}
 
 		// try map otherwise
-		compFields, ok := comp.(map[string]interface{})
+		compFields, ok := comp.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("%s must be a map of strings to components or one of required|optional",
 				compWhat)
@@ -410,7 +410,7 @@ func checkComponentsForMaps(m map[string]interface{}, validModes []string, what 
 
 // unextended case support
 
-func checkSnapWithTrack(headers map[string]interface{}, which string) (*ModelSnap, error) {
+func checkSnapWithTrack(headers map[string]any, which string) (*ModelSnap, error) {
 	_, ok := headers[which]
 	if !ok {
 		return nil, nil
@@ -787,7 +787,7 @@ var _ consistencyChecker = (*Model)(nil)
 // limit model to only lowercase for now
 var validModel = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
 
-func checkModel(headers map[string]interface{}) (string, error) {
+func checkModel(headers map[string]any) (string, error) {
 	s, err := checkStringMatches(headers, "model", validModel)
 	if err != nil {
 		return "", err
@@ -810,7 +810,7 @@ func checkAuthorityMatchesBrand(a Assertion) error {
 	return nil
 }
 
-func checkOptionalAuthority(headers map[string]interface{}, name string, brandID string, acceptsWildcard bool) ([]string, error) {
+func checkOptionalAuthority(headers map[string]any, name string, brandID string, acceptsWildcard bool) ([]string, error) {
 	ids := []string{brandID}
 	v, ok := headers[name]
 	if !ok {
@@ -821,7 +821,7 @@ func checkOptionalAuthority(headers map[string]interface{}, name string, brandID
 		if acceptsWildcard && x == "*" {
 			return nil, nil
 		}
-	case []interface{}:
+	case []any:
 		lst, err := checkStringListMatches(headers, name, validAccountID)
 		if err == nil {
 			if !strutil.ListContains(lst, brandID) {
@@ -838,22 +838,22 @@ func checkOptionalAuthority(headers map[string]interface{}, name string, brandID
 	}
 }
 
-func checkOptionalSerialAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
+func checkOptionalSerialAuthority(headers map[string]any, brandID string) ([]string, error) {
 	const acceptsWildcard = false
 	return checkOptionalAuthority(headers, "serial-authority", brandID, acceptsWildcard)
 }
 
-func checkOptionalSystemUserAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
+func checkOptionalSystemUserAuthority(headers map[string]any, brandID string) ([]string, error) {
 	const acceptsWildcard = true
 	return checkOptionalAuthority(headers, "system-user-authority", brandID, acceptsWildcard)
 }
 
-func checkOptionalPreseedAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
+func checkOptionalPreseedAuthority(headers map[string]any, brandID string) ([]string, error) {
 	const acceptsWildcard = false
 	return checkOptionalAuthority(headers, "preseed-authority", brandID, acceptsWildcard)
 }
 
-func checkModelValidationSetAccountID(headers map[string]interface{}, what, brandID string) (string, error) {
+func checkModelValidationSetAccountID(headers map[string]any, what, brandID string) (string, error) {
 	accountID, err := checkOptionalStringWhat(headers, "account-id", what)
 	if err != nil {
 		return "", err
@@ -869,7 +869,7 @@ func checkModelValidationSetAccountID(headers map[string]interface{}, what, bran
 // checkOptionalModelValidationSetSequence reads the optional 'sequence' member, if
 // not set, returns 0 as this means unpinned. Unfortunately we are not able
 // to reuse `checkSequence` as it operates inside different parameters.
-func checkOptionalModelValidationSetSequence(headers map[string]interface{}, what string) (int, error) {
+func checkOptionalModelValidationSetSequence(headers map[string]any, what string) (int, error) {
 	// Default to 0 when the sequence header is not present
 	if _, ok := headers["sequence"]; !ok {
 		return 0, nil
@@ -887,7 +887,7 @@ func checkOptionalModelValidationSetSequence(headers map[string]interface{}, wha
 	return seq, nil
 }
 
-func checkModelValidationSetMode(headers map[string]interface{}, what string) (ModelValidationSetMode, error) {
+func checkModelValidationSetMode(headers map[string]any, what string) (ModelValidationSetMode, error) {
 	modeStr, err := checkNotEmptyStringWhat(headers, "mode", what)
 	if err != nil {
 		return "", err
@@ -899,7 +899,7 @@ func checkModelValidationSetMode(headers map[string]interface{}, what string) (M
 	return ModelValidationSetMode(modeStr), nil
 }
 
-func checkModelValidationSet(headers map[string]interface{}, brandID string) (*ModelValidationSet, error) {
+func checkModelValidationSet(headers map[string]any, brandID string) (*ModelValidationSet, error) {
 	name, err := checkStringMatchesWhat(headers, "name", "of validation-set", validValidationSetName)
 	if err != nil {
 		return nil, err
@@ -930,13 +930,13 @@ func checkModelValidationSet(headers map[string]interface{}, brandID string) (*M
 	}, nil
 }
 
-func checkOptionalModelValidationSets(headers map[string]interface{}, brandID string) ([]*ModelValidationSet, error) {
+func checkOptionalModelValidationSets(headers map[string]any, brandID string) ([]*ModelValidationSet, error) {
 	valSets, ok := headers["validation-sets"]
 	if !ok {
 		return nil, nil
 	}
 
-	entries, ok := valSets.([]interface{})
+	entries, ok := valSets.([]any)
 	if !ok {
 		return nil, fmt.Errorf(`"validation-sets" must be a list of validation sets`)
 	}
@@ -944,7 +944,7 @@ func checkOptionalModelValidationSets(headers map[string]interface{}, brandID st
 	vss := make([]*ModelValidationSet, len(entries))
 	seen := make(map[string]bool, len(entries))
 	for i, entry := range entries {
-		data, ok := entry.(map[string]interface{})
+		data, ok := entry.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(`entry in "validation-sets" is not a valid validation-set`)
 		}

--- a/asserts/pool_test.go
+++ b/asserts/pool_test.go
@@ -59,21 +59,21 @@ func (s *poolSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	s.hub = assertstest.NewStoreStack("hub", nil)
-	s.dev1Acct = assertstest.NewAccount(s.hub, "developer1", map[string]interface{}{
+	s.dev1Acct = assertstest.NewAccount(s.hub, "developer1", map[string]any{
 		"account-id": "developer1",
 	}, "")
-	s.dev2Acct = assertstest.NewAccount(s.hub, "developer2", map[string]interface{}{
+	s.dev2Acct = assertstest.NewAccount(s.hub, "developer2", map[string]any{
 		"account-id": "developer2",
 	}, "")
 
-	a, err := s.hub.Sign(asserts.TestOnlyDeclType, map[string]interface{}{
+	a, err := s.hub.Sign(asserts.TestOnlyDeclType, map[string]any{
 		"id":     "one",
 		"dev-id": "developer1",
 	}, nil, "")
 	c.Assert(err, IsNil)
 	s.decl1 = a.(*asserts.TestOnlyDecl)
 
-	a, err = s.hub.Sign(asserts.TestOnlyDeclType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlyDeclType, map[string]any{
 		"id":       "one",
 		"dev-id":   "developer1",
 		"revision": "1",
@@ -81,14 +81,14 @@ func (s *poolSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.decl1_1 = a.(*asserts.TestOnlyDecl)
 
-	a, err = s.hub.Sign(asserts.TestOnlyDeclType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlyDeclType, map[string]any{
 		"id":     "two",
 		"dev-id": "developer2",
 	}, nil, "")
 	c.Assert(err, IsNil)
 	s.decl2 = a.(*asserts.TestOnlyDecl)
 
-	a, err = s.hub.Sign(asserts.TestOnlyRevType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlyRevType, map[string]any{
 		"h":      "1111",
 		"id":     "one",
 		"dev-id": "developer1",
@@ -96,7 +96,7 @@ func (s *poolSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.rev1_1111 = a.(*asserts.TestOnlyRev)
 
-	a, err = s.hub.Sign(asserts.TestOnlyRevType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlyRevType, map[string]any{
 		"h":      "3333",
 		"id":     "one",
 		"dev-id": "developer1",
@@ -104,7 +104,7 @@ func (s *poolSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.rev1_3333 = a.(*asserts.TestOnlyRev)
 
-	a, err = s.hub.Sign(asserts.TestOnlyRevType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlyRevType, map[string]any{
 		"h":      "2222",
 		"id":     "two",
 		"dev-id": "developer2",
@@ -114,7 +114,7 @@ func (s *poolSuite) SetUpTest(c *C) {
 
 	// sequence-forming
 
-	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]any{
 		"n":        "1111",
 		"sequence": "1",
 		"id":       "one",
@@ -124,7 +124,7 @@ func (s *poolSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.seq1_1111r5 = a.(*asserts.TestOnlySeq)
 
-	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]any{
 		"n":        "1111",
 		"sequence": "1",
 		"id":       "one",
@@ -134,7 +134,7 @@ func (s *poolSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.seq1_1111r6 = a.(*asserts.TestOnlySeq)
 
-	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]any{
 		"n":        "1111",
 		"sequence": "2",
 		"id":       "one",
@@ -144,7 +144,7 @@ func (s *poolSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.seq2_1111r7 = a.(*asserts.TestOnlySeq)
 
-	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]interface{}{
+	a, err = s.hub.Sign(asserts.TestOnlySeqType, map[string]any{
 		"n":        "1111",
 		"sequence": "3",
 		"id":       "one",
@@ -672,7 +672,7 @@ func (s *poolSuite) TestAddFormatTooNew(c *C) {
 		restore := asserts.MockMaxSupportedFormat(asserts.TestOnlyDeclType, 2)
 		defer restore()
 
-		a, err = s.hub.Sign(asserts.TestOnlyDeclType, map[string]interface{}{
+		a, err = s.hub.Sign(asserts.TestOnlyDeclType, map[string]any{
 			"id":     "three",
 			"dev-id": "developer1",
 			"format": "2",

--- a/asserts/preseed.go
+++ b/asserts/preseed.go
@@ -111,7 +111,7 @@ func (p *Preseed) Snaps() []*PreseedSnap {
 	return p.snaps
 }
 
-func checkPreseedSnap(snap map[string]interface{}) (*PreseedSnap, error) {
+func checkPreseedSnap(snap map[string]any) (*PreseedSnap, error) {
 	name, err := checkNotEmptyStringWhat(snap, "name", "of snap")
 	if err != nil {
 		return nil, err
@@ -163,10 +163,10 @@ func checkPreseedSnap(snap map[string]interface{}) (*PreseedSnap, error) {
 	}, nil
 }
 
-func checkPreseedComponents(comps interface{}, snapRevision int) ([]PreseedComponent, error) {
+func checkPreseedComponents(comps any, snapRevision int) ([]PreseedComponent, error) {
 	const wrongHeaderType = `"components" header must be a list of maps`
 
-	entries, ok := comps.([]interface{})
+	entries, ok := comps.([]any)
 	if !ok {
 		return nil, errors.New(wrongHeaderType)
 	}
@@ -174,7 +174,7 @@ func checkPreseedComponents(comps interface{}, snapRevision int) ([]PreseedCompo
 	seen := make(map[string]bool)
 	components := make([]PreseedComponent, 0, len(entries))
 	for _, entry := range entries {
-		comp, ok := entry.(map[string]interface{})
+		comp, ok := entry.(map[string]any)
 		if !ok {
 			return nil, errors.New(wrongHeaderType)
 		}
@@ -195,7 +195,7 @@ func checkPreseedComponents(comps interface{}, snapRevision int) ([]PreseedCompo
 	return components, nil
 }
 
-func checkPreseedComponent(comp map[string]interface{}, snapRevision int) (PreseedComponent, error) {
+func checkPreseedComponent(comp map[string]any, snapRevision int) (PreseedComponent, error) {
 	name, err := checkNotEmptyStringWhat(comp, "name", "of component")
 	if err != nil {
 		return PreseedComponent{}, err
@@ -228,10 +228,10 @@ func checkPreseedComponent(comp map[string]interface{}, snapRevision int) (Prese
 	}, nil
 }
 
-func checkPreseedSnaps(snapList interface{}) ([]*PreseedSnap, error) {
+func checkPreseedSnaps(snapList any) ([]*PreseedSnap, error) {
 	const wrongHeaderType = `"snaps" header must be a list of maps`
 
-	entries, ok := snapList.([]interface{})
+	entries, ok := snapList.([]any)
 	if !ok {
 		return nil, fmt.Errorf(wrongHeaderType)
 	}
@@ -240,7 +240,7 @@ func checkPreseedSnaps(snapList interface{}) ([]*PreseedSnap, error) {
 	seenIDs := make(map[string]string, len(entries))
 	snaps := make([]*PreseedSnap, 0, len(entries))
 	for _, entry := range entries {
-		snap, ok := entry.(map[string]interface{})
+		snap, ok := entry.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(wrongHeaderType)
 		}

--- a/asserts/serial_asserts_test.go
+++ b/asserts/serial_asserts_test.go
@@ -139,13 +139,13 @@ func (ss *serialSuite) TestSerialCheck(c *C) {
 	brandID := brandDB.AuthorityID
 	brandKeyID := brandDB.KeyID
 	genericKeyID := storeDB.GenericKey.PublicKeyID()
-	modelNA := []interface{}(nil)
-	brandOnly := []interface{}{}
+	modelNA := []any(nil)
+	brandOnly := []any{}
 	tests := []struct {
 		// serial-authority setting in model
 		// nil == model not available at check (modelNA)
 		// empty ==  just brand (brandOnly)
-		serialAuth  []interface{}
+		serialAuth  []any
 		signDB      assertstest.SignerDB
 		authID      string
 		keyID       string
@@ -153,19 +153,19 @@ func (ss *serialSuite) TestSerialCheck(c *C) {
 	}{
 		{modelNA, brandDB, "", brandKeyID, ""},
 		{brandOnly, brandDB, "", brandKeyID, ""},
-		{[]interface{}{"generic"}, brandDB, "", brandKeyID, ""},
-		{[]interface{}{"generic", brandID}, brandDB, "", brandKeyID, ""},
-		{[]interface{}{"generic"}, storeDB, "generic", genericKeyID, ""},
+		{[]any{"generic"}, brandDB, "", brandKeyID, ""},
+		{[]any{"generic", brandID}, brandDB, "", brandKeyID, ""},
+		{[]any{"generic"}, storeDB, "generic", genericKeyID, ""},
 		{brandOnly, storeDB, "generic", genericKeyID, serialMismatchErr},
 		{modelNA, storeDB, "generic", genericKeyID, serialMismatchErr},
-		{[]interface{}{"other"}, storeDB, "generic", genericKeyID, serialMismatchErr},
+		{[]any{"other"}, storeDB, "generic", genericKeyID, serialMismatchErr},
 	}
 
 	for _, test := range tests {
 		checkDB := db.WithStackedBackstore(asserts.NewMemoryBackstore())
 
 		if test.serialAuth != nil {
-			modHeaders := map[string]interface{}{
+			modHeaders := map[string]any{
 				"series":       "16",
 				"brand-id":     brandID,
 				"architecture": "amd64",
@@ -208,7 +208,7 @@ func (ss *serialSuite) TestSerialCheck(c *C) {
 
 func (ss *serialSuite) TestSerialRequestHappy(c *C) {
 	sreq, err := asserts.SignWithoutAuthority(asserts.SerialRequestType,
-		map[string]interface{}{
+		map[string]any{
 			"brand-id":   "brand-id1",
 			"model":      "baz-3000",
 			"device-key": ss.encodedDevKey,
@@ -236,7 +236,7 @@ func (ss *serialSuite) TestSerialRequestHappy(c *C) {
 
 func (ss *serialSuite) TestSerialRequestHappyOptionalSerial(c *C) {
 	sreq, err := asserts.SignWithoutAuthority(asserts.SerialRequestType,
-		map[string]interface{}{
+		map[string]any{
 			"brand-id":   "brand-id1",
 			"model":      "baz-3000",
 			"serial":     "pserial",
@@ -310,7 +310,7 @@ func (ss *serialSuite) TestSerialRequestDecodeKeyIDMismatch(c *C) {
 func (ss *serialSuite) TestDeviceSessionRequest(c *C) {
 	ts := time.Now().UTC().Round(time.Second)
 	sessReq, err := asserts.SignWithoutAuthority(asserts.DeviceSessionRequestType,
-		map[string]interface{}{
+		map[string]any{
 			"brand-id":  "brand-id1",
 			"model":     "baz-3000",
 			"serial":    "99990",

--- a/asserts/signtool/sign.go
+++ b/asserts/signtool/sign.go
@@ -54,12 +54,12 @@ type Options struct {
 	// Complement are an error, except for "type" that needs
 	// instead to match if present. Pseudo-header "body" can also
 	// be specified here.
-	Complement map[string]interface{}
+	Complement map[string]any
 }
 
 // Sign produces the text of a signed assertion as specified by opts.
 func Sign(opts *Options, keypairMgr asserts.KeypairManager) ([]byte, error) {
-	var headers map[string]interface{}
+	var headers map[string]any
 	err := json.Unmarshal(opts.Statement, &headers)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse the assertion input as JSON: %v", err)

--- a/asserts/signtool/sign_test.go
+++ b/asserts/signtool/sign_test.go
@@ -51,16 +51,16 @@ func (s *signSuite) SetUpSuite(c *C) {
 	encPubKey, err := asserts.EncodePublicKey(testKey.PublicKey())
 	c.Assert(err, IsNil)
 	s.testAccKey = assertstest.FakeAssertionWithBody(encPubKey,
-		map[string]interface{}{
+		map[string]any{
 			"type":                "account-key",
 			"authority-id":        "canonical",
 			"public-key-sha3-384": s.testKeyID,
 			"account-id":          "user-id1",
 			"since":               "2015-11-01T20:00:00Z",
 			"body-length":         strconv.Itoa(len(encPubKey)),
-			"constraints": []interface{}{
-				map[string]interface{}{
-					"headers": map[string]interface{}{
+			"constraints": []any{
+				map[string]any{
+					"headers": map[string]any{
 						"type":  "model",
 						"model": `baz-.*`,
 					},
@@ -70,8 +70,8 @@ func (s *signSuite) SetUpSuite(c *C) {
 	).(*asserts.AccountKey)
 }
 
-func expectedModelHeaders(a asserts.Assertion) map[string]interface{} {
-	m := map[string]interface{}{
+func expectedModelHeaders(a asserts.Assertion) map[string]any {
+	m := map[string]any{
 		"type":           "model",
 		"authority-id":   "user-id1",
 		"series":         "16",
@@ -81,7 +81,7 @@ func expectedModelHeaders(a asserts.Assertion) map[string]interface{} {
 		"gadget":         "brand-gadget",
 		"kernel":         "baz-linux",
 		"store":          "brand-store",
-		"required-snaps": []interface{}{"foo", "bar"},
+		"required-snaps": []any{"foo", "bar"},
 		"timestamp":      "2015-11-25T20:00:00Z",
 	}
 	if a != nil {
@@ -90,7 +90,7 @@ func expectedModelHeaders(a asserts.Assertion) map[string]interface{} {
 	return m
 }
 
-func exampleJSON(overrides map[string]interface{}) []byte {
+func exampleJSON(overrides map[string]any) []byte {
 	m := expectedModelHeaders(nil)
 	for k, v := range overrides {
 		if v == nil {
@@ -158,7 +158,7 @@ func (s *signSuite) TestSignJSONWithAccountKeyCrossCheck(c *C) {
 }
 
 func (s *signSuite) TestSignJSONWithBodyAndRevision(c *C) {
-	statement := exampleJSON(map[string]interface{}{
+	statement := exampleJSON(map[string]any{
 		"body":     "BODY",
 		"revision": "11",
 	})
@@ -187,14 +187,14 @@ func (s *signSuite) TestSignJSONWithBodyAndRevision(c *C) {
 }
 
 func (s *signSuite) TestSignJSONWithBodyAndComplementRevision(c *C) {
-	statement := exampleJSON(map[string]interface{}{
+	statement := exampleJSON(map[string]any{
 		"body": "BODY",
 	})
 	opts := signtool.Options{
 		KeyID: s.testKeyID,
 
 		Statement: statement,
-		Complement: map[string]interface{}{
+		Complement: map[string]any{
 			"revision": "11",
 		},
 	}
@@ -218,14 +218,14 @@ func (s *signSuite) TestSignJSONWithBodyAndComplementRevision(c *C) {
 }
 
 func (s *signSuite) TestSignJSONWithRevisionAndComplementBodyAndRepeatedType(c *C) {
-	statement := exampleJSON(map[string]interface{}{
+	statement := exampleJSON(map[string]any{
 		"revision": "11",
 	})
 	opts := signtool.Options{
 		KeyID: s.testKeyID,
 
 		Statement: statement,
-		Complement: map[string]interface{}{
+		Complement: map[string]any{
 			"type": "model",
 			"body": "BODY",
 		},
@@ -254,12 +254,12 @@ func (s *signSuite) TestSignErrors(c *C) {
 		KeyID: s.testKeyID,
 	}
 
-	emptyList := []interface{}{}
+	emptyList := []any{}
 
 	tests := []struct {
 		expError        string
 		brokenStatement []byte
-		complement      map[string]interface{}
+		complement      map[string]any
 		accKey          *asserts.AccountKey
 	}{
 		{`cannot parse the assertion input as JSON:.*`,
@@ -267,43 +267,43 @@ func (s *signSuite) TestSignErrors(c *C) {
 			nil, nil,
 		},
 		{`invalid assertion type: what`,
-			exampleJSON(map[string]interface{}{"type": "what"}),
+			exampleJSON(map[string]any{"type": "what"}),
 			nil, nil,
 		},
 		{`assertion type must be a string, not: \[\]`,
-			exampleJSON(map[string]interface{}{"type": emptyList}),
+			exampleJSON(map[string]any{"type": emptyList}),
 			nil, nil,
 		},
 		{`missing assertion type header`,
-			exampleJSON(map[string]interface{}{"type": nil}),
+			exampleJSON(map[string]any{"type": nil}),
 			nil, nil,
 		},
 		{"revision should be positive: -10",
-			exampleJSON(map[string]interface{}{"revision": "-10"}),
+			exampleJSON(map[string]any{"revision": "-10"}),
 			nil, nil,
 		},
 		{`"authority-id" header is mandatory`,
-			exampleJSON(map[string]interface{}{"authority-id": nil}),
+			exampleJSON(map[string]any{"authority-id": nil}),
 			nil, nil,
 		},
 		{`body if specified must be a string`,
-			exampleJSON(map[string]interface{}{"body": emptyList}),
+			exampleJSON(map[string]any{"body": emptyList}),
 			nil, nil,
 		},
 		{`repeated assertion type does not match`,
 			exampleJSON(nil),
-			map[string]interface{}{"type": "foo"}, nil,
+			map[string]any{"type": "foo"}, nil,
 		},
 		{`complementary header "kernel" clashes with assertion input`,
 			exampleJSON(nil),
-			map[string]interface{}{"kernel": "foo"}, nil,
+			map[string]any{"kernel": "foo"}, nil,
 		},
 		{`authority-id does not match the account-id of the signing account-key`,
-			exampleJSON(map[string]interface{}{"authority-id": "user-id2", "brand-id": "user-id2"}),
+			exampleJSON(map[string]any{"authority-id": "user-id2", "brand-id": "user-id2"}),
 			nil, s.testAccKey,
 		},
 		{`the assertion headers do not match the constraints of the signing account-key`,
-			exampleJSON(map[string]interface{}{"model": "bar"}),
+			exampleJSON(map[string]any{"model": "bar"}),
 			nil, s.testAccKey,
 		},
 	}

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -145,7 +145,7 @@ func (snapdcl *SnapDeclaration) Prerequisites() []*Ref {
 	}
 }
 
-func compilePlugRules(plugs map[string]interface{}, compiled func(iface string, plugRule *PlugRule)) error {
+func compilePlugRules(plugs map[string]any, compiled func(iface string, plugRule *PlugRule)) error {
 	for iface, rule := range plugs {
 		plugRule, err := compilePlugRule(iface, rule)
 		if err != nil {
@@ -156,7 +156,7 @@ func compilePlugRules(plugs map[string]interface{}, compiled func(iface string, 
 	return nil
 }
 
-func compileSlotRules(slots map[string]interface{}, compiled func(iface string, slotRule *SlotRule)) error {
+func compileSlotRules(slots map[string]any, compiled func(iface string, slotRule *SlotRule)) error {
 	for iface, rule := range slots {
 		slotRule, err := compileSlotRule(iface, rule)
 		if err != nil {
@@ -167,7 +167,7 @@ func compileSlotRules(slots map[string]interface{}, compiled func(iface string, 
 	return nil
 }
 
-func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (formatnum int, err error) {
+func snapDeclarationFormatAnalyze(headers map[string]any, body []byte) (formatnum int, err error) {
 	_, plugsOk := headers["plugs"]
 	_, slotsOk := headers["slots"]
 	if !(plugsOk || slotsOk) {
@@ -234,12 +234,12 @@ func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (
 	return formatnum, nil
 }
 
-func checkAliases(headers map[string]interface{}) (map[string]string, error) {
+func checkAliases(headers map[string]any) (map[string]string, error) {
 	value, ok := headers["aliases"]
 	if !ok {
 		return nil, nil
 	}
-	aliasList, ok := value.([]interface{})
+	aliasList, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf(`"aliases" header must be a list of alias maps`)
 	}
@@ -249,7 +249,7 @@ func checkAliases(headers map[string]interface{}) (map[string]string, error) {
 
 	aliasMap := make(map[string]string, len(aliasList))
 	for i, item := range aliasList {
-		aliasItem, ok := item.(map[string]interface{})
+		aliasItem, ok := item.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(`"aliases" header must be a list of alias maps`)
 		}
@@ -344,7 +344,7 @@ func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 
 	ra, ok := assert.headers["revision-authority"]
 	if ok {
-		ramaps, ok := ra.([]interface{})
+		ramaps, ok := ra.([]any)
 		if !ok {
 			return nil, fmt.Errorf("revision-authority stanza must be a list of maps")
 		}
@@ -354,7 +354,7 @@ func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 		}
 		ras = make([]*RevisionAuthority, 0, len(ramaps))
 		for _, ramap := range ramaps {
-			m, ok := ramap.(map[string]interface{})
+			m, ok := ramap.(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("revision-authority stanza must be a list of maps")
 			}
@@ -710,7 +710,7 @@ func (snaprev *SnapRevision) Prerequisites() []*Ref {
 	}
 }
 
-func checkSnapRevisionWhat(headers map[string]interface{}, name, what string) (snapRevision int, err error) {
+func checkSnapRevisionWhat(headers map[string]any, name, what string) (snapRevision int, err error) {
 	snapRevision, err = checkIntWhat(headers, name, what)
 	if err != nil {
 		return 0, err
@@ -721,21 +721,21 @@ func checkSnapRevisionWhat(headers map[string]interface{}, name, what string) (s
 	return snapRevision, nil
 }
 
-func checkOptionalSnapRevisionWhat(headers map[string]interface{}, name, what string) (snapRevision int, err error) {
+func checkOptionalSnapRevisionWhat(headers map[string]any, name, what string) (snapRevision int, err error) {
 	if _, ok := headers[name]; !ok {
 		return 0, nil
 	}
 	return checkSnapRevisionWhat(headers, name, what)
 }
 
-func checkSnapIntegrity(headers map[string]interface{}) ([]SnapIntegrityData, error) {
+func checkSnapIntegrity(headers map[string]any) ([]SnapIntegrityData, error) {
 	value, ok := headers["integrity"]
 	if !ok {
 		// integrity stanzas are optional
 		return nil, nil
 	}
 
-	integrityList, ok := value.([]interface{})
+	integrityList, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf(`"integrity" header must contain a list of integrity data`)
 	}
@@ -746,7 +746,7 @@ func checkSnapIntegrity(headers map[string]interface{}) ([]SnapIntegrityData, er
 	var snapIntegrityDataList []SnapIntegrityData
 
 	for i, il := range integrityList {
-		id, ok := il.(map[string]interface{})
+		id, ok := il.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(`"integrity" header must contain a list of integrity data`)
 		}
@@ -1070,7 +1070,7 @@ func BuiltinBaseDeclaration() *BaseDeclaration {
 
 var (
 	builtinBaseDeclarationCheckOrder      = []string{"type", "authority-id", "series"}
-	builtinBaseDeclarationExpectedHeaders = map[string]interface{}{
+	builtinBaseDeclarationExpectedHeaders = map[string]any{
 		"type":         "base-declaration",
 		"authority-id": "canonical",
 		"series":       release.Series,
@@ -1226,12 +1226,12 @@ func assembleSnapDeveloper(assert assertionBase) (Assertion, error) {
 	}, nil
 }
 
-func checkDevelopers(headers map[string]interface{}) (map[string][]*dateRange, error) {
+func checkDevelopers(headers map[string]any) (map[string][]*dateRange, error) {
 	value, ok := headers["developers"]
 	if !ok {
 		return nil, nil
 	}
-	developers, ok := value.([]interface{})
+	developers, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf(`"developers" must be a list of developer maps`)
 	}
@@ -1246,7 +1246,7 @@ func checkDevelopers(headers map[string]interface{}) (map[string][]*dateRange, e
 
 	developerRanges := make(map[string][]*dateRange)
 	for i, item := range developers {
-		developer, ok := item.(map[string]interface{})
+		developer, ok := item.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(`"developers" must be a list of developer maps`)
 		}

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -52,7 +52,7 @@ type snapDeclSuite struct {
 
 type emptyAttrerObject struct{}
 
-func (o emptyAttrerObject) Lookup(path string) (interface{}, bool) {
+func (o emptyAttrerObject) Lookup(path string) (any, bool) {
 	return nil, false
 }
 
@@ -509,8 +509,8 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 0)
 
-	headers := map[string]interface{}{
-		"plugs": map[string]interface{}{
+	headers := map[string]any{
+		"plugs": map[string]any{
 			"interface1": "true",
 		},
 	}
@@ -518,8 +518,8 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 1)
 
-	headers = map[string]interface{}{
-		"slots": map[string]interface{}{
+	headers = map[string]any{
+		"slots": map[string]any{
 			"interface2": "true",
 		},
 	}
@@ -527,11 +527,11 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 1)
 
-	headers = map[string]interface{}{
-		"plugs": map[string]interface{}{
-			"interface3": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"plug-attributes": map[string]interface{}{
+	headers = map[string]any{
+		"plugs": map[string]any{
+			"interface3": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"plug-attributes": map[string]any{
 						"x": "$SLOT(x)",
 					},
 				},
@@ -542,11 +542,11 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 2)
 
-	headers = map[string]interface{}{
-		"slots": map[string]interface{}{
-			"interface3": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"plug-attributes": map[string]interface{}{
+	headers = map[string]any{
+		"slots": map[string]any{
+			"interface3": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"plug-attributes": map[string]any{
 						"x": "$SLOT(x)",
 					},
 				},
@@ -561,10 +561,10 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	for _, side := range []string{"plugs", "slots"} {
 		for k, vals := range deviceScopeConstrs {
 
-			headers := map[string]interface{}{
-				side: map[string]interface{}{
-					"interface3": map[string]interface{}{
-						"allow-installation": map[string]interface{}{
+			headers := map[string]any{
+				side: map[string]any{
+					"interface3": map[string]any{
+						"allow-installation": map[string]any{
 							k: vals,
 						},
 					},
@@ -576,10 +576,10 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 
 			for _, conn := range []string{"connection", "auto-connection"} {
 
-				headers = map[string]interface{}{
-					side: map[string]interface{}{
-						"interface3": map[string]interface{}{
-							"allow-" + conn: map[string]interface{}{
+				headers = map[string]any{
+					side: map[string]any{
+						"interface3": map[string]any{
+							"allow-" + conn: map[string]any{
 								k: vals,
 							},
 						},
@@ -594,18 +594,18 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 
 	// higher format features win
 
-	headers = map[string]interface{}{
-		"plugs": map[string]interface{}{
-			"interface3": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"on-store": []interface{}{"store"},
+	headers = map[string]any{
+		"plugs": map[string]any{
+			"interface3": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"on-store": []any{"store"},
 				},
 			},
 		},
-		"slots": map[string]interface{}{
-			"interface4": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"plug-attributes": map[string]interface{}{
+		"slots": map[string]any{
+			"interface4": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"plug-attributes": map[string]any{
 						"x": "$SLOT(x)",
 					},
 				},
@@ -616,20 +616,20 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 3)
 
-	headers = map[string]interface{}{
-		"plugs": map[string]interface{}{
-			"interface4": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"slot-attributes": map[string]interface{}{
+	headers = map[string]any{
+		"plugs": map[string]any{
+			"interface4": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"slot-attributes": map[string]any{
 						"x": "$SLOT(x)",
 					},
 				},
 			},
 		},
-		"slots": map[string]interface{}{
-			"interface3": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"on-store": []interface{}{"store"},
+		"slots": map[string]any{
+			"interface3": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"on-store": []any{"store"},
 				},
 			},
 		},
@@ -639,13 +639,13 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	c.Check(fmtnum, Equals, 3)
 
 	// errors
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"plugs": "what",
 	}
 	_, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
 	c.Assert(err, ErrorMatches, `assertion snap-declaration: "plugs" header must be a map`)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"slots": "what",
 	}
 	_, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
@@ -654,11 +654,11 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 	// plug-names/slot-names => format 4
 	for _, sidePrefix := range []string{"plug", "slot"} {
 		side := sidePrefix + "s"
-		headers := map[string]interface{}{
-			side: map[string]interface{}{
-				"interface3": map[string]interface{}{
-					"allow-installation": map[string]interface{}{
-						sidePrefix + "-names": []interface{}{"foo"},
+		headers := map[string]any{
+			side: map[string]any{
+				"interface3": map[string]any{
+					"allow-installation": map[string]any{
+						sidePrefix + "-names": []any{"foo"},
 					},
 				},
 			},
@@ -669,11 +669,11 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 
 		for _, conn := range []string{"connection", "auto-connection"} {
 
-			headers = map[string]interface{}{
-				side: map[string]interface{}{
-					"interface3": map[string]interface{}{
-						"allow-" + conn: map[string]interface{}{
-							sidePrefix + "-names": []interface{}{"foo"},
+			headers = map[string]any{
+				side: map[string]any{
+					"interface3": map[string]any{
+						"allow-" + conn: map[string]any{
+							sidePrefix + "-names": []any{"foo"},
 						},
 					},
 				},
@@ -682,12 +682,12 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 			c.Assert(err, IsNil)
 			c.Check(fmtnum, Equals, 4)
 
-			headers = map[string]interface{}{
-				side: map[string]interface{}{
-					"interface3": map[string]interface{}{
-						"allow-" + conn: map[string]interface{}{
-							"plug-names": []interface{}{"Pfoo"},
-							"slot-names": []interface{}{"Sfoo"},
+			headers = map[string]any{
+				side: map[string]any{
+					"interface3": map[string]any{
+						"allow-" + conn: map[string]any{
+							"plug-names": []any{"Pfoo"},
+							"slot-names": []any{"Sfoo"},
 						},
 					},
 				},
@@ -700,12 +700,12 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 
 	// alt matcher (so far unused) => format 5
 	for _, sidePrefix := range []string{"plug", "slot"} {
-		headers = map[string]interface{}{
-			sidePrefix + "s": map[string]interface{}{
-				"interface5": map[string]interface{}{
-					"allow-auto-connection": map[string]interface{}{
-						sidePrefix + "-attributes": map[string]interface{}{
-							"x": []interface{}{"alt1", "alt2"}, // alt matcher
+		headers = map[string]any{
+			sidePrefix + "s": map[string]any{
+				"interface5": map[string]any{
+					"allow-auto-connection": map[string]any{
+						sidePrefix + "-attributes": map[string]any{
+							"x": []any{"alt1", "alt2"}, // alt matcher
 						},
 					},
 				},
@@ -718,11 +718,11 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 
 	for _, cstr := range []string{"$PLUG_PUBLISHER_ID", "$SLOT_PUBLISHER_ID"} {
 		for _, sidePrefix := range []string{"plug", "slot"} {
-			headers = map[string]interface{}{
-				sidePrefix + "s": map[string]interface{}{
-					"interface6": map[string]interface{}{
-						"allow-auto-connection": map[string]interface{}{
-							sidePrefix + "-attributes": map[string]interface{}{
+			headers = map[string]any{
+				sidePrefix + "s": map[string]any{
+					"interface6": map[string]any{
+						"allow-auto-connection": map[string]any{
+							sidePrefix + "-attributes": map[string]any{
 								"x": cstr,
 							},
 						},
@@ -738,7 +738,7 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 }
 
 func prereqDevAccount(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {
-	dev1Acct := assertstest.NewAccount(storeDB, "developer1", map[string]interface{}{
+	dev1Acct := assertstest.NewAccount(storeDB, "developer1", map[string]any{
 		"account-id": "dev-id1",
 	}, "")
 	err := db.Add(dev1Acct)
@@ -750,7 +750,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheck(c *C) {
 
 	prereqDevAccount(c, storeDB, db)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -769,7 +769,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheckUntrustedAuthority(c *C) {
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -786,7 +786,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheckUntrustedAuthority(c *C) {
 func (sds *snapDeclSuite) TestSnapDeclarationCheckMissingPublisherAccount(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -948,7 +948,7 @@ func makeStoreAndCheckDB(c *C) (store *assertstest.StoreStack, checkDB *asserts.
 func setup3rdPartySigning(c *C, username string, storeDB assertstest.SignerDB, checkDB *asserts.Database) (signingDB *assertstest.SigningDB) {
 	privKey := testPrivKey2
 
-	acct := assertstest.NewAccount(storeDB, username, map[string]interface{}{
+	acct := assertstest.NewAccount(storeDB, username, map[string]any{
 		"account-id": username,
 	}, "")
 	accKey := assertstest.NewAccountKey(storeDB, acct, nil, privKey.PublicKey(), "")
@@ -965,7 +965,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheck(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "devel1", storeDB, db)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  "devel1",
 		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",
@@ -984,7 +984,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "devel1", storeDB, db)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",
 		"grade":         "devel",
@@ -1051,8 +1051,8 @@ func (srs *snapRevSuite) makeValidEncodedWithIntegrity() string {
 		"AXNpZw=="
 }
 
-func makeSnapRevisionHeaders(overrides map[string]interface{}) map[string]interface{} {
-	headers := map[string]interface{}{
+func makeSnapRevisionHeaders(overrides map[string]any) map[string]any {
+	headers := map[string]any{
 		"authority-id":  "canonical",
 		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",
@@ -1068,7 +1068,7 @@ func makeSnapRevisionHeaders(overrides map[string]interface{}) map[string]interf
 	return headers
 }
 
-func (srs *snapRevSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
+func (srs *snapRevSuite) makeHeaders(overrides map[string]any) map[string]any {
 	return makeSnapRevisionHeaders(overrides)
 }
 
@@ -1228,7 +1228,7 @@ func (srs *snapRevSuite) TestDecodeInvalidWithIntegrity(c *C) {
 }
 
 func prereqSnapDecl(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -1257,7 +1257,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheck(c *C) {
 func (srs *snapRevSuite) TestSnapRevisionCheckInconsistentTimestamp(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
-	headers := srs.makeHeaders(map[string]interface{}{
+	headers := srs.makeHeaders(map[string]any{
 		"timestamp": "2013-01-01T14:00:00Z",
 	})
 	snapRev, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
@@ -1272,7 +1272,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckUntrustedAuthority(c *C) {
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := srs.makeHeaders(map[string]interface{}{
+	headers := srs.makeHeaders(map[string]any{
 		"authority-id": "other",
 	})
 	snapRev, err := otherDB.Sign(asserts.SnapRevisionType, headers, nil, "")
@@ -1310,7 +1310,7 @@ func (srs *snapRevSuite) TestRevisionAuthorityCheck(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
-	headers := srs.makeHeaders(map[string]interface{}{
+	headers := srs.makeHeaders(map[string]any{
 		"authority-id":  "delegated-id",
 		"developer-id":  "delegated-id",
 		"snap-revision": "200",
@@ -1405,7 +1405,7 @@ AXNpZw==`))
 	storeDB, db := makeStoreAndCheckDB(c)
 
 	delegatedDB := setup3rdPartySigning(c, "my-brand", storeDB, db)
-	headers := srs.makeHeaders(map[string]interface{}{
+	headers := srs.makeHeaders(map[string]any{
 		"authority-id":  "my-brand",
 		"developer-id":  "my-brand",
 		"snap-revision": "200",
@@ -1490,7 +1490,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
 
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -1501,7 +1501,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := srs.makeHeaders(map[string]interface{}{
+	headers := srs.makeHeaders(map[string]any{
 		"authority-id": "delegated-id",
 		"developer-id": "delegated-id",
 		"provenance":   "prov1",
@@ -1513,20 +1513,20 @@ func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
 	c.Check(err, ErrorMatches, `snap-revision assertion with provenance "prov1" for snap id "snap-id-1" is not signed by an authorized authority: delegated-id`)
 
 	// establish delegation
-	snapDecl, err = storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err = storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": "delegated-id",
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": "delegated-id",
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
 				// present but not checked at this level
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 			},
@@ -1548,19 +1548,19 @@ func (srs *snapRevSuite) TestSnapRevisionDelegationRevisionOutOfRange(c *C) {
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
 
 	// establish delegation
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": "delegated-id",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": "delegated-id",
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
 				// present but not checked at this level
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 				"max-revision": "200",
@@ -1572,7 +1572,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegationRevisionOutOfRange(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := srs.makeHeaders(map[string]interface{}{
+	headers := srs.makeHeaders(map[string]any{
 		"authority-id":  "delegated-id",
 		"developer-id":  "delegated-id",
 		"provenance":    "prov1",
@@ -1644,8 +1644,8 @@ func (vs *validationSuite) makeValidEncoded() string {
 		"AXNpZw=="
 }
 
-func (vs *validationSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
-	headers := map[string]interface{}{
+func (vs *validationSuite) makeHeaders(overrides map[string]any) map[string]any {
+	headers := map[string]any{
 		"authority-id":           "dev-id1",
 		"series":                 "16",
 		"snap-id":                "snap-id-1",
@@ -1707,7 +1707,7 @@ func (vs *validationSuite) TestDecodeInvalid(c *C) {
 }
 
 func prereqSnapDecl2(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-2",
 		"snap-name":    "bar",
@@ -1741,7 +1741,7 @@ func (vs *validationSuite) TestValidationCheckWrongAuthority(c *C) {
 	prereqSnapDecl(c, storeDB, db)
 	prereqSnapDecl2(c, storeDB, db)
 
-	headers := vs.makeHeaders(map[string]interface{}{
+	headers := vs.makeHeaders(map[string]any{
 		"authority-id": "canonical", // not the publisher
 	})
 	validation, err := storeDB.Sign(asserts.ValidationType, headers, nil, "")
@@ -1997,7 +1997,7 @@ func (s *baseDeclSuite) TestBaseDeclarationCheckUntrustedAuthority(c *C) {
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":    "16",
 		"timestamp": time.Now().Format(time.RFC3339),
 	}
@@ -2243,7 +2243,7 @@ func (sds *snapDevSuite) TestAuthorityIsPublisher(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "dev-id1", storeDB, db)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "snap-name-1",
@@ -2254,7 +2254,7 @@ func (sds *snapDevSuite) TestAuthorityIsPublisher(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
+	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]any{
 		"snap-id":      "snap-id-1",
 		"publisher-id": "dev-id1",
 	}, nil, "")
@@ -2271,7 +2271,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisher(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "dev-id1", storeDB, db)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "snap-name-1",
@@ -2282,7 +2282,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisher(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
+	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]any{
 		"authority-id": "dev-id1",
 		"snap-id":      "snap-id-1",
 		"publisher-id": "dev-id2",
@@ -2299,7 +2299,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisher(c *C) {
 func (sds *snapDevSuite) TestAuthorityIsNotPublisherButIsTrusted(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
-	account, err := storeDB.Sign(asserts.AccountType, map[string]interface{}{
+	account, err := storeDB.Sign(asserts.AccountType, map[string]any{
 		"account-id":   "dev-id1",
 		"display-name": "dev-id1",
 		"validation":   "unknown",
@@ -2309,7 +2309,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisherButIsTrusted(c *C) {
 	err = db.Add(account)
 	c.Assert(err, IsNil)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "snap-name-1",
@@ -2320,7 +2320,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisherButIsTrusted(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	snapDev, err := storeDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
+	snapDev, err := storeDB.Sign(asserts.SnapDeveloperType, map[string]any{
 		"snap-id":      "snap-id-1",
 		"publisher-id": "dev-id1",
 	}, nil, "")
@@ -2336,7 +2336,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisherButIsTrusted(c *C) {
 func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
-	account, err := storeDB.Sign(asserts.AccountType, map[string]interface{}{
+	account, err := storeDB.Sign(asserts.AccountType, map[string]any{
 		"account-id":   "dev-id1",
 		"display-name": "dev-id1",
 		"validation":   "unknown",
@@ -2346,7 +2346,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 	err = db.Add(account)
 	c.Assert(err, IsNil)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "snap-name-1",
@@ -2357,7 +2357,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	snapDev, err := storeDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
+	snapDev, err := storeDB.Sign(asserts.SnapDeveloperType, map[string]any{
 		"snap-id":      "snap-id-1",
 		"publisher-id": "dev-id2",
 	}, nil, "")
@@ -2371,7 +2371,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 	c.Assert(err, ErrorMatches, `snap-developer assertion for snap-id "snap-id-1" does not have a matching account assertion for the publisher "dev-id2"`)
 
 	// But once the dev-id2 account is added the snap-developer is ok.
-	account, err = storeDB.Sign(asserts.AccountType, map[string]interface{}{
+	account, err = storeDB.Sign(asserts.AccountType, map[string]any{
 		"account-id":   "dev-id2",
 		"display-name": "dev-id2",
 		"validation":   "unknown",
@@ -2389,7 +2389,7 @@ func (sds *snapDevSuite) TestCheckDeveloperAccountExists(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "dev-id1", storeDB, db)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "snap-name-1",
@@ -2400,11 +2400,11 @@ func (sds *snapDevSuite) TestCheckDeveloperAccountExists(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
+	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]any{
 		"snap-id":      "snap-id-1",
 		"publisher-id": "dev-id1",
-		"developers": []interface{}{
-			map[string]interface{}{
+		"developers": []any{
+			map[string]any{
 				"developer-id": "dev-id2",
 				"since":        "2017-01-01T00:00:00.0Z",
 			},
@@ -2419,7 +2419,7 @@ func (sds *snapDevSuite) TestCheckMissingDeclaration(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "dev-id1", storeDB, db)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": "dev-id1",
 		"snap-id":      "snap-id-1",
 		"publisher-id": "dev-id1",

--- a/asserts/snap_resource_asserts.go
+++ b/asserts/snap_resource_asserts.go
@@ -139,7 +139,7 @@ func (resrev *SnapResourceRevision) Prerequisites() []*Ref {
 	}
 }
 
-func checkResourceName(headers map[string]interface{}) error {
+func checkResourceName(headers map[string]any) error {
 	resName, err := checkNotEmptyString(headers, "resource-name")
 	if err != nil {
 		return err

--- a/asserts/snap_resource_asserts_test.go
+++ b/asserts/snap_resource_asserts_test.go
@@ -60,8 +60,8 @@ func (s *snapResourceRevSuite) makeValidEncoded() string {
 		"AXNpZw=="
 }
 
-func makeSnapResourceRevisionHeaders(overrides map[string]interface{}) map[string]interface{} {
-	headers := map[string]interface{}{
+func makeSnapResourceRevisionHeaders(overrides map[string]any) map[string]any {
+	headers := map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           "snap-id-1",
 		"resource-name":     "comp-name",
@@ -78,7 +78,7 @@ func makeSnapResourceRevisionHeaders(overrides map[string]interface{}) map[strin
 	return headers
 }
 
-func (s *snapResourceRevSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
+func (s *snapResourceRevSuite) makeHeaders(overrides map[string]any) map[string]any {
 	return makeSnapResourceRevisionHeaders(overrides)
 }
 
@@ -228,7 +228,7 @@ func (s *snapResourceRevSuite) TestCheckUntrustedAuthority(c *C) {
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := s.makeHeaders(map[string]interface{}{
+	headers := s.makeHeaders(map[string]any{
 		"authority-id": "other",
 	})
 	snapResRev, err := otherDB.Sign(asserts.SnapResourceRevisionType, headers, nil, "")
@@ -242,7 +242,7 @@ func (s *snapResourceRevSuite) TestRevisionAuthorityCheck(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
-	headers := s.makeHeaders(map[string]interface{}{
+	headers := s.makeHeaders(map[string]any{
 		"authority-id":      "delegated-id",
 		"developer-id":      "delegated-id",
 		"resource-revision": "200",
@@ -307,7 +307,7 @@ func (s *snapResourceRevSuite) TestSnapResourceRevisionDelegation(c *C) {
 
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -318,7 +318,7 @@ func (s *snapResourceRevSuite) TestSnapResourceRevisionDelegation(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := s.makeHeaders(map[string]interface{}{
+	headers := s.makeHeaders(map[string]any{
 		"authority-id": "delegated-id",
 		"developer-id": "delegated-id",
 		"provenance":   "prov1",
@@ -330,20 +330,20 @@ func (s *snapResourceRevSuite) TestSnapResourceRevisionDelegation(c *C) {
 	c.Check(err, ErrorMatches, `snap-resource-revision assertion with provenance "prov1" for snap id "snap-id-1" is not signed by an authorized authority: delegated-id`)
 
 	// establish delegation
-	snapDecl, err = storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err = storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": "delegated-id",
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": "delegated-id",
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
 				// present but not checked at this level
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 			},
@@ -365,19 +365,19 @@ func (s *snapResourceRevSuite) TestSnapResourceRevisionDelegationRevisionOutOfRa
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
 
 	// establish delegation
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": "delegated-id",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": "delegated-id",
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
 				// present but not checked at this level
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 				"max-revision": "200",
@@ -389,7 +389,7 @@ func (s *snapResourceRevSuite) TestSnapResourceRevisionDelegationRevisionOutOfRa
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := s.makeHeaders(map[string]interface{}{
+	headers := s.makeHeaders(map[string]any{
 		"authority-id":      "delegated-id",
 		"developer-id":      "delegated-id",
 		"provenance":        "prov1",
@@ -428,8 +428,8 @@ func (s *snapResourcePairSuite) makeValidEncoded() string {
 		"AXNpZw=="
 }
 
-func (s *snapResourcePairSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
-	headers := map[string]interface{}{
+func (s *snapResourcePairSuite) makeHeaders(overrides map[string]any) map[string]any {
+	headers := map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           "snap-id-1",
 		"resource-name":     "comp-name",
@@ -582,7 +582,7 @@ func (s *snapResourcePairSuite) TestCheckUntrustedAuthority(c *C) {
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := s.makeHeaders(map[string]interface{}{
+	headers := s.makeHeaders(map[string]any{
 		"authority-id": "other",
 	})
 	snapResPair, err := otherDB.Sign(asserts.SnapResourcePairType, headers, nil, "")
@@ -597,7 +597,7 @@ func (s *snapResourcePairSuite) TestDelegation(c *C) {
 
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
 
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -608,7 +608,7 @@ func (s *snapResourcePairSuite) TestDelegation(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := s.makeHeaders(map[string]interface{}{
+	headers := s.makeHeaders(map[string]any{
 		"authority-id": "delegated-id",
 		"developer-id": "delegated-id",
 		"provenance":   "prov1",
@@ -620,20 +620,20 @@ func (s *snapResourcePairSuite) TestDelegation(c *C) {
 	c.Check(err, ErrorMatches, `snap-resource-pair assertion with provenance "prov1" for snap id "snap-id-1" is not signed by an authorized authority: delegated-id`)
 
 	// establish delegation
-	snapDecl, err = storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err = storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": "delegated-id",
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": "delegated-id",
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
 				// present but not checked at this level
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 			},
@@ -655,19 +655,19 @@ func (s *snapResourcePairSuite) TestDelegationRevisionOutOfRange(c *C) {
 	delegatedDB := setup3rdPartySigning(c, "delegated-id", storeDB, db)
 
 	// establish delegation
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": "delegated-id",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": "delegated-id",
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
 				// present but not checked at this level
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 				"max-revision": "200",
@@ -679,7 +679,7 @@ func (s *snapResourcePairSuite) TestDelegationRevisionOutOfRange(c *C) {
 	err = db.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := s.makeHeaders(map[string]interface{}{
+	headers := s.makeHeaders(map[string]any{
 		"authority-id":  "delegated-id",
 		"developer-id":  "delegated-id",
 		"provenance":    "prov1",

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -81,7 +81,7 @@ func (s *snapassertsSuite) SetUpTest(c *C) {
 
 	s.dev1Signing = assertstest.NewSigningDB(s.dev1Acct.AccountID(), privKey)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -117,7 +117,7 @@ func makeDigest(rev int) string {
 func (s *snapassertsSuite) TestCrossCheckHappy(c *C) {
 	digest := makeDigest(12)
 	size := uint64(len(fakeSnap(12)))
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -148,7 +148,7 @@ func (s *snapassertsSuite) TestCrossCheckHappy(c *C) {
 func (s *snapassertsSuite) TestCrossCheckErrors(c *C) {
 	digest := makeDigest(12)
 	size := uint64(len(fakeSnap(12)))
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -206,7 +206,7 @@ func (s *snapassertsSuite) TestCrossCheckErrors(c *C) {
 
 func (s *snapassertsSuite) TestCrossCheckRevokedSnapDecl(c *C) {
 	// revoked snap declaration (snap-name=="") !
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "",
@@ -221,7 +221,7 @@ func (s *snapassertsSuite) TestCrossCheckRevokedSnapDecl(c *C) {
 
 	digest := makeDigest(12)
 	size := uint64(len(fakeSnap(12)))
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -251,7 +251,7 @@ version: 1`, nil)
 	digest, size, err := asserts.SnapFileSHA3_384(fooSnap)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -288,7 +288,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoNoSignatures(c *C) {
 func (s *snapassertsSuite) TestDeriveSideInfoSizeMismatch(c *C) {
 	digest := makeDigest(42)
 	size := uint64(len(fakeSnap(42)))
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size+5), // broken
@@ -312,7 +312,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoSizeMismatch(c *C) {
 
 func (s *snapassertsSuite) TestDeriveSideInfoRevokedSnapDecl(c *C) {
 	// revoked snap declaration (snap-name=="") !
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "",
@@ -327,7 +327,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoRevokedSnapDecl(c *C) {
 
 	digest := makeDigest(42)
 	size := uint64(len(fakeSnap(42)))
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -350,16 +350,16 @@ func (s *snapassertsSuite) TestDeriveSideInfoRevokedSnapDecl(c *C) {
 }
 
 func (s *snapassertsSuite) TestCrossCheckDelegatedSnapHappy(c *C) {
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
 			},
@@ -372,7 +372,7 @@ func (s *snapassertsSuite) TestCrossCheckDelegatedSnapHappy(c *C) {
 
 	digest := makeDigest(42)
 	size := uint64(len(fakeSnap(42)))
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
@@ -403,7 +403,7 @@ func (s *snapassertsSuite) TestCrossCheckDelegatedSnapHappy(c *C) {
 }
 
 func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapHappy(c *C) {
-	a, err := s.dev1Signing.Sign(asserts.ModelType, map[string]interface{}{
+	a, err := s.dev1Signing.Sign(asserts.ModelType, map[string]any{
 		"brand-id":     s.dev1Acct.AccountID(),
 		"series":       "16",
 		"model":        "dev-model",
@@ -417,29 +417,29 @@ func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapHappy(c *C) {
 	c.Assert(err, IsNil)
 	model := a.(*asserts.Model)
 
-	substore, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	substore, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":           "substore",
 		"operator-id":     "can0nical",
-		"friendly-stores": []interface{}{"store1"},
+		"friendly-stores": []any{"store1"},
 		"timestamp":       time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 	err = s.localDB.Add(substore)
 	c.Assert(err, IsNil)
 
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 			},
@@ -452,7 +452,7 @@ func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapHappy(c *C) {
 
 	digest := makeDigest(42)
 	size := uint64(len(fakeSnap(42)))
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
@@ -483,7 +483,7 @@ func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapHappy(c *C) {
 }
 
 func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapUnhappy(c *C) {
-	a, err := s.dev1Signing.Sign(asserts.ModelType, map[string]interface{}{
+	a, err := s.dev1Signing.Sign(asserts.ModelType, map[string]any{
 		"brand-id":     s.dev1Acct.AccountID(),
 		"series":       "16",
 		"model":        "dev-model",
@@ -497,29 +497,29 @@ func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapUnhappy(c *C) {
 	c.Assert(err, IsNil)
 	model := a.(*asserts.Model)
 
-	substore, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	substore, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":           "substore",
 		"operator-id":     "can0nical",
-		"friendly-stores": []interface{}{"store1"},
+		"friendly-stores": []any{"store1"},
 		"timestamp":       time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 	err = s.localDB.Add(substore)
 	c.Assert(err, IsNil)
 
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov1",
 				},
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store2",
 				},
 			},
@@ -532,7 +532,7 @@ func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapUnhappy(c *C) {
 
 	digest := makeDigest(42)
 	size := uint64(len(fakeSnap(42)))
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
@@ -560,7 +560,7 @@ func (s *snapassertsSuite) TestCrossCheckWithDeviceDelegatedSnapUnhappy(c *C) {
 func (s *snapassertsSuite) TestCrossCheckSpuriousProvenanceUnhappy(c *C) {
 	digest := makeDigest(12)
 	size := uint64(len(fakeSnap(12)))
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -585,7 +585,7 @@ func (s *snapassertsSuite) TestCrossCheckSpuriousProvenanceUnhappy(c *C) {
 func (s *snapassertsSuite) TestCheckProvenanceWithVerifiedRevision(c *C) {
 	digest := makeDigest(12)
 	size := uint64(len(fakeSnap(12)))
-	snapRevGlobalUpload := assertstest.FakeAssertion(map[string]interface{}{
+	snapRevGlobalUpload := assertstest.FakeAssertion(map[string]any{
 		"type":          "snap-revision",
 		"authority-id":  "can0nical",
 		"snap-id":       "snap-id-1",
@@ -595,7 +595,7 @@ func (s *snapassertsSuite) TestCheckProvenanceWithVerifiedRevision(c *C) {
 		"developer-id":  s.dev1Acct.AccountID(),
 		"timestamp":     time.Now().Format(time.RFC3339),
 	}).(*asserts.SnapRevision)
-	snapRevProv := assertstest.FakeAssertion(map[string]interface{}{
+	snapRevProv := assertstest.FakeAssertion(map[string]any{
 		"type":          "snap-revision",
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
@@ -606,7 +606,7 @@ func (s *snapassertsSuite) TestCheckProvenanceWithVerifiedRevision(c *C) {
 		"developer-id":  s.dev1Acct.AccountID(),
 		"timestamp":     time.Now().Format(time.RFC3339),
 	}).(*asserts.SnapRevision)
-	snapRevProv2 := assertstest.FakeAssertion(map[string]interface{}{
+	snapRevProv2 := assertstest.FakeAssertion(map[string]any{
 		"type":          "snap-revision",
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
@@ -647,7 +647,7 @@ version: 1
 func (s *snapassertsSuite) TestCheckComponentProvenanceWithVerifiedRevision(c *C) {
 	digest := makeDigest(12)
 	size := uint64(len(fakeSnap(12)))
-	snapResRev := assertstest.FakeAssertion(map[string]interface{}{
+	snapResRev := assertstest.FakeAssertion(map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      s.dev1Acct.AccountID(),
 		"snap-id":           "snap-id-1",
@@ -659,7 +659,7 @@ func (s *snapassertsSuite) TestCheckComponentProvenanceWithVerifiedRevision(c *C
 		"resource-size":     fmt.Sprintf("%d", size),
 		"timestamp":         time.Now().Format(time.RFC3339),
 	}).(*asserts.SnapResourceRevision)
-	snapResRev2 := assertstest.FakeAssertion(map[string]interface{}{
+	snapResRev2 := assertstest.FakeAssertion(map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      s.dev1Acct.AccountID(),
 		"snap-id":           "snap-id-1",
@@ -706,7 +706,7 @@ provenance: prov`, nil)
 	digest, size, err := asserts.SnapFileSHA3_384(withProv)
 	c.Assert(err, IsNil)
 
-	a, err := s.dev1Signing.Sign(asserts.ModelType, map[string]interface{}{
+	a, err := s.dev1Signing.Sign(asserts.ModelType, map[string]any{
 		"brand-id":     s.dev1Acct.AccountID(),
 		"series":       "16",
 		"model":        "dev-model",
@@ -720,29 +720,29 @@ provenance: prov`, nil)
 	c.Assert(err, IsNil)
 	model := a.(*asserts.Model)
 
-	substore, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	substore, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":           "substore",
 		"operator-id":     "can0nical",
-		"friendly-stores": []interface{}{"store1"},
+		"friendly-stores": []any{"store1"},
 		"timestamp":       time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 	err = s.localDB.Add(substore)
 	c.Assert(err, IsNil)
 
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov",
 				},
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 			},
@@ -753,7 +753,7 @@ provenance: prov`, nil)
 	err = s.localDB.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
@@ -790,16 +790,16 @@ provenance: prov`, nil)
 	digest, size, err := asserts.SnapFileSHA3_384(withProv)
 	c.Assert(err, IsNil)
 
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov",
 					"prov2",
 				},
@@ -811,7 +811,7 @@ provenance: prov`, nil)
 	err = s.localDB.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
@@ -827,7 +827,7 @@ provenance: prov`, nil)
 	err = s.localDB.Add(snapRev)
 	c.Check(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"snap-id":       "snap-id-1",
 		"snap-sha3-384": digest,
@@ -855,12 +855,12 @@ func assertedSnapID(snapName string) string {
 	return snaptest.AssertedSnapID(snapName)
 }
 
-func (s *snapassertsSuite) makeUC20Model(c *C, extraHeaders map[string]interface{}) *asserts.Model {
-	comps := map[string]interface{}{
+func (s *snapassertsSuite) makeUC20Model(c *C, extraHeaders map[string]any) *asserts.Model {
+	comps := map[string]any{
 		"comp1": "required",
 		"comp2": "optional",
 	}
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"brand-id":     s.dev1Acct.AccountID(),
 		"series":       "16",
 		"model":        "dev-model",
@@ -868,20 +868,20 @@ func (s *snapassertsSuite) makeUC20Model(c *C, extraHeaders map[string]interface
 		"architecture": "amd64",
 		"base":         "core20",
 		"timestamp":    time.Now().Format(time.RFC3339),
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              assertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              assertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":       "required20",
 				"id":         assertedSnapID("required20"),
 				"components": comps,
@@ -919,7 +919,7 @@ version: 1.0.2
 	digest, size, err := asserts.SnapFileSHA3_384(compPath)
 	c.Assert(err, IsNil)
 
-	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      "can0nical",
 		"snap-id":           "snap-id-1",
@@ -978,7 +978,7 @@ version: 1.0.2
 	c.Check(err, ErrorMatches, "snap-resource-revision assertion not found")
 	c.Check(csi, IsNil)
 
-	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      "can0nical",
 		"snap-id":           "snap-id-1",
@@ -1012,7 +1012,7 @@ version: 1.0.2
 	digest, size, err := asserts.SnapFileSHA3_384(compPath)
 	c.Assert(err, IsNil)
 
-	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      "can0nical",
 		"snap-id":           "snap-id-1",
@@ -1035,7 +1035,7 @@ version: 1.0.2
 }
 
 func (s *snapassertsSuite) TestDeriveComponentSideInfoFromDigestAndSizeWithProvenance(c *C) {
-	model := s.makeUC20Model(c, map[string]interface{}{"store": "store1"})
+	model := s.makeUC20Model(c, map[string]any{"store": "store1"})
 	compPath := snaptest.MakeTestComponentWithFiles(c, "comp1", `component: snap+comp1
 type: standard
 provenance: prov
@@ -1044,20 +1044,20 @@ version: 1.0.2
 	digest, size, err := asserts.SnapFileSHA3_384(compPath)
 	c.Assert(err, IsNil)
 
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					"prov",
 					"prov2",
 				},
-				"on-store": []interface{}{
+				"on-store": []any{
 					"store1",
 				},
 			},
@@ -1069,7 +1069,7 @@ version: 1.0.2
 	c.Assert(err, IsNil)
 
 	// Ok result
-	resRev, err := s.dev1Signing.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev, err := s.dev1Signing.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      s.dev1Acct.AccountID(),
 		"snap-id":           "snap-id-1",
@@ -1101,7 +1101,7 @@ version: 1.0.2
 	c.Check(csi, IsNil)
 
 	// Same hash but different provenance
-	resRev2, err := s.dev1Signing.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev2, err := s.dev1Signing.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      s.dev1Acct.AccountID(),
 		"snap-id":           "snap-id-1",
@@ -1130,7 +1130,7 @@ func (s *snapassertsSuite) TestCrossCheckResource(c *C) {
 	const resourceName = "standard-component"
 	const snapID = "snap-id-1"
 
-	revHeaders := map[string]interface{}{
+	revHeaders := map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
 		"resource-sha3-384": digest,
@@ -1145,7 +1145,7 @@ func (s *snapassertsSuite) TestCrossCheckResource(c *C) {
 	err = s.localDB.Add(expectedResourceRev)
 	c.Assert(err, IsNil)
 
-	pairHeaders := map[string]interface{}{
+	pairHeaders := map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
 		"resource-revision": componentRev.String(),
@@ -1214,16 +1214,16 @@ func (s *snapassertsSuite) TestCrossCheckResourceProvenance(c *C) {
 		provenance = "prov"
 	)
 
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "1",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					provenance,
 				},
 			},
@@ -1241,7 +1241,7 @@ func (s *snapassertsSuite) TestCrossCheckResourceProvenance(c *C) {
 		resourceName = "standard-component"
 	)
 
-	revHeaders := map[string]interface{}{
+	revHeaders := map[string]any{
 		"authority-id":      s.dev1Acct.AccountID(),
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
@@ -1258,7 +1258,7 @@ func (s *snapassertsSuite) TestCrossCheckResourceProvenance(c *C) {
 	err = s.localDB.Add(expectedResourceRev)
 	c.Assert(err, IsNil)
 
-	pairHeaders := map[string]interface{}{
+	pairHeaders := map[string]any{
 		"authority-id":      s.dev1Acct.AccountID(),
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
@@ -1290,16 +1290,16 @@ func (s *snapassertsSuite) TestCrossCheckResourceProvenance(c *C) {
 
 	// update the snap-decl with a mismatch provenance and check that the cross
 	// check fails
-	snapDecl, err = s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err = s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
 		"revision":     "2",
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					"new-prov",
 				},
 			},
@@ -1324,7 +1324,7 @@ func (s *snapassertsSuite) TestCrossCheckResourceErrors(c *C) {
 		snapID       = "snap-id-1"
 	)
 
-	originalRevHeaders := map[string]interface{}{
+	originalRevHeaders := map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
 		"resource-sha3-384": digest,
@@ -1334,7 +1334,7 @@ func (s *snapassertsSuite) TestCrossCheckResourceErrors(c *C) {
 		"timestamp":         time.Now().Format(time.RFC3339),
 	}
 
-	originalPairHeaders := map[string]interface{}{
+	originalPairHeaders := map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
 		"resource-revision": componentRev.String(),
@@ -1343,7 +1343,7 @@ func (s *snapassertsSuite) TestCrossCheckResourceErrors(c *C) {
 		"timestamp":         time.Now().Format(time.RFC3339),
 	}
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -1354,32 +1354,32 @@ func (s *snapassertsSuite) TestCrossCheckResourceErrors(c *C) {
 	c.Assert(err, IsNil)
 
 	type test struct {
-		revisionOverrides map[string]interface{}
-		pairOverrides     map[string]interface{}
+		revisionOverrides map[string]any
+		pairOverrides     map[string]any
 		err               string
 	}
 
 	tests := []test{
 		{
-			revisionOverrides: map[string]interface{}{
+			revisionOverrides: map[string]any{
 				"resource-size": "1023",
 			},
 			err: `resource \"standard-component\" file does not have expected size according to signatures \(download is broken or tampered\): 1024 != 1023`,
 		},
 		{
-			revisionOverrides: map[string]interface{}{
+			revisionOverrides: map[string]any{
 				"resource-revision": "25",
 			},
 			err: `resource \"standard-component\" does not have expected revision according to assertions \(metadata is broken or tampered\): 24 != 25`,
 		},
 		{
-			pairOverrides: map[string]interface{}{
+			pairOverrides: map[string]any{
 				"resource-revision": "25",
 			},
 			err: `cannot find snap-resource-pair for standard-component: snap-resource-pair assertion not found`,
 		},
 		{
-			revisionOverrides: map[string]interface{}{
+			revisionOverrides: map[string]any{
 				"resource-name": "nope",
 			},
 			err: `internal error: cannot find pre-populated snap-resource-revision assertion for \"standard-component\": .*`,
@@ -1433,8 +1433,8 @@ func (s *snapassertsSuite) TestCrossCheckResourceErrors(c *C) {
 	}
 }
 
-func copyMapWithOverrides(m map[string]interface{}, overrides map[string]interface{}) map[string]interface{} {
-	c := make(map[string]interface{}, len(m))
+func copyMapWithOverrides(m map[string]any, overrides map[string]any) map[string]any {
+	c := make(map[string]any, len(m))
 	for k, v := range m {
 		c[k] = v
 	}

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -43,15 +43,15 @@ type validationSetsSuite struct{}
 var _ = Suite(&validationSetsSuite{})
 
 func (s *validationSetsSuite) TestAddFromSameSequence(c *C) {
-	mySnapAt7Valset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapAt7Valset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -60,15 +60,15 @@ func (s *validationSetsSuite) TestAddFromSameSequence(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapAt8Valset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapAt8Valset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -85,15 +85,15 @@ func (s *validationSetsSuite) TestAddFromSameSequence(c *C) {
 }
 
 func (s *validationSetsSuite) TestIntersections(c *C) {
-	mySnapAt7Valset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapAt7Valset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -102,15 +102,15 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapAt7Valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapAt7Valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -119,15 +119,15 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapAt8Valset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapAt8Valset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl-other",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -136,15 +136,15 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapAt8OptValset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapAt8OptValset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl-opt",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "optional",
@@ -153,15 +153,15 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapInvalidValset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapInvalidValset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl-inv",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "invalid",
@@ -169,15 +169,15 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapAt7OptValset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapAt7OptValset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl-opt2",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "optional",
@@ -186,15 +186,15 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapReqValset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapReqValset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl-req-only",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -202,15 +202,15 @@ func (s *validationSetsSuite) TestIntersections(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	mySnapOptValset := assertstest.FakeAssertion(map[string]interface{}{
+	mySnapOptValset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl-opt-only",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "optional",
@@ -285,26 +285,26 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsNoValidationSets(c *C) {
 func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 	// require: snapB rev 3, snapC rev 2.
 	// invalid: snapA
-	vs1 := assertstest.FakeAssertion(map[string]interface{}{
+	vs1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "fooname",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-b",
 				"id":       "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				"revision": "3",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-c",
 				"id":       "mysnapcccccccccccccccccccccccccc",
 				"revision": "2",
@@ -315,20 +315,20 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 
 	// require: snapD any rev
 	// optional: snapE any rev
-	vs2 := assertstest.FakeAssertion(map[string]interface{}{
+	vs2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "barname",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-d",
 				"id":       "mysnapdddddddddddddddddddddddddd",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-e",
 				"id":       "mysnapeeeeeeeeeeeeeeeeeeeeeeeeee",
 				"presence": "optional",
@@ -339,15 +339,15 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 	// optional: snapE any rev
 	// note: since it only has an optional snap, acme/bazname is not expected
 	// not be invalid by any of the checks.
-	vs3 := assertstest.FakeAssertion(map[string]interface{}{
+	vs3 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "bazname",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-e",
 				"id":       "mysnapeeeeeeeeeeeeeeeeeeeeeeeeee",
 				"presence": "optional",
@@ -356,15 +356,15 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 	}).(*asserts.ValidationSet)
 
 	// invalid: snapA
-	vs4 := assertstest.FakeAssertion(map[string]interface{}{
+	vs4 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "booname",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"presence": "invalid",
@@ -372,15 +372,15 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	vs5 := assertstest.FakeAssertion(map[string]interface{}{
+	vs5 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "huhname",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-f",
 				"id":       "mysnapffffffffffffffffffffffffff",
 				"revision": "4",
@@ -389,15 +389,15 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	vs6 := assertstest.FakeAssertion(map[string]interface{}{
+	vs6 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "duhname",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-f",
 				"id":       "mysnapffffffffffffffffffffffffff",
 				"revision": "4",
@@ -406,15 +406,15 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	vs7 := assertstest.FakeAssertion(map[string]interface{}{
+	vs7 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "bahname",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-f",
 				"id":       "mysnapffffffffffffffffffffffffff",
 				"presence": "required",
@@ -695,19 +695,19 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 }
 
 func (s *validationSetsSuite) TestCheckInstalledSnapsWithComponents(c *C) {
-	sets := map[string][]interface{}{
+	sets := map[string][]any{
 		"one": {
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       snaptest.AssertedSnapID("snap-a"),
 				"presence": "optional",
 				"revision": "11",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 						"revision": "2",
 					},
-					"comp-2": map[string]interface{}{
+					"comp-2": map[string]any{
 						"presence": "optional",
 						"revision": "3",
 					},
@@ -715,13 +715,13 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsWithComponents(c *C) {
 			},
 		},
 		"two": {
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       snaptest.AssertedSnapID("snap-a"),
 				"presence": "optional",
 				"revision": "11",
-				"components": map[string]interface{}{
-					"comp-2": map[string]interface{}{
+				"components": map[string]any{
+					"comp-2": map[string]any{
 						"presence": "required",
 						"revision": "3",
 					},
@@ -729,33 +729,33 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsWithComponents(c *C) {
 			},
 		},
 		"three": {
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       snaptest.AssertedSnapID("snap-a"),
 				"presence": "optional",
-				"components": map[string]interface{}{
-					"comp-2": map[string]interface{}{
+				"components": map[string]any{
+					"comp-2": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
 		},
 		"four": {
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       snaptest.AssertedSnapID("snap-a"),
 				"presence": "required",
 				"revision": "13",
-				"components": map[string]interface{}{
-					"comp-3": map[string]interface{}{
+				"components": map[string]any{
+					"comp-3": map[string]any{
 						"presence": "required",
 						"revision": "1",
 					},
-					"comp-4": map[string]interface{}{
+					"comp-4": map[string]any{
 						"presence": "required",
 						"revision": "2",
 					},
-					"comp-5": map[string]interface{}{
+					"comp-5": map[string]any{
 						"presence": "optional",
 						"revision": "3",
 					},
@@ -766,7 +766,7 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsWithComponents(c *C) {
 
 	assertions := make(map[string]*asserts.ValidationSet)
 	for name, set := range sets {
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"type":         "validation-set",
 			"authority-id": "acme",
 			"series":       "16",
@@ -995,26 +995,26 @@ func (s *validationSetsSuite) TestValidationSetsValidationErrorStringWithCompone
 func (s *validationSetsSuite) TestCheckInstalledSnapsIgnoreValidation(c *C) {
 	// require: snapB rev 3, snapC rev 2.
 	// invalid: snapA
-	vs := assertstest.FakeAssertion(map[string]interface{}{
+	vs := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "fooname",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-b",
 				"id":       "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				"revision": "3",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-c",
 				"id":       "mysnapcccccccccccccccccccccccccc",
 				"revision": "2",
@@ -1046,20 +1046,20 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsIgnoreValidation(c *C) {
 }
 
 func (s *validationSetsSuite) TestCheckInstalledSnapsErrorFormat(c *C) {
-	vs1 := assertstest.FakeAssertion(map[string]interface{}{
+	vs1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "fooname",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-a",
 				"id":       "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-b",
 				"id":       "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				"revision": "3",
@@ -1067,15 +1067,15 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsErrorFormat(c *C) {
 			},
 		},
 	}).(*asserts.ValidationSet)
-	vs2 := assertstest.FakeAssertion(map[string]interface{}{
+	vs2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "acme",
 		"series":       "16",
 		"account-id":   "acme",
 		"name":         "barname",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-b",
 				"id":       "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				"presence": "required",
@@ -1134,21 +1134,21 @@ func (s *validationSetsSuite) TestSortByRevision(c *C) {
 }
 
 func (s *validationSetsSuite) TestCheckPresenceRequired(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
 				"revision": "7",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       "123456ididididididididididididid",
 				"presence": "optional",
@@ -1156,21 +1156,21 @@ func (s *validationSetsSuite) TestCheckPresenceRequired(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
 				"revision": "7",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       "123456ididididididididididididid",
 				"presence": "invalid",
@@ -1179,15 +1179,15 @@ func (s *validationSetsSuite) TestCheckPresenceRequired(c *C) {
 	}).(*asserts.ValidationSet)
 
 	// my-snap required but no specific revision set.
-	valset3 := assertstest.FakeAssertion(map[string]interface{}{
+	valset3 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl3",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -1237,20 +1237,20 @@ func (s *validationSetsSuite) TestCheckPresenceRequired(c *C) {
 }
 
 func (s *validationSetsSuite) TestIsPresenceInvalid(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       "123456ididididididididididididid",
 				"presence": "optional",
@@ -1258,15 +1258,15 @@ func (s *validationSetsSuite) TestIsPresenceInvalid(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "invalid",
@@ -1370,15 +1370,15 @@ func (s *validationSetsSuite) TestValidationSetKeyFormat(c *C) {
 	series, acc, name := "a", "b", "c"
 	sequence := 1
 
-	valSet := assertstest.FakeAssertion(map[string]interface{}{
+	valSet := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": acc,
 		"series":       series,
 		"account-id":   acc,
 		"name":         name,
 		"sequence":     strconv.Itoa(sequence),
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -1406,15 +1406,15 @@ func (s *validationSetsSuite) TestValidationSetKeySliceCommaSeparated(c *C) {
 }
 
 func (s *validationSetsSuite) TestValidationSetKeyComponents(c *C) {
-	valsetKey := snapasserts.NewValidationSetKey(assertstest.FakeAssertion(map[string]interface{}{
+	valsetKey := snapasserts.NewValidationSetKey(assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"series":       "a",
 		"authority-id": "b",
 		"account-id":   "b",
 		"name":         "c",
 		"sequence":     "13",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -1425,27 +1425,27 @@ func (s *validationSetsSuite) TestValidationSetKeyComponents(c *C) {
 }
 
 func (s *validationSetsSuite) TestRevisions(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       snaptest.AssertedSnapID("my-snap"),
 				"presence": "optional",
 				"revision": "10",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "required",
 			},
 			// invalid snap should not be present in the result of (*ValidationSets).Revisions()
-			map[string]interface{}{
+			map[string]any{
 				"name":     "invalid-snap",
 				"id":       snaptest.AssertedSnapID("invalid-snap"),
 				"presence": "invalid",
@@ -1453,21 +1453,21 @@ func (s *validationSetsSuite) TestRevisions(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "optional",
 				"revision": "11",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "another-snap",
 				"id":       snaptest.AssertedSnapID("another-snap"),
 				"presence": "required",
@@ -1502,20 +1502,20 @@ func (s *validationSetsSuite) TestRevisions(c *C) {
 
 func (s *validationSetsSuite) TestCanBePresent(c *C) {
 	var snaps []*asserts.ValidationSetSnap
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       snaptest.AssertedSnapID("my-snap"),
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "required",
@@ -1525,20 +1525,20 @@ func (s *validationSetsSuite) TestCanBePresent(c *C) {
 
 	snaps = append(snaps, valset1.Snaps()...)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "another-snap",
 				"id":       snaptest.AssertedSnapID("another-snap"),
 				"presence": "invalid",
@@ -1562,24 +1562,24 @@ func (s *validationSetsSuite) TestCanBePresent(c *C) {
 }
 
 func (s *validationSetsSuite) TestKeys(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps":        []interface{}{},
+		"snaps":        []any{},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps":        []interface{}{},
+		"snaps":        []any{},
 	}).(*asserts.ValidationSet)
 
 	valsets := snapasserts.NewValidationSets()
@@ -1594,14 +1594,14 @@ func (s *validationSetsSuite) TestKeys(c *C) {
 }
 
 func (s *validationSetsSuite) TestEmpty(c *C) {
-	a := assertstest.FakeAssertion(map[string]interface{}{
+	a := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps":        []interface{}{},
+		"snaps":        []any{},
 	}).(*asserts.ValidationSet)
 
 	vsets := snapasserts.NewValidationSets()
@@ -1611,20 +1611,20 @@ func (s *validationSetsSuite) TestEmpty(c *C) {
 }
 
 func (s *validationSetsSuite) TestRequiredSnapNames(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       snaptest.AssertedSnapID("my-snap"),
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "required",
@@ -1632,20 +1632,20 @@ func (s *validationSetsSuite) TestRequiredSnapNames(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "another-snap",
 				"id":       snaptest.AssertedSnapID("another-snap"),
 				"presence": "required",
@@ -1665,15 +1665,15 @@ func (s *validationSetsSuite) TestRequiredSnapNames(c *C) {
 }
 
 func (s *validationSetsSuite) TestRevisionsConflict(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       snaptest.AssertedSnapID("my-snap"),
 				"presence": "required",
@@ -1682,15 +1682,15 @@ func (s *validationSetsSuite) TestRevisionsConflict(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       snaptest.AssertedSnapID("my-snap"),
 				"presence": "required",
@@ -1717,21 +1717,21 @@ func (s *validationSetsSuite) TestComponentConflicts(c *C) {
 	cases := []test{{
 		summary: "component revision conflict",
 		sets: []*asserts.ValidationSet{assertstest.FakeAssertion(
-			map[string]interface{}{
+			map[string]any{
 				"type":         "validation-set",
 				"authority-id": "account-id",
 				"series":       "16",
 				"account-id":   "account-id",
 				"name":         "one",
 				"sequence":     "1",
-				"snaps": []interface{}{
-					map[string]interface{}{
+				"snaps": []any{
+					map[string]any{
 						"name":     "snap-a",
 						"id":       snaptest.AssertedSnapID("snap-a"),
 						"presence": "required",
 						"revision": "10",
-						"components": map[string]interface{}{
-							"comp-2": map[string]interface{}{
+						"components": map[string]any{
+							"comp-2": map[string]any{
 								"presence": "optional",
 								"revision": "3",
 							},
@@ -1739,21 +1739,21 @@ func (s *validationSetsSuite) TestComponentConflicts(c *C) {
 					},
 				},
 			}).(*asserts.ValidationSet), assertstest.FakeAssertion(
-			map[string]interface{}{
+			map[string]any{
 				"type":         "validation-set",
 				"authority-id": "account-id",
 				"series":       "16",
 				"account-id":   "account-id",
 				"name":         "two",
 				"sequence":     "1",
-				"snaps": []interface{}{
-					map[string]interface{}{
+				"snaps": []any{
+					map[string]any{
 						"name":     "snap-a",
 						"id":       snaptest.AssertedSnapID("snap-a"),
 						"presence": "required",
 						"revision": "10",
-						"components": map[string]interface{}{
-							"comp-2": map[string]interface{}{
+						"components": map[string]any{
+							"comp-2": map[string]any{
 								"presence": "required",
 								"revision": "2",
 							},
@@ -1766,40 +1766,40 @@ func (s *validationSetsSuite) TestComponentConflicts(c *C) {
 	}, {
 		summary: "component presence conflict",
 		sets: []*asserts.ValidationSet{assertstest.FakeAssertion(
-			map[string]interface{}{
+			map[string]any{
 				"type":         "validation-set",
 				"authority-id": "account-id",
 				"series":       "16",
 				"account-id":   "account-id",
 				"name":         "one",
 				"sequence":     "1",
-				"snaps": []interface{}{
-					map[string]interface{}{
+				"snaps": []any{
+					map[string]any{
 						"name":     "snap-a",
 						"id":       snaptest.AssertedSnapID("snap-a"),
 						"presence": "optional",
-						"components": map[string]interface{}{
-							"comp-2": map[string]interface{}{
+						"components": map[string]any{
+							"comp-2": map[string]any{
 								"presence": "invalid",
 							},
 						},
 					},
 				},
 			}).(*asserts.ValidationSet), assertstest.FakeAssertion(
-			map[string]interface{}{
+			map[string]any{
 				"type":         "validation-set",
 				"authority-id": "account-id",
 				"series":       "16",
 				"account-id":   "account-id",
 				"name":         "two",
 				"sequence":     "1",
-				"snaps": []interface{}{
-					map[string]interface{}{
+				"snaps": []any{
+					map[string]any{
 						"name":     "snap-a",
 						"id":       snaptest.AssertedSnapID("snap-a"),
 						"presence": "optional",
-						"components": map[string]interface{}{
-							"comp-2": map[string]interface{}{
+						"components": map[string]any{
+							"comp-2": map[string]any{
 								"presence": "required",
 							},
 						},
@@ -1811,55 +1811,55 @@ func (s *validationSetsSuite) TestComponentConflicts(c *C) {
 	}, {
 		summary: "component presence conflict and snap presence conflict",
 		sets: []*asserts.ValidationSet{assertstest.FakeAssertion(
-			map[string]interface{}{
+			map[string]any{
 				"type":         "validation-set",
 				"authority-id": "account-id",
 				"series":       "16",
 				"account-id":   "account-id",
 				"name":         "one",
 				"sequence":     "1",
-				"snaps": []interface{}{
-					map[string]interface{}{
+				"snaps": []any{
+					map[string]any{
 						"name":     "snap-a",
 						"id":       snaptest.AssertedSnapID("snap-a"),
 						"presence": "required",
-						"components": map[string]interface{}{
-							"comp-2": map[string]interface{}{
+						"components": map[string]any{
+							"comp-2": map[string]any{
 								"presence": "invalid",
 							},
 						},
 					},
 				},
 			}).(*asserts.ValidationSet), assertstest.FakeAssertion(
-			map[string]interface{}{
+			map[string]any{
 				"type":         "validation-set",
 				"authority-id": "account-id",
 				"series":       "16",
 				"account-id":   "account-id",
 				"name":         "two",
 				"sequence":     "1",
-				"snaps": []interface{}{
-					map[string]interface{}{
+				"snaps": []any{
+					map[string]any{
 						"name":     "snap-a",
 						"id":       snaptest.AssertedSnapID("snap-a"),
 						"presence": "optional",
-						"components": map[string]interface{}{
-							"comp-2": map[string]interface{}{
+						"components": map[string]any{
+							"comp-2": map[string]any{
 								"presence": "required",
 							},
 						},
 					},
 				},
 			}).(*asserts.ValidationSet), assertstest.FakeAssertion(
-			map[string]interface{}{
+			map[string]any{
 				"type":         "validation-set",
 				"authority-id": "account-id",
 				"series":       "16",
 				"account-id":   "account-id",
 				"name":         "three",
 				"sequence":     "1",
-				"snaps": []interface{}{
-					map[string]interface{}{
+				"snaps": []any{
+					map[string]any{
 						"name":     "snap-a",
 						"id":       snaptest.AssertedSnapID("snap-a"),
 						"presence": "invalid",
@@ -1894,24 +1894,24 @@ func (s *validationSetsSuite) TestValidationSetsConflictErrorIs(c *C) {
 }
 
 func (s *validationSetsSuite) TestSets(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps":        []interface{}{},
+		"snaps":        []any{},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps":        []interface{}{},
+		"snaps":        []any{},
 	}).(*asserts.ValidationSet)
 
 	valsets := snapasserts.NewValidationSets()
@@ -1924,20 +1924,20 @@ func (s *validationSetsSuite) TestSets(c *C) {
 }
 
 func (s *validationSetsSuite) TestSnapConstrained(c *C) {
-	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+	valset1 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       snaptest.AssertedSnapID("my-snap"),
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "required",
@@ -1945,20 +1945,20 @@ func (s *validationSetsSuite) TestSnapConstrained(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+	valset2 := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "my-snap-ctl2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "other-snap",
 				"id":       snaptest.AssertedSnapID("other-snap"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "another-snap",
 				"id":       snaptest.AssertedSnapID("another-snap"),
 				"presence": "required",
@@ -1983,30 +1983,30 @@ func (s *validationSetsSuite) TestSnapConstrained(c *C) {
 }
 
 func (s *validationSetsSuite) TestSnapPresence(c *C) {
-	one := assertstest.FakeAssertion(map[string]interface{}{
+	one := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "one",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-1",
 				"id":       snaptest.AssertedSnapID("snap-1"),
 				"presence": "invalid",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-2",
 				"id":       snaptest.AssertedSnapID("snap-2"),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-3",
 				"id":       snaptest.AssertedSnapID("snap-3"),
 				"presence": "optional",
-				"components": map[string]interface{}{
-					"comp-4": map[string]interface{}{
+				"components": map[string]any{
+					"comp-4": map[string]any{
 						"presence": "required",
 					},
 				},
@@ -2014,25 +2014,25 @@ func (s *validationSetsSuite) TestSnapPresence(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	two := assertstest.FakeAssertion(map[string]interface{}{
+	two := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "account-id",
 		"series":       "16",
 		"account-id":   "account-id",
 		"name":         "two",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-2",
 				"id":       snaptest.AssertedSnapID("snap-2"),
 				"presence": "optional",
 				"revision": "2",
-				"components": map[string]interface{}{
-					"comp-2": map[string]interface{}{
+				"components": map[string]any{
+					"comp-2": map[string]any{
 						"presence": "required",
 						"revision": "22",
 					},
-					"comp-3": map[string]interface{}{
+					"comp-3": map[string]any{
 						"presence": "invalid",
 					},
 				},

--- a/asserts/store_asserts.go
+++ b/asserts/store_asserts.go
@@ -96,7 +96,7 @@ func (store *Store) Prerequisites() []*Ref {
 }
 
 // checkStoreURL validates the "url" header and returns a full URL or nil.
-func checkStoreURL(headers map[string]interface{}) (*url.URL, error) {
+func checkStoreURL(headers map[string]any) (*url.URL, error) {
 	s, err := checkOptionalString(headers, "url")
 	if err != nil {
 		return nil, err

--- a/asserts/store_asserts_test.go
+++ b/asserts/store_asserts_test.go
@@ -171,7 +171,7 @@ func (s *storeSuite) TestCheckAuthority(c *C) {
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	storeHeaders := map[string]interface{}{
+	storeHeaders := map[string]any{
 		"store":       "store1",
 		"operator-id": operator.HeaderString("account-id"),
 		"timestamp":   time.Now().Format(time.RFC3339),
@@ -206,7 +206,7 @@ func (s *storeSuite) TestFriendlyStores(c *C) {
 func (s *storeSuite) TestCheckOperatorAccount(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
-	store, err := storeDB.Sign(asserts.StoreType, map[string]interface{}{
+	store, err := storeDB.Sign(asserts.StoreType, map[string]any{
 		"store":       "store1",
 		"operator-id": "op-id1",
 		"timestamp":   time.Now().Format(time.RFC3339),
@@ -218,7 +218,7 @@ func (s *storeSuite) TestCheckOperatorAccount(c *C) {
 	c.Assert(err, ErrorMatches, `store assertion "store1" does not have a matching account assertion for the operator "op-id1"`)
 
 	// Add the op-id1 account.
-	operator := assertstest.NewAccount(storeDB, "op-id1", map[string]interface{}{"account-id": "op-id1"}, "")
+	operator := assertstest.NewAccount(storeDB, "op-id1", map[string]any{"account-id": "op-id1"}, "")
 	err = db.Add(operator)
 	c.Assert(err, IsNil)
 

--- a/asserts/sysdb/sysdb_test.go
+++ b/asserts/sysdb/sysdb_test.go
@@ -51,13 +51,13 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 
 	signingDB := assertstest.NewSigningDB("can0nical", pk)
 
-	trustedAcct := assertstest.NewAccount(signingDB, "can0nical", map[string]interface{}{
+	trustedAcct := assertstest.NewAccount(signingDB, "can0nical", map[string]any{
 		"account-id": "can0nical",
 		"validation": "verified",
 		"timestamp":  "2015-11-20T15:04:00Z",
 	}, "")
 
-	trustedAccKey := assertstest.NewAccountKey(signingDB, trustedAcct, map[string]interface{}{
+	trustedAccKey := assertstest.NewAccountKey(signingDB, trustedAcct, map[string]any{
 		"account-id": "can0nical",
 		"since":      "2015-11-20T15:04:00Z",
 		"until":      "2500-11-20T15:04:00Z",
@@ -65,7 +65,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 
 	sdbs.extraTrusted = []asserts.Assertion{trustedAcct, trustedAccKey}
 
-	otherAcct := assertstest.NewAccount(signingDB, "gener1c", map[string]interface{}{
+	otherAcct := assertstest.NewAccount(signingDB, "gener1c", map[string]any{
 		"account-id": "gener1c",
 		"validation": "verified",
 		"timestamp":  "2015-11-20T15:04:00Z",
@@ -73,7 +73,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 
 	sdbs.extraGeneric = []asserts.Assertion{otherAcct}
 
-	a, err := signingDB.Sign(asserts.ModelType, map[string]interface{}{
+	a, err := signingDB.Sign(asserts.ModelType, map[string]any{
 		"series":    "16",
 		"brand-id":  "can0nical",
 		"model":     "other-model",

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -182,7 +182,7 @@ func parseShadowLine(line string) (*shadow, error) {
 // see crypt(3) for the legal chars
 var isValidSaltAndHash = regexp.MustCompile(`^[a-zA-Z0-9./]+$`).MatchString
 
-func checkHashedPassword(headers map[string]interface{}, name string) (string, error) {
+func checkHashedPassword(headers map[string]any, name string) (string, error) {
 	pw, err := checkOptionalString(headers, name)
 	if err != nil {
 		return "", err
@@ -333,7 +333,7 @@ func assembleSystemUser(assert assertionBase) (Assertion, error) {
 	}, nil
 }
 
-func systemUserFormatAnalyze(headers map[string]interface{}, body []byte) (formatnum int, err error) {
+func systemUserFormatAnalyze(headers map[string]any, body []byte) (formatnum int, err error) {
 	formatnum = 0
 
 	serials, err := checkStringList(headers, "serials")

--- a/asserts/system_user_test.go
+++ b/asserts/system_user_test.go
@@ -292,14 +292,14 @@ func (s *systemUserSuite) TestSuggestedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 0)
 
-	headers := map[string]interface{}{
-		"serials": []interface{}{"serialserial"},
+	headers := map[string]any{
+		"serials": []any{"serialserial"},
 	}
 	fmtnum, err = asserts.SuggestFormat(asserts.SystemUserType, headers, nil)
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 1)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"user-presence": "until-expiration",
 	}
 	fmtnum, err = asserts.SuggestFormat(asserts.SystemUserType, headers, nil)

--- a/asserts/validation_set.go
+++ b/asserts/validation_set.go
@@ -49,7 +49,7 @@ func presencesAsStrings(presences ...Presence) []string {
 
 var validValidationSetSnapPresences = presencesAsStrings(PresenceRequired, PresenceOptional, PresenceInvalid)
 
-func checkOptionalPresence(headers map[string]interface{}, which string, valid []string) (Presence, error) {
+func checkOptionalPresence(headers map[string]any, which string, valid []string) (Presence, error) {
 	presence, err := checkOptionalStringWhat(headers, "presence", which)
 	if err != nil {
 		return Presence(""), err
@@ -60,7 +60,7 @@ func checkOptionalPresence(headers map[string]interface{}, which string, valid [
 	return Presence(presence), nil
 }
 
-func checkPresence(headers map[string]interface{}, which string, valid []string) (Presence, error) {
+func checkPresence(headers map[string]any, which string, valid []string) (Presence, error) {
 	presence, err := checkExistsStringWhat(headers, "presence", which)
 	if err != nil {
 		return "", err
@@ -97,7 +97,7 @@ func (s *ValidationSetSnap) ID() string {
 	return s.SnapID
 }
 
-func checkValidationSetSnap(snap map[string]interface{}) (*ValidationSetSnap, error) {
+func checkValidationSetSnap(snap map[string]any) (*ValidationSetSnap, error) {
 	snapName, err := checkNotEmptyStringWhat(snap, "name", "of snap")
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func checkValidationSetSnap(snap map[string]interface{}) (*ValidationSetSnap, er
 	}, nil
 }
 
-func checkValidationSetComponents(snapName string, snap map[string]interface{}, snapRevision int) (map[string]ValidationSetComponent, error) {
+func checkValidationSetComponents(snapName string, snap map[string]any, snapRevision int) (map[string]ValidationSetComponent, error) {
 	mapping, err := checkMapWhat(snap, "components", fmt.Sprintf("of snap %q", snapName))
 	if err != nil {
 		return nil, errors.New(`"components" field in "snaps" header must be a map`)
@@ -156,12 +156,12 @@ func checkValidationSetComponents(snapName string, snap map[string]interface{}, 
 
 	components := make(map[string]ValidationSetComponent, len(mapping))
 	for name, comp := range mapping {
-		var parsed map[string]interface{}
+		var parsed map[string]any
 		switch c := comp.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			parsed = c
 		case string:
-			parsed = map[string]interface{}{"presence": c}
+			parsed = map[string]any{"presence": c}
 		default:
 			return nil, errors.New(`each field in "components" map must be either a map or a string`)
 		}
@@ -176,7 +176,7 @@ func checkValidationSetComponents(snapName string, snap map[string]interface{}, 
 	return components, nil
 }
 
-func checkValidationSetComponent(compName string, comp map[string]interface{}, snapName string, snapRevision int) (ValidationSetComponent, error) {
+func checkValidationSetComponent(compName string, comp map[string]any, snapName string, snapRevision int) (ValidationSetComponent, error) {
 	if err := naming.ValidateSnap(compName); err != nil {
 		return ValidationSetComponent{}, fmt.Errorf("invalid component name %q", compName)
 	}
@@ -211,10 +211,10 @@ func checkValidationSetComponent(compName string, comp map[string]interface{}, s
 	}, nil
 }
 
-func checkValidationSetSnaps(snapList interface{}) ([]*ValidationSetSnap, error) {
+func checkValidationSetSnaps(snapList any) ([]*ValidationSetSnap, error) {
 	const wrongHeaderType = `"snaps" header must be a list of maps`
 
-	entries, ok := snapList.([]interface{})
+	entries, ok := snapList.([]any)
 	if !ok {
 		return nil, errors.New(wrongHeaderType)
 	}
@@ -223,7 +223,7 @@ func checkValidationSetSnaps(snapList interface{}) ([]*ValidationSetSnap, error)
 	seenIDs := make(map[string]string, len(entries))
 	snaps := make([]*ValidationSetSnap, 0, len(entries))
 	for _, entry := range entries {
-		snap, ok := entry.(map[string]interface{})
+		snap, ok := entry.(map[string]any)
 		if !ok {
 			return nil, errors.New(wrongHeaderType)
 		}
@@ -307,7 +307,7 @@ func (vs *ValidationSet) Timestamp() time.Time {
 	return vs.timestamp
 }
 
-func checkSequence(headers map[string]interface{}, name string) (int, error) {
+func checkSequence(headers map[string]any, name string) (int, error) {
 	seqnum, err := checkInt(headers, name)
 	if err != nil {
 		return -1, err

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -771,7 +771,7 @@ func (s *bootenvSuite) TestKernelWithModel(c *C) {
 }
 
 func (s *bootenvSuite) TestParticipantClassicWithModesWithModel(c *C) {
-	modelHdrs := map[string]interface{}{
+	modelHdrs := map[string]any{
 		"type":         "model",
 		"authority-id": "brand",
 		"series":       "16",
@@ -781,13 +781,13 @@ func (s *bootenvSuite) TestParticipantClassicWithModesWithModel(c *C) {
 		"classic":      "true",
 		"distribution": "ubuntu",
 		"base":         "core22",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "kernel",
 				"id":   "pclinuxdidididididididididididid",
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "gadget",
 				"id":   "pcididididididididididididididid",
 				"type": "gadget",

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -319,10 +319,10 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 	d, err := json.Marshal(predictableChains)
 	c.Assert(err, IsNil)
 
-	var data []map[string]interface{}
+	var data []map[string]any
 	err = json.Unmarshal(d, &data)
 	c.Assert(err, IsNil)
-	c.Check(data, DeepEquals, []map[string]interface{}{
+	c.Check(data, DeepEquals, []map[string]any{
 		{
 			"model":             "foo",
 			"brand-id":          "mybrand",
@@ -330,13 +330,13 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			"model-sign-key-id": "my-key-id",
 			"kernel":            "pc-kernel-other",
 			"kernel-revision":   "12",
-			"kernel-cmdlines": []interface{}{
+			"kernel-cmdlines": []any{
 				`snapd_recovery_mode=recover snapd_recovery_system=12 foo`,
 				`snapd_recovery_mode=recover snapd_recovery_system=23 foo`,
 			},
-			"asset-chain": []interface{}{
-				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"y", "x"}},
-				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
+			"asset-chain": []any{
+				map[string]any{"role": "recovery", "name": "shim", "hashes": []any{"y", "x"}},
+				map[string]any{"role": "recovery", "name": "loader", "hashes": []any{"c", "d"}},
 			},
 		}, {
 			"model":             "foo",
@@ -345,11 +345,11 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			"model-sign-key-id": "my-key-id",
 			"kernel":            "pc-kernel-other",
 			"kernel-revision":   "1234",
-			"kernel-cmdlines":   []interface{}{"snapd_recovery_mode=run foo"},
-			"asset-chain": []interface{}{
-				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"y", "x"}},
-				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
-				map[string]interface{}{"role": "run-mode", "name": "loader", "hashes": []interface{}{"b", "a"}},
+			"kernel-cmdlines":   []any{"snapd_recovery_mode=run foo"},
+			"asset-chain": []any{
+				map[string]any{"role": "recovery", "name": "shim", "hashes": []any{"y", "x"}},
+				map[string]any{"role": "recovery", "name": "loader", "hashes": []any{"c", "d"}},
+				map[string]any{"role": "run-mode", "name": "loader", "hashes": []any{"b", "a"}},
 			},
 		}, {
 			"model":             "foo",
@@ -358,11 +358,11 @@ func (s *bootchainSuite) TestPredictableBootChainsFullMarshal(c *C) {
 			"model-sign-key-id": "my-key-id",
 			"kernel":            "pc-kernel-other",
 			"kernel-revision":   "2345",
-			"kernel-cmdlines":   []interface{}{"snapd_recovery_mode=run foo"},
-			"asset-chain": []interface{}{
-				map[string]interface{}{"role": "recovery", "name": "shim", "hashes": []interface{}{"x", "y"}},
-				map[string]interface{}{"role": "recovery", "name": "loader", "hashes": []interface{}{"c", "d"}},
-				map[string]interface{}{"role": "run-mode", "name": "loader", "hashes": []interface{}{"z", "x"}},
+			"kernel-cmdlines":   []any{"snapd_recovery_mode=run foo"},
+			"asset-chain": []any{
+				map[string]any{"role": "recovery", "name": "shim", "hashes": []any{"x", "y"}},
+				map[string]any{"role": "recovery", "name": "loader", "hashes": []any{"c", "d"}},
+				map[string]any{"role": "run-mode", "name": "loader", "hashes": []any{"z", "x"}},
 			},
 		},
 	})

--- a/boot/boottest/device_test.go
+++ b/boot/boottest/device_test.go
@@ -111,15 +111,15 @@ func (s *boottestSuite) testMockDeviceWithModes(c *C, isUC bool) {
 	dev = makeMockDevice("recover", nil)
 	c.Check(dev.RunMode(), Equals, false)
 
-	model := makeMockModel(map[string]interface{}{
+	model := makeMockModel(map[string]any{
 		"model": "other-model-uc20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "pc-linux",
 				"id":   "pclinuxdidididididididididididid",
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "pc",
 				"id":   "pcididididididididididididididid",
 				"type": "gadget",

--- a/boot/boottest/model.go
+++ b/boot/boottest/model.go
@@ -24,8 +24,8 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 )
 
-func MakeMockModel(overrides ...map[string]interface{}) *asserts.Model {
-	headers := map[string]interface{}{
+func MakeMockModel(overrides ...map[string]any) *asserts.Model {
+	headers := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -38,11 +38,11 @@ func MakeMockModel(overrides ...map[string]interface{}) *asserts.Model {
 		"kernel":       "pc-kernel=18",
 		"timestamp":    "2018-01-01T08:00:00+00:00",
 	}
-	return assertstest.FakeAssertion(append([]map[string]interface{}{headers}, overrides...)...).(*asserts.Model)
+	return assertstest.FakeAssertion(append([]map[string]any{headers}, overrides...)...).(*asserts.Model)
 }
 
-func MakeMockUC20Model(overrides ...map[string]interface{}) *asserts.Model {
-	headers := map[string]interface{}{
+func MakeMockUC20Model(overrides ...map[string]any) *asserts.Model {
+	headers := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -53,24 +53,24 @@ func MakeMockUC20Model(overrides ...map[string]interface{}) *asserts.Model {
 		"base":         "core20",
 		"grade":        "dangerous",
 		"timestamp":    "2019-11-01T08:00:00+00:00",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "pc-kernel",
 				"id":   "pckernelidididididididididididid",
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "pc",
 				"id":   "pcididididididididididididididid",
 				"type": "gadget",
 			},
 		},
 	}
-	return assertstest.FakeAssertion(append([]map[string]interface{}{headers}, overrides...)...).(*asserts.Model)
+	return assertstest.FakeAssertion(append([]map[string]any{headers}, overrides...)...).(*asserts.Model)
 }
 
-func MakeMockClassicWithModesModel(overrides ...map[string]interface{}) *asserts.Model {
-	headers := map[string]interface{}{
+func MakeMockClassicWithModesModel(overrides ...map[string]any) *asserts.Model {
+	headers := map[string]any{
 		"type":         "model",
 		"classic":      "true",
 		"distribution": "ubuntu",
@@ -83,18 +83,18 @@ func MakeMockClassicWithModesModel(overrides ...map[string]interface{}) *asserts
 		"base":         "core20",
 		"grade":        "dangerous",
 		"timestamp":    "2019-11-01T08:00:00+00:00",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "pc-kernel",
 				"id":   "pckernelidididididididididididid",
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "pc",
 				"id":   "pcididididididididididididididid",
 				"type": "gadget",
 			},
 		},
 	}
-	return assertstest.FakeAssertion(append([]map[string]interface{}{headers}, overrides...)...).(*asserts.Model)
+	return assertstest.FakeAssertion(append([]map[string]any{headers}, overrides...)...).(*asserts.Model)
 }

--- a/boot/errors.go
+++ b/boot/errors.go
@@ -32,7 +32,7 @@ func (sre trySnapError) Error() string {
 	return string(sre)
 }
 
-func newTrySnapErrorf(format string, args ...interface{}) error {
+func newTrySnapErrorf(format string, args ...any) error {
 	return trySnapError(fmt.Sprintf(format, args...))
 }
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -535,7 +535,7 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20(c *C, opts testMakeSystem
 
 	var model *asserts.Model
 	if opts.classic {
-		model = boottest.MakeMockUC20Model(map[string]interface{}{
+		model = boottest.MakeMockUC20Model(map[string]any{
 			"classic":      "true",
 			"distribution": "ubuntu",
 		})
@@ -2411,7 +2411,7 @@ func (s *makeBootable20Suite) TestMakeBootableImageOptionalKernelArgsBothBootOpt
 }
 
 func (s *makeBootable20Suite) TestMakeBootableImageOptionalKernelArgsSignedAndDangerous(c *C) {
-	model := boottest.MakeMockUC20Model(map[string]interface{}{
+	model := boottest.MakeMockUC20Model(map[string]any{
 		"grade": "signed",
 	})
 	const cmdline = "param1=val param2"

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -430,7 +430,7 @@ type modeenvValueUnmarshaller interface {
 
 // marshalModeenvEntryTo marshals to out what as value for an entry
 // with the given key. If what is empty this is a no-op.
-func marshalModeenvEntryTo(out io.Writer, key string, what interface{}) error {
+func marshalModeenvEntryTo(out io.Writer, key string, what any) error {
 	var asString string
 	switch v := what.(type) {
 	case string:
@@ -473,7 +473,7 @@ func marshalModeenvEntryTo(out io.Writer, key string, what interface{}) error {
 // unmarshalModeenvValueFromCfg unmarshals the value of the entry with
 // the given key to dest. If there's no such entry dest might be left
 // empty.
-func unmarshalModeenvValueFromCfg(cfg *goconfigparser.ConfigParser, key string, dest interface{}) error {
+func unmarshalModeenvValueFromCfg(cfg *goconfigparser.ConfigParser, key string, dest any) error {
 	if dest == nil {
 		return fmt.Errorf("internal error: cannot unmarshal to nil")
 	}

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -60,20 +60,20 @@ var (
 	brandPrivKey, _ = assertstest.GenerateKey(752)
 )
 
-func makeEncodableModel(signingAccounts *assertstest.SigningAccounts, overrides map[string]interface{}) *asserts.Model {
-	headers := map[string]interface{}{
+func makeEncodableModel(signingAccounts *assertstest.SigningAccounts, overrides map[string]any) *asserts.Model {
+	headers := map[string]any{
 		"model":        "my-model-uc20",
 		"display-name": "My Model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "pc-kernel",
 				"id":   "pckernelidididididididididididid",
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "pc",
 				"id":   "pcididididididididididididididid",
 				"type": "gadget",
@@ -101,7 +101,7 @@ func (s *modelSuite) SetUpTest(c *C) {
 
 	s.AddCleanup(restore)
 	s.oldUc20dev = boottest.MockUC20Device("", makeEncodableModel(brands, nil))
-	s.newUc20dev = boottest.MockUC20Device("", makeEncodableModel(brands, map[string]interface{}{
+	s.newUc20dev = boottest.MockUC20Device("", makeEncodableModel(brands, map[string]any{
 		"model": "my-new-model-uc20",
 		"grade": "secured",
 	}))
@@ -1044,14 +1044,14 @@ func (s *modelSuite) TestDeviceChangeRebootRestoreModelKeyChangeMockedWriteModel
 	newKeyID := "ZZZ_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"
 	// model can be mocked freely as we will not encode it as we mocked a
 	// function that writes out the model too
-	s.oldUc20dev = boottest.MockUC20Device("", boottest.MakeMockUC20Model(map[string]interface{}{
+	s.oldUc20dev = boottest.MockUC20Device("", boottest.MakeMockUC20Model(map[string]any{
 		"model":             "my-model-uc20",
 		"brand-id":          "my-brand",
 		"grade":             "dangerous",
 		"sign-key-sha3-384": oldKeyID,
 	}))
 
-	s.newUc20dev = boottest.MockUC20Device("", boottest.MakeMockUC20Model(map[string]interface{}{
+	s.newUc20dev = boottest.MockUC20Device("", boottest.MakeMockUC20Model(map[string]any{
 		"model":             "my-model-uc20",
 		"brand-id":          "my-brand",
 		"grade":             "dangerous",

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -1317,7 +1317,7 @@ func (s *sealSuite) TestRecoveryBootChainsForSystems(c *C) {
 			case "20200831":
 				kernelRev = 3
 			case "off-model":
-				systemModel = boottest.MakeMockUC20Model(map[string]interface{}{
+				systemModel = boottest.MakeMockUC20Model(map[string]any{
 					"model": "model-mismatch-uc20",
 				})
 			default:
@@ -1414,7 +1414,7 @@ func (s *sealSuite) TestSealKeyModelParams(c *C) {
 		"loader-loader-hash2",
 	})
 
-	oldmodel := boottest.MakeMockUC20Model(map[string]interface{}{
+	oldmodel := boottest.MakeMockUC20Model(map[string]any{
 		"model":     "old-model-uc20",
 		"timestamp": "2019-10-01T08:00:00+00:00",
 	})
@@ -1778,7 +1778,7 @@ func (s *sealSuite) testResealKeyToModeenvWithTryModel(c *C, shimId, grubId stri
 
 	model := boottest.MakeMockUC20Model()
 	// a try model which would normally only appear during remodel
-	tryModel := boottest.MakeMockUC20Model(map[string]interface{}{
+	tryModel := boottest.MakeMockUC20Model(map[string]any{
 		"model": "try-my-model-uc20",
 		"grade": "secured",
 	})
@@ -1829,7 +1829,7 @@ func (s *sealSuite) testResealKeyToModeenvWithTryModel(c *C, shimId, grubId stri
 		}
 		if label == "off-model" {
 			// a model that matches neither current not try models
-			systemModel = boottest.MakeMockUC20Model(map[string]interface{}{
+			systemModel = boottest.MakeMockUC20Model(map[string]any{
 				"model": "different-model-uc20",
 				"grade": "secured",
 			})

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -232,7 +232,7 @@ func (s *systemsSuite) TestSetTryRecoverySystemRemodelEncrypted(c *C) {
 	s.stampSealedKeys(c, s.rootdir)
 
 	model := s.uc20dev.Model()
-	newModel := boottest.MakeMockUC20Model(map[string]interface{}{
+	newModel := boottest.MakeMockUC20Model(map[string]any{
 		"model": "my-new-model",
 	})
 
@@ -1131,7 +1131,7 @@ func (s *systemsSuite) TestClearRecoverySystemRemodelHappy(c *C) {
 
 	s.testClearRecoverySystem(c, mtbl, clearRecoverySystemTestCase{
 		systemLabel: "1234",
-		tryModel: boottest.MakeMockUC20Model(map[string]interface{}{
+		tryModel: boottest.MakeMockUC20Model(map[string]any{
 			"tryModelodel": "my-new-model",
 		}),
 	})

--- a/boot/unlocked_state_test.go
+++ b/boot/unlocked_state_test.go
@@ -56,22 +56,22 @@ func (s *diskUnlockStateSuite) TestUnlockedStateWriteTo(c *C) {
 
 	jsonData, err := os.ReadFile(filepath.Join(s.rootDir, "run/snapd/snap-bootstrap/test.json"))
 	c.Assert(err, IsNil)
-	var data map[string]interface{}
+	var data map[string]any
 	err = json.Unmarshal(jsonData, &data)
 	c.Assert(err, IsNil)
-	c.Check(data, DeepEquals, map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{},
-		"ubuntu-data": map[string]interface{}{
+	c.Check(data, DeepEquals, map[string]any{
+		"ubuntu-boot": map[string]any{},
+		"ubuntu-data": map[string]any{
 			"mount-state": "mounted",
 		},
-		"ubuntu-save": map[string]interface{}{},
-		"error-log":   interface{}(nil),
+		"ubuntu-save": map[string]any{},
+		"error-log":   any(nil),
 	})
 }
 
 func (s *diskUnlockStateSuite) TestUnlockedStateLoad(c *C) {
-	data := map[string]interface{}{
-		"ubuntu-data": map[string]interface{}{
+	data := map[string]any{
+		"ubuntu-data": map[string]any{
 			"mount-state": "mounted",
 		},
 	}

--- a/bootloader/lkenv/lkenv_test.go
+++ b/bootloader/lkenv/lkenv_test.go
@@ -312,7 +312,7 @@ func (l *lkenvTestSuite) TestLoadValidatesCRC32(c *C) {
 
 		// make an out of band lkenv object and set the wrong signature to be
 		// able to export it to a file
-		var rawStruct interface{}
+		var rawStruct any
 		switch version {
 		case lkenv.V1:
 			rawStruct = lkenv.SnapBootSelect_v1{
@@ -474,7 +474,7 @@ func (l *lkenvTestSuite) TestLoadValidatesVersionSignatureConsistency(c *C) {
 
 		// make an out of band lkenv object and set the wrong signature to be
 		// able to export it to a file
-		var rawStruct interface{}
+		var rawStruct any
 		switch t.version {
 		case lkenv.V1:
 			rawStruct = lkenv.SnapBootSelect_v1{

--- a/client/aliases_test.go
+++ b/client/aliases_test.go
@@ -44,11 +44,11 @@ func (cs *clientSuite) TestClientAlias(c *check.C) {
 	id, err := cs.cli.Alias("alias-snap", "cmd1", "alias1")
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "chgid")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "alias",
 		"snap":   "alias-snap",
 		"app":    "cmd1",
@@ -73,11 +73,11 @@ func (cs *clientSuite) TestClientUnalias(c *check.C) {
 	id, err := cs.cli.Unalias("alias1")
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "chgid")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "unalias",
 		"snap":   "alias1",
 		"alias":  "alias1",
@@ -101,11 +101,11 @@ func (cs *clientSuite) TestClientDisableAllAliases(c *check.C) {
 	id, err := cs.cli.DisableAllAliases("some-snap")
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "chgid")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "unalias",
 		"snap":   "some-snap",
 	})
@@ -128,11 +128,11 @@ func (cs *clientSuite) TestClientRemoveManualAlias(c *check.C) {
 	id, err := cs.cli.RemoveManualAlias("alias1")
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "chgid")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "unalias",
 		"alias":  "alias1",
 	})
@@ -155,11 +155,11 @@ func (cs *clientSuite) TestClientPrefer(c *check.C) {
 	id, err := cs.cli.Prefer("some-snap")
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "chgid")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "prefer",
 		"snap":   "some-snap",
 	})

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -230,17 +230,17 @@ func (cs *clientSuite) TestClientLogsNotFound(c *check.C) {
 	c.Check(actual, check.HasLen, 0)
 }
 
-func (cs *clientSuite) checkCommonFields(c *check.C, reqOp map[string]interface{}, names []string, scope client.ScopeSelector, users client.UserSelector, comment check.CommentInterface) {
-	inames := make([]interface{}, len(names))
+func (cs *clientSuite) checkCommonFields(c *check.C, reqOp map[string]any, names []string, scope client.ScopeSelector, users client.UserSelector, comment check.CommentInterface) {
+	inames := make([]any, len(names))
 	for i, name := range names {
-		inames[i] = interface{}(name)
+		inames[i] = any(name)
 	}
 
 	c.Check(reqOp["names"], check.DeepEquals, inames, comment)
 	if len(scope) > 0 {
-		snames := make([]interface{}, len(scope))
+		snames := make([]any, len(scope))
 		for i, scope := range scope {
-			snames[i] = interface{}(scope)
+			snames[i] = any(scope)
 		}
 		c.Check(reqOp["scope"], check.DeepEquals, snames, comment)
 	} else {
@@ -253,9 +253,9 @@ func (cs *clientSuite) checkCommonFields(c *check.C, reqOp map[string]interface{
 		c.Check(reqOp["users"], check.Equals, `all`, comment)
 	case client.UserSelectionList:
 		if len(users.Names) > 0 {
-			unames := make([]interface{}, len(users.Names))
+			unames := make([]any, len(users.Names))
 			for i, u := range users.Names {
-				unames[i] = interface{}(u)
+				unames[i] = any(u)
 			}
 			c.Check(reqOp["users"], check.DeepEquals, unames, comment)
 		} else {
@@ -338,7 +338,7 @@ func (cs *clientSuite) TestClientServiceStart(c *check.C) {
 			c.Check(cs.req.Method, check.Equals, "POST", comment)
 			c.Check(cs.req.URL.Query(), check.HasLen, 0, comment)
 
-			var reqOp map[string]interface{}
+			var reqOp map[string]any
 			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, comment)
 			c.Check(reqOp["action"], check.Equals, "start", comment)
 			cs.checkCommonFields(c, reqOp, sc.names, sc.scope, sc.users, comment)
@@ -425,7 +425,7 @@ func (cs *clientSuite) TestClientServiceStop(c *check.C) {
 			c.Check(cs.req.Method, check.Equals, "POST", comment)
 			c.Check(cs.req.URL.Query(), check.HasLen, 0, comment)
 
-			var reqOp map[string]interface{}
+			var reqOp map[string]any
 			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, comment)
 			c.Check(reqOp["action"], check.Equals, "stop", comment)
 			cs.checkCommonFields(c, reqOp, sc.names, sc.scope, sc.users, comment)
@@ -512,7 +512,7 @@ func (cs *clientSuite) TestClientServiceRestart(c *check.C) {
 			c.Check(cs.req.Method, check.Equals, "POST", comment)
 			c.Check(cs.req.URL.Query(), check.HasLen, 0, comment)
 
-			var reqOp map[string]interface{}
+			var reqOp map[string]any
 			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, comment)
 			cs.checkCommonFields(c, reqOp, sc.names, sc.scope, sc.users, comment)
 			c.Check(reqOp["action"], check.Equals, "restart", comment)

--- a/client/asserts.go
+++ b/client/asserts.go
@@ -39,7 +39,7 @@ import (
 // verified with a known public key and the assertion consistent with
 // and its prerequisite in the database.
 func (client *Client) Ack(b []byte) error {
-	var rsp interface{}
+	var rsp any
 	if _, err := client.doSync("POST", "/v2/assertions", nil, nil, bytes.NewReader(b), &rsp); err != nil {
 		return err
 	}

--- a/client/change.go
+++ b/client/change.go
@@ -46,7 +46,7 @@ type Change struct {
 var ErrNoData = fmt.Errorf("data entry not found")
 
 // Get unmarshals into value the kind-specific data with the provided key.
-func (c *Change) Get(key string, value interface{}) error {
+func (c *Change) Get(key string, value any) error {
 	raw := c.data[key]
 	if raw == nil {
 		return ErrNoData

--- a/client/clientutil/config.go
+++ b/client/clientutil/config.go
@@ -42,12 +42,12 @@ type ParseConfigOptions struct {
 // By default, values are parsed if valid JSON and stored as-is if not.
 // Returns a map of config keys to values to set and a slice of keys in the order
 // they were passed in.
-func ParseConfigValues(confValues []string, opts *ParseConfigOptions) (map[string]interface{}, []string, error) {
+func ParseConfigValues(confValues []string, opts *ParseConfigOptions) (map[string]any, []string, error) {
 	if opts == nil {
 		opts = &ParseConfigOptions{}
 	}
 
-	patchValues := make(map[string]interface{}, len(confValues))
+	patchValues := make(map[string]any, len(confValues))
 	keys := make([]string, 0, len(confValues))
 	for _, patchValue := range confValues {
 		parts := strings.SplitN(patchValue, "=", 2)
@@ -73,7 +73,7 @@ func ParseConfigValues(confValues []string, opts *ParseConfigOptions) (map[strin
 		if opts.String {
 			patchValues[parts[0]] = parts[1]
 		} else {
-			var value interface{}
+			var value any
 			if err := jsonutil.DecodeWithNumber(strings.NewReader(parts[1]), &value); err != nil {
 				if opts.Typed {
 					return nil, nil, fmt.Errorf(i18n.G("failed to parse JSON: %w"), err)

--- a/client/clientutil/config_test.go
+++ b/client/clientutil/config_test.go
@@ -34,7 +34,7 @@ func (s *parseSuite) TestParseConfigValues(c *C) {
 	// check basic setting and unsetting behaviour
 	confValues, keys, err := clientutil.ParseConfigValues([]string{"foo=bar", "baz!"}, nil)
 	c.Assert(err, IsNil)
-	c.Assert(confValues, DeepEquals, map[string]interface{}{
+	c.Assert(confValues, DeepEquals, map[string]any{
 		"foo": "bar",
 		"baz": nil,
 	})
@@ -46,8 +46,8 @@ func (s *parseSuite) TestParseConfigValues(c *C) {
 	}
 	confValues, keys, err = clientutil.ParseConfigValues([]string{`foo={"bar": 1}`}, opts)
 	c.Assert(err, IsNil)
-	c.Assert(confValues, DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Assert(confValues, DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"bar": json.Number("1"),
 		},
 	})
@@ -57,7 +57,7 @@ func (s *parseSuite) TestParseConfigValues(c *C) {
 	opts.String = true
 	confValues, keys, err = clientutil.ParseConfigValues([]string{`foo={"bar": 1}`}, opts)
 	c.Assert(err, IsNil)
-	c.Assert(confValues, DeepEquals, map[string]interface{}{
+	c.Assert(confValues, DeepEquals, map[string]any{
 		"foo": `{"bar": 1}`,
 	})
 	c.Assert(keys, DeepEquals, []string{"foo"})
@@ -65,8 +65,8 @@ func (s *parseSuite) TestParseConfigValues(c *C) {
 	// default is to parse
 	confValues, keys, err = clientutil.ParseConfigValues([]string{`foo={"bar": 1}`}, nil)
 	c.Assert(err, IsNil)
-	c.Assert(confValues, DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Assert(confValues, DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"bar": json.Number("1"),
 		},
 	})
@@ -75,7 +75,7 @@ func (s *parseSuite) TestParseConfigValues(c *C) {
 	// unless it's not valid JSON
 	confValues, keys, err = clientutil.ParseConfigValues([]string{`foo={"bar": 1`}, nil)
 	c.Assert(err, IsNil)
-	c.Assert(confValues, DeepEquals, map[string]interface{}{
+	c.Assert(confValues, DeepEquals, map[string]any{
 		"foo": `{"bar": 1`,
 	})
 	c.Assert(keys, DeepEquals, []string{"foo"})

--- a/client/clientutil/modelinfo.go
+++ b/client/clientutil/modelinfo.go
@@ -56,8 +56,8 @@ var (
 
 // ModelAssertJSON is used to represent a model assertion as-is in JSON.
 type ModelAssertJSON struct {
-	Headers map[string]interface{} `json:"headers,omitempty"`
-	Body    string                 `json:"body,omitempty"`
+	Headers map[string]any `json:"headers,omitempty"`
+	Body    string         `json:"body,omitempty"`
 }
 
 // ModelFormatter is a helper interface to format special model elements
@@ -100,14 +100,14 @@ func formatInvalidTypeErr(headers ...string) error {
 	return fmt.Errorf("invalid type for %q header", strings.Join(headers, "/"))
 }
 
-func printVerboseSnapsList(w *tabwriter.Writer, snaps []interface{}) error {
-	printModes := func(snapName string, members map[string]interface{}) error {
+func printVerboseSnapsList(w *tabwriter.Writer, snaps []any) error {
+	printModes := func(snapName string, members map[string]any) error {
 		modes, ok := members["modes"]
 		if !ok {
 			return nil
 		}
 
-		modesSlice, ok := modes.([]interface{})
+		modesSlice, ok := modes.([]any)
 		if !ok {
 			return formatInvalidTypeErr("snaps", snapName, "modes")
 		}
@@ -130,7 +130,7 @@ func printVerboseSnapsList(w *tabwriter.Writer, snaps []interface{}) error {
 	}
 
 	for _, sn := range snaps {
-		snMap, ok := sn.(map[string]interface{})
+		snMap, ok := sn.(map[string]any)
 		if !ok {
 			return formatInvalidTypeErr("snaps")
 		}
@@ -179,7 +179,7 @@ func printVerboseModelAssertionHeaders(w *tabwriter.Writer, assertion asserts.As
 		switch headerName {
 		// list of scalars
 		case "required-snaps", "system-user-authority":
-			headerIfaceList, ok := headerValue.([]interface{})
+			headerIfaceList, ok := headerValue.([]any)
 			if !ok {
 				// system-user-authority can also appear as string
 				headerString, ok := headerValue.(string)
@@ -243,7 +243,7 @@ func printVerboseModelAssertionHeaders(w *tabwriter.Writer, assertion asserts.As
 			// also flush the writer before continuing so the previous keys
 			// don't try to align with this key
 			w.Flush()
-			snapsHeader, ok := headerValue.([]interface{})
+			snapsHeader, ok := headerValue.([]any)
 			if !ok {
 				return formatInvalidTypeErr(headerName)
 			}
@@ -394,7 +394,7 @@ func PrintSerialAssertionYAML(w *tabwriter.Writer, serialAssertion asserts.Seria
 // PrintModelAssertionJSON will format the provided serial or model assertion based on the parameters given in
 // JSON format. The output will be written to the provided io.Writer.
 func PrintModelAssertionJSON(w *tabwriter.Writer, modelAssertion asserts.Model, serialAssertion *asserts.Serial, opts PrintModelAssertionOptions) error {
-	serializeJSON := func(v interface{}) error {
+	serializeJSON := func(v any) error {
 		marshalled, err := json.MarshalIndent(v, "", "  ")
 		if err != nil {
 			return err
@@ -414,7 +414,7 @@ func PrintModelAssertionJSON(w *tabwriter.Writer, modelAssertion asserts.Model, 
 		return serializeJSON(modelJSON)
 	}
 
-	modelData := make(map[string]interface{})
+	modelData := make(map[string]any)
 	modelData["brand-id"] = modelAssertion.HeaderString("brand-id")
 	modelData["model"] = modelAssertion.HeaderString("model")
 

--- a/client/cohort_test.go
+++ b/client/cohort_test.go
@@ -35,12 +35,12 @@ func (cs *clientSuite) TestClientCreateCohortsEndpoint(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var jsonBody map[string]interface{}
+	var jsonBody map[string]any
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, check.IsNil)
-	c.Check(jsonBody, check.DeepEquals, map[string]interface{}{
+	c.Check(jsonBody, check.DeepEquals, map[string]any{
 		"action": "create",
-		"snaps":  []interface{}{"foo", "bar"},
+		"snaps":  []any{"foo", "bar"},
 	})
 }
 
@@ -59,12 +59,12 @@ func (cs *clientSuite) TestClientCreateCohorts(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var jsonBody map[string]interface{}
+	var jsonBody map[string]any
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, check.IsNil)
-	c.Check(jsonBody, check.DeepEquals, map[string]interface{}{
+	c.Check(jsonBody, check.DeepEquals, map[string]any{
 		"action": "create",
-		"snaps":  []interface{}{"foo", "bar"},
+		"snaps":  []any{"foo", "bar"},
 	})
 }
 

--- a/client/conf.go
+++ b/client/conf.go
@@ -27,7 +27,7 @@ import (
 )
 
 // SetConf requests a snap to apply the provided patch to the configuration.
-func (client *Client) SetConf(snapName string, patch map[string]interface{}) (changeID string, err error) {
+func (client *Client) SetConf(snapName string, patch map[string]any) (changeID string, err error) {
 	b, err := json.Marshal(patch)
 	if err != nil {
 		return "", err
@@ -38,7 +38,7 @@ func (client *Client) SetConf(snapName string, patch map[string]interface{}) (ch
 // Conf asks for a snap's current configuration.
 //
 // Note that the configuration may include json.Numbers.
-func (client *Client) Conf(snapName string, keys []string) (configuration map[string]interface{}, err error) {
+func (client *Client) Conf(snapName string, keys []string) (configuration map[string]any, err error) {
 	// Prepare query
 	query := url.Values{}
 	query.Set("keys", strings.Join(keys, ","))

--- a/client/conf_test.go
+++ b/client/conf_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (cs *clientSuite) TestClientSetConfCallsEndpoint(c *check.C) {
-	cs.cli.SetConf("snap-name", map[string]interface{}{"key": "value"})
+	cs.cli.SetConf("snap-name", map[string]any{"key": "value"})
 	c.Check(cs.req.Method, check.Equals, "PUT")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/snaps/snap-name/conf")
 }
@@ -53,14 +53,14 @@ func (cs *clientSuite) TestClientSetConf(c *check.C) {
 		"result": { },
 		"change": "foo"
 	}`
-	id, err := cs.cli.SetConf("snap-name", map[string]interface{}{"key": "value"})
+	id, err := cs.cli.SetConf("snap-name", map[string]any{"key": "value"})
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "foo")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"key": "value",
 	})
 }
@@ -73,7 +73,7 @@ func (cs *clientSuite) TestClientGetConf(c *check.C) {
 	}`
 	value, err := cs.cli.Conf("snap-name", []string{"test-key"})
 	c.Assert(err, check.IsNil)
-	c.Check(value, check.DeepEquals, map[string]interface{}{"test-key": "test-value"})
+	c.Check(value, check.DeepEquals, map[string]any{"test-key": "test-value"})
 }
 
 func (cs *clientSuite) TestClientGetConfBigInt(c *check.C) {
@@ -84,7 +84,7 @@ func (cs *clientSuite) TestClientGetConfBigInt(c *check.C) {
 	}`
 	value, err := cs.cli.Conf("snap-name", []string{"test-key"})
 	c.Assert(err, check.IsNil)
-	c.Check(value, check.DeepEquals, map[string]interface{}{"test-key": json.Number("1234567890")})
+	c.Check(value, check.DeepEquals, map[string]any{"test-key": json.Number("1234567890")})
 }
 
 func (cs *clientSuite) TestClientGetConfMultipleKeys(c *check.C) {
@@ -98,7 +98,7 @@ func (cs *clientSuite) TestClientGetConfMultipleKeys(c *check.C) {
 	}`
 	value, err := cs.cli.Conf("snap-name", []string{"test-key1", "test-key2"})
 	c.Assert(err, check.IsNil)
-	c.Check(value, check.DeepEquals, map[string]interface{}{
+	c.Check(value, check.DeepEquals, map[string]any{
 		"test-key1": "test-value1",
 		"test-key2": "test-value2",
 	})

--- a/client/confdb.go
+++ b/client/confdb.go
@@ -35,7 +35,7 @@ func (c *Client) ConfdbGetViaView(viewID string, requests []string) (changeID st
 	return c.doAsync("GET", endpoint, query, nil, nil)
 }
 
-func (c *Client) ConfdbSetViaView(viewID string, requestValues map[string]interface{}) (changeID string, err error) {
+func (c *Client) ConfdbSetViaView(viewID string, requestValues map[string]any) (changeID string, err error) {
 	body, err := json.Marshal(requestValues)
 	if err != nil {
 		return "", err

--- a/client/confdb_test.go
+++ b/client/confdb_test.go
@@ -47,7 +47,7 @@ func (cs *clientSuite) TestConfdbSet(c *C) {
 	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "123"}`
 
-	chgID, err := cs.cli.ConfdbSetViaView("a/b/c", map[string]interface{}{"foo": "bar", "baz": json.Number("1")})
+	chgID, err := cs.cli.ConfdbSetViaView("a/b/c", map[string]any{"foo": "bar", "baz": json.Number("1")})
 	c.Check(err, IsNil)
 	c.Check(chgID, Equals, "123")
 	c.Assert(cs.reqs, HasLen, 1)
@@ -58,8 +58,8 @@ func (cs *clientSuite) TestConfdbSet(c *C) {
 	c.Assert(err, IsNil)
 
 	// need to decode because entries may have been encoded in any order
-	res := make(map[string]interface{})
+	res := make(map[string]any)
 	err = json.Unmarshal(data, &res)
 	c.Assert(err, IsNil)
-	c.Check(res, DeepEquals, map[string]interface{}{"foo": "bar", "baz": float64(1)})
+	c.Check(res, DeepEquals, map[string]any{"foo": "bar", "baz": float64(1)})
 }

--- a/client/connections.go
+++ b/client/connections.go
@@ -33,9 +33,9 @@ type Connection struct {
 	// Gadget is set for connections that were enabled by the gadget snap.
 	Gadget bool `json:"gadget"`
 	// SlotAttrs is the list of attributes of the slot side of the connection.
-	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
+	SlotAttrs map[string]any `json:"slot-attrs,omitempty"`
 	// PlugAttrs is the list of attributes of the plug side of the connection.
-	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
+	PlugAttrs map[string]any `json:"plug-attrs,omitempty"`
 }
 
 // Connections contains information about connections, as well as related plugs

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -33,7 +33,7 @@ func (client *Client) SetDoer(d doer) {
 type DoOptions = doOptions
 
 // Do does do.
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}, opts *DoOptions) (statusCode int, err error) {
+func (client *Client) Do(method, path string, query url.Values, body io.Reader, v any, opts *DoOptions) (statusCode int, err error) {
 	return client.do(method, path, query, nil, body, v, opts)
 }
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -28,13 +28,13 @@ import (
 
 // Plug represents the potential of a given snap to connect to a slot.
 type Plug struct {
-	Snap        string                 `json:"snap"`
-	Name        string                 `json:"plug"`
-	Interface   string                 `json:"interface,omitempty"`
-	Attrs       map[string]interface{} `json:"attrs,omitempty"`
-	Apps        []string               `json:"apps,omitempty"`
-	Label       string                 `json:"label,omitempty"`
-	Connections []SlotRef              `json:"connections,omitempty"`
+	Snap        string         `json:"snap"`
+	Name        string         `json:"plug"`
+	Interface   string         `json:"interface,omitempty"`
+	Attrs       map[string]any `json:"attrs,omitempty"`
+	Apps        []string       `json:"apps,omitempty"`
+	Label       string         `json:"label,omitempty"`
+	Connections []SlotRef      `json:"connections,omitempty"`
 }
 
 // PlugRef is a reference to a plug.
@@ -45,13 +45,13 @@ type PlugRef struct {
 
 // Slot represents a capacity offered by a snap.
 type Slot struct {
-	Snap        string                 `json:"snap"`
-	Name        string                 `json:"slot"`
-	Interface   string                 `json:"interface,omitempty"`
-	Attrs       map[string]interface{} `json:"attrs,omitempty"`
-	Apps        []string               `json:"apps,omitempty"`
-	Label       string                 `json:"label,omitempty"`
-	Connections []PlugRef              `json:"connections,omitempty"`
+	Snap        string         `json:"snap"`
+	Name        string         `json:"slot"`
+	Interface   string         `json:"interface,omitempty"`
+	Attrs       map[string]any `json:"attrs,omitempty"`
+	Apps        []string       `json:"apps,omitempty"`
+	Label       string         `json:"label,omitempty"`
+	Connections []PlugRef      `json:"connections,omitempty"`
 }
 
 // SlotRef is a reference to a slot.

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -173,20 +173,20 @@ func (cs *clientSuite) TestClientConnect(c *check.C) {
 	id, err := cs.cli.Connect("producer", "plug", "consumer", "slot")
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "foo")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "connect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"snap": "producer",
 				"plug": "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"snap": "consumer",
 				"slot": "slot",
 			},
@@ -212,20 +212,20 @@ func (cs *clientSuite) TestClientDisconnect(c *check.C) {
 	id, err := cs.cli.Disconnect("producer", "plug", "consumer", "slot", opts)
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "42")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "disconnect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"snap": "producer",
 				"plug": "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"snap": "consumer",
 				"slot": "slot",
 			},
@@ -245,21 +245,21 @@ func (cs *clientSuite) TestClientDisconnectForget(c *check.C) {
 	id, err := cs.cli.Disconnect("producer", "plug", "consumer", "slot", opts)
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "42")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "disconnect",
 		"forget": true,
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"snap": "producer",
 				"plug": "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"snap": "consumer",
 				"slot": "slot",
 			},

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -128,7 +128,7 @@ func (cs *clientSuite) TestClientRemodel(c *C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, IsNil)
-	jsonBody := make(map[string]interface{})
+	jsonBody := make(map[string]any)
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, IsNil)
 	c.Check(jsonBody, HasLen, 1)
@@ -152,7 +152,7 @@ func (cs *clientSuite) TestClientRemodelOffline(c *C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, IsNil)
-	jsonBody := make(map[string]interface{})
+	jsonBody := make(map[string]any)
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, IsNil)
 	c.Check(jsonBody, HasLen, 2)

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -81,26 +81,26 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/quotas")
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = jsonutil.DecodeWithNumber(bytes.NewReader(body), &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action":     "ensure",
 		"group-name": "foo",
 		"parent":     "bar",
-		"snaps":      []interface{}{"snap-a", "snap-b"},
-		"services":   []interface{}{"snap-a.svc1", "snap-b.svc1"},
-		"constraints": map[string]interface{}{
+		"snaps":      []any{"snap-a", "snap-b"},
+		"services":   []any{"snap-a.svc1", "snap-b.svc1"},
+		"constraints": map[string]any{
 			"memory": json.Number("1001"),
-			"cpu": map[string]interface{}{
+			"cpu": map[string]any{
 				"count":      json.Number("1"),
 				"percentage": json.Number("50"),
 			},
-			"cpu-set": map[string]interface{}{
-				"cpus": []interface{}{json.Number("0")},
+			"cpu-set": map[string]any{
+				"cpus": []any{json.Number("0")},
 			},
 			"threads": json.Number("32"),
-			"journal": map[string]interface{}{
+			"journal": map[string]any{
 				"size":        json.Number("1048576"),
 				"rate-count":  json.Number("150"),
 				"rate-period": json.Number("60000000000"),
@@ -177,10 +177,10 @@ func (cs *clientSuite) TestRemoveQuotaGroup(c *check.C) {
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/quotas")
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action":     "remove",
 		"group-name": "foo",
 	})

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -209,11 +209,11 @@ func (cs *clientSuite) TestClientMultiOpSnap(c *check.C) {
 
 		body, err := io.ReadAll(cs.req.Body)
 		c.Assert(err, check.IsNil, check.Commentf(s.action))
-		jsonBody := make(map[string]interface{})
+		jsonBody := make(map[string]any)
 		err = json.Unmarshal(body, &jsonBody)
 		c.Assert(err, check.IsNil, check.Commentf(s.action))
 		c.Check(jsonBody["action"], check.Equals, s.action, check.Commentf(s.action))
-		c.Check(jsonBody["snaps"], check.DeepEquals, []interface{}{pkgName}, check.Commentf(s.action))
+		c.Check(jsonBody["snaps"], check.DeepEquals, []any{pkgName}, check.Commentf(s.action))
 		c.Check(jsonBody, check.HasLen, 2, check.Commentf(s.action))
 
 		c.Check(cs.req.URL.Path, check.Equals, "/v2/snaps", check.Commentf(s.action))
@@ -238,11 +238,11 @@ func (cs *clientSuite) TestClientMultiOpSnapTransactional(c *check.C) {
 
 		body, err := io.ReadAll(cs.req.Body)
 		c.Assert(err, check.IsNil, check.Commentf(s.action))
-		jsonBody := make(map[string]interface{})
+		jsonBody := make(map[string]any)
 		err = json.Unmarshal(body, &jsonBody)
 		c.Assert(err, check.IsNil, check.Commentf(s.action))
 		c.Check(jsonBody["action"], check.Equals, s.action, check.Commentf(s.action))
-		c.Check(jsonBody["snaps"], check.DeepEquals, []interface{}{pkgName}, check.Commentf(s.action))
+		c.Check(jsonBody["snaps"], check.DeepEquals, []any{pkgName}, check.Commentf(s.action))
 		c.Check(jsonBody["transaction"], check.Equals, string(client.TransactionAllSnaps),
 			check.Commentf(s.action))
 		c.Check(jsonBody, check.HasLen, 3, check.Commentf(s.action))
@@ -269,11 +269,11 @@ func (cs *clientSuite) TestClientMultiOpSnapIgnoreRunning(c *check.C) {
 
 		body, err := io.ReadAll(cs.req.Body)
 		c.Assert(err, check.IsNil, check.Commentf(s.action))
-		jsonBody := make(map[string]interface{})
+		jsonBody := make(map[string]any)
 		err = json.Unmarshal(body, &jsonBody)
 		c.Assert(err, check.IsNil, check.Commentf(s.action))
 		c.Check(jsonBody["action"], check.Equals, s.action, check.Commentf(s.action))
-		c.Check(jsonBody["snaps"], check.DeepEquals, []interface{}{pkgName}, check.Commentf(s.action))
+		c.Check(jsonBody["snaps"], check.DeepEquals, []any{pkgName}, check.Commentf(s.action))
 		c.Check(jsonBody["ignore-running"], check.Equals, true,
 			check.Commentf(s.action))
 		c.Check(jsonBody, check.HasLen, 3, check.Commentf(s.action))
@@ -298,11 +298,11 @@ func (cs *clientSuite) TestClientMultiSnapshot(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	jsonBody := make(map[string]interface{})
+	jsonBody := make(map[string]any)
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, check.IsNil)
 	c.Check(jsonBody["action"], check.Equals, "snapshot")
-	c.Check(jsonBody["snaps"], check.DeepEquals, []interface{}{pkgName})
+	c.Check(jsonBody["snaps"], check.DeepEquals, []any{pkgName})
 	c.Check(jsonBody, check.HasLen, 2)
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/snaps")
 	c.Check(setID, check.Equals, uint64(42))
@@ -593,7 +593,7 @@ func (cs *clientSuite) TestClientOpInstallUnaliased(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	jsonBody := make(map[string]interface{})
+	jsonBody := make(map[string]any)
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, check.IsNil, check.Commentf("body: %v", string(body)))
 	c.Check(jsonBody["unaliased"], check.Equals, true, check.Commentf("body: %v", string(body)))
@@ -629,7 +629,7 @@ func (cs *clientSuite) TestClientOpInstallTransactional(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	jsonBody := make(map[string]interface{})
+	jsonBody := make(map[string]any)
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, check.IsNil, check.Commentf("body: %v", string(body)))
 	c.Check(jsonBody["transaction"], check.Equals, string(client.TransactionAllSnaps),
@@ -667,7 +667,7 @@ func (cs *clientSuite) TestClientOpInstallPrefer(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var jsonBody map[string]interface{}
+	var jsonBody map[string]any
 	err = json.Unmarshal(body, &jsonBody)
 	c.Assert(err, check.IsNil, check.Commentf("body: %v", string(body)))
 	c.Check(jsonBody["prefer"], check.Equals, true, check.Commentf("body: %v", string(body)))
@@ -956,11 +956,11 @@ func (cs *clientSuite) testClientOpWithComponents(c *check.C, action func(name s
 	_, err := action("foo", []string{"one", "two"}, nil)
 	c.Assert(err, check.IsNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.NewDecoder(cs.req.Body).Decode(&body)
 	c.Assert(err, check.IsNil)
 
-	c.Check(body["components"], check.DeepEquals, []interface{}{"one", "two"})
+	c.Check(body["components"], check.DeepEquals, []any{"one", "two"})
 }
 
 func (cs *clientSuite) TestClientOpInstallWithComponents(c *check.C) {
@@ -991,13 +991,13 @@ func (cs *clientSuite) testClientOpManyWithComponents(c *check.C, action func(na
 	_, err := action([]string{"foo", "bar"}, comps, nil)
 	c.Assert(err, check.IsNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.NewDecoder(cs.req.Body).Decode(&body)
 	c.Assert(err, check.IsNil)
 
-	c.Check(body["components"], check.DeepEquals, map[string]interface{}{
-		"foo": []interface{}{"one", "two"},
-		"bar": []interface{}{"three", "four"},
+	c.Check(body["components"], check.DeepEquals, map[string]any{
+		"foo": []any{"one", "two"},
+		"bar": []any{"three", "four"},
 	})
 }
 

--- a/client/snapctl_test.go
+++ b/client/snapctl_test.go
@@ -60,13 +60,13 @@ func (cs *clientSuite) TestClientRunSnapctl(c *check.C) {
 	c.Check(string(stdout), check.Equals, "test stdout")
 	c.Check(string(stderr), check.Equals, "test stderr")
 
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"context-id": "1234ABCD",
-		"args":       []interface{}{"foo", "bar"},
+		"args":       []any{"foo", "bar"},
 
 		// json byte-stream is b64 encoded
 		"stdin": base64.StdEncoding.EncodeToString([]byte("some-input")),

--- a/client/snapshot.go
+++ b/client/snapshot.go
@@ -69,7 +69,7 @@ type Snapshot struct {
 	Version  string        `json:"version"`
 
 	// the snap's configuration at snapshot time
-	Conf map[string]interface{} `json:"conf,omitempty"`
+	Conf map[string]any `json:"conf,omitempty"`
 
 	// the hash of the archives' data, keyed by archive path
 	// (either 'archive.tgz' for the system archive, or

--- a/client/systems.go
+++ b/client/systems.go
@@ -188,11 +188,11 @@ type StorageEncryption struct {
 type SystemDetails struct {
 	// First part is designed to look like `client.System` - the
 	// only difference is how the model is represented
-	Current bool                   `json:"current,omitempty"`
-	Label   string                 `json:"label,omitempty"`
-	Model   map[string]interface{} `json:"model,omitempty"`
-	Brand   snap.StoreAccount      `json:"brand,omitempty"`
-	Actions []SystemAction         `json:"actions,omitempty"`
+	Current bool              `json:"current,omitempty"`
+	Label   string            `json:"label,omitempty"`
+	Model   map[string]any    `json:"model,omitempty"`
+	Brand   snap.StoreAccount `json:"brand,omitempty"`
+	Actions []SystemAction    `json:"actions,omitempty"`
 
 	// Volumes contains the volumes defined from the gadget snap
 	Volumes map[string]*gadget.Volume `json:"volumes,omitempty"`

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -144,10 +144,10 @@ func (cs *clientSuite) TestRequestSystemActionHappy(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action": "do",
 		"title":  "reinstall",
 		"mode":   "install",
@@ -186,10 +186,10 @@ func (cs *clientSuite) TestRequestSystemRebootHappy(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action": "reboot",
 		"mode":   "install",
 	})
@@ -286,7 +286,7 @@ func (cs *clientSuite) TestSystemDetailsHappy(c *check.C) {
 	c.Check(sys, check.DeepEquals, &client.SystemDetails{
 		Current: true,
 		Label:   "20200101",
-		Model: map[string]interface{}{
+		Model: map[string]any{
 			"model":        "this-is-model-id",
 			"brand-id":     "brand-id-1",
 			"display-name": "wonky model",
@@ -388,19 +388,19 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action": "install",
 		"step":   "finish",
-		"on-volumes": map[string]interface{}{
-			"pc": map[string]interface{}{
+		"on-volumes": map[string]any{
+			"pc": map[string]any{
 				"schema":     "dos",
 				"bootloader": "mbr",
 				"id":         "id",
-				"structure": []interface{}{
-					map[string]interface{}{
+				"structure": []any{
+					map[string]any{
 						"device":           "/dev/sda1",
 						"filesystem-label": "label",
 						"name":             "vol-name",
@@ -413,7 +413,7 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 						"offset":           nil,
 						"offset-write":     nil,
 						"content":          nil,
-						"update": map[string]interface{}{
+						"update": map[string]any{
 							"edition":  float64(0),
 							"preserve": nil,
 						},
@@ -421,7 +421,7 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 				},
 			},
 		},
-		"volumes-auth": map[string]interface{}{
+		"volumes-auth": map[string]any{
 			"mode":       "passphrase",
 			"passphrase": "1234",
 			"kdf-type":   "argon2i",

--- a/client/users.go
+++ b/client/users.go
@@ -61,7 +61,7 @@ type userAction struct {
 	*RemoveUserOptions
 }
 
-func (client *Client) doUserAction(act *userAction, result interface{}) error {
+func (client *Client) doUserAction(act *userAction, result any) error {
 	data, err := json.Marshal(act)
 	if err != nil {
 		return err

--- a/client/validate_test.go
+++ b/client/validate_test.go
@@ -98,10 +98,10 @@ func (cs *clientSuite) TestApplyValidationSetMonitor(c *check.C) {
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/validation-sets/foo/bar")
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action":   "apply",
 		"mode":     "monitor",
 		"sequence": float64(3),
@@ -128,10 +128,10 @@ func (cs *clientSuite) TestApplyValidationSetEnforce(c *check.C) {
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/validation-sets/foo/bar")
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action":   "apply",
 		"mode":     "enforce",
 		"sequence": float64(3),
@@ -166,10 +166,10 @@ func (cs *clientSuite) TestForgetValidationSet(c *check.C) {
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/validation-sets/foo/bar")
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
-	var req map[string]interface{}
+	var req map[string]any
 	err = json.Unmarshal(body, &req)
 	c.Assert(err, check.IsNil)
-	c.Assert(req, check.DeepEquals, map[string]interface{}{
+	c.Assert(req, check.DeepEquals, map[string]any{
 		"action":   "forget",
 		"sequence": float64(3),
 	})

--- a/client/warnings_test.go
+++ b/client/warnings_test.go
@@ -108,7 +108,7 @@ func (cs *clientSuite) TestOkay(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Query(), check.HasLen, 0)
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "okay")

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -818,7 +818,7 @@ func (r *recoverDegradedState) serializeTo(name string) error {
 	return exportState.WriteTo(name)
 }
 
-func (r *recoverDegradedState) LogErrorf(format string, v ...interface{}) {
+func (r *recoverDegradedState) LogErrorf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 	r.ErrorLog = append(r.ErrorLog, msg)
 	logger.Notice(msg)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_factoryreset_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_factoryreset_test.go
@@ -156,10 +156,10 @@ grade=signed
 `)
 
 	// we should have written a boot state file
-	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{},
-		"ubuntu-data": map[string]interface{}{},
-		"ubuntu-save": map[string]interface{}{
+	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]any{
+		"ubuntu-boot": map[string]any{},
+		"ubuntu-data": map[string]any{},
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"find-state":     "found",
 			"unlock-state":   "unlocked",
@@ -167,7 +167,7 @@ grade=signed
 			"mount-state":    "mounted",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{},
+		"error-log": []any{},
 	})
 
 	c.Check(saveActivated, Equals, true)
@@ -253,16 +253,16 @@ model=my-brand/my-model
 grade=signed
 `)
 	// we should have written a boot state file
-	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{},
-		"ubuntu-data": map[string]interface{}{},
-		"ubuntu-save": map[string]interface{}{
+	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]any{
+		"ubuntu-boot": map[string]any{},
+		"ubuntu-data": map[string]any{},
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/disk/by-partuuid/ubuntu-save-partuuid",
 			"find-state":     "found",
 			"mount-state":    "mounted",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{},
+		"error-log": []any{},
 	})
 }
 
@@ -334,14 +334,14 @@ grade=signed
 `)
 	// we should have written a boot state file with save marked as
 	// absent-but-optional
-	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{},
-		"ubuntu-data": map[string]interface{}{},
-		"ubuntu-save": map[string]interface{}{
+	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]any{
+		"ubuntu-boot": map[string]any{},
+		"ubuntu-data": map[string]any{},
+		"ubuntu-save": map[string]any{
 			"find-state":  "not-found",
 			"mount-state": "absent-but-optional",
 		},
-		"error-log": []interface{}{},
+		"error-log": []any{},
 	})
 }
 
@@ -446,15 +446,15 @@ grade=signed
 `)
 
 	// we should have written a boot state file
-	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{},
-		"ubuntu-data": map[string]interface{}{},
-		"ubuntu-save": map[string]interface{}{
+	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]any{
+		"ubuntu-boot": map[string]any{},
+		"ubuntu-data": map[string]any{},
+		"ubuntu-save": map[string]any{
 			"device":       "/dev/disk/by-partuuid/ubuntu-save-enc-partuuid",
 			"unlock-state": "error-unlocking",
 			"find-state":   "found",
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot unlock encrypted ubuntu-save partition with sealed fallback key: ubuntu-save unlock fail",
 		},
 	})
@@ -557,17 +557,17 @@ grade=signed
 `)
 
 	// we should have written a boot state file
-	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{},
-		"ubuntu-data": map[string]interface{}{},
-		"ubuntu-save": map[string]interface{}{
+	checkDegradedJSON(c, "factory-reset-bootstrap.json", map[string]any{
+		"ubuntu-boot": map[string]any{},
+		"ubuntu-data": map[string]any{},
+		"ubuntu-save": map[string]any{
 			"device":       "/dev/mapper/ubuntu-save-random",
 			"unlock-state": "unlocked",
 			"unlock-key":   "fallback",
 			"find-state":   "found",
 			"mount-state":  "error-mounting",
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot mount ubuntu-save: mount failed",
 		},
 	})

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_recover_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_recover_test.go
@@ -1058,14 +1058,14 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 
 	s.testRecoverModeHappy(c, "core20")
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"find-state":     "found",
 			"mount-state":    "mounted",
 			"device":         "/dev/disk/by-partuuid/ubuntu-boot-partuuid",
 			"mount-location": boot.InitramfsUbuntuBootDir,
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"device":         "/dev/mapper/ubuntu-data-random",
 			"unlock-state":   "unlocked",
 			"find-state":     "found",
@@ -1073,7 +1073,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			"unlock-key":     "fallback",
 			"mount-location": boot.InitramfsHostUbuntuDataDir,
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"unlock-key":     "run",
 			"unlock-state":   "unlocked",
@@ -1081,7 +1081,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedDa
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot unlock encrypted ubuntu-data (device /dev/disk/by-partuuid/ubuntu-data-enc-partuuid) with sealed run key: failed to unlock ubuntu-data",
 		},
 	})
@@ -1238,14 +1238,14 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 
 	s.testRecoverModeHappy(c, "core20")
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"find-state":     "found",
 			"mount-state":    "mounted",
 			"device":         "/dev/disk/by-partuuid/ubuntu-boot-partuuid",
 			"mount-location": boot.InitramfsUbuntuBootDir,
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"device":         "/dev/mapper/ubuntu-data-random",
 			"unlock-state":   "unlocked",
 			"find-state":     "found",
@@ -1253,7 +1253,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 			"unlock-key":     "run",
 			"mount-location": boot.InitramfsHostUbuntuDataDir,
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"unlock-key":     "fallback",
 			"unlock-state":   "unlocked",
@@ -1261,7 +1261,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedSa
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot unlock encrypted ubuntu-save (device /dev/disk/by-partuuid/ubuntu-save-enc-partuuid) with sealed run key: failed to unlock ubuntu-save with run object",
 		},
 	})
@@ -1404,11 +1404,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	s.testRecoverModeHappy(c, "core20")
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"find-state": "not-found",
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"device":         "/dev/mapper/ubuntu-data-random",
 			"unlock-state":   "unlocked",
 			"find-state":     "found",
@@ -1416,7 +1416,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			"unlock-key":     "fallback",
 			"mount-location": boot.InitramfsHostUbuntuDataDir,
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"unlock-key":     "run",
 			"unlock-state":   "unlocked",
@@ -1424,7 +1424,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot find ubuntu-boot partition on disk defaultEncDevNoBoot",
 		},
 	})
@@ -1568,11 +1568,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 
 	s.testRecoverModeHappy(c, "core20")
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"find-state": "not-found",
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"device":         "/dev/mapper/ubuntu-data-random",
 			"unlock-state":   "unlocked",
 			"find-state":     "found",
@@ -1580,7 +1580,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			"unlock-key":     "recovery",
 			"mount-location": boot.InitramfsHostUbuntuDataDir,
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"unlock-key":     "run",
 			"unlock-state":   "unlocked",
@@ -1588,7 +1588,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeEncryptedDegradedAb
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot find ubuntu-boot partition on disk defaultEncDevNoBoot",
 		},
 	})
@@ -1760,19 +1760,19 @@ model=my-brand/my-model
 grade=signed
 `)
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"device":         "/dev/disk/by-partuuid/ubuntu-boot-partuuid",
 			"mount-state":    "mounted",
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuBootDir,
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"find-state":   "found",
 			"device":       "/dev/disk/by-partuuid/ubuntu-data-enc-partuuid",
 			"unlock-state": "error-unlocking",
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"unlock-key":     "fallback",
 			"unlock-state":   "unlocked",
@@ -1780,7 +1780,7 @@ grade=signed
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot unlock encrypted ubuntu-data (device /dev/disk/by-partuuid/ubuntu-data-enc-partuuid) with sealed run key: failed to unlock ubuntu-data with run object",
 			"cannot unlock encrypted ubuntu-data partition with sealed fallback key: failed to unlock ubuntu-data with fallback object",
 		},
@@ -1951,23 +1951,23 @@ model=my-brand/my-model
 grade=signed
 `)
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"device":         "/dev/disk/by-partuuid/ubuntu-boot-partuuid",
 			"mount-state":    "mounted",
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuBootDir,
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"find-state": "not-found",
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/disk/by-partuuid/ubuntu-save-partuuid",
 			"mount-state":    "mounted",
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot locate ubuntu-data partition for mounting host data: error enumerating to find ubuntu-data",
 		},
 	})
@@ -2555,17 +2555,17 @@ model=my-brand/my-model
 grade=signed
 `)
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"device":         "/dev/disk/by-partuuid/ubuntu-boot-partuuid",
 			"mount-state":    "mounted",
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuBootDir,
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"find-state": "not-found",
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"unlock-key":     "fallback",
 			"unlock-state":   "unlocked",
@@ -2573,7 +2573,7 @@ grade=signed
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot locate ubuntu-data partition for mounting host data: error enumerating to find ubuntu-data",
 		},
 	})
@@ -2758,24 +2758,24 @@ model=my-brand/my-model
 grade=signed
 `)
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"device":         "/dev/disk/by-partuuid/ubuntu-boot-partuuid",
 			"mount-state":    "mounted",
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuBootDir,
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"find-state":   "found",
 			"device":       "/dev/disk/by-partuuid/ubuntu-data-enc-partuuid",
 			"unlock-state": "error-unlocking",
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"find-state":   "found",
 			"device":       "/dev/disk/by-partuuid/ubuntu-save-enc-partuuid",
 			"unlock-state": "error-unlocking",
 		},
-		"error-log": []interface{}{
+		"error-log": []any{
 			"cannot unlock encrypted ubuntu-data (device /dev/disk/by-partuuid/ubuntu-data-enc-partuuid) with sealed run key: failed to unlock ubuntu-data with run object",
 			"cannot unlock encrypted ubuntu-data partition with sealed fallback key: failed to unlock ubuntu-data with fallback object",
 			"cannot unlock encrypted ubuntu-save partition with sealed fallback key: failed to unlock ubuntu-save with fallback object",
@@ -2940,14 +2940,14 @@ model=my-brand/my-model
 grade=signed
 `)
 
-	checkDegradedJSON(c, "degraded.json", map[string]interface{}{
-		"ubuntu-boot": map[string]interface{}{
+	checkDegradedJSON(c, "degraded.json", map[string]any{
+		"ubuntu-boot": map[string]any{
 			"device":         "/dev/disk/by-partuuid/ubuntu-boot-partuuid",
 			"mount-state":    "mounted",
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuBootDir,
 		},
-		"ubuntu-data": map[string]interface{}{
+		"ubuntu-data": map[string]any{
 			"device":         "/dev/mapper/ubuntu-data-random",
 			"unlock-state":   "unlocked",
 			"find-state":     "found",
@@ -2955,7 +2955,7 @@ grade=signed
 			"unlock-key":     "run",
 			"mount-location": boot.InitramfsHostUbuntuDataDir,
 		},
-		"ubuntu-save": map[string]interface{}{
+		"ubuntu-save": map[string]any{
 			"device":         "/dev/mapper/ubuntu-save-random",
 			"unlock-key":     "run",
 			"unlock-state":   "unlocked",
@@ -2963,7 +2963,7 @@ grade=signed
 			"find-state":     "found",
 			"mount-location": boot.InitramfsUbuntuSaveDir,
 		},
-		"error-log": []interface{}{"cannot trust ubuntu-data, ubuntu-save and ubuntu-data are not marked as from the same install"},
+		"error-log": []any{"cannot trust ubuntu-data, ubuntu-save and ubuntu-data are not marked as from the same install"},
 	})
 
 	bloader2, err := bootloader.Find("", nil)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -276,10 +276,10 @@ volumes:
 	c.Assert(err, IsNil)
 }
 
-func checkDegradedJSON(c *C, name string, exp map[string]interface{}) {
+func checkDegradedJSON(c *C, name string, exp map[string]any) {
 	b, err := os.ReadFile(filepath.Join(dirs.SnapBootstrapRunDir, name))
 	c.Assert(err, IsNil)
-	degradedJSONObj := make(map[string]interface{})
+	degradedJSONObj := make(map[string]any)
 	err = json.Unmarshal(b, &degradedJSONObj)
 	c.Assert(err, IsNil)
 
@@ -527,7 +527,7 @@ func (s *baseInitramfsMountsSuite) setupSeed(c *C, modelAssertTime time.Time, ga
 	s.AddCleanup(restore)
 
 	// XXX: we don't really use this but seedtest always expects my-brand
-	testSeed.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	testSeed.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 
@@ -556,38 +556,38 @@ func (s *baseInitramfsMountsSuite) setupSeed(c *C, modelAssertTime time.Time, ga
 	}
 
 	s.sysLabel = "20191118"
-	var kernel map[string]interface{}
+	var kernel map[string]any
 	if opts.hasKModsComps {
-		kernel = map[string]interface{}{
+		kernel = map[string]any{
 			"name":            "pc-kernel",
 			"id":              testSeed.AssertedSnapID("pc-kernel"),
 			"type":            "kernel",
 			"default-channel": channel,
-			"components": map[string]interface{}{
+			"components": map[string]any{
 				"kcomp1": "required",
 				"kcomp2": "required",
-				"kcomp3": map[string]interface{}{
+				"kcomp3": map[string]any{
 					"presence": "optional",
-					"modes":    []interface{}{"ephemeral"},
+					"modes":    []any{"ephemeral"},
 				},
 			},
 		}
 	} else {
-		kernel = map[string]interface{}{
+		kernel = map[string]any{
 			"name":            "pc-kernel",
 			"id":              testSeed.AssertedSnapID("pc-kernel"),
 			"type":            "kernel",
 			"default-channel": channel,
 		}
 	}
-	model := map[string]interface{}{
+	model := map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         base,
 		"timestamp":    modelAssertTime.Format(time.RFC3339),
-		"snaps": []interface{}{
+		"snaps": []any{
 			kernel,
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              testSeed.AssertedSnapID("pc"),
 				"type":            "gadget",

--- a/cmd/snap-recovery-chooser/main_test.go
+++ b/cmd/snap-recovery-chooser/main_test.go
@@ -169,7 +169,7 @@ type mockSystemRequestResponse struct {
 	label  string
 	code   int
 	reboot bool
-	expect map[string]interface{}
+	expect map[string]any
 }
 
 func (s *mockedClientCmdSuite) mockSuccessfulResponse(c *C, rspSystems *main.ChooserSystems, rspPostSystem *mockSystemRequestResponse) {
@@ -191,7 +191,7 @@ func (s *mockedClientCmdSuite) mockSuccessfulResponse(c *C, rspSystems *main.Cho
 			c.Check(r.URL.Path, Equals, "/v2/systems/"+rspPostSystem.label)
 			c.Check(r.Method, Equals, "POST")
 
-			var data map[string]interface{}
+			var data map[string]any
 			err := json.NewDecoder(r.Body).Decode(&data)
 			c.Assert(err, IsNil)
 			c.Check(data, DeepEquals, rspPostSystem.expect)
@@ -202,9 +202,9 @@ func (s *mockedClientCmdSuite) mockSuccessfulResponse(c *C, rspSystems *main.Cho
 				rspType = "error"
 				rspData = map[string]string{"message": "failed in mock"}
 			}
-			var maintenance map[string]interface{}
+			var maintenance map[string]any
 			if rspPostSystem.reboot {
-				maintenance = map[string]interface{}{
+				maintenance = map[string]any{
 					"kind":    client.ErrorKindSystemRestart,
 					"message": "system is restartring",
 				}
@@ -224,10 +224,10 @@ func (s *mockedClientCmdSuite) mockSuccessfulResponse(c *C, rspSystems *main.Cho
 }
 
 type apiResponse struct {
-	Type        string      `json:"type"`
-	Result      interface{} `json:"result"`
-	StatusCode  int         `json:"status-code"`
-	Maintenance interface{} `json:"maintenance"`
+	Type        string `json:"type"`
+	Result      any    `json:"result"`
+	StatusCode  int    `json:"status-code"`
+	Maintenance any    `json:"maintenance"`
 }
 
 func (s *mockedClientCmdSuite) TestMainChooserWithTool(c *C) {
@@ -250,7 +250,7 @@ echo '{"label":"label","action":{"mode":"install","title":"reinstall"}}'
 	s.mockSuccessfulResponse(c, mockSystems, &mockSystemRequestResponse{
 		code:  200,
 		label: "label",
-		expect: map[string]interface{}{
+		expect: map[string]any{
 			"action": "do",
 			"mode":   "install",
 			"title":  "reinstall",
@@ -337,7 +337,7 @@ func (s *mockedClientCmdSuite) testMainChooserConsoleConfAlternatives(c *C, setu
 	s.mockSuccessfulResponse(c, mockSystems, &mockSystemRequestResponse{
 		code:  200,
 		label: "label",
-		expect: map[string]interface{}{
+		expect: map[string]any{
 			"action": "do",
 			"mode":   "install",
 			"title":  "reinstall",
@@ -475,7 +475,7 @@ echo '{"label":"label","action":{"mode":"install","title":"reinstall"}}'
 	s.mockSuccessfulResponse(c, mockSystems, &mockSystemRequestResponse{
 		code:  400,
 		label: "label",
-		expect: map[string]interface{}{
+		expect: map[string]any{
 			"action": "do",
 			"mode":   "install",
 			"title":  "reinstall",

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -437,11 +437,11 @@ func checkStream(brandID string, repairID int, r []asserts.Assertion) (repair *a
 }
 
 type peekResp struct {
-	Headers map[string]interface{} `json:"headers"`
+	Headers map[string]any `json:"headers"`
 }
 
 // Peek retrieves the headers for the repair with the given ids.
-func (run *Runner) Peek(brandID string, repairID int) (headers map[string]interface{}, err error) {
+func (run *Runner) Peek(brandID string, repairID int) (headers map[string]any, err error) {
 	if isStoreOffline(dirs.SnapRepairConfigFile) {
 		return nil, errStoreOffline
 	}
@@ -856,12 +856,12 @@ func (run *Runner) SaveState() error {
 	return nil
 }
 
-func stringList(headers map[string]interface{}, name string) ([]string, error) {
+func stringList(headers map[string]any, name string) ([]string, error) {
 	v, ok := headers[name]
 	if !ok {
 		return nil, nil
 	}
-	l, ok := v.([]interface{})
+	l, ok := v.([]any)
 	if !ok {
 		return nil, fmt.Errorf("header %q is not a list", name)
 	}
@@ -877,7 +877,7 @@ func stringList(headers map[string]interface{}, name string) ([]string, error) {
 }
 
 // Applicable returns whether a repair with the given headers is applicable to the device.
-func (run *Runner) Applicable(headers map[string]interface{}) bool {
+func (run *Runner) Applicable(headers map[string]any) bool {
 	if headers["disabled"] == "true" {
 		return false
 	}

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -93,13 +93,13 @@ func (s *baseRunnerSuite) SetUpSuite(c *C) {
 
 	brandPrivKey, _ := assertstest.GenerateKey(752)
 
-	s.brandAcct = assertstest.NewAccount(s.storeSigning, "my-brand", map[string]interface{}{
+	s.brandAcct = assertstest.NewAccount(s.storeSigning, "my-brand", map[string]any{
 		"account-id": "my-brand",
 	}, "")
 	s.brandAcctKey = assertstest.NewAccountKey(s.storeSigning, s.brandAcct, nil, brandPrivKey.PublicKey(), "")
 	s.brandSigning = assertstest.NewSigningDB("my-brand", brandPrivKey)
 
-	modelAs, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+	modelAs, err := s.brandSigning.Sign(asserts.ModelType, map[string]any{
 		"series":       "16",
 		"brand-id":     "my-brand",
 		"model":        "my-model-2",
@@ -151,8 +151,8 @@ func (s *baseRunnerSuite) signSeqRepairs(c *C, repairs []string) []string {
 	return seq
 }
 
-func checkStateJSON(c *C, file string, exp map[string]interface{}) {
-	stateFile := map[string]interface{}{}
+func checkStateJSON(c *C, file string, exp map[string]any) {
+	stateFile := map[string]any{}
 	b, err := os.ReadFile(file)
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(b, &stateFile)
@@ -168,7 +168,7 @@ func (s *baseRunnerSuite) freshState(c *C) {
 func (s *baseRunnerSuite) freshStateWithBaseAndMode(c *C, base, mode string) {
 	err := os.MkdirAll(dirs.SnapRepairDir, 0775)
 	c.Assert(err, IsNil)
-	stateJSON := map[string]interface{}{
+	stateJSON := map[string]any{
 		"device": map[string]string{
 			"brand": "my-brand",
 			"model": "my-model",
@@ -532,9 +532,9 @@ func (s *runnerSuite) TestPeek(c *C) {
 
 	h, err := runner.Peek("canonical", 2)
 	c.Assert(err, IsNil)
-	c.Check(h["series"], DeepEquals, []interface{}{"16"})
-	c.Check(h["architectures"], DeepEquals, []interface{}{"amd64", "arm64"})
-	c.Check(h["models"], DeepEquals, []interface{}{"xyz/frobinator"})
+	c.Check(h["series"], DeepEquals, []any{"16"})
+	c.Check(h["architectures"], DeepEquals, []any{"amd64", "arm64"})
+	c.Check(h["models"], DeepEquals, []any{"xyz/frobinator"})
 
 	s.checkBrokenTimeNowMitigated(c, runner)
 }
@@ -681,16 +681,16 @@ func (s *runnerSuite) TestSaveState(c *C) {
 	err = runner.SaveState()
 	c.Assert(err, IsNil)
 
-	exp := map[string]interface{}{
-		"device": map[string]interface{}{
+	exp := map[string]any{
+		"device": map[string]any{
 			"brand": "my-brand",
 			"model": "my-model",
 			"base":  "core18",
 			"mode":  "",
 		},
-		"sequences": map[string]interface{}{
-			"canonical": []interface{}{
-				map[string]interface{}{
+		"sequences": map[string]any{
+			"canonical": []any{
+				map[string]any{
 					// all json numbers are floats
 					"sequence": 1.0,
 					"revision": 3.0,
@@ -713,57 +713,57 @@ func (s *runnerSuite) TestApplicable(c *C) {
 
 	scenarios := []struct {
 		device     *dev
-		headers    map[string]interface{}
+		headers    map[string]any
 		applicable bool
 	}{
 		{nil, nil, true},
-		{nil, map[string]interface{}{"series": []interface{}{"18"}}, false},
-		{nil, map[string]interface{}{"series": []interface{}{"18", "16"}}, true},
-		{nil, map[string]interface{}{"series": "18"}, false},
-		{nil, map[string]interface{}{"series": []interface{}{18}}, false},
-		{nil, map[string]interface{}{"architectures": []interface{}{arch.DpkgArchitecture()}}, true},
-		{nil, map[string]interface{}{"architectures": []interface{}{"other-arch"}}, false},
-		{nil, map[string]interface{}{"architectures": []interface{}{"other-arch", arch.DpkgArchitecture()}}, true},
-		{nil, map[string]interface{}{"architectures": arch.DpkgArchitecture()}, false},
-		{nil, map[string]interface{}{"models": []interface{}{"my-brand/my-model"}}, true},
-		{nil, map[string]interface{}{"models": []interface{}{"other-brand/other-model"}}, false},
-		{nil, map[string]interface{}{"models": []interface{}{"other-brand/other-model", "my-brand/my-model"}}, true},
-		{nil, map[string]interface{}{"models": "my-brand/my-model"}, false},
+		{nil, map[string]any{"series": []any{"18"}}, false},
+		{nil, map[string]any{"series": []any{"18", "16"}}, true},
+		{nil, map[string]any{"series": "18"}, false},
+		{nil, map[string]any{"series": []any{18}}, false},
+		{nil, map[string]any{"architectures": []any{arch.DpkgArchitecture()}}, true},
+		{nil, map[string]any{"architectures": []any{"other-arch"}}, false},
+		{nil, map[string]any{"architectures": []any{"other-arch", arch.DpkgArchitecture()}}, true},
+		{nil, map[string]any{"architectures": arch.DpkgArchitecture()}, false},
+		{nil, map[string]any{"models": []any{"my-brand/my-model"}}, true},
+		{nil, map[string]any{"models": []any{"other-brand/other-model"}}, false},
+		{nil, map[string]any{"models": []any{"other-brand/other-model", "my-brand/my-model"}}, true},
+		{nil, map[string]any{"models": "my-brand/my-model"}, false},
 		// modes for uc16 / uc18 devices
-		{nil, map[string]interface{}{"modes": []interface{}{}}, true},
-		{nil, map[string]interface{}{"modes": []interface{}{"run"}}, false},
-		{nil, map[string]interface{}{"modes": []interface{}{"recover"}}, false},
-		{nil, map[string]interface{}{"modes": []interface{}{"run", "recover"}}, false},
+		{nil, map[string]any{"modes": []any{}}, true},
+		{nil, map[string]any{"modes": []any{"run"}}, false},
+		{nil, map[string]any{"modes": []any{"recover"}}, false},
+		{nil, map[string]any{"modes": []any{"run", "recover"}}, false},
 		// run mode for uc20 devices
-		{&dev{mode: "run"}, map[string]interface{}{"modes": []interface{}{}}, true},
-		{&dev{mode: "run"}, map[string]interface{}{"modes": []interface{}{"run"}}, true},
-		{&dev{mode: "run"}, map[string]interface{}{"modes": []interface{}{"recover"}}, false},
-		{&dev{mode: "run"}, map[string]interface{}{"modes": []interface{}{"run", "recover"}}, true},
+		{&dev{mode: "run"}, map[string]any{"modes": []any{}}, true},
+		{&dev{mode: "run"}, map[string]any{"modes": []any{"run"}}, true},
+		{&dev{mode: "run"}, map[string]any{"modes": []any{"recover"}}, false},
+		{&dev{mode: "run"}, map[string]any{"modes": []any{"run", "recover"}}, true},
 		// recover mode for uc20 devices
-		{&dev{mode: "recover"}, map[string]interface{}{"modes": []interface{}{}}, false},
-		{&dev{mode: "recover"}, map[string]interface{}{"modes": []interface{}{"run"}}, false},
-		{&dev{mode: "recover"}, map[string]interface{}{"modes": []interface{}{"recover"}}, true},
-		{&dev{mode: "recover"}, map[string]interface{}{"modes": []interface{}{"run", "recover"}}, true},
+		{&dev{mode: "recover"}, map[string]any{"modes": []any{}}, false},
+		{&dev{mode: "recover"}, map[string]any{"modes": []any{"run"}}, false},
+		{&dev{mode: "recover"}, map[string]any{"modes": []any{"recover"}}, true},
+		{&dev{mode: "recover"}, map[string]any{"modes": []any{"run", "recover"}}, true},
 		// bases for uc16 devices
-		{&dev{base: "core"}, map[string]interface{}{"bases": []interface{}{"core"}}, true},
-		{&dev{base: "core"}, map[string]interface{}{"bases": []interface{}{"core18"}}, false},
-		{&dev{base: "core"}, map[string]interface{}{"bases": []interface{}{"core", "core18"}}, true},
+		{&dev{base: "core"}, map[string]any{"bases": []any{"core"}}, true},
+		{&dev{base: "core"}, map[string]any{"bases": []any{"core18"}}, false},
+		{&dev{base: "core"}, map[string]any{"bases": []any{"core", "core18"}}, true},
 		// bases for uc18 devices
-		{&dev{base: "core18"}, map[string]interface{}{"bases": []interface{}{"core18"}}, true},
-		{&dev{base: "core18"}, map[string]interface{}{"bases": []interface{}{"core"}}, false},
-		{&dev{base: "core18"}, map[string]interface{}{"bases": []interface{}{"core", "core18"}}, true},
+		{&dev{base: "core18"}, map[string]any{"bases": []any{"core18"}}, true},
+		{&dev{base: "core18"}, map[string]any{"bases": []any{"core"}}, false},
+		{&dev{base: "core18"}, map[string]any{"bases": []any{"core", "core18"}}, true},
 		// bases for uc20 devices
-		{&dev{base: "core20"}, map[string]interface{}{"bases": []interface{}{"core20"}}, true},
-		{&dev{base: "core20"}, map[string]interface{}{"bases": []interface{}{"core"}}, false},
-		{&dev{base: "core20"}, map[string]interface{}{"bases": []interface{}{"core", "core20"}}, true},
+		{&dev{base: "core20"}, map[string]any{"bases": []any{"core20"}}, true},
+		{&dev{base: "core20"}, map[string]any{"bases": []any{"core"}}, false},
+		{&dev{base: "core20"}, map[string]any{"bases": []any{"core", "core20"}}, true},
 		// model prefix matches
-		{nil, map[string]interface{}{"models": []interface{}{"my-brand/*"}}, true},
-		{nil, map[string]interface{}{"models": []interface{}{"my-brand/my-mod*"}}, true},
-		{nil, map[string]interface{}{"models": []interface{}{"my-brand/xxx*"}}, false},
-		{nil, map[string]interface{}{"models": []interface{}{"my-brand/my-mod*", "my-brand/xxx*"}}, true},
-		{nil, map[string]interface{}{"models": []interface{}{"my*"}}, false},
-		{nil, map[string]interface{}{"disabled": "true"}, false},
-		{nil, map[string]interface{}{"disabled": "false"}, true},
+		{nil, map[string]any{"models": []any{"my-brand/*"}}, true},
+		{nil, map[string]any{"models": []any{"my-brand/my-mod*"}}, true},
+		{nil, map[string]any{"models": []any{"my-brand/xxx*"}}, false},
+		{nil, map[string]any{"models": []any{"my-brand/my-mod*", "my-brand/xxx*"}}, true},
+		{nil, map[string]any{"models": []any{"my*"}}, false},
+		{nil, map[string]any{"disabled": "true"}, false},
+		{nil, map[string]any{"disabled": "false"}, true},
 	}
 
 	for _, scen := range scenarios {
@@ -898,7 +898,7 @@ func makeMockServer(c *C, seqRepairs *[]string, redirectFirst bool) *httptest.Se
 
 		switch r.Header.Get("Accept") {
 		case "application/json":
-			b, err := json.Marshal(map[string]interface{}{
+			b, err := json.Marshal(map[string]any{
 				"headers": repair.Headers(),
 			})
 			c.Assert(err, IsNil)
@@ -933,7 +933,7 @@ func (s *runnerSuite) TestVerify(c *C) {
 
 	runner := repair.NewRunner()
 
-	a, err := s.repairsSigning.Sign(asserts.RepairType, map[string]interface{}{
+	a, err := s.repairsSigning.Sign(asserts.RepairType, map[string]any{
 		"brand-id":  "canonical",
 		"repair-id": "2",
 		"summary":   "repair two",
@@ -1200,8 +1200,8 @@ func (s *runnerSuite) TestNextNotFound(c *C) {
 	c.Assert(err, Equals, repair.ErrRepairNotFound)
 
 	// we saved new time lower bound
-	stateFileExp := map[string]interface{}{
-		"device": map[string]interface{}{
+	stateFileExp := map[string]any{
+		"device": map[string]any{
 			"brand": "my-brand",
 			"model": "my-model",
 			"base":  "core18",
@@ -1279,7 +1279,7 @@ func (s *runnerSuite) TestNextVerifySelfSigned(c *C) {
 	randomSigning := assertstest.NewSigningDB("canonical", randoKey)
 	randoKeyEncoded, err := asserts.EncodePublicKey(randoKey.PublicKey())
 	c.Assert(err, IsNil)
-	acctKey, err := randomSigning.Sign(asserts.AccountKeyType, map[string]interface{}{
+	acctKey, err := randomSigning.Sign(asserts.AccountKeyType, map[string]any{
 		"authority-id":        "canonical",
 		"account-id":          "canonical",
 		"public-key-sha3-384": randoKey.PublicKey().ID(),
@@ -1288,7 +1288,7 @@ func (s *runnerSuite) TestNextVerifySelfSigned(c *C) {
 	}, randoKeyEncoded, "")
 	c.Assert(err, IsNil)
 
-	rpr, err := randomSigning.Sign(asserts.RepairType, map[string]interface{}{
+	rpr, err := randomSigning.Sign(asserts.RepairType, map[string]any{
 		"brand-id":  "canonical",
 		"repair-id": "1",
 		"summary":   "repair one",

--- a/cmd/snap/cmd_abort_test.go
+++ b/cmd/snap/cmd_abort_test.go
@@ -40,7 +40,7 @@ func (s *SnapSuite) TestAbortLast(c *check.C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/two")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "abort"})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "abort"})
 			fmt.Fprintln(w, mockChangeJSON)
 		default:
 			c.Errorf("expected 2 queries, currently on %d", n)

--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -49,7 +49,7 @@ func (s *SnapSuite) TestAlias(c *C) {
 		switch r.URL.Path {
 		case "/v2/aliases":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "alias",
 				"snap":   "alias-snap",
 				"app":    "cmd1",

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -49,7 +49,7 @@ func (s *SnapSuite) TestAliases(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": map[string]map[string]client.AliasStatus{
 				"foo": {
@@ -85,7 +85,7 @@ func (s *SnapSuite) TestAliasesFilterSnap(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": map[string]map[string]client.AliasStatus{
 				"foo": {
@@ -117,7 +117,7 @@ func (s *SnapSuite) TestAliasesNone(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": map[string]map[string]client.AliasStatus{},
 		})
@@ -135,7 +135,7 @@ func (s *SnapSuite) TestAliasesNoneFilterSnap(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": map[string]map[string]client.AliasStatus{
 				"bar": {

--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -481,7 +481,7 @@ func (s *SnapSuite) TestAutoImportUC20CandidatesIgnoresSystemPartitions(c *C) {
 	dirs.SetRootDir(rootDir)
 	defer func() { dirs.SetRootDir("") }()
 
-	args := make([]interface{}, 0, len(mountDirs)+1)
+	args := make([]any, 0, len(mountDirs)+1)
 	args = append(args, dirs.GlobalRootDir)
 	// pretend there are auto-import.asserts on all of them
 	for _, dir := range mountDirs {

--- a/cmd/snap/cmd_components_test.go
+++ b/cmd/snap/cmd_components_test.go
@@ -203,7 +203,7 @@ func (s *SnapSuite) testComponents(c *check.C, opts testComponentOpts) {
 			c.Check(r.URL.RawQuery, check.Equals, fmt.Sprintf("snaps=%s", strings.Join(opts.provided, ",")))
 		}
 
-		response := map[string]interface{}{
+		response := map[string]any{
 			"type":   "sync",
 			"result": opts.installed,
 		}

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -65,16 +65,16 @@ func (s *SnapSuite) TestConnectExplicitEverything(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "connect",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "producer",
 						"plug": "plug",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "consumer",
 						"slot": "slot",
 					},
@@ -99,16 +99,16 @@ func (s *SnapSuite) TestConnectExplicitPlugImplicitSlot(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "connect",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "producer",
 						"plug": "plug",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "consumer",
 						"slot": "",
 					},
@@ -133,16 +133,16 @@ func (s *SnapSuite) TestConnectImplicitPlugExplicitSlot(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "connect",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "",
 						"plug": "plug",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "consumer",
 						"slot": "slot",
 					},
@@ -167,16 +167,16 @@ func (s *SnapSuite) TestConnectImplicitPlugImplicitSlot(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "connect",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "",
 						"plug": "plug",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "consumer",
 						"slot": "",
 					},
@@ -282,7 +282,7 @@ func (s *SnapSuite) TestConnectCompletion(c *C) {
 		switch r.URL.Path {
 		case "/v2/connections":
 			c.Assert(r.Method, Equals, "GET")
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": fortestingConnectionList,
 			})

--- a/cmd/snap/cmd_connections_test.go
+++ b/cmd/snap/cmd_connections_test.go
@@ -41,7 +41,7 @@ func (s *SnapSuite) TestConnectionsNoneConnected(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -102,7 +102,7 @@ func (s *SnapSuite) TestConnectionsNoneConnectedPlugs(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -144,7 +144,7 @@ func (s *SnapSuite) TestConnectionsNoneConnectedSlots(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -260,7 +260,7 @@ func (s *SnapSuite) TestConnectionsSomeConnected(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -363,7 +363,7 @@ func (s *SnapSuite) TestConnectionsSomeDisconnected(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -415,7 +415,7 @@ func (s *SnapSuite) TestConnectionsOnlyDisconnected(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -444,7 +444,7 @@ func (s *SnapSuite) TestConnectionsFiltering(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -618,7 +618,7 @@ func (s *SnapSuite) TestConnectionsSorting(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})
@@ -650,13 +650,13 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 				Plug:      client.PlugRef{Snap: "foo", Name: "a-plug"},
 				Slot:      client.SlotRef{Snap: "a-content-provider", Name: "data"},
 				Interface: "content",
-				PlugAttrs: map[string]interface{}{
+				PlugAttrs: map[string]any{
 					"content": "plug-some-data",
 					"target":  "$SNAP/foo",
 				},
-				SlotAttrs: map[string]interface{}{
+				SlotAttrs: map[string]any{
 					"content": "slot-some-data",
-					"source": map[string]interface{}{
+					"source": map[string]any{
 						"read": []string{"$SNAP/bar"},
 					},
 				},
@@ -664,13 +664,13 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 				Plug:      client.PlugRef{Snap: "foo", Name: "b-plug"},
 				Slot:      client.SlotRef{Snap: "b-content-provider", Name: "data"},
 				Interface: "content",
-				PlugAttrs: map[string]interface{}{
+				PlugAttrs: map[string]any{
 					// no content attribute for plug, falls back to slot
 					"target": "$SNAP/foo",
 				},
-				SlotAttrs: map[string]interface{}{
+				SlotAttrs: map[string]any{
 					"content": "slot-some-data",
-					"source": map[string]interface{}{
+					"source": map[string]any{
 						"read": []string{"$SNAP/bar"},
 					},
 				},
@@ -678,13 +678,13 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 				Plug:      client.PlugRef{Snap: "foo", Name: "c-plug"},
 				Slot:      client.SlotRef{Snap: "c-content-provider", Name: "data"},
 				Interface: "content",
-				PlugAttrs: map[string]interface{}{
+				PlugAttrs: map[string]any{
 					// no content attribute for plug
 					"target": "$SNAP/foo",
 				},
-				SlotAttrs: map[string]interface{}{
+				SlotAttrs: map[string]any{
 					// no content attribute for slot either
-					"source": map[string]interface{}{
+					"source": map[string]any{
 						"read": []string{"$SNAP/bar"},
 					},
 				},
@@ -698,10 +698,10 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 				Slot: client.SlotRef{Snap: "core", Name: "desktop"},
 				// desktop interface does not have any defining attributes
 				Interface: "desktop",
-				PlugAttrs: map[string]interface{}{
+				PlugAttrs: map[string]any{
 					"this-is-ignored": "foo",
 				},
-				SlotAttrs: map[string]interface{}{
+				SlotAttrs: map[string]any{
 					"this-is-ignored-too": "foo",
 				},
 			},
@@ -715,7 +715,7 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 					Snap: "a-content-provider",
 					Name: "data",
 				}},
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"content": "plug-some-data",
 					"target":  "$SNAP/foo",
 				},
@@ -727,7 +727,7 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 					Snap: "b-content-provider",
 					Name: "data",
 				}},
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					// no content attribute for plug, falls back to slot
 					"target": "$SNAP/foo",
 				},
@@ -739,7 +739,7 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 					Snap: "c-content-provider",
 					Name: "data",
 				}},
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					// no content attribute for plug
 					"target": "$SNAP/foo",
 				},
@@ -770,9 +770,9 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 					Snap: "foo",
 					Name: "a-plug",
 				}},
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"content": "slot-some-data",
-					"source": map[string]interface{}{
+					"source": map[string]any{
 						"read": []string{"$SNAP/bar"},
 					},
 				},
@@ -784,9 +784,9 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 					Snap: "foo",
 					Name: "a-plug",
 				}},
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"content": "slot-some-data",
-					"source": map[string]interface{}{
+					"source": map[string]any{
 						"read": []string{"$SNAP/bar"},
 					},
 				},
@@ -798,8 +798,8 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 					Snap: "foo",
 					Name: "a-plug",
 				}},
-				Attrs: map[string]interface{}{
-					"source": map[string]interface{}{
+				Attrs: map[string]any{
+					"source": map[string]any{
 						"read": []string{"$SNAP/bar"},
 					},
 				},
@@ -832,7 +832,7 @@ func (s *SnapSuite) TestConnectionsDefiningAttribute(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": result,
 		})

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -36,12 +36,12 @@ func makeCreateUserChecker(c *check.C, n *int, email string, sudoer, known bool)
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/users")
-			var gotBody map[string]interface{}
+			var gotBody map[string]any
 			dec := json.NewDecoder(r.Body)
 			err := dec.Decode(&gotBody)
 			c.Assert(err, check.IsNil)
 
-			wantBody := map[string]interface{}{
+			wantBody := map[string]any{
 				"action": "create",
 			}
 			if email != "" {

--- a/cmd/snap/cmd_debug_api.go
+++ b/cmd/snap/cmd_debug_api.go
@@ -129,7 +129,7 @@ func (x *cmdDebugAPI) Execute(args []string) error {
 	if rsp.Header.Get("Content-Type") == "application/json" {
 		// pretty print JSON response by default
 
-		var temp map[string]interface{}
+		var temp map[string]any
 		if err := json.NewDecoder(rsp.Body).Decode(&temp); err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_debug_migrate_test.go
+++ b/cmd/snap/cmd_debug_migrate_test.go
@@ -50,9 +50,9 @@ func serverWithChange(chgRsp string, c *C) func(w http.ResponseWriter, r *http.R
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/debug")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "migrate-home",
-				"snaps":  []interface{}{"foo"},
+				"snaps":  []any{"foo"},
 			})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type": "async", "status-code": 202, "result": {}, "change": "12"}`)
@@ -88,9 +88,9 @@ func (s *MigrateHomeSuite) TestMigrateHomeManySnaps(c *C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/debug")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "migrate-home",
-				"snaps":  []interface{}{"foo", "bar"},
+				"snaps":  []any{"foo", "bar"},
 			})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type": "async", "status-code": 202, "result": {}, "change": "12"}`)

--- a/cmd/snap/cmd_debug_seeding.go
+++ b/cmd/snap/cmd_debug_seeding.go
@@ -125,10 +125,10 @@ func (x *cmdSeeding) Execute(args []string) error {
 		// properly compare them
 
 		// we use raw json messages here so that the interfaces pkg can do the
-		// real unmarshalling to a real systemKey interface{} that can be
-		// compared with SystemKeysMatch, if we had instead unmarshalled here,
-		// we would have to remarshal the map[string]interface{} we got above
-		// and then pass those bytes back to the interfaces pkg which is awkward
+		// real unmarshalling to a real systemKey any that can be compared with
+		// SystemKeysMatch, if we had instead unmarshalled here, we would have
+		// to remarshal the map[string]any we got above and then pass those
+		// bytes back to the interfaces pkg which is awkward
 		seedSk, err := interfaces.UnmarshalJSONSystemKey(bytes.NewReader(*resp.SeedRestartSystemKey))
 		if err != nil {
 			return err

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -64,16 +64,16 @@ func (s *SnapSuite) TestDisconnectExplicitEverything(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "disconnect",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "producer",
 						"plug": "plug",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "consumer",
 						"slot": "slot",
 					},
@@ -100,17 +100,17 @@ func (s *SnapSuite) TestDisconnectWithForgetFlag(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "disconnect",
 				"forget": true,
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "consumer",
 						"plug": "plug",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "producer",
 						"slot": "slot",
 					},
@@ -137,16 +137,16 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSlot(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "disconnect",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "",
 						"plug": "",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "consumer",
 						"slot": "slot",
 					},
@@ -173,16 +173,16 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnapPlugOrSlot(c *C) {
 		switch r.URL.Path {
 		case "/v2/interfaces":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "disconnect",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap": "",
 						"plug": "",
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap": "consumer",
 						"slot": "plug-or-slot",
 					},
@@ -220,7 +220,7 @@ func (s *SnapSuite) TestDisconnectCompletion(c *C) {
 		switch r.URL.Path {
 		case "/v2/connections":
 			c.Assert(r.Method, Equals, "GET")
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": fortestingConnectionList,
 			})

--- a/cmd/snap/cmd_export_key.go
+++ b/cmd/snap/cmd_export_key.go
@@ -77,7 +77,7 @@ func (x *cmdExportKey) Execute(args []string) error {
 			return fmt.Errorf("cannot find key named %q: %v", keyName, err)
 		}
 		pubKey := privKey.PublicKey()
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"account-id":          x.Account,
 			"name":                keyName,
 			"public-key-sha3-384": pubKey.ID(),

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -523,7 +523,7 @@ func (s *SnapSuite) TestSectionCompletion(c *check.C) {
 		case 0, 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/sections")
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": []string{"foo", "bar", "baz"},
 			})
@@ -581,7 +581,7 @@ func (s *SnapSuite) TestFindSnapSectionOverview(c *check.C) {
 		case 0, 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/sections")
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": []string{"sec2", "sec1"},
 			})
@@ -613,7 +613,7 @@ func (s *SnapSuite) TestFindSnapInvalidSection(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/sections")
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": []string{"sec1"},
 			})
@@ -634,7 +634,7 @@ func (s *SnapSuite) TestFindSnapNotFoundInSection(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/sections")
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": []string{"foobar"},
 			})
@@ -644,7 +644,7 @@ func (s *SnapSuite) TestFindSnapNotFoundInSection(c *check.C) {
 			v, ok := r.URL.Query()["section"]
 			c.Check(ok, check.Equals, true)
 			c.Check(v, check.DeepEquals, []string{"foobar"})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": []string{},
 			})
@@ -668,7 +668,7 @@ func (s *SnapSuite) TestFindSnapCachedSection(c *check.C) {
 		numHits++
 		c.Check(numHits, check.Equals, 1)
 		c.Check(r.URL.Path, check.Equals, "/v2/sections")
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": []string{"sec1", "sec2", "sec3"},
 		})

--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -172,7 +172,7 @@ func (x *cmdInterface) showManyInterfaces(infos []*client.Interface) {
 	}
 }
 
-func (x *cmdInterface) showAttrs(w io.Writer, attrs map[string]interface{}, indent string) {
+func (x *cmdInterface) showAttrs(w io.Writer, attrs map[string]any, indent string) {
 	if len(attrs) == 0 {
 		return
 	}

--- a/cmd/snap/cmd_interface_test.go
+++ b/cmd/snap/cmd_interface_test.go
@@ -58,7 +58,7 @@ func (s *SnapSuite) TestInterfaceListEmpty(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": []*client.Interface{},
 		})
@@ -78,7 +78,7 @@ func (s *SnapSuite) TestInterfaceListAllEmpty(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": []*client.Interface{},
 		})
@@ -98,7 +98,7 @@ func (s *SnapSuite) TestInterfaceList(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": []*client.Interface{{
 				Name:    "network",
@@ -128,7 +128,7 @@ func (s *SnapSuite) TestInterfaceListAll(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": []*client.Interface{{
 				Name:    "network",
@@ -162,7 +162,7 @@ func (s *SnapSuite) TestInterfaceDetails(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": []*client.Interface{{
 				Name:    "network",
@@ -200,7 +200,7 @@ func (s *SnapSuite) TestInterfaceDetailsAndAttrs(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": []*client.Interface{{
 				Name:    "serial-port",
@@ -212,7 +212,7 @@ func (s *SnapSuite) TestInterfaceDetailsAndAttrs(c *C) {
 					Snap:  "gizmo-gadget",
 					Name:  "debug-serial-port",
 					Label: "serial port for debugging",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"header":   "pin-array",
 						"location": "internal",
 						"path":     "/dev/ttyS0",
@@ -245,7 +245,7 @@ func (s *SnapSuite) TestInterfaceCompletion(c *C) {
 		c.Assert(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/v2/interfaces")
 		c.Check(r.URL.RawQuery, Equals, "select=all")
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": []*client.Interface{{
 				Name:    "network",

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -39,7 +39,7 @@ func (s *SnapSuite) TestInterfacesZeroSlotsOnePlug(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Plugs: []client.Plug{
@@ -68,7 +68,7 @@ func (s *SnapSuite) TestInterfacesZeroPlugsOneSlot(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -99,7 +99,7 @@ func (s *SnapSuite) TestInterfacesOneSlotOnePlug(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -165,7 +165,7 @@ func (s *SnapSuite) TestInterfacesTwoPlugs(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -206,7 +206,7 @@ func (s *SnapSuite) TestInterfacesPlugsWithCommonName(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -273,7 +273,7 @@ func (s *SnapSuite) TestInterfacesOsSnapSlots(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -340,7 +340,7 @@ func (s *SnapSuite) TestInterfacesTwoSlotsAndFiltering(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -389,7 +389,7 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnap(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -433,7 +433,7 @@ func (s *SnapSuite) TestInterfacesOfSystemNicknameSnap(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -488,7 +488,7 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnapAndSlot(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -531,7 +531,7 @@ func (s *SnapSuite) TestInterfacesNothingAtAll(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type":   "sync",
 			"result": client.Connections{},
 		})
@@ -552,7 +552,7 @@ func (s *SnapSuite) TestInterfacesOfSpecificType(c *C) {
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{
@@ -595,7 +595,7 @@ func (s *SnapSuite) TestInterfacesCompletion(c *C) {
 		switch r.URL.Path {
 		case "/v2/connections":
 			c.Assert(r.Method, Equals, "GET")
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": fortestingConnectionList,
 			})
@@ -651,7 +651,7 @@ func (s *SnapSuite) checkConnectionsSystemCoreRemapping(c *C, apiSnapName, cliSn
 		body, err := io.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
+		EncodeResponseBody(c, w, map[string]any{
 			"type": "sync",
 			"result": client.Connections{
 				Slots: []client.Slot{

--- a/cmd/snap/cmd_prefer_test.go
+++ b/cmd/snap/cmd_prefer_test.go
@@ -48,7 +48,7 @@ func (s *SnapSuite) TestPrefer(c *C) {
 		switch r.URL.Path {
 		case "/v2/aliases":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "prefer",
 				"snap":   "some-snap",
 			})

--- a/cmd/snap/cmd_remodel_test.go
+++ b/cmd/snap/cmd_remodel_test.go
@@ -56,7 +56,7 @@ func (s *SnapSuite) TestRemodelOffline(c *C) {
 		c.Check(r.URL.Path, Equals, "/v2/model")
 		w.WriteHeader(202)
 
-		var req map[string]interface{}
+		var req map[string]any
 		err := json.NewDecoder(r.Body).Decode(&req)
 		c.Assert(err, IsNil)
 

--- a/cmd/snap/cmd_remove_user_test.go
+++ b/cmd/snap/cmd_remove_user_test.go
@@ -56,12 +56,12 @@ func makeRemoveUserChecker(c *check.C, n *int, username string, fmtJsonReply str
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/users")
-			var gotBody map[string]interface{}
+			var gotBody map[string]any
 			dec := json.NewDecoder(r.Body)
 			err := dec.Decode(&gotBody)
 			c.Assert(err, check.IsNil)
 
-			wantBody := map[string]interface{}{
+			wantBody := map[string]any{
 				"username": username,
 				"action":   "remove",
 			}

--- a/cmd/snap/cmd_routine_console_conf.go
+++ b/cmd/snap/cmd_routine_console_conf.go
@@ -58,7 +58,7 @@ func init() {
 	c.hidden = true
 }
 
-func printfFunc(msg string, format ...interface{}) func() {
+func printfFunc(msg string, format ...any) func() {
 	return func() {
 		fmt.Fprintf(Stderr, msg, format...)
 	}

--- a/cmd/snap/cmd_routine_file_access_test.go
+++ b/cmd/snap/cmd_routine_file_access_test.go
@@ -97,7 +97,7 @@ func (s *SnapRoutineFileAccessSuite) setUpClient(c *C, isClassic, hasHome, hasRe
 				})
 			}
 			result := client.Connections{Established: connections}
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})

--- a/cmd/snap/cmd_routine_portal_info_test.go
+++ b/cmd/snap/cmd_routine_portal_info_test.go
@@ -127,7 +127,7 @@ func (s *SnapSuite) TestPortalInfo(c *C) {
 					},
 				},
 			}
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -173,7 +173,7 @@ func (s *SnapSuite) TestPortalInfoCommonID(c *C) {
 				"interface": []string{"network-status"},
 			})
 			result := client.Connections{}
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -220,7 +220,7 @@ func (s *SnapSuite) TestPortalInfoNoAppInfo(c *C) {
 				"interface": []string{"network-status"},
 			})
 			result := client.Connections{}
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -54,15 +54,15 @@ func (s *appOpSuite) TearDownTest(c *check.C) {
 	s.BaseSnapSuite.TearDownTest(c)
 }
 
-func (s *appOpSuite) expectedBody(op string, names, extra []string) map[string]interface{} {
-	inames := make([]interface{}, len(names))
+func (s *appOpSuite) expectedBody(op string, names, extra []string) map[string]any {
+	inames := make([]any, len(names))
 	for i, name := range names {
 		inames[i] = name
 	}
-	expectedBody := map[string]interface{}{
+	expectedBody := map[string]any{
 		"action": op,
 		"names":  inames,
-		"users":  []interface{}{},
+		"users":  []any{},
 	}
 	for _, x := range extra {
 		expectedBody[x] = true
@@ -173,7 +173,7 @@ func (s *appOpSuite) TestAppOps(c *check.C) {
 
 func (s *appOpSuite) TestAppOpsScopeSwitches(c *check.C) {
 	var n int
-	var body map[string]interface{}
+	var body map[string]any
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch n {
 		case 0:
@@ -197,7 +197,7 @@ func (s *appOpSuite) TestAppOpsScopeSwitches(c *check.C) {
 		n++
 	})
 
-	checkInvocation := func(op, summary string, names, args []string) map[string]interface{} {
+	checkInvocation := func(op, summary string, names, args []string) map[string]any {
 		n = 0
 		body = nil
 		s.stdout.Reset()
@@ -218,33 +218,33 @@ func (s *appOpSuite) TestAppOpsScopeSwitches(c *check.C) {
 
 		// Check without any scope options, that should default to empty
 		// 'users' and no scope. This is the same as '--system --users'
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, nil), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, nil), check.DeepEquals, map[string]any{
 			"action": op,
-			"names":  []interface{}{"foo", "bar"},
-			"users":  []interface{}{},
+			"names":  []any{"foo", "bar"},
+			"users":  []any{},
 		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"user"}), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"user"}), check.DeepEquals, map[string]any{
 			"action": op,
-			"names":  []interface{}{"foo", "bar"},
-			"scope":  []interface{}{"user"},
+			"names":  []any{"foo", "bar"},
+			"scope":  []any{"user"},
 			"users":  "self",
 		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=all"}), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=all"}), check.DeepEquals, map[string]any{
 			"action": op,
-			"names":  []interface{}{"foo", "bar"},
-			"scope":  []interface{}{"user"},
+			"names":  []any{"foo", "bar"},
+			"scope":  []any{"user"},
 			"users":  "all",
 		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=all", "system"}), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=all", "system"}), check.DeepEquals, map[string]any{
 			"action": op,
-			"names":  []interface{}{"foo", "bar"},
+			"names":  []any{"foo", "bar"},
 			"users":  "all",
 		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"system"}), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"system"}), check.DeepEquals, map[string]any{
 			"action": op,
-			"names":  []interface{}{"foo", "bar"},
-			"scope":  []interface{}{"system"},
-			"users":  []interface{}{},
+			"names":  []any{"foo", "bar"},
+			"scope":  []any{"system"},
+			"users":  []any{},
 		})
 	}
 }
@@ -279,9 +279,9 @@ func (s *appOpSuite) TestAppStatus(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			w.WriteHeader(200)
 			enc := json.NewEncoder(w)
-			enc.Encode(map[string]interface{}{
+			enc.Encode(map[string]any{
 				"type": "sync",
-				"result": []map[string]interface{}{
+				"result": []map[string]any{
 					{
 						"snap":         "foo",
 						"name":         "bar",
@@ -289,7 +289,7 @@ func (s *appOpSuite) TestAppStatus(c *check.C) {
 						"daemon-scope": "system",
 						"active":       false,
 						"enabled":      true,
-						"activators": []map[string]interface{}{
+						"activators": []map[string]any{
 							{"name": "bar", "type": "timer", "active": true, "enabled": true},
 						},
 					}, {
@@ -299,7 +299,7 @@ func (s *appOpSuite) TestAppStatus(c *check.C) {
 						"daemon-scope": "system",
 						"active":       false,
 						"enabled":      true,
-						"activators": []map[string]interface{}{
+						"activators": []map[string]any{
 							{"name": "baz-sock1", "type": "socket", "active": true, "enabled": true},
 							{"name": "baz-sock2", "type": "socket", "active": false, "enabled": true},
 						},
@@ -378,9 +378,9 @@ func (s *appOpSuite) TestAppStatusGlobal(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			w.WriteHeader(200)
 			enc := json.NewEncoder(w)
-			enc.Encode(map[string]interface{}{
+			enc.Encode(map[string]any{
 				"type": "sync",
-				"result": []map[string]interface{}{
+				"result": []map[string]any{
 					{
 						"snap":         "foo",
 						"name":         "bar",
@@ -388,7 +388,7 @@ func (s *appOpSuite) TestAppStatusGlobal(c *check.C) {
 						"daemon-scope": "system",
 						"active":       false,
 						"enabled":      true,
-						"activators": []map[string]interface{}{
+						"activators": []map[string]any{
 							{"name": "bar", "type": "timer", "active": true, "enabled": true},
 						},
 					}, {
@@ -398,7 +398,7 @@ func (s *appOpSuite) TestAppStatusGlobal(c *check.C) {
 						"daemon-scope": "system",
 						"active":       false,
 						"enabled":      true,
-						"activators": []map[string]interface{}{
+						"activators": []map[string]any{
 							{"name": "baz-sock1", "type": "socket", "active": true, "enabled": true},
 							{"name": "baz-sock2", "type": "socket", "active": false, "enabled": true},
 						},
@@ -448,9 +448,9 @@ func (s *appOpSuite) TestServiceCompletion(c *check.C) {
 		c.Check(r.Method, check.Equals, "GET")
 		w.WriteHeader(200)
 		enc := json.NewEncoder(w)
-		enc.Encode(map[string]interface{}{
+		enc.Encode(map[string]any{
 			"type": "sync",
-			"result": []map[string]interface{}{
+			"result": []map[string]any{
 				{"snap": "a-snap", "name": "foo", "daemon": "simple"},
 				{"snap": "a-snap", "name": "bar", "daemon": "simple"},
 				{"snap": "b-snap", "name": "baz", "daemon": "simple"},
@@ -515,9 +515,9 @@ func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			w.WriteHeader(200)
 			enc := json.NewEncoder(w)
-			enc.Encode(map[string]interface{}{
+			enc.Encode(map[string]any{
 				"type":        "sync",
-				"result":      []map[string]interface{}{},
+				"result":      []map[string]any{},
 				"status":      "OK",
 				"status-code": 200,
 			})
@@ -552,7 +552,7 @@ func (s *appOpSuite) TestLogsCommand(c *check.C) {
 			c.Assert(err, check.IsNil)
 
 			enc := json.NewEncoder(w)
-			err = enc.Encode(map[string]interface{}{
+			err = enc.Encode(map[string]any{
 				"timestamp": timestamp,
 				"message":   message,
 				"sid":       sid,
@@ -597,7 +597,7 @@ func (s *appOpSuite) TestLogsCommandWithAbsTimeFlag(c *check.C) {
 			c.Assert(err, check.IsNil)
 
 			enc := json.NewEncoder(w)
-			err = enc.Encode(map[string]interface{}{
+			err = enc.Encode(map[string]any{
 				"timestamp": timestamp,
 				"message":   message,
 				"sid":       sid,

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -85,7 +85,7 @@ func (s *snapSetSuite) TestSnapSetIntegrationBigInt(c *check.C) {
 
 func (s *snapSetSuite) TestSnapSetIntegrationJson(c *check.C) {
 	// and mock the server
-	s.mockSetConfigServer(c, map[string]interface{}{"subkey": "value"})
+	s.mockSetConfigServer(c, map[string]any{"subkey": "value"})
 
 	// Set a config value for the active snap
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", `key={"subkey":"value"}`})
@@ -115,7 +115,7 @@ func (s *snapSetSuite) TestSnapSetIntegrationStringWithExclamationMark(c *check.
 
 func (s *snapSetSuite) TestSnapSetParseStrictJSON(c *check.C) {
 	// mock server
-	s.mockSetConfigServer(c, map[string]interface{}{"a": "b", "c": json.Number("1"), "d": map[string]interface{}{"e": "f"}})
+	s.mockSetConfigServer(c, map[string]any{"a": "b", "c": json.Number("1"), "d": map[string]any{"e": "f"}})
 
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "-t", `key={"a":"b", "c":1, "d": {"e": "f"}}`})
 	c.Assert(err, check.IsNil)
@@ -142,12 +142,12 @@ func (s *snapSetSuite) TestSnapSetAsString(c *check.C) {
 	c.Check(s.setConfApiCalls, check.Equals, 1)
 }
 
-func (s *snapSetSuite) mockSetConfigServer(c *check.C, expectedValue interface{}) {
+func (s *snapSetSuite) mockSetConfigServer(c *check.C, expectedValue any) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v2/snaps/snapname/conf":
 			c.Check(r.Method, check.Equals, "PUT")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"key": expectedValue,
 			})
 			w.WriteHeader(202)

--- a/cmd/snap/cmd_sign_build.go
+++ b/cmd/snap/cmd_sign_build.go
@@ -98,7 +98,7 @@ func (x *cmdSignBuild) Execute(args []string) error {
 	pubKey := privKey.PublicKey()
 	timestamp := time.Now().Format(time.RFC3339)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"developer-id":  x.DeveloperID,
 		"authority-id":  x.DeveloperID,
 		"snap-sha3-384": snapDigest,

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -177,14 +177,14 @@ func multiHandler(c *check.C, snaps []string, snapToComps map[string][]string, c
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 
-			var results []interface{}
+			var results []any
 			for _, snap := range snaps {
-				result := map[string]interface{}{
+				result := map[string]any{
 					"name":      snap,
 					"status":    "active",
 					"version":   "1.0",
 					"developer": "bar",
-					"publisher": map[string]interface{}{
+					"publisher": map[string]any{
 						"id":           "bar-id",
 						"username":     "bar",
 						"display-name": "Bar",
@@ -208,7 +208,7 @@ func multiHandler(c *check.C, snaps []string, snapToComps map[string][]string, c
 				results = append(results, result)
 			}
 
-			err := json.NewEncoder(w).Encode(map[string]interface{}{
+			err := json.NewEncoder(w).Encode(map[string]any{
 				"type":   "sync",
 				"result": results,
 			})
@@ -374,7 +374,7 @@ func (s *SnapOpSuite) TestWaitStateShowsLog(c *check.C) {
 func (s *SnapOpSuite) TestInstall(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "candidate",
 			"cohort-key":  "what",
@@ -396,11 +396,11 @@ func (s *SnapOpSuite) TestInstall(c *check.C) {
 func (s *SnapOpSuite) TestInstallWithComponent(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "candidate",
 			"cohort-key":  "what",
-			"components":  []interface{}{"comp1", "comp2"},
+			"components":  []any{"comp1", "comp2"},
 			"transaction": string(client.TransactionPerSnap),
 		})
 		s.srv.channel = "candidate"
@@ -429,12 +429,12 @@ func (s *SnapOpSuite) TestInstallManyWithComponents(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "install",
-				"snaps":  []interface{}{"one", "two", "three"},
-				"components": map[string]interface{}{
-					"one": []interface{}{"comp1", "comp2"},
-					"two": []interface{}{"comp3", "comp4"},
+				"snaps":  []any{"one", "two", "three"},
+				"components": map[string]any{
+					"one": []any{"comp1", "comp2"},
+					"two": []any{"comp3", "comp4"},
 				},
 				"transaction": string(client.TransactionPerSnap),
 			})
@@ -489,9 +489,9 @@ func (s *SnapOpSuite) TestRemoveWithComponent(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":     "remove",
-				"components": []interface{}{"comp1", "comp2"},
+				"components": []any{"comp1", "comp2"},
 			})
 
 			c.Check(r.Method, check.Equals, "POST")
@@ -531,12 +531,12 @@ func (s *SnapOpSuite) TestRemoveManyWithComponents(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "remove",
-				"snaps":  []interface{}{"three"},
-				"components": map[string]interface{}{
-					"one": []interface{}{"comp1", "comp2"},
-					"two": []interface{}{"comp3", "comp4"},
+				"snaps":  []any{"three"},
+				"components": map[string]any{
+					"one": []any{"comp1", "comp2"},
+					"two": []any{"comp3", "comp4"},
 				},
 			})
 
@@ -581,12 +581,12 @@ func (s *SnapOpSuite) TestRemoveManyWithComponentsSomeNotInstalled(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "remove",
-				"snaps":  []interface{}{"three"},
-				"components": map[string]interface{}{
-					"one": []interface{}{"comp1", "comp2"},
-					"two": []interface{}{"comp3", "comp4"},
+				"snaps":  []any{"three"},
+				"components": map[string]any{
+					"one": []any{"comp1", "comp2"},
+					"two": []any{"comp3", "comp4"},
 				},
 			})
 
@@ -663,7 +663,7 @@ func (s *SnapOpSuite) TestListReportsRestartError(c *check.C) {
 	})
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "foo"})
-	c.Assert(err, check.DeepEquals, &client.Error{Kind: client.ErrorKindSystemRestart, Value: map[string]interface{}{"op": "system-restart"}, Message: "system is restarting"})
+	c.Assert(err, check.DeepEquals, &client.Error{Kind: client.ErrorKindSystemRestart, Value: map[string]any{"op": "system-restart"}, Message: "system is restarting"})
 	c.Assert(rest, check.DeepEquals, []string{"foo"})
 	c.Check(s.Stdout(), check.Matches, "")
 	c.Check(s.Stderr(), check.Equals, "")
@@ -674,7 +674,7 @@ func (s *SnapOpSuite) TestListReportsRestartError(c *check.C) {
 func (s *SnapOpSuite) TestInstallIgnoreRunning(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":         "install",
 			"ignore-running": true,
 			"transaction":    string(client.TransactionPerSnap),
@@ -702,7 +702,7 @@ func (s *SnapOpSuite) TestInstallNoPATH(c *check.C) {
 
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "candidate",
 			"transaction": string(client.TransactionPerSnap),
@@ -731,7 +731,7 @@ func (s *SnapOpSuite) TestInstallNoPATHMaybeResetBySudo(c *check.C) {
 	defer restore()
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "candidate",
 			"transaction": string(client.TransactionPerSnap),
@@ -752,7 +752,7 @@ func (s *SnapOpSuite) TestInstallNoPATHMaybeResetBySudo(c *check.C) {
 func (s *SnapOpSuite) TestInstallFromTrack(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "3.4",
 			"transaction": string(client.TransactionPerSnap),
@@ -774,7 +774,7 @@ func (s *SnapOpSuite) TestInstallFromTrack(c *check.C) {
 func (s *SnapOpSuite) TestInstallFromBranch(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "3.4/stable/hotfix-1",
 			"transaction": string(client.TransactionPerSnap),
@@ -795,7 +795,7 @@ func (s *SnapOpSuite) TestInstallFromBranch(c *check.C) {
 func (s *SnapOpSuite) TestInstallSameRiskInTrack(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "latest/stable",
 			"transaction": string(client.TransactionPerSnap),
@@ -817,7 +817,7 @@ func (s *SnapOpSuite) TestInstallSameRiskInTrack(c *check.C) {
 func (s *SnapOpSuite) TestInstallSameRiskInDefaultTrack(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "stable",
 			"transaction": string(client.TransactionPerSnap),
@@ -839,7 +839,7 @@ func (s *SnapOpSuite) TestInstallSameRiskInDefaultTrack(c *check.C) {
 func (s *SnapOpSuite) TestInstallRiskChannelClosed(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "edge",
 			"transaction": string(client.TransactionPerSnap),
@@ -863,7 +863,7 @@ Channel edge for foo is closed; temporarily forwarding to stable.
 func (s *SnapOpSuite) TestInstallDevMode(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"devmode":     true,
 			"channel":     "beta",
@@ -885,7 +885,7 @@ func (s *SnapOpSuite) TestInstallDevMode(c *check.C) {
 func (s *SnapOpSuite) TestInstallQuotaGroup(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "candidate",
 			"quota-group": "test-group",
@@ -907,7 +907,7 @@ func (s *SnapOpSuite) TestInstallQuotaGroup(c *check.C) {
 func (s *SnapOpSuite) TestInstallClassic(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"classic":     true,
 			"transaction": string(client.TransactionPerSnap),
@@ -928,7 +928,7 @@ func (s *SnapOpSuite) TestInstallClassic(c *check.C) {
 func (s *SnapOpSuite) TestInstallStrictWithClassicFlag(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"classic":     true,
 			"transaction": string(client.TransactionPerSnap),
@@ -949,7 +949,7 @@ func (s *SnapOpSuite) TestInstallStrictWithClassicFlag(c *check.C) {
 func (s *SnapOpSuite) TestInstallUnaliased(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"unaliased":   true,
 			"transaction": string(client.TransactionPerSnap),
@@ -969,7 +969,7 @@ func (s *SnapOpSuite) TestInstallUnaliased(c *check.C) {
 func (s *SnapOpSuite) TestInstallPrefer(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"prefer":      true,
 			"transaction": string(client.TransactionPerSnap),
@@ -1721,7 +1721,7 @@ func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
 	s.srv.channel = "potato"
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action": "revert",
 		})
 	}
@@ -1956,7 +1956,7 @@ func (s *SnapSuite) TestRefreshHoldAllForever(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":     "hold",
 				"time":       "forever",
 				"hold-level": "auto-refresh",
@@ -1999,11 +1999,11 @@ func (s *SnapSuite) TestRefreshHoldManySpecificTime(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":     "hold",
 				"time":       "3000-01-01T07:00:00Z",
 				"hold-level": "general",
-				"snaps":      []interface{}{"foo", "bar"},
+				"snaps":      []any{"foo", "bar"},
 			})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
@@ -2043,7 +2043,7 @@ func (s *SnapSuite) TestRefreshHoldSnapUntilSpecificTime(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":     "hold",
 				"hold-level": "general",
 				"time":       "3000-01-01T07:00:00Z",
@@ -2079,7 +2079,7 @@ func (s *SnapSuite) TestRefreshHoldSnapForever(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":     "hold",
 				"time":       "forever",
 				"hold-level": "general",
@@ -2115,7 +2115,7 @@ func (s *SnapSuite) TestRefreshUnholdAllSnaps(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "unhold",
 			})
 			w.WriteHeader(202)
@@ -2149,7 +2149,7 @@ func (s *SnapSuite) TestRefreshUnholdOneSnap(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "unhold",
 			})
 			w.WriteHeader(202)
@@ -2183,9 +2183,9 @@ func (s *SnapSuite) TestRefreshUnholdManySnaps(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "unhold",
-				"snaps":  []interface{}{"foo", "bar"},
+				"snaps":  []any{"foo", "bar"},
 			})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
@@ -2241,7 +2241,7 @@ func (s *SnapSuite) TestRefreshHoldAllowedTimeUnits(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":     "hold",
 				"time":       holdTime,
 				"hold-level": "general",
@@ -2329,7 +2329,7 @@ func (s *SnapOpSuite) TestRefreshOne(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"transaction": string(client.TransactionPerSnap),
 		})
@@ -2344,10 +2344,10 @@ func (s *SnapOpSuite) TestRefreshOneAdditionalComponents(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"transaction": string(client.TransactionPerSnap),
-			"components":  []interface{}{"comp1", "comp2"},
+			"components":  []any{"comp1", "comp2"},
 		})
 	}
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "foo+comp1+comp2"})
@@ -2359,13 +2359,13 @@ func (s *SnapOpSuite) TestRefreshManyAdditionalComponents(c *check.C) {
 	checker := func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"transaction": string(client.TransactionPerSnap),
-			"snaps":       []interface{}{"foo", "bar"},
-			"components": map[string]interface{}{
-				"foo": []interface{}{"comp1", "comp2"},
-				"bar": []interface{}{"comp3", "comp4"},
+			"snaps":       []any{"foo", "bar"},
+			"components": map[string]any{
+				"foo": []any{"comp1", "comp2"},
+				"bar": []any{"comp3", "comp4"},
 			},
 		})
 	}
@@ -2389,7 +2389,7 @@ func (s *SnapOpSuite) TestRefreshOneSwitchChannel(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"channel":     "beta",
 			"transaction": string(client.TransactionPerSnap),
@@ -2406,7 +2406,7 @@ func (s *SnapOpSuite) TestRefreshOneSwitchCohort(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"cohort-key":  "what",
 			"transaction": string(client.TransactionPerSnap),
@@ -2422,7 +2422,7 @@ func (s *SnapOpSuite) TestRefreshOneLeaveCohort(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":       "refresh",
 			"leave-cohort": true,
 			"transaction":  string(client.TransactionPerSnap),
@@ -2438,7 +2438,7 @@ func (s *SnapOpSuite) TestRefreshOneWithPinnedTrack(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"channel":     "stable",
 			"transaction": string(client.TransactionPerSnap),
@@ -2456,7 +2456,7 @@ func (s *SnapOpSuite) TestRefreshOneClassic(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"classic":     true,
 			"transaction": string(client.TransactionPerSnap),
@@ -2471,7 +2471,7 @@ func (s *SnapOpSuite) TestRefreshOneDevmode(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"devmode":     true,
 			"transaction": string(client.TransactionPerSnap),
@@ -2486,7 +2486,7 @@ func (s *SnapOpSuite) TestRefreshOneJailmode(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"jailmode":    true,
 			"transaction": string(client.TransactionPerSnap),
@@ -2501,7 +2501,7 @@ func (s *SnapOpSuite) TestRefreshOneIgnoreValidation(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":            "refresh",
 			"ignore-validation": true,
 			"transaction":       string(client.TransactionPerSnap),
@@ -2516,7 +2516,7 @@ func (s *SnapOpSuite) TestRefreshOneRebooting(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/core")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"transaction": string(client.TransactionPerSnap),
 		})
@@ -2536,7 +2536,7 @@ func (s *SnapOpSuite) TestRefreshOneHalting(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/core")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"transaction": string(client.TransactionPerSnap),
 		})
@@ -2556,7 +2556,7 @@ func (s *SnapOpSuite) TestRefreshOnePoweringOff(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/core")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"transaction": string(client.TransactionPerSnap),
 		})
@@ -2574,7 +2574,7 @@ func (s *SnapOpSuite) TestRefreshOnePoweringOff(c *check.C) {
 func (s *SnapOpSuite) TestRefreshOneChanDeprecated(c *check.C) {
 	var in, out string
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh", "channel": out, "transaction": string(client.TransactionPerSnap)})
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh", "channel": out, "transaction": string(client.TransactionPerSnap)})
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "snap not found", "value": "foo", "kind": "snap-not-found"}, "status-code": 404}`)
 	})
 
@@ -2613,7 +2613,7 @@ func (s *SnapOpSuite) TestRefreshOneIgnoreRunning(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":         "refresh",
 			"ignore-running": true,
 			"transaction":    "per-snap",
@@ -2628,9 +2628,9 @@ func (s *SnapOpSuite) TestRefreshManyIgnoreRunning(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":         "refresh",
-			"snaps":          []interface{}{"one", "two"},
+			"snaps":          []any{"one", "two"},
 			"ignore-running": true,
 			"transaction":    "per-snap",
 		})
@@ -2662,7 +2662,7 @@ func (s *SnapOpSuite) TestRefreshOneAmend(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "refresh",
 			"amend":       true,
 			"transaction": string(client.TransactionPerSnap),
@@ -2879,7 +2879,7 @@ func (s *SnapOpSuite) TestNotInstalledError(c *check.C) {
 func (s *SnapOpSuite) TestInstallFromChannel(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":      "install",
 			"channel":     "edge",
 			"transaction": string(client.TransactionPerSnap),
@@ -2902,7 +2902,7 @@ func (s *SnapOpSuite) TestInstallOneIgnoreValidation(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":            "install",
 			"ignore-validation": true,
 			"transaction":       string(client.TransactionPerSnap),
@@ -2922,7 +2922,7 @@ func (s *SnapOpSuite) TestEnable(c *check.C) {
 	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action": "enable",
 		})
 	}
@@ -2941,7 +2941,7 @@ func (s *SnapOpSuite) TestDisable(c *check.C) {
 	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action": "disable",
 		})
 	}
@@ -2960,7 +2960,7 @@ func (s *SnapOpSuite) TestRemove(c *check.C) {
 	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action": "remove",
 		})
 	}
@@ -2979,7 +2979,7 @@ func (s *SnapOpSuite) TestRemoveWithPurge(c *check.C) {
 	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action": "remove",
 			"purge":  true,
 		})
@@ -2999,7 +2999,7 @@ func (s *SnapOpSuite) TestRemoveWithTerminate(c *check.C) {
 	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":    "remove",
 			"terminate": true,
 		})
@@ -3082,7 +3082,7 @@ func (s *SnapOpSuite) TestRemoveRevision(c *check.C) {
 	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":   "remove",
 			"revision": "17",
 		})
@@ -3111,9 +3111,9 @@ func (s *SnapOpSuite) TestRemoveMany(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "remove",
-				"snaps":  []interface{}{"one", "two"},
+				"snaps":  []any{"one", "two"},
 			})
 
 			c.Check(r.Method, check.Equals, "POST")
@@ -3151,9 +3151,9 @@ func (s *SnapOpSuite) TestRemoveManyPurge(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action": "remove",
-				"snaps":  []interface{}{"one", "two"},
+				"snaps":  []any{"one", "two"},
 				"purge":  true,
 			})
 
@@ -3204,9 +3204,9 @@ func (s *SnapOpSuite) TestInstallMany(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":      "install",
-				"snaps":       []interface{}{"one", "two"},
+				"snaps":       []any{"one", "two"},
 				"transaction": string(client.TransactionPerSnap),
 			})
 
@@ -3251,9 +3251,9 @@ func (s *SnapOpSuite) TestInstallManyNoChanges(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":      "install",
-				"snaps":       []interface{}{"one", "two"},
+				"snaps":       []any{"one", "two"},
 				"transaction": string(client.TransactionPerSnap),
 			})
 
@@ -3293,9 +3293,9 @@ func (s *SnapOpSuite) TestRefreshManyNoChanges(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 				"action":      "refresh",
-				"snaps":       []interface{}{"one", "two"},
+				"snaps":       []any{"one", "two"},
 				"transaction": string(client.TransactionPerSnap),
 			})
 
@@ -3489,7 +3489,7 @@ func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
 	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":  "switch",
 			"channel": "beta",
 		})
@@ -3512,7 +3512,7 @@ func (s *SnapOpSuite) TestSwitchHappyCohort(c *check.C) {
 	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":     "switch",
 			"cohort-key": "what",
 		})
@@ -3532,7 +3532,7 @@ func (s *SnapOpSuite) TestSwitchHappyLeaveCohort(c *check.C) {
 	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":       "switch",
 			"leave-cohort": true,
 		})
@@ -3552,7 +3552,7 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
 	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":     "switch",
 			"cohort-key": "what",
 			"channel":    "edge",
@@ -3574,7 +3574,7 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndLeaveCohort(c *check.C) {
 	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
-		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
 			"action":       "switch",
 			"leave-cohort": true,
 			"channel":      "edge",

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -48,7 +48,7 @@ func (s *SnapSuite) TestUnalias(c *C) {
 		switch r.URL.Path {
 		case "/v2/aliases":
 			c.Check(r.Method, Equals, "POST")
-			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
+			c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]any{
 				"action": "unalias",
 				"snap":   "alias1",
 				"alias":  "alias1",

--- a/cmd/snap/cmd_unset.go
+++ b/cmd/snap/cmd_unset.go
@@ -76,7 +76,7 @@ func init() {
 }
 
 func (x *cmdUnset) Execute(args []string) error {
-	patchValues := make(map[string]interface{})
+	patchValues := make(map[string]any)
 	for _, confKey := range x.Positional.ConfKeys {
 		if confKey == "" {
 			return errors.New(i18n.G("configuration keys cannot be empty"))

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -77,7 +77,7 @@ func isNoOption(err error) bool {
 // needs to becomes a generic "trueish" helper we need to resurrect
 // the code in 306ba60edfba8d6501060c6f773235d8c994a319 (and add nil
 // to it).
-func trueishJSON(vi interface{}) (bool, error) {
+func trueishJSON(vi any) (bool, error) {
 	switch v := vi.(type) {
 	// limited to the types that json unmarhal can produce
 	case nil:

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -68,7 +68,7 @@ func isNoOption(err error) bool {
 	return false
 }
 
-// trueishJSON takes an interface{} and returns true if the interface value
+// trueishJSON takes an any and returns true if the interface value
 // looks "true". For strings thats if len(string) > 0 for numbers that
 // they are != 0 and for maps/slices/arrays that they have elements.
 //

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -67,7 +67,7 @@ func (s *SnapSuite) TestCmdWaitMissingConfKey(c *C) {
 
 func (s *SnapSuite) TestTrueishJSON(c *C) {
 	tests := []struct {
-		v      interface{}
+		v      any
 		b      bool
 		errStr string
 	}{
@@ -87,20 +87,20 @@ func (s *SnapSuite) TestTrueishJSON(c *C) {
 		{json.Number("-1.0"), true, ""},
 		{json.Number("0.0"), false, ""},
 		// slices
-		{[]interface{}{"a"}, true, ""},
-		{[]interface{}{}, false, ""},
+		{[]any{"a"}, true, ""},
+		{[]any{}, false, ""},
 		{[]string{"a"}, true, ""},
 		{[]string{}, false, ""},
 		// arrays
-		{[2]interface{}{"a", "b"}, true, ""},
-		{[0]interface{}{}, false, ""},
+		{[2]any{"a", "b"}, true, ""},
+		{[0]any{}, false, ""},
 		{[2]string{"a", "b"}, true, ""},
 		{[0]string{}, false, ""},
 		// maps
-		{map[string]interface{}{"a": "a"}, true, ""},
-		{map[string]interface{}{}, false, ""},
-		{map[interface{}]interface{}{"a": "a"}, true, ""},
-		{map[interface{}]interface{}{}, false, ""},
+		{map[string]any{"a": "a"}, true, ""},
+		{map[string]any{}, false, ""},
+		{map[any]any{"a": "a"}, true, ""},
+		{map[any]any{}, false, ""},
 		// invalid
 		{int(1), false, "cannot test type int for truth"},
 	}

--- a/cmd/snap/cmd_warnings_test.go
+++ b/cmd/snap/cmd_warnings_test.go
@@ -155,7 +155,7 @@ func (s *warningSuite) TestOkay(c *check.C) {
 		}
 		c.Check(r.URL.Path, check.Equals, "/v2/warnings")
 		c.Check(r.URL.Query(), check.HasLen, 0)
-		c.Assert(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "okay", "timestamp": t0.Format(time.RFC3339Nano)})
+		c.Assert(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "okay", "timestamp": t0.Format(time.RFC3339Nano)})
 		c.Check(r.Method, check.Equals, "POST")
 		w.WriteHeader(200)
 		fmt.Fprintln(w, `{

--- a/cmd/snap/color_test.go
+++ b/cmd/snap/color_test.go
@@ -97,7 +97,7 @@ func (s *SnapSuite) TestColorTable(c *check.C) {
 	type T struct {
 		isTTY         bool
 		noColor, term string
-		expected      interface{}
+		expected      any
 		desc          string
 	}
 

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -130,7 +130,7 @@ Try 'snapcraft prime' in your project directory, then 'snap try' again.`)
 		}
 	case client.ErrorKindSnapChannelNotAvailable,
 		client.ErrorKindSnapArchitectureNotAvailable:
-		values, ok := err.Value.(map[string]interface{})
+		values, ok := err.Value.(map[string]any)
 		if ok {
 			candName, _ := values["snap-name"].(string)
 			if candName != "" {
@@ -139,7 +139,7 @@ Try 'snapcraft prime' in your project directory, then 'snap try' again.`)
 			action, _ := values["action"].(string)
 			arch, _ := values["architecture"].(string)
 			channel, _ := values["channel"].(string)
-			releases, _ := values["releases"].([]interface{})
+			releases, _ := values["releases"].([]any)
 			if snapName != "" && action != "" && arch != "" && channel != "" && len(releases) != 0 {
 				usesSnapName = false
 				msg = snapRevisionNotAvailableMessage(err.Kind, snapName, action, arch, channel, releases)
@@ -230,7 +230,7 @@ If you understand and want to proceed repeat the command including --classic.
 		isError = false
 		usesSnapName = false
 		msg = i18n.G("snapd is about to reboot the system")
-		values, ok := err.Value.(map[string]interface{})
+		values, ok := err.Value.(map[string]any)
 		if ok {
 			op, ok := values["op"].(string)
 			if ok {
@@ -245,10 +245,10 @@ If you understand and want to proceed repeat the command including --classic.
 	case client.ErrorKindInsufficientDiskSpace:
 		// this error carries multiple snap names
 		usesSnapName = false
-		values, ok := err.Value.(map[string]interface{})
+		values, ok := err.Value.(map[string]any)
 		if ok {
 			changeKind, _ := values["change-kind"].(string)
-			snaps, _ := values["snap-names"].([]interface{})
+			snaps, _ := values["snap-names"].([]any)
 			snapNames := make([]string, len(snaps))
 			for i, v := range snaps {
 				snapNames[i] = fmt.Sprint(v)
@@ -284,7 +284,7 @@ If you understand and want to proceed repeat the command including --classic.
 	return msg, nil
 }
 
-func snapRevisionNotAvailableMessage(kind client.ErrorKind, snapName, action, arch, snapChannel string, releases []interface{}) string {
+func snapRevisionNotAvailableMessage(kind client.ErrorKind, snapName, action, arch, snapChannel string, releases []any) string {
 	// releases contains all available (arch x channel)
 	// as reported by the store through the daemon
 	req, err := channel.Parse(snapChannel, arch)
@@ -296,7 +296,7 @@ func snapRevisionNotAvailableMessage(kind client.ErrorKind, snapName, action, ar
 	}
 	avail := make([]*channel.Channel, 0, len(releases))
 	for _, v := range releases {
-		rel, _ := v.(map[string]interface{})
+		rel, _ := v.(map[string]any)
 		relCh, _ := rel["channel"].(string)
 		relArch, _ := rel["architecture"].(string)
 		if relArch == "" {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -595,7 +595,7 @@ fixed-width fonts, so it can be hard to tell.
 	return nil
 }
 
-func panicOnDebug(msg string, v ...interface{}) {
+func panicOnDebug(msg string, v ...any) {
 	if osutil.GetenvBool("SNAPD_DEBUG") || snapdenv.Testing() {
 		logger.Panicf(msg, v...)
 	}

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -157,8 +157,8 @@ type SnapSuite struct {
 var _ = Suite(&SnapSuite{})
 
 // DecodedRequestBody returns the JSON-decoded body of the request.
-func DecodedRequestBody(c *C, r *http.Request) map[string]interface{} {
-	var body map[string]interface{}
+func DecodedRequestBody(c *C, r *http.Request) map[string]any {
+	var body map[string]any
 	decoder := json.NewDecoder(r.Body)
 	decoder.UseNumber()
 	err := decoder.Decode(&body)
@@ -167,7 +167,7 @@ func DecodedRequestBody(c *C, r *http.Request) map[string]interface{} {
 }
 
 // EncodeResponseBody writes JSON-serialized body to the response writer.
-func EncodeResponseBody(c *C, w http.ResponseWriter, body interface{}) {
+func EncodeResponseBody(c *C, w http.ResponseWriter, body any) {
 	encoder := json.NewEncoder(w)
 	err := encoder.Encode(body)
 	c.Assert(err, IsNil)

--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -67,7 +67,7 @@ func main() {
 		if e, ok := err.(*client.Error); ok {
 			switch e.Kind {
 			case client.ErrorKindUnsuccessful:
-				if errRes, ok := e.Value.(map[string]interface{}); ok {
+				if errRes, ok := e.Value.(map[string]any); ok {
 					if stdout, ok := errRes["stdout"].(string); ok {
 						os.Stdout.Write([]byte(stdout))
 					}

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -108,8 +108,8 @@ func badRequestErrorFrom(v *View, operation, request, msg string) *BadRequestErr
 
 // Databag controls access to the confdb data storage.
 type Databag interface {
-	Get(path string) (interface{}, error)
-	Set(path string, value interface{}) error
+	Get(path string) (any, error)
+	Set(path string, value any) error
 	Unset(path string) error
 	Data() ([]byte, error)
 }
@@ -217,7 +217,7 @@ func pathChangeAffects(modified, affected string) bool {
 
 // NewSchema returns a new confdb schema with the specified views (and their
 // rules) and storage schema.
-func NewSchema(account string, dbSchemaName string, views map[string]interface{}, schema DatabagSchema) (*Schema, error) {
+func NewSchema(account string, dbSchemaName string, views map[string]any, schema DatabagSchema) (*Schema, error) {
 	if len(views) == 0 {
 		return nil, errors.New(`cannot define confdb schema: no views`)
 	}
@@ -234,7 +234,7 @@ func NewSchema(account string, dbSchemaName string, views map[string]interface{}
 			return nil, fmt.Errorf("cannot define view %q: name must conform to %s", name, subkeyRegex)
 		}
 
-		viewMap, ok := v.(map[string]interface{})
+		viewMap, ok := v.(map[string]any)
 		if !ok || len(viewMap) == 0 {
 			return nil, fmt.Errorf("cannot define view %q: view must be non-empty map", name)
 		}
@@ -245,7 +245,7 @@ func NewSchema(account string, dbSchemaName string, views map[string]interface{}
 			}
 		}
 
-		rules, ok := viewMap["rules"].([]interface{})
+		rules, ok := viewMap["rules"].([]any)
 		if !ok || len(rules) == 0 {
 			return nil, fmt.Errorf("cannot define view %q: view rules must be non-empty list", name)
 		}
@@ -261,7 +261,7 @@ func NewSchema(account string, dbSchemaName string, views map[string]interface{}
 	return dbSchema, nil
 }
 
-func newView(dbSchema *Schema, name string, viewRules []interface{}) (*View, error) {
+func newView(dbSchema *Schema, name string, viewRules []any) (*View, error) {
 	view := &View{
 		Name:   name,
 		rules:  make([]*viewRule, 0, len(viewRules)),
@@ -308,8 +308,8 @@ func newView(dbSchema *Schema, name string, viewRules []interface{}) (*View, err
 	return view, nil
 }
 
-func parseRule(parent *viewRule, ruleRaw interface{}) ([]*viewRule, error) {
-	ruleMap, ok := ruleRaw.(map[string]interface{})
+func parseRule(parent *viewRule, ruleRaw any) ([]*viewRule, error) {
+	ruleMap, ok := ruleRaw.(map[string]any)
 	if !ok {
 		return nil, errors.New("each view rule should be a map")
 	}
@@ -362,7 +362,7 @@ func parseRule(parent *viewRule, ruleRaw interface{}) ([]*viewRule, error) {
 
 	rules := []*viewRule{rule}
 	if contentRaw, ok := ruleMap["content"]; ok {
-		contentRulesRaw, ok := contentRaw.([]interface{})
+		contentRulesRaw, ok := contentRaw.([]any)
 		if !ok || len(contentRulesRaw) == 0 {
 			return nil, fmt.Errorf(`"content" must be a non-empty list`)
 		}
@@ -482,7 +482,7 @@ type expandedMatch struct {
 
 	// value is the nested value obtained after removing the original values' outer
 	// layers that correspond to the unmatched suffix.
-	value interface{}
+	value any
 }
 
 // maxValueDepth is the limit on a value's nestedness. Creating a highly nested
@@ -492,14 +492,14 @@ type expandedMatch struct {
 var maxValueDepth = 64
 
 // validateSetValue checks that map keys conform to the same format as path sub-keys.
-func validateSetValue(v interface{}, depth int) error {
+func validateSetValue(v any, depth int) error {
 	if depth > maxValueDepth {
 		return fmt.Errorf("value cannot have more than %d nested levels", maxValueDepth)
 	}
 
-	var nestedVals []interface{}
+	var nestedVals []any
 	switch typedVal := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for k, v := range typedVal {
 			if !validSubkey.Match([]byte(k)) {
 				return fmt.Errorf(`key %q doesn't conform to required format: %s`, k, validSubkey.String())
@@ -508,7 +508,7 @@ func validateSetValue(v interface{}, depth int) error {
 			nestedVals = append(nestedVals, v)
 		}
 
-	case []interface{}:
+	case []any:
 		nestedVals = typedVal
 	}
 
@@ -527,7 +527,7 @@ func validateSetValue(v interface{}, depth int) error {
 }
 
 // Set sets the named view to a specified non-nil value.
-func (v *View) Set(databag Databag, request string, value interface{}) error {
+func (v *View) Set(databag Databag, request string, value any) error {
 	if err := validateViewDottedPath(request, nil); err != nil {
 		return badRequestErrorFrom(v, "set", request, err.Error())
 	}
@@ -756,7 +756,7 @@ func schemaTypesStr(types []SchemaType) string {
 // will be used to complete the storage path.
 var getValuesThroughPaths = getValuesThroughPathsImpl
 
-func getValuesThroughPathsImpl(storagePath string, reqSuffixParts []string, val interface{}) (map[string]interface{}, error) {
+func getValuesThroughPathsImpl(storagePath string, reqSuffixParts []string, val any) (map[string]any, error) {
 	// use the non-placeholder parts of the suffix to find the value to write
 	var placeIndex int
 	for _, part := range reqSuffixParts {
@@ -765,7 +765,7 @@ func getValuesThroughPathsImpl(storagePath string, reqSuffixParts []string, val 
 			break
 		}
 
-		mapVal, ok := val.(map[string]interface{})
+		mapVal, ok := val.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf(`expected map for unmatched request parts but got %T`, val)
 		}
@@ -781,15 +781,15 @@ func getValuesThroughPathsImpl(storagePath string, reqSuffixParts []string, val 
 	// we reached the end of the suffix (there are no unmatched placeholders) so
 	// we have the full storage path and final value
 	if placeIndex == len(reqSuffixParts) {
-		return map[string]interface{}{storagePath: val}, nil
+		return map[string]any{storagePath: val}, nil
 	}
 
-	mapVal, ok := val.(map[string]interface{})
+	mapVal, ok := val.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf(`expected map for unmatched request parts but got %T`, val)
 	}
 
-	storagePathsToValues := make(map[string]interface{})
+	storagePathsToValues := make(map[string]any)
 	// suffix has an unmatched placeholder, try all possible values to fill it and
 	// find the corresponding nested value.
 	for cand, candVal := range mapVal {
@@ -819,7 +819,7 @@ func replaceIn(path, key, value string) string {
 }
 
 // checkForUnusedBranches checks that the value is entirely covered by the paths.
-func checkForUnusedBranches(value interface{}, paths map[string]struct{}) error {
+func checkForUnusedBranches(value any, paths map[string]struct{}) error {
 	// prune each path from the value. If anything is left at the end, the paths
 	// don't collectively cover the entire value
 	copyValue := deepCopy(value)
@@ -843,7 +843,7 @@ func checkForUnusedBranches(value interface{}, paths map[string]struct{}) error 
 
 	var parts []string
 	for copyValue != nil {
-		mapVal, ok := copyValue.(map[string]interface{})
+		mapVal, ok := copyValue.(map[string]any)
 		if !ok {
 			break
 		}
@@ -860,17 +860,17 @@ func checkForUnusedBranches(value interface{}, paths map[string]struct{}) error 
 
 // deepCopy returns a deep copy of the value. Only supports the types that the
 // API can take (so maps, slices and primitive types).
-func deepCopy(value interface{}) interface{} {
+func deepCopy(value any) any {
 	switch typeVal := value.(type) {
-	case map[string]interface{}:
-		mapCopy := make(map[string]interface{}, len(typeVal))
+	case map[string]any:
+		mapCopy := make(map[string]any, len(typeVal))
 		for k, v := range typeVal {
 			mapCopy[k] = deepCopy(v)
 		}
 		return mapCopy
 
-	case []interface{}:
-		sliceCopy := make([]interface{}, 0, len(typeVal))
+	case []any:
+		sliceCopy := make([]any, 0, len(typeVal))
 		for _, v := range typeVal {
 			sliceCopy = append(sliceCopy, deepCopy(v))
 		}
@@ -881,21 +881,21 @@ func deepCopy(value interface{}) interface{} {
 	}
 }
 
-func prunePathInValue(parts []string, val interface{}) (interface{}, error) {
+func prunePathInValue(parts []string, val any) (any, error) {
 	if len(parts) == 0 {
 		return nil, nil
 	} else if val == nil {
 		return nil, nil
 	}
 
-	mapVal, ok := val.(map[string]interface{})
+	mapVal, ok := val.(map[string]any)
 	if !ok {
 		// shouldn't happen since we already checked this
 		return nil, fmt.Errorf(`expected map but got %T`, val)
 	}
 
 	if isPlaceholder(parts[0]) {
-		nested := make(map[string]interface{})
+		nested := make(map[string]any)
 		for k, v := range mapVal {
 			newVal, err := prunePathInValue(parts[1:], v)
 			if err != nil {
@@ -941,7 +941,7 @@ func prunePathInValue(parts []string, val interface{}) (interface{}, error) {
 // namespaceResult creates a nested namespace around the result that corresponds
 // to the unmatched entry parts. Unmatched placeholders are filled in using maps
 // of all the matching values in the databag.
-func namespaceResult(res interface{}, suffixParts []string) (interface{}, error) {
+func namespaceResult(res any, suffixParts []string) (any, error) {
 	if len(suffixParts) == 0 {
 		return res, nil
 	}
@@ -950,12 +950,12 @@ func namespaceResult(res interface{}, suffixParts []string) (interface{}, error)
 	// by the databag with all possible values
 	part := suffixParts[0]
 	if isPlaceholder(part) {
-		values, ok := res.(map[string]interface{})
+		values, ok := res.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("internal error: expected storage to return map for unmatched placeholder")
 		}
 
-		level := make(map[string]interface{}, len(values))
+		level := make(map[string]any, len(values))
 		for k, v := range values {
 			nested, err := namespaceResult(v, suffixParts[1:])
 			if err != nil {
@@ -973,12 +973,12 @@ func namespaceResult(res interface{}, suffixParts []string) (interface{}, error)
 		return nil, err
 	}
 
-	return map[string]interface{}{part: nested}, nil
+	return map[string]any{part: nested}, nil
 }
 
 // Get returns the view value identified by the request. If either the named
 // view or the corresponding value can't be found, a NotFoundError is returned.
-func (v *View) Get(databag Databag, request string) (interface{}, error) {
+func (v *View) Get(databag Databag, request string) (any, error) {
 	if request != "" {
 		if err := validateViewDottedPath(request, nil); err != nil {
 			return nil, badRequestErrorFrom(v, "get", request, err.Error())
@@ -990,7 +990,7 @@ func (v *View) Get(databag Databag, request string) (interface{}, error) {
 		return nil, err
 	}
 
-	var merged interface{}
+	var merged any
 	for _, match := range matches {
 		val, err := databag.Get(match.storagePath)
 		if err != nil {
@@ -1025,7 +1025,7 @@ func (v *View) Get(databag Databag, request string) (interface{}, error) {
 	return merged, nil
 }
 
-func mergeNamespaces(old, new interface{}) (interface{}, error) {
+func mergeNamespaces(old, new any) (any, error) {
 	if old == nil {
 		return new, nil
 	}
@@ -1041,7 +1041,7 @@ func mergeNamespaces(old, new interface{}) (interface{}, error) {
 	}
 
 	// if the values are maps, merge them recursively
-	oldMap, newMap := old.(map[string]interface{}), new.(map[string]interface{})
+	oldMap, newMap := old.(map[string]any), new.(map[string]any)
 	for k, v := range newMap {
 		if storeVal, ok := oldMap[k]; ok {
 			merged, err := mergeNamespaces(storeVal, v)
@@ -1304,7 +1304,7 @@ func (e PathError) Is(err error) bool {
 	return ok
 }
 
-func pathErrorf(str string, v ...interface{}) PathError {
+func pathErrorf(str string, v ...any) PathError {
 	return PathError(fmt.Sprintf(str, v...))
 }
 
@@ -1320,9 +1320,9 @@ func NewJSONDatabag() JSONDatabag {
 // Get takes a path and a pointer to a variable into which the value referenced
 // by the path is written. The path can be dotted. For each dot a JSON object
 // is expected to exist (e.g., "a.b" is mapped to {"a": {"b": <value>}}).
-func (s JSONDatabag) Get(path string) (interface{}, error) {
+func (s JSONDatabag) Get(path string) (any, error) {
 	// TODO: create this in the return below as well?
-	var value interface{}
+	var value any
 	subKeys := strings.Split(path, ".")
 	if err := get(subKeys, 0, s, &value); err != nil {
 		return nil, err
@@ -1336,7 +1336,7 @@ func (s JSONDatabag) Get(path string) (interface{}, error) {
 // traverse the tree, or a bracketed placeholder (e.g., "{foo}"). For placeholders,
 // we take all sub-paths and try to match the remaining path. The results for
 // any sub-path that matched the request path are then merged in a map and returned.
-func get(subKeys []string, index int, node map[string]json.RawMessage, result *interface{}) error {
+func get(subKeys []string, index int, node map[string]json.RawMessage, result *any) error {
 	key := subKeys[index]
 	matchAll := isPlaceholder(key)
 
@@ -1350,9 +1350,9 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 	if index == len(subKeys)-1 {
 		if matchAll {
 			// request ends in placeholder so return map to all values (but unmarshal the rest first)
-			level := make(map[string]interface{}, len(node))
+			level := make(map[string]any, len(node))
 			for k, v := range node {
-				var deser interface{}
+				var deser any
 				if err := json.Unmarshal(v, &deser); err != nil {
 					return fmt.Errorf(`internal error: %w`, err)
 				}
@@ -1371,7 +1371,7 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 	}
 
 	if matchAll {
-		results := make(map[string]interface{})
+		results := make(map[string]any)
 
 		for k, v := range node {
 			var level map[string]json.RawMessage
@@ -1386,7 +1386,7 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 
 			// walk the path under all possible values, only return an error if no value
 			// is found under any path
-			var res interface{}
+			var res any
 			if err := get(subKeys, index+1, level, &res); err != nil {
 				if errors.Is(err, PathError("")) {
 					continue
@@ -1423,7 +1423,7 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result *i
 // Set takes a path to which the value will be written. The path can be dotted,
 // in which case, a nested JSON object is created for each sub-key found after a dot.
 // If the value is nil, the entry is deleted.
-func (s JSONDatabag) Set(path string, value interface{}) error {
+func (s JSONDatabag) Set(path string, value any) error {
 	subKeys := strings.Split(path, ".")
 
 	var err error
@@ -1436,8 +1436,8 @@ func (s JSONDatabag) Set(path string, value interface{}) error {
 	return err
 }
 
-func removeNilValues(value interface{}) interface{} {
-	level, ok := value.(map[string]interface{})
+func removeNilValues(value any) any {
+	level, ok := value.(map[string]any)
 	if !ok {
 		return value
 	}
@@ -1454,7 +1454,7 @@ func removeNilValues(value interface{}) interface{} {
 	return level
 }
 
-func set(subKeys []string, index int, node map[string]json.RawMessage, value interface{}) (json.RawMessage, error) {
+func set(subKeys []string, index int, node map[string]json.RawMessage, value any) (json.RawMessage, error) {
 	key := subKeys[index]
 	if index == len(subKeys)-1 {
 		// remove nil values that may be nested in the value

--- a/confdb/confdb_control.go
+++ b/confdb/confdb_control.go
@@ -92,7 +92,7 @@ func (cc *Control) IsDelegated(operatorID, view string, authMeth []string) (bool
 
 // Groups returns the groups in a format that can be used to assemble the next revision
 // of the confdb-control assertion.
-func (cc *Control) Groups() []interface{} {
+func (cc *Control) Groups() []any {
 	// Group operators by authentication and views
 	// i.e. authentication > views > operator-ids
 	authMap := map[authentication]map[viewRef][]string{}
@@ -114,7 +114,7 @@ func (cc *Control) Groups() []interface{} {
 	// Sort auths for consistent output
 	sort.Slice(auths, func(i, j int) bool { return auths[i] < auths[j] })
 
-	var groups []interface{}
+	var groups []any
 	for _, auth := range auths {
 		authStrs := auth.toStrings()
 
@@ -129,7 +129,7 @@ func (cc *Control) Groups() []interface{} {
 
 		for ops, views := range opGroups {
 			sort.Strings(views)
-			groups = append(groups, map[string]interface{}{
+			groups = append(groups, map[string]any{
 				"operators":       toInterfaceSlice(strings.Split(ops, ",")),
 				"authentications": toInterfaceSlice(authStrs),
 				"views":           toInterfaceSlice(views),
@@ -345,8 +345,8 @@ func (op operator) clone() *operator {
 }
 
 // toInterfaceSlice converts []string to []interface{}.
-func toInterfaceSlice(strs []string) []interface{} {
-	result := make([]interface{}, len(strs))
+func toInterfaceSlice(strs []string) []any {
+	result := make([]any, len(strs))
 	for i, str := range strs {
 		result[i] = str
 	}

--- a/confdb/confdb_control.go
+++ b/confdb/confdb_control.go
@@ -130,9 +130,9 @@ func (cc *Control) Groups() []any {
 		for ops, views := range opGroups {
 			sort.Strings(views)
 			groups = append(groups, map[string]any{
-				"operators":       toInterfaceSlice(strings.Split(ops, ",")),
-				"authentications": toInterfaceSlice(authStrs),
-				"views":           toInterfaceSlice(views),
+				"operators":       toAnySlice(strings.Split(ops, ",")),
+				"authentications": toAnySlice(authStrs),
+				"views":           toAnySlice(views),
 			})
 		}
 	}
@@ -344,8 +344,8 @@ func (op operator) clone() *operator {
 	return clone
 }
 
-// toInterfaceSlice converts []string to []interface{}.
-func toInterfaceSlice(strs []string) []any {
+// toAnySlice converts []string to []any.
+func toAnySlice(strs []string) []any {
 	result := make([]any, len(strs))
 	for i, str := range strs {
 		result[i] = str

--- a/confdb/confdb_control_test.go
+++ b/confdb/confdb_control_test.go
@@ -305,36 +305,36 @@ func (s *ctrlSuite) TestGroups(c *C) {
 
 	groups := cc.Groups()
 	c.Assert(groups, HasLen, 6)
-	expectedGroups := []interface{}{
-		map[string]interface{}{
-			"operators":       []interface{}{"aa", "cc"},
-			"authentications": []interface{}{"operator-key"},
-			"views":           []interface{}{"pp/qq/rr"},
+	expectedGroups := []any{
+		map[string]any{
+			"operators":       []any{"aa", "cc"},
+			"authentications": []any{"operator-key"},
+			"views":           []any{"pp/qq/rr"},
 		},
-		map[string]interface{}{
-			"operators":       []interface{}{"bb"},
-			"authentications": []interface{}{"operator-key"},
-			"views":           []interface{}{"aa/bb/cc"},
+		map[string]any{
+			"operators":       []any{"bb"},
+			"authentications": []any{"operator-key"},
+			"views":           []any{"aa/bb/cc"},
 		},
-		map[string]interface{}{
-			"operators":       []interface{}{"aa", "bb"},
-			"authentications": []interface{}{"store"},
-			"views":           []interface{}{"mm/nn/oo"},
+		map[string]any{
+			"operators":       []any{"aa", "bb"},
+			"authentications": []any{"store"},
+			"views":           []any{"mm/nn/oo"},
 		},
-		map[string]interface{}{
-			"operators":       []interface{}{"bb", "cc"},
-			"authentications": []interface{}{"operator-key", "store"},
-			"views":           []interface{}{"xx/yy/zz"},
+		map[string]any{
+			"operators":       []any{"bb", "cc"},
+			"authentications": []any{"operator-key", "store"},
+			"views":           []any{"xx/yy/zz"},
 		},
-		map[string]interface{}{
-			"operators":       []interface{}{"aa", "bb", "cc"},
-			"authentications": []interface{}{"operator-key", "store"},
-			"views":           []interface{}{"dd/ee/ff", "gg/hh/ii", "jj/kk/ll"},
+		map[string]any{
+			"operators":       []any{"aa", "bb", "cc"},
+			"authentications": []any{"operator-key", "store"},
+			"views":           []any{"dd/ee/ff", "gg/hh/ii", "jj/kk/ll"},
 		},
-		map[string]interface{}{
-			"operators":       []interface{}{"aa"},
-			"authentications": []interface{}{"operator-key", "store"},
-			"views":           []interface{}{"ss/tt/vv"},
+		map[string]any{
+			"operators":       []any{"aa"},
+			"authentications": []any{"operator-key", "store"},
+			"views":           []any{"ss/tt/vv"},
 		},
 	}
 	for _, expected := range expectedGroups {

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -58,7 +58,7 @@ func (f *failingSchema) Ephemeral() bool {
 
 func (*viewSuite) TestNewConfdb(c *C) {
 	type testcase struct {
-		confdb map[string]interface{}
+		confdb map[string]any
 		err    string
 	}
 
@@ -67,71 +67,71 @@ func (*viewSuite) TestNewConfdb(c *C) {
 			err: `cannot define confdb schema: no views`,
 		},
 		{
-			confdb: map[string]interface{}{"0-a": map[string]interface{}{}},
+			confdb: map[string]any{"0-a": map[string]any{}},
 			err:    `cannot define view "0-a": name must conform to [a-z](?:-?[a-z0-9])*`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": "baz"},
+			confdb: map[string]any{"bar": "baz"},
 			err:    `cannot define view "bar": view must be non-empty map`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{}},
+			confdb: map[string]any{"bar": map[string]any{}},
 			err:    `cannot define view "bar": view must be non-empty map`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": "bar"}},
+			confdb: map[string]any{"bar": map[string]any{"rules": "bar"}},
 			err:    `cannot define view "bar": view rules must be non-empty list`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{}}},
 			err:    `cannot define view "bar": view rules must be non-empty list`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{"a"}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{"a"}}},
 			err:    `cannot define view "bar": each view rule should be a map`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{}}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{map[string]any{}}}},
 			err:    `cannot define view "bar": view rules must have a "storage" field`,
 		},
 
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo", "storage": 1}}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{map[string]any{"request": "foo", "storage": 1}}}},
 			err:    `cannot define view "bar": "storage" must be a string`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"storage": "foo", "request": 1}}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{map[string]any{"storage": "foo", "request": 1}}}},
 			err:    `cannot define view "bar": "request" must be a string`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"storage": "foo", "request": ""}}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{map[string]any{"storage": "foo", "request": ""}}}},
 			err:    `cannot define view "bar": view rules' "request" field must be non-empty, if it exists`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo", "storage": 1}}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{map[string]any{"request": "foo", "storage": 1}}}},
 			err:    `cannot define view "bar": "storage" must be a string`,
 		},
 		{
-			confdb: map[string]interface{}{
-				"bar": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "b"},
-						map[string]interface{}{"request": "a", "storage": "c"},
+			confdb: map[string]any{
+				"bar": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "b"},
+						map[string]any{"request": "a", "storage": "c"},
 					},
 				},
 			},
 			err: `cannot define view "bar": cannot have several reading rules with the same "request" field`,
 		},
 		{
-			confdb: map[string]interface{}{"bar": map[string]interface{}{"rules": []interface{}{map[string]interface{}{"request": "foo", "storage": "bar", "access": 1}}}},
+			confdb: map[string]any{"bar": map[string]any{"rules": []any{map[string]any{"request": "foo", "storage": "bar", "access": 1}}}},
 			err:    `cannot define view "bar": "access" must be a string`,
 		},
 		{
-			confdb: map[string]interface{}{
-				"bar": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "c", "access": "write"},
-						map[string]interface{}{"request": "a", "storage": "b"},
+			confdb: map[string]any{
+				"bar": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "c", "access": "write"},
+						map[string]any{"request": "a", "storage": "b"},
 					},
 				},
 			},
@@ -153,10 +153,10 @@ func (*viewSuite) TestNewConfdb(c *C) {
 
 func (s *viewSuite) TestMissingRequestDefaultsToStorage(c *C) {
 	databag := confdb.NewJSONDatabag()
-	views := map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"storage": "a.b"},
+	views := map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"storage": "a.b"},
 			},
 		},
 	}
@@ -171,22 +171,22 @@ func (s *viewSuite) TestMissingRequestDefaultsToStorage(c *C) {
 
 	value, err := view.Get(databag, "")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{
-		"a": map[string]interface{}{
+	c.Assert(value, DeepEquals, map[string]any{
+		"a": map[string]any{
 			"b": "value",
 		},
 	})
 }
 
 func (s *viewSuite) TestBundleWithSample(c *C) {
-	views := map[string]interface{}{
-		"wifi-setup": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "ssids", "storage": "wifi.ssids"},
-				map[string]interface{}{"access": "read-write", "request": "ssid", "storage": "wifi.ssid"},
-				map[string]interface{}{"access": "write", "request": "password", "storage": "wifi.psk"},
-				map[string]interface{}{"access": "read", "request": "status", "storage": "wifi.status"},
-				map[string]interface{}{"request": "private.{key}", "storage": "wifi.{key}"},
+	views := map[string]any{
+		"wifi-setup": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "ssids", "storage": "wifi.ssids"},
+				map[string]any{"access": "read-write", "request": "ssid", "storage": "wifi.ssid"},
+				map[string]any{"access": "write", "request": "password", "storage": "wifi.psk"},
+				map[string]any{"access": "read", "request": "status", "storage": "wifi.status"},
+				map[string]any{"request": "private.{key}", "storage": "wifi.{key}"},
 			},
 		},
 	}
@@ -224,10 +224,10 @@ func (s *viewSuite) TestAccessTypes(c *C) {
 			err:    true,
 		},
 	} {
-		schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-			"bar": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "a", "storage": "b", "access": t.access},
+		schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+			"bar": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "a", "storage": "b", "access": t.access},
 				},
 			},
 		}, confdb.NewJSONSchema())
@@ -245,13 +245,13 @@ func (s *viewSuite) TestAccessTypes(c *C) {
 
 func (*viewSuite) TestGetAndSetViews(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("system", "network", map[string]interface{}{
-		"wifi-setup": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "ssids", "storage": "wifi.ssids"},
-				map[string]interface{}{"request": "ssid", "storage": "wifi.ssid"},
-				map[string]interface{}{"request": "top-level", "storage": "top-level"},
-				map[string]interface{}{"request": "dotted.path", "storage": "dotted"},
+	schema, err := confdb.NewSchema("system", "network", map[string]any{
+		"wifi-setup": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "ssids", "storage": "wifi.ssids"},
+				map[string]any{"request": "ssid", "storage": "wifi.ssid"},
+				map[string]any{"request": "top-level", "storage": "top-level"},
+				map[string]any{"request": "dotted.path", "storage": "dotted"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -273,7 +273,7 @@ func (*viewSuite) TestGetAndSetViews(c *C) {
 
 	ssids, err := wsView.Get(databag, "ssids")
 	c.Assert(err, IsNil)
-	c.Check(ssids, DeepEquals, []interface{}{"one", "two"})
+	c.Check(ssids, DeepEquals, []any{"one", "two"})
 
 	// top-level string
 	err = wsView.Set(databag, "top-level", "randomValue")
@@ -294,10 +294,10 @@ func (*viewSuite) TestGetAndSetViews(c *C) {
 
 func (*viewSuite) TestSetWithNilValueFail(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("system", "test", map[string]interface{}{
-		"test": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
+	schema, err := confdb.NewSchema("system", "test", map[string]any{
+		"test": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -318,12 +318,12 @@ func (*viewSuite) TestSetWithNilValueFail(c *C) {
 
 func (s *viewSuite) TestConfdbNotFound(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "top-level", "storage": "top-level"},
-				map[string]interface{}{"request": "nested", "storage": "top.nested-one"},
-				map[string]interface{}{"request": "other-nested", "storage": "top.nested-two"},
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "top-level", "storage": "top-level"},
+				map[string]any{"request": "nested", "storage": "top.nested-one"},
+				map[string]any{"request": "other-nested", "storage": "top.nested-two"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -364,11 +364,11 @@ func (s *viewSuite) TestConfdbNotFound(c *C) {
 
 func (s *viewSuite) TestViewBadRead(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "one", "storage": "one"},
-				map[string]interface{}{"request": "onetwo", "storage": "one.two"},
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "one", "storage": "one"},
+				map[string]any{"request": "onetwo", "storage": "one.two"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -408,10 +408,10 @@ func (s *viewSuite) TestViewAccessControl(c *C) {
 	} {
 		cmt := Commentf("sub-test with %q access failed", t.access)
 		databag := confdb.NewJSONDatabag()
-		schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-			"foo": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "foo", "storage": "foo", "access": t.access},
+		schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+			"foo": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "foo", "storage": "foo", "access": t.access},
 				},
 			},
 		}, confdb.NewJSONSchema())
@@ -444,12 +444,12 @@ func newWitnessDatabag(bag confdb.Databag) *witnessDatabag {
 	return &witnessDatabag{bag: bag}
 }
 
-func (s *witnessDatabag) Get(path string) (interface{}, error) {
+func (s *witnessDatabag) Get(path string) (any, error) {
 	s.getPath = path
 	return s.bag.Get(path)
 }
 
-func (s *witnessDatabag) Set(path string, value interface{}) error {
+func (s *witnessDatabag) Set(path string, value any) error {
 	s.setPath = path
 	return s.bag.Set(path, value)
 }
@@ -472,53 +472,53 @@ func (s *witnessDatabag) getLastPaths() (get, set string) {
 
 func (s *viewSuite) TestViewAssertionWithPlaceholder(c *C) {
 	for _, t := range []struct {
-		rule     map[string]interface{}
+		rule     map[string]any
 		testName string
 		request  string
 		storage  string
 	}{
 		{
 			testName: "placeholder last to mid",
-			rule:     map[string]interface{}{"request": "defaults.{foo}", "storage": "first.{foo}.last"},
+			rule:     map[string]any{"request": "defaults.{foo}", "storage": "first.{foo}.last"},
 			request:  "defaults.abc",
 			storage:  "first.abc.last",
 		},
 		{
 			testName: "placeholder first to last",
-			rule:     map[string]interface{}{"request": "{bar}.name", "storage": "first.{bar}"},
+			rule:     map[string]any{"request": "{bar}.name", "storage": "first.{bar}"},
 			request:  "foo.name",
 			storage:  "first.foo",
 		},
 		{
 			testName: "placeholder mid to first",
-			rule:     map[string]interface{}{"request": "first.{baz}.last", "storage": "{baz}.last"},
+			rule:     map[string]any{"request": "first.{baz}.last", "storage": "{baz}.last"},
 			request:  "first.foo.last",
 			storage:  "foo.last",
 		},
 		{
 			testName: "two placeholders in order",
-			rule:     map[string]interface{}{"request": "first.{foo}.{bar}", "storage": "{foo}.mid.{bar}"},
+			rule:     map[string]any{"request": "first.{foo}.{bar}", "storage": "{foo}.mid.{bar}"},
 			request:  "first.one.two",
 			storage:  "one.mid.two",
 		},
 		{
 			testName: "two placeholders out of order",
-			rule:     map[string]interface{}{"request": "{foo}.mid1.{bar}", "storage": "{bar}.mid2.{foo}"},
+			rule:     map[string]any{"request": "{foo}.mid1.{bar}", "storage": "{bar}.mid2.{foo}"},
 			request:  "first2.mid1.two2",
 			storage:  "two2.mid2.first2",
 		},
 		{
 			testName: "one placeholder mapping to several",
-			rule:     map[string]interface{}{"request": "multi.{foo}", "storage": "{foo}.multi.{foo}"},
+			rule:     map[string]any{"request": "multi.{foo}", "storage": "{foo}.multi.{foo}"},
 			request:  "multi.firstlast",
 			storage:  "firstlast.multi.firstlast",
 		},
 	} {
 		cmt := Commentf("sub-test %q failed", t.testName)
 
-		schema, err := confdb.NewSchema("acc", "db", map[string]interface{}{
-			"foo": map[string]interface{}{
-				"rules": []interface{}{t.rule},
+		schema, err := confdb.NewSchema("acc", "db", map[string]any{
+			"foo": map[string]any{
+				"rules": []any{t.rule},
 			},
 		}, confdb.NewJSONSchema())
 		c.Assert(err, IsNil)
@@ -600,10 +600,10 @@ func (s *viewSuite) TestViewRequestAndStorageValidation(c *C) {
 			request:  "a. .c", storage: "a.b", err: `invalid request "a. .c": invalid subkey " "`,
 		},
 	} {
-		_, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-			"foo": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": tc.request, "storage": tc.storage},
+		_, err := confdb.NewSchema("acc", "foo", map[string]any{
+			"foo": map[string]any{
+				"rules": []any{
+					map[string]any{"request": tc.request, "storage": tc.storage},
 				},
 			},
 		}, confdb.NewJSONSchema())
@@ -616,11 +616,11 @@ func (s *viewSuite) TestViewRequestAndStorageValidation(c *C) {
 
 func (s *viewSuite) TestViewUnsetTopLevelEntry(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"my-view": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
-				map[string]interface{}{"request": "bar", "storage": "bar"},
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"my-view": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
+				map[string]any{"request": "bar", "storage": "bar"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -646,11 +646,11 @@ func (s *viewSuite) TestViewUnsetTopLevelEntry(c *C) {
 
 func (s *viewSuite) TestViewUnsetLeafWithSiblings(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"my-view": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "bar", "storage": "foo.bar"},
-				map[string]interface{}{"request": "baz", "storage": "foo.baz"},
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"my-view": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "bar", "storage": "foo.bar"},
+				map[string]any{"request": "baz", "storage": "foo.baz"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -677,11 +677,11 @@ func (s *viewSuite) TestViewUnsetLeafWithSiblings(c *C) {
 
 func (s *viewSuite) TestViewUnsetWithNestedEntry(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"my-view": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
-				map[string]interface{}{"request": "bar", "storage": "foo.bar"},
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"my-view": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
+				map[string]any{"request": "bar", "storage": "foo.bar"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -703,11 +703,11 @@ func (s *viewSuite) TestViewUnsetWithNestedEntry(c *C) {
 
 func (s *viewSuite) TestViewUnsetLeafLeavesEmptyParent(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"my-view": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
-				map[string]interface{}{"request": "bar", "storage": "foo.bar"},
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"my-view": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
+				map[string]any{"request": "bar", "storage": "foo.bar"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -726,16 +726,16 @@ func (s *viewSuite) TestViewUnsetLeafLeavesEmptyParent(c *C) {
 
 	value, err = view.Get(databag, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{})
+	c.Assert(value, DeepEquals, map[string]any{})
 }
 
 func (s *viewSuite) TestViewUnsetAlreadyUnsetEntry(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"my-view": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
-				map[string]interface{}{"request": "bar", "storage": "one.bar"},
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"my-view": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
+				map[string]any{"request": "bar", "storage": "one.bar"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -805,19 +805,19 @@ func (s *viewSuite) TestJSONDataOverwrite(c *C) {
 
 func (s *viewSuite) TestViewGetResultNamespaceMatchesRequest(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "one", "storage": "one"},
-				map[string]interface{}{"request": "one.two", "storage": "one.two"},
-				map[string]interface{}{"request": "onetwo", "storage": "one.two"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "one", "storage": "one"},
+				map[string]any{"request": "one.two", "storage": "one.two"},
+				map[string]any{"request": "onetwo", "storage": "one.two"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 
 	view := schema.View("bar")
-	err = databag.Set("one", map[string]interface{}{"two": "value"})
+	err = databag.Set("one", map[string]any{"two": "value"})
 	c.Assert(err, IsNil)
 
 	value, err := view.Get(databag, "one.two")
@@ -831,23 +831,23 @@ func (s *viewSuite) TestViewGetResultNamespaceMatchesRequest(c *C) {
 
 	value, err = view.Get(databag, "one")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"two": "value"})
+	c.Assert(value, DeepEquals, map[string]any{"two": "value"})
 }
 
 func (s *viewSuite) TestViewGetMatchesOnPrefix(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"statuses": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "snapd.status", "storage": "snaps.snapd.status"},
-				map[string]interface{}{"request": "snaps", "storage": "snaps"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"statuses": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "snapd.status", "storage": "snaps.snapd.status"},
+				map[string]any{"request": "snaps", "storage": "snaps"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 
 	view := schema.View("statuses")
-	err = view.Set(databag, "snaps", map[string]map[string]interface{}{
+	err = view.Set(databag, "snaps", map[string]map[string]any{
 		"snapd":   {"status": "active", "version": "1.0"},
 		"firefox": {"status": "inactive", "version": "9.0"},
 	})
@@ -859,15 +859,15 @@ func (s *viewSuite) TestViewGetMatchesOnPrefix(c *C) {
 
 	value, err = view.Get(databag, "snapd")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"status": "active"})
+	c.Assert(value, DeepEquals, map[string]any{"status": "active"})
 }
 
 func (s *viewSuite) TestViewUnsetValidates(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"test": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"test": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
 			},
 		},
 	}, &failingSchema{err: errors.New("boom")})
@@ -880,10 +880,10 @@ func (s *viewSuite) TestViewUnsetValidates(c *C) {
 
 func (s *viewSuite) TestViewUnsetSkipsReadOnly(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"test": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo", "access": "read"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"test": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo", "access": "read"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -896,17 +896,17 @@ func (s *viewSuite) TestViewUnsetSkipsReadOnly(c *C) {
 
 func (s *viewSuite) TestViewGetNoMatchRequestLongerThanPattern(c *C) {
 	databag := confdb.NewJSONDatabag()
-	db, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"statuses": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "snapd", "storage": "snaps.snapd"},
+	db, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"statuses": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "snapd", "storage": "snaps.snapd"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 
 	view := db.View("statuses")
-	err = view.Set(databag, "snapd", map[string]interface{}{
+	err = view.Set(databag, "snapd", map[string]any{
 		"status": "active", "version": "1.0",
 	})
 	c.Assert(err, IsNil)
@@ -917,11 +917,11 @@ func (s *viewSuite) TestViewGetNoMatchRequestLongerThanPattern(c *C) {
 
 func (s *viewSuite) TestViewManyPrefixMatches(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"statuses": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "status.firefox", "storage": "snaps.firefox.status"},
-				map[string]interface{}{"request": "status.snapd", "storage": "snaps.snapd.status"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"statuses": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "status.firefox", "storage": "snaps.firefox.status"},
+				map[string]any{"request": "status.snapd", "storage": "snaps.snapd.status"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -937,7 +937,7 @@ func (s *viewSuite) TestViewManyPrefixMatches(c *C) {
 	value, err := view.Get(databag, "status")
 	c.Assert(err, IsNil)
 	c.Assert(value, DeepEquals,
-		map[string]interface{}{
+		map[string]any{
 			"snapd":   "disabled",
 			"firefox": "active",
 		})
@@ -945,21 +945,21 @@ func (s *viewSuite) TestViewManyPrefixMatches(c *C) {
 
 func (s *viewSuite) TestViewCombineNamespacesInPrefixMatches(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"statuses": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "status.foo.bar.firefox", "storage": "snaps.firefox.status"},
-				map[string]interface{}{"request": "status.foo.snapd", "storage": "snaps.snapd.status"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"statuses": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "status.foo.bar.firefox", "storage": "snaps.firefox.status"},
+				map[string]any{"request": "status.foo.snapd", "storage": "snaps.snapd.status"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 
-	err = databag.Set("snaps", map[string]interface{}{
-		"firefox": map[string]interface{}{
+	err = databag.Set("snaps", map[string]any{
+		"firefox": map[string]any{
 			"status": "active",
 		},
-		"snapd": map[string]interface{}{
+		"snapd": map[string]any{
 			"status": "disabled",
 		},
 	})
@@ -970,9 +970,9 @@ func (s *viewSuite) TestViewCombineNamespacesInPrefixMatches(c *C) {
 	value, err := view.Get(databag, "status")
 	c.Assert(err, IsNil)
 	c.Assert(value, DeepEquals,
-		map[string]interface{}{
-			"foo": map[string]interface{}{
-				"bar": map[string]interface{}{
+		map[string]any{
+			"foo": map[string]any{
+				"bar": map[string]any{
 					"firefox": "active",
 				},
 				"snapd": "disabled",
@@ -982,24 +982,24 @@ func (s *viewSuite) TestViewCombineNamespacesInPrefixMatches(c *C) {
 
 func (s *viewSuite) TestGetScalarOverwritesLeafOfMapValue(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"motors": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "motors.a.speed", "storage": "new-speed.a"},
-				map[string]interface{}{"request": "motors", "storage": "motors"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"motors": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "motors.a.speed", "storage": "new-speed.a"},
+				map[string]any{"request": "motors", "storage": "motors"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 
-	err = databag.Set("motors", map[string]interface{}{
-		"a": map[string]interface{}{
+	err = databag.Set("motors", map[string]any{
+		"a": map[string]any{
 			"speed": 100,
 		},
 	})
 	c.Assert(err, IsNil)
 
-	err = databag.Set("new-speed", map[string]interface{}{
+	err = databag.Set("new-speed", map[string]any{
 		"a": 101.5,
 	})
 	c.Assert(err, IsNil)
@@ -1008,15 +1008,15 @@ func (s *viewSuite) TestGetScalarOverwritesLeafOfMapValue(c *C) {
 
 	value, err := view.Get(databag, "motors")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"a": map[string]interface{}{"speed": 101.5}})
+	c.Assert(value, DeepEquals, map[string]any{"a": map[string]any{"speed": 101.5}})
 }
 
 func (s *viewSuite) TestGetSingleScalarOk(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1034,11 +1034,11 @@ func (s *viewSuite) TestGetSingleScalarOk(c *C) {
 
 func (s *viewSuite) TestGetMatchScalarAndMapError(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "bar"},
-				map[string]interface{}{"request": "foo.baz", "storage": "baz"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "bar"},
+				map[string]any{"request": "foo.baz", "storage": "baz"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1057,33 +1057,33 @@ func (s *viewSuite) TestGetMatchScalarAndMapError(c *C) {
 
 func (s *viewSuite) TestGetRulesAreSortedByParentage(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.bar.baz", "storage": "third"},
-				map[string]interface{}{"request": "foo", "storage": "first"},
-				map[string]interface{}{"request": "foo.bar", "storage": "second"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.bar.baz", "storage": "third"},
+				map[string]any{"request": "foo", "storage": "first"},
+				map[string]any{"request": "foo.bar", "storage": "second"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 	view := schema.View("foo")
 
-	err = databag.Set("first", map[string]interface{}{"bar": map[string]interface{}{"baz": "first"}})
+	err = databag.Set("first", map[string]any{"bar": map[string]any{"baz": "first"}})
 	c.Assert(err, IsNil)
 
 	value, err := view.Get(databag, "foo")
 	c.Assert(err, IsNil)
 	// returned the value read by entry "foo"
-	c.Assert(value, DeepEquals, map[string]interface{}{"bar": map[string]interface{}{"baz": "first"}})
+	c.Assert(value, DeepEquals, map[string]any{"bar": map[string]any{"baz": "first"}})
 
-	err = databag.Set("second", map[string]interface{}{"baz": "second"})
+	err = databag.Set("second", map[string]any{"baz": "second"})
 	c.Assert(err, IsNil)
 
 	value, err = view.Get(databag, "foo")
 	c.Assert(err, IsNil)
 	// the leaf is replaced by a value read from a rule that is nested
-	c.Assert(value, DeepEquals, map[string]interface{}{"bar": map[string]interface{}{"baz": "second"}})
+	c.Assert(value, DeepEquals, map[string]any{"bar": map[string]any{"baz": "second"}})
 
 	err = databag.Set("third", "third")
 	c.Assert(err, IsNil)
@@ -1091,15 +1091,15 @@ func (s *viewSuite) TestGetRulesAreSortedByParentage(c *C) {
 	value, err = view.Get(databag, "foo")
 	c.Assert(err, IsNil)
 	// lastly, it reads the value from "foo.bar.baz" the most nested entry
-	c.Assert(value, DeepEquals, map[string]interface{}{"bar": map[string]interface{}{"baz": "third"}})
+	c.Assert(value, DeepEquals, map[string]any{"bar": map[string]any{"baz": "third"}})
 }
 
 func (s *viewSuite) TestGetUnmatchedPlaceholderReturnsAll(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"snaps": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "snaps.{snap}", "storage": "snaps.{snap}"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"snaps": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "snaps.{snap}", "storage": "snaps.{snap}"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1107,9 +1107,9 @@ func (s *viewSuite) TestGetUnmatchedPlaceholderReturnsAll(c *C) {
 	view := schema.View("snaps")
 	c.Assert(view, NotNil)
 
-	err = databag.Set("snaps", map[string]interface{}{
+	err = databag.Set("snaps", map[string]any{
 		"snapd": 1,
-		"foo": map[string]interface{}{
+		"foo": map[string]any{
 			"bar": 2,
 		},
 	})
@@ -1117,15 +1117,15 @@ func (s *viewSuite) TestGetUnmatchedPlaceholderReturnsAll(c *C) {
 
 	value, err := view.Get(databag, "snaps")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"snapd": float64(1), "foo": map[string]interface{}{"bar": float64(2)}})
+	c.Assert(value, DeepEquals, map[string]any{"snapd": float64(1), "foo": map[string]any{"bar": float64(2)}})
 }
 
 func (s *viewSuite) TestGetUnmatchedPlaceholdersWithNestedValues(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"statuses": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "snaps.{snap}.status", "storage": "snaps.{snap}.status"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"statuses": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "snaps.{snap}.status", "storage": "snaps.{snap}.status"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1133,11 +1133,11 @@ func (s *viewSuite) TestGetUnmatchedPlaceholdersWithNestedValues(c *C) {
 	view := schema.View("statuses")
 	c.Assert(view, NotNil)
 
-	err = databag.Set("snaps", map[string]interface{}{
-		"snapd": map[string]interface{}{
+	err = databag.Set("snaps", map[string]any{
+		"snapd": map[string]any{
 			"status": "active",
 		},
-		"foo": map[string]interface{}{
+		"foo": map[string]any{
 			"version": 2,
 		},
 	})
@@ -1145,15 +1145,15 @@ func (s *viewSuite) TestGetUnmatchedPlaceholdersWithNestedValues(c *C) {
 
 	value, err := view.Get(databag, "snaps")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{"snapd": map[string]interface{}{"status": "active"}})
+	c.Assert(value, DeepEquals, map[string]any{"snapd": map[string]any{"status": "active"}})
 }
 
 func (s *viewSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "a.{b}.c.{d}.e", "storage": "a.{b}.c.{d}.e"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a.{b}.c.{d}.e", "storage": "a.{b}.c.{d}.e"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1161,11 +1161,11 @@ func (s *viewSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = databag.Set("a", map[string]interface{}{
-		"b1": map[string]interface{}{
-			"c": map[string]interface{}{
+	err = databag.Set("a", map[string]any{
+		"b1": map[string]any{
+			"c": map[string]any{
 				// the request can be fulfilled here
-				"d1": map[string]interface{}{
+				"d1": map[string]any{
 					"e": "end",
 					"f": "not-included",
 				},
@@ -1173,8 +1173,8 @@ func (s *viewSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
 			},
 			"x": 1,
 		},
-		"b2": map[string]interface{}{
-			"c": map[string]interface{}{
+		"b2": map[string]any{
+			"c": map[string]any{
 				// but not here
 				"d1": "e",
 				"d2": "f",
@@ -1186,10 +1186,10 @@ func (s *viewSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
 
 	value, err := view.Get(databag, "a")
 	c.Assert(err, IsNil)
-	expected := map[string]interface{}{
-		"b1": map[string]interface{}{
-			"c": map[string]interface{}{
-				"d1": map[string]interface{}{
+	expected := map[string]any{
+		"b1": map[string]any{
+			"c": map[string]any{
+				"d1": map[string]any{
 					"e": "end",
 				},
 			},
@@ -1200,13 +1200,13 @@ func (s *viewSuite) TestGetSeveralUnmatchedPlaceholders(c *C) {
 
 func (s *viewSuite) TestGetMergeAtDifferentLevels(c *C) {
 	databag := confdb.NewJSONDatabag()
-	confdb, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "a.{b}.c.{d}.e", "storage": "a.{b}.c.{d}.e"},
-				map[string]interface{}{"request": "a.{b}.c.{d}", "storage": "a.{b}.c.{d}"},
-				map[string]interface{}{"request": "a.{b}", "storage": "a.{b}"},
-				map[string]interface{}{"request": "a", "storage": "a"},
+	confdb, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a.{b}.c.{d}.e", "storage": "a.{b}.c.{d}.e"},
+				map[string]any{"request": "a.{b}.c.{d}", "storage": "a.{b}.c.{d}"},
+				map[string]any{"request": "a.{b}", "storage": "a.{b}"},
+				map[string]any{"request": "a", "storage": "a"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1214,10 +1214,10 @@ func (s *viewSuite) TestGetMergeAtDifferentLevels(c *C) {
 	view := confdb.View("foo")
 	c.Assert(view, NotNil)
 
-	err = databag.Set("a", map[string]interface{}{
-		"b": map[string]interface{}{
-			"c": map[string]interface{}{
-				"d": map[string]interface{}{
+	err = databag.Set("a", map[string]any{
+		"b": map[string]any{
+			"c": map[string]any{
+				"d": map[string]any{
 					"e": "end",
 				},
 			},
@@ -1227,10 +1227,10 @@ func (s *viewSuite) TestGetMergeAtDifferentLevels(c *C) {
 
 	value, err := view.Get(databag, "a")
 	c.Assert(err, IsNil)
-	expected := map[string]interface{}{
-		"b": map[string]interface{}{
-			"c": map[string]interface{}{
-				"d": map[string]interface{}{
+	expected := map[string]any{
+		"b": map[string]any{
+			"c": map[string]any{
+				"d": map[string]any{
 					"e": "end",
 				},
 			},
@@ -1241,10 +1241,10 @@ func (s *viewSuite) TestGetMergeAtDifferentLevels(c *C) {
 
 func (s *viewSuite) TestBadRequestPaths(c *C) {
 	databag := confdb.NewJSONDatabag()
-	confdb, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "a.{b}.c", "storage": "a.{b}.c"},
+	confdb, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a.{b}.c", "storage": "a.{b}.c"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1253,8 +1253,8 @@ func (s *viewSuite) TestBadRequestPaths(c *C) {
 	view := confdb.View("foo")
 	c.Assert(view, NotNil)
 
-	err = databag.Set("a", map[string]interface{}{
-		"b": map[string]interface{}{
+	err = databag.Set("a", map[string]any{
+		"b": map[string]any{
 			"c": "value",
 		},
 	})
@@ -1322,11 +1322,11 @@ func (s *viewSuite) TestBadRequestPaths(c *C) {
 
 func (s *viewSuite) TestSetAllowedOnSameRequestButDifferentPaths(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "a.b.c", "storage": "new", "access": "write"},
-				map[string]interface{}{"request": "a.b.c", "storage": "old", "access": "write"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a.b.c", "storage": "new", "access": "write"},
+				map[string]any{"request": "a.b.c", "storage": "old", "access": "write"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1348,12 +1348,12 @@ func (s *viewSuite) TestSetAllowedOnSameRequestButDifferentPaths(c *C) {
 
 func (s *viewSuite) TestSetWritesToMoreNestedLast(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
 		// purposefully unordered to check that Set doesn't depend on well-ordered entries in assertions
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "snaps.snapd.name", "storage": "snaps.snapd.name"},
-				map[string]interface{}{"request": "snaps.snapd", "storage": "snaps.snapd"},
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "snaps.snapd.name", "storage": "snaps.snapd.name"},
+				map[string]any{"request": "snaps.snapd", "storage": "snaps.snapd"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1362,7 +1362,7 @@ func (s *viewSuite) TestSetWritesToMoreNestedLast(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "snaps.snapd", map[string]interface{}{
+	err = view.Set(databag, "snaps.snapd", map[string]any{
 		"name": "snapd",
 	})
 	c.Assert(err, IsNil)
@@ -1370,8 +1370,8 @@ func (s *viewSuite) TestSetWritesToMoreNestedLast(c *C) {
 	val, err := databag.Get("snaps")
 	c.Assert(err, IsNil)
 
-	c.Assert(val, DeepEquals, map[string]interface{}{
-		"snapd": map[string]interface{}{
+	c.Assert(val, DeepEquals, map[string]any{
+		"snapd": map[string]any{
 			"name": "snapd",
 		},
 	})
@@ -1379,10 +1379,10 @@ func (s *viewSuite) TestSetWritesToMoreNestedLast(c *C) {
 
 func (s *viewSuite) TestReadWriteRead(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "a.b.c", "storage": "a.b.c"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a.b.c", "storage": "a.b.c"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1391,8 +1391,8 @@ func (s *viewSuite) TestReadWriteRead(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	initData := map[string]interface{}{
-		"b": map[string]interface{}{
+	initData := map[string]any{
+		"b": map[string]any{
 			"c": "end",
 		},
 	}
@@ -1413,10 +1413,10 @@ func (s *viewSuite) TestReadWriteRead(c *C) {
 
 func (s *viewSuite) TestReadWriteSameDataAtDifferentLevels(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "a.b.c", "storage": "a.b.c"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a.b.c", "storage": "a.b.c"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1424,8 +1424,8 @@ func (s *viewSuite) TestReadWriteSameDataAtDifferentLevels(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	initialData := map[string]interface{}{
-		"b": map[string]interface{}{
+	initialData := map[string]any{
+		"b": map[string]any{
 			"c": "end",
 		},
 	}
@@ -1447,10 +1447,10 @@ func (s *viewSuite) TestReadWriteSameDataAtDifferentLevels(c *C) {
 
 func (s *viewSuite) TestSetValueMissingNestedLevels(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "a.b", "storage": "a.b"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a.b", "storage": "a.b"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1461,7 +1461,7 @@ func (s *viewSuite) TestSetValueMissingNestedLevels(c *C) {
 	err = view.Set(databag, "a", "foo")
 	c.Assert(err, ErrorMatches, `cannot set "a" in confdb view acc/confdb/foo: expected map for unmatched request parts but got string`)
 
-	err = view.Set(databag, "a", map[string]interface{}{"c": "foo"})
+	err = view.Set(databag, "a", map[string]any{"c": "foo"})
 	c.Assert(err, ErrorMatches, `cannot set "a" in confdb view acc/confdb/foo: cannot use unmatched part "b" as key in map\[c:foo\]`)
 }
 
@@ -1471,18 +1471,18 @@ func (s *viewSuite) TestGetReadsStorageLessNestedNamespaceBefore(c *C) {
 	// a virtual document from locations in the storage that may evolve over time.
 	// In this example, the storage evolve to have version data in a different place
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "snaps.snapd", "storage": "snaps.snapd"},
-				map[string]interface{}{"request": "snaps.snapd.version", "storage": "anewversion"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "snaps.snapd", "storage": "snaps.snapd"},
+				map[string]any{"request": "snaps.snapd.version", "storage": "anewversion"},
 			},
 		},
 	}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 
-	err = databag.Set("snaps", map[string]interface{}{
-		"snapd": map[string]interface{}{
+	err = databag.Set("snaps", map[string]any{
+		"snapd": map[string]any{
 			"version": 1,
 		},
 	})
@@ -1496,8 +1496,8 @@ func (s *viewSuite) TestGetReadsStorageLessNestedNamespaceBefore(c *C) {
 
 	data, err := view.Get(databag, "snaps")
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{
-		"snapd": map[string]interface{}{
+	c.Assert(data, DeepEquals, map[string]any{
+		"snapd": map[string]any{
 			"version": float64(2),
 		},
 	})
@@ -1505,10 +1505,10 @@ func (s *viewSuite) TestGetReadsStorageLessNestedNamespaceBefore(c *C) {
 
 func (s *viewSuite) TestSetValidateError(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "bar", "storage": "bar"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "bar", "storage": "bar"},
 			},
 		},
 	}, &failingSchema{err: errors.New("expected error")})
@@ -1531,7 +1531,7 @@ func (s *viewSuite) TestSetOverwriteValueWithNewLevel(c *C) {
 
 	data, err := databag.Get("foo")
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{"bar": "baz"})
+	c.Assert(data, DeepEquals, map[string]any{"bar": "baz"})
 }
 
 func (s *viewSuite) TestSetValidatesDataWithSchemaPass(c *C) {
@@ -1559,11 +1559,11 @@ func (s *viewSuite) TestSetValidatesDataWithSchemaPass(c *C) {
 	c.Assert(err, IsNil)
 
 	databag := confdb.NewJSONDatabag()
-	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
-				map[string]interface{}{"request": "bar", "storage": "bar"},
+	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
+				map[string]any{"request": "bar", "storage": "bar"},
 			},
 		},
 	}, schema)
@@ -1583,7 +1583,7 @@ func (s *viewSuite) TestSetPreCheckValueFailsIncompatibleTypes(c *C) {
 	type schemaType struct {
 		schemaStr string
 		typ       string
-		value     interface{}
+		value     any
 	}
 
 	types := []schemaType{
@@ -1634,11 +1634,11 @@ func (s *viewSuite) TestSetPreCheckValueFailsIncompatibleTypes(c *C) {
 }`, one.schemaStr, other.schemaStr)))
 			c.Assert(err, IsNil)
 
-			_, err = confdb.NewSchema("acc", "confdb", map[string]interface{}{
-				"foo": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "foo", "storage": "foo", "access": "write"},
-						map[string]interface{}{"request": "foo", "storage": "bar", "access": "write"},
+			_, err = confdb.NewSchema("acc", "confdb", map[string]any{
+				"foo": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "foo", "storage": "foo", "access": "write"},
+						map[string]any{"request": "foo", "storage": "bar", "access": "write"},
 					},
 				},
 			}, schema)
@@ -1657,11 +1657,11 @@ func (s *viewSuite) TestSetPreCheckValueAllowsIntNumberMismatch(c *C) {
 	c.Assert(err, IsNil)
 
 	databag := confdb.NewJSONDatabag()
-	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo", "access": "write"},
-				map[string]interface{}{"request": "foo", "storage": "bar", "access": "write"},
+	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo", "access": "write"},
+				map[string]any{"request": "foo", "storage": "bar", "access": "write"},
 			},
 		},
 	}, schema)
@@ -1688,11 +1688,11 @@ func (*viewSuite) TestSetPreCheckMultipleAlternativeTypesFail(c *C) {
 	schema, err := confdb.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	_, err = confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo", "access": "write"},
-				map[string]interface{}{"request": "foo", "storage": "bar", "access": "write"},
+	_, err = confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo", "access": "write"},
+				map[string]any{"request": "foo", "storage": "bar", "access": "write"},
 			},
 		},
 	}, schema)
@@ -1713,11 +1713,11 @@ func (*viewSuite) TestAssertionRuleSchemaMismatch(c *C) {
 	schema, err := confdb.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo.b.c", "access": "write"},
-				map[string]interface{}{"request": "foo", "storage": "bar.b.c", "access": "write"},
+	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo.b.c", "access": "write"},
+				map[string]any{"request": "foo", "storage": "bar.b.c", "access": "write"},
 			},
 		},
 	}, schema)
@@ -1742,11 +1742,11 @@ func (*viewSuite) TestSchemaMismatchCheckDifferentLevelPaths(c *C) {
 	schema, err := confdb.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	_, err = confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "snaps.{snap}", "storage": "snaps.{snap}"},
-				map[string]interface{}{"request": "snaps.{snap}.status", "storage": "snaps.{snap}.status"},
+	_, err = confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "snaps.{snap}", "storage": "snaps.{snap}"},
+				map[string]any{"request": "snaps.{snap}.status", "storage": "snaps.{snap}.status"},
 			},
 		},
 	}, schema)
@@ -1764,11 +1764,11 @@ func (*viewSuite) TestSchemaMismatchCheckMultipleAlternativeTypesHappy(c *C) {
 	c.Assert(err, IsNil)
 
 	databag := confdb.NewJSONDatabag()
-	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo", "access": "write"},
-				map[string]interface{}{"request": "foo", "storage": "bar", "access": "write"},
+	confdbSchema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo", "access": "write"},
+				map[string]any{"request": "foo", "storage": "bar", "access": "write"},
 			},
 		},
 	}, schema)
@@ -1783,10 +1783,10 @@ func (*viewSuite) TestSchemaMismatchCheckMultipleAlternativeTypesHappy(c *C) {
 
 func (s *viewSuite) TestSetUnmatchedPlaceholderLeaf(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.{bar}", "storage": "foo.{bar}"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.{bar}", "storage": "foo.{bar}"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1795,7 +1795,7 @@ func (s *viewSuite) TestSetUnmatchedPlaceholderLeaf(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"bar": "value",
 		"baz": "other",
 	})
@@ -1803,7 +1803,7 @@ func (s *viewSuite) TestSetUnmatchedPlaceholderLeaf(c *C) {
 
 	data, err := view.Get(databag, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{
+	c.Assert(data, DeepEquals, map[string]any{
 		"bar": "value",
 		"baz": "other",
 	})
@@ -1811,10 +1811,10 @@ func (s *viewSuite) TestSetUnmatchedPlaceholderLeaf(c *C) {
 
 func (s *viewSuite) TestSetUnmatchedPlaceholderMidPath(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.{bar}.nested", "storage": "foo.{bar}.nested"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.{bar}.nested", "storage": "foo.{bar}.nested"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1823,26 +1823,26 @@ func (s *viewSuite) TestSetUnmatchedPlaceholderMidPath(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
-		"bar": map[string]interface{}{"nested": "value"},
-		"baz": map[string]interface{}{"nested": "other"},
+	err = view.Set(databag, "foo", map[string]any{
+		"bar": map[string]any{"nested": "value"},
+		"baz": map[string]any{"nested": "other"},
 	})
 	c.Assert(err, IsNil)
 
 	data, err := view.Get(databag, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{
-		"bar": map[string]interface{}{"nested": "value"},
-		"baz": map[string]interface{}{"nested": "other"},
+	c.Assert(data, DeepEquals, map[string]any{
+		"bar": map[string]any{"nested": "value"},
+		"baz": map[string]any{"nested": "other"},
 	})
 }
 
 func (s *viewSuite) TestSetManyUnmatchedPlaceholders(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.{bar}.a.{baz}", "storage": "foo.{bar}.{baz}"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.{bar}.a.{baz}", "storage": "foo.{bar}.{baz}"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1851,12 +1851,12 @@ func (s *viewSuite) TestSetManyUnmatchedPlaceholders(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
-		"a": map[string]interface{}{"a": map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
+		"a": map[string]any{"a": map[string]any{
 			"c": "value",
 			"d": "other",
 		}},
-		"b": map[string]interface{}{"a": map[string]interface{}{
+		"b": map[string]any{"a": map[string]any{
 			"e": "value",
 			"f": "other",
 		}},
@@ -1865,12 +1865,12 @@ func (s *viewSuite) TestSetManyUnmatchedPlaceholders(c *C) {
 
 	data, err := view.Get(databag, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{
-		"a": map[string]interface{}{"a": map[string]interface{}{
+	c.Assert(data, DeepEquals, map[string]any{
+		"a": map[string]any{"a": map[string]any{
 			"c": "value",
 			"d": "other",
 		}},
-		"b": map[string]interface{}{"a": map[string]interface{}{
+		"b": map[string]any{"a": map[string]any{
 			"e": "value",
 			"f": "other",
 		}},
@@ -1879,10 +1879,10 @@ func (s *viewSuite) TestSetManyUnmatchedPlaceholders(c *C) {
 
 func (s *viewSuite) TestUnsetUnmatchedPlaceholderLast(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.{bar}", "storage": "foo.{bar}"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.{bar}", "storage": "foo.{bar}"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1891,7 +1891,7 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderLast(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"bar": "value",
 		"baz": "other",
 	})
@@ -1907,11 +1907,11 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderLast(c *C) {
 
 func (s *viewSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "all.{bar}", "storage": "foo.{bar}"},
-				map[string]interface{}{"request": "one.{bar}", "storage": "foo.{bar}.one"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "all.{bar}", "storage": "foo.{bar}"},
+				map[string]any{"request": "one.{bar}", "storage": "foo.{bar}.one"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1920,18 +1920,18 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "all", map[string]interface{}{
+	err = view.Set(databag, "all", map[string]any{
 		// should remove only the "one" path
-		"a": map[string]interface{}{
+		"a": map[string]any{
 			"one": "value",
 			"two": "other",
 		},
 		// the nested value should be removed, leaving an empty map
-		"b": map[string]interface{}{
+		"b": map[string]any{
 			"one": "value",
 		},
 		// should be untouched (no "one" path)
-		"c": map[string]interface{}{
+		"c": map[string]any{
 			"two": "value",
 		},
 	})
@@ -1942,12 +1942,12 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {
 
 	val, err := view.Get(databag, "all")
 	c.Assert(err, IsNil)
-	c.Assert(val, DeepEquals, map[string]interface{}{
-		"a": map[string]interface{}{
+	c.Assert(val, DeepEquals, map[string]any{
+		"a": map[string]any{
 			"two": "other",
 		},
-		"b": map[string]interface{}{},
-		"c": map[string]interface{}{
+		"b": map[string]any{},
+		"c": map[string]any{
 			"two": "value",
 		},
 	})
@@ -1957,8 +1957,8 @@ func (s *viewSuite) TestGetValuesThroughPaths(c *C) {
 	type testcase struct {
 		path     string
 		suffix   []string
-		value    interface{}
-		expected map[string]interface{}
+		value    any
+		expected map[string]any
 		err      string
 	}
 
@@ -1967,41 +1967,41 @@ func (s *viewSuite) TestGetValuesThroughPaths(c *C) {
 			path:     "foo.bar",
 			suffix:   nil,
 			value:    "value",
-			expected: map[string]interface{}{"foo.bar": "value"},
+			expected: map[string]any{"foo.bar": "value"},
 		},
 		{
 			path:     "foo.{bar}",
 			suffix:   []string{"{bar}"},
-			value:    map[string]interface{}{"a": "value", "b": "other"},
-			expected: map[string]interface{}{"foo.a": "value", "foo.b": "other"},
+			value:    map[string]any{"a": "value", "b": "other"},
+			expected: map[string]any{"foo.a": "value", "foo.b": "other"},
 		},
 		{
 			path:   "foo.{bar}.baz",
 			suffix: []string{"{bar}", "baz"},
-			value: map[string]interface{}{
-				"a": map[string]interface{}{"baz": "value"},
-				"b": map[string]interface{}{"baz": "other"},
+			value: map[string]any{
+				"a": map[string]any{"baz": "value"},
+				"b": map[string]any{"baz": "other"},
 			},
-			expected: map[string]interface{}{"foo.a.baz": "value", "foo.b.baz": "other"},
+			expected: map[string]any{"foo.a.baz": "value", "foo.b.baz": "other"},
 		},
 		{
 			path:   "foo.{bar}.{baz}.last",
 			suffix: []string{"{bar}", "{baz}"},
-			value: map[string]interface{}{
-				"a": map[string]interface{}{"b": "value"},
-				"c": map[string]interface{}{"d": "other"},
+			value: map[string]any{
+				"a": map[string]any{"b": "value"},
+				"c": map[string]any{"d": "other"},
 			},
-			expected: map[string]interface{}{"foo.a.b.last": "value", "foo.c.d.last": "other"},
+			expected: map[string]any{"foo.a.b.last": "value", "foo.c.d.last": "other"},
 		},
 
 		{
 			path:   "foo.{bar}",
 			suffix: []string{"{bar}", "baz"},
-			value: map[string]interface{}{
-				"a": map[string]interface{}{"baz": "value", "ignore": 1},
-				"b": map[string]interface{}{"baz": "other", "ignore": 1},
+			value: map[string]any{
+				"a": map[string]any{"baz": "value", "ignore": 1},
+				"b": map[string]any{"baz": "other", "ignore": 1},
 			},
-			expected: map[string]interface{}{"foo.a": "value", "foo.b": "other"},
+			expected: map[string]any{"foo.a": "value", "foo.b": "other"},
 		},
 		{
 			path:   "foo.{bar}",
@@ -2012,9 +2012,9 @@ func (s *viewSuite) TestGetValuesThroughPaths(c *C) {
 		{
 			path:   "foo.{bar}",
 			suffix: []string{"{bar}", "baz"},
-			value: map[string]interface{}{
-				"a": map[string]interface{}{"notbaz": 1},
-				"b": map[string]interface{}{"notbaz": 1},
+			value: map[string]any{
+				"a": map[string]any{"notbaz": 1},
+				"b": map[string]any{"notbaz": 1},
 			},
 			err: `cannot use unmatched part "baz" as key in map\[notbaz:1\]`,
 		},
@@ -2037,39 +2037,39 @@ func (s *viewSuite) TestGetValuesThroughPaths(c *C) {
 func (s *viewSuite) TestViewSetErrorIfValueContainsUnusedParts(c *C) {
 	type testcase struct {
 		request string
-		value   interface{}
+		value   any
 		err     string
 	}
 
 	tcs := []testcase{
 		{
 			request: "a",
-			value: map[string]interface{}{
-				"b": map[string]interface{}{"d": "value", "u": 1},
+			value: map[string]any{
+				"b": map[string]any{"d": "value", "u": 1},
 			},
 			err: `cannot set "a" in confdb view acc/confdb/foo: value contains unused data under "b.u"`,
 		},
 		{
 			request: "a",
-			value: map[string]interface{}{
-				"b": map[string]interface{}{"d": "value", "u": 1},
-				"c": map[string]interface{}{"d": "value"},
+			value: map[string]any{
+				"b": map[string]any{"d": "value", "u": 1},
+				"c": map[string]any{"d": "value"},
 			},
 			err: `cannot set "a" in confdb view acc/confdb/foo: value contains unused data under "b.u"`,
 		},
 		{
 			request: "b",
-			value: map[string]interface{}{
-				"e": []interface{}{"a"},
+			value: map[string]any{
+				"e": []any{"a"},
 				"f": 1,
 			},
 			err: `cannot set "b" in confdb view acc/confdb/foo: value contains unused data under "e"`,
 		},
 		{
 			request: "c",
-			value: map[string]interface{}{
-				"d": map[string]interface{}{
-					"e": map[string]interface{}{
+			value: map[string]any{
+				"d": map[string]any{
+					"e": map[string]any{
 						"f": "value",
 					},
 					"f": 1,
@@ -2082,12 +2082,12 @@ func (s *viewSuite) TestViewSetErrorIfValueContainsUnusedParts(c *C) {
 	for i, tc := range tcs {
 		cmt := Commentf("failed test number %d", i+1)
 		databag := confdb.NewJSONDatabag()
-		schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-			"foo": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "a.{x}.d", "storage": "a.{x}"},
-					map[string]interface{}{"request": "c.d.e.f", "storage": "d"},
-					map[string]interface{}{"request": "b.f", "storage": "b.f"},
+		schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+			"foo": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "a.{x}.d", "storage": "a.{x}"},
+					map[string]any{"request": "c.d.e.f", "storage": "d"},
+					map[string]any{"request": "b.f", "storage": "b.f"},
 				},
 			},
 		}, confdb.NewJSONSchema())
@@ -2106,17 +2106,17 @@ func (s *viewSuite) TestViewSetErrorIfValueContainsUnusedParts(c *C) {
 }
 
 func (*viewSuite) TestViewSummaryWrongType(c *C) {
-	for _, val := range []interface{}{
+	for _, val := range []any{
 		1,
 		true,
-		[]interface{}{"foo"},
-		map[string]interface{}{"foo": "bar"},
+		[]any{"foo"},
+		map[string]any{"foo": "bar"},
 	} {
-		schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-			"foo": map[string]interface{}{
+		schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+			"foo": map[string]any{
 				"summary": val,
-				"rules": []interface{}{
-					map[string]interface{}{"request": "foo", "storage": "foo"},
+				"rules": []any{
+					map[string]any{"request": "foo", "storage": "foo"},
 				},
 			},
 		}, nil)
@@ -2126,11 +2126,11 @@ func (*viewSuite) TestViewSummaryWrongType(c *C) {
 }
 
 func (*viewSuite) TestViewSummary(c *C) {
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
 			"summary": "some summary of the view",
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -2140,12 +2140,12 @@ func (*viewSuite) TestViewSummary(c *C) {
 
 func (s *viewSuite) TestGetEntireView(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.{bar}", "storage": "foo-path.{bar}"},
-				map[string]interface{}{"request": "abc", "storage": "abc-path"},
-				map[string]interface{}{"request": "write-only", "storage": "write-only", "access": "write"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.{bar}", "storage": "foo-path.{bar}"},
+				map[string]any{"request": "abc", "storage": "abc-path"},
+				map[string]any{"request": "write-only", "storage": "write-only", "access": "write"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -2154,7 +2154,7 @@ func (s *viewSuite) TestGetEntireView(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"bar": "value",
 		"baz": "other",
 	})
@@ -2169,8 +2169,8 @@ func (s *viewSuite) TestGetEntireView(c *C) {
 	result, err := view.Get(databag, "")
 	c.Assert(err, IsNil)
 
-	c.Assert(result, DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Assert(result, DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"bar": "value",
 			"baz": "other",
 		},
@@ -2179,14 +2179,14 @@ func (s *viewSuite) TestGetEntireView(c *C) {
 }
 
 func (*viewSuite) TestViewContentRule(c *C) {
-	views := map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{
+	views := map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{
 					"request": "a",
 					"storage": "c",
-					"content": []interface{}{
-						map[string]interface{}{
+					"content": []any{
+						map[string]any{
 							"request": "b",
 							"storage": "d",
 						},
@@ -2217,15 +2217,15 @@ func (*viewSuite) TestViewContentRule(c *C) {
 }
 
 func (*viewSuite) TestViewWriteContentRuleNestedInRead(c *C) {
-	views := map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{
+	views := map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{
 					"request": "a",
 					"storage": "c",
 					"access":  "read",
-					"content": []interface{}{
-						map[string]interface{}{
+					"content": []any{
+						map[string]any{
 							"request": "b",
 							"storage": "d",
 							"access":  "write",
@@ -2249,35 +2249,35 @@ func (*viewSuite) TestViewWriteContentRuleNestedInRead(c *C) {
 
 	val, err := view.Get(databag, "a")
 	c.Assert(err, IsNil)
-	c.Assert(val, DeepEquals, map[string]interface{}{"d": "value"})
+	c.Assert(val, DeepEquals, map[string]any{"d": "value"})
 }
 
 func (*viewSuite) TestViewInvalidContentRules(c *C) {
 	type testcase struct {
-		content interface{}
+		content any
 		err     string
 	}
 
 	tcs := []testcase{
 		{
-			content: []interface{}{},
+			content: []any{},
 			err:     `.*"content" must be a non-empty list`,
 		},
 		{
-			content: map[string]interface{}{},
+			content: map[string]any{},
 			err:     `.*"content" must be a non-empty list`,
 		},
 		{
-			content: []interface{}{map[string]interface{}{"request": "a"}},
+			content: []any{map[string]any{"request": "a"}},
 			err:     `.*view rules must have a "storage" field`,
 		},
 	}
 
 	for _, tc := range tcs {
-		rules := map[string]interface{}{
-			"bar": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{
+		rules := map[string]any{
+			"bar": map[string]any{
+				"rules": []any{
+					map[string]any{
 						"request": "a",
 						"storage": "c",
 						"content": tc.content,
@@ -2292,18 +2292,18 @@ func (*viewSuite) TestViewInvalidContentRules(c *C) {
 }
 
 func (*viewSuite) TestViewSeveralNestedContentRules(c *C) {
-	rules := map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{
+	rules := map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{
 					"request": "a",
 					"storage": "a",
-					"content": []interface{}{
-						map[string]interface{}{
+					"content": []any{
+						map[string]any{
 							"request": "b.c",
 							"storage": "b.c",
-							"content": []interface{}{
-								map[string]interface{}{
+							"content": []any{
+								map[string]any{
 									"request": "d",
 									"storage": "d",
 								},
@@ -2329,10 +2329,10 @@ func (*viewSuite) TestViewSeveralNestedContentRules(c *C) {
 }
 
 func (*viewSuite) TestViewInvalidMapKeys(c *C) {
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{
 					"request": "foo",
 					"storage": "foo",
 				},
@@ -2345,41 +2345,41 @@ func (*viewSuite) TestViewInvalidMapKeys(c *C) {
 	view := schema.View("bar")
 
 	type testcase struct {
-		value      interface{}
+		value      any
 		invalidKey string
 	}
 
 	tcs := []testcase{
 		{
-			value:      map[string]interface{}{"-foo": 2},
+			value:      map[string]any{"-foo": 2},
 			invalidKey: "-foo",
 		},
 		{
-			value:      map[string]interface{}{"foo--bar": 2},
+			value:      map[string]any{"foo--bar": 2},
 			invalidKey: "foo--bar",
 		},
 		{
-			value:      map[string]interface{}{"foo-": 2},
+			value:      map[string]any{"foo-": 2},
 			invalidKey: "foo-",
 		},
 		{
-			value:      map[string]interface{}{"foo": map[string]interface{}{"-bar": 2}},
+			value:      map[string]any{"foo": map[string]any{"-bar": 2}},
 			invalidKey: "-bar",
 		},
 		{
-			value:      map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz-": 2}}},
+			value:      map[string]any{"foo": map[string]any{"bar": map[string]any{"baz-": 2}}},
 			invalidKey: "baz-",
 		},
 		{
-			value:      []interface{}{map[string]interface{}{"foo": 2}, map[string]interface{}{"bar-": 2}},
+			value:      []any{map[string]any{"foo": 2}, map[string]any{"bar-": 2}},
 			invalidKey: "bar-",
 		},
 		{
-			value:      []interface{}{nil, map[string]interface{}{"bar-": 2}},
+			value:      []any{nil, map[string]any{"bar-": 2}},
 			invalidKey: "bar-",
 		},
 		{
-			value:      map[string]interface{}{"foo": nil, "bar": map[string]interface{}{"-baz": 2}},
+			value:      map[string]any{"foo": nil, "bar": map[string]any{"-baz": 2}},
 			invalidKey: "-baz",
 		},
 	}
@@ -2393,12 +2393,12 @@ func (*viewSuite) TestViewInvalidMapKeys(c *C) {
 
 func (s *viewSuite) TestSetUsingMapWithNilValuesAtLeaves(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
-				map[string]interface{}{"request": "foo.a", "storage": "foo.a"},
-				map[string]interface{}{"request": "foo.b", "storage": "foo.b"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
+				map[string]any{"request": "foo.a", "storage": "foo.a"},
+				map[string]any{"request": "foo.b", "storage": "foo.b"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -2407,13 +2407,13 @@ func (s *viewSuite) TestSetUsingMapWithNilValuesAtLeaves(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"a": "value",
 		"b": "other",
 	})
 	c.Assert(err, IsNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"a": nil,
 		"b": nil,
 	})
@@ -2421,16 +2421,16 @@ func (s *viewSuite) TestSetUsingMapWithNilValuesAtLeaves(c *C) {
 
 	value, err := view.Get(databag, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{})
+	c.Assert(value, DeepEquals, map[string]any{})
 }
 
 func (s *viewSuite) TestSetWithMultiplePathsNestedAtLeaves(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "confdb", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.a", "storage": "foo.a"},
-				map[string]interface{}{"request": "foo.b", "storage": "foo.b"},
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.a", "storage": "foo.a"},
+				map[string]any{"request": "foo.b", "storage": "foo.b"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -2439,8 +2439,8 @@ func (s *viewSuite) TestSetWithMultiplePathsNestedAtLeaves(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
-		"a": map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
+		"a": map[string]any{
 			"c": "value",
 			"d": "other",
 		},
@@ -2448,8 +2448,8 @@ func (s *viewSuite) TestSetWithMultiplePathsNestedAtLeaves(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
-		"a": map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
+		"a": map[string]any{
 			"d": nil,
 		},
 		"b": nil,
@@ -2458,18 +2458,18 @@ func (s *viewSuite) TestSetWithMultiplePathsNestedAtLeaves(c *C) {
 
 	value, err := view.Get(databag, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(value, DeepEquals, map[string]interface{}{
+	c.Assert(value, DeepEquals, map[string]any{
 		// consistent with the previous configuration mechanism
-		"a": map[string]interface{}{},
+		"a": map[string]any{},
 	})
 }
 
 func (s *viewSuite) TestSetWithNilAndNonNilLeaves(c *C) {
 	databag := confdb.NewJSONDatabag()
-	schema, err := confdb.NewSchema("acc", "db", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
+	schema, err := confdb.NewSchema("acc", "db", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -2478,13 +2478,13 @@ func (s *viewSuite) TestSetWithNilAndNonNilLeaves(c *C) {
 	view := schema.View("foo")
 	c.Assert(view, NotNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"a": "value",
 		"b": "other",
 	})
 	c.Assert(err, IsNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"a": nil,
 		"c": "value",
 	})
@@ -2493,7 +2493,7 @@ func (s *viewSuite) TestSetWithNilAndNonNilLeaves(c *C) {
 	value, err := view.Get(databag, "foo")
 	c.Assert(err, IsNil)
 	// nil values aren't stored but non-nil values are
-	c.Assert(value, DeepEquals, map[string]interface{}{
+	c.Assert(value, DeepEquals, map[string]any{
 		"c": "value",
 	})
 }
@@ -2502,10 +2502,10 @@ func (*viewSuite) TestSetEnforcesNestednessLimit(c *C) {
 	restore := confdb.MockMaxValueDepth(2)
 	defer restore()
 
-	schema, err := confdb.NewSchema("acc", "foo", map[string]interface{}{
-		"bar": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{
+	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
+		"bar": map[string]any{
+			"rules": []any{
+				map[string]any{
 					"request": "foo",
 					"storage": "foo",
 				},
@@ -2517,13 +2517,13 @@ func (*viewSuite) TestSetEnforcesNestednessLimit(c *C) {
 	databag := confdb.NewJSONDatabag()
 	view := schema.View("bar")
 
-	err = view.Set(databag, "foo", map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
 		"bar": "baz",
 	})
 	c.Assert(err, IsNil)
 
-	err = view.Set(databag, "foo", map[string]interface{}{
-		"bar": map[string]interface{}{
+	err = view.Set(databag, "foo", map[string]any{
+		"bar": map[string]any{
 			"baz": "value",
 		},
 	})
@@ -2532,7 +2532,7 @@ func (*viewSuite) TestSetEnforcesNestednessLimit(c *C) {
 
 func (*viewSuite) TestGetAffectedViews(c *C) {
 	type testcase struct {
-		views    map[string]interface{}
+		views    map[string]any
 		affected []string
 		modified string
 	}
@@ -2540,10 +2540,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 	tcs := []testcase{
 		{
 			// same path
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "a"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "a"},
 					},
 				},
 			},
@@ -2552,10 +2552,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// view path is more specific
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "a.b"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "a.b"},
 					},
 				},
 			},
@@ -2564,10 +2564,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// view path is more generic
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "a"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "a"},
 					},
 				},
 			},
@@ -2576,10 +2576,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// unrelated
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "a"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "a"},
 					},
 				},
 			},
@@ -2587,10 +2587,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// partially shared path but diverges at the end
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "a.b"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "a.b"},
 					},
 				},
 			},
@@ -2598,10 +2598,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// view path contains placeholder
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a.{x}", "storage": "a.{x}.c"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a.{x}", "storage": "a.{x}.c"},
 					},
 				},
 			},
@@ -2610,10 +2610,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// view path ends in placeholder
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a.{x}", "storage": "a.{x}"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a.{x}", "storage": "a.{x}"},
 					},
 				},
 			},
@@ -2622,10 +2622,10 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// path has placeholder but diverges after
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a.{x}", "storage": "a.{x}.b"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a.{x}", "storage": "a.{x}.b"},
 					},
 				},
 			},
@@ -2633,21 +2633,21 @@ func (*viewSuite) TestGetAffectedViews(c *C) {
 		},
 		{
 			// several affected views
-			views: map[string]interface{}{
-				"view-1": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "d", "storage": "d"},
+			views: map[string]any{
+				"view-1": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "d", "storage": "d"},
 					},
 				},
-				"view-2": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "{x}.b", "storage": "{x}.b"},
-						map[string]interface{}{"request": "{x}.c", "storage": "{x}.c"},
+				"view-2": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "{x}.b", "storage": "{x}.b"},
+						map[string]any{"request": "{x}.c", "storage": "{x}.c"},
 					},
 				},
-				"view-3": map[string]interface{}{
-					"rules": []interface{}{
-						map[string]interface{}{"request": "a", "storage": "a"},
+				"view-3": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a", "storage": "a"},
 					},
 				},
 			},

--- a/confdb/schema.go
+++ b/confdb/schema.go
@@ -284,7 +284,7 @@ func (s *StorageSchema) parse(raw json.RawMessage) (DatabagSchema, error) {
 
 // parseTypeDefinition tries to parse the raw JSON as a list, a map or a string
 // (the accepted ways to express types).
-func parseTypeDefinition(raw json.RawMessage) (interface{}, error) {
+func parseTypeDefinition(raw json.RawMessage) (any, error) {
 	var typeErr *json.UnmarshalTypeError
 
 	var l []json.RawMessage
@@ -544,7 +544,7 @@ func (v *mapSchema) Validate(raw []byte) error {
 				if err := validator.Validate(val); err != nil {
 					var valErr *ValidationError
 					if errors.As(err, &valErr) {
-						valErr.Path = append([]interface{}{key}, valErr.Path...)
+						valErr.Path = append([]any{key}, valErr.Path...)
 					}
 					return err
 				}
@@ -565,7 +565,7 @@ func (v *mapSchema) Validate(raw []byte) error {
 			if err := v.keySchema.Validate(rawKey); err != nil {
 				var valErr *ValidationError
 				if errors.As(err, &valErr) {
-					valErr.Path = append([]interface{}{k}, valErr.Path...)
+					valErr.Path = append([]any{k}, valErr.Path...)
 				}
 				return err
 			}
@@ -577,7 +577,7 @@ func (v *mapSchema) Validate(raw []byte) error {
 			if err := v.valueSchema.Validate(val); err != nil {
 				var valErr *ValidationError
 				if errors.As(err, &valErr) {
-					valErr.Path = append([]interface{}{k}, valErr.Path...)
+					valErr.Path = append([]any{k}, valErr.Path...)
 				}
 				return err
 			}
@@ -991,7 +991,7 @@ func (v *anySchema) Validate(raw []byte) (err error) {
 		}
 	}()
 
-	var val interface{}
+	var val any
 	if err := json.Unmarshal(raw, &val); err != nil {
 		return err
 	}
@@ -1225,7 +1225,7 @@ func (v *arraySchema) Validate(raw []byte) error {
 		if err := v.elementType.Validate([]byte(val)); err != nil {
 			var vErr *ValidationError
 			if errors.As(err, &vErr) {
-				vErr.Path = append([]interface{}{e}, vErr.Path...)
+				vErr.Path = append([]any{e}, vErr.Path...)
 			}
 			return err
 		}
@@ -1309,7 +1309,7 @@ func (v *arraySchema) expectsConstraints() bool { return true }
 // to have more concise errors when there are many possible types
 // https://github.com/snapcore/snapd/pull/13502#discussion_r1463658230
 type ValidationError struct {
-	Path []interface{}
+	Path []any
 	Err  error
 }
 
@@ -1345,7 +1345,7 @@ func validationErrorFrom(err error) error {
 	return &ValidationError{Err: err}
 }
 
-func validationErrorf(format string, v ...interface{}) error {
+func validationErrorf(format string, v ...any) error {
 	return &ValidationError{Err: fmt.Errorf(format, v...)}
 }
 
@@ -1358,7 +1358,7 @@ func (e *schemaAtError) Error() string {
 	return e.err.Error()
 }
 
-func schemaAtErrorf(path []string, format string, v ...interface{}) error {
+func schemaAtErrorf(path []string, format string, v ...any) error {
 	return &schemaAtError{
 		left: len(path),
 		err:  fmt.Errorf(format, v...),

--- a/confdb/schema_test.go
+++ b/confdb/schema_test.go
@@ -1861,25 +1861,25 @@ func (*schemaSuite) TestPathManyUserDefinedTypeReferences(c *C) {
 
 func (*schemaSuite) TestValidationError(c *C) {
 	type testcase struct {
-		path     []interface{}
+		path     []any
 		expected string
 	}
 
 	cases := []testcase{
 		{
-			path:     []interface{}{"foo", "bar"},
+			path:     []any{"foo", "bar"},
 			expected: "foo.bar",
 		},
 		{
-			path:     []interface{}{"foo", 1, "bar"},
+			path:     []any{"foo", 1, "bar"},
 			expected: "foo[1].bar",
 		},
 		{
-			path:     []interface{}{"foo", 1, 2, "bar"},
+			path:     []any{"foo", 1, 2, "bar"},
 			expected: "foo[1][2].bar",
 		},
 		{
-			path:     []interface{}{"foo", 2.9, 1},
+			path:     []any{"foo", 2.9, 1},
 			expected: "foo.<n/a>[1]",
 		},
 	}
@@ -1898,7 +1898,7 @@ func (*schemaSuite) TestUnexpectedTypes(c *C) {
 	type testcase struct {
 		schemaType   string
 		expectedType string
-		testValue    interface{}
+		testValue    any
 	}
 
 	tcs := []testcase{
@@ -1959,7 +1959,7 @@ func (*schemaSuite) TestAlternativeTypesHappy(c *C) {
 	schema, err := confdb.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	for _, val := range []interface{}{`"one"`, `1`} {
+	for _, val := range []any{`"one"`, `1`} {
 		input := []byte(fmt.Sprintf(`{"foo":%s}`, val))
 		err = schema.Validate(input)
 		c.Assert(err, IsNil)
@@ -1976,7 +1976,7 @@ func (*schemaSuite) TestAlternativeTypesFail(c *C) {
 	schema, err := confdb.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	for _, val := range []interface{}{"1.1", "true", `{"bar": 1}`, `[1, 2]`} {
+	for _, val := range []any{"1.1", "true", `{"bar": 1}`, `[1, 2]`} {
 		input := []byte(fmt.Sprintf(`{"foo":%s}`, val))
 		err = schema.Validate(input)
 		c.Assert(err, ErrorMatches, `cannot accept element in "foo": no matching schema:
@@ -2003,7 +2003,7 @@ func (*schemaSuite) TestAlternativeTypesWithConstraintsHappy(c *C) {
 	schema, err := confdb.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	for _, val := range []interface{}{"3", "0", `"Bar"`, `"bar"`} {
+	for _, val := range []any{"3", "0", `"Bar"`, `"bar"`} {
 		input := []byte(fmt.Sprintf(`{"foo":%s}`, val))
 		err = schema.Validate(input)
 		c.Assert(err, IsNil)
@@ -2048,7 +2048,7 @@ func (*schemaSuite) TestAlternativeTypesNestedHappy(c *C) {
 	schema, err := confdb.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	for _, val := range []interface{}{`"one"`, `1`, `1.3`} {
+	for _, val := range []any{`"one"`, `1`, `1.3`} {
 		input := []byte(fmt.Sprintf(`{"foo":%s}`, val))
 		err = schema.Validate(input)
 		c.Assert(err, IsNil)

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -280,8 +280,8 @@ plugs:
 	// Now connect the marker interface
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"some-snap:snap-themes-control core:snap-themes-control": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"some-snap:snap-themes-control core:snap-themes-control": map[string]any{
 			"interface": "snap-themes-control",
 		},
 	})
@@ -295,11 +295,11 @@ plugs:
 
 	// Now connect both interfaces
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"some-snap:snap-themes-control core:snap-themes-control": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"some-snap:snap-themes-control core:snap-themes-control": map[string]any{
 			"interface": "snap-themes-control",
 		},
-		"some-snap:snap-refresh-control core:snap-refresh-control": map[string]interface{}{
+		"some-snap:snap-refresh-control core:snap-refresh-control": map[string]any{
 			"interface": "snap-refresh-control",
 		},
 	})
@@ -312,8 +312,8 @@ plugs:
 
 	// A left over "undesired" connection does not grant access
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"some-snap:snap-themes-control core:snap-themes-control": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"some-snap:snap-themes-control core:snap-themes-control": map[string]any{
 			"interface": "snap-themes-control",
 			"undesired": true,
 		},
@@ -545,11 +545,11 @@ plugs:
 	// Now connect both interfaces
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"fwupd-app:fwupd-consumer fwupd-app:fwupd-provider": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"fwupd-app:fwupd-consumer fwupd-app:fwupd-provider": map[string]any{
 			"interface": "fwupd",
 		},
-		"connected-fwupd-caller:fwupd fwupd-app:fwupd-provider": map[string]interface{}{
+		"connected-fwupd-caller:fwupd fwupd-app:fwupd-provider": map[string]any{
 			"interface": "fwupd",
 		},
 	})

--- a/daemon/api_aliases_test.go
+++ b/daemon/api_aliases_test.go
@@ -83,7 +83,7 @@ func (s *aliasesSuite) TestAliasSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -135,16 +135,16 @@ func (s *aliasesSuite) TestAliasChangeConflict(c *check.C) {
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 409)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"status-code": 409.,
 		"status":      "Conflict",
-		"result": map[string]interface{}{
+		"result": map[string]any{
 			"message": `snap "alias-snap" has "manip" change in progress`,
 			"kind":    "snap-change-conflict",
-			"value": map[string]interface{}{
+			"value": map[string]any{
 				"change-kind": "manip",
 				"snap-name":   "alias-snap",
 			},
@@ -215,7 +215,7 @@ func (s *aliasesSuite) TestUnaliasSnapSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -270,7 +270,7 @@ func (s *aliasesSuite) TestUnaliasDWIMSnapSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -326,7 +326,7 @@ func (s *aliasesSuite) TestUnaliasAliasSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -408,7 +408,7 @@ func (s *aliasesSuite) TestUnaliasDWIMAliasSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -489,7 +489,7 @@ func (s *aliasesSuite) TestPreferSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)

--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -165,8 +165,8 @@ func assertsFindMany(c *Command, r *http.Request, user *auth.UserState) Response
 
 	if opts.jsonResult {
 		assertsJSON := make([]struct {
-			Headers map[string]interface{} `json:"headers,omitempty"`
-			Body    string                 `json:"body,omitempty"`
+			Headers map[string]any `json:"headers,omitempty"`
+			Body    string         `json:"body,omitempty"`
 		}, len(assertions))
 		for i := range assertions {
 			assertsJSON[i].Headers = assertions[i].Headers()

--- a/daemon/api_asserts_test.go
+++ b/daemon/api_asserts_test.go
@@ -153,7 +153,7 @@ func (s *assertsSuite) TestAssertError(c *check.C) {
 }
 
 func (s *assertsSuite) TestAssertsFindManyAll(c *check.C) {
-	acct := assertstest.NewAccount(s.StoreSigning, "developer1", map[string]interface{}{
+	acct := assertstest.NewAccount(s.StoreSigning, "developer1", map[string]any{
 		"account-id": "developer1-id",
 	}, "")
 	s.addAsserts(acct)
@@ -271,11 +271,11 @@ func (s *assertsSuite) testAssertsFindManyJSONFilter(c *check.C, urlPath string)
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Assert(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, []interface{}{
-		map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, []any{
+		map[string]any{
 			"headers": acct.Headers(),
 		},
 	})
@@ -296,10 +296,10 @@ func (s *assertsSuite) TestAssertsFindManyJSONNoResults(c *check.C) {
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Assert(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, []interface{}{})
+	c.Check(body["result"], check.DeepEquals, []any{})
 }
 
 func (s *assertsSuite) TestAssertsFindManyJSONWithBody(c *check.C) {
@@ -318,16 +318,16 @@ func (s *assertsSuite) TestAssertsFindManyJSONWithBody(c *check.C) {
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	var got []string
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Assert(err, check.IsNil)
-	for _, a := range body["result"].([]interface{}) {
-		h := a.(map[string]interface{})["headers"].(map[string]interface{})
+	for _, a := range body["result"].([]any) {
+		h := a.(map[string]any)["headers"].(map[string]any)
 		got = append(got, h["account-id"].(string)+"/"+h["name"].(string))
 		// check body
 		l, err := strconv.Atoi(h["body-length"].(string))
 		c.Assert(err, check.IsNil)
-		c.Check(a.(map[string]interface{})["body"], check.HasLen, l)
+		c.Check(a.(map[string]any)["body"], check.HasLen, l)
 	}
 	sort.Strings(got)
 	c.Check(got, check.DeepEquals, []string{"can0nical/root", "can0nical/store", "canonical/root", "generic/models"})
@@ -349,14 +349,14 @@ func (s *assertsSuite) TestAssertsFindManyJSONHeadersOnly(c *check.C) {
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	var got []string
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Assert(err, check.IsNil)
-	for _, a := range body["result"].([]interface{}) {
-		h := a.(map[string]interface{})["headers"].(map[string]interface{})
+	for _, a := range body["result"].([]any) {
+		h := a.(map[string]any)["headers"].(map[string]any)
 		got = append(got, h["account-id"].(string)+"/"+h["name"].(string))
 		// check body absent
-		_, ok := a.(map[string]interface{})["body"]
+		_, ok := a.(map[string]any)["body"]
 		c.Assert(ok, check.Equals, false)
 	}
 	sort.Strings(got)
@@ -382,7 +382,7 @@ func (s *assertsSuite) TestAssertsFindManyJSONInvalidParam(c *check.C) {
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
-	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, check.DeepEquals, map[string]any{
 		"message": `"json" query parameter when used must be set to "true" or "headers"`,
 	})
 }
@@ -426,7 +426,7 @@ func (s *assertsSuite) TestAssertsFindManyRemoteInvalidParam(c *check.C) {
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
-	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, check.DeepEquals, map[string]any{
 		"message": `"remote" query parameter when used must be set to "true" or "false" or left unset`,
 	})
 }

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -310,7 +310,7 @@ func newStoreUpdateGoalRecorder(snaps ...snapstate.StoreUpdate) snapstate.Update
 func (s *apiBaseSuite) mockModel(st *state.State, model *asserts.Model) {
 	// realistic model setup
 	if model == nil {
-		model = s.Brands.Model("can0nical", "pc", map[string]interface{}{
+		model = s.Brands.Model("can0nical", "pc", map[string]any{
 			"architecture": "amd64",
 			"gadget":       "gadget",
 			"kernel":       "kernel",
@@ -571,7 +571,7 @@ version: %s
 		return snapInfo
 	}
 
-	devAcct := assertstest.NewAccount(s.StoreSigning, developer, map[string]interface{}{
+	devAcct := assertstest.NewAccount(s.StoreSigning, developer, map[string]any{
 		"account-id": developer + "-id",
 	}, "")
 
@@ -582,7 +582,7 @@ version: %s
 		Validation:  devAcct.Validation(),
 	}
 
-	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"snap-name":    snapName,
@@ -596,7 +596,7 @@ version: %s
 	h := sha3.Sum384(content)
 	dgst, err := asserts.EncodeDigest(crypto.SHA3_384, h[:])
 	c.Assert(err, check.IsNil)
-	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": string(dgst),
 		"snap-size":     "999",
 		"snap-id":       snapID,

--- a/daemon/api_buy_unsupp_test.go
+++ b/daemon/api_buy_unsupp_test.go
@@ -88,7 +88,7 @@ var buyTests = []struct {
 	result               *client.BuyResult
 	err                  error
 	expectedStatus       int
-	expectedResult       interface{}
+	expectedResult       any
 	expectedResponseType daemon.ResponseType
 	expectedBuyOptions   *client.BuyOptions
 }{
@@ -203,8 +203,8 @@ func (s *buySuite) TestBuySnap(c *check.C) {
 var readyToBuyTests = []struct {
 	input    error
 	status   int
-	respType interface{}
-	response interface{}
+	respType any
+	response any
 }{
 	{
 		// Success

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -94,7 +94,7 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	account, schemaName, viewName := vars["account"], vars["confdb-schema"], vars["view"]
 
 	decoder := json.NewDecoder(r.Body)
-	var values map[string]interface{}
+	var values map[string]any
 	if err := decoder.Decode(&values); err != nil {
 		return BadRequest("cannot decode confdb request body: %v", err)
 	}

--- a/daemon/api_connections.go
+++ b/daemon/api_connections.go
@@ -92,8 +92,8 @@ func (b byPlugRef) Less(i, j int) bool {
 
 // mergeAttrs merges attributes from 2 disjoint sets of static and dynamic slot or
 // plug attributes into a single map.
-func mergeAttrs(one map[string]interface{}, other map[string]interface{}) map[string]interface{} {
-	merged := make(map[string]interface{}, len(one)+len(other))
+func mergeAttrs(one map[string]any, other map[string]any) map[string]any {
+	merged := make(map[string]any, len(one)+len(other))
 	for k, v := range one {
 		merged[k] = v
 	}

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -66,7 +66,7 @@ func getBaseDeclaration(st *state.State) Response {
 	if err != nil {
 		return InternalError("cannot get base declaration: %s", err)
 	}
-	return SyncResponse(map[string]interface{}{
+	return SyncResponse(map[string]any{
 		"base-declaration": string(asserts.Encode(bd)),
 	})
 
@@ -354,7 +354,7 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		if err != nil {
 			return InternalError("cannot get model: %v", err)
 		}
-		return SyncResponse(map[string]interface{}{
+		return SyncResponse(map[string]any{
 			"model": string(asserts.Encode(model)),
 		})
 

--- a/daemon/api_debug_seeding.go
+++ b/daemon/api_debug_seeding.go
@@ -52,11 +52,11 @@ type seedingInfo struct {
 
 	// PreseedSystemKey is the system-key that was created during preseeding
 	// (when snap-preseed was ran).
-	PreseedSystemKey interface{} `json:"preseed-system-key,omitempty"`
+	PreseedSystemKey any `json:"preseed-system-key,omitempty"`
 
 	// SeedRestartSystemKey is the system-key that was created on first boot of the
 	// preseeded image.
-	SeedRestartSystemKey interface{} `json:"seed-restart-system-key,omitempty"`
+	SeedRestartSystemKey any `json:"seed-restart-system-key,omitempty"`
 
 	// SeedError is set if no seed change succeeded yet and at
 	// least one was in error. It is set to the error of the
@@ -74,7 +74,7 @@ func getSeedingInfo(st *state.State) Response {
 		return InternalError(err.Error())
 	}
 
-	var preseedSysKey, seedRestartSysKey interface{}
+	var preseedSysKey, seedRestartSysKey any
 	if err := st.Get("preseed-system-key", &preseedSysKey); err != nil && !errors.Is(err, state.ErrNoState) {
 		return InternalError(err.Error())
 	}

--- a/daemon/api_debug_seeding_test.go
+++ b/daemon/api_debug_seeding_test.go
@@ -40,7 +40,7 @@ func (s *seedingDebugSuite) SetUpTest(c *C) {
 	s.daemonWithOverlordMock()
 }
 
-func (s *seedingDebugSuite) getSeedingDebug(c *C) interface{} {
+func (s *seedingDebugSuite) getSeedingDebug(c *C) any {
 	req, err := http.NewRequest("GET", "/v2/debug?aspect=seeding", nil)
 	c.Assert(err, IsNil)
 

--- a/daemon/api_debug_test.go
+++ b/daemon/api_debug_test.go
@@ -107,7 +107,7 @@ func (s *postDebugSuite) TestGetDebugBaseDeclaration(c *check.C) {
 
 	rsp := s.syncReq(c, req, nil)
 
-	c.Check(rsp.Result.(map[string]interface{})["base-declaration"],
+	c.Check(rsp.Result.(map[string]any)["base-declaration"],
 		testutil.Contains, "type: base-declaration")
 }
 
@@ -120,7 +120,7 @@ func mockDurationThreshold() func() {
 	return restore
 }
 
-func (s *postDebugSuite) getDebugTimings(c *check.C, request string) []interface{} {
+func (s *postDebugSuite) getDebugTimings(c *check.C, request string) []any {
 	defer mockDurationThreshold()()
 
 	s.daemonWithOverlordMock()
@@ -169,7 +169,7 @@ func (s *postDebugSuite) getDebugTimings(c *check.C, request string) []interface
 	rsp := s.syncReq(c, req, nil)
 	data, err := json.Marshal(rsp.Result)
 	c.Assert(err, check.IsNil)
-	var dataJSON []interface{}
+	var dataJSON []any
 	json.Unmarshal(data, &dataJSON)
 
 	return dataJSON
@@ -179,7 +179,7 @@ func (s *postDebugSuite) TestGetDebugTimingsSingleChange(c *check.C) {
 	dataJSON := s.getDebugTimings(c, "/v2/debug?aspect=change-timings&change-id=1")
 
 	c.Check(dataJSON, check.HasLen, 1)
-	tmData := dataJSON[0].(map[string]interface{})
+	tmData := dataJSON[0].(map[string]any)
 	c.Check(tmData["change-id"], check.DeepEquals, "1")
 	c.Check(tmData["change-timings"], check.NotNil)
 }
@@ -188,7 +188,7 @@ func (s *postDebugSuite) TestGetDebugTimingsEnsureLatest(c *check.C) {
 	dataJSON := s.getDebugTimings(c, "/v2/debug?aspect=change-timings&ensure=foo&all=false")
 	c.Assert(dataJSON, check.HasLen, 1)
 
-	tmData := dataJSON[0].(map[string]interface{})
+	tmData := dataJSON[0].(map[string]any)
 	c.Check(tmData["change-id"], check.DeepEquals, "2")
 	c.Check(tmData["change-timings"], check.NotNil)
 	c.Check(tmData["total-duration"], check.NotNil)
@@ -198,12 +198,12 @@ func (s *postDebugSuite) TestGetDebugTimingsEnsureAll(c *check.C) {
 	dataJSON := s.getDebugTimings(c, "/v2/debug?aspect=change-timings&ensure=foo&all=true")
 
 	c.Assert(dataJSON, check.HasLen, 2)
-	tmData := dataJSON[0].(map[string]interface{})
+	tmData := dataJSON[0].(map[string]any)
 	c.Check(tmData["change-id"], check.DeepEquals, "1")
 	c.Check(tmData["change-timings"], check.NotNil)
 	c.Check(tmData["total-duration"], check.NotNil)
 
-	tmData = dataJSON[1].(map[string]interface{})
+	tmData = dataJSON[1].(map[string]any)
 	c.Check(tmData["change-id"], check.DeepEquals, "2")
 	c.Check(tmData["change-timings"], check.NotNil)
 	c.Check(tmData["total-duration"], check.NotNil)

--- a/daemon/api_find.go
+++ b/daemon/api_find.go
@@ -267,7 +267,7 @@ func mapRemote(remoteSnap *snap.Info) *client.Snap {
 }
 
 type findResponse struct {
-	Results           interface{}
+	Results           any
 	Sources           []string
 	SuggestedCurrency string
 }

--- a/daemon/api_find_test.go
+++ b/daemon/api_find_test.go
@@ -297,7 +297,7 @@ func (s *findSuite) TestFindCommonID(c *check.C) {
 
 	snaps := snapList(rsp.Result)
 	c.Assert(snaps, check.HasLen, 1)
-	c.Check(snaps[0]["common-ids"], check.DeepEquals, []interface{}{"org.foo"})
+	c.Check(snaps[0]["common-ids"], check.DeepEquals, []any{"org.foo"})
 }
 
 func (s *findSuite) TestFindByCommonID(c *check.C) {
@@ -360,13 +360,13 @@ func (s *findSuite) TestFindOne(c *check.C) {
 	c.Assert(snaps, check.HasLen, 1)
 	c.Check(snaps[0]["name"], check.Equals, "store")
 	c.Check(snaps[0]["base"], check.Equals, "base0")
-	c.Check(snaps[0]["publisher"], check.DeepEquals, map[string]interface{}{
+	c.Check(snaps[0]["publisher"], check.DeepEquals, map[string]any{
 		"id":           "foo-id",
 		"username":     "foo",
 		"display-name": "Foo",
 		"validation":   "verified",
 	})
-	m := snaps[0]["channels"].(map[string]interface{})["stable"].(map[string]interface{})
+	m := snaps[0]["channels"].(map[string]any)["stable"].(map[string]any)
 
 	c.Check(m["revision"], check.Equals, "42")
 }
@@ -531,7 +531,7 @@ func (s *findSuite) TestFindPriced(c *check.C) {
 
 	snap := snaps[0]
 	c.Check(snap["name"], check.Equals, "banana")
-	c.Check(snap["prices"], check.DeepEquals, map[string]interface{}{
+	c.Check(snap["prices"], check.DeepEquals, map[string]any{
 		"EUR": 2.34,
 		"GBP": 1.23,
 	})
@@ -578,14 +578,14 @@ func (s *findSuite) TestFindScreenshotted(c *check.C) {
 	c.Assert(snaps, check.HasLen, 1)
 
 	c.Check(snaps[0]["name"], check.Equals, "test-screenshot")
-	c.Check(snaps[0]["media"], check.DeepEquals, []interface{}{
-		map[string]interface{}{
+	c.Check(snaps[0]["media"], check.DeepEquals, []any{
+		map[string]any{
 			"type":   "screenshot",
 			"url":    "http://example.com/screenshot.png",
 			"width":  float64(800),
 			"height": float64(1280),
 		},
-		map[string]interface{}{
+		map[string]any{
 			"type": "screenshot",
 			"url":  "http://example.com/screenshot2.png",
 		},

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -132,7 +132,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		refreshInfo.Schedule = refreshScheduleStr
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"series":         release.Series,
 		"version":        c.d.Version,
 		"build-id":       buildID,
@@ -140,7 +140,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		"on-classic":     release.OnClassic,
 		"managed":        len(users) > 0,
 		"kernel-version": osutil.KernelVersion(),
-		"locations": map[string]interface{}{
+		"locations": map[string]any{
 			"snap-mount-dir": dirs.SnapMountDir,
 			"snap-bin-dir":   dirs.SnapBinariesDir,
 		},

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -74,7 +74,7 @@ func (s *generalSuite) TestRoot(c *check.C) {
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
-	expected := []interface{}{"TBD"}
+	expected := []any{"TBD"}
 	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 200)
@@ -132,26 +132,26 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"series":  "16",
 		"version": "42b1",
-		"os-release": map[string]interface{}{
+		"os-release": map[string]any{
 			"id":         "distro-id",
 			"version-id": "1.2",
 		},
 		"build-id":   buildID,
 		"on-classic": true,
 		"managed":    false,
-		"locations": map[string]interface{}{
+		"locations": map[string]any{
 			"snap-mount-dir": dirs.SnapMountDir,
 			"snap-bin-dir":   dirs.SnapBinariesDir,
 		},
-		"refresh": map[string]interface{}{
+		"refresh": map[string]any{
 			// only the "timer" field
 			"timer": "8:00~9:00/2",
 		},
 		"confinement":      "partial",
-		"sandbox-features": map[string]interface{}{"confinement-options": []interface{}{"classic", "devmode"}},
+		"sandbox-features": map[string]any{"confinement-options": []any{"classic", "devmode"}},
 		"architecture":     arch.DpkgArchitecture(),
 		"virtualization":   "magic",
 		"system-mode":      "run",
@@ -162,23 +162,23 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	// Ensure that we had a kernel-verrsion but don't check the actual value.
 	const kernelVersionKey = "kernel-version"
-	c.Check(rsp.Result.(map[string]interface{})[kernelVersionKey], check.Not(check.Equals), "")
-	delete(rsp.Result.(map[string]interface{}), kernelVersionKey)
+	c.Check(rsp.Result.(map[string]any)[kernelVersionKey], check.Not(check.Equals), "")
+	delete(rsp.Result.(map[string]any), kernelVersionKey)
 	// Extract "features" field and remove it from result; check it later.
 	const featuresKey = "features"
-	resultFeatures := rsp.Result.(map[string]interface{})[featuresKey]
+	resultFeatures := rsp.Result.(map[string]any)[featuresKey]
 	c.Check(resultFeatures, check.Not(check.Equals), "")
-	delete(rsp.Result.(map[string]interface{}), featuresKey)
+	delete(rsp.Result.(map[string]any), featuresKey)
 
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
 	// Check that "features" is map
-	featuresAll, ok := resultFeatures.(map[string]interface{})
+	featuresAll, ok := resultFeatures.(map[string]any)
 	c.Assert(ok, check.Equals, true)
 	// Ensure that Layouts exists and is feature.FeatureInfo
 	layoutsInfoRaw, exists := featuresAll[features.Layouts.String()]
 	c.Assert(exists, check.Equals, true)
-	layoutsInfo, ok := layoutsInfoRaw.(map[string]interface{})
+	layoutsInfo, ok := layoutsInfoRaw.(map[string]any)
 	c.Assert(ok, check.Equals, true, check.Commentf("%+v", layoutsInfoRaw))
 	// Ensure that Layouts is supported and enabled
 	c.Check(layoutsInfo["supported"], check.Equals, true)
@@ -188,7 +188,7 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	// Ensure that ParallelInstances exists and is a feature.FeatureInfo
 	parallelInstancesInfoRaw, exists := featuresAll[features.ParallelInstances.String()]
 	c.Assert(exists, check.Equals, true)
-	parallelInstancesInfo, ok := parallelInstancesInfoRaw.(map[string]interface{})
+	parallelInstancesInfo, ok := parallelInstancesInfoRaw.(map[string]any)
 	c.Assert(ok, check.Equals, true)
 	// Ensure that ParallelInstances is supported and not enabled
 	c.Check(parallelInstancesInfo["supported"], check.Equals, true)
@@ -198,7 +198,7 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	// Ensure that QuotaGroups exists and is a feature.FeatureInfo
 	quotaGroupsInfoRaw, exists := featuresAll[features.QuotaGroups.String()]
 	c.Assert(exists, check.Equals, true)
-	quotaGroupsInfo, ok := quotaGroupsInfoRaw.(map[string]interface{})
+	quotaGroupsInfo, ok := quotaGroupsInfoRaw.(map[string]any)
 	c.Assert(ok, check.Equals, true)
 	// Ensure that QuotaGroups is unsupported but enabled
 	c.Check(quotaGroupsInfo["supported"], check.Equals, false)
@@ -260,28 +260,28 @@ func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"series":  "16",
 		"version": "42b1",
-		"os-release": map[string]interface{}{
+		"os-release": map[string]any{
 			"id":         "distro-id",
 			"version-id": "1.2",
 		},
 		"build-id":   buildID,
 		"on-classic": true,
 		"managed":    false,
-		"locations": map[string]interface{}{
+		"locations": map[string]any{
 			"snap-mount-dir": dirs.SnapMountDir,
 			"snap-bin-dir":   dirs.SnapBinariesDir,
 		},
-		"refresh": map[string]interface{}{
+		"refresh": map[string]any{
 			// only the "schedule" field
 			"schedule": "00:00-9:00/12:00-13:00",
 		},
 		"confinement": "partial",
-		"sandbox-features": map[string]interface{}{
-			"apparmor":            []interface{}{"feature-1", "feature-2"},
-			"confinement-options": []interface{}{"classic", "devmode"}, // we know it's this because of the release.Mock... calls above
+		"sandbox-features": map[string]any{
+			"apparmor":            []any{"feature-1", "feature-2"},
+			"confinement-options": []any{"classic", "devmode"}, // we know it's this because of the release.Mock... calls above
 		},
 		"architecture":   arch.DpkgArchitecture(),
 		"virtualization": "kvm",
@@ -292,9 +292,9 @@ func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	const kernelVersionKey = "kernel-version"
-	delete(rsp.Result.(map[string]interface{}), kernelVersionKey)
+	delete(rsp.Result.(map[string]any), kernelVersionKey)
 	const featuresKey = "features"
-	delete(rsp.Result.(map[string]interface{}), featuresKey)
+	delete(rsp.Result.(map[string]any), featuresKey)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 
@@ -343,27 +343,27 @@ func (s *generalSuite) testSysInfoSystemMode(c *check.C, mode string) {
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"series":  "16",
 		"version": "42b1",
-		"os-release": map[string]interface{}{
+		"os-release": map[string]any{
 			"id":         "distro-id",
 			"version-id": "1.2",
 		},
 		"build-id":   buildID,
 		"on-classic": false,
 		"managed":    false,
-		"locations": map[string]interface{}{
+		"locations": map[string]any{
 			"snap-mount-dir": dirs.SnapMountDir,
 			"snap-bin-dir":   dirs.SnapBinariesDir,
 		},
-		"refresh": map[string]interface{}{
+		"refresh": map[string]any{
 			"timer": "00:00~24:00/4",
 		},
 		"confinement": "strict",
-		"sandbox-features": map[string]interface{}{
-			"apparmor":            []interface{}{"feature-1", "feature-2"},
-			"confinement-options": []interface{}{"devmode", "strict"}, // we know it's this because of the release.Mock... calls above
+		"sandbox-features": map[string]any{
+			"apparmor":            []any{"feature-1", "feature-2"},
+			"confinement-options": []any{"devmode", "strict"}, // we know it's this because of the release.Mock... calls above
 		},
 		"architecture": arch.DpkgArchitecture(),
 		"system-mode":  mode,
@@ -373,9 +373,9 @@ func (s *generalSuite) testSysInfoSystemMode(c *check.C, mode string) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeSync)
 	const kernelVersionKey = "kernel-version"
-	delete(rsp.Result.(map[string]interface{}), kernelVersionKey)
+	delete(rsp.Result.(map[string]any), kernelVersionKey)
 	const featuresKey = "features"
-	delete(rsp.Result.(map[string]interface{}), featuresKey)
+	delete(rsp.Result.(map[string]any), featuresKey)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 
@@ -409,7 +409,7 @@ func (s *generalSuite) TestSysInfoIsManaged(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rsp := s.syncReq(c, req, nil)
-	c.Check(rsp.Result.(map[string]interface{})["managed"], check.Equals, true)
+	c.Check(rsp.Result.(map[string]any)["managed"], check.Equals, true)
 }
 
 func (s *generalSuite) TestSysInfoWorksDegraded(c *check.C) {
@@ -665,37 +665,37 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         ids[0],
 		"kind":       "install",
 		"summary":    "install...",
 		"status":     "Do",
 		"ready":      false,
 		"spawn-time": "2016-04-21T01:02:03Z",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         ids[2],
 				"kind":       "download",
 				"summary":    "1...",
 				"status":     "Do",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"log":        []any{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
-				"data":       map[string]interface{}{"affected-snaps": []interface{}{"some-snap"}},
+				"data":       map[string]any{"affected-snaps": []any{"some-snap"}},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":         ids[3],
 				"kind":       "activate",
 				"summary":    "2...",
 				"status":     "Do",
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 			},
 		},
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"n": float64(42),
 		},
 	})
@@ -742,10 +742,10 @@ func (s *generalSuite) TestStateChangeAbort(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         ids[0],
 		"kind":       "install",
 		"summary":    "install...",
@@ -753,23 +753,23 @@ func (s *generalSuite) TestStateChangeAbort(c *check.C) {
 		"ready":      true,
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"ready-time": "2016-04-21T01:02:03Z",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         ids[2],
 				"kind":       "download",
 				"summary":    "1...",
 				"status":     "Hold",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"log":        []any{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 				"ready-time": "2016-04-21T01:02:03Z",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":         ids[3],
 				"kind":       "activate",
 				"summary":    "2...",
 				"status":     "Hold",
-				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 				"ready-time": "2016-04-21T01:02:03Z",
 			},
@@ -805,15 +805,15 @@ func (s *generalSuite) TestStateChangeAbortIsReady(c *check.C) {
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(rspe.Status, check.Equals, 400)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"message": fmt.Sprintf("cannot abort change %s with nothing pending", ids[0]),
 	})
 }
 
-func (s *generalSuite) testWarnings(c *check.C, all bool, body io.Reader) (calls string, result interface{}) {
+func (s *generalSuite) testWarnings(c *check.C, all bool, body io.Reader) (calls string, result any) {
 	s.daemon(c)
 
 	s.expectManageAccess()

--- a/daemon/api_interfaces_test.go
+++ b/daemon/api_interfaces_test.go
@@ -150,7 +150,7 @@ func (s *interfacesSuite) TestConnectPlugSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -198,11 +198,11 @@ func (s *interfacesSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "cannot connect consumer:plug (\"test\" interface) to producer:slot (\"different\" interface)",
 		},
 		"status":      "Bad Request",
@@ -236,11 +236,11 @@ func (s *interfacesSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "snap \"consumer\" has no plug named \"missingplug\"",
 		},
 		"status":      "Bad Request",
@@ -272,8 +272,8 @@ func (s *interfacesSuite) TestConnectAlreadyConnected(c *check.C) {
 
 	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, check.IsNil)
-	conns := map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	conns := map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"auto": false,
 		},
 	}
@@ -295,7 +295,7 @@ func (s *interfacesSuite) TestConnectAlreadyConnected(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -329,11 +329,11 @@ func (s *interfacesSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "snap \"producer\" has no slot named \"missingslot\"",
 		},
 		"status":      "Bad Request",
@@ -377,12 +377,12 @@ func (s *interfacesSuite) testConnectFailureNoSnap(c *check.C, installedSnap str
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	if producer {
-		c.Check(body, check.DeepEquals, map[string]interface{}{
-			"result": map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
+			"result": map[string]any{
 				"message": "snap \"consumer\" is not installed",
 			},
 			"status":      "Bad Request",
@@ -390,8 +390,8 @@ func (s *interfacesSuite) testConnectFailureNoSnap(c *check.C, installedSnap str
 			"type":        "error",
 		})
 	} else {
-		c.Check(body, check.DeepEquals, map[string]interface{}{
-			"result": map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
+			"result": map[string]any{
 				"message": "snap \"producer\" is not installed",
 			},
 			"status":      "Bad Request",
@@ -433,16 +433,16 @@ func (s *interfacesSuite) TestConnectPlugChangeConflict(c *check.C) {
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 409)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"status-code": 409.,
 		"status":      "Conflict",
-		"result": map[string]interface{}{
+		"result": map[string]any{
 			"message": `snap "consumer" has "manip" change in progress`,
 			"kind":    "snap-change-conflict",
-			"value": map[string]interface{}{
+			"value": map[string]any{
 				"change-kind": "manip",
 				"snap-name":   "consumer",
 			},
@@ -474,7 +474,7 @@ func (s *interfacesSuite) TestConnectCoreSystemAlias(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -521,8 +521,8 @@ func (s *interfacesSuite) testDisconnect(c *check.C, plugSnap, plugName, slotSna
 
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test",
 		},
 	})
@@ -544,7 +544,7 @@ func (s *interfacesSuite) testDisconnect(c *check.C, plugSnap, plugName, slotSna
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -598,11 +598,11 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "snap \"consumer\" has no plug named \"missingplug\"",
 		},
 		"status":      "Bad Request",
@@ -641,13 +641,13 @@ func (s *interfacesSuite) testDisconnectFailureNoSnap(c *check.C, installedSnap 
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 
 	if producer {
-		c.Check(body, check.DeepEquals, map[string]interface{}{
-			"result": map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
+			"result": map[string]any{
 				"message": "snap \"consumer\" is not installed",
 			},
 			"status":      "Bad Request",
@@ -655,8 +655,8 @@ func (s *interfacesSuite) testDisconnectFailureNoSnap(c *check.C, installedSnap 
 			"type":        "error",
 		})
 	} else {
-		c.Check(body, check.DeepEquals, map[string]interface{}{
-			"result": map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
+			"result": map[string]any{
 				"message": "snap \"producer\" is not installed",
 			},
 			"status":      "Bad Request",
@@ -695,11 +695,11 @@ func (s *interfacesSuite) TestDisconnectPlugNothingToDo(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "nothing to do",
 			"kind":    "interfaces-unchanged",
 		},
@@ -731,11 +731,11 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "snap \"producer\" has no slot named \"missingslot\"",
 		},
 		"status":      "Bad Request",
@@ -766,11 +766,11 @@ func (s *interfacesSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "cannot disconnect consumer:plug from producer:slot, it is not connected",
 		},
 		"status":      "Bad Request",
@@ -802,11 +802,11 @@ func (s *interfacesSuite) TestDisconnectForgetPlugFailureNotConnected(c *check.C
 	s.req(c, req, nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "cannot forget connection consumer:plug from producer:slot, it was not connected",
 		},
 		"status":      "Bad Request",
@@ -833,8 +833,8 @@ func (s *interfacesSuite) TestDisconnectConflict(c *check.C) {
 
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test",
 		},
 	})
@@ -857,16 +857,16 @@ func (s *interfacesSuite) TestDisconnectConflict(c *check.C) {
 
 	c.Check(rec.Code, check.Equals, 409)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"status-code": 409.,
 		"status":      "Conflict",
-		"result": map[string]interface{}{
+		"result": map[string]any{
 			"message": `snap "consumer" has "manip" change in progress`,
 			"kind":    "snap-change-conflict",
-			"value": map[string]interface{}{
+			"value": map[string]any{
 				"change-kind": "manip",
 				"snap-name":   "consumer",
 			},
@@ -892,8 +892,8 @@ func (s *interfacesSuite) TestDisconnectCoreSystemAlias(c *check.C) {
 
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"consumer:plug core:slot": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"consumer:plug core:slot": map[string]any{
 			"interface": "test",
 		},
 	})
@@ -915,7 +915,7 @@ func (s *interfacesSuite) TestDisconnectCoreSystemAlias(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -944,11 +944,11 @@ func (s *interfacesSuite) TestUnsupportedInterfaceRequest(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "cannot decode request body into an interface action: invalid character 'g' looking for beginning of value",
 		},
 		"status":      "Bad Request",
@@ -968,11 +968,11 @@ func (s *interfacesSuite) TestMissingInterfaceAction(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "interface action not specified",
 		},
 		"status":      "Bad Request",
@@ -992,11 +992,11 @@ func (s *interfacesSuite) TestUnsupportedInterfaceAction(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "unsupported interface action: \"foo\"",
 		},
 		"status":      "Bad Request",
@@ -1042,17 +1042,17 @@ plugs:
 
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 		},
-		"another-consumer-def:plug producer:slot": map[string]interface{}{
+		"another-consumer-def:plug producer:slot": map[string]any{
 			"interface": "test",
 			"by-gadget": true,
 			"auto":      true,
 		},
-		"another-consumer-abc:plug producer:slot": map[string]interface{}{
+		"another-consumer-abc:plug producer:slot": map[string]any{
 			"interface": "test",
 			"by-gadget": true,
 			"auto":      true,
@@ -1065,58 +1065,58 @@ plugs:
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
-			"plugs": []interface{}{
-				map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
+			"plugs": []any{
+				map[string]any{
 					"snap":      "another-consumer-abc",
 					"plug":      "plug",
 					"interface": "test",
-					"attrs":     map[string]interface{}{"key": "value"},
-					"apps":      []interface{}{"app"},
+					"attrs":     map[string]any{"key": "value"},
+					"apps":      []any{"app"},
 					"label":     "label",
-					"connections": []interface{}{
-						map[string]interface{}{"snap": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"snap": "producer", "slot": "slot"},
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"snap":      "another-consumer-def",
 					"plug":      "plug",
 					"interface": "test",
-					"attrs":     map[string]interface{}{"key": "value"},
-					"apps":      []interface{}{"app"},
+					"attrs":     map[string]any{"key": "value"},
+					"apps":      []any{"app"},
 					"label":     "label",
-					"connections": []interface{}{
-						map[string]interface{}{"snap": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"snap": "producer", "slot": "slot"},
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"snap":      "consumer",
 					"plug":      "plug",
 					"interface": "test",
-					"attrs":     map[string]interface{}{"key": "value"},
-					"apps":      []interface{}{"app"},
+					"attrs":     map[string]any{"key": "value"},
+					"apps":      []any{"app"},
 					"label":     "label",
-					"connections": []interface{}{
-						map[string]interface{}{"snap": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"snap": "producer", "slot": "slot"},
 					},
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"snap":      "producer",
 					"slot":      "slot",
 					"interface": "test",
-					"attrs":     map[string]interface{}{"key": "value"},
-					"apps":      []interface{}{"app"},
+					"attrs":     map[string]any{"key": "value"},
+					"apps":      []any{"app"},
 					"label":     "label",
-					"connections": []interface{}{
-						map[string]interface{}{"snap": "another-consumer-abc", "plug": "plug"},
-						map[string]interface{}{"snap": "another-consumer-def", "plug": "plug"},
-						map[string]interface{}{"snap": "consumer", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"snap": "another-consumer-abc", "plug": "plug"},
+						map[string]any{"snap": "another-consumer-def", "plug": "plug"},
+						map[string]any{"snap": "consumer", "plug": "plug"},
 					},
 				},
 			},
@@ -1152,29 +1152,29 @@ func (s *interfacesSuite) TestInterfacesModern(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": []interface{}{
-			map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": []any{
+			map[string]any{
 				"name":    "test",
 				"doc-url": "https://snapcraft.io/docs/test-interface",
-				"plugs": []interface{}{
-					map[string]interface{}{
+				"plugs": []any{
+					map[string]any{
 						"snap":  "consumer",
 						"plug":  "plug",
 						"label": "label",
-						"attrs": map[string]interface{}{
+						"attrs": map[string]any{
 							"key": "value",
 						},
 					}},
-				"slots": []interface{}{
-					map[string]interface{}{
+				"slots": []any{
+					map[string]any{
 						"snap":  "producer",
 						"slot":  "slot",
 						"label": "label",
-						"attrs": map[string]interface{}{
+						"attrs": map[string]any{
 							"key": "value",
 						},
 					},
@@ -1195,13 +1195,13 @@ func (s *interfacesSuite) TestInterfacesAllDefaultDocURL(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 
-	if result, ok := body["result"].([]interface{}); ok {
+	if result, ok := body["result"].([]any); ok {
 		for _, content := range result {
-			if contentMap, ok := content.(map[string]interface{}); ok {
+			if contentMap, ok := content.(map[string]any); ok {
 				name := contentMap["name"].(string)
 				summary := contentMap["summary"].(string)
 				docURL := contentMap["doc-url"].(string)

--- a/daemon/api_json.go
+++ b/daemon/api_json.go
@@ -25,24 +25,24 @@ import (
 
 // plugJSON aids in marshaling snap.PlugInfo into JSON.
 type plugJSON struct {
-	Snap      string                 `json:"snap"`
-	Name      string                 `json:"plug"`
-	Interface string                 `json:"interface,omitempty"`
-	Attrs     map[string]interface{} `json:"attrs,omitempty"`
-	Apps      []string               `json:"apps,omitempty"`
-	Label     string                 `json:"label,omitempty"`
+	Snap      string         `json:"snap"`
+	Name      string         `json:"plug"`
+	Interface string         `json:"interface,omitempty"`
+	Attrs     map[string]any `json:"attrs,omitempty"`
+	Apps      []string       `json:"apps,omitempty"`
+	Label     string         `json:"label,omitempty"`
 	// Connections are synthesized, they are not on the original type.
 	Connections []interfaces.SlotRef `json:"connections,omitempty"`
 }
 
 // slotJSON aids in marshaling snap.SlotInfo into JSON.
 type slotJSON struct {
-	Snap      string                 `json:"snap"`
-	Name      string                 `json:"slot"`
-	Interface string                 `json:"interface,omitempty"`
-	Attrs     map[string]interface{} `json:"attrs,omitempty"`
-	Apps      []string               `json:"apps,omitempty"`
-	Label     string                 `json:"label,omitempty"`
+	Snap      string         `json:"snap"`
+	Name      string         `json:"slot"`
+	Interface string         `json:"interface,omitempty"`
+	Attrs     map[string]any `json:"attrs,omitempty"`
+	Apps      []string       `json:"apps,omitempty"`
+	Label     string         `json:"label,omitempty"`
 	// Connections are synthesized, they are not on the original type.
 	Connections []interfaces.PlugRef `json:"connections,omitempty"`
 }
@@ -67,13 +67,13 @@ type interfaceAction struct {
 // connectionsJSON aids in marshalling information about a single connection
 // into JSON
 type connectionJSON struct {
-	Slot      interfaces.SlotRef     `json:"slot"`
-	Plug      interfaces.PlugRef     `json:"plug"`
-	Interface string                 `json:"interface"`
-	Manual    bool                   `json:"manual,omitempty"`
-	Gadget    bool                   `json:"gadget,omitempty"`
-	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
-	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
+	Slot      interfaces.SlotRef `json:"slot"`
+	Plug      interfaces.PlugRef `json:"plug"`
+	Interface string             `json:"interface"`
+	Manual    bool               `json:"manual,omitempty"`
+	Gadget    bool               `json:"gadget,omitempty"`
+	SlotAttrs map[string]any     `json:"slot-attrs,omitempty"`
+	PlugAttrs map[string]any     `json:"plug-attrs,omitempty"`
 }
 
 // legacyConnectionsJSON aids in marshaling legacy connections into JSON.

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -54,7 +54,7 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
-var modelDefaults = map[string]interface{}{
+var modelDefaults = map[string]any{
 	"architecture": "amd64",
 	"gadget":       "gadget",
 	"kernel":       "kernel",
@@ -113,7 +113,7 @@ func (s *modelSuite) testPostRemodel(c *check.C, offline bool) {
 	s.expectRootAccess()
 
 	oldModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
-	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]interface{}{
+	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]any{
 		"revision": "2",
 	})
 
@@ -376,7 +376,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 	s.mockModel(st, theModel)
 
-	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]any{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-old-model",
@@ -444,7 +444,7 @@ func (s *modelSuite) TestGetModelJSONHasSerialAssertion(c *check.C) {
 	assertstatetest.AddMany(st, s.Brands.AccountsAndKeys("my-brand")...)
 	s.mockModel(st, theModel)
 
-	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]any{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-old-model",
@@ -577,7 +577,7 @@ func (s *modelSuite) testPostOfflineRemodel(c *check.C, params *testPostOfflineR
 	s.expectRootAccess()
 
 	oldModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
-	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]interface{}{
+	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]any{
 		"revision": "2",
 	})
 
@@ -636,7 +636,7 @@ func (s *modelSuite) testPostOfflineRemodel(c *check.C, params *testPostOfflineR
 	}
 
 	// valid revision assertion to make it part of the arguments
-	revAssert := assertstest.FakeAssertion(map[string]interface{}{
+	revAssert := assertstest.FakeAssertion(map[string]any{
 		"type":          "snap-revision",
 		"authority-id":  "can0nical",
 		"snap-id":       "snap-id-1",
@@ -685,7 +685,7 @@ func (s *modelSuite) TestPostOfflineRemodelWithComponents(c *check.C) {
 	s.expectRootAccess()
 
 	oldModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults)
-	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]interface{}{
+	newModel := s.Brands.Model("my-brand", "my-old-model", modelDefaults, map[string]any{
 		"revision": "2",
 	})
 
@@ -724,7 +724,7 @@ func (s *modelSuite) TestPostOfflineRemodelWithComponents(c *check.C) {
 	c.Assert(err, check.IsNil)
 	snapFormData[filepath.Base(snapPath)] = string(content)
 
-	rev := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapRevisionType, map[string]interface{}{
+	rev := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapRevisionType, map[string]any{
 		"snap-id":       snapID,
 		"snap-sha3-384": digest,
 		"developer-id":  account.AccountID(),
@@ -732,7 +732,7 @@ func (s *modelSuite) TestPostOfflineRemodelWithComponents(c *check.C) {
 		"snap-revision": "10",
 	})
 
-	decl := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapDeclarationType, map[string]interface{}{
+	decl := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"snap-name":    snapName,
@@ -747,7 +747,7 @@ func (s *modelSuite) TestPostOfflineRemodelWithComponents(c *check.C) {
 	// we handle components that are not associated with any of the snaps that
 	// are being uploaded a little differently, this part of the test helps
 	// cover that case
-	extraSnapDecl := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapDeclarationType, map[string]interface{}{
+	extraSnapDecl := mockStoreAssertion(c, signer, signer.AuthorityID, account.AccountID(), asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      snaptest.AssertedSnapID("other-snap"),
 		"snap-name":    "other-snap",

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -117,8 +117,8 @@ const (
 type invalidFieldValue struct {
 	Reason invalidReason `json:"reason"`
 	// Value is a []string for unsupported value errors and string for parse errors
-	Value     interface{} `json:"value,omitempty"`
-	Supported []string    `json:"supported,omitempty"`
+	Value     any      `json:"value,omitempty"`
+	Supported []string `json:"supported,omitempty"`
 	// TODO: once documentation exists for user-defined fields
 	// DocumentationURL string `json:"documentation"`
 }

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -260,11 +260,11 @@ func (s *promptingSuite) TestPromptingNotRunningError(c *C) {
 	jsonResp := apiResp.JSON()
 	rec := httptest.NewRecorder()
 	jsonResp.ServeHTTP(rec, nil)
-	var body map[string]interface{}
+	var body map[string]any
 	err := json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, IsNil)
-	c.Check(body, DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "AppArmor Prompting is not running",
 			"kind":    string(client.ErrorKindAppArmorPromptingNotRunning),
 		},
@@ -277,12 +277,12 @@ func (s *promptingSuite) TestPromptingNotRunningError(c *C) {
 func (s *promptingSuite) TestPromptingError(c *C) {
 	for _, testCase := range []struct {
 		err  error
-		body map[string]interface{}
+		body map[string]any
 	}{
 		{
 			err: prompting_errors.ErrPromptNotFound,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrPromptNotFound.Error(),
 					"kind":    string(client.ErrorKindInterfacesRequestsPromptNotFound),
 				},
@@ -293,8 +293,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrRuleNotFound,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrRuleNotFound.Error(),
 					"kind":    string(client.ErrorKindInterfacesRequestsRuleNotFound),
 				},
@@ -305,8 +305,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrRuleNotAllowed,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrRuleNotAllowed.Error(),
 					"kind":    string(client.ErrorKindInterfacesRequestsRuleNotFound),
 				},
@@ -317,8 +317,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrPromptsClosed,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrPromptsClosed.Error(),
 				},
 				"status":      "Internal Server Error",
@@ -328,8 +328,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrRulesClosed,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrRulesClosed.Error(),
 				},
 				"status":      "Internal Server Error",
@@ -339,8 +339,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrTooManyPrompts,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrTooManyPrompts.Error(),
 				},
 				"status":      "Internal Server Error",
@@ -350,8 +350,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrRuleIDConflict,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrRuleIDConflict.Error(),
 				},
 				"status":      "Internal Server Error",
@@ -361,8 +361,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrRuleDBInconsistent,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrRuleDBInconsistent.Error(),
 				},
 				"status":      "Internal Server Error",
@@ -372,15 +372,15 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewInvalidOutcomeError("foo", []string{"bar", "baz"}),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid outcome: "foo"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"outcome": map[string]interface{}{
+					"value": map[string]any{
+						"outcome": map[string]any{
 							"reason":    "unsupported-value",
-							"supported": []interface{}{"bar", "baz"},
-							"value":     []interface{}{"foo"},
+							"supported": []any{"bar", "baz"},
+							"value":     []any{"foo"},
 						},
 					},
 				},
@@ -391,15 +391,15 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewInvalidLifespanError("foo", []string{"bar", "baz"}),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid lifespan: "foo"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"lifespan": map[string]interface{}{
+					"value": map[string]any{
+						"lifespan": map[string]any{
 							"reason":    "unsupported-value",
-							"supported": []interface{}{"bar", "baz"},
-							"value":     []interface{}{"foo"},
+							"supported": []any{"bar", "baz"},
+							"value":     []any{"foo"},
 						},
 					},
 				},
@@ -410,15 +410,15 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewRuleLifespanSingleError([]string{"bar", "baz"}),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `cannot create rule with lifespan "single"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"lifespan": map[string]interface{}{
+					"value": map[string]any{
+						"lifespan": map[string]any{
 							"reason":    "unsupported-value",
-							"supported": []interface{}{"bar", "baz"},
-							"value":     []interface{}{"single"},
+							"supported": []any{"bar", "baz"},
+							"value":     []any{"single"},
 						},
 					},
 				},
@@ -429,15 +429,15 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewInvalidInterfaceError("foo", []string{"bar", "baz"}),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid interface: "foo"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"interface": map[string]interface{}{
+					"value": map[string]any{
+						"interface": map[string]any{
 							"reason":    "unsupported-value",
-							"supported": []interface{}{"bar", "baz"},
-							"value":     []interface{}{"foo"},
+							"supported": []any{"bar", "baz"},
+							"value":     []any{"foo"},
 						},
 					},
 				},
@@ -448,15 +448,15 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewInvalidPermissionsError("foo", []string{"bar", "baz"}, []string{"fizz", "buzz"}),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid permissions for foo interface: "bar", "baz"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"permissions": map[string]interface{}{
+					"value": map[string]any{
+						"permissions": map[string]any{
 							"reason":    "unsupported-value",
-							"supported": []interface{}{"fizz", "buzz"},
-							"value":     []interface{}{"bar", "baz"},
+							"supported": []any{"fizz", "buzz"},
+							"value":     []any{"bar", "baz"},
 						},
 					},
 				},
@@ -467,15 +467,15 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewPermissionsEmptyError("foo", []string{"bar", "baz"}),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid permissions for foo interface: permissions empty`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"permissions": map[string]interface{}{
+					"value": map[string]any{
+						"permissions": map[string]any{
 							"reason":    "unsupported-value",
-							"supported": []interface{}{"bar", "baz"},
-							"value":     []interface{}{},
+							"supported": []any{"bar", "baz"},
+							"value":     []any{},
 						},
 					},
 				},
@@ -486,12 +486,12 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewInvalidDurationError("foo", "really terrible"),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid duration: really terrible: "foo"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"duration": map[string]interface{}{
+					"value": map[string]any{
+						"duration": map[string]any{
 							"reason": "parse-error",
 							"value":  "foo",
 						},
@@ -504,12 +504,12 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewInvalidExpirationError(time.Date(1, time.February, 3, 4, 5, 6, 7, time.UTC), "really terrible"),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid expiration: really terrible: "0001-02-03T04:05:06.000000007Z"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"expiration": map[string]interface{}{
+					"value": map[string]any{
+						"expiration": map[string]any{
 							"reason": "parse-error",
 							"value":  "0001-02-03T04:05:06.000000007Z",
 						},
@@ -522,12 +522,12 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.NewInvalidPathPatternError(`invalid/pattern`, "must start with '/'"),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": `invalid path pattern: must start with '/': "invalid/pattern"`,
 					"kind":    "interfaces-requests-invalid-fields",
-					"value": map[string]interface{}{
-						"path-pattern": map[string]interface{}{
+					"value": map[string]any{
+						"path-pattern": map[string]any{
 							"reason": "parse-error",
 							"value":  "invalid/pattern",
 						},
@@ -540,8 +540,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: prompting_errors.ErrPatchedRuleHasNoPerms,
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": "cannot patch rule to have no permissions",
 					"kind":    "interfaces-requests-patched-rule-has-no-permissions",
 				},
@@ -555,12 +555,12 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 				Requested: "foo",
 				Replied:   "bar",
 			},
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": fmt.Sprintf(`%v "foo": "bar"`, prompting_errors.ErrReplyNotMatchRequestedPath),
 					"kind":    "interfaces-requests-reply-not-match-request",
-					"value": map[string]interface{}{
-						"path-pattern": map[string]interface{}{
+					"value": map[string]any{
+						"path-pattern": map[string]any{
 							"requested-path":  "foo",
 							"replied-pattern": "bar",
 						},
@@ -576,14 +576,14 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 				Requested: []string{"foo", "bar", "baz"},
 				Replied:   []string{"fizz", "buzz"},
 			},
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": fmt.Sprintf(`%v [foo bar baz]: [fizz buzz]`, prompting_errors.ErrReplyNotMatchRequestedPermissions),
 					"kind":    "interfaces-requests-reply-not-match-request",
-					"value": map[string]interface{}{
-						"permissions": map[string]interface{}{
-							"requested-permissions": []interface{}{"foo", "bar", "baz"},
-							"replied-permissions":   []interface{}{"fizz", "buzz"},
+					"value": map[string]any{
+						"permissions": map[string]any{
+							"requested-permissions": []any{"foo", "bar", "baz"},
+							"replied-permissions":   []any{"fizz", "buzz"},
 						},
 					},
 				},
@@ -607,18 +607,18 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 					},
 				},
 			},
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": prompting_errors.ErrRuleConflict.Error(),
 					"kind":    "interfaces-requests-rule-conflict",
-					"value": map[string]interface{}{
-						"conflicts": []interface{}{
-							map[string]interface{}{
+					"value": map[string]any{
+						"conflicts": []any{
+							map[string]any{
 								"permission":     "foo",
 								"variant":        "variant 1",
 								"conflicting-id": "conflicting rule 1",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"permission":     "bar",
 								"variant":        "variant 2",
 								"conflicting-id": "conflicting rule 2",
@@ -633,8 +633,8 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		},
 		{
 			err: fmt.Errorf("some arbitrary error"),
-			body: map[string]interface{}{
-				"result": map[string]interface{}{
+			body: map[string]any{
+				"result": map[string]any{
 					"message": "some arbitrary error",
 				},
 				"status":      "Internal Server Error",
@@ -647,7 +647,7 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 		jsonResp := apiResp.JSON()
 		rec := httptest.NewRecorder()
 		jsonResp.ServeHTTP(rec, nil)
-		var body map[string]interface{}
+		var body map[string]any
 		err := json.Unmarshal(rec.Body.Bytes(), &body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, testCase.body)

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -238,7 +238,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 	rspe := s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 409)
 	c.Check(rspe.Message, check.Equals, `quota group "booze" has "quota-control" change in progress`)
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"change-kind": "quota-control",
 		"quota-name":  "booze",
 	})
@@ -249,7 +249,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 	rspe = s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 409)
 	c.Check(rspe.Message, check.Equals, `snap "some-snap" has "disable" change in progress`)
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"change-kind": "disable",
 		"snap-name":   "some-snap",
 	})
@@ -538,7 +538,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	rspe := s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 409)
 	c.Check(rspe.Message, check.Equals, `quota group "ginger-ale" has "quota-control" change in progress`)
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"change-kind": "quota-control",
 		"quota-name":  "ginger-ale",
 	})
@@ -549,7 +549,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	rspe = s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 409)
 	c.Check(rspe.Message, check.Equals, `snap "some-snap" has "disable" change in progress`)
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"change-kind": "disable",
 		"snap-name":   "some-snap",
 	})
@@ -622,7 +622,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	rspe := s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 409)
 	c.Check(rspe.Message, check.Equals, `quota group "booze" has "quota-control" change in progress`)
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"change-kind": "quota-control",
 		"quota-name":  "booze",
 	})
@@ -633,7 +633,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	rspe = s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 409)
 	c.Check(rspe.Message, check.Equals, `snap "some-snap" has "disable" change in progress`)
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"change-kind": "disable",
 		"snap-name":   "some-snap",
 	})

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -440,7 +440,7 @@ func sideloadManySnaps(ctx context.Context, st *state.State, uploads []*uploaded
 	msg := multiPathInstallMessage(slInfo)
 
 	chg := newChange(st, "install-snap", msg, tss, snapNames)
-	apiData := make(map[string]interface{}, 0)
+	apiData := make(map[string]any, 0)
 
 	if len(snapNames) > 0 {
 		apiData["snap-names"] = snapNames
@@ -588,9 +588,9 @@ func sideloadSnap(_ context.Context, st *state.State, upload *uploadedContainer,
 
 	msg := fmt.Sprintf(i18n.G("Install %s from file %q"), message, upload.filename)
 	chg := newChange(st, "install-"+contType, msg, []*state.TaskSet{tset}, []string{instanceName})
-	apiData := map[string]interface{}{}
+	apiData := map[string]any{}
 	if compInfo == nil {
-		apiData = map[string]interface{}{
+		apiData = map[string]any{
 			"snap-name":  instanceName,
 			"snap-names": []string{instanceName},
 		}
@@ -986,7 +986,7 @@ func trySnap(st *state.State, trydir string, flags snapstate.Flags) Response {
 
 	msg := fmt.Sprintf(i18n.G("Try %q snap from %s"), info.InstanceName(), trydir)
 	chg := newChange(st, "try-snap", msg, []*state.TaskSet{tset}, []string{info.InstanceName()})
-	chg.Set("api-data", map[string]interface{}{
+	chg.Set("api-data", map[string]any{
 		"snap-name":  info.InstanceName(),
 		"snap-names": []string{info.InstanceName()},
 	})

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -78,7 +78,7 @@ func (s *sideloadSuite) markSeeded(d *daemon.Daemon) {
 	st.Lock()
 	defer st.Unlock()
 	st.Set("seeded", true)
-	model := s.Brands.Model("can0nical", "pc", map[string]interface{}{
+	model := s.Brands.Model("can0nical", "pc", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "gadget",
 		"kernel":       "kernel",
@@ -266,12 +266,12 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 	err = chg.Get("snap-names", &names)
 	c.Assert(err, check.IsNil)
 	c.Check(names, check.DeepEquals, []string{expectedInstanceName})
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, check.IsNil)
-	c.Check(apiData, check.DeepEquals, map[string]interface{}{
+	c.Check(apiData, check.DeepEquals, map[string]any{
 		"snap-name":  expectedInstanceName,
-		"snap-names": []interface{}{expectedInstanceName},
+		"snap-names": []any{expectedInstanceName},
 	})
 
 	summary = chg.Summary()
@@ -435,7 +435,7 @@ func (s *sideloadSuite) makeComponentAssertions(c *check.C, snapName, compName, 
 	digest, size, err := asserts.SnapFileSHA3_384(compPath)
 	c.Assert(err, check.IsNil)
 
-	resRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"type":              "snap-resource-revision",
 		"snap-id":           snapID,
 		"resource-name":     compName,
@@ -448,7 +448,7 @@ func (s *sideloadSuite) makeComponentAssertions(c *check.C, snapName, compName, 
 	}, nil, "")
 	c.Assert(err, check.IsNil)
 
-	resPair, err := s.StoreSigning.Sign(asserts.SnapResourcePairType, map[string]interface{}{
+	resPair, err := s.StoreSigning.Sign(asserts.SnapResourcePairType, map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     compName,
 		"resource-revision": "22",
@@ -466,7 +466,7 @@ func (s *sideloadSuite) makeSnapAssertions(c *check.C, snapName, snapPath string
 
 	snapID := snaptest.AssertedSnapID(snapName)
 
-	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"snap-name":    snapName,
@@ -475,7 +475,7 @@ func (s *sideloadSuite) makeSnapAssertions(c *check.C, snapName, snapPath string
 	}, nil, "")
 	c.Assert(err, check.IsNil)
 
-	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
 		"snap-id":       snapID,
@@ -945,12 +945,12 @@ func (s *sideloadSuite) sideloadComponentCheck(
 
 	c.Assert(err, check.IsNil)
 	c.Check(names, check.DeepEquals, []string{expectedInstanceName})
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, check.IsNil)
-	c.Check(apiData, check.DeepEquals, map[string]interface{}{
-		"components": map[string]interface{}{
-			expectedInstanceName: []interface{}{expectedCompSideInfo.Component.ComponentName}},
+	c.Check(apiData, check.DeepEquals, map[string]any{
+		"components": map[string]any{
+			expectedInstanceName: []any{expectedCompSideInfo.Component.ComponentName}},
 	})
 
 	summary = chg.Summary()
@@ -1025,7 +1025,7 @@ version: 1`, nil)
 
 	dev1Acct := assertstest.NewAccount(s.StoreSigning, "devel1", nil, "")
 
-	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "foo",
@@ -1034,7 +1034,7 @@ version: 1`, nil)
 	}, nil, "")
 	c.Assert(err, check.IsNil)
 
-	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
 		"snap-id":       "foo-id",
@@ -1081,12 +1081,12 @@ version: 1`, nil)
 	err = chg.Get("snap-names", &names)
 	c.Assert(err, check.IsNil)
 	c.Check(names, check.DeepEquals, []string{"foo"})
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, check.IsNil)
-	c.Check(apiData, check.DeepEquals, map[string]interface{}{
+	c.Check(apiData, check.DeepEquals, map[string]any{
 		"snap-name":  "foo",
-		"snap-names": []interface{}{"foo"},
+		"snap-names": []any{"foo"},
 	})
 }
 
@@ -1658,14 +1658,14 @@ func (s *sideloadSuite) testSideloadManySnapsAndComponents(c *check.C, opts side
 	c.Assert(chg, check.NotNil)
 	c.Check(chg.Summary(), check.Equals, fmt.Sprintf(`Install snaps "one" (with component "comp-one"), "two" (with components "comp-two", "comp-three") and component "three+comp-four" from files %s`, strutil.Quoted(expectedFileNames)))
 
-	var data map[string]interface{}
+	var data map[string]any
 	c.Assert(chg.Get("api-data", &data), check.IsNil)
-	c.Check(data, check.DeepEquals, map[string]interface{}{
-		"snap-names": []interface{}{"one", "two"},
-		"components": map[string]interface{}{
-			"one":   []interface{}{"comp-one"},
-			"two":   []interface{}{"comp-two", "comp-three"},
-			"three": []interface{}{"comp-four"},
+	c.Check(data, check.DeepEquals, map[string]any{
+		"snap-names": []any{"one", "two"},
+		"components": map[string]any{
+			"one":   []any{"comp-one"},
+			"two":   []any{"comp-two", "comp-three"},
+			"three": []any{"comp-four"},
 		},
 	})
 }
@@ -1819,14 +1819,14 @@ func (s *sideloadSuite) TestSideloadManyAssertedSnapsAndComponents(c *check.C) {
 	c.Assert(chg, check.NotNil)
 	c.Check(chg.Summary(), check.Equals, fmt.Sprintf(`Install snaps "one" (with component "comp-one"), "two" (with components "comp-two", "comp-three") and component "three+comp-four" from files %s`, strutil.Quoted(expectedFileNames)))
 
-	var data map[string]interface{}
+	var data map[string]any
 	c.Assert(chg.Get("api-data", &data), check.IsNil)
-	c.Check(data, check.DeepEquals, map[string]interface{}{
-		"snap-names": []interface{}{"one", "two"},
-		"components": map[string]interface{}{
-			"one":   []interface{}{"comp-one"},
-			"two":   []interface{}{"comp-two", "comp-three"},
-			"three": []interface{}{"comp-four"},
+	c.Check(data, check.DeepEquals, map[string]any{
+		"snap-names": []any{"one", "two"},
+		"components": map[string]any{
+			"one":   []any{"comp-one"},
+			"two":   []any{"comp-two", "comp-three"},
+			"three": []any{"comp-four"},
 		},
 	})
 }
@@ -2037,11 +2037,11 @@ func (s *sideloadSuite) TestSideloadManyOnlyComponents(c *check.C) {
 	c.Assert(chg, check.NotNil)
 	c.Check(chg.Summary(), check.Equals, fmt.Sprintf(`Install components %s from files %s`, strutil.Quoted(fullComponentNames), strutil.Quoted(expectedFileNames)))
 
-	var data map[string]interface{}
+	var data map[string]any
 	c.Assert(chg.Get("api-data", &data), check.IsNil)
-	c.Check(data, check.DeepEquals, map[string]interface{}{
-		"components": map[string]interface{}{
-			"one": []interface{}{"comp-one", "comp-two", "comp-three", "comp-four"},
+	c.Check(data, check.DeepEquals, map[string]any{
+		"components": map[string]any{
+			"one": []any{"comp-one", "comp-two", "comp-three", "comp-four"},
 		},
 	})
 }
@@ -2244,7 +2244,7 @@ version: 1`, snap), nil)
 		snapData = append(snapData, thisSnapData)
 
 		dev1Acct := assertstest.NewAccount(s.StoreSigning, "devel1", nil, "")
-		snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+		snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 			"series":       "16",
 			"snap-id":      snap + "-id",
 			"snap-name":    snap,
@@ -2252,7 +2252,7 @@ version: 1`, snap), nil)
 			"timestamp":    time.Now().Format(time.RFC3339),
 		}, nil, "")
 		c.Assert(err, check.IsNil)
-		snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+		snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 			"snap-sha3-384": digest,
 			"snap-size":     fmt.Sprintf("%d", size),
 			"snap-id":       snap + "-id",
@@ -2394,12 +2394,12 @@ func (s *trySuite) TestTrySnap(c *check.C) {
 		err = chg.Get("snap-names", &names)
 		c.Assert(err, check.IsNil, check.Commentf(t.desc))
 		c.Check(names, check.DeepEquals, []string{"foo"}, check.Commentf(t.desc))
-		var apiData map[string]interface{}
+		var apiData map[string]any
 		err = chg.Get("api-data", &apiData)
 		c.Assert(err, check.IsNil, check.Commentf(t.desc))
-		c.Check(apiData, check.DeepEquals, map[string]interface{}{
+		c.Check(apiData, check.DeepEquals, map[string]any{
 			"snap-name":  "foo",
-			"snap-names": []interface{}{"foo"},
+			"snap-names": []any{"foo"},
 		}, check.Commentf(t.desc))
 
 		c.Check(soon, check.Equals, 1, check.Commentf(t.desc))

--- a/daemon/api_snap_conf.go
+++ b/daemon/api_snap_conf.go
@@ -55,18 +55,18 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 	tr := config.NewTransaction(s)
 	s.Unlock()
 
-	currentConfValues := make(map[string]interface{})
+	currentConfValues := make(map[string]any)
 	// Special case - return root document
 	if len(keys) == 0 {
 		keys = []string{""}
 	}
 	for _, key := range keys {
-		var value interface{}
+		var value any
 		if err := tr.Get(snapName, key, &value); err != nil {
 			if config.IsNoOption(err) {
 				if key == "" {
 					// no configuration - return empty document
-					currentConfValues = make(map[string]interface{})
+					currentConfValues = make(map[string]any)
 					break
 				}
 				return &apiError{
@@ -106,7 +106,7 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 //
 // This helper should only be called for core configurations. Any errors when parsing
 // core config are ignored and val is returned without modification.
-func pruneExperimentalFlags(key string, val interface{}) interface{} {
+func pruneExperimentalFlags(key string, val any) any {
 	if val == nil {
 		return val
 	}
@@ -118,13 +118,13 @@ func pruneExperimentalFlags(key string, val interface{}) interface{} {
 		return val
 	}
 
-	experimentalFlags, ok := val.(map[string]interface{})
+	experimentalFlags, ok := val.(map[string]any)
 	if !ok {
 		// XXX: This should never happen, skip cleaning
 		return val
 	}
 	if key == "" {
-		experimentalFlags, ok = experimentalFlags["experimental"].(map[string]interface{})
+		experimentalFlags, ok = experimentalFlags["experimental"].(map[string]any)
 		if !ok {
 			// No experimental key, do nothing
 			return val
@@ -146,7 +146,7 @@ func setSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 	vars := muxVars(r)
 	snapName := configstate.RemapSnapFromRequest(vars["name"])
 
-	var patchValues map[string]interface{}
+	var patchValues map[string]any
 	if err := jsonutil.DecodeWithNumber(r.Body, &patchValues); err != nil {
 		return BadRequest("cannot decode request body into patch values: %v", err)
 	}

--- a/daemon/api_snapctl.go
+++ b/daemon/api_snapctl.go
@@ -74,7 +74,7 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 	stdout, stderr, err := ctlcmdRun(context, snapctlPostData.Args, ucred.Uid)
 	if err != nil {
 		if e, ok := err.(*ctlcmd.UnsuccessfulError); ok {
-			result := map[string]interface{}{
+			result := map[string]any{
 				"stdout":    string(stdout),
 				"stderr":    string(stderr),
 				"exit-code": e.ExitCode,

--- a/daemon/api_snapctl_test.go
+++ b/daemon/api_snapctl_test.go
@@ -108,7 +108,7 @@ func (s *snapctlSuite) TestSnapctlUnsuccesfulError(c *check.C) {
 	rspe := s.errorReq(c, req, nil)
 	c.Check(rspe.Status, check.Equals, 200)
 	c.Check(rspe.Kind, check.Equals, client.ErrorKindUnsuccessful)
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"stdout":    "",
 		"stderr":    "",
 		"exit-code": 123,

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -165,7 +165,7 @@ func postSnap(c *Command, r *http.Request, user *auth.UserState) Response {
 		chg.Set("system-restart-immediate", true)
 	}
 
-	apiData := map[string]interface{}{}
+	apiData := map[string]any{}
 	if len(res.Affected) > 0 {
 		apiData["snap-names"] = res.Affected
 	}
@@ -430,7 +430,7 @@ type snapInstructionResult struct {
 	Affected           []string
 	AffectedComponents map[string][]string
 	Tasksets           []*state.TaskSet
-	Result             map[string]interface{}
+	Result             map[string]any
 }
 
 var errDevJailModeConflict = errors.New("cannot use devmode and jailmode flags together")
@@ -831,7 +831,7 @@ func snapOpMany(c *Command, r *http.Request, user *auth.UserState) Response {
 		chg.Set("system-restart-immediate", true)
 	}
 
-	apiData := map[string]interface{}{}
+	apiData := map[string]any{}
 	if len(res.Affected) > 0 {
 		apiData["snap-names"] = res.Affected
 	}
@@ -1285,7 +1285,7 @@ func snapHoldMany(_ context.Context, inst *snapInstruction, st *state.State) (re
 		if inst.holdLevel() == snapstate.HoldGeneral {
 			return nil, errors.New("holding general refreshes for all snaps is not supported")
 		}
-		patchValues := map[string]interface{}{"refresh.hold": inst.Time}
+		patchValues := map[string]any{"refresh.hold": inst.Time}
 		ts, err := configstateConfigureInstalled(st, "core", patchValues, 0)
 		if err != nil {
 			return nil, err
@@ -1317,7 +1317,7 @@ func snapUnholdMany(_ context.Context, inst *snapInstruction, st *state.State) (
 	var tss []*state.TaskSet
 
 	if len(inst.Snaps) == 0 {
-		patchValues := map[string]interface{}{"refresh.hold": nil}
+		patchValues := map[string]any{"refresh.hold": nil}
 		ts, err := configstateConfigureInstalled(st, "core", patchValues, 0)
 		if err != nil {
 			return nil, err

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -95,8 +95,8 @@ func (s *snapsSuite) TestSnapsInfoIntegrationAllSome(c *check.C) {
 	s.checkSnapsInfoIntegration(c, true, []string{"foo", "baz"})
 }
 
-func snapList(rawSnaps interface{}) []map[string]interface{} {
-	snaps := make([]map[string]interface{}, len(rawSnaps.([]*json.RawMessage)))
+func snapList(rawSnaps any) []map[string]any {
+	snaps := make([]map[string]any, len(rawSnaps.([]*json.RawMessage)))
 	for i, raw := range rawSnaps.([]*json.RawMessage) {
 		err := json.Unmarshal([]byte(*raw), &snaps[i])
 		if err != nil {
@@ -167,7 +167,7 @@ func (s *snapsSuite) checkSnapsInfoIntegration(c *check.C, all bool, names []str
 		if !((all || s.active) && s.wanted) {
 			continue
 		}
-		var got map[string]interface{}
+		var got map[string]any
 		for _, got = range snaps {
 			if got["name"].(string) == s.name && got["revision"].(string) == snap.R(s.rev).String() {
 				break
@@ -214,7 +214,7 @@ func (s *snapsSuite) TestSnapsInfoOnlyLocal(c *check.C) {
 	snaps := snapList(rsp.Result)
 	c.Assert(snaps, check.HasLen, 1)
 	c.Assert(snaps[0]["name"], check.Equals, "local")
-	c.Check(snaps[0]["health"], check.DeepEquals, map[string]interface{}{
+	c.Check(snaps[0]["health"], check.DeepEquals, map[string]any{
 		"status":    "okay",
 		"revision":  "unset",
 		"timestamp": "0001-01-01T00:00:00Z",
@@ -237,7 +237,7 @@ func (s *snapsSuite) TestSnapsInfoAllMixedPublishers(c *check.C) {
 	snaps := snapList(rsp.Result)
 	c.Assert(snaps, check.HasLen, 3)
 
-	publisher := map[string]interface{}{
+	publisher := map[string]any{
 		"id":           "foo-id",
 		"username":     "foo",
 		"display-name": "Foo",
@@ -698,9 +698,9 @@ func (s *snapsSuite) testPostSnapsOp(c *check.C, extraJSON, contentType string) 
 	defer st.Unlock()
 	chg := st.Change(rsp.Change)
 	c.Check(chg.Summary(), check.Equals, `Refresh snaps "fake1", "fake2"`)
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Check(chg.Get("api-data", &apiData), check.IsNil)
-	c.Check(apiData["snap-names"], check.DeepEquals, []interface{}{"fake1", "fake2"})
+	c.Check(apiData["snap-names"], check.DeepEquals, []any{"fake1", "fake2"})
 	err = chg.Get("system-restart-immediate", &systemRestartImmediate)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		c.Error(err)
@@ -1529,12 +1529,12 @@ func (s *snapsSuite) TestSnapManyInfosReturnsRefreshInhibitProceedTime(c *check.
 		testCmt := check.Commentf("snap %s failed", snap["name"])
 		switch snap["name"] {
 		case "snap-a":
-			refreshInhibit := snap["refresh-inhibit"].(map[string]interface{})
+			refreshInhibit := snap["refresh-inhibit"].(map[string]any)
 			proceedTime, err := time.Parse(time.RFC3339Nano, refreshInhibit["proceed-time"].(string))
 			c.Assert(err, check.IsNil)
 			c.Assert(proceedTime.Equal(expectedProceedTimeA), check.Equals, true, testCmt)
 		case "snap-b":
-			refreshInhibit := snap["refresh-inhibit"].(map[string]interface{})
+			refreshInhibit := snap["refresh-inhibit"].(map[string]any)
 			proceedTime, err := time.Parse(time.RFC3339Nano, refreshInhibit["proceed-time"].(string))
 			c.Assert(err, check.IsNil)
 			c.Assert(proceedTime.Equal(expectedProceedTimeB), check.Equals, true, testCmt)
@@ -1593,12 +1593,12 @@ func (s *snapsSuite) TestSnapManyInfosSelectRefreshInhibited(c *check.C) {
 		testCmt := check.Commentf("snap %s failed", snap["name"])
 		switch snap["name"] {
 		case "snap-a":
-			refreshInhibit := snap["refresh-inhibit"].(map[string]interface{})
+			refreshInhibit := snap["refresh-inhibit"].(map[string]any)
 			proceedTime, err := time.Parse(time.RFC3339Nano, refreshInhibit["proceed-time"].(string))
 			c.Assert(err, check.IsNil)
 			c.Assert(proceedTime.Equal(expectedProceedTimeA), check.Equals, true, testCmt)
 		case "snap-b":
-			refreshInhibit := snap["refresh-inhibit"].(map[string]interface{})
+			refreshInhibit := snap["refresh-inhibit"].(map[string]any)
 			proceedTime, err := time.Parse(time.RFC3339Nano, refreshInhibit["proceed-time"].(string))
 			c.Assert(err, check.IsNil)
 			c.Assert(proceedTime.Equal(expectedProceedTimeB), check.Equals, true, testCmt)
@@ -2086,9 +2086,9 @@ func (s *snapsSuite) testPostSnap(c *check.C, extraJSON string, checkOpts func(o
 	c.Check(soon, check.Equals, 1)
 	c.Check(chg.Tasks()[0].Summary(), check.Equals, "Doing a fake install")
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Check(chg.Get("api-data", &apiData), check.IsNil)
-	c.Check(apiData["snap-names"], check.DeepEquals, []interface{}{"foo"})
+	c.Check(apiData["snap-names"], check.DeepEquals, []any{"foo"})
 
 	summary = chg.Summary()
 	err = chg.Get("system-restart-immediate", &systemRestartImmediate)
@@ -3080,12 +3080,12 @@ func (s *snapsSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 		Status:  404,
 		Message: "no snap revision on specified channel",
 		Kind:    client.ErrorKindSnapChannelNotAvailable,
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"snap-name":    "foo",
 			"action":       "install",
 			"channel":      "stable",
 			"architecture": thisArch,
-			"releases": []map[string]interface{}{
+			"releases": []map[string]any{
 				{"architecture": thisArch, "channel": "beta"},
 			},
 		},
@@ -3103,12 +3103,12 @@ func (s *snapsSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 		Status:  404,
 		Message: "no snap revision on specified architecture",
 		Kind:    client.ErrorKindSnapArchitectureNotAvailable,
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"snap-name":    "foo",
 			"action":       "install",
 			"channel":      "stable",
 			"architecture": thisArch,
-			"releases": []map[string]interface{}{
+			"releases": []map[string]any{
 				{"architecture": "other-arch", "channel": "beta"},
 			},
 		},
@@ -3133,7 +3133,7 @@ func (s *snapsSuite) TestErrToResponseForChangeConflict(c *check.C) {
 		Status:  409,
 		Message: `snap "foo" has "install" change in progress`,
 		Kind:    client.ErrorKindSnapChangeConflict,
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"snap-name":   "foo",
 			"change-kind": "install",
 		},
@@ -3146,7 +3146,7 @@ func (s *snapsSuite) TestErrToResponseForChangeConflict(c *check.C) {
 		Status:  409,
 		Message: `snap "foo" has changes in progress`,
 		Kind:    client.ErrorKindSnapChangeConflict,
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"snap-name": "foo",
 		},
 	})
@@ -3158,7 +3158,7 @@ func (s *snapsSuite) TestErrToResponseForChangeConflict(c *check.C) {
 		Status:  409,
 		Message: "specific error msg",
 		Kind:    client.ErrorKindSnapChangeConflict,
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"change-kind": "some-global-op",
 		},
 	})
@@ -3195,30 +3195,30 @@ func (s *snapsSuite) TestPostSnapWrongTransaction(c *check.C) {
 }
 
 func (s *snapsSuite) TestRefreshEnforce(c *check.C) {
-	installValset := assertstest.FakeAssertion(map[string]interface{}{
+	installValset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "foo",
 		"series":       "16",
 		"account-id":   "foo",
 		"name":         "baz",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "install-snap",
 				"id":       "mysnapdddddddddddddddddddddddddd",
 				"presence": "required",
 			},
 		},
 	}).(*asserts.ValidationSet)
-	updateValset := assertstest.FakeAssertion(map[string]interface{}{
+	updateValset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "foo",
 		"series":       "16",
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "update-snap",
 				"id":       "mysnapcccccccccccccccccccccccccc",
 				"presence": "required",
@@ -3262,15 +3262,15 @@ func (s *snapsSuite) TestRefreshEnforce(c *check.C) {
 }
 
 func (s *snapsSuite) TestRefreshEnforceWithPreexistingSet(c *check.C) {
-	unpinned := assertstest.FakeAssertion(map[string]interface{}{
+	unpinned := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "foo",
 		"series":       "16",
 		"account-id":   "foo",
 		"name":         "preexisting-unpinned",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "install-snap",
 				"id":       "mysnapdddddddddddddddddddddddddd",
 				"presence": "required",
@@ -3278,15 +3278,15 @@ func (s *snapsSuite) TestRefreshEnforceWithPreexistingSet(c *check.C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	pinned := assertstest.FakeAssertion(map[string]interface{}{
+	pinned := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "foo",
 		"series":       "16",
 		"account-id":   "foo",
 		"name":         "preexisting-pinned",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "install-snap",
 				"id":       "mysnapdddddddddddddddddddddddddd",
 				"presence": "required",
@@ -3315,15 +3315,15 @@ func (s *snapsSuite) TestRefreshEnforceWithPreexistingSet(c *check.C) {
 	})
 	st.Unlock()
 
-	vset := assertstest.FakeAssertion(map[string]interface{}{
+	vset := assertstest.FakeAssertion(map[string]any{
 		"type":         "validation-set",
 		"authority-id": "foo",
 		"series":       "16",
 		"account-id":   "foo",
 		"name":         "new",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "install-snap",
 				"id":       "mysnapcccccccccccccccccccccccccc",
 				"presence": "required",
@@ -3509,9 +3509,9 @@ func (s *snapsSuite) TestHoldAllRefreshes(c *check.C) {
 
 	for _, time := range []string{"forever", "0001-02-03T00:00:00Z"} {
 		called := false
-		restore := daemon.MockConfigstateConfigureInstalled(func(s *state.State, name string, patchValues map[string]interface{}, flags int) (*state.TaskSet, error) {
+		restore := daemon.MockConfigstateConfigureInstalled(func(s *state.State, name string, patchValues map[string]any, flags int) (*state.TaskSet, error) {
 			called = true
-			c.Assert(patchValues, check.DeepEquals, map[string]interface{}{"refresh.hold": time})
+			c.Assert(patchValues, check.DeepEquals, map[string]any{"refresh.hold": time})
 			c.Assert(name, check.Equals, "core")
 			return state.NewTaskSet(s.NewTask("fake-task", "Fakeness")), nil
 		})
@@ -3599,8 +3599,8 @@ func (s *snapsSuite) TestHoldRefresh(c *check.C) {
 }
 
 func (s *snapsSuite) TestUnholdAllRefreshes(c *check.C) {
-	restore := daemon.MockConfigstateConfigureInstalled(func(s *state.State, name string, patchValues map[string]interface{}, flags int) (*state.TaskSet, error) {
-		c.Assert(patchValues, check.DeepEquals, map[string]interface{}{"refresh.hold": nil})
+	restore := daemon.MockConfigstateConfigureInstalled(func(s *state.State, name string, patchValues map[string]any, flags int) (*state.TaskSet, error) {
+		c.Assert(patchValues, check.DeepEquals, map[string]any{"refresh.hold": nil})
 		c.Assert(name, check.Equals, "core")
 		return state.NewTaskSet(s.NewTask("fake-task", "Fakeness")), nil
 	})
@@ -3802,11 +3802,11 @@ func (s *snapsSuite) TestPostRemoveComponents(c *check.C) {
 	c.Check(tasks[0], check.DeepEquals, t)
 	c.Check(chg.Summary(), check.Equals, `Remove component(s) [comp1 comp2] for "foo" snap`)
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Check(chg.Get("api-data", &apiData), check.IsNil)
 	c.Check(apiData["snap-names"], check.IsNil)
 	c.Check(apiData["components"], check.DeepEquals,
-		map[string]interface{}{"foo": []interface{}{"comp1", "comp2"}})
+		map[string]any{"foo": []any{"comp1", "comp2"}})
 }
 
 func (s *snapsSuite) TestPostComponentsWrongAction(c *check.C) {
@@ -3868,13 +3868,13 @@ func (s *snapsSuite) TestPostComponentsRemoveMany(c *check.C) {
 	c.Check(len(tasks), check.Equals, 2)
 	c.Check(numCalls, check.Equals, 2)
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Check(chg.Get("api-data", &apiData), check.IsNil)
 	c.Check(apiData["snap-names"], check.IsNil)
 	c.Check(apiData["components"], check.DeepEquals,
-		map[string]interface{}{
-			"snap1": []interface{}{"comp1", "comp2"},
-			"snap2": []interface{}{"comp3", "comp4"}},
+		map[string]any{
+			"snap1": []any{"comp1", "comp2"},
+			"snap2": []any{"comp3", "comp4"}},
 	)
 }
 
@@ -3926,13 +3926,13 @@ func (s *snapsSuite) TestPostComponentsRemoveManyWithSnaps(c *check.C) {
 	c.Check(len(tasks), check.Equals, 3)
 	c.Check(numCalls, check.Equals, 2)
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Check(chg.Get("api-data", &apiData), check.IsNil)
-	c.Check(apiData["snap-names"], check.DeepEquals, []interface{}{"foo", "bar"})
+	c.Check(apiData["snap-names"], check.DeepEquals, []any{"foo", "bar"})
 	c.Check(apiData["components"], check.DeepEquals,
-		map[string]interface{}{
-			"snap1": []interface{}{"comp1", "comp2"},
-			"snap2": []interface{}{"comp3", "comp4"}},
+		map[string]any{
+			"snap1": []any{"comp1", "comp2"},
+			"snap2": []any{"comp3", "comp4"}},
 	)
 }
 
@@ -3996,13 +3996,13 @@ func (s *snapsSuite) TestInstallWithComponents(c *check.C) {
 
 	c.Check(chg.Tasks(), check.HasLen, 1)
 
-	var data map[string]interface{}
+	var data map[string]any
 	err = chg.Get("api-data", &data)
 	c.Assert(err, check.IsNil)
-	c.Check(data, check.DeepEquals, map[string]interface{}{
-		"snap-names": []interface{}{"some-snap"},
-		"components": map[string]interface{}{
-			"some-snap": []interface{}{"comp1", "comp2"},
+	c.Check(data, check.DeepEquals, map[string]any{
+		"snap-names": []any{"some-snap"},
+		"components": map[string]any{
+			"some-snap": []any{"comp1", "comp2"},
 		},
 	})
 
@@ -4050,13 +4050,13 @@ func (s *snapsSuite) TestUpdateWithAdditionalComponents(c *check.C) {
 
 	c.Check(chg.Tasks(), check.HasLen, 1)
 
-	var data map[string]interface{}
+	var data map[string]any
 	err = chg.Get("api-data", &data)
 	c.Assert(err, check.IsNil)
-	c.Check(data, check.DeepEquals, map[string]interface{}{
-		"snap-names": []interface{}{"some-snap"},
-		"components": map[string]interface{}{
-			"some-snap": []interface{}{"comp1", "comp2"},
+	c.Check(data, check.DeepEquals, map[string]any{
+		"snap-names": []any{"some-snap"},
+		"components": map[string]any{
+			"some-snap": []any{"comp1", "comp2"},
 		},
 	})
 

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -159,7 +159,7 @@ func changeSnapshots(c *Command, r *http.Request, user *auth.UserState) Response
 	}
 
 	chg := newChange(st, action.Action+"-snapshot", action.String(), []*state.TaskSet{ts}, affected)
-	chg.Set("api-data", map[string]interface{}{"snap-names": affected})
+	chg.Set("api-data", map[string]any{"snap-names": affected})
 	ensureStateSoon(st)
 
 	return AsyncResponse(nil, chg.ID())
@@ -213,7 +213,7 @@ func doSnapshotImport(c *Command, r *http.Request, user *auth.UserState) Respons
 		return BadRequest(err.Error())
 	}
 
-	result := map[string]interface{}{"set-id": setID, "snaps": snapNames}
+	result := map[string]any{"set-id": setID, "snaps": snapNames}
 	return SyncResponse(result)
 }
 
@@ -235,6 +235,6 @@ func snapshotMany(_ context.Context, inst *snapInstruction, st *state.State) (*s
 		Summary:  msg,
 		Affected: snapshotted,
 		Tasksets: []*state.TaskSet{ts},
-		Result:   map[string]interface{}{"set-id": setID},
+		Result:   map[string]any{"set-id": setID},
 	}, nil
 }

--- a/daemon/api_snapshots_test.go
+++ b/daemon/api_snapshots_test.go
@@ -346,11 +346,11 @@ func (s *snapshotSuite) TestChangeSnapshot(c *check.C) {
 		c.Assert(chg.Tasks(), check.HasLen, 0)
 
 		c.Check(chg.Kind(), check.Equals, action+"-snapshot")
-		var apiData map[string]interface{}
+		var apiData map[string]any
 		err = chg.Get("api-data", &apiData)
 		c.Assert(err, check.IsNil)
-		c.Check(apiData, check.DeepEquals, map[string]interface{}{
-			"snap-names": []interface{}{"foo"},
+		c.Check(apiData, check.DeepEquals, map[string]any{
+			"snap-names": []any{"foo"},
 		})
 	}
 }
@@ -414,7 +414,7 @@ func (s *snapshotSuite) TestImportSnapshot(c *check.C) {
 
 	rsp := s.syncReq(c, req, nil)
 	c.Check(rsp.Status, check.Equals, 200)
-	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{"set-id": setID, "snaps": snapNames})
+	c.Check(rsp.Result, check.DeepEquals, map[string]any{"set-id": setID, "snaps": snapNames})
 }
 
 func (s *snapshotSuite) TestImportSnapshotError(c *check.C) {

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -659,7 +659,7 @@ func postSystemActionCheckPassphrase(c *Command, systemLabel string, req *system
 				Status:  400,
 				Kind:    client.ErrorKindInvalidPassphrase,
 				Message: "passphrase did not pass quality checks",
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"reasons":          qualityErr.Reasons,
 					"entropy-bits":     qualityErr.Entropy,
 					"min-entropy-bits": qualityErr.MinEntropy,
@@ -700,7 +700,7 @@ func postSystemActionCheckPIN(c *Command, systemLabel string, req *systemActionR
 				Status:  400,
 				Kind:    client.ErrorKindInvalidPIN,
 				Message: "PIN did not pass quality checks",
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"reasons":          qualityErr.Reasons,
 					"entropy-bits":     qualityErr.Entropy,
 					"min-entropy-bits": qualityErr.MinEntropy,

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -147,46 +147,46 @@ func (s *systemsSuite) mockSystemSeeds(c *check.C) (restore func()) {
 	seed20.MakeAssertedSnap(c, "name: pc\nversion: 1\ntype: gadget\nbase: core20", gadgetFiles, snap.R(1), "my-brand", s.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: pc-kernel\nversion: 1\ntype: kernel", nil, snap.R(1), "my-brand", s.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: core20\nversion: 1\ntype: base", nil, snap.R(1), "my-brand", s.StoreSigning.Database)
-	s.seedModelForLabel20191119 = seed20.MakeSeed(c, "20191119", "my-brand", "my-model", map[string]interface{}{
+	s.seedModelForLabel20191119 = seed20.MakeSeed(c, "20191119", "my-brand", "my-model", map[string]any{
 		"display-name": "my fancy model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "snapd",
 				"id":   seed20.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              seed20.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              seed20.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
 	}, nil)
-	seed20.MakeSeed(c, "20200318", "my-brand", "my-model-2", map[string]interface{}{
+	seed20.MakeSeed(c, "20200318", "my-brand", "my-model-2", map[string]any{
 		"display-name": "same brand different model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "snapd",
 				"id":   seed20.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              seed20.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              seed20.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -213,7 +213,7 @@ func (s *systemsSuite) TestSystemsGetSome(c *check.C) {
 
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("seeded-systems", []map[string]interface{}{{
+	st.Set("seeded-systems", []map[string]any{{
 		"system": "20200318", "model": "my-model-2", "brand-id": "my-brand",
 		"revision": 2, "timestamp": "2009-11-10T23:00:00Z",
 		"seed-time": "2009-11-10T23:00:00Z",
@@ -422,19 +422,19 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 	restore := s.mockSystemSeeds(c)
 	defer restore()
 
-	model := s.Brands.Model("my-brand", "pc", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
 		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -443,7 +443,7 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 		},
 	})
 
-	currentSystem := []map[string]interface{}{{
+	currentSystem := []map[string]any{{
 		"system": "20191119", "model": "my-model", "brand-id": "my-brand",
 		"revision": 2, "timestamp": "2009-11-10T23:00:00Z",
 		"seed-time": "2009-11-10T23:00:00Z",
@@ -585,14 +585,14 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 			c.Check(rec.Code, check.Equals, 200, check.Commentf(tc.comment))
 		}
 
-		var rspBody map[string]interface{}
+		var rspBody map[string]any
 		err = json.Unmarshal(rec.Body.Bytes(), &rspBody)
 		c.Assert(err, check.IsNil, check.Commentf(tc.comment))
 
-		var expResp map[string]interface{}
+		var expResp map[string]any
 		if tc.expUnsupported {
-			expResp = map[string]interface{}{
-				"result": map[string]interface{}{
+			expResp = map[string]any{
+				"result": map[string]any{
 					"message": fmt.Sprintf("requested action is not supported by system %q", "20191119"),
 				},
 				"status":      "Bad Request",
@@ -600,17 +600,17 @@ func (s *systemsSuite) TestSystemActionRequestWithSeeded(c *check.C) {
 				"type":        "error",
 			}
 		} else {
-			expResp = map[string]interface{}{
+			expResp = map[string]any{
 				"result":      nil,
 				"status":      "OK",
 				"status-code": 200.0,
 				"type":        "sync",
 			}
 			if tc.expRestart {
-				expResp["maintenance"] = map[string]interface{}{
+				expResp["maintenance"] = map[string]any{
 					"kind":    "system-restart",
 					"message": "system is restarting",
-					"value": map[string]interface{}{
+					"value": map[string]any{
 						"op": "reboot",
 					},
 				}
@@ -686,11 +686,11 @@ func (s *systemsSuite) TestSystemActionNonRoot(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	c.Assert(rec.Code, check.Equals, 403)
 
-	var rspBody map[string]interface{}
+	var rspBody map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &rspBody)
 	c.Check(err, check.IsNil)
-	c.Check(rspBody, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(rspBody, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "access denied",
 			"kind":    "login-required",
 		},
@@ -792,11 +792,11 @@ func (s *systemsSuite) TestSystemRebootUnhappy(c *check.C) {
 		c.Check(rec.Code, check.Equals, tc.expectedHttpCode)
 		c.Check(called, check.Equals, 1)
 
-		var rspBody map[string]interface{}
+		var rspBody map[string]any
 		err = json.Unmarshal(rec.Body.Bytes(), &rspBody)
 		c.Check(err, check.IsNil)
 		c.Check(rspBody["status-code"], check.Equals, float64(tc.expectedHttpCode))
-		result := rspBody["result"].(map[string]interface{})
+		result := rspBody["result"].(map[string]any)
 		c.Check(result["message"], check.Equals, tc.expectedErr)
 	}
 }
@@ -1171,15 +1171,15 @@ func (s *systemsSuite) testSystemInstallActionFinishCallsDevicestate(c *check.C,
 	})
 	defer r()
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "install",
 		"step":   "finish",
-		"on-volumes": map[string]interface{}{
-			"pc": map[string]interface{}{
+		"on-volumes": map[string]any{
+			"pc": map[string]any{
 				"bootloader": "grub",
 			},
 		},
-		"optional-install": map[string]interface{}{
+		"optional-install": map[string]any{
 			"snaps":      optionalInstall.Snaps,
 			"components": optionalInstall.Components,
 			"all":        optionalInstall.All,
@@ -1221,15 +1221,15 @@ func (s *systemsSuite) testSystemInstallActionFinishCallsDevicestate(c *check.C,
 func (s *systemsSuite) TestSystemInstallActionFinishCallsDevicestateAllAndSpecificInstallsFails(c *check.C) {
 	s.daemon(c)
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "install",
 		"step":   "finish",
-		"on-volumes": map[string]interface{}{
-			"pc": map[string]interface{}{
+		"on-volumes": map[string]any{
+			"pc": map[string]any{
 				"bootloader": "grub",
 			},
 		},
-		"optional-install": map[string]interface{}{
+		"optional-install": map[string]any{
 			"snaps":      []string{"snap1", "snap2"},
 			"components": map[string][]string{"snap1": {"comp1"}, "snap2": {"comp2"}},
 			"all":        true,
@@ -1269,15 +1269,15 @@ func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionCallsDevices
 	})
 	defer r()
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "install",
 		"step":   "setup-storage-encryption",
-		"on-volumes": map[string]interface{}{
-			"pc": map[string]interface{}{
+		"on-volumes": map[string]any{
+			"pc": map[string]any{
 				"bootloader": "grub",
 			},
 		},
-		"volumes-auth": map[string]interface{}{
+		"volumes-auth": map[string]any{
 			"mode":       "passphrase",
 			"passphrase": "1234",
 		},
@@ -1328,11 +1328,11 @@ func (s *systemsSuite) TestSystemInstallActionGeneratesTasks(c *check.C) {
 		{"setup-storage-encryption", 1},
 	} {
 		soon = 0
-		body := map[string]interface{}{
+		body := map[string]any{
 			"action": "install",
 			"step":   tc.installStep,
-			"on-volumes": map[string]interface{}{
-				"pc": map[string]interface{}{
+			"on-volumes": map[string]any{
+				"pc": map[string]any{
 					"bootloader": "grub",
 				},
 			},
@@ -1366,7 +1366,7 @@ func (s *systemsSuite) TestSystemInstallActionErrorMissingVolumes(c *check.C) {
 		{"finish", `cannot finish install for "20191119": cannot finish install without volumes data (api)`},
 		{"setup-storage-encryption", `cannot setup storage encryption for install from "20191119": cannot setup storage encryption without volumes data (api)`},
 	} {
-		body := map[string]interface{}{
+		body := map[string]any{
 			"action": "install",
 			"step":   tc.installStep,
 			// note that "on-volumes" is missing which will
@@ -1415,7 +1415,7 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 		expectedStatus   int
 		expectedErrKind  client.ErrorKind
 		expectedErrMsg   string
-		expectedErrValue interface{}
+		expectedErrValue any
 
 		mockSupportErr error
 	}{
@@ -1438,7 +1438,7 @@ func (s *systemsSuite) TestSystemActionCheckPassphraseError(c *check.C) {
 		{
 			passphrase:     "bad-passphrase",
 			expectedStatus: 400, expectedErrKind: "invalid-passphrase", expectedErrMsg: "passphrase did not pass quality checks",
-			expectedErrValue: map[string]interface{}{
+			expectedErrValue: map[string]any{
 				"reasons":          []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
 				"entropy-bits":     expectedEntropy,
 				"min-entropy-bits": expectedMinEntropy,
@@ -1504,7 +1504,7 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 		expectedStatus   int
 		expectedErrKind  client.ErrorKind
 		expectedErrMsg   string
-		expectedErrValue interface{}
+		expectedErrValue any
 
 		mockSupportErr error
 	}{
@@ -1527,7 +1527,7 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 		{
 			pin:            "0",
 			expectedStatus: 400, expectedErrKind: "invalid-pin", expectedErrMsg: "PIN did not pass quality checks",
-			expectedErrValue: map[string]interface{}{
+			expectedErrValue: map[string]any{
 				"reasons":          []device.AuthQualityErrorReason{device.AuthQualityErrorReasonLowEntropy},
 				"entropy-bits":     expectedEntropy,
 				"min-entropy-bits": expectedMinEntropy,
@@ -1645,8 +1645,8 @@ type systemsCreateSuite struct {
 	mockAssertionFn           func(at *asserts.AssertionType, headers []string, user *auth.UserState) (asserts.Assertion, error)
 }
 
-func (s *systemsCreateSuite) mockDevAssertion(c *check.C, t *asserts.AssertionType, extras map[string]interface{}) asserts.Assertion {
-	headers := map[string]interface{}{
+func (s *systemsCreateSuite) mockDevAssertion(c *check.C, t *asserts.AssertionType, extras map[string]any) asserts.Assertion {
+	headers := map[string]any{
 		"type":         t.Name,
 		"authority-id": s.dev1acct.AccountID(),
 		"account-id":   s.dev1acct.AccountID(),
@@ -1664,7 +1664,7 @@ func (s *systemsCreateSuite) mockDevAssertion(c *check.C, t *asserts.AssertionTy
 	return vs
 }
 
-func (s *systemsCreateSuite) mockStoreAssertion(c *check.C, t *asserts.AssertionType, extras map[string]interface{}) asserts.Assertion {
+func (s *systemsCreateSuite) mockStoreAssertion(c *check.C, t *asserts.AssertionType, extras map[string]any) asserts.Assertion {
 	return mockStoreAssertion(c, s.storeSigning, s.storeSigning.AuthorityID, s.dev1acct.AccountID(), t, extras)
 }
 
@@ -1673,9 +1673,9 @@ func mockStoreAssertion(
 	signer assertstest.SignerDB,
 	authorityID, accountID string,
 	t *asserts.AssertionType,
-	extras map[string]interface{},
+	extras map[string]any,
 ) asserts.Assertion {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         t.Name,
 		"authority-id": authorityID,
 		"account-id":   accountID,
@@ -1738,28 +1738,28 @@ func (s *systemsCreateSuite) SeqFormingAssertion(assertType *asserts.AssertionTy
 
 func (s *systemsCreateSuite) TestCreateSystemActionBadRequests(c *check.C) {
 	type test struct {
-		body       map[string]interface{}
+		body       map[string]any
 		routeLabel string
 		result     string
 	}
 
 	tests := []test{
 		{
-			body: map[string]interface{}{
+			body: map[string]any{
 				"action": "create",
 			},
 			routeLabel: "label",
 			result:     `label should not be provided in route when creating a system \(api\)`,
 		},
 		{
-			body: map[string]interface{}{
+			body: map[string]any{
 				"action": "create",
 				"label":  "",
 			},
 			result: `label must be provided in request body for action "create" \(api\)`,
 		},
 		{
-			body: map[string]interface{}{
+			body: map[string]any{
 				"action": "create",
 				"label":  "label",
 				"validation-sets": []string{
@@ -1769,7 +1769,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionBadRequests(c *check.C) {
 			result: `cannot parse validation sets: cannot parse validation set "not-a-validation-set": expected a single account/name \(api\)`,
 		},
 		{
-			body: map[string]interface{}{
+			body: map[string]any{
 				"action": "create",
 				"label":  "label",
 				"validation-sets": []string{
@@ -1815,20 +1815,20 @@ func (s *systemsCreateSuite) TestCreateSystemActionSpecificValdationSet(c *check
 }
 
 func (s *systemsCreateSuite) testCreateSystemAction(c *check.C, requestedValSetSequence int) {
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       snaptest.AssertedSnapID("pc-kernel"),
 			"revision": "10",
 			"presence": "required",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "pc",
 			"id":       snaptest.AssertedSnapID("pc"),
 			"revision": "10",
 			"presence": "required",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "core20",
 			"id":       snaptest.AssertedSnapID("core20"),
 			"revision": "10",
@@ -1840,7 +1840,7 @@ func (s *systemsCreateSuite) testCreateSystemAction(c *check.C, requestedValSetS
 
 	const validationSet = "validation-set-1"
 
-	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]any{
 		"name":     validationSet,
 		"sequence": "1",
 		"snaps":    snaps,
@@ -1892,7 +1892,7 @@ func (s *systemsCreateSuite) testCreateSystemAction(c *check.C, requestedValSetS
 		valSetString += "=" + strconv.Itoa(requestedValSetSequence)
 	}
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action":          "create",
 		"label":           expectedLabel,
 		"validation-sets": []string{valSetString},
@@ -1949,7 +1949,7 @@ func (s *systemsCreateSuite) TestRemoveSystemAction(c *check.C) {
 		return st.NewChange("change", "..."), nil
 	})
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "remove",
 	}
 
@@ -1976,7 +1976,7 @@ func (s *systemsCreateSuite) TestRemoveSystemActionNotFound(c *check.C) {
 		return nil, devicestate.ErrNoRecoverySystem
 	})
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "remove",
 	}
 
@@ -2080,20 +2080,20 @@ func (s *systemsCreateSuite) TestCreateSystemActionOfflineBadRequests(c *check.C
 }
 
 func (s *systemsCreateSuite) TestCreateSystemActionOffline(c *check.C) {
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       snaptest.AssertedSnapID("pc-kernel"),
 			"revision": "10",
 			"presence": "required",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "pc",
 			"id":       snaptest.AssertedSnapID("pc"),
 			"revision": "10",
 			"presence": "required",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "core20",
 			"id":       snaptest.AssertedSnapID("core20"),
 			"revision": "10",
@@ -2108,7 +2108,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionOffline(c *check.C) {
 		expectedLabel = "1234"
 	)
 
-	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]any{
 		"name":     validationSet,
 		"sequence": "1",
 		"snaps":    snaps,
@@ -2126,7 +2126,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionOffline(c *check.C) {
 		digest, size, err := asserts.SnapFileSHA3_384(f)
 		c.Assert(err, check.IsNil)
 
-		rev := s.mockStoreAssertion(c, asserts.SnapRevisionType, map[string]interface{}{
+		rev := s.mockStoreAssertion(c, asserts.SnapRevisionType, map[string]any{
 			"snap-id":       snaptest.AssertedSnapID(name),
 			"snap-sha3-384": digest,
 			"developer-id":  s.dev1acct.AccountID(),
@@ -2135,7 +2135,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionOffline(c *check.C) {
 		})
 
 		// this is required right now. should it be?
-		decl := s.mockStoreAssertion(c, asserts.SnapDeclarationType, map[string]interface{}{
+		decl := s.mockStoreAssertion(c, asserts.SnapDeclarationType, map[string]any{
 			"series":       "16",
 			"snap-id":      snaptest.AssertedSnapID(name),
 			"snap-name":    name,
@@ -2190,26 +2190,26 @@ func (s *systemsCreateSuite) TestCreateSystemActionOffline(c *check.C) {
 }
 
 func (s *systemsCreateSuite) TestCreateSystemActionWithComponentsOffline(c *check.C) {
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       snaptest.AssertedSnapID("pc-kernel"),
 			"revision": "10",
 			"presence": "required",
-			"components": map[string]interface{}{
-				"kmod": map[string]interface{}{
+			"components": map[string]any{
+				"kmod": map[string]any{
 					"revision": "10",
 					"presence": "required",
 				},
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "pc",
 			"id":       snaptest.AssertedSnapID("pc"),
 			"revision": "10",
 			"presence": "required",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "core20",
 			"id":       snaptest.AssertedSnapID("core20"),
 			"revision": "10",
@@ -2224,7 +2224,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionWithComponentsOffline(c *chec
 		expectedLabel = "1234"
 	)
 
-	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]any{
 		"name":     validationSet,
 		"sequence": "1",
 		"snaps":    snaps,
@@ -2251,7 +2251,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionWithComponentsOffline(c *chec
 
 		snapID := snaptest.AssertedSnapID(name)
 
-		rev := s.mockStoreAssertion(c, asserts.SnapRevisionType, map[string]interface{}{
+		rev := s.mockStoreAssertion(c, asserts.SnapRevisionType, map[string]any{
 			"snap-id":       snapID,
 			"snap-sha3-384": digest,
 			"developer-id":  s.dev1acct.AccountID(),
@@ -2259,7 +2259,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionWithComponentsOffline(c *chec
 			"snap-revision": "10",
 		})
 
-		decl := s.mockStoreAssertion(c, asserts.SnapDeclarationType, map[string]interface{}{
+		decl := s.mockStoreAssertion(c, asserts.SnapDeclarationType, map[string]any{
 			"series":       "16",
 			"snap-id":      snapID,
 			"snap-name":    name,
@@ -2359,7 +2359,7 @@ func makeStandardComponent(
 	digest, size, err := asserts.SnapFileSHA3_384(compPath)
 	c.Assert(err, check.IsNil)
 
-	resRev := mockStoreAssertion(c, signer, authorityID, accountID, asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev := mockStoreAssertion(c, signer, authorityID, accountID, asserts.SnapResourceRevisionType, map[string]any{
 		"snap-id":           snaptest.AssertedSnapID(snapName),
 		"developer-id":      accountID,
 		"resource-name":     compName,
@@ -2369,7 +2369,7 @@ func makeStandardComponent(
 		"timestamp":         time.Now().Format(time.RFC3339),
 	})
 
-	resPair := mockStoreAssertion(c, signer, authorityID, accountID, asserts.SnapResourcePairType, map[string]interface{}{
+	resPair := mockStoreAssertion(c, signer, authorityID, accountID, asserts.SnapResourcePairType, map[string]any{
 		"snap-id":           snaptest.AssertedSnapID(snapName),
 		"developer-id":      accountID,
 		"resource-name":     compName,
@@ -2395,7 +2395,7 @@ func (s *systemsCreateSuite) TestCreateSystemActionOfflinePreinstalledJSON(c *ch
 		return st.NewChange("change", "..."), nil
 	})
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action":  "create",
 		"label":   expectedLabel,
 		"offline": true,
@@ -2459,23 +2459,23 @@ func (s *systemsCreateSuite) TestCreateSystemActionOfflineJustValidationSets(c *
 		expectedLabel = "1234"
 	)
 
-	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert := s.mockDevAssertion(c, asserts.ValidationSetType, map[string]any{
 		"name":     validationSet,
 		"sequence": "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       snaptest.AssertedSnapID("pc-kernel"),
 				"revision": "10",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       snaptest.AssertedSnapID("pc"),
 				"revision": "10",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       snaptest.AssertedSnapID("core20"),
 				"revision": "10",

--- a/daemon/api_themes.go
+++ b/daemon/api_themes.go
@@ -87,7 +87,7 @@ func installedThemes(overlord *overlord.Overlord) (gtkThemes, iconThemes, soundT
 			default:
 				continue
 			}
-			var sources []interface{}
+			var sources []any
 			if err := slot.Attr("source.read", &sources); err != nil {
 				continue
 			}
@@ -262,6 +262,6 @@ func installThemes(c *Command, r *http.Request, user *auth.UserState) Response {
 		chg = newChange(st, "install-themes", summary, tasksets, names)
 		ensureStateSoon(st)
 	}
-	chg.Set("api-data", map[string]interface{}{"snap-names": names})
+	chg.Set("api-data", map[string]any{"snap-names": names})
 	return AsyncResponse(nil, chg.ID())
 }

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -243,7 +243,7 @@ func removeUser(c *Command, username string, opts postUserDeleteData) Response {
 		return InternalError(err.Error())
 	}
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"removed": []userResponseData{
 			{ID: u.ID, Username: u.Username, Email: u.Email},
 		},

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -498,7 +498,7 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 	})()
 
 	var req *http.Request
-	var expected interface{}
+	var expected any
 	expectedItem := daemon.UserResponseData{
 		Username: expectedUsername,
 		SSHKeys: []string{
@@ -687,7 +687,7 @@ func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 	expected := []daemon.UserResponseData{
 		{ID: expectedID, Username: expectedUsername, Email: expectedEmail},
 	}
-	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, check.DeepEquals, map[string]any{
 		"removed": expected,
 	})
 	c.Check(called, check.Equals, 1)
@@ -696,7 +696,7 @@ func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 func (s *userSuite) setupSigner(accountID string, signerPrivKey asserts.PrivateKey) *assertstest.SigningDB {
 	st := s.d.Overlord().State()
 
-	signerSigning := s.Brands.Register(accountID, signerPrivKey, map[string]interface{}{
+	signerSigning := s.Brands.Register(accountID, signerPrivKey, map[string]any{
 		"account-id":   accountID,
 		"verification": "verified",
 	})
@@ -713,7 +713,7 @@ var (
 	unknownPrivKey, _ = assertstest.GenerateKey(752)
 )
 
-func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interface{}) {
+func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]any) {
 	st := s.d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
@@ -724,12 +724,12 @@ func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interfa
 	s.setupSigner("partner", partnerPrivKey)
 	s.setupSigner("unknown", unknownPrivKey)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":          "amd64",
 		"gadget":                "pc",
 		"kernel":                "pc-kernel",
-		"required-snaps":        []interface{}{"required-snap1"},
-		"system-user-authority": []interface{}{"my-brand", "partner"},
+		"required-snaps":        []any{"required-snap1"},
+		"system-user-authority": []any{"my-brand", "partner"},
 	})
 	// now add model related stuff to the system
 	assertstatetest.AddMany(st, model)
@@ -737,7 +737,7 @@ func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interfa
 	deviceKey, _ := assertstest.GenerateKey(752)
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, check.IsNil)
-	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.Brands.Signing("my-brand").Sign(asserts.SerialType, map[string]any{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-model",
@@ -765,12 +765,12 @@ func (s *userSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interfa
 	c.Assert(err, check.IsNil)
 }
 
-var goodUser = map[string]interface{}{
+var goodUser = map[string]any{
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "foo@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model", "other-model"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model", "other-model"},
 	"name":         "Boring Guy",
 	"username":     "guy",
 	"password":     "$6$salt$hash",
@@ -778,12 +778,12 @@ var goodUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var partnerUser = map[string]interface{}{
+var partnerUser = map[string]any{
 	"authority-id": "partner",
 	"brand-id":     "my-brand",
 	"email":        "p@partner.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
 	"name":         "Partner Guy",
 	"username":     "partnerguy",
 	"password":     "$6$salt$hash",
@@ -791,14 +791,14 @@ var partnerUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var serialUser = map[string]interface{}{
+var serialUser = map[string]any{
 	"format":       "1",
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "serial@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
-	"serials":      []interface{}{"serialserial"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
+	"serials":      []any{"serialserial"},
 	"name":         "Serial Guy",
 	"username":     "goodserialguy",
 	"password":     "$6$salt$hash",
@@ -806,13 +806,13 @@ var serialUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var badUser = map[string]interface{}{
+var badUser = map[string]any{
 	// bad user (not valid for this model)
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "foobar@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"non-of-the-models-i-have"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"non-of-the-models-i-have"},
 	"name":         "Random Gal",
 	"username":     "gal",
 	"password":     "$6$salt$hash",
@@ -820,14 +820,14 @@ var badUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var badUserNoMatchingSerial = map[string]interface{}{
+var badUserNoMatchingSerial = map[string]any{
 	"format":       "1",
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "noserial@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
-	"serials":      []interface{}{"different-serialserial"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
+	"serials":      []any{"different-serialserial"},
 	"name":         "No Serial Guy",
 	"username":     "noserial",
 	"password":     "$6$salt$hash",
@@ -835,12 +835,12 @@ var badUserNoMatchingSerial = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var unknownUser = map[string]interface{}{
+var unknownUser = map[string]any{
 	"authority-id": "unknown",
 	"brand-id":     "my-brand",
 	"email":        "x@partner.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
 	"name":         "XGuy",
 	"username":     "xguy",
 	"password":     "$6$salt$hash",
@@ -852,7 +852,7 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownClassicErrors(c *chec
 	restore := release.MockOnClassic(true)
 	defer restore()
 
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	// do it!
 	buf := bytes.NewBufferString(`{"known":true}`)
@@ -864,7 +864,7 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownClassicErrors(c *chec
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -887,7 +887,7 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *che
 }
 
 func (s *userSuite) TestPostCreateUserAutomaticManagedDoesNotActOrError(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	st := s.d.Overlord().State()
 	st.Lock()
@@ -914,7 +914,7 @@ func (s *userSuite) TestPostCreateUserAutomaticManagedDoesNotActOrError(c *check
 }
 
 func (s *userSuite) TestPostCreateUserAutomaticDisabled(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	// disable automatic user creation
 	st := s.d.Overlord().State()
@@ -1053,7 +1053,7 @@ func (s *userSuite) TestUsersHasUser(c *check.C) {
 }
 
 func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string, expectSudoer bool) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
 
 	// mock the calls that create the user
 	var deviceStateCreateUserCalled bool

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -74,7 +74,7 @@ func modeString(mode assertstate.ValidationSetMode) (string, error) {
 }
 
 func validationSetNotFound(accountID, name string, sequence int) Response {
-	v := map[string]interface{}{
+	v := map[string]any{
 		"account-id": accountID,
 		"name":       name,
 	}

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -97,8 +97,8 @@ func (s *apiValidationSetsSuite) SetUpTest(c *check.C) {
 }
 
 func (s *apiValidationSetsSuite) mockValidationSetsTracking(st *state.State) {
-	st.Set("validation-sets", map[string]interface{}{
-		fmt.Sprintf("%s/foo", s.dev1acct.AccountID()): map[string]interface{}{
+	st.Set("validation-sets", map[string]any{
+		fmt.Sprintf("%s/foo", s.dev1acct.AccountID()): map[string]any{
 			"account-id": s.dev1acct.AccountID(),
 			"name":       "foo",
 			"mode":       assertstate.Enforce,
@@ -106,7 +106,7 @@ func (s *apiValidationSetsSuite) mockValidationSetsTracking(st *state.State) {
 			// Current should equal pinned-at if pinned-at != 0 but let's check api_validate is robust
 			"current": 99,
 		},
-		fmt.Sprintf("%s/baz", s.dev1acct.AccountID()): map[string]interface{}{
+		fmt.Sprintf("%s/baz", s.dev1acct.AccountID()): map[string]any{
 			"account-id": s.dev1acct.AccountID(),
 			"name":       "baz",
 			"mode":       assertstate.Monitor,
@@ -117,13 +117,13 @@ func (s *apiValidationSetsSuite) mockValidationSetsTracking(st *state.State) {
 }
 
 func (s *apiValidationSetsSuite) mockAssert(c *check.C, name, sequence string) asserts.Assertion {
-	snaps := []interface{}{map[string]interface{}{
+	snaps := []any{map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 		"name":     "snap-b",
 		"presence": "required",
 		"revision": "1",
 	}}
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": s.dev1acct.AccountID(),
 		"account-id":   s.dev1acct.AccountID(),
 		"name":         name,
@@ -329,7 +329,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetNotFound(c *check.C) {
 	rspe := s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 404)
 	c.Check(string(rspe.Kind), check.Equals, "validation-set-not-found")
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"account-id": "foo",
 		"name":       "other",
 	})
@@ -593,7 +593,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinnedNotFound(c *check.C) 
 	rspe := s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 404)
 	c.Check(string(rspe.Kind), check.Equals, "validation-set-not-found")
-	c.Check(rspe.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(rspe.Value, check.DeepEquals, map[string]any{
 		"account-id": "foo",
 		"name":       "bar",
 		"sequence":   333,

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -301,7 +301,7 @@ func (s *daemonSuite) TestCommandRestartingState(c *check.C) {
 		c.Assert(err, check.IsNil)
 		var val errorValue
 		if t.op != "" {
-			val = map[string]interface{}{
+			val = map[string]any{
 				"op": t.op,
 			}
 		}
@@ -1054,7 +1054,7 @@ func (s *daemonSuite) testRestartSystemWiring(c *check.C, prep func(d *Daemon), 
 	maintErr := &errorResult{}
 	c.Assert(json.Unmarshal(b, maintErr), check.IsNil)
 	c.Check(maintErr.Kind, check.Equals, client.ErrorKindSystemRestart)
-	c.Check(maintErr.Value, check.DeepEquals, map[string]interface{}{
+	c.Check(maintErr.Value, check.DeepEquals, map[string]any{
 		"op": expectedOp,
 	})
 
@@ -1314,7 +1314,7 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *check.C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	var v interface{}
+	var v any
 	// these were cleared
 	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
 	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
@@ -1338,7 +1338,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	var v interface{}
+	var v any
 	// these were cleared
 	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
 	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -73,7 +73,7 @@ func (ae *apiError) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // check it implements StructuredResponse
 var _ StructuredResponse = (*apiError)(nil)
 
-type errorValue interface{}
+type errorValue any
 
 type errorResult struct {
 	Message string `json:"message"` // note no omitempty
@@ -84,11 +84,11 @@ type errorResult struct {
 
 // errorResponder is a callable that produces an error Response.
 // e.g., InternalError("something broke: %v", err), etc.
-type errorResponder func(string, ...interface{}) *apiError
+type errorResponder func(string, ...any) *apiError
 
 // makeErrorResponder builds an errorResponder from the given error status.
 func makeErrorResponder(status int) errorResponder {
-	return func(format string, v ...interface{}) *apiError {
+	return func(format string, v ...any) *apiError {
 		var msg string
 		if len(v) == 0 {
 			msg = format
@@ -166,24 +166,24 @@ func MissingSnapResourcePair(csi *snap.ComponentSideInfo, snapRev snap.Revision)
 // in the given context (e.g. request an install from a stable
 // channel when this channel is empty).
 func SnapRevisionNotAvailable(snapName string, rnaErr *store.RevisionNotAvailableError) *apiError {
-	var value interface{} = snapName
+	var value any = snapName
 	kind := client.ErrorKindSnapRevisionNotAvailable
 	msg := rnaErr.Error()
 	if len(rnaErr.Releases) != 0 && rnaErr.Channel != "" {
 		thisArch := arch.DpkgArchitecture()
-		values := map[string]interface{}{
+		values := map[string]any{
 			"snap-name":    snapName,
 			"action":       rnaErr.Action,
 			"channel":      rnaErr.Channel,
 			"architecture": thisArch,
 		}
 		archOK := false
-		releases := make([]map[string]interface{}, 0, len(rnaErr.Releases))
+		releases := make([]map[string]any, 0, len(rnaErr.Releases))
 		for _, c := range rnaErr.Releases {
 			if c.Architecture == thisArch {
 				archOK = true
 			}
-			releases = append(releases, map[string]interface{}{
+			releases = append(releases, map[string]any{
 				"architecture": c.Architecture,
 				"channel":      c.Name,
 			})
@@ -213,7 +213,7 @@ func SnapRevisionNotAvailable(snapName string, rnaErr *store.RevisionNotAvailabl
 // SnapChangeConflict is an error responder used when an operation would
 // conflict with another ongoing change.
 func SnapChangeConflict(cce *snapstate.ChangeConflictError) *apiError {
-	value := map[string]interface{}{}
+	value := map[string]any{}
 	if cce.Snap != "" {
 		value["snap-name"] = cce.Snap
 	}
@@ -232,7 +232,7 @@ func SnapChangeConflict(cce *snapstate.ChangeConflictError) *apiError {
 // QuotaChangeConflict is an error responder used when an operation would
 // conflict with another ongoing change.
 func QuotaChangeConflict(qce *servicestate.QuotaChangeConflictError) *apiError {
-	value := map[string]interface{}{}
+	value := map[string]any{}
 	if qce.Quota != "" {
 		value["quota-name"] = qce.Quota
 	}
@@ -251,7 +251,7 @@ func QuotaChangeConflict(qce *servicestate.QuotaChangeConflictError) *apiError {
 // InsufficientSpace is an error responder used when an operation cannot
 // be performed due to low disk space.
 func InsufficientSpace(dserr *snapstate.InsufficientSpaceError) *apiError {
-	value := map[string]interface{}{}
+	value := map[string]any{}
 	if len(dserr.Snaps) > 0 {
 		value["snap-names"] = dserr.Snaps
 	}
@@ -268,7 +268,7 @@ func InsufficientSpace(dserr *snapstate.InsufficientSpaceError) *apiError {
 
 // AppNotFound is an error responder used when an operation is
 // requested on a app that doesn't exist.
-func AppNotFound(format string, v ...interface{}) *apiError {
+func AppNotFound(format string, v ...any) *apiError {
 	return &apiError{
 		Status:  404,
 		Message: fmt.Sprintf(format, v...),
@@ -278,7 +278,7 @@ func AppNotFound(format string, v ...interface{}) *apiError {
 
 // AuthCancelled is an error responder used when a user cancelled
 // the auth process.
-func AuthCancelled(format string, v ...interface{}) *apiError {
+func AuthCancelled(format string, v ...any) *apiError {
 	return &apiError{
 		Status:  403,
 		Message: fmt.Sprintf(format, v...),
@@ -288,7 +288,7 @@ func AuthCancelled(format string, v ...interface{}) *apiError {
 
 // InterfacesUnchanged is an error responder used when an operation
 // that would normally change interfaces finds it has nothing to do
-func InterfacesUnchanged(format string, v ...interface{}) *apiError {
+func InterfacesUnchanged(format string, v ...any) *apiError {
 	return &apiError{
 		Status:  400,
 		Message: fmt.Sprintf(format, v...),
@@ -296,7 +296,7 @@ func InterfacesUnchanged(format string, v ...interface{}) *apiError {
 	}
 }
 
-func errToResponse(err error, snaps []string, fallback errorResponder, format string, v ...interface{}) *apiError {
+func errToResponse(err error, snaps []string, fallback errorResponder, format string, v ...any) *apiError {
 	var kind client.ErrorKind
 	var snapName string
 

--- a/daemon/errors_test.go
+++ b/daemon/errors_test.go
@@ -142,7 +142,7 @@ func (s *errorsSuite) TestErrToResponse(c *C) {
 	// this one can't happen (but fun to test):
 	saXe := &store.SnapActionError{Refresh: map[string]error{"foo": sa1e}}
 
-	makeErrorRsp := func(kind client.ErrorKind, err error, value interface{}) *daemon.APIError {
+	makeErrorRsp := func(kind client.ErrorKind, err error, value any) *daemon.APIError {
 		return &daemon.APIError{
 			Status:  400,
 			Message: err.Error(),
@@ -235,7 +235,7 @@ func (s *errorsSuite) TestErrToResponseInsufficentSpace(c *C) {
 		Status:  507,
 		Message: "specific error msg",
 		Kind:    client.ErrorKindInsufficientDiskSpace,
-		Value: map[string]interface{}{
+		Value: map[string]any{
 			"snap-names":  []string{"foo", "bar"},
 			"change-kind": "some-change",
 		},

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -305,7 +305,7 @@ func MockSnapstateRemoveComponents(mock func(st *state.State, snapName string, c
 	}
 }
 
-func MockConfigstateConfigureInstalled(f func(st *state.State, name string, patchValues map[string]interface{}, flags int) (*state.TaskSet, error)) (restore func()) {
+func MockConfigstateConfigureInstalled(f func(st *state.State, name string, patchValues map[string]any, flags int) (*state.TaskSet, error)) (restore func()) {
 	old := configstateConfigureInstalled
 	configstateConfigureInstalled = f
 	return func() {
@@ -424,7 +424,7 @@ func MockConfdbstateGetView(f func(_ *state.State, _, _, _ string) (*confdb.View
 	return testutil.Mock(&confdbstateGetView, f)
 }
 
-func MockConfdbstateSetViaView(f func(confdb.Databag, *confdb.View, map[string]interface{}) error) (restore func()) {
+func MockConfdbstateSetViaView(f func(confdb.Databag, *confdb.View, map[string]any) error) (restore func()) {
 	return testutil.Mock(&confdbstateSetViaView, f)
 }
 
@@ -440,6 +440,6 @@ func ValidateFeatureFlag(st *state.State, feature features.SnapdFeature) *apiErr
 	return validateFeatureFlag(st, feature)
 }
 
-func MockDeviceStateSignConfdbControl(f func(m *devicestate.DeviceManager, groups []interface{}, revision int) (*asserts.ConfdbControl, error)) (restore func()) {
+func MockDeviceStateSignConfdbControl(f func(m *devicestate.DeviceManager, groups []any, revision int) (*asserts.ConfdbControl, error)) (restore func()) {
 	return testutil.Mock(&devicestateSignConfdbControl, f)
 }

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -72,7 +72,7 @@ type respJSON struct {
 	// StatusText is filled by the serving pipeline.
 	StatusText string `json:"status"`
 	// Result is a free-form optional result object.
-	Result interface{} `json:"result"`
+	Result any `json:"result"`
 	// Change is the change ID for an async response.
 	Change string `json:"change,omitempty"`
 	// Sources is used in find responses.
@@ -95,19 +95,19 @@ func maintenanceForRestartType(rst restart.RestartType) *errorResult {
 	case restart.RestartSystem, restart.RestartSystemNow:
 		e.Kind = client.ErrorKindSystemRestart
 		e.Message = systemRestartMsg
-		e.Value = map[string]interface{}{
+		e.Value = map[string]any{
 			"op": "reboot",
 		}
 	case restart.RestartSystemHaltNow:
 		e.Kind = client.ErrorKindSystemRestart
 		e.Message = systemHaltMsg
-		e.Value = map[string]interface{}{
+		e.Value = map[string]any{
 			"op": "halt",
 		}
 	case restart.RestartSystemPoweroffNow:
 		e.Kind = client.ErrorKindSystemRestart
 		e.Message = systemPoweroffMsg
-		e.Value = map[string]interface{}{
+		e.Value = map[string]any{
 			"op": "poweroff",
 		}
 	case restart.RestartDaemon:
@@ -151,7 +151,7 @@ func (r *respJSON) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	hdr := w.Header()
 	if r.Status == 202 || r.Status == 201 {
-		if m, ok := r.Result.(map[string]interface{}); ok {
+		if m, ok := r.Result.(map[string]any); ok {
 			if location, ok := m["resource"]; ok {
 				if location, ok := location.(string); ok && location != "" {
 					hdr.Set("Location", location)
@@ -166,7 +166,7 @@ func (r *respJSON) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 }
 
 // SyncResponse builds a "sync" response from the given result.
-func SyncResponse(result interface{}) Response {
+func SyncResponse(result any) Response {
 	if rsp, ok := result.(Response); ok {
 		return rsp
 	}
@@ -183,7 +183,7 @@ func SyncResponse(result interface{}) Response {
 }
 
 // AsyncResponse builds an "async" response for a created change
-func AsyncResponse(result map[string]interface{}, change string) Response {
+func AsyncResponse(result map[string]any, change string) Response {
 	return &respJSON{
 		Type:   ResponseTypeAsync,
 		Status: 202,

--- a/daemon/response_test.go
+++ b/daemon/response_test.go
@@ -41,7 +41,7 @@ func (s *responseSuite) TestRespSetsLocationIfAccepted(c *check.C) {
 
 	rsp := &daemon.RespJSON{
 		Status: 202,
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}
@@ -56,7 +56,7 @@ func (s *responseSuite) TestRespSetsLocationIfCreated(c *check.C) {
 
 	rsp := &daemon.RespJSON{
 		Status: 201,
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}
@@ -71,7 +71,7 @@ func (s *responseSuite) TestRespDoesNotSetLocationIfOther(c *check.C) {
 
 	rsp := &daemon.RespJSON{
 		Status: 418, // I'm a teapot
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}

--- a/dbusutil/dbustest/dbustest.go
+++ b/dbusutil/dbustest/dbustest.go
@@ -119,7 +119,7 @@ func (s *testDBusStream) decodeRequest(req []byte) {
 				dbus.FieldReplySerial: dbus.MakeVariant(msgIn.Serial()),
 				dbus.FieldSignature:   dbus.MakeVariant(dbus.SignatureOf("")),
 			},
-			Body: []interface{}{":test"},
+			Body: []any{":test"},
 		})
 		s.sendMsg(&dbus.Message{
 			Type: dbus.TypeSignal,
@@ -131,7 +131,7 @@ func (s *testDBusStream) decodeRequest(req []byte) {
 				dbus.FieldSender:      dbus.MakeVariant("org.freedesktop.DBus"),
 				dbus.FieldSignature:   dbus.MakeVariant(dbus.SignatureOf("")),
 			},
-			Body: []interface{}{testDBusClientName},
+			Body: []any{testDBusClientName},
 		})
 	default:
 		msgOutList, err := s.handler(msgIn, s.n-1)

--- a/desktop/notification/fdo_test.go
+++ b/desktop/notification/fdo_test.go
@@ -268,7 +268,7 @@ func (s *fdoSuite) TestProcessNotificationClosedUnknownNotificationNoError(c *C)
 	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	err := srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(1), uint32(2)},
+		Body: []any{uint32(1), uint32(2)},
 	}, &testObserver{
 		notificationClosed: func(id notification.ID, reason notification.CloseReason) error {
 			called = true
@@ -285,7 +285,7 @@ func (s *fdoSuite) TestProcessActionInvokedSignalSuccess(c *C) {
 	err := srv.ProcessSignal(&dbus.Signal{
 		// Sender and Path are not used
 		Name: "org.freedesktop.Notifications.ActionInvoked",
-		Body: []interface{}{uint32(42), "action-key"},
+		Body: []any{uint32(42), "action-key"},
 	}, &testObserver{
 		actionInvoked: func(id uint32, actionKey string) error {
 			called = true
@@ -302,7 +302,7 @@ func (s *fdoSuite) TestProcessActionInvokedSignalError(c *C) {
 	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	err := srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
-		Body: []interface{}{uint32(42), "action-key"},
+		Body: []any{uint32(42), "action-key"},
 	}, &testObserver{
 		actionInvoked: func(id uint32, actionKey string) error {
 			return fmt.Errorf("boom")
@@ -315,25 +315,25 @@ func (s *fdoSuite) TestProcessActionInvokedSignalBodyParseErrors(c *C) {
 	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	err := srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
-		Body: []interface{}{uint32(42), "action-key", "unexpected"},
+		Body: []any{uint32(42), "action-key", "unexpected"},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process ActionInvoked signal: unexpected number of body elements: 3")
 
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
-		Body: []interface{}{uint32(42)},
+		Body: []any{uint32(42)},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process ActionInvoked signal: unexpected number of body elements: 1")
 
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
-		Body: []interface{}{uint32(42), true},
+		Body: []any{uint32(42), true},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process ActionInvoked signal: expected second body element to be string, got bool")
 
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.ActionInvoked",
-		Body: []interface{}{true, "action-key"},
+		Body: []any{true, "action-key"},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process ActionInvoked signal: expected first body element to be uint32, got bool")
 }
@@ -346,7 +346,7 @@ func (s *fdoSuite) TestProcessNotificationClosedSignalSuccess(c *C) {
 	called := false
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(1), uint32(2)},
+		Body: []any{uint32(1), uint32(2)},
 	}, &testObserver{
 		notificationClosed: func(id notification.ID, reason notification.CloseReason) error {
 			called = true
@@ -366,7 +366,7 @@ func (s *fdoSuite) TestProcessNotificationClosedSignalError(c *C) {
 	c.Assert(err, IsNil)
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(1), uint32(2)},
+		Body: []any{uint32(1), uint32(2)},
 	}, &testObserver{
 		notificationClosed: func(id notification.ID, reason notification.CloseReason) error {
 			return fmt.Errorf("boom")
@@ -379,25 +379,25 @@ func (s *fdoSuite) TestProcessNotificationClosedSignalBodyParseErrors(c *C) {
 	srv := notification.NewFdoBackend(s.SessionBus, "desktop-id").(*notification.FdoBackend)
 	err := srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(42), uint32(2), "unexpected"},
+		Body: []any{uint32(42), uint32(2), "unexpected"},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process NotificationClosed signal: unexpected number of body elements: 3")
 
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(42)},
+		Body: []any{uint32(42)},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process NotificationClosed signal: unexpected number of body elements: 1")
 
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{uint32(42), true},
+		Body: []any{uint32(42), true},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process NotificationClosed signal: expected second body element to be uint32, got bool")
 
 	err = srv.ProcessSignal(&dbus.Signal{
 		Name: "org.freedesktop.Notifications.NotificationClosed",
-		Body: []interface{}{true, uint32(2)},
+		Body: []any{true, uint32(2)},
 	}, &testObserver{})
 	c.Assert(err, ErrorMatches, "cannot process NotificationClosed signal: expected first body element to be uint32, got bool")
 }

--- a/desktop/notification/gtk_test.go
+++ b/desktop/notification/gtk_test.go
@@ -75,7 +75,7 @@ func (s *gtkSuite) TestSendNotificationSuccess(c *C) {
 		Info: map[string]dbus.Variant{
 			"title":    dbus.MakeVariant("some title"),
 			"body":     dbus.MakeVariant("a body"),
-			"icon":     dbus.MakeVariant([]interface{}{"file", dbus.MakeVariant("an icon")}),
+			"icon":     dbus.MakeVariant([]any{"file", dbus.MakeVariant("an icon")}),
 			"priority": dbus.MakeVariant("urgent"),
 		},
 	})

--- a/desktop/notification/notificationtest/fdo.go
+++ b/desktop/notification/notificationtest/fdo.go
@@ -191,7 +191,7 @@ func (a fdoApi) CloseNotification(id uint32) *dbus.Error {
 	if err := a.server.Close(id, 3); err != nil {
 		return &dbus.Error{
 			Name: "org.freedesktop.DBus.Error.Failed",
-			Body: []interface{}{err.Error()},
+			Body: []any{err.Error()},
 		}
 	}
 	return nil

--- a/desktop/notification/notificationtest/gtk.go
+++ b/desktop/notification/notificationtest/gtk.go
@@ -169,7 +169,7 @@ func (a gtkApi) RemoveNotification(desktopId, id string) *dbus.Error {
 	if err := a.server.Close(id); err != nil {
 		return &dbus.Error{
 			Name: "org.gtk.Notifications.Failed",
-			Body: []interface{}{err.Error()},
+			Body: []any{err.Error()},
 		}
 	}
 	return nil

--- a/desktop/notification/notify.go
+++ b/desktop/notification/notify.go
@@ -107,7 +107,7 @@ type Action struct {
 // Specification: https://developer.gnome.org/notification-spec/#hints
 type Hint struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 // ServerCapability describes a single capability of the notification server.

--- a/desktop/portal/launcher.go
+++ b/desktop/portal/launcher.go
@@ -136,7 +136,7 @@ func portalCall(bus *dbus.Conn, call func() (dbus.ObjectPath, error)) error {
 			}
 
 			var response uint32
-			var results map[string]interface{} // don't care
+			var results map[string]any // don't care
 			if err := dbus.Store(signal.Body, &response, &results); err != nil {
 				return &ResponseError{msg: fmt.Sprintf("cannot unpack response: %v", err)}
 			}

--- a/features/features.go
+++ b/features/features.go
@@ -253,12 +253,12 @@ func (f SnapdFeature) IsEnabled() bool {
 }
 
 type confGetter interface {
-	GetMaybe(snapName, key string, result interface{}) error
+	GetMaybe(snapName, key string, result any) error
 }
 
 // Flag returns whether the given feature flag is enabled.
 func Flag(tr confGetter, feature SnapdFeature) (bool, error) {
-	var isEnabled interface{}
+	var isEnabled any
 	snapName, confName := feature.ConfigOption()
 	if err := tr.GetMaybe(snapName, confName, &isEnabled); err != nil {
 		return false, err

--- a/gadget/edition/number.go
+++ b/gadget/edition/number.go
@@ -30,7 +30,7 @@ import (
 // applied.
 type Number uint32
 
-func (e *Number) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *Number) UnmarshalYAML(unmarshal func(any) error) error {
 	var es string
 	if err := unmarshal(&es); err != nil {
 		return errors.New(`cannot unmarshal "edition"`)

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -130,7 +130,7 @@ type Info struct {
 	VolumeAssignments []*VolumeAssignment `yaml:"volume-assignments,omitempty"`
 
 	// Default configuration for snaps (snap-id => key => value).
-	Defaults map[string]map[string]interface{} `yaml:"defaults,omitempty"`
+	Defaults map[string]map[string]any `yaml:"defaults,omitempty"`
 
 	Connections []Connection `yaml:"connections"`
 
@@ -967,7 +967,7 @@ func (gcplug *ConnectionPlug) Empty() bool {
 	return gcplug.SnapID == "" && gcplug.Plug == ""
 }
 
-func (gcplug *ConnectionPlug) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (gcplug *ConnectionPlug) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -990,7 +990,7 @@ func (gcslot *ConnectionSlot) Empty() bool {
 	return gcslot.SnapID == "" && gcslot.Slot == ""
 }
 
-func (gcslot *ConnectionSlot) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (gcslot *ConnectionSlot) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -1185,7 +1185,7 @@ func InfoFromGadgetYaml(gadgetYaml []byte, model Model) (*Info, error) {
 		if err != nil {
 			return nil, fmt.Errorf("default value %q of %q: %v", v, k, err)
 		}
-		gi.Defaults[k] = dflt.(map[string]interface{})
+		gi.Defaults[k] = dflt.(map[string]any)
 	}
 
 	for i, gconn := range gi.Connections {
@@ -1924,7 +1924,7 @@ func parseRelativeOffset(grs string) (*RelativeOffset, error) {
 	}, nil
 }
 
-func (s *RelativeOffset) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *RelativeOffset) UnmarshalYAML(unmarshal func(any) error) error {
 	var grs string
 	if err := unmarshal(&grs); err != nil {
 		return errors.New(`cannot unmarshal gadget relative offset`)
@@ -2023,8 +2023,8 @@ func FindBootVolume(vols map[string]*Volume) (*Volume, error) {
 	return nil, fmt.Errorf("no volume has system-boot role")
 }
 
-func flatten(path string, cfg interface{}, out map[string]interface{}) {
-	if cfgMap, ok := cfg.(map[string]interface{}); ok {
+func flatten(path string, cfg any, out map[string]any) {
+	if cfgMap, ok := cfg.(map[string]any); ok {
 		for k, v := range cfgMap {
 			p := k
 			if path != "" {
@@ -2038,10 +2038,10 @@ func flatten(path string, cfg interface{}, out map[string]interface{}) {
 }
 
 // SystemDefaults returns default system configuration from gadget defaults.
-func SystemDefaults(gadgetDefaults map[string]map[string]interface{}) map[string]interface{} {
+func SystemDefaults(gadgetDefaults map[string]map[string]any) map[string]any {
 	for _, systemSnap := range []string{"system", naming.WellKnownSnapID("core")} {
 		if defaults, ok := gadgetDefaults[systemSnap]; ok {
-			coreDefaults := map[string]interface{}{}
+			coreDefaults := map[string]any{}
 			flatten("", defaults, coreDefaults)
 			return coreDefaults
 		}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -699,29 +699,29 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOnylDefaultsIsValid(c *
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
 	c.Assert(err, IsNil)
 	c.Assert(ginfo, DeepEquals, &gadget.Info{
-		Defaults: map[string]map[string]interface{}{
+		Defaults: map[string]map[string]any{
 			"system": {"something": true},
 			// keep this comment so that gofmt 1.10+ does not
 			// realign this, thus breaking our gofmt 1.9 checks
-			"otheridididididididididididididi": {"foo": map[string]interface{}{"bar": "baz"}},
+			"otheridididididididididididididi": {"foo": map[string]any{"bar": "baz"}},
 		},
 	})
 }
 
 func (s *gadgetYamlTestSuite) TestFlatten(c *C) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"foo":         "bar",
 		"some.option": true,
-		"sub": map[string]interface{}{
+		"sub": map[string]any{
 			"option1": true,
-			"option2": map[string]interface{}{
+			"option2": map[string]any{
 				"deep": "2",
 			},
 		},
 	}
-	out := map[string]interface{}{}
+	out := map[string]any{}
 	gadget.Flatten("", cfg, out)
-	c.Check(out, DeepEquals, map[string]interface{}{
+	c.Check(out, DeepEquals, map[string]any{
 		"foo":              "bar",
 		"some.option":      true,
 		"sub.option1":      true,
@@ -736,7 +736,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
 	c.Assert(err, IsNil)
 	defaults := gadget.SystemDefaults(ginfo.Defaults)
-	c.Check(defaults, DeepEquals, map[string]interface{}{
+	c.Check(defaults, DeepEquals, map[string]any{
 		"ssh.disable": true,
 	})
 
@@ -751,7 +751,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
 	c.Assert(err, IsNil)
 
 	defaults = gadget.SystemDefaults(ginfo.Defaults)
-	c.Check(defaults, DeepEquals, map[string]interface{}{
+	c.Check(defaults, DeepEquals, map[string]any{
 		"something": true,
 	})
 }
@@ -776,11 +776,11 @@ func (s *gadgetYamlTestSuite) TestReadGadgetDefaultsMultiline(c *C) {
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
 	c.Assert(err, IsNil)
 	c.Assert(ginfo, DeepEquals, &gadget.Info{
-		Defaults: map[string]map[string]interface{}{
+		Defaults: map[string]map[string]any{
 			"system": {"something": true},
 			// keep this comment so that gofmt 1.10+ does not
 			// realign this, thus breaking our gofmt 1.9 checks
-			"otheridididididididididididididi": {"foosnap": map[string]interface{}{"multiline": "foo\nbar\n"}},
+			"otheridididididididididididididi": {"foosnap": map[string]any{"multiline": "foo\nbar\n"}},
 		},
 	})
 }
@@ -823,7 +823,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlValid(c *C) {
 	ginfo, err := gadget.ReadInfo(s.dir, coreMod)
 	c.Assert(err, IsNil)
 	expectedgi := &gadget.Info{
-		Defaults: map[string]map[string]interface{}{
+		Defaults: map[string]map[string]any{
 			"system": {"something": true},
 		},
 		Connections: []gadget.Connection{
@@ -4271,7 +4271,7 @@ func (s *gadgetYamlTestSuite) TestGadgetInfoHasSameYamlAndJsonTags(c *C) {
 		return s.PkgPath == ""
 	}
 
-	tagsValid := func(c *C, i interface{}, noYaml []string) {
+	tagsValid := func(c *C, i any, noYaml []string) {
 		st := reflect.TypeOf(i).Elem()
 		num := st.NumField()
 		for i := 0; i < num; i++ {

--- a/gadget/quantity/offset.go
+++ b/gadget/quantity/offset.go
@@ -45,7 +45,7 @@ func (o *Offset) IECString() string {
 	return iecSizeString(int64(*o))
 }
 
-func (o *Offset) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (o *Offset) UnmarshalYAML(unmarshal func(any) error) error {
 	var gs string
 	if err := unmarshal(&gs); err != nil {
 		return errors.New(`cannot unmarshal gadget offset`)

--- a/gadget/quantity/size.go
+++ b/gadget/quantity/size.go
@@ -74,7 +74,7 @@ func (s Size) IECString() string {
 	return iecSizeString(int64(s))
 }
 
-func (s *Size) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Size) UnmarshalYAML(unmarshal func(any) error) error {
 	var gs string
 	if err := unmarshal(&gs); err != nil {
 		return errors.New(`cannot unmarshal gadget size`)

--- a/httputil/logger_test.go
+++ b/httputil/logger_test.go
@@ -55,7 +55,7 @@ func (s *loggerSuite) SetUpTest(c *check.C) {
 }
 
 func (loggerSuite) TestFlags(c *check.C) {
-	for _, f := range []interface{}{
+	for _, f := range []any{
 		httputil.DebugRequest,
 		httputil.DebugResponse,
 		httputil.DebugBody,

--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -94,7 +94,7 @@ func (s *retrySuite) TestRetryRequestOnEOF(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -108,7 +108,7 @@ func (s *retrySuite) TestRetryRequestOnEOF(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(failure, Equals, false)
-	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Check(got, DeepEquals, map[string]any{"ok": true})
 	c.Assert(n, Equals, 4)
 }
 
@@ -132,7 +132,7 @@ func (s *retrySuite) TestRetryRequestFailWithEOF(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -172,7 +172,7 @@ func (s *retrySuite) TestRetryRequestOn500(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -186,7 +186,7 @@ func (s *retrySuite) TestRetryRequestOn500(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(failure, Equals, false)
-	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Check(got, DeepEquals, map[string]any{"ok": true})
 	c.Assert(n, Equals, 4)
 }
 
@@ -209,7 +209,7 @@ func (s *retrySuite) TestRetryRequestFailOn500(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -257,7 +257,7 @@ func (s *retrySuite) TestRetryRequestUnexpectedEOFHandling(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -286,7 +286,7 @@ func (s *retrySuite) TestRetryRequestUnexpectedEOFHandling(c *C) {
 	c.Assert(err, IsNil)
 	// check that we retried 4 times
 	c.Check(failure, Equals, false)
-	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Check(got, DeepEquals, map[string]any{"ok": true})
 	c.Assert(somewhatBrokenSrvCalls, Equals, 4)
 }
 
@@ -307,7 +307,7 @@ func (s *retrySuite) TestRetryRequestFailOnReadResponseBody(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -340,7 +340,7 @@ func (s *retrySuite) TestRetryRequestReadResponseBodyFailure(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -392,7 +392,7 @@ func (s *retrySuite) TestRetryRequestTimeoutHandling(c *C) {
 	}
 
 	failure := false
-	var got interface{}
+	var got any
 	readResponseBody := func(resp *http.Response) error {
 		failure = false
 		if resp.StatusCode != 200 {
@@ -423,7 +423,7 @@ func (s *retrySuite) TestRetryRequestTimeoutHandling(c *C) {
 	c.Assert(err, IsNil)
 	// check that we retried 4 times
 	c.Check(failure, Equals, false)
-	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Check(got, DeepEquals, map[string]any{"ok": true})
 	c.Assert(somewhatBrokenSrvCalls.Count(), Equals, 3)
 }
 

--- a/i18n/xgettext-go/main.go
+++ b/i18n/xgettext-go/main.go
@@ -69,7 +69,7 @@ func findCommentsForTranslation(fset *token.FileSet, f *ast.File, posCall token.
 	return formatedComment
 }
 
-func constructValue(val interface{}) string {
+func constructValue(val any) string {
 	switch val.(type) {
 	case *ast.BasicLit:
 		return val.(*ast.BasicLit).Value
@@ -212,7 +212,7 @@ var formatTime = func() string {
 
 // mustFprintf will write the given format string to the given
 // writer. Any error will make it panic.
-func mustFprintf(w io.Writer, format string, a ...interface{}) {
+func mustFprintf(w io.Writer, format string, a ...any) {
 	_, err := fmt.Fprintf(w, format, a...)
 	if err != nil {
 		panic(fmt.Sprintf("cannot write output: %v", err))

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -122,20 +122,20 @@ func (s *imageSuite) SetUpTest(c *C) {
 
 	s.SeedSnaps = &seedtest.SeedSnaps{}
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
 
-	s.model = s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	s.model = s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
+		"required-snaps": []any{"required-snap1"},
 	})
 
-	otherAcct := assertstest.NewAccount(s.StoreSigning, "other", map[string]interface{}{
+	otherAcct := assertstest.NewAccount(s.StoreSigning, "other", map[string]any{
 		"account-id": "other",
 	}, "")
 	s.StoreSigning.Add(otherAcct)
@@ -1127,12 +1127,12 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
 		"base":           "core18",
-		"required-snaps": []interface{}{"other-base"},
+		"required-snaps": []any{"other-base"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -1271,7 +1271,7 @@ func (s *imageSuite) TestSetupSeedWithBaseWithCloudConf(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc18",
 		"kernel":       "pc-kernel",
@@ -1314,7 +1314,7 @@ func (s *imageSuite) testSetupSeedWithBaseWithCustomizationsAndDefaults(c *C, wi
            disable: true
 `
 	}
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc18",
 		"kernel":       "pc-kernel",
@@ -1393,7 +1393,7 @@ func (s *imageSuite) TestPrepareClassicCustomizationsUnsupported(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic": "true",
 	})
 	fn := filepath.Join(c.MkDir(), "model.assertion")
@@ -1416,7 +1416,7 @@ func (s *imageSuite) TestPrepareUC18CustomizationsUnsupported(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc18",
 		"kernel":       "pc-kernel",
@@ -1442,12 +1442,12 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
 		"base":           "core18",
-		"required-snaps": []interface{}{"required-snap1"},
+		"required-snaps": []any{"required-snap1"},
 	})
 
 	// required-snap1 needs core, for backward compatibility
@@ -1587,12 +1587,12 @@ func (s *imageSuite) TestSetupSeedWithBaseDefaultTrackSnap(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
 		"base":           "core18",
-		"required-snaps": []interface{}{"default-track-snap18"},
+		"required-snaps": []any{"default-track-snap18"},
 	})
 
 	// default-track-snap18 has a default-track
@@ -1706,9 +1706,9 @@ func (s *imageSuite) TestInstallCloudConfigWithCloudConfig(c *C) {
 	c.Check(filepath.Join(targetDir, "etc/cloud/cloud.cfg"), testutil.FileEquals, canary)
 }
 
-func (s *imageSuite) addSnapDecl(c *C, snapName, publisher string, headers map[string]interface{}) {
+func (s *imageSuite) addSnapDecl(c *C, snapName, publisher string, headers map[string]any) {
 	snapID := s.AssertedSnapID(snapName)
-	fullHeaders := map[string]interface{}{
+	fullHeaders := map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"publisher-id": publisher,
@@ -1740,11 +1740,11 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithStoreAsserts(c *C) {
 		},
 		PrepareDir: filepath.Dir(rootdir),
 	}
-	s.addSnapDecl(c, "required-snap1", "my-brand", map[string]interface{}{
+	s.addSnapDecl(c, "required-snap1", "my-brand", map[string]any{
 		"revision": "1",
 		"format":   "4",
 	})
-	s.addSnapDecl(c, "required-snap1", "my-brand", map[string]interface{}{
+	s.addSnapDecl(c, "required-snap1", "my-brand", map[string]any{
 		"revision": "2",
 		"format":   "5",
 	})
@@ -2146,7 +2146,7 @@ func (s *imageSuite) TestPrepareClassicModelNoClassicMode(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic": "true",
 	})
 
@@ -2164,7 +2164,7 @@ func (s *imageSuite) TestPrepareClassicModelArchOverrideFails(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":      "true",
 		"architecture": "amd64",
 	})
@@ -2185,7 +2185,7 @@ func (s *imageSuite) TestPrepareClassicModelSnapsButNoArchFails(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic": "true",
 		"gadget":  "classic-gadget",
 	})
@@ -2249,7 +2249,7 @@ func (s *imageSuite) TestSetupSeedWithKernelAndGadgetTrack(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
@@ -2329,7 +2329,7 @@ func (s *imageSuite) TestSetupSeedWithKernelTrackWithDefaultChannel(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel=18",
@@ -2388,7 +2388,7 @@ func (s *imageSuite) TestSetupSeedWithKernelTrackOnLocalSnap(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel=18",
@@ -2443,12 +2443,12 @@ func (s *imageSuite) TestSetupSeedWithBaseAndLocalLegacyCoreOrdering(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
+		"required-snaps": []any{"required-snap1"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2491,12 +2491,12 @@ func (s *imageSuite) TestSetupSeedWithBaseAndLegacyCoreOrdering(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1", "core"},
+		"required-snaps": []any{"required-snap1", "core"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2535,12 +2535,12 @@ func (s *imageSuite) TestSetupSeedGadgetBaseModelBaseMismatch(c *C) {
 	defer restore()
 	// replace model with a model that uses core18 and a gadget
 	// without a base
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
+		"required-snaps": []any{"required-snap1"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2560,11 +2560,11 @@ func (s *imageSuite) TestSetupSeedGadgetBaseModelBaseMismatch(c *C) {
 func (s *imageSuite) TestSetupSeedSnapReqBase(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"snap-req-other-base"},
+		"required-snaps": []any{"snap-req-other-base"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2585,11 +2585,11 @@ func (s *imageSuite) TestSetupSeedSnapReqBase(c *C) {
 func (s *imageSuite) TestSetupSeedBaseNone(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"snap-base-none"},
+		"required-snaps": []any{"snap-base-none"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2614,7 +2614,7 @@ func (s *imageSuite) TestSetupSeedCore18GadgetDefaults(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc18",
 		"kernel":       "pc-kernel",
@@ -2654,7 +2654,7 @@ func (s *imageSuite) TestSetupSeedCore18GadgetDefaults(c *C) {
 func (s *imageSuite) TestSetupSeedStoreAssertionMissing(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel",
@@ -2680,7 +2680,7 @@ func (s *imageSuite) TestSetupSeedStoreAssertionFetched(c *C) {
 	defer restore()
 
 	// add store assertion
-	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "my-store",
 		"operator-id": "canonical",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -2689,7 +2689,7 @@ func (s *imageSuite) TestSetupSeedStoreAssertionFetched(c *C) {
 	err = s.StoreSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel",
@@ -2727,11 +2727,11 @@ func (s *imageSuite) TestSetupSeedSnapReqBaseFromLocal(c *C) {
 	// See TestSetupSeedSnapReqBaseFromExtraFails.
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"other-base", "snap-req-other-base"},
+		"required-snaps": []any{"other-base", "snap-req-other-base"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2755,11 +2755,11 @@ func (s *imageSuite) TestSetupSeedSnapReqBaseFromLocal(c *C) {
 func (s *imageSuite) TestSetupSeedSnapReqBaseFromExtraFails(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"snap-req-other-base"},
+		"required-snaps": []any{"snap-req-other-base"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2783,11 +2783,11 @@ func (s *imageSuite) TestSetupSeedSnapReqBaseFromExtraFails(c *C) {
 func (s *imageSuite) TestSetupSeedMissingContentProvider(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"snap-req-content-provider"},
+		"required-snaps": []any{"snap-req-content-provider"},
 	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
@@ -2811,11 +2811,11 @@ func (s *imageSuite) TestSetupSeedClassic(c *C) {
 	defer restore()
 
 	// classic model with gadget etc
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":        "true",
 		"architecture":   "amd64",
 		"gadget":         "classic-gadget",
-		"required-snaps": []interface{}{"required-snap1"},
+		"required-snaps": []any{"required-snap1"},
 	})
 
 	rootdir := c.MkDir()
@@ -2900,26 +2900,26 @@ func (s *imageSuite) TestSetupSeedClassicUC20(c *C) {
 	s.makeSnap(c, "required20", nil, snap.R(21), "other")
 
 	// classic UC20+ based model
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":      "true",
 		"distribution": "ubuntu",
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			},
@@ -2993,7 +2993,7 @@ func (s *imageSuite) TestSetupSeedClassicWithLocalClassicSnap(c *C) {
 	defer restore()
 
 	// classic model
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":      "true",
 		"architecture": "amd64",
 	})
@@ -3056,11 +3056,11 @@ func (s *imageSuite) TestSetupSeedClassicSnapdOnly(c *C) {
 	defer restore()
 
 	// classic model with gadget etc
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":        "true",
 		"architecture":   "amd64",
 		"gadget":         "classic-gadget18",
-		"required-snaps": []interface{}{"core18", "required-snap18"},
+		"required-snaps": []any{"core18", "required-snap18"},
 	})
 
 	rootdir := c.MkDir()
@@ -3131,7 +3131,7 @@ func (s *imageSuite) TestSetupSeedClassicNoSnaps(c *C) {
 	defer restore()
 
 	// classic model with gadget etc
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic": "true",
 	})
 
@@ -3174,11 +3174,11 @@ func (s *imageSuite) TestSetupSeedClassicSnapdOnlyMissingCore16(c *C) {
 	defer restore()
 
 	// classic model with gadget etc
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":        "true",
 		"architecture":   "amd64",
 		"gadget":         "classic-gadget18",
-		"required-snaps": []interface{}{"core18", "snap-req-core16-base"},
+		"required-snaps": []any{"core18", "snap-req-core16-base"},
 	})
 
 	rootdir := c.MkDir()
@@ -3200,7 +3200,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapd(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"gadget":       "pc18",
 		"kernel":       "pc-kernel",
@@ -3241,29 +3241,29 @@ func (s *imageSuite) makeSnap(c *C, yamlKey string, files [][]string, revno snap
 	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml[yamlKey], files, revno, publisher)
 }
 
-func (s *imageSuite) makeUC20Model(extraHeaders map[string]interface{}) *asserts.Model {
-	comps := map[string]interface{}{
+func (s *imageSuite) makeUC20Model(extraHeaders map[string]any) *asserts.Model {
+	comps := map[string]any{
 		"comp1": "required",
 		"comp2": "optional",
 	}
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":       "required20",
 				"id":         s.AssertedSnapID("required20"),
 				"components": comps,
@@ -3491,18 +3491,18 @@ func (s *imageSuite) TestSetupSeedCore20UBoot(c *C) {
 	defer restore()
 
 	// a model that uses core20 and our gadget
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"display-name": "my model",
 		"architecture": "arm64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "arm-kernel",
 				"id":              s.AssertedSnapID("arm-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "uboot-gadget",
 				"id":              s.AssertedSnapID("uboot-gadget"),
 				"type":            "gadget",
@@ -3587,18 +3587,18 @@ func (s *imageSuite) TestSetupSeedCore20NoKernelRefsConsumed(c *C) {
 	defer restore()
 
 	// a model that uses core20 and our gadget
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"display-name": "my model",
 		"architecture": "arm64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "arm-kernel",
 				"id":              s.AssertedSnapID("arm-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "uboot-gadget",
 				"id":              s.AssertedSnapID("uboot-gadget"),
 				"type":            "gadget",
@@ -3709,9 +3709,9 @@ func (s *imageSuite) TestSetupSeedCore20DelegatedSnap(c *C) {
 	}
 	s.makeSnap(c, "pc=20", gadgetContent, snap.R(22), "")
 
-	ra := map[string]interface{}{
+	ra := map[string]any{
 		"account-id": "my-brand",
-		"provenance": []interface{}{"delegated-prov"},
+		"provenance": []any{"delegated-prov"},
 	}
 	s.MakeAssertedDelegatedSnap(c, seedtest.SampleSnapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "my-brand", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
@@ -3746,9 +3746,9 @@ func (s *imageSuite) TestSetupSeedCore20DelegatedComponentMismatch(c *C) {
 	}
 	s.makeSnap(c, "pc=20", gadgetContent, snap.R(22), "")
 
-	ra := map[string]interface{}{
+	ra := map[string]any{
 		"account-id": "my-brand",
-		"provenance": []interface{}{"delegated-prov"},
+		"provenance": []any{"delegated-prov"},
 	}
 	s.MakeAssertedDelegatedSnap(
 		c,
@@ -3785,7 +3785,7 @@ func (s *imageSuite) TestSetupSeedCore20ComponentTamperedWith(c *C) {
 
 	prepareDir := c.MkDir()
 
-	s.TamperWithResourceRevisions = func(headers map[string]interface{}) {
+	s.TamperWithResourceRevisions = func(headers map[string]any) {
 		n, err := strconv.Atoi(headers["resource-revision"].(string))
 		c.Assert(err, IsNil)
 		headers["resource-revision"] = strconv.Itoa(n + 1)
@@ -3836,21 +3836,21 @@ func (s *imageSuite) TestSetupSeedCore20DelegatedSnapAssertionMaxFormatsHappy(c 
 
 	s.prepSetupSeedCore20DelegatedSnapAssertionMaxFormats(c)
 
-	ra := map[string]interface{}{
+	ra := map[string]any{
 		"account-id": "my-brand",
-		"provenance": []interface{}{"delegated-prov"},
+		"provenance": []any{"delegated-prov"},
 	}
 	s.MakeAssertedDelegatedSnap(c, seedtest.SampleSnapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "my-brand", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
-	s.addSnapDecl(c, "required20", "my-brand", map[string]interface{}{
+	s.addSnapDecl(c, "required20", "my-brand", map[string]any{
 		"revision":           "1",
 		"format":             "4",
-		"revision-authority": []interface{}{ra},
+		"revision-authority": []any{ra},
 	})
-	s.addSnapDecl(c, "required20", "my-brand", map[string]interface{}{
+	s.addSnapDecl(c, "required20", "my-brand", map[string]any{
 		"revision":           "2",
 		"format":             "5",
-		"revision-authority": []interface{}{ra},
+		"revision-authority": []any{ra},
 	})
 
 	opts := &image.Options{
@@ -3905,21 +3905,21 @@ func (s *imageSuite) TestSetupSeedCore20DelegatedSnapAssertionMaxFormatsAuthorit
 
 	s.prepSetupSeedCore20DelegatedSnapAssertionMaxFormats(c)
 
-	ra := map[string]interface{}{
+	ra := map[string]any{
 		"account-id": "my-brand",
-		"provenance": []interface{}{"delegated-prov"},
+		"provenance": []any{"delegated-prov"},
 	}
 	s.MakeAssertedDelegatedSnap(c, seedtest.SampleSnapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "my-brand", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
 	// format 4 will be used but does not have revision-authority set up
-	s.addSnapDecl(c, "required20", "my-brand", map[string]interface{}{
+	s.addSnapDecl(c, "required20", "my-brand", map[string]any{
 		"revision": "1",
 		"format":   "4",
 	})
-	s.addSnapDecl(c, "required20", "my-brand", map[string]interface{}{
+	s.addSnapDecl(c, "required20", "my-brand", map[string]any{
 		"revision":           "2",
 		"format":             "5",
-		"revision-authority": []interface{}{ra},
+		"revision-authority": []any{ra},
 	})
 
 	opts := &image.Options{
@@ -4599,8 +4599,8 @@ func (s *imageSuite) TestLocalSnapWithCompsRevisionMatchingStoreRevision(c *C) {
 	})
 }
 
-func (s *imageSuite) setupValidationSet(c *C, name string, snaps []interface{}) *asserts.ValidationSet {
-	vs, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+func (s *imageSuite) setupValidationSet(c *C, name string, snaps []any) *asserts.ValidationSet {
+	vs, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
@@ -4621,14 +4621,14 @@ func (s *imageSuite) TestSetupSeedValidationSetsUnmetCriteria(c *C) {
 	defer restore()
 
 	// a model that uses validation-sets
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"required-snaps": []any{"required-snap1"},
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"mode":       "enforce",
@@ -4637,8 +4637,8 @@ func (s *imageSuite) TestSetupSeedValidationSetsUnmetCriteria(c *C) {
 	})
 
 	// setup validation-sets that will fail the check
-	vsa := s.setupValidationSet(c, "base-set", []interface{}{
-		map[string]interface{}{
+	vsa := s.setupValidationSet(c, "base-set", []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
@@ -4700,14 +4700,14 @@ func (s *imageSuite) TestSetupSeedValidationSetsUnmetCriteriaButIgnoredValidatio
 	defer restore()
 
 	// a model that uses validation-sets
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"required-snaps": []any{"required-snap1"},
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"mode":       "enforce",
@@ -4716,8 +4716,8 @@ func (s *imageSuite) TestSetupSeedValidationSetsUnmetCriteriaButIgnoredValidatio
 	})
 
 	// setup validation-sets that will fail the check
-	vsa := s.setupValidationSet(c, "base-set", []interface{}{
-		map[string]interface{}{
+	vsa := s.setupValidationSet(c, "base-set", []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
@@ -4779,14 +4779,14 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 	defer restore()
 
 	// a model that uses validation-sets
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"required-snaps": []any{"required-snap1"},
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"mode":       "enforce",
@@ -4795,15 +4795,15 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 	})
 
 	// setup validation-sets
-	vsa := s.setupValidationSet(c, "base-set", []interface{}{
-		map[string]interface{}{
+	vsa := s.setupValidationSet(c, "base-set", []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
 			// setupSnaps sets pc-kernel to snap.R(2)
 			"revision": "2",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "pc",
 			"id":       s.AssertedSnapID("pc"),
 			"presence": "required",
@@ -4869,14 +4869,14 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 	defer restore()
 
 	// a model that uses validation-sets
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"required-snaps": []any{"required-snap1"},
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"mode":       "enforce",
@@ -4885,15 +4885,15 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 	})
 
 	// setup validation-sets
-	vsa := s.setupValidationSet(c, "base-set", []interface{}{
-		map[string]interface{}{
+	vsa := s.setupValidationSet(c, "base-set", []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
 			// setupSnaps sets pc-kernel to snap.R(2)
 			"revision": "2",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "pc",
 			"id":       s.AssertedSnapID("pc"),
 			"presence": "required",
@@ -4978,19 +4978,19 @@ func (s *imageSuite) TestImageSeedValidationSetConflict(c *C) {
 	defer restore()
 
 	// a model that uses validation-sets
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required-snap1"},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"required-snaps": []any{"required-snap1"},
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"mode":       "enforce",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "other-set",
 				"mode":       "enforce",
@@ -5000,16 +5000,16 @@ func (s *imageSuite) TestImageSeedValidationSetConflict(c *C) {
 
 	// setup conflicting validation-sets, one that requests revision
 	// 1 of pc-kernel, and one that requests revision 7
-	s.setupValidationSet(c, "base-set", []interface{}{
-		map[string]interface{}{
+	s.setupValidationSet(c, "base-set", []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
 			"revision": "1",
 		},
 	})
-	s.setupValidationSet(c, "other-set", []interface{}{
-		map[string]interface{}{
+	s.setupValidationSet(c, "other-set", []any{
+		map[string]any{
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
@@ -5114,24 +5114,24 @@ func (s *imageSuite) TestSetupSeedSnapInvalidArchitecture(c *C) {
 	s.MakeAssertedSnap(c, marchSnap, nil, snap.R(18), "canonical")
 
 	// replace model with a model that has an extra snap
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "march-snap",
 				"id":   s.AssertedSnapID("march-snap"),
 				"type": "app",
@@ -5195,7 +5195,7 @@ func (s *imageSuite) TestSetupSeedLocalComponents(c *C) {
 	defer restore()
 
 	// a model that uses core20
-	model := s.makeUC20Model(map[string]interface{}{"grade": "dangerous"})
+	model := s.makeUC20Model(map[string]any{"grade": "dangerous"})
 
 	prepareDir := c.MkDir()
 
@@ -5356,7 +5356,7 @@ func (s *imageSuite) TestSetupSeedLocalComponentsNoLocalSnap(c *C) {
 	defer restore()
 
 	// a model that uses core20
-	model := s.makeUC20Model(map[string]interface{}{"grade": "dangerous"})
+	model := s.makeUC20Model(map[string]any{"grade": "dangerous"})
 
 	prepareDir := c.MkDir()
 
@@ -5381,7 +5381,7 @@ func (s *imageSuite) TestSetupSeedLocalComponentNotDefinedBySnap(c *C) {
 	defer restore()
 
 	// a model that uses core20
-	model := s.makeUC20Model(map[string]interface{}{"grade": "dangerous"})
+	model := s.makeUC20Model(map[string]any{"grade": "dangerous"})
 
 	prepareDir := c.MkDir()
 
@@ -5408,7 +5408,7 @@ func (s *imageSuite) TestSetupSeedLocalComponentBadType(c *C) {
 	defer restore()
 
 	// a model that uses core20
-	model := s.makeUC20Model(map[string]interface{}{"grade": "dangerous"})
+	model := s.makeUC20Model(map[string]any{"grade": "dangerous"})
 
 	prepareDir := c.MkDir()
 

--- a/image/preseed/preseed.go
+++ b/image/preseed/preseed.go
@@ -143,9 +143,9 @@ func writePreseedAssertion(artifactDigest []byte, opts *preseedCoreOptions) erro
 		return err
 	}
 
-	snaps := []interface{}{}
+	snaps := []any{}
 	addSnap := func(sn *seed.Snap) {
-		preseedSnap := map[string]interface{}{}
+		preseedSnap := map[string]any{}
 		preseedSnap["name"] = sn.SnapName()
 
 		asserted := sn.ID() != ""
@@ -154,9 +154,9 @@ func writePreseedAssertion(artifactDigest []byte, opts *preseedCoreOptions) erro
 			preseedSnap["revision"] = sn.PlaceInfo().SnapRevision().String()
 		}
 
-		components := make([]interface{}, 0, len(sn.Components))
+		components := make([]any, 0, len(sn.Components))
 		for _, c := range sn.Components {
-			comp := map[string]interface{}{
+			comp := map[string]any{
 				"name": c.CompSideInfo.Component.ComponentName,
 			}
 			if asserted {
@@ -187,7 +187,7 @@ func writePreseedAssertion(artifactDigest []byte, opts *preseedCoreOptions) erro
 	if err != nil {
 		return err
 	}
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":              "preseed",
 		"authority-id":      model.AuthorityID(),
 		"series":            "16",

--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -83,7 +83,7 @@ func mockChrootDirs(c *C, rootDir string, apparmorDir bool) func() {
 // Fake implementation of seed.Seed interface
 
 func mockClassicModel() *asserts.Model {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "model",
 		"authority-id": "brand",
 		"series":       "16",
@@ -107,7 +107,7 @@ func (fs *FakeSeed) Model() *asserts.Model {
 }
 
 func (fs *FakeSeed) Brand() (*asserts.Account, error) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "account",
 		"account-id":   "brand",
 		"display-name": "fake brand",

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -98,7 +98,7 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 
 	ts := &toolingStore{&seedtest.SeedSnaps{}}
 	ts.SeedSnaps.SetupAssertSigning("canonical")
-	ts.Brands.Register("my-brand", testKey, map[string]interface{}{
+	ts.Brands.Register("my-brand", testKey, map[string]any{
 		"verification": "verified",
 	})
 
@@ -113,19 +113,19 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 	restoreTrusted := preseed.MockTrusted(ts.StoreSigning.Trusted)
 	defer restoreTrusted()
 
-	model := ts.Brands.Model("my-brand", "my-model-uc20", map[string]interface{}{
+	model := ts.Brands.Model("my-brand", "my-model-uc20", map[string]any{
 		"display-name": "My Model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"timestamp":    "2019-11-01T08:00:00+00:00",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "pc-kernel",
 				"id":   "pckernelidididididididididididid",
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "pc",
 				"id":   "pcididididididididididididididid",
 				"type": "gadget",

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -445,7 +445,7 @@ func (s *backendSuite) TestTimings(c *C) {
 		defer st.Unlock()
 		perf.Save(st)
 
-		var allTimings []map[string]interface{}
+		var allTimings []map[string]any
 		c.Assert(st.Get("timings", &allTimings), IsNil)
 		c.Assert(allTimings, HasLen, 1)
 
@@ -453,9 +453,9 @@ func (s *backendSuite) TestTimings(c *C) {
 		c.Assert(ok, Equals, true)
 
 		c.Assert(timings, HasLen, 2)
-		timingsList, ok := timings.([]interface{})
+		timingsList, ok := timings.([]any)
 		c.Assert(ok, Equals, true)
-		tm := timingsList[0].(map[string]interface{})
+		tm := timingsList[0].(map[string]any)
 		c.Check(tm["label"], Equals, "load-profiles[changed]")
 
 		s.RemoveSnap(c, snapInfo)

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -458,7 +458,7 @@ func (spec *Specification) AddUpdateNS(snippet string) {
 }
 
 // AddUpdateNSf formats and adds a new apparmor snippet for the snap-update-ns program.
-func (spec *Specification) AddUpdateNSf(f string, args ...interface{}) {
+func (spec *Specification) AddUpdateNSf(f string, args ...any) {
 	spec.AddUpdateNS(fmt.Sprintf(f, args...))
 }
 
@@ -609,7 +609,7 @@ func isProbablyPresent(path string) bool {
 }
 
 // GenWritableMimicProfile generates apparmor rules for a writable mimic at the given path.
-func GenWritableMimicProfile(emit func(f string, args ...interface{}), path string, assumedPrefixDepth int) {
+func GenWritableMimicProfile(emit func(f string, args ...any), path string, assumedPrefixDepth int) {
 	emit("  # Writable mimic %s\n", path)
 
 	iter, err := strutil.NewPathIterator(path)
@@ -671,7 +671,7 @@ func GenWritableMimicProfile(emit func(f string, args ...interface{}), path stri
 }
 
 // GenWritableFileProfile writes a profile for snap-update-ns for making given file writable.
-func GenWritableFileProfile(emit func(f string, args ...interface{}), path string, assumedPrefixDepth int) {
+func GenWritableFileProfile(emit func(f string, args ...any), path string, assumedPrefixDepth int) {
 	if path == "/" {
 		return
 	}
@@ -688,7 +688,7 @@ func GenWritableFileProfile(emit func(f string, args ...interface{}), path strin
 }
 
 // GenWritableProfile generates a profile for snap-update-ns for making given directory writable.
-func GenWritableProfile(emit func(f string, args ...interface{}), path string, assumedPrefixDepth int) {
+func GenWritableProfile(emit func(f string, args ...any), path string, assumedPrefixDepth int) {
 	if path == "/" {
 		return
 	}

--- a/interfaces/builtin/common_files.go
+++ b/interfaces/builtin/common_files.go
@@ -57,7 +57,7 @@ func (a filesAAPerm) String() string {
 	panic(fmt.Sprintf("invalid perm: %d", a))
 }
 
-func formatPath(ip interface{}) (string, error) {
+func formatPath(ip any) (string, error) {
 	p, ok := ip.(string)
 	if !ok {
 		return "", fmt.Errorf("%[1]v (%[1]T) is not a string", ip)
@@ -76,7 +76,7 @@ func formatPath(ip interface{}) (string, error) {
 	return fmt.Sprintf("%s%q", prefix, p), nil
 }
 
-func allowPathAccess(buf *bytes.Buffer, perm filesAAPerm, paths []interface{}) error {
+func allowPathAccess(buf *bytes.Buffer, perm filesAAPerm, paths []any) error {
 	for _, rawPath := range paths {
 		p, err := formatPath(rawPath)
 		if err != nil {
@@ -87,7 +87,7 @@ func allowPathAccess(buf *bytes.Buffer, perm filesAAPerm, paths []interface{}) e
 	return nil
 }
 
-func (iface *commonFilesInterface) validatePaths(attrName string, paths []interface{}) error {
+func (iface *commonFilesInterface) validatePaths(attrName string, paths []any) error {
 	for _, npp := range paths {
 		np, ok := npp.(string)
 		if !ok {
@@ -139,7 +139,7 @@ func (iface *commonFilesInterface) BeforePreparePlug(plug *snap.PlugInfo) error 
 		if _, ok := plug.Attrs[att]; !ok {
 			continue
 		}
-		paths, ok := plug.Attrs[att].([]interface{})
+		paths, ok := plug.Attrs[att].([]any)
 		if !ok {
 			return fmt.Errorf("cannot add %s plug: %q must be a list of strings", iface.name, att)
 		}
@@ -156,7 +156,7 @@ func (iface *commonFilesInterface) BeforePreparePlug(plug *snap.PlugInfo) error 
 }
 
 func (iface *commonFilesInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	var reads, writes []interface{}
+	var reads, writes []any
 	_ = plug.Attr("read", &reads)
 	_ = plug.Attr("write", &writes)
 

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -86,7 +86,7 @@ func (iface *contentInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	content, ok := slot.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
 		if slot.Attrs == nil {
-			slot.Attrs = make(map[string]interface{})
+			slot.Attrs = make(map[string]any)
 		}
 		// content defaults to "slot" name if unspecified
 		slot.Attrs["content"] = slot.Name
@@ -124,7 +124,7 @@ func (iface *contentInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 	content, ok := plug.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
 		if plug.Attrs == nil {
-			plug.Attrs = make(map[string]interface{})
+			plug.Attrs = make(map[string]any)
 		}
 		// content defaults to "plug" name if unspecified
 		plug.Attrs["content"] = plug.Name
@@ -147,13 +147,13 @@ func (iface *contentInterface) path(attrs interfaces.Attrer, name string) []stri
 		panic("internal error, path can only be used with read/write")
 	}
 
-	var paths []interface{}
-	var source map[string]interface{}
+	var paths []any
+	var source map[string]any
 
 	if err := attrs.Attr("source", &source); err == nil {
 		// Access either "source.read" or "source.write" attribute.
 		var ok bool
-		if paths, ok = source[name].([]interface{}); !ok {
+		if paths, ok = source[name].([]any); !ok {
 			return nil
 		}
 	} else {
@@ -202,7 +202,7 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 	target = resolveSpecialVariable(target, plug.Snap())
 
 	// Check if the "source" section is present.
-	var unused map[string]interface{}
+	var unused map[string]any
 	if err := slot.Attr("source", &unused); err == nil {
 		_, sourceName := filepath.Split(source)
 		target = filepath.Join(target, sourceName)

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -121,7 +121,7 @@ func (iface *customDeviceInterface) validatePaths(attrName string, paths []strin
 	return nil
 }
 
-func (iface *customDeviceInterface) validateUDevValue(value interface{}) error {
+func (iface *customDeviceInterface) validateUDevValue(value any) error {
 	stringValue, ok := value.(string)
 	if !ok {
 		return fmt.Errorf(`value "%v" is not a string`, value)
@@ -134,8 +134,8 @@ func (iface *customDeviceInterface) validateUDevValue(value interface{}) error {
 	return nil
 }
 
-func (iface *customDeviceInterface) validateUDevValueMap(value interface{}) error {
-	valueMap, ok := value.(map[string]interface{})
+func (iface *customDeviceInterface) validateUDevValueMap(value any) error {
+	valueMap, ok := value.(map[string]any)
 	if !ok {
 		return fmt.Errorf(`value "%v" is not a map`, value)
 	}
@@ -170,7 +170,7 @@ func (iface *customDeviceInterface) validateKernelMatchesOneDeviceBasename(kerne
 	}
 }
 
-func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]interface{}, devices []string) error {
+func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]any, devices []string) error {
 	hasKernelTag := false
 	kernelVal := ""
 	deviceOverrideVal := ""
@@ -242,7 +242,7 @@ func (iface *customDeviceInterface) StaticInfo() interfaces.StaticInfo {
 
 func (iface *customDeviceInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	if slot.Attrs == nil {
-		slot.Attrs = make(map[string]interface{})
+		slot.Attrs = make(map[string]any)
 	}
 	customDeviceAttr, isSet := slot.Attrs["custom-device"]
 	customDevice, ok := customDeviceAttr.(string)
@@ -308,7 +308,7 @@ func (iface *customDeviceInterface) BeforePrepareSlot(slot *snap.SlotInfo) error
 		return fmt.Errorf("cannot use custom-device slot without any files or devices")
 	}
 
-	var udevTaggingRules []map[string]interface{}
+	var udevTaggingRules []map[string]any
 	err = slot.Attr("udev-tagging", &udevTaggingRules)
 	if err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
 		return err
@@ -331,7 +331,7 @@ func (iface *customDeviceInterface) BeforePreparePlug(plug *snap.PlugInfo) error
 	}
 	if customDevice == "" {
 		if plug.Attrs == nil {
-			plug.Attrs = make(map[string]interface{})
+			plug.Attrs = make(map[string]any)
 		}
 		// custom-device defaults to "plug" name if unspecified
 		plug.Attrs["custom-device"] = plug.Name
@@ -386,8 +386,8 @@ func (iface *customDeviceInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 // returns its value as a map[string]string.
 // No validation is performed, since it already occurred before connecting the
 // interface.
-func (iface *customDeviceInterface) extractStringMapAttribute(container map[string]interface{}, key string) map[string]string {
-	valueMap, ok := container[key].(map[string]interface{})
+func (iface *customDeviceInterface) extractStringMapAttribute(container map[string]any, key string) map[string]string {
+	valueMap, ok := container[key].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -429,7 +429,7 @@ func (iface *customDeviceInterface) UDevConnectedPlug(spec *udev.Specification, 
 	// Generate udev rules from the "udev-tagging" attribute; note that these
 	// rules might override the simpler KERNEL=="<device>" rules we computed
 	// above -- that's fine.
-	var udevTaggingRules []map[string]interface{}
+	var udevTaggingRules []map[string]any
 	_ = slot.Attr("udev-tagging", &udevTaggingRules)
 	for _, udevTaggingRule := range udevTaggingRules {
 		rule := &bytes.Buffer{}

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -825,7 +825,7 @@ func (iface *desktopInterface) validateDesktopFileIDs(attribs interfaces.Attrer)
 	}
 
 	// desktop-file-ids must be a list of strings.
-	desktopFileIDs, ok := attrVal.([]interface{})
+	desktopFileIDs, ok := attrVal.([]any)
 	if !ok {
 		return fmt.Errorf(`cannot add %s plug: "desktop-file-ids" must be a list of strings`, iface.name)
 	}

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -39,7 +39,7 @@ var (
 	StringListAttribute         = stringListAttribute
 )
 
-func MprisGetName(iface interfaces.Interface, attribs map[string]interface{}) (string, error) {
+func MprisGetName(iface interfaces.Interface, attribs map[string]any) (string, error) {
 	return iface.(*mprisInterface).getName(attribs)
 }
 

--- a/interfaces/builtin/kernel_module_load.go
+++ b/interfaces/builtin/kernel_module_load.go
@@ -72,7 +72,7 @@ var kernelModuleNameRegexp = regexp.MustCompile(`^[-a-zA-Z0-9_]+$`)
 var kernelModuleOptionsRegexp = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9_]*(=[[:graph:]]+)? *)+$`)
 
 func enumerateModules(plug interfaces.Attrer, handleModule func(moduleInfo *ModuleInfo) error) error {
-	var modules []map[string]interface{}
+	var modules []map[string]any
 	err := plug.Attr("modules", &modules)
 	if err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
 		return modulesAttrTypeError

--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -291,11 +291,11 @@ func (mi *MountInfo) hasType() bool {
 	return len(mi.types) > 0
 }
 
-func parseStringList(mountEntry map[string]interface{}, fieldName string) ([]string, error) {
+func parseStringList(mountEntry map[string]any, fieldName string) ([]string, error) {
 	var list []string
 	value, ok := mountEntry[fieldName]
 	if ok {
-		interfaceList, ok := value.([]interface{})
+		interfaceList, ok := value.([]any)
 		if !ok {
 			return nil, fmt.Errorf(`mount-control "%s" must be an array of strings (got %q)`, fieldName, value)
 		}
@@ -311,7 +311,7 @@ func parseStringList(mountEntry map[string]interface{}, fieldName string) ([]str
 }
 
 func enumerateMounts(plug interfaces.Attrer, fn func(mountInfo *MountInfo) error) error {
-	var mounts []map[string]interface{}
+	var mounts []map[string]any
 	err := plug.Attr("mount", &mounts)
 	if err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
 		return mountAttrTypeError
@@ -601,7 +601,7 @@ func (iface *mountControlInterface) BeforeConnectPlug(plug *interfaces.Connected
 
 func (iface *mountControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	mountControlSnippet := bytes.NewBuffer(nil)
-	emit := func(f string, args ...interface{}) {
+	emit := func(f string, args ...any) {
 		fmt.Fprintf(mountControlSnippet, f, args...)
 	}
 	snapInfo := plug.Snap()

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -214,7 +214,7 @@ func (iface *mprisInterface) AppArmorConnectedSlot(spec *apparmor.Specification,
 
 var isValidDBusElement = regexp.MustCompile("^[a-zA-Z0-9_-]*$").MatchString
 
-func (iface *mprisInterface) getName(attribs map[string]interface{}) (string, error) {
+func (iface *mprisInterface) getName(attribs map[string]any) (string, error) {
 	// default to snap instance name if 'name' attribute not set
 	// parallel-installs: snaps utilizing the mpris interface must adjust
 	// themselves accordingly for parallel installs and use

--- a/interfaces/builtin/posix_mq.go
+++ b/interfaces/builtin/posix_mq.go
@@ -215,7 +215,7 @@ func (iface *posixMQInterface) validatePath(name, path string) error {
 	return nil
 }
 
-func (iface *posixMQInterface) checkPosixMQAttr(name string, attrs *map[string]interface{}) error {
+func (iface *posixMQInterface) checkPosixMQAttr(name string, attrs *map[string]any) error {
 	posixMQAttr, isSet := (*attrs)["posix-mq"]
 	posixMQ, ok := posixMQAttr.(string)
 	if isSet && !ok {
@@ -223,7 +223,7 @@ func (iface *posixMQInterface) checkPosixMQAttr(name string, attrs *map[string]i
 	}
 	if posixMQ == "" {
 		if *attrs == nil {
-			*attrs = make(map[string]interface{})
+			*attrs = make(map[string]any)
 		}
 		// posix-mq attribute defaults to name if unspecified
 		(*attrs)["posix-mq"] = name

--- a/interfaces/builtin/qualcomm_ipc_router.go
+++ b/interfaces/builtin/qualcomm_ipc_router.go
@@ -293,7 +293,7 @@ func (iface *qualcomIPCRouterInterface) verifySupport(what string) error {
 
 func (iface *qualcomIPCRouterInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	if slot.Attrs == nil {
-		slot.Attrs = make(map[string]interface{})
+		slot.Attrs = make(map[string]any)
 	}
 	if isSlotInfoSystem(slot) {
 		return nil

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -222,7 +222,7 @@ func (iface *serialPortInterface) HotplugDeviceDetected(di *hotplug.HotplugDevic
 	}
 
 	slot := hotplug.ProposedSlot{
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"path": di.DeviceName(),
 		},
 	}

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -730,7 +730,7 @@ func (s *SerialPortInterfaceSuite) TestHotplugDeviceDetected(c *C) {
 	c.Assert(err, IsNil)
 	proposedSlot, err := hotplugIface.HotplugDeviceDetected(di)
 	c.Assert(err, IsNil)
-	c.Assert(proposedSlot, DeepEquals, &hotplug.ProposedSlot{Attrs: map[string]interface{}{"path": "/dev/ttyUSB0", "usb-vendor": "1234", "usb-product": "5678"}})
+	c.Assert(proposedSlot, DeepEquals, &hotplug.ProposedSlot{Attrs: map[string]any{"path": "/dev/ttyUSB0", "usb-vendor": "1234", "usb-product": "5678"}})
 }
 
 func (s *SerialPortInterfaceSuite) TestHotplugDeviceDetectedNotSerialPort(c *C) {

--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -167,7 +167,7 @@ func (iface *sharedMemoryInterface) BeforePrepareSlot(slot *snap.SlotInfo) error
 	}
 	if sharedMemory == "" {
 		if slot.Attrs == nil {
-			slot.Attrs = make(map[string]interface{})
+			slot.Attrs = make(map[string]any)
 		}
 		// shared-memory defaults to "slot" name if unspecified
 		slot.Attrs["shared-memory"] = slot.Name
@@ -238,7 +238,7 @@ func (iface *sharedMemoryInterface) BeforePreparePlug(plug *snap.PlugInfo) error
 		return fmt.Errorf(`shared-memory "private" attribute must be a bool, not %v`, privateAttr)
 	}
 	if plug.Attrs == nil {
-		plug.Attrs = make(map[string]interface{})
+		plug.Attrs = make(map[string]any)
 	}
 	plug.Attrs["private"] = private
 

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -115,7 +115,7 @@ func MockConnectedSlot(c *C, yaml string, si *snap.SideInfo, slotName string) (*
 	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
 }
 
-func MockHotplugSlot(c *C, yaml string, si *snap.SideInfo, hotplugKey snap.HotplugKey, ifaceName, slotName string, staticAttrs map[string]interface{}) *snap.SlotInfo {
+func MockHotplugSlot(c *C, yaml string, si *snap.SideInfo, hotplugKey snap.HotplugKey, ifaceName, slotName string, staticAttrs map[string]any) *snap.SlotInfo {
 	info := snaptest.MockInfo(c, yaml, si)
 	if _, ok := info.Slots[slotName]; ok {
 		panic(fmt.Sprintf("slot %q already present in the snap yaml", slotName))

--- a/interfaces/connection_test.go
+++ b/interfaces/connection_test.go
@@ -97,10 +97,10 @@ func (s *connSuite) TestStaticSlotAttrs(c *C) {
 	c.Assert(slot.StaticAttr("unknown", &val), ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
 
 	attrs := slot.StaticAttrs()
-	c.Assert(attrs, DeepEquals, map[string]interface{}{
+	c.Assert(attrs, DeepEquals, map[string]any{
 		"attr":    "value",
 		"number":  int64(100),
-		"complex": map[string]interface{}{"a": "b"},
+		"complex": map[string]any{"a": "b"},
 	})
 	slot.StaticAttr("attr", &val)
 	c.Assert(val, Equals, "value")
@@ -110,7 +110,7 @@ func (s *connSuite) TestStaticSlotAttrs(c *C) {
 	c.Check(slot.StaticAttr("attr", val), ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over slot.Attrs
-	slot2 := interfaces.NewConnectedSlot(s.slot, s.slotAppSet, map[string]interface{}{"foo": "bar"}, nil)
+	slot2 := interfaces.NewConnectedSlot(s.slot, s.slotAppSet, map[string]any{"foo": "bar"}, nil)
 	slot2.StaticAttr("foo", &val)
 	c.Assert(val, Equals, "bar")
 }
@@ -136,9 +136,9 @@ func (s *connSuite) TestStaticPlugAttrs(c *C) {
 	c.Assert(plug.StaticAttr("unknown", &val), ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
 
 	attrs := plug.StaticAttrs()
-	c.Assert(attrs, DeepEquals, map[string]interface{}{
+	c.Assert(attrs, DeepEquals, map[string]any{
 		"attr":    "value",
-		"complex": map[string]interface{}{"c": "d"},
+		"complex": map[string]any{"c": "d"},
 	})
 	plug.StaticAttr("attr", &val)
 	c.Assert(val, Equals, "value")
@@ -148,13 +148,13 @@ func (s *connSuite) TestStaticPlugAttrs(c *C) {
 	c.Check(plug.StaticAttr("attr", val), ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over plug.Attrs
-	plug2 := interfaces.NewConnectedPlug(s.plug, s.plugAppSet, map[string]interface{}{"foo": "bar"}, nil)
+	plug2 := interfaces.NewConnectedPlug(s.plug, s.plugAppSet, map[string]any{"foo": "bar"}, nil)
 	plug2.StaticAttr("foo", &val)
 	c.Assert(val, Equals, "bar")
 }
 
 func (s *connSuite) TestDynamicSlotAttrs(c *C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"foo":    "bar",
 		"number": int(100),
 	}
@@ -163,7 +163,7 @@ func (s *connSuite) TestDynamicSlotAttrs(c *C) {
 
 	var strVal string
 	var intVal int64
-	var mapVal map[string]interface{}
+	var mapVal map[string]any
 
 	c.Assert(slot.Attr("foo", &strVal), IsNil)
 	c.Assert(strVal, Equals, "bar")
@@ -174,7 +174,7 @@ func (s *connSuite) TestDynamicSlotAttrs(c *C) {
 	c.Assert(slot.Attr("number", &intVal), IsNil)
 	c.Assert(intVal, Equals, int64(100))
 
-	err := slot.SetAttr("other", map[string]interface{}{"number-two": int(222)})
+	err := slot.SetAttr("other", map[string]any{"number-two": int(222)})
 	c.Assert(err, IsNil)
 	c.Assert(slot.Attr("other", &mapVal), IsNil)
 	num := mapVal["number-two"]
@@ -186,8 +186,8 @@ func (s *connSuite) TestDynamicSlotAttrs(c *C) {
 }
 
 func (s *connSuite) TestDottedPathSlot(c *C) {
-	attrs := map[string]interface{}{
-		"nested": map[string]interface{}{
+	attrs := map[string]any{
+		"nested": map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -217,9 +217,9 @@ func (s *connSuite) TestDottedPathSlot(c *C) {
 }
 
 func (s *connSuite) TestDottedPathPlug(c *C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"a": "b",
-		"nested": map[string]interface{}{
+		"nested": map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -259,7 +259,7 @@ func (s *connSuite) TestDottedPathPlug(c *C) {
 }
 
 func (s *connSuite) TestLookupFailure(c *C) {
-	attrs := map[string]interface{}{}
+	attrs := map[string]any{}
 
 	slot := interfaces.NewConnectedSlot(s.slot, s.slotAppSet, nil, attrs)
 	c.Assert(slot, NotNil)
@@ -276,7 +276,7 @@ func (s *connSuite) TestLookupFailure(c *C) {
 }
 
 func (s *connSuite) TestDynamicPlugAttrs(c *C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"foo":    "bar",
 		"number": int(100),
 	}
@@ -285,7 +285,7 @@ func (s *connSuite) TestDynamicPlugAttrs(c *C) {
 
 	var strVal string
 	var intVal int64
-	var mapVal map[string]interface{}
+	var mapVal map[string]any
 
 	c.Assert(plug.Attr("foo", &strVal), IsNil)
 	c.Assert(strVal, Equals, "bar")
@@ -296,7 +296,7 @@ func (s *connSuite) TestDynamicPlugAttrs(c *C) {
 	c.Assert(plug.Attr("number", &intVal), IsNil)
 	c.Assert(intVal, Equals, int64(100))
 
-	err := plug.SetAttr("other", map[string]interface{}{"number-two": int(222)})
+	err := plug.SetAttr("other", map[string]any{"number-two": int(222)})
 	c.Assert(err, IsNil)
 	c.Assert(plug.Attr("other", &mapVal), IsNil)
 	num := mapVal["number-two"]
@@ -308,7 +308,7 @@ func (s *connSuite) TestDynamicPlugAttrs(c *C) {
 }
 
 func (s *connSuite) TestOverwriteStaticAttrError(c *C) {
-	attrs := map[string]interface{}{}
+	attrs := map[string]any{}
 
 	plug := interfaces.NewConnectedPlug(s.plug, s.plugAppSet, nil, attrs)
 	c.Assert(plug, NotNil)
@@ -325,51 +325,51 @@ func (s *connSuite) TestOverwriteStaticAttrError(c *C) {
 }
 
 func (s *connSuite) TestCopyAttributes(c *C) {
-	orig := map[string]interface{}{
+	orig := map[string]any{
 		"a": "A",
 		"b": true,
 		"c": int(100),
-		"d": []interface{}{"x", "y", true},
-		"e": map[string]interface{}{"e1": "E1"},
+		"d": []any{"x", "y", true},
+		"e": map[string]any{"e1": "E1"},
 	}
 
 	cpy := utils.CopyAttributes(orig)
 	c.Check(cpy, DeepEquals, orig)
 
-	cpy["d"].([]interface{})[0] = 999
-	c.Check(orig["d"].([]interface{})[0], Equals, "x")
-	cpy["e"].(map[string]interface{})["e1"] = "x"
-	c.Check(orig["e"].(map[string]interface{})["e1"], Equals, "E1")
+	cpy["d"].([]any)[0] = 999
+	c.Check(orig["d"].([]any)[0], Equals, "x")
+	cpy["e"].(map[string]any)["e1"] = "x"
+	c.Check(orig["e"].(map[string]any)["e1"], Equals, "E1")
 }
 
 func (s *connSuite) TestNewConnectedPlugExplicitStaticAttrs(c *C) {
-	staticAttrs := map[string]interface{}{
+	staticAttrs := map[string]any{
 		"baz": "boom",
 	}
-	dynAttrs := map[string]interface{}{
+	dynAttrs := map[string]any{
 		"foo": "bar",
 	}
 	plug := interfaces.NewConnectedPlug(s.plug, s.plugAppSet, staticAttrs, dynAttrs)
 	c.Assert(plug, NotNil)
-	c.Assert(plug.StaticAttrs(), DeepEquals, map[string]interface{}{"baz": "boom"})
-	c.Assert(plug.DynamicAttrs(), DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(plug.StaticAttrs(), DeepEquals, map[string]any{"baz": "boom"})
+	c.Assert(plug.DynamicAttrs(), DeepEquals, map[string]any{"foo": "bar"})
 }
 
 func (s *connSuite) TestNewConnectedSlotExplicitStaticAttrs(c *C) {
-	staticAttrs := map[string]interface{}{
+	staticAttrs := map[string]any{
 		"baz": "boom",
 	}
-	dynAttrs := map[string]interface{}{
+	dynAttrs := map[string]any{
 		"foo": "bar",
 	}
 	slot := interfaces.NewConnectedSlot(s.slot, s.slotAppSet, staticAttrs, dynAttrs)
 	c.Assert(slot, NotNil)
-	c.Assert(slot.StaticAttrs(), DeepEquals, map[string]interface{}{"baz": "boom"})
-	c.Assert(slot.DynamicAttrs(), DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(slot.StaticAttrs(), DeepEquals, map[string]any{"baz": "boom"})
+	c.Assert(slot.DynamicAttrs(), DeepEquals, map[string]any{"foo": "bar"})
 }
 
 func (s *connSuite) TestGetAttributeUnhappy(c *C) {
-	attrs := map[string]interface{}{}
+	attrs := map[string]any{}
 	var stringVal string
 	err := interfaces.GetAttribute("snap0", "iface0", attrs, attrs, "non-existent", &stringVal)
 	c.Check(stringVal, Equals, "")
@@ -378,11 +378,11 @@ func (s *connSuite) TestGetAttributeUnhappy(c *C) {
 }
 
 func (s *connSuite) TestGetAttributeHappy(c *C) {
-	staticAttrs := map[string]interface{}{
+	staticAttrs := map[string]any{
 		"attr0": "a string",
 		"attr1": 12,
 	}
-	dynamicAttrs := map[string]interface{}{
+	dynamicAttrs := map[string]any{
 		"attr0": "second string",
 		"attr1": 42,
 	}

--- a/interfaces/hotplug/proposed_slot.go
+++ b/interfaces/hotplug/proposed_slot.go
@@ -46,9 +46,9 @@ type ProposedSlot struct {
 	// Name is how the interface wants to name the slot. When left empty,
 	// one will be generated on demand. The hotplug machinery appends a
 	// suffix to ensure uniqueness of the name.
-	Name  string                 `json:"name"`
-	Label string                 `json:"label"`
-	Attrs map[string]interface{} `json:"attrs,omitempty"`
+	Name  string         `json:"name"`
+	Label string         `json:"label"`
+	Attrs map[string]any `json:"attrs,omitempty"`
 }
 
 // Clean returns a copy of the input slot with normalized attributes and validated slot name (unless its empty).
@@ -62,12 +62,12 @@ func (slot *ProposedSlot) Clean() (*ProposedSlot, error) {
 	}
 	attrs := slot.Attrs
 	if attrs == nil {
-		attrs = make(map[string]interface{})
+		attrs = make(map[string]any)
 	}
 
 	return &ProposedSlot{
 		Name:  slot.Name,
 		Label: slot.Label,
-		Attrs: utils.NormalizeInterfaceAttributes(attrs).(map[string]interface{}),
+		Attrs: utils.NormalizeInterfaceAttributes(attrs).(map[string]any),
 	}, nil
 }

--- a/interfaces/hotplug/proposed_slot_test.go
+++ b/interfaces/hotplug/proposed_slot_test.go
@@ -43,33 +43,33 @@ func (s *proposedSlotSuite) TearDownTest(c *C) {
 }
 
 func (s *proposedSlotSuite) TestCleanHappy(c *C) {
-	slot := &ProposedSlot{Name: "slot1", Label: "A slot", Attrs: map[string]interface{}{"foo": "bar"}}
+	slot := &ProposedSlot{Name: "slot1", Label: "A slot", Attrs: map[string]any{"foo": "bar"}}
 	slot, err := slot.Clean()
 	c.Assert(err, IsNil)
-	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "slot1", Label: "A slot", Attrs: map[string]interface{}{"foo": "bar"}})
+	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "slot1", Label: "A slot", Attrs: map[string]any{"foo": "bar"}})
 }
 
 func (s *proposedSlotSuite) TestNilAttrs(c *C) {
 	slot := &ProposedSlot{Name: "slot"}
 	slot, err := slot.Clean()
 	c.Assert(err, IsNil)
-	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "slot", Attrs: map[string]interface{}{}})
+	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "slot", Attrs: map[string]any{}})
 }
 
 func (s *proposedSlotSuite) TestDeepCopy(c *C) {
-	attrs := map[string]interface{}{"foo": "bar"}
+	attrs := map[string]any{"foo": "bar"}
 	slot := &ProposedSlot{Name: "slot1", Attrs: attrs}
 	slot, err := slot.Clean()
 	c.Assert(err, IsNil)
 	attrs["foo"] = "modified"
-	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "slot1", Label: "", Attrs: map[string]interface{}{"foo": "bar"}})
+	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "slot1", Label: "", Attrs: map[string]any{"foo": "bar"}})
 }
 
 func (s *proposedSlotSuite) TestEmptyName(c *C) {
-	slot := &ProposedSlot{Label: "A slot", Attrs: map[string]interface{}{"foo": "bar"}}
+	slot := &ProposedSlot{Label: "A slot", Attrs: map[string]any{"foo": "bar"}}
 	slot, err := slot.Clean()
 	c.Assert(err, IsNil)
-	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "", Label: "A slot", Attrs: map[string]interface{}{"foo": "bar"}})
+	c.Assert(slot, DeepEquals, &ProposedSlot{Name: "", Label: "A slot", Attrs: map[string]any{"foo": "bar"}})
 }
 
 func (s *proposedSlotSuite) TestInvalidName(c *C) {

--- a/interfaces/ifacetest/app_set.go
+++ b/interfaces/ifacetest/app_set.go
@@ -80,7 +80,7 @@ func MockConnectedPlugWithComponents(c *check.C, yaml string, si *snap.SideInfo,
 	return interfaces.NewConnectedPlug(plugInfo, set, nil, nil), plugInfo
 }
 
-func MockConnectedSlotWithAttrs(c *check.C, yaml string, si *snap.SideInfo, slotName string, staticAttrs, dynamicAttrs map[string]interface{}) (*interfaces.ConnectedSlot, *snap.SlotInfo) {
+func MockConnectedSlotWithAttrs(c *check.C, yaml string, si *snap.SideInfo, slotName string, staticAttrs, dynamicAttrs map[string]any) (*interfaces.ConnectedSlot, *snap.SlotInfo) {
 	info := snaptest.MockInfo(c, yaml, si)
 
 	set, err := interfaces.NewSnapAppSet(info, nil)
@@ -94,7 +94,7 @@ func MockConnectedSlotWithAttrs(c *check.C, yaml string, si *snap.SideInfo, slot
 	return interfaces.NewConnectedSlot(slotInfo, set, staticAttrs, dynamicAttrs), slotInfo
 }
 
-func MockConnectedPlugWithAttrs(c *check.C, yaml string, si *snap.SideInfo, plugName string, staticAttrs, dynamicAttrs map[string]interface{}) (*interfaces.ConnectedPlug, *snap.PlugInfo) {
+func MockConnectedPlugWithAttrs(c *check.C, yaml string, si *snap.SideInfo, plugName string, staticAttrs, dynamicAttrs map[string]any) (*interfaces.ConnectedPlug, *snap.PlugInfo) {
 	info := snaptest.MockInfo(c, yaml, si)
 
 	set, err := interfaces.NewSnapAppSet(info, nil)

--- a/interfaces/policy/helpers_test.go
+++ b/interfaces/policy/helpers_test.go
@@ -42,7 +42,7 @@ plugs:
  plug:
   interface: interface
 `
-	plug, _ := ifacetest.MockConnectedPlugWithAttrs(c, consumerYaml, nil, "plug", nil, map[string]interface{}{
+	plug, _ := ifacetest.MockConnectedPlugWithAttrs(c, consumerYaml, nil, "plug", nil, map[string]any{
 		"a": "123",
 	})
 
@@ -54,7 +54,7 @@ slots:
  slot:
   interface: interface
 `
-	slot, slotInfo := ifacetest.MockConnectedSlotWithAttrs(c, producerYaml, nil, "slot", nil, map[string]interface{}{
+	slot, slotInfo := ifacetest.MockConnectedSlotWithAttrs(c, producerYaml, nil, "slot", nil, map[string]any{
 		"a": "123",
 	})
 
@@ -68,15 +68,15 @@ slots:
 	c.Check(err, IsNil)
 	c.Check(v, Equals, "123")
 
-	slot = interfaces.NewConnectedSlot(slotInfo, slot.AppSet(), nil, map[string]interface{}{
-		"a": map[string]interface{}{
-			"b": []interface{}{"1", "2", "3"},
+	slot = interfaces.NewConnectedSlot(slotInfo, slot.AppSet(), nil, map[string]any{
+		"a": map[string]any{
+			"b": []any{"1", "2", "3"},
 		},
 	})
 
 	v, err = policy.NestedGet("slot", slot, "a.b")
 	c.Check(err, IsNil)
-	c.Check(v, DeepEquals, []interface{}{"1", "2", "3"})
+	c.Check(v, DeepEquals, []any{"1", "2", "3"})
 }
 
 func (s *helpersSuite) TestSnapdTypeCheck(c *C) {

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -139,7 +139,7 @@ type ConnectCandidate struct {
 	Store *asserts.Store
 }
 
-func nestedGet(which string, attrs interfaces.Attrer, path string) (interface{}, error) {
+func nestedGet(which string, attrs interfaces.Attrer, path string) (any, error) {
 	val, ok := attrs.Lookup(path)
 	if !ok {
 		return nil, fmt.Errorf("%s attribute %q not found", which, path)
@@ -147,11 +147,11 @@ func nestedGet(which string, attrs interfaces.Attrer, path string) (interface{},
 	return val, nil
 }
 
-func (connc *ConnectCandidate) PlugAttr(arg string) (interface{}, error) {
+func (connc *ConnectCandidate) PlugAttr(arg string) (any, error) {
 	return nestedGet("plug", connc.Plug, arg)
 }
 
-func (connc *ConnectCandidate) SlotAttr(arg string) (interface{}, error) {
+func (connc *ConnectCandidate) SlotAttr(arg string) (any, error) {
 	return nestedGet("slot", connc.Slot, arg)
 }
 

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -2500,7 +2500,7 @@ func (s *policySuite) TestDollarMissingConnection(c *C) {
 func (s *policySuite) TestSlotDollarPlugDynamicAttrConnection(c *C) {
 	// "c" attribute of the plug missing
 	cand := policy.ConnectCandidate{
-		Plug:            interfaces.NewConnectedPlug(s.plugSnap.Plugs["slot-plug-attr-dynamic"], s.plugAppSet, nil, map[string]interface{}{}),
+		Plug:            interfaces.NewConnectedPlug(s.plugSnap.Plugs["slot-plug-attr-dynamic"], s.plugAppSet, nil, map[string]any{}),
 		Slot:            interfaces.NewConnectedSlot(s.slotSnap.Slots["slot-plug-attr"], s.slotAppSet, nil, nil),
 		BaseDeclaration: s.baseDecl,
 	}
@@ -2508,7 +2508,7 @@ func (s *policySuite) TestSlotDollarPlugDynamicAttrConnection(c *C) {
 
 	// plug attr == slot attr, "c" attribute of the plug provided by dynamic attribute
 	cand = policy.ConnectCandidate{
-		Plug: interfaces.NewConnectedPlug(s.plugSnap.Plugs["slot-plug-attr-dynamic"], s.plugAppSet, nil, map[string]interface{}{
+		Plug: interfaces.NewConnectedPlug(s.plugSnap.Plugs["slot-plug-attr-dynamic"], s.plugAppSet, nil, map[string]any{
 			"c": "C",
 		}),
 
@@ -2522,7 +2522,7 @@ func (s *policySuite) TestPlugDollarSlotDynamicAttrConnection(c *C) {
 	// "c" attribute of the slot missing
 	cand := policy.ConnectCandidate{
 		Plug:            interfaces.NewConnectedPlug(s.plugSnap.Plugs["plug-plug-attr"], s.plugAppSet, nil, nil),
-		Slot:            interfaces.NewConnectedSlot(s.slotSnap.Slots["plug-plug-attr-dynamic"], s.slotAppSet, nil, map[string]interface{}{}),
+		Slot:            interfaces.NewConnectedSlot(s.slotSnap.Slots["plug-plug-attr-dynamic"], s.slotAppSet, nil, map[string]any{}),
 		BaseDeclaration: s.baseDecl,
 	}
 	c.Check(cand.Check(), ErrorMatches, "connection not allowed.*")
@@ -2530,7 +2530,7 @@ func (s *policySuite) TestPlugDollarSlotDynamicAttrConnection(c *C) {
 	// plug attr == slot attr, "c" attribute of the slot provided by dynamic attribute
 	cand = policy.ConnectCandidate{
 		Plug: interfaces.NewConnectedPlug(s.plugSnap.Plugs["plug-plug-attr"], s.plugAppSet, nil, nil),
-		Slot: interfaces.NewConnectedSlot(s.slotSnap.Slots["plug-plug-attr-dynamic"], s.slotAppSet, nil, map[string]interface{}{
+		Slot: interfaces.NewConnectedSlot(s.slotSnap.Slots["plug-plug-attr-dynamic"], s.slotAppSet, nil, map[string]any{
 			"c": "C",
 		}),
 

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -515,7 +515,7 @@ type PolicyFunc func(*ConnectedPlug, *ConnectedSlot) (bool, error)
 // Connect establishes a connection between a plug and a slot.
 // The plug and the slot must have the same interface.
 // When connections are reloaded policyCheck is null (we don't check policy again).
-func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, slotStaticAttrs, slotDynamicAttrs map[string]interface{}, policyCheck PolicyFunc) (*Connection, error) {
+func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, slotStaticAttrs, slotDynamicAttrs map[string]any, policyCheck PolicyFunc) (*Connection, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -754,7 +754,7 @@ func (r *Repository) SlotForHotplugKey(ifaceName string, hotplugKey snap.Hotplug
 
 // UpdateHotplugSlotAttrs updates static attributes of hotplug slot associated with given hotplugkey, and returns the resulting
 // slot. Slots can only be updated if not connected to any plug.
-func (r *Repository) UpdateHotplugSlotAttrs(ifaceName string, hotplugKey snap.HotplugKey, staticAttrs map[string]interface{}) (*snap.SlotInfo, error) {
+func (r *Repository) UpdateHotplugSlotAttrs(ifaceName string, hotplugKey snap.HotplugKey, staticAttrs map[string]any) (*snap.SlotInfo, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -2050,8 +2050,8 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 	s2 := ifacetest.MockInfoAndAppSet(c, ifacehooksSnap2, nil, nil)
 	c.Assert(s.emptyRepo.AddAppSet(s2), IsNil)
 
-	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
-	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+	plugDynAttrs := map[string]any{"attr1": "val1"}
+	slotDynAttrs := map[string]any{"attr1": "val1"}
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
 	conn, err := s.emptyRepo.Connect(&ConnRef{PlugRef: PlugRef{Snap: "s1", Name: "consumer"}, SlotRef: SlotRef{Snap: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
@@ -2061,10 +2061,10 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 	c.Assert(conn.Plug, NotNil)
 	c.Assert(conn.Slot, NotNil)
 
-	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"attr0": "val0"})
-	c.Assert(conn.Plug.DynamicAttrs(), DeepEquals, map[string]interface{}{"attr1": "val1-validated"})
-	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"attr0": "val0"})
-	c.Assert(conn.Slot.DynamicAttrs(), DeepEquals, map[string]interface{}{"attr1": "val1-validated"})
+	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"attr0": "val0"})
+	c.Assert(conn.Plug.DynamicAttrs(), DeepEquals, map[string]any{"attr1": "val1-validated"})
+	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"attr0": "val0"})
+	c.Assert(conn.Slot.DynamicAttrs(), DeepEquals, map[string]any{"attr1": "val1-validated"})
 }
 
 func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
@@ -2084,8 +2084,8 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 	s2 := ifacetest.MockInfoAndAppSet(c, ifacehooksSnap2, nil, nil)
 	c.Assert(s.emptyRepo.AddAppSet(s2), IsNil)
 
-	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
-	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+	plugDynAttrs := map[string]any{"attr1": "val1"}
+	slotDynAttrs := map[string]any{"attr1": "val1"}
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
 
@@ -2108,8 +2108,8 @@ func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
 	s2 := ifacetest.MockInfoAndAppSet(c, ifacehooksSnap2, nil, nil)
 	c.Assert(s.emptyRepo.AddAppSet(s2), IsNil)
 
-	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
-	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+	plugDynAttrs := map[string]any{"attr1": "val1"}
+	slotDynAttrs := map[string]any{"attr1": "val1"}
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
 		return false, fmt.Errorf("policy check failed")
@@ -2155,8 +2155,8 @@ func (s *RepositorySuite) TestConnectWithStaticAttrs(c *C) {
 
 	connRef := NewConnRef(s.consumerPlug, s.producerSlot)
 
-	plugAttrs := map[string]interface{}{"foo": "bar"}
-	slotAttrs := map[string]interface{}{"boo": "baz"}
+	plugAttrs := map[string]any{"foo": "bar"}
+	slotAttrs := map[string]any{"boo": "baz"}
 	_, err := s.testRepo.Connect(connRef, plugAttrs, nil, slotAttrs, nil, nil)
 	c.Assert(err, IsNil)
 
@@ -2222,7 +2222,7 @@ func (s *RepositorySuite) TestUpdateHotplugSlotAttrs(c *C) {
 		Name:       "test-slot",
 		Interface:  "interface",
 		HotplugKey: "1234",
-		Attrs:      map[string]interface{}{"a": "b"},
+		Attrs:      map[string]any{"a": "b"},
 	}
 	s.coreSnap.Slots["test-slot"] = coreSlot
 	c.Assert(s.testRepo.AddAppSet(s.coreSnapAppSet), IsNil)
@@ -2231,14 +2231,14 @@ func (s *RepositorySuite) TestUpdateHotplugSlotAttrs(c *C) {
 	c.Assert(err, ErrorMatches, `cannot find hotplug slot for interface interface and hotplug key "unknownkey"`)
 	c.Assert(slot, IsNil)
 
-	newAttrs := map[string]interface{}{"c": "d"}
+	newAttrs := map[string]any{"c": "d"}
 	slot, err = s.testRepo.UpdateHotplugSlotAttrs("interface", "1234", newAttrs)
 	// attributes are copied, so this change shouldn't be visible
 	newAttrs["c"] = "tainted"
 	c.Assert(err, IsNil)
 	c.Assert(slot, NotNil)
-	c.Assert(slot.Attrs, DeepEquals, map[string]interface{}{"c": "d"})
-	c.Assert(coreSlot.Attrs, DeepEquals, map[string]interface{}{"c": "d"})
+	c.Assert(slot.Attrs, DeepEquals, map[string]any{"c": "d"})
+	c.Assert(coreSlot.Attrs, DeepEquals, map[string]any{"c": "d"})
 }
 
 func (s *RepositorySuite) TestUpdateHotplugSlotAttrsConnectedError(c *C) {
@@ -2255,7 +2255,7 @@ func (s *RepositorySuite) TestUpdateHotplugSlotAttrsConnectedError(c *C) {
 	_, err := s.testRepo.Connect(NewConnRef(s.consumerPlug, coreSlot), nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	slot, err := s.testRepo.UpdateHotplugSlotAttrs("interface", "1234", map[string]interface{}{"c": "d"})
+	slot, err := s.testRepo.UpdateHotplugSlotAttrs("interface", "1234", map[string]any{"c": "d"})
 	c.Assert(err, ErrorMatches, `internal error: cannot update slot test-slot while connected`)
 	c.Assert(slot, IsNil)
 }

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -346,7 +346,7 @@ func readSystemKey() (*systemKey, error) {
 	return &diskSystemKey, nil
 }
 
-// RecordedSystemKey returns the system key read from the disk as opaque interface{}.
+// RecordedSystemKey returns the system key read from the disk as opaque type.
 func RecordedSystemKey() (any, error) {
 	diskSystemKey, err := readSystemKey()
 	if err != nil {
@@ -355,7 +355,7 @@ func RecordedSystemKey() (any, error) {
 	return diskSystemKey, nil
 }
 
-// CurrentSystemKey calculates and returns the current system key as opaque interface{}.
+// CurrentSystemKey calculates and returns the current system key as opaque type.
 func CurrentSystemKey() (any, error) {
 	currentSystemKey, err := generateSystemKey()
 	return currentSystemKey, err

--- a/interfaces/utils/utils.go
+++ b/interfaces/utils/utils.go
@@ -26,21 +26,21 @@ import (
 // NormalizeInterfaceAttributes normalises types of an attribute values.
 // The following transformations are applied: int -> int64, float32 -> float64.
 // The normalisation proceeds recursively through maps and slices.
-func NormalizeInterfaceAttributes(value interface{}) interface{} {
+func NormalizeInterfaceAttributes(value any) any {
 	// Normalize ints/floats using their 64-bit variants.
 	switch v := value.(type) {
 	case int:
 		return int64(v)
 	case float32:
 		return float64(v)
-	case []interface{}:
-		vc := make([]interface{}, len(v))
+	case []any:
+		vc := make([]any, len(v))
 		for i, el := range v {
 			vc[i] = NormalizeInterfaceAttributes(el)
 		}
 		return vc
-	case map[string]interface{}:
-		vc := make(map[string]interface{}, len(v))
+	case map[string]any:
+		vc := make(map[string]any, len(v))
 		for key, item := range v {
 			vc[key] = NormalizeInterfaceAttributes(item)
 		}
@@ -57,22 +57,22 @@ func NormalizeInterfaceAttributes(value interface{}) interface{} {
 }
 
 // CopyAttributes makes a deep copy of the attributes map.
-func CopyAttributes(value map[string]interface{}) map[string]interface{} {
-	return copyRecursive(value).(map[string]interface{})
+func CopyAttributes(value map[string]any) map[string]any {
+	return copyRecursive(value).(map[string]any)
 }
 
-func copyRecursive(value interface{}) interface{} {
+func copyRecursive(value any) any {
 	// note: ensure all the mutable types (or types that need a conversion)
 	// are handled here.
 	switch v := value.(type) {
-	case []interface{}:
-		arr := make([]interface{}, len(v))
+	case []any:
+		arr := make([]any, len(v))
 		for i, el := range v {
 			arr[i] = copyRecursive(el)
 		}
 		return arr
-	case map[string]interface{}:
-		mp := make(map[string]interface{}, len(v))
+	case map[string]any:
+		mp := make(map[string]any, len(v))
 		for key, item := range v {
 			mp[key] = copyRecursive(item)
 		}

--- a/interfaces/utils/utils_test.go
+++ b/interfaces/utils/utils_test.go
@@ -45,38 +45,38 @@ func (s *utilsSuite) TestNormalizeInterfaceAttributes(c *C) {
 	// Funny that, I noticed it only because of missing test coverage.
 	c.Assert(normalize(float32(3.14)), Equals, float64(3.140000104904175))
 	c.Assert(normalize("banana"), Equals, "banana")
-	c.Assert(normalize([]interface{}{42, 3.14, "banana", json.Number("21"), json.Number("0.5")}), DeepEquals,
-		[]interface{}{int64(42), float64(3.14), "banana", int64(21), float64(0.5)})
-	c.Assert(normalize(map[string]interface{}{"i": 42, "f": 3.14, "s": "banana"}),
-		DeepEquals, map[string]interface{}{"i": int64(42), "f": float64(3.14), "s": "banana"})
+	c.Assert(normalize([]any{42, 3.14, "banana", json.Number("21"), json.Number("0.5")}), DeepEquals,
+		[]any{int64(42), float64(3.14), "banana", int64(21), float64(0.5)})
+	c.Assert(normalize(map[string]any{"i": 42, "f": 3.14, "s": "banana"}),
+		DeepEquals, map[string]any{"i": int64(42), "f": float64(3.14), "s": "banana"})
 	c.Assert(normalize(json.Number("1")), Equals, int64(1))
 	c.Assert(normalize(json.Number("2.5")), Equals, float64(2.5))
 
 	// Normalize doesn't mutate slices it is given
-	sliceIn := []interface{}{42}
+	sliceIn := []any{42}
 	sliceOut := normalize(sliceIn)
-	c.Assert(sliceIn, DeepEquals, []interface{}{42})
-	c.Assert(sliceOut, DeepEquals, []interface{}{int64(42)})
+	c.Assert(sliceIn, DeepEquals, []any{42})
+	c.Assert(sliceOut, DeepEquals, []any{int64(42)})
 
 	// Normalize doesn't mutate maps it is given
-	mapIn := map[string]interface{}{"i": 42}
+	mapIn := map[string]any{"i": 42}
 	mapOut := normalize(mapIn)
-	c.Assert(mapIn, DeepEquals, map[string]interface{}{"i": 42})
-	c.Assert(mapOut, DeepEquals, map[string]interface{}{"i": int64(42)})
+	c.Assert(mapIn, DeepEquals, map[string]any{"i": 42})
+	c.Assert(mapOut, DeepEquals, map[string]any{"i": int64(42)})
 }
 
 func (s *utilsSuite) TestCopyAttributes(c *C) {
 	cpattr := utils.CopyAttributes
 
-	attrsIn := map[string]interface{}{"i": 42}
+	attrsIn := map[string]any{"i": 42}
 	attrsOut := cpattr(attrsIn)
 	attrsIn["i"] = "changed"
-	c.Assert(attrsIn, DeepEquals, map[string]interface{}{"i": "changed"})
-	c.Assert(attrsOut, DeepEquals, map[string]interface{}{"i": 42})
+	c.Assert(attrsIn, DeepEquals, map[string]any{"i": "changed"})
+	c.Assert(attrsOut, DeepEquals, map[string]any{"i": 42})
 
-	attrsIn = map[string]interface{}{"ao": []interface{}{1, 2, 3}}
+	attrsIn = map[string]any{"ao": []any{1, 2, 3}}
 	attrsOut = cpattr(attrsIn)
-	attrsIn["ao"].([]interface{})[1] = "changed"
-	c.Assert(attrsIn, DeepEquals, map[string]interface{}{"ao": []interface{}{1, "changed", 3}})
-	c.Assert(attrsOut, DeepEquals, map[string]interface{}{"ao": []interface{}{1, 2, 3}})
+	attrsIn["ao"].([]any)[1] = "changed"
+	c.Assert(attrsIn, DeepEquals, map[string]any{"ao": []any{1, "changed", 3}})
+	c.Assert(attrsOut, DeepEquals, map[string]any{"ao": []any{1, 2, 3}})
 }

--- a/jsonutil/json.go
+++ b/jsonutil/json.go
@@ -31,7 +31,7 @@ import (
 
 // DecodeWithNumber decodes input data using json.Decoder, ensuring numbers are preserved
 // via json.Number data type. It errors out on invalid json or any excess input.
-func DecodeWithNumber(r io.Reader, value interface{}) error {
+func DecodeWithNumber(r io.Reader, value any) error {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
 	if err := dec.Decode(&value); err != nil {
@@ -47,7 +47,7 @@ func DecodeWithNumber(r io.Reader, value interface{}) error {
 // and returns a list of the fields in the struct that are JSON-tagged
 // and whose tag is not in the list of exceptions.
 // The struct can be nil.
-func StructFields(s interface{}, exceptions ...string) []string {
+func StructFields(s any, exceptions ...string) []string {
 	st := reflect.TypeOf(s).Elem()
 	num := st.NumField()
 	fields := make([]string, 0, num)

--- a/jsonutil/json_test.go
+++ b/jsonutil/json_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&utilSuite{})
 
 func (s *utilSuite) TestDecodeError(c *C) {
 	input := "{]"
-	var output interface{}
+	var output any
 	err := jsonutil.DecodeWithNumber(strings.NewReader(input), &output)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `invalid character ']' looking for beginning of object key string`)
@@ -45,7 +45,7 @@ func (s *utilSuite) TestDecodeError(c *C) {
 
 func (s *utilSuite) TestDecodeErrorOnExcessData(c *C) {
 	input := "1000000000[1,2]"
-	var output interface{}
+	var output any
 	err := jsonutil.DecodeWithNumber(strings.NewReader(input), &output)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot parse json value`)
@@ -53,10 +53,10 @@ func (s *utilSuite) TestDecodeErrorOnExcessData(c *C) {
 
 func (s *utilSuite) TestDecodeSuccess(c *C) {
 	input := `{"a":1000000000, "b": 1.2, "c": "foo", "d":null}`
-	var output interface{}
+	var output any
 	err := jsonutil.DecodeWithNumber(strings.NewReader(input), &output)
 	c.Assert(err, IsNil)
-	c.Assert(output, DeepEquals, map[string]interface{}{
+	c.Assert(output, DeepEquals, map[string]any{
 		"a": json.Number("1000000000"),
 		"b": json.Number("1.2"),
 		"c": "foo",

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -662,8 +662,8 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversTreeCompsWithTargetDir(c 
 	doDirChecks(c, fwUpdates, expected)
 }
 
-func mockModel16(override map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func mockModel16(override map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -677,8 +677,8 @@ func mockModel16(override map[string]interface{}) *asserts.Model {
 	return assertstest.FakeAssertion(model, override).(*asserts.Model)
 }
 
-func mockModel20plus(override map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func mockModel20plus(override map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -688,14 +688,14 @@ func mockModel20plus(override map[string]interface{}) *asserts.Model {
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -712,9 +712,9 @@ func (s *kernelDriversTestSuite) TestNeedsKernelDriversTree(c *C) {
 	c.Assert(kernel.NeedsKernelDriversTree(uc16model), Equals, false)
 	uc20model := mockModel20plus(nil)
 	c.Assert(kernel.NeedsKernelDriversTree(uc20model), Equals, false)
-	uc22model := mockModel20plus(map[string]interface{}{"base": "core22"})
+	uc22model := mockModel20plus(map[string]any{"base": "core22"})
 	c.Assert(kernel.NeedsKernelDriversTree(uc22model), Equals, false)
-	uc24model := mockModel20plus(map[string]interface{}{"base": "core24"})
+	uc24model := mockModel20plus(map[string]any{"base": "core24"})
 	c.Assert(kernel.NeedsKernelDriversTree(uc24model), Equals, true)
 }
 
@@ -730,7 +730,7 @@ func (s *kernelDriversTestSuite) TestNeedsKernelDriversTreeClassicWithWrongBase(
 	} {
 		defer release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: tc.version})()
 
-		uc22model := mockModel20plus(map[string]interface{}{"base": "core22",
+		uc22model := mockModel20plus(map[string]any{"base": "core22",
 			"classic": "true", "distribution": "ubuntu"})
 		c.Assert(kernel.NeedsKernelDriversTree(uc22model), Equals, tc.result)
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -63,7 +63,7 @@ var (
 )
 
 // Panicf notifies the user and then panics
-func Panicf(format string, v ...interface{}) {
+func Panicf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 
 	lock.Lock()
@@ -74,7 +74,7 @@ func Panicf(format string, v ...interface{}) {
 }
 
 // Noticef notifies the user of something
-func Noticef(format string, v ...interface{}) {
+func Noticef(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 	lock.Lock()
 	defer lock.Unlock()
@@ -91,7 +91,7 @@ func Notice(msg string) {
 }
 
 // Debugf records something in the debug log
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 	lock.Lock()
 	defer lock.Unlock()
@@ -108,7 +108,7 @@ func Debug(msg string) {
 }
 
 // NoGuardDebugf records something in the debug log
-func NoGuardDebugf(format string, v ...interface{}) {
+func NoGuardDebugf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 
 	lock.Lock()

--- a/metautil/normalize.go
+++ b/metautil/normalize.go
@@ -26,7 +26,7 @@ import (
 
 // NormalizeValue validates values and returns a normalized version of it
 // (map[interface{}]interface{} is turned into map[string]interface{})
-func NormalizeValue(v interface{}) (interface{}, error) {
+func NormalizeValue(v any) (any, error) {
 	switch x := v.(type) {
 	case string:
 		return x, nil
@@ -40,8 +40,8 @@ func NormalizeValue(v interface{}) (interface{}, error) {
 		return x, nil
 	case float32:
 		return float64(x), nil
-	case []interface{}:
-		l := make([]interface{}, len(x))
+	case []any:
+		l := make([]any, len(x))
 		for i, el := range x {
 			el, err := NormalizeValue(el)
 			if err != nil {
@@ -50,8 +50,8 @@ func NormalizeValue(v interface{}) (interface{}, error) {
 			l[i] = el
 		}
 		return l, nil
-	case map[interface{}]interface{}:
-		m := make(map[string]interface{}, len(x))
+	case map[any]any:
+		m := make(map[string]any, len(x))
 		for k, item := range x {
 			kStr, ok := k.(string)
 			if !ok {
@@ -64,8 +64,8 @@ func NormalizeValue(v interface{}) (interface{}, error) {
 			m[kStr] = item
 		}
 		return m, nil
-	case map[string]interface{}:
-		m := make(map[string]interface{}, len(x))
+	case map[string]any:
+		m := make(map[string]any, len(x))
 		for k, item := range x {
 			item, err := NormalizeValue(item)
 			if err != nil {

--- a/metautil/normalize.go
+++ b/metautil/normalize.go
@@ -25,7 +25,7 @@ import (
 )
 
 // NormalizeValue validates values and returns a normalized version of it
-// (map[interface{}]interface{} is turned into map[string]interface{})
+// (map[any]any is turned into map[string]any)
 func NormalizeValue(v any) (any, error) {
 	switch x := v.(type) {
 	case string:

--- a/metautil/normalize_test.go
+++ b/metautil/normalize_test.go
@@ -36,8 +36,8 @@ func TestMain(t *testing.T) { TestingT(t) }
 
 func (s *normalizeTestSuite) TestNormalize(c *C) {
 	for _, tc := range []struct {
-		v   interface{}
-		exp interface{}
+		v   any
+		exp any
 		err string
 	}{
 		{v: "foo", exp: "foo"},
@@ -47,18 +47,18 @@ func (s *normalizeTestSuite) TestNormalize(c *C) {
 		{v: 0.5, exp: float64(0.5)},
 		{v: float32(0.5), exp: float64(0.5)},
 		{v: float64(0.5), exp: float64(0.5)},
-		{v: []interface{}{1, 0.5, "foo"}, exp: []interface{}{int64(1), float64(0.5), "foo"}},
-		{v: map[string]interface{}{"foo": 1}, exp: map[string]interface{}{"foo": int64(1)}},
-		{v: map[interface{}]interface{}{"foo": 1}, exp: map[string]interface{}{"foo": int64(1)}},
+		{v: []any{1, 0.5, "foo"}, exp: []any{int64(1), float64(0.5), "foo"}},
+		{v: map[string]any{"foo": 1}, exp: map[string]any{"foo": int64(1)}},
+		{v: map[any]any{"foo": 1}, exp: map[string]any{"foo": int64(1)}},
 		{
-			v:   map[interface{}]interface{}{"foo": map[interface{}]interface{}{"bar": 0.5}},
-			exp: map[string]interface{}{"foo": map[string]interface{}{"bar": float64(0.5)}},
+			v:   map[any]any{"foo": map[any]any{"bar": 0.5}},
+			exp: map[string]any{"foo": map[string]any{"bar": float64(0.5)}},
 		},
 		{v: uint(1), err: "invalid scalar: 1"},
-		{v: map[interface{}]interface{}{2: 1}, err: "non-string key: 2"},
-		{v: []interface{}{uint(1)}, err: "invalid scalar: 1"},
-		{v: map[string]interface{}{"foo": uint(1)}, err: "invalid scalar: 1"},
-		{v: map[interface{}]interface{}{"foo": uint(1)}, err: "invalid scalar: 1"},
+		{v: map[any]any{2: 1}, err: "non-string key: 2"},
+		{v: []any{uint(1)}, err: "invalid scalar: 1"},
+		{v: map[string]any{"foo": uint(1)}, err: "invalid scalar: 1"},
+		{v: map[any]any{"foo": uint(1)}, err: "invalid scalar: 1"},
 	} {
 		res, err := metautil.NormalizeValue(tc.v)
 		if tc.err == "" {

--- a/metautil/type_conversions.go
+++ b/metautil/type_conversions.go
@@ -95,7 +95,7 @@ func (e AttributeNotCompatibleError) Is(target error) bool {
 // error messages, but are not otherwise significant. This function only
 // operates converting the attrVal parameter into a value which can fit into
 // the val parameter, which therefore must be a pointer.
-func SetValueFromAttribute(snapName string, ifaceName string, attrName string, attrVal interface{}, val interface{}) error {
+func SetValueFromAttribute(snapName string, ifaceName string, attrName string, attrVal any, val any) error {
 	rt := reflect.TypeOf(val)
 	if rt.Kind() != reflect.Ptr || val == nil {
 		return fmt.Errorf("internal error: cannot get %q attribute of interface %q with non-pointer value", attrName, ifaceName)

--- a/metautil/type_conversions_test.go
+++ b/metautil/type_conversions_test.go
@@ -35,8 +35,8 @@ var _ = Suite(&conversionssSuite{})
 
 func (s *conversionssSuite) TestConvertHappy(c *C) {
 	data := []struct {
-		inputValue    interface{}
-		expectedValue interface{}
+		inputValue    any
+		expectedValue any
 	}{
 		// Basic types
 		{"a string", "a string"},
@@ -48,11 +48,11 @@ func (s *conversionssSuite) TestConvertHappy(c *C) {
 		{[]int{24, 42}, []int{24, 42}},
 
 		// Complex types with conversion
-		{[]interface{}{"one", "two"}, []string{"one", "two"}},
-		{[]interface{}{24, 42}, []int{24, 42}},
-		{[]interface{}{[]string{"one"}, []string{"two"}}, [][]string{{"one"}, {"two"}}},
-		{[]interface{}{map[string]int{"one": 1}, map[string]int{"two": 2}}, []map[string]int{{"one": 1}, {"two": 2}}},
-		{map[interface{}]interface{}{"one": 1, "two": 2}, map[string]int{"one": 1, "two": 2}},
+		{[]any{"one", "two"}, []string{"one", "two"}},
+		{[]any{24, 42}, []int{24, 42}},
+		{[]any{[]string{"one"}, []string{"two"}}, [][]string{{"one"}, {"two"}}},
+		{[]any{map[string]int{"one": 1}, map[string]int{"two": 2}}, []map[string]int{{"one": 1}, {"two": 2}}},
+		{map[any]any{"one": 1, "two": 2}, map[string]int{"one": 1, "two": 2}},
 	}
 
 	for _, testData := range data {
@@ -69,7 +69,7 @@ func (s *conversionssSuite) TestConvertHappy(c *C) {
 func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 	t := reflect.TypeOf
 	data := []struct {
-		inputValue    interface{}
+		inputValue    any
 		outputType    reflect.Type
 		expectedError string
 	}{
@@ -78,13 +78,13 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 		{true, t(""), `cannot convert value "true" into a string`},
 
 		// Complex types
-		{[]interface{}{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},
-		{[]interface{}{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
+		{[]any{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},
+		{[]any{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
 		{[]int{1, 2}, t([]string{}), `cannot convert value "1" into a string`},
 		{[]int{1, 2}, t(1), `cannot convert value "\[1 2\]" into a int`},
-		{map[interface{}]interface{}{"one": 1}, t(map[int]int{}), `cannot convert value "one" into a int`},
-		{map[interface{}]interface{}{1: 2}, t(map[int]string{}), `cannot convert value "2" into a string`},
-		{map[interface{}]interface{}{"one": 1}, t([]string{}), `cannot convert value "map\[one:1\]" into a \[\]string`},
+		{map[any]any{"one": 1}, t(map[int]int{}), `cannot convert value "one" into a int`},
+		{map[any]any{1: 2}, t(map[int]string{}), `cannot convert value "2" into a string`},
+		{map[any]any{"one": 1}, t([]string{}), `cannot convert value "map\[one:1\]" into a \[\]string`},
 	}
 
 	for _, testData := range data {
@@ -99,7 +99,7 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 }
 
 func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
-	interfaceArray := []interface{}{12, -3}
+	interfaceArray := []any{12, -3}
 	var outputValue []int
 	err := metautil.SetValueFromAttribute("snap0", "iface0", "attr0", interfaceArray, &outputValue)
 	c.Assert(err, IsNil)
@@ -112,8 +112,8 @@ func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 		snapName      string
 		ifaceName     string
 		attrName      string
-		inputValue    interface{}
-		outputValue   interface{}
+		inputValue    any
+		outputValue   any
 		expectedError string
 	}{
 		// error if output value parameter is not a pointer

--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -185,7 +185,7 @@ func (mockstat) Size() int64        { return 42 }
 func (mockstat) Mode() os.FileMode  { return 0644 }
 func (mockstat) ModTime() time.Time { return time.Now() }
 func (mockstat) IsDir() bool        { return false }
-func (mockstat) Sys() interface{}   { return nil }
+func (mockstat) Sys() any           { return nil }
 
 func (s *cpSuite) TestCopySpecialFileSimple(c *C) {
 	sync := testutil.MockCommand(c, "sync", "")

--- a/osutil/kcmdline/kcmdline.go
+++ b/osutil/kcmdline/kcmdline.go
@@ -210,7 +210,7 @@ type Argument struct {
 }
 
 // UnmarshalYAML implements the Unmarshaler interface.
-func (ka *Argument) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ka *Argument) UnmarshalYAML(unmarshal func(any) error) error {
 	var arg string
 	if err := unmarshal(&arg); err != nil {
 		return errors.New("cannot unmarshal kernel argument")
@@ -466,7 +466,7 @@ func (kap *ArgumentPattern) MarshalText() ([]byte, error) {
 	return []byte(kap.marshalToString()), nil
 }
 
-func (kap *ArgumentPattern) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (kap *ArgumentPattern) UnmarshalYAML(unmarshal func(any) error) error {
 	var arg string
 	if err := unmarshal(&arg); err != nil {
 		return fmt.Errorf("cannot unmarshal kernel argument: %v", err)

--- a/osutil/udev/netlink/matcher_test.go
+++ b/osutil/udev/netlink/matcher_test.go
@@ -5,7 +5,7 @@ import "testing"
 type Testcases []Testcase
 
 type Testcase struct {
-	Object interface{}
+	Object any
 	Valid  bool
 }
 

--- a/osutil/udev/netlink/uevent_test.go
+++ b/osutil/udev/netlink/uevent_test.go
@@ -9,7 +9,7 @@ type testingWrapper struct {
 	*testing.T
 }
 
-func (t *testingWrapper) FatalfIf(cond bool, msg string, args ...interface{}) {
+func (t *testingWrapper) FatalfIf(cond bool, msg string, args ...any) {
 	if cond {
 		if len(args) == 0 {
 			t.Fatal(msg)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -388,7 +388,7 @@ func (s *assertMgrSuite) TestAddBatchPartial(c *C) {
 
 	// too old
 	rev := 1
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "foo-id",
 		"snap-sha3-384": makeDigest(rev),
 		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
@@ -432,7 +432,7 @@ func (s *assertMgrSuite) TestAddBatchPrecheckPartial(c *C) {
 
 	// too old
 	rev := 1
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "foo-id",
 		"snap-sha3-384": makeDigest(rev),
 		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
@@ -478,7 +478,7 @@ func (s *assertMgrSuite) TestAddBatchPrecheckHappy(c *C) {
 
 	rev := 1
 	revDigest := makeDigest(rev)
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       "foo-id",
 		"snap-sha3-384": revDigest,
 		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
@@ -535,7 +535,7 @@ func (s *assertMgrSuite) prereqSnapAssertions(c *C, db *asserts.Database, proven
 		db = s.storeSigning.Database
 	}
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -543,10 +543,10 @@ func (s *assertMgrSuite) prereqSnapAssertions(c *C, db *asserts.Database, proven
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
 	if provenance != "" {
-		headers["revision-authority"] = []interface{}{
-			map[string]interface{}{
+		headers["revision-authority"] = []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{
+				"provenance": []any{
 					provenance,
 				},
 			},
@@ -568,7 +568,7 @@ func (s *assertMgrSuite) prereqSnapAssertions(c *C, db *asserts.Database, proven
 		paths[rev] = snapPath
 		digests[rev] = digest
 
-		headers = map[string]interface{}{
+		headers = map[string]any{
 			"snap-id":       "snap-id-1",
 			"snap-sha3-384": digest,
 			"snap-size":     fmt.Sprintf("%d", sz),
@@ -623,7 +623,7 @@ version: 1.0.2
 		resourceRevivion.N += 1
 	}
 
-	revHeaders := map[string]interface{}{
+	revHeaders := map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
 		"resource-sha3-384": digest,
@@ -644,7 +644,7 @@ version: 1.0.2
 	err = s.storeSigning.Add(resourceRev)
 	c.Assert(err, IsNil)
 
-	pairHeaders := map[string]interface{}{
+	pairHeaders := map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     resourceName,
 		"resource-revision": opts.compRev.String(),
@@ -746,7 +746,7 @@ func (s *assertMgrSuite) TestFetchUnsupportedUpdateIgnored(c *C) {
 	(func() {
 		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
 		defer restore()
-		snapDeclFoo1 = s.snapDecl(c, "foo", map[string]interface{}{
+		snapDeclFoo1 = s.snapDecl(c, "foo", map[string]any{
 			"format":   "999",
 			"revision": "1",
 		})
@@ -787,7 +787,7 @@ func (s *assertMgrSuite) TestFetchUnsupportedError(c *C) {
 	(func() {
 		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
 		defer restore()
-		snapDeclFoo1 = s.snapDecl(c, "foo", map[string]interface{}{
+		snapDeclFoo1 = s.snapDecl(c, "foo", map[string]any{
 			"format":   "999",
 			"revision": "1",
 		})
@@ -818,7 +818,7 @@ func (s *assertMgrSuite) setModel(model *asserts.Model) {
 
 func (s *assertMgrSuite) setupModelAndStore(c *C) *asserts.Store {
 	// setup a model and store assertion
-	a := assertstest.FakeAssertion(map[string]interface{}{
+	a := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -831,7 +831,7 @@ func (s *assertMgrSuite) setupModelAndStore(c *C) *asserts.Store {
 	})
 	s.setModel(a.(*asserts.Model))
 
-	a, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	a, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"authority-id": s.storeSigning.AuthorityID,
 		"operator-id":  s.storeSigning.AuthorityID,
 		"store":        "my-brand-store",
@@ -1017,17 +1017,17 @@ func (s *assertMgrSuite) TestValidateDelegatedSnap(c *C) {
 	digest, sz, err := asserts.SnapFileSHA3_384(snapPath)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
-		"revision-authority": []interface{}{
-			map[string]interface{}{
+		"revision-authority": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
-				"provenance": []interface{}{"delegated-prov"},
-				"on-store":   []interface{}{"my-brand-store"},
-				"on-model":   []interface{}{"my-brand/my-model"},
+				"provenance": []any{"delegated-prov"},
+				"on-store":   []any{"my-brand-store"},
+				"on-model":   []any{"my-brand/my-model"},
 			},
 		},
 		"timestamp": time.Now().Format(time.RFC3339),
@@ -1037,7 +1037,7 @@ func (s *assertMgrSuite) TestValidateDelegatedSnap(c *C) {
 	err = s.storeSigning.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"series":        "16",
 		"snap-id":       "snap-id-1",
@@ -1099,9 +1099,9 @@ func (s *assertMgrSuite) TestValidateDelegatedSnap(c *C) {
 }
 
 func (s *assertMgrSuite) TestValidateDelegatedSnapProvenanceMismatch(c *C) {
-	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov-other`, "delegated-prov-other", "delegated-prov", map[string]interface{}{
+	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov-other`, "delegated-prov-other", "delegated-prov", map[string]any{
 		"account-id": s.dev1Acct.AccountID(),
-		"provenance": []interface{}{"delegated-prov"},
+		"provenance": []any{"delegated-prov"},
 	})
 	c.Check(err, ErrorMatches, `(?s).*cannot verify snap "foo", no matching signatures found.*`)
 }
@@ -1109,24 +1109,24 @@ func (s *assertMgrSuite) TestValidateDelegatedSnapProvenanceMismatch(c *C) {
 func (s *assertMgrSuite) TestValidateDelegatedSnapStoreProvenanceMismatch(c *C) {
 	// this is a scenario where a store is serving information matching
 	// the assertions which themselves don't match the snap
-	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov-other`, "delegated-prov", "delegated-prov", map[string]interface{}{
+	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov-other`, "delegated-prov", "delegated-prov", map[string]any{
 		"account-id": s.dev1Acct.AccountID(),
-		"provenance": []interface{}{"delegated-prov"},
+		"provenance": []any{"delegated-prov"},
 	})
 	c.Check(err, ErrorMatches, `(?s).*snap ".*foo.*\.snap" has been signed under provenance "delegated-prov" different from the metadata one: "delegated-prov-other".*`)
 }
 
-func (s *assertMgrSuite) testValidateDelegatedSnapMismatch(c *C, provenanceFrag, expectedProv, revProvenance string, revisionAuthority map[string]interface{}) error {
+func (s *assertMgrSuite) testValidateDelegatedSnapMismatch(c *C, provenanceFrag, expectedProv, revProvenance string, revisionAuthority map[string]any) error {
 	snapPath := s.makeTestSnap(c, 10, provenanceFrag)
 	digest, sz, err := asserts.SnapFileSHA3_384(snapPath)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
 		"publisher-id": s.dev1Acct.AccountID(),
-		"revision-authority": []interface{}{
+		"revision-authority": []any{
 			revisionAuthority,
 		},
 		"timestamp": time.Now().Format(time.RFC3339),
@@ -1136,7 +1136,7 @@ func (s *assertMgrSuite) testValidateDelegatedSnapMismatch(c *C, provenanceFrag,
 	err = s.storeSigning.Add(snapDecl)
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"authority-id":  s.dev1Acct.AccountID(),
 		"series":        "16",
 		"snap-id":       "snap-id-1",
@@ -1186,37 +1186,37 @@ func (s *assertMgrSuite) testValidateDelegatedSnapMismatch(c *C, provenanceFrag,
 }
 
 func (s *assertMgrSuite) TestValidateDelegatedSnapDeviceMismatch(c *C) {
-	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov`, "delegated-prov", "delegated-prov", map[string]interface{}{
+	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov`, "delegated-prov", "delegated-prov", map[string]any{
 		"account-id": s.dev1Acct.AccountID(),
-		"provenance": []interface{}{"delegated-prov"},
-		"on-store":   []interface{}{"other-store"},
+		"provenance": []any{"delegated-prov"},
+		"on-store":   []any{"other-store"},
 	})
 	c.Check(err, ErrorMatches, `(?s).*snap "foo" revision assertion with provenance "delegated-prov" is not signed by an authority authorized on this device: .*`)
 }
 
 func (s *assertMgrSuite) TestValidateDelegatedSnapDefaultProvenanceMismatch(c *C) {
-	err := s.testValidateDelegatedSnapMismatch(c, "", "", "delegated-prov", map[string]interface{}{
+	err := s.testValidateDelegatedSnapMismatch(c, "", "", "delegated-prov", map[string]any{
 		"account-id": s.dev1Acct.AccountID(),
-		"provenance": []interface{}{"delegated-prov"},
-		"on-store":   []interface{}{"my-brand-store"},
+		"provenance": []any{"delegated-prov"},
+		"on-store":   []any{"my-brand-store"},
 	})
 	c.Check(err, ErrorMatches, `(?s).*cannot verify snap "foo", no matching signatures found.*`)
 }
 
 func (s *assertMgrSuite) validationSetAssert(c *C, name, sequence, revision string, snapPresence, requiredRevision string) *asserts.ValidationSet {
-	snaps := []interface{}{map[string]interface{}{
+	snaps := []any{map[string]any{
 		"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 		"name":     "foo",
 		"presence": snapPresence,
 	}}
 	if requiredRevision != "" {
-		snaps[0].(map[string]interface{})["revision"] = requiredRevision
+		snaps[0].(map[string]any)["revision"] = requiredRevision
 	}
 	return s.validationSetAssertForSnaps(c, name, sequence, revision, snaps)
 }
 
-func (s *assertMgrSuite) validationSetAssertForSnaps(c *C, name, sequence, revision string, snaps []interface{}) *asserts.ValidationSet {
-	headers := map[string]interface{}{
+func (s *assertMgrSuite) validationSetAssertForSnaps(c *C, name, sequence, revision string, snaps []any) *asserts.ValidationSet {
+	headers := map[string]any{
 		"series":       "16",
 		"account-id":   s.dev1Acct.AccountID(),
 		"authority-id": s.dev1Acct.AccountID(),
@@ -1232,8 +1232,8 @@ func (s *assertMgrSuite) validationSetAssertForSnaps(c *C, name, sequence, revis
 	return a.(*asserts.ValidationSet)
 }
 
-func (s *assertMgrSuite) snapDecl(c *C, name string, extraHeaders map[string]interface{}) *asserts.SnapDeclaration {
-	headers := map[string]interface{}{
+func (s *assertMgrSuite) snapDecl(c *C, name string, extraHeaders map[string]any) *asserts.SnapDeclaration {
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      name + "-id",
 		"snap-name":    name,
@@ -1297,7 +1297,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	assertstate.UpdateValidationSet(s.state, &tr)
 
 	// changed snap decl assertion
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "fo-o",
@@ -1406,7 +1406,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
 	c.Assert(err, IsNil)
 
 	// one changed assertion
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "fo-o",
@@ -1454,7 +1454,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
 		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
 		defer restore()
 
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"format":       "999",
 			"series":       "16",
 			"snap-id":      "foo-id",
@@ -1504,14 +1504,14 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsChangingKey(c *C) {
 	storePrivKey2, _ := assertstest.GenerateKey(752)
 	err = s.storeSigning.ImportKey(storePrivKey2)
 	c.Assert(err, IsNil)
-	storeKey2 := assertstest.NewAccountKey(s.storeSigning.RootSigning, s.storeSigning.TrustedAccount, map[string]interface{}{
+	storeKey2 := assertstest.NewAccountKey(s.storeSigning.RootSigning, s.storeSigning.TrustedAccount, map[string]any{
 		"name": "store2",
 	}, storePrivKey2.PublicKey(), "")
 	err = s.storeSigning.Add(storeKey2)
 	c.Assert(err, IsNil)
 
 	// one changed assertion signed with different key
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "foo",
@@ -1564,7 +1564,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsWithStore(c *C) {
 	c.Assert(err, IsNil)
 
 	// one changed assertion
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "fo-o",
@@ -1589,7 +1589,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsWithStore(c *C) {
 	c.Check(a.(*asserts.SnapDeclaration).SnapName(), Equals, "fo-o")
 
 	// changed again
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "f-oo",
@@ -1622,7 +1622,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsWithStore(c *C) {
 	c.Assert(err, IsNil)
 
 	// store assertion has changed
-	a, err = s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	a, err = s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"authority-id": s.storeSigning.AuthorityID,
 		"operator-id":  s.storeSigning.AuthorityID,
 		"store":        "my-brand-store",
@@ -1663,7 +1663,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsDownloadError(c *C) {
 	c.Assert(err, IsNil)
 
 	// one changed assertion
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "fo-o",
@@ -1702,7 +1702,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsPersistentNetworkError(c *C)
 	c.Assert(err, IsNil)
 
 	// one changed assertion
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      "foo-id",
 		"snap-name":    "fo-o",
@@ -1790,7 +1790,7 @@ func (s *assertMgrSuite) testRefreshSnapDeclarationsMany(c *C, n int) error {
 		c.Assert(err, IsNil)
 
 		// make an update on top
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"series":       "16",
 			"snap-id":      name + "-id",
 			"snap-name":    fmt.Sprintf("fo-o-%d", i),
@@ -2005,8 +2005,8 @@ func (s *assertMgrSuite) TestValidateRefreshesMissingValidation(c *C) {
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
 	s.stateFromDecl(c, snapDeclBar, "", snap.R(3))
@@ -2034,8 +2034,8 @@ func (s *assertMgrSuite) TestParallelInstanceValidateRefreshesMissingValidation(
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
 	s.stateFromDecl(c, snapDeclFoo, "foo_instance", snap.R(7))
@@ -2065,8 +2065,8 @@ func (s *assertMgrSuite) TestValidateRefreshesMissingValidationButIgnore(c *C) {
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
 	s.stateFromDecl(c, snapDeclBar, "", snap.R(3))
@@ -2094,8 +2094,8 @@ func (s *assertMgrSuite) TestParallelInstanceValidateRefreshesMissingValidationB
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
 	s.stateFromDecl(c, snapDeclFoo, "foo_instance", snap.R(7))
@@ -2129,8 +2129,8 @@ func (s *assertMgrSuite) TestParallelInstanceValidateRefreshesMissingValidationB
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "foo_instance", snap.R(7))
 	s.stateFromDecl(c, snapDeclBar, "", snap.R(3))
@@ -2159,8 +2159,8 @@ func (s *assertMgrSuite) TestParallelInstanceValidateRefreshesMissingValidationB
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
 	s.stateFromDecl(c, snapDeclFoo, "foo_instance", snap.R(7))
@@ -2193,11 +2193,11 @@ func (s *assertMgrSuite) TestValidateRefreshesValidationOK(c *C) {
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
-	snapDeclBaz := s.snapDecl(c, "baz", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBaz := s.snapDecl(c, "baz", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
 	s.stateFromDecl(c, snapDeclFoo, "foo_instance", snap.R(7))
@@ -2212,7 +2212,7 @@ func (s *assertMgrSuite) TestValidateRefreshesValidationOK(c *C) {
 	})
 
 	// validation by bar
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":                 "16",
 		"snap-id":                "bar-id",
 		"approved-snap-id":       "foo-id",
@@ -2225,7 +2225,7 @@ func (s *assertMgrSuite) TestValidateRefreshesValidationOK(c *C) {
 	c.Assert(err, IsNil)
 
 	// validation by baz
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":                 "16",
 		"snap-id":                "baz-id",
 		"approved-snap-id":       "foo-id",
@@ -2266,11 +2266,11 @@ func (s *assertMgrSuite) TestValidateRefreshesRevokedValidation(c *C) {
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBar := s.snapDecl(c, "bar", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
-	snapDeclBaz := s.snapDecl(c, "baz", map[string]interface{}{
-		"refresh-control": []interface{}{"foo-id"},
+	snapDeclBaz := s.snapDecl(c, "baz", map[string]any{
+		"refresh-control": []any{"foo-id"},
 	})
 	s.stateFromDecl(c, snapDeclFoo, "", snap.R(7))
 	s.stateFromDecl(c, snapDeclBar, "", snap.R(3))
@@ -2284,7 +2284,7 @@ func (s *assertMgrSuite) TestValidateRefreshesRevokedValidation(c *C) {
 	})
 
 	// validation by bar
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":                 "16",
 		"snap-id":                "bar-id",
 		"approved-snap-id":       "foo-id",
@@ -2297,7 +2297,7 @@ func (s *assertMgrSuite) TestValidateRefreshesRevokedValidation(c *C) {
 	c.Assert(err, IsNil)
 
 	// revoked validation by baz
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":                 "16",
 		"snap-id":                "baz-id",
 		"approved-snap-id":       "foo-id",
@@ -2424,8 +2424,8 @@ apps:
 	c.Check(aliases, HasLen, 0)
 
 	// some aliases
-	snapDeclFoo = s.snapDecl(c, "foo", map[string]interface{}{
-		"auto-aliases": []interface{}{"alias1", "alias2", "alias3"},
+	snapDeclFoo = s.snapDecl(c, "foo", map[string]any{
+		"auto-aliases": []any{"alias1", "alias2", "alias3"},
 		"revision":     "1",
 	})
 	err = assertstate.Add(s.state, snapDeclFoo)
@@ -2477,17 +2477,17 @@ func (s *assertMgrSuite) TestAutoAliasesExplicit(c *C) {
 	c.Check(aliases, HasLen, 0)
 
 	// some aliases
-	snapDeclFoo = s.snapDecl(c, "foo", map[string]interface{}{
-		"aliases": []interface{}{
-			map[string]interface{}{
+	snapDeclFoo = s.snapDecl(c, "foo", map[string]any{
+		"aliases": []any{
+			map[string]any{
 				"name":   "alias1",
 				"target": "cmd1",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":   "alias2",
 				"target": "cmd2",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":   "alias-missing",
 				"target": "cmd-missing",
 			},
@@ -2568,7 +2568,7 @@ func (s *assertMgrSuite) TestStore(c *C) {
 	c.Assert(err, IsNil)
 	err = assertstate.Add(s.state, s.dev1Acct)
 	c.Assert(err, IsNil)
-	storeHeaders := map[string]interface{}{
+	storeHeaders := map[string]any{
 		"store":       "foo",
 		"operator-id": s.dev1Acct.AccountID(),
 		"timestamp":   time.Now().Format(time.RFC3339),
@@ -3706,7 +3706,7 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	err := assertstate.Add(st, s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)
 
-	a, err := s.storeSigning.Sign(asserts.ModelType, map[string]interface{}{
+	a, err := s.storeSigning.Sign(asserts.ModelType, map[string]any{
 		"type":         "model",
 		"series":       "16",
 		"authority-id": s.storeSigning.AuthorityID,
@@ -3720,7 +3720,7 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	c.Assert(err, IsNil)
 	model := a.(*asserts.Model)
 
-	aRev2, err := s.storeSigning.Sign(asserts.ModelType, map[string]interface{}{
+	aRev2, err := s.storeSigning.Sign(asserts.ModelType, map[string]any{
 		"type":         "model",
 		"series":       "16",
 		"authority-id": s.storeSigning.AuthorityID,
@@ -4104,8 +4104,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsValidationError(c
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// pretend we are already enforcing a validation set foo
-	snaps3 := []interface{}{
-		map[string]interface{}{
+	snaps3 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4120,22 +4120,22 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsValidationError(c
 	})
 
 	// add validation set assertions to the store
-	snaps1 := []interface{}{
-		map[string]interface{}{
+	snaps1 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
 			"revision": "3",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"id":       "aAqKhntON3vR7kwEbVPsILm7bUViPDaa",
 			"name":     "other-snap",
 			"presence": "required",
 		}}
 	vsetAs := s.validationSetAssertForSnaps(c, "bar", "2", "2", snaps1)
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
-	snaps2 := []interface{}{
-		map[string]interface{}{
+	snaps2 := []any{
+		map[string]any{
 			"id":       "cccchntON3vR7kwEbVPsILm7bUViPDcc",
 			"name":     "invalid-snap",
 			"presence": "invalid",
@@ -4195,8 +4195,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsOK(c *C) {
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// pretend we are already enforcing a validation set foo
-	snaps3 := []interface{}{
-		map[string]interface{}{
+	snaps3 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4211,8 +4211,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsOK(c *C) {
 	})
 
 	// add validation set assertions to the store
-	snaps1 := []interface{}{
-		map[string]interface{}{
+	snaps1 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4220,8 +4220,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsOK(c *C) {
 		}}
 	vsetAs := s.validationSetAssertForSnaps(c, "bar", "2", "2", snaps1)
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
-	snaps2 := []interface{}{
-		map[string]interface{}{
+	snaps2 := []any{
+		map[string]any{
 			"id":       "aAqKhntON3vR7kwEbVPsILm7bUViPDaa",
 			"name":     "other-snap",
 			"presence": "optional",
@@ -4312,8 +4312,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsAlreadyTrackedUpd
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// pretend we are already enforcing a validation set foo
-	snaps3 := []interface{}{
-		map[string]interface{}{
+	snaps3 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4328,8 +4328,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsAlreadyTrackedUpd
 	})
 
 	// add validation set assertions to the store
-	snaps1 := []interface{}{
-		map[string]interface{}{
+	snaps1 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4392,8 +4392,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsConflictError(c *
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// pretend we are already enforcing a validation set foo
-	snaps3 := []interface{}{
-		map[string]interface{}{
+	snaps3 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4408,8 +4408,8 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsConflictError(c *
 	})
 
 	// add a validation set assertion to the store
-	snaps1 := []interface{}{
-		map[string]interface{}{
+	snaps1 := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "invalid",
@@ -4602,8 +4602,8 @@ func (s *assertMgrSuite) testEnforceValidationSets(c *C, pinnedSeq int) {
 	c.Assert(assertstate.Add(st, s.dev1AcctKey), IsNil)
 
 	// validation set that we refreshed to enforce
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4612,8 +4612,8 @@ func (s *assertMgrSuite) testEnforceValidationSets(c *C, pinnedSeq int) {
 	c.Assert(assertstate.Add(st, localVs), IsNil)
 
 	// add a more recent conflicting version to the store
-	snaps = []interface{}{
-		map[string]interface{}{
+	snaps = []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "invalid",
@@ -4669,8 +4669,8 @@ func (s *assertMgrSuite) TestEnforceValidationSetsWithNoLocalAssertions(c *C) {
 	c.Assert(s.storeSigning.Add(storeAs), IsNil)
 
 	// validation set that we refreshed to enforce
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4680,8 +4680,8 @@ func (s *assertMgrSuite) TestEnforceValidationSetsWithNoLocalAssertions(c *C) {
 	c.Assert(s.storeSigning.Add(oldVs), IsNil)
 
 	// add a more recent conflicting version to the store which shouldn't be pulled
-	snaps = []interface{}{
-		map[string]interface{}{
+	snaps = []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "invalid",
@@ -4738,8 +4738,8 @@ func (s *assertMgrSuite) TestEnforceValidationSetsWithMismatchedPinnedSeq(c *C) 
 	snapstate.ReplaceStore(st, s.fakeStore)
 	s.setupModelAndStore(c)
 
-	vs := s.validationSetAssertForSnaps(c, "foo", "1", "1", []interface{}{
-		map[string]interface{}{
+	vs := s.validationSetAssertForSnaps(c, "foo", "1", "1", []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4765,8 +4765,8 @@ func (s *assertMgrSuite) TestEnforceValidationSetsWithUnmetConstraints(c *C) {
 	storeAs := s.setupModelAndStore(c)
 	c.Assert(s.storeSigning.Add(storeAs), IsNil)
 
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4809,8 +4809,8 @@ func (s *assertMgrSuite) testApplyLocalEnforcedValidationSets(c *C, pinnedSeq in
 	defer st.Unlock()
 
 	// validation set that we refreshed to enforce
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4861,8 +4861,8 @@ func (s *assertMgrSuite) TestApplyLocalEnforcedValidationSetsWithMismatchedPinne
 	st.Lock()
 	defer st.Unlock()
 
-	localVs := s.validationSetAssertForSnaps(c, "foo", "1", "1", []interface{}{
-		map[string]interface{}{
+	localVs := s.validationSetAssertForSnaps(c, "foo", "1", "1", []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4889,8 +4889,8 @@ func (s *assertMgrSuite) TestApplyLocalEnforcedValidationSetsWithUnmetConstraint
 	st.Lock()
 	defer st.Unlock()
 
-	snaps := []interface{}{
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{
 			"id":       "qOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "some-snap",
 			"presence": "required",
@@ -4919,9 +4919,9 @@ func (s *assertMgrSuite) TestApplyLocalEnforcedValidationSetsWithUnmetConstraint
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 }
 
-func (s *assertMgrSuite) mockDeviceWithValidationSets(c *C, validationSets []interface{}) {
+func (s *assertMgrSuite) mockDeviceWithValidationSets(c *C, validationSets []any) {
 	st := s.state
-	a := assertstest.FakeAssertion(map[string]interface{}{
+	a := assertstest.FakeAssertion(map[string]any{
 		"type":            "model",
 		"authority-id":    "my-brand",
 		"series":          "16",
@@ -4935,7 +4935,7 @@ func (s *assertMgrSuite) mockDeviceWithValidationSets(c *C, validationSets []int
 	})
 	s.setModel(a.(*asserts.Model))
 
-	a, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	a, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"authority-id": s.storeSigning.AuthorityID,
 		"operator-id":  s.storeSigning.AuthorityID,
 		"store":        "my-brand-store",
@@ -4953,8 +4953,8 @@ func (s *assertMgrSuite) mockDeviceWithValidationSets(c *C, validationSets []int
 func (s *assertMgrSuite) TestFetchAndApplyEnforcedValidationSetEnforceModeSequenceMismatch(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.mockDeviceWithValidationSets(c, []interface{}{
-		map[string]interface{}{
+	s.mockDeviceWithValidationSets(c, []any{
+		map[string]any{
 			"account-id": s.dev1Acct.AccountID(),
 			"name":       "bar",
 			"mode":       "enforce",
@@ -4970,8 +4970,8 @@ func (s *assertMgrSuite) TestFetchAndApplyEnforcedValidationSetEnforceModeSequen
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.mockDeviceWithValidationSets(c, []interface{}{
-		map[string]interface{}{
+	s.mockDeviceWithValidationSets(c, []any{
+		map[string]any{
 			"account-id": s.dev1Acct.AccountID(),
 			"name":       "bar",
 			"mode":       "enforce",
@@ -4997,8 +4997,8 @@ func (s *assertMgrSuite) TestFetchAndApplyEnforcedValidationSetEnforceModeSequen
 func (s *assertMgrSuite) TestMonitorValidationSetEnforceModeSequenceMismatch(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.mockDeviceWithValidationSets(c, []interface{}{
-		map[string]interface{}{
+	s.mockDeviceWithValidationSets(c, []any{
+		map[string]any{
 			"account-id": s.dev1Acct.AccountID(),
 			"name":       "bar",
 			"mode":       "enforce",
@@ -5014,8 +5014,8 @@ func (s *assertMgrSuite) TestMonitorValidationSetEnforceModeSequenceFromModel(c 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.mockDeviceWithValidationSets(c, []interface{}{
-		map[string]interface{}{
+	s.mockDeviceWithValidationSets(c, []any{
+		map[string]any{
 			"account-id": s.dev1Acct.AccountID(),
 			"name":       "bar",
 			"mode":       "enforce",
@@ -5041,8 +5041,8 @@ func (s *assertMgrSuite) TestMonitorValidationSetEnforceModeSequenceFromModel(c 
 func (s *assertMgrSuite) TestForgetValidationSetEnforcedByModel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.mockDeviceWithValidationSets(c, []interface{}{
-		map[string]interface{}{
+	s.mockDeviceWithValidationSets(c, []any{
+		map[string]any{
 			"account-id": s.dev1Acct.AccountID(),
 			"name":       "foo",
 			"mode":       "enforce",
@@ -5074,8 +5074,8 @@ func (s *assertMgrSuite) TestForgetValidationSetEnforcedByModel(c *C) {
 func (s *assertMgrSuite) TestForgetValidationSetPreferEnforcedByModelHappy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.mockDeviceWithValidationSets(c, []interface{}{
-		map[string]interface{}{
+	s.mockDeviceWithValidationSets(c, []any{
+		map[string]any{
 			"account-id": s.dev1Acct.AccountID(),
 			"name":       "foo",
 			"mode":       "prefer-enforce",
@@ -5142,8 +5142,8 @@ func (s *assertMgrSuite) testFetchValidationSets(c *C, opts testFetchValidationS
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapsInFoo := []interface{}{
-		map[string]interface{}{
+	snapsInFoo := []any{
+		map[string]any{
 			"id":       snaptest.AssertedSnapID("some-snap"),
 			"name":     "some-snap",
 			"presence": "required",
@@ -5152,8 +5152,8 @@ func (s *assertMgrSuite) testFetchValidationSets(c *C, opts testFetchValidationS
 
 	fooVset := s.validationSetAssertForSnaps(c, "foo", "1", "1", snapsInFoo)
 
-	snapsInBar := []interface{}{
-		map[string]interface{}{
+	snapsInBar := []any{
+		map[string]any{
 			"id":       snaptest.AssertedSnapID("some-other-snap"),
 			"name":     "some-other-snap",
 			"presence": "required",
@@ -5213,7 +5213,7 @@ func (s *assertMgrSuite) testFetchValidationSets(c *C, opts testFetchValidationS
 	var sets *snapasserts.ValidationSets
 
 	if opts.FromModel {
-		model := assertstest.FakeAssertion(map[string]interface{}{
+		model := assertstest.FakeAssertion(map[string]any{
 			"type":         "model",
 			"authority-id": "my-brand",
 			"series":       "16",
@@ -5222,13 +5222,13 @@ func (s *assertMgrSuite) testFetchValidationSets(c *C, opts testFetchValidationS
 			"architecture": "amd64",
 			"gadget":       "gadget",
 			"kernel":       "krnl",
-			"validation-sets": []interface{}{
-				map[string]interface{}{
+			"validation-sets": []any{
+				map[string]any{
 					"account-id": s.dev1Acct.AccountID(),
 					"name":       "foo",
 					"mode":       "enforce",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"account-id": s.dev1Acct.AccountID(),
 					"name":       "bar",
 					"sequence":   "2",
@@ -5280,7 +5280,7 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	model := assertstest.FakeAssertion(map[string]interface{}{
+	model := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -5289,13 +5289,13 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 		"architecture": "amd64",
 		"gadget":       "gadget",
 		"kernel":       "krnl",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
 				"name":       "foo",
 				"mode":       "enforce",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": s.dev1Acct.AccountID(),
 				"name":       "bar",
 				"sequence":   "2",
@@ -5306,8 +5306,8 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 
 	s.setModel(model)
 
-	snapsInFoo := []interface{}{
-		map[string]interface{}{
+	snapsInFoo := []any{
+		map[string]any{
 			"id":       snaptest.AssertedSnapID("some-snap"),
 			"name":     "some-snap",
 			"presence": "required",
@@ -5316,8 +5316,8 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 
 	fooVset := s.validationSetAssertForSnaps(c, "foo", "1", "1", snapsInFoo)
 
-	snapsInBar := []interface{}{
-		map[string]interface{}{
+	snapsInBar := []any{
+		map[string]any{
 			"id":       snaptest.AssertedSnapID("some-snap"),
 			"name":     "some-snap",
 			"presence": "invalid",
@@ -5338,8 +5338,8 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 	c.Check(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})
 }
 
-func (s *assertMgrSuite) confdb(c *C, name string, extraHeaders map[string]interface{}, body string) *asserts.ConfdbSchema {
-	headers := map[string]interface{}{
+func (s *assertMgrSuite) confdb(c *C, name string, extraHeaders map[string]any, body string) *asserts.ConfdbSchema {
+	headers := map[string]any{
 		"series":       "16",
 		"account-id":   s.dev1AcctKey.AccountID(),
 		"authority-id": s.dev1AcctKey.AccountID(),
@@ -5367,12 +5367,12 @@ func (s *assertMgrSuite) TestConfdb(c *C) {
 	err = assertstate.Add(s.state, s.dev1AcctKey)
 	c.Assert(err, IsNil)
 
-	confdbFoo := s.confdb(c, "foo", map[string]interface{}{
-		"views": map[string]interface{}{
-			"a-view": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "a", "storage": "a"},
-					map[string]interface{}{"request": "b", "storage": "b"},
+	confdbFoo := s.confdb(c, "foo", map[string]any{
+		"views": map[string]any{
+			"a-view": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "a", "storage": "a"},
+					map[string]any{"request": "b", "storage": "b"},
 				},
 			},
 		},
@@ -5586,7 +5586,7 @@ func (s *assertMgrSuite) testValidateComponentNoDownload(c *C, invalid bool) {
 	paths, _ := s.prereqSnapAssertions(c, db, "", 10)
 	snapPath := paths[10]
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":           "snap-id-1",
 		"resource-name":     "comp",
 		"resource-revision": compRev.String(),
@@ -5647,12 +5647,12 @@ func (s *assertMgrSuite) testValidateComponentNoDownload(c *C, invalid bool) {
 }
 
 func (s *assertMgrSuite) setupConfdb(c *C) *snap.SideInfo {
-	extraHeaders := map[string]interface{}{
+	extraHeaders := map[string]any{
 		"revision": "1",
-		"views": map[string]interface{}{
-			"my-view": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "foo", "storage": "foo"},
+		"views": map[string]any{
+			"my-view": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "foo", "storage": "foo"},
 				},
 			},
 		},
@@ -5758,12 +5758,12 @@ func (s *assertMgrSuite) testConfdbAssertionsAutoRefresh(c *C) {
 	err := s.storeSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	extraHeaders := map[string]interface{}{
+	extraHeaders := map[string]any{
 		"revision": "1",
-		"views": map[string]interface{}{
-			"my-view": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "foo", "storage": "foo"},
+		"views": map[string]any{
+			"my-view": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "foo", "storage": "foo"},
 				},
 			},
 		},
@@ -5816,7 +5816,7 @@ func (s *assertMgrSuite) TestSnapResourcePair(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      snaptest.AssertedSnapID("snap-1"),
 		"snap-name":    "snap-1",
@@ -5827,7 +5827,7 @@ func (s *assertMgrSuite) TestSnapResourcePair(c *C) {
 	decl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"snap-id":           snaptest.AssertedSnapID("snap-1"),
 		"resource-name":     "comp",
 		"resource-revision": "11",

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -140,7 +140,7 @@ func (s *validationSetTrackingSuite) TestUpdate(c *C) {
 }
 
 func (s *validationSetTrackingSuite) mockModel() {
-	a := assertstest.FakeAssertion(map[string]interface{}{
+	a := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -217,12 +217,12 @@ func (s *validationSetTrackingSuite) TestGet(c *C) {
 }
 
 func (s *validationSetTrackingSuite) mockAssert(c *C, name, sequence, presence string) asserts.Assertion {
-	snaps := []interface{}{map[string]interface{}{
+	snaps := []any{map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 		"name":     "snap-b",
 		"presence": presence,
 	}}
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": s.dev1acct.AccountID(),
 		"account-id":   s.dev1acct.AccountID(),
 		"name":         name,
@@ -584,7 +584,7 @@ func (s *validationSetTrackingSuite) TestTrackedEnforcedValidationSets(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	a := assertstest.FakeAssertion(map[string]interface{}{
+	a := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -594,14 +594,14 @@ func (s *validationSetTrackingSuite) TestTrackedEnforcedValidationSets(c *C) {
 		"store":        "my-brand-store",
 		"gadget":       "gadget",
 		"kernel":       "krnl",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": s.dev1acct.AccountID(),
 				"name":       "foo",
 				"mode":       "enforce",
 				"sequence":   "9",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": s.dev1acct.AccountID(),
 				"name":       "bar",
 				"mode":       "prefer-enforce",

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -147,14 +147,14 @@ func (m *ConfdbManager) doLoadDataIntoChange(t *state.Task, _ *tomb.Tomb) error 
 }
 
 func readViewIntoChange(chg *state.Change, tx *Transaction, view *confdb.View, requests []string) error {
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err := chg.Get("api-data", &apiData)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
 	if apiData == nil {
-		apiData = make(map[string]interface{})
+		apiData = make(map[string]any)
 	}
 
 	result, err := GetViaView(tx, view, requests)

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -39,7 +39,7 @@ import (
 var assertstateConfdbSchema = assertstate.ConfdbSchema
 
 // SetViaView uses the view to set the requests in the transaction's databag.
-func SetViaView(bag confdb.Databag, view *confdb.View, requests map[string]interface{}) error {
+func SetViaView(bag confdb.Databag, view *confdb.View, requests map[string]any) error {
 	for field, value := range requests {
 		var err error
 		if value == nil {
@@ -79,7 +79,7 @@ func GetView(st *state.State, account, dbSchemaName, viewName string) (*confdb.V
 
 // GetViaView uses the view to get values for the fields from the databag in
 // the transaction.
-func GetViaView(bag confdb.Databag, view *confdb.View, fields []string) (interface{}, error) {
+func GetViaView(bag confdb.Databag, view *confdb.View, fields []string) (any, error) {
 	if len(fields) == 0 {
 		val, err := view.Get(bag, "")
 		if err != nil {
@@ -89,7 +89,7 @@ func GetViaView(bag confdb.Databag, view *confdb.View, fields []string) (interfa
 		return val, nil
 	}
 
-	results := make(map[string]interface{}, len(fields))
+	results := make(map[string]any, len(fields))
 	for _, field := range fields {
 		value, err := view.Get(bag, field)
 		if err != nil {

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -107,18 +107,18 @@ func (s *confdbTestSuite) SetUpTest(c *C) {
 	c.Check(signingDB, NotNil)
 	c.Assert(storeSigning.Add(devAccKey), IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": devAccKey.AccountID(),
 		"account-id":   devAccKey.AccountID(),
 		"name":         "network",
-		"views": map[string]interface{}{
-			"setup-wifi": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "ssids", "storage": "wifi.ssids"},
-					map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
-					map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
-					map[string]interface{}{"request": "status", "storage": "wifi.status", "access": "read"},
-					map[string]interface{}{"request": "private.{placeholder}", "storage": "private.{placeholder}"},
+		"views": map[string]any{
+			"setup-wifi": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "ssids", "storage": "wifi.ssids"},
+					map[string]any{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
+					map[string]any{"request": "password", "storage": "wifi.psk", "access": "write"},
+					map[string]any{"request": "status", "storage": "wifi.status", "access": "read"},
+					map[string]any{"request": "private.{placeholder}", "storage": "private.{placeholder}"},
 				},
 			},
 		},
@@ -173,7 +173,7 @@ func (s *confdbTestSuite) TestGetView(c *C) {
 
 	res, err := confdbstate.GetViaView(bag, view, []string{"ssid"})
 	c.Assert(err, IsNil)
-	c.Assert(res, DeepEquals, map[string]interface{}{"ssid": "foo"})
+	c.Assert(res, DeepEquals, map[string]any{"ssid": "foo"})
 }
 
 func (s *confdbTestSuite) TestGetNotFound(c *C) {
@@ -214,7 +214,7 @@ func (s *confdbTestSuite) TestSetView(c *C) {
 	view, err := confdbstate.GetView(s.state, s.devAccID, "network", "setup-wifi")
 	c.Assert(err, IsNil)
 
-	err = confdbstate.SetViaView(bag, view, map[string]interface{}{"ssid": "foo"})
+	err = confdbstate.SetViaView(bag, view, map[string]any{"ssid": "foo"})
 	c.Assert(err, IsNil)
 
 	val, err := bag.Get("wifi.ssid")
@@ -230,7 +230,7 @@ func (s *confdbTestSuite) TestSetNotFound(c *C) {
 	view, err := confdbstate.GetView(s.state, s.devAccID, "network", "setup-wifi")
 	c.Assert(err, IsNil)
 
-	err = confdbstate.SetViaView(bag, view, map[string]interface{}{"foo": "bar"})
+	err = confdbstate.SetViaView(bag, view, map[string]any{"foo": "bar"})
 	c.Assert(err, FitsTypeOf, &confdb.NotFoundError{})
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot set "foo" through %s/network/setup-wifi: no matching rule`, s.devAccID))
 
@@ -251,7 +251,7 @@ func (s *confdbTestSuite) TestUnsetView(c *C) {
 	view, err := confdbstate.GetView(s.state, s.devAccID, "network", "setup-wifi")
 	c.Assert(err, IsNil)
 
-	err = confdbstate.SetViaView(bag, view, map[string]interface{}{"ssid": nil})
+	err = confdbstate.SetViaView(bag, view, map[string]any{"ssid": nil})
 	c.Assert(err, IsNil)
 
 	val, err := bag.Get("wifi.ssid")
@@ -264,9 +264,9 @@ func (s *confdbTestSuite) TestConfdbstateGetEntireView(c *C) {
 	defer s.state.Unlock()
 
 	bag := confdb.NewJSONDatabag()
-	c.Assert(bag.Set("wifi.ssids", []interface{}{"foo", "bar"}), IsNil)
+	c.Assert(bag.Set("wifi.ssids", []any{"foo", "bar"}), IsNil)
 	c.Assert(bag.Set("wifi.psk", "pass"), IsNil)
-	c.Assert(bag.Set("private", map[string]interface{}{
+	c.Assert(bag.Set("private", map[string]any{
 		"a": 1,
 		"b": 2,
 	}), IsNil)
@@ -276,9 +276,9 @@ func (s *confdbTestSuite) TestConfdbstateGetEntireView(c *C) {
 
 	res, err := confdbstate.GetViaView(bag, view, nil)
 	c.Assert(err, IsNil)
-	c.Assert(res, DeepEquals, map[string]interface{}{
-		"ssids": []interface{}{"foo", "bar"},
-		"private": map[string]interface{}{
+	c.Assert(res, DeepEquals, map[string]any{
+		"ssids": []any{"foo", "bar"},
+		"private": map[string]any{
 			"a": float64(1),
 			"b": float64(2),
 		},
@@ -310,29 +310,29 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml string, hooks []string) *
 }
 
 func (s *confdbTestSuite) TestPlugsAffectedByPaths(c *C) {
-	confdb, err := confdb.NewSchema(s.devAccID, "confdb", map[string]interface{}{
+	confdb, err := confdb.NewSchema(s.devAccID, "confdb", map[string]any{
 		// exact match
-		"view-1": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.bar", "storage": "foo.bar"},
+		"view-1": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.bar", "storage": "foo.bar"},
 			},
 		},
 		// unrelated
-		"view-2": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "bar", "storage": "bar"},
+		"view-2": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "bar", "storage": "bar"},
 			},
 		},
 		// more specific
-		"view-3": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo.bar.baz", "storage": "foo.bar.baz"},
+		"view-3": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.bar.baz", "storage": "foo.bar.baz"},
 			},
 		},
 		// more generic but we won't connect a plug for this view
-		"view-4": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
+		"view-4": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
 			},
 		},
 	}, confdb.NewJSONSchema())
@@ -1087,10 +1087,10 @@ func (s *confdbTestSuite) TestGetDifferentTransactionThanOngoing(c *C) {
 	refTask.Set("tx-task", commitTask.ID())
 
 	// make some other confdb to access concurrently
-	confdb, err := confdb.NewSchema("foo", "bar", map[string]interface{}{
-		"foo": map[string]interface{}{
-			"rules": []interface{}{
-				map[string]interface{}{"request": "foo", "storage": "foo"},
+	confdb, err := confdb.NewSchema("foo", "bar", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo", "storage": "foo"},
 			}}}, confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
 	s.state.Unlock()
@@ -1580,13 +1580,13 @@ func (s *confdbTestSuite) TestGetTransactionForAPI(c *C) {
 	c.Assert(loadTask.Get("requests", &requests), IsNil)
 	c.Assert(requests, DeepEquals, []string{"ssid", "ssids"})
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil)
 	val := apiData["confdb-data"]
-	c.Assert(val, DeepEquals, map[string]interface{}{
+	c.Assert(val, DeepEquals, map[string]any{
 		"ssid":  "foo",
-		"ssids": []interface{}{"abc", "xyz"},
+		"ssids": []any{"abc", "xyz"},
 	})
 }
 
@@ -1620,13 +1620,13 @@ func (s *confdbTestSuite) TestGetTransactionForAPINoHooks(c *C) {
 	err = s.state.Get("confdb-tx-commits", &ongoingTxs)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil)
 	val := apiData["confdb-data"]
-	c.Assert(val, DeepEquals, map[string]interface{}{
+	c.Assert(val, DeepEquals, map[string]any{
 		"ssid":  "foo",
-		"ssids": []interface{}{"abc", "xyz"},
+		"ssids": []any{"abc", "xyz"},
 	})
 }
 
@@ -1650,7 +1650,7 @@ func (s *confdbTestSuite) TestGetTransactionForAPINoHooksError(c *C) {
 	err = s.state.Get("confdb-tx-commits", &ongoingTxs)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil)
 	errStr := apiData["confdb-error"].(string)
@@ -1678,7 +1678,7 @@ func (s *confdbTestSuite) TestGetTransactionForAPIError(c *C) {
 	chg := s.state.Change(chgID)
 	s.checkGetConfdbTasks(c, chg, nil)
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil, Commentf("%+v", chg))
 	errStr := apiData["confdb-error"].(string)

--- a/overlord/confdbstate/transaction.go
+++ b/overlord/confdbstate/transaction.go
@@ -40,7 +40,7 @@ type Transaction struct {
 	ConfdbName    string
 
 	modified      confdb.JSONDatabag
-	deltas        []map[string]interface{}
+	deltas        []map[string]any
 	appliedDeltas int
 
 	abortingSnap string
@@ -73,9 +73,9 @@ type marshalledTransaction struct {
 	ConfdbAccount string `json:"confdb-account,omitempty"`
 	ConfdbName    string `json:"confdb-name,omitempty"`
 
-	Modified      confdb.JSONDatabag       `json:"modified,omitempty"`
-	Deltas        []map[string]interface{} `json:"deltas,omitempty"`
-	AppliedDeltas int                      `json:"applied-deltas,omitempty"`
+	Modified      confdb.JSONDatabag `json:"modified,omitempty"`
+	Deltas        []map[string]any   `json:"deltas,omitempty"`
+	AppliedDeltas int                `json:"applied-deltas,omitempty"`
 
 	AbortingSnap string `json:"aborting-snap,omitempty"`
 	AbortReason  string `json:"abort-reason,omitempty"`
@@ -116,7 +116,7 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 
 // Set sets a value in the transaction's databag. The change isn't persisted
 // until Commit returns without errors.
-func (t *Transaction) Set(path string, value interface{}) error {
+func (t *Transaction) Set(path string, value any) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -124,7 +124,7 @@ func (t *Transaction) Set(path string, value interface{}) error {
 		return errors.New("cannot write to aborted transaction")
 	}
 
-	t.deltas = append(t.deltas, map[string]interface{}{path: value})
+	t.deltas = append(t.deltas, map[string]any{path: value})
 	return nil
 }
 
@@ -138,12 +138,12 @@ func (t *Transaction) Unset(path string) error {
 		return errors.New("cannot write to aborted transaction")
 	}
 
-	t.deltas = append(t.deltas, map[string]interface{}{path: nil})
+	t.deltas = append(t.deltas, map[string]any{path: nil})
 	return nil
 }
 
 // Get reads a value from the transaction's databag including uncommitted changes.
-func (t *Transaction) Get(path string) (interface{}, error) {
+func (t *Transaction) Get(path string) (any, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -254,7 +254,7 @@ func (t *Transaction) applyChanges() error {
 	return nil
 }
 
-func applyDeltas(bag confdb.JSONDatabag, deltas []map[string]interface{}) error {
+func applyDeltas(bag confdb.JSONDatabag, deltas []map[string]any) error {
 	// changes must be applied in the order they were written
 	for _, delta := range deltas {
 		for k, v := range delta {

--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -102,9 +102,9 @@ func PatchConfig(snapName string, subkeys []string, pos int, config any, value *
 			return nil, fmt.Errorf("snap %q option %q is not a map", snapName, strings.Join(subkeys[:pos], "."))
 		}
 		// preserve the invariant that if PatchConfig is
-		// passed a map[string]interface{} it is not nil.
+		// passed a map[string]any it is not nil.
 		// If the value was set to null in the same
-		// transaction use (interface{})(nil) which is handled
+		// transaction use (any)(nil) which is handled
 		// by the first case here.
 		// (see LP: #1920773)
 		var cfg any

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -54,9 +54,9 @@ func (s *configHelpersSuite) TestConfigSnapshot(c *C) {
 	c.Assert(config.SaveRevisionConfig(s.state, "snap1", snap.R(1)), IsNil)
 	c.Assert(config.SaveRevisionConfig(s.state, "snap2", snap.R(7)), IsNil)
 
-	var cfgsnapshot map[string]map[string]map[string]interface{}
+	var cfgsnapshot map[string]map[string]map[string]any
 	c.Assert(s.state.Get("revision-config", &cfgsnapshot), IsNil)
-	c.Assert(cfgsnapshot, DeepEquals, map[string]map[string]map[string]interface{}{
+	c.Assert(cfgsnapshot, DeepEquals, map[string]map[string]map[string]any{
 		"snap1": {"1": {"foo": "a"}},
 		"snap2": {"7": {"bar": "q"}},
 	})
@@ -72,7 +72,7 @@ func (s *configHelpersSuite) TestConfigSnapshot(c *C) {
 	c.Assert(config.SaveRevisionConfig(s.state, "snap1", snap.R(2)), IsNil)
 
 	c.Assert(s.state.Get("revision-config", &cfgsnapshot), IsNil)
-	c.Assert(cfgsnapshot, DeepEquals, map[string]map[string]map[string]interface{}{
+	c.Assert(cfgsnapshot, DeepEquals, map[string]map[string]map[string]any{
 		"snap1": {"1": {"foo": "a"}, "2": {"foo": "b"}},
 		"snap2": {"7": {"bar": "q"}},
 	})
@@ -104,7 +104,7 @@ func (s *configHelpersSuite) TestDiscardRevisionConfig(c *C) {
 		c.Assert(config.SaveRevisionConfig(s.state, "snap3", snap.R(i)), IsNil)
 	}
 
-	var cfgsnapshot map[string]map[string]interface{}
+	var cfgsnapshot map[string]map[string]any
 	c.Assert(s.state.Get("revision-config", &cfgsnapshot), IsNil)
 	c.Assert(cfgsnapshot["snap3"], NotNil)
 	c.Assert(cfgsnapshot["snap3"], HasLen, 3)
@@ -179,7 +179,7 @@ func (s *configHelpersSuite) TestSnapConfig(c *C) {
 		c.Check(rawCfg, IsNil)
 
 		// and there is no entry for the snap in state
-		var config map[string]interface{}
+		var config map[string]any
 		c.Assert(s.state.Get("config", &config), IsNil)
 		_, ok := config["snap1"]
 		c.Check(ok, Equals, false)
@@ -197,35 +197,35 @@ func (s *configHelpersSuite) TestPatchInvalidConfig(c *C) {
 }
 
 func (s *configHelpersSuite) TestPurgeNulls(c *C) {
-	cfg1 := map[string]interface{}{
+	cfg1 := map[string]any{
 		"foo": nil,
-		"bar": map[string]interface{}{
+		"bar": map[string]any{
 			"one": 1,
 			"two": nil,
 		},
-		"baz": map[string]interface{}{
+		"baz": map[string]any{
 			"three": nil,
 		},
 	}
 	config.PurgeNulls(cfg1)
-	c.Check(cfg1, DeepEquals, map[string]interface{}{
-		"bar": map[string]interface{}{
+	c.Check(cfg1, DeepEquals, map[string]any{
+		"bar": map[string]any{
 			"one": 1,
 		},
-		"baz": map[string]interface{}{},
+		"baz": map[string]any{},
 	})
 
-	cfg2 := map[string]interface{}{"foo": nil}
-	c.Check(config.PurgeNulls(cfg2), DeepEquals, map[string]interface{}{})
-	c.Check(cfg2, DeepEquals, map[string]interface{}{})
+	cfg2 := map[string]any{"foo": nil}
+	c.Check(config.PurgeNulls(cfg2), DeepEquals, map[string]any{})
+	c.Check(cfg2, DeepEquals, map[string]any{})
 
-	jsonData, err := json.Marshal(map[string]interface{}{
+	jsonData, err := json.Marshal(map[string]any{
 		"foo": nil,
-		"bar": map[string]interface{}{
+		"bar": map[string]any{
 			"one": 2,
 			"two": nil,
 		},
-		"baz": map[string]interface{}{
+		"baz": map[string]any{
 			"three": nil,
 		},
 	})
@@ -239,24 +239,24 @@ func (s *configHelpersSuite) TestPurgeNulls(c *C) {
 	val, ok := cfg4["root"]
 	c.Assert(ok, Equals, true)
 
-	var out interface{}
+	var out any
 	jsonutil.DecodeWithNumber(bytes.NewReader(*val), &out)
-	c.Check(out, DeepEquals, map[string]interface{}{
-		"bar": map[string]interface{}{
+	c.Check(out, DeepEquals, map[string]any{
+		"bar": map[string]any{
 			"one": json.Number("2"),
 		},
-		"baz": map[string]interface{}{},
+		"baz": map[string]any{},
 	})
 
 	sub := json.RawMessage(`{"foo":"bar"}`)
-	cfg5 := map[string]interface{}{
+	cfg5 := map[string]any{
 		"core": map[string]*json.RawMessage{
 			"proxy": nil,
 			"sub":   &sub,
 		},
 	}
 	config.PurgeNulls(cfg5)
-	c.Check(cfg5, DeepEquals, map[string]interface{}{
+	c.Check(cfg5, DeepEquals, map[string]any{
 		"core": map[string]*json.RawMessage{
 			"sub": &sub,
 		},
@@ -283,14 +283,14 @@ func (s *configHelpersSuite) TestPurgeNullsTopLevelNull(c *C) {
 	cfgJSON2, err := json.Marshal(cfg)
 	c.Assert(err, IsNil)
 
-	var out interface{}
+	var out any
 	jsonutil.DecodeWithNumber(bytes.NewReader(cfgJSON2), &out)
-	c.Check(out, DeepEquals, map[string]interface{}{
-		"experimental": map[string]interface{}{
+	c.Check(out, DeepEquals, map[string]any{
+		"experimental": map[string]any{
 			"parallel-instances": true,
 			"snapd-snap":         true,
 		},
-		"seed": map[string]interface{}{
+		"seed": map[string]any{
 			"loaded": true,
 		},
 	})
@@ -298,10 +298,10 @@ func (s *configHelpersSuite) TestPurgeNullsTopLevelNull(c *C) {
 
 func (s *configHelpersSuite) TestSortPatchKeys(c *C) {
 	// empty case
-	keys := config.SortPatchKeysByDepth(map[string]interface{}{})
+	keys := config.SortPatchKeysByDepth(map[string]any{})
 	c.Assert(keys, IsNil)
 
-	patch := map[string]interface{}{
+	patch := map[string]any{
 		"a.b.c":         0,
 		"a":             0,
 		"a.b.c.d":       0,
@@ -317,26 +317,26 @@ func (s *configHelpersSuite) TestPatch(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("config", map[string]map[string]interface{}{
-		"some-snap": {"a": map[string]interface{}{"b": 1}},
+	s.state.Set("config", map[string]map[string]any{
+		"some-snap": {"a": map[string]any{"b": 1}},
 	})
 
-	patch := map[string]interface{}{
+	patch := map[string]any{
 		"a.b1": 1,
-		"a":    map[string]interface{}{},
-		"a.b2": map[string]interface{}{"c": "C"},
+		"a":    map[string]any{},
+		"a.b2": map[string]any{"c": "C"},
 	}
 
 	tr := config.NewTransaction(s.state)
 	err := config.Patch(tr, "some-snap", patch)
 	c.Assert(err, IsNil)
 
-	var a map[string]interface{}
+	var a map[string]any
 	err = tr.Get("some-snap", "a", &a)
 	c.Check(err, IsNil)
 
-	c.Check(a, DeepEquals, map[string]interface{}{
+	c.Check(a, DeepEquals, map[string]any{
 		"b1": json.Number("1"),
-		"b2": map[string]interface{}{"c": "C"},
+		"b2": map[string]any{"c": "C"},
 	})
 }

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -181,8 +181,7 @@ func (t *Transaction) Set(instanceName, key string, value any) error {
 	}
 
 	// config here is never nil and PatchConfig always operates
-	// directly on and returns config if it's a
-	// map[string]interface{}
+	// directly on and returns config if it's a map[string]any
 	_, err = PatchConfig(instanceName, subkeys, 0, config, &raw)
 	if err != nil {
 		return err

--- a/overlord/configstate/configcore/backlight_test.go
+++ b/overlord/configstate/configcore/backlight_test.go
@@ -46,7 +46,7 @@ func (s *backlightSuite) TestConfigureBacklightServiceMaskIntegration(c *C) {
 	s.systemctlArgs = nil
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.disable-backlight-service": true,
 		},
 	})
@@ -60,7 +60,7 @@ func (s *backlightSuite) TestConfigureBacklightServiceUnmaskIntegration(c *C) {
 	s.systemctlArgs = nil
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.disable-backlight-service": false,
 		},
 	})
@@ -71,7 +71,7 @@ func (s *backlightSuite) TestConfigureBacklightServiceUnmaskIntegration(c *C) {
 }
 
 func (s *backlightSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"system.disable-backlight-service": "true",
 	})
 	tmpDir := c.MkDir()

--- a/overlord/configstate/configcore/certs_test.go
+++ b/overlord/configstate/configcore/certs_test.go
@@ -39,7 +39,7 @@ var _ = Suite(&certsSuite{})
 func (s *certsSuite) TestConfigureCertsUnhappyName(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store-certs.cert-illegal-!": "xxx",
 		},
 	})
@@ -76,7 +76,7 @@ jVaMaA==
 func (s *certsSuite) TestConfigureCertsHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store-certs.cert1": mockCert,
 		},
 	})
@@ -88,7 +88,7 @@ func (s *certsSuite) TestConfigureCertsSimulteRevert(c *C) {
 	// do a normal "snap set"
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store-certs.cert1": mockCert,
 		},
 	})
@@ -97,10 +97,10 @@ func (s *certsSuite) TestConfigureCertsSimulteRevert(c *C) {
 	// and one more with a new cert that will be reverted
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"store-certs.cert1": mockCert,
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store-certs.certthatwillbereverted": mockCert,
 		},
 	})
@@ -113,7 +113,7 @@ func (s *certsSuite) TestConfigureCertsSimulteRevert(c *C) {
 	// of the reverted core
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"store-certs.cert1": mockCert,
 		},
 	})
@@ -130,7 +130,7 @@ jVaMaA==
 func (s *certsSuite) TestConfigureCertsFailsToParse(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store-certs.cert1": certThatFailsToParse,
 		},
 	})
@@ -140,7 +140,7 @@ func (s *certsSuite) TestConfigureCertsFailsToParse(c *C) {
 func (s *certsSuite) TestConfigureCertsUnhappyContent(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store-certs.cert-bad": "xxx",
 		},
 	})

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -39,14 +39,14 @@ var (
 
 // ConfGetter is an interface for reading of config values.
 type ConfGetter interface {
-	Get(snapName, key string, result interface{}) error
-	GetMaybe(snapName, key string, result interface{}) error
-	GetPristine(snapName, key string, result interface{}) error
+	Get(snapName, key string, result any) error
+	GetMaybe(snapName, key string, result any) error
+	GetPristine(snapName, key string, result any) error
 }
 
 // coreCfg returns the configuration value for the core snap.
 func coreCfg(tr ConfGetter, key string) (result string, err error) {
-	var v interface{} = ""
+	var v any = ""
 	if err := tr.Get("core", key, &v); err != nil && !config.IsNoOption(err) {
 		return "", err
 	}
@@ -76,10 +76,10 @@ func validateBoolFlag(tr ConfGetter, flag string) error {
 
 // plainCoreConfig carries a read-only copy of core config and implements
 // ConfGetter interface.
-type plainCoreConfig map[string]interface{}
+type plainCoreConfig map[string]any
 
 // Get implements ConfGetter interface.
-func (cfg plainCoreConfig) Get(snapName, key string, result interface{}) error {
+func (cfg plainCoreConfig) Get(snapName, key string, result any) error {
 	if snapName != "core" {
 		return fmt.Errorf("internal error: expected core snap in Get(), %q was requested", snapName)
 	}
@@ -98,12 +98,12 @@ func (cfg plainCoreConfig) Get(snapName, key string, result interface{}) error {
 // for plainCoreConfig, there are no "pristine" values, so just return nothing
 // this has the effect that every setting will be viewed as "dirty" and needing
 // to be applied
-func (cfg plainCoreConfig) GetPristine(snapName, key string, result interface{}) error {
+func (cfg plainCoreConfig) GetPristine(snapName, key string, result any) error {
 	return nil
 }
 
 // GetMaybe implements ConfGetter interface.
-func (cfg plainCoreConfig) GetMaybe(instanceName, key string, result interface{}) error {
+func (cfg plainCoreConfig) GetMaybe(instanceName, key string, result any) error {
 	err := cfg.Get(instanceName, key, result)
 	if err != nil && !config.IsNoOption(err) {
 		return err

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -43,18 +43,18 @@ func Test(t *testing.T) { TestingT(t) }
 
 type mockConf struct {
 	state   *state.State
-	conf    map[string]interface{}
-	changes map[string]interface{}
+	conf    map[string]any
+	changes map[string]any
 	err     error
 	task    *state.Task
 }
 
-func (cfg *mockConf) Get(snapName, key string, result interface{}) error {
+func (cfg *mockConf) Get(snapName, key string, result any) error {
 	if snapName != "core" {
 		return fmt.Errorf("mockConf only knows about core")
 	}
 
-	var value interface{}
+	var value any
 	value = cfg.changes[key]
 	if value == nil {
 		value = cfg.conf[key]
@@ -67,7 +67,7 @@ func (cfg *mockConf) Get(snapName, key string, result interface{}) error {
 	return cfg.err
 }
 
-func (cfg *mockConf) GetMaybe(snapName, key string, result interface{}) error {
+func (cfg *mockConf) GetMaybe(snapName, key string, result any) error {
 	err := cfg.Get(snapName, key, result)
 	if err != nil && !config.IsNoOption(err) {
 		return err
@@ -75,12 +75,12 @@ func (cfg *mockConf) GetMaybe(snapName, key string, result interface{}) error {
 	return nil
 }
 
-func (cfg *mockConf) GetPristine(snapName, key string, result interface{}) error {
+func (cfg *mockConf) GetPristine(snapName, key string, result any) error {
 	if snapName != "core" {
 		return fmt.Errorf("mockConf only knows about core")
 	}
 
-	var value interface{}
+	var value any
 	value = cfg.conf[key]
 	if value != nil {
 		v1 := reflect.ValueOf(result)
@@ -90,7 +90,7 @@ func (cfg *mockConf) GetPristine(snapName, key string, result interface{}) error
 	return cfg.err
 }
 
-func (cfg *mockConf) GetPristineMaybe(snapName, key string, result interface{}) error {
+func (cfg *mockConf) GetPristineMaybe(snapName, key string, result any) error {
 	err := cfg.GetPristine(snapName, key, result)
 	if err != nil && !config.IsNoOption(err) {
 		return err
@@ -102,12 +102,12 @@ func (cfg *mockConf) Task() *state.Task {
 	return cfg.task
 }
 
-func (cfg *mockConf) Set(snapName, key string, v interface{}) error {
+func (cfg *mockConf) Set(snapName, key string, v any) error {
 	if snapName != "core" {
 		return fmt.Errorf("mockConf only knows about core")
 	}
 	if cfg.conf == nil {
-		cfg.conf = make(map[string]interface{})
+		cfg.conf = make(map[string]any)
 	}
 	cfg.conf[key] = v
 	return nil
@@ -246,26 +246,26 @@ func (s *applyCfgSuite) TestEmptyRootDir(c *C) {
 }
 
 func (s *applyCfgSuite) TestSmoke(c *C) {
-	c.Assert(configcore.FilesystemOnlyApply(coreDev, s.tmpDir, map[string]interface{}{}), IsNil)
+	c.Assert(configcore.FilesystemOnlyApply(coreDev, s.tmpDir, map[string]any{}), IsNil)
 }
 
 func (s *applyCfgSuite) TestPlainCoreConfigGetErrorIfNotCore(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{})
-	var val interface{}
+	conf := configcore.PlainCoreConfig(map[string]any{})
+	var val any
 	c.Assert(conf.Get("some-snap", "a", &val), ErrorMatches, `internal error: expected core snap in Get\(\), "some-snap" was requested`)
 }
 
 func (s *applyCfgSuite) TestPlainCoreConfigGet(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{"foo": "bar"})
-	var val interface{}
+	conf := configcore.PlainCoreConfig(map[string]any{"foo": "bar"})
+	var val any
 	c.Assert(conf.Get("core", "a", &val), DeepEquals, &config.NoOptionError{SnapName: "core", Key: "a"})
 	c.Assert(conf.Get("core", "foo", &val), IsNil)
 	c.Check(val, DeepEquals, "bar")
 }
 
 func (s *applyCfgSuite) TestPlainCoreConfigGetMaybe(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{"foo": "bar"})
-	var val interface{}
+	conf := configcore.PlainCoreConfig(map[string]any{"foo": "bar"})
+	var val any
 	c.Assert(conf.GetMaybe("core", "a", &val), IsNil)
 	c.Assert(val, IsNil)
 	c.Assert(conf.Get("core", "foo", &val), IsNil)

--- a/overlord/configstate/configcore/coredump_test.go
+++ b/overlord/configstate/configcore/coredump_test.go
@@ -48,7 +48,7 @@ func (s *coredumpSuite) SetUpTest(c *C) {
 func (s *coredumpSuite) TestConfigureCoredumpDefault(c *C) {
 	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{},
+		conf:  map[string]any{},
 	})
 	c.Assert(err, IsNil)
 
@@ -59,7 +59,7 @@ func (s *coredumpSuite) TestConfigureCoredumpDefault(c *C) {
 func (s *coredumpSuite) TestConfigureCoredumpDisable(c *C) {
 	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.coredump.enable": false,
 			"system.coredump.maxuse": "100M",
 		},
@@ -73,7 +73,7 @@ func (s *coredumpSuite) TestConfigureCoredumpDisable(c *C) {
 func (s *coredumpSuite) TestConfigureCoredumpDefaultMaxUse(c *C) {
 	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.coredump.enable": true,
 		},
 	})
@@ -88,7 +88,7 @@ func (s *coredumpSuite) TestConfigureCoredumpWithMaxUse(c *C) {
 	for _, size := range []string{"104857600", "16M", "2G", "0"} {
 		err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"system.coredump.enable": true,
 				"system.coredump.maxuse": size,
 			},
@@ -107,7 +107,7 @@ func (s *coredumpSuite) TestConfigureCoredumpInvalidMaxUse(c *C) {
 
 		err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"system.coredump.enable": true,
 				"system.coredump.maxuse": size,
 			},
@@ -121,7 +121,7 @@ func (s *coredumpSuite) TestConfigureCoredumpInvalidMaxUse(c *C) {
 func (s *coredumpSuite) TestConfigureCoredumpNoModeEnv(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.coredump.enable": true,
 		},
 	})

--- a/overlord/configstate/configcore/ctrlaltdel_test.go
+++ b/overlord/configstate/configcore/ctrlaltdel_test.go
@@ -102,7 +102,7 @@ func (s *ctrlaltdelSuite) SetUpTest(c *C) {
 func (s *ctrlaltdelSuite) TestCtrlAltDelInvalidAction(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"system.ctrl-alt-del-action": "xxx",
 		},
 	})
@@ -114,7 +114,7 @@ func (s *ctrlaltdelSuite) TestCtrlAltDelInvalidSystemctlReply(c *C) {
 	s.unit = unitStateMulti
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"system.ctrl-alt-del-action": "none",
 		},
 	})
@@ -126,7 +126,7 @@ func (s *ctrlaltdelSuite) TestCtrlAltDelInvalidInstalledState(c *C) {
 	s.unit = unitStateUninstalled
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"system.ctrl-alt-del-action": "none",
 		},
 	})
@@ -138,7 +138,7 @@ func (s *ctrlaltdelSuite) TestCtrlAltDelInvalidEnabledState(c *C) {
 	s.unit = unitStateEnabled
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"system.ctrl-alt-del-action": "none",
 		},
 	})
@@ -155,7 +155,7 @@ func (s *ctrlaltdelSuite) TestCtrlAltDelValidDisabledState(c *C) {
 		for _, opt := range []string{"reboot", "none"} {
 			err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 				state:   s.state,
-				changes: map[string]interface{}{"system.ctrl-alt-del-action": opt},
+				changes: map[string]any{"system.ctrl-alt-del-action": opt},
 			})
 			c.Assert(err, IsNil)
 			c.Check(s.systemctlArgs, HasLen, 2)
@@ -174,7 +174,7 @@ func (s *ctrlaltdelSuite) TestCtrlAltDelValidDisabledState(c *C) {
 }
 
 func (s *ctrlaltdelSuite) TestFilesystemOnlyApplyNone(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"system.ctrl-alt-del-action": "none",
 	})
 	tmpDir := c.MkDir()
@@ -187,7 +187,7 @@ func (s *ctrlaltdelSuite) TestFilesystemOnlyApplyNone(c *C) {
 
 func (s *ctrlaltdelSuite) TestFilesystemOnlyApplyReboot(c *C) {
 	// slightly strange test as this is the default
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"system.ctrl-alt-del-action": "reboot",
 	})
 	tmpDir := c.MkDir()

--- a/overlord/configstate/configcore/debug_test.go
+++ b/overlord/configstate/configcore/debug_test.go
@@ -76,8 +76,8 @@ func (s *debugSuite) testConfigureDebugSnapdLogGoodVals(c *C, valChanges bool) {
 		}
 		err := configcore.Run(coreDev, &mockConf{
 			state:   s.state,
-			conf:    map[string]interface{}{"debug.snapd.log": prevVal},
-			changes: map[string]interface{}{"debug.snapd.log": val},
+			conf:    map[string]any{"debug.snapd.log": prevVal},
+			changes: map[string]any{"debug.snapd.log": val},
 		})
 
 		c.Assert(err, IsNil)
@@ -113,8 +113,8 @@ func (s *debugSuite) TestConfigureDebugSnapdLogBadVals(c *C) {
 	for _, val := range []string{"1", "foo"} {
 		err := configcore.Run(coreDev, &mockConf{
 			state:   s.state,
-			conf:    map[string]interface{}{"debug.snapd.log": ""},
-			changes: map[string]interface{}{"debug.snapd.log": val},
+			conf:    map[string]any{"debug.snapd.log": ""},
+			changes: map[string]any{"debug.snapd.log": val},
 		})
 		c.Assert(err, ErrorMatches,
 			"debug.snapd.log can only be set to 'true' or 'false'")
@@ -138,8 +138,8 @@ func (s *debugSuite) TestConfigureSystemdLogLevelGoodVals(c *C) {
 	for _, val := range validVals {
 		conf := &mockConf{
 			state:   s.state,
-			conf:    map[string]interface{}{"debug.systemd.log-level": ""},
-			changes: map[string]interface{}{"debug.systemd.log-level": val},
+			conf:    map[string]any{"debug.systemd.log-level": ""},
+			changes: map[string]any{"debug.systemd.log-level": val},
 		}
 		err := configcore.Run(coreDev, conf)
 
@@ -170,8 +170,8 @@ func (s *debugSuite) TestConfigureSystemdLogLevelBadVals(c *C) {
 	for _, val := range []string{"foo", "8", "-1"} {
 		conf := &mockConf{
 			state:   s.state,
-			conf:    map[string]interface{}{"debug.systemd.log-level": "info"},
-			changes: map[string]interface{}{"debug.systemd.log-level": val},
+			conf:    map[string]any{"debug.systemd.log-level": "info"},
+			changes: map[string]any{"debug.systemd.log-level": val},
 		}
 		err := configcore.Run(coreDev, conf)
 
@@ -195,8 +195,8 @@ func (s *debugSuite) TestConfigureSystemdLogLevelOldSystemd(c *C) {
 	val := "debug"
 	err := configcore.Run(coreDev, &mockConf{
 		state:   s.state,
-		conf:    map[string]interface{}{"debug.systemd.log-level": ""},
-		changes: map[string]interface{}{"debug.systemd.log-level": val},
+		conf:    map[string]any{"debug.systemd.log-level": ""},
+		changes: map[string]any{"debug.systemd.log-level": val},
 	})
 	c.Assert(err, IsNil)
 

--- a/overlord/configstate/configcore/early_test.go
+++ b/overlord/configstate/configcore/early_test.go
@@ -34,7 +34,7 @@ type earlySuite struct {
 var _ = Suite(&earlySuite{})
 
 func (s *earlySuite) TestEarly(c *C) {
-	patch := map[string]interface{}{
+	patch := map[string]any{
 		"experimental.parallel-instances": true,
 		"experimental.user-daemons":       true,
 		"service.ssh.disable":             true,
@@ -46,7 +46,7 @@ func (s *earlySuite) TestEarly(c *C) {
 	// only early options as described by flags earlyConfigFilters
 	// were processed
 
-	c.Check(tr.conf, DeepEquals, map[string]interface{}{
+	c.Check(tr.conf, DeepEquals, map[string]any{
 		"experimental.parallel-instances": true,
 		"experimental.user-daemons":       true,
 	})

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -37,7 +37,7 @@ func init() {
 	}
 }
 
-func earlyExperimentalSettingsFilter(values, early map[string]interface{}) {
+func earlyExperimentalSettingsFilter(values, early map[string]any) {
 	for key, v := range values {
 		if strings.HasPrefix(key, "experimental.") && supportedConfigurations["core."+key] {
 			early[key] = v

--- a/overlord/configstate/configcore/experimental_test.go
+++ b/overlord/configstate/configcore/experimental_test.go
@@ -45,7 +45,7 @@ func (s *experimentalSuite) TestConfigureExperimentalSettingsInvalid(c *C) {
 	for _, feature := range features.KnownFeatures() {
 		conf := &mockConf{
 			state:   s.state,
-			changes: map[string]interface{}{featureConf(feature): "foo"},
+			changes: map[string]any{featureConf(feature): "foo"},
 		}
 		err := configcore.FilesystemOnlyRun(classicDev, conf)
 		c.Check(err, ErrorMatches, fmt.Sprintf(`%s can only be set to 'true' or 'false'`, featureConf(feature)))
@@ -57,7 +57,7 @@ func (s *experimentalSuite) TestConfigureExperimentalSettingsHappy(c *C) {
 		for _, t := range []string{"true", "false"} {
 			conf := &mockConf{
 				state: s.state,
-				conf:  map[string]interface{}{featureConf(feature): t},
+				conf:  map[string]any{featureConf(feature): t},
 			}
 			err := configcore.FilesystemOnlyRun(classicDev, conf)
 			c.Check(err, IsNil)
@@ -68,7 +68,7 @@ func (s *experimentalSuite) TestConfigureExperimentalSettingsHappy(c *C) {
 func (s *experimentalSuite) TestExportedFeatures(c *C) {
 	conf := &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{featureConf(features.PerUserMountNamespace): true},
+		conf:  map[string]any{featureConf(features.PerUserMountNamespace): true},
 	}
 	err := configcore.FilesystemOnlyRun(classicDev, conf)
 	c.Assert(err, IsNil)
@@ -81,7 +81,7 @@ func (s *experimentalSuite) TestExportedFeatures(c *C) {
 }
 
 func (s *experimentalSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"experimental.refresh-app-awareness": "true",
 	})
 	tmpDir := c.MkDir()
@@ -90,7 +90,7 @@ func (s *experimentalSuite) TestFilesystemOnlyApply(c *C) {
 }
 
 func (s *experimentalSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"experimental.refresh-app-awareness": 1,
 	})
 	tmpDir := c.MkDir()

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -166,7 +166,7 @@ func (h *fsOnlyHandler) handle(dev sysconfig.Device, cfg ConfGetter, opts *fsOnl
 // early during boot, before all the configuration is applied as part of
 // normal execution of configure hook.
 // Exposed for use via sysconfig.ApplyFilesystemOnlyDefaults.
-func filesystemOnlyApply(dev sysconfig.Device, rootDir string, values map[string]interface{}) error {
+func filesystemOnlyApply(dev sysconfig.Device, rootDir string, values map[string]any) error {
 	if rootDir == "" {
 		return fmt.Errorf("internal error: root directory for configcore.FilesystemOnlyApply() not set")
 	}

--- a/overlord/configstate/configcore/homedirs_test.go
+++ b/overlord/configstate/configcore/homedirs_test.go
@@ -97,7 +97,7 @@ func (s *homedirsSuite) TestValidationUnhappy(c *C) {
 	} {
 		err := configcore.FilesystemOnlyRun(classicDev, &mockConf{
 			state: s.state,
-			changes: map[string]interface{}{
+			changes: map[string]any{
 				"homedirs": testData.homedirs,
 			},
 		})
@@ -115,10 +115,10 @@ func (s *homedirsSuite) TestConfigureUnchangedConfig(c *C) {
 
 	err := configcore.FilesystemOnlyRun(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"homedirs": "/home/existingDir",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"homedirs": "/home/existingDir",
 		},
 	})
@@ -136,7 +136,7 @@ func (s *homedirsSuite) TestConfigureApparmorTunableFailure(c *C) {
 
 	err := configcore.FilesystemOnlyRun(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"homedirs": "/home/existingDir/one,/home/existingDir/two",
 		},
 	})
@@ -152,7 +152,7 @@ func (s *homedirsSuite) TestConfigureApparmorReloadFailure(c *C) {
 	defer restore()
 	err := configcore.FilesystemOnlyRun(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"homedirs": "/home/existingDir",
 		},
 	})
@@ -196,7 +196,7 @@ func (s *homedirsSuite) TestConfigureApparmorUnsupported(c *C) {
 
 		err := configcore.FilesystemOnlyRun(classicDev, &mockConf{
 			state: s.state,
-			changes: map[string]interface{}{
+			changes: map[string]any{
 				"homedirs": "/home/existingDir",
 			},
 		})
@@ -230,7 +230,7 @@ func (s *homedirsSuite) TestConfigureHomedirsHappy(c *C) {
 
 	err := configcore.FilesystemOnlyRun(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"homedirs": "/home/existingDir",
 		},
 	})
@@ -264,7 +264,7 @@ func (s *homedirsSuite) TestConfigureHomedirsEmptyHappy(c *C) {
 	defer restore()
 	err := configcore.FilesystemOnlyRun(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"homedirs": "",
 		},
 	})
@@ -296,7 +296,7 @@ func (s *homedirsSuite) TestConfigureHomedirsNotOnCore(c *C) {
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"homedirs": "/home/existingDir",
 		},
 	})

--- a/overlord/configstate/configcore/hostname.go
+++ b/overlord/configstate/configcore/hostname.go
@@ -102,7 +102,7 @@ func handleHostnameConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnly
 	return nil
 }
 
-func getHostnameFromSystemHelper(key string) (interface{}, error) {
+func getHostnameFromSystemHelper(key string) (any, error) {
 	// XXX: should we error for subkeys here?
 	return getHostnameFromSystem()
 }

--- a/overlord/configstate/configcore/hostname_test.go
+++ b/overlord/configstate/configcore/hostname_test.go
@@ -70,7 +70,7 @@ func (s *hostnameSuite) TestConfigureHostnameFsOnlyInvalid(c *C) {
 	}
 
 	for _, name := range invalidHostnames {
-		conf := configcore.PlainCoreConfig(map[string]interface{}{
+		conf := configcore.PlainCoreConfig(map[string]any{
 			"system.hostname": name,
 		})
 		err := configcore.FilesystemOnlyApply(coreDev, tmpdir, conf)
@@ -107,7 +107,7 @@ func (s *hostnameSuite) TestConfigureHostnameFsOnlyHappy(c *C) {
 	}
 
 	for _, name := range validHostnames {
-		conf := configcore.PlainCoreConfig(map[string]interface{}{
+		conf := configcore.PlainCoreConfig(map[string]any{
 			"system.hostname": name,
 		})
 		err := configcore.FilesystemOnlyApply(coreDev, tmpdir, conf)
@@ -126,7 +126,7 @@ func (s *hostnameSuite) TestConfigureHostnameWithStateOnlyHostnamectlValidates(c
 	for _, hostname := range hostnames {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"system.hostname": hostname,
 			},
 		})
@@ -153,7 +153,7 @@ fi`
 	hostname := "simulated-invalid-hostname"
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.hostname": hostname,
 		},
 	})
@@ -169,7 +169,7 @@ func (s *hostnameSuite) TestConfigureHostnameIntegrationSameHostname(c *C) {
 	// already returning "bar"
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			// hostname is already "bar"
 			"system.hostname": "bar",
 		},
@@ -194,7 +194,7 @@ fi`
 	// and set new hostname to "bar"
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			// hostname is already "bar"
 			"system.hostname": "bar",
 		},
@@ -207,7 +207,7 @@ fi`
 }
 
 func (s *hostnameSuite) TestFilesystemOnlyApplyHappy(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"system.hostname": "bar",
 	})
 	tmpDir := c.MkDir()

--- a/overlord/configstate/configcore/journal_test.go
+++ b/overlord/configstate/configcore/journal_test.go
@@ -71,7 +71,7 @@ func (s *journalSuite) SetUpTest(c *C) {
 func (s *journalSuite) TestConfigurePersistentJournalInvalid(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"journal.persistent": "foo"},
+		conf:  map[string]any{"journal.persistent": "foo"},
 	})
 	c.Assert(err, ErrorMatches, `journal.persistent can only be set to 'true' or 'false'`)
 }
@@ -79,7 +79,7 @@ func (s *journalSuite) TestConfigurePersistentJournalInvalid(c *C) {
 func (s *journalSuite) TestConfigurePersistentJournalOnCore(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"journal.persistent": "true"},
+		conf:  map[string]any{"journal.persistent": "true"},
 	})
 	c.Assert(err, IsNil)
 
@@ -99,7 +99,7 @@ func (s *journalSuite) TestConfigurePersistentJournalOldSystemd(c *C) {
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"journal.persistent": "true"},
+		conf:  map[string]any{"journal.persistent": "true"},
 	})
 	c.Assert(err, IsNil)
 
@@ -119,7 +119,7 @@ func (s *journalSuite) TestConfigurePersistentJournalOnCoreNoopIfExists(c *C) {
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"journal.persistent": "true"},
+		conf:  map[string]any{"journal.persistent": "true"},
 	})
 	c.Assert(err, IsNil)
 
@@ -140,7 +140,7 @@ func (s *journalSuite) TestDisablePersistentJournalNotManagedBySnapdError(c *C) 
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"journal.persistent": "false"},
+		conf:  map[string]any{"journal.persistent": "false"},
 	})
 	c.Assert(err, ErrorMatches, `.*/var/log/journal directory was not created by snapd.*`)
 	exists, _, _ := osutil.DirExists(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"))
@@ -153,7 +153,7 @@ func (s *journalSuite) TestDisablePersistentJournalOnCore(c *C) {
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"journal.persistent": "false"},
+		conf:  map[string]any{"journal.persistent": "false"},
 	})
 	c.Assert(err, IsNil)
 
@@ -168,7 +168,7 @@ func (s *journalSuite) TestDisablePersistentJournalOnCore(c *C) {
 }
 
 func (s *journalSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"journal.persistent": "true",
 	})
 	tmpDir := c.MkDir()

--- a/overlord/configstate/configcore/kernel_test.go
+++ b/overlord/configstate/configcore/kernel_test.go
@@ -163,7 +163,7 @@ func (s *kernelSuite) mockClassicBootModelWithoutSnaps() {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	extras := map[string]interface{}{
+	extras := map[string]any{
 		"architecture": "amd64",
 		"classic":      "true",
 	}
@@ -182,18 +182,18 @@ func (s *kernelSuite) mockModelWithModeenv(grade string, isClassic bool) {
 	defer s.state.Unlock()
 
 	// model setup
-	extras := map[string]interface{}{
+	extras := map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        grade,
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
 				"type":            "gadget",
@@ -321,7 +321,7 @@ func (s *kernelSuite) testConfigureKernelCmdlineHappy(c *C, option []cmdlineOpti
 	s.state.Unlock()
 
 	hookCtx.Lock()
-	patchVals := make(map[string]interface{})
+	patchVals := make(map[string]any)
 	for _, opt := range option {
 		patchVals[opt.name] = opt.cmdline
 	}

--- a/overlord/configstate/configcore/lockout_test.go
+++ b/overlord/configstate/configcore/lockout_test.go
@@ -49,7 +49,7 @@ func (s *faillockSuite) SetUpTest(c *C) {
 func (s *faillockSuite) TestFaillockSetTrue(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"users.lockout": "true"},
+		conf:  map[string]any{"users.lockout": "true"},
 	})
 	c.Assert(err, IsNil)
 	c.Check(s.markerPath, testutil.FilePresent)
@@ -58,7 +58,7 @@ func (s *faillockSuite) TestFaillockSetTrue(c *C) {
 func (s *faillockSuite) TestFaillockSetFalse(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"users.lockout": "false"},
+		conf:  map[string]any{"users.lockout": "false"},
 	})
 	c.Assert(err, IsNil)
 	c.Check(s.markerPath, testutil.FileAbsent)
@@ -70,7 +70,7 @@ func (s *faillockSuite) TestFaillockSetFalseReset(c *C) {
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"users.lockout": "false"},
+		conf:  map[string]any{"users.lockout": "false"},
 	})
 	c.Assert(err, IsNil)
 	c.Check(s.markerPath, testutil.FileAbsent)
@@ -79,7 +79,7 @@ func (s *faillockSuite) TestFaillockSetFalseReset(c *C) {
 func (s *faillockSuite) TestFaillockHandlesErrors(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"users.lockout": "invalid-value"},
+		conf:  map[string]any{"users.lockout": "invalid-value"},
 	})
 	c.Assert(err, ErrorMatches, "users.lockout can only be set to 'true' or 'false'")
 }
@@ -90,7 +90,7 @@ func (s *faillockSuite) TestFaillockUnsetChangeNothing(c *C) {
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"users.lockout": ""},
+		conf:  map[string]any{"users.lockout": ""},
 	})
 	c.Assert(err, IsNil)
 	c.Check(s.markerPath, testutil.FilePresent)

--- a/overlord/configstate/configcore/netplan.go
+++ b/overlord/configstate/configcore/netplan.go
@@ -160,7 +160,7 @@ func handleNetplanConfiguration(tr RunTransaction, opts *fsOnlyContext) (err err
 		return nil
 	}
 
-	var cfg map[string]interface{}
+	var cfg map[string]any
 	if err := tr.Get("core", "system.network.netplan", &cfg); err != nil && !config.IsNoOption(err) {
 		return fmt.Errorf("cannot get netpan config: %v", err)
 	}
@@ -257,7 +257,7 @@ func handleNetplanConfiguration(tr RunTransaction, opts *fsOnlyContext) (err err
 	return nil
 }
 
-func getNetplanFromSystem(key string) (result interface{}, err error) {
+func getNetplanFromSystem(key string) (result any, err error) {
 	if release.OnClassic {
 		return nil, nil
 	}
@@ -282,7 +282,7 @@ func getNetplanFromSystem(key string) (result interface{}, err error) {
 		}
 	}()
 
-	var cfg map[string]interface{}
+	var cfg map[string]any
 	if err := yaml.Unmarshal([]byte(netplanYamlCfg), &cfg); err != nil {
 		return nil, err
 	}

--- a/overlord/configstate/configcore/netplan.go
+++ b/overlord/configstate/configcore/netplan.go
@@ -27,9 +27,9 @@ package configcore
 //
 // Move this part of the code to yaml.v3 because without it we run
 // into incompatibilites of maps between json and yaml:
-// "json: unsupported type: map[interface{}]interface{}" because
-// because yaml.v2 unmarshalls by default to "map[interface{}]interface{}"
-// v3 fixes this, see https://github.com/go-yaml/yaml/pull/385#issuecomment-475588596
+// "json: unsupported type: map[any]any" because yaml.v2 unmarshalls by default
+// to "map[any]any" v3 fixes this, see
+// https://github.com/go-yaml/yaml/pull/385#issuecomment-475588596
 import (
 	"encoding/json"
 	"fmt"

--- a/overlord/configstate/configcore/netplan_test.go
+++ b/overlord/configstate/configcore/netplan_test.go
@@ -126,7 +126,7 @@ func (s *netplanSuite) TestNetplanGetFromDBusNoSuchService(c *C) {
 	// Note that we do not export any netplan dbus api here
 
 	tr := config.NewTransaction(s.state)
-	netplanCfg := make(map[string]interface{})
+	netplanCfg := make(map[string]any)
 	err := tr.Get("core", "system.network.netplan", &netplanCfg)
 	c.Assert(err, ErrorMatches, `snap "core" has no "system.network.netplan" configuration option`)
 }
@@ -157,7 +157,7 @@ func (s *netplanSuite) TestNetplanGetNoSupportOnClassic(c *C) {
 	s.backend.ExportApiV2()
 
 	tr := config.NewTransaction(s.state)
-	netplanCfg := make(map[string]interface{})
+	netplanCfg := make(map[string]any)
 	err := tr.Get("core", "system.network.netplan", &netplanCfg)
 	c.Assert(err, ErrorMatches, `snap "core" has no "system.network.netplan" configuration option`)
 }
@@ -172,11 +172,11 @@ func (s *netplanSuite) TestNetplanGetFromDBusHappy(c *C) {
 	tr := config.NewTransaction(s.state)
 
 	// full doc
-	netplanCfg := make(map[string]interface{})
+	netplanCfg := make(map[string]any)
 	err := tr.Get("core", "system.network.netplan", &netplanCfg)
 	c.Assert(err, IsNil)
-	c.Check(netplanCfg, DeepEquals, map[string]interface{}{
-		"network": map[string]interface{}{
+	c.Check(netplanCfg, DeepEquals, map[string]any{
+		"network": map[string]any{
 			"renderer": "NetworkManager",
 			"version":  json.Number("2"),
 		},
@@ -187,10 +187,10 @@ func (s *netplanSuite) TestNetplanGetFromDBusHappy(c *C) {
 	})
 
 	// only the "network" subset
-	netplanCfg = make(map[string]interface{})
+	netplanCfg = make(map[string]any)
 	err = tr.Get("core", "system.network.netplan.network", &netplanCfg)
 	c.Assert(err, IsNil)
-	c.Check(netplanCfg, DeepEquals, map[string]interface{}{
+	c.Check(netplanCfg, DeepEquals, map[string]any{
 		"renderer": "NetworkManager",
 		"version":  json.Number("2"),
 	})
@@ -226,11 +226,11 @@ func (s *netplanSuite) TestNetplanGetFromDBusCancelFails(c *C) {
 	s.backend.ExportApiV2()
 
 	tr := config.NewTransaction(s.state)
-	netplanCfg := make(map[string]interface{})
+	netplanCfg := make(map[string]any)
 	err := tr.Get("core", "system.network.netplan", &netplanCfg)
 	c.Assert(err, IsNil)
-	c.Check(netplanCfg, DeepEquals, map[string]interface{}{
-		"network": map[string]interface{}{
+	c.Check(netplanCfg, DeepEquals, map[string]any{
+		"network": map[string]any{
 			"renderer": "NetworkManager",
 			"version":  json.Number("2"),
 		},
@@ -250,11 +250,11 @@ func (s *netplanSuite) TestNetplanGetFromDBusCancelErr(c *C) {
 	s.backend.ExportApiV2()
 
 	tr := config.NewTransaction(s.state)
-	netplanCfg := make(map[string]interface{})
+	netplanCfg := make(map[string]any)
 	err := tr.Get("core", "system.network.netplan", &netplanCfg)
 	c.Assert(err, IsNil)
-	c.Check(netplanCfg, DeepEquals, map[string]interface{}{
-		"network": map[string]interface{}{
+	c.Check(netplanCfg, DeepEquals, map[string]any{
+		"network": map[string]any{
 			"renderer": "NetworkManager",
 			"version":  json.Number("2"),
 		},
@@ -580,7 +580,7 @@ func (s *netplanSuite) TestNetplanNoApplyOnClassic(c *C) {
 
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"system.network.netplan.network.renderer": "networkd",
 		},
 	})
@@ -588,9 +588,9 @@ func (s *netplanSuite) TestNetplanNoApplyOnClassic(c *C) {
 
 	err = configcore.Run(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
-			"system.network.netplan": map[string]interface{}{
-				"network": map[string]interface{}{
+		changes: map[string]any{
+			"system.network.netplan": map[string]any{
+				"network": map[string]any{
 					"version": 2,
 				},
 			},

--- a/overlord/configstate/configcore/network_test.go
+++ b/overlord/configstate/configcore/network_test.go
@@ -54,7 +54,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 	// disable ipv6
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"network.disable-ipv6": true,
 		},
 	})
@@ -69,7 +69,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 	// enable it again
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"network.disable-ipv6": false,
 		},
 	})
@@ -84,7 +84,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 	// enable it yet again, this does not trigger another syscall
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"network.disable-ipv6": false,
 		},
 	})
@@ -95,7 +95,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationIPv6(c *C) {
 func (s *networkSuite) TestConfigureNetworkIntegrationNoSetting(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{},
+		conf:  map[string]any{},
 	})
 	c.Assert(err, IsNil)
 
@@ -106,7 +106,7 @@ func (s *networkSuite) TestConfigureNetworkIntegrationNoSetting(c *C) {
 }
 
 func (s *networkSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"network.disable-ipv6": true,
 	})
 
@@ -122,7 +122,7 @@ func (s *networkSuite) TestFilesystemOnlyApply(c *C) {
 }
 
 func (s *networkSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"network.disable-ipv6": "0",
 	})
 

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -128,7 +128,7 @@ func (s *piCfgSuite) TestConfigurePiConfigNoChangeSet(c *C) {
 func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"pi-config.disable-overscan": 1,
 		},
 	})
@@ -139,7 +139,7 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"pi-config.disable-overscan": "",
 		},
 	})
@@ -151,7 +151,7 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 func (s *piCfgSuite) TestConfigurePiConfigRegression(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"pi-config.gpu-mem-512": true,
 		},
 	})
@@ -184,7 +184,7 @@ func (s *piCfgSuite) TestUpdateConfigUC20RunMode(c *C) {
 	// apply the config
 	err = configcore.FilesystemOnlyRun(uc20DevRunMode, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"pi-config.gpu-mem-512": true,
 		},
 	})
@@ -216,7 +216,7 @@ func (s *piCfgSuite) testUpdateConfigUC20NonRunMode(c *C, mode string) {
 	// apply the config
 	err = configcore.FilesystemOnlyRun(uc20DevMode, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"pi-config.gpu-mem-512": true,
 		},
 	})
@@ -235,7 +235,7 @@ func (s *piCfgSuite) TestUpdateConfigUC20InstallModeDoesNothing(c *C) {
 }
 
 func (s *piCfgSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"pi-config.gpu-mem-512": true,
 	})
 
@@ -260,7 +260,7 @@ func (s *piCfgSuite) TestConfigurePiConfigSkippedOnAvnetKernel(c *C) {
 
 	err := configcore.FilesystemOnlyRun(avnetDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"pi-config.disable-overscan": 1,
 		},
 	})
@@ -283,7 +283,7 @@ func (s *piCfgSuite) TestConfigurePiConfigSkippedOnWrongMode(c *C) {
 
 	err := configcore.FilesystemOnlyRun(uc20DevInstallMode, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"pi-config.disable-overscan": 1,
 		},
 	})
@@ -318,7 +318,7 @@ func (s *piCfgSuite) TestConfigurePiConfigSkippedOnIgnoreHeader(c *C) {
 		s.mockConfig(c, mockConfigWithHeader)
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"pi-config.disable-overscan": 1,
 			},
 		})

--- a/overlord/configstate/configcore/powerbtn_test.go
+++ b/overlord/configstate/configcore/powerbtn_test.go
@@ -56,7 +56,7 @@ func (s *powerbtnSuite) TestConfigurePowerIntegration(c *C) {
 
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"system.power-key-action": action,
 			},
 		})
@@ -70,7 +70,7 @@ func (s *powerbtnSuite) TestConfigurePowerIntegration(c *C) {
 }
 
 func (s *powerbtnSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"system.power-key-action": "reboot",
 	})
 	tmpDir := c.MkDir()

--- a/overlord/configstate/configcore/prompting_test.go
+++ b/overlord/configstate/configcore/prompting_test.go
@@ -410,10 +410,10 @@ func (s *promptingSuite) TestDoExperimentalApparmorPromptingChecksHandlersDiscon
 	defer restore()
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"test-snap:snap-interfaces-requests-control core:snap-interfaces-requests-control": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"test-snap:snap-interfaces-requests-control core:snap-interfaces-requests-control": map[string]any{
 			"interface": "snap-interfaces-requests-control",
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"handler-service": "prompts-handler",
 			},
 			// manually disconnected
@@ -625,22 +625,22 @@ plugs:
 		SnapType: "app",
 	})
 
-	plugStatic := map[string]interface{}{}
+	plugStatic := map[string]any{}
 	if opts.hasHandler {
 		plugStatic["handler-service"] = "prompts-handler"
 	}
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	if err != nil {
 		if errors.Is(err, state.ErrNoState) {
-			conns = map[string]interface{}{}
+			conns = map[string]any{}
 		} else {
 			c.Fatalf("unexpected error: %v", err)
 		}
 	}
 
-	conns[fmt.Sprintf("%s:snap-interfaces-requests-control core:snap-interfaces-requests-control", name)] = map[string]interface{}{
+	conns[fmt.Sprintf("%s:snap-interfaces-requests-control core:snap-interfaces-requests-control", name)] = map[string]any{
 		"interface":   "snap-interfaces-requests-control",
 		"plug-static": plugStatic,
 	}

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -85,7 +85,7 @@ func (s *proxySuite) TestConfigureProxyUnhappy(c *C) {
 	defer r()
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"proxy.http": "http://example.com",
 		},
 	})
@@ -99,7 +99,7 @@ func (s *proxySuite) TestConfigureProxy(c *C) {
 
 		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				fmt.Sprintf("proxy.%s", proto): fmt.Sprintf("%s://example.com", proto),
 			},
 		})
@@ -117,7 +117,7 @@ func (s *proxySuite) TestConfigureNoProxy(c *C) {
 	s.makeMockEtcEnvironment(c)
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"proxy.no-proxy": "example.com,bar.com",
 		},
 	})
@@ -147,7 +147,7 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 	// no related change
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"refresh.rate-limit": "1MB",
 		},
 	})
@@ -156,7 +156,7 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 	// set to ""
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"proxy.store": "",
 		},
 	})
@@ -165,7 +165,7 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 	// no assertion
 	conf := &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"proxy.store": "foo",
 		},
 	}
@@ -177,7 +177,7 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
 	// have a store assertion
-	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "foo",
 		"operator-id": operatorAcct.AccountID(),
 		"url":         "http://store.interal:9943",
@@ -198,10 +198,10 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 	// no value change
 	conf = &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"proxy.store": "foo",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"proxy.store": "foo",
 		},
 	}
@@ -215,14 +215,14 @@ func (s *proxySuite) TestConfigureProxyStore(c *C) {
 func (s *proxySuite) TestConfigureProxyStoreNoURL(c *C) {
 	conf := &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"proxy.store": "foo",
 		},
 	}
 
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
 	// have a store assertion but no url
-	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "foo",
 		"operator-id": operatorAcct.AccountID(),
 		"timestamp":   time.Now().Format(time.RFC3339),

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&refreshSuite{})
 func (s *refreshSuite) TestConfigureRefreshTimerHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.timer": "8:00~12:00/2",
 		},
 	})
@@ -47,7 +47,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerHappy(c *C) {
 func (s *refreshSuite) TestConfigureRefreshTimerRejected(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.timer": "invalid",
 		},
 	})
@@ -59,7 +59,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerManagedIgnored(c *C) {
 		cfg := &mockConf{
 			state: s.state,
 			// invalid value present in the state
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				opt: "managed",
 			},
 		}
@@ -79,11 +79,11 @@ func (s *refreshSuite) TestConfigureRefreshTimerManagedChangeError(c *C) {
 	for _, opt := range []string{"refresh.timer", "refresh.schedule"} {
 		cfg := &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				// valid value in the state, should remain intact
 				opt: "fri",
 			},
-			changes: map[string]interface{}{
+			changes: map[string]any{
 				opt: "managed",
 			},
 		}
@@ -97,7 +97,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerManagedChangeError(c *C) {
 func (s *refreshSuite) TestConfigureLegacyRefreshScheduleHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.schedule": "8:00-12:00",
 		},
 	})
@@ -107,7 +107,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleHappy(c *C) {
 func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.schedule": "invalid",
 		},
 	})
@@ -116,7 +116,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 	// check that refresh.schedule is verified against legacy parser
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.schedule": "8:00~12:00/2",
 		},
 	})
@@ -126,7 +126,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 func (s *refreshSuite) TestConfigureRefreshHoldHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.hold": "2018-08-18T15:00:00Z",
 		},
 	})
@@ -136,7 +136,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldHappy(c *C) {
 func (s *refreshSuite) TestConfigureRefreshHoldForeverHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.hold": "forever",
 		},
 	})
@@ -146,7 +146,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldForeverHappy(c *C) {
 func (s *refreshSuite) TestConfigureRefreshHoldInvalid(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.hold": "invalid",
 		},
 	})
@@ -156,7 +156,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldInvalid(c *C) {
 func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredInvalid(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.metered": "invalid",
 		},
 	})
@@ -166,7 +166,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredInvalid(c *C) {
 func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.metered": "hold",
 		},
 	})
@@ -174,7 +174,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredHappy(c *C) {
 
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.metered": "",
 		},
 	})
@@ -184,7 +184,7 @@ func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredHappy(c *C) {
 func (s *refreshSuite) TestConfigureRefreshRetainHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.retain": "4",
 		},
 	})
@@ -194,7 +194,7 @@ func (s *refreshSuite) TestConfigureRefreshRetainHappy(c *C) {
 func (s *refreshSuite) TestConfigureRefreshRetainUnderRange(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.retain": "1",
 		},
 	})
@@ -204,7 +204,7 @@ func (s *refreshSuite) TestConfigureRefreshRetainUnderRange(c *C) {
 func (s *refreshSuite) TestConfigureRefreshRetainOverRange(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.retain": "100",
 		},
 	})
@@ -214,7 +214,7 @@ func (s *refreshSuite) TestConfigureRefreshRetainOverRange(c *C) {
 func (s *refreshSuite) TestConfigureRefreshRetainInvalid(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"refresh.retain": "invalid",
 		},
 	})
@@ -223,7 +223,7 @@ func (s *refreshSuite) TestConfigureRefreshRetainInvalid(c *C) {
 
 func (s *refreshSuite) TestConfigureRefreshMaxInhibitionDays(c *C) {
 	data := []struct {
-		val interface{}
+		val any
 		err string
 	}{
 		{val: "zzz", err: `max-inhibition-days must be a number between 1 and 21, not "zzz"`},
@@ -241,7 +241,7 @@ func (s *refreshSuite) TestConfigureRefreshMaxInhibitionDays(c *C) {
 	for _, tc := range data {
 		err := configcore.Run(classicDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"refresh.max-inhibition-days": tc.val,
 			},
 		})

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -80,11 +80,11 @@ func init() {
 // RunTransaction is an interface describing how to access
 // the system configuration state and transaction.
 type RunTransaction interface {
-	Get(snapName, key string, result interface{}) error
-	GetMaybe(snapName, key string, result interface{}) error
-	GetPristine(snapName, key string, result interface{}) error
+	Get(snapName, key string, result any) error
+	GetMaybe(snapName, key string, result any) error
+	GetPristine(snapName, key string, result any) error
 	Task() *state.Task
-	Set(snapName, key string, value interface{}) error
+	Set(snapName, key string, value any) error
 	Changes() []string
 	State() *state.State
 	Commit()
@@ -194,7 +194,7 @@ func applyHandlers(dev sysconfig.Device, cfg RunTransaction, handlers []configHa
 	return nil
 }
 
-func Early(dev sysconfig.Device, cfg RunTransaction, values map[string]interface{}) error {
+func Early(dev sysconfig.Device, cfg RunTransaction, values map[string]any) error {
 	early, relevant := applyFilters(func(f flags) filterFunc {
 		return f.earlyConfigFilter
 	}, values)

--- a/overlord/configstate/configcore/runwithstate_test.go
+++ b/overlord/configstate/configcore/runwithstate_test.go
@@ -33,7 +33,7 @@ func (s *configcoreSuite) TestNilHandleWithStateHandlerPanic(c *C) {
 func (r *configcoreSuite) TestConfigureUnknownOption(c *C) {
 	conf := &mockConf{
 		state: r.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"unknown.option": "1",
 		},
 	}

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -315,7 +315,7 @@ func validateServiceConfiguration(tr ConfGetter) error {
 
 func handleServiceConfigSSHListen(dev sysconfig.Device, tr ConfGetter, opts *fsOnlyContext) error {
 	// see if anything needs to happen
-	var pristineSSHListen, newSSHListen interface{}
+	var pristineSSHListen, newSSHListen any
 
 	if err := tr.GetPristine("core", sshListenOpt, &pristineSSHListen); err != nil && !config.IsNoOption(err) {
 		return err

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -74,7 +74,7 @@ func (s *servicesSuite) SetUpTest(c *C) {
 func (s *servicesSuite) TestConfigureServiceInvalidValue(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"service.ssh.disable": "xxx",
 		},
 	})
@@ -125,7 +125,7 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 		s.serviceInstalled = service.installed
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				fmt.Sprintf("service.%s.disable", service.cfgName): true,
 			},
 		})
@@ -159,7 +159,7 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfDisableFSOnly(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"service.console-conf.disable": true,
 	})
 
@@ -171,7 +171,7 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableFSOnly(c *C) {
 }
 
 func (s *servicesSuite) TestConfigureConsoleConfEnabledFSOnly(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"service.console-conf.disable": false,
 	})
 
@@ -199,7 +199,7 @@ recovery_system=20200202
 	// now enable it
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.console-conf.disable": false,
 		},
 	})
@@ -219,7 +219,7 @@ recovery_system=20200202
 	// now try to enable it
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.console-conf.disable": true,
 		},
 	})
@@ -238,7 +238,7 @@ recovery_system=20200202
 	// file. So console-conf is already enabled
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.console-conf.disable": false,
 		},
 	})
@@ -261,7 +261,7 @@ recovery_system=20200202
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.console-conf.disable": true,
 		},
 	})
@@ -277,7 +277,7 @@ recovery_system=20200202
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.console-conf.disable": true,
 		},
 	})
@@ -305,7 +305,7 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 		s.serviceInstalled = service.installed
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				fmt.Sprintf("service.%s.disable", service.cfgName): false,
 			},
 		})
@@ -343,7 +343,7 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 func (s *servicesSuite) TestConfigureServiceUnsupportedService(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.snapd.disable": true,
 		},
 	})
@@ -358,7 +358,7 @@ func (s *servicesSuite) TestFilesystemOnlyApply(c *C) {
 	tmpDir := c.MkDir()
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "etc", "ssh"), 0755), IsNil)
 
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"service.ssh.disable":     "true",
 		"service.rsyslog.disable": "true",
 	})
@@ -371,7 +371,7 @@ func (s *servicesSuite) TestFilesystemOnlyApply(c *C) {
 func (s *servicesSuite) TestConfigureNetworkSSHListenAddressFailsOnNonCore20(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"service.ssh.listen-address": ":8022",
 		},
 	})
@@ -382,7 +382,7 @@ func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongRange(c *C)
 	for _, invalidPort := range []int{0, 65536, -1, 99999} {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			changes: map[string]interface{}{
+			changes: map[string]any{
 				"service.ssh.listen-address": fmt.Sprintf(":%v", invalidPort),
 			},
 		})
@@ -407,7 +407,7 @@ func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongAddr(c *C) 
 	} {
 		err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 			state: s.state,
-			changes: map[string]interface{}{
+			changes: map[string]any{
 				"service.ssh.listen-address": tc.confStr,
 			},
 		})
@@ -436,7 +436,7 @@ func (s *servicesSuite) TestConfigureNetworkValid(c *C) {
 	} {
 		err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 			state: s.state,
-			changes: map[string]interface{}{
+			changes: map[string]any{
 				"service.ssh.listen-address": tc.confStr,
 			},
 		})
@@ -452,7 +452,7 @@ func (s *servicesSuite) TestConfigureNetworkValidWithSocketPresent(c *C) {
 	sshListenCfg := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_config.d/listen.conf")
 	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"service.ssh.listen-address": "10.0.2.2",
 		},
 	})
@@ -470,10 +470,10 @@ func (s *servicesSuite) TestConfigureNetworkValidWithSocketPresent(c *C) {
 func (s *servicesSuite) TestSamePortNoChange(c *C) {
 	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.ssh.listen-address": ":8022",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"service.ssh.listen-address": ":8022",
 		},
 	})
@@ -484,7 +484,7 @@ func (s *servicesSuite) TestSamePortNoChange(c *C) {
 func (s *servicesSuite) TestConfigureNetworkIntegrationSSHListenAddress(c *C) {
 	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"service.ssh.listen-address": ":8022",
 		},
 	})
@@ -500,10 +500,10 @@ func (s *servicesSuite) TestConfigureNetworkIntegrationSSHListenAddress(c *C) {
 	// disable port again
 	err = configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"service.ssh.listen-address": ":8022",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"service.ssh.listen-address": "",
 		},
 	})
@@ -514,7 +514,7 @@ func (s *servicesSuite) TestConfigureNetworkIntegrationSSHListenAddress(c *C) {
 func (s *servicesSuite) TestConfigureNetworkIntegrationSSHListenAddressMulti(c *C) {
 	err := configcore.FilesystemOnlyRun(core20Dev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"service.ssh.listen-address": ":8022,192.168.99.4:9922",
 		},
 	})

--- a/overlord/configstate/configcore/snapshots_test.go
+++ b/overlord/configstate/configcore/snapshots_test.go
@@ -35,7 +35,7 @@ var _ = Suite(&snapshotsSuite{})
 func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationHappy(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"snapshots.automatic.retention": "40h",
 		},
 	})
@@ -45,7 +45,7 @@ func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationHappy(c *C) {
 func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationTooLow(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"snapshots.automatic.retention": "10m",
 		},
 	})
@@ -55,7 +55,7 @@ func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsExpirationTooLow(c *C) {
 func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsDisable(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"snapshots.automatic.retention": "no",
 		},
 	})
@@ -65,7 +65,7 @@ func (s *snapshotsSuite) TestConfigureAutomaticSnapshotsDisable(c *C) {
 func (s *refreshSuite) TestConfigureAutomaticSnapshotsExpirationInvalid(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"snapshots.automatic.retention": "invalid",
 		},
 	})

--- a/overlord/configstate/configcore/store_test.go
+++ b/overlord/configstate/configcore/store_test.go
@@ -51,7 +51,7 @@ func (s *storeSuite) SetUpTest(c *C) {
 func (s *storeSuite) TestStoreAccessHappy(c *C) {
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store.access": "offline",
 		},
 	})
@@ -71,7 +71,7 @@ func (s *storeSuite) TestStoreAccessHappy(c *C) {
 func (s *storeSuite) TestStoreAccessUnhappy(c *C) {
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"store.access": "invalid",
 		},
 	})
@@ -79,7 +79,7 @@ func (s *storeSuite) TestStoreAccessUnhappy(c *C) {
 }
 
 func (s *storeSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"store.access": "offline",
 	})
 

--- a/overlord/configstate/configcore/swap_test.go
+++ b/overlord/configstate/configcore/swap_test.go
@@ -56,7 +56,7 @@ func (s *swapCfgSuite) TestConfigureSwapSizeOnlyWhenChanged(c *C) {
 	// set it to 1M initially
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"swap.size": "1048576",
 		},
 	})
@@ -77,10 +77,10 @@ SIZE=1
 	// running it with the same changes as conf results in no calls to systemd
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"swap.size": "1048576",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"swap.size": "1048576",
 		},
 	})
@@ -97,7 +97,7 @@ func (s *swapCfgSuite) TestConfigureSwapSize(c *C) {
 	// set it to 1M initially
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"swap.size": "1048576",
 		},
 	})
@@ -118,10 +118,10 @@ SIZE=1
 	// now change it to empty
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"swap.size": "1048576",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"swap.size": "",
 		},
 	})
@@ -178,7 +178,7 @@ func (s *swapCfgSuite) TestSwapSizeNumberFormats(c *C) {
 	c.Assert(err, IsNil)
 
 	for _, t := range tt {
-		conf := configcore.PlainCoreConfig(map[string]interface{}{
+		conf := configcore.PlainCoreConfig(map[string]any{
 			"swap.size": t.sizeStr,
 		})
 
@@ -195,7 +195,7 @@ SIZE=%s
 }
 
 func (s *swapCfgSuite) TestSwapSizeFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"swap.size": "1024M",
 	})
 
@@ -211,7 +211,7 @@ SIZE=1024
 }
 
 func (s *swapCfgSuite) TestSwapSizeFilesystemOnlyApplyExistingConfig(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"swap.size": "1024M",
 	})
 

--- a/overlord/configstate/configcore/sysctl_test.go
+++ b/overlord/configstate/configcore/sysctl_test.go
@@ -55,7 +55,7 @@ func (s *sysctlSuite) TearDownTest(c *C) {
 func (s *sysctlSuite) TestConfigureSysctlIntegration(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.kernel.printk.console-loglevel": "2",
 		},
 	})
@@ -69,7 +69,7 @@ func (s *sysctlSuite) TestConfigureSysctlIntegration(c *C) {
 	// Unset console-loglevel and restore default vaule
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.kernel.printk.console-loglevel": "",
 		},
 	})
@@ -83,7 +83,7 @@ func (s *sysctlSuite) TestConfigureSysctlIntegration(c *C) {
 func (s *sysctlSuite) TestConfigureLoglevelUnderRange(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.kernel.printk.console-loglevel": "-1",
 		},
 	})
@@ -94,7 +94,7 @@ func (s *sysctlSuite) TestConfigureLoglevelUnderRange(c *C) {
 func (s *sysctlSuite) TestConfigureLoglevelOverRange(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.kernel.printk.console-loglevel": "8",
 		},
 	})
@@ -105,7 +105,7 @@ func (s *sysctlSuite) TestConfigureLoglevelOverRange(c *C) {
 func (s *sysctlSuite) TestConfigureLevelRejected(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"system.kernel.printk.console-loglevel": "invalid",
 		},
 	})
@@ -116,14 +116,14 @@ func (s *sysctlSuite) TestConfigureLevelRejected(c *C) {
 func (s *sysctlSuite) TestConfigureSysctlIntegrationNoSetting(c *C) {
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{},
+		conf:  map[string]any{},
 	})
 	c.Assert(err, IsNil)
 	c.Check(osutil.FileExists(s.mockSysctlConfPath), Equals, false)
 }
 
 func (s *sysctlSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"system.kernel.printk.console-loglevel": "4",
 	})
 

--- a/overlord/configstate/configcore/timezone.go
+++ b/overlord/configstate/configcore/timezone.go
@@ -102,7 +102,7 @@ func handleTimezoneConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnly
 	return nil
 }
 
-func getTimezoneFromSystemVC(key string) (interface{}, error) {
+func getTimezoneFromSystemVC(key string) (any, error) {
 	return getTimezoneFromSystem()
 }
 

--- a/overlord/configstate/configcore/timezone_test.go
+++ b/overlord/configstate/configcore/timezone_test.go
@@ -54,7 +54,7 @@ func (s *timezoneSuite) TestConfigureTimezoneInvalid(c *C) {
 	for _, tz := range invalidTimezones {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"system.timezone": tz,
 			},
 		})
@@ -75,7 +75,7 @@ func (s *timezoneSuite) TestConfigureTimezoneIntegration(c *C) {
 	for _, tz := range validTimezones {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"system.timezone": tz,
 			},
 		})
@@ -88,7 +88,7 @@ func (s *timezoneSuite) TestConfigureTimezoneIntegration(c *C) {
 }
 
 func (s *timezoneSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"system.timezone": "Europe/Berlin",
 	})
 	tmpDir := c.MkDir()

--- a/overlord/configstate/configcore/tmp_test.go
+++ b/overlord/configstate/configcore/tmp_test.go
@@ -58,7 +58,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsGoodVals(c *C) {
 	for _, size := range []string{"104857600", "16M", "7G", "0"} {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"tmp.size": size,
 			},
 		})
@@ -81,7 +81,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsBadVals(c *C) {
 
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"tmp.size": size,
 			},
 		})
@@ -99,7 +99,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsTooSmall(c *C) {
 
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"tmp.size": size,
 			},
 		})
@@ -124,7 +124,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsAllConfDirExistsAlready(c *C) {
 	size := "100M"
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"tmp.size": size,
 		},
 	})
@@ -156,7 +156,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsNoFileUpdate(c *C) {
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"tmp.size": size,
 		},
 	})
@@ -189,7 +189,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsRemovesIfUnset(c *C) {
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"tmp.size": "",
 		},
 	})
@@ -208,7 +208,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsRemovesIfUnset(c *C) {
 
 // Test applying on image preparation
 func (s *tmpfsSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"tmp.size": "16777216",
 	})
 

--- a/overlord/configstate/configcore/users.go
+++ b/overlord/configstate/configcore/users.go
@@ -28,7 +28,7 @@ func init() {
 	supportedConfigurations["core.users.create.automatic"] = true
 }
 
-func earlyUsersSettingsFilter(values, early map[string]interface{}) {
+func earlyUsersSettingsFilter(values, early map[string]any) {
 	for key, v := range values {
 		if strings.HasPrefix(key, "users.") && supportedConfigurations["core."+key] {
 			early[key] = v

--- a/overlord/configstate/configcore/users_test.go
+++ b/overlord/configstate/configcore/users_test.go
@@ -33,14 +33,14 @@ type usersSuite struct {
 var _ = Suite(&usersSuite{})
 
 func (s *usersSuite) TestUsersCreateAutomaticEarly(c *C) {
-	patch := map[string]interface{}{
+	patch := map[string]any{
 		"users.create.automatic": "false",
 	}
 	tr := &mockConf{state: s.state}
 	err := configcore.Early(classicDev, tr, patch)
 	c.Assert(err, IsNil)
 
-	c.Check(tr.conf, DeepEquals, map[string]interface{}{
+	c.Check(tr.conf, DeepEquals, map[string]any{
 		"users.create.automatic": false,
 	})
 }
@@ -48,14 +48,14 @@ func (s *usersSuite) TestUsersCreateAutomaticEarly(c *C) {
 func (s *usersSuite) TestUsersCreateAutomaticInvalid(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf:  map[string]interface{}{"users.create.automatic": "foo"},
+		conf:  map[string]any{"users.create.automatic": "foo"},
 	})
 	c.Assert(err, ErrorMatches, `users.create.automatic can only be set to 'true' or 'false'`)
 }
 
 func (s *usersSuite) TestUsersCreateAutomaticConfigure(c *C) {
 	tests := []struct {
-		value    interface{}
+		value    any
 		expected bool
 	}{
 		{"true", true},
@@ -67,7 +67,7 @@ func (s *usersSuite) TestUsersCreateAutomaticConfigure(c *C) {
 	for _, t := range tests {
 		conf := &mockConf{
 			state: s.state,
-			conf:  map[string]interface{}{"users.create.automatic": t.value},
+			conf:  map[string]any{"users.create.automatic": t.value},
 		}
 
 		err := configcore.Run(classicDev, conf)

--- a/overlord/configstate/configcore/utils.go
+++ b/overlord/configstate/configcore/utils.go
@@ -96,11 +96,11 @@ func updateKeyValueStream(r io.Reader, supportedConfigKeys map[string]bool, newC
 	return nil, nil
 }
 
-type filterFunc func(values, filtered map[string]interface{})
+type filterFunc func(values, filtered map[string]any)
 
-func applyFilters(flagFilter func(f flags) filterFunc, values map[string]interface{}) (map[string]interface{}, []configHandler) {
+func applyFilters(flagFilter func(f flags) filterFunc, values map[string]any) (map[string]any, []configHandler) {
 	// filter the values to only keep values that use the preinstall flag
-	filteredValues := make(map[string]interface{})
+	filteredValues := make(map[string]any)
 
 	// find the handlers which have the specified flag set
 	var filteredHandlers []configHandler

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&vitalitySuite{})
 func (s *vitalitySuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 
-	uc18model := assertstest.FakeAssertion(map[string]interface{}{
+	uc18model := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "canonical",
 		"series":       "16",
@@ -71,7 +71,7 @@ func (s *vitalitySuite) SetUpTest(c *C) {
 func (s *vitalitySuite) TestConfigureVitalityUnhappyName(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "-invalid-snap-name!yf",
 		},
 	})
@@ -81,7 +81,7 @@ func (s *vitalitySuite) TestConfigureVitalityUnhappyName(c *C) {
 func (s *vitalitySuite) TestConfigureVitalityNoSnapd(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "snapd",
 		},
 	})
@@ -91,7 +91,7 @@ func (s *vitalitySuite) TestConfigureVitalityNoSnapd(c *C) {
 func (s *vitalitySuite) TestConfigureVitalityhappyName(c *C) {
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "valid-snapname",
 		},
 	})
@@ -108,7 +108,7 @@ apps:
 `
 
 func (s *vitalitySuite) TestConfigureVitalityWithValidSnapUC16(c *C) {
-	uc16model := assertstest.FakeAssertion(map[string]interface{}{
+	uc16model := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "canonical",
 		"series":       "16",
@@ -142,7 +142,7 @@ func (s *vitalitySuite) testConfigureVitalityWithValidSnap(c *C, uc18 bool) {
 
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "unrelated,test-snap",
 		},
 	})
@@ -202,7 +202,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "unrelated,test-snap",
 		},
 	})
@@ -228,7 +228,7 @@ func (s *vitalitySuite) TestConfigureVitalityHintTooMany(c *C) {
 	manyStr := strings.Join(l, ",")
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": manyStr,
 		},
 	})
@@ -252,7 +252,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnaps(c *C) {
 	// snap1,snap2,snap3
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "snap1,snap2,snap3",
 		},
 	})
@@ -283,10 +283,10 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsDelta(c *C) {
 	// snap1,snap2,snap3 switch to snap3,snap1
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"resilience.vitality-hint": "snap1,snap2,snap3",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "snap3,snap1",
 		},
 	})
@@ -318,7 +318,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsOneRemovedOneUnchanged(c *
 	// first run generates the snap1,snap2 configs
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "snap1,snap2",
 		},
 	})
@@ -334,10 +334,10 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsOneRemovedOneUnchanged(c *
 	// now we change the configuration and set snap1,snap3
 	err = configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"resilience.vitality-hint": "snap1,snap2",
 		},
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "snap1,snap3",
 		},
 	})
@@ -374,7 +374,7 @@ func (s *vitalitySuite) TestConfigureVitalityNotActiveSnap(c *C) {
 
 	err := configcore.Run(classicDev, &mockConf{
 		state: s.state,
-		changes: map[string]interface{}{
+		changes: map[string]any{
 			"resilience.vitality-hint": "unrelated,test-snap",
 		},
 	})

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -52,7 +52,7 @@ func (s *watchdogSuite) TestConfigureWatchdog(c *C) {
 
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				fmt.Sprintf("watchdog.%s", option): val + "s",
 			},
 		})
@@ -85,7 +85,7 @@ func (s *watchdogSuite) TestConfigureWatchdogUnits(c *C) {
 	for _, tunit := range []timeUnit{{"s", 1}, {"m", 60}, {"h", 3600}} {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"watchdog.runtime-timeout":  fmt.Sprintf("%d", times[0]) + tunit.unit,
 				"watchdog.shutdown-timeout": fmt.Sprintf("%d", times[1]) + tunit.unit,
 			},
@@ -101,7 +101,7 @@ func (s *watchdogSuite) TestConfigureWatchdogAll(c *C) {
 	times := []int{10, 100}
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
 			"watchdog.shutdown-timeout": fmt.Sprintf("%ds", times[1]),
 		},
@@ -124,7 +124,7 @@ func (s *watchdogSuite) TestConfigureWatchdogAllConfDirExistsAlready(c *C) {
 	times := []int{10, 100}
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
 			"watchdog.shutdown-timeout": fmt.Sprintf("%ds", times[1]),
 		},
@@ -149,7 +149,7 @@ func (s *watchdogSuite) TestConfigureWatchdogBadFormat(c *C) {
 		{"34k", ".*unknown unit.*"}} {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			conf: map[string]any{
 				"watchdog.runtime-timeout": badVal.val,
 			},
 		})
@@ -179,7 +179,7 @@ func (s *watchdogSuite) TestConfigureWatchdogNoFileUpdate(c *C) {
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
 			"watchdog.shutdown-timeout": fmt.Sprintf("%ds", times[1]),
 		},
@@ -211,7 +211,7 @@ ShutdownWatchdogSec=20
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		conf: map[string]any{
 			"watchdog.runtime-timeout":  0,
 			"watchdog.shutdown-timeout": 0,
 		},
@@ -230,7 +230,7 @@ ShutdownWatchdogSec=20
 }
 
 func (s *watchdogSuite) TestFilesystemOnlyApply(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"watchdog.runtime-timeout": "4s",
 	})
 
@@ -242,7 +242,7 @@ func (s *watchdogSuite) TestFilesystemOnlyApply(c *C) {
 }
 
 func (s *watchdogSuite) TestFilesystemOnlyApplyValidationFails(c *C) {
-	conf := configcore.PlainCoreConfig(map[string]interface{}{
+	conf := configcore.PlainCoreConfig(map[string]any{
 		"watchdog.runtime-timeout": "foo",
 	})
 

--- a/overlord/configstate/configstate.go
+++ b/overlord/configstate/configstate.go
@@ -96,7 +96,7 @@ func canConfigure(st *state.State, snapName string) error {
 // ConfigureInstalled returns a taskset to apply the given
 // configuration patch for an installed snap. It returns
 // snap.NotInstalledError if the snap is not installed.
-func ConfigureInstalled(st *state.State, snapName string, patch map[string]interface{}, flags int) (*state.TaskSet, error) {
+func ConfigureInstalled(st *state.State, snapName string, patch map[string]any, flags int) (*state.TaskSet, error) {
 	if err := canConfigure(st, snapName); err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func ConfigureInstalled(st *state.State, snapName string, patch map[string]inter
 }
 
 // Configure returns a taskset to apply the given configuration patch.
-func Configure(st *state.State, snapName string, patch map[string]interface{}, flags int) *state.TaskSet {
+func Configure(st *state.State, snapName string, patch map[string]any, flags int) *state.TaskSet {
 	summary := fmt.Sprintf(i18n.G("Run configure hook of %q snap"), snapName)
 	// regular configuration hook
 	hooksup := &hookstate.HookSetup{
@@ -117,11 +117,11 @@ func Configure(st *state.State, snapName string, patch map[string]interface{}, f
 		// all configure hooks must finish within this timeout
 		Timeout: ConfigureHookTimeout(),
 	}
-	var contextData map[string]interface{}
+	var contextData map[string]any
 	if flags&snapstate.UseConfigDefaults != 0 {
-		contextData = map[string]interface{}{"use-defaults": true}
+		contextData = map[string]any{"use-defaults": true}
 	} else if len(patch) > 0 {
-		contextData = map[string]interface{}{"patch": patch}
+		contextData = map[string]any{"patch": patch}
 	}
 
 	if hooksup.Optional {

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -58,7 +58,7 @@ func (s *tasksetsSuite) SetUpTest(c *C) {
 }
 
 var configureTests = []struct {
-	patch       map[string]interface{}
+	patch       map[string]any
 	optional    bool
 	ignoreError bool
 	useDefaults bool
@@ -67,11 +67,11 @@ var configureTests = []struct {
 	optional:    true,
 	ignoreError: false,
 }, {
-	patch:       map[string]interface{}{},
+	patch:       map[string]any{},
 	optional:    true,
 	ignoreError: false,
 }, {
-	patch:       map[string]interface{}{"foo": "bar"},
+	patch:       map[string]any{"foo": "bar"},
 	optional:    false,
 	ignoreError: false,
 }, {
@@ -140,7 +140,7 @@ func (s *tasksetsSuite) TestConfigureInstalled(c *C) {
 		c.Check(context.SnapRevision(), Equals, snap.Revision{})
 		c.Check(context.HookName(), Equals, "configure")
 
-		var patch map[string]interface{}
+		var patch map[string]any
 		var useDefaults bool
 		context.Lock()
 		context.Get("use-defaults", &useDefaults)
@@ -174,13 +174,13 @@ func (s *tasksetsSuite) TestConfigureInstalledConflict(c *C) {
 	chg := s.state.NewChange("other-change", "...")
 	chg.AddAll(ts)
 
-	patch := map[string]interface{}{"foo": "bar"}
+	patch := map[string]any{"foo": "bar"}
 	_, err = configstate.ConfigureInstalled(s.state, "test-snap", patch, 0)
 	c.Check(err, ErrorMatches, `snap "test-snap" has "other-change" change in progress`)
 }
 
 func (s *tasksetsSuite) TestConfigureNotInstalled(c *C) {
-	patch := map[string]interface{}{"foo": "bar"}
+	patch := map[string]any{"foo": "bar"}
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -193,7 +193,7 @@ func (s *tasksetsSuite) TestConfigureNotInstalled(c *C) {
 }
 
 func (s *tasksetsSuite) TestConfigureInstalledDenyBases(c *C) {
-	patch := map[string]interface{}{"foo": "bar"}
+	patch := map[string]any{"foo": "bar"}
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.Set(s.state, "test-base", &snapstate.SnapState{
@@ -210,7 +210,7 @@ func (s *tasksetsSuite) TestConfigureInstalledDenyBases(c *C) {
 }
 
 func (s *tasksetsSuite) TestConfigureInstalledDenySnapd(c *C) {
-	patch := map[string]interface{}{"foo": "bar"}
+	patch := map[string]any{"foo": "bar"}
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
@@ -268,7 +268,7 @@ func (s *tasksetsSuite) TestDefaultConfigure(c *C) {
 	c.Check(context.SnapRevision(), Equals, snap.Revision{})
 	c.Check(context.HookName(), Equals, "default-configure")
 
-	var patch map[string]interface{}
+	var patch map[string]any
 	var useDefaults bool
 	context.Lock()
 	context.Get("use-defaults", &useDefaults)
@@ -345,7 +345,7 @@ func (s *configcoreHijackSuite) TestHijack(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	ts := configstate.Configure(s.state, "core", map[string]interface{}{
+	ts := configstate.Configure(s.state, "core", map[string]any{
 		"witness": true,
 	}, 0)
 	c.Assert(len(ts.Tasks()), Equals, 1)
@@ -510,14 +510,14 @@ func (s *earlyConfigSuite) TestEarlyConfigFromGadget(c *C) {
 	ok, err = features.Flag(tr, features.UserDaemons)
 	c.Assert(err, IsNil)
 	c.Check(ok, Equals, true)
-	var serviceCfg map[string]interface{}
+	var serviceCfg map[string]any
 	err = tr.Get("core", "services", &serviceCfg)
 	// nothing of this was set
 	c.Assert(config.IsNoOption(err), Equals, true)
 }
 
 func (s *earlyConfigSuite) TestEarlyConfigFromGadgetErr(c *C) {
-	defer configstate.MockConfigcoreEarly(func(sysconfig.Device, configcore.RunTransaction, map[string]interface{}) error {
+	defer configstate.MockConfigcoreEarly(func(sysconfig.Device, configcore.RunTransaction, map[string]any) error {
 		return fmt.Errorf("boom")
 	})()
 
@@ -533,7 +533,7 @@ func (s *earlyConfigSuite) TestEarlyConfigFromGadgetErr(c *C) {
 }
 
 func (s *earlyConfigSuite) TestEarlyConfigNoHookTask(c *C) {
-	defer configstate.MockConfigcoreEarly(func(dev sysconfig.Device, cfg configcore.RunTransaction, vals map[string]interface{}) error {
+	defer configstate.MockConfigcoreEarly(func(dev sysconfig.Device, cfg configcore.RunTransaction, vals map[string]any) error {
 		c.Assert(cfg.Task(), IsNil)
 		return nil
 	})()

--- a/overlord/configstate/export_test.go
+++ b/overlord/configstate/export_test.go
@@ -36,7 +36,7 @@ func MockConfigcoreExportExperimentalFlags(mock func(tr configcore.ConfGetter) e
 	}
 }
 
-func MockConfigcoreEarly(mock func(dev sysconfig.Device, cfg configcore.RunTransaction, values map[string]interface{}) error) (restore func()) {
+func MockConfigcoreEarly(mock func(dev sysconfig.Device, cfg configcore.RunTransaction, values map[string]any) error) (restore func()) {
 	old := configcoreEarly
 	configcoreEarly = mock
 	return func() {

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -101,7 +101,7 @@ type: os
 func (s *configureHandlerSuite) TestBeforeInitializesTransaction(c *C) {
 	// Initialize context
 	s.context.Lock()
-	s.context.Set("patch", map[string]interface{}{
+	s.context.Set("patch", map[string]any{
 		"foo": "bar",
 	})
 	s.context.Unlock()
@@ -117,8 +117,8 @@ func (s *configureHandlerSuite) TestBeforeInitializesTransaction(c *C) {
 	c.Check(value, Equals, "bar")
 }
 
-func makeModel(override map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func makeModel(override map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "brand",
 		"series":       "16",
@@ -165,7 +165,7 @@ volumes:
 		SnapType: "gadget",
 	})
 
-	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]any{
 		"gadget": "canonical-pc",
 	}))
 	defer r()
@@ -239,7 +239,7 @@ volumes:
 		SnapType: "gadget",
 	})
 
-	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]any{
 		"gadget": "canonical-pc",
 	}))
 	defer r()
@@ -370,7 +370,7 @@ volumes:
 		SnapType: "gadget",
 	})
 
-	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]any{
 		"gadget": "canonical-pc",
 	}))
 	defer r()
@@ -460,7 +460,7 @@ func (s *configcoreHandlerSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.o.AddManager(s.o.TaskRunner())
 
-	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]any{
 		"gadget": "canonical-pc",
 	}))
 	s.AddCleanup(r)

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -48,7 +48,7 @@ func (h *configureHandler) Before() error {
 	// Initialize the transaction if there's a patch provided in the
 	// context or useDefaults is set in which case gadget defaults are used.
 
-	var patch map[string]interface{}
+	var patch map[string]any
 	var useDefaults bool
 	if err := h.context.Get("use-defaults", &useDefaults); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err

--- a/overlord/devicestate/devicectx_test.go
+++ b/overlord/devicestate/devicectx_test.go
@@ -51,7 +51,7 @@ func (s *deviceCtxSuite) testGroundDeviceContext(c *C, mode string) {
 	var devCtx snapstate.DeviceContext
 
 	// Classic with classic initramfs
-	classicModel := assertstest.FakeAssertion(map[string]interface{}{
+	classicModel := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"classic":      "true",
 		"authority-id": "my-brand",

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1971,7 +1971,7 @@ func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 }
 
 // SignConfdbControl signs a confdb-control assertion using the device's key as it needs to be attested by the device.
-func (m *DeviceManager) SignConfdbControl(groups []interface{}, revision int) (*asserts.ConfdbControl, error) {
+func (m *DeviceManager) SignConfdbControl(groups []any, revision int) (*asserts.ConfdbControl, error) {
 	serial, err := m.Serial()
 	if err != nil {
 		return nil, fmt.Errorf("cannot sign confdb-control without a serial")
@@ -1982,7 +1982,7 @@ func (m *DeviceManager) SignConfdbControl(groups []interface{}, revision int) (*
 		return nil, fmt.Errorf("cannot sign confdb-control without device key")
 	}
 
-	a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]interface{}{
+	a, err := asserts.SignWithoutAuthority(asserts.ConfdbControlType, map[string]any{
 		"brand-id": serial.BrandID(),
 		"model":    serial.Model(),
 		"serial":   serial.Serial(),
@@ -2649,7 +2649,7 @@ func (scb storeContextBackend) SignDeviceSessionRequest(serial *asserts.Serial, 
 		return nil, err
 	}
 
-	a, err := asserts.SignWithoutAuthority(asserts.DeviceSessionRequestType, map[string]interface{}{
+	a, err := asserts.SignWithoutAuthority(asserts.DeviceSessionRequestType, map[string]any{
 		"brand-id":  serial.BrandID(),
 		"model":     serial.Model(),
 		"serial":    serial.Serial(),
@@ -2736,7 +2736,7 @@ func (m *DeviceManager) runFDESetupHook(req *fde.SetupRequest) ([]byte, error) {
 		// XXX: should this be configurable somehow?
 		Timeout: 5 * time.Minute,
 	}
-	contextData := map[string]interface{}{
+	contextData := map[string]any{
 		"fde-setup-request": req,
 	}
 	st.Unlock()

--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -114,7 +114,7 @@ func (s *deviceMgrBootconfigSuite) setupUC20ModelWithGrade(c *C, grade string) *
 		Model:  "pc-model-20",
 		Serial: "didididi",
 	})
-	headers := make(map[string]interface{})
+	headers := make(map[string]any)
 	for k, v := range mockCore20ModelHeaders {
 		headers[k] = v
 	}
@@ -129,18 +129,18 @@ func (s *deviceMgrBootconfigSuite) setupClassicWithModesModel(c *C) *asserts.Mod
 		Serial: "didididi",
 	})
 	return s.makeModelAssertionInState(c, "canonical", "classic-with-modes",
-		map[string]interface{}{
+		map[string]any{
 			"architecture": "amd64",
 			"classic":      "true",
 			"distribution": "ubuntu",
 			"base":         "core22",
-			"snaps": []interface{}{
-				map[string]interface{}{
+			"snaps": []any{
+				map[string]any{
 					"name": "pc-linux",
 					"id":   "pclinuxdidididididididididididid",
 					"type": "kernel",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name": "pc",
 					"id":   "pcididididididididididididididid",
 					"type": "gadget",
@@ -548,7 +548,7 @@ func (s *deviceMgrBootconfigSuite) TestBootConfigNoUC20(c *C) {
 		Model:  "pc-model",
 		Serial: "didididi",
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -577,7 +577,7 @@ func (s *deviceMgrBootconfigSuite) TestBootConfigRemodelDoNothing(c *C) {
 
 	uc20Model := s.setupUC20Model(c)
 	// save the hassle and try a trivial remodel
-	newModel := s.brands.Model("canonical", "pc-model-20", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model-20", map[string]any{
 		"brand":        "canonical",
 		"model":        "pc-model-20",
 		"architecture": "amd64",

--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -73,19 +73,19 @@ func (s *cloudInitUC20Suite) SetUpTest(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc20-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc20-model", map[string]any{
 		"display-name": "UC20 pc model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "signed",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              "pckernelidididididididididididid",
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              "pcididididididididididididididid",
 				"type":            "gadget",
@@ -220,7 +220,7 @@ func (s *cloudInitSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -168,7 +168,7 @@ func (s *deviceMgrGadgetSuite) mockModeenvForMode(c *C, mode string) {
 }
 
 func (s *deviceMgrGadgetSuite) setupModelWithGadget(c *C, gadget string) {
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       gadget,
@@ -182,19 +182,19 @@ func (s *deviceMgrGadgetSuite) setupModelWithGadget(c *C, gadget string) {
 }
 
 func (s *deviceMgrGadgetSuite) setupUC20ModelWithGadget(c *C, gadget, grade string) {
-	s.makeModelAssertionInState(c, "canonical", "pc20-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc20-model", map[string]any{
 		"display-name": "UC20 pc model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        grade,
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              "pckernelidididididididididididid",
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            gadget,
 				"id":              "pcididididididididididididididid",
 				"type":            "gadget",
@@ -215,18 +215,18 @@ func (s *deviceMgrGadgetSuite) setupClassicWithModesModel(c *C, gadget string) *
 		Serial: "didididi",
 	})
 	return s.makeModelAssertionInState(c, "canonical", "classic-with-modes",
-		map[string]interface{}{
+		map[string]any{
 			"architecture": "amd64",
 			"classic":      "true",
 			"distribution": "ubuntu",
 			"base":         "core22",
-			"snaps": []interface{}{
-				map[string]interface{}{
+			"snaps": []any{
+				map[string]any{
 					"name": "pc-linux",
 					"id":   "pclinuxdidididididididididididid",
 					"type": "kernel",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name": gadget,
 					"id":   "pcididididididididididididididid",
 					"type": "gadget",
@@ -826,7 +826,7 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 		Type:     snap.TypeGadget,
 	}
 
-	model := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "foo-gadget",
@@ -1147,7 +1147,7 @@ func (s *deviceMgrGadgetSuite) TestUpdateGadgetOnCoreFromKernelRemodel(c *C) {
 	chg, t := s.makeMinimalKernelAssetsUpdateChange(c)
 	devicestate.SetBootOkRan(s.mgr, true)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "foo-gadget",

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -872,7 +872,7 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 	})
 	c.Check(encrytpPartCalls, Equals, 1)
 	// Check that some data has been stored in the change
-	apiData := make(map[string]interface{})
+	apiData := make(map[string]any)
 	c.Check(chg.Get("api-data", &apiData), IsNil)
 	_, ok := apiData["encrypted-devices"]
 	c.Check(ok, Equals, true)

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -124,46 +124,46 @@ func (s *deviceMgrInstallSuite) setupSystemSeed(c *C, sysLabel, gadgetYaml strin
 
 	s.MakeAssertedSnapWithComps(c, seedtest.SampleSnapYaml["optional24"], nil, snap.R(1), nil, "my-brand", s.StoreSigning.Database)
 
-	var kmods map[string]interface{}
+	var kmods map[string]any
 	if len(kModsRevs) > 0 {
-		kmods = map[string]interface{}{
+		kmods = map[string]any{
 			"kcomp1": "required",
 			"kcomp2": "required",
 		}
 	}
-	model := map[string]interface{}{
+	model := map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core24",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "24",
 				"components":      kmods,
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "24",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core24",
 				"id":   s.AssertedSnapID("core24"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "optional24",
 				"id":   s.AssertedSnapID("optional24"),
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "optional",
 				},
 			},
@@ -529,19 +529,19 @@ func (s *deviceMgrInstallModeSuite) makeMockInstalledPcGadget(c *C, installDevic
 }
 
 func (s *deviceMgrInstallModeSuite) makeMockInstallModel(c *C, grade string) *asserts.Model {
-	return s.makeMockInstallModelExtras(c, grade, map[string]interface{}{
+	return s.makeMockInstallModelExtras(c, grade, map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        grade,
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              pcKernelSnapID,
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              pcSnapID,
 				"type":            "gadget",
@@ -561,7 +561,7 @@ func (s *deviceMgrInstallModeSuite) addModelToState(modelAs *asserts.Model) {
 	})
 }
 
-func (s *deviceMgrInstallModeSuite) makeMockInstallModelExtras(c *C, grade string, extras map[string]interface{}) *asserts.Model {
+func (s *deviceMgrInstallModeSuite) makeMockInstallModelExtras(c *C, grade string, extras map[string]any) *asserts.Model {
 	mockModel := s.makeModelAssertionInState(c, "my-brand", "my-model", extras)
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "my-brand",
@@ -573,23 +573,23 @@ func (s *deviceMgrInstallModeSuite) makeMockInstallModelExtras(c *C, grade strin
 }
 
 func (s *deviceMgrInstallModeSuite) makeMockInstallModelWithKMods(c *C, grade string) *asserts.Model {
-	mockModel := s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]interface{}{
+	mockModel := s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core24",
 		"grade":        grade,
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              pcKernelSnapID,
 				"type":            "kernel",
 				"default-channel": "24",
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"kcomp1": "required",
 					"kcomp2": "required",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              pcSnapID,
 				"type":            "gadget",
@@ -2090,19 +2090,19 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncrypted(c *C) {
 
 	s.makeMockInstalledPcGadget(c, "", "")
 
-	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	mockModel := s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              pcKernelSnapID,
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              pcSnapID,
 				"type":            "gadget",
@@ -2544,7 +2544,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 func makeDeviceSerialAssertionInDir(c *C, where string, storeStack *assertstest.StoreStack, brands *assertstest.SigningAccounts, model *asserts.Model, key asserts.PrivateKey, serialN string) *asserts.Serial {
 	encDevKey, err := asserts.EncodePublicKey(key.PublicKey())
 	c.Assert(err, IsNil)
-	serial, err := brands.Signing(model.BrandID()).Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := brands.Signing(model.BrandID()).Sign(asserts.SerialType, map[string]any{
 		"brand-id":            model.BrandID(),
 		"model":               model.Model(),
 		"serial":              serialN,

--- a/overlord/devicestate/devicestate_recovery_keys_test.go
+++ b/overlord/devicestate/devicestate_recovery_keys_test.go
@@ -92,20 +92,20 @@ func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeysBackwardCompat(c *C) 
 func (s *deviceMgrBaseSuite) setClassicWithModesModelInState(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.makeModelAssertionInState(c, "canonical", "pc-22", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-22", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core22",
 		"classic":      "true",
 		"distribution": "ubuntu",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "22",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -133,7 +133,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelInvalidPathSnap(c *C) {
 	defer s.state.Unlock()
 	s.state.Set("seeded", true)
 
-	newModel := s.brands.Model("canonical", "pc", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -158,7 +158,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelCannotProvideLocalSnapsWhenNotOffline
 	defer s.state.Unlock()
 	s.state.Set("seeded", true)
 
-	model := s.brands.Model("canonical", "pc", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -195,7 +195,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUnhappyNotSeeded(c *C) {
 	defer s.state.Unlock()
 	s.state.Set("seeded", false)
 
-	newModel := s.brands.Model("canonical", "pc", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -210,7 +210,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelSnapdBasedToCoreBased(c *C) {
 	defer st.Unlock()
 	s.state.Set("seeded", true)
 
-	model := s.brands.Model("canonical", "my-model", modelDefaults, map[string]interface{}{
+	model := s.brands.Model("canonical", "my-model", modelDefaults, map[string]any{
 		"base": "core18",
 	})
 
@@ -226,7 +226,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelSnapdBasedToCoreBased(c *C) {
 	s.makeSerialAssertionInState(c, "canonical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := s.brands.Model("canonical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("canonical", "my-model", modelDefaults, map[string]any{
 		"revision": "1",
 	})
 
@@ -235,7 +235,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelSnapdBasedToCoreBased(c *C) {
 	c.Assert(chg, IsNil)
 }
 
-var mockCore20ModelHeaders = map[string]interface{}{
+var mockCore20ModelHeaders = map[string]any{
 	"brand":        "canonical",
 	"model":        "pc-model-20",
 	"architecture": "amd64",
@@ -244,14 +244,14 @@ var mockCore20ModelHeaders = map[string]interface{}{
 	"snaps":        mockCore20ModelSnaps,
 }
 
-var mockCore20ModelSnaps = []interface{}{
-	map[string]interface{}{
+var mockCore20ModelSnaps = []any{
+	map[string]any{
 		"name":            "pc-kernel",
 		"id":              "pckernelidididididididididididid",
 		"type":            "kernel",
 		"default-channel": "20",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"name":            "pc",
 		"id":              "pcididididididididididididididid",
 		"type":            "gadget",
@@ -261,7 +261,7 @@ var mockCore20ModelSnaps = []interface{}{
 
 // copy current model unless new model test data is different
 // and delete nil keys in new model
-func mergeMockModelHeaders(cur, new map[string]interface{}) {
+func mergeMockModelHeaders(cur, new map[string]any) {
 	for k, v := range cur {
 		if v, ok := new[k]; ok {
 			if v == nil {
@@ -279,14 +279,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelUnhappy(c *C) {
 	s.state.Set("seeded", true)
 
 	// set a model assertion
-	cur := map[string]interface{}{
+	cur := map[string]any{
 		"brand":        "canonical",
 		"model":        "pc-model",
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 	}
-	s.makeModelAssertionInState(c, cur["brand"].(string), cur["model"].(string), map[string]interface{}{
+	s.makeModelAssertionInState(c, cur["brand"].(string), cur["model"].(string), map[string]any{
 		"architecture": cur["architecture"],
 		"kernel":       cur["kernel"],
 		"gadget":       cur["gadget"],
@@ -300,14 +300,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelUnhappy(c *C) {
 
 	// ensure all error cases are checked
 	for _, t := range []struct {
-		new    map[string]interface{}
+		new    map[string]any
 		errStr string
 	}{
-		{map[string]interface{}{"architecture": "pdp-7"}, "cannot remodel to different architectures yet"},
-		{map[string]interface{}{"base": "core18"}, "cannot remodel from core to bases yet"},
+		{map[string]any{"architecture": "pdp-7"}, "cannot remodel to different architectures yet"},
+		{map[string]any{"base": "core18"}, "cannot remodel from core to bases yet"},
 		// pre-UC20 to UC20
-		{map[string]interface{}{"base": "core20", "kernel": nil, "gadget": nil, "snaps": mockCore20ModelSnaps}, `cannot remodel from pre-UC20 to UC20\+ models`},
-		{map[string]interface{}{"base": "core20", "kernel": nil, "gadget": nil, "classic": "true", "distribution": "ubuntu", "snaps": mockCore20ModelSnaps}, `cannot remodel across classic and non-classic models`},
+		{map[string]any{"base": "core20", "kernel": nil, "gadget": nil, "snaps": mockCore20ModelSnaps}, `cannot remodel from pre-UC20 to UC20\+ models`},
+		{map[string]any{"base": "core20", "kernel": nil, "gadget": nil, "classic": "true", "distribution": "ubuntu", "snaps": mockCore20ModelSnaps}, `cannot remodel across classic and non-classic models`},
 	} {
 		mergeMockModelHeaders(cur, t.new)
 		new := s.brands.Model(t.new["brand"].(string), t.new["model"].(string), t.new)
@@ -323,14 +323,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelFromClassicUnhappy(c *C) {
 	s.state.Set("seeded", true)
 
 	// set a model assertion
-	cur := map[string]interface{}{
+	cur := map[string]any{
 		"brand":        "canonical",
 		"model":        "pc-model",
 		"architecture": "amd64",
 		"classic":      "true",
 		"gadget":       "pc",
 	}
-	s.makeModelAssertionInState(c, cur["brand"].(string), cur["model"].(string), map[string]interface{}{
+	s.makeModelAssertionInState(c, cur["brand"].(string), cur["model"].(string), map[string]any{
 		"architecture": cur["architecture"],
 		"gadget":       cur["gadget"],
 		"classic":      cur["classic"],
@@ -342,7 +342,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelFromClassicUnhappy(c *C) {
 		Serial: "orig-serial",
 	})
 
-	new := s.brands.Model(cur["brand"].(string), "new-model", map[string]interface{}{
+	new := s.brands.Model(cur["brand"].(string), "new-model", map[string]any{
 		"architecture": cur["architecture"],
 		"gadget":       cur["gadget"],
 		"classic":      cur["classic"],
@@ -359,7 +359,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelCheckGrade(c *C) {
 
 	// set a model assertion
 	cur := mockCore20ModelHeaders
-	s.makeModelAssertionInState(c, cur["brand"].(string), cur["model"].(string), map[string]interface{}{
+	s.makeModelAssertionInState(c, cur["brand"].(string), cur["model"].(string), map[string]any{
 		"architecture": cur["architecture"],
 		"base":         cur["base"],
 		"grade":        cur["grade"],
@@ -374,14 +374,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelCheckGrade(c *C) {
 
 	// ensure all error cases are checked
 	for idx, t := range []struct {
-		new    map[string]interface{}
+		new    map[string]any
 		errStr string
 	}{
 		// uc20 model
-		{map[string]interface{}{"grade": "signed"}, "cannot remodel from grade dangerous to grade signed"},
-		{map[string]interface{}{"grade": "secured"}, "cannot remodel from grade dangerous to grade secured"},
+		{map[string]any{"grade": "signed"}, "cannot remodel from grade dangerous to grade signed"},
+		{map[string]any{"grade": "secured"}, "cannot remodel from grade dangerous to grade secured"},
 		// non-uc20 model
-		{map[string]interface{}{"snaps": nil, "grade": nil, "base": "core", "gadget": "pc", "kernel": "pc-kernel"}, "cannot remodel from grade dangerous to grade unset"},
+		{map[string]any{"snaps": nil, "grade": nil, "base": "core", "gadget": "pc", "kernel": "pc-kernel"}, "cannot remodel from grade dangerous to grade unset"},
 	} {
 		c.Logf("tc: %v", idx)
 		mergeMockModelHeaders(cur, t.new)
@@ -398,14 +398,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelCannotUseOldModel(c *C) {
 	s.state.Set("seeded", true)
 
 	// set a model assertion
-	cur := map[string]interface{}{
+	cur := map[string]any{
 		"brand":        "canonical",
 		"model":        "pc-model",
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 	}
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -417,7 +417,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelCannotUseOldModel(c *C) {
 		Model: "pc-model",
 	})
 
-	newModelHdrs := map[string]interface{}{
+	newModelHdrs := map[string]any{
 		"revision": "1",
 	}
 	mergeMockModelHeaders(cur, newModelHdrs)
@@ -433,14 +433,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelRequiresSerial(c *C) {
 	s.state.Set("seeded", true)
 
 	// set a model assertion
-	cur := map[string]interface{}{
+	cur := map[string]any{
 		"brand":        "canonical",
 		"model":        "pc-model",
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 	}
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -451,7 +451,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelRequiresSerial(c *C) {
 		Model: "pc-model",
 	})
 
-	newModelHdrs := map[string]interface{}{
+	newModelHdrs := map[string]any{
 		"revision": "2",
 	}
 	mergeMockModelHeaders(cur, newModelHdrs)
@@ -462,18 +462,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelRequiresSerial(c *C) {
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchGadgetTrack(c *C) {
-	s.testRemodelTasksSwitchTrack(c, "pc", map[string]interface{}{
+	s.testRemodelTasksSwitchTrack(c, "pc", map[string]any{
 		"gadget": "pc=18",
 	})
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchKernelTrack(c *C) {
-	s.testRemodelTasksSwitchTrack(c, "pc-kernel", map[string]interface{}{
+	s.testRemodelTasksSwitchTrack(c, "pc-kernel", map[string]any{
 		"kernel": "pc-kernel=18",
 	})
 }
 
-func (s *deviceMgrRemodelSuite) testRemodelTasksSwitchTrack(c *C, whatRefreshes string, newModelOverrides map[string]interface{}) {
+func (s *deviceMgrRemodelSuite) testRemodelTasksSwitchTrack(c *C, whatRefreshes string, newModelOverrides map[string]any) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.state.Set("seeded", true)
@@ -539,7 +539,7 @@ func (s *deviceMgrRemodelSuite) testRemodelTasksSwitchTrack(c *C, whatRefreshes 
 	defer restore()
 
 	// set a model assertion
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -552,12 +552,12 @@ func (s *deviceMgrRemodelSuite) testRemodelTasksSwitchTrack(c *C, whatRefreshes 
 		Model: "pc-model",
 	})
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 		"revision":       "1",
 	}
 	for k, v := range newModelOverrides {
@@ -600,7 +600,7 @@ epoch: 1
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchGadget(c *C) {
 	newTrack := map[string]string{"other-gadget": "18"}
 	s.testRemodelSwitchTasks(c, newTrack,
-		map[string]interface{}{"gadget": "other-gadget=18"}, nil, "")
+		map[string]any{"gadget": "other-gadget=18"}, nil, "")
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchLocalGadget(c *C) {
@@ -608,14 +608,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchLocalGadget(c *C) {
 	localSnaps := make([]snapstate.PathSnap, 1)
 	localSnaps[0].SideInfo, localSnaps[0].Path = createLocalSnap(c, "other-gadget", "pcididididididididididididididid", 3, "gadget", "", nil)
 	s.testRemodelSwitchTasks(c, newTrack,
-		map[string]interface{}{"gadget": "other-gadget=18"},
+		map[string]any{"gadget": "other-gadget=18"},
 		localSnaps, "")
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchKernel(c *C) {
 	newTrack := map[string]string{"other-kernel": "18"}
 	s.testRemodelSwitchTasks(c, newTrack,
-		map[string]interface{}{"kernel": "other-kernel=18"}, nil, "")
+		map[string]any{"kernel": "other-kernel=18"}, nil, "")
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchLocalKernel(c *C) {
@@ -623,14 +623,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchLocalKernel(c *C) {
 	localSnaps := make([]snapstate.PathSnap, 1)
 	localSnaps[0].SideInfo, localSnaps[0].Path = createLocalSnap(c, "other-kernel", "pckernelidididididididididididid", 3, "kernel", "", nil)
 	s.testRemodelSwitchTasks(c, newTrack,
-		map[string]interface{}{"kernel": "other-kernel=18"},
+		map[string]any{"kernel": "other-kernel=18"},
 		localSnaps, "")
 }
 
 func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchKernelAndGadget(c *C) {
 	newTrack := map[string]string{"other-kernel": "18", "other-gadget": "18"}
 	s.testRemodelSwitchTasks(c, newTrack,
-		map[string]interface{}{
+		map[string]any{
 			"kernel": "other-kernel=18",
 			"gadget": "other-gadget=18"}, nil, "")
 }
@@ -641,7 +641,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchLocalKernelAndGadget(c *C)
 	localSnaps[0].SideInfo, localSnaps[0].Path = createLocalSnap(c, "other-kernel", "pckernelidididididididididididid", 3, "kernel", "", nil)
 	localSnaps[1].SideInfo, localSnaps[1].Path = createLocalSnap(c, "other-gadget", "pcididididididididididididididid", 3, "gadget", "", nil)
 	s.testRemodelSwitchTasks(c, newTrack,
-		map[string]interface{}{
+		map[string]any{
 			"kernel": "other-kernel=18",
 			"gadget": "other-gadget=18"},
 		localSnaps, "")
@@ -653,14 +653,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelTasksSwitchLocalKernelAndGadgetFails(
 	localSnaps := make([]snapstate.PathSnap, 1)
 	localSnaps[0].SideInfo, localSnaps[0].Path = createLocalSnap(c, "other-kernel", "pckernelidididididididididididid", 3, "kernel", "", nil)
 	s.testRemodelSwitchTasks(c, newTrack,
-		map[string]interface{}{
+		map[string]any{
 			"kernel": "other-kernel=18",
 			"gadget": "other-gadget=18"},
 		localSnaps,
 		`no snap file provided for "other-gadget"`)
 }
 
-func (s *deviceMgrRemodelSuite) testRemodelSwitchTasks(c *C, whatNewTrack map[string]string, newModelOverrides map[string]interface{}, localSnaps []snapstate.PathSnap, expectedErr string) {
+func (s *deviceMgrRemodelSuite) testRemodelSwitchTasks(c *C, whatNewTrack map[string]string, newModelOverrides map[string]any, localSnaps []snapstate.PathSnap, expectedErr string) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.state.Set("seeded", true)
@@ -734,7 +734,7 @@ func (s *deviceMgrRemodelSuite) testRemodelSwitchTasks(c *C, whatNewTrack map[st
 	defer restore()
 
 	// set a model assertion
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -749,7 +749,7 @@ func (s *deviceMgrRemodelSuite) testRemodelSwitchTasks(c *C, whatNewTrack map[st
 		Model: "pc-model",
 	})
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -813,7 +813,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelRequiredSnaps(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -826,12 +826,12 @@ func (s *deviceMgrRemodelSuite) TestRemodelRequiredSnaps(c *C) {
 		Serial: "1234",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 		"revision":       "1",
 	})
 	chg, err := devicestate.Remodel(s.state, new, devicestate.RemodelOptions{})
@@ -956,7 +956,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelSwitchKernelTrack(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -969,12 +969,12 @@ func (s *deviceMgrRemodelSuite) TestRemodelSwitchKernelTrack(c *C) {
 		Serial: "1234",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1"},
+		"required-snaps": []any{"new-required-snap-1"},
 		"revision":       "1",
 	})
 	chg, err := devicestate.Remodel(s.state, new, devicestate.RemodelOptions{})
@@ -1036,12 +1036,12 @@ func (s *deviceMgrRemodelSuite) TestRemodelLessRequiredSnaps(c *C) {
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core18", nil, nil)
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"some-required-snap"},
+		"required-snaps": []any{"some-required-snap"},
 	})
 	s.makeSerialAssertionInState(c, "canonical", "pc-model", "1234")
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
@@ -1050,7 +1050,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelLessRequiredSnaps(c *C) {
 		Serial: "1234",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1115,7 +1115,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelStoreSwitch(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1128,13 +1128,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelStoreSwitch(c *C) {
 		Serial: "1234",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
 		"store":          "switched-store",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 		"revision":       "1",
 	})
 
@@ -1178,7 +1178,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelRereg(c *C) {
 	s.state.Set("seeded", true)
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1192,12 +1192,12 @@ func (s *deviceMgrRemodelSuite) TestRemodelRereg(c *C) {
 		SessionMacaroon: "old-session",
 	})
 
-	new := s.brands.Model("canonical", "rereg-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "rereg-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 	})
 
 	s.newFakeStore = func(devBE storecontext.DeviceBackend) snapstate.StoreService {
@@ -1237,7 +1237,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelReregLocalFails(c *C) {
 	s.state.Set("seeded", true)
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1251,12 +1251,12 @@ func (s *deviceMgrRemodelSuite) TestRemodelReregLocalFails(c *C) {
 		SessionMacaroon: "old-session",
 	})
 
-	new := s.brands.Model("canonical", "rereg-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "rereg-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 	})
 
 	s.newFakeStore = func(devBE storecontext.DeviceBackend) snapstate.StoreService {
@@ -1320,7 +1320,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelClash(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1335,20 +1335,20 @@ func (s *deviceMgrRemodelSuite) TestRemodelClash(c *C) {
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core18", nil, nil)
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 		"revision":       "1",
 	})
-	other := s.brands.Model("canonical", "pc-model-other", map[string]interface{}{
+	other := s.brands.Model("canonical", "pc-model-other", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 	})
 
 	clashing = other
@@ -1401,7 +1401,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelClashInProgress(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1416,12 +1416,12 @@ func (s *deviceMgrRemodelSuite) TestRemodelClashInProgress(c *C) {
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core18", nil, nil)
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1"},
+		"required-snaps": []any{"new-required-snap-1"},
 		"revision":       "1",
 	})
 
@@ -1465,7 +1465,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelClashWithRecoverySystem(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1480,12 +1480,12 @@ func (s *deviceMgrRemodelSuite) TestRemodelClashWithRecoverySystem(c *C) {
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core18", nil, nil)
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1"},
+		"required-snaps": []any{"new-required-snap-1"},
 		"revision":       "1",
 	})
 
@@ -1503,7 +1503,7 @@ func (s *deviceMgrRemodelSuite) TestReregRemodelClashAnyChange(c *C) {
 	s.state.Set("seeded", true)
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1517,12 +1517,12 @@ func (s *deviceMgrRemodelSuite) TestReregRemodelClashAnyChange(c *C) {
 		SessionMacaroon: "old-session",
 	})
 
-	new := s.brands.Model("canonical", "pc-model-2", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model-2", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 		"revision":       "1",
 	})
 	s.newFakeStore = func(devBE storecontext.DeviceBackend) snapstate.StoreService {
@@ -1573,7 +1573,7 @@ func (s *deviceMgrRemodelSuite) TestDeviceCtxNoTask(c *C) {
 	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a model assertion
-	model := s.brands.Model("canonical", "pc", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc", map[string]any{
 		"gadget":       "pc",
 		"kernel":       "kernel",
 		"architecture": "amd64",
@@ -1601,7 +1601,7 @@ func (s *deviceMgrRemodelSuite) TestDeviceCtxGroundContext(c *C) {
 	defer s.state.Unlock()
 
 	// have a model assertion
-	model := s.brands.Model("canonical", "pc", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc", map[string]any{
 		"gadget":       "pc",
 		"kernel":       "kernel",
 		"architecture": "amd64",
@@ -1625,7 +1625,7 @@ func (s *deviceMgrRemodelSuite) TestDeviceCtxProvided(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	model := assertstest.FakeAssertion(map[string]interface{}{
+	model := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "canonical",
 		"series":       "16",
@@ -1674,7 +1674,7 @@ volumes:
 
 	s.setupBrands()
 
-	oldModel := fakeMyModel(map[string]interface{}{
+	oldModel := fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"gadget":       "gadget",
 		"kernel":       "kernel",
@@ -1682,7 +1682,7 @@ volumes:
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: oldModel}
 
 	// model assertion in device context
-	newModel := fakeMyModel(map[string]interface{}{
+	newModel := fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"gadget":       "new-gadget",
 		"kernel":       "kernel",
@@ -1743,7 +1743,7 @@ volumes:
 		Brand: "canonical",
 		Model: "gadget",
 	})
-	s.makeModelAssertionInState(c, "canonical", "gadget", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "gadget", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "kernel",
 		"gadget":       "gadget",
@@ -1805,12 +1805,12 @@ version: 123
 
 	s.setupBrands()
 	// model assertion in device context
-	oldModel := fakeMyModel(map[string]interface{}{
+	oldModel := fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"gadget":       "new-gadget",
 		"kernel":       "krnl",
 	})
-	model := fakeMyModel(map[string]interface{}{
+	model := fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"gadget":       "new-gadget",
 		"kernel":       "krnl",
@@ -1906,7 +1906,7 @@ volumes:
 	s.mockTasksNopHandler("fake-download", "validate-snap", "set-model")
 
 	// set a model assertion we remodel from
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1934,7 +1934,7 @@ volumes:
 	devicestate.SetBootRevisionsUpdated(s.mgr, true)
 
 	// the target model
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"base":         "core18",
@@ -2104,7 +2104,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
 	s.mockTasksNopHandler("fake-download", "validate-snap", "set-model")
 
 	// set a model assertion we remodel from
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2132,7 +2132,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
 	devicestate.SetBootRevisionsUpdated(s.mgr, true)
 
 	// the target model
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"base":         "core18",
@@ -2228,7 +2228,7 @@ func (s *deviceMgrSuite) TestRemodelSwitchBaseIncompatibleGadget(c *C) {
 	defer restore()
 
 	// set a model assertion
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2241,7 +2241,7 @@ func (s *deviceMgrSuite) TestRemodelSwitchBaseIncompatibleGadget(c *C) {
 		Model: "pc-model",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2289,7 +2289,7 @@ func (s *deviceMgrSuite) TestRemodelSwitchBase(c *C) {
 	defer restore()
 
 	// set a model assertion
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2302,7 +2302,7 @@ func (s *deviceMgrSuite) TestRemodelSwitchBase(c *C) {
 		Model: "pc-model",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc-20",
@@ -2382,24 +2382,24 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              snaptest.AssertedSnapID("snapd"),
 				"type":            "snapd",
@@ -2467,41 +2467,41 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 	})
 
 	// New model, that changes snapd tracking channel and with 2 new required snaps
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              snaptest.AssertedSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "new-required-snap-1",
 				"id":       snaptest.AssertedSnapID("new-required-snap-1"),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "new-required-snap-2",
 				"id":       snaptest.AssertedSnapID("new-required-snap-2"),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "new-optional-snap-1",
 				"id":       snaptest.AssertedSnapID("new-optional-snap-1"),
 				"presence": "optional",
@@ -2616,13 +2616,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 	})
 
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            expectedLabel,
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
-		"snap-setup-tasks": []interface{}{tDownloadSnap1.ID(), tDownloadSnap2.ID(), tDownloadSnap3.ID()},
+		"snap-setup-tasks": []any{tDownloadSnap1.ID(), tDownloadSnap2.ID(), tDownloadSnap3.ID()},
 		"test-system":      true,
 	})
 	// cross references of to recovery system setup data
@@ -2730,18 +2730,18 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelGadgetBaseSnaps(c *C,
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2800,25 +2800,25 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelGadgetBaseSnaps(c *C,
 		newGadget = "pc-new"
 	}
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "21/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            newGadget,
 				"id":              snaptest.AssertedSnapID(newGadget),
 				"type":            "gadget",
 				"default-channel": "21/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20",
 				"id":              snaptest.AssertedSnapID("core20"),
 				"type":            "base",
@@ -2953,13 +2953,13 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelGadgetBaseSnaps(c *C,
 	})
 
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            expectedLabel,
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
-		"snap-setup-tasks": []interface{}{tDownloadKernel.ID(), tDownloadBase.ID(), tDownloadGadget.ID()},
+		"snap-setup-tasks": []any{tDownloadKernel.ID(), tDownloadBase.ID(), tDownloadGadget.ID()},
 		"test-system":      true,
 	})
 }
@@ -2997,18 +2997,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3057,14 +3057,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 	}
 	appSnapPath, _ := snaptest.MakeTestSnapInfoWithFiles(c, "name: app-snap\nversion: 1\ntype: app\n", nil, appSnap)
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
 		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				// switch to a new kernel which also is already
 				// installed
 				"name":            "pc-kernel-new",
@@ -3072,13 +3072,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-new",
 				"id":              snaptest.AssertedSnapID("pc-new"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "app-snap",
 				"id":              snaptest.AssertedSnapID("app-snap"),
 				"type":            "app",
@@ -3210,13 +3210,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 		tCreateRecovery, tFinalizeRecovery,
 	})
 
-	snapsups := []interface{}{tPrepareKernel.ID(), tPrepareBase.ID(), tPrepareGadget.ID(), tValidateApp.ID()}
+	snapsups := []any{tPrepareKernel.ID(), tPrepareBase.ID(), tPrepareGadget.ID(), tValidateApp.ID()}
 
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            expectedLabel,
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
 		"snap-setup-tasks": snapsups,
@@ -3256,18 +3256,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3316,14 +3316,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 	}
 	appSnapPath, _ := snaptest.MakeTestSnapInfoWithFiles(c, "name: app-snap\nversion: 1\ntype: app\n", nil, appSnap)
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
 		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				// switch to a new kernel which also is already
 				// installed
 				"name":            "pc-kernel-new",
@@ -3331,13 +3331,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 				"type":            "kernel",
 				"default-channel": "20/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-new",
 				"id":              snaptest.AssertedSnapID("pc-new"),
 				"type":            "gadget",
 				"default-channel": "20/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "app-snap",
 				"id":              snaptest.AssertedSnapID("app-snap"),
 				"type":            "app",
@@ -3473,13 +3473,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 		tCreateRecovery, tFinalizeRecovery,
 	})
 
-	snapsups := []interface{}{tSwitchKernel.ID(), tPrepareBase.ID(), tSwitchGadget.ID(), tValidateApp.ID()}
+	snapsups := []any{tSwitchKernel.ID(), tPrepareBase.ID(), tSwitchGadget.ID(), tValidateApp.ID()}
 
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            expectedLabel,
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
 		"snap-setup-tasks": snapsups,
@@ -3517,18 +3517,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3595,14 +3595,14 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		})
 	}
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
 		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				// switch to a new kernel which also is already
 				// installed
 				"name":            "pc-kernel-new",
@@ -3610,7 +3610,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 				"type":            "kernel",
 				"default-channel": "20/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-new",
 				"id":              snaptest.AssertedSnapID("pc-new"),
 				"type":            "gadget",
@@ -3725,13 +3725,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		tCreateRecovery, tFinalizeRecovery,
 	})
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            expectedLabel,
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
-		"snap-setup-tasks": []interface{}{tPrepareKernel.ID(), tPrepareBase.ID(), tPrepareGadget.ID()},
+		"snap-setup-tasks": []any{tPrepareKernel.ID(), tPrepareBase.ID(), tPrepareGadget.ID()},
 		"test-system":      true,
 	})
 }
@@ -3849,18 +3849,18 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3928,14 +3928,14 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		})
 	}
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
 		"base":     "core24-new",
 		"grade":    "dangerous",
 		"revision": "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				// switch to a new kernel which also is already
 				// installed, but tracks a different channel
 				// than what we have in snap state
@@ -3944,13 +3944,13 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-new",
 				"id":              snaptest.AssertedSnapID("pc-new"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				// similar case for the base snap
 				"name":            "core24-new",
 				"id":              snaptest.AssertedSnapID("core24-new"),
@@ -4070,14 +4070,14 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		tCreateRecovery, tFinalizeRecovery,
 	})
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":     expectedLabel,
 		"directory": filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
 		// tasks carrying snap-setup are tracked
-		"snap-setup-tasks": []interface{}{
+		"snap-setup-tasks": []any{
 			tSwitchChannelKernel.ID(),
 			tSwitchChannelBase.ID(),
 			tSwitchChannelGadget.ID(),
@@ -4133,18 +4133,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseSnapsInstalledSna
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -4209,26 +4209,26 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseSnapsInstalledSna
 	}
 
 	// new kernel and base are already installed, but using a different channel
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		// switch to a new base which is already installed
 		"base":     "core20-new",
 		"grade":    "dangerous",
 		"revision": "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel-new",
 				"id":              snaptest.AssertedSnapID("pc-kernel-new"),
 				"type":            "kernel",
 				"default-channel": "kernel/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20-new",
 				"id":              snaptest.AssertedSnapID("core20-new"),
 				"type":            "base",
@@ -4322,13 +4322,13 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseSnapsInstalledSna
 	})
 
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            expectedLabel,
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
-		"snap-setup-tasks": []interface{}{tDownloadKernel.ID(), tDownloadBase.ID()},
+		"snap-setup-tasks": []any{tDownloadKernel.ID(), tDownloadBase.ID()},
 		"test-system":      true,
 	})
 }
@@ -4359,18 +4359,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentCh
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -4429,25 +4429,25 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentCh
 	})
 
 	// new kernel and base are already installed, but using a different channel
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20",
 				"id":              snaptest.AssertedSnapID("core20"),
 				"type":            "base",
@@ -4500,10 +4500,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentCh
 	})
 
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":       expectedLabel,
 		"directory":   filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
 		"test-system": true,
@@ -4535,18 +4535,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelFailWhenUsingUnassertedSnapForSpecifi
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -4601,15 +4601,15 @@ func (s *deviceMgrRemodelSuite) TestRemodelFailWhenUsingUnassertedSnapForSpecifi
 		TrackingChannel: "",
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       snaptest.AssertedSnapID("pc-kernel"),
 				"revision": "10",
@@ -4625,32 +4625,32 @@ func (s *deviceMgrRemodelSuite) TestRemodelFailWhenUsingUnassertedSnapForSpecifi
 
 	// new kernel and base are already installed, but kernel needs a new
 	// revision and base is a new channel
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20",
 				"id":              snaptest.AssertedSnapID("core20"),
 				"type":            "base",
@@ -4709,18 +4709,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20BaseNoDownloadSimpleChannelSwitch
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -4777,25 +4777,25 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20BaseNoDownloadSimpleChannelSwitch
 	})
 
 	// base uses a new default channel
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20",
 				"id":              snaptest.AssertedSnapID("core20"),
 				"type":            "base",
@@ -4852,10 +4852,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20BaseNoDownloadSimpleChannelSwitch
 	})
 
 	// verify recovery system setup data on appropriate tasks
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":       expectedLabel,
 		"directory":   filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", expectedLabel),
 		"test-system": true,
@@ -4904,30 +4904,30 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1",
 				"id":              snaptest.AssertedSnapID("snap-1"),
 				"type":            "app",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1-base",
 				"id":              snaptest.AssertedSnapID("snap-1-base"),
 				"type":            "base",
@@ -5019,31 +5019,31 @@ base: snap-1-base
 	})
 
 	// snap-1 uses a new default channel
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1",
 				"id":              snaptest.AssertedSnapID("snap-1"),
 				"type":            "app",
 				"default-channel": "latest/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1-base",
 				"id":              snaptest.AssertedSnapID("snap-1-base"),
 				"type":            "app",
@@ -5110,18 +5110,18 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20LabelConflicts(c *C, tc remodelUC
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -5175,19 +5175,19 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20LabelConflicts(c *C, tc remodelUC
 		TrackingChannel: "latest/stable",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -5236,7 +5236,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20LabelConflicts(c *C, tc remodelUC
 		happyLabel := labelBase + "-991"
 		c.Assert(tCreateRecovery, NotNil)
 		c.Assert(tCreateRecovery.Summary(), Equals, fmt.Sprintf("Create recovery system with label %q", happyLabel))
-		var systemSetupData map[string]interface{}
+		var systemSetupData map[string]any
 		err = tCreateRecovery.Get("recovery-system-setup", &systemSetupData)
 		c.Assert(err, IsNil)
 		c.Assert(systemSetupData["label"], Equals, happyLabel)
@@ -5287,18 +5287,18 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelSetModel(c *C, tc uc20RemodelSetM
 		"create-recovery-system", "finalize-recovery-system")
 
 	// set a model assertion we remodel from
-	model := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -5373,19 +5373,19 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelSetModel(c *C, tc uc20RemodelSetM
 	})
 
 	// the target model
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -5604,14 +5604,14 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 		"create-recovery-system", "finalize-recovery-system")
 
 	// set a model assertion we remodel from
-	essentialSnaps := []interface{}{
-		map[string]interface{}{
+	essentialSnaps := []any{
+		map[string]any{
 			"name":            "pc-kernel",
 			"id":              snaptest.AssertedSnapID("pc-kernel"),
 			"type":            "kernel",
 			"default-channel": "20",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":            "pc",
 			"id":              snaptest.AssertedSnapID("pc"),
 			"type":            "gadget",
@@ -5620,14 +5620,14 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 	}
 	snaps := essentialSnaps
 	if tc.isUpdate {
-		snaps = append(snaps, map[string]interface{}{
+		snaps = append(snaps, map[string]any{
 			"name":            "some-snap",
 			"id":              snaptest.AssertedSnapID("some-snap"),
 			"type":            "app",
 			"default-channel": "latest",
 		})
 	}
-	model := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
@@ -5711,14 +5711,14 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 	}
 
 	newModelSnaps := essentialSnaps
-	newModelSnaps = append(newModelSnaps, map[string]interface{}{
+	newModelSnaps = append(newModelSnaps, map[string]any{
 		"name":            "some-snap",
 		"id":              snaptest.AssertedSnapID("some-snap"),
 		"type":            "app",
 		"default-channel": "new-channel",
 	})
 
-	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
@@ -5921,18 +5921,18 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 		"create-recovery-system", "finalize-recovery-system")
 
 	// set a model assertion we remodel from
-	model := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -6012,19 +6012,19 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 
 	// the target model, since it's a new model altogether a reregistration
 	// will be triggered
-	new := s.brands.Model("canonical", "pc-new-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-new-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -6268,18 +6268,18 @@ func (s *deviceMgrRemodelSuite) testRemodelTasksSelfContainedModelMissingDep(c *
 	var testDeviceCtx snapstate.DeviceContext
 
 	// set a model assertion we remodel from
-	current := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	current := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -6411,25 +6411,25 @@ plugs:
 	})
 	defer restore()
 
-	new := s.brands.Model("canonical", "pc-new-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-new-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "foo-missing-deps",
 				"id":   snaptest.AssertedSnapID("foo-missing-deps"),
 			},
@@ -6541,18 +6541,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelTasksSelfContainedModelMissingDepsOfM
 	var testDeviceCtx snapstate.DeviceContext
 
 	// set a model assertion we remodel from
-	current := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	current := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -6664,29 +6664,29 @@ plugs:
 	})
 	defer restore()
 
-	new := s.brands.Model("canonical", "pc-new-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-new-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "foo-missing-deps",
 				"id":   snaptest.AssertedSnapID("foo-missing-deps"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "bar-missing-deps",
 				"id":   snaptest.AssertedSnapID("bar-missing-deps"),
 			},
@@ -7391,29 +7391,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponents(c *C) {
 	restore, installed := mockSnapstateInstallOne(c, expectedInstalls)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -7432,40 +7432,40 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponents(c *C) {
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core24", nil, nil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "some-snap",
 				"id":              fakeSnapID("some-snap"),
 				"type":            "app",
@@ -7521,9 +7521,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponents(c *C) {
 	})
 
 	createRecoverySystem := tss[2].Tasks()[0]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, []interface{}{
+	checkRecoverySystemSetup(createRecoverySystem, c, now, []any{
 		updated["pc-kernel"], installed["some-snap"],
-	}, []interface{}{
+	}, []any{
 		updated["pc-kernel+kmod"],
 	})
 }
@@ -7562,29 +7562,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsNewComponentSwitchSnap(
 	restore, updated := mockSnapstateUpdateOne(c, expectedUpdates)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -7614,34 +7614,34 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsNewComponentSwitchSnap(
 		Channel:  "latest/stable",
 	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/edge",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -7686,9 +7686,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsNewComponentSwitchSnap(
 	})
 
 	createRecoverySystem := tss[1].Tasks()[0]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, []interface{}{
+	checkRecoverySystemSetup(createRecoverySystem, c, now, []any{
 		updated["pc-kernel"],
-	}, []interface{}{
+	}, []any{
 		updated["pc-kernel+kmod"],
 	})
 }
@@ -7708,29 +7708,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsToAlreadyInstalledKerne
 	restore := devicestate.MockTimeNow(func() time.Time { return now })
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -7771,34 +7771,34 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsToAlreadyInstalledKerne
 
 	snapstate.Set(s.state, "iot-kernel", &snapst)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "iot-kernel",
 				"id":              fakeSnapID("iot-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -7837,16 +7837,16 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsToAlreadyInstalledKerne
 	})
 
 	createRecoverySystem := tss[1].Tasks()[0]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, []interface{}{"1"}, []interface{}{"4"})
+	checkRecoverySystemSetup(createRecoverySystem, c, now, []any{"1"}, []any{"4"})
 }
 
-func checkRecoverySystemSetup(t *state.Task, c *C, now time.Time, snapsups, compsups []interface{}) {
-	var data map[string]interface{}
+func checkRecoverySystemSetup(t *state.Task, c *C, now time.Time, snapsups, compsups []any) {
+	var data map[string]any
 	err := t.Get("recovery-system-setup", &data)
 	c.Assert(err, IsNil)
 
 	label := now.Format("20060102")
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"label":       label,
 		"directory":   filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", label),
 		"test-system": true,
@@ -7897,29 +7897,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsNewSnapAndComponent(c *
 	restore, installed := mockSnapstateInstallOne(c, expectedInstalls)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -7938,41 +7938,41 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsNewSnapAndComponent(c *
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core24", nil, nil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-with-comps",
 				"id":              fakeSnapID("snap-with-comps"),
 				"type":            "app",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 					},
 				},
@@ -8016,9 +8016,9 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsNewSnapAndComponent(c *
 	})
 
 	createRecoverySystem := tss[1].Tasks()[0]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, []interface{}{
+	checkRecoverySystemSetup(createRecoverySystem, c, now, []any{
 		installed["snap-with-comps"],
-	}, []interface{}{
+	}, []any{
 		installed["snap-with-comps+comp-1"],
 	})
 }
@@ -8057,29 +8057,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsAddComponentsToSnap(c *
 	restore, installed := mockSnapstateInstallComponents(c, expectedComponentInstalls)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8110,37 +8110,37 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsAddComponentsToSnap(c *
 		Channel:  "latest/stable",
 	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
-					"other-kmod": map[string]interface{}{
+					"other-kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8194,7 +8194,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsAddComponentsToSnap(c *
 	})
 
 	createRecoverySystem := tss[3].Tasks()[0]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, nil, []interface{}{
+	checkRecoverySystemSetup(createRecoverySystem, c, now, nil, []any{
 		installed["pc-kernel+kmod"],
 		installed["pc-kernel+other-kmod"],
 	})
@@ -8211,29 +8211,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsSkipOptionalComponent(c
 	restore := devicestate.MockTimeNow(func() time.Time { return now })
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8263,34 +8263,34 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsSkipOptionalComponent(c
 		Channel:  "latest/stable",
 	}, snapstatetest.InstallSnapOptions{Required: true})
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "optional",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8359,29 +8359,29 @@ func (s *deviceMgrRemodelSuite) testRemodelWithComponentsChangeBecauseOfValidati
 	restore, installed := mockSnapstateInstallComponents(c, expectedComponentInstalls)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8423,41 +8423,41 @@ func (s *deviceMgrRemodelSuite) testRemodelWithComponentsChangeBecauseOfValidati
 
 	snapstate.Set(s.state, "pc-kernel", &snapst)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": componentPresence,
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8466,21 +8466,21 @@ func (s *deviceMgrRemodelSuite) testRemodelWithComponentsChangeBecauseOfValidati
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": "1",
 				"presence": "required",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"revision": "12",
 						"presence": "required",
 					},
@@ -8536,7 +8536,7 @@ func (s *deviceMgrRemodelSuite) testRemodelWithComponentsChangeBecauseOfValidati
 	})
 
 	createRecoverySystem := tss[2].Tasks()[0]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, nil, []interface{}{
+	checkRecoverySystemSetup(createRecoverySystem, c, now, nil, []any{
 		installed["pc-kernel+kmod"],
 	})
 }
@@ -8604,29 +8604,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOffline(c *C) {
 	restore, installedComps := mockSnapstateInstallComponentPath(c, expectedCompInstalls)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8657,57 +8657,57 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOffline(c *C) {
 		Channel:  "latest/stable",
 	}, snapstatetest.InstallSnapOptions{})
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "some-snap",
 				"id":              fakeSnapID("some-snap"),
 				"type":            "app",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "other-snap",
 				"id":              fakeSnapID("other-snap"),
 				"type":            "app",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"comp-2": map[string]interface{}{
+				"components": map[string]any{
+					"comp-2": map[string]any{
 						"presence": "required",
 					},
 				},
@@ -8831,10 +8831,10 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOffline(c *C) {
 	})
 
 	createRecoverySystem := tss[3].Tasks()[0]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, []interface{}{
+	checkRecoverySystemSetup(createRecoverySystem, c, now, []any{
 		updated["pc-kernel"],
 		installed["some-snap"],
-	}, []interface{}{
+	}, []any{
 		updated["pc-kernel+kmod"],
 		installed["some-snap+comp-1"],
 		installedComps["other-snap+comp-2"],
@@ -8848,29 +8848,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOfflineMissingComponent
 	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "some-privacy-key")
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8889,34 +8889,34 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOfflineMissingComponent
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core24", nil, nil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -8967,29 +8967,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOfflineMissingComponent
 	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "some-privacy-key")
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -9008,41 +9008,41 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOfflineMissingComponent
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core24", nil, nil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "some-snap",
 				"id":              fakeSnapID("some-snap"),
 				"type":            "app",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 					},
 				},
@@ -9092,29 +9092,29 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOfflineMissingComponent
 	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "some-privacy-key")
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
@@ -9145,41 +9145,41 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsOfflineMissingComponent
 		Channel:  "latest/stable",
 	}, snapstatetest.InstallSnapOptions{})
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              fakeSnapID("core24"),
 				"type":            "base",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              fakeSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "some-snap",
 				"id":              fakeSnapID("some-snap"),
 				"type":            "app",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 					},
 				},
@@ -9288,23 +9288,23 @@ func (s *deviceMgrSuite) testRemodelUpdateFromValidationSet(c *C, sequence strin
 	})
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1",
 				"id":              snaptest.AssertedSnapID("snap-1"),
 				"type":            "app",
@@ -9369,7 +9369,7 @@ func (s *deviceMgrSuite) testRemodelUpdateFromValidationSet(c *C, sequence strin
 		TrackingChannel: "latest/stable",
 	})
 
-	validationSetInModel := map[string]interface{}{
+	validationSetInModel := map[string]any{
 		"account-id": "canonical",
 		"name":       "vset-1",
 		"mode":       "enforce",
@@ -9379,25 +9379,25 @@ func (s *deviceMgrSuite) testRemodelUpdateFromValidationSet(c *C, sequence strin
 		validationSetInModel["sequence"] = sequence
 	}
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":    "amd64",
 		"base":            "core20",
 		"revision":        "1",
-		"validation-sets": []interface{}{validationSetInModel},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{validationSetInModel},
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1",
 				"id":              snaptest.AssertedSnapID("snap-1"),
 				"type":            "app",
@@ -9406,21 +9406,21 @@ func (s *deviceMgrSuite) testRemodelUpdateFromValidationSet(c *C, sequence strin
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-1",
 				"id":       snaptest.AssertedSnapID("snap-1"),
 				"revision": "2",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       snaptest.AssertedSnapID("pc"),
 				"revision": "2",
@@ -9476,17 +9476,17 @@ func (s *deviceMgrSuite) testRemodelInvalidFromValidationSet(c *C, invalidSnap s
 
 	var testDeviceCtx snapstate.DeviceContext
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9503,31 +9503,31 @@ func (s *deviceMgrSuite) testRemodelInvalidFromValidationSet(c *C, invalidSnap s
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1",
 				"id":              snaptest.AssertedSnapID("snap-1"),
 				"type":            "app",
@@ -9536,15 +9536,15 @@ func (s *deviceMgrSuite) testRemodelInvalidFromValidationSet(c *C, invalidSnap s
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     invalidSnap,
 				"id":       snaptest.AssertedSnapID(invalidSnap),
 				"presence": "invalid",
@@ -9590,17 +9590,17 @@ func (s *deviceMgrSuite) testOfflineRemodelValidationSet(c *C, withValSet bool) 
 
 	var testDeviceCtx snapstate.DeviceContext
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9617,31 +9617,31 @@ func (s *deviceMgrSuite) testOfflineRemodelValidationSet(c *C, withValSet bool) 
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snap-1",
 				"id":              snaptest.AssertedSnapID("snap-1"),
 				"type":            "app",
@@ -9651,15 +9651,15 @@ func (s *deviceMgrSuite) testOfflineRemodelValidationSet(c *C, withValSet bool) 
 	})
 
 	if withValSet {
-		vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+		vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 			"type":         "validation-set",
 			"authority-id": "canonical",
 			"series":       "16",
 			"account-id":   "canonical",
 			"name":         "vset-1",
 			"sequence":     "1",
-			"snaps": []interface{}{
-				map[string]interface{}{
+			"snaps": []any{
+				map[string]any{
 					"name":     "snap-1",
 					"id":       snaptest.AssertedSnapID("snap-1"),
 					"presence": "invalid",
@@ -9709,17 +9709,17 @@ func (s *deviceMgrSuite) TestOfflineRemodelMissingSnap(c *C) {
 
 	var testDeviceCtx snapstate.DeviceContext
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9736,18 +9736,18 @@ func (s *deviceMgrSuite) TestOfflineRemodelMissingSnap(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-new",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9772,17 +9772,17 @@ func (s *deviceMgrSuite) TestOfflineRemodelPreinstalledIncorrectRevision(c *C) {
 
 	var testDeviceCtx snapstate.DeviceContext
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9799,25 +9799,25 @@ func (s *deviceMgrSuite) TestOfflineRemodelPreinstalledIncorrectRevision(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9826,15 +9826,15 @@ func (s *deviceMgrSuite) TestOfflineRemodelPreinstalledIncorrectRevision(c *C) {
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       snaptest.AssertedSnapID("pc-kernel"),
 				"presence": "required",
@@ -9915,17 +9915,17 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevision(c *
 	})
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core22",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9942,25 +9942,25 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevision(c *
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core22",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -9969,21 +9969,21 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevision(c *
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       snaptest.AssertedSnapID("pc-kernel"),
 				"presence": "required",
 				"revision": "1",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core22",
 				"id":       snaptest.AssertedSnapID("core22"),
 				"presence": "required",
@@ -10079,17 +10079,17 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevisionWith
 	restore, updated := mockSnapstateUpdateOneFromFile(c, expectedUpdates)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10106,30 +10106,30 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevisionWith
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10138,15 +10138,15 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevisionWith
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       snaptest.AssertedSnapID("pc-kernel"),
 				"presence": "required",
@@ -10183,9 +10183,9 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevisionWith
 	})
 
 	createRecoverySystem := chg.Tasks()[6]
-	checkRecoverySystemSetup(createRecoverySystem, c, now, []interface{}{
+	checkRecoverySystemSetup(createRecoverySystem, c, now, []any{
 		updated["pc-kernel"],
-	}, []interface{}{
+	}, []any{
 		updated["pc-kernel+kmod"],
 	})
 }
@@ -10261,17 +10261,17 @@ func (s *deviceMgrRemodelSuite) testOfflineRemodelPreinstalledUseOldRevisionMiss
 	restore, _ = mockSnapstateUpdateOneFromFile(c, expectedUpdates)
 	defer restore()
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10288,30 +10288,30 @@ func (s *deviceMgrRemodelSuite) testOfflineRemodelPreinstalledUseOldRevisionMiss
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core24",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10320,7 +10320,7 @@ func (s *deviceMgrRemodelSuite) testOfflineRemodelPreinstalledUseOldRevisionMiss
 		},
 	})
 
-	snaps := map[string]interface{}{
+	snaps := map[string]any{
 		"name":     "pc-kernel",
 		"id":       snaptest.AssertedSnapID("pc-kernel"),
 		"presence": "required",
@@ -10328,22 +10328,22 @@ func (s *deviceMgrRemodelSuite) testOfflineRemodelPreinstalledUseOldRevisionMiss
 	}
 
 	if wrongRevisionInstalled {
-		snaps["components"] = map[string]interface{}{
-			"kmod": map[string]interface{}{
+		snaps["components"] = map[string]any{
+			"kmod": map[string]any{
 				"revision": "12",
 				"presence": "required",
 			},
 		}
 	}
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
+		"snaps": []any{
 			snaps,
 		},
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
@@ -10371,17 +10371,17 @@ func (s *deviceMgrSuite) TestRemodelRequiredSnapMissingFromModel(c *C) {
 
 	var testDeviceCtx snapstate.DeviceContext
 
-	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10398,25 +10398,25 @@ func (s *deviceMgrSuite) TestRemodelRequiredSnapMissingFromModel(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"revision":     "1",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10425,15 +10425,15 @@ func (s *deviceMgrSuite) TestRemodelRequiredSnapMissingFromModel(c *C) {
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-1",
 				"id":       snaptest.AssertedSnapID("snap-1"),
 				"presence": "required",
@@ -10470,18 +10470,18 @@ func (s *deviceMgrRemodelSuite) TestRemodelVerifyOrderOfTasks(c *C) {
 	var testDeviceCtx snapstate.DeviceContext
 
 	// set a model assertion we remodel from
-	current := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	current := s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10574,38 +10574,38 @@ func (s *deviceMgrRemodelSuite) TestRemodelVerifyOrderOfTasks(c *C) {
 	})
 	defer restore()
 
-	new := s.brands.Model("canonical", "pc-new-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-new-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "kernel-new",
 				"id":              snaptest.AssertedSnapID("kernel-new"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "foo-with-base",
 				"id":   snaptest.AssertedSnapID("foo-with-base"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "bar-with-base",
 				"id":   snaptest.AssertedSnapID("bar-with-base"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "foo-base",
 				"type": "base",
 				"id":   snaptest.AssertedSnapID("foo-base"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "bar-base",
 				"type": "base",
 				"id":   snaptest.AssertedSnapID("bar-base"),
@@ -10719,20 +10719,20 @@ func (s *deviceMgrRemodelSuite) TestRemodelHybridSystemSkipSeed(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"classic":      "true",
 		"distribution": "ubuntu",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10772,27 +10772,27 @@ volumes:
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core20", gadgetFiles, nil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
 		"classic":      "true",
 		"distribution": "ubuntu",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "21/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "21/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20",
 				"id":              snaptest.AssertedSnapID("core20"),
 				"type":            "base",
@@ -10854,20 +10854,20 @@ func (s *deviceMgrRemodelSuite) TestRemodelHybridSystem(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"classic":      "true",
 		"distribution": "ubuntu",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -10903,27 +10903,27 @@ volumes:
 
 	snapstatetest.InstallEssentialSnaps(c, s.state, "core20", gadgetFiles, nil)
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "1",
 		"classic":      "true",
 		"distribution": "ubuntu",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "21/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "21/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20",
 				"id":              snaptest.AssertedSnapID("core20"),
 				"type":            "base",

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -73,7 +73,7 @@ func (s *deviceMgrSerialSuite) SetUpTest(c *C) {
 	s.setupBaseTest(c, classic)
 }
 
-func (s *deviceMgrSerialSuite) signSerial(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]interface{}, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
+func (s *deviceMgrSerialSuite) signSerial(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]any, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
 	brandID := headers["brand-id"].(string)
 	model := headers["model"].(string)
 	keyID := ""
@@ -144,7 +144,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -238,7 +238,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
 
 	// have a store assertion.
-	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "foo",
 		"url":         mockServer.URL,
 		"operator-id": operatorAcct.AccountID(),
@@ -248,7 +248,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 
 	assertstatetest.AddMany(s.state, operatorAcct, stoAs)
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -321,7 +321,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyClassicNoGadget(c 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "classic-alt-store", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "classic-alt-store", map[string]any{
 		"classic": "true",
 		"store":   "alt-store",
 	})
@@ -459,11 +459,11 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationMyBrandAcceptGenericHap
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "my-brand", "my-model-accept-generic", map[string]interface{}{
+	s.makeModelAssertionInState(c, "my-brand", "my-model-accept-generic", map[string]any{
 		"classic": "true",
 		"store":   "alt-store",
 		// accept generic as well to sign serials for this
-		"serial-authority": []interface{}{"generic"},
+		"serial-authority": []any{"generic"},
 	})
 
 	devicestatetest.MockGadget(c, s.state, "gadget", snap.R(2), nil)
@@ -523,7 +523,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationMyBrandMismatchedAuthor
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "my-brand", "my-model-accept-generic", map[string]interface{}{
+	s.makeModelAssertionInState(c, "my-brand", "my-model-accept-generic", map[string]any{
 		"classic": "true",
 		"store":   "alt-store",
 		// no serial-authority set
@@ -567,7 +567,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialIdempotentAfterAddSerial(c *C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -650,7 +650,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -724,7 +724,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -778,7 +778,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialMaxTentatives(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -937,7 +937,7 @@ func (s *deviceMgrSerialSuite) makeRequestChangeWithTransport(c *C, rt http.Roun
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1017,7 +1017,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationPollHappy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1109,7 +1109,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(
 	r3 := devicestate.MockBaseStoreURL(mockServer.URL + "/direct/baad/")
 	defer r3()
 
-	s.makeModelAssertionInState(c, "canonical", "pc2", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc2", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "gadget",
@@ -1160,11 +1160,11 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(
 	c.Assert(err, IsNil)
 	serial := a.(*asserts.Serial)
 
-	var details map[string]interface{}
+	var details map[string]any
 	err = yaml.Unmarshal(serial.Body(), &details)
 	c.Assert(err, IsNil)
 
-	c.Check(details, DeepEquals, map[string]interface{}{
+	c.Check(details, DeepEquals, map[string]any{
 		"mac": "00:00:00:00:ff:00",
 	})
 
@@ -1253,7 +1253,7 @@ func (s *deviceMgrSerialSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
 
 	// have a store assertion.
-	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "foo",
 		"url":         mockServer.URL,
 		"operator-id": operatorAcct.AccountID(),
@@ -1263,7 +1263,7 @@ func (s *deviceMgrSerialSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c
 
 	assertstatetest.AddMany(s.state, operatorAcct, stoAs)
 
-	s.makeModelAssertionInState(c, "canonical", "pc2", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc2", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "gadget",
@@ -1327,7 +1327,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 	// validity
 	c.Check(devicestate.EnsureOperationalAttempts(s.state), Equals, 0)
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1423,7 +1423,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationMismatchedSerial(c *C) 
 
 	devicestatetest.MockGadget(c, s.state, "gadget", snap.R(2), nil)
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "gadget",
@@ -1469,7 +1469,7 @@ func (s *deviceMgrSerialSuite) TestModelAndSerial(c *C) {
 	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a model assertion
-	model := s.brands.Model("canonical", "pc", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc", map[string]any{
 		"gadget":       "pc",
 		"kernel":       "kernel",
 		"architecture": "amd64",
@@ -1544,7 +1544,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a model assertion
-	model := s.brands.Model("canonical", "pc", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc", map[string]any{
 		"gadget":       "pc",
 		"kernel":       "kernel",
 		"architecture": "amd64",
@@ -1588,7 +1588,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendDeviceSessionRequestParams
 	defer s.state.Unlock()
 
 	// set model as seeding would
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1607,7 +1607,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendDeviceSessionRequestParams
 	// setup state as done by device initialisation
 	encDevKey, err := asserts.EncodePublicKey(devKey.PublicKey())
 	c.Check(err, IsNil)
-	seriala, err := s.storeSigning.Sign(asserts.SerialType, map[string]interface{}{
+	seriala, err := s.storeSigning.Sign(asserts.SerialType, map[string]any{
 		"brand-id":            "canonical",
 		"model":               "pc",
 		"serial":              "8989",
@@ -1669,7 +1669,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendProxyStore(c *C) {
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
 
 	// have a store assertion.
-	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "foo",
 		"operator-id": operatorAcct.AccountID(),
 		"url":         mockServer.URL,
@@ -1711,7 +1711,7 @@ func (s *deviceMgrSerialSuite) TestInitialRegistrationContext(c *C) {
 	defer s.state.Unlock()
 
 	// have a model assertion
-	model, err := s.storeSigning.Sign(asserts.ModelType, map[string]interface{}{
+	model, err := s.storeSigning.Sign(asserts.ModelType, map[string]any{
 		"series":       "16",
 		"brand-id":     "canonical",
 		"model":        "pc",
@@ -1841,7 +1841,7 @@ func (s *deviceMgrSerialSuite) testDoRequestSerialReregistration(c *C, setAncill
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1865,7 +1865,7 @@ func (s *deviceMgrSerialSuite) testDoRequestSerialReregistration(c *C, setAncill
 		setAncillary(serial0)
 	}
 
-	new := s.brands.Model("rereg-brand", "rereg-model", map[string]interface{}{
+	new := s.brands.Model("rereg-brand", "rereg-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1994,7 +1994,7 @@ func (s *deviceMgrSerialSuite) TestDeviceRegistrationNotInInstallMode(c *C) {
 	st := s.state
 	// setup state as will be done by first-boot
 	st.Lock()
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2041,18 +2041,18 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationUC20Happy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"base": "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2365,18 +2365,18 @@ func (s *deviceMgrSerialSuite) TestDeviceSerialRestoreHappy(c *C) {
 	err = db.Add(s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)
 
-	model := s.makeModelAssertionInState(c, "my-brand", "pc-20", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc-20", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"base": "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2529,7 +2529,7 @@ func (s *deviceMgrSerialSuite) TestDeviceManagerFullAccess(c *C) {
 		Model: "pc",
 	})
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2565,7 +2565,7 @@ func (s *deviceMgrSerialSuite) TestDeviceManagerNoAccessHasKeyID(c *C) {
 		KeyID: "key-id",
 	})
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2600,7 +2600,7 @@ func (s *deviceMgrSerialSuite) TestDeviceManagerNoAccessNoKeyID(c *C) {
 		Model: "pc",
 	})
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -91,7 +91,7 @@ func (s *deviceMgrSystemsBaseSuite) SetUpTest(c *C) {
 	classic := false
 	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
-	s.brands.Register("other-brand", brandPrivKey3, map[string]interface{}{
+	s.brands.Register("other-brand", brandPrivKey3, map[string]any{
 		"display-name": "other publisher",
 	})
 	s.state.Lock()
@@ -101,30 +101,30 @@ func (s *deviceMgrSystemsBaseSuite) SetUpTest(c *C) {
 		Brands:       s.brands,
 	}
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
 		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.ss.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
@@ -188,54 +188,54 @@ func (s *deviceMgrSystemsSuite) SetUpTest(c *C) {
 	seed20.MakeAssertedSnap(c, "name: pc-kernel\nversion: 1\ntype: kernel", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: core20\nversion: 1\ntype: base", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 
-	model1 := seed20.MakeSeed(c, "20191119", "my-brand", "my-model", map[string]interface{}{
+	model1 := seed20.MakeSeed(c, "20191119", "my-brand", "my-model", map[string]any{
 		"display-name": "my fancy model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              seed20.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              seed20.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
 	}, nil)
-	model2 := seed20.MakeSeed(c, "20200318", "my-brand", "my-model-2", map[string]interface{}{
+	model2 := seed20.MakeSeed(c, "20200318", "my-brand", "my-model-2", map[string]any{
 		"display-name": "same brand different model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              seed20.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              seed20.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
 	}, nil)
-	model3 := seed20.MakeSeed(c, "other-20200318", "other-brand", "other-model", map[string]interface{}{
+	model3 := seed20.MakeSeed(c, "other-20200318", "other-brand", "other-model", map[string]any{
 		"display-name": "different brand different model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              seed20.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              seed20.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -1260,7 +1260,7 @@ func (s *deviceMgrSystemsSuite) TestRecordSeededSystem(c *C) {
 	err := devicestate.RecordSeededSystem(s.mgr, s.state, &sys)
 	c.Assert(err, IsNil)
 
-	expectedSeededOneSys := []map[string]interface{}{
+	expectedSeededOneSys := []map[string]any{
 		{
 			"system":    "1234",
 			"model":     "my-model",
@@ -1270,7 +1270,7 @@ func (s *deviceMgrSystemsSuite) TestRecordSeededSystem(c *C) {
 			"seed-time": now.Format(time.RFC3339Nano),
 		},
 	}
-	var seededSystemsFromState []map[string]interface{}
+	var seededSystemsFromState []map[string]any
 	err = s.state.Get("seeded-systems", &seededSystemsFromState)
 	c.Assert(err, IsNil)
 	c.Assert(seededSystemsFromState, DeepEquals, expectedSeededOneSys)
@@ -1299,7 +1299,7 @@ func (s *deviceMgrSystemsSuite) TestRecordSeededSystem(c *C) {
 	c.Assert(err, IsNil)
 	err = s.state.Get("seeded-systems", &seededSystemsFromState)
 	c.Assert(err, IsNil)
-	expectedWithNewRev := []map[string]interface{}{
+	expectedWithNewRev := []map[string]any{
 		{
 			// new entry is added at the beginning
 			"system":    "1234",
@@ -1341,7 +1341,7 @@ func (s *deviceMgrSystemsSuite) TestRecordSeededSystem(c *C) {
 	c.Assert(err, IsNil)
 	err = s.state.Get("seeded-systems", &seededSystemsFromState)
 	c.Assert(err, IsNil)
-	expectedWithNewModel := []map[string]interface{}{
+	expectedWithNewModel := []map[string]any{
 		{
 			// and another one got added at the beginning
 			"system":    "9999",
@@ -1431,10 +1431,10 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemTasks
 	tskFinalize := tsks[1]
 	c.Check(tskCreate.Summary(), Matches, `Create recovery system with label "1234"`)
 	c.Check(tskFinalize.Summary(), Matches, `Finalize recovery system with label "1234"`)
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tskCreate.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":       "1234",
 		"directory":   filepath.Join(boot.InitramfsUbuntuSeedDir, "systems/1234"),
 		"test-system": true,
@@ -1476,18 +1476,18 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoveryRequiredInV
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.model = s.brands.Model("canonical", "pc-20", map[string]interface{}{
+	s.model = s.brands.Model("canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -1497,15 +1497,15 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoveryRequiredInV
 		"revision": "2",
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "required-snap",
 				"id":       s.ss.AssertedSnapID("other"),
 				"presence": "required",
@@ -1776,13 +1776,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	tskFinalize := tsks[1]
 	c.Assert(tskCreate.Summary(), Matches, `Create recovery system with label "1234"`)
 	c.Check(tskFinalize.Summary(), Matches, `Finalize recovery system with label "1234"`)
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tskCreate.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            "1234",
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems/1234"),
-		"snap-setup-tasks": []interface{}{tSnapsup1.ID(), tSnapsup2.ID()},
+		"snap-setup-tasks": []any{tSnapsup1.ID(), tSnapsup2.ID()},
 		"test-system":      true,
 	})
 	tss.WaitFor(tSnapsup1)
@@ -1795,30 +1795,30 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 
 	// downloads are only accepted if the tasks are executed as part of
 	// remodel, so procure a new model
-	newModel := s.brands.Model("canonical", "pc-20", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
 		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "foo",
 				"id":       s.ss.AssertedSnapID("foo"),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "bar",
 				"presence": "required",
 			},
@@ -1942,10 +1942,10 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	c.Assert(tskCreate.Summary(), Matches, `Create recovery system with label "1234"`)
 	c.Check(tskFinalize.Summary(), Matches, `Finalize recovery system with label "1234"`)
 
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tskCreate.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":       "1234",
 		"directory":   filepath.Join(boot.InitramfsUbuntuSeedDir, "systems/1234"),
 		"test-system": true,
@@ -1956,32 +1956,32 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 
 	// downloads are only accepted if the tasks are executed as part of
 	// remodel, so procure a new model
-	newModel := s.brands.Model("canonical", "pc-20", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
 		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
 		},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-2",
 				"sequence":   "2",
@@ -1993,15 +1993,15 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 
 	chg.Set("new-model", string(asserts.Encode(newModel)))
 
-	setSnaps := []interface{}{
-		map[string]interface{}{
+	setSnaps := []any{
+		map[string]any{
 			"id":       snaptest.AssertedSnapID("some-snap"),
 			"name":     "some-snap",
 			"presence": "invalid",
 		},
 	}
 
-	setOne := map[string]interface{}{
+	setOne := map[string]any{
 		"series":       "16",
 		"account-id":   "canonical",
 		"authority-id": "canonical",
@@ -2013,7 +2013,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 		"revision":     "1",
 	}
 
-	setTwo := map[string]interface{}{
+	setTwo := map[string]any{
 		"series":       "16",
 		"account-id":   "canonical",
 		"authority-id": "canonical",
@@ -2155,13 +2155,13 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	tskFinalize := tsks[1]
 	c.Assert(tskCreate.Summary(), Matches, `Create recovery system with label "1234missingdownload"`)
 	c.Check(tskFinalize.Summary(), Matches, `Finalize recovery system with label "1234missingdownload"`)
-	var systemSetupData map[string]interface{}
+	var systemSetupData map[string]any
 	err = tskCreate.Get("recovery-system-setup", &systemSetupData)
 	c.Assert(err, IsNil)
-	c.Assert(systemSetupData, DeepEquals, map[string]interface{}{
+	c.Assert(systemSetupData, DeepEquals, map[string]any{
 		"label":            "1234missingdownload",
 		"directory":        filepath.Join(boot.InitramfsUbuntuSeedDir, "systems/1234missingdownload"),
-		"snap-setup-tasks": []interface{}{tSnapsup1.ID()},
+		"snap-setup-tasks": []any{tSnapsup1.ID()},
 		"test-system":      true,
 	})
 	tss.WaitFor(tSnapsup1)
@@ -2172,26 +2172,26 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 
 	// downloads are only accepted if the tasks are executed as part of
 	// remodel, so procure a new model
-	newModel := s.brands.Model("canonical", "pc-20", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
 		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
 			// we have a download task for snap foo, but not for bar
-			map[string]interface{}{
+			map[string]any{
 				"name":     "bar",
 				"presence": "required",
 			},
@@ -2902,29 +2902,29 @@ func (s *modelAndGadgetInfoSuite) makeMockUC20SeedWithGadgetYaml(c *C, label, ga
 	}
 	seed20.MakeAssertedSnap(c, "name: pc\nversion: 1\ntype: gadget\nbase: core20", gadgetFiles, snap.R(1), "my-brand", s.storeSigning.Database)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"display-name": "my fancy model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "snapd",
 				"id":   seed20.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              seed20.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              seed20.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "optional-snap",
 				"presence":        "optional",
 				"id":              seed20.AssertedSnapID("optional-snap"),
@@ -3098,33 +3098,33 @@ func fakeSnapID(name string) string {
 func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValidationSetsSnapInvalid(c *C) {
 	devicestate.SetBootOkRan(s.mgr, true)
 
-	vset1, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset1, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": "12",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core22",
 				"id":       fakeSnapID("core20"),
 				"revision": "12",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": "12",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"presence": "invalid",
@@ -3146,15 +3146,15 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValidationSetsConflict(c *C) {
 	devicestate.SetBootOkRan(s.mgr, true)
 
-	vset1, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset1, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": "12",
@@ -3165,15 +3165,15 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	vset2, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset2, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-2",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": "13",
@@ -3203,37 +3203,37 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.ss.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 		},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-model",
 				"mode":       "enforce",
@@ -3241,15 +3241,15 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		},
 	})
 
-	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-model",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": "12",
@@ -3268,15 +3268,15 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		Current:   1,
 	})
 
-	vset1, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset1, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": "13",
@@ -3430,43 +3430,43 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.ss.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-required",
 				"id":       s.ss.AssertedSnapID("other-required"),
 				"type":     "app",
 				"presence": "optional",
 			},
 		},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-model",
 				"mode":       "enforce",
@@ -3474,15 +3474,15 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		},
 	})
 
-	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-model",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"presence": "required",
@@ -3518,33 +3518,33 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 
 	var validationSets []*asserts.ValidationSet
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": snapRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": snapRevisions["pc-kernel"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": snapRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": snapRevisions["snapd"].String(),
@@ -3562,15 +3562,15 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 	}
 
 	if opts.RequireOptionalSnapInValidationSet {
-		vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+		vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 			"type":         "validation-set",
 			"authority-id": "canonical",
 			"series":       "16",
 			"account-id":   "canonical",
 			"name":         "vset-2",
 			"sequence":     "1",
-			"snaps": []interface{}{
-				map[string]interface{}{
+			"snaps": []any{
+				map[string]any{
 					"name":     "other-required",
 					"id":       fakeSnapID("other-required"),
 					"revision": snapRevisions["other-required"].String(),
@@ -3930,45 +3930,45 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		"pc-kernel-with-kmods": {"kmod"},
 	}
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel-with-kmods",
 				"id":              s.ss.AssertedSnapID("pc-kernel-with-kmods"),
 				"type":            "kernel",
 				"default-channel": "20",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": opts.kmodModelPresence,
 					},
-					"other-kmod": map[string]interface{}{
+					"other-kmod": map[string]any{
 						"presence": "optional",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.ss.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 		},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-model",
 				"mode":       "enforce",
@@ -3976,21 +3976,21 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		},
 	})
 
-	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetModel, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-model",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel-with-kmods",
 				"id":       fakeSnapID("pc-kernel-with-kmods"),
 				"presence": "required",
 				"revision": "11",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"revision": "20",
 						"presence": opts.kmodVsetPresence,
 					},
@@ -4043,33 +4043,33 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 
 	var validationSets []*asserts.ValidationSet
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": snapRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel-with-kmods",
 				"id":       fakeSnapID("pc-kernel-with-kmods"),
 				"revision": snapRevisions["pc-kernel-with-kmods"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": snapRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": snapRevisions["snapd"].String(),
@@ -4460,42 +4460,42 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 
 	devicestate.SetBootOkRan(s.mgr, true)
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel-with-kmods",
 				"id":              s.ss.AssertedSnapID("pc-kernel-with-kmods"),
 				"type":            "kernel",
 				"default-channel": "20",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.ss.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 		},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "vset-model",
 				"mode":       "enforce",
@@ -4503,21 +4503,21 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-model",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel-with-kmods",
 				"id":       fakeSnapID("pc-kernel-with-kmods"),
 				"presence": "required",
 				"revision": "11",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"revision": "22",
 						"presence": "required",
 					},
@@ -4806,33 +4806,33 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		"snapd":     snap.TypeSnapd,
 	}
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": snapRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": snapRevisions["pc-kernel"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": snapRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": snapRevisions["snapd"].String(),
@@ -5138,49 +5138,49 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel-with-kmods",
 				"id":              s.ss.AssertedSnapID("pc-kernel-with-kmods"),
 				"type":            "kernel",
 				"default-channel": "20",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": opts.kmodModelPresence,
 					},
-					"other-kmod": map[string]interface{}{
+					"other-kmod": map[string]any{
 						"presence": "optional",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.ss.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-with-components",
 				"id":       s.ss.AssertedSnapID("snap-with-components"),
 				"type":     "app",
 				"presence": "optional",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "optional",
 					},
 				},
@@ -5188,32 +5188,32 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		},
 	})
 
-	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vset, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel-with-kmods",
 				"id":       fakeSnapID("pc-kernel-with-kmods"),
 				"revision": snapRevisions["pc-kernel-with-kmods"].String(),
 				"presence": "required",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": opts.kmodVsetPresence,
 						"revision": componentRevisions[naming.NewComponentRef("pc-kernel-with-kmods", "kmod")].String(),
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-with-components",
 				"id":       fakeSnapID("snap-with-components"),
 				"presence": "optional",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "optional",
 					},
 				},
@@ -5331,33 +5331,33 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		"snapd":     snap.TypeSnapd,
 	}
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": expectedRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": expectedRevisions["pc-kernel"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": expectedRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": expectedRevisions["snapd"].String(),
@@ -5399,35 +5399,35 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemOffli
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core24",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel-with-kmods",
 				"id":              s.ss.AssertedSnapID("pc-kernel-with-kmods"),
 				"type":            "kernel",
 				"default-channel": "20",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core24",
 				"id":   s.ss.AssertedSnapID("core24"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
@@ -5478,35 +5478,35 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemOffli
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core24",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel-with-kmods",
 				"id":              s.ss.AssertedSnapID("pc-kernel-with-kmods"),
 				"type":            "kernel",
 				"default-channel": "20",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core24",
 				"id":   s.ss.AssertedSnapID("core24"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
@@ -5514,21 +5514,21 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemOffli
 		},
 	})
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel-with-kmods",
 				"id":       fakeSnapID("pc-kernel-with-kmods"),
 				"presence": "required",
 				"revision": "11",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"revision": "33",
 						"presence": "required",
 					},
@@ -5597,29 +5597,29 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemMissi
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
 		"revision":     "10",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.ss.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
@@ -5731,33 +5731,33 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		"snapd":     snap.TypeSnapd,
 	}
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": expectedRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": expectedRevisions["pc-kernel"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": expectedRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": expectedRevisions["snapd"].String(),
@@ -5810,33 +5810,33 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		"snapd":     snap.TypeSnapd,
 	}
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": snapRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": snapRevisions["pc-kernel"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": snapRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": snapRevisions["snapd"].String(),
@@ -5938,33 +5938,33 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		"snapd":     snap.R(13),
 	}
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": snapRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": snapRevisions["pc-kernel"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": snapRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": snapRevisions["snapd"].String(),
@@ -6228,33 +6228,33 @@ func (s *deviceMgrSystemsCreateSuite) testRemoveRecoverySystem(c *C, mockRetry b
 		s.makeSnapInState(c, name, rev, [][]string{{"random-file", "random-content"}}, nil)
 	}
 
-	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert, err := s.brands.Signing("canonical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"revision": snapRevisions["pc"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": snapRevisions["pc-kernel"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "core20",
 				"id":       fakeSnapID("core20"),
 				"revision": snapRevisions["core20"].String(),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": snapRevisions["snapd"].String(),

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -216,7 +216,7 @@ func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 	s.AddCleanup(sysdb.MockGenericClassicModel(s.storeSigning.GenericClassicModel))
 
 	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
-	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.brands.Register("my-brand", brandPrivKey, map[string]any{
 		"display-name": "fancy model publisher",
 		"validation":   "certified",
 	})
@@ -311,7 +311,7 @@ func (s *deviceMgrBaseSuite) seeding() {
 	s.state.Set("seeded", false)
 }
 
-func (s *deviceMgrBaseSuite) makeModelAssertionInState(c *C, brandID, model string, extras map[string]interface{}) *asserts.Model {
+func (s *deviceMgrBaseSuite) makeModelAssertionInState(c *C, brandID, model string, extras map[string]any) *asserts.Model {
 	modelAs := s.brands.Model(brandID, model, extras)
 
 	s.setupBrands()
@@ -322,7 +322,7 @@ func (s *deviceMgrBaseSuite) makeModelAssertionInState(c *C, brandID, model stri
 func (s *deviceMgrBaseSuite) setPCModelInState(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -338,19 +338,19 @@ func (s *deviceMgrBaseSuite) setPCModelInState(c *C) {
 func (s *deviceMgrBaseSuite) setUC20PCModelInState(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]any{
 		"architecture": "amd64",
 		// UC20
 		"grade": "dangerous",
 		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -368,14 +368,14 @@ func (s *deviceMgrBaseSuite) setUC20PCModelInState(c *C) {
 
 func (s *deviceMgrBaseSuite) setupBrands() {
 	assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
-	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]interface{}{
+	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]any{
 		"account-id": "other-brand",
 	}, "")
 	assertstatetest.AddMany(s.state, otherAcct)
 }
 
 func (s *deviceMgrBaseSuite) setupSnapDeclForNameAndID(c *C, name, snapID, publisherID string) {
-	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-name":    name,
 		"snap-id":      snapID,
@@ -387,7 +387,7 @@ func (s *deviceMgrBaseSuite) setupSnapDeclForNameAndID(c *C, name, snapID, publi
 }
 
 func (s *deviceMgrBaseSuite) setupSnapResourcePair(c *C, comp, snapID, publisherID string, resRev, snapRev snap.Revision) {
-	assertion, err := s.storeSigning.Sign(asserts.SnapResourcePairType, map[string]interface{}{
+	assertion, err := s.storeSigning.Sign(asserts.SnapResourcePairType, map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     comp,
 		"resource-revision": strconv.Itoa(resRev.N),
@@ -403,7 +403,7 @@ func (s *deviceMgrBaseSuite) setupSnapResourceRevision(c *C, file string, comp, 
 	sha, size, err := asserts.SnapFileSHA3_384(file)
 	c.Assert(err, IsNil)
 
-	assertion, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	assertion, err := s.storeSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"snap-id":           snapID,
 		"resource-name":     comp,
 		"resource-sha3-384": sha,
@@ -424,7 +424,7 @@ func (s *deviceMgrBaseSuite) setupSnapRevisionForFileAndID(c *C, file, snapID, p
 	sha3_384, size, err := asserts.SnapFileSHA3_384(file)
 	c.Assert(err, IsNil)
 
-	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": sha3_384,
 		"snap-size":     fmt.Sprintf("%d", size),
 		"snap-id":       snapID,
@@ -443,7 +443,7 @@ func (s *deviceMgrBaseSuite) setupSnapRevision(c *C, info *snap.Info, publisherI
 func makeSerialAssertionInState(c *C, brands *assertstest.SigningAccounts, st *state.State, brandID, model, serialN string) *asserts.Serial {
 	encDevKey, err := asserts.EncodePublicKey(devKey.PublicKey())
 	c.Assert(err, IsNil)
-	serial, err := brands.Signing(brandID).Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := brands.Signing(brandID).Sign(asserts.SerialType, map[string]any{
 		"brand-id":            brandID,
 		"model":               model,
 		"serial":              serialN,
@@ -772,8 +772,8 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkError(c *C) {
 	c.Assert(err, ErrorMatches, "devicemgr: cannot mark boot successful: bootloader err")
 }
 
-func fakeMyModel(extra map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func fakeMyModel(extra map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -791,7 +791,7 @@ func (s *deviceMgrSuite) TestCheckGadget(c *C) {
 
 	s.setupBrands()
 	// model assertion in device context
-	model := fakeMyModel(map[string]interface{}{
+	model := fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"gadget":       "gadget",
 		"kernel":       "krnl",
@@ -849,7 +849,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassic(c *C) {
 
 	s.setupBrands()
 	// model assertion in device context
-	model := fakeMyModel(map[string]interface{}{
+	model := fakeMyModel(map[string]any{
 		"classic": "true",
 		"gadget":  "gadget",
 	})
@@ -901,7 +901,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassicGadgetNotSpecified(c *C) {
 
 	s.setupBrands()
 	// model assertion in device context
-	model := fakeMyModel(map[string]interface{}{
+	model := fakeMyModel(map[string]any{
 		"classic": "true",
 	})
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model}
@@ -915,7 +915,7 @@ func (s *deviceMgrSuite) TestCheckGadgetValid(c *C) {
 	defer s.state.Unlock()
 
 	// model assertion in device context
-	model := fakeMyModel(map[string]interface{}{
+	model := fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"gadget":       "gadget",
 		"kernel":       "krnl",
@@ -948,7 +948,7 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 	// not on classic without modes
 	release.OnClassic = true
 	// model assertion in device context
-	model := fakeMyModel(map[string]interface{}{
+	model := fakeMyModel(map[string]any{
 		"classic": "true",
 	})
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model}
@@ -958,7 +958,7 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 
 	s.setupBrands()
 	// model assertion in device context
-	model = fakeMyModel(map[string]interface{}{
+	model = fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"gadget":       "gadget",
 		"kernel":       "krnl",
@@ -1014,20 +1014,20 @@ func (s *deviceMgrSuite) TestCheckKernelOnClassicWithModes(c *C) {
 	kernelInfo := snaptest.MockInfo(c, "{type: kernel, name: pc-kernel, version: 0}", nil)
 
 	// model assertion in device context
-	model := fakeMyModel(map[string]interface{}{
+	model := fakeMyModel(map[string]any{
 		"architecture": "amd64",
 		"classic":      "true",
 		"grade":        "dangerous",
 		"distribution": "ubuntu",
 		"base":         "core22",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "22",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -1060,7 +1060,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnCore(c *C) {
 		Brand: "canonical",
 		Model: "pc",
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1100,7 +1100,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshNoSerialFallback(c *C) {
 		Brand: "canonical",
 		Model: "pc",
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1140,7 +1140,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnClassic(c *C) {
 		Brand: "canonical",
 		Model: "pc",
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"classic": "true",
 	})
 	c.Check(canAutoRefresh(), Equals, false)
@@ -1460,7 +1460,7 @@ func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC18(c *C) {
 	defer s.state.Unlock()
 
 	// have a model
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1809,7 +1809,7 @@ func (s *deviceMgrSuite) TestHasFdeSetupHook(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1839,7 +1839,7 @@ func (s *deviceMgrSuite) TestHasFdeSetupHookOtherKernel(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1867,7 +1867,7 @@ func (s *deviceMgrSuite) TestRunFDESetupHookHappy(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1923,7 +1923,7 @@ func (s *deviceMgrSuite) TestRunFDESetupHookErrors(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -1958,7 +1958,7 @@ func (s *deviceMgrSuite) TestRunFDESetupHookErrorResult(c *C) {
 
 	st.Lock()
 	makeInstalledMockKernelSnap(c, st, kernelYamlWithFdeSetup)
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2104,7 +2104,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshNTP(c *C) {
 
 	// CanAutoRefresh is ready
 	s.state.Set("seeded", true)
-	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2571,30 +2571,30 @@ volumes:
 	makeSnap("pc=20")
 	optSnapPath := snaptest.MakeTestSnapWithFiles(c, seedtest.SampleSnapYaml["optional20-a"], nil)
 
-	model := map[string]interface{}{
+	model := map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              seed20.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              seed20.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   seed20.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   seed20.AssertedSnapID("core20"),
 				"type": "base",
@@ -2827,7 +2827,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlNoSerial(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_, err := s.mgr.SignConfdbControl([]interface{}{}, 2)
+	_, err := s.mgr.SignConfdbControl([]any{}, 2)
 	c.Assert(err, ErrorMatches, "cannot sign confdb-control without a serial")
 }
 
@@ -2838,7 +2838,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlNoKey(c *C) {
 
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
 
-	_, err := s.mgr.SignConfdbControl([]interface{}{}, 3)
+	_, err := s.mgr.SignConfdbControl([]any{}, 3)
 	c.Assert(err, ErrorMatches, "cannot sign confdb-control without device key")
 }
 
@@ -2850,7 +2850,7 @@ func (s *deviceMgrSuite) TestSignConfdbControlInvalid(c *C) {
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
 	s.addKeyToManagerInState(c)
 
-	groups := []interface{}{map[string]interface{}{"operators": []interface{}{"jane"}}}
+	groups := []any{map[string]any{"operators": []any{"jane"}}}
 	_, err := s.mgr.SignConfdbControl(groups, 4)
 	c.Assert(
 		err,
@@ -2867,15 +2867,15 @@ func (s *deviceMgrSuite) TestSignConfdbControlOK(c *C) {
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
 	s.addKeyToManagerInState(c)
 
-	jane := map[string]interface{}{
-		"operators":       []interface{}{"jane"},
-		"authentications": []interface{}{"operator-key"},
-		"views": []interface{}{
+	jane := map[string]any{
+		"operators":       []any{"jane"},
+		"authentications": []any{"operator-key"},
+		"views": []any{
 			"canonical/network/observe-interfaces",
 			"canonical/network/control-interfaces",
 		},
 	}
-	groups := []interface{}{jane}
+	groups := []any{jane}
 
 	cc, err := s.mgr.SignConfdbControl(groups, 5)
 	c.Assert(err, IsNil)
@@ -2914,7 +2914,7 @@ func (s *deviceMgrSuite) TestConfbControlUnknownSigningKey(c *C) {
 	s.makeSerialAssertionInState(c, "canonical", "pc", "serialserialserial")
 	s.addKeyToManagerInState(c)
 
-	cc, err := s.mgr.SignConfdbControl([]interface{}{}, 10)
+	cc, err := s.mgr.SignConfdbControl([]any{}, 10)
 	c.Assert(err, IsNil)
 	assertstatetest.AddMany(s.state, cc)
 
@@ -2923,7 +2923,7 @@ func (s *deviceMgrSuite) TestConfbControlUnknownSigningKey(c *C) {
 	encDevKey, err := asserts.EncodePublicKey(anotherKey.PublicKey())
 	c.Assert(err, IsNil)
 
-	serial, err := s.brands.Signing("canonical").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.brands.Signing("canonical").Sign(asserts.SerialType, map[string]any{
 		"brand-id":            "canonical",
 		"model":               "pc",
 		"serial":              "serialserialserial",
@@ -2951,7 +2951,7 @@ func (s *deviceMgrSuite) TestConfdbControlFindExisting(c *C) {
 	s.addKeyToManagerInState(c)
 
 	// add assertion
-	cc, err := s.mgr.SignConfdbControl([]interface{}{}, 10)
+	cc, err := s.mgr.SignConfdbControl([]any{}, 10)
 	c.Assert(err, IsNil)
 	assertstatetest.AddMany(s.state, cc)
 

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -329,7 +329,7 @@ func (s *usersSuite) TestUserActionRemoveNoUsername(c *check.C) {
 
 func (s *usersSuite) setupSigner(accountID string, signerPrivKey asserts.PrivateKey) *assertstest.SigningDB {
 
-	signerSigning := s.brands.Register(accountID, signerPrivKey, map[string]interface{}{
+	signerSigning := s.brands.Register(accountID, signerPrivKey, map[string]any{
 		"account-id":   accountID,
 		"verification": "verified",
 	})
@@ -346,7 +346,7 @@ var (
 	unknownPrivKey, _ = assertstest.GenerateKey(752)
 )
 
-func (s *usersSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interface{}) {
+func (s *usersSuite) makeSystemUsers(c *check.C, systemUsers []map[string]any) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -356,12 +356,12 @@ func (s *usersSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interf
 	s.setupSigner("partner", partnerPrivKey)
 	s.setupSigner("unknown", unknownPrivKey)
 
-	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.brands.Model("my-brand", "my-model", map[string]any{
 		"architecture":          "amd64",
 		"gadget":                "pc",
 		"kernel":                "pc-kernel",
-		"required-snaps":        []interface{}{"required-snap1"},
-		"system-user-authority": []interface{}{"my-brand", "partner"},
+		"required-snaps":        []any{"required-snap1"},
+		"system-user-authority": []any{"my-brand", "partner"},
 	})
 	// now add model related stuff to the system
 	assertstatetest.AddMany(s.state, model)
@@ -369,7 +369,7 @@ func (s *usersSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interf
 	deviceKey, _ := assertstest.GenerateKey(752)
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, check.IsNil)
-	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]any{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-model",
@@ -397,12 +397,12 @@ func (s *usersSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interf
 	c.Assert(err, check.IsNil)
 }
 
-var goodUser = map[string]interface{}{
+var goodUser = map[string]any{
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "foo@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model", "other-model"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model", "other-model"},
 	"name":         "Boring Guy",
 	"username":     "guy",
 	"password":     "$6$salt$hash",
@@ -410,12 +410,12 @@ var goodUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var partnerUser = map[string]interface{}{
+var partnerUser = map[string]any{
 	"authority-id": "partner",
 	"brand-id":     "my-brand",
 	"email":        "p@partner.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
 	"name":         "Partner Guy",
 	"username":     "partnerguy",
 	"password":     "$6$salt$hash",
@@ -423,14 +423,14 @@ var partnerUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var serialUser = map[string]interface{}{
+var serialUser = map[string]any{
 	"format":       "1",
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "serial@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
-	"serials":      []interface{}{"serialserial"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
+	"serials":      []any{"serialserial"},
 	"name":         "Serial Guy",
 	"username":     "goodserialguy",
 	"password":     "$6$salt$hash",
@@ -438,13 +438,13 @@ var serialUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var badUser = map[string]interface{}{
+var badUser = map[string]any{
 	// bad user (not valid for this model)
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "foobar@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"non-of-the-models-i-have"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"non-of-the-models-i-have"},
 	"name":         "Random Gal",
 	"username":     "gal",
 	"password":     "$6$salt$hash",
@@ -452,14 +452,14 @@ var badUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var badUserNoMatchingSerial = map[string]interface{}{
+var badUserNoMatchingSerial = map[string]any{
 	"format":       "1",
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "noserial@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
-	"serials":      []interface{}{"different-serialserial"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
+	"serials":      []any{"different-serialserial"},
 	"name":         "No Serial Guy",
 	"username":     "noserial",
 	"password":     "$6$salt$hash",
@@ -467,12 +467,12 @@ var badUserNoMatchingSerial = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var unknownUser = map[string]interface{}{
+var unknownUser = map[string]any{
 	"authority-id": "unknown",
 	"brand-id":     "my-brand",
 	"email":        "x@partner.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model"},
 	"name":         "XGuy",
 	"username":     "xguy",
 	"password":     "$6$salt$hash",
@@ -480,13 +480,13 @@ var unknownUser = map[string]interface{}{
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-var expireUser = map[string]interface{}{
+var expireUser = map[string]any{
 	"format":        "2",
 	"authority-id":  "my-brand",
 	"brand-id":      "my-brand",
 	"email":         "foo@bar.com",
-	"series":        []interface{}{"16", "18"},
-	"models":        []interface{}{"my-model", "other-model"},
+	"series":        []any{"16", "18"},
+	"models":        []any{"my-model", "other-model"},
 	"name":          "Boring Guy",
 	"username":      "guy",
 	"password":      "$6$salt$hash",
@@ -496,7 +496,7 @@ var expireUser = map[string]interface{}{
 }
 
 func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	s.state.Lock()
 	model, err := s.mgr.Model()
@@ -517,12 +517,12 @@ func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 }
 
 func (s *usersSuite) TestCreateUserFromAssertion(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 	s.createUserFromAssertion(c, false)
 }
 
 func (s *usersSuite) TestCreateUserExpireFromAssertion(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{expireUser})
+	s.makeSystemUsers(c, []map[string]any{expireUser})
 	users := s.createUserFromAssertion(c, false)
 	c.Assert(len(users), check.Equals, 1)
 	until, err := time.Parse(time.RFC3339, expireUser["until"].(string))
@@ -531,12 +531,12 @@ func (s *usersSuite) TestCreateUserExpireFromAssertion(c *check.C) {
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionWithForcePasswordChange(c *check.C) {
-	user := make(map[string]interface{})
+	user := make(map[string]any)
 	for k, v := range goodUser {
 		user[k] = v
 	}
 	user["force-password-change"] = "true"
-	lusers := []map[string]interface{}{user}
+	lusers := []map[string]any{user}
 	s.makeSystemUsers(c, lusers)
 	s.createUserFromAssertion(c, true)
 }
@@ -594,7 +594,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllAutomatic(c *check.C) {
 }
 
 func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, expectSudoer bool) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
 	created := map[string]bool{}
 
 	// mock the calls that create the user
@@ -677,7 +677,7 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{expireUser})
+	s.makeSystemUsers(c, []map[string]any{expireUser})
 	created := map[string]bool{}
 
 	// mock the calls that create the user
@@ -749,7 +749,7 @@ func (s *usersSuite) TestCreateUserFromAssertionNoSerial(c *check.C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	s.makeSystemUsers(c, []map[string]interface{}{serialUser})
+	s.makeSystemUsers(c, []map[string]any{serialUser})
 
 	s.state.Lock()
 	err := devicestatetest.SetDevice(s.state, &auth.DeviceState{
@@ -775,7 +775,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 	defer restore()
 
 	// initialize device, and add system-user assertion for serialUser
-	s.makeSystemUsers(c, []map[string]interface{}{serialUser})
+	s.makeSystemUsers(c, []map[string]any{serialUser})
 
 	created := map[string]bool{}
 
@@ -868,7 +868,7 @@ func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	s.makeSystemUsers(c, []map[string]interface{}{serialUser})
+	s.makeSystemUsers(c, []map[string]any{serialUser})
 
 	s.state.Lock()
 	err := devicestatetest.SetDevice(s.state, &auth.DeviceState{
@@ -890,7 +890,7 @@ func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	s.state.Lock()
 	_, err := auth.NewUser(s.state, auth.NewUserParams{
@@ -939,7 +939,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllKnownButSkipExists(c *check.C) {
-	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
+	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	s.state.Lock()
 	_, err := auth.NewUser(s.state, auth.NewUserParams{

--- a/overlord/devicestate/devicestatetest/devicesvc.go
+++ b/overlord/devicestate/devicestatetest/devicesvc.go
@@ -45,7 +45,7 @@ type DeviceServiceBehavior struct {
 	Head          func(c *C, bhv *DeviceServiceBehavior, w http.ResponseWriter, r *http.Request)
 	PostPreflight func(c *C, bhv *DeviceServiceBehavior, w http.ResponseWriter, r *http.Request)
 
-	SignSerial func(c *C, bhv *DeviceServiceBehavior, headers map[string]interface{}, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error)
+	SignSerial func(c *C, bhv *DeviceServiceBehavior, headers map[string]any, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error)
 }
 
 // Request IDs for hard-coded behaviors.
@@ -224,7 +224,7 @@ func MockDeviceService(c *C, bhv *DeviceServiceBehavior) (mockServer *httptest.S
 				c.Check(mod.BrandID(), Equals, brandID)
 				c.Check(mod.Model(), Equals, model)
 			}
-			serial, ancillary, err := bhv.SignSerial(c, bhv, map[string]interface{}{
+			serial, ancillary, err := bhv.SignSerial(c, bhv, map[string]any{
 				"authority-id":        "canonical",
 				"brand-id":            brandID,
 				"model":               model,

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -624,19 +624,19 @@ snaps:
 	c.Check(seedTime.IsZero(), Equals, false)
 
 	// verify that connections was made
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(st.Get("conns", &conns), IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"foo:network core:network": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"foo:network core:network": map[string]any{
 			"auto": true, "interface": "network"},
-		"foo:shared-data-plug bar:shared-data-slot": map[string]interface{}{
+		"foo:shared-data-plug bar:shared-data-slot": map[string]any{
 			"auto": true, "interface": "content",
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"content": "mylib", "target": "import",
 			},
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"content": "mylib",
-				"read": []interface{}{
+				"read": []any{
 					"/",
 				},
 			},

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -108,11 +108,11 @@ func (t *firstBootBaseTest) setupBaseTest(c *C, s *seedtest.SeedSnaps) {
 	t.AddCleanup(t.systemctl.Restore)
 
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 
-	t.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
+	t.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]any{
 		"account-id": "developerid",
 	}, "")
 
@@ -216,8 +216,8 @@ func checkTrivialSeeding(c *C, tsAll []*state.TaskSet) {
 	c.Check(tasks[0].Kind(), Equals, "mark-seeded")
 }
 
-func modelHeaders(modelStr string, reqSnaps ...string) map[string]interface{} {
-	headers := map[string]interface{}{
+func modelHeaders(modelStr string, reqSnaps ...string) map[string]any {
+	headers := map[string]any{
 		"architecture": "amd64",
 		"store":        "canonical",
 	}
@@ -227,14 +227,14 @@ func modelHeaders(modelStr string, reqSnaps ...string) map[string]interface{} {
 		headers["classic"] = "true"
 		headers["distribution"] = "ubuntu"
 		headers["base"] = "core22"
-		headers["snaps"] = []interface{}{
-			map[string]interface{}{
+		headers["snaps"] = []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "22",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -246,7 +246,7 @@ func modelHeaders(modelStr string, reqSnaps ...string) map[string]interface{} {
 		headers["gadget"] = "pc"
 	}
 	if len(reqSnaps) != 0 {
-		reqs := make([]interface{}, len(reqSnaps))
+		reqs := make([]any, len(reqSnaps))
 		for i, req := range reqSnaps {
 			reqs[i] = req
 		}
@@ -255,7 +255,7 @@ func modelHeaders(modelStr string, reqSnaps ...string) map[string]interface{} {
 	return headers
 }
 
-func (s *firstBoot16BaseTest) makeModelAssertionChain(c *C, modName string, extraHeaders map[string]interface{}, reqSnaps ...string) []asserts.Assertion {
+func (s *firstBoot16BaseTest) makeModelAssertionChain(c *C, modName string, extraHeaders map[string]any, reqSnaps ...string) []asserts.Assertion {
 	return s.MakeModelAssertionChain("my-brand", modName, modelHeaders(modName, reqSnaps...), extraHeaders)
 }
 
@@ -1100,12 +1100,12 @@ snaps:
 	c.Check(pubAcct.AccountID(), Equals, "developerid")
 
 	// check connection
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, HasLen, 1)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"foo:network-control core:network-control": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"foo:network-control core:network-control": map[string]any{
 			"interface": "network-control", "auto": true, "by-gadget": true,
 		},
 	})
@@ -1429,7 +1429,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedWithBaseHappy(c *C) {
 	s.WriteAssertions("developer.account", s.devAcct)
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]interface{}{"base": "core18"})
+	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]any{"base": "core18"})
 	s.WriteAssertions("model.asserts", assertsChain...)
 
 	// create a seed.yaml
@@ -1533,7 +1533,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOrdering(c *C) {
 	s.WriteAssertions("developer.account", s.devAcct)
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]interface{}{"base": "core18"})
+	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]any{"base": "core18"})
 	s.WriteAssertions("model.asserts", assertsChain...)
 
 	core18Fname, snapdFname, kernelFname, gadgetFname := s.makeCore18Snaps(c, nil)
@@ -1585,7 +1585,7 @@ func (s *firstBoot16Suite) TestFirstbootGadgetBaseModelBaseMismatch(c *C) {
 	s.WriteAssertions("developer.account", s.devAcct)
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]interface{}{"base": "core18"})
+	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]any{"base": "core18"})
 	s.WriteAssertions("model.asserts", assertsChain...)
 
 	core18Fname, snapdFname, kernelFname, _ := s.makeCore18Snaps(c, nil)
@@ -1701,14 +1701,14 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// verify the result
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = st.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, HasLen, 1)
 	conn, hasConn := conns["gnome-calculator:gtk-3-themes gtk-common-themes:gtk-3-themes"]
 	c.Check(hasConn, Equals, true)
-	c.Check(conn.(map[string]interface{})["auto"], Equals, true)
-	c.Check(conn.(map[string]interface{})["interface"], Equals, "content")
+	c.Check(conn.(map[string]any)["auto"], Equals, true)
+	c.Check(conn.(map[string]any)["interface"], Equals, "content")
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedAlternativeContentProviderAndOrder(c *C) {
@@ -1796,14 +1796,14 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// verify the result
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = st.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, HasLen, 1)
 	conn, hasConn := conns["gnome-calculator:gtk-3-themes gtk-common-themes-alt:gtk-3-themes"]
 	c.Check(hasConn, Equals, true)
-	c.Check(conn.(map[string]interface{})["auto"], Equals, true)
-	c.Check(conn.(map[string]interface{})["interface"], Equals, "content")
+	c.Check(conn.(map[string]any)["auto"], Equals, true)
+	c.Check(conn.(map[string]any)["interface"], Equals, "content")
 
 	c.Check(logbuf.String(), Matches, `(?sm).*seed prerequisites: snap "gnome-calculator" requires a provider for content "gtk-3-themes", a candidate slot is available \(gtk-common-themes-alt:gtk-3-themes\) but not the default-provider, ensure a single auto-connection \(or possibly a connection\) is in-place.*`)
 }
@@ -2015,7 +2015,7 @@ base: core18
 	s.WriteAssertions("foo.asserts", s.devAcct, fooRev, fooDecl)
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model-classic", map[string]interface{}{"gadget": "pc"})
+	assertsChain := s.makeModelAssertionChain(c, "my-model-classic", map[string]any{"gadget": "pc"})
 	s.WriteAssertions("model.asserts", assertsChain...)
 
 	// create a seed.yaml
@@ -2281,19 +2281,19 @@ snaps:
 	c.Check(hooksCalled[0].HookName(), Equals, "connect-plug-network")
 
 	// verify that connections was made
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(st.Get("conns", &conns), IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"foo:network snapd:network": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"foo:network snapd:network": map[string]any{
 			"auto": true, "interface": "network"},
-		"foo:shared-data-plug bar:shared-data-slot": map[string]interface{}{
+		"foo:shared-data-plug bar:shared-data-slot": map[string]any{
 			"auto": true, "interface": "content",
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"content": "mylib", "target": "import",
 			},
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"content": "mylib",
-				"read": []interface{}{
+				"read": []any{
 					"/",
 				},
 			},
@@ -2317,13 +2317,13 @@ func (s *firstBoot16Suite) mockServer(c *C, reqID string) *httptest.Server {
 	return mockServer
 }
 
-func (s *firstBoot16Suite) signSerial(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]interface{}, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
+func (s *firstBoot16Suite) signSerial(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]any, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
 	signing := assertstest.NewStoreStack("canonical", nil)
 	a, err := signing.Sign(asserts.SerialType, headers, body, "")
 	return a, nil, err
 }
 
-func (s *firstBoot16Suite) testPopulateFromSeedCore18ValidationSetTracking(c *C, vsAsserts []asserts.Assertion, vsHeaders []interface{}) *state.Change {
+func (s *firstBoot16Suite) testPopulateFromSeedCore18ValidationSetTracking(c *C, vsAsserts []asserts.Assertion, vsHeaders []any) *state.Change {
 	var sysdLog [][]string
 	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
@@ -2342,7 +2342,7 @@ func (s *firstBoot16Suite) testPopulateFromSeedCore18ValidationSetTracking(c *C,
 	core18Fname, snapdFname, kernelFname, gadgetFname := s.makeCore18Snaps(c, &core18SnapsOpts{})
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]interface{}{"base": "core18", "validation-sets": vsHeaders})
+	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]any{"base": "core18", "validation-sets": vsHeaders})
 	s.WriteAssertions("model.asserts", assertsChain...)
 
 	// write validation set assertions
@@ -2383,7 +2383,7 @@ snaps:
 	expectedSeqs := make(map[string]int)
 	expectedVss := make(map[string][]string)
 	for _, vs := range vsHeaders {
-		hdrs := vs.(map[string]interface{})
+		hdrs := vs.(map[string]any)
 		seq, err := strconv.Atoi(hdrs["sequence"].(string))
 		c.Assert(err, IsNil)
 		key := fmt.Sprintf("%s/%s/%s", release.Series, hdrs["account-id"].(string), hdrs["name"].(string))
@@ -2428,21 +2428,21 @@ snaps:
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingHappy(c *C) {
-	a, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	a, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "base-set",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       s.AssertedSnapID("pc-kernel"),
 				"presence": "required",
 				"revision": "1",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       s.AssertedSnapID("pc"),
 				"presence": "required",
@@ -2453,13 +2453,13 @@ func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingHappy(
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"account-id": "canonical",
 		"name":       "base-set",
 		"sequence":   "1",
 		"mode":       "enforce",
 	}
-	chg := s.testPopulateFromSeedCore18ValidationSetTracking(c, []asserts.Assertion{a}, []interface{}{headers})
+	chg := s.testPopulateFromSeedCore18ValidationSetTracking(c, []asserts.Assertion{a}, []any{headers})
 
 	s.overlord.State().Lock()
 	defer s.overlord.State().Unlock()
@@ -2479,22 +2479,22 @@ func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingHappy(
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingUnmetCriteria(c *C) {
-	a, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	a, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "base-set",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       s.AssertedSnapID("pc-kernel"),
 				"presence": "required",
 				// Set required revision of pc-kernel to 7, this should make it fail
 				"revision": "7",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       s.AssertedSnapID("pc"),
 				"presence": "required",
@@ -2505,13 +2505,13 @@ func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingUnmetC
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"account-id": "canonical",
 		"name":       "base-set",
 		"sequence":   "1",
 		"mode":       "enforce",
 	}
-	chg := s.testPopulateFromSeedCore18ValidationSetTracking(c, []asserts.Assertion{a}, []interface{}{headers})
+	chg := s.testPopulateFromSeedCore18ValidationSetTracking(c, []asserts.Assertion{a}, []any{headers})
 
 	st := s.overlord.State()
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1329,7 +1329,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 	}
 
 	// Store created devices in the change so they can be accessed from the installer
-	apiData := map[string]interface{}{
+	apiData := map[string]any{
 		"encrypted-devices": encryptionSetupData.EncryptedDevices(),
 	}
 	chg := t.Change()

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -169,7 +169,7 @@ func (m *DeviceManager) doSetModel(t *state.Task, _ *tomb.Tomb) (err error) {
 		remodCtx.setRecoverySystemLabel(recoverySetup.Label)
 	}
 
-	logEverywhere := func(format string, args ...interface{}) {
+	logEverywhere := func(format string, args ...any) {
 		t.Logf(format, args)
 		logger.Noticef(format, args)
 	}

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -182,7 +182,7 @@ type registrationContext interface {
 	Model() *asserts.Model
 
 	GadgetForSerialRequestConfig() string
-	SerialRequestExtraHeaders() map[string]interface{}
+	SerialRequestExtraHeaders() map[string]any
 	SerialRequestAncillaryAssertions() []asserts.Assertion
 
 	FinishRegistration(serial *asserts.Serial) error
@@ -214,7 +214,7 @@ func (rc *initialRegistrationContext) GadgetForSerialRequestConfig() string {
 	return rc.model.Gadget()
 }
 
-func (rc *initialRegistrationContext) SerialRequestExtraHeaders() map[string]interface{} {
+func (rc *initialRegistrationContext) SerialRequestExtraHeaders() map[string]any {
 	return nil
 }
 
@@ -270,7 +270,7 @@ type requestIDResp struct {
 	RequestID string `json:"request-id"`
 }
 
-func retryErr(t *state.Task, nTentatives int, reason string, a ...interface{}) error {
+func retryErr(t *state.Task, nTentatives int, reason string, a ...any) error {
 	t.State().Lock()
 	defer t.State().Unlock()
 	if nTentatives >= maxTentatives {
@@ -394,7 +394,7 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 
 	}
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"brand-id":   device.Brand,
 		"model":      device.Model,
 		"request-id": requestID.RequestID,

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -61,12 +61,12 @@ func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 		Brand: "canonical",
 		Model: "pc-model",
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo", "bar"},
+		"required-snaps": []any{"foo", "bar"},
 	})
 	// foo and bar
 	fooSI := &snap.SideInfo{
@@ -104,12 +104,12 @@ func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 	})
 	s.state.Unlock()
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "other-kernel",
 		"gadget":         "pc",
 		"revision":       "2",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	s.state.Lock()
@@ -154,18 +154,18 @@ func (s *deviceMgrSuite) TestSetModelHandlerValidationSets(c *C) {
 		Brand: accountID,
 		Model: "pc-model",
 	})
-	s.makeModelAssertionInState(c, accountID, "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, accountID, "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -189,15 +189,15 @@ func (s *deviceMgrSuite) TestSetModelHandlerValidationSets(c *C) {
 
 	signer := s.brands.Signing(accountID)
 
-	vsetOne, err := signer.Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetOne, err := signer.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": accountID,
 		"series":       "16",
 		"account-id":   accountID,
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-1",
 				"id":       snaptest.AssertedSnapID("snap-1"),
 				"presence": "optional",
@@ -209,15 +209,15 @@ func (s *deviceMgrSuite) TestSetModelHandlerValidationSets(c *C) {
 
 	assertstate.Add(s.state, vsetOne)
 
-	vsetTwo, err := signer.Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetTwo, err := signer.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": accountID,
 		"series":       "16",
 		"account-id":   accountID,
 		"name":         "vset-2",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-2",
 				"id":       snaptest.AssertedSnapID("snap-2"),
 				"presence": "optional",
@@ -229,32 +229,32 @@ func (s *deviceMgrSuite) TestSetModelHandlerValidationSets(c *C) {
 
 	assertstate.Add(s.state, vsetTwo)
 
-	newModel := s.brands.Model(accountID, "pc-model", map[string]interface{}{
+	newModel := s.brands.Model(accountID, "pc-model", map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
 		"revision":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
 		},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": accountID,
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": accountID,
 				"name":       "vset-2",
 				"sequence":   "2",
@@ -315,7 +315,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerValidationSets(c *C) {
 }
 
 func (s *deviceMgrSuite) TestSetModelHandlerSameRevisionNoError(c *C) {
-	model := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -352,7 +352,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerStoreSwitch(c *C) {
 		Brand: "canonical",
 		Model: "pc-model",
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -360,7 +360,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerStoreSwitch(c *C) {
 	})
 	s.state.Unlock()
 
-	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -431,7 +431,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerRereg(c *C) {
 		Model:  "pc-model",
 		Serial: "orig-serial",
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -439,7 +439,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerRereg(c *C) {
 	s.makeSerialAssertionInState(c, "canonical", "pc-model", "orig-serial")
 	s.state.Unlock()
 
-	newModel := s.brands.Model("canonical", "rereg-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "rereg-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -524,7 +524,7 @@ func (s *deviceMgrSuite) TestDoPrepareRemodeling(c *C) {
 	defer restore()
 
 	// set a model assertion
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -538,12 +538,12 @@ func (s *deviceMgrSuite) TestDoPrepareRemodeling(c *C) {
 		SessionMacaroon: "old-session",
 	})
 
-	new := s.brands.Model("canonical", "rereg-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "rereg-model", map[string]any{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",
 		"base":           "core18",
-		"required-snaps": []interface{}{"new-required-snap-1", "new-required-snap-2"},
+		"required-snaps": []any{"new-required-snap-1", "new-required-snap-2"},
 	})
 
 	freshStore := &freshSessionStore{}
@@ -725,7 +725,7 @@ func (s *preseedingClassicSuite) TestDoMarkPreseeded(c *C) {
 	c.Assert(st.Get("preseeded", &preseeded), IsNil)
 	c.Check(preseeded, Equals, true)
 
-	var systemKey map[string]interface{}
+	var systemKey map[string]any
 	c.Assert(st.Get("seed-restart-system-key", &systemKey), testutil.ErrorIs, state.ErrNoState)
 	c.Assert(st.Get("preseed-system-key", &systemKey), IsNil)
 	c.Check(systemKey["build-id"], Equals, "abcde")
@@ -807,7 +807,7 @@ func (s *preseedingClassicDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {
 	c.Check(s.cmdUmount.Calls(), HasLen, 0)
 	c.Check(s.restartRequests, HasLen, 0)
 
-	var systemKey map[string]interface{}
+	var systemKey map[string]any
 	// in real world preseed-system-key would be present at this point because
 	// mark-preseeded would be run twice (before & after preseeding); this is
 	// not the case in this test.
@@ -864,30 +864,30 @@ volumes:
 	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["core20"], nil, snap.R(1), "canonical", s.StoreSigning.Database)
 	s.MakeAssertedSnap(c, seedtest.SampleSnapYaml["pc=20"], [][]string{{"meta/gadget.yaml", gadgetYaml}}, snap.R(1), "canonical", s.StoreSigning.Database)
 
-	model := map[string]interface{}{
+	model := map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.AssertedSnapID("core20"),
 				"type": "base",
@@ -912,7 +912,7 @@ func (s *preseedingUC20Suite) TestEarlyPreloadGadgetPicksSystemOnCore20(c *C) {
 	defer restore()
 
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 	_ = s.setupCore20Seed(c, "20220108")

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -523,8 +523,8 @@ func (rc *reregRemodelContext) GadgetForSerialRequestConfig() string {
 	return rc.origModel.Gadget()
 }
 
-func (rc *reregRemodelContext) SerialRequestExtraHeaders() map[string]interface{} {
-	return map[string]interface{}{
+func (rc *reregRemodelContext) SerialRequestExtraHeaders() map[string]any {
+	return map[string]any{
 		"original-brand-id": rc.origSerial.BrandID(),
 		"original-model":    rc.origSerial.Model(),
 		"original-serial":   rc.origSerial.Serial(),

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -109,16 +109,16 @@ type remodelLogicSuite struct {
 
 var _ = Suite(&remodelLogicSuite{})
 
-var modelDefaults = map[string]interface{}{
+var modelDefaults = map[string]any{
 	"architecture":   "amd64",
 	"kernel":         "my-brand-kernel",
 	"gadget":         "my-brand-gadget",
 	"store":          "my-brand-store",
-	"required-snaps": []interface{}{"required1"},
+	"required-snaps": []any{"required1"},
 }
 
-func fakeRemodelingModel(extra map[string]interface{}) *asserts.Model {
-	primary := map[string]interface{}{
+func fakeRemodelingModel(extra map[string]any) *asserts.Model {
+	primary := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -132,34 +132,34 @@ func (s *remodelLogicSuite) TestClassifyRemodel(c *C) {
 	oldModel := fakeRemodelingModel(nil)
 
 	cases := []struct {
-		newHeaders map[string]interface{}
+		newHeaders map[string]any
 		kind       devicestate.RemodelKind
 	}{
-		{map[string]interface{}{}, devicestate.UpdateRemodel},
-		{map[string]interface{}{
-			"required-snaps": []interface{}{"required1", "required2"},
+		{map[string]any{}, devicestate.UpdateRemodel},
+		{map[string]any{
+			"required-snaps": []any{"required1", "required2"},
 			"revision":       "1",
 		}, devicestate.UpdateRemodel},
-		{map[string]interface{}{
+		{map[string]any{
 			"store":    "my-other-store",
 			"revision": "1",
 		}, devicestate.StoreSwitchRemodel},
-		{map[string]interface{}{
+		{map[string]any{
 			"model": "my-other-model",
 			"store": "my-other-store",
 		}, devicestate.ReregRemodel},
-		{map[string]interface{}{
+		{map[string]any{
 			"authority-id": "other-brand",
 			"brand-id":     "other-brand",
 			"model":        "other-model",
 		}, devicestate.ReregRemodel},
-		{map[string]interface{}{
+		{map[string]any{
 			"authority-id":   "other-brand",
 			"brand-id":       "other-brand",
 			"model":          "other-model",
-			"required-snaps": []interface{}{"other-required1"},
+			"required-snaps": []any{"other-required1"},
 		}, devicestate.ReregRemodel},
-		{map[string]interface{}{
+		{map[string]any{
 			"authority-id": "other-brand",
 			"brand-id":     "other-brand",
 			"model":        "other-model",
@@ -175,8 +175,8 @@ func (s *remodelLogicSuite) TestClassifyRemodel(c *C) {
 
 func (s *remodelLogicSuite) TestUpdateRemodelContext(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
-		"required-snaps": []interface{}{"required1", "required2"},
+	newModel := fakeRemodelingModel(map[string]any{
+		"required-snaps": []any{"required1", "required2"},
 		"revision":       "1",
 	})
 
@@ -209,7 +209,7 @@ func (s *remodelLogicSuite) TestUpdateRemodelContext(c *C) {
 
 func (s *remodelLogicSuite) TestNewStoreRemodelContextInit(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -257,7 +257,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextInit(c *C) {
 
 func (s *remodelLogicSuite) TestRemodelDeviceBackendNoChangeYet(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -318,7 +318,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendNoChangeYet(c *C) {
 
 func (s *remodelLogicSuite) TestRemodelDeviceBackend(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -377,7 +377,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackend(c *C) {
 
 func (s *remodelLogicSuite) TestRemodelDeviceBackendIsolation(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -422,7 +422,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendIsolation(c *C) {
 }
 func (s *remodelLogicSuite) TestNewStoreRemodelContextStore(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -465,7 +465,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextStore(c *C) {
 
 func (s *remodelLogicSuite) TestNewStoreRemodelContextFinish(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -516,7 +516,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextFinish(c *C) {
 
 func (s *remodelLogicSuite) TestNewStoreRemodelContextFinishVsGlobalUpdateDeviceAuth(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -588,7 +588,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextFinishVsGlobalUpdateDevice
 
 func (s *remodelLogicSuite) TestRemodelDeviceBackendKeptSerial(c *C) {
 	oldModel := fakeRemodelingModel(nil)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -629,7 +629,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendKeptSerial(c *C) {
 
 func (s *remodelLogicSuite) TestRemodelContextSystemModeDefaultRun(c *C) {
 	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
-	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{"revision": "2"})
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{"revision": "2"})
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -648,7 +648,7 @@ func (s *remodelLogicSuite) TestRemodelContextSystemModeDefaultRun(c *C) {
 
 func (s *remodelLogicSuite) TestRemodelContextSystemModeWorks(c *C) {
 	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
-	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{"revision": "2"})
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{"revision": "2"})
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -668,7 +668,7 @@ func (s *remodelLogicSuite) TestRemodelContextSystemModeWorks(c *C) {
 
 func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
 	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
-	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
@@ -736,7 +736,7 @@ func (s *remodelLogicSuite) TestRemodelContextForTaskNo(c *C) {
 
 func (s *remodelLogicSuite) setupForRereg(c *C) (oldModel, newModel *asserts.Model) {
 	oldModel = s.brands.Model("my-brand", "my-model", modelDefaults)
-	newModel = s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+	newModel = s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{
 		"authority-id": "other-brand",
 		"brand-id":     "other-brand",
 		"model":        "other-model",
@@ -748,7 +748,7 @@ func (s *remodelLogicSuite) setupForRereg(c *C) (oldModel, newModel *asserts.Mod
 
 	encDevKey, err := asserts.EncodePublicKey(devKey.PublicKey())
 	c.Assert(err, IsNil)
-	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]any{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-model",
@@ -852,7 +852,7 @@ func (s *remodelLogicSuite) TestReregRemodelContextAsRegistrationContext(c *C) {
 		KeyID: "device-key-id",
 	})
 	c.Check(regCtx.GadgetForSerialRequestConfig(), Equals, "my-brand-gadget")
-	c.Check(regCtx.SerialRequestExtraHeaders(), DeepEquals, map[string]interface{}{
+	c.Check(regCtx.SerialRequestExtraHeaders(), DeepEquals, map[string]any{
 		"original-brand-id": "my-brand",
 		"original-model":    "my-model",
 		"original-serial":   "orig-serial",
@@ -866,7 +866,7 @@ func (s *remodelLogicSuite) TestReregRemodelContextAsRegistrationContext(c *C) {
 func (s *remodelLogicSuite) TestReregRemodelContextNewSerial(c *C) {
 	// re-registration case
 	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
-	newModel := fakeRemodelingModel(map[string]interface{}{
+	newModel := fakeRemodelingModel(map[string]any{
 		"model": "other-model",
 	})
 
@@ -1014,18 +1014,18 @@ func (s *uc20RemodelLogicSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 }
 
-var uc20ModelDefaults = map[string]interface{}{
+var uc20ModelDefaults = map[string]any{
 	"architecture": "amd64",
 	"base":         "core20",
 	"grade":        "dangerous",
-	"snaps": []interface{}{
-		map[string]interface{}{
+	"snaps": []any{
+		map[string]any{
 			"name":            "pc-kernel",
 			"id":              snaptest.AssertedSnapID("pc-kernel"),
 			"type":            "kernel",
 			"default-channel": "20",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":            "pc",
 			"id":              snaptest.AssertedSnapID("pc"),
 			"type":            "gadget",
@@ -1129,11 +1129,11 @@ func (s *uc20RemodelLogicSuite) TestReregRemodelContextUC20(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(resealKeysCalls, Equals, 2)
 
-	var seededSystemsFromState []map[string]interface{}
+	var seededSystemsFromState []map[string]any
 	err = s.state.Get("seeded-systems", &seededSystemsFromState)
 	c.Assert(err, IsNil)
 	c.Assert(seededSystemsFromState, HasLen, 2)
-	c.Assert(seededSystemsFromState[1], DeepEquals, map[string]interface{}{
+	c.Assert(seededSystemsFromState[1], DeepEquals, map[string]any{
 		"system":    "0000",
 		"model":     "my-model",
 		"brand-id":  "my-brand",
@@ -1146,7 +1146,7 @@ func (s *uc20RemodelLogicSuite) TestReregRemodelContextUC20(c *C) {
 	newSeedTs, err := time.Parse(time.RFC3339Nano, seededSystemsFromState[0]["seed-time"].(string))
 	c.Assert(err, IsNil)
 	seededSystemsFromState[0]["seed-time"] = ""
-	c.Assert(seededSystemsFromState[0], DeepEquals, map[string]interface{}{
+	c.Assert(seededSystemsFromState[0], DeepEquals, map[string]any{
 		"system":    "1234",
 		"model":     "other-model",
 		"brand-id":  "my-brand",
@@ -1163,7 +1163,7 @@ func (s *uc20RemodelLogicSuite) TestReregRemodelContextUC20(c *C) {
 }
 
 func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
-	modelDefaults := make(map[string]interface{}, len(uc20ModelDefaults))
+	modelDefaults := make(map[string]any, len(uc20ModelDefaults))
 	for k, v := range uc20ModelDefaults {
 		modelDefaults[k] = v
 	}
@@ -1235,11 +1235,11 @@ func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(resealKeysCalls, Equals, 2)
 
-	var seededSystemsFromState []map[string]interface{}
+	var seededSystemsFromState []map[string]any
 	err = s.state.Get("seeded-systems", &seededSystemsFromState)
 	c.Assert(err, IsNil)
 	c.Assert(seededSystemsFromState, HasLen, 2)
-	c.Assert(seededSystemsFromState[1], DeepEquals, map[string]interface{}{
+	c.Assert(seededSystemsFromState[1], DeepEquals, map[string]any{
 		"system":    "0000",
 		"model":     "my-model",
 		"brand-id":  "my-brand",
@@ -1252,7 +1252,7 @@ func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
 	newSeedTs, err := time.Parse(time.RFC3339Nano, seededSystemsFromState[0]["seed-time"].(string))
 	c.Assert(err, IsNil)
 	seededSystemsFromState[0]["seed-time"] = ""
-	c.Assert(seededSystemsFromState[0], DeepEquals, map[string]interface{}{
+	c.Assert(seededSystemsFromState[0], DeepEquals, map[string]any{
 		"system":    "1234",
 		"model":     "my-model",
 		"brand-id":  "my-brand",
@@ -1269,7 +1269,7 @@ func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
 }
 
 func (s *uc20RemodelLogicSuite) TestSimpleRemodelErr(c *C) {
-	modelDefaults := make(map[string]interface{}, len(uc20ModelDefaults))
+	modelDefaults := make(map[string]any, len(uc20ModelDefaults))
 	for k, v := range uc20ModelDefaults {
 		modelDefaults[k] = v
 	}
@@ -1327,10 +1327,10 @@ func (s *uc20RemodelLogicSuite) TestSimpleRemodelErr(c *C) {
 	c.Check(resealKeysCalls, Equals, 1)
 
 	// the error occurred before seeded systems was updated
-	var seededSystemsFromState []map[string]interface{}
+	var seededSystemsFromState []map[string]any
 	err = s.state.Get("seeded-systems", &seededSystemsFromState)
 	c.Assert(err, IsNil)
-	c.Assert(seededSystemsFromState, DeepEquals, []map[string]interface{}{{
+	c.Assert(seededSystemsFromState, DeepEquals, []map[string]any{{
 		"system":    "0000",
 		"model":     "my-model",
 		"brand-id":  "my-brand",

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -279,53 +279,53 @@ func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
 	infos["other-core18"] = s.makeSnap(c, "other-core18", snap.R(7))
 	infos["core18"] = s.makeSnap(c, "core18", snap.R(8))
 
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 			// optional but not present
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-not-present",
 				"id":       s.ss.AssertedSnapID("other-not-present"),
 				"presence": "optional",
 			},
 			// optional and present
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-present",
 				"id":       s.ss.AssertedSnapID("other-present"),
 				"presence": "optional",
 			},
 			// required
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-required",
 				"id":       s.ss.AssertedSnapID("other-required"),
 				"presence": "required",
 			},
 			// different base
-			map[string]interface{}{
+			map[string]any{
 				"name": "other-core18",
 				"id":   s.ss.AssertedSnapID("other-core18"),
 			},
 			// and the actual base for that snap
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.ss.AssertedSnapID("core18"),
 				"type": "base",
@@ -416,71 +416,71 @@ func (s *createSystemSuite) TestCreateSystemFromAssertedSnapsComponents(c *C) {
 	}
 	infos["snap-with-components"] = info
 
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel-with-kmods",
 				"id":              s.ss.AssertedSnapID("pc-kernel-with-kmods"),
 				"type":            "kernel",
 				"default-channel": "20",
-				"components": map[string]interface{}{
-					"kmod": map[string]interface{}{
+				"components": map[string]any{
+					"kmod": map[string]any{
 						"presence": "required",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 			// optional but not present
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-not-present",
 				"id":       s.ss.AssertedSnapID("other-not-present"),
 				"presence": "optional",
 			},
 			// optional and present
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-present",
 				"id":       s.ss.AssertedSnapID("other-present"),
 				"presence": "optional",
 			},
 			// required
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-required",
 				"id":       s.ss.AssertedSnapID("other-required"),
 				"presence": "required",
 			},
 			// different base
-			map[string]interface{}{
+			map[string]any{
 				"name": "other-core18",
 				"id":   s.ss.AssertedSnapID("other-core18"),
 			},
 			// and the actual base for that snap
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.ss.AssertedSnapID("core18"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snap-with-components",
 				"id":   s.ss.AssertedSnapID("snap-with-components"),
 				"type": "app",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 					},
-					"comp-2": map[string]interface{}{
+					"comp-2": map[string]any{
 						"presence": "optional",
 					},
 				},
@@ -561,30 +561,30 @@ func (s *createSystemSuite) TestCreateSystemFromUnassertedSnaps(c *C) {
 	// unasserted with local revision
 	infos["other-unasserted"] = s.makeSnap(c, "other-unasserted", snap.R(-1))
 
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 			// required
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-unasserted",
 				"presence": "required",
 			},
@@ -650,34 +650,34 @@ func (s *createSystemSuite) TestCreateSystemFromUnassertedSnapsComponents(c *C) 
 	})
 	infos["other-unasserted"] = unassertedInfo
 
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 			// required
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-unasserted",
 				"presence": "required",
-				"components": map[string]interface{}{
-					"comp": map[string]interface{}{
+				"components": map[string]any{
+					"comp": map[string]any{
 						"presence": "required",
 					},
 				},
@@ -754,24 +754,24 @@ func (s *createSystemSuite) TestCreateSystemWithSomeSnapsAlreadyExisting(c *C) {
 	defer s.state.Unlock()
 	s.setupBrands()
 	infos := s.makeEssentialSnapInfos(c)
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
@@ -825,30 +825,30 @@ func (s *createSystemSuite) TestCreateSystemWithSomeSnapsAlreadyExisting(c *C) {
 
 	// add an unasserted snap
 	infos["other-unasserted"] = s.makeSnap(c, "other-unasserted", snap.R(-1))
-	modelWithUnasserted := s.makeModelAssertionInState(c, "my-brand", "pc-with-unasserted", map[string]interface{}{
+	modelWithUnasserted := s.makeModelAssertionInState(c, "my-brand", "pc-with-unasserted", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
 			// required
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-unasserted",
 				"presence": "required",
 			},
@@ -887,40 +887,40 @@ func (s *createSystemSuite) TestCreateSystemInfoAndAssertsChecks(c *C) {
 	infos["core20"] = s.makeSnap(c, "core20", snap.R(3))
 	infos["snapd"] = s.makeSnap(c, "snapd", snap.R(4))
 	infos["snap-with-components"] = s.makeSnap(c, "snap-with-components", snap.R(2))
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
 			// pc snap is the gadget, but we have no info for it
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-required",
 				"id":       s.ss.AssertedSnapID("other-required"),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-with-components",
 				"id":       s.ss.AssertedSnapID("snap-with-components"),
 				"presence": "optional",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 					},
 				},
@@ -998,30 +998,30 @@ func (s *createSystemSuite) TestCreateSystemGetInfoErr(c *C) {
 	// missing info for the pc snap
 	infos := s.makeEssentialSnapInfos(c)
 	infos["other-required"] = s.makeSnap(c, "other-required", snap.R(5))
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
 			// pc snap is the gadget, but we have no info for it
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.ss.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "other-required",
 				"id":       s.ss.AssertedSnapID("other-required"),
 				"presence": "required",
@@ -1079,7 +1079,7 @@ func (s *createSystemSuite) TestCreateSystemNonUC20(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.setupBrands()
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"base":         "core18",
 		"kernel":       "pc-kernel",
@@ -1111,19 +1111,19 @@ func (s *createSystemSuite) TestCreateSystemImplicitSnaps(c *C) {
 	infos := s.makeEssentialSnapInfos(c)
 
 	// snapd snap is implicitly required
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		// base does not need to be listed among snaps
 		"base": "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -1165,19 +1165,19 @@ func (s *createSystemSuite) TestCreateSystemObserverErr(c *C) {
 	infos := s.makeEssentialSnapInfos(c)
 
 	// snapd snap is implicitly required
-	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]interface{}{
+	model := s.makeModelAssertionInState(c, "my-brand", "pc", map[string]any{
 		"architecture": "amd64",
 		"grade":        "dangerous",
 		// base does not need to be listed among snaps
 		"base": "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.ss.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.ss.AssertedSnapID("pc"),
 				"type":            "gadget",

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -81,7 +81,7 @@ var ContainsChain Checker = &containsChainChecker{
 	&CheckerInfo{Name: "ContainsChain", Params: []string{"chainscontainer", "chain"}},
 }
 
-func (c *containsChainChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *containsChainChecker) Check(params []any, names []string) (result bool, error string) {
 	allowed, ok := params[0].([]*secboot.LoadChain)
 	if !ok {
 		return false, "Wrong type for chain container"

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -46,7 +46,7 @@ type Context struct {
 	id      string
 	handler Handler
 
-	cache  map[interface{}]interface{}
+	cache  map[any]any
 	onDone []func() error
 
 	mutex        sync.Mutex
@@ -72,11 +72,11 @@ func NewContext(task *state.Task, state *state.State, setup *HookSetup, handler 
 		setup:   setup,
 		id:      contextID,
 		handler: handler,
-		cache:   make(map[interface{}]interface{}),
+		cache:   make(map[any]any),
 	}, nil
 }
 
-func newEphemeralHookContextWithData(st *state.State, setup *HookSetup, contextData map[string]interface{}) (*Context, error) {
+func newEphemeralHookContextWithData(st *state.State, setup *HookSetup, contextData map[string]any) (*Context, error) {
 	context, err := NewContext(nil, st, setup, nil, "")
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func (c *Context) writing() {
 // Set associates value with key. The provided value must properly marshal and
 // unmarshal with encoding/json. Note that the context needs to be locked and
 // unlocked by the caller.
-func (c *Context) Set(key string, value interface{}) {
+func (c *Context) Set(key string, value any) {
 	c.writing()
 
 	var data map[string]*json.RawMessage
@@ -227,7 +227,7 @@ func (c *Context) Set(key string, value interface{}) {
 // Get unmarshals the stored value associated with the provided key into the
 // value parameter. Note that the context needs to be locked/unlocked by the
 // caller.
-func (c *Context) Get(key string, value interface{}) error {
+func (c *Context) Get(key string, value any) error {
 	c.reading()
 
 	var data map[string]*json.RawMessage
@@ -263,7 +263,7 @@ func (c *Context) State() *state.State {
 // Cached returns the cached value associated with the provided key. It returns
 // nil if there is no entry for key. Note that the context needs to be locked
 // and unlocked by the caller.
-func (c *Context) Cached(key interface{}) interface{} {
+func (c *Context) Cached(key any) any {
 	c.reading()
 
 	return c.cache[key]
@@ -271,7 +271,7 @@ func (c *Context) Cached(key interface{}) interface{} {
 
 // Cache associates value with key. The cached value is not persisted. Note that
 // the context needs to be locked/unlocked by the caller.
-func (c *Context) Cache(key, value interface{}) {
+func (c *Context) Cache(key, value any) {
 	c.writing()
 
 	c.cache[key] = value
@@ -323,7 +323,7 @@ func (c *Context) ChangeID() string {
 // or the task log.
 //
 // Context must be locked.
-func (c *Context) Logf(fmt string, args ...interface{}) {
+func (c *Context) Logf(fmt string, args ...any) {
 	c.writing()
 	if c.IsEphemeral() {
 		logger.Noticef(fmt, args...)
@@ -336,7 +336,7 @@ func (c *Context) Logf(fmt string, args ...interface{}) {
 // ephemeral contexts or the task log.
 //
 // Context must be locked.
-func (c *Context) Errorf(format string, args ...interface{}) {
+func (c *Context) Errorf(format string, args ...any) {
 	c.writing()
 	if c.IsEphemeral() {
 		// XXX: loger has no Errorf() :/

--- a/overlord/hookstate/context_test.go
+++ b/overlord/hookstate/context_test.go
@@ -110,7 +110,7 @@ func (s *contextSuite) TestSetAndGetNumber(c *C) {
 
 	s.context.Set("num", 1234567890)
 
-	var output interface{}
+	var output any
 	c.Check(s.context.Get("num", &output), IsNil)
 	c.Assert(output, Equals, json.Number("1234567890"))
 }

--- a/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -61,7 +61,7 @@ func (c *baseCommand) setStdout(w io.Writer) {
 	c.stdout = w
 }
 
-func (c *baseCommand) printf(format string, a ...interface{}) {
+func (c *baseCommand) printf(format string, a ...any) {
 	c.print(fmt.Sprintf(format, a...))
 }
 

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -103,8 +103,8 @@ func init() {
 	})
 }
 
-func (c *getCommand) printValues(getByKey func(string) (interface{}, bool, error)) error {
-	patch := make(map[string]interface{})
+func (c *getCommand) printValues(getByKey func(string) (any, bool, error)) error {
+	patch := make(map[string]any)
 	for _, key := range c.Positional.Keys {
 		value, output, err := getByKey(key)
 		if err == nil {
@@ -119,10 +119,10 @@ func (c *getCommand) printValues(getByKey func(string) (interface{}, bool, error
 	return c.printPatch(patch)
 }
 
-func (c *getCommand) printPatch(patch interface{}) error {
-	var confToPrint interface{} = patch
+func (c *getCommand) printPatch(patch any) error {
+	var confToPrint any = patch
 	if !c.Document && len(c.Positional.Keys) == 1 {
-		if confMap, ok := patch.(map[string]interface{}); ok {
+		if confMap, ok := patch.(map[string]any); ok {
 			confToPrint = confMap[c.Positional.Keys[0]]
 		}
 	}
@@ -210,8 +210,8 @@ func (c *getCommand) getConfigSetting(context *hookstate.Context) error {
 	transaction := configstate.ContextTransaction(context)
 	context.Unlock()
 
-	return c.printValues(func(key string) (interface{}, bool, error) {
-		var value interface{}
+	return c.printValues(func(key string) (any, bool, error) {
+		var value any
 		err := transaction.Get(c.context().InstanceName(), key, &value)
 		if err == nil {
 			return value, true, nil
@@ -341,7 +341,7 @@ func (c *getCommand) getInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	st.Lock()
 	defer st.Unlock()
 
-	var staticAttrs, dynamicAttrs map[string]interface{}
+	var staticAttrs, dynamicAttrs map[string]any
 	if err = attrsTask.Get(which+"-static", &staticAttrs); err != nil {
 		return fmt.Errorf(i18n.G("internal error: cannot get %s from appropriate task"), which)
 	}
@@ -349,13 +349,13 @@ func (c *getCommand) getInterfaceSetting(context *hookstate.Context, plugOrSlot 
 		return fmt.Errorf(i18n.G("internal error: cannot get %s from appropriate task"), which)
 	}
 
-	return c.printValues(func(key string) (interface{}, bool, error) {
+	return c.printValues(func(key string) (any, bool, error) {
 		subkeys, err := config.ParseKey(key)
 		if err != nil {
 			return nil, false, err
 		}
 
-		var value interface{}
+		var value any
 		err = getAttribute(context.InstanceName(), subkeys, 0, staticAttrs, &value)
 		if err == nil {
 			return value, true, nil

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -165,7 +165,7 @@ func (s *getSuite) TestGetTests(c *C) {
 
 var getTests2 = []struct {
 	setPath      string
-	setValue     interface{}
+	setValue     any
 	args, stdout string
 }{{
 	setPath:  "root.key1",
@@ -184,7 +184,7 @@ var getTests2 = []struct {
 	stdout:   "{\n\t\"sub1\": \"z\",\n\t\"sub2\": \"y\"\n}\n",
 }, {
 	setPath:  "root.key3",
-	setValue: map[string]interface{}{"sub3": "z"},
+	setValue: map[string]any{"sub3": "z"},
 	args:     "get root",
 	stdout:   "{\n\t\"key1\": \"a\",\n\t\"key2\": \"b\",\n\t\"key3\": {\n\t\t\"sub3\": \"z\"\n\t}\n}\n",
 }}
@@ -207,7 +207,7 @@ func (s *getSuite) TestGetPartialNestedStruct(c *C) {
 
 		// Initialize configuration
 		tr := config.NewTransaction(state)
-		tr.Set("test-snap", "root", map[string]interface{}{"key1": "a", "key2": "b", "key3": map[string]interface{}{"sub1": "x", "sub2": "y"}})
+		tr.Set("test-snap", "root", map[string]any{"key1": "a", "key2": "b", "key3": map[string]any{"sub1": "x", "sub2": "y"}})
 		tr.Commit()
 
 		state.Unlock()
@@ -229,9 +229,9 @@ func (s *getSuite) TestGetPartialNestedStruct(c *C) {
 		state.Lock()
 		defer state.Unlock()
 		tr3 := config.NewTransaction(state)
-		var config map[string]interface{}
+		var config map[string]any
 		c.Assert(tr3.Get("test-snap", "root", &config), IsNil)
-		c.Assert(config, DeepEquals, map[string]interface{}{"key1": "a", "key2": "b", "key3": map[string]interface{}{"sub1": "x", "sub2": "y"}})
+		c.Assert(config, DeepEquals, map[string]any{"key1": "a", "key2": "b", "key3": map[string]any{"sub1": "x", "sub2": "y"}})
 	}
 }
 
@@ -276,11 +276,11 @@ func (s *setSuite) TestNull(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify config value
-	var value interface{}
+	var value any
 	tr := config.NewTransaction(s.mockContext.State())
 	c.Assert(config.IsNoOption(tr.Get("test-snap", "foo", &value)), Equals, true)
 	c.Assert(tr.Get("test-snap", "bar", &value), IsNil)
-	c.Assert(value, DeepEquals, []interface{}{nil})
+	c.Assert(value, DeepEquals, []any{nil})
 }
 
 func (s *getAttrSuite) SetUpTest(c *C) {
@@ -293,20 +293,20 @@ func (s *getAttrSuite) SetUpTest(c *C) {
 	attrsTask := state.NewTask("connect-task", "my connect task")
 	attrsTask.Set("plug", &interfaces.PlugRef{Snap: "a", Name: "aplug"})
 	attrsTask.Set("slot", &interfaces.SlotRef{Snap: "b", Name: "bslot"})
-	staticPlugAttrs := map[string]interface{}{
+	staticPlugAttrs := map[string]any{
 		"aattr":   "foo",
 		"baz":     []string{"a", "b"},
-		"mapattr": map[string]interface{}{"mapattr1": "mapval1", "mapattr2": "mapval2"},
+		"mapattr": map[string]any{"mapattr1": "mapval1", "mapattr2": "mapval2"},
 	}
-	dynamicPlugAttrs := map[string]interface{}{
+	dynamicPlugAttrs := map[string]any{
 		"dyn-plug-attr": "c",
 		"nilattr":       nil,
 	}
-	dynamicSlotAttrs := map[string]interface{}{
+	dynamicSlotAttrs := map[string]any{
 		"dyn-slot-attr": "d",
 	}
 
-	staticSlotAttrs := map[string]interface{}{
+	staticSlotAttrs := map[string]any{
 		"battr": "bar",
 	}
 	attrsTask.Set("plug-static", staticPlugAttrs)
@@ -507,21 +507,21 @@ func (s *confdbSuite) SetUpTest(c *C) {
 	c.Check(s.signingDB, NotNil)
 	c.Assert(storeSigning.Add(devAccKey), IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": s.devAccID,
 		"account-id":   s.devAccID,
 		"name":         "network",
-		"views": map[string]interface{}{
-			"read-wifi": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "read"},
-					map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "read"},
+		"views": map[string]any{
+			"read-wifi": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "ssid", "storage": "wifi.ssid", "access": "read"},
+					map[string]any{"request": "password", "storage": "wifi.psk", "access": "read"},
 				},
 			},
-			"write-wifi": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "ssid", "storage": "wifi.ssid", "access": "write"},
-					map[string]interface{}{"request": "password", "storage": "wifi.psk", "access": "write"},
+			"write-wifi": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "ssid", "storage": "wifi.ssid", "access": "write"},
+					map[string]any{"request": "password", "storage": "wifi.psk", "access": "write"},
 				},
 			},
 		},
@@ -791,15 +791,15 @@ func (s *confdbSuite) TestConfdbGetAndSetAssertionNotFound(c *C) {
 }
 
 func (s *confdbSuite) TestConfdbGetAndSetViewNotFound(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id": s.devAccID,
 		"account-id":   s.devAccID,
 		"revision":     "1",
 		"name":         "network",
-		"views": map[string]interface{}{
-			"other": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "a", "storage": "a"},
+		"views": map[string]any{
+			"other": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "a", "storage": "a"},
 				},
 			},
 		},
@@ -901,10 +901,10 @@ func (s *confdbSuite) TestConfdbGetDifferentViewThanOngoingTx(c *C) {
 	defer s.state.Lock()
 
 	restore := ctlcmd.MockConfdbstateGetView(func(st *state.State, account, confdbName, viewName string) (*confdb.View, error) {
-		reg, err := confdb.NewSchema(s.devAccID, "other", map[string]interface{}{
-			"other": map[string]interface{}{
-				"rules": []interface{}{
-					map[string]interface{}{"request": "ssid", "storage": "ssid"},
+		reg, err := confdb.NewSchema(s.devAccID, "other", map[string]any{
+			"other": map[string]any{
+				"rules": []any{
+					map[string]any{"request": "ssid", "storage": "ssid"},
 				},
 			},
 		}, confdb.NewJSONSchema())

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -368,7 +368,7 @@ func isNoAttribute(err error) bool {
 	return ok
 }
 
-func jsonRaw(v interface{}) *json.RawMessage {
+func jsonRaw(v any) *json.RawMessage {
 	data, err := json.Marshal(v)
 	if err != nil {
 		panic(fmt.Errorf("internal error: cannot marshal attributes: %v", err))
@@ -381,7 +381,7 @@ func jsonRaw(v interface{}) *json.RawMessage {
 // If the key does not exist, an error of type *NoAttributeError is returned.
 // The provided key may be formed as a dotted key path through nested maps.
 // For example, the "a.b.c" key describes the {a: {b: {c: value}}} map.
-func getAttribute(snapName string, subkeys []string, pos int, attrs map[string]interface{}, result interface{}) error {
+func getAttribute(snapName string, subkeys []string, pos int, attrs map[string]any, result any) error {
 	if pos >= len(subkeys) {
 		return fmt.Errorf("internal error: invalid subkeys index %d for subkeys %q", pos, subkeys)
 	}
@@ -402,7 +402,7 @@ func getAttribute(snapName string, subkeys []string, pos int, attrs map[string]i
 		return nil
 	}
 
-	attrsm, ok := value.(map[string]interface{})
+	attrsm, ok := value.(map[string]any)
 	if !ok {
 		raw, ok := value.(*json.RawMessage)
 		if !ok {

--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -201,13 +201,13 @@ plugs:
 	})
 	defer restore()
 
-	s.st.Set("conns", map[string]interface{}{
-		"snap1:plug1 snap2:slot2": map[string]interface{}{},
-		"snap1:plug2 snap3:slot3": map[string]interface{}{"undesired": true},
-		"snap1:plug3 snap4:slot4": map[string]interface{}{"hotplug-gone": true},
-		"snap3:plug4 snap1:slot1": map[string]interface{}{},
-		"snap3:cc snap1:cc":       map[string]interface{}{},
-		"snap5:cc snap1:cc":       map[string]interface{}{},
+	s.st.Set("conns", map[string]any{
+		"snap1:plug1 snap2:slot2": map[string]any{},
+		"snap1:plug2 snap3:slot3": map[string]any{"undesired": true},
+		"snap1:plug3 snap4:slot4": map[string]any{"hotplug-gone": true},
+		"snap3:plug4 snap1:slot1": map[string]any{},
+		"snap3:cc snap1:cc":       map[string]any{},
+		"snap5:cc snap1:cc":       map[string]any{},
 	})
 
 	s.st.Unlock()
@@ -274,8 +274,8 @@ plugs:
   plug1:
     interface: x11`, "")
 
-	s.st.Set("conns", map[string]interface{}{
-		"snap1:plug1 snap2:slot2": map[string]interface{}{},
+	s.st.Set("conns", map[string]any{
+		"snap1:plug1 snap2:slot2": map[string]any{},
 	})
 
 	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1)}
@@ -335,12 +335,12 @@ slots:
     interface: x11
   slot3b:
     interface: x11`, "")
-	s.st.Set("conns", map[string]interface{}{
-		"snap1:plug1a snap2:slot2a": map[string]interface{}{},
-		"snap2:plug2a snap1:slot1a": map[string]interface{}{},
-		"snap3:plug3a snap1:slot1a": map[string]interface{}{},
-		"snap1:plug1c snap3:slot3a": map[string]interface{}{"undesired": true},
-		"snap1:plug1d snap3:slot3b": map[string]interface{}{"hotplug-gone": true},
+	s.st.Set("conns", map[string]any{
+		"snap1:plug1a snap2:slot2a": map[string]any{},
+		"snap2:plug2a snap1:slot1a": map[string]any{},
+		"snap3:plug3a snap1:slot1a": map[string]any{},
+		"snap1:plug1c snap3:slot3a": map[string]any{"undesired": true},
+		"snap1:plug1d snap3:slot3b": map[string]any{"hotplug-gone": true},
 	})
 
 	s.st.Unlock()

--- a/overlord/hookstate/ctlcmd/kmod.go
+++ b/overlord/hookstate/ctlcmd/kmod.go
@@ -111,7 +111,7 @@ func (k *KModRemoveCmd) Execute([]string) error {
 
 // kmodMatchConnection checks whether the given kmod connection attributes give
 // the snap permission to execute the kmod command
-func kmodMatchConnection(attributes map[string]interface{}, moduleName string, moduleOptions []string) bool {
+func kmodMatchConnection(attributes map[string]any, moduleName string, moduleOptions []string) bool {
 	load, found := attributes["load"]
 	if !found || load.(string) != "dynamic" {
 		return false
@@ -166,13 +166,13 @@ var kmodCheckConnection = func(context *hookstate.Context, moduleName string, mo
 			continue
 		}
 
-		modules, ok := connState.StaticPlugAttrs["modules"].([]interface{})
+		modules, ok := connState.StaticPlugAttrs["modules"].([]any)
 		if !ok {
 			continue
 		}
 
 		for _, moduleAttributes := range modules {
-			attributes := moduleAttributes.(map[string]interface{})
+			attributes := moduleAttributes.(map[string]any)
 			if kmodMatchConnection(attributes, moduleName, moduleOptions) {
 				return nil
 			}

--- a/overlord/hookstate/ctlcmd/kmod_test.go
+++ b/overlord/hookstate/ctlcmd/kmod_test.go
@@ -41,7 +41,7 @@ type kmodSuite struct {
 	hookTask    *state.Task
 	// A connection state for a snap using the kmod interface with the plug
 	// properly configured, which we'll be reusing in different test cases
-	regularConnState map[string]interface{}
+	regularConnState map[string]any
 }
 
 var _ = Suite(&kmodSuite{})
@@ -62,15 +62,15 @@ func (s *kmodSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.mockContext = ctx
 
-	s.regularConnState = map[string]interface{}{
+	s.regularConnState = map[string]any{
 		"interface": "kernel-module-load",
-		"plug-static": map[string]interface{}{
-			"modules": []interface{}{
-				map[string]interface{}{
+		"plug-static": map[string]any{
+			"modules": []any{
+				map[string]any{
 					"name": "module1",
 					"load": "dynamic",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":    "module2",
 					"load":    "dynamic",
 					"options": "*",
@@ -84,7 +84,7 @@ func (s *kmodSuite) SetUpTest(c *C) {
 func (s *kmodSuite) injectSnapWithProperPlug(c *C) {
 	s.state.Lock()
 	mockInstalledSnap(c, s.state, `name: snap1`, "")
-	s.state.Set("conns", map[string]interface{}{
+	s.state.Set("conns", map[string]any{
 		"snap1:plug1 snap2:slot2": s.regularConnState,
 	})
 	s.state.Unlock()
@@ -99,27 +99,27 @@ func (s *kmodSuite) TestMissingContext(c *C) {
 
 func (s *kmodSuite) TestMatchConnection(c *C) {
 	for _, td := range []struct {
-		attributes    map[string]interface{}
+		attributes    map[string]any
 		moduleName    string
 		moduleOptions []string
 		expectedMatch bool
 	}{
 		// missing "load" attribute
-		{map[string]interface{}{}, "", []string{}, false},
+		{map[string]any{}, "", []string{}, false},
 		// empty "load" attribute
-		{map[string]interface{}{"load": ""}, "", []string{}, false},
+		{map[string]any{"load": ""}, "", []string{}, false},
 		// "load" attribute must be set to "dynamic"
-		{map[string]interface{}{"load": "on-boot"}, "", []string{}, false},
+		{map[string]any{"load": "on-boot"}, "", []string{}, false},
 		// different module name
-		{map[string]interface{}{"load": "dynamic", "name": "mod1"}, "mod2", []string{}, false},
+		{map[string]any{"load": "dynamic", "name": "mod1"}, "mod2", []string{}, false},
 		// options given but plug does not have "options" attribute
-		{map[string]interface{}{"load": "dynamic", "name": "mod1"}, "mod1", []string{"opt1"}, false},
+		{map[string]any{"load": "dynamic", "name": "mod1"}, "mod1", []string{"opt1"}, false},
 		// options given but plug does not have "options" set to "*"
-		{map[string]interface{}{"load": "dynamic", "name": "mod1", "options": "opt1"}, "mod1", []string{"opt1"}, false},
+		{map[string]any{"load": "dynamic", "name": "mod1", "options": "opt1"}, "mod1", []string{"opt1"}, false},
 		// happy with no options
-		{map[string]interface{}{"load": "dynamic", "name": "mod1"}, "mod1", []string{}, true},
+		{map[string]any{"load": "dynamic", "name": "mod1"}, "mod1", []string{}, true},
 		// happy with options and "*" on plug
-		{map[string]interface{}{"load": "dynamic", "name": "mod1", "options": "*"}, "mod1", []string{"opt1"}, true},
+		{map[string]any{"load": "dynamic", "name": "mod1", "options": "*"}, "mod1", []string{"opt1"}, true},
 	} {
 		testLabel := Commentf("Attrs: %v, name: %q, opts: %q", td.attributes, td.moduleName, td.moduleOptions)
 		matches := ctlcmd.KmodMatchConnection(td.attributes, td.moduleName, td.moduleOptions)
@@ -149,7 +149,7 @@ func (s *kmodSuite) TestFindConnectionMissingProperPlug(c *C) {
 	mockInstalledSnap(c, s.state, `name: snap1`, "")
 	// Inject a lot of connections in the state, but all of them defective for
 	// one or another reason
-	connections := make(map[string]interface{})
+	connections := make(map[string]any)
 	// wrong interface
 	conn := CopyMap(s.regularConnState)
 	conn["interface"] = "unrelated"

--- a/overlord/hookstate/ctlcmd/model.go
+++ b/overlord/hookstate/ctlcmd/model.go
@@ -105,7 +105,7 @@ func (c *modelCommand) newTabWriter(output io.Writer) *tabwriter.Writer {
 }
 
 // reportError prints the error message to stderr
-func (c *modelCommand) reportError(format string, a ...interface{}) {
+func (c *modelCommand) reportError(format string, a ...any) {
 	w := c.newTabWriter(c.stderr)
 	fmt.Fprintf(w, format, a...)
 	w.Flush()

--- a/overlord/hookstate/ctlcmd/model_test.go
+++ b/overlord/hookstate/ctlcmd/model_test.go
@@ -106,7 +106,7 @@ func (s *modelSuite) SetUpTest(c *C) {
 	s.AddCleanup(sysdb.MockGenericClassicModel(s.storeSigning.GenericClassicModel))
 
 	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
-	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.brands.Register("my-brand", brandPrivKey, map[string]any{
 		"display-name": "fancy model publisher",
 		"validation":   "certified",
 	})
@@ -163,14 +163,14 @@ func (s *modelSuite) setupBrands() {
 	defer s.state.Unlock()
 
 	assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
-	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]interface{}{
+	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]any{
 		"account-id": "other-brand",
 	}, "")
 	assertstatetest.AddMany(s.state, otherAcct)
 }
 
 func (s *modelSuite) addSnapDeclaration(c *C, snapID, developerID, snapName string) {
-	declA, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	declA, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"publisher-id": developerID,
@@ -219,7 +219,7 @@ func (s *modelSuite) TestUnhappyModelCommandInsufficientPermissions(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -255,7 +255,7 @@ func (s *modelSuite) TestHappyModelCommandIdenticalPublisher(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -296,7 +296,7 @@ func (s *modelSuite) TestHappyModelCommandSnapdControlPlug(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -316,8 +316,8 @@ func (s *modelSuite) TestHappyModelCommandSnapdControlPlug(c *C) {
 	c.Assert(err, IsNil)
 	mockInstalledSnap(c, s.state, snapWithSnapdControlOnlyYaml, "")
 
-	s.state.Set("conns", map[string]interface{}{
-		"snap1-control:plug core:slot": map[string]interface{}{"interface": "snapd-control"},
+	s.state.Set("conns", map[string]any{
+		"snap1-control:plug core:slot": map[string]any{"interface": "snapd-control"},
 	})
 	s.state.Unlock()
 
@@ -335,7 +335,7 @@ func (s *modelSuite) TestHappyModelCommandPublisherYaml(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -386,7 +386,7 @@ func (s *modelSuite) testHappyModelCommandForSnap(c *C, snapName, snapYaml strin
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("my-brand", "pc-model", map[string]interface{}{
+	current := s.brands.Model("my-brand", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -427,7 +427,7 @@ func (s *modelSuite) TestHappyModelCommandGadgetJson(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -469,7 +469,7 @@ func (s *modelSuite) TestHappyModelCommandAssertionGadgetYaml(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -502,7 +502,7 @@ func (s *modelSuite) TestHappyModelCommandAssertionGadgetJson(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -549,7 +549,7 @@ func (s *modelSuite) TestRunWithoutHook(c *C) {
 
 	// set a model assertion
 	s.state.Lock()
-	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -620,9 +620,9 @@ func (s *modelSuite) TestLongPublisherVerified(c *C) {
 	c.Assert(ctlcmd.FormatLongPublisher(snapInfo, ""), Equals, "Canonical**")
 }
 
-func (s *modelSuite) signSerial(accountID, model, serial string, timestamp time.Time, extras ...map[string]interface{}) *asserts.Serial {
+func (s *modelSuite) signSerial(accountID, model, serial string, timestamp time.Time, extras ...map[string]any) *asserts.Serial {
 	encodedPubKey, _ := asserts.EncodePublicKey(brandPrivKey2.PublicKey())
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":              "16",
 		"serial":              serial,
 		"brand-id":            accountID,
@@ -648,7 +648,7 @@ func (s *modelSuite) signSerial(accountID, model, serial string, timestamp time.
 
 func (s *modelSuite) TestFindSerialAssertionNone(c *C) {
 	s.setupBrands()
-	model := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -666,13 +666,13 @@ func (s *modelSuite) TestFindSerialAssertionNone(c *C) {
 
 func (s *modelSuite) TestFindSerialAssertionMatch(c *C) {
 	s.setupBrands()
-	model := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 		"base":         "core18",
 	})
-	serial := s.signSerial("canonical", "pc-model", "1", time.Now(), map[string]interface{}{
+	serial := s.signSerial("canonical", "pc-model", "1", time.Now(), map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -696,19 +696,19 @@ func (s *modelSuite) TestFindSerialAssertionMultiple(c *C) {
 	now := time.Now()
 	tomorrow := now.AddDate(0, 0, 1)
 
-	model := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc-model", map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 		"base":         "core18",
 	})
-	serial := s.signSerial("canonical", "pc-model", "1", now, map[string]interface{}{
+	serial := s.signSerial("canonical", "pc-model", "1", now, map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 		"base":         "core18",
 	})
-	serialnext := s.signSerial("canonical", "pc-model", "2", tomorrow, map[string]interface{}{
+	serialnext := s.signSerial("canonical", "pc-model", "2", tomorrow, map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",

--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -59,7 +59,7 @@ type mountCommand struct {
 	optionsList []string
 }
 
-func matchMountPathAttribute(path string, attribute interface{}, snapInfo *snap.Info) bool {
+func matchMountPathAttribute(path string, attribute any, snapInfo *snap.Info) bool {
 	pattern, ok := attribute.(string)
 	if !ok {
 		return false
@@ -72,7 +72,7 @@ func matchMountPathAttribute(path string, attribute interface{}, snapInfo *snap.
 	return err == nil && pp.Matches(path)
 }
 
-func matchMountSourceAttribute(path string, attribute interface{}, fsType string, snapInfo *snap.Info) bool {
+func matchMountSourceAttribute(path string, attribute any, fsType string, snapInfo *snap.Info) bool {
 	switch fsType {
 	case "nfs":
 		// NFS mount source AppArmor profiles expects a match for "*:**", so
@@ -113,9 +113,9 @@ func matchMountSourceAttribute(path string, attribute interface{}, fsType string
 
 // matchConnection checks whether the given mount connection attributes give
 // the snap permission to execute the mount command
-func (m *mountCommand) matchConnection(attributes map[string]interface{}) bool {
+func (m *mountCommand) matchConnection(attributes map[string]any) bool {
 	if m.Type != "" {
-		if types, ok := attributes["type"].([]interface{}); ok {
+		if types, ok := attributes["type"].([]any); ok {
 			found := false
 			for _, iface := range types {
 				if typeString, ok := iface.(string); ok && typeString == m.Type {
@@ -150,7 +150,7 @@ func (m *mountCommand) matchConnection(attributes map[string]interface{}) bool {
 	// in -o <option-list>, would need to spell out all authentication options
 	// directly in plug declaration. This may be unacceptable in certain
 	// scenarios, e.g. CIFS with user=foo,password=foo options.
-	if optionsIfaces, ok := attributes["options"].([]interface{}); ok {
+	if optionsIfaces, ok := attributes["options"].([]any); ok {
 		var allowedOptions []string
 		for _, iface := range optionsIfaces {
 			if option, ok := iface.(string); ok {
@@ -210,13 +210,13 @@ func (m *mountCommand) checkConnections(context *hookstate.Context) error {
 			continue
 		}
 
-		mounts, ok := connState.StaticPlugAttrs["mount"].([]interface{})
+		mounts, ok := connState.StaticPlugAttrs["mount"].([]any)
 		if !ok {
 			continue
 		}
 
 		for _, mountAttributes := range mounts {
-			if m.matchConnection(mountAttributes.(map[string]interface{})) {
+			if m.matchConnection(mountAttributes.(map[string]any)) {
 				return nil
 			}
 		}

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -48,7 +48,7 @@ type refreshSuite struct {
 
 var _ = Suite(&refreshSuite{})
 
-func mockRefreshCandidate(snapName, channel, version string, revision snap.Revision) interface{} {
+func mockRefreshCandidate(snapName, channel, version string, revision snap.Revision) any {
 	sup := &snapstate.SnapSetup{
 		Channel: channel,
 		SideInfo: &snap.SideInfo{
@@ -79,7 +79,7 @@ var refreshFromHookTests = []struct {
 	args                []string
 	base, restart       bool
 	inhibited           bool
-	refreshCandidates   map[string]interface{}
+	refreshCandidates   map[string]any
 	stdout, stderr, err string
 	exitCode            int
 }{{
@@ -93,7 +93,7 @@ var refreshFromHookTests = []struct {
 	err:  "cannot use --hold and --show-lock together",
 }, {
 	args: []string{"refresh", "--pending"},
-	refreshCandidates: map[string]interface{}{
+	refreshCandidates: map[string]any{
 		"snap1": mockRefreshCandidate("snap1", "edge", "v1", snap.Revision{N: 3}),
 	},
 	stdout: "pending: ready\nchannel: edge\nversion: v1\nrevision: 3\nbase: false\nrestart: false\n",
@@ -102,13 +102,13 @@ var refreshFromHookTests = []struct {
 	stdout: "pending: none\nchannel: stable\nbase: false\nrestart: false\n",
 }, {
 	args: []string{"refresh", "--pending"},
-	refreshCandidates: map[string]interface{}{
+	refreshCandidates: map[string]any{
 		"snap1-base": mockRefreshCandidate("snap1-base", "edge", "v1", snap.Revision{N: 3}),
 	},
 	stdout: "pending: none\nchannel: stable\nbase: true\nrestart: false\n",
 }, {
 	args: []string{"refresh", "--pending"},
-	refreshCandidates: map[string]interface{}{
+	refreshCandidates: map[string]any{
 		"kernel": mockRefreshCandidate("kernel", "edge", "v1", snap.Revision{N: 3}),
 	},
 	stdout: "pending: none\nchannel: stable\nbase: false\nrestart: true\n",
@@ -189,7 +189,7 @@ type: base
 version: 1
 `, "")
 
-	candidates := map[string]interface{}{
+	candidates := map[string]any{
 		"snap1-base": mockRefreshCandidate("snap1-base", "edge", "v1", snap.Revision{N: 3}),
 	}
 	s.st.Set("refresh-candidates", candidates)
@@ -207,7 +207,7 @@ version: 1
 	c.Assert(action, NotNil)
 	c.Check(action, Equals, snapstate.GateAutoRefreshHold)
 
-	var gating map[string]map[string]interface{}
+	var gating map[string]map[string]any
 	c.Assert(s.st.Get("snaps-hold", &gating), IsNil)
 	c.Check(gating["snap1-base"]["snap1"], NotNil)
 }
@@ -229,7 +229,7 @@ version: 1
 	s.st.Unlock()
 
 	// validity check
-	var gating map[string]map[string]interface{}
+	var gating map[string]map[string]any
 	s.st.Lock()
 	snapsHold := s.st.Get("snaps-hold", &gating)
 	s.st.Unlock()
@@ -304,8 +304,8 @@ func (s *refreshSuite) TestRefreshProceedFromSnap(c *C) {
 version: 1
 `, "")
 
-	s.st.Set("conns", map[string]interface{}{
-		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
+	s.st.Set("conns", map[string]any{
+		"foo:plug core:slot": map[string]any{"interface": "snap-refresh-control"},
 	})
 
 	// enable gate-auto-refresh-hook feature
@@ -365,8 +365,8 @@ version: 1
 	c.Check(string(stdout), Equals, "pending: none\nchannel: stable\nbase: false\nrestart: false\n")
 
 	s.st.Lock()
-	s.st.Set("conns", map[string]interface{}{
-		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
+	s.st.Set("conns", map[string]any{
+		"foo:plug core:slot": map[string]any{"interface": "snap-refresh-control"},
 	})
 	s.st.Unlock()
 
@@ -389,8 +389,8 @@ version: 1
 	mockContext, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
 	c.Check(err, IsNil)
 
-	s.st.Set("conns", map[string]interface{}{
-		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
+	s.st.Set("conns", map[string]any{
+		"foo:plug core:slot": map[string]any{"interface": "snap-refresh-control"},
 	})
 
 	s.st.Unlock()
@@ -415,8 +415,8 @@ func (s *refreshSuite) TestRefreshProceedFromSnapError(c *C) {
 	mockInstalledSnap(c, s.st, `name: foo
 version: 1
 `, "")
-	s.st.Set("conns", map[string]interface{}{
-		"foo:plug core:slot": map[string]interface{}{"interface": "snap-refresh-control"},
+	s.st.Set("conns", map[string]any{
+		"foo:plug core:slot": map[string]any{"interface": "snap-refresh-control"},
 	})
 
 	// enable gate-auto-refresh-hook feature
@@ -449,8 +449,8 @@ func (s *refreshSuite) TestRefreshProceedFromSnapErrorNoSnapRefreshControl(c *C)
 	mockInstalledSnap(c, s.st, `name: foo
 version: 1
 `, "")
-	s.st.Set("conns", map[string]interface{}{
-		"foo:plug core:slot": map[string]interface{}{
+	s.st.Set("conns", map[string]any{
+		"foo:plug core:slot": map[string]any{
 			"interface": "snap-refresh-control",
 			"undesired": true,
 		},
@@ -473,8 +473,8 @@ version: 1
 	c.Assert(called, Equals, false)
 
 	s.st.Lock()
-	s.st.Set("conns", map[string]interface{}{
-		"foo:plug core:slot": map[string]interface{}{
+	s.st.Set("conns", map[string]any{
+		"foo:plug core:slot": map[string]any{
 			"interface": "other",
 		},
 	})

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -142,7 +142,7 @@ func (s *setCommand) setConfigSetting(context *hookstate.Context) error {
 	return nil
 }
 
-func setInterfaceAttribute(context *hookstate.Context, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, key string, value interface{}) error {
+func setInterfaceAttribute(context *hookstate.Context, staticAttrs map[string]any, dynamicAttrs map[string]any, key string, value any) error {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("cannot marshal snap %q option %q: %s", context.InstanceName(), key, err)
@@ -160,7 +160,7 @@ func setInterfaceAttribute(context *hookstate.Context, staticAttrs map[string]in
 	if len(subkeys) == 0 {
 		return fmt.Errorf("internal error: unexpected empty subkeys for key %q", key)
 	}
-	var existing interface{}
+	var existing any
 	err = getAttribute(context.InstanceName(), subkeys[:1], 0, staticAttrs, &existing)
 	if err == nil {
 		return fmt.Errorf(i18n.G("attribute %q cannot be overwritten"), key)
@@ -201,7 +201,7 @@ func (s *setCommand) setInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	context.Lock()
 	defer context.Unlock()
 
-	var staticAttrs, dynamicAttrs map[string]interface{}
+	var staticAttrs, dynamicAttrs map[string]any
 	if err = attrsTask.Get(which+"-static", &staticAttrs); err != nil {
 		return fmt.Errorf(i18n.G("internal error: cannot get %s from appropriate task, %s"), which, err)
 	}
@@ -217,7 +217,7 @@ func (s *setCommand) setInterfaceSetting(context *hookstate.Context, plugOrSlot 
 			return fmt.Errorf(i18n.G("invalid parameter: %q (want key=value)"), attrValue)
 		}
 
-		var value interface{}
+		var value any
 		if err := jsonutil.DecodeWithNumber(strings.NewReader(parts[1]), &value); err != nil {
 			// Not valid JSON, save the string as-is
 			value = parts[1]
@@ -232,7 +232,7 @@ func (s *setCommand) setInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	return nil
 }
 
-func setConfdbValues(ctx *hookstate.Context, plugName string, requests map[string]interface{}) error {
+func setConfdbValues(ctx *hookstate.Context, plugName string, requests map[string]any) error {
 	ctx.Lock()
 	defer ctx.Unlock()
 

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -160,9 +160,9 @@ func (s *setSuite) TestUnsetConfigOptionWithInitialConfiguration(c *C) {
 	c.Check(tr.Get("test-snap", "test-key2", &value), IsNil)
 	c.Check(value, Equals, "test-value2")
 	c.Check(tr.Get("test-snap", "test-key1", &value), ErrorMatches, `snap "test-snap" has no "test-key1" configuration option`)
-	var value2 interface{}
+	var value2 any
 	c.Check(tr.Get("test-snap", "test-key3", &value2), IsNil)
-	c.Check(value2, DeepEquals, map[string]interface{}{"bar": "bar-value"})
+	c.Check(value2, DeepEquals, map[string]any{"bar": "bar-value"})
 }
 
 func (s *setSuite) TestUnsetConfigOptionWithNoInitialConfiguration(c *C) {
@@ -177,7 +177,7 @@ func (s *setSuite) TestUnsetConfigOptionWithNoInitialConfiguration(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	var value interface{}
+	var value any
 	tr := config.NewTransaction(s.mockContext.State())
 	c.Check(tr.Get("test-snap", "test-key.key2", &value), IsNil)
 	c.Check(value, DeepEquals, "value2")
@@ -197,7 +197,7 @@ func (s *setSuite) TestSetNumbers(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	var value interface{}
+	var value any
 	tr := config.NewTransaction(s.mockContext.State())
 	c.Check(tr.Get("test-snap", "foo", &value), IsNil)
 	c.Check(value, Equals, json.Number("1234567890"))
@@ -218,10 +218,10 @@ func (s *setSuite) TestSetStrictJSON(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	var value interface{}
+	var value any
 	tr := config.NewTransaction(s.mockContext.State())
 	c.Assert(tr.Get("test-snap", "key", &value), IsNil)
-	c.Check(value, DeepEquals, map[string]interface{}{"a": "b", "c": json.Number("1"), "d": map[string]interface{}{"e": "f"}})
+	c.Check(value, DeepEquals, map[string]any{"a": "b", "c": json.Number("1"), "d": map[string]any{"e": "f"}})
 }
 
 func (s *setSuite) TestSetFailWithStrictJSON(c *C) {
@@ -242,7 +242,7 @@ func (s *setSuite) TestSetAsString(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	var value interface{}
+	var value any
 	tr := config.NewTransaction(s.mockContext.State())
 	c.Assert(tr.Get("test-snap", "key", &value), IsNil)
 	c.Check(value, Equals, expected)
@@ -297,13 +297,13 @@ func (s *setAttrSuite) SetUpTest(c *C) {
 	attrsTask := state.NewTask("connect-task", "my connect task")
 	attrsTask.Set("plug", &interfaces.PlugRef{Snap: "a", Name: "aplug"})
 	attrsTask.Set("slot", &interfaces.SlotRef{Snap: "b", Name: "bslot"})
-	staticAttrs := map[string]interface{}{
+	staticAttrs := map[string]any{
 		"lorem": "ipsum",
-		"nested": map[string]interface{}{
+		"nested": map[string]any{
 			"x": "y",
 		},
 	}
-	dynamicAttrs := make(map[string]interface{})
+	dynamicAttrs := make(map[string]any)
 	attrsTask.Set("plug-static", staticAttrs)
 	attrsTask.Set("plug-dynamic", dynamicAttrs)
 	attrsTask.Set("slot-static", staticAttrs)
@@ -356,7 +356,7 @@ func (s *setAttrSuite) TestSetPlugAttributesInPlugHook(c *C) {
 	st := s.mockPlugHookContext.State()
 	st.Lock()
 	defer st.Unlock()
-	dynattrs := make(map[string]interface{})
+	dynattrs := make(map[string]any)
 	err = attrsTask.Get("plug-dynamic", &dynattrs)
 	c.Assert(err, IsNil)
 	c.Check(dynattrs["foo"], Equals, "bar")
@@ -373,10 +373,10 @@ func (s *setAttrSuite) TestSetPlugAttributesSupportsDottedSyntax(c *C) {
 	st := s.mockPlugHookContext.State()
 	st.Lock()
 	defer st.Unlock()
-	dynattrs := make(map[string]interface{})
+	dynattrs := make(map[string]any)
 	err = attrsTask.Get("plug-dynamic", &dynattrs)
 	c.Assert(err, IsNil)
-	c.Check(dynattrs["my"], DeepEquals, map[string]interface{}{"attr1": "foo", "attr2": "bar"})
+	c.Check(dynattrs["my"], DeepEquals, map[string]any{"attr1": "foo", "attr2": "bar"})
 }
 
 func (s *setAttrSuite) TestPlugOrSlotEmpty(c *C) {

--- a/overlord/hookstate/ctlcmd/unset.go
+++ b/overlord/hookstate/ctlcmd/unset.go
@@ -95,7 +95,7 @@ func (s *unsetCommand) Execute(args []string) error {
 		return errors.New(i18n.G("cannot unset confdb: no paths provided to unset"))
 	}
 
-	confs := make(map[string]interface{}, len(s.Positional.ConfKeys)-1)
+	confs := make(map[string]any, len(s.Positional.ConfKeys)-1)
 	for _, key := range s.Positional.ConfKeys[1:] {
 		confs[key] = nil
 	}

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -70,7 +70,7 @@ func (s *unsetSuite) TestUnsetOne(c *C) {
 	s.mockContext.State().Unlock()
 
 	// Validity check
-	var value interface{}
+	var value any
 	s.mockContext.State().Lock()
 	tr = config.NewTransaction(s.mockContext.State())
 	c.Check(tr.Get("test-snap", "foo", &value), IsNil)
@@ -113,7 +113,7 @@ func (s *unsetSuite) TestUnsetMany(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	var value interface{}
+	var value any
 	tr = config.NewTransaction(s.mockContext.State())
 	c.Check(tr.Get("test-snap", "foo", &value), ErrorMatches, `snap "test-snap" has no "foo" configuration option`)
 	c.Check(tr.Get("test-snap", "bar", &value), ErrorMatches, `snap "test-snap" has no "bar" configuration option`)
@@ -141,7 +141,7 @@ func (s *unsetSuite) TestSetThenUnset(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	var value interface{}
+	var value any
 	tr = config.NewTransaction(s.mockContext.State())
 	c.Check(tr.Get("test-snap", "agent.x.a", &value), ErrorMatches, `snap "test-snap" has no "agent.x.a" configuration option`)
 }

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -300,7 +300,7 @@ func (m *HookManager) undoRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	return m.runHookForTask(task, tomb, snapst, hooksup)
 }
 
-func (m *HookManager) EphemeralRunHook(ctx context.Context, hooksup *HookSetup, contextData map[string]interface{}) (*Context, error) {
+func (m *HookManager) EphemeralRunHook(ctx context.Context, hooksup *HookSetup, contextData map[string]any) (*Context, error) {
 	var snapst snapstate.SnapState
 	m.state.Lock()
 	err := snapstate.Get(m.state, hooksup.Snap, &snapst)

--- a/overlord/hookstate/hooks_test.go
+++ b/overlord/hookstate/hooks_test.go
@@ -107,7 +107,7 @@ func (s *gateAutoRefreshHookSuite) TearDownTest(c *C) {
 	s.commonTearDownTest(c)
 }
 
-func mockRefreshCandidate(snapName, instanceKey, channel, version string, revision snap.Revision) interface{} {
+func mockRefreshCandidate(snapName, instanceKey, channel, version string, revision snap.Revision) any {
 	sup := &snapstate.SnapSetup{
 		Channel:     channel,
 		InstanceKey: instanceKey,
@@ -126,13 +126,13 @@ func (s *gateAutoRefreshHookSuite) settle(c *C) {
 }
 
 func checkIsHeld(c *C, st *state.State, heldSnap, gatingSnap string) {
-	var held map[string]map[string]interface{}
+	var held map[string]map[string]any
 	c.Assert(st.Get("snaps-hold", &held), IsNil)
 	c.Check(held[heldSnap][gatingSnap], NotNil)
 }
 
 func checkIsNotHeld(c *C, st *state.State, heldSnap string) {
-	var held map[string]map[string]interface{}
+	var held map[string]map[string]any
 	c.Assert(st.Get("snaps-hold", &held), IsNil)
 	c.Check(held[heldSnap], IsNil)
 }
@@ -355,7 +355,7 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookError(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	candidates := map[string]interface{}{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
+	candidates := map[string]any{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
 	st.Set("refresh-candidates", candidates)
 
 	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a")
@@ -407,7 +407,7 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookErrorAfterProceed(c *C
 	st.Lock()
 	defer st.Unlock()
 
-	candidates := map[string]interface{}{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
+	candidates := map[string]any{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
 	st.Set("refresh-candidates", candidates)
 
 	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a")
@@ -458,7 +458,7 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookErrorRuninhibitUnlock(
 	tr.Set("core", "experimental.refresh-app-awareness", true)
 	tr.Commit()
 
-	candidates := map[string]interface{}{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
+	candidates := map[string]any{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
 	st.Set("refresh-candidates", candidates)
 
 	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a")
@@ -504,7 +504,7 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookErrorHoldErrorLogged(c
 	st.Lock()
 	defer st.Unlock()
 
-	candidates := map[string]interface{}{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
+	candidates := map[string]any{"snap-a": mockRefreshCandidate("snap-a", "", "edge", "v1", snap.Revision{N: 3})}
 	st.Set("refresh-candidates", candidates)
 
 	task := hookstate.SetupGateAutoRefreshHook(st, "snap-a")
@@ -527,7 +527,7 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshHookErrorHoldErrorLogged(c
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
 	// and snap-b is not held (due to hold error).
-	var held map[string]map[string]interface{}
+	var held map[string]map[string]any
 	c.Assert(st.Get("snaps-hold", &held), IsNil)
 	c.Check(held, HasLen, 0)
 

--- a/overlord/hookstate/hookstate.go
+++ b/overlord/hookstate/hookstate.go
@@ -27,7 +27,7 @@ import (
 
 // HookTaskWithUndo returns a task that will run the specified hook. On error the undo hook will be executed.
 // Note that the initial context must properly marshal and unmarshal with encoding/json.
-func HookTaskWithUndo(st *state.State, summary string, setup *HookSetup, undo *HookSetup, contextData map[string]interface{}) *state.Task {
+func HookTaskWithUndo(st *state.State, summary string, setup *HookSetup, undo *HookSetup, contextData map[string]any) *state.Task {
 	task := st.NewTask("run-hook", summary)
 	task.Set("hook-setup", setup)
 	if undo != nil {
@@ -43,6 +43,6 @@ func HookTaskWithUndo(st *state.State, summary string, setup *HookSetup, undo *H
 
 // HookTask returns a task that will run the specified hook. Note that the
 // initial context must properly marshal and unmarshal with encoding/json.
-func HookTask(st *state.State, summary string, setup *HookSetup, contextData map[string]interface{}) *state.Task {
+func HookTask(st *state.State, summary string, setup *HookSetup, contextData map[string]any) *state.Task {
 	return HookTaskWithUndo(st, summary, setup, nil, contextData)
 }

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -117,7 +117,7 @@ func (s *baseHookManagerSuite) setUpSnap(c *C, instanceName string, yaml string)
 		Revision: snap.R(1),
 	}
 
-	initialContext := map[string]interface{}{
+	initialContext := map[string]any{
 		"test-key": "test-value",
 	}
 
@@ -703,7 +703,7 @@ func (s *hookManagerSuite) TestHookUndoRunsOnError(c *C) {
 		Revision: snap.R(1),
 	}
 
-	initialContext := map[string]interface{}{}
+	initialContext := map[string]any{}
 
 	s.state.Lock()
 	task := hookstate.HookTaskWithUndo(s.state, "test summary", hooksup, undohooksup, initialContext)
@@ -1152,7 +1152,7 @@ func (s *hookManagerSuite) TestHookHijackingNoConflict(c *C) {
 }
 
 func (s *hookManagerSuite) TestEphemeralRunHook(c *C) {
-	contextData := map[string]interface{}{
+	contextData := map[string]any{
 		"key":  "value",
 		"key2": "value2",
 	}
@@ -1160,11 +1160,11 @@ func (s *hookManagerSuite) TestEphemeralRunHook(c *C) {
 }
 
 func (s *hookManagerSuite) TestEphemeralRunHookNoContextData(c *C) {
-	var contextData map[string]interface{} = nil
+	var contextData map[string]any = nil
 	s.testEphemeralRunHook(c, contextData)
 }
 
-func (s *hookManagerSuite) testEphemeralRunHook(c *C, contextData map[string]interface{}) {
+func (s *hookManagerSuite) testEphemeralRunHook(c *C, contextData map[string]any) {
 	var hookInvokeCalled []string
 	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 		c.Check(ctx.HookName(), Equals, "configure")
@@ -1214,7 +1214,7 @@ func (s *hookManagerSuite) TestEphemeralRunHookNoSnap(c *C) {
 		Revision: snap.R(1),
 		Hook:     "configure",
 	}
-	contextData := map[string]interface{}{
+	contextData := map[string]any{
 		"key": "value",
 	}
 	_, err := s.manager.EphemeralRunHook(context.Background(), hooksup, contextData)

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -186,7 +186,7 @@ func UpdateConnectionInConnState(conns map[string]*schema.ConnState, conn *inter
 	}
 }
 
-func GetConnStateAttrs(conns map[string]*schema.ConnState, connID string) (plugStatic, plugDynamic, slotStatic, SlotDynamic map[string]interface{}, ok bool) {
+func GetConnStateAttrs(conns map[string]*schema.ConnState, connID string) (plugStatic, plugDynamic, slotStatic, SlotDynamic map[string]any, ok bool) {
 	conn, ok := conns[connID]
 	if !ok {
 		return nil, nil, nil, nil, false

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -552,7 +552,7 @@ func (m *InterfaceManager) undoDiscardConns(task *state.Task, _ *tomb.Tomb) erro
 	return nil
 }
 
-func getDynamicHookAttributes(task *state.Task) (plugAttrs, slotAttrs map[string]interface{}, err error) {
+func getDynamicHookAttributes(task *state.Task) (plugAttrs, slotAttrs map[string]any, err error) {
 	if err = task.Get("plug-dynamic", &plugAttrs); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, nil, err
 	}
@@ -560,16 +560,16 @@ func getDynamicHookAttributes(task *state.Task) (plugAttrs, slotAttrs map[string
 		return nil, nil, err
 	}
 	if plugAttrs == nil {
-		plugAttrs = make(map[string]interface{})
+		plugAttrs = make(map[string]any)
 	}
 	if slotAttrs == nil {
-		slotAttrs = make(map[string]interface{})
+		slotAttrs = make(map[string]any)
 	}
 
 	return plugAttrs, slotAttrs, nil
 }
 
-func setDynamicHookAttributes(task *state.Task, plugAttrs, slotAttrs map[string]interface{}) {
+func setDynamicHookAttributes(task *state.Task, plugAttrs, slotAttrs map[string]any) {
 	task.Set("plug-dynamic", plugAttrs)
 	task.Set("slot-dynamic", slotAttrs)
 }
@@ -1822,7 +1822,7 @@ func (m *InterfaceManager) doHotplugUpdateSlot(task *state.Task, _ *tomb.Tomb) e
 		return fmt.Errorf("internal error: cannot get hotplug task attributes: %s", err)
 	}
 
-	var attrs map[string]interface{}
+	var attrs map[string]any
 	if err := task.Get("slot-attrs", &attrs); err != nil {
 		return fmt.Errorf("internal error: cannot get slot-attrs attribute for device %s, interface %s: %s", hotplugKey, ifaceName, err)
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -437,8 +437,8 @@ ConnsLoop:
 		var updateStaticAttrs bool
 		staticPlugAttrs := connState.StaticPlugAttrs
 		staticSlotAttrs := connState.StaticSlotAttrs
-		newStaticPlugAttrs := utils.NormalizeInterfaceAttributes(plugInfo.Attrs).(map[string]interface{})
-		newStaticSlotAttrs := utils.NormalizeInterfaceAttributes(slotInfo.Attrs).(map[string]interface{})
+		newStaticPlugAttrs := utils.NormalizeInterfaceAttributes(plugInfo.Attrs).(map[string]any)
+		newStaticSlotAttrs := utils.NormalizeInterfaceAttributes(slotInfo.Attrs).(map[string]any)
 
 		// if the interface was originally autoconnected, update the static attrs if it would
 		// still be allowed to autoconnect. Otherwise, update the static attrs if it would still
@@ -1045,10 +1045,10 @@ func getConns(st *state.State) (conns map[string]*schema.ConnState, err error) {
 		}
 		cref.PlugRef.Snap = RemapSnapFromState(cref.PlugRef.Snap)
 		cref.SlotRef.Snap = RemapSnapFromState(cref.SlotRef.Snap)
-		cstate.StaticSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticSlotAttrs).(map[string]interface{})
-		cstate.DynamicSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicSlotAttrs).(map[string]interface{})
-		cstate.StaticPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticPlugAttrs).(map[string]interface{})
-		cstate.DynamicPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicPlugAttrs).(map[string]interface{})
+		cstate.StaticSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticSlotAttrs).(map[string]any)
+		cstate.DynamicSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicSlotAttrs).(map[string]any)
+		cstate.StaticPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticPlugAttrs).(map[string]any)
+		cstate.DynamicPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicPlugAttrs).(map[string]any)
 		remapped[cref.ID()] = cstate
 	}
 	return remapped, nil
@@ -1422,10 +1422,10 @@ func addHotplugSeqWaitTask(hotplugChange *state.Change, hotplugKey snap.HotplugK
 }
 
 type HotplugSlotInfo struct {
-	Name        string                 `json:"name"`
-	Interface   string                 `json:"interface"`
-	StaticAttrs map[string]interface{} `json:"static-attrs,omitempty"`
-	HotplugKey  snap.HotplugKey        `json:"hotplug-key"`
+	Name        string          `json:"name"`
+	Interface   string          `json:"interface"`
+	StaticAttrs map[string]any  `json:"static-attrs,omitempty"`
+	HotplugKey  snap.HotplugKey `json:"hotplug-key"`
 
 	// device was unplugged but has connections, so slot is remembered
 	HotplugGone bool `json:"hotplug-gone"`

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -65,8 +65,8 @@ func (s *helpersSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 }
 
-func (s *helpersSuite) MockModel(c *C, extraHeaders map[string]interface{}) {
-	model := assertstest.FakeAssertion(map[string]interface{}{
+func (s *helpersSuite) MockModel(c *C, extraHeaders map[string]any) {
+	model := assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -167,11 +167,11 @@ func (s *helpersSuite) TestMappingFunctions(c *C) {
 func (s *helpersSuite) TestGetConns(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
-	s.st.Set("conns", map[string]interface{}{
-		"app:network core:network": map[string]interface{}{
+	s.st.Set("conns", map[string]any{
+		"app:network core:network": map[string]any{
 			"auto":      true,
 			"interface": "network",
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"number": int(78),
 			},
 		},
@@ -199,11 +199,11 @@ func (s *helpersSuite) TestSetConns(c *C) {
 
 	// This has upper-case data internally, see export_test.go
 	ifacestate.SetConns(s.st, ifacestate.UpperCaseConnState())
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.st.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"app:network core:network": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"app:network core:network": map[string]any{
 			"auto":      true,
 			"interface": "network",
 		}})
@@ -249,18 +249,18 @@ func (s *helpersSuite) TestHotplugSlotInfo(c *C) {
 	defs["foo"] = &ifacestate.HotplugSlotInfo{
 		Name:        "foo",
 		Interface:   "iface",
-		StaticAttrs: map[string]interface{}{"attr": "value"},
+		StaticAttrs: map[string]any{"attr": "value"},
 		HotplugKey:  "key",
 	}
 	ifacestate.SetHotplugSlots(s.st, defs)
 
-	var data map[string]interface{}
+	var data map[string]any
 	c.Assert(s.st.Get("hotplug-slots", &data), IsNil)
-	c.Assert(data, DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Assert(data, DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"name":         "foo",
 			"interface":    "iface",
-			"static-attrs": map[string]interface{}{"attr": "value"},
+			"static-attrs": map[string]any{"attr": "value"},
 			"hotplug-key":  "key",
 			"hotplug-gone": false,
 		}})
@@ -277,20 +277,20 @@ func (s *helpersSuite) TestFindConnsForHotplugKey(c *C) {
 
 	// Set conns in the state and get them via GetConns to avoid having to
 	// know the internals of connState struct.
-	st.Set("conns", map[string]interface{}{
-		"snap1:plug1 core:slot1": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"snap1:plug1 core:slot1": map[string]any{
 			"interface":   "iface1",
 			"hotplug-key": "key1",
 		},
-		"snap1:plug2 core:slot2": map[string]interface{}{
+		"snap1:plug2 core:slot2": map[string]any{
 			"interface":   "iface2",
 			"hotplug-key": "key1",
 		},
-		"snap1:plug3 core:slot3": map[string]interface{}{
+		"snap1:plug3 core:slot3": map[string]any{
 			"interface":   "iface2",
 			"hotplug-key": "key2",
 		},
-		"snap2:plug1 core:slot1": map[string]interface{}{
+		"snap2:plug1 core:slot1": map[string]any{
 			"interface":   "iface2",
 			"hotplug-key": "key2",
 		},
@@ -698,7 +698,7 @@ func (s *helpersSuite) TestAddHotplugSlot(c *C) {
 		Label:      "label",
 		Snap:       coreAppSet.Info(),
 		Interface:  "test",
-		Attrs:      map[string]interface{}{"foo": "bar"},
+		Attrs:      map[string]any{"foo": "bar"},
 		HotplugKey: "key",
 	}
 	c.Assert(ifacestate.AddHotplugSlot(s.st, repo, stateSlots, iface, slot), IsNil)
@@ -716,7 +716,7 @@ func (s *helpersSuite) TestAddHotplugSlot(c *C) {
 	c.Check(stateSlot, DeepEquals, &ifacestate.HotplugSlotInfo{
 		Name:        "slot",
 		Interface:   "test",
-		StaticAttrs: map[string]interface{}{"foo": "bar"},
+		StaticAttrs: map[string]any{"foo": "bar"},
 		HotplugKey:  "key",
 		HotplugGone: false})
 }

--- a/overlord/ifacestate/hotplug.go
+++ b/overlord/ifacestate/hotplug.go
@@ -429,7 +429,7 @@ func hotplugSlotName(hotplugKey snap.HotplugKey, systemSnapInstanceName, slotSpe
 }
 
 // updateDevice creates tasks to disconnect slots of given device and update the slot in the repository.
-func updateDevice(st *state.State, ifaceName string, hotplugKey snap.HotplugKey, newAttrs map[string]interface{}) *state.TaskSet {
+func updateDevice(st *state.State, ifaceName string, hotplugKey snap.HotplugKey, newAttrs map[string]any) *state.TaskSet {
 	hotplugDisconnect := st.NewTask("hotplug-disconnect", fmt.Sprintf("Disable connections of interface %q, hotplug key %q", ifaceName, hotplugKey.ShortString()))
 	setHotplugAttrs(hotplugDisconnect, ifaceName, hotplugKey)
 

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -212,7 +212,7 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 		HotplugDeviceDetectedCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (*hotplug.ProposedSlot, error) {
 			return &hotplug.ProposedSlot{
 				Name: "hotplugslot-a",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"slot-a-attr1": "a",
 					"path":         deviceInfo.DevicePath(),
 				}}, nil
@@ -317,7 +317,7 @@ func (s *hotplugSuite) TestHotplugAddBasic(c *C) {
 	slots := repo.AllSlots("test-a")
 	c.Assert(slots, HasLen, 1)
 	c.Check(slots[0].Name, Equals, "hotplugslot-a")
-	c.Check(slots[0].Attrs, DeepEquals, map[string]interface{}{
+	c.Check(slots[0].Attrs, DeepEquals, map[string]any{
 		"path":         di.DevicePath(),
 		"slot-a-attr1": "a"})
 	c.Check(slots[0].HotplugKey, DeepEquals, snap.HotplugKey("key-1"))
@@ -334,7 +334,7 @@ func (s *hotplugSuite) TestHotplugAddBasic(c *C) {
 }
 
 func (s *hotplugSuite) TestHotplugConnectWithGadgetSlot(c *C) {
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"gadget": "the-gadget",
 	})
 
@@ -496,13 +496,13 @@ func (s *hotplugSuite) TestHotplugRemove(c *C) {
 	st := s.state
 	st.Lock()
 
-	st.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test-a",
 			"hotplug-key":  "key-1",
 			"hotplug-gone": false}})
-	st.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	st.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":         "hotplugslot",
 			"interface":    "test-a",
 			"hotplug-key":  "key-1",
@@ -524,7 +524,7 @@ func (s *hotplugSuite) TestHotplugRemove(c *C) {
 	c.Assert(repo.AddSlot(&snap.SlotInfo{
 		Interface:  "test-a",
 		Name:       "hotplugslot",
-		Attrs:      map[string]interface{}{},
+		Attrs:      map[string]any{},
 		Snap:       core,
 		HotplugKey: "key-1",
 	}), IsNil)
@@ -565,10 +565,10 @@ func (s *hotplugSuite) TestHotplugRemove(c *C) {
 	slot, _ = repo.SlotForHotplugKey("test-a", "key-1")
 	c.Assert(slot, IsNil)
 
-	var newconns map[string]interface{}
+	var newconns map[string]any
 	c.Assert(st.Get("conns", &newconns), IsNil)
-	c.Assert(newconns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	c.Assert(newconns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test-a",
 			"hotplug-key":  "key-1",
 			"hotplug-gone": true}})
@@ -581,8 +581,8 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 	st.Lock()
 
 	// existing connection
-	st.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test-a",
 			"hotplug-key":  "key-other-device",
 			"hotplug-gone": false}})
@@ -603,7 +603,7 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 	c.Assert(repo.AddSlot(&snap.SlotInfo{
 		Interface:  "test-a",
 		Name:       "hotplugslot",
-		Attrs:      map[string]interface{}{},
+		Attrs:      map[string]any{},
 		Snap:       core,
 		HotplugKey: "key-other-device",
 	}), IsNil)
@@ -615,12 +615,12 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(conn, NotNil)
 
-	st.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	st.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test-a",
 			"hotplug-key": "key-other-device"},
-		"anotherslot": map[string]interface{}{
+		"anotherslot": map[string]any{
 			"name":        "anotherslot",
 			"interface":   "test-a",
 			"hotplug-key": "yet-another-device"}})
@@ -654,22 +654,22 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 
 	// and the connection for missing device is marked with hotplug-gone: true;
 	// "anotherslot" is removed completely since there was no connection for it.
-	var newconns map[string]interface{}
+	var newconns map[string]any
 	c.Assert(st.Get("conns", &newconns), IsNil)
-	c.Check(newconns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	c.Check(newconns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"hotplug-gone": true,
 			"hotplug-key":  "key-other-device",
 			"interface":    "test-a"}})
 
-	var newHotplugSlots map[string]interface{}
+	var newHotplugSlots map[string]any
 	c.Assert(st.Get("hotplug-slots", &newHotplugSlots), IsNil)
-	c.Check(newHotplugSlots, DeepEquals, map[string]interface{}{
-		"hotplugslot-a": map[string]interface{}{
-			"interface": "test-a", "hotplug-gone": false, "static-attrs": map[string]interface{}{"slot-a-attr1": "a", "path": di.DevicePath()}, "hotplug-key": "key-1", "name": "hotplugslot-a"},
-		"hotplugslot-b": map[string]interface{}{
+	c.Check(newHotplugSlots, DeepEquals, map[string]any{
+		"hotplugslot-a": map[string]any{
+			"interface": "test-a", "hotplug-gone": false, "static-attrs": map[string]any{"slot-a-attr1": "a", "path": di.DevicePath()}, "hotplug-key": "key-1", "name": "hotplugslot-a"},
+		"hotplugslot-b": map[string]any{
 			"name": "hotplugslot-b", "hotplug-gone": false, "interface": "test-b", "hotplug-key": "key-2"},
-		"hotplugslot": map[string]interface{}{"name": "hotplugslot", "hotplug-gone": true, "interface": "test-a", "hotplug-key": "key-other-device"}})
+		"hotplugslot": map[string]any{"name": "hotplugslot", "hotplug-gone": true, "interface": "test-a", "hotplug-key": "key-other-device"}})
 }
 
 func (s *hotplugSuite) TestHotplugDeviceUpdate(c *C) {
@@ -678,12 +678,12 @@ func (s *hotplugSuite) TestHotplugDeviceUpdate(c *C) {
 	st.Lock()
 
 	// existing connection
-	st.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot-a": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot-a": map[string]any{
 			"interface":    "test-a",
 			"hotplug-key":  "key-1",
 			"hotplug-gone": false,
-			"slot-static":  map[string]interface{}{"path": "/path-1"}}})
+			"slot-static":  map[string]any{"path": "/path-1"}}})
 
 	repo := s.mgr.Repository()
 	si := &snap.SideInfo{RealName: "consumer", Revision: snap.R(1)}
@@ -700,7 +700,7 @@ func (s *hotplugSuite) TestHotplugDeviceUpdate(c *C) {
 	c.Assert(repo.AddSlot(&snap.SlotInfo{
 		Interface:  "test-a",
 		Name:       "hotplugslot-a",
-		Attrs:      map[string]interface{}{"path": "/path-1"},
+		Attrs:      map[string]any{"path": "/path-1"},
 		Snap:       core,
 		HotplugKey: "key-1",
 	}), IsNil)
@@ -712,12 +712,12 @@ func (s *hotplugSuite) TestHotplugDeviceUpdate(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(conn, NotNil)
 
-	st.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot-a": map[string]interface{}{
+	st.Set("hotplug-slots", map[string]any{
+		"hotplugslot-a": map[string]any{
 			"name":         "hotplugslot-a",
 			"interface":    "test-a",
 			"hotplug-key":  "key-1",
-			"static-attrs": map[string]interface{}{"path": "/path-1"}}})
+			"static-attrs": map[string]any{"path": "/path-1"}}})
 	st.Unlock()
 
 	// simulate device update
@@ -751,23 +751,23 @@ func (s *hotplugSuite) TestHotplugDeviceUpdate(c *C) {
 	// make sure slots for new device have been updated in the repo
 	slot, err := repo.SlotForHotplugKey("test-a", "key-1")
 	c.Assert(err, IsNil)
-	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"path": di.DevicePath(), "slot-a-attr1": "a"})
+	c.Check(slot.Attrs, DeepEquals, map[string]any{"path": di.DevicePath(), "slot-a-attr1": "a"})
 
 	// and the connection attributes have been updated
-	var newconns map[string]interface{}
+	var newconns map[string]any
 	c.Assert(st.Get("conns", &newconns), IsNil)
-	c.Check(newconns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot-a": map[string]interface{}{
+	c.Check(newconns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot-a": map[string]any{
 			"hotplug-key": "key-1",
 			"interface":   "test-a",
-			"slot-static": map[string]interface{}{"path": di.DevicePath(), "slot-a-attr1": "a"},
+			"slot-static": map[string]any{"path": di.DevicePath(), "slot-a-attr1": "a"},
 		}})
 
-	var newHotplugSlots map[string]interface{}
+	var newHotplugSlots map[string]any
 	c.Assert(st.Get("hotplug-slots", &newHotplugSlots), IsNil)
-	c.Check(newHotplugSlots["hotplugslot-a"], DeepEquals, map[string]interface{}{
+	c.Check(newHotplugSlots["hotplugslot-a"], DeepEquals, map[string]any{
 		"interface":    "test-a",
-		"static-attrs": map[string]interface{}{"slot-a-attr1": "a", "path": di.DevicePath()},
+		"static-attrs": map[string]any{"slot-a-attr1": "a", "path": di.DevicePath()},
 		"hotplug-key":  "key-1",
 		"name":         "hotplugslot-a",
 		"hotplug-gone": false})
@@ -1098,7 +1098,7 @@ func (s *hotplugSuite) TestUpdateDeviceTasks(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	tss := ifacestate.UpdateDevice(st, "interface", "key", map[string]interface{}{"attr": "value"})
+	tss := ifacestate.UpdateDevice(st, "interface", "key", map[string]any{"attr": "value"})
 	c.Assert(tss, NotNil)
 	c.Assert(tss.Tasks(), HasLen, 2)
 
@@ -1110,9 +1110,9 @@ func (s *hotplugSuite) TestUpdateDeviceTasks(c *C) {
 	c.Assert(task2.Kind(), Equals, "hotplug-update-slot")
 	testHotplugTaskAttrs(c, task2, "interface", "key")
 
-	var attrs map[string]interface{}
+	var attrs map[string]any
 	c.Assert(task2.Get("slot-attrs", &attrs), IsNil)
-	c.Assert(attrs, DeepEquals, map[string]interface{}{"attr": "value"})
+	c.Assert(attrs, DeepEquals, map[string]any{"attr": "value"})
 
 	wt := task2.WaitTasks()
 	c.Assert(wt, HasLen, 1)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -364,10 +364,10 @@ type ConnectionState struct {
 	// Undesired indicates whether the connection, otherwise established
 	// automatically, was explicitly disconnected
 	Undesired        bool
-	StaticPlugAttrs  map[string]interface{}
-	DynamicPlugAttrs map[string]interface{}
-	StaticSlotAttrs  map[string]interface{}
-	DynamicSlotAttrs map[string]interface{}
+	StaticPlugAttrs  map[string]any
+	DynamicPlugAttrs map[string]any
+	StaticSlotAttrs  map[string]any
+	DynamicSlotAttrs map[string]any
 	HotplugGone      bool
 }
 

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -146,7 +146,7 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 	}
 
 	connectInterface := st.NewTask("connect", fmt.Sprintf(i18n.G("Connect %s:%s to %s:%s"), plugSnap, plugName, slotSnap, slotName))
-	initialContext := make(map[string]interface{})
+	initialContext := make(map[string]any)
 	initialContext["attrs-task"] = connectInterface.ID()
 
 	tasks := state.NewTaskSet()
@@ -211,7 +211,7 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 
 	// Expose a copy of all plug and slot attributes coming from yaml to interface hooks. The hooks will be able
 	// to modify them but all attributes will be checked against assertions after the hooks are run.
-	emptyDynamicAttrs := map[string]interface{}{}
+	emptyDynamicAttrs := map[string]any{}
 	connectInterface.Set("plug-static", plugStatic)
 	connectInterface.Set("slot-static", slotStatic)
 	connectInterface.Set("plug-dynamic", emptyDynamicAttrs)
@@ -280,7 +280,7 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 	return tasks, nil
 }
 
-func initialConnectAttributes(st *state.State, plugSnapInfo *snap.Info, plugSnap string, plugName string, slotSnapInfo *snap.Info, slotSnap string, slotName string) (plugStatic, slotStatic map[string]interface{}, err error) {
+func initialConnectAttributes(st *state.State, plugSnapInfo *snap.Info, plugSnap string, plugName string, slotSnapInfo *snap.Info, slotSnap string, slotName string) (plugStatic, slotStatic map[string]any, err error) {
 	var plugSnapst snapstate.SnapState
 
 	if err = snapstate.Get(st, plugSnap, &plugSnapst); err != nil {
@@ -412,7 +412,7 @@ func disconnectTasks(st *state.State, conn *interfaces.Connection, flags disconn
 		prev = t
 	}
 
-	initialContext := make(map[string]interface{})
+	initialContext := make(map[string]any)
 	initialContext["attrs-task"] = disconnectTask.ID()
 
 	plugSnapInfo, err := plugSnapst.CurrentInfo()

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -97,8 +97,8 @@ func (am *AssertsMock) SetupAsserts(c *C, st *state.State, cleaner cleaner) {
 	st.Unlock()
 }
 
-func (am *AssertsMock) mockModel(extraHeaders map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func (am *AssertsMock) mockModel(extraHeaders map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -112,29 +112,29 @@ func (am *AssertsMock) mockModel(extraHeaders map[string]interface{}) *asserts.M
 	return assertstest.FakeAssertion(model, extraHeaders).(*asserts.Model)
 }
 
-func (am *AssertsMock) MockModel(c *C, extraHeaders map[string]interface{}) {
+func (am *AssertsMock) MockModel(c *C, extraHeaders map[string]any) {
 	model := am.mockModel(extraHeaders)
 	am.cleaner.AddCleanup(snapstatetest.MockDeviceModel(model))
 }
 
-func (am *AssertsMock) TrivialDeviceContext(c *C, extraHeaders map[string]interface{}) *snapstatetest.TrivialDeviceContext {
+func (am *AssertsMock) TrivialDeviceContext(c *C, extraHeaders map[string]any) *snapstatetest.TrivialDeviceContext {
 	model := am.mockModel(extraHeaders)
 	return &snapstatetest.TrivialDeviceContext{DeviceModel: model}
 }
 
-func (am *AssertsMock) MockSnapDecl(c *C, name, publisher string, extraHeaders map[string]interface{}) {
+func (am *AssertsMock) MockSnapDecl(c *C, name, publisher string, extraHeaders map[string]any) {
 	_, err := am.Db.Find(asserts.AccountType, map[string]string{
 		"account-id": publisher,
 	})
 	if errors.Is(err, &asserts.NotFoundError{}) {
-		acct := assertstest.NewAccount(am.storeSigning, publisher, map[string]interface{}{
+		acct := assertstest.NewAccount(am.storeSigning, publisher, map[string]any{
 			"account-id": publisher,
 		}, "")
 		err = am.Db.Add(acct)
 	}
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-name":    name,
 		"publisher-id": publisher,
@@ -152,8 +152,8 @@ func (am *AssertsMock) MockSnapDecl(c *C, name, publisher string, extraHeaders m
 	c.Assert(err, IsNil)
 }
 
-func (am *AssertsMock) MockStore(c *C, st *state.State, storeID string, extraHeaders map[string]interface{}) {
-	headers := map[string]interface{}{
+func (am *AssertsMock) MockStore(c *C, st *state.State, storeID string, extraHeaders map[string]any) {
+	headers := map[string]any{
 		"store":       storeID,
 		"operator-id": am.storeSigning.AuthorityID,
 		"timestamp":   time.Now().Format(time.RFC3339),
@@ -530,19 +530,19 @@ func (s *interfaceManagerSuite) TestConnectTask(c *C) {
 	c.Assert(autoconnect, Equals, false)
 
 	// verify initial attributes are present in connect task
-	var plugStaticAttrs map[string]interface{}
-	var plugDynamicAttrs map[string]interface{}
+	var plugStaticAttrs map[string]any
+	var plugDynamicAttrs map[string]any
 	c.Assert(task.Get("plug-static", &plugStaticAttrs), IsNil)
-	c.Assert(plugStaticAttrs, DeepEquals, map[string]interface{}{"attr1": "value1"})
+	c.Assert(plugStaticAttrs, DeepEquals, map[string]any{"attr1": "value1"})
 	c.Assert(task.Get("plug-dynamic", &plugDynamicAttrs), IsNil)
-	c.Assert(plugDynamicAttrs, DeepEquals, map[string]interface{}{})
+	c.Assert(plugDynamicAttrs, DeepEquals, map[string]any{})
 
-	var slotStaticAttrs map[string]interface{}
-	var slotDynamicAttrs map[string]interface{}
+	var slotStaticAttrs map[string]any
+	var slotDynamicAttrs map[string]any
 	c.Assert(task.Get("slot-static", &slotStaticAttrs), IsNil)
-	c.Assert(slotStaticAttrs, DeepEquals, map[string]interface{}{"attr2": "value2"})
+	c.Assert(slotStaticAttrs, DeepEquals, map[string]any{"attr2": "value2"})
 	c.Assert(task.Get("slot-dynamic", &slotDynamicAttrs), IsNil)
-	c.Assert(slotDynamicAttrs, DeepEquals, map[string]interface{}{})
+	c.Assert(slotDynamicAttrs, DeepEquals, map[string]any{})
 
 	i++
 	task = ts.Tasks()[i]
@@ -946,23 +946,23 @@ func (s *interfaceManagerSuite) TestParallelInstallConnectTask(c *C) {
 	c.Assert(autoconnect, Equals, false)
 
 	// verify initial attributes are present in connect task
-	var plugStaticAttrs map[string]interface{}
-	var plugDynamicAttrs map[string]interface{}
+	var plugStaticAttrs map[string]any
+	var plugDynamicAttrs map[string]any
 	err = task.Get("plug-static", &plugStaticAttrs)
 	c.Assert(err, IsNil)
-	c.Assert(plugStaticAttrs, DeepEquals, map[string]interface{}{"attr1": "value1"})
+	c.Assert(plugStaticAttrs, DeepEquals, map[string]any{"attr1": "value1"})
 	err = task.Get("plug-dynamic", &plugDynamicAttrs)
 	c.Assert(err, IsNil)
-	c.Assert(plugDynamicAttrs, DeepEquals, map[string]interface{}{})
+	c.Assert(plugDynamicAttrs, DeepEquals, map[string]any{})
 
-	var slotStaticAttrs map[string]interface{}
-	var slotDynamicAttrs map[string]interface{}
+	var slotStaticAttrs map[string]any
+	var slotDynamicAttrs map[string]any
 	err = task.Get("slot-static", &slotStaticAttrs)
 	c.Assert(err, IsNil)
-	c.Assert(slotStaticAttrs, DeepEquals, map[string]interface{}{"attr2": "value2"})
+	c.Assert(slotStaticAttrs, DeepEquals, map[string]any{"attr2": "value2"})
 	err = task.Get("slot-dynamic", &slotDynamicAttrs)
 	c.Assert(err, IsNil)
-	c.Assert(slotDynamicAttrs, DeepEquals, map[string]interface{}{})
+	c.Assert(slotDynamicAttrs, DeepEquals, map[string]any{})
 
 	i++
 	task = ts.Tasks()[i]
@@ -987,8 +987,8 @@ func (s *interfaceManagerSuite) TestConnectAlreadyConnected(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	conns := map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	conns := map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"auto": false,
 		},
 	}
@@ -1002,8 +1002,8 @@ func (s *interfaceManagerSuite) TestConnectAlreadyConnected(c *C) {
 	c.Assert(alreadyConnected.Connection, DeepEquals, interfaces.ConnRef{PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"}, SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}})
 	c.Assert(err, ErrorMatches, `already connected: "consumer:plug producer:slot"`)
 
-	conns = map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	conns = map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"auto":      true,
 			"undesired": true,
 		},
@@ -1015,7 +1015,7 @@ func (s *interfaceManagerSuite) TestConnectAlreadyConnected(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(ts, NotNil)
 
-	conns = map[string]interface{}{"consumer:plug producer:slot": map[string]interface{}{"hotplug-gone": true}}
+	conns = map[string]any{"consumer:plug producer:slot": map[string]any{"hotplug-gone": true}}
 	s.state.Set("conns", conns)
 
 	// ErrAlreadyConnected is not reported if connection was removed by hotplug
@@ -1568,7 +1568,7 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeNoStore(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeWrongStore(c *C) {
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "other-store",
 	})
 
@@ -1583,7 +1583,7 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeWrongStore(c *C) 
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeRightStore(c *C) {
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "my-store",
 	})
 
@@ -1601,12 +1601,12 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeRightStore(c *C) 
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeWrongFriendlyStore(c *C) {
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "my-substore",
 	})
 
-	s.MockStore(c, s.state, "my-substore", map[string]interface{}{
-		"friendly-stores": []interface{}{"other-store"},
+	s.MockStore(c, s.state, "my-substore", map[string]any{
+		"friendly-stores": []any{"other-store"},
 	})
 
 	s.testConnectTaskCheckDeviceScope(c, func(change *state.Change) {
@@ -1620,12 +1620,12 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeWrongFriendlyStor
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeRightFriendlyStore(c *C) {
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "my-substore",
 	})
 
-	s.MockStore(c, s.state, "my-substore", map[string]interface{}{
-		"friendly-stores": []interface{}{"my-store"},
+	s.MockStore(c, s.state, "my-substore", map[string]any{
+		"friendly-stores": []any{"my-store"},
 	})
 
 	s.testConnectTaskCheckDeviceScope(c, func(change *state.Change) {
@@ -1655,12 +1655,12 @@ slots:
 
 	s.MockSnapDecl(c, "producer", "one-publisher", nil)
 	s.mockSnap(c, producerYaml)
-	s.MockSnapDecl(c, "consumer", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "consumer", "one-publisher", map[string]any{
 		"format": "3",
-		"plugs": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-connection": map[string]interface{}{
-					"on-store": []interface{}{"my-store"},
+		"plugs": map[string]any{
+			"test": map[string]any{
+				"allow-connection": map[string]any{
+					"on-store": []any{"my-store"},
 				},
 			},
 		},
@@ -1692,8 +1692,8 @@ func (s *interfaceManagerSuite) TestDisconnectTask(c *C) {
 	slotAppSet := s.mockAppSet(c, producerYaml)
 
 	conn := &interfaces.Connection{
-		Plug: interfaces.NewConnectedPlug(plugAppSet.Info().Plugs["plug"], plugAppSet, nil, map[string]interface{}{"attr3": "value3"}),
-		Slot: interfaces.NewConnectedSlot(slotAppSet.Info().Slots["slot"], slotAppSet, nil, map[string]interface{}{"attr4": "value4"}),
+		Plug: interfaces.NewConnectedPlug(plugAppSet.Info().Plugs["plug"], plugAppSet, nil, map[string]any{"attr3": "value3"}),
+		Slot: interfaces.NewConnectedSlot(slotAppSet.Info().Slots["slot"], slotAppSet, nil, map[string]any{"attr4": "value4"}),
 	}
 
 	s.state.Lock()
@@ -1737,17 +1737,17 @@ func (s *interfaceManagerSuite) TestDisconnectTask(c *C) {
 	c.Assert(slot.Name, Equals, "slot")
 
 	// verify connection attributes are present in the disconnect task
-	var plugStaticAttrs1, plugDynamicAttrs1, slotStaticAttrs1, slotDynamicAttrs1 map[string]interface{}
+	var plugStaticAttrs1, plugDynamicAttrs1, slotStaticAttrs1, slotDynamicAttrs1 map[string]any
 
 	c.Assert(task.Get("plug-static", &plugStaticAttrs1), IsNil)
-	c.Assert(plugStaticAttrs1, DeepEquals, map[string]interface{}{"attr1": "value1"})
+	c.Assert(plugStaticAttrs1, DeepEquals, map[string]any{"attr1": "value1"})
 	c.Assert(task.Get("plug-dynamic", &plugDynamicAttrs1), IsNil)
-	c.Assert(plugDynamicAttrs1, DeepEquals, map[string]interface{}{"attr3": "value3"})
+	c.Assert(plugDynamicAttrs1, DeepEquals, map[string]any{"attr3": "value3"})
 
 	c.Assert(task.Get("slot-static", &slotStaticAttrs1), IsNil)
-	c.Assert(slotStaticAttrs1, DeepEquals, map[string]interface{}{"attr2": "value2"})
+	c.Assert(slotStaticAttrs1, DeepEquals, map[string]any{"attr2": "value2"})
 	c.Assert(task.Get("slot-dynamic", &slotDynamicAttrs1), IsNil)
-	c.Assert(slotDynamicAttrs1, DeepEquals, map[string]interface{}{"attr4": "value4"})
+	c.Assert(slotDynamicAttrs1, DeepEquals, map[string]any{"attr4": "value4"})
 }
 
 // Disconnect works when both plug and slot are specified
@@ -1778,8 +1778,8 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 	// Put a connection in the state so that it automatically gets set up when
 	// we create the manager.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 	s.state.Unlock()
 
@@ -1817,7 +1817,7 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
 	// Ensure that the connection has been removed from the state
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, HasLen, 0)
@@ -1886,13 +1886,13 @@ components:
 	s.mockComponentForSnap(c, "comp", "component: consumer+comp\ntype: standard", consumer)
 	s.mockComponentForSnap(c, "comp", "component: producer+comp\ntype: standard", producer)
 
-	connState := map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	connState := map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface":    "test",
-			"slot-static":  map[string]interface{}{"static": "slot-static-value"},
-			"slot-dynamic": map[string]interface{}{"dynamic": "slot-dynamic-value"},
-			"plug-static":  map[string]interface{}{"static": "plug-static-value"},
-			"plug-dynamic": map[string]interface{}{"dynamic": "plug-dynamic-value"},
+			"slot-static":  map[string]any{"static": "slot-static-value"},
+			"slot-dynamic": map[string]any{"dynamic": "slot-dynamic-value"},
+			"plug-static":  map[string]any{"static": "plug-static-value"},
+			"plug-dynamic": map[string]any{"dynamic": "plug-dynamic-value"},
 		},
 	}
 
@@ -1928,7 +1928,7 @@ components:
 		c.Assert(t.Status(), Equals, state.UndoneStatus)
 	}
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
 	c.Assert(conns, DeepEquals, connState)
 
@@ -1962,13 +1962,13 @@ func (s *interfaceManagerSuite) TestForgetUndo(c *C) {
 	s.mockSnap(c, producerYaml)
 
 	// plug3 and slot3 do not exist, so the connection is not in the repository.
-	connState := map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	connState := map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface":   "test",
-			"plug-static": map[string]interface{}{"attr1": "value1"},
-			"slot-static": map[string]interface{}{"attr2": "value2"},
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
 		},
-		"consumer:plug3 producer:slot3": map[string]interface{}{"interface": "test2"},
+		"consumer:plug3 producer:slot3": map[string]any{"interface": "test2"},
 	}
 
 	s.state.Lock()
@@ -2009,7 +2009,7 @@ func (s *interfaceManagerSuite) TestForgetUndo(c *C) {
 	// Ensure that disconnect task was undone
 	c.Assert(task.Status(), Equals, state.UndoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
 	c.Assert(conns, DeepEquals, connState)
 
@@ -2022,8 +2022,8 @@ func (s *interfaceManagerSuite) TestStaleConnectionsIgnoredInReloadConnections(c
 	// Put a stray connection in the state so that it automatically gets set up
 	// when we create the manager.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 	s.state.Unlock()
 
@@ -2060,9 +2060,9 @@ func (s *interfaceManagerSuite) testStaleAutoConnectionsNotRemovedIfSnapBroken(c
 	restore := ifacestate.MockRemoveStaleConnections(func(s *state.State) error { return nil })
 	defer restore()
 
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot":             map[string]interface{}{"interface": "test", "auto": true},
-		"other-consumer:plug other-producer:slot": map[string]interface{}{"interface": "test", "auto": true},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot":             map[string]any{"interface": "test", "auto": true},
+		"other-consumer:plug other-producer:slot": map[string]any{"interface": "test", "auto": true},
 	})
 	sideInfo := &snap.SideInfo{
 		RealName: brokenSnapName,
@@ -2098,10 +2098,10 @@ func (s *interfaceManagerSuite) testStaleAutoConnectionsNotRemovedIfSnapBroken(c
 
 	// but the consumer:plug producer:slot connection is kept in the state and only the other one
 	// got dropped.
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test", "auto": true},
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test", "auto": true},
 	})
 
 	c.Check(s.log.String(), testutil.Contains, fmt.Sprintf("Snap %q is broken, ignored by reloadConnections", brokenSnapName))
@@ -2120,8 +2120,8 @@ func (s *interfaceManagerSuite) TestStaleConnectionsRemoved(c *C) {
 
 	s.state.Lock()
 	// Add stale connection to the state
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 	s.state.Unlock()
 
@@ -2132,7 +2132,7 @@ func (s *interfaceManagerSuite) TestStaleConnectionsRemoved(c *C) {
 	defer s.state.Unlock()
 
 	// Ensure that nothing got connected and connection was removed
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, HasLen, 0)
@@ -2150,9 +2150,9 @@ func (s *interfaceManagerSuite) testForget(c *C, plugSnap, plugName, slotSnap, s
 	s.mockSnap(c, producerYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot":   map[string]interface{}{"interface": "test"},
-		"consumer:plug2 producer:slot2": map[string]interface{}{"interface": "test2"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot":   map[string]any{"interface": "test"},
+		"consumer:plug2 producer:slot2": map[string]any{"interface": "test2"},
 	})
 	s.state.Unlock()
 
@@ -2216,13 +2216,13 @@ func (s *interfaceManagerSuite) TestForgetInactiveConnection(c *C) {
 	defer s.state.Unlock()
 
 	// Ensure that the connection has been removed from the state
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface":   "test",
-			"plug-static": map[string]interface{}{"attr1": "value1"},
-			"slot-static": map[string]interface{}{"attr2": "value2"},
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
 		},
 	})
 
@@ -2253,10 +2253,10 @@ func (s *interfaceManagerSuite) TestForgetActiveConnection(c *C) {
 	defer s.state.Unlock()
 
 	// Ensure that the connection has been removed from the state
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug2 producer:slot2": map[string]interface{}{"interface": "test2"},
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug2 producer:slot2": map[string]any{"interface": "test2"},
 	})
 }
 
@@ -2907,8 +2907,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsUndesiredFlag(c *C)
 	s.MockModel(c, nil)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"snap:network ubuntu-core:network": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"snap:network ubuntu-core:network": map[string]any{
 			"undesired": true,
 		},
 	})
@@ -2938,11 +2938,11 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsUndesiredFlag(c *C)
 	// Ensure that the task succeeded
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"snap:network ubuntu-core:network": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"snap:network ubuntu-core:network": map[string]any{
 			"undesired": true,
 		},
 	})
@@ -3022,11 +3022,11 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsPlugs(c *C) {
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
 	// Ensure that "network" is now saved in the state as auto-connected.
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"snap:network ubuntu-core:network": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"snap:network ubuntu-core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -3072,14 +3072,14 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
 	// Ensure that "slot" is now saved in the state as auto-connected.
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test", "auto": true,
-			"plug-static": map[string]interface{}{"attr1": "value1"},
-			"slot-static": map[string]interface{}{"attr2": "value2"},
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
 		},
 	})
 
@@ -3130,19 +3130,19 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlotsMultiple
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
 	// Ensure that "slot" is now saved in the state as auto-connected.
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test", "auto": true,
-			"plug-static": map[string]interface{}{"attr1": "value1"},
-			"slot-static": map[string]interface{}{"attr2": "value2"},
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
 		},
-		"consumer2:plug producer:slot": map[string]interface{}{
+		"consumer2:plug producer:slot": map[string]any{
 			"interface": "test", "auto": true,
-			"plug-static": map[string]interface{}{"attr1": "value1"},
-			"slot-static": map[string]interface{}{"attr2": "value2"},
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
 		},
 	})
 
@@ -3194,7 +3194,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectSlotsIfAlter
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
 	// Ensure that no connections were made
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(conns, HasLen, 0)
@@ -3202,12 +3202,12 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectSlotsIfAlter
 
 // The auto-connect task will auto-connect plugs with viable candidates also condidering snap declarations.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBased(c *C) {
-	s.testDoSetupSnapSecurityAutoConnectsDeclBased(c, true, func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	s.testDoSetupSnapSecurityAutoConnectsDeclBased(c, true, func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// Ensure that "test" plug is now saved in the state as auto-connected.
-		c.Check(conns, DeepEquals, map[string]interface{}{
-			"consumer:plug producer:slot": map[string]interface{}{"auto": true, "interface": "test",
-				"plug-static": map[string]interface{}{"attr1": "value1"},
-				"slot-static": map[string]interface{}{"attr2": "value2"},
+		c.Check(conns, DeepEquals, map[string]any{
+			"consumer:plug producer:slot": map[string]any{"auto": true, "interface": "test",
+				"plug-static": map[string]any{"attr1": "value1"},
+				"slot-static": map[string]any{"attr2": "value2"},
 			}})
 		// Ensure that "test" is really connected.
 		c.Check(repoConns, HasLen, 1)
@@ -3216,14 +3216,14 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBased(c *
 
 // The auto-connect task will *not* auto-connect plugs with viable candidates when snap declarations are missing.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedWhenMissingDecl(c *C) {
-	s.testDoSetupSnapSecurityAutoConnectsDeclBased(c, false, func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	s.testDoSetupSnapSecurityAutoConnectsDeclBased(c, false, func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// Ensure nothing is connected.
 		c.Check(conns, HasLen, 0)
 		c.Check(repoConns, HasLen, 0)
 	})
 }
 
-func (s *interfaceManagerSuite) testDoSetupSnapSecurityAutoConnectsDeclBased(c *C, withDecl bool, check func(map[string]interface{}, []*interfaces.ConnRef)) {
+func (s *interfaceManagerSuite) testDoSetupSnapSecurityAutoConnectsDeclBased(c *C, withDecl bool, check func(map[string]any, []*interfaces.ConnRef)) {
 	s.MockModel(c, nil)
 
 	restore := assertstest.MockBuiltinBaseDeclaration([]byte(`
@@ -3267,7 +3267,7 @@ slots:
 	// Ensure that the task succeeded.
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	_ = s.state.Get("conns", &conns)
 
 	repo := mgr.Repository()
@@ -3284,7 +3284,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDevi
 
 	s.MockModel(c, nil)
 
-	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// Ensure nothing is connected.
 		c.Check(conns, HasLen, 0)
 		c.Check(repoConns, HasLen, 0)
@@ -3296,11 +3296,11 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDevi
 // store in the model assertion fails an on-store constraint.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScopeWrongStore(c *C) {
 
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "other-store",
 	})
 
-	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// Ensure nothing is connected.
 		c.Check(conns, HasLen, 0)
 		c.Check(repoConns, HasLen, 0)
@@ -3312,16 +3312,16 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDevi
 // store in the model assertion passes an on-store constraint.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScopeRightStore(c *C) {
 
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "my-store",
 	})
 
-	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// Ensure that "test" plug is now saved in the state as auto-connected.
-		c.Check(conns, DeepEquals, map[string]interface{}{
-			"consumer:plug producer:slot": map[string]interface{}{"auto": true, "interface": "test",
-				"plug-static": map[string]interface{}{"attr1": "value1"},
-				"slot-static": map[string]interface{}{"attr2": "value2"},
+		c.Check(conns, DeepEquals, map[string]any{
+			"consumer:plug producer:slot": map[string]any{"auto": true, "interface": "test",
+				"plug-static": map[string]any{"attr1": "value1"},
+				"slot-static": map[string]any{"attr2": "value2"},
 			}})
 		// Ensure that "test" is really connected.
 		c.Check(repoConns, HasLen, 1)
@@ -3334,15 +3334,15 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDevi
 // on-store constraint.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScopeWrongFriendlyStore(c *C) {
 
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "my-substore",
 	})
 
-	s.MockStore(c, s.state, "my-substore", map[string]interface{}{
-		"friendly-stores": []interface{}{"other-store"},
+	s.MockStore(c, s.state, "my-substore", map[string]any{
+		"friendly-stores": []any{"other-store"},
 	})
 
-	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// Ensure nothing is connected.
 		c.Check(conns, HasLen, 0)
 		c.Check(repoConns, HasLen, 0)
@@ -3355,27 +3355,27 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDevi
 // on-store constraint.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScopeFriendlyStore(c *C) {
 
-	s.MockModel(c, map[string]interface{}{
+	s.MockModel(c, map[string]any{
 		"store": "my-substore",
 	})
 
-	s.MockStore(c, s.state, "my-substore", map[string]interface{}{
-		"friendly-stores": []interface{}{"my-store"},
+	s.MockStore(c, s.state, "my-substore", map[string]any{
+		"friendly-stores": []any{"my-store"},
 	})
 
-	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c, func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// Ensure that "test" plug is now saved in the state as auto-connected.
-		c.Check(conns, DeepEquals, map[string]interface{}{
-			"consumer:plug producer:slot": map[string]interface{}{"auto": true, "interface": "test",
-				"plug-static": map[string]interface{}{"attr1": "value1"},
-				"slot-static": map[string]interface{}{"attr2": "value2"},
+		c.Check(conns, DeepEquals, map[string]any{
+			"consumer:plug producer:slot": map[string]any{"auto": true, "interface": "test",
+				"plug-static": map[string]any{"attr1": "value1"},
+				"slot-static": map[string]any{"attr2": "value2"},
 			}})
 		// Ensure that "test" is really connected.
 		c.Check(repoConns, HasLen, 1)
 	})
 }
 
-func (s *interfaceManagerSuite) testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c *C, check func(map[string]interface{}, []*interfaces.ConnRef)) {
+func (s *interfaceManagerSuite) testDoSetupSnapSecurityAutoConnectsDeclBasedDeviceScope(c *C, check func(map[string]any, []*interfaces.ConnRef)) {
 	restore := assertstest.MockBuiltinBaseDeclaration([]byte(`
 type: base-declaration
 authority-id: canonical
@@ -3393,12 +3393,12 @@ slots:
 	// Initialize the manager. This registers the producer snap.
 	mgr := s.manager(c)
 
-	s.MockSnapDecl(c, "consumer", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "consumer", "one-publisher", map[string]any{
 		"format": "3",
-		"plugs": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"on-store": []interface{}{"my-store"},
+		"plugs": map[string]any{
+			"test": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"on-store": []any{"my-store"},
 				},
 			},
 		},
@@ -3421,7 +3421,7 @@ slots:
 	// Ensure that the task succeeded.
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	_ = s.state.Get("conns", &conns)
 
 	repo := mgr.Repository()
@@ -3447,8 +3447,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityKeepsExistingConnectionSt
 
 	// Put fake information about connections for another snap into the state.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"other-snap:network ubuntu-core:network": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"other-snap:network ubuntu-core:network": map[string]any{
 			"interface": "network",
 		},
 	})
@@ -3469,17 +3469,17 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityKeepsExistingConnectionSt
 	// Ensure that the task succeeded.
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
 		// The sample snap was auto-connected, as expected.
-		"snap:network ubuntu-core:network": map[string]interface{}{
+		"snap:network ubuntu-core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 		// Connection state for the fake snap is preserved.
 		// The task didn't alter state of other snaps.
-		"other-snap:network ubuntu-core:network": map[string]interface{}{
+		"other-snap:network ubuntu-core:network": map[string]any{
 			"interface": "network",
 		},
 	})
@@ -3490,12 +3490,12 @@ func (s *interfaceManagerSuite) TestReloadingConnectionsOnStartupUpdatesStaticAt
 	// adding below. The connection contains a copy of the static attributes
 	// but refers to the "old" values, in contrast to what the snaps define.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface":   "content",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"content": "foo", "attr": "old-plug-attr"},
-			"slot-static": map[string]interface{}{"content": "foo", "attr": "old-slot-attr"},
+			"plug-static": map[string]any{"content": "foo", "attr": "old-plug-attr"},
+			"slot-static": map[string]any{"content": "foo", "attr": "old-slot-attr"},
 		},
 	})
 	s.state.Unlock()
@@ -3545,8 +3545,8 @@ slots:
 			// see the old attribute values.
 			conn, err := repo.Connection(connRef)
 			c.Assert(err, IsNil)
-			c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo", "attr": "new-plug-attr"})
-			c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo", "attr": "new-slot-attr"})
+			c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "new-plug-attr"})
+			c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "new-slot-attr"})
 			return nil
 		},
 	}
@@ -3563,8 +3563,8 @@ slots:
 	repo := mgr.Repository()
 	conn, err := repo.Connection(connRef)
 	c.Assert(err, IsNil)
-	c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo", "attr": "new-plug-attr"})
-	c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo", "attr": "new-slot-attr"})
+	c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "new-plug-attr"})
+	c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "new-slot-attr"})
 
 	// Because of the fact that during testing the system key always
 	// mismatches, the security setup is performed.
@@ -3577,20 +3577,20 @@ func (s *interfaceManagerSuite) testDoSetupProfilesUpdatesStaticAttributes(c *C,
 	// adding below. The connection reflects the snaps as they are now, and
 	// carries no attribute data.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "content",
 		},
-		"consumer:plug3 producer:slot2": map[string]interface{}{
+		"consumer:plug3 producer:slot2": map[string]any{
 			"interface": "system-files",
 		},
-		"consumer:plug4 producer:slot3": map[string]interface{}{
+		"consumer:plug4 producer:slot3": map[string]any{
 			"interface": "shared-memory",
 		},
-		"unrelated-a:plug unrelated-b:slot": map[string]interface{}{
+		"unrelated-a:plug unrelated-b:slot": map[string]any{
 			"interface":   "unrelated",
-			"plug-static": map[string]interface{}{"attr": "unrelated-stale"},
-			"slot-static": map[string]interface{}{"attr": "unrelated-stale"},
+			"plug-static": map[string]any{"attr": "unrelated-stale"},
+			"slot-static": map[string]any{"attr": "unrelated-stale"},
 		},
 	})
 	s.state.Unlock()
@@ -3727,26 +3727,26 @@ slots:
 			c.Assert(err3, IsNil)
 			switch appSet.Info().Version {
 			case "1":
-				c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo"})
-				c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo"})
-				c.Check(sysFilesConn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{})
-				c.Check(shmConn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"shared-memory": "baz"})
-				c.Check(shmConn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"shared-memory": "baz", "read": []interface{}{"baz"}})
+				c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"content": "foo"})
+				c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"content": "foo"})
+				c.Check(sysFilesConn.Plug.StaticAttrs(), DeepEquals, map[string]any{})
+				c.Check(shmConn.Plug.StaticAttrs(), DeepEquals, map[string]any{"shared-memory": "baz"})
+				c.Check(shmConn.Slot.StaticAttrs(), DeepEquals, map[string]any{"shared-memory": "baz", "read": []any{"baz"}})
 			case "2":
 				switch snapNameToSetup {
 				case "consumer":
 					// When the consumer has security setup the consumer's plug attribute is updated.
-					c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo", "attr": "plug-value"})
-					c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo"})
-					c.Check(sysFilesConn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"read": []interface{}{"/etc/foo"}})
-					c.Check(shmConn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"shared-memory": "baz"})
-					c.Check(shmConn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"shared-memory": "baz", "read": []interface{}{"baz"}})
+					c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "plug-value"})
+					c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"content": "foo"})
+					c.Check(sysFilesConn.Plug.StaticAttrs(), DeepEquals, map[string]any{"read": []any{"/etc/foo"}})
+					c.Check(shmConn.Plug.StaticAttrs(), DeepEquals, map[string]any{"shared-memory": "baz"})
+					c.Check(shmConn.Slot.StaticAttrs(), DeepEquals, map[string]any{"shared-memory": "baz", "read": []any{"baz"}})
 				case "producer":
 					// When the producer has security setup the producer's slot attribute is updated.
-					c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo"})
-					c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"content": "foo", "attr": "slot-value"})
-					c.Check(shmConn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"shared-memory": "baz"})
-					c.Check(shmConn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"shared-memory": "baz", "read": []interface{}{"baz", "qux"}})
+					c.Check(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"content": "foo"})
+					c.Check(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"content": "foo", "attr": "slot-value"})
+					c.Check(shmConn.Plug.StaticAttrs(), DeepEquals, map[string]any{"shared-memory": "baz"})
+					c.Check(shmConn.Slot.StaticAttrs(), DeepEquals, map[string]any{"shared-memory": "baz", "read": []any{"baz", "qux"}})
 				}
 			}
 			return nil
@@ -3810,8 +3810,8 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesUpdatesStaticAttributesSlotSn
 
 func (s *interfaceManagerSuite) TestUpdateStaticAttributesIgnoresContentMismatch(c *C) {
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "content",
 			"auto":      true,
 			"content":   "foo",
@@ -3903,14 +3903,14 @@ slots:
 	defer s.state.Unlock()
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.state.Get("conns", &conns)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface":   "content",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"content": "foo"},
-			"slot-static": map[string]interface{}{"content": "foo"},
+			"plug-static": map[string]any{"content": "foo"},
+			"slot-static": map[string]any{"content": "foo"},
 		},
 	})
 }
@@ -3932,17 +3932,17 @@ slots:
 	restore = builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer restore()
 
-	initialConns := map[string]interface{}{
-		"test-consumer:test test-producer:test": map[string]interface{}{
+	initialConns := map[string]any{
+		"test-consumer:test test-producer:test": map[string]any{
 			"interface":   "test",
 			"test-update": "foo",
 		},
 	}
 	if auto {
-		initialConns["test-consumer:test test-producer:test"].(map[string]interface{})["auto"] = true
+		initialConns["test-consumer:test test-producer:test"].(map[string]any)["auto"] = true
 	}
 	if byGadget {
-		initialConns["test-consumer:test test-producer:test"].(map[string]interface{})["by-gadget"] = true
+		initialConns["test-consumer:test test-producer:test"].(map[string]any)["by-gadget"] = true
 	}
 
 	s.state.Lock()
@@ -3974,21 +3974,21 @@ slots:
   interface: test
 `
 
-	s.MockSnapDecl(c, "test-consumer", "publisher-foo", map[string]interface{}{
+	s.MockSnapDecl(c, "test-consumer", "publisher-foo", map[string]any{
 		"format": "5",
-		"plugs": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"plug-attributes": map[string]interface{}{
-						"test-update": []interface{}{
+		"plugs": map[string]any{
+			"test": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"plug-attributes": map[string]any{
+						"test-update": []any{
 							"auto",
 							"foo",
 						},
 					},
 				},
-				"allow-connection": map[string]interface{}{
-					"plug-attributes": map[string]interface{}{
-						"test-update": []interface{}{
+				"allow-connection": map[string]any{
+					"plug-attributes": map[string]any{
+						"test-update": []any{
 							"auto",
 							"manual",
 							"foo",
@@ -4000,10 +4000,10 @@ slots:
 		},
 	})
 
-	s.MockSnapDecl(c, "test-producer", "publisher-foo", map[string]interface{}{
+	s.MockSnapDecl(c, "test-producer", "publisher-foo", map[string]any{
 		"format": "5",
-		"slots": map[string]interface{}{
-			"test": map[string]interface{}{
+		"slots": map[string]any{
+			"test": map[string]any{
 				"allow-installation": "true",
 			},
 		},
@@ -4046,23 +4046,23 @@ slots:
 	defer s.state.Unlock()
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.state.Get("conns", &conns)
 
-	expectedConns := map[string]interface{}{
-		"test-consumer:test test-producer:test": map[string]interface{}{
+	expectedConns := map[string]any{
+		"test-consumer:test test-producer:test": map[string]any{
 			"interface":   "test",
-			"plug-static": map[string]interface{}{"test-update": "foo"},
+			"plug-static": map[string]any{"test-update": "foo"},
 		},
 	}
 	if auto {
-		expectedConns["test-consumer:test test-producer:test"].(map[string]interface{})["auto"] = true
+		expectedConns["test-consumer:test test-producer:test"].(map[string]any)["auto"] = true
 	}
 	if byGadget {
-		expectedConns["test-consumer:test test-producer:test"].(map[string]interface{})["by-gadget"] = true
+		expectedConns["test-consumer:test test-producer:test"].(map[string]any)["by-gadget"] = true
 	}
 	if shouldUpdate {
-		expectedConns["test-consumer:test test-producer:test"].(map[string]interface{})["plug-static"].(map[string]interface{})["test-update"] = testUpdateVal
+		expectedConns["test-consumer:test test-producer:test"].(map[string]any)["plug-static"].(map[string]any)["test-update"] = testUpdateVal
 	}
 	c.Check(conns, DeepEquals, expectedConns)
 }
@@ -4133,8 +4133,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityIgnoresStrayConnection(c 
 
 	// Put fake information about connections for another snap into the state.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"removed-snap:network ubuntu-core:network": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"removed-snap:network ubuntu-core:network": map[string]any{
 			"interface": "network",
 		},
 	})
@@ -4233,8 +4233,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 
 func (s *interfaceManagerSuite) testDoSetupSnapSecurityReloadsConnectionsWhenInvokedOn(c *C, snapName string, revision snap.Revision) {
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 	s.state.Unlock()
 
@@ -4357,8 +4357,8 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	// This is done so that DisconnectSnap returns both snaps as "affected"
 	// and so that the previously broken code path is exercised.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"snap:network ubuntu-core:network": map[string]interface{}{"interface": "network"},
+	s.state.Set("conns", map[string]any{
+		"snap:network ubuntu-core:network": map[string]any{"interface": "network"},
 	})
 	s.state.Unlock()
 
@@ -4879,28 +4879,28 @@ func (s *interfaceManagerSuite) TestSetupProfilesOfAffectedSnapWithComponents(c 
 func (s *interfaceManagerSuite) TestSetupProfilesKeepsUndesiredConnection(c *C) {
 	undesired := true
 	byGadget := false
-	s.testAutoconnectionsRemovedForMissingPlugs(c, undesired, byGadget, map[string]interface{}{
-		"snap:test1 ubuntu-core:test1": map[string]interface{}{"interface": "test1", "auto": true, "undesired": true},
-		"snap:test2 ubuntu-core:test2": map[string]interface{}{"interface": "test2", "auto": true},
+	s.testAutoconnectionsRemovedForMissingPlugs(c, undesired, byGadget, map[string]any{
+		"snap:test1 ubuntu-core:test1": map[string]any{"interface": "test1", "auto": true, "undesired": true},
+		"snap:test2 ubuntu-core:test2": map[string]any{"interface": "test2", "auto": true},
 	})
 }
 
 func (s *interfaceManagerSuite) TestSetupProfilesRemovesMissingAutoconnectedPlugs(c *C) {
-	s.testAutoconnectionsRemovedForMissingPlugs(c, false, false, map[string]interface{}{
-		"snap:test2 ubuntu-core:test2": map[string]interface{}{"interface": "test2", "auto": true},
+	s.testAutoconnectionsRemovedForMissingPlugs(c, false, false, map[string]any{
+		"snap:test2 ubuntu-core:test2": map[string]any{"interface": "test2", "auto": true},
 	})
 }
 
 func (s *interfaceManagerSuite) TestSetupProfilesKeepsMissingGadgetAutoconnectedPlugs(c *C) {
 	undesired := false
 	byGadget := true
-	s.testAutoconnectionsRemovedForMissingPlugs(c, undesired, byGadget, map[string]interface{}{
-		"snap:test1 ubuntu-core:test1": map[string]interface{}{"interface": "test1", "auto": true, "by-gadget": true},
-		"snap:test2 ubuntu-core:test2": map[string]interface{}{"interface": "test2", "auto": true},
+	s.testAutoconnectionsRemovedForMissingPlugs(c, undesired, byGadget, map[string]any{
+		"snap:test1 ubuntu-core:test1": map[string]any{"interface": "test1", "auto": true, "by-gadget": true},
+		"snap:test2 ubuntu-core:test2": map[string]any{"interface": "test2", "auto": true},
 	})
 }
 
-func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingPlugs(c *C, undesired, byGadget bool, expectedConns map[string]interface{}) {
+func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingPlugs(c *C, undesired, byGadget bool, expectedConns map[string]any) {
 	s.MockModel(c, nil)
 
 	// Mock the interface that will be used by the test
@@ -4911,8 +4911,8 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingPlugs(c *C, 
 	newSnapInfo := s.mockSnap(c, refreshedSnapYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"snap:test1 ubuntu-core:test1": map[string]interface{}{"interface": "test1", "auto": true, "undesired": undesired, "by-gadget": byGadget},
+	s.state.Set("conns", map[string]any{
+		"snap:test1 ubuntu-core:test1": map[string]any{"interface": "test1", "auto": true, "undesired": undesired, "by-gadget": byGadget},
 	})
 	s.state.Unlock()
 
@@ -4935,18 +4935,18 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingPlugs(c *C, 
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
 	// Verify that old connection is gone and new one got connected
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
 	c.Check(conns, DeepEquals, expectedConns)
 }
 
 func (s *interfaceManagerSuite) TestSetupProfilesRemovesMissingAutoconnectedSlots(c *C) {
-	s.testAutoconnectionsRemovedForMissingSlots(c, map[string]interface{}{
-		"snap:test2 snap2:test2": map[string]interface{}{"interface": "test2", "auto": true},
+	s.testAutoconnectionsRemovedForMissingSlots(c, map[string]any{
+		"snap:test2 snap2:test2": map[string]any{"interface": "test2", "auto": true},
 	})
 }
 
-func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingSlots(c *C, expectedConns map[string]interface{}) {
+func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingSlots(c *C, expectedConns map[string]any) {
 	s.MockModel(c, nil)
 
 	// Mock the interface that will be used by the test
@@ -4957,8 +4957,8 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingSlots(c *C, 
 	_ = s.mockSnap(c, slotSnapYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"snap:test1 snap2:test1": map[string]interface{}{"interface": "test1", "auto": true},
+	s.state.Set("conns", map[string]any{
+		"snap:test1 snap2:test1": map[string]any{"interface": "test1", "auto": true},
 	})
 	s.state.Unlock()
 
@@ -4981,7 +4981,7 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingSlots(c *C, 
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
 	// Verify that old connection is gone and new one got connected
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
 	c.Check(conns, DeepEquals, expectedConns)
 }
@@ -5099,8 +5099,8 @@ func (s *interfaceManagerSuite) TestUndoDiscardConnsSlot(c *C) {
 func (s *interfaceManagerSuite) testDoDiscardConns(c *C, snapName string) {
 	s.state.Lock()
 	// Store information about a connection in the state.
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test",
 		},
 	})
@@ -5131,17 +5131,17 @@ func (s *interfaceManagerSuite) testDoDiscardConns(c *C, snapName string) {
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
 	// Information about the connection was removed
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{})
+	c.Check(conns, DeepEquals, map[string]any{})
 
 	// But removed connections are preserved in the task for undo.
-	var removed map[string]interface{}
+	var removed map[string]any
 	err = change.Tasks()[0].Get("removed", &removed)
 	c.Assert(err, IsNil)
-	c.Check(removed, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	c.Check(removed, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 }
 
@@ -5150,8 +5150,8 @@ func (s *interfaceManagerSuite) testUndoDiscardConns(c *C, snapName string) {
 
 	s.state.Lock()
 	// Store information about a connection in the state.
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 
 	// Store empty snap state. This snap has an empty sequence now.
@@ -5174,14 +5174,14 @@ func (s *interfaceManagerSuite) testUndoDiscardConns(c *C, snapName string) {
 	c.Assert(t.Status(), Equals, state.UndoneStatus)
 
 	// Information about the connection is intact
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 
-	var removed map[string]interface{}
+	var removed map[string]any
 	err = change.Tasks()[0].Get("removed", &removed)
 	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 }
@@ -5206,8 +5206,8 @@ slots:
 	s.mockSnap(c, producerYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 	s.state.Unlock()
 
@@ -5248,11 +5248,11 @@ slots:
 	c.Check(s.secBackend.SetupCalls[0].AppSet.InstanceName(), Equals, "producer")
 
 	// Connection state was left intact
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 
 	// no pending SideInfo
@@ -5293,14 +5293,14 @@ func (s *interfaceManagerSuite) TestConnectTracksConnectionsInState(c *C) {
 
 	c.Assert(change.Err(), IsNil)
 	c.Check(change.Status(), Equals, state.DoneStatus)
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface":   "test",
-			"plug-static": map[string]interface{}{"attr1": "value1"},
-			"slot-static": map[string]interface{}{"attr2": "value2"},
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
 		},
 	})
 }
@@ -5401,12 +5401,12 @@ func (s *interfaceManagerSuite) TestConnectSetsHotplugKeyFromTheSlot(c *C) {
 	s.mockSnap(c, coreSnapYaml)
 
 	s.state.Lock()
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"slot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"slot": map[string]any{
 			"name":         "slot",
 			"interface":    "test",
 			"hotplug-key":  "1234",
-			"static-attrs": map[string]interface{}{"attr2": "value2"}}})
+			"static-attrs": map[string]any{"attr2": "value2"}}})
 	s.state.Unlock()
 
 	_ = s.manager(c)
@@ -5427,14 +5427,14 @@ func (s *interfaceManagerSuite) TestConnectSetsHotplugKeyFromTheSlot(c *C) {
 	c.Assert(change.Err(), IsNil)
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer2:plug core:slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer2:plug core:slot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
-			"plug-static": map[string]interface{}{"attr1": "value1"},
-			"slot-static": map[string]interface{}{"attr2": "value2"},
+			"plug-static": map[string]any{"attr1": "value1"},
+			"slot-static": map[string]any{"attr2": "value2"},
 		},
 	})
 }
@@ -5445,8 +5445,8 @@ func (s *interfaceManagerSuite) TestDisconnectSetsUpSecurity(c *C) {
 	s.mockSnap(c, producerYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 	s.state.Unlock()
 
@@ -5488,8 +5488,8 @@ func (s *interfaceManagerSuite) TestDisconnectTracksConnectionsInState(c *C) {
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 	s.state.Unlock()
 
@@ -5516,10 +5516,10 @@ func (s *interfaceManagerSuite) TestDisconnectTracksConnectionsInState(c *C) {
 
 	c.Assert(change.Err(), IsNil)
 	c.Check(change.Status(), Equals, state.DoneStatus)
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{})
+	c.Check(conns, DeepEquals, map[string]any{})
 }
 
 func (s *interfaceManagerSuite) TestDisconnectDisablesAutoConnect(c *C) {
@@ -5527,8 +5527,8 @@ func (s *interfaceManagerSuite) TestDisconnectDisablesAutoConnect(c *C) {
 	plugAppSet := s.mockAppSet(c, consumerYaml)
 	slotAppSet := s.mockAppSet(c, producerYaml)
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test", "auto": true},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test", "auto": true},
 	})
 	s.state.Unlock()
 
@@ -5560,11 +5560,11 @@ func (s *interfaceManagerSuite) TestDisconnectDisablesAutoConnect(c *C) {
 
 	c.Assert(change.Err(), IsNil)
 	c.Check(change.Status(), Equals, state.DoneStatus)
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test", "auto": true, "undesired": true},
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test", "auto": true, "undesired": true},
 	})
 }
 
@@ -5587,12 +5587,12 @@ plugs:
 	}
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplug-slot": map[string]interface{}{"interface": "test"},
-		"consumer:plug core:slot2":        map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplug-slot": map[string]any{"interface": "test"},
+		"consumer:plug core:slot2":        map[string]any{"interface": "test"},
 	})
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplug-slot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplug-slot": map[string]any{
 			"name":        "hotplug-slot",
 			"interface":   "test",
 			"hotplug-key": "1234",
@@ -5623,16 +5623,16 @@ plugs:
 	c.Assert(change.Err(), IsNil)
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplug-slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplug-slot": map[string]any{
 			"interface":    "test",
 			"hotplug-gone": true,
-			"plug-static":  map[string]interface{}{"attr": "plug-attr"},
+			"plug-static":  map[string]any{"attr": "plug-attr"},
 		},
-		"consumer:plug core:slot2": map[string]interface{}{
+		"consumer:plug core:slot2": map[string]any{
 			"interface": "test",
 		},
 	})
@@ -5670,8 +5670,8 @@ hooks:
 	producerAppSet := s.mockAppSet(c, producerYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{"interface": "test"},
 	})
 
 	s.state.Unlock()
@@ -5748,16 +5748,16 @@ slots:
 	s.mockSnap(c, producerYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "content",
 			"auto":      true,
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"content":    "foo",
 				"attr":       "stored-plug-value",
 				"other-attr": "irrelevant-value",
 			},
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"interface":  "content",
 				"content":    "foo",
 				"attr":       "stored-slot-value",
@@ -5778,12 +5778,12 @@ slots:
 	conn, err := repo.Connection(cref)
 	c.Assert(err, IsNil)
 	c.Assert(conn.Plug.Name(), Equals, "plug")
-	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{
+	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{
 		"content": "foo",
 		"attr":    "plug-value",
 	})
 	c.Assert(conn.Slot.Name(), Equals, "slot")
-	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{
+	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{
 		"content": "foo",
 		"attr":    "slot-value",
 	})
@@ -5795,8 +5795,8 @@ func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(
 	s.mockSnap(c, producerYaml)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 			"undesired": true,
@@ -5816,8 +5816,8 @@ func (s *interfaceManagerSuite) setupHotplugSlot(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"slot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"slot": map[string]any{
 			"name":        "slot",
 			"interface":   "test",
 			"hotplug-key": "abcd",
@@ -5828,8 +5828,8 @@ func (s *interfaceManagerSuite) TestManagerDoesntReloadHotplugGoneConnection(c *
 	s.setupHotplugSlot(c)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:slot": map[string]any{
 			"interface":    "test",
 			"hotplug-gone": true,
 		}})
@@ -5843,8 +5843,8 @@ func (s *interfaceManagerSuite) TestManagerReloadsHotplugConnection(c *C) {
 	s.setupHotplugSlot(c)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:slot": map[string]any{
 			"interface":    "test",
 			"hotplug-gone": false,
 		}})
@@ -6024,9 +6024,9 @@ slots:
 	defer restore()
 	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
-	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]any{
 		"format": "1",
-		"slots": map[string]interface{}{
+		"slots": map[string]any{
 			"test": "true",
 		},
 	})
@@ -6038,7 +6038,7 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeviceScopeRightStore(c *C) {
-	deviceCtx := s.TrivialDeviceContext(c, map[string]interface{}{
+	deviceCtx := s.TrivialDeviceContext(c, map[string]any{
 		"store": "my-store",
 	})
 
@@ -6053,12 +6053,12 @@ slots:
 	defer restore()
 	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
-	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]any{
 		"format": "3",
-		"slots": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-installation": map[string]interface{}{
-					"on-store": []interface{}{"my-store"},
+		"slots": map[string]any{
+			"test": map[string]any{
+				"allow-installation": map[string]any{
+					"on-store": []any{"my-store"},
 				},
 			},
 		},
@@ -6084,12 +6084,12 @@ slots:
 	defer restore()
 	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
-	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]any{
 		"format": "3",
-		"slots": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-installation": map[string]interface{}{
-					"on-store": []interface{}{"my-store"},
+		"slots": map[string]any{
+			"test": map[string]any{
+				"allow-installation": map[string]any{
+					"on-store": []any{"my-store"},
 				},
 			},
 		},
@@ -6102,7 +6102,7 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeviceScopeWrongStore(c *C) {
-	deviceCtx := s.TrivialDeviceContext(c, map[string]interface{}{
+	deviceCtx := s.TrivialDeviceContext(c, map[string]any{
 		"store": "other-store",
 	})
 
@@ -6117,12 +6117,12 @@ slots:
 	defer restore()
 	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
-	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]any{
 		"format": "3",
-		"slots": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-installation": map[string]interface{}{
-					"on-store": []interface{}{"my-store"},
+		"slots": map[string]any{
+			"test": map[string]any{
+				"allow-installation": map[string]any{
+					"on-store": []any{"my-store"},
 				},
 			},
 		},
@@ -6135,12 +6135,12 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeviceScopeRightFriendlyStore(c *C) {
-	deviceCtx := s.TrivialDeviceContext(c, map[string]interface{}{
+	deviceCtx := s.TrivialDeviceContext(c, map[string]any{
 		"store": "my-substore",
 	})
 
-	s.MockStore(c, s.state, "my-substore", map[string]interface{}{
-		"friendly-stores": []interface{}{"my-store"},
+	s.MockStore(c, s.state, "my-substore", map[string]any{
+		"friendly-stores": []any{"my-store"},
 	})
 
 	restore := assertstest.MockBuiltinBaseDeclaration([]byte(`
@@ -6154,12 +6154,12 @@ slots:
 	defer restore()
 	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
-	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]any{
 		"format": "3",
-		"slots": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-installation": map[string]interface{}{
-					"on-store": []interface{}{"my-store"},
+		"slots": map[string]any{
+			"test": map[string]any{
+				"allow-installation": map[string]any{
+					"on-store": []any{"my-store"},
 				},
 			},
 		},
@@ -6172,12 +6172,12 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeviceScopeWrongFriendlyStore(c *C) {
-	deviceCtx := s.TrivialDeviceContext(c, map[string]interface{}{
+	deviceCtx := s.TrivialDeviceContext(c, map[string]any{
 		"store": "my-substore",
 	})
 
-	s.MockStore(c, s.state, "my-substore", map[string]interface{}{
-		"friendly-stores": []interface{}{"other-store"},
+	s.MockStore(c, s.state, "my-substore", map[string]any{
+		"friendly-stores": []any{"other-store"},
 	})
 
 	restore := assertstest.MockBuiltinBaseDeclaration([]byte(`
@@ -6191,12 +6191,12 @@ slots:
 	defer restore()
 	s.mockIface(&ifacetest.TestInterface{InterfaceName: "test"})
 
-	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "producer", "producer-publisher", map[string]any{
 		"format": "3",
-		"slots": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-installation": map[string]interface{}{
-					"on-store": []interface{}{"my-store"},
+		"slots": map[string]any{
+			"test": map[string]any{
+				"allow-installation": map[string]any{
+					"on-store": []any{"my-store"},
 				},
 			},
 		},
@@ -6387,8 +6387,8 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCore(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.state.Set("conns", map[string]interface{}{
-		"httpd:network ubuntu-core:network": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"httpd:network ubuntu-core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -6406,12 +6406,12 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCore(c *C) {
 	s.state.Lock()
 
 	c.Assert(change.Status(), Equals, state.DoneStatus)
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	// ensure the connection went from "ubuntu-core" to "core"
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"httpd:network core:network": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"httpd:network core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -6426,8 +6426,8 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCoreUndo(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.state.Set("conns", map[string]interface{}{
-		"httpd:network ubuntu-core:network": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"httpd:network ubuntu-core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -6452,12 +6452,12 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCoreUndo(c *C) {
 	c.Assert(change.Status(), Equals, state.ErrorStatus)
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	// ensure the connection have not changed (still ubuntu-core)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"httpd:network ubuntu-core:network": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"httpd:network ubuntu-core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -6470,11 +6470,11 @@ func (s *interfaceManagerSuite) TestCoreConnectionsRenamed(c *C) {
 
 	// Put state with old connection data.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"core:core-support core:core-support": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"core:core-support core:core-support": map[string]any{
 			"interface": "core-support", "auto": true,
 		},
-		"snap:unrelated core:unrelated": map[string]interface{}{
+		"snap:unrelated core:unrelated": map[string]any{
 			"interface": "unrelated", "auto": true,
 		},
 	})
@@ -6489,15 +6489,15 @@ func (s *interfaceManagerSuite) TestCoreConnectionsRenamed(c *C) {
 
 	// Check that "core-support" connection got renamed.
 	s.state.Lock()
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	s.state.Unlock()
 	c.Assert(err, IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"core:core-support-plug core:core-support": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"core:core-support-plug core:core-support": map[string]any{
 			"interface": "core-support", "auto": true,
 		},
-		"snap:unrelated core:unrelated": map[string]interface{}{
+		"snap:unrelated core:unrelated": map[string]any{
 			"interface": "unrelated", "auto": true,
 		},
 	})
@@ -6560,11 +6560,11 @@ func (s *interfaceManagerSuite) TestAutoConnectDuringCoreTransition(c *C) {
 	// Ensure that "network" is now saved in the state as auto-connected and
 	// that it is connected to the new core snap rather than the old
 	// ubuntu-core snap.
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"snap:network core:network": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"snap:network core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -6623,11 +6623,11 @@ type: snapd
 
 	// make sure that network is connected, note that it is still recorded as
 	// connected to core, even though the is is actually connected to snapd
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"snap:network core:network": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"snap:network core:network": map[string]any{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -6651,7 +6651,7 @@ func makeAutoConnectChange(st *state.State, plugSnap, plug, slotSnap, slot strin
 	t := st.NewTask("connect", "other connect task")
 	t.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slot})
 	t.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plug})
-	var plugAttrs, slotAttrs map[string]interface{}
+	var plugAttrs, slotAttrs map[string]any
 	t.Set("plug-dynamic", plugAttrs)
 	t.Set("slot-dynamic", slotAttrs)
 	t.Set("auto", true)
@@ -6680,7 +6680,7 @@ func makeAutoConnectChange(st *state.State, plugSnap, plug, slotSnap, slot strin
 	return chg
 }
 
-func (s *interfaceManagerSuite) mockConnectForUndo(c *C, conns map[string]interface{}, delayedSetupProfiles bool) *state.Change {
+func (s *interfaceManagerSuite) mockConnectForUndo(c *C, conns map[string]any, delayedSetupProfiles bool) *state.Change {
 	s.MockModel(c, nil)
 
 	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"})
@@ -6720,9 +6720,9 @@ func (s *interfaceManagerSuite) mockConnectForUndo(c *C, conns map[string]interf
 func (s *interfaceManagerSuite) TestUndoConnect(c *C) {
 	// "consumer:plug producer:slot" wouldn't normally be present in conns when connecting because
 	// ifacestate.Connect() checks for existing connection; it's used here to test removal on undo.
-	conns := map[string]interface{}{
-		"snap1:plug snap2:slot":       map[string]interface{}{},
-		"consumer:plug producer:slot": map[string]interface{}{},
+	conns := map[string]any{
+		"snap1:plug snap2:slot":       map[string]any{},
+		"consumer:plug producer:slot": map[string]any{},
 	}
 	chg := s.mockConnectForUndo(c, conns, false)
 
@@ -6735,16 +6735,16 @@ func (s *interfaceManagerSuite) TestUndoConnect(c *C) {
 	for _, t := range chg.Tasks() {
 		if t.Kind() != "error-trigger" {
 			c.Assert(t.Status(), Equals, state.UndoneStatus)
-			var old interface{}
+			var old any
 			c.Assert(t.Get("old-conn", &old), NotNil)
 		}
 	}
 
 	// connection is removed from conns, other connection is left intact
-	var realConns map[string]interface{}
+	var realConns map[string]any
 	c.Assert(s.state.Get("conns", &realConns), IsNil)
-	c.Check(realConns, DeepEquals, map[string]interface{}{
-		"snap1:plug snap2:slot": map[string]interface{}{},
+	c.Check(realConns, DeepEquals, map[string]any{
+		"snap1:plug snap2:slot": map[string]any{},
 	})
 
 	cref := &interfaces.ConnRef{
@@ -6776,9 +6776,9 @@ func (s *interfaceManagerSuite) TestUndoConnect(c *C) {
 func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {
 	// "consumer:plug producer:slot" wouldn't normally be present in conns when connecting because
 	// ifacestate.Connect() checks for existing connection; it's used here to test removal on undo.
-	conns := map[string]interface{}{
-		"snap1:plug snap2:slot":       map[string]interface{}{},
-		"consumer:plug producer:slot": map[string]interface{}{"undesired": true},
+	conns := map[string]any{
+		"snap1:plug snap2:slot":       map[string]any{},
+		"consumer:plug producer:slot": map[string]any{"undesired": true},
 	}
 	chg := s.mockConnectForUndo(c, conns, false)
 
@@ -6792,19 +6792,19 @@ func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {
 		if t.Kind() != "error-trigger" {
 			c.Assert(t.Status(), Equals, state.UndoneStatus)
 			if t.Kind() == "connect" {
-				var old interface{}
+				var old any
 				c.Assert(t.Get("old-conn", &old), IsNil)
-				c.Check(old, DeepEquals, map[string]interface{}{"undesired": true})
+				c.Check(old, DeepEquals, map[string]any{"undesired": true})
 			}
 		}
 	}
 
 	// connection is left in conns because of undesired flag
-	var realConns map[string]interface{}
+	var realConns map[string]any
 	c.Assert(s.state.Get("conns", &realConns), IsNil)
-	c.Check(realConns, DeepEquals, map[string]interface{}{
-		"snap1:plug snap2:slot":       map[string]interface{}{},
-		"consumer:plug producer:slot": map[string]interface{}{"undesired": true},
+	c.Check(realConns, DeepEquals, map[string]any{
+		"snap1:plug snap2:slot":       map[string]any{},
+		"consumer:plug producer:slot": map[string]any{"undesired": true},
 	})
 
 	// but it's not in the repo
@@ -6828,7 +6828,7 @@ func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestUndoConnectNoSetupProfilesWithDelayedSetupProfiles(c *C) {
-	conns := map[string]interface{}{"consumer:plug producer:slot": map[string]interface{}{}}
+	conns := map[string]any{"consumer:plug producer:slot": map[string]any{}}
 
 	delayedSetupProfiles := true
 	chg := s.mockConnectForUndo(c, conns, delayedSetupProfiles)
@@ -6841,7 +6841,7 @@ func (s *interfaceManagerSuite) TestUndoConnectNoSetupProfilesWithDelayedSetupPr
 	c.Assert(chg.Status().Ready(), Equals, true)
 
 	// connection is removed from conns
-	var realConns map[string]interface{}
+	var realConns map[string]any
 	c.Assert(s.state.Get("conns", &realConns), IsNil)
 	c.Check(realConns, HasLen, 0)
 
@@ -6881,7 +6881,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingSlotSnapOnAutoConnect(c *
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
 	c.Assert(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*snap "producer" is no longer available for auto-connecting.*`)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
 }
 
@@ -6907,7 +6907,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingPlugSnapOnAutoConnect(c *
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Assert(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*snap "consumer" is no longer available for auto-connecting.*`)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
 }
 
@@ -6937,7 +6937,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingPlugOnAutoConnect(c *C) {
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Assert(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*snap "consumer" has no "plug" plug.*`)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
@@ -6969,7 +6969,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingSlotOnAutoConnect(c *C) {
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Assert(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*snap "producer" has no "slot" slot.*`)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
@@ -7004,17 +7004,17 @@ func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {
 	c.Assert(task.Status(), Equals, state.DoneStatus)
 
 	// Ensure that "slot" is now auto-connected.
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"attr1": "value1",
 			},
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"attr2": "value2",
 			},
 		},
@@ -7233,7 +7233,7 @@ func (s *interfaceManagerSuite) TestStartupTimings(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var allTimings []map[string]interface{}
+	var allTimings []map[string]any
 	c.Assert(s.state.Get("timings", &allTimings), IsNil)
 	c.Check(allTimings, HasLen, 1)
 
@@ -7242,15 +7242,15 @@ func (s *interfaceManagerSuite) TestStartupTimings(c *C) {
 
 	// one backed expected; the other fake backend from test setup doesn't have a name and is ignored by regenerateAllSecurityProfiles
 	c.Assert(timings, HasLen, 1)
-	timingsList, ok := timings.([]interface{})
+	timingsList, ok := timings.([]any)
 	c.Assert(ok, Equals, true)
-	tm := timingsList[0].(map[string]interface{})
+	tm := timingsList[0].(map[string]any)
 	c.Check(tm["label"], Equals, "setup-security-backend")
 	c.Check(tm["summary"], Matches, `setup security backend "fake" for snap "consumer"`)
 
 	tags, ok := allTimings[0]["tags"]
 	c.Assert(ok, Equals, true)
-	c.Check(tags, DeepEquals, map[string]interface{}{"startup": "ifacemgr"})
+	c.Check(tags, DeepEquals, map[string]any{"startup": "ifacemgr"})
 }
 
 func (s *interfaceManagerSuite) TestStartupWarningForDisabledAppArmor(c *C) {
@@ -7732,10 +7732,10 @@ func (s *interfaceManagerSuite) TestDisconnectInterfaces(c *C) {
 	c.Assert(repo.AddAppSet(consumerAppSet), IsNil)
 	c.Assert(repo.AddAppSet(producerAppSet), IsNil)
 
-	plugDynAttrs := map[string]interface{}{
+	plugDynAttrs := map[string]any{
 		"attr3": "value3",
 	}
-	slotDynAttrs := map[string]interface{}{
+	slotDynAttrs := map[string]any{
 		"attr4": "value4",
 	}
 	repo.Connect(&interfaces.ConnRef{
@@ -7763,16 +7763,16 @@ func (s *interfaceManagerSuite) TestDisconnectInterfaces(c *C) {
 	var autoDisconnect bool
 	c.Assert(ht[2].Get("auto-disconnect", &autoDisconnect), IsNil)
 	c.Assert(autoDisconnect, Equals, true)
-	var plugDynamic, slotDynamic, plugStatic, slotStatic map[string]interface{}
+	var plugDynamic, slotDynamic, plugStatic, slotStatic map[string]any
 	c.Assert(ht[2].Get("plug-static", &plugStatic), IsNil)
 	c.Assert(ht[2].Get("plug-dynamic", &plugDynamic), IsNil)
 	c.Assert(ht[2].Get("slot-static", &slotStatic), IsNil)
 	c.Assert(ht[2].Get("slot-dynamic", &slotDynamic), IsNil)
 
-	c.Assert(plugStatic, DeepEquals, map[string]interface{}{"attr1": "value1"})
-	c.Assert(slotStatic, DeepEquals, map[string]interface{}{"attr2": "value2"})
-	c.Assert(plugDynamic, DeepEquals, map[string]interface{}{"attr3": "value3"})
-	c.Assert(slotDynamic, DeepEquals, map[string]interface{}{"attr4": "value4"})
+	c.Assert(plugStatic, DeepEquals, map[string]any{"attr1": "value1"})
+	c.Assert(slotStatic, DeepEquals, map[string]any{"attr2": "value2"})
+	c.Assert(plugDynamic, DeepEquals, map[string]any{"attr3": "value3"})
+	c.Assert(slotDynamic, DeepEquals, map[string]any{"attr4": "value4"})
 
 	var expectedHooks = []struct{ snap, hook string }{
 		{snap: "producer", hook: "disconnect-slot-slot"},
@@ -8070,8 +8070,8 @@ func (s *interfaceManagerSuite) TestAutoConnectGadgetAlreadyConnected(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test", "auto": true,
 		},
 	})
@@ -8271,12 +8271,12 @@ volumes:
 	c.Assert(chg.Status().Ready(), Equals, true)
 
 	// check connection
-	var conns map[string]interface{}
+	var conns map[string]any
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, HasLen, 1)
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"foo:network-control core:network-control": map[string]interface{}{
+	c.Check(conns, DeepEquals, map[string]any{
+		"foo:network-control core:network-control": map[string]any{
 			"interface": "network-control", "auto": true, "by-gadget": true,
 		},
 	})
@@ -8488,7 +8488,7 @@ func (s *interfaceManagerSuite) TestAttributesRestoredFromConns(c *C) {
 	c.Assert(err, IsNil)
 
 	// create connection in conns state
-	dynamicAttrs := map[string]interface{}{"dynamic-number": 7}
+	dynamicAttrs := map[string]any{"dynamic-number": 7}
 	conn := &interfaces.Connection{
 		Plug: interfaces.NewConnectedPlug(plug, plugAppSet, nil, nil),
 		Slot: interfaces.NewConnectedSlot(slot, slotAppSet, nil, dynamicAttrs),
@@ -8537,8 +8537,8 @@ func (s *interfaceManagerSuite) setupHotplugConnectTestData(c *C) *state.Change 
 	c.Assert(repo.AddAppSet(testSnap), IsNil)
 
 	s.state.Lock()
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
@@ -8561,8 +8561,8 @@ func (s *interfaceManagerSuite) TestHotplugConnect(c *C) {
 	chg := s.setupHotplugConnectTestData(c)
 
 	// simulate a device that was known and connected before
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test",
 			"hotplug-key":  "1234",
 			"hotplug-gone": true,
@@ -8574,13 +8574,13 @@ func (s *interfaceManagerSuite) TestHotplugConnect(c *C) {
 
 	c.Assert(chg.Err(), IsNil)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
-			"plug-static": map[string]interface{}{"attr1": "value1"},
+			"plug-static": map[string]any{"attr1": "value1"},
 		}})
 }
 
@@ -8592,8 +8592,8 @@ func (s *interfaceManagerSuite) TestHotplugConnectIgnoresUndesired(c *C) {
 	chg := s.setupHotplugConnectTestData(c)
 
 	// simulate a device that was known and connected before
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
 			"undesired":   true,
@@ -8607,10 +8607,10 @@ func (s *interfaceManagerSuite) TestHotplugConnectIgnoresUndesired(c *C) {
 	c.Check(chg.Tasks(), HasLen, 1)
 	c.Assert(chg.Err(), IsNil)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
 			"undesired":   true,
@@ -8665,8 +8665,8 @@ func (s *interfaceManagerSuite) TestHotplugConnectNothingTodo(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1",
@@ -8694,8 +8694,8 @@ func (s *interfaceManagerSuite) TestHotplugConnectConflictRetry(c *C) {
 	chg := s.setupHotplugConnectTestData(c)
 
 	// simulate a device that was known and connected before
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test",
 			"hotplug-key":  "1234",
 			"hotplug-gone": true,
@@ -8734,14 +8734,14 @@ func (s *interfaceManagerSuite) TestHotplugAutoconnect(c *C) {
 
 	c.Assert(chg.Err(), IsNil)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"attr1": "value1"},
+			"plug-static": map[string]any{"attr1": "value1"},
 		}})
 }
 
@@ -8802,8 +8802,8 @@ func (s *interfaceManagerSuite) TestHotplugConnectAndAutoconnect(c *C) {
 	}), IsNil)
 
 	s.state.Lock()
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{"name": "hotplugslot", "interface": "test", "hotplug-key": "1234"},
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{"name": "hotplugslot", "interface": "test", "hotplug-key": "1234"},
 	})
 
 	mockConsumer(c, s.state, repo, consumerYaml, "consumer", "plug")
@@ -8815,8 +8815,8 @@ func (s *interfaceManagerSuite) TestHotplugConnectAndAutoconnect(c *C) {
 	chg.AddTask(t)
 
 	// simulate a device that was known and connected before to only one consumer, this connection will be restored
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test",
 			"hotplug-key":  "1234",
 			"hotplug-gone": true,
@@ -8829,19 +8829,19 @@ func (s *interfaceManagerSuite) TestHotplugConnectAndAutoconnect(c *C) {
 	c.Assert(chg.Err(), IsNil)
 
 	// two connections now present (restored one for consumer, and new one for consumer2)
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
-			"plug-static": map[string]interface{}{"attr1": "value1"},
+			"plug-static": map[string]any{"attr1": "value1"},
 		},
-		"consumer2:plug core:hotplugslot": map[string]interface{}{
+		"consumer2:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"attr1": "value1"},
+			"plug-static": map[string]any{"attr1": "value1"},
 		}})
 }
 
@@ -8868,14 +8868,14 @@ func (s *interfaceManagerSuite) TestHotplugDisconnect(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
@@ -8908,10 +8908,10 @@ func (s *interfaceManagerSuite) TestHotplugDisconnect(c *C) {
 	c.Assert(byHotplug, Equals, true)
 
 	// hotplug-gone flag on the connection is set
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(s.state.Get("conns", &conns), IsNil)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test",
 			"hotplug-key":  "1234",
 			"hotplug-gone": true,
@@ -8941,14 +8941,14 @@ func (s *interfaceManagerSuite) testHotplugDisconnectWaitsForCoreRefresh(c *C, t
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
@@ -9030,14 +9030,14 @@ func (s *interfaceManagerSuite) TestHotplugDisconnectWaitsForDisconnectPlug(c *C
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
@@ -9101,7 +9101,7 @@ func (s *interfaceManagerSuite) testHotplugAddNewSlot(c *C, devData map[string]s
 	t := s.state.NewTask("hotplug-add-slot", "")
 	t.Set("hotplug-key", "1234")
 	t.Set("interface", "test")
-	proposedSlot := hotplug.ProposedSlot{Name: specName, Attrs: map[string]interface{}{"foo": "bar"}}
+	proposedSlot := hotplug.ProposedSlot{Name: specName, Attrs: map[string]any{"foo": "bar"}}
 	t.Set("proposed-slot", proposedSlot)
 	devinfo, _ := hotplug.NewHotplugDeviceInfo(devData)
 	t.Set("device-info", devinfo)
@@ -9117,17 +9117,17 @@ func (s *interfaceManagerSuite) testHotplugAddNewSlot(c *C, devData map[string]s
 	// hotplugslot is created in the repository
 	slot := repo.Slot("core", expectedName)
 	c.Assert(slot, NotNil)
-	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Check(slot.Attrs, DeepEquals, map[string]any{"foo": "bar"})
 	c.Check(slot.HotplugKey, Equals, snap.HotplugKey("1234"))
 
-	var hotplugSlots map[string]interface{}
+	var hotplugSlots map[string]any
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
 	c.Assert(hotplugSlots, HasLen, 1)
-	c.Check(hotplugSlots[expectedName], DeepEquals, map[string]interface{}{
+	c.Check(hotplugSlots[expectedName], DeepEquals, map[string]any{
 		"name":         expectedName,
 		"interface":    "test",
 		"hotplug-key":  "1234",
-		"static-attrs": map[string]interface{}{"foo": "bar"},
+		"static-attrs": map[string]any{"foo": "bar"},
 		"hotplug-gone": false,
 	})
 }
@@ -9153,11 +9153,11 @@ func (s *interfaceManagerSuite) TestHotplugAddGoneSlot(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot-old-name": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot-old-name": map[string]any{
 			"name":         "hotplugslot-old-name",
 			"interface":    "test",
-			"static-attrs": map[string]interface{}{"foo": "old"},
+			"static-attrs": map[string]any{"foo": "old"},
 			"hotplug-key":  "1234",
 			"hotplug-gone": true,
 		}})
@@ -9166,7 +9166,7 @@ func (s *interfaceManagerSuite) TestHotplugAddGoneSlot(c *C) {
 	t := s.state.NewTask("hotplug-add-slot", "")
 	t.Set("hotplug-key", "1234")
 	t.Set("interface", "test")
-	proposedSlot := hotplug.ProposedSlot{Name: "hotplugslot", Label: "", Attrs: map[string]interface{}{"foo": "bar"}}
+	proposedSlot := hotplug.ProposedSlot{Name: "hotplugslot", Label: "", Attrs: map[string]any{"foo": "bar"}}
 	t.Set("proposed-slot", proposedSlot)
 	t.Set("device-info", map[string]string{"DEVPATH": "/a", "NAME": "hdcamera"})
 	chg.AddTask(t)
@@ -9181,17 +9181,17 @@ func (s *interfaceManagerSuite) TestHotplugAddGoneSlot(c *C) {
 	// hotplugslot is re-created in the repository, reuses old name and has new attributes
 	slot := repo.Slot("core", "hotplugslot-old-name")
 	c.Assert(slot, NotNil)
-	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Check(slot.Attrs, DeepEquals, map[string]any{"foo": "bar"})
 	c.Check(slot.HotplugKey, DeepEquals, snap.HotplugKey("1234"))
 
-	var hotplugSlots map[string]interface{}
+	var hotplugSlots map[string]any
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
-	c.Check(hotplugSlots, DeepEquals, map[string]interface{}{
-		"hotplugslot-old-name": map[string]interface{}{
+	c.Check(hotplugSlots, DeepEquals, map[string]any{
+		"hotplugslot-old-name": map[string]any{
 			"name":         "hotplugslot-old-name",
 			"interface":    "test",
 			"hotplug-key":  "1234",
-			"static-attrs": map[string]interface{}{"foo": "bar"},
+			"static-attrs": map[string]any{"foo": "bar"},
 			"hotplug-gone": false,
 		}})
 }
@@ -9207,17 +9207,17 @@ func (s *interfaceManagerSuite) TestHotplugAddSlotWithChangedAttrs(c *C) {
 		Name:       "hotplugslot",
 		Interface:  "test",
 		HotplugKey: "1234",
-		Attrs:      map[string]interface{}{"foo": "oldfoo"},
+		Attrs:      map[string]any{"foo": "oldfoo"},
 	}), IsNil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":         "hotplugslot",
 			"interface":    "test",
-			"static-attrs": map[string]interface{}{"foo": "old"},
+			"static-attrs": map[string]any{"foo": "old"},
 			"hotplug-key":  "1234",
 		},
 	})
@@ -9226,7 +9226,7 @@ func (s *interfaceManagerSuite) TestHotplugAddSlotWithChangedAttrs(c *C) {
 	t := s.state.NewTask("hotplug-add-slot", "")
 	t.Set("hotplug-key", "1234")
 	t.Set("interface", "test")
-	proposedSlot := hotplug.ProposedSlot{Name: "hotplugslot", Label: "", Attrs: map[string]interface{}{"foo": "newfoo"}}
+	proposedSlot := hotplug.ProposedSlot{Name: "hotplugslot", Label: "", Attrs: map[string]any{"foo": "newfoo"}}
 	t.Set("proposed-slot", proposedSlot)
 	devinfo, _ := hotplug.NewHotplugDeviceInfo(map[string]string{"DEVPATH": "/a"})
 	t.Set("device-info", devinfo)
@@ -9244,17 +9244,17 @@ func (s *interfaceManagerSuite) TestHotplugAddSlotWithChangedAttrs(c *C) {
 	// hotplugslot is re-created in the repository
 	slot := repo.Slot("core", "hotplugslot")
 	c.Assert(slot, NotNil)
-	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"foo": "newfoo"})
+	c.Check(slot.Attrs, DeepEquals, map[string]any{"foo": "newfoo"})
 	c.Check(slot.HotplugKey, DeepEquals, snap.HotplugKey("1234"))
 
-	var hotplugSlots map[string]interface{}
+	var hotplugSlots map[string]any
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
-	c.Check(hotplugSlots, DeepEquals, map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	c.Check(hotplugSlots, DeepEquals, map[string]any{
+		"hotplugslot": map[string]any{
 			"name":         "hotplugslot",
 			"interface":    "test",
 			"hotplug-key":  "1234",
-			"static-attrs": map[string]interface{}{"foo": "newfoo"},
+			"static-attrs": map[string]any{"foo": "newfoo"},
 			"hotplug-gone": false,
 		}})
 }
@@ -9280,8 +9280,8 @@ func (s *interfaceManagerSuite) TestHotplugUpdateSlot(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
@@ -9291,7 +9291,7 @@ func (s *interfaceManagerSuite) TestHotplugUpdateSlot(c *C) {
 	t := s.state.NewTask("hotplug-update-slot", "")
 	t.Set("hotplug-key", "1234")
 	t.Set("interface", "test")
-	t.Set("slot-attrs", map[string]interface{}{"foo": "bar"})
+	t.Set("slot-attrs", map[string]any{"foo": "bar"})
 	chg.AddTask(t)
 
 	s.state.Unlock()
@@ -9304,16 +9304,16 @@ func (s *interfaceManagerSuite) TestHotplugUpdateSlot(c *C) {
 	// hotplugslot is updated in the repository
 	slot := repo.Slot("core", "hotplugslot")
 	c.Assert(slot, NotNil)
-	c.Assert(slot.Attrs, DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(slot.Attrs, DeepEquals, map[string]any{"foo": "bar"})
 
-	var hotplugSlots map[string]interface{}
+	var hotplugSlots map[string]any
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
-	c.Assert(hotplugSlots, DeepEquals, map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	c.Assert(hotplugSlots, DeepEquals, map[string]any{
+		"hotplugslot": map[string]any{
 			"name":         "hotplugslot",
 			"interface":    "test",
 			"hotplug-key":  "1234",
-			"static-attrs": map[string]interface{}{"foo": "bar"},
+			"static-attrs": map[string]any{"foo": "bar"},
 			"hotplug-gone": false,
 		}})
 }
@@ -9343,14 +9343,14 @@ func (s *interfaceManagerSuite) TestHotplugUpdateSlotWhenConnected(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test",
 			"hotplug-key":  "1234",
 			"hotplug-gone": true,
@@ -9364,7 +9364,7 @@ func (s *interfaceManagerSuite) TestHotplugUpdateSlotWhenConnected(c *C) {
 	t := s.state.NewTask("hotplug-update-slot", "")
 	t.Set("hotplug-key", "1234")
 	t.Set("interface", "test")
-	t.Set("slot-attrs", map[string]interface{}{})
+	t.Set("slot-attrs", map[string]any{})
 	chg.AddTask(t)
 
 	s.state.Unlock()
@@ -9377,10 +9377,10 @@ func (s *interfaceManagerSuite) TestHotplugUpdateSlotWhenConnected(c *C) {
 	// hotplugslot is not removed because of existing connection
 	c.Assert(repo.Slot("core", "hotplugslot"), NotNil)
 
-	var hotplugSlots map[string]interface{}
+	var hotplugSlots map[string]any
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
-	c.Assert(hotplugSlots, DeepEquals, map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	c.Assert(hotplugSlots, DeepEquals, map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
@@ -9408,13 +9408,13 @@ func (s *interfaceManagerSuite) TestHotplugRemoveSlot(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
 		},
-		"otherslot": map[string]interface{}{
+		"otherslot": map[string]any{
 			"name":        "otherslot",
 			"interface":   "test",
 			"hotplug-key": "5678",
@@ -9439,10 +9439,10 @@ func (s *interfaceManagerSuite) TestHotplugRemoveSlot(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(slot, IsNil)
 
-	var hotplugSlots map[string]interface{}
+	var hotplugSlots map[string]any
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
-	c.Assert(hotplugSlots, DeepEquals, map[string]interface{}{
-		"otherslot": map[string]interface{}{
+	c.Assert(hotplugSlots, DeepEquals, map[string]any{
+		"otherslot": map[string]any{
 			"name":         "otherslot",
 			"interface":    "test",
 			"hotplug-key":  "5678",
@@ -9471,14 +9471,14 @@ func (s *interfaceManagerSuite) TestHotplugRemoveSlotWhenConnected(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("hotplug-slots", map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	s.state.Set("hotplug-slots", map[string]any{
+		"hotplugslot": map[string]any{
 			"name":        "hotplugslot",
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:hotplugslot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug core:hotplugslot": map[string]any{
 			"interface":    "test",
 			"hotplug-key":  "1234",
 			"hotplug-gone": true,
@@ -9503,10 +9503,10 @@ func (s *interfaceManagerSuite) TestHotplugRemoveSlotWhenConnected(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(slot, IsNil)
 
-	var hotplugSlots map[string]interface{}
+	var hotplugSlots map[string]any
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
-	c.Assert(hotplugSlots, DeepEquals, map[string]interface{}{
-		"hotplugslot": map[string]interface{}{
+	c.Assert(hotplugSlots, DeepEquals, map[string]any{
+		"hotplugslot": map[string]any{
 			"name":         "hotplugslot",
 			"interface":    "test",
 			"hotplug-key":  "1234",
@@ -9579,8 +9579,8 @@ func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undes
 	c.Assert(slot, NotNil)
 	plug := plugSnap.Plugs["plug"]
 	c.Assert(plug, NotNil)
-	dynamicPlugAttrs := map[string]interface{}{"dynamic-number": 7}
-	dynamicSlotAttrs := map[string]interface{}{"other-number": 9}
+	dynamicPlugAttrs := map[string]any{"dynamic-number": 7}
+	dynamicSlotAttrs := map[string]any{"other-number": 9}
 	// create connection in conns state
 	conn := &interfaces.Connection{
 		Plug: interfaces.NewConnectedPlug(plug, plugAppSet, nil, dynamicPlugAttrs),
@@ -9602,16 +9602,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
-			StaticPlugAttrs: map[string]interface{}{
+			StaticPlugAttrs: map[string]any{
 				"attr1": "value1",
 			},
-			DynamicPlugAttrs: map[string]interface{}{
+			DynamicPlugAttrs: map[string]any{
 				"dynamic-number": int64(7),
 			},
-			StaticSlotAttrs: map[string]interface{}{
+			StaticSlotAttrs: map[string]any{
 				"attr2": "value2",
 			},
-			DynamicSlotAttrs: map[string]interface{}{
+			DynamicSlotAttrs: map[string]any{
 				"other-number": int64(9),
 			},
 		}})
@@ -9624,16 +9624,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
 			Interface: "test",
 			Auto:      true,
 			ByGadget:  true,
-			StaticPlugAttrs: map[string]interface{}{
+			StaticPlugAttrs: map[string]any{
 				"attr1": "value1",
 			},
-			DynamicPlugAttrs: map[string]interface{}{
+			DynamicPlugAttrs: map[string]any{
 				"dynamic-number": int64(7),
 			},
-			StaticSlotAttrs: map[string]interface{}{
+			StaticSlotAttrs: map[string]any{
 				"attr2": "value2",
 			},
-			DynamicSlotAttrs: map[string]interface{}{
+			DynamicSlotAttrs: map[string]any{
 				"other-number": int64(9),
 			},
 		}})
@@ -9646,16 +9646,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *C) {
 			Interface: "test",
 			Auto:      true,
 			Undesired: true,
-			StaticPlugAttrs: map[string]interface{}{
+			StaticPlugAttrs: map[string]any{
 				"attr1": "value1",
 			},
-			DynamicPlugAttrs: map[string]interface{}{
+			DynamicPlugAttrs: map[string]any{
 				"dynamic-number": int64(7),
 			},
-			StaticSlotAttrs: map[string]interface{}{
+			StaticSlotAttrs: map[string]any{
 				"attr2": "value2",
 			},
-			DynamicSlotAttrs: map[string]interface{}{
+			DynamicSlotAttrs: map[string]any{
 				"other-number": int64(9),
 			},
 		}})
@@ -9667,16 +9667,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesHotplugGone(c *C) {
 		"consumer:plug producer:slot": {
 			Interface:   "test",
 			HotplugGone: true,
-			StaticPlugAttrs: map[string]interface{}{
+			StaticPlugAttrs: map[string]any{
 				"attr1": "value1",
 			},
-			DynamicPlugAttrs: map[string]interface{}{
+			DynamicPlugAttrs: map[string]any{
 				"dynamic-number": int64(7),
 			},
-			StaticSlotAttrs: map[string]interface{}{
+			StaticSlotAttrs: map[string]any{
 				"attr2": "value2",
 			},
-			DynamicSlotAttrs: map[string]interface{}{
+			DynamicSlotAttrs: map[string]any{
 				"other-number": int64(9),
 			},
 		}})
@@ -9689,7 +9689,7 @@ func (s *interfaceManagerSuite) TestResolveDisconnectFromConns(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("conns", map[string]interface{}{"some-snap:plug core:slot": map[string]interface{}{"interface": "foo"}})
+	st.Set("conns", map[string]any{"some-snap:plug core:slot": map[string]any{"interface": "foo"}})
 
 	forget := true
 	ref, err := mgr.ResolveDisconnect("some-snap", "plug", "core", "slot", forget)
@@ -9835,14 +9835,14 @@ func (s *interfaceManagerSuite) TestTransitionConnectionsCoreMigration(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(repoConns, HasLen, 1)
 
-	st.Set("conns", map[string]interface{}{"some-snap:network ubuntu-core:network": map[string]interface{}{"interface": "network", "auto": true}})
+	st.Set("conns", map[string]any{"some-snap:network ubuntu-core:network": map[string]any{"interface": "network", "auto": true}})
 
 	c.Assert(mgr.TransitionConnectionsCoreMigration(st, "ubuntu-core", "core"), IsNil)
 
 	// check connections
-	var conns map[string]interface{}
+	var conns map[string]any
 	st.Get("conns", &conns)
-	c.Assert(conns, DeepEquals, map[string]interface{}{"some-snap:network core:network": map[string]interface{}{"interface": "network", "auto": true}})
+	c.Assert(conns, DeepEquals, map[string]any{"some-snap:network core:network": map[string]any{"interface": "network", "auto": true}})
 
 	repoConns, err = repo.Connections("ubuntu-core")
 	c.Assert(err, IsNil)
@@ -9857,7 +9857,7 @@ func (s *interfaceManagerSuite) TestTransitionConnectionsCoreMigration(c *C) {
 	// check connections
 	conns = nil
 	st.Get("conns", &conns)
-	c.Assert(conns, DeepEquals, map[string]interface{}{"some-snap:network ubuntu-core:network": map[string]interface{}{"interface": "network", "auto": true}})
+	c.Assert(conns, DeepEquals, map[string]any{"some-snap:network ubuntu-core:network": map[string]any{"interface": "network", "auto": true}})
 	repoConns, err = repo.Connections("ubuntu-core")
 	c.Assert(err, IsNil)
 	c.Assert(repoConns, HasLen, 1)
@@ -9876,32 +9876,32 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	s.MockSnapDecl(c, "theme2", "one-publisher", nil)
 
 	// the consumer
-	s.MockSnapDecl(c, "theme-consumer", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "theme-consumer", "one-publisher", map[string]any{
 		"format": "1",
-		"plugs": map[string]interface{}{
-			"content": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
+		"plugs": map[string]any{
+			"content": map[string]any{
+				"allow-auto-connection": map[string]any{
 					"slots-per-plug": "*",
 				},
 			},
 		},
 	})
 
-	check := func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	check := func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		c.Check(repoConns, HasLen, 2)
 
-		c.Check(conns, DeepEquals, map[string]interface{}{
-			"theme-consumer:plug theme1:slot": map[string]interface{}{
+		c.Check(conns, DeepEquals, map[string]any{
+			"theme-consumer:plug theme1:slot": map[string]any{
 				"auto":        true,
 				"interface":   "content",
-				"plug-static": map[string]interface{}{"content": "themes"},
-				"slot-static": map[string]interface{}{"content": "themes"},
+				"plug-static": map[string]any{"content": "themes"},
+				"slot-static": map[string]any{"content": "themes"},
 			},
-			"theme-consumer:plug theme2:slot": map[string]interface{}{
+			"theme-consumer:plug theme2:slot": map[string]any{
 				"auto":        true,
 				"interface":   "content",
-				"plug-static": map[string]interface{}{"content": "themes"},
-				"slot-static": map[string]interface{}{"content": "themes"},
+				"plug-static": map[string]any{"content": "themes"},
+				"slot-static": map[string]any{"content": "themes"},
 			},
 		})
 	}
@@ -9909,7 +9909,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	s.testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c, check)
 }
 
-func (s *interfaceManagerSuite) testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c *C, check func(map[string]interface{}, []*interfaces.ConnRef)) {
+func (s *interfaceManagerSuite) testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c *C, check func(map[string]any, []*interfaces.ConnRef)) {
 	const theme1Yaml = `
 name: theme1
 version: 1
@@ -9957,7 +9957,7 @@ plugs:
 	// Ensure that the task succeeded.
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	_ = s.state.Get("conns", &conns)
 
 	repo := mgr.Repository()
@@ -9971,11 +9971,11 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	s.MockModel(c, nil)
 
 	// the producer snap
-	s.MockSnapDecl(c, "theme1", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "theme1", "one-publisher", map[string]any{
 		"format": "1",
-		"slots": map[string]interface{}{
-			"content": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
+		"slots": map[string]any{
+			"content": map[string]any{
+				"allow-auto-connection": map[string]any{
 					"slots-per-plug": "*",
 				},
 			},
@@ -9983,11 +9983,11 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	})
 
 	// 2nd producer snap
-	s.MockSnapDecl(c, "theme2", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "theme2", "one-publisher", map[string]any{
 		"format": "1",
-		"slots": map[string]interface{}{
-			"content": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
+		"slots": map[string]any{
+			"content": map[string]any{
+				"allow-auto-connection": map[string]any{
 					"slots-per-plug": "*",
 				},
 			},
@@ -9997,21 +9997,21 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	// the consumer
 	s.MockSnapDecl(c, "theme-consumer", "one-publisher", nil)
 
-	check := func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	check := func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		c.Check(repoConns, HasLen, 2)
 
-		c.Check(conns, DeepEquals, map[string]interface{}{
-			"theme-consumer:plug theme1:slot": map[string]interface{}{
+		c.Check(conns, DeepEquals, map[string]any{
+			"theme-consumer:plug theme1:slot": map[string]any{
 				"auto":        true,
 				"interface":   "content",
-				"plug-static": map[string]interface{}{"content": "themes"},
-				"slot-static": map[string]interface{}{"content": "themes"},
+				"plug-static": map[string]any{"content": "themes"},
+				"slot-static": map[string]any{"content": "themes"},
 			},
-			"theme-consumer:plug theme2:slot": map[string]interface{}{
+			"theme-consumer:plug theme2:slot": map[string]any{
 				"auto":        true,
 				"interface":   "content",
-				"plug-static": map[string]interface{}{"content": "themes"},
-				"slot-static": map[string]interface{}{"content": "themes"},
+				"plug-static": map[string]any{"content": "themes"},
+				"slot-static": map[string]any{"content": "themes"},
 			},
 		})
 	}
@@ -10023,11 +10023,11 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	s.MockModel(c, nil)
 
 	// the producer snap
-	s.MockSnapDecl(c, "theme1", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "theme1", "one-publisher", map[string]any{
 		"format": "1",
-		"slots": map[string]interface{}{
-			"content": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
+		"slots": map[string]any{
+			"content": map[string]any{
+				"allow-auto-connection": map[string]any{
 					"slots-per-plug": "*",
 				},
 			},
@@ -10035,11 +10035,11 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	})
 
 	// 2nd producer snap
-	s.MockSnapDecl(c, "theme2", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "theme2", "one-publisher", map[string]any{
 		"format": "1",
-		"slots": map[string]interface{}{
-			"content": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
+		"slots": map[string]any{
+			"content": map[string]any{
+				"allow-auto-connection": map[string]any{
 					"slots-per-plug": "1",
 				},
 			},
@@ -10049,7 +10049,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 	// the consumer
 	s.MockSnapDecl(c, "theme-consumer", "one-publisher", nil)
 
-	check := func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+	check := func(conns map[string]any, repoConns []*interfaces.ConnRef) {
 		// slots-per-plug were ambigous, nothing was connected
 		c.Check(repoConns, HasLen, 0)
 		c.Check(conns, HasLen, 0)
@@ -10088,12 +10088,12 @@ slots:
 
 	mgr := s.manager(c)
 
-	s.MockSnapDecl(c, "consumer", "one-publisher", map[string]interface{}{
+	s.MockSnapDecl(c, "consumer", "one-publisher", map[string]any{
 		"format": "4",
-		"plugs": map[string]interface{}{
-			"test": map[string]interface{}{
-				"allow-auto-connection": map[string]interface{}{
-					"slot-names": []interface{}{
+		"plugs": map[string]any{
+			"test": map[string]any{
+				"allow-auto-connection": map[string]any{
+					"slot-names": []any{
 						"test1",
 					},
 				},
@@ -10124,15 +10124,15 @@ plugs:
 	// Ensure that the task succeeded.
 	c.Assert(change.Status(), Equals, state.DoneStatus)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	_ = s.state.Get("conns", &conns)
 
 	repo := mgr.Repository()
 	plug := repo.Plug("consumer", "test")
 	c.Assert(plug, Not(IsNil))
 
-	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:test gadget:test1": map[string]interface{}{"auto": true, "interface": "test"},
+	c.Check(conns, DeepEquals, map[string]any{
+		"consumer:test gadget:test1": map[string]any{"auto": true, "interface": "test"},
 	})
 	c.Check(repo.Interfaces().Connections, HasLen, 1)
 }
@@ -10902,7 +10902,7 @@ version: 1.0
 	_, err = repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	s.state.Set("conns", map[string]interface{}{"consumer2:plug producer2:slot": map[string]interface{}{"interface": "test"}})
+	s.state.Set("conns", map[string]any{"consumer2:plug producer2:slot": map[string]any{"interface": "test"}})
 
 	// mock new snaps for the refresh
 	snaptest.MockSnap(c, consumer2Yaml, &snap.SideInfo{Revision: snap.R(2)})
@@ -11034,10 +11034,10 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsControlHandlerServicesDisc
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.state.Set("conns", map[string]interface{}{
-		"test-snap:snap-interfaces-requests-control core:snap-interfaces-requests-control": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"test-snap:snap-interfaces-requests-control core:snap-interfaces-requests-control": map[string]any{
 			"interface": "snap-interfaces-requests-control",
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"handler-service": "prompts-handler",
 			},
 			// manually disconnected
@@ -11125,22 +11125,22 @@ plugs:
 		SnapType: "app",
 	})
 
-	plugStatic := map[string]interface{}{}
+	plugStatic := map[string]any{}
 	if opts.hasHandler {
 		plugStatic["handler-service"] = "prompts-handler"
 	}
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	err := s.state.Get("conns", &conns)
 	if err != nil {
 		if errors.Is(err, state.ErrNoState) {
-			conns = map[string]interface{}{}
+			conns = map[string]any{}
 		} else {
 			c.Fatalf("unexpected error: %v", err)
 		}
 	}
 
-	conns[fmt.Sprintf("%s:snap-interfaces-requests-control core:snap-interfaces-requests-control", name)] = map[string]interface{}{
+	conns[fmt.Sprintf("%s:snap-interfaces-requests-control core:snap-interfaces-requests-control", name)] = map[string]any{
 		"interface":   "snap-interfaces-requests-control",
 		"plug-static": plugStatic,
 	}
@@ -11151,14 +11151,14 @@ plugs:
 func (s *interfaceManagerSuite) testDoSetupProfilesForMultiConnectedPlugOnRefresh(c *C, refreshedSnap string) (consideredConns []string) {
 	// Have a plug connected to two slots. And second witness plug on a different snap.
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"consumer:plug producer:slot": map[string]any{
 			"interface": "test",
 		},
-		"consumer:plug producer2:slot": map[string]interface{}{
+		"consumer:plug producer2:slot": map[string]any{
 			"interface": "test",
 		},
-		"consumer2:plug producer3:slot": map[string]interface{}{
+		"consumer2:plug producer3:slot": map[string]any{
 			"interface": "test",
 		},
 	})

--- a/overlord/ifacestate/implicit_test.go
+++ b/overlord/ifacestate/implicit_test.go
@@ -42,7 +42,7 @@ func (implicitSuite) TestAddImplicitInterfacesOnCore(c *C) {
 		"foo": {
 			Name:        "foo",
 			Interface:   "empty",
-			StaticAttrs: map[string]interface{}{"attr": "value"},
+			StaticAttrs: map[string]any{"attr": "value"},
 			HotplugKey:  "1234",
 		}}
 	st.Lock()
@@ -71,7 +71,7 @@ func (implicitSuite) TestAddImplicitInterfacesOnCore(c *C) {
 	slot := info.Slots["foo"]
 	c.Assert(slot, NotNil)
 	c.Assert(slot.Interface, Equals, "empty")
-	c.Assert(slot.Attrs, DeepEquals, map[string]interface{}{"attr": "value"})
+	c.Assert(slot.Attrs, DeepEquals, map[string]any{"attr": "value"})
 	c.Assert(slot.HotplugKey, DeepEquals, snap.HotplugKey("1234"))
 }
 

--- a/overlord/ifacestate/schema/schema.go
+++ b/overlord/ifacestate/schema/schema.go
@@ -29,11 +29,11 @@ type ConnState struct {
 	Interface string `json:"interface,omitempty" yaml:"interface"`
 	// Undesired tracks connections that were manually disconnected after being auto-connected,
 	// so that they are not automatically reconnected again in the future.
-	Undesired        bool                   `json:"undesired,omitempty" yaml:"undesired"`
-	StaticPlugAttrs  map[string]interface{} `json:"plug-static,omitempty" yaml:"plug-static,omitempty"`
-	DynamicPlugAttrs map[string]interface{} `json:"plug-dynamic,omitempty" yaml:"plug-dynamic,omitempty"`
-	StaticSlotAttrs  map[string]interface{} `json:"slot-static,omitempty" yaml:"slot-static,omitempty"`
-	DynamicSlotAttrs map[string]interface{} `json:"slot-dynamic,omitempty" yaml:"slot-dynamic,omitempty"`
+	Undesired        bool           `json:"undesired,omitempty" yaml:"undesired"`
+	StaticPlugAttrs  map[string]any `json:"plug-static,omitempty" yaml:"plug-static,omitempty"`
+	DynamicPlugAttrs map[string]any `json:"plug-dynamic,omitempty" yaml:"plug-dynamic,omitempty"`
+	StaticSlotAttrs  map[string]any `json:"slot-static,omitempty" yaml:"slot-static,omitempty"`
+	DynamicSlotAttrs map[string]any `json:"slot-dynamic,omitempty" yaml:"slot-dynamic,omitempty"`
 	// Hotplug-related attributes: HotplugGone indicates a connection that
 	// disappeared because the device was removed, but may potentially be
 	// restored in the future if we see the device again. HotplugKey is the

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -96,7 +96,7 @@ func (s *installSuite) SetUpTest(c *C) {
 
 	s.TestingSeed20 = &seedtest.TestingSeed20{}
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 	// needed by TestingSeed20.MakeSeed (to work with makeSnap)
@@ -179,20 +179,20 @@ func (s *installSuite) mountedGadget(c *C) (gadgetInfo *gadget.Info, gadgetDir s
 	return gadgetInfo, gadgetDir
 }
 
-func (s *installSuite) mockModel(override map[string]interface{}) *asserts.Model {
-	m := map[string]interface{}{
+func (s *installSuite) mockModel(override map[string]any) *asserts.Model {
+	m := map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -366,7 +366,7 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmErr })
 		defer restore()
 
-		mockModel := s.mockModel(map[string]interface{}{
+		mockModel := s.mockModel(map[string]any{
 			"grade":          tc.grade,
 			"storage-safety": tc.storageSafety,
 		})
@@ -479,7 +479,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmErr })
 		defer restore()
 
-		mockModel := s.mockModel(map[string]interface{}{
+		mockModel := s.mockModel(map[string]any{
 			"grade":          tc.grade,
 			"storage-safety": tc.storageSafety,
 		})
@@ -604,7 +604,7 @@ func (s *installSuite) TestEncryptionSupportInfoGadgetIncompatibleWithEncryption
 		},
 	}
 	for _, tc := range testCases {
-		mockModel := s.mockModel(map[string]interface{}{
+		mockModel := s.mockModel(map[string]any{
 			"grade":          tc.grade,
 			"storage-safety": tc.storageSafety,
 		})
@@ -759,7 +759,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportStorageSafety(c *C) {
 		{"secured", "encrypted", true},
 	}
 	for _, tc := range testCases {
-		mockModel := s.mockModel(map[string]interface{}{
+		mockModel := s.mockModel(map[string]any{
 			"grade":          tc.grade,
 			"storage-safety": tc.storageSafety,
 		})
@@ -801,7 +801,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportErrors(c *C) {
 		},
 	}
 	for _, tc := range testCases {
-		mockModel := s.mockModel(map[string]interface{}{
+		mockModel := s.mockModel(map[string]any{
 			"grade":          tc.grade,
 			"storage-safety": tc.storageSafety,
 		})
@@ -1103,7 +1103,7 @@ func (s *installSuite) TestPrepareRunSystemDataSupportsCloudInitGadgetAndSeedCon
 	}
 
 	_, gadgetDir := s.mountedGadget(c)
-	mockModel := s.mockModel(map[string]interface{}{
+	mockModel := s.mockModel(map[string]any{
 		"grade": "signed",
 	})
 
@@ -1159,7 +1159,7 @@ func (s *installSuite) TestPrepareRunSystemDataSupportsCloudInitBothGadgetAndUbu
 func (s *installSuite) TestPrepareRunSystemDataSignedNoUbuntuSeedCloudInit(c *C) {
 	// pretend we have no cloud-init config anywhere
 	_, gadgetDir := s.mountedGadget(c)
-	mockModel := s.mockModel(map[string]interface{}{
+	mockModel := s.mockModel(map[string]any{
 		"grade": "signed",
 	})
 
@@ -1179,7 +1179,7 @@ func (s *installSuite) TestPrepareRunSystemDataSignedNoUbuntuSeedCloudInit(c *C)
 
 func (s *installSuite) TestPrepareRunSystemDataSecuredGadgetCloudConfCloudInit(c *C) {
 	_, gadgetDir := s.mountedGadget(c)
-	mockModel := s.mockModel(map[string]interface{}{
+	mockModel := s.mockModel(map[string]any{
 		"grade": "secured",
 	})
 
@@ -1210,7 +1210,7 @@ func (s *installSuite) TestPrepareRunSystemDataSecuredNoUbuntuSeedCloudInit(c *C
 	}
 
 	_, gadgetDir := s.mountedGadget(c)
-	mockModel := s.mockModel(map[string]interface{}{
+	mockModel := s.mockModel(map[string]any{
 		"grade": "secured",
 	})
 
@@ -1295,38 +1295,38 @@ func (s *installSuite) setupCore20Seed(c *C) *asserts.Model {
 		snap.R(1), compRevs, "canonical", s.StoreSigning.Database,
 	)
 
-	model := map[string]interface{}{
+	model := map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "snapd",
 				"id":   s.AssertedSnapID("snapd"),
 				"type": "snapd",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				"id":   s.AssertedSnapID("core20"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 				},
 			},
@@ -1336,8 +1336,8 @@ func (s *installSuite) setupCore20Seed(c *C) *asserts.Model {
 	return s.MakeSeed(c, "20220401", "my-brand", "my-model", model, []*seedwriter.OptionsSnap{{Path: optSnapPath}})
 }
 
-func (s *installSuite) mockPreseedAssertion(c *C, brandID, modelName, series, preseedAsPath, sysLabel string, digest string, snaps []interface{}) {
-	headers := map[string]interface{}{
+func (s *installSuite) mockPreseedAssertion(c *C, brandID, modelName, series, preseedAsPath, sysLabel string, digest string, snaps []any) {
+	headers := map[string]any{
 		"type":              "preseed",
 		"authority-id":      brandID,
 		"series":            series,
@@ -1381,23 +1381,23 @@ func (s *installSuite) TestApplyPreseededData(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "snaps"), 0755), IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
 
-	snaps := []interface{}{
-		map[string]interface{}{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
-		map[string]interface{}{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
-		map[string]interface{}{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
-		map[string]interface{}{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
-		map[string]interface{}{
+	snaps := []any{
+		map[string]any{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
+		map[string]any{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
+		map[string]any{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
+		map[string]any{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
+		map[string]any{
 			"name":     "required20",
 			"id":       s.AssertedSnapID("required20"),
 			"revision": "1",
-			"components": []interface{}{
-				map[string]interface{}{
+			"components": []any{
+				map[string]any{
 					"name":     "comp1",
 					"revision": "2",
 				},
 			},
 		},
-		map[string]interface{}{"name": "optional20-a"},
+		map[string]any{"name": "optional20-a"},
 	}
 	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
 	c.Assert(err, IsNil)
@@ -1517,7 +1517,7 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
 	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 
-	model := s.mockModel(map[string]interface{}{
+	model := s.mockModel(map[string]any{
 		"grade": "dangerous",
 	})
 
@@ -1551,22 +1551,22 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 		{"extra-snap", "1", "id000000000000000000000000000000", `seed has 3 snaps but 4 snaps are required by preseed assertion`},
 	} {
 
-		preseedAsSnaps := []interface{}{
-			map[string]interface{}{"name": "essential-snap", "id": "id111111111111111111111111111111", "revision": "1"},
-			map[string]interface{}{"name": "mode-snap", "id": "id222222222222222222222222222222", "revision": "3"},
-			map[string]interface{}{"name": "mode-snap2"},
+		preseedAsSnaps := []any{
+			map[string]any{"name": "essential-snap", "id": "id111111111111111111111111111111", "revision": "1"},
+			map[string]any{"name": "mode-snap", "id": "id222222222222222222222222222222", "revision": "3"},
+			map[string]any{"name": "mode-snap2"},
 		}
 
 		var found bool
 		for i, ps := range preseedAsSnaps {
-			if ps.(map[string]interface{})["name"] == tc.snapName {
-				preseedAsSnaps[i] = map[string]interface{}{"name": tc.snapName, "id": tc.snapID, "revision": tc.rev}
+			if ps.(map[string]any)["name"] == tc.snapName {
+				preseedAsSnaps[i] = map[string]any{"name": tc.snapName, "id": tc.snapID, "revision": tc.rev}
 				found = true
 				break
 			}
 		}
 		if !found {
-			preseedAsSnaps = append(preseedAsSnaps, map[string]interface{}{"name": tc.snapName, "id": tc.snapID, "revision": tc.rev})
+			preseedAsSnaps = append(preseedAsSnaps, map[string]any{"name": tc.snapName, "id": tc.snapID, "revision": tc.rev})
 		}
 
 		s.mockPreseedAssertion(c, model.BrandID(), model.Model(), "16", preseedAsPath, sysLabel, digest, preseedAsSnaps)
@@ -1577,10 +1577,10 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 	// mode-snap is preseeded in the seed but missing in the preseed assertion;
 	// add other-snap to preseed assertion to satisfy the check for number of
 	// snaps.
-	preseedAsSnaps := []interface{}{
-		map[string]interface{}{"name": "essential-snap", "id": "id111111111111111111111111111111", "revision": "1"},
-		map[string]interface{}{"name": "other-snap", "id": "id333222222222222222222222222222", "revision": "2"},
-		map[string]interface{}{"name": "mode-snap2"},
+	preseedAsSnaps := []any{
+		map[string]any{"name": "essential-snap", "id": "id111111111111111111111111111111", "revision": "1"},
+		map[string]any{"name": "other-snap", "id": "id333222222222222222222222222222", "revision": "2"},
+		map[string]any{"name": "mode-snap2"},
 	}
 	s.mockPreseedAssertion(c, model.BrandID(), model.Model(), "16", preseedAsPath, sysLabel, digest, preseedAsSnaps)
 	err = install.ApplyPreseededData(sysSeed, writableDir)
@@ -1588,24 +1588,24 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 }
 
 func (s *installSuite) TestApplyPreseededDataComponentMismatchWrongRevision(c *C) {
-	preseed := []interface{}{
-		map[string]interface{}{
+	preseed := []any{
+		map[string]any{
 			"name":     "essential-snap",
 			"id":       snaptest.AssertedSnapID("essential-snap"),
 			"revision": "1",
-			"components": []interface{}{
-				map[string]interface{}{
+			"components": []any{
+				map[string]any{
 					"name":     "comp1",
 					"revision": "5",
 				},
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "mode-snap",
 			"id":       snaptest.AssertedSnapID("mode-snap"),
 			"revision": "3",
-			"components": []interface{}{
-				map[string]interface{}{
+			"components": []any{
+				map[string]any{
 					"name":     "comp2",
 					"revision": "4",
 				},
@@ -1620,28 +1620,28 @@ func (s *installSuite) TestApplyPreseededDataComponentMismatchWrongRevision(c *C
 }
 
 func (s *installSuite) TestApplyPreseededDataComponentMismatchMissingComponent(c *C) {
-	preseed := []interface{}{
-		map[string]interface{}{
+	preseed := []any{
+		map[string]any{
 			"name":     "essential-snap",
 			"id":       snaptest.AssertedSnapID("essential-snap"),
 			"revision": "1",
-			"components": []interface{}{
-				map[string]interface{}{
+			"components": []any{
+				map[string]any{
 					"name":     "comp1",
 					"revision": "2",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":     "comp3",
 					"revision": "5",
 				},
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "mode-snap",
 			"id":       snaptest.AssertedSnapID("mode-snap"),
 			"revision": "3",
-			"components": []interface{}{
-				map[string]interface{}{
+			"components": []any{
+				map[string]any{
 					"name":     "comp2",
 					"revision": "4",
 				},
@@ -1656,24 +1656,24 @@ func (s *installSuite) TestApplyPreseededDataComponentMismatchMissingComponent(c
 }
 
 func (s *installSuite) TestApplyPreseededDataComponentMismatchExtraComponent(c *C) {
-	preseed := []interface{}{
-		map[string]interface{}{
+	preseed := []any{
+		map[string]any{
 			"name":     "essential-snap",
 			"id":       snaptest.AssertedSnapID("essential-snap"),
 			"revision": "1",
-			"components": []interface{}{
-				map[string]interface{}{
+			"components": []any{
+				map[string]any{
 					"name":     "comp1",
 					"revision": "2",
 				},
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":     "mode-snap",
 			"id":       snaptest.AssertedSnapID("mode-snap"),
 			"revision": "3",
-			"components": []interface{}{
-				map[string]interface{}{
+			"components": []any{
+				map[string]any{
 					"name":     "comp2",
 					"revision": "4",
 				},
@@ -1694,7 +1694,7 @@ func (s *installSuite) TestApplyPreseededDataComponentMismatchExtraComponent(c *
 }
 
 type preseededDataComponentMismatchOpts struct {
-	preseed             []interface{}
+	preseed             []any
 	errMsg              string
 	extraSeedComponents []seed.Component
 }
@@ -1716,7 +1716,7 @@ func (s *installSuite) testApplyPreseededDataComponentMismatch(c *C, opts presee
 	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
 	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 
-	model := s.mockModel(map[string]interface{}{
+	model := s.mockModel(map[string]any{
 		"grade": "dangerous",
 	})
 
@@ -1779,7 +1779,7 @@ func (s *installSuite) TestApplyPreseededDataWrongDigest(c *C) {
 	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
 	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 
-	model := s.mockModel(map[string]interface{}{
+	model := s.mockModel(map[string]any{
 		"grade": "dangerous",
 	})
 
@@ -1790,8 +1790,8 @@ func (s *installSuite) TestApplyPreseededDataWrongDigest(c *C) {
 		essentialSnaps:  []*seed.Snap{{Path: snapPath1, SideInfo: &snap.SideInfo{RealName: "essential-snap", Revision: snap.R(1)}}},
 	}
 
-	snaps := []interface{}{
-		map[string]interface{}{"name": "essential-snap", "id": "id111111111111111111111111111111", "revision": "1"},
+	snaps := []any{
+		map[string]any{"name": "essential-snap", "id": "id111111111111111111111111111111", "revision": "1"},
 	}
 
 	wrongDigest := "DGOnW4ReT30BEH2FLkwkhcUaUKqqlPxhmV5xu-6YOirDcTgxJkrbR_traaaY1fAE"

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -118,7 +118,7 @@ var (
 
 type automaticSnapshotCall struct {
 	InstanceName string
-	SnapConfig   map[string]interface{}
+	SnapConfig   map[string]any
 	Usernames    []string
 	Options      *snap.SnapshotOptions
 }
@@ -218,7 +218,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	})
 
 	s.automaticSnapshots = nil
-	r := snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]interface{}, usernames []string,
+	r := snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]any, usernames []string,
 		options *snap.SnapshotOptions, _ *dirs.SnapDirOptions) (*client.Snapshot, error) {
 		s.automaticSnapshots = append(s.automaticSnapshots, automaticSnapshotCall{InstanceName: si.InstanceName(), SnapConfig: cfg, Usernames: usernames, Options: options})
 		return nil, nil
@@ -246,12 +246,12 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
-	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.brands.Register("my-brand", brandPrivKey, map[string]any{
 		"validation": "verified",
 	})
 	s.AddCleanup(sysdb.InjectTrusted(s.storeSigning.Trusted))
 
-	s.devAcct = assertstest.NewAccount(s.storeSigning, "devdevdev", map[string]interface{}{
+	s.devAcct = assertstest.NewAccount(s.storeSigning, "devdevdev", map[string]any{
 		"account-id": "devdevdev",
 	}, "")
 	err = s.storeSigning.Add(s.devAcct)
@@ -296,7 +296,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	defer st.Unlock()
 
 	// add "core" snap declaration
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-name":    "core",
 		"publisher-id": "can0nical",
@@ -315,7 +315,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// add "snap1" snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "snap1",
 		"publisher-id": "can0nical",
@@ -328,7 +328,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a2), IsNil)
 
 	// add "snap2" snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "snap2",
 		"publisher-id": "can0nical",
@@ -341,7 +341,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a3), IsNil)
 
 	// add "some-snap" snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "some-snap",
 		"publisher-id": "can0nical",
@@ -354,7 +354,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a4), IsNil)
 
 	// add "other-snap" snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "other-snap",
 		"publisher-id": "can0nical",
@@ -367,7 +367,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a5), IsNil)
 
 	// add pc-kernel snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "pc-kernel",
 		"publisher-id": "can0nical",
@@ -380,7 +380,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a6), IsNil)
 
 	// add pc snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "pc",
 		"publisher-id": "can0nical",
@@ -393,7 +393,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a7), IsNil)
 
 	// add pi snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "pi",
 		"publisher-id": "can0nical",
@@ -406,7 +406,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a8), IsNil)
 
 	// add pi-kernel snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "pi-kernel",
 		"publisher-id": "can0nical",
@@ -419,7 +419,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a9), IsNil)
 
 	// add core18 snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "core18",
 		"publisher-id": "can0nical",
@@ -432,7 +432,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a10), IsNil)
 
 	// add core20 snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "core20",
 		"publisher-id": "can0nical",
@@ -445,7 +445,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(a11), IsNil)
 
 	// add snapd snap declaration
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":       "16",
 		"snap-name":    "snapd",
 		"publisher-id": "can0nical",
@@ -526,7 +526,7 @@ SNAPD_APPARMOR_REEXEC=1
 func (s *baseMgrsSuite) makeSerialAssertionInState(c *C, st *state.State, brandID, model, serialN string) *asserts.Serial {
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, IsNil)
-	serial, err := s.brands.Signing(brandID).Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.brands.Signing(brandID).Sign(asserts.SerialType, map[string]any{
 		"brand-id":            brandID,
 		"model":               model,
 		"serial":              serialN,
@@ -813,7 +813,7 @@ apps:
 	c.Assert(osutil.FileExists(mup), Equals, false)
 
 	// automatic snapshot was created
-	c.Assert(s.automaticSnapshots, DeepEquals, []automaticSnapshotCall{{"foo", map[string]interface{}{"key": "value"}, nil, nil}})
+	c.Assert(s.automaticSnapshots, DeepEquals, []automaticSnapshotCall{{"foo", map[string]any{"key": "value"}, nil, nil}})
 }
 
 func (s *mgrsSuite) TestHappyRemoveWithQuotas(c *C) {
@@ -957,13 +957,13 @@ const (
 
 var fooSnapID = fakeSnapID("foo")
 
-func (s *baseMgrsSuite) prereqSnapAssertions(c *C, extraHeaders ...map[string]interface{}) *asserts.SnapDeclaration {
+func (s *baseMgrsSuite) prereqSnapAssertions(c *C, extraHeaders ...map[string]any) *asserts.SnapDeclaration {
 	if len(extraHeaders) == 0 {
-		extraHeaders = []map[string]interface{}{{}}
+		extraHeaders = []map[string]any{{}}
 	}
 	var snapDecl *asserts.SnapDeclaration
 	for _, extraHeaders := range extraHeaders {
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"series":       "16",
 			"snap-name":    "foo",
 			"publisher-id": "devdevdev",
@@ -1001,7 +1001,7 @@ func (s *baseMgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (
 }
 
 func (s *baseMgrsSuite) makeStoreSnapRevision(c *C, name, revno, digest string, size uint64) asserts.Assertion {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"snap-id":       fakeSnapID(name),
 		"snap-sha3-384": digest,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -1293,7 +1293,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 				})
 			}
 			w.WriteHeader(200)
-			output, err := json.Marshal(map[string]interface{}{
+			output, err := json.Marshal(map[string]any{
 				"results": results,
 			})
 			if err != nil {
@@ -1638,7 +1638,7 @@ func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBump(c *C) {
 
 	snapNames := []string{"aaaa", "bbbb", "cccc"}
 	for _, name := range snapNames {
-		s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
 		s.serveSnap(snapPath, "1")
 	}
@@ -1718,7 +1718,7 @@ func (s *mgrsSuite) TestTransactionalInstallManyFails(c *C) {
 
 	snapNames := []string{"aaaa", "bbbb", "cccc"}
 	for _, name := range snapNames {
-		s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
 		s.serveSnap(snapPath, "1")
 	}
@@ -1764,7 +1764,7 @@ func (s *mgrsSuite) TestTransactionalInstallManyOkUpdateManyFails(c *C) {
 
 	snapNames := []string{"aaaa", "bbbb", "cccc"}
 	for _, name := range snapNames {
-		s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
 		s.serveSnap(snapPath, "1")
 	}
@@ -1850,7 +1850,7 @@ func (s *mgrsSuite) TestTransactionalInstallManyOkUpdateManyOk(c *C) {
 
 	snapNames := []string{"aaaa", "bbbb", "cccc"}
 	for _, name := range snapNames {
-		s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
 		s.serveSnap(snapPath, "1")
 	}
@@ -1928,7 +1928,7 @@ func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBumpAndOneFailin
 
 	snapNames := []string{"aaaa", "bbbb", "cccc"}
 	for _, name := range snapNames {
-		s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
 		s.serveSnap(snapPath, "1")
 	}
@@ -2229,12 +2229,12 @@ version: @VERSION@
 
 	// Setup refresh control
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":          "16",
 		"snap-id":         "bar-id",
 		"snap-name":       "bar",
 		"publisher-id":    "devdevdev",
-		"refresh-control": []interface{}{fooSnapID},
+		"refresh-control": []any{fooSnapID},
 		"timestamp":       time.Now().Format(time.RFC3339),
 	}
 	snapDeclBar, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
@@ -2271,7 +2271,7 @@ version: @VERSION@
 	c.Check(err, ErrorMatches, `cannot refresh "foo" to revision 50: no validation by "bar"`)
 
 	// setup validation
-	headers = map[string]interface{}{
+	headers = map[string]any{
 		"series":                 "16",
 		"snap-id":                "bar-id",
 		"approved-snap-id":       fooSnapID,
@@ -2308,7 +2308,7 @@ version: @VERSION@
 
 // core & kernel
 
-var modelDefaults = map[string]interface{}{
+var modelDefaults = map[string]any{
 	"architecture": "amd64",
 	"store":        "my-brand-store-id",
 	"gadget":       "pc",
@@ -2772,18 +2772,18 @@ func (s *mgrsSuiteCore) TestInstallKernelSnap20UpdatesBootloaderEnv(c *C) {
 	restore = release.MockOnClassic(false)
 	defer restore()
 
-	uc20ModelDefaults := map[string]interface{}{
+	uc20ModelDefaults := map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"store":        "my-brand-store-id",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2942,18 +2942,18 @@ func (s *mgrsSuiteCore) TestInstallKernelSnap20UndoUpdatesBootloaderEnv(c *C) {
 	restore = release.MockOnClassic(false)
 	defer restore()
 
-	uc20ModelDefaults := map[string]interface{}{
+	uc20ModelDefaults := map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"store":        "my-brand-store-id",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3320,11 +3320,11 @@ apps:
 }
 
 func (s *mgrsSuite) TestHappyRemoteInstallAutoAliases(c *C) {
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app1", "target": "app1"},
-			map[string]interface{}{"name": "app2", "target": "app2"},
+		"aliases": []any{
+			map[string]any{"name": "app1", "target": "app1"},
+			map[string]any{"name": "app2", "target": "app2"},
 		},
 	})
 
@@ -3383,10 +3383,10 @@ apps:
 }
 
 func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliases(c *C) {
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app1", "target": "app1"},
+		"aliases": []any{
+			map[string]any{"name": "app1", "target": "app1"},
 		},
 	})
 
@@ -3439,10 +3439,10 @@ apps:
 	c.Assert(err, IsNil)
 	c.Check(dest, Equals, "foo.app1")
 
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app2", "target": "app2"},
+		"aliases": []any{
+			map[string]any{"name": "app2", "target": "app2"},
 		},
 		"revision": "1",
 	})
@@ -3489,10 +3489,10 @@ apps:
 }
 
 func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliasesUnaliased(c *C) {
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app1", "target": "app1"},
+		"aliases": []any{
+			map[string]any{"name": "app1", "target": "app1"},
 		},
 	})
 
@@ -3543,10 +3543,10 @@ apps:
 	app1Alias := filepath.Join(dirs.SnapBinariesDir, "app1")
 	c.Check(osutil.IsSymlink(app1Alias), Equals, false)
 
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app2", "target": "app2"},
+		"aliases": []any{
+			map[string]any{"name": "app2", "target": "app2"},
 		},
 		"revision": "1",
 	})
@@ -3588,12 +3588,12 @@ apps:
 }
 
 func (s *mgrsSuite) TestHappyOrthogonalRefreshAutoAliases(c *C) {
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app1", "target": "app1"},
+		"aliases": []any{
+			map[string]any{"name": "app1", "target": "app1"},
 		},
-	}, map[string]interface{}{
+	}, map[string]any{
 		"snap-name": "bar",
 	})
 
@@ -3676,17 +3676,17 @@ apps:
 	// bar gets only the latter
 	// app1 is transferred from foo to bar
 	// UpdateMany after a snap-declaration refresh handles all of this
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app2", "target": "app2"},
+		"aliases": []any{
+			map[string]any{"name": "app2", "target": "app2"},
 		},
 		"revision": "1",
-	}, map[string]interface{}{
+	}, map[string]any{
 		"snap-name": "bar",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app1", "target": "app1"},
-			map[string]interface{}{"name": "app3", "target": "app3"},
+		"aliases": []any{
+			map[string]any{"name": "app1", "target": "app1"},
+			map[string]any{"name": "app3", "target": "app3"},
 		},
 		"revision": "1",
 	})
@@ -3757,11 +3757,11 @@ func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateWithAndWithoutAppsForAutoAlia
 	// there is a single snap declaration that covers all tracks/channels,
 	// because of this it can list auto aliases for apps that do not exist
 	// in a particular channel the the snap is installed from and track
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
-		"aliases": []interface{}{
-			map[string]interface{}{"name": "app1", "target": "app1"},
-			map[string]interface{}{"name": "app2", "target": "app2"},
+		"aliases": []any{
+			map[string]any{"name": "app1", "target": "app1"},
+			map[string]any{"name": "app2", "target": "app2"},
 		},
 	})
 
@@ -4091,7 +4091,7 @@ func (s *storeCtxSetupSuite) SetUpTest(c *C) {
 	s.restoreTrusted = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
 	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
-	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 	assertstest.AddMany(s.storeSigning, s.brands.AccountsAndKeys("my-brand")...)
@@ -4100,7 +4100,7 @@ func (s *storeCtxSetupSuite) SetUpTest(c *C) {
 
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, IsNil)
-	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]any{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-model",
@@ -4215,7 +4215,7 @@ func (s *storeCtxSetupSuite) TestProxyStoreParams(c *C) {
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
 	err = assertstate.Add(st, operatorAcct)
 	c.Assert(err, IsNil)
-	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "foo",
 		"operator-id": operatorAcct.AccountID(),
 		"url":         "http://foo.internal",
@@ -4306,7 +4306,7 @@ func (s *mgrsSuite) testTwoInstalls(c *C, snapName1, snapYaml1, snapName2, snapY
 	c.Assert(slotRef.Name, Equals, "shared-data-slot")
 
 	// verify that connection was made
-	var conns map[string]interface{}
+	var conns map[string]any
 	c.Assert(st.Get("conns", &conns), IsNil)
 	c.Assert(conns, HasLen, 1)
 
@@ -4393,7 +4393,7 @@ version: @VERSION@`
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("conns", map[string]interface{}{})
+	st.Set("conns", map[string]any{})
 
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
 	snapInfo := snaptest.MockSnap(c, someSnapYaml, si)
@@ -4482,12 +4482,12 @@ version: @VERSION@`
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
 	// check connections
-	var conns map[string]interface{}
+	var conns map[string]any
 	st.Get("conns", &conns)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"some-snap:home core:home":                 map[string]interface{}{"interface": "home", "auto": true},
-		"some-snap:network core:network":           map[string]interface{}{"interface": "network", "auto": true},
-		"other-snap:media-hub some-snap:media-hub": map[string]interface{}{"interface": "media-hub", "auto": true},
+	c.Assert(conns, DeepEquals, map[string]any{
+		"some-snap:home core:home":                 map[string]any{"interface": "home", "auto": true},
+		"some-snap:network core:network":           map[string]any{"interface": "network", "auto": true},
+		"other-snap:media-hub some-snap:media-hub": map[string]any{"interface": "media-hub", "auto": true},
 	})
 
 	connections, err := repo.Connections("some-snap")
@@ -4574,10 +4574,10 @@ version: 1`
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
 	// check connections
-	var conns map[string]interface{}
+	var conns map[string]any
 	st.Get("conns", &conns)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"some-snap:network core:network": map[string]interface{}{"interface": "network", "auto": true},
+	c.Assert(conns, DeepEquals, map[string]any{
+		"some-snap:network core:network": map[string]any{"interface": "network", "auto": true},
 	})
 }
 
@@ -4696,7 +4696,7 @@ func (s *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, removeS
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("conns", map[string]interface{}{})
+	st.Set("conns", map[string]any{})
 
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
 	snapInfo := snaptest.MockSnap(c, someSnapYaml, si)
@@ -4786,7 +4786,7 @@ func (s *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, removeS
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
 	// check connections
-	var conns map[string]interface{}
+	var conns map[string]any
 	st.Get("conns", &conns)
 	c.Assert(conns, HasLen, 0)
 }
@@ -4822,8 +4822,8 @@ hooks:
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("conns", map[string]interface{}{
-		"other-snap:media-hub some-snap:media-hub": map[string]interface{}{"interface": "media-hub", "auto": false},
+	st.Set("conns", map[string]any{
+		"other-snap:media-hub some-snap:media-hub": map[string]any{"interface": "media-hub", "auto": false},
 	})
 
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
@@ -4882,7 +4882,7 @@ hooks:
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
 	// check connections
-	var conns map[string]interface{}
+	var conns map[string]any
 	st.Get("conns", &conns)
 	c.Assert(conns, HasLen, 0)
 
@@ -4918,8 +4918,8 @@ func (s *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("conns", map[string]interface{}{
-		"other-snap:media-hub some-snap:media-hub": map[string]interface{}{"interface": "media-hub", "auto": true},
+	st.Set("conns", map[string]any{
+		"other-snap:media-hub some-snap:media-hub": map[string]any{"interface": "media-hub", "auto": true},
 	})
 
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
@@ -4969,7 +4969,7 @@ func (s *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
 	// check connections; auto-connection should be removed completely from conns on uninstall.
-	var conns map[string]interface{}
+	var conns map[string]any
 	st.Get("conns", &conns)
 	c.Assert(conns, HasLen, 0)
 }
@@ -5136,7 +5136,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAdded(c *C) {
 	defer bootloader.Force(nil)
 
 	for _, name := range []string{"foo", "bar", "baz"} {
-		s.prereqSnapAssertions(c, map[string]interface{}{
+		s.prereqSnapAssertions(c, map[string]any{
 			"snap-name": name,
 		})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0}", name), "1")
@@ -5178,8 +5178,8 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAdded(c *C) {
 	s.makeSerialAssertionInState(c, st, "my-brand", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
-		"required-snaps": []interface{}{"foo", "bar", "baz"},
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{
+		"required-snaps": []any{"foo", "bar", "baz"},
 		"revision":       "1",
 	})
 
@@ -5243,7 +5243,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	defer bootloader.Force(nil)
 
 	for _, name := range []string{"foo", "bar", "baz"} {
-		s.prereqSnapAssertions(c, map[string]interface{}{
+		s.prereqSnapAssertions(c, map[string]any{
 			"snap-name": name,
 		})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0}", name), "1")
@@ -5284,8 +5284,8 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	s.makeSerialAssertionInState(c, st, "my-brand", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
-		"required-snaps": []interface{}{"foo", "bar", "baz"},
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{
+		"required-snaps": []any{"foo", "bar", "baz"},
 		"revision":       "1",
 	})
 
@@ -5354,7 +5354,7 @@ type: base`
 	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"base":     "core18",
 		"revision": "1",
 	})
@@ -5415,7 +5415,7 @@ volumes:
 	})
 
 	// add "pc-20" snap to fake store
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	ms.prereqSnapAssertions(c, map[string]any{
 		"snap-name":    "pc-20",
 		"publisher-id": "can0nical",
 	})
@@ -5437,14 +5437,14 @@ version: 20.04`
 	ms.serveSnap(snapPath, "2")
 
 	// add "foo" snap to fake store
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	ms.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
 	})
 	snapPath, _ = ms.makeStoreTestSnap(c, `{name: "foo", version: 1.0, base: "core20"}`, "1")
 	ms.serveSnap(snapPath, "1")
 
 	// create/set custom model assertion
-	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"base": "core18",
 	})
 
@@ -5459,11 +5459,11 @@ version: 20.04`
 	ms.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"base":           "core20",
 		"gadget":         "pc-20",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
@@ -5584,7 +5584,7 @@ volumes:
 	})
 
 	// add "pc-20" snap to fake store
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	ms.prereqSnapAssertions(c, map[string]any{
 		"snap-name":    "pc-20",
 		"publisher-id": "can0nical",
 	})
@@ -5606,14 +5606,14 @@ version: 20.04`
 	ms.serveSnap(snapPath, "2")
 
 	// add "foo" snap to fake store
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	ms.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
 	})
 	snapPath, _ = ms.makeStoreTestSnap(c, `{name: "foo", version: 1.0, base: "core20"}`, "1")
 	ms.serveSnap(snapPath, "1")
 
 	// create/set custom model assertion
-	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"base": "core18",
 	})
 
@@ -5628,11 +5628,11 @@ version: 20.04`
 	ms.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"base":           "core20",
 		"gadget":         "pc-20",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
@@ -5748,7 +5748,7 @@ volumes:
 	})
 
 	// add "pc-20" snap to fake store
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	ms.prereqSnapAssertions(c, map[string]any{
 		"snap-name":    "pc-20",
 		"publisher-id": "can0nical",
 	})
@@ -5770,14 +5770,14 @@ version: 20.04`
 	ms.serveSnap(snapPath, "2")
 
 	// add "foo" snap to fake store
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	ms.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
 	})
 	snapPath, _ = ms.makeStoreTestSnap(c, `{name: "foo", version: 1.0, base: "core20"}`, "1")
 	ms.serveSnap(snapPath, "1")
 
 	// create/set custom model assertion
-	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"base": "core18",
 	})
 
@@ -5792,11 +5792,11 @@ version: 20.04`
 	ms.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"base":           "core20",
 		"gadget":         "pc-20",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
@@ -6148,14 +6148,14 @@ version: 2.0`
 	const brandKernelYaml = `name: brand-kernel
 type: kernel
 version: 1.0`
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name":    "brand-kernel",
 		"publisher-id": "can0nical",
 	})
 	snapPath, _ = s.makeStoreTestSnap(c, brandKernelYaml, "2")
 	s.serveSnap(snapPath, "2")
 
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
 	})
 	snapPath, _ = s.makeStoreTestSnap(c, `{name: "foo", version: 1.0}`, "1")
@@ -6168,10 +6168,10 @@ func (s *kernelSuite) TestRemodelSwitchKernelTrack(c *C) {
 	defer st.Unlock()
 
 	// create a new model
-	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"kernel":         "pc-kernel=18",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
@@ -6222,10 +6222,10 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernel(c *C) {
 	defer st.Unlock()
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"kernel":         "brand-kernel",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	chg, err := devicestate.Remodel(st, newModel, devicestate.RemodelOptions{})
@@ -6311,10 +6311,10 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndo(c *C) {
 	defer st.Unlock()
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"kernel":         "brand-kernel",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
@@ -6369,10 +6369,10 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndoOnRollback(c *C) {
 	defer st.Unlock()
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"kernel":         "brand-kernel",
 		"revision":       "1",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	devicestate.InjectSetModelError(fmt.Errorf("boom"))
@@ -6423,7 +6423,7 @@ func (s *mgrsSuiteCore) TestRemodelStoreSwitch(c *C) {
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
 	})
 	snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0}", "foo"), "1")
@@ -6469,7 +6469,7 @@ func (s *mgrsSuiteCore) TestRemodelStoreSwitch(c *C) {
 
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, IsNil)
-	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]any{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-model",
@@ -6490,9 +6490,9 @@ func (s *mgrsSuiteCore) TestRemodelStoreSwitch(c *C) {
 	})
 
 	// create a new model
-	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{
 		"store":          "switched-store",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 		"revision":       "1",
 	})
 
@@ -6601,7 +6601,7 @@ volumes:
 	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"gadget":   "pc=18",
 		"revision": "1",
 	})
@@ -6715,7 +6715,7 @@ volumes:
 	const otherPcYaml = `name: other-pc
 type: gadget
 version: 2`
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name":    "other-pc",
 		"publisher-id": "can0nical",
 	})
@@ -6762,7 +6762,7 @@ volumes:
 	defer restore()
 
 	// create/set custom model assertion
-	model := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	model := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"gadget": "pc",
 	})
 
@@ -6777,7 +6777,7 @@ volumes:
 	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"gadget":   "other-pc=18",
 		"revision": "1",
 	})
@@ -6887,7 +6887,7 @@ volumes:
             type: 00000000-0000-0000-0000-0000deadcafe
             size: 20M
 `
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name":    "other-pc",
 		"publisher-id": "can0nical",
 	})
@@ -6897,7 +6897,7 @@ volumes:
 	s.serveSnap(snapPath, "2")
 
 	// create/set custom model assertion
-	model := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	model := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"gadget": "pc",
 	})
 
@@ -6912,7 +6912,7 @@ volumes:
 	s.makeSerialAssertionInState(c, st, "can0nical", "my-model", "serialserialserial")
 
 	// create a new model
-	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"gadget":   "other-pc=18",
 		"revision": "1",
 	})
@@ -6936,7 +6936,7 @@ func (s *mgrsSuiteCore) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	mockStoreServer := s.mockStore(c)
 	defer mockStoreServer.Close()
 
-	model := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+	model := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{
 		"gadget": "gadget",
 	})
 
@@ -6960,7 +6960,7 @@ func (s *mgrsSuiteCore) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
-	signSerial := func(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]interface{}, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
+	signSerial := func(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]any, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
 		brandID := headers["brand-id"].(string)
 		model := headers["model"].(string)
 		c.Check(brandID, Equals, "my-brand")
@@ -7031,11 +7031,11 @@ func (s *mgrsSuiteCore) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	c.Assert(err, IsNil)
 	serial := a.(*asserts.Serial)
 
-	var details map[string]interface{}
+	var details map[string]any
 	err = yaml.Unmarshal(serial.Body(), &details)
 	c.Assert(err, IsNil)
 
-	c.Check(details, DeepEquals, map[string]interface{}{
+	c.Check(details, DeepEquals, map[string]any{
 		"mac": "00:00:00:00:ff:00",
 	})
 
@@ -7047,7 +7047,7 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "foo",
 	})
 	snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0}", "foo"), "1")
@@ -7076,7 +7076,7 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 		newDAC = true
 	}
 
-	model := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+	model := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]any{
 		"gadget": "gadget",
 	})
 
@@ -7098,7 +7098,7 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, IsNil)
-	serialHeaders := map[string]interface{}{
+	serialHeaders := map[string]any{
 		"brand-id":            "my-brand",
 		"model":               "my-model",
 		"serial":              "orig-serial",
@@ -7112,7 +7112,7 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 	err = assertstate.Add(st, serial)
 	c.Assert(err, IsNil)
 
-	signSerial := func(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]interface{}, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
+	signSerial := func(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]any, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
 		brandID := headers["brand-id"].(string)
 		model := headers["model"].(string)
 		c.Check(brandID, Equals, "my-brand")
@@ -7148,10 +7148,10 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 
 	// run the remodel
 	// create a new model
-	newModel := s.brands.Model("my-brand", "other-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("my-brand", "other-model", modelDefaults, map[string]any{
 		"store":          "my-brand-substore",
 		"gadget":         "gadget",
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []any{"foo"},
 	})
 
 	s.expectedSerial = "orig-serial"
@@ -7342,18 +7342,18 @@ var (
 	}
 
 	// headers of a regular UC20 model assertion
-	uc20ModelDefaults = map[string]interface{}{
+	uc20ModelDefaults = map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
@@ -7454,7 +7454,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 
 	// new snaps from the store
 	for _, name := range []string{"foo", "bar"} {
-		s.prereqSnapAssertions(c, map[string]interface{}{
+		s.prereqSnapAssertions(c, map[string]any{
 			"snap-name": name,
 		})
 		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0, base: core20}", name), "1")
@@ -7504,7 +7504,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	// already installed snaps that do not have their snap delarations added
 	// in set up and need a new revision in the store
 	for _, name := range []string{"baz"} {
-		decl := s.prereqSnapAssertions(c, map[string]interface{}{
+		decl := s.prereqSnapAssertions(c, map[string]any{
 			"snap-name":    name,
 			"publisher-id": "can0nical",
 		})
@@ -7557,29 +7557,29 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	}, nil)
 
 	// create a new model
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
-		"snaps": []interface{}{
-			map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "foo",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "bar",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "baz",
 				"presence": "required",
 				// use a different default channel
@@ -7850,7 +7850,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 		c.Assert(secbootResealCalls, Equals, 0)
 	}
 
-	var seededSystems []map[string]interface{}
+	var seededSystems []map[string]any
 	err = st.Get("seeded-systems", &seededSystems)
 	c.Assert(err, IsNil)
 	c.Assert(seededSystems, HasLen, 1)
@@ -7862,7 +7862,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	// should be more than enough for the test to finish
 	c.Check(ts.Before(now.Add(10*time.Minute)), Equals, true, Commentf("seed-time is too late: %v", ts))
 	seededSystems[0]["seed-time"] = ""
-	c.Check(seededSystems, DeepEquals, []map[string]interface{}{
+	c.Check(seededSystems, DeepEquals, []map[string]any{
 		{
 			"system":    expectedLabel,
 			"model":     newModel.Model(),
@@ -7888,7 +7888,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20WithRecoverySystemUnencrypted(c *C) {
 	s.testRemodelUC20WithRecoverySystem(c, encrypted)
 }
 
-func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C, modelExtras ...map[string]interface{}) {
+func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C, modelExtras ...map[string]any) {
 	restore := release.MockOnClassic(false)
 	s.AddCleanup(restore)
 
@@ -7945,7 +7945,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C, model
 	// state of the current model
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir, "device"), 0755), IsNil)
 
-	modelArgs := []map[string]interface{}{uc20ModelDefaults}
+	modelArgs := []map[string]any{uc20ModelDefaults}
 	modelArgs = append(modelArgs, modelExtras...)
 
 	model := s.brands.Model("can0nical", "my-model", modelArgs...)
@@ -8017,15 +8017,15 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentKernelChannel(c *C) {
 	// use a different set of files, such that the snap digest must also be different
 	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["pc-kernel"], "33", snapFilesForRemodel["pc-kernel-rev-33"])
 	s.serveSnap(snapPath, "33")
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
-		"snaps": []interface{}{
-			map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "21/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
@@ -8161,15 +8161,15 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentGadgetChannel(c *C) {
 	// use a different set of files, such that the snap digest must also be different
 	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["pc"], "33", snapFilesForRemodel["pc-rev-33"])
 	s.serveSnap(snapPath, "33")
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
-		"snaps": []interface{}{
-			map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
@@ -8307,21 +8307,21 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentBaseChannel(c *C) {
 	// use a different set of files, such that the snap digest must also be different
 	snapPath, _ := s.makeStoreTestSnapWithFiles(c, snapYamlsForRemodel["core20"], "33", snapFilesForRemodel["core20-rev-33"])
 	s.serveSnap(snapPath, "33")
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
-		"snaps": []interface{}{
-			map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core20",
 				"id":              fakeSnapID("core20"),
 				"type":            "base",
@@ -8441,15 +8441,15 @@ func (s *mgrsSuiteCore) TestRemodelUC20BackToPreviousGadget(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
 	restore := kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
-		"snaps": []interface{}{
-			map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "old-pc",
 				"id":              fakeSnapID("old-pc"),
 				"type":            "gadget",
@@ -8465,7 +8465,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20BackToPreviousGadget(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-name":    "old-pc",
 		"snap-id":      fakeSnapID("old-pc"),
@@ -8626,15 +8626,15 @@ func (s *mgrsSuiteCore) TestRemodelUC20ExistingGadgetSnapDifferentChannel(c *C) 
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
 	restore := kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
-		"snaps": []interface{}{
-			map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "old-pc",
 				"id":              fakeSnapID("old-pc"),
 				"type":            "gadget",
@@ -8650,7 +8650,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20ExistingGadgetSnapDifferentChannel(c *C) 
 	st.Lock()
 	defer st.Unlock()
 
-	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-name":    "old-pc",
 		"snap-id":      fakeSnapID("old-pc"),
@@ -8823,21 +8823,21 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
 	restore := kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
-		"snaps": []interface{}{
-			map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "prereq",
 				"id":   fakeSnapID("prereq"),
 			},
@@ -8850,7 +8850,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	s.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]any{
 		"snap-name": "prereq",
 	})
 
@@ -8902,8 +8902,8 @@ func (s *mgrsSuite) TestCheckRefreshFailureWithConcurrentRemoveOfConnectedSnap(c
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("conns", map[string]interface{}{
-		"other-snap:media-hub some-snap:media-hub": map[string]interface{}{"interface": "media-hub", "auto": false},
+	st.Set("conns", map[string]any{
+		"other-snap:media-hub some-snap:media-hub": map[string]any{"interface": "media-hub", "auto": false},
 	})
 
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
@@ -8998,15 +8998,15 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	st := s.o.State()
 
 	st.Lock()
-	vsetAssert1, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert1, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": "2",
@@ -9019,15 +9019,15 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	c.Assert(assertstate.Add(st, vsetAssert1), IsNil)
 	c.Assert(s.storeSigning.Add(vsetAssert1), IsNil)
 
-	vsetAssert2, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert2, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "vset-2",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": "33",
@@ -9040,15 +9040,15 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	c.Assert(assertstate.Add(st, vsetAssert2), IsNil)
 	c.Assert(s.storeSigning.Add(vsetAssert2), IsNil)
 
-	vsetAssert3, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert3, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "vset-3",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": "4",
@@ -9062,9 +9062,9 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAssert3), IsNil)
 	st.Unlock()
 
-	modelValSets := map[string]interface{}{
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+	modelValSets := map[string]any{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "can0nical",
 				"name":       "vset-1",
 				"mode":       "enforce",
@@ -9102,7 +9102,7 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	c.Assert(err, IsNil)
 
 	// make core22 a thing
-	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-name":    "core22",
 		"snap-id":      fakeSnapID("core22"),
@@ -9120,24 +9120,24 @@ func (s *mgrsSuiteCore) TestRemodelRollbackValidationSets(c *C) {
 	snapPath, _ = s.makeStoreTestSnapWithFiles(c, pcGadget22SnapYaml, "34", snapFilesForRemodel["pc-track-22"])
 	s.serveSnap(snapPath, "34")
 
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
 		// replace the base
 		"base": "core22",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "can0nical",
 				"name":       "vset-2",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
+		"snaps": []any{
 			// kernel and gadget snaps with new tracks
-			map[string]interface{}{
+			map[string]any{
 				"name": "pc-kernel",
 				"id":   fakeSnapID("pc-kernel"),
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
@@ -9421,15 +9421,15 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 
 	st.Lock()
 	// this validation set only appears in the first model
-	vsetAssert1, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert1, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "vset-1",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": "2",
@@ -9443,15 +9443,15 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAssert1), IsNil)
 
 	// this validation set only appears in the second model
-	vsetAssert2, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert2, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "vset-2",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       fakeSnapID("pc-kernel"),
 				"revision": "33",
@@ -9466,15 +9466,15 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 
 	// this validation set appears in neither model, bus is still tracked by the
 	// system
-	vsetAssert3, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert3, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "vset-3",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snapd",
 				"id":       fakeSnapID("snapd"),
 				"revision": "4",
@@ -9488,15 +9488,15 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAssert3), IsNil)
 
 	// this validation set appears in both models
-	vsetAssert4, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]interface{}{
+	vsetAssert4, err := s.brands.Signing("can0nical").Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "can0nical",
 		"series":       "16",
 		"account-id":   "can0nical",
 		"name":         "vset-4",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       fakeSnapID("pc"),
 				"presence": "required",
@@ -9510,14 +9510,14 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 
 	st.Unlock()
 
-	modelValSets := map[string]interface{}{
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+	modelValSets := map[string]any{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "can0nical",
 				"name":       "vset-1",
 				"mode":       "enforce",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": "can0nical",
 				"name":       "vset-4",
 				"mode":       "enforce",
@@ -9557,7 +9557,7 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	c.Assert(err, IsNil)
 
 	// make core22 a thing
-	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-name":    "core22",
 		"snap-id":      fakeSnapID("core22"),
@@ -9575,29 +9575,29 @@ func (s *mgrsSuiteCore) TestRemodelReplaceValidationSets(c *C) {
 	snapPath, _ = s.makeStoreTestSnapWithFiles(c, pcGadget22SnapYaml, "34", snapFilesForRemodel["pc-track-22"])
 	s.serveSnap(snapPath, "34")
 
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
 		// replace the base
 		"base": "core22",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "can0nical",
 				"name":       "vset-2",
 				"mode":       "enforce",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": "can0nical",
 				"name":       "vset-4",
 				"mode":       "enforce",
 			},
 		},
-		"snaps": []interface{}{
+		"snaps": []any{
 			// kernel and gadget snaps with new tracks
-			map[string]interface{}{
+			map[string]any{
 				"name": "pc-kernel",
 				"id":   fakeSnapID("pc-kernel"),
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
@@ -9876,7 +9876,7 @@ func (s *mgrsSuiteCore) testRemodelUC20ToUC22(c *C, mockSnapdRefresh bool) {
 	defer st.Unlock()
 
 	// make core22 a thing
-	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	a11, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-name":    "core22",
 		"snap-id":      fakeSnapID("core22"),
@@ -9894,18 +9894,18 @@ func (s *mgrsSuiteCore) testRemodelUC20ToUC22(c *C, mockSnapdRefresh bool) {
 	snapPath, _ = s.makeStoreTestSnapWithFiles(c, pcGadget22SnapYaml, "34", snapFilesForRemodel["pc-track-22"])
 	s.serveSnap(snapPath, "34")
 
-	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]any{
 		// replace the base
 		"base": "core22",
-		"snaps": []interface{}{
+		"snaps": []any{
 			// kernel and gadget snaps with new tracks
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              fakeSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "22",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              fakeSnapID("pc"),
 				"type":            "gadget",
@@ -10154,7 +10154,7 @@ func mockTestSystemDefaultToFalse(chg *state.Change) error {
 			continue
 		}
 
-		var setup map[string]interface{}
+		var setup map[string]any
 		if err := t.Get("recovery-system-setup", &setup); err != nil {
 			return err
 		}
@@ -10450,7 +10450,7 @@ NeedDaemonReload=no
 		Serial: "serialserialserial",
 	})
 	// model := s.brands.Model("my-brand", "my-model", modelDefaults)
-	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.brands.Model("my-brand", "my-model", map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -10696,7 +10696,7 @@ NeedDaemonReload=no
 		Serial: "serialserialserial",
 	})
 	// model := s.brands.Model("my-brand", "my-model", modelDefaults)
-	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.brands.Model("my-brand", "my-model", map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -10793,18 +10793,18 @@ func (s *mgrsSuite) testUC20RunUpdateManagedBootConfig(c *C, snapPath string, si
 	// pretend we booted with the right kernel
 	bl.SetBootVars(map[string]string{"snap_kernel": "pc-kernel_1.snap"})
 
-	uc20ModelDefaults := map[string]interface{}{
+	uc20ModelDefaults := map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"store":        "my-brand-store-id",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -11186,18 +11186,18 @@ func (s *mgrsSuiteCore) testGadgetKernelCommandLine(c *C, gadgetPath string, gad
 	// pretend we booted with the right kernel
 	bl.SetBootVars(map[string]string{"snap_kernel": "pc-kernel_1.snap"})
 
-	uc20ModelDefaults := map[string]interface{}{
+	uc20ModelDefaults := map[string]any{
 		"architecture": "amd64",
 		"base":         "core20",
 		"store":        "my-brand-store-id",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              snaptest.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              snaptest.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -12535,7 +12535,7 @@ func (ms *gadgetUpdatesSuite) SetUpTest(c *C) {
 	defer st.Unlock()
 
 	// setup model assertion
-	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	model := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]any{
 		"gadget": "pi",
 		"kernel": "pi-kernel",
 	})
@@ -13881,7 +13881,7 @@ func (s *mgrsSuite) TestAutoRefreshOneWithMonitoring(c *C) {
 	c.Assert(err, IsNil)
 
 	rev := snap.R(1)
-	snapDecl := s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": "held-with-app-running"})
+	snapDecl := s.prereqSnapAssertions(c, map[string]any{"snap-name": "held-with-app-running"})
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
 
@@ -13922,7 +13922,7 @@ func (s *mgrsSuite) TestAutoRefreshOneWithMonitoring(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(si.Revision, Equals, snap.R(1))
 
-	var candidates map[string]interface{}
+	var candidates map[string]any
 	st.Get("refresh-candidates", &candidates)
 	c.Logf("candidates: %v", candidates)
 
@@ -13973,7 +13973,7 @@ func (s *mgrsSuite) TestAutoRefreshWithMonitoring(c *C) {
 	snapNames := []string{"aaaa", "held-with-app-running"}
 	for _, name := range snapNames {
 		rev := snap.R(1)
-		snapDecl := s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		snapDecl := s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		err = assertstate.Add(st, snapDecl)
 		c.Assert(err, IsNil)
 
@@ -14024,7 +14024,7 @@ func (s *mgrsSuite) TestAutoRefreshWithMonitoring(c *C) {
 	c.Check(si.Revision, Equals, snap.R(1))
 
 	// state information about snap being monitored is supposed to be preserved
-	var candidates map[string]interface{}
+	var candidates map[string]any
 	st.Get("refresh-candidates", &candidates)
 	c.Logf("candidates: %v", candidates)
 
@@ -14076,7 +14076,7 @@ func (s *mgrsSuite) TestAutoRefreshStoreUpdateWhileWaitingWithMonitoring(c *C) {
 	snapNames := []string{"aaaa", "held-with-app-running"}
 	for _, name := range snapNames {
 		rev := snap.R(1)
-		snapDecl := s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		snapDecl := s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		err = assertstate.Add(st, snapDecl)
 		c.Assert(err, IsNil)
 
@@ -14126,7 +14126,7 @@ func (s *mgrsSuite) TestAutoRefreshStoreUpdateWhileWaitingWithMonitoring(c *C) {
 	c.Check(si.Revision, Equals, snap.R(1))
 
 	// state information about snap being monitored is supposed to be preserved
-	var candidates map[string]interface{}
+	var candidates map[string]any
 	st.Get("refresh-candidates", &candidates)
 	c.Logf("candidates: %v", candidates)
 
@@ -14211,7 +14211,7 @@ func (s *mgrsSuite) TestAutoRefreshStorePreDownloadWhileWaitingWithMonitoring(c 
 	snapNames := []string{"aaaa", "held-with-app-running"}
 	for _, name := range snapNames {
 		rev := snap.R(1)
-		snapDecl := s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		snapDecl := s.prereqSnapAssertions(c, map[string]any{"snap-name": name})
 		err = assertstate.Add(st, snapDecl)
 		c.Assert(err, IsNil)
 
@@ -14272,7 +14272,7 @@ func (s *mgrsSuite) TestAutoRefreshStorePreDownloadWhileWaitingWithMonitoring(c 
 	c.Check(si.Revision, Equals, snap.R(1))
 
 	// the pre-download handler must have created a state entry for the held snap
-	var candidates map[string]interface{}
+	var candidates map[string]any
 	st.Get("refresh-candidates", &candidates)
 	c.Logf("candidates: %v", candidates)
 
@@ -14564,11 +14564,11 @@ func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, 
 	for name, yaml := range snapNames {
 		rev := snap.R(1)
 		if name != "core" {
-			snapDecl := s.prereqSnapAssertions(c, map[string]interface{}{
+			snapDecl := s.prereqSnapAssertions(c, map[string]any{
 				"snap-name": name,
 				"format":    "1",
-				"plugs": map[string]interface{}{
-					"snapd-control": map[string]interface{}{
+				"plugs": map[string]any{
+					"snapd-control": map[string]any{
 						"allow-installation": "true",
 						"auto-connect":       "true",
 						"refresh-schedule":   "managed",
@@ -14590,8 +14590,8 @@ func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, 
 
 	// setup connection in state to emulate that we have a snap installed with an active
 	// connection.
-	st.Set("conns", map[string]interface{}{
-		"snap-with-snapd-control:snapd-control core:snapd-control": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"snap-with-snapd-control:snapd-control core:snapd-control": map[string]any{
 			"interface": "snapd-control",
 			"auto":      true,
 		},
@@ -14636,14 +14636,14 @@ func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, 
 	c.Assert(canAutoRefreshCalls > 0, Equals, true)
 
 	// check connections are fine after running the expected task-set.
-	var conns map[string]interface{}
+	var conns map[string]any
 	st.Get("conns", &conns)
 	c.Logf("connections: %v", conns)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"snap-with-snapd-control:snapd-control core:snapd-control": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"snap-with-snapd-control:snapd-control core:snapd-control": map[string]any{
 			"interface": "snapd-control",
 			"auto":      true,
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"refresh-schedule": "managed",
 			},
 		},
@@ -14677,11 +14677,11 @@ func (s *mgrsSuite) testConnectionDurabilityDuringRefreshesAndAutoRefresh(c *C, 
 
 	// The connection state should not change
 	st.Get("conns", &conns)
-	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"snap-with-snapd-control:snapd-control core:snapd-control": map[string]interface{}{
+	c.Assert(conns, DeepEquals, map[string]any{
+		"snap-with-snapd-control:snapd-control core:snapd-control": map[string]any{
 			"interface": "snapd-control",
 			"auto":      true,
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"refresh-schedule": "managed",
 			},
 		},

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -196,7 +196,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	d, err := state.MarshalJSON()
 	c.Assert(err, IsNil)
 
-	var got, expected map[string]interface{}
+	var got, expected map[string]any
 	err = json.Unmarshal(d, &got)
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(fakeState, &expected)
@@ -214,7 +214,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 		delete(got, "last-notice-timestamp")
 	}
 
-	data, _ := got["data"].(map[string]interface{})
+	data, _ := got["data"].(map[string]any)
 	c.Assert(data, NotNil)
 
 	c.Check(got, DeepEquals, expected)

--- a/overlord/patch/patch4.go
+++ b/overlord/patch/patch4.go
@@ -167,17 +167,17 @@ func (p4 patch4T) snapSetupAndState(task *state.Task) (*patch4SnapSetup, *patch4
 }
 
 // getMaybe calls task.Get and wraps any non-ErrNoState error in an informative message
-func (p4 patch4T) getMaybe(task *state.Task, key string, value interface{}) error {
+func (p4 patch4T) getMaybe(task *state.Task, key string, value any) error {
 	return p4.gget(task, key, true, value)
 }
 
 // get calls task.Get and wraps any error in an informative message
-func (p4 patch4T) get(task *state.Task, key string, value interface{}) error {
+func (p4 patch4T) get(task *state.Task, key string, value any) error {
 	return p4.gget(task, key, false, value)
 }
 
 // gget does the actual work of get and getMaybe
-func (patch4T) gget(task *state.Task, key string, passThroughMissing bool, value interface{}) error {
+func (patch4T) gget(task *state.Task, key string, passThroughMissing bool, value any) error {
 	err := task.Get(key, value)
 	if err == nil || (passThroughMissing && errors.Is(err, state.ErrNoState)) {
 		return err

--- a/overlord/patch/patch6_1.go
+++ b/overlord/patch/patch6_1.go
@@ -28,14 +28,14 @@ import (
 )
 
 type connStatePatch6_1 struct {
-	Auto             bool                   `json:"auto,omitempty"`
-	ByGadget         bool                   `json:"by-gadget,omitempty"`
-	Interface        string                 `json:"interface,omitempty"`
-	Undesired        bool                   `json:"undesired,omitempty"`
-	StaticPlugAttrs  map[string]interface{} `json:"plug-static,omitempty"`
-	DynamicPlugAttrs map[string]interface{} `json:"plug-dynamic,omitempty"`
-	StaticSlotAttrs  map[string]interface{} `json:"slot-static,omitempty"`
-	DynamicSlotAttrs map[string]interface{} `json:"slot-dynamic,omitempty"`
+	Auto             bool           `json:"auto,omitempty"`
+	ByGadget         bool           `json:"by-gadget,omitempty"`
+	Interface        string         `json:"interface,omitempty"`
+	Undesired        bool           `json:"undesired,omitempty"`
+	StaticPlugAttrs  map[string]any `json:"plug-static,omitempty"`
+	DynamicPlugAttrs map[string]any `json:"plug-dynamic,omitempty"`
+	StaticSlotAttrs  map[string]any `json:"slot-static,omitempty"`
+	DynamicSlotAttrs map[string]any `json:"slot-dynamic,omitempty"`
 }
 
 // processConns updates conns map and augments it with plug-static and slot-static attributes from current snap info.

--- a/overlord/patch/patch6_1_test.go
+++ b/overlord/patch/patch6_1_test.go
@@ -221,58 +221,58 @@ func (s *patch61Suite) TestPatch61(c *C) {
 		st.Get("patch-sublevel", &sublevel)
 		c.Assert(sublevel, Equals, 1)
 
-		var conns map[string]interface{}
+		var conns map[string]any
 		c.Assert(st.Get("conns", &conns), IsNil)
-		c.Assert(conns, DeepEquals, map[string]interface{}{
-			"gnome-calculator:icon-themes gtk-common-themes:icon-themes": map[string]interface{}{
+		c.Assert(conns, DeepEquals, map[string]any{
+			"gnome-calculator:icon-themes gtk-common-themes:icon-themes": map[string]any{
 				"auto":      true,
 				"interface": "content",
-				"plug-static": map[string]interface{}{
+				"plug-static": map[string]any{
 					"content":          "icon-themes",
 					"default-provider": "gtk-common-themes",
 					"target":           "$SNAP/data-dir/icons",
 				},
-				"slot-static": map[string]interface{}{
+				"slot-static": map[string]any{
 					"content": "icon-themes",
-					"source": map[string]interface{}{
-						"read": []interface{}{"$SNAP/share/icons/Adwaita"},
+					"source": map[string]any{
+						"read": []any{"$SNAP/share/icons/Adwaita"},
 					},
 				},
 			},
-			"foobar:fooplug gtk-common-themes:icon-themes": map[string]interface{}{
+			"foobar:fooplug gtk-common-themes:icon-themes": map[string]any{
 				"auto":      true,
 				"interface": "content",
-				"plug-static": map[string]interface{}{
+				"plug-static": map[string]any{
 					"target": "$SNAP/foo-dir/icons",
 				},
-				"slot-static": map[string]interface{}{
+				"slot-static": map[string]any{
 					"bus":  "session",
 					"name": "org.gnome.Calculator",
 				},
 			},
-			"gnome-calculator:network core:network": map[string]interface{}{
+			"gnome-calculator:network core:network": map[string]any{
 				"auto":      true,
 				"interface": "network",
 			},
-			"other-snap:icon-themes gtk-common-themes:icon-themes": map[string]interface{}{
+			"other-snap:icon-themes gtk-common-themes:icon-themes": map[string]any{
 				"undesired": true,
 				"auto":      true,
 				"interface": "content",
 			},
 		})
 
-		var removed map[string]interface{}
+		var removed map[string]any
 		task := st.Task("11")
 		c.Assert(task, NotNil)
 		c.Assert(task.Get("removed", &removed), IsNil)
-		c.Assert(removed, DeepEquals, map[string]interface{}{
-			"foobar:fooplug gtk-common-themes:icon-themes": map[string]interface{}{
+		c.Assert(removed, DeepEquals, map[string]any{
+			"foobar:fooplug gtk-common-themes:icon-themes": map[string]any{
 				"auto":      true,
 				"interface": "content",
-				"plug-static": map[string]interface{}{
+				"plug-static": map[string]any{
 					"target": "$SNAP/foo-dir/icons",
 				},
-				"slot-static": map[string]interface{}{
+				"slot-static": map[string]any{
 					"bus":  "session",
 					"name": "org.gnome.Calculator",
 				},

--- a/overlord/patch/patch6_2.go
+++ b/overlord/patch/patch6_2.go
@@ -66,13 +66,13 @@ type patch62SnapState struct {
 	Current  snap.Revision      `json:"current"`
 	Channel  string             `json:"channel,omitempty"`
 	patch62Flags
-	Aliases              interface{} `json:"aliases,omitempty"`
-	AutoAliasesDisabled  bool        `json:"auto-aliases-disabled,omitempty"`
-	AliasesPending       bool        `json:"aliases-pending,omitempty"`
-	UserID               int         `json:"user-id,omitempty"`
-	InstanceKey          string      `json:"instance-key,omitempty"`
-	CohortKey            string      `json:"cohort-key,omitempty"`
-	RefreshInhibitedTime *time.Time  `json:"refresh-inhibited-time,omitempty"`
+	Aliases              any        `json:"aliases,omitempty"`
+	AutoAliasesDisabled  bool       `json:"auto-aliases-disabled,omitempty"`
+	AliasesPending       bool       `json:"aliases-pending,omitempty"`
+	UserID               int        `json:"user-id,omitempty"`
+	InstanceKey          string     `json:"instance-key,omitempty"`
+	CohortKey            string     `json:"cohort-key,omitempty"`
+	RefreshInhibitedTime *time.Time `json:"refresh-inhibited-time,omitempty"`
 }
 
 type patch62SnapSetup struct {
@@ -85,14 +85,14 @@ type patch62SnapSetup struct {
 	Prereq    []string  `json:"prereq,omitempty"`
 	patch62Flags
 	SnapPath     string           `json:"snap-path,omitempty"`
-	DownloadInfo interface{}      `json:"download-info,omitempty"`
+	DownloadInfo any              `json:"download-info,omitempty"`
 	SideInfo     *patch62SideInfo `json:"side-info,omitempty"`
 	patch62auxStoreInfo
 	InstanceKey string `json:"instance-key,omitempty"`
 }
 
 type patch62auxStoreInfo struct {
-	Media interface{} `json:"media,omitempty"`
+	Media any `json:"media,omitempty"`
 }
 
 func hasSnapdSnapID(snapst patch62SnapState) bool {

--- a/overlord/patch/patch6_3.go
+++ b/overlord/patch/patch6_3.go
@@ -51,7 +51,7 @@ func patch6_3(st *state.State) error {
 	// Migrate snapstate
 	dirty := false
 	for name, raw := range snaps {
-		var snapst map[string]interface{}
+		var snapst map[string]any
 		if err := json.Unmarshal([]byte(*raw), &snapst); err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func patch6_3(st *state.State) error {
 		}
 
 		// check task snap-setup
-		var snapsup map[string]interface{}
+		var snapsup map[string]any
 		err := task.Get("snap-setup", &snapsup)
 		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return fmt.Errorf("internal error: cannot get snap-setup of task %s: %s", task.ID(), err)

--- a/overlord/patch/patch_test.go
+++ b/overlord/patch/patch_test.go
@@ -348,7 +348,7 @@ func (s *patchSuite) testMaybeResetPatchLevel6(c *C, snapdVersion, lastVersion s
 	defer st.Unlock()
 	var level, sublevel int
 	var ver string
-	var lastRefresh interface{}
+	var lastRefresh any
 	c.Assert(st.Get("patch-level", &level), IsNil)
 	c.Assert(st.Get("patch-sublevel", &sublevel), IsNil)
 	c.Assert(st.Get("patch-sublevel-last-version", &ver), IsNil)

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -102,7 +102,7 @@ func (s *baseServiceMgrTestSuite) SetUpTest(c *C) {
 	s.state.Set("seeded", true)
 	s.state.Unlock()
 
-	s.uc18Model = assertstest.FakeAssertion(map[string]interface{}{
+	s.uc18Model = assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "canonical",
 		"series":       "16",
@@ -114,7 +114,7 @@ func (s *baseServiceMgrTestSuite) SetUpTest(c *C) {
 		"base":         "core18",
 	}).(*asserts.Model)
 
-	s.uc16Model = assertstest.FakeAssertion(map[string]interface{}{
+	s.uc16Model = assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "canonical",
 		"series":       "16",

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -239,7 +239,7 @@ NeedDaemonReload=no
 				Snap:      snp,
 				Name:      "dbus-slot",
 				Interface: "dbus",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"bus":  "system",
 					"name": "org.example.Svc",
 				},
@@ -283,7 +283,7 @@ NeedDaemonReload=no
 				Snap:      snp,
 				Name:      "dbus-slot",
 				Interface: "dbus",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"bus":  "session",
 					"name": "org.example.Svc",
 				},
@@ -391,7 +391,7 @@ NeedDaemonReload=no
 				Snap:      snp,
 				Name:      "dbus-slot",
 				Interface: "dbus",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"bus":  "session",
 					"name": "org.example.Svc",
 				},

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -302,7 +302,7 @@ func EstimateSnapshotSize(si *snap.Info, usernames []string, dirOpts *dirs.SnapD
 }
 
 // Save a snapshot
-func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interface{}, usernames []string, dynSnapshotOpts *snap.SnapshotOptions, dirOpts *dirs.SnapDirOptions) (*client.Snapshot, error) {
+func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]any, usernames []string, dynSnapshotOpts *snap.SnapshotOptions, dirOpts *dirs.SnapDirOptions) (*client.Snapshot, error) {
 	if err := os.MkdirAll(dirs.SnapshotsDir, 0700); err != nil {
 		return nil, err
 	}

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -448,7 +448,7 @@ func (s *snapshotSuite) TestIterSetIDoverride(c *check.C) {
 
 	epoch := snap.E("42*")
 	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: epoch}
-	cfg := map[string]interface{}{"some-setting": false}
+	cfg := map[string]any{"some-setting": false}
 
 	shw, err := backend.Save(context.TODO(), 12, info, cfg, []string{"snapuser"}, nil, nil)
 	c.Assert(err, check.IsNil)
@@ -716,7 +716,7 @@ func (s *snapshotSuite) testHappyRoundtrip(c *check.C, marker string) {
 
 	epoch := snap.E("42*")
 	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: epoch}
-	cfg := map[string]interface{}{"some-setting": false}
+	cfg := map[string]any{"some-setting": false}
 	shID := uint64(12)
 
 	statExcludes := []string{"$SNAP_USER_DATA/exclude", "$SNAP_USER_COMMON/exclude"}
@@ -808,7 +808,7 @@ func (s *snapshotSuite) TestOpenSetIDoverride(c *check.C) {
 
 	epoch := snap.E("42*")
 	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: epoch}
-	cfg := map[string]interface{}{"some-setting": false}
+	cfg := map[string]any{"some-setting": false}
 
 	shw, err := backend.Save(context.TODO(), 12, info, cfg, []string{"snapuser"}, nil, nil)
 	c.Assert(err, check.IsNil)
@@ -1136,7 +1136,7 @@ func (s *snapshotSuite) TestImportExportRoundtrip(c *check.C) {
 
 	epoch := snap.E("42*")
 	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: epoch}
-	cfg := map[string]interface{}{"some-setting": false}
+	cfg := map[string]any{"some-setting": false}
 	shID := uint64(12)
 
 	shw, err := backend.Save(ctx, shID, info, cfg, []string{"snapuser"}, nil, nil)

--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -189,7 +189,7 @@ func (r *Reader) Check(ctx context.Context, usernames []string) error {
 }
 
 // Logf is the type implemented by logging functions.
-type Logf func(format string, args ...interface{})
+type Logf func(format string, args ...any)
 
 // Restore the data from the snapshot.
 //

--- a/overlord/snapshotstate/backend/restorestate.go
+++ b/overlord/snapshotstate/backend/restorestate.go
@@ -38,7 +38,7 @@ type RestoreState struct {
 	Created []string `json:"created,omitempty"`
 	Moved   []string `json:"moved,omitempty"`
 	// Config is here for convenience; this package doesn't touch it
-	Config map[string]interface{} `json:"config,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
 }
 
 // Cleanup the backed up data from disk.

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -542,19 +542,19 @@ func (snapshotSuite) TestSaveSomeSnaps(c *check.C) {
 	c.Check(tasks[0].Kind(), check.Equals, "save-snapshot")
 	c.Check(tasks[0].Summary(), check.Equals, `Save data of snap "a-snap" in snapshot set #1`)
 
-	var snapshot [2]map[string]interface{}
+	var snapshot [2]map[string]any
 	c.Assert(tasks[0].Get("snapshot-setup", &snapshot[0]), check.IsNil)
-	c.Check(snapshot[0], check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot[0], check.DeepEquals, map[string]any{
 		"set-id":  1.,
 		"snap":    "a-snap",
-		"options": map[string]interface{}{"exclude": []interface{}{"$SNAP_COMMON/exclude", "$SNAP_DATA/exclude"}},
+		"options": map[string]any{"exclude": []any{"$SNAP_COMMON/exclude", "$SNAP_DATA/exclude"}},
 		"current": "unset",
 	})
 
 	c.Check(tasks[1].Kind(), check.Equals, "save-snapshot")
 	c.Check(tasks[1].Summary(), check.Equals, `Save data of snap "c-snap" in snapshot set #1`)
 	c.Assert(tasks[1].Get("snapshot-setup", &snapshot[1]), check.IsNil)
-	c.Check(snapshot[1], check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot[1], check.DeepEquals, map[string]any{
 		"set-id":  1.,
 		"snap":    "c-snap",
 		"current": "unset",
@@ -587,12 +587,12 @@ func (s snapshotSuite) TestSaveOneSnap(c *check.C) {
 	c.Assert(tasks, check.HasLen, 1)
 	c.Check(tasks[0].Kind(), check.Equals, "save-snapshot")
 	c.Check(tasks[0].Summary(), check.Equals, `Save data of snap "a-snap" in snapshot set #1`)
-	var snapshot map[string]interface{}
+	var snapshot map[string]any
 	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
-	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot, check.DeepEquals, map[string]any{
 		"set-id":  1.,
 		"snap":    "a-snap",
-		"users":   []interface{}{"a-user"},
+		"users":   []any{"a-user"},
 		"current": "unset",
 	})
 }
@@ -1150,9 +1150,9 @@ func (snapshotSuite) TestRestoreWorksWithCompatibleEpoch(c *check.C) {
 	c.Check(tasks[0].Kind(), check.Equals, "restore-snapshot")
 	c.Check(tasks[1].Kind(), check.Equals, "cleanup-after-restore")
 	c.Check(tasks[0].Summary(), check.Equals, `Restore data of snap "a-snap" from snapshot set #42`)
-	var snapshot map[string]interface{}
+	var snapshot map[string]any
 	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
-	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot, check.DeepEquals, map[string]any{
 		"set-id":   42.,
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
@@ -1187,13 +1187,13 @@ func (snapshotSuite) TestRestore(c *check.C) {
 	c.Check(tasks[0].Kind(), check.Equals, "restore-snapshot")
 	c.Check(tasks[1].Kind(), check.Equals, "cleanup-after-restore")
 	c.Check(tasks[0].Summary(), check.Equals, `Restore data of snap "a-snap" from snapshot set #42`)
-	var snapshot map[string]interface{}
+	var snapshot map[string]any
 	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
-	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot, check.DeepEquals, map[string]any{
 		"set-id":   42.,
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
-		"users":    []interface{}{"a-user"},
+		"users":    []any{"a-user"},
 		"current":  "unset",
 	})
 }
@@ -1470,13 +1470,13 @@ func (snapshotSuite) TestCheck(c *check.C) {
 	c.Assert(tasks, check.HasLen, 1)
 	c.Check(tasks[0].Kind(), check.Equals, "check-snapshot")
 	c.Check(tasks[0].Summary(), check.Equals, `Check data of snap "a-snap" in snapshot set #42`)
-	var snapshot map[string]interface{}
+	var snapshot map[string]any
 	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
-	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot, check.DeepEquals, map[string]any{
 		"set-id":   42.,
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
-		"users":    []interface{}{"a-user"},
+		"users":    []any{"a-user"},
 		"current":  "unset",
 	})
 }
@@ -1608,9 +1608,9 @@ func (snapshotSuite) TestForget(c *check.C) {
 	c.Assert(tasks, check.HasLen, 1)
 	c.Check(tasks[0].Kind(), check.Equals, "forget-snapshot")
 	c.Check(tasks[0].Summary(), check.Equals, `Drop data of snap "a-snap" from snapshot set #42`)
-	var snapshot map[string]interface{}
+	var snapshot map[string]any
 	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
-	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot, check.DeepEquals, map[string]any{
 		"set-id":   42.,
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
@@ -1623,7 +1623,7 @@ func (snapshotSuite) TestSaveExpiration(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	var expirations map[uint64]interface{}
+	var expirations map[uint64]any
 	tm, err := time.Parse(time.RFC3339, "2019-03-11T11:24:00Z")
 	c.Assert(err, check.IsNil)
 	c.Assert(snapshotstate.SaveExpiration(st, 12, tm), check.IsNil)
@@ -1633,9 +1633,9 @@ func (snapshotSuite) TestSaveExpiration(c *check.C) {
 	c.Assert(snapshotstate.SaveExpiration(st, 13, tm), check.IsNil)
 
 	c.Assert(st.Get("snapshots", &expirations), check.IsNil)
-	c.Check(expirations, check.DeepEquals, map[uint64]interface{}{
-		12: map[string]interface{}{"expiry-time": "2019-03-11T11:24:00Z"},
-		13: map[string]interface{}{"expiry-time": "2019-02-12T12:50:00Z"},
+	c.Check(expirations, check.DeepEquals, map[uint64]any{
+		12: map[string]any{"expiry-time": "2019-03-11T11:24:00Z"},
+		13: map[string]any{"expiry-time": "2019-02-12T12:50:00Z"},
 	})
 }
 
@@ -1644,18 +1644,18 @@ func (snapshotSuite) TestRemoveSnapshotState(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("snapshots", map[uint64]interface{}{
-		12: map[string]interface{}{"expiry-time": "2019-01-11T11:11:00Z"},
-		13: map[string]interface{}{"expiry-time": "2019-02-12T12:11:00Z"},
-		14: map[string]interface{}{"expiry-time": "2019-03-12T13:11:00Z"},
+	st.Set("snapshots", map[uint64]any{
+		12: map[string]any{"expiry-time": "2019-01-11T11:11:00Z"},
+		13: map[string]any{"expiry-time": "2019-02-12T12:11:00Z"},
+		14: map[string]any{"expiry-time": "2019-03-12T13:11:00Z"},
 	})
 
 	snapshotstate.RemoveSnapshotState(st, 12, 14)
 
-	var snapshots map[uint64]interface{}
+	var snapshots map[uint64]any
 	c.Assert(st.Get("snapshots", &snapshots), check.IsNil)
-	c.Check(snapshots, check.DeepEquals, map[uint64]interface{}{
-		13: map[string]interface{}{"expiry-time": "2019-02-12T12:11:00Z"},
+	c.Check(snapshots, check.DeepEquals, map[uint64]any{
+		13: map[string]any{"expiry-time": "2019-02-12T12:11:00Z"},
 	})
 }
 
@@ -1714,9 +1714,9 @@ func (snapshotSuite) TestAutomaticSnapshot(c *check.C) {
 	c.Assert(tasks, check.HasLen, 1)
 	c.Check(tasks[0].Kind(), check.Equals, "save-snapshot")
 	c.Check(tasks[0].Summary(), check.Equals, `Save data of snap "foo" in automatic snapshot set #1`)
-	var snapshot map[string]interface{}
+	var snapshot map[string]any
 	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
-	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
+	c.Check(snapshot, check.DeepEquals, map[string]any{
 		"set-id":  1.,
 		"snap":    "foo",
 		"current": "unset",
@@ -1767,9 +1767,9 @@ func (snapshotSuite) TestListSetsAutoFlag(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 
-	st.Set("snapshots", map[uint64]interface{}{
-		1: map[string]interface{}{"expiry-time": "2019-01-11T11:11:00Z"},
-		2: map[string]interface{}{"expiry-time": "2019-02-12T12:11:00Z"},
+	st.Set("snapshots", map[uint64]any{
+		1: map[string]any{"expiry-time": "2019-01-11T11:11:00Z"},
+		2: map[string]any{"expiry-time": "2019-02-12T12:11:00Z"},
 	})
 
 	restore := snapshotstate.MockBackendList(func(ctx context.Context, setID uint64, snapNames []string) ([]client.SnapshotSet, error) {
@@ -1880,9 +1880,9 @@ func (snapshotSuite) TestImportSnapshotDuplicate(c *check.C) {
 	defer restore()
 
 	st.Lock()
-	st.Set("snapshots", map[uint64]interface{}{
-		2: map[string]interface{}{"expiry-time": "2019-01-11T11:11:00Z"},
-		3: map[string]interface{}{"expiry-time": "2019-02-12T12:11:00Z"},
+	st.Set("snapshots", map[uint64]any{
+		2: map[string]any{"expiry-time": "2019-01-11T11:11:00Z"},
+		3: map[string]any{"expiry-time": "2019-02-12T12:11:00Z"},
 	})
 	st.Unlock()
 
@@ -1894,10 +1894,10 @@ func (snapshotSuite) TestImportSnapshotDuplicate(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 	// expiry-time has been removed for snapshot set 3
-	var snapshots map[uint64]interface{}
+	var snapshots map[uint64]any
 	c.Assert(st.Get("snapshots", &snapshots), check.IsNil)
-	c.Check(snapshots, check.DeepEquals, map[uint64]interface{}{
-		2: map[string]interface{}{"expiry-time": "2019-01-11T11:11:00Z"},
+	c.Check(snapshots, check.DeepEquals, map[uint64]any{
+		2: map[string]any{"expiry-time": "2019-01-11T11:11:00Z"},
 	})
 }
 

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -449,7 +449,7 @@ func (m *SnapManager) ensureAliasesV2() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	var aliasesV1 map[string]interface{}
+	var aliasesV1 map[string]any
 	err := m.state.Get("aliases", &aliasesV1)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
@@ -472,7 +472,7 @@ func (m *SnapManager) ensureAliasesV2() error {
 	// the start of wait chains
 	for _, t := range m.state.Tasks() {
 		if t.Kind() == "alias" && !t.Status().Ready() {
-			var param interface{}
+			var param any
 			err := t.Get("aliases", &param)
 			if errors.Is(err, state.ErrNoState) {
 				// not the old variant, leave alone

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -657,7 +657,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 		chg.AddAll(ts)
 	}
 	chg.Set("snap-names", updated)
-	chg.Set("api-data", map[string]interface{}{"snap-names": updated})
+	chg.Set("api-data", map[string]any{"snap-names": updated})
 	state.TagTimingsWithChange(perfTimings, chg)
 
 	return nil
@@ -971,7 +971,7 @@ func removeRefreshInhibitWarning(st *state.State) error {
 }
 
 // for testing outside of snapstate
-func MockRefreshCandidate(snapSetup *SnapSetup) interface{} {
+func MockRefreshCandidate(snapSetup *SnapSetup) any {
 	return &refreshCandidate{
 		SnapSetup: *snapSetup,
 	}
@@ -1076,14 +1076,14 @@ func processFailedAutoRefresh(chg *state.Change, _ state.Status, new state.Statu
 
 	// Attach failed snaps to change api data. This intended to guide
 	// agents on devices that manage their own refresh cycle.
-	var data map[string]interface{}
+	var data map[string]any
 	err := chg.Get("api-data", &data)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		logger.Debugf("internal error: failed to get api-data for change %s: %v", chg.ID(), err)
 		return
 	}
 	if len(data) == 0 {
-		data = make(map[string]interface{})
+		data = make(map[string]any)
 	}
 	sort.Strings(failedSnapNames)
 	data["refresh-failed"] = failedSnapNames

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -828,7 +828,7 @@ func AutoRefreshForGatingSnap(st *state.State, gatingSnap string) error {
 		chg.AddAll(ts)
 	}
 	chg.Set("snap-names", updated)
-	chg.Set("api-data", map[string]interface{}{"snap-names": updated})
+	chg.Set("api-data", map[string]any{"snap-names": updated})
 
 	return nil
 }

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2017,7 +2017,7 @@ func (s *snapmgrTestSuite) testAutoRefreshPhase2(c *C, beforePhase1 func(), gate
 	c.Assert(err, IsNil)
 	c.Check(names, DeepEquals, []string{"base-snap-b", "snap-a"})
 
-	var snaps map[string]interface{}
+	var snaps map[string]any
 	c.Assert(tss[0].Tasks()[0].Kind(), Equals, "conditional-auto-refresh")
 	c.Assert(tss[0].Tasks()[0].Get("snaps", &snaps), IsNil)
 	c.Assert(snaps, HasLen, 2)
@@ -2102,7 +2102,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2(c *C) {
 	tasks := chg.Tasks()
 	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snaps "base-snap-b", "snap-a" to determine whether extra refresh steps are required`)
 
-	var snaps map[string]interface{}
+	var snaps map[string]any
 	c.Assert(chg.Tasks()[0].Kind(), Equals, "conditional-auto-refresh")
 	chg.Tasks()[0].Get("snaps", &snaps)
 	c.Assert(snaps, HasLen, 2)
@@ -2159,7 +2159,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Held(c *C) {
 	c.Assert(logbuf.String(), testutil.Contains, `skipping refresh of held snaps: base-snap-b`)
 	tasks := chg.Tasks()
 
-	var snaps map[string]interface{}
+	var snaps map[string]any
 	c.Assert(chg.Tasks()[0].Kind(), Equals, "conditional-auto-refresh")
 	chg.Tasks()[0].Get("snaps", &snaps)
 	c.Assert(snaps, HasLen, 1)
@@ -2677,12 +2677,12 @@ func (s *autorefreshGatingSuite) TestAutoRefreshForGatingSnap(c *C) {
 	c.Assert(chg.Kind(), Equals, "auto-refresh")
 	c.Check(chg.Summary(), Equals, `Auto-refresh snaps "base-snap-b", "snap-b"`)
 	var snapNames []string
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Assert(chg.Get("snap-names", &snapNames), IsNil)
 	c.Check(snapNames, DeepEquals, []string{"base-snap-b", "snap-b"})
 	c.Assert(chg.Get("api-data", &apiData), IsNil)
-	c.Check(apiData, DeepEquals, map[string]interface{}{
-		"snap-names": []interface{}{"base-snap-b", "snap-b"},
+	c.Check(apiData, DeepEquals, map[string]any{
+		"snap-names": []any{"base-snap-b", "snap-b"},
 	})
 
 	tasks := chg.Tasks()
@@ -2784,12 +2784,12 @@ func (s *autorefreshGatingSuite) TestAutoRefreshForGatingSnapMoreAffectedSnaps(c
 	c.Assert(chg.Kind(), Equals, "auto-refresh")
 	c.Check(chg.Summary(), Equals, `Auto-refresh snaps "base-snap-b", "snap-b"`)
 	var snapNames []string
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Assert(chg.Get("snap-names", &snapNames), IsNil)
 	c.Check(snapNames, DeepEquals, []string{"base-snap-b", "snap-b"})
 	c.Assert(chg.Get("api-data", &apiData), IsNil)
-	c.Check(apiData, DeepEquals, map[string]interface{}{
-		"snap-names": []interface{}{"base-snap-b", "snap-b"},
+	c.Check(apiData, DeepEquals, map[string]any{
+		"snap-names": []any{"base-snap-b", "snap-b"},
 	})
 
 	tasks := chg.Tasks()
@@ -3127,13 +3127,13 @@ func (s *validationSetsSuite) TestAutoRefreshPhase1WithValidationSets(c *C) {
 	var requiredRevision string
 	restoreEnforcedValidationSets := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
 			"revision": requiredRevision,
 		}
-		snapC := map[string]interface{}{
+		snapC := map[string]any{
 			"id":       "aOqKhntON3vR7kwEbVPsILm7bUViPDzz",
 			"name":     "snap-c",
 			"presence": "required",

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1197,7 +1197,7 @@ func (s *autoRefreshTestSuite) TestTooSoonError(c *C) {
 	c.Check(snapstate.TooSoonError{}.Error(), Equals, "cannot auto-refresh so soon")
 }
 
-func setStoreAccess(s *state.State, access interface{}) {
+func setStoreAccess(s *state.State, access any) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -1622,7 +1622,7 @@ func (s *autoRefreshTestSuite) TestAutoRefreshWithConfdbs(c *C) {
 			Snap:      info,
 			Name:      "my-plug",
 			Interface: "confdb",
-			Attrs: map[string]interface{}{
+			Attrs: map[string]any{
 				"account": "my-publisher",
 				"view":    "my-reg/my-view",
 			},

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -390,7 +390,7 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 			Snap:      info,
 			Name:      "dbus-slot",
 			Interface: "dbus",
-			Attrs: map[string]interface{}{
+			Attrs: map[string]any{
 				"bus":  "system",
 				"name": "org.example.Foo",
 			},
@@ -415,7 +415,7 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				Snap:      info,
 				Interface: "confdb",
 				Name:      "my-plug",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"account": "my-publisher",
 					"view":    "my-reg/my-view",
 				},
@@ -441,8 +441,8 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 				Snap:      info,
 				Interface: "desktop",
 				Name:      "desktop",
-				Attrs: map[string]interface{}{
-					"desktop-file-ids": []interface{}{"org.example.Foo"},
+				Attrs: map[string]any{
+					"desktop-file-ids": []any{"org.example.Foo"},
 				},
 			},
 		}
@@ -642,7 +642,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 			"content-plug": {
 				Snap:      info,
 				Interface: "content",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"content":          "some-content",
 					"default-provider": "outdated-producer",
 				},
@@ -653,7 +653,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 			"content-slot": {
 				Snap:      info,
 				Interface: "content",
-				Attrs:     map[string]interface{}{"content": "some-content"},
+				Attrs:     map[string]any{"content": "some-content"},
 			},
 		}
 	} else if name == "provenance-snap" {
@@ -680,7 +680,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 				Snap:      info,
 				Interface: "confdb",
 				Name:      "my-plug",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"account": "my-publisher",
 					"view":    "my-reg/my-view",
 				},

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -230,7 +230,7 @@ func validateInfoAndFlags(info *snap.Info, snapst *SnapState, flags Flags) error
 
 var openSnapFile = backend.OpenSnapFile
 
-func validateContainer(c snap.Container, s *snap.Info, logf func(format string, v ...interface{})) error {
+func validateContainer(c snap.Container, s *snap.Info, logf func(format string, v ...any)) error {
 	err := snap.ValidateSnapContainer(c, s, logf)
 	if err == nil {
 		return nil

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -55,7 +55,7 @@ func (s *checkSnapSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.st = state.New(nil)
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
-	s.deviceCtx = &snapstatetest.TrivialDeviceContext{DeviceModel: MakeModel(map[string]interface{}{
+	s.deviceCtx = &snapstatetest.TrivialDeviceContext{DeviceModel: MakeModel(map[string]any{
 		"kernel": "kernel",
 		"gadget": "gadget",
 	})}
@@ -477,21 +477,21 @@ func (s *checkSnapSuite) TestCheckUnassertedOrAssertedGadgetKernelSnapVsModelGra
 	defer reset()
 
 	gradeUnsetDeviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel(map[string]interface{}{
+		DeviceModel: MakeModel(map[string]any{
 			"kernel": "kernel",
 			"gadget": "gadget",
 		}),
 	}
 	c.Check(gradeUnsetDeviceCtx.DeviceModel.Grade(), Equals, asserts.ModelGradeUnset)
 	gradeSignedDeviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel20("gadget", map[string]interface{}{
+		DeviceModel: MakeModel20("gadget", map[string]any{
 			"base":  "core20",
 			"grade": "signed",
 		}),
 	}
 	c.Check(gradeSignedDeviceCtx.DeviceModel.Grade(), Equals, asserts.ModelSigned)
 	gradeDangerousDeviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel20("gadget", map[string]interface{}{
+		DeviceModel: MakeModel20("gadget", map[string]any{
 			"base":  "core20",
 			"grade": "dangerous",
 		}),
@@ -1433,7 +1433,7 @@ version: 2
 	// happy case, the new-kernel matches the model
 	deviceCtx := &snapstatetest.TrivialDeviceContext{
 		Remodeling: true,
-		DeviceModel: MakeModel(map[string]interface{}{
+		DeviceModel: MakeModel(map[string]any{
 			"kernel": "new-kernel",
 			"gadget": "gadget",
 		}),
@@ -1485,7 +1485,7 @@ version: 2
 	// support this yet
 	deviceCtx := &snapstatetest.TrivialDeviceContext{
 		Remodeling: true,
-		DeviceModel: MakeModel(map[string]interface{}{
+		DeviceModel: MakeModel(map[string]any{
 			"kernel": "kernel",
 			"gadget": "new-gadget",
 		}),

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1074,7 +1074,7 @@ func continueInhibitedAutoRefresh(st *state.State, snapName string) error {
 			chg.AddAll(ts)
 		}
 		chg.Set("snap-names", snaps)
-		chg.Set("api-data", map[string]interface{}{"snap-names": snaps})
+		chg.Set("api-data", map[string]any{"snap-names": snaps})
 	}
 
 	st.EnsureBefore(0)
@@ -1380,16 +1380,16 @@ func (m *SnapManager) restoreUnlinkOnError(t *state.Task, info *snap.Info, other
 }
 
 var onRefreshInhibitionTimeout = func(chg *state.Change, snapName string) error {
-	var data map[string]interface{}
+	var data map[string]any
 	err := chg.Get("api-data", &data)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if len(data) == 0 {
-		data = make(map[string]interface{})
+		data = make(map[string]any)
 	}
 
-	cur, _ := data["refresh-forced"].([]interface{})
+	cur, _ := data["refresh-forced"].([]any)
 	cur = append(cur, snapName)
 	data["refresh-forced"] = cur
 
@@ -4360,16 +4360,16 @@ type changedAlias struct {
 
 func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {
 	chg := t.Change()
-	var data map[string]interface{}
+	var data map[string]any
 	err := chg.Get("api-data", &data)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if len(data) == 0 {
-		data = make(map[string]interface{})
+		data = make(map[string]any)
 	}
 
-	curAdded, _ := data["aliases-added"].([]interface{})
+	curAdded, _ := data["aliases-added"].([]any)
 	for _, a := range added {
 		snap, app := snap.SplitSnapApp(a.Target)
 		curAdded = append(curAdded, &changedAlias{
@@ -4380,7 +4380,7 @@ func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {
 	}
 	data["aliases-added"] = curAdded
 
-	curRemoved, _ := data["aliases-removed"].([]interface{})
+	curRemoved, _ := data["aliases-removed"].([]any)
 	for _, a := range removed {
 		snap, app := snap.SplitSnapApp(a.Target)
 		curRemoved = append(curRemoved, &changedAlias{

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -127,7 +127,7 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatibility(c *C) {
 func (s *downloadSnapSuite) TestDoDownloadSnapCompatibilityValidationSets(c *C) {
 	s.state.Lock()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -135,8 +135,8 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatibilityValidationSets(c *C) 
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "foo",
 				"id":       snaptest.AssertedSnapID("foo"),
 				"presence": "required",
@@ -221,7 +221,7 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatibilityValidationSetsInvalid
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -229,8 +229,8 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatibilityValidationSetsInvalid
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "foo",
 				"id":       snaptest.AssertedSnapID("foo"),
 				"presence": "invalid",
@@ -281,7 +281,7 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatibilityValidationSetsWrongRe
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -289,8 +289,8 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatibilityValidationSetsWrongRe
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "foo",
 				"id":       snaptest.AssertedSnapID("foo"),
 				"presence": "required",

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -90,7 +90,7 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 }
 
 func checkHasCookieForSnap(c *C, st *state.State, instanceName string) {
-	var contexts map[string]interface{}
+	var contexts map[string]any
 	err := st.Get("snap-cookies", &contexts)
 	c.Assert(err, IsNil)
 	c.Check(contexts, HasLen, 1)
@@ -2619,8 +2619,8 @@ func (s *linkSnapSuite) testDoUnlinkSnapRefreshAwareness(c *C) *state.Change {
 }
 
 func (s *linkSnapSuite) setMockKernelRemodelCtx(c *C, oldKernel, newKernel string) {
-	newModel := MakeModel(map[string]interface{}{"kernel": newKernel})
-	oldModel := MakeModel(map[string]interface{}{"kernel": oldKernel})
+	newModel := MakeModel(map[string]any{"kernel": newKernel})
+	oldModel := MakeModel(map[string]any{"kernel": oldKernel})
 	mockRemodelCtx := &snapstatetest.TrivialDeviceContext{
 		DeviceModel:    newModel,
 		OldDeviceModel: oldModel,

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -101,7 +101,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshFailsIfUpdateFails(c *C) {
 	s.state.Lock()
 	chg := changeWithLanesAndSnapSetups(s.state, "some-snap")
 	task := s.state.NewTask("check-rerefresh", "test")
-	task.Set("rerefresh-setup", map[string]interface{}{})
+	task.Set("rerefresh-setup", map[string]any{})
 	chg.AddTask(task)
 	s.state.Unlock()
 
@@ -125,7 +125,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshNoReRefreshes(c *C) {
 	s.state.Lock()
 	chg := changeWithLanesAndSnapSetups(s.state, "some-snap")
 	task := s.state.NewTask("check-rerefresh", "test")
-	task.Set("rerefresh-setup", map[string]interface{}{})
+	task.Set("rerefresh-setup", map[string]any{})
 	chg.AddTask(task)
 	s.state.Unlock()
 
@@ -158,7 +158,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 
 	s.state.Lock()
 	task := s.state.NewTask("check-rerefresh", "test")
-	task.Set("rerefresh-setup", map[string]interface{}{
+	task.Set("rerefresh-setup", map[string]any{
 		"user-id":  42,
 		"devmode":  true,
 		"jailmode": true,
@@ -194,7 +194,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
 	s.state.Lock()
 	chg := changeWithLanesAndSnapSetups(s.state, "foo", "bar", "baz")
 	task := s.state.NewTask("check-rerefresh", "check rerefresh")
-	task.Set("rerefresh-setup", map[string]interface{}{})
+	task.Set("rerefresh-setup", map[string]any{})
 	chg.AddTask(task)
 	s.state.Unlock()
 
@@ -243,7 +243,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshWaitOnPendingRestart(c *C) {
 	chg.AddTask(tsk)
 	tsk.JoinLane(lane)
 	task := s.state.NewTask("check-rerefresh", "test")
-	task.Set("rerefresh-setup", map[string]interface{}{})
+	task.Set("rerefresh-setup", map[string]any{})
 	chg.AddTask(task)
 	s.state.Unlock()
 
@@ -522,8 +522,8 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 		enforcedValidationSetsCalled++
 
 		vs := snapasserts.NewValidationSets()
-		var snap1, snap2, snap3 map[string]interface{}
-		snap3 = map[string]interface{}{
+		var snap1, snap2, snap3 map[string]any
+		snap3 = map[string]any{
 			"id":       "abcKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap3",
 			"presence": "required",
@@ -532,7 +532,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 		switch enforcedValidationSetsCalled {
 		case 1:
 			// refreshed validation sets
-			snap1 = map[string]interface{}{
+			snap1 = map[string]any{
 				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
 				"name":     "some-snap1",
 				"presence": "required",
@@ -540,7 +540,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 			}
 			// require snap2 at revision 5 (if snap refresh succeeded, but it didn't, so
 			// current revision of the snap is wrong)
-			snap2 = map[string]interface{}{
+			snap2 = map[string]any{
 				"id":       "bgtKhntON3vR7kwEbVPsILm7bUViPDzx",
 				"name":     "some-snap2",
 				"presence": "required",
@@ -548,13 +548,13 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 			}
 		case 2:
 			// validation sets restored from history
-			snap1 = map[string]interface{}{
+			snap1 = map[string]any{
 				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
 				"name":     "some-snap1",
 				"presence": "required",
 				"revision": "1",
 			}
-			snap2 = map[string]interface{}{
+			snap2 = map[string]any{
 				"id":       "bgtKhntON3vR7kwEbVPsILm7bUViPDzx",
 				"name":     "some-snap2",
 				"presence": "required",
@@ -659,7 +659,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertNoSnapsRefr
 		enforcedValidationSetsCalled++
 
 		vs := snapasserts.NewValidationSets()
-		snap1 := map[string]interface{}{
+		snap1 := map[string]any{
 			"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap1",
 			"presence": "required",
@@ -710,8 +710,8 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidat
 		enforcedValidationSetsCalled++
 
 		vs := snapasserts.NewValidationSets()
-		var snap1, snap2 map[string]interface{}
-		snap2 = map[string]interface{}{
+		var snap1, snap2 map[string]any
+		snap2 = map[string]any{
 			"id":       "abcKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap2",
 			"presence": "required",
@@ -721,7 +721,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidat
 		case 1:
 			// refreshed validation sets
 			// snap1 revision 3 is now required (but snap wasn't refreshed)
-			snap1 = map[string]interface{}{
+			snap1 = map[string]any{
 				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
 				"name":     "some-snap1",
 				"presence": "required",
@@ -729,7 +729,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidat
 			}
 		case 2:
 			// validation sets restored from history
-			snap1 = map[string]interface{}{
+			snap1 = map[string]any{
 				"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
 				"name":     "some-snap1",
 				"presence": "required",
@@ -790,7 +790,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertStillValid(
 		enforcedValidationSetsCalled++
 
 		vs := snapasserts.NewValidationSets()
-		snap2 := map[string]interface{}{
+		snap2 := map[string]any{
 			"id":       "abcKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap2",
 			"presence": "required",
@@ -800,7 +800,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertStillValid(
 
 		// refreshed validation sets
 		// snap1 revision 3 is now required (but snap wasn't refreshed)
-		snap1 := map[string]interface{}{
+		snap1 := map[string]any{
 			"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap1",
 			"presence": "required",

--- a/overlord/snapstate/models_test.go
+++ b/overlord/snapstate/models_test.go
@@ -26,23 +26,23 @@ import (
 )
 
 func ModelWithBase(baseName string) *asserts.Model {
-	return MakeModel(map[string]interface{}{"base": baseName})
+	return MakeModel(map[string]any{"base": baseName})
 }
 
 func ModelWithKernelTrack(kernelTrack string) *asserts.Model {
-	return MakeModel(map[string]interface{}{"kernel": "kernel=" + kernelTrack})
+	return MakeModel(map[string]any{"kernel": "kernel=" + kernelTrack})
 }
 
 func ModelWithGadgetTrack(gadgetTrack string) *asserts.Model {
-	return MakeModel(map[string]interface{}{"gadget": "brand-gadget=" + gadgetTrack})
+	return MakeModel(map[string]any{"gadget": "brand-gadget=" + gadgetTrack})
 }
 
 func DefaultModel() *asserts.Model {
 	return MakeModel(nil)
 }
 
-func MakeModel(override map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func MakeModel(override map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "brand",
 		"series":       "16",
@@ -56,8 +56,8 @@ func MakeModel(override map[string]interface{}) *asserts.Model {
 	return assertstest.FakeAssertion(model, override).(*asserts.Model)
 }
 
-func MakeModel20(gadgetName string, override map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func MakeModel20(gadgetName string, override map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "brand",
 		"series":       "16",
@@ -67,14 +67,14 @@ func MakeModel20(gadgetName string, override map[string]interface{}) *asserts.Mo
 		"base":         "core20",
 		"grade":        "dangerous",
 		"timestamp":    "2018-01-01T08:00:00+00:00",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "kernel",
 				"id":              "kerneldididididididididididididi",
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            gadgetName,
 				"id":              snaptest.AssertedSnapID(gadgetName),
 				"type":            "gadget",
@@ -85,8 +85,8 @@ func MakeModel20(gadgetName string, override map[string]interface{}) *asserts.Mo
 	return assertstest.FakeAssertion(model, override).(*asserts.Model)
 }
 
-func MakeModelClassicWithModes(gadgetName string, override map[string]interface{}) *asserts.Model {
-	model := map[string]interface{}{
+func MakeModelClassicWithModes(gadgetName string, override map[string]any) *asserts.Model {
+	model := map[string]any{
 		"type":         "model",
 		"authority-id": "brand",
 		"series":       "16",
@@ -96,13 +96,13 @@ func MakeModelClassicWithModes(gadgetName string, override map[string]interface{
 		"classic":      "true",
 		"distribution": "ubuntu",
 		"base":         "core22",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name": "kernel",
 				"id":   "pclinuxdidididididididididididid",
 				"type": "kernel",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": gadgetName,
 				"id":   "pcididididididididididididididid",
 				"type": "gadget",
@@ -113,7 +113,7 @@ func MakeModelClassicWithModes(gadgetName string, override map[string]interface{
 }
 
 func ClassicModel() *asserts.Model {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "model",
 		"authority-id": "brand",
 		"series":       "16",

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -228,7 +228,7 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 	// refresh-candidates in the correct format expected here.
 	// See https://forum.snapcraft.io/t/cannot-r-emove-snap-json-cannot-unmarshal-array-into-go-value-of-type-map-string-snapstate-refreshcandidate/27276
 	if !gateAutoRefreshHook {
-		var rc interface{}
+		var rc any
 		err = st.Get("refresh-candidates", &rc)
 		if err != nil {
 			if errors.Is(err, state.ErrNoState) {

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -292,7 +292,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 			Snap:      info2,
 			Name:      "plug",
 			Interface: "content",
-			Attrs: map[string]interface{}{
+			Attrs: map[string]any{
 				"default-provider": "foo-snap:",
 				"content":          "some-content",
 			},
@@ -537,7 +537,7 @@ func (s *refreshHintsTestSuite) TestPruneRefreshCandidatesIncorrectFormat(c *C) 
 
 	// it doesn't fail as long as experimental.gate-auto-refresh-hook is not enabled
 	c.Assert(snapstate.PruneRefreshCandidates(st, "snap-a"), IsNil)
-	var data interface{}
+	var data any
 	// and refresh-candidates has been removed from the state
 	c.Check(st.Get("refresh-candidates", data), testutil.ErrorIs, state.ErrNoState)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -204,11 +204,11 @@ func refreshRetain(st *state.State) int {
 	var retain int
 	if err == nil {
 		switch v := val.(type) {
-		// this is the expected value; confusingly, since we pass interface{} to Get(), we get json.Number type; if int reference was passed,
+		// this is the expected value; confusingly, since we pass any to Get(), we get json.Number type; if int reference was passed,
 		// we would get an int instead of json.Number.
 		case json.Number:
 			retain, err = strconv.Atoi(string(v))
-		// not really expected when requesting interface{}.
+		// not really expected when requesting any.
 		case int:
 			retain = v
 		// we can get string here due to lax validation of refresh.retain on Set in older releases.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -197,7 +197,7 @@ func isParallelInstallable(snapsup *SnapSetup) error {
 // refreshRetain returns refresh.retain value if set, or the default value (different for core and classic).
 // It deals with potentially wrong type due to lax validation.
 func refreshRetain(st *state.State) int {
-	var val interface{}
+	var val any
 	// due to lax validation of refresh.retain on set we might end up having a string representing a number here; handle it gracefully
 	// for backwards compatibility.
 	err := config.NewTransaction(st).Get("core", "refresh.retain", &val)
@@ -961,7 +961,7 @@ func ConfigureSnap(st *state.State, snapName string, confFlags int) *state.TaskS
 	return Configure(st, snapName, nil, confFlags)
 }
 
-var Configure = func(st *state.State, snapName string, patch map[string]interface{}, flags int) *state.TaskSet {
+var Configure = func(st *state.State, snapName string, patch map[string]any, flags int) *state.TaskSet {
 	panic("internal error: snapstate.Configure is unset")
 }
 
@@ -4673,7 +4673,7 @@ func coreInfo(st *state.State) (*snap.Info, error) {
 // ConfigDefaults returns the configuration defaults for the snap as
 // specified in the gadget for the given device context.
 // If gadget is absent or the snap has no snap-id it returns ErrNoState.
-func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (map[string]interface{}, error) {
+func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (map[string]any, error) {
 	info, err := GadgetInfo(st, deviceCtx)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/snapstate_config_defaults_test.go
+++ b/overlord/snapstate/snapstate_config_defaults_test.go
@@ -57,7 +57,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "some-snap")
 	c.Assert(err, IsNil)
-	c.Assert(defls, DeepEquals, map[string]interface{}{"key": "value"})
+	c.Assert(defls, DeepEquals, map[string]any{"key": "value"})
 
 	snapstate.Set(s.state, "local-snap", &snapstate.SnapState{
 		Active: true,
@@ -117,7 +117,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSmokeUC20(c *C) {
 
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "some-snap")
 	c.Assert(err, IsNil)
-	c.Assert(defls, DeepEquals, map[string]interface{}{"key": "value"})
+	c.Assert(defls, DeepEquals, map[string]any{"key": "value"})
 }
 
 func (s *snapmgrTestSuite) TestConfigDefaultsNoGadget(c *C) {
@@ -177,7 +177,7 @@ defaults:
 
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)
-	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(defls, DeepEquals, map[string]any{"foo": "bar"})
 }
 
 var snapdSnapYaml = `name: snapd
@@ -202,7 +202,7 @@ defaults:
 `)
 
 	deviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel(map[string]interface{}{
+		DeviceModel: MakeModel(map[string]any{
 			"gadget": "the-gadget",
 			"base":   "the-base",
 		}),
@@ -225,7 +225,7 @@ defaults:
 
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)
-	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(defls, DeepEquals, map[string]any{"foo": "bar"})
 }
 
 func (s *snapmgrTestSuite) TestConfigDefaultsSystemConflictsCoreSnapId(c *C) {
@@ -263,7 +263,7 @@ defaults:
 	// 'system' key defaults take precedence over snap-id ones
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)
-	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(defls, DeepEquals, map[string]any{"foo": "bar"})
 }
 
 func (s *snapmgrTestSuite) TestTransitionCoreTasksNoUbuntuCore(c *C) {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4370,7 +4370,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaultsInstalled(c *C) {
 	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}, snapPath, "", "edge", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
-	var m map[string]interface{}
+	var m map[string]any
 	runHooks := tasksWithKind(ts, "run-hook")
 
 	c.Assert(runHooks[0].Kind(), Equals, "run-hook")
@@ -4408,7 +4408,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaults(c *C) {
 	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
-	var m map[string]interface{}
+	var m map[string]any
 	runHooks := tasksWithKind(ts, "run-hook")
 
 	c.Assert(taskKinds(runHooks), DeepEquals, []string{
@@ -4423,7 +4423,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaults(c *C) {
 
 	err = runHooks[2].Get("hook-context", &m)
 	c.Assert(err, IsNil)
-	c.Assert(m, DeepEquals, map[string]interface{}{"use-defaults": true})
+	c.Assert(m, DeepEquals, map[string]any{"use-defaults": true})
 }
 
 func (s *snapmgrTestSuite) TestGadgetDefaultsNotForOS(c *C) {
@@ -4450,7 +4450,7 @@ version: 1.0
 	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "core", SnapID: "core-id", Revision: snap.R(1)}, snapPath, "", "edge", snapstate.Flags{}, nil)
 	c.Assert(err, IsNil)
 
-	var m map[string]interface{}
+	var m map[string]any
 	runHooks := tasksWithKind(ts, "run-hook")
 
 	c.Assert(taskKinds(runHooks), DeepEquals, []string{
@@ -4496,7 +4496,7 @@ volumes:
 		IgnoreError: false,
 	}
 
-	contextData := map[string]interface{}{"patch": gi.Defaults}
+	contextData := map[string]any{"patch": gi.Defaults}
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -4557,8 +4557,8 @@ func (s *validationSetsSuite) SetUpTest(c *C) {
 	c.Assert(s.storeSigning.Add(s.acct1Key), IsNil)
 }
 
-func (s *validationSetsSuite) mockValidationSetAssert(c *C, name, sequence string, snaps ...interface{}) asserts.Assertion {
-	headers := map[string]interface{}{
+func (s *validationSetsSuite) mockValidationSetAssert(c *C, name, sequence string, snaps ...any) asserts.Assertion {
+	headers := map[string]any{
 		"authority-id": "foo",
 		"account-id":   "foo",
 		"name":         name,
@@ -4580,7 +4580,7 @@ func (s *validationSetsSuite) installSnapReferencedByValidationSet(c *C, presenc
 
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": presence,
@@ -4685,7 +4685,7 @@ func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevis
 func (s *validationSetsSuite) installManySnapReferencedByValidationSet(c *C, snapOnePresence, snapOneRequiredRev, snapTwoPresence, snapTwoRequiredRev string) error {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		snapOne := map[string]interface{}{
+		snapOne := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "one",
 			"presence": snapOnePresence,
@@ -4693,7 +4693,7 @@ func (s *validationSetsSuite) installManySnapReferencedByValidationSet(c *C, sna
 		if snapOneRequiredRev != "" {
 			snapOne["revision"] = snapOneRequiredRev
 		}
-		snapTwo := map[string]interface{}{
+		snapTwo := map[string]any{
 			"id":       "xxxahntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "two",
 			"presence": snapTwoPresence,
@@ -4724,7 +4724,7 @@ func (s *validationSetsSuite) installManySnapReferencedByValidationSet(c *C, sna
 
 func (s *validationSetsSuite) TestInstallManyWithRevisionOpts(c *C) {
 	enforced := snapasserts.NewValidationSets()
-	err := enforced.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]interface{}{
+	err := enforced.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "invalid",
@@ -4748,7 +4748,7 @@ func (s *validationSetsSuite) TestInstallManyWithRevisionOpts(c *C) {
 	assertstate.UpdateValidationSet(s.state, &tr)
 
 	provided := snapasserts.NewValidationSets()
-	err = provided.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]interface{}{
+	err = provided.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "optional",
@@ -4861,13 +4861,13 @@ func (s *validationSetsSuite) TestInstallManyRequiredRevisionForValidationSetOK(
 func (s *validationSetsSuite) testInstallSnapRequiredByValidationSetWithBase(c *C, presenceForBase string) error {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap-with-base",
 			"presence": "required",
 		}
 		// base snap is invalid
-		someBase := map[string]interface{}{
+		someBase := map[string]any{
 			"id":       "aOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-base",
 			"presence": presenceForBase,
@@ -4967,19 +4967,19 @@ func (s *snapmgrTestSuite) TestHasAllContentAttributes(c *C) {
 			Name:      "some-content-slot",
 			Snap:      mySnap,
 			Interface: "content",
-			Attrs:     map[string]interface{}{"content": "some"},
+			Attrs:     map[string]any{"content": "some"},
 		},
 		{
 			Name:      "wrong-tag-slot",
 			Snap:      mySnap,
 			Interface: "content",
-			Attrs:     map[string]interface{}{"stuff": "wrong-tag"},
+			Attrs:     map[string]any{"stuff": "wrong-tag"},
 		},
 		{
 			Name:      "wrong-iface-slot",
 			Snap:      mySnap,
 			Interface: "diff",
-			Attrs:     map[string]interface{}{"content": "wrong-iface"},
+			Attrs:     map[string]any{"content": "wrong-iface"},
 		},
 	}
 
@@ -5023,7 +5023,7 @@ func (s *snapmgrTestSuite) TestHasAllContentAttributes(c *C) {
 		Name:      "bad-content-slot",
 		Snap:      mySnap,
 		Interface: "content",
-		Attrs:     map[string]interface{}{"content": 123},
+		Attrs:     map[string]any{"content": 123},
 	})
 	c.Assert(err, IsNil)
 
@@ -5119,7 +5119,7 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	defer s.state.Unlock()
 
 	vsets := snapasserts.NewValidationSets()
-	bar := s.mockValidationSetAssert(c, "bar", "1", map[string]interface{}{
+	bar := s.mockValidationSetAssert(c, "bar", "1", map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "optional",
@@ -5127,7 +5127,7 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	})
 	err := vsets.Add(bar.(*asserts.ValidationSet))
 	c.Assert(err, IsNil)
-	baz := s.mockValidationSetAssert(c, "baz", "1", map[string]interface{}{
+	baz := s.mockValidationSetAssert(c, "baz", "1", map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "required",
@@ -6696,7 +6696,7 @@ func (s *snapmgrTestSuite) testInstallComponentsRunThrough(c *C, opts testInstal
 		defer mockCmd.Restore()
 	}
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	// sort these so that we can predict the order of the ops
@@ -7127,7 +7127,7 @@ func (s *snapmgrTestSuite) testInstallComponentsFromPathRunThrough(c *C, opts te
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	// make sure that the store is never hit
@@ -7576,15 +7576,15 @@ func (s *snapmgrTestSuite) TestInstallWithConfdb(c *C) {
 type testInstallComponentsValidationSetsOpts struct {
 	comps   []string
 	err     string
-	headers map[string]interface{}
+	headers map[string]any
 }
 
 func (s *validationSetsSuite) TestInstallComponentsValidationSetsInvalid(c *C) {
 	s.testInstallComponentsValidationSets(c, testInstallComponentsValidationSetsOpts{
 		comps: []string{"test-component"},
 		err:   `cannot install component "test-snap\+test-component" due to enforcing rules of validation set 16/foo/bar/1`,
-		headers: map[string]interface{}{
-			"components": map[string]interface{}{
+		headers: map[string]any{
+			"components": map[string]any{
 				"test-component": "invalid",
 			},
 		},
@@ -7595,8 +7595,8 @@ func (s *validationSetsSuite) TestInstallComponentsValidationSetsMissingRequired
 	s.testInstallComponentsValidationSets(c, testInstallComponentsValidationSetsOpts{
 		comps: nil,
 		err:   `cannot install snap "test-snap" without component "test-component" required by validation sets 16/foo/bar/1`,
-		headers: map[string]interface{}{
-			"components": map[string]interface{}{
+		headers: map[string]any{
+			"components": map[string]any{
 				"test-component": "required",
 			},
 		},
@@ -7607,10 +7607,10 @@ func (s *validationSetsSuite) TestInstallComponentsValidationSetsWrongRevision(c
 	s.testInstallComponentsValidationSets(c, testInstallComponentsValidationSetsOpts{
 		comps: []string{"test-component"},
 		err:   `cannot install component "test-snap\+test-component" at revision 1 without --ignore-validation, revision 10 is required by validation sets: 16/foo/bar/1`,
-		headers: map[string]interface{}{
+		headers: map[string]any{
 			"revision": "7",
-			"components": map[string]interface{}{
-				"test-component": map[string]interface{}{
+			"components": map[string]any{
+				"test-component": map[string]any{
 					"presence": "optional",
 					"revision": "10",
 				},
@@ -7622,10 +7622,10 @@ func (s *validationSetsSuite) TestInstallComponentsValidationSetsWrongRevision(c
 func (s *validationSetsSuite) TestInstallComponentsValidationSetsCorrectRevision(c *C) {
 	s.testInstallComponentsValidationSets(c, testInstallComponentsValidationSetsOpts{
 		comps: []string{"test-component"},
-		headers: map[string]interface{}{
+		headers: map[string]any{
 			"revision": "7",
-			"components": map[string]interface{}{
-				"test-component": map[string]interface{}{
+			"components": map[string]any{
+				"test-component": map[string]any{
 					"presence": "optional",
 					"revision": "1",
 				},
@@ -7637,9 +7637,9 @@ func (s *validationSetsSuite) TestInstallComponentsValidationSetsCorrectRevision
 func (s *validationSetsSuite) TestInstallComponentsValidationSetsRequired(c *C) {
 	s.testInstallComponentsValidationSets(c, testInstallComponentsValidationSetsOpts{
 		comps: []string{"test-component"},
-		headers: map[string]interface{}{
-			"components": map[string]interface{}{
-				"test-component": map[string]interface{}{
+		headers: map[string]any{
+			"components": map[string]any{
+				"test-component": map[string]any{
 					"presence": "required",
 				},
 			},
@@ -7673,7 +7673,7 @@ func (s *validationSetsSuite) testInstallComponentsValidationSets(c *C, opts tes
 
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"id":       snapID,
 			"name":     snapName,
 			"presence": "optional",
@@ -7734,17 +7734,17 @@ func (s *validationSetsSuite) testInstallComponentsValidationSets(c *C, opts tes
 type testUpdateComponentsValidationSetsOpts struct {
 	comps   []string
 	err     string
-	headers map[string]interface{}
+	headers map[string]any
 }
 
 func (s *validationSetsSuite) TestUpdateComponentsValidationSetsToWrongRevision(c *C) {
 	s.testUpdateComponentsValidationSets(c, testUpdateComponentsValidationSetsOpts{
 		comps: []string{"test-component"},
 		err:   `cannot update component "test-snap\+test-component" to revision 2 without --ignore-validation, revision 1 is required by validation sets: 16/foo/bar/1`,
-		headers: map[string]interface{}{
+		headers: map[string]any{
 			"revision": "11",
-			"components": map[string]interface{}{
-				"test-component": map[string]interface{}{
+			"components": map[string]any{
+				"test-component": map[string]any{
 					"presence": "optional",
 					"revision": "1",
 				},
@@ -7756,10 +7756,10 @@ func (s *validationSetsSuite) TestUpdateComponentsValidationSetsToWrongRevision(
 func (s *validationSetsSuite) TestUpdateComponentsValidationSetsToCorrectRevision(c *C) {
 	s.testUpdateComponentsValidationSets(c, testUpdateComponentsValidationSetsOpts{
 		comps: []string{"test-component"},
-		headers: map[string]interface{}{
+		headers: map[string]any{
 			"revision": "11",
-			"components": map[string]interface{}{
-				"test-component": map[string]interface{}{
+			"components": map[string]any{
+				"test-component": map[string]any{
 					"presence": "optional",
 					"revision": "2",
 				},
@@ -7772,9 +7772,9 @@ func (s *validationSetsSuite) TestUpdateComponentsValidationSetsMissingRequired(
 	s.testUpdateComponentsValidationSets(c, testUpdateComponentsValidationSetsOpts{
 		comps: nil,
 		err:   `cannot update snap "test-snap" without component "test-component" required by validation sets 16/foo/bar/1`,
-		headers: map[string]interface{}{
-			"components": map[string]interface{}{
-				"test-component": map[string]interface{}{
+		headers: map[string]any{
+			"components": map[string]any{
+				"test-component": map[string]any{
 					"presence": "required",
 				},
 			},
@@ -7785,9 +7785,9 @@ func (s *validationSetsSuite) TestUpdateComponentsValidationSetsMissingRequired(
 func (s *validationSetsSuite) TestUpdateComponentsValidationSetsWithRequired(c *C) {
 	s.testUpdateComponentsValidationSets(c, testUpdateComponentsValidationSetsOpts{
 		comps: []string{"test-component"},
-		headers: map[string]interface{}{
-			"components": map[string]interface{}{
-				"test-component": map[string]interface{}{
+		headers: map[string]any{
+			"components": map[string]any{
+				"test-component": map[string]any{
 					"presence": "required",
 				},
 			},
@@ -7858,7 +7858,7 @@ func (s *validationSetsSuite) testUpdateComponentsValidationSets(c *C, opts test
 
 	restore = snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"id":       snapID,
 			"name":     snapName,
 			"presence": "optional",

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1825,7 +1825,7 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 func (s *validationSetsSuite) removeSnapReferencedByValidationSet(c *C, presence string) error {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": presence,
@@ -1882,7 +1882,7 @@ func (s *validationSetsSuite) TestRemoveInvalidSnapOK(c *C) {
 func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetAtSpecificRevisionRefused(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -1935,7 +1935,7 @@ func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetAtSpecificRev
 func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetAtSpecificRevisionNotActive(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1150,7 +1150,7 @@ func (s *snapmgrTestSuite) TestDoUpdateHadSlots(c *C) {
 				Snap:      info,
 				Name:      "shared-content",
 				Interface: "content",
-				Attrs: map[string]interface{}{
+				Attrs: map[string]any{
 					"content": "shared-content",
 				},
 			},
@@ -1483,11 +1483,11 @@ func (s *snapmgrTestSuite) TestRevertRestoresConfigSnapshot(c *C) {
 	s.settle(c)
 
 	// config snapshot of rev. 2 has been made by 'revert'
-	var cfgs map[string]interface{}
+	var cfgs map[string]any
 	c.Assert(s.state.Get("revision-config", &cfgs), IsNil)
-	c.Assert(cfgs["some-snap"], DeepEquals, map[string]interface{}{
-		"1": map[string]interface{}{"foo": "100"},
-		"2": map[string]interface{}{"foo": "200"},
+	c.Assert(cfgs["some-snap"], DeepEquals, map[string]any{
+		"1": map[string]any{"foo": "100"},
+		"2": map[string]any{"foo": "200"},
 	})
 
 	// current snap configuration has been restored from rev. 1 config snapshot
@@ -4773,7 +4773,7 @@ func (s *snapmgrQuerySuite) TestKernelInfo(c *C) {
 		DeviceModel: ClassicModel(),
 	}
 	deviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel(map[string]interface{}{
+		DeviceModel: MakeModel(map[string]any{
 			"kernel": "pc-kernel",
 		}),
 	}
@@ -4818,7 +4818,7 @@ func (s *snapmgrQuerySuite) TestBootBaseInfo(c *C) {
 		DeviceModel: ClassicModel(),
 	}
 	deviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel20("gadget", map[string]interface{}{
+		DeviceModel: MakeModel20("gadget", map[string]any{
 			"base": "core20",
 		}),
 	}
@@ -5362,7 +5362,7 @@ func (s *snapmgrTestSuite) TestRefreshRetain(c *C) {
 	defer restoreLogger()
 
 	for i, val := range []struct {
-		input    interface{}
+		input    any
 		expected int
 		msg      string
 	}{
@@ -5370,7 +5370,7 @@ func (s *snapmgrTestSuite) TestRefreshRetain(c *C) {
 		{json.Number("2"), 2, "^$"},
 		{"6", 6, "^$"},
 		// invalid => default value for core
-		{map[string]interface{}{"foo": "bar"}, 3, `.*internal error: refresh.retain system option has unexpected type: map\[string\]interface {}\n`},
+		{map[string]any{"foo": "bar"}, 3, `.*internal error: refresh.retain system option has unexpected type: map\[string\]interface {}\n`},
 	} {
 		tr := config.NewTransaction(s.state)
 		tr.Set("core", "refresh.retain", val.input)
@@ -5526,7 +5526,7 @@ version: 1.0
 
 func deviceWithGadgetContext(gadgetName string) snapstate.DeviceContext {
 	return &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel(map[string]interface{}{
+		DeviceModel: MakeModel(map[string]any{
 			"gadget": gadgetName,
 		}),
 	}
@@ -6019,7 +6019,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreValidationSetsInvalid(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -6027,8 +6027,8 @@ func (s *snapmgrTestSuite) TestTransitionCoreValidationSetsInvalid(c *C) {
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "core",
 				"id":       snaptest.AssertedSnapID("core"),
 				"presence": "invalid",
@@ -6067,7 +6067,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreValidationSetsRevision(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -6075,8 +6075,8 @@ func (s *snapmgrTestSuite) TestTransitionCoreValidationSetsRevision(c *C) {
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "core",
 				"id":       snaptest.AssertedSnapID("core"),
 				"presence": "required",
@@ -6285,7 +6285,7 @@ func (s *snapmgrTestSuite) TestEnsureAliasesV2(c *C) {
 	s.state.Lock()
 	c.Assert(err, IsNil)
 
-	var gone interface{}
+	var gone any
 	err = s.state.Get("aliases", &gone)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
@@ -6354,7 +6354,7 @@ func (s *snapmgrTestSuite) TestEnsureAliasesV2SnapDisabled(c *C) {
 	s.state.Lock()
 	c.Assert(err, IsNil)
 
-	var gone interface{}
+	var gone any
 	err = s.state.Get("aliases", &gone)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
@@ -6565,7 +6565,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 					Snap:      info,
 					Name:      "shared-content",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"default-provider": "snap-content-slot",
 						"content":          "shared-content",
 					},
@@ -6577,7 +6577,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 					Snap:      info,
 					Name:      "shared-content",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"default-provider": "snap-content-slot:some-slot",
 						"content":          "shared-content",
 					},
@@ -6589,7 +6589,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 					Snap:      info,
 					Name:      "shared-content",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"content": "shared-content",
 					},
 				},
@@ -6600,7 +6600,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 					Snap:      info,
 					Name:      "circular-plug1",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"default-provider": "snap-content-circular2",
 						"content":          "circular2",
 					},
@@ -6611,7 +6611,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 					Snap:      info,
 					Name:      "circular-slot1",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"content": "circular1",
 					},
 				},
@@ -6622,7 +6622,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 					Snap:      info,
 					Name:      "circular-plug2",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"default-provider": "snap-content-circular1",
 						"content":          "circular2",
 					},
@@ -6633,7 +6633,7 @@ func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.Curr
 					Snap:      info,
 					Name:      "circular-slot2",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"content": "circular1",
 					},
 				},
@@ -7284,7 +7284,7 @@ func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnUC20KernelRefresh(c *C) {
 
 func (s *snapmgrTestSuite) TestGadgetUpdateTaskAddedOnUC24KernelRefresh(c *C) {
 	s.testGadgetUpdateTaskAddedOnUCKernelRefresh(c,
-		MakeModel20("brand-gadget", map[string]interface{}{"base": "core24"}),
+		MakeModel20("brand-gadget", map[string]any{"base": "core24"}),
 		doesReRefresh|needsKernelSetup)
 }
 
@@ -7339,7 +7339,7 @@ func (s *snapmgrTestSuite) testGadgetUpdateTaskAddedOnUCKernelRefreshHybrid(c *C
 	defer s.state.Unlock()
 
 	defer snapstatetest.MockDeviceModel(MakeModelClassicWithModes(
-		"brand-gadget", map[string]interface{}{"base": base}))()
+		"brand-gadget", map[string]any{"base": base}))()
 
 	snapstate.Set(s.state, "brand-kernel", &snapstate.SnapState{
 		Active: true,
@@ -8157,7 +8157,7 @@ func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrUC20KernelHappyWithKmodCompon
 func (s *snapmgrTestSuite) TestRemodelLinkNewBaseOrUC24KernelHappy(c *C) {
 	// UC24 model has additional tasks for the kernel
 	s.testRemodelLinkNewBaseOrKernelHappy(c,
-		MakeModel20("brand-gadget", map[string]interface{}{"base": "core24"}),
+		MakeModel20("brand-gadget", map[string]any{"base": "core24"}),
 		needsKernelSetup)
 }
 
@@ -8354,7 +8354,7 @@ func (s *snapmgrTestSuite) TestRemodelAddLinkNewBaseOrUC20Kernel(c *C) {
 func (s *snapmgrTestSuite) TestRemodelAddLinkNewBaseOrUC24Kernel(c *C) {
 	// UC24 model has additional tasks for the kernel
 	s.testRemodelAddLinkNewBaseOrKernel(c,
-		MakeModel20("brand-gadget", map[string]interface{}{"base": "core24"}),
+		MakeModel20("brand-gadget", map[string]any{"base": "core24"}),
 		needsKernelSetup)
 }
 
@@ -8928,7 +8928,7 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementError(c *C) {
 		Active:   true,
 	})
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -8936,14 +8936,14 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementError(c *C) {
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "some-snap",
 				"id":       "mysnapdddddddddddddddddddddddddd",
 				"presence": "required",
 				"revision": "1",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "some-other-snap",
 				"id":       "mysnapcccccccccccccccccccccccccc",
 				"presence": "required",
@@ -9021,7 +9021,7 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorInvalidCompo
 }
 
 func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorComponents(c *C) {
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -9029,66 +9029,66 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorComponents(c
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-with-missing-comps-at-wrong-rev",
 				"id":       snaptest.AssertedSnapID("snap-with-missing-comps-at-wrong-rev"),
 				"presence": "required",
 				"revision": "2",
-				"components": map[string]interface{}{
-					"one": map[string]interface{}{
+				"components": map[string]any{
+					"one": map[string]any{
 						"presence": "required",
 						"revision": "11",
 					},
-					"two": map[string]interface{}{
+					"two": map[string]any{
 						"presence": "required",
 						"revision": "22",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-with-wrong-rev-comp-at-wrong-rev",
 				"id":       snaptest.AssertedSnapID("snap-with-wrong-rev-comp-at-wrong-rev"),
 				"presence": "required",
 				"revision": "2",
-				"components": map[string]interface{}{
-					"three": map[string]interface{}{
+				"components": map[string]any{
+					"three": map[string]any{
 						"presence": "required",
 						"revision": "33",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-with-wrong-rev-comp",
 				"id":       snaptest.AssertedSnapID("snap-with-wrong-rev-comp"),
 				"presence": "required",
 				"revision": "1",
-				"components": map[string]interface{}{
-					"four": map[string]interface{}{
+				"components": map[string]any{
+					"four": map[string]any{
 						"presence": "required",
 						"revision": "44",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-with-missing-comps",
 				"id":       snaptest.AssertedSnapID("snap-with-missing-comps"),
 				"presence": "required",
 				"revision": "1",
-				"components": map[string]interface{}{
-					"five": map[string]interface{}{
+				"components": map[string]any{
+					"five": map[string]any{
 						"presence": "required",
 						"revision": "55",
 					},
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "snap-missing-with-missing-comps",
 				"id":       snaptest.AssertedSnapID("snap-missing-with-missing-comps"),
 				"presence": "required",
 				"revision": "1",
-				"components": map[string]interface{}{
-					"six": map[string]interface{}{
+				"components": map[string]any{
+					"six": map[string]any{
 						"presence": "required",
 						"revision": "66",
 					},
@@ -9359,7 +9359,7 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorReverse(c *C
 		Active:   true,
 	})
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -9367,13 +9367,13 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorReverse(c *C
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "some-snap",
 				"id":       "mysnapdddddddddddddddddddddddddd",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "some-other-snap",
 				"id":       "mysnapcccccccccccccccccccccccccc",
 				"presence": "required",
@@ -10348,7 +10348,7 @@ func (s *snapmgrTestSuite) TestDownloadWithComponentsWithMismatchValidationSets(
 		return nil
 	}
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -10356,14 +10356,14 @@ func (s *snapmgrTestSuite) TestDownloadWithComponentsWithMismatchValidationSets(
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-1",
 				"id":       snaptest.AssertedSnapID("snap-1"),
 				"presence": "required",
 				"revision": "11",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 						"revision": "1",
 					},
@@ -10437,7 +10437,7 @@ func (s *snapmgrTestSuite) TestDownloadWithComponentsWithValidationSets(c *C) {
 		return nil
 	}
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "validation-set",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"authority-id": "foo",
@@ -10445,18 +10445,18 @@ func (s *snapmgrTestSuite) TestDownloadWithComponentsWithValidationSets(c *C) {
 		"account-id":   "foo",
 		"name":         "bar",
 		"sequence":     "3",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "snap-1",
 				"id":       snaptest.AssertedSnapID("snap-1"),
 				"presence": "required",
 				"revision": "11",
-				"components": map[string]interface{}{
-					"comp-1": map[string]interface{}{
+				"components": map[string]any{
+					"comp-1": map[string]any{
 						"presence": "required",
 						"revision": "1",
 					},
-					"comp-2": map[string]interface{}{
+					"comp-2": map[string]any{
 						"presence": "required",
 						"revision": "2",
 					},

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -804,7 +804,7 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 	}
 	snaptest.MockSnap(c, `name: some-kernel`, &si)
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	s.state.Lock()
@@ -1859,7 +1859,7 @@ func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
 		Snap:      sn,
 		Name:      "snap-content-slot",
 		Interface: "content",
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"content": "shared-content",
 		},
 	}
@@ -2697,7 +2697,7 @@ func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 	tr.Set("some-snap", "foo", "bar")
 	tr.Commit()
 
-	var cfgs map[string]interface{}
+	var cfgs map[string]any
 	// we don't have config snapshots yet
 	c.Assert(s.state.Get("revision-config", &cfgs), testutil.ErrorIs, state.ErrNoState)
 
@@ -2715,8 +2715,8 @@ func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 	cfgs = nil
 	// config copy of rev. 1 has been made
 	c.Assert(s.state.Get("revision-config", &cfgs), IsNil)
-	c.Assert(cfgs["some-snap"], DeepEquals, map[string]interface{}{
-		"1": map[string]interface{}{
+	c.Assert(cfgs["some-snap"], DeepEquals, map[string]any{
+		"1": map[string]any{
 			"foo": "bar",
 		},
 	})
@@ -4884,7 +4884,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksCoreSetsIgnoreOnConfigure(c *C) {
 	defer func() { snapstate.Configure = oldConfigure }()
 
 	var configureFlags int
-	snapstate.Configure = func(st *state.State, snapName string, patch map[string]interface{}, flags int) *state.TaskSet {
+	snapstate.Configure = func(st *state.State, snapName string, patch map[string]any, flags int) *state.TaskSet {
 		configureFlags = flags
 		return state.NewTaskSet()
 	}
@@ -5923,7 +5923,7 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
 func (s *validationSetsSuite) TestUpdateManyWithRevisionOpts(c *C) {
 	// current validation set forbids "some-snap"
 	vsets := snapasserts.NewValidationSets()
-	someSnapConstraint := map[string]interface{}{
+	someSnapConstraint := map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "required",
@@ -6671,9 +6671,9 @@ func (s *snapmgrTestSuite) TestRefreshDoesntRestoreRevisionConfig(c *C) {
 
 	// set per-revision config for the upcoming rev. 2, we don't expect it restored though
 	// since only revert restores revision configs.
-	s.state.Set("revision-config", map[string]interface{}{
-		"some-snap": map[string]interface{}{
-			"2": map[string]interface{}{"foo": "200"},
+	s.state.Set("revision-config", map[string]any{
+		"some-snap": map[string]any{
+			"2": map[string]any{"foo": "200"},
 		},
 	})
 
@@ -6686,11 +6686,11 @@ func (s *snapmgrTestSuite) TestRefreshDoesntRestoreRevisionConfig(c *C) {
 	s.settle(c)
 
 	// config of rev. 1 has been stored in per-revision map
-	var cfgs map[string]interface{}
+	var cfgs map[string]any
 	c.Assert(s.state.Get("revision-config", &cfgs), IsNil)
-	c.Assert(cfgs["some-snap"], DeepEquals, map[string]interface{}{
-		"1": map[string]interface{}{"foo": "100"},
-		"2": map[string]interface{}{"foo": "200"},
+	c.Assert(cfgs["some-snap"], DeepEquals, map[string]any{
+		"1": map[string]any{"foo": "100"},
+		"2": map[string]any{"foo": "200"},
 	})
 
 	// config of rev. 2 hasn't been restored by refresh, old value returned
@@ -7188,7 +7188,7 @@ func findStrictlyOnePrereqTask(c *C, chg *state.Change) *state.Task {
 func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAlreadyAtRequiredRevision(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7227,7 +7227,7 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAlreadyAtRequ
 func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationRefreshToRequiredRevision(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7299,7 +7299,7 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAnyRevision(c
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
 		// no revision specified
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7369,7 +7369,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationSetAny
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
 		// no revision specified
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7439,7 +7439,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationSetAny
 func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationWithMatchingRevision(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7508,7 +7508,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationWithMa
 func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationAlreadyAtRevisionNoop(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7564,7 +7564,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationWrongR
 func (s *validationSetsSuite) testUpdateToRevisionSnapRequiredByValidationWrongRevisionError(c *C, instanceKey string) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7620,7 +7620,7 @@ func (s *validationSetsSuite) testUpdateToRevisionSnapRequiredByValidationWrongR
 func (s *validationSetsSuite) TestUpdateToWrongRevisionIgnoreValidation(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7696,7 +7696,7 @@ func (s *validationSetsSuite) TestUpdateToWrongRevisionIgnoreValidation(c *C) {
 func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetAlreadyAtCorrectRevisionNoop(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7736,7 +7736,7 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetAlreadyAtCorr
 func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetsCohortIgnored(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVs ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7803,7 +7803,7 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetsCohortIgnore
 func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetIgnoreValidation(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7871,7 +7871,7 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetIgnoreValidat
 func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAlreadyAtRequiredRevisionIgnoreValidationOK(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		someSnap := map[string]interface{}{
+		someSnap := map[string]any{
 			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
@@ -7942,12 +7942,12 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 	refreshedDate := fakeRevDateEpoch.AddDate(0, 0, 1)
 
 	vsets := snapasserts.NewValidationSets()
-	vsets.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]interface{}{
+	vsets.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "required",
 	}).(*asserts.ValidationSet))
-	vsets.Add(s.mockValidationSetAssert(c, "baz", "2", map[string]interface{}{
+	vsets.Add(s.mockValidationSetAssert(c, "baz", "2", map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "required",
@@ -8007,7 +8007,7 @@ func (s *validationSetsSuite) TestUpdateWithValidationSetsInvalidSnap(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 
 	vsets := snapasserts.NewValidationSets()
-	vsets.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]interface{}{
+	vsets.Add(s.mockValidationSetAssert(c, "bar", "1", map[string]any{
 		"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
 		"name":     "some-snap",
 		"presence": "invalid",
@@ -8079,12 +8079,12 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 	var enforcedValidationSetsCalls int
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
-		snap1 := map[string]interface{}{
+		snap1 := map[string]any{
 			"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-snap",
 			"presence": "required",
 		}
-		snap2 := map[string]interface{}{
+		snap2 := map[string]any{
 			"id":       "bgtKhntON3vR7kwEbVPsILm7bUViPDzx",
 			"name":     "some-other-snap",
 			"presence": "required",
@@ -9016,7 +9016,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	}))
 	c.Assert(err, IsNil)
 
-	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]interface{}{
+	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]any{
 		"kernel": "kernel",
 		"base":   "core18",
 	}))
@@ -9572,7 +9572,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootWithCannotRebootSetHa
 	}))
 	c.Assert(err, IsNil)
 
-	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]interface{}{
+	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]any{
 		"kernel": "kernel",
 		"base":   "core18",
 	}))
@@ -9800,7 +9800,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetKernelSingleReboot(c *C) {
 	}))
 	c.Assert(err, IsNil)
 
-	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]interface{}{
+	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]any{
 		"kernel": "kernel",
 		"base":   "core18",
 	}))
@@ -11007,13 +11007,13 @@ func (s *snapmgrTestSuite) testAutoRefreshRecordsFailures(c *C, afterReboot bool
 		c.Assert(snapstate.Get(s.state, name, &snapst), IsNil)
 		return snapst.RefreshFailures
 	}
-	getRefreshFailed := func(chg *state.Change) []interface{} {
-		var apiData map[string]interface{}
+	getRefreshFailed := func(chg *state.Change) []any {
+		var apiData map[string]any
 		c.Assert(chg.Get("api-data", &apiData), IsNil)
 		if apiData["refresh-failed"] == nil {
 			return nil
 		}
-		refreshFailed := apiData["refresh-failed"].([]interface{})
+		refreshFailed := apiData["refresh-failed"].([]any)
 		return refreshFailed
 	}
 	getRevision := func(name string) snap.Revision {
@@ -11086,7 +11086,7 @@ func (s *snapmgrTestSuite) testAutoRefreshRecordsFailures(c *C, afterReboot bool
 	c.Check(chgs[1].Err(), ErrorMatches, expectedAutoConnectErrPattern)
 	c.Check(chgs[1].Status(), Equals, state.ErrorStatus)
 	c.Check(buf.String(), testutil.Contains, fmt.Sprintf("snap %q auto-refresh to revision 12 has failed, next auto-refresh attempt will be delayed by %d hours", badSnap, expectedMinDelay))
-	c.Check(getRefreshFailed(chgs[1]), DeepEquals, []interface{}{badSnap})
+	c.Check(getRefreshFailed(chgs[1]), DeepEquals, []any{badSnap})
 	c.Check(getRefreshFailures(badSnap).Revision, Equals, badSnapRevision)
 	c.Check(getRefreshFailures(badSnap).FailureCount, Equals, 1)
 	c.Check(getRefreshFailures(badSnap).LastFailureSeverity, Equals, expectedFailureSeverity)
@@ -11136,7 +11136,7 @@ func (s *snapmgrTestSuite) testAutoRefreshRecordsFailures(c *C, afterReboot bool
 	c.Check(chgs[3].Err(), ErrorMatches, expectedAutoConnectErrPattern)
 	c.Check(chgs[3].Status(), Equals, state.ErrorStatus)
 	c.Check(buf.String(), testutil.Contains, fmt.Sprintf("snap %q auto-refresh to revision 12 has failed, next auto-refresh attempt will be delayed by %d hours", badSnap, expectedMaxDelay))
-	c.Check(getRefreshFailed(chgs[3]), DeepEquals, []interface{}{badSnap})
+	c.Check(getRefreshFailed(chgs[3]), DeepEquals, []any{badSnap})
 	c.Check(getRefreshFailures(badSnap).Revision, Equals, badSnapRevision)
 	c.Check(getRefreshFailures(badSnap).FailureCount, Equals, 101) // Backoff delay passed, increment for new failure
 	c.Check(getRefreshFailures(badSnap).LastFailureSeverity, Equals, expectedFailureSeverity)
@@ -12262,13 +12262,13 @@ func (s *snapmgrTestSuite) TestRefreshForcedOnRefreshInhibitionTimeout(c *C) {
 	s.settle(c)
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
-	var apiData map[string]interface{}
+	var apiData map[string]any
 	c.Assert(chg.Get("api-data", &apiData), IsNil)
-	refreshForced := apiData["refresh-forced"].([]interface{})
+	refreshForced := apiData["refresh-forced"].([]any)
 	sort.Slice(refreshForced, func(i, j int) bool {
 		return refreshForced[i].(string) < refreshForced[j].(string)
 	})
-	c.Check(refreshForced, DeepEquals, []interface{}{"some-other-snap", "some-snap"})
+	c.Check(refreshForced, DeepEquals, []any{"some-other-snap", "some-snap"})
 
 	notices := s.state.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
 	c.Assert(notices, HasLen, 1)
@@ -12662,7 +12662,7 @@ func (s *snapmgrTestSuite) TestPreDownloadCleansSnapDownloads(c *C) {
 	defer restore()
 
 	// mock that snap is monitored (i.e. non-nil abort channel)
-	mockAbortChans := map[string]interface{}{"some-snap": func() {}}
+	mockAbortChans := map[string]any{"some-snap": func() {}}
 	s.state.Cache("monitored-snaps", mockAbortChans)
 
 	preDlChg := s.state.NewChange("pre-download", "pre-download change")
@@ -13167,7 +13167,7 @@ func (s *snapmgrTestSuite) testUpdateManyRevOptsOrder(c *C, isThrottled map[stri
 
 	signer := assertstest.NewStoreStack("can0nical", nil)
 	valSetForSnap := func(snapName string) *snapasserts.ValidationSets {
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"authority-id": "foo",
 			"account-id":   "foo",
 			"name":         snapName,
@@ -13175,8 +13175,8 @@ func (s *snapmgrTestSuite) testUpdateManyRevOptsOrder(c *C, isThrottled map[stri
 			"revision":     "5",
 			"sequence":     "1",
 			"timestamp":    "2030-11-06T09:16:26Z",
-			"snaps": []interface{}{
-				map[string]interface{}{
+			"snaps": []any{
+				map[string]any{
 					"id":       snaptest.AssertedSnapID(snapName),
 					"name":     snapName,
 					"presence": "required",
@@ -14127,7 +14127,7 @@ func (s hybridContentStore) SnapAction(ctx context.Context, currentSnaps []*stor
 					Snap:      info,
 					Name:      "shared-content",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"default-provider": "snap-content-slot",
 						"content":          "shared-content",
 					},
@@ -14139,7 +14139,7 @@ func (s hybridContentStore) SnapAction(ctx context.Context, currentSnaps []*stor
 					Snap:      info,
 					Name:      "shared-content",
 					Interface: "content",
-					Attrs: map[string]interface{}{
+					Attrs: map[string]any{
 						"content": "shared-content",
 					},
 				},
@@ -14939,7 +14939,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		channel     = "channel-for-components-only-component-refresh"
 	)
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	components := []string{"standard-component", "kernel-modules-component"}
@@ -15382,7 +15382,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 		channel     = "channel-for-components-only-component-refresh"
 	)
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	currentSnapRev := snap.R(11)
@@ -15868,7 +15868,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		c.Error("boo")
 	}
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	channel := "channel-for-components"
@@ -16525,7 +16525,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 		snapID   = "kernel-id"
 	)
 
-	restore := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	restore := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer restore()
 
 	channel := "channel-for-components"
@@ -17211,7 +17211,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, inst
 		snapID = "some-snap-id"
 	}
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	if refreshAppAwarenessUX {
@@ -17708,7 +17708,7 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathBackToInstalledRevisi
 		snapID       = "kernel-id"
 	)
 
-	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]interface{}{"base": "core24"}))
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
 
 	s.enableRefreshAppAwarenessUX()
@@ -18080,7 +18080,7 @@ func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsRunThroughOnlyCompone
 }
 
 func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate(c *C, opts updateWithComponentsOpts) {
-	model := MakeModel20("pc", map[string]interface{}{"base": "core24"})
+	model := MakeModel20("pc", map[string]any{"base": "core24"})
 	r := snapstatetest.MockDeviceModel(model)
 	defer r()
 

--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -266,14 +266,14 @@ func (c *Change) Summary() string {
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (c *Change) Set(key string, value interface{}) {
+func (c *Change) Set(key string, value any) {
 	c.state.writing()
 	c.data.set(key, value)
 }
 
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
-func (c *Change) Get(key string, value interface{}) error {
+func (c *Change) Get(key string, value any) error {
 	c.state.reading()
 	return c.data.get(key, value)
 }

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -43,7 +43,7 @@ type Backend interface {
 
 type customData map[string]*json.RawMessage
 
-func (data customData) get(key string, value interface{}) error {
+func (data customData) get(key string, value any) error {
 	entryJSON := data[key]
 	if entryJSON == nil {
 		return &NoStateError{Key: key}
@@ -59,7 +59,7 @@ func (data customData) has(key string) bool {
 	return data[key] != nil
 }
 
-func (data customData) set(key string, value interface{}) {
+func (data customData) set(key string, value any) {
 	if value == nil {
 		delete(data, key)
 		return
@@ -104,7 +104,7 @@ type State struct {
 
 	modified bool
 
-	cache map[interface{}]interface{}
+	cache map[any]any
 
 	pendingChangeByAttr map[string]func(*Change) bool
 
@@ -126,7 +126,7 @@ func New(backend Backend) *State {
 		warnings:            make(map[string]*Warning),
 		notices:             make(map[noticeKey]*Notice),
 		modified:            true,
-		cache:               make(map[interface{}]interface{}),
+		cache:               make(map[any]any),
 		pendingChangeByAttr: make(map[string]func(*Change) bool),
 		taskHandlers:        make(map[int]func(t *Task, old Status, new Status) bool),
 		changeHandlers:      make(map[int]func(chg *Change, old Status, new Status)),
@@ -316,7 +316,7 @@ func (e *NoStateError) Is(err error) bool {
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
 // It returns ErrNoState if there is no entry for key.
-func (s *State) Get(key string, value interface{}) error {
+func (s *State) Get(key string, value any) error {
 	s.reading()
 	return s.data.get(key, value)
 }
@@ -329,21 +329,21 @@ func (s *State) Has(key string) bool {
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (s *State) Set(key string, value interface{}) {
+func (s *State) Set(key string, value any) {
 	s.writing()
 	s.data.set(key, value)
 }
 
 // Cached returns the cached value associated with the provided key.
 // It returns nil if there is no entry for key.
-func (s *State) Cached(key interface{}) interface{} {
+func (s *State) Cached(key any) any {
 	s.reading()
 	return s.cache[key]
 }
 
 // Cache associates value with key for future consulting by managers.
 // The cached value is not persisted.
-func (s *State) Cache(key, value interface{}) {
+func (s *State) Cache(key, value any) {
 	s.reading() // Doesn't touch persisted data.
 	if value == nil {
 		delete(s.cache, key)
@@ -533,7 +533,7 @@ NextChange:
 }
 
 // GetMaybeTimings implements timings.GetSaver
-func (s *State) GetMaybeTimings(timings interface{}) error {
+func (s *State) GetMaybeTimings(timings any) error {
 	if err := s.Get("timings", timings); err != nil && !errors.Is(err, ErrNoState) {
 		return err
 	}
@@ -599,7 +599,7 @@ func (s *State) notifyChangeStatusChangedHandlers(chg *Change, old, new Status) 
 }
 
 // SaveTimings implements timings.GetSaver
-func (s *State) SaveTimings(timings interface{}) {
+func (s *State) SaveTimings(timings any) {
 	s.Set("timings", timings)
 }
 
@@ -616,7 +616,7 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 	s.backend = backend
 	s.noticeCond = sync.NewCond(s)
 	s.modified = false
-	s.cache = make(map[interface{}]interface{})
+	s.cache = make(map[any]any)
 	s.pendingChangeByAttr = make(map[string]func(*Change) bool)
 	s.changeHandlers = make(map[int]func(chg *Change, old Status, new Status))
 	s.taskHandlers = make(map[int]func(t *Task, old Status, new Status) bool)

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -420,7 +420,7 @@ func MockTime(now time.Time) (restore func()) {
 	return func() { timeNow = time.Now }
 }
 
-func (t *Task) addLog(kind, format string, args []interface{}) {
+func (t *Task) addLog(kind, format string, args []any) {
 	if len(t.log) > 9 {
 		copy(t.log, t.log[len(t.log)-9:])
 		t.log = t.log[:9]
@@ -449,27 +449,27 @@ func (t *Task) Log() []string {
 }
 
 // Logf logs information about the progress of the task.
-func (t *Task) Logf(format string, args ...interface{}) {
+func (t *Task) Logf(format string, args ...any) {
 	t.state.writing()
 	t.addLog(LogInfo, format, args)
 }
 
 // Errorf logs error information about the progress of the task.
-func (t *Task) Errorf(format string, args ...interface{}) {
+func (t *Task) Errorf(format string, args ...any) {
 	t.state.writing()
 	t.addLog(LogError, format, args)
 }
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (t *Task) Set(key string, value interface{}) {
+func (t *Task) Set(key string, value any) {
 	t.state.writing()
 	t.data.set(key, value)
 }
 
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
-func (t *Task) Get(key string, value interface{}) error {
+func (t *Task) Get(key string, value any) error {
 	t.state.reading()
 	return t.data.get(key, value)
 }

--- a/overlord/state/warning.go
+++ b/overlord/state/warning.go
@@ -174,7 +174,7 @@ func (s *State) unflattenWarnings(flat []*Warning) {
 // message it'll be added (with its firstAdded and lastAdded set to the
 // current time), otherwise the existing one will have its lastAdded
 // updated.
-func (s *State) Warnf(template string, args ...interface{}) {
+func (s *State) Warnf(template string, args ...any) {
 	var message string
 	if len(args) > 0 {
 		message = fmt.Sprintf(template, args...)

--- a/polkit/validate/validate.go
+++ b/polkit/validate/validate.go
@@ -88,7 +88,7 @@ func ValidatePolicy(r io.Reader) (actionIDs []string, err error) {
 		return nil, err
 	}
 	// check for additional data after the root element
-	if err := decoder.Decode(new(interface{})); err != io.EOF {
+	if err := decoder.Decode(new(any)); err != io.EOF {
 		return nil, fmt.Errorf("invalid XML: additional data after root element")
 	}
 

--- a/sandbox/cgroup/tracking.go
+++ b/sandbox/cgroup/tracking.go
@@ -271,13 +271,13 @@ func startTransientScope(conn *dbus.Conn, unitName string, pid int) (job dbus.Ob
 	// jobMode string  // corresponds to --job-mode= (see systemctl(1) manual page)
 	// properties []struct{
 	//   Name string
-	//   Value interface{}
+	//   Value any
 	// } // properties describe properties of the started unit
 	// auxUnits []struct {
 	//   Name string
 	//   Properties []struct{
 	//   	Name string
-	//   	Value interface{}
+	//   	Value any
 	//	 }
 	// } // auxUnits describe any additional units to define.
 	type property struct {

--- a/sandbox/cgroup/tracking.go
+++ b/sandbox/cgroup/tracking.go
@@ -282,7 +282,7 @@ func startTransientScope(conn *dbus.Conn, unitName string, pid int) (job dbus.Ob
 	// } // auxUnits describe any additional units to define.
 	type property struct {
 		Name  string
-		Value interface{}
+		Value any
 	}
 	type auxUnit struct {
 		Name  string

--- a/sandbox/cgroup/tracking_test.go
+++ b/sandbox/cgroup/tracking_test.go
@@ -577,7 +577,7 @@ func checkAndRespondToStartTransientUnit(c *C, msg *dbus.Message, scopeName stri
 	// XXX: Those types might live in a package somewhere
 	type Property struct {
 		Name  string
-		Value interface{}
+		Value any
 	}
 	type Unit struct {
 		Name  string
@@ -595,13 +595,13 @@ func checkAndRespondToStartTransientUnit(c *C, msg *dbus.Message, scopeName stri
 		dbus.FieldMember:      dbus.MakeVariant("StartTransientUnit"),
 		dbus.FieldSignature:   dbus.MakeVariant(requestSig),
 	})
-	c.Check(msg.Body, DeepEquals, []interface{}{
+	c.Check(msg.Body, DeepEquals, []any{
 		scopeName,
 		"fail",
-		[][]interface{}{
+		[][]any{
 			{"PIDs", dbus.MakeVariant([]uint32{uint32(pid)})},
 		},
-		[][]interface{}{},
+		[][]any{},
 	})
 
 	responseSig := dbus.SignatureOf(dbus.ObjectPath(""))
@@ -614,7 +614,7 @@ func checkAndRespondToStartTransientUnit(c *C, msg *dbus.Message, scopeName stri
 			dbus.FieldSignature: dbus.MakeVariant(responseSig),
 		},
 		// The object path returned in the body is not used by snap run yet.
-		Body: []interface{}{dbus.ObjectPath("/org/freedesktop/systemd1/job/1462")},
+		Body: []any{dbus.ObjectPath("/org/freedesktop/systemd1/job/1462")},
 	}
 }
 
@@ -643,7 +643,7 @@ func mockJobRemovedSignal(unit, result string) *dbus.Message {
 			dbus.FieldSignature: dbus.MakeVariant(
 				dbus.SignatureOf(uint32(0), dbus.ObjectPath(""), "", "")),
 		},
-		Body: []interface{}{
+		Body: []any{
 			uint32(1),
 			dbus.ObjectPath("/org/freedesktop/systemd1/job/1462"),
 			unit,

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1937,7 +1937,7 @@ func makeMockSealedKeyFile(c *C, handle json.RawMessage) string {
 	return mockSealedKeyFile
 }
 
-var fakeModel = assertstest.FakeAssertion(map[string]interface{}{
+var fakeModel = assertstest.FakeAssertion(map[string]any{
 	"type":         "model",
 	"authority-id": "my-brand",
 	"series":       "16",
@@ -1946,14 +1946,14 @@ var fakeModel = assertstest.FakeAssertion(map[string]interface{}{
 	"grade":        "signed",
 	"architecture": "amd64",
 	"base":         "core20",
-	"snaps": []interface{}{
-		map[string]interface{}{
+	"snaps": []any{
+		map[string]any{
 			"name":            "pc-kernel",
 			"id":              "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
 			"type":            "kernel",
 			"default-channel": "20",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"name":            "pc",
 			"id":              "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
 			"type":            "gadget",

--- a/seed/helpers_test.go
+++ b/seed/helpers_test.go
@@ -58,7 +58,7 @@ func (s *helpersSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(s.assertsDir, 0755)
 	c.Assert(err, IsNil)
 
-	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
+	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]any{
 		"account-id": "developerid",
 	}, "")
 

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -65,13 +65,13 @@ func (s *seed16Suite) SetUpTest(c *C) {
 
 	s.TestingSeed16 = &seedtest.TestingSeed16{}
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 
 	s.SeedDir = c.MkDir()
 
-	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
+	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]any{
 		"account-id": "developerid",
 	}, "")
 	assertstest.AddMany(s.StoreSigning, s.devAcct)
@@ -109,7 +109,7 @@ func (s *seed16Suite) TestLoadAssertionsTwoModelAssertionsError(c *C) {
 	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -127,7 +127,7 @@ func (s *seed16Suite) TestLoadAssertionsConsistencyError(c *C) {
 	c.Assert(err, IsNil)
 
 	// write out only the model assertion
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -142,7 +142,7 @@ func (s *seed16Suite) TestLoadAssertionsModelHappy(c *C) {
 	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -171,7 +171,7 @@ func (s *seed16Suite) TestLoadAssertionsModelTempDBHappy(c *C) {
 	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -195,7 +195,7 @@ func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {
 	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -214,7 +214,7 @@ func (s *seed16Suite) TestLoadMetaInvalidSeedYaml(c *C) {
 	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -226,7 +226,7 @@ func (s *seed16Suite) TestLoadMetaInvalidSeedYaml(c *C) {
 	c.Assert(err, IsNil)
 
 	// create a seed.yaml
-	content, err := yaml.Marshal(map[string]interface{}{
+	content, err := yaml.Marshal(map[string]any{
 		"snaps": []*seed.InternalSnap16{{
 			Name:    "core",
 			Channel: "track/not-a-risk",
@@ -351,8 +351,8 @@ var (
 	}
 )
 
-func (s *seed16Suite) makeSeed(c *C, modelHeaders map[string]interface{}, seedSnaps ...*seed.InternalSnap16) []*seed.InternalSnap16 {
-	coreHeaders := map[string]interface{}{
+func (s *seed16Suite) makeSeed(c *C, modelHeaders map[string]any, seedSnaps ...*seed.InternalSnap16) []*seed.InternalSnap16 {
+	coreHeaders := map[string]any{
 		"architecture": "amd64",
 	}
 
@@ -405,7 +405,7 @@ func (s *seed16Suite) makeSeed(c *C, modelHeaders map[string]interface{}, seedSn
 
 func (s *seed16Suite) writeSeed(c *C, seedSnaps []*seed.InternalSnap16) {
 	// create a seed.yaml
-	content, err := yaml.Marshal(map[string]interface{}{
+	content, err := yaml.Marshal(map[string]any{
 		"snaps": seedSnaps,
 	})
 	c.Assert(err, IsNil)
@@ -462,8 +462,8 @@ func (s *seed16Suite) TestLoadMetaCore16Minimal(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaCore16(c *C) {
-	s.makeSeed(c, map[string]interface{}{
-		"required-snaps": []interface{}{"required"},
+	s.makeSeed(c, map[string]any{
+		"required-snaps": []any{"required"},
 	}, coreSeed, kernelSeed, gadgetSeed, requiredSeed)
 
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
@@ -509,7 +509,7 @@ func (s *seed16Suite) TestLoadMetaCore16(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaCore18Minimal(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":   "core18",
 		"kernel": "pc-kernel=18",
 		"gadget": "pc=18",
@@ -564,11 +564,11 @@ func (s *seed16Suite) TestLoadMetaCore18Minimal(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaCore18(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"core", "required", "required18"},
+		"required-snaps": []any{"core", "required", "required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, requiredSeed, coreSeed, required18Seed)
 
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
@@ -638,7 +638,7 @@ func (s *seed16Suite) TestLoadMetaCore18(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaClassicNothing(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"classic": "true",
 	})
 
@@ -659,7 +659,7 @@ func (s *seed16Suite) TestLoadMetaClassicNothing(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaClassicCore(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"classic": "true",
 	}, coreSeed, classicSnapSeed)
 
@@ -699,7 +699,7 @@ func (s *seed16Suite) TestLoadMetaClassicCore(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaClassicCoreWithGadget(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"classic": "true",
 		"gadget":  "classic-gadget",
 	}, coreSeed, classicGadgetSeed)
@@ -739,9 +739,9 @@ func (s *seed16Suite) TestLoadMetaClassicCoreWithGadget(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaClassicSnapd(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"classic":        "true",
-		"required-snaps": []interface{}{"core18", "required18"},
+		"required-snaps": []any{"core18", "required18"},
 	}, snapdSeed, core18Seed, required18Seed)
 
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
@@ -784,7 +784,7 @@ func (s *seed16Suite) TestLoadMetaClassicSnapd(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaClassicSnapdWithGadget(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"classic": "true",
 		"gadget":  "classic-gadget",
 	}, snapdSeed, classicGadgetSeed, coreSeed)
@@ -833,10 +833,10 @@ func (s *seed16Suite) TestLoadMetaClassicSnapdWithGadget(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaClassicSnapdWithGadget18(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"classic":        "true",
 		"gadget":         "classic-gadget18",
-		"required-snaps": []interface{}{"core", "required"},
+		"required-snaps": []any{"core", "required"},
 	}, snapdSeed, coreSeed, requiredSeed, classicGadget18Seed, core18Seed)
 
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
@@ -901,11 +901,11 @@ func (s *seed16Suite) TestLoadMetaCore18Local(c *C) {
 		Unasserted: true,
 		DevMode:    true,
 	}
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"core", "required18"},
+		"required-snaps": []any{"core", "required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, localRequired18Seed)
 
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
@@ -969,11 +969,11 @@ func (s *seed16Suite) TestLoadMetaCore18SnapHandler(c *C) {
 		Unasserted: true,
 		DevMode:    true,
 	}
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"core", "required18"},
+		"required-snaps": []any{"core", "required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, localRequired18Seed)
 
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
@@ -1049,11 +1049,11 @@ func (s *seed16Suite) TestLoadMetaCore18SnapHandlerChangePath(c *C) {
 		Unasserted: true,
 		DevMode:    true,
 	}
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"core", "required18"},
+		"required-snaps": []any{"core", "required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, localRequired18Seed)
 
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
@@ -1125,7 +1125,7 @@ func (s *seed16Suite) TestLoadMetaCore18SnapHandlerChangePath(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaCore18StoreInfo(c *C) {
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":   "core18",
 		"kernel": "pc-kernel=18",
 		"gadget": "pc=18",
@@ -1164,7 +1164,7 @@ func (s *seed16Suite) TestLoadMetaCore18StoreInfo(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaCore18EnforcePinnedTracks(c *C) {
-	seedSnaps := s.makeSeed(c, map[string]interface{}{
+	seedSnaps := s.makeSeed(c, map[string]any{
 		"base":   "core18",
 		"kernel": "pc-kernel=18",
 		"gadget": "pc=18",
@@ -1230,11 +1230,11 @@ func (s *seed16Suite) TestLoadMetaCore18EnforcePinnedTracks(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaBrokenSeed(c *C) {
-	seedSnap16s := s.makeSeed(c, map[string]interface{}{
+	seedSnap16s := s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"required18"},
+		"required-snaps": []any{"required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, required18Seed)
 
 	otherSnapFile := snaptest.MakeTestSnapWithFiles(c, `name: other
@@ -1313,11 +1313,11 @@ func (s *seed16Suite) TestLoadEssentialMetaCore18(c *C) {
 	r := seed.MockTrusted(s.StoreSigning.Trusted)
 	defer r()
 
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"core", "required", "required18"},
+		"required-snaps": []any{"core", "required", "required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, requiredSeed, coreSeed, required18Seed)
 
 	snapdSnap := &seed.Snap{
@@ -1418,11 +1418,11 @@ func (s *seed16Suite) TestLoadEssentialMetaWithSnapHandlerCore18(c *C) {
 	r := seed.MockTrusted(s.StoreSigning.Trusted)
 	defer r()
 
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"core", "required", "required18"},
+		"required-snaps": []any{"core", "required", "required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, requiredSeed, coreSeed, required18Seed)
 
 	snapdSnap := &seed.Snap{
@@ -1489,11 +1489,11 @@ func (s *seed16Suite) TestLoadEssentialAndMetaCore18(c *C) {
 	r := seed.MockTrusted(s.StoreSigning.Trusted)
 	defer r()
 
-	s.makeSeed(c, map[string]interface{}{
+	s.makeSeed(c, map[string]any{
 		"base":           "core18",
 		"kernel":         "pc-kernel=18",
 		"gadget":         "pc=18",
-		"required-snaps": []interface{}{"core", "required", "required18"},
+		"required-snaps": []any{"core", "required", "required18"},
 	}, snapdSeed, core18Seed, kernel18Seed, gadget18Seed, requiredSeed, coreSeed, required18Seed)
 
 	snapdSnap := &seed.Snap{

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -123,13 +123,13 @@ func (s *seed20Suite) SetUpTest(c *C) {
 
 	s.TestingSeed20 = &seedtest.TestingSeed20{}
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 	s.Brands.Register("other-brand", otherbrandPrivKey, nil)
 	// needed by TestingSeed20.MakeSeed (to work with makeSnap)
 
-	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
+	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]any{
 		"account-id": "developerid",
 	}, "")
 	assertstest.AddMany(s.StoreSigning, s.devAcct)
@@ -168,18 +168,18 @@ func (s *seed20Suite) TestLoadMetaCore20Minimal(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20191018"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -256,18 +256,18 @@ func (s *seed20Suite) makeCore20MinimalSeed(c *C, sysLabel string) string {
 	s.makeSnap(c, "pc-kernel=20", "")
 	s.makeSnap(c, "pc=20", "")
 
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -372,7 +372,7 @@ func (s *seed20Suite) TestLoadAssertionsMultiSnapRev(c *C) {
 	sysLabel := "20191031"
 	sysDir := s.makeCore20MinimalSeed(c, sysLabel)
 
-	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": strings.Repeat("B", 64),
 		"snap-size":     "1000",
 		"snap-id":       s.AssertedSnapID("core20"),
@@ -399,7 +399,7 @@ func (s *seed20Suite) TestLoadAssertionsMultiSnapDecl(c *C) {
 	sysLabel := "20191031"
 	sysDir := s.makeCore20MinimalSeed(c, sysLabel)
 
-	spuriousDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	spuriousDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "idididididididididididididididid",
 		"publisher-id": "canonical",
@@ -408,7 +408,7 @@ func (s *seed20Suite) TestLoadAssertionsMultiSnapDecl(c *C) {
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": strings.Repeat("B", 64),
 		"snap-size":     "1000",
 		"snap-id":       s.AssertedSnapID("core20"),
@@ -442,25 +442,25 @@ func (s *seed20Suite) TestLoadMetaMissingSnapDeclByName(c *C) {
 	s.makeSnap(c, "pc-kernel=20", "")
 	s.makeSnap(c, "pc=20", "")
 
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core20",
 				// no id
 				"type": "base",
@@ -469,7 +469,7 @@ func (s *seed20Suite) TestLoadMetaMissingSnapDeclByName(c *C) {
 
 	sysDir := filepath.Join(s.SeedDir, "systems", sysLabel)
 
-	wrongDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	wrongDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "idididididididididididididididid",
 		"publisher-id": "canonical",
@@ -478,7 +478,7 @@ func (s *seed20Suite) TestLoadMetaMissingSnapDeclByName(c *C) {
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": strings.Repeat("B", 64),
 		"snap-size":     "1000",
 		"snap-id":       "idididididididididididididididid",
@@ -512,7 +512,7 @@ func (s *seed20Suite) TestLoadMetaMissingSnapDeclByID(c *C) {
 	sysLabel := "20191031"
 	sysDir := s.makeCore20MinimalSeed(c, sysLabel)
 
-	wrongDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	wrongDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "idididididididididididididididid",
 		"publisher-id": "canonical",
@@ -521,7 +521,7 @@ func (s *seed20Suite) TestLoadMetaMissingSnapDeclByID(c *C) {
 	}, nil, "")
 	c.Assert(err, IsNil)
 
-	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": strings.Repeat("B", 64),
 		"snap-size":     "1000",
 		"snap-id":       "idididididididididididididididid",
@@ -590,7 +590,7 @@ func (s *seed20Suite) TestLoadMetaWrongHashSnap(c *C) {
 	sysDir := s.makeCore20MinimalSeed(c, sysLabel)
 
 	pcRev := s.AssertedSnapRevision("pc")
-	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": strings.Repeat("B", 64),
 		"snap-size":     pcRev.HeaderString("snap-size"),
 		"snap-id":       s.AssertedSnapID("pc"),
@@ -663,24 +663,24 @@ func (s *seed20Suite) TestLoadMetaCore20(c *C) {
 	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20191018"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -759,35 +759,35 @@ func (s *seed20Suite) TestLoadMetaCore20DelegatedSnap(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
-	ra := map[string]interface{}{
+	ra := map[string]any{
 		"account-id": "my-brand",
-		"provenance": []interface{}{"delegated-prov"},
-		"on-store":   []interface{}{"my-brand-store"},
+		"provenance": []any{"delegated-prov"},
+		"on-store":   []any{"my-brand-store"},
 	}
 	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
 	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20220705"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-brand-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -864,33 +864,33 @@ func (s *seed20Suite) TestLoadMetaCore20DelegatedSnapProvenanceMismatch(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
-	ra := map[string]interface{}{
+	ra := map[string]any{
 		"account-id": "my-brand",
-		"provenance": []interface{}{"delegated-prov"},
-		"on-store":   []interface{}{"my-brand-store"},
+		"provenance": []any{"delegated-prov"},
+		"on-store":   []any{"my-brand-store"},
 	}
 	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov-other\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
 	sysLabel := "20220705"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-brand-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -913,33 +913,33 @@ func (s *seed20Suite) TestLoadMetaCore20DelegatedSnapDeviceMismatch(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
-	ra := map[string]interface{}{
+	ra := map[string]any{
 		"account-id": "my-brand",
-		"provenance": []interface{}{"delegated-prov"},
-		"on-model":   []interface{}{"my-brand/my-other-model"},
+		"provenance": []any{"delegated-prov"},
+		"on-model":   []any{"my-brand/my-other-model"},
 	}
 	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", "delegated-prov", ra, s.StoreSigning.Database)
 
 	sysLabel := "20220705"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-brand-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -990,29 +990,29 @@ func (s *seed20Suite) TestLoadEssentialMetaCore20(c *C) {
 	s.makeSnap(c, "required18", "developerid")
 
 	sysLabel := "20191018"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.AssertedSnapID("core18"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required18",
 				"id":   s.AssertedSnapID("required18"),
 			}},
@@ -1130,29 +1130,29 @@ func (s *seed20Suite) TestLoadEssentialMetaWithSnapHandlerCore20(c *C) {
 	s.makeSnap(c, "required18", "developerid")
 
 	sysLabel := "20191018"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.AssertedSnapID("core18"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required18",
 				"id":   s.AssertedSnapID("required18"),
 			}},
@@ -1234,30 +1234,30 @@ func (s *seed20Suite) TestReadSystemEssentialAndBetterEarliestTime(c *C) {
 	baseLabel := "20210315"
 
 	testReadSystemEssentialAndBetterEarliestTime := func(sysLabel string, earliestTime, modelTime, improvedTime time.Time) {
-		s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 			"display-name": "my model",
 			"timestamp":    modelTime.Format(time.RFC3339),
 			"architecture": "amd64",
 			"base":         "core20",
-			"snaps": []interface{}{
-				map[string]interface{}{
+			"snaps": []any{
+				map[string]any{
 					"name":            "pc-kernel",
 					"id":              s.AssertedSnapID("pc-kernel"),
 					"type":            "kernel",
 					"default-channel": "20",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":            "pc",
 					"id":              s.AssertedSnapID("pc"),
 					"type":            "gadget",
 					"default-channel": "20",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name": "core18",
 					"id":   s.AssertedSnapID("core18"),
 					"type": "base",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name": "required18",
 					"id":   s.AssertedSnapID("required18"),
 				}},
@@ -1308,19 +1308,19 @@ func (s *seed20Suite) TestReadSystemEssentialAndBetterEarliestTimeParallelism(c 
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20191018"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"timestamp":    time.Now().Format(time.RFC3339),
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -1346,29 +1346,29 @@ func (s *seed20Suite) TestLoadEssentialAndMetaCore20(c *C) {
 	s.makeSnap(c, "required18", "developerid")
 
 	sysLabel := "20191018"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.AssertedSnapID("core18"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required18",
 				"id":   s.AssertedSnapID("required18"),
 			}},
@@ -1472,25 +1472,25 @@ func (s *seed20Suite) TestLoadMetaCore20LocalSnaps(c *C) {
 	requiredFn := s.makeLocalSnap(c, "required20")
 
 	sysLabel := "20191030"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -1565,25 +1565,25 @@ func (s *seed20Suite) TestLoadMetaCore20SnapHandler(c *C) {
 	requiredFn := s.makeLocalSnap(c, "required20")
 
 	sysLabel := "20191030"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -1670,25 +1670,25 @@ func (s *seed20Suite) TestLoadMetaCore20SnapHandlerChangePath(c *C) {
 	requiredFn := s.makeLocalSnap(c, "required20")
 
 	sysLabel := "20191030"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -1778,25 +1778,25 @@ func (s *seed20Suite) TestLoadMetaCore20ChannelOverride(c *C) {
 	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20191018"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -1873,25 +1873,25 @@ func (s *seed20Suite) TestLoadMetaCore20ChannelOverrideSnapd(c *C) {
 	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20191121"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -1965,19 +1965,19 @@ func (s *seed20Suite) TestLoadMetaCore20LocalSnapd(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20191121"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2044,24 +2044,24 @@ func (s *seed20Suite) TestLoadMetaCore20ModelOverrideSnapd(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20191121"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "snapd",
 				"type":            "snapd",
 				"default-channel": "latest/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2129,30 +2129,30 @@ func (s *seed20Suite) TestLoadMetaCore20OptionalSnaps(c *C) {
 	s.makeSnap(c, "optional20-b", "developerid")
 
 	sysLabel := "20191122"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "signed",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-b",
 				"id":       s.AssertedSnapID("optional20-b"),
 				"presence": "optional",
@@ -2229,30 +2229,30 @@ func (s *seed20Suite) TestLoadMetaCore20OptionalSnapsLocal(c *C) {
 	optional20bFn := s.makeLocalSnap(c, "optional20-b")
 
 	sysLabel := "20191122"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-b",
 				"id":       s.AssertedSnapID("optional20-b"),
 				"presence": "optional",
@@ -2330,19 +2330,19 @@ func (s *seed20Suite) TestLoadMetaCore20ExtraSnaps(c *C) {
 	contConsumerFn := s.makeLocalSnap(c, "cont-consumer")
 
 	sysLabel := "20191122"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2437,40 +2437,40 @@ func (s *seed20Suite) TestLoadMetaCore20NotRunSnaps(c *C) {
 	s.makeSnap(c, "optional20-b", "developerid")
 
 	sysLabel := "20191122"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "signed",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "required20",
 				"id":    s.AssertedSnapID("required20"),
-				"modes": []interface{}{"run", "ephemeral"},
+				"modes": []any{"run", "ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "optional",
-				"modes":    []interface{}{"ephemeral"},
+				"modes":    []any{"ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-b",
 				"id":       s.AssertedSnapID("optional20-b"),
 				"presence": "optional",
-				"modes":    []interface{}{"install"},
+				"modes":    []any{"install"},
 			}},
 	}, []*seedwriter.OptionsSnap{
 		{Name: "optional20-a"},
@@ -2632,40 +2632,40 @@ func (s *seed20Suite) testLoadMetaCore20PreciseNotRunSnapsWithParallelism(c *C, 
 	s.makeSnap(c, "optional20-b", "developerid")
 
 	sysLabel := "20191122"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "signed",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "required20",
 				"id":    s.AssertedSnapID("required20"),
-				"modes": []interface{}{"run", "ephemeral"},
+				"modes": []any{"run", "ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "optional",
-				"modes":    []interface{}{"ephemeral"},
+				"modes":    []any{"ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-b",
 				"id":       s.AssertedSnapID("optional20-b"),
 				"presence": "optional",
-				"modes":    []interface{}{"install"},
+				"modes":    []any{"install"},
 			}},
 	}, []*seedwriter.OptionsSnap{
 		{Name: "optional20-a"},
@@ -2841,19 +2841,19 @@ func (s *seed20Suite) TestLoadMetaCore20LocalAssertedSnaps(c *C) {
 	s.makeSnap(c, "required20", "developerid")
 
 	sysLabel := "20191209"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2947,25 +2947,25 @@ func (s *seed20Suite) TestLoadMetaCore20Iter(c *C) {
 	s.makeSnap(c, "required20", "developerid")
 
 	sysLabel := "20191209"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			},
@@ -3013,7 +3013,7 @@ func (s *seed20Suite) TestLoadMetaWrongHashSnapParallelism2(c *C) {
 	sysDir := s.makeCore20MinimalSeed(c, sysLabel)
 
 	pcKernelRev := s.AssertedSnapRevision("pc-kernel")
-	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]any{
 		"snap-sha3-384": strings.Repeat("B", 64),
 		"snap-size":     pcKernelRev.HeaderString("snap-size"),
 		"snap-id":       s.AssertedSnapID("pc-kernel"),
@@ -3141,20 +3141,20 @@ func (s *seed20Suite) createMinimalSeed(c *C, grade string, sysLabel string) see
 	s.makeSnap(c, "pc-kernel=20", "")
 	s.makeSnap(c, "pc=20", "")
 
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name":          "my model",
 		"architecture":          "amd64",
 		"base":                  "core20",
 		"grade":                 grade,
-		"system-user-authority": []interface{}{"my-brand", "other-brand"},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"system-user-authority": []any{"my-brand", "other-brand"},
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3197,18 +3197,18 @@ func (s *seed20Suite) TestPreseedCapableSeed(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20230406"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3223,13 +3223,13 @@ func (s *seed20Suite) TestPreseedCapableSeed(c *C) {
 	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)
 	c.Assert(err, IsNil)
 
-	snaps := []interface{}{
-		map[string]interface{}{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
-		map[string]interface{}{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
-		map[string]interface{}{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
-		map[string]interface{}{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
+	snaps := []any{
+		map[string]any{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
+		map[string]any{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
+		map[string]any{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
+		map[string]any{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
 	}
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":              "preseed",
 		"series":            "16",
 		"brand-id":          "my-brand",
@@ -3274,18 +3274,18 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20230406"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3300,18 +3300,18 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)
 	c.Assert(err, IsNil)
 
-	snaps := []interface{}{
-		map[string]interface{}{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
-		map[string]interface{}{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
-		map[string]interface{}{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
-		map[string]interface{}{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
+	snaps := []any{
+		map[string]any{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
+		map[string]any{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
+		map[string]any{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
+		map[string]any{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
 	}
 
 	tests := []struct {
 		omitPreseedAssert bool
 		dupPreseedAssert  bool
 
-		overrides map[string]interface{}
+		overrides map[string]any
 		asserts   []asserts.Assertion
 		err       string
 	}{
@@ -3319,15 +3319,15 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 		// this works for contrast
 		{asserts: s.Brands.AccountsAndKeys("my-brand"), err: ""},
 		{dupPreseedAssert: true, err: `system preseed assertion file cannot contain multiple preseed assertions`},
-		{overrides: map[string]interface{}{"system-label": "other-label"}, err: `preseed assertion system label "other-label" doesn't match system label "20230406"`},
-		{overrides: map[string]interface{}{"model": "other-model"}, err: `preseed assertion model "other-model" doesn't match the model "my-model"`},
-		{overrides: map[string]interface{}{"series": "other-series"}, err: `preseed assertion series "other-series" doesn't match model series "16"`},
-		{overrides: map[string]interface{}{"authority-id": "other-brand"}, asserts: s.Brands.AccountsAndKeys("other-brand"), err: `preseed authority-id "other-brand" is not allowed by the model`},
-		{overrides: map[string]interface{}{"brand-id": "other-brand", "authority-id": "other-brand"}, err: `cannot resolve prerequisite assertion:.*`},
+		{overrides: map[string]any{"system-label": "other-label"}, err: `preseed assertion system label "other-label" doesn't match system label "20230406"`},
+		{overrides: map[string]any{"model": "other-model"}, err: `preseed assertion model "other-model" doesn't match the model "my-model"`},
+		{overrides: map[string]any{"series": "other-series"}, err: `preseed assertion series "other-series" doesn't match model series "16"`},
+		{overrides: map[string]any{"authority-id": "other-brand"}, asserts: s.Brands.AccountsAndKeys("other-brand"), err: `preseed authority-id "other-brand" is not allowed by the model`},
+		{overrides: map[string]any{"brand-id": "other-brand", "authority-id": "other-brand"}, err: `cannot resolve prerequisite assertion:.*`},
 	}
 
 	for _, tc := range tests {
-		headers := map[string]interface{}{
+		headers := map[string]any{
 			"type":              "preseed",
 			"series":            "16",
 			"brand-id":          "my-brand",
@@ -3382,18 +3382,18 @@ func (s *seed20Suite) TestPreseedCapableSeedNoPreseedAssertion(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20230406"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3429,22 +3429,22 @@ func (s *seed20Suite) TestPreseedCapableSeedAlternateAuthority(c *C) {
 	s.makeSnap(c, "pc=20", "")
 
 	sysLabel := "20230406"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"preseed-authority": []interface{}{
+		"preseed-authority": []any{
 			"my-brand",
 			"my-signer",
 		},
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3459,17 +3459,17 @@ func (s *seed20Suite) TestPreseedCapableSeedAlternateAuthority(c *C) {
 	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)
 	c.Assert(err, IsNil)
 
-	snaps := []interface{}{
-		map[string]interface{}{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
-		map[string]interface{}{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
-		map[string]interface{}{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
-		map[string]interface{}{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
+	snaps := []any{
+		map[string]any{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
+		map[string]any{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
+		map[string]any{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
+		map[string]any{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
 	}
 
 	signerKey, _ := assertstest.GenerateKey(752)
 	s.Brands.Register("my-signer", signerKey, nil)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":              "preseed",
 		"series":            "16",
 		"brand-id":          "my-brand",
@@ -3725,44 +3725,44 @@ func (s *seed20Suite) testCopy(c *C, opts testCopyOpts) {
 	)
 
 	const srcLabel = "20191030"
-	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "required20",
 				"id":       s.AssertedSnapID("required20"),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "aux-info-test",
 				"id":       s.AssertedSnapID("aux-info-test"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "component-test",
 				"id":       s.AssertedSnapID("component-test"),
 				"presence": "optional",
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 					"comp2": "optional",
 				},
@@ -3986,39 +3986,39 @@ func (s *seed20Suite) TestOptionalContainers(c *C) {
 	)
 
 	const srcLabel = "20191030"
-	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-b",
 				"id":       s.AssertedSnapID("optional20-b"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "component-test",
 				"id":       s.AssertedSnapID("component-test"),
 				"presence": "optional",
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 					"comp2": "optional",
 					"comp3": "optional",
@@ -4084,34 +4084,34 @@ func (s *seed20Suite) TestOptionalContainersAllRequired(c *C) {
 	)
 
 	const srcLabel = "20191030"
-	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "required20",
 				"id":       s.AssertedSnapID("required20"),
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "component-test",
 				"id":       s.AssertedSnapID("component-test"),
 				"presence": "required",
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 					"comp2": "required",
 					"comp3": "required",
@@ -4143,25 +4143,25 @@ func (s *seed20Suite) TestCopyCleanup(c *C) {
 	requiredFn := s.makeLocalSnap(c, "required20")
 
 	const label = "20191030"
-	s.MakeSeed(c, label, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, label, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			}},
@@ -4227,48 +4227,48 @@ func (s *seed20Suite) TestModeSnaps(c *C) {
 	)
 
 	const srcLabel = "20191030"
-	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "required",
-				"modes":    []interface{}{"ephemeral"},
+				"modes":    []any{"ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "required20",
 				"id":       s.AssertedSnapID("required20"),
 				"presence": "required",
-				"modes":    []interface{}{"run"},
+				"modes":    []any{"run"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "component-test",
 				"id":       s.AssertedSnapID("component-test"),
 				"presence": "required",
-				"modes":    []interface{}{"run", "ephemeral"},
-				"components": map[string]interface{}{
-					"comp1": map[string]interface{}{
-						"modes":    []interface{}{"run"},
+				"modes":    []any{"run", "ephemeral"},
+				"components": map[string]any{
+					"comp1": map[string]any{
+						"modes":    []any{"run"},
 						"presence": "required",
 					},
-					"comp2": map[string]interface{}{
-						"modes":    []interface{}{"run", "ephemeral"},
+					"comp2": map[string]any{
+						"modes":    []any{"run", "ephemeral"},
 						"presence": "required",
 					},
 				},
@@ -4422,9 +4422,9 @@ func (s *seed20Suite) makeCore20SeedWithComps(c *C, sysLabel string, opts seedOp
 		"comp2": snap.R(33),
 	}
 	if opts.delegated {
-		ra := map[string]interface{}{
+		ra := map[string]any{
 			"account-id": "my-brand",
-			"provenance": []interface{}{"delegated-prov", "other-prov"},
+			"provenance": []any{"delegated-prov", "other-prov"},
 		}
 
 		resourceProv := "delegated-prov"
@@ -4441,28 +4441,28 @@ func (s *seed20Suite) makeCore20SeedWithComps(c *C, sysLabel string, opts seedOp
 			snap.R(11), compRevs, "canonical", s.StoreSigning.Database)
 	}
 
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 				"type": "app",
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 					"comp2": "required",
 				},
@@ -4633,7 +4633,7 @@ func (s *seed20Suite) TestLoadMetaWithComponentsBadSize(c *C) {
 
 	finfo, err := os.Stat(filepath.Join(s.SeedDir, "snaps", "required20+comp1_22.comp"))
 	c.Assert(err, IsNil)
-	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp1",
@@ -4672,7 +4672,7 @@ func (s *seed20Suite) TestLoadMetaWithComponentsBadHash(c *C) {
 
 	finfo, err := os.Stat(filepath.Join(s.SeedDir, "snaps", "required20+comp1_22.comp"))
 	c.Assert(err, IsNil)
-	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp1",
@@ -4716,7 +4716,7 @@ func (s *seed20Suite) TestLoadMetaWithComponentsUnmatchedProvenanceInResRev(c *C
 	snapSHA3_384_1, size1, err := asserts.SnapFileSHA3_384(
 		filepath.Join(s.SeedDir, "snaps", "required20+comp1_22.comp"))
 	c.Assert(err, IsNil)
-	resRev1, err := myBrandSigner.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev1, err := myBrandSigner.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"authority-id":      "my-brand",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp1",
@@ -4732,7 +4732,7 @@ func (s *seed20Suite) TestLoadMetaWithComponentsUnmatchedProvenanceInResRev(c *C
 	snapSHA3_384_2, size2, err := asserts.SnapFileSHA3_384(
 		filepath.Join(s.SeedDir, "snaps", "required20+comp2_33.comp"))
 	c.Assert(err, IsNil)
-	resRev2, err := myBrandSigner.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev2, err := myBrandSigner.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"authority-id":      "my-brand",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp2",
@@ -4776,7 +4776,7 @@ func (s *seed20Suite) TestLoadMetaWithComponentsUnmatchedProvenanceInResPair(c *
 	sysDir := s.makeCore20SeedWithComps(c, sysLabel, seedOpts{delegated: true})
 
 	myBrandSigner := s.Brands.Signing("my-brand")
-	pairRev1, err := myBrandSigner.Sign(asserts.SnapResourcePairType, map[string]interface{}{
+	pairRev1, err := myBrandSigner.Sign(asserts.SnapResourcePairType, map[string]any{
 		"authority-id":      "my-brand",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp1",
@@ -4787,7 +4787,7 @@ func (s *seed20Suite) TestLoadMetaWithComponentsUnmatchedProvenanceInResPair(c *
 		"timestamp":         time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	pairRev2, err := myBrandSigner.Sign(asserts.SnapResourcePairType, map[string]interface{}{
+	pairRev2, err := myBrandSigner.Sign(asserts.SnapResourcePairType, map[string]any{
 		"authority-id":      "my-brand",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp2",
@@ -4864,7 +4864,7 @@ func (s *seed20Suite) TestLoadAssertionsNoMatchingPair(c *C) {
 	sysLabel := "20241031"
 	sysDir := s.makeCore20SeedWithComps(c, sysLabel, seedOpts{delegated: false})
 
-	pairRev, err := s.StoreSigning.Sign(asserts.SnapResourcePairType, map[string]interface{}{
+	pairRev, err := s.StoreSigning.Sign(asserts.SnapResourcePairType, map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp1",
@@ -4895,7 +4895,7 @@ func (s *seed20Suite) TestLoadAssertionsMultipleResRevForComp(c *C) {
 	sysLabel := "20241031"
 	sysDir := s.makeCore20SeedWithComps(c, sysLabel, seedOpts{delegated: false})
 
-	resRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	resRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp1",
@@ -4907,7 +4907,7 @@ func (s *seed20Suite) TestLoadAssertionsMultipleResRevForComp(c *C) {
 		"timestamp":         time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	pairRev, err := s.StoreSigning.Sign(asserts.SnapResourcePairType, map[string]interface{}{
+	pairRev, err := s.StoreSigning.Sign(asserts.SnapResourcePairType, map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           s.AssertedSnapID("required20"),
 		"resource-name":     "comp1",
@@ -4938,7 +4938,7 @@ func (s *seed20Suite) TestLoadAssertionsNoMatchingResRevForResPair(c *C) {
 	sysLabel := "20241031"
 	sysDir := s.makeCore20SeedWithComps(c, sysLabel, seedOpts{delegated: false})
 
-	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]interface{}{
+	spuriousRev, err := s.StoreSigning.Sign(asserts.SnapResourceRevisionType, map[string]any{
 		"authority-id":      "canonical",
 		"snap-id":           s.AssertedSnapID("core20"),
 		"resource-name":     "comp1",
@@ -4977,29 +4977,29 @@ func (s *seed20Suite) TestLoadMetaWithLocalComponents(c *C) {
 	localComp2Path := snaptest.MakeTestComponent(c, seedtest.SampleSnapYaml["required20+comp2"])
 
 	sysLabel := "20240805"
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 				"type": "app",
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 					"comp2": "required",
 				},
@@ -5114,19 +5114,19 @@ func (s *seed20Suite) TestLoadMetaCore20ExtraSnapsWithComps(c *C) {
 		snap.R(11), comRevs, "canonical", s.StoreSigning.Database)
 
 	sysLabel := "20251122"
-	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -5230,29 +5230,29 @@ func (s *seed20Suite) TestSeedWithComponentsInModelAndOptions(c *C) {
 	)
 
 	const srcLabel = "20191030"
-	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]interface{}{
+	s.MakeSeedWithLocalComponents(c, srcLabel, "my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "component-test",
 				"id":       s.AssertedSnapID("component-test"),
 				"presence": "required",
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 					"comp2": "required",
 				},

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -61,7 +61,7 @@ type SeedSnaps struct {
 	// TamperWithResourceRevisions can be set to modify resource revision
 	// assertions before they get committed to the database. Mostly useful for
 	// forcing some consistency check errors.
-	TamperWithResourceRevisions func(headers map[string]interface{})
+	TamperWithResourceRevisions func(headers map[string]any)
 }
 
 // SetupAssertSigning initializes StoreSigning for storeBrandID and Brands.
@@ -104,7 +104,7 @@ func (ss *SeedSnaps) MakeAssertedDelegatedSnapWithComps(
 	revision snap.Revision,
 	compRevisions map[string]snap.Revision,
 	developerID, delegateID, revProvenance, resourceRevProvenance string,
-	revisionAuthority map[string]interface{},
+	revisionAuthority map[string]any,
 	dbs ...*asserts.Database,
 ) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
 	return ss.makeAssertedSnap(c, snapYaml, files, revision, compRevisions, developerID, ss.Brands.Signing(delegateID), revProvenance, resourceRevProvenance, revisionAuthority, dbs...)
@@ -120,7 +120,7 @@ func (ss *SeedSnaps) makeAssertedSnap(
 	revSigning *assertstest.SigningDB,
 	revProvenance string,
 	componentProvenance string,
-	revisionAuthority map[string]interface{},
+	revisionAuthority map[string]any,
 	dbs ...*asserts.Database,
 ) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
 	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
@@ -130,7 +130,7 @@ func (ss *SeedSnaps) makeAssertedSnap(
 	snapFile := snaptest.MakeTestSnapWithFiles(c, snapYaml, files)
 
 	snapID := ss.AssertedSnapID(snapName)
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"series":       "16",
 		"snap-id":      snapID,
 		"publisher-id": developerID,
@@ -138,7 +138,7 @@ func (ss *SeedSnaps) makeAssertedSnap(
 		"timestamp":    ss.snapAssertionNow().UTC().Format(time.RFC3339),
 	}
 	if revisionAuthority != nil {
-		headers["revision-authority"] = []interface{}{revisionAuthority}
+		headers["revision-authority"] = []any{revisionAuthority}
 	}
 	declA, err := ss.StoreSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
@@ -146,7 +146,7 @@ func (ss *SeedSnaps) makeAssertedSnap(
 	sha3_384, size, err := asserts.SnapFileSHA3_384(snapFile)
 	c.Assert(err, IsNil)
 
-	revHeaders := map[string]interface{}{
+	revHeaders := map[string]any{
 		"authority-id":  revSigning.AuthorityID,
 		"snap-sha3-384": sha3_384,
 		"snap-size":     fmt.Sprintf("%d", size),
@@ -219,7 +219,7 @@ func (ss *SeedSnaps) makeAssertedSnap(
 
 		// Now add the resource revision assertion
 		compRev := compRevisions[comp.Name]
-		resRevHeads := map[string]interface{}{
+		resRevHeads := map[string]any{
 			"authority-id":      revSigning.AuthorityID,
 			"snap-id":           snapID,
 			"resource-name":     comp.Name,
@@ -242,7 +242,7 @@ func (ss *SeedSnaps) makeAssertedSnap(
 		resRevs = append(resRevs, resRev.(*asserts.SnapResourceRevision))
 
 		// and the resource pair revision
-		resPairHeads := map[string]interface{}{
+		resPairHeads := map[string]any{
 			"authority-id":      revSigning.AuthorityID,
 			"snap-id":           snapID,
 			"resource-name":     comp.Name,
@@ -294,7 +294,7 @@ func (ss *SeedSnaps) MakeAssertedDelegatedSnap(
 	files [][]string,
 	revision snap.Revision,
 	developerID, delegateID, revProvenance, resourceProvenance string,
-	revisionAuthority map[string]interface{},
+	revisionAuthority map[string]any,
 	dbs ...*asserts.Database,
 ) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
 	return ss.makeAssertedSnap(c, snapYaml, files, revision, nil, developerID, ss.Brands.Signing(delegateID), revProvenance, resourceProvenance, revisionAuthority, dbs...)
@@ -356,7 +356,7 @@ func (s *TestingSeed16) MakeAssertedSnap(c *C, snapYaml string, files [][]string
 	return snapFname, decl, rev
 }
 
-func (s *TestingSeed16) MakeModelAssertionChain(brandID, model string, extras ...map[string]interface{}) []asserts.Assertion {
+func (s *TestingSeed16) MakeModelAssertionChain(brandID, model string, extras ...map[string]any) []asserts.Assertion {
 	assertChain := []asserts.Assertion{}
 	modelA := s.Brands.Model(brandID, model, extras...)
 
@@ -415,7 +415,7 @@ type TestingSeed20 struct {
 }
 
 // MakeSeed creates the seed with given label and generates model assertions
-func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHeaders map[string]interface{}, optSnaps []*seedwriter.OptionsSnap) *asserts.Model {
+func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHeaders map[string]any, optSnaps []*seedwriter.OptionsSnap) *asserts.Model {
 	model := s.Brands.Model(brandID, modelID, modelHeaders)
 
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys(brandID)...)
@@ -424,7 +424,7 @@ func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHead
 	return model
 }
 
-func (s *TestingSeed20) MakeSeedWithLocalComponents(c *C, label, brandID, modelID string, modelHeaders map[string]interface{}, optSnaps []*seedwriter.OptionsSnap, compPathsBySnap map[string][]string) *asserts.Model {
+func (s *TestingSeed20) MakeSeedWithLocalComponents(c *C, label, brandID, modelID string, modelHeaders map[string]any, optSnaps []*seedwriter.OptionsSnap, compPathsBySnap map[string][]string) *asserts.Model {
 	model := s.Brands.Model(brandID, modelID, modelHeaders)
 
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys(brandID)...)
@@ -661,12 +661,12 @@ func ValidateSeed(c *C, root, label string, usesSnapd bool, trusted []asserts.As
 	return sd
 }
 
-var goodUser = map[string]interface{}{
+var goodUser = map[string]any{
 	"authority-id": "my-brand",
 	"brand-id":     "my-brand",
 	"email":        "foo@bar.com",
-	"series":       []interface{}{"16", "18"},
-	"models":       []interface{}{"my-model", "other-model"},
+	"series":       []any{"16", "18"},
+	"models":       []any{"my-model", "other-model"},
 	"name":         "Boring Guy",
 	"username":     "guy",
 	"password":     "$6$salt$hash",
@@ -675,7 +675,7 @@ var goodUser = map[string]interface{}{
 }
 
 func WriteValidAutoImportAssertion(c *C, brands *assertstest.SigningAccounts, seedDir, sysLabel string, perm os.FileMode) {
-	systemUsers := []map[string]interface{}{goodUser}
+	systemUsers := []map[string]any{goodUser}
 	// write system user assertion to the system seed root
 	autoImportAssert := filepath.Join(seedDir, "systems", sysLabel, "auto-import.assert")
 	f, err := os.OpenFile(autoImportAssert, os.O_CREATE|os.O_WRONLY, perm)

--- a/seed/seedwriter/fetcher_test.go
+++ b/seed/seedwriter/fetcher_test.go
@@ -43,7 +43,7 @@ func (s *fetcherSuite) SetUpTest(c *C) {
 }
 
 func (s *fetcherSuite) setupTestAssertion(c *C) asserts.Assertion {
-	modelAs, err := s.storeSigning.Sign(asserts.ModelType, map[string]interface{}{
+	modelAs, err := s.storeSigning.Sign(asserts.ModelType, map[string]any{
 		"series":       "16",
 		"brand-id":     "can0nical",
 		"model":        "my-model-2",

--- a/seed/seedwriter/manifest_test.go
+++ b/seed/seedwriter/manifest_test.go
@@ -264,21 +264,21 @@ func (s *manifestSuite) TestManifestSetAllowedValidationSetInvalidSequence(c *C)
 }
 
 func (s *manifestSuite) setupValidationSet(c *C) *asserts.ValidationSet {
-	vs, err := s.storeSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	vs, err := s.storeSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "base-set",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       "123456ididididididididididididid",
 				"presence": "required",
 				"revision": "1",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -334,20 +334,20 @@ func (s *manifestSuite) TestManifestMarkValidationSetSeededUsedHappy(c *C) {
 }
 
 func (s *manifestSuite) setupValidationSetWithNothingToTrack(c *C) *asserts.ValidationSet {
-	vs, err := s.storeSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	vs, err := s.storeSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "weird-set",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       "123456ididididididididididididid",
 				"presence": "required",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       "mysnapididididididididididididid",
 				"presence": "invalid",

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -39,7 +39,7 @@ type policy16 struct {
 	model *asserts.Model
 	opts  *Options
 
-	warningf func(format string, a ...interface{})
+	warningf func(format string, a ...any)
 
 	needsCore   []string
 	needsCore16 []string

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -37,7 +37,7 @@ type policy20 struct {
 	model *asserts.Model
 	opts  *Options
 
-	warningf func(format string, a ...interface{})
+	warningf func(format string, a ...any)
 }
 
 var errNotAllowedExceptForDangerous = errors.New("cannot override channels, add devmode snaps, local snaps, or extra snaps/components with a model of grade higher than dangerous")

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -418,7 +418,7 @@ func (w *Writer) checkStep(thisStep writerStep) error {
 }
 
 // warningf adds a warning that can be later retrieved via Warnings.
-func (w *Writer) warningf(format string, a ...interface{}) {
+func (w *Writer) warningf(format string, a ...any) {
 	w.warnings = append(w.warnings, fmt.Sprintf(format, a...))
 }
 

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -122,12 +122,12 @@ func (s *writerSuite) SetUpTest(c *C) {
 
 	s.SeedSnaps = &seedtest.SeedSnaps{}
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
 
-	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
+	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]any{
 		"account-id": "developerid",
 	}, "")
 	assertstest.AddMany(s.StoreSigning, s.devAcct)
@@ -287,12 +287,12 @@ func (s *writerSuite) fillMetaDownloadedSnap(c *C, w *seedwriter.Writer, sn *see
 }
 
 func (s *writerSuite) TestNewDefaultChannelError(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	s.opts.DefaultChannel = "foo/bar"
@@ -302,12 +302,12 @@ func (s *writerSuite) TestNewDefaultChannelError(c *C) {
 }
 
 func (s writerSuite) TestSetOptionsSnapsErrors(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	tests := []struct {
@@ -332,26 +332,26 @@ func (s writerSuite) TestSetOptionsSnapsErrors(c *C) {
 }
 
 func (s writerSuite) TestSetOptionsSnapsIgnoreExtensions(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			},
@@ -388,12 +388,12 @@ func (s writerSuite) TestSetOptionsSnapsIgnoreExtensions(c *C) {
 }
 
 func (s *writerSuite) TestSnapsToDownloadCore16(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	w, err := seedwriter.New(model, s.opts)
@@ -418,12 +418,12 @@ func (s *writerSuite) TestSnapsToDownloadCore16(c *C) {
 }
 
 func (s *writerSuite) TestSnapsToDownloadOptionTrack(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	w, err := seedwriter.New(model, s.opts)
@@ -444,12 +444,12 @@ func (s *writerSuite) TestSnapsToDownloadOptionTrack(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCore16(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	s.makeSnap(c, "core", "")
@@ -488,13 +488,13 @@ func (s *writerSuite) TestDownloadedCore16(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCore18(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -538,13 +538,13 @@ func (s *writerSuite) TestDownloadedCore18(c *C) {
 }
 
 func (s *writerSuite) TestSnapsToDownloadCore18IncompatibleTrack(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -568,13 +568,13 @@ func (s *writerSuite) TestSnapsToDownloadCore18IncompatibleTrack(c *C) {
 }
 
 func (s *writerSuite) TestSnapsToDownloadDefaultChannel(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -635,7 +635,7 @@ func (s *writerSuite) upToDownloaded(c *C, model *asserts.Model, fill func(c *C,
 }
 
 func (s *writerSuite) TestDownloadedCheckBaseGadget(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core18",
@@ -654,12 +654,12 @@ func (s *writerSuite) TestDownloadedCheckBaseGadget(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCheckBase(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"cont-producer"},
+		"required-snaps": []any{"cont-producer"},
 	})
 
 	s.makeSnap(c, "core", "")
@@ -675,12 +675,12 @@ func (s *writerSuite) TestDownloadedCheckBase(c *C) {
 }
 
 func (s *writerSuite) TestOutOfOrder(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	w, err := seedwriter.New(model, s.opts)
@@ -703,12 +703,12 @@ func (s *writerSuite) TestOutOfOrder(c *C) {
 }
 
 func (s *writerSuite) TestOutOfOrderWithLocalSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	w, err := seedwriter.New(model, s.opts)
@@ -733,12 +733,12 @@ func (s *writerSuite) TestOutOfOrderWithLocalSnaps(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedInfosNotSet(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	doNothingFill := func(*C, *seedwriter.Writer, *seedwriter.SeedSnap) {}
@@ -748,12 +748,12 @@ func (s *writerSuite) TestDownloadedInfosNotSet(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedUnexpectedClassicSnap(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"classic-snap"},
+		"required-snaps": []any{"classic-snap"},
 	})
 
 	s.makeSnap(c, "core", "")
@@ -768,7 +768,7 @@ func (s *writerSuite) TestDownloadedUnexpectedClassicSnap(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedPublisherMismatchKernel(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"gadget":       "pc",
@@ -786,7 +786,7 @@ func (s *writerSuite) TestDownloadedPublisherMismatchKernel(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedPublisherMismatchGadget(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"gadget":       "pc",
@@ -804,13 +804,13 @@ func (s *writerSuite) TestDownloadedPublisherMismatchGadget(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedMissingDefaultProvider(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer"},
+		"required-snaps": []any{"cont-consumer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -832,13 +832,13 @@ func (s *writerSuite) TestDownloadedCheckType(c *C) {
 	s.makeSnap(c, "cont-producer", "developerid")
 	s.makeSnap(c, "cont-consumer", "developerid")
 
-	core18headers := map[string]interface{}{
+	core18headers := map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	}
 
 	tests := []struct {
@@ -854,11 +854,11 @@ func (s *writerSuite) TestDownloadedCheckType(c *C) {
 	}
 
 	for _, t := range tests {
-		var wrongTypeSnap interface{} = t.wrongTypeSnap
+		var wrongTypeSnap any = t.wrongTypeSnap
 		if t.header == "required-snaps" {
-			wrongTypeSnap = []interface{}{wrongTypeSnap}
+			wrongTypeSnap = []any{wrongTypeSnap}
 		}
-		model := s.Brands.Model("my-brand", "my-model", core18headers, map[string]interface{}{
+		model := s.Brands.Model("my-brand", "my-model", core18headers, map[string]any{
 			t.header: wrongTypeSnap,
 		})
 
@@ -870,7 +870,7 @@ func (s *writerSuite) TestDownloadedCheckType(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCheckTypeSnapd(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core18",
@@ -890,7 +890,7 @@ func (s *writerSuite) TestDownloadedCheckTypeSnapd(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCheckTypeCore(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"gadget":       "pc",
@@ -908,7 +908,7 @@ func (s *writerSuite) TestDownloadedCheckTypeCore(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore16(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"gadget":       "pc",
@@ -1019,13 +1019,13 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore16(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -1139,7 +1139,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore18StoreAssertion(c *C) {
 	// add store assertion
-	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "my-store",
 		"operator-id": "canonical",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -1148,7 +1148,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18StoreAssertion(c *C) {
 	err = s.StoreSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core18",
@@ -1180,13 +1180,13 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18StoreAssertion(c *C) {
 }
 
 func (s *writerSuite) TestLocalSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	core18Fn := s.makeLocalSnap(c, "core18")
@@ -1218,13 +1218,13 @@ func (s *writerSuite) TestLocalSnaps(c *C) {
 }
 
 func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -1363,13 +1363,13 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaDefaultTrackCore18(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"required18"},
+		"required-snaps": []any{"required18"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -1428,13 +1428,13 @@ func (s *writerSuite) TestSeedSnapsWriteMetaDefaultTrackCore18(c *C) {
 }
 
 func (s *writerSuite) TestSetRedirectChannelErrors(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"required18"},
+		"required-snaps": []any{"required18"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -1464,13 +1464,13 @@ func (s *writerSuite) TestSetRedirectChannelErrors(c *C) {
 }
 
 func (s *writerSuite) TestInfoDerivedInfosNotSet(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	core18Fn := s.makeLocalSnap(c, "core18")
@@ -1498,13 +1498,13 @@ func (s *writerSuite) TestInfoDerivedInfosNotSet(c *C) {
 }
 
 func (s *writerSuite) TestInfoDerivedRepeatedLocalSnap(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	core18Fn := s.makeLocalSnap(c, "core18")
@@ -1542,13 +1542,13 @@ func (s *writerSuite) TestInfoDerivedRepeatedLocalSnap(c *C) {
 }
 
 func (s *writerSuite) TestInfoDerivedInconsistentChannel(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	core18Fn := s.makeLocalSnap(c, "core18")
@@ -1586,7 +1586,7 @@ func (s *writerSuite) TestInfoDerivedInconsistentChannel(c *C) {
 }
 
 func (s *writerSuite) TestSetRedirectChannelLocalError(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core18",
@@ -1624,11 +1624,11 @@ func (s *writerSuite) TestSetRedirectChannelLocalError(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaClassicWithCore(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":        "true",
 		"architecture":   "amd64",
 		"gadget":         "classic-gadget",
-		"required-snaps": []interface{}{"required"},
+		"required-snaps": []any{"required"},
 	})
 
 	s.makeSnap(c, "core", "")
@@ -1689,11 +1689,11 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicWithCore(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaClassicSnapdOnly(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"classic":        "true",
 		"architecture":   "amd64",
 		"gadget":         "classic-gadget18",
-		"required-snaps": []interface{}{"core18", "required18"},
+		"required-snaps": []any{"core18", "required18"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -1750,7 +1750,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicSnapdOnly(c *C) {
 func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelNoSysSnap(c *C) {
 	// this is a degenerate case but has been historically supported,
 	// see image_test.go TestPrepareClassicModelNoModelAssertion
-	model := s.Brands.Model("my-brand", "my-min-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-min-model", map[string]any{
 		"classic": "true",
 	})
 
@@ -1821,7 +1821,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelNoSysSnap(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelCore(c *C) {
-	model := s.Brands.Model("my-brand", "my-min-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-min-model", map[string]any{
 		"classic": "true",
 	})
 
@@ -1891,7 +1891,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelCore(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelSnapdFromOptionsWins(c *C) {
-	model := s.Brands.Model("my-brand", "my-min-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-min-model", map[string]any{
 		"classic": "true",
 	})
 
@@ -1963,9 +1963,9 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelSnapdFromOptionsWins(
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelSnapdFromModelWins(c *C) {
-	model := s.Brands.Model("my-brand", "my-min-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-min-model", map[string]any{
 		"classic":        "true",
-		"required-snaps": []interface{}{"core", "required", "snapd"},
+		"required-snaps": []any{"core", "required", "snapd"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -2024,13 +2024,13 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelSnapdFromModelWins(c 
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaExtraSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -2149,13 +2149,13 @@ func (s *writerSuite) TestSeedSnapsWriteMetaExtraSnaps(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc=18",
 		"kernel":         "pc-kernel=18",
-		"required-snaps": []interface{}{"cont-consumer", "cont-producer"},
+		"required-snaps": []any{"cont-consumer", "cont-producer"},
 	})
 
 	s.makeSnap(c, "snapd", "")
@@ -2293,7 +2293,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 	// add store assertion
-	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "my-store",
 		"operator-id": "canonical",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -2302,34 +2302,34 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 	err = s.StoreSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.AssertedSnapID("core18"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "cont-consumer",
 				"id":   s.AssertedSnapID("cont-consumer"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "cont-producer",
 				"id":   s.AssertedSnapID("cont-producer"),
 			},
@@ -2474,16 +2474,16 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 
 	b, err := os.ReadFile(filepath.Join(systemDir, "snaps", "aux-info.json"))
 	c.Assert(err, IsNil)
-	var auxInfos map[string]map[string]interface{}
+	var auxInfos map[string]map[string]any
 	err = json.Unmarshal(b, &auxInfos)
 	c.Assert(err, IsNil)
-	c.Check(auxInfos, DeepEquals, map[string]map[string]interface{}{
+	c.Check(auxInfos, DeepEquals, map[string]map[string]any{
 		s.AssertedSnapID("cont-consumer"): {
 			"private": true,
 		},
 		s.AssertedSnapID("cont-producer"): {
-			"links": map[string]interface{}{
-				"contact": []interface{}{"mailto:author@cont-producer.net"},
+			"links": map[string]any{
+				"contact": []any{"mailto:author@cont-producer.net"},
 			},
 			"contact": "mailto:author@cont-producer.net",
 		},
@@ -2498,19 +2498,19 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 }
 
 func (s *writerSuite) TestCore20InvalidLabel(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2534,25 +2534,25 @@ func (s *writerSuite) TestCore20InvalidLabel(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCore20CheckBase(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "cont-producer",
 				"id":   s.AssertedSnapID("cont-producer"),
 			},
@@ -2575,33 +2575,33 @@ func (s *writerSuite) TestDownloadedCore20CheckBase(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCore20CheckBaseModes(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.AssertedSnapID("core18"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "cont-producer",
 				"id":    s.AssertedSnapID("cont-producer"),
-				"modes": []interface{}{"run", "ephemeral"},
+				"modes": []any{"run", "ephemeral"},
 			},
 		},
 	})
@@ -2622,34 +2622,34 @@ func (s *writerSuite) TestDownloadedCore20CheckBaseModes(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCore20CheckBaseEphemeralOK(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "core18",
 				"id":    s.AssertedSnapID("core18"),
 				"type":  "base",
-				"modes": []interface{}{"ephemeral"},
+				"modes": []any{"ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "cont-producer",
 				"id":    s.AssertedSnapID("cont-producer"),
-				"modes": []interface{}{"recover"},
+				"modes": []any{"recover"},
 			},
 		},
 	})
@@ -2677,35 +2677,35 @@ func (s *writerSuite) TestDownloadedCore20CheckBaseCoreXX(c *C) {
 	s.makeSnap(c, "core", "")
 	s.makeSnap(c, "required", "")
 
-	coreEnt := map[string]interface{}{
+	coreEnt := map[string]any{
 		"name": "core",
 		"id":   s.AssertedSnapID("core"),
 		"type": "core",
 	}
-	requiredEnt := map[string]interface{}{
+	requiredEnt := map[string]any{
 		"name": "required",
 		"id":   s.AssertedSnapID("required"),
 	}
 
 	tests := []struct {
-		snaps []interface{}
+		snaps []any
 		err   string
 	}{
-		{[]interface{}{coreEnt, requiredEnt}, ""},
-		{[]interface{}{requiredEnt}, `cannot add snap "required" without also adding its base "core" explicitly`},
+		{[]any{coreEnt, requiredEnt}, ""},
+		{[]any{requiredEnt}, `cannot add snap "required" without also adding its base "core" explicitly`},
 	}
 
 	baseLabel := "20191003"
 	for idx, t := range tests {
 		s.opts.Label = fmt.Sprintf("%s%d", baseLabel, idx)
-		snaps := []interface{}{
-			map[string]interface{}{
+		snaps := []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2715,7 +2715,7 @@ func (s *writerSuite) TestDownloadedCore20CheckBaseCoreXX(c *C) {
 
 		snaps = append(snaps, t.snaps...)
 
-		model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		model := s.Brands.Model("my-brand", "my-model", map[string]any{
 			"display-name": "my model",
 			"architecture": "amd64",
 			"store":        "my-store",
@@ -2732,38 +2732,38 @@ func (s *writerSuite) TestDownloadedCore20CheckBaseCoreXX(c *C) {
 	}
 }
 func (s *writerSuite) TestDownloadedCore20MissingDefaultProviderModes(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "core18",
 				"id":    s.AssertedSnapID("core18"),
 				"type":  "base",
-				"modes": []interface{}{"run", "ephemeral"},
+				"modes": []any{"run", "ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "cont-producer",
 				"id":   s.AssertedSnapID("cont-producer"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "cont-consumer",
 				"id":    s.AssertedSnapID("cont-consumer"),
-				"modes": []interface{}{"recover"},
+				"modes": []any{"recover"},
 			},
 		},
 	})
@@ -2785,43 +2785,43 @@ func (s *writerSuite) TestDownloadedCore20MissingDefaultProviderModes(c *C) {
 }
 
 func (s *writerSuite) TestDownloadedCore20AlternativeProviderModes(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "core18",
 				"id":    s.AssertedSnapID("core18"),
 				"type":  "base",
-				"modes": []interface{}{"run", "ephemeral"},
+				"modes": []any{"run", "ephemeral"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "cont-producer",
 				"id":   s.AssertedSnapID("cont-producer"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "cont-consumer",
 				"id":    s.AssertedSnapID("cont-consumer"),
-				"modes": []interface{}{"recover"},
+				"modes": []any{"recover"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":  "alt-cont-producer",
 				"id":    s.AssertedSnapID("alt-cont-producer"),
-				"modes": []interface{}{"recover"},
+				"modes": []any{"recover"},
 			},
 		},
 	})
@@ -2851,25 +2851,25 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedDevmodeSnaps(c *C) {
 
 	s.makeSnap(c, "my-devmode", "canonical")
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "my-devmode",
 				"id":   s.AssertedSnapID("my-devmode"),
 				"type": "app",
@@ -2904,19 +2904,19 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedDevmodeSnaps(c *C) {
 }
 
 func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -2989,19 +2989,19 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 }
 
 func (s *writerSuite) TestCore20NonDangerousNoChannelOverride(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3029,7 +3029,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalSnapsWithComps(c *C) {
 
 func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps bool) {
 	// add store assertion
-	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "my-store",
 		"operator-id": "canonical",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -3038,26 +3038,26 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 	err = s.StoreSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			},
@@ -3196,7 +3196,7 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20LocalSnaps(c *C, withComps boo
 
 func (s *writerSuite) TestSetComponentOptionsBad(c *C) {
 	// add store assertion
-	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "my-store",
 		"operator-id": "canonical",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -3205,29 +3205,29 @@ func (s *writerSuite) TestSetComponentOptionsBad(c *C) {
 	err = s.StoreSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "required",
 					"comp2": "optional",
 				},
@@ -3301,7 +3301,7 @@ func (s *writerSuite) TestSetComponentOptionsBad(c *C) {
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore20ChannelOverrides(c *C) {
 	// add store assertion
-	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "my-store",
 		"operator-id": "canonical",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -3310,26 +3310,26 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ChannelOverrides(c *C) {
 	err = s.StoreSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			},
@@ -3415,24 +3415,24 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ChannelOverrides(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore20ModelOverrideSnapd(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "snapd",
 				"id":              s.AssertedSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/edge",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3506,34 +3506,34 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ModelOverrideSnapd(c *C) {
 }
 
 func (s *writerSuite) TestSnapsToDownloadCore20OptionalSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core18",
 				"id":   s.AssertedSnapID("core18"),
 				"type": "base",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-a",
 				"id":       s.AssertedSnapID("optional20-a"),
 				"presence": "optional",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "optional20-b",
 				"id":       s.AssertedSnapID("optional20-b"),
 				"presence": "optional",
@@ -3568,25 +3568,25 @@ func (s *writerSuite) TestSnapsToDownloadCore20OptionalSnaps(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "component-test",
 				"id":   s.AssertedSnapID("component-test"),
 			},
@@ -3824,19 +3824,19 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 }
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalAssertedSnaps(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -3958,28 +3958,28 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnapsWithCo
 }
 
 func (s *writerSuite) testSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C, withComps bool) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "signed",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
-				"components": map[string]interface{}{
+				"components": map[string]any{
 					"comp1": "optional",
 					"comp2": "optional",
 				},
@@ -4104,19 +4104,19 @@ func (s *writerSuite) testSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C,
 }
 
 func (s *writerSuite) TestSeedSnapsWriteCore20ErrWhenDirExists(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "signed",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -4137,15 +4137,15 @@ func (s *writerSuite) TestSeedSnapsWriteCore20ErrWhenDirExists(c *C) {
 }
 
 func (s *writerSuite) testDownloadedCore20CheckClassic(c *C, modelGrade asserts.ModelGrade, classicFlag bool) error {
-	classicSnap := map[string]interface{}{
+	classicSnap := map[string]any{
 		"name":  "classic-snap",
 		"id":    s.AssertedSnapID("classic-snap"),
-		"modes": []interface{}{"run"},
+		"modes": []any{"run"},
 	}
 	if classicFlag {
 		classicSnap["classic"] = "true"
 	}
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
@@ -4153,20 +4153,20 @@ func (s *writerSuite) testDownloadedCore20CheckClassic(c *C, modelGrade asserts.
 		"classic":      "true",
 		"distribution": "ubuntu",
 		"grade":        string(modelGrade),
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "core",
 				"id":   s.AssertedSnapID("core"),
 				"type": "core",
@@ -4206,21 +4206,21 @@ func (s *writerSuite) TestDownloadedCore20CheckClassicSignedWithFlag(c *C) {
 }
 
 func (s *writerSuite) setupValidationSets(c *C) {
-	valSetA, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	valSetA, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "base-set",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       s.AssertedSnapID("pc-kernel"),
 				"presence": "required",
 				"revision": "7",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       s.AssertedSnapID("pc"),
 				"presence": "required",
@@ -4233,21 +4233,21 @@ func (s *writerSuite) setupValidationSets(c *C) {
 	err = s.StoreSigning.Add(valSetA)
 	c.Check(err, IsNil)
 
-	valSetB, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	valSetB, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "base-set",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc-kernel",
 				"id":       s.AssertedSnapID("pc-kernel"),
 				"presence": "required",
 				"revision": "1",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":     "pc",
 				"id":       s.AssertedSnapID("pc"),
 				"presence": "required",
@@ -4260,15 +4260,15 @@ func (s *writerSuite) setupValidationSets(c *C) {
 	err = s.StoreSigning.Add(valSetB)
 	c.Check(err, IsNil)
 
-	valSetC, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	valSetC, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "opt-set",
 		"sequence":     "2",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "my-snap",
 				"id":       "mysnapididididididididididididid",
 				"presence": "required",
@@ -4283,32 +4283,32 @@ func (s *writerSuite) setupValidationSets(c *C) {
 }
 
 func (s *writerSuite) TestValidateValidationSetsCore20EnforcedInvalid(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"sequence":   "1",
 				"mode":       "enforce",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "opt-set",
 				"mode":       "prefer-enforce",
@@ -4389,26 +4389,26 @@ func (s *writerSuite) TestValidateValidationSetsCore20EnforcedInvalid(c *C) {
 }
 
 func (s *writerSuite) TestValidateValidationSetsCore20EnforcedHappy(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				// Enforce sequence 2 instead, which requires revision
@@ -4510,14 +4510,14 @@ func (s *writerSuite) TestValidateValidationSetsCore20EnforcedHappy(c *C) {
 }
 
 func (s *writerSuite) TestValidateValidationSetsCore18EnforcedHappy(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core18",
 		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				// Enforce sequence 2, which requires revision
@@ -4614,14 +4614,14 @@ func (s *writerSuite) TestValidateValidationSetsCore18EnforcedHappy(c *C) {
 }
 
 func (s *writerSuite) TestCheckValidateValidationSetsToEarly(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core18",
 		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				// Enforce sequence 2, which requires revision
@@ -4656,19 +4656,19 @@ func (s *writerSuite) TestCheckValidateValidationSetsToEarly(c *C) {
 }
 
 func (s *writerSuite) TestManifestCorrectlyProduced(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -4743,19 +4743,19 @@ snapd 1
 }
 
 func (s *writerSuite) TestManifestPreProvidedFailsMarkSeeding(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
@@ -4825,26 +4825,26 @@ func (s *writerSuite) TestManifestPreProvidedFailsMarkSeeding(c *C) {
 }
 
 func (s *writerSuite) TestManifestPreProvidedSequenceNotMatchingModelSequence(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"sequence":   "2",
@@ -4866,26 +4866,26 @@ func (s *writerSuite) TestManifestPreProvidedSequenceNotMatchingModelSequence(c 
 }
 
 func (s *writerSuite) TestManifestPreProvidedSequenceNotMatchingModelPinned(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"mode":       "enforce",
@@ -4906,26 +4906,26 @@ func (s *writerSuite) TestManifestPreProvidedSequenceNotMatchingModelPinned(c *C
 }
 
 func (s *writerSuite) TestValidateValidationSetsManifestsCorrectly(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			}},
-		"validation-sets": []interface{}{
-			map[string]interface{}{
+		"validation-sets": []any{
+			map[string]any{
 				"account-id": "canonical",
 				"name":       "base-set",
 				"mode":       "enforce",
@@ -5033,29 +5033,29 @@ snapd 1
 }
 
 func (s *writerSuite) TestOptionalComponentNotIncluded(c *C) {
-	comps := map[string]interface{}{
+	comps := map[string]any{
 		"comp1": "required",
 		"comp2": "optional",
 	}
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "24",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "24",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":       "required20",
 				"id":         s.AssertedSnapID("required20"),
 				"components": comps,
@@ -5133,7 +5133,7 @@ func (s *writerSuite) TestOptionalComponentNotIncluded(c *C) {
 
 func (s *writerSuite) TestSeedSnapsWriteMetaCore20BadLocalComps(c *C) {
 	// add store assertion
-	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]interface{}{
+	storeAs, err := s.StoreSigning.Sign(asserts.StoreType, map[string]any{
 		"store":       "my-store",
 		"operator-id": "canonical",
 		"timestamp":   time.Now().UTC().Format(time.RFC3339),
@@ -5142,26 +5142,26 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20BadLocalComps(c *C) {
 	err = s.StoreSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core20",
 		"grade":        "dangerous",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name": "required20",
 				"id":   s.AssertedSnapID("required20"),
 			},
@@ -5223,31 +5223,31 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20BadLocalComps(c *C) {
 }
 
 func (s *writerSuite) TestVerifySnapBootstrapCompatibility(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"store":        "my-store",
 		"base":         "core24",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "pc-kernel",
 				"id":              s.AssertedSnapID("pc-kernel"),
 				"type":            "kernel",
 				"default-channel": "24/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              s.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": "24/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "snapd",
 				"id":              s.AssertedSnapID("snapd"),
 				"type":            "snapd",
 				"default-channel": "latest/stable",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "core24",
 				"id":              s.AssertedSnapID("core24"),
 				"type":            "base",

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -66,7 +66,7 @@ func (s *validateSuite) SetUpTest(c *C) {
 
 	s.TestingSeed16 = &seedtest.TestingSeed16{}
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 
@@ -79,7 +79,7 @@ func (s *validateSuite) SetUpTest(c *C) {
 	err = os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
-	modelChain := s.MakeModelAssertionChain("my-brand", "my-model", map[string]interface{}{
+	modelChain := s.MakeModelAssertionChain("my-brand", "my-model", map[string]any{
 		"classic": "true",
 	})
 	s.WriteAssertions("model.asserts", modelChain...)
@@ -219,9 +219,9 @@ snaps:
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapMissingSnapd(c *C) {
-	modelChain := s.MakeModelAssertionChain("my-brand", "my-model", map[string]interface{}{
+	modelChain := s.MakeModelAssertionChain("my-brand", "my-model", map[string]any{
 		"classic":        "true",
-		"required-snaps": []interface{}{"snapd"},
+		"required-snaps": []any{"snapd"},
 	})
 	s.WriteAssertions("model.asserts", modelChain...)
 

--- a/snap/container.go
+++ b/snap/container.go
@@ -221,7 +221,7 @@ func evalAndValidateSymlink(c Container, path string) (symlinkInfo, error) {
 }
 
 // ValidateComponentContainer does a minimal quick check on a snap component container.
-func ValidateComponentContainer(c Container, contName string, logf func(format string, v ...interface{})) error {
+func ValidateComponentContainer(c Container, contName string, logf func(format string, v ...any)) error {
 	needsrx := map[string]bool{
 		".":    true,
 		"meta": true,
@@ -235,7 +235,7 @@ func ValidateComponentContainer(c Container, contName string, logf func(format s
 }
 
 // ValidateSnapContainer does a minimal quick check on a snap container.
-func ValidateSnapContainer(c Container, s *Info, logf func(format string, v ...interface{})) error {
+func ValidateSnapContainer(c Container, s *Info, logf func(format string, v ...any)) error {
 	needsrx := map[string]bool{
 		".":    true,
 		"meta": true,
@@ -313,7 +313,7 @@ func ValidateSnapContainer(c Container, s *Info, logf func(format string, v ...i
 // - noskipd tracks directories we want to descend into despite not being in needs*
 // The function also takes the type and name for the container (for logging
 // purposes) and a log function.
-func validateContainer(c Container, needsrx, needsx, needsr, needsf, noskipd map[string]bool, contType, name string, logf func(format string, v ...interface{})) error {
+func validateContainer(c Container, needsrx, needsx, needsr, needsf, noskipd map[string]bool, contType, name string, logf func(format string, v ...any)) error {
 	seen := make(map[string]bool, len(needsx)+len(needsrx)+len(needsr))
 
 	// bad modes are logged instead of being returned because the end user

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -51,7 +51,7 @@ type squashfsContainerValidateSuite struct{ validateSuite }
 var _ = Suite(&dirContainerValidateSuite{validateSuite{containerType: "dir"}})
 var _ = Suite(&squashfsContainerValidateSuite{validateSuite{containerType: "squashfs"}})
 
-func discard(string, ...interface{}) {}
+func discard(string, ...any) {}
 
 func (s *validateSuite) container() snap.Container {
 	if s.containerType == "squashfs" {
@@ -460,7 +460,7 @@ version: 1
 	info, err := snap.InfoFromSnapYaml([]byte(yaml))
 	c.Assert(err, IsNil)
 
-	mockLogf := func(format string, v ...interface{}) {
+	mockLogf := func(format string, v ...any) {
 		msg := fmt.Sprintf(format, v...)
 		c.Check(msg, Equals, "external symlink found: meta/gui/icons/snap.empty-snap.png -> /etc/shadow")
 	}
@@ -483,7 +483,7 @@ version: 1
 	info, err := snap.InfoFromSnapYaml([]byte(yaml))
 	c.Assert(err, IsNil)
 
-	mockLogf := func(format string, v ...interface{}) {
+	mockLogf := func(format string, v ...any) {
 		msg := fmt.Sprintf(format, v...)
 		c.Check(msg, Equals, "external symlink found: meta/gui/icons/snap.empty-snap.png -> 1/../../2/../../3/4/../../../../..")
 	}
@@ -525,7 +525,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	metaDirSymlinkErrFound := false
-	mockLogf := func(format string, v ...interface{}) {
+	mockLogf := func(format string, v ...any) {
 		msg := fmt.Sprintf(format, v...)
 		if msg == "meta directory cannot be a symlink" {
 			metaDirSymlinkErrFound = true
@@ -610,7 +610,7 @@ version: 1
 	c.Assert(err, IsNil)
 
 	loopFound := false
-	mockLogf := func(format string, v ...interface{}) {
+	mockLogf := func(format string, v ...any) {
 		msg := fmt.Sprintf(format, v...)
 		if msg == "too many levels of symbolic links" {
 			loopFound = true

--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -127,12 +127,12 @@ func (e *Epoch) fromStructured(structured structuredEpoch) error {
 }
 
 func (e *Epoch) UnmarshalJSON(bs []byte) error {
-	return e.UnmarshalYAML(func(v interface{}) error {
+	return e.UnmarshalYAML(func(v any) error {
 		return json.Unmarshal(bs, &v)
 	})
 }
 
-func (e *Epoch) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *Epoch) UnmarshalYAML(unmarshal func(any) error) error {
 	var shortEpoch string
 	if err := unmarshal(&shortEpoch); err == nil {
 		return e.fromString(shortEpoch)
@@ -202,7 +202,7 @@ func (e *Epoch) Validate() error {
 	return &EpochError{Message: noEpochIntersection}
 }
 
-func (e *Epoch) simplify() interface{} {
+func (e *Epoch) simplify() any {
 	if e.IsZero() {
 		return "0"
 	}
@@ -226,7 +226,7 @@ func (e Epoch) MarshalJSON() ([]byte, error) {
 	return json.Marshal(se)
 }
 
-func (Epoch) MarshalYAML() (interface{}, error) {
+func (Epoch) MarshalYAML() (any, error) {
 	panic("unexpected attempt to marshal an Epoch to YAML")
 }
 
@@ -322,7 +322,7 @@ func parseInt(s string) (uint32, error) {
 
 type uint32slice []uint32
 
-func (z *uint32slice) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (z *uint32slice) UnmarshalYAML(unmarshal func(any) error) error {
 	var ss []string
 	if err := unmarshal(&ss); err != nil {
 		return &EpochError{Message: badEpochList}

--- a/snap/info.go
+++ b/snap/info.go
@@ -969,7 +969,7 @@ func (s *Info) DesktopPlugFileIDs() ([]string, error) {
 	// error reporting.
 
 	// desktop-file-ids must be a list of strings
-	attrList, ok := attrVal.([]interface{})
+	attrList, ok := attrVal.([]any)
 	if !ok {
 		return nil, errors.New(`internal error: "desktop-file-ids" must be a list of strings`)
 	}
@@ -1111,7 +1111,7 @@ type PlugInfo struct {
 
 	Name      string
 	Interface string
-	Attrs     map[string]interface{}
+	Attrs     map[string]any
 	Label     string
 	Apps      map[string]*AppInfo
 
@@ -1121,15 +1121,15 @@ type PlugInfo struct {
 	Unscoped bool
 }
 
-func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
-	var v interface{}
+func lookupAttr(attrs map[string]any, path string) (any, bool) {
+	var v any
 	comps := strings.FieldsFunc(path, func(r rune) bool { return r == '.' })
 	if len(comps) == 0 {
 		return nil, false
 	}
 	v = attrs
 	for _, comp := range comps {
-		m, ok := v.(map[string]interface{})
+		m, ok := v.(map[string]any)
 		if !ok {
 			return nil, false
 		}
@@ -1142,7 +1142,7 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 	return v, true
 }
 
-func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
+func getAttribute(snapName string, ifaceName string, attrs map[string]any, key string, val any) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
 		return AttributeNotFoundError{fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName)}
@@ -1151,11 +1151,11 @@ func getAttribute(snapName string, ifaceName string, attrs map[string]interface{
 	return metautil.SetValueFromAttribute(snapName, ifaceName, key, v, val)
 }
 
-func (plug *PlugInfo) Attr(key string, val interface{}) error {
+func (plug *PlugInfo) Attr(key string, val any) error {
 	return getAttribute(plug.Snap.InstanceName(), plug.Interface, plug.Attrs, key, val)
 }
 
-func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {
+func (plug *PlugInfo) Lookup(key string) (any, bool) {
 	return lookupAttr(plug.Attrs, key)
 }
 
@@ -1164,11 +1164,11 @@ func (plug *PlugInfo) String() string {
 	return fmt.Sprintf("%s:%s", plug.Snap.InstanceName(), plug.Name)
 }
 
-func (slot *SlotInfo) Attr(key string, val interface{}) error {
+func (slot *SlotInfo) Attr(key string, val any) error {
 	return getAttribute(slot.Snap.InstanceName(), slot.Interface, slot.Attrs, key, val)
 }
 
-func (slot *SlotInfo) Lookup(key string) (interface{}, bool) {
+func (slot *SlotInfo) Lookup(key string) (any, bool) {
 	return lookupAttr(slot.Attrs, key)
 }
 
@@ -1219,7 +1219,7 @@ type SlotInfo struct {
 
 	Name      string
 	Interface string
-	Attrs     map[string]interface{}
+	Attrs     map[string]any
 	Label     string
 	Apps      map[string]*AppInfo
 
@@ -1417,7 +1417,7 @@ func (hook *HookInfo) Runnable() Runnable {
 type SystemUsernameInfo struct {
 	Name  string
 	Scope string
-	Attrs map[string]interface{}
+	Attrs map[string]any
 }
 
 type CategoryInfo struct {

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -48,12 +48,12 @@ type snapYaml struct {
 	Base            string                   `yaml:"base,omitempty"`
 	Confinement     ConfinementType          `yaml:"confinement,omitempty"`
 	Environment     strutil.OrderedMap       `yaml:"environment,omitempty"`
-	Plugs           map[string]interface{}   `yaml:"plugs,omitempty"`
-	Slots           map[string]interface{}   `yaml:"slots,omitempty"`
+	Plugs           map[string]any           `yaml:"plugs,omitempty"`
+	Slots           map[string]any           `yaml:"slots,omitempty"`
 	Apps            map[string]appYaml       `yaml:"apps,omitempty"`
 	Hooks           map[string]hookYaml      `yaml:"hooks,omitempty"`
 	Layout          map[string]layoutYaml    `yaml:"layout,omitempty"`
-	SystemUsernames map[string]interface{}   `yaml:"system-usernames,omitempty"`
+	SystemUsernames map[string]any           `yaml:"system-usernames,omitempty"`
 	Links           map[string][]string      `yaml:"links,omitempty"`
 	Components      map[string]componentYaml `yaml:"components,omitempty"`
 
@@ -65,7 +65,7 @@ type typoDetector struct {
 	Hint string
 }
 
-func (td *typoDetector) UnmarshalYAML(func(interface{}) error) error {
+func (td *typoDetector) UnmarshalYAML(func(any) error) error {
 	return fmt.Errorf("typo detected: %s", td.Hint)
 }
 
@@ -723,15 +723,15 @@ func bindImplicitHooks(snap *Info, strk *scopedTracker) {
 	}
 }
 
-func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, label string, attrs map[string]interface{}, err error) {
+func convertToSlotOrPlugData(plugOrSlot, name string, data any) (iface, label string, attrs map[string]any, err error) {
 	iface = name
 	switch data.(type) {
 	case string:
 		return data.(string), "", nil, nil
 	case nil:
 		return name, "", nil, nil
-	case map[interface{}]interface{}:
-		for keyData, valueData := range data.(map[interface{}]interface{}) {
+	case map[any]any:
+		for keyData, valueData := range data.(map[any]any) {
 			key, ok := keyData.(string)
 			if !ok {
 				err := fmt.Errorf("%s %q has attribute key that is not a string (found %T)",
@@ -763,7 +763,7 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 				label = value
 			default:
 				if attrs == nil {
-					attrs = make(map[string]interface{})
+					attrs = make(map[string]any)
 				}
 				value, err := metautil.NormalizeValue(valueData)
 				if err != nil {
@@ -793,14 +793,14 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 //	    scope: shared
 //	    attrib1: ...
 //	    attrib2: ...
-func convertToUsernamesData(user string, data interface{}) (scope string, attrs map[string]interface{}, err error) {
+func convertToUsernamesData(user string, data any) (scope string, attrs map[string]any, err error) {
 	switch data.(type) {
 	case string:
 		return data.(string), nil, nil
 	case nil:
 		return "", nil, nil
-	case map[interface{}]interface{}:
-		for keyData, valueData := range data.(map[interface{}]interface{}) {
+	case map[any]any:
+		for keyData, valueData := range data.(map[any]any) {
 			key, ok := keyData.(string)
 			if !ok {
 				err := fmt.Errorf("system username %q has attribute key that is not a string (found %T)", user, keyData)
@@ -818,7 +818,7 @@ func convertToUsernamesData(user string, data interface{}) (scope string, attrs 
 				return "", nil, fmt.Errorf("system username %q has an empty attribute key", user)
 			default:
 				if attrs == nil {
-					attrs = make(map[string]interface{})
+					attrs = make(map[string]any)
 				}
 				value, err := metautil.NormalizeValue(valueData)
 				if err != nil {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -201,7 +201,7 @@ plugs:
 		Snap:      info,
 		Name:      "net",
 		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Attrs:     map[string]any{"ipv6-aware": true},
 		Unscoped:  true,
 	})
 }
@@ -227,10 +227,10 @@ plugs:
 		Snap:      info,
 		Name:      "iface",
 		Interface: "complex",
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"i": int64(3),
-			"l": []interface{}{int64(1), int64(2), int64(3)},
-			"m": map[string]interface{}{"a": "A", "b": "B"},
+			"l": []any{int64(1), int64(2), int64(3)},
+			"m": map[string]any{"a": "A", "b": "B"},
 		},
 		Unscoped: true,
 	})
@@ -256,7 +256,7 @@ plugs:
 		Snap:      info,
 		Name:      "net",
 		Interface: "network-client",
-		Attrs:     map[string]interface{}{"attr": int64(2)},
+		Attrs:     map[string]any{"attr": int64(2)},
 		Unscoped:  true,
 	})
 }
@@ -405,7 +405,7 @@ plugs:
 		Snap:      info,
 		Name:      "network-client",
 		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Attrs:     map[string]any{"ipv6-aware": true},
 		Unscoped:  true,
 	})
 }
@@ -602,7 +602,7 @@ slots:
 		Snap:      info,
 		Name:      "net",
 		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Attrs:     map[string]any{"ipv6-aware": true},
 		Unscoped:  true,
 	})
 }
@@ -627,10 +627,10 @@ slots:
 		Snap:      info,
 		Name:      "iface",
 		Interface: "complex",
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"i": int64(3),
-			"l": []interface{}{int64(1), int64(2)},
-			"m": map[string]interface{}{"a": "A"},
+			"l": []any{int64(1), int64(2)},
+			"m": map[string]any{"a": "A"},
 		},
 		Unscoped: true,
 	})
@@ -656,7 +656,7 @@ slots:
 		Snap:      info,
 		Name:      "net",
 		Interface: "network-client",
-		Attrs:     map[string]interface{}{"attr": int64(2)},
+		Attrs:     map[string]any{"attr": int64(2)},
 		Unscoped:  true,
 	})
 }
@@ -766,7 +766,7 @@ slots:
 		Snap:      info,
 		Name:      "network-client",
 		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Attrs:     map[string]any{"ipv6-aware": true},
 		Unscoped:  true,
 	})
 }
@@ -1359,7 +1359,7 @@ slots:
 	c.Check(slot1.Snap, Equals, info)
 	c.Check(slot1.Name, Equals, "foo-socket-slot")
 	c.Check(slot1.Interface, Equals, "socket")
-	c.Check(slot1.Attrs, DeepEquals, map[string]interface{}{
+	c.Check(slot1.Attrs, DeepEquals, map[string]any{
 		"protocol": "foo", "path": "$SNAP_DATA/socket"})
 	c.Check(slot1.Label, Equals, "")
 	c.Check(slot1.Apps, DeepEquals, map[string]*snap.AppInfo{app1.Name: app1})
@@ -1996,7 +1996,7 @@ system-usernames:
 	c.Assert(info.SystemUsernames["baz"], DeepEquals, &snap.SystemUsernameInfo{
 		Name:  "baz",
 		Scope: "private",
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"attr1": "norf",
 			"attr2": "corge",
 			"attr3": "",

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1661,7 +1661,7 @@ func (s *infoSuite) TestPlugInfoAttr(c *C) {
 	var val string
 	var intVal int
 
-	plug := &snap.PlugInfo{Snap: &snap.Info{SuggestedName: "snap"}, Name: "plug", Interface: "interface", Attrs: map[string]interface{}{"key": "value", "number": int(123)}}
+	plug := &snap.PlugInfo{Snap: &snap.Info{SuggestedName: "snap"}, Name: "plug", Interface: "interface", Attrs: map[string]any{"key": "value", "number": int(123)}}
 	c.Assert(plug.Attr("key", &val), IsNil)
 	c.Check(val, Equals, "value")
 
@@ -1677,7 +1677,7 @@ func (s *infoSuite) TestSlotInfoAttr(c *C) {
 	var val string
 	var intVal int
 
-	slot := &snap.SlotInfo{Snap: &snap.Info{SuggestedName: "snap"}, Name: "plug", Interface: "interface", Attrs: map[string]interface{}{"key": "value", "number": int(123)}}
+	slot := &snap.SlotInfo{Snap: &snap.Info{SuggestedName: "snap"}, Name: "plug", Interface: "interface", Attrs: map[string]any{"key": "value", "number": int(123)}}
 
 	c.Assert(slot.Attr("key", &val), IsNil)
 	c.Check(val, Equals, "value")
@@ -1691,8 +1691,8 @@ func (s *infoSuite) TestSlotInfoAttr(c *C) {
 }
 
 func (s *infoSuite) TestDottedPathSlot(c *C) {
-	attrs := map[string]interface{}{
-		"nested": map[string]interface{}{
+	attrs := map[string]any{
+		"nested": map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -1706,7 +1706,7 @@ func (s *infoSuite) TestDottedPathSlot(c *C) {
 
 	v, ok = slot.Lookup("nested")
 	c.Assert(ok, Equals, true)
-	c.Assert(v, DeepEquals, map[string]interface{}{
+	c.Assert(v, DeepEquals, map[string]any{
 		"foo": "bar",
 	})
 
@@ -1724,8 +1724,8 @@ func (s *infoSuite) TestDottedPathSlot(c *C) {
 }
 
 func (s *infoSuite) TestDottedPathPlug(c *C) {
-	attrs := map[string]interface{}{
-		"nested": map[string]interface{}{
+	attrs := map[string]any{
+		"nested": map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -1735,7 +1735,7 @@ func (s *infoSuite) TestDottedPathPlug(c *C) {
 
 	v, ok := plug.Lookup("nested")
 	c.Assert(ok, Equals, true)
-	c.Assert(v, DeepEquals, map[string]interface{}{
+	c.Assert(v, DeepEquals, map[string]any{
 		"foo": "bar",
 	})
 
@@ -2165,7 +2165,7 @@ func (s *infoSuite) TestHelpersWithHiddenSnapFolder(c *C) {
 }
 
 func (s *infoSuite) TestGetAttributeUnhappy(c *C) {
-	attrs := map[string]interface{}{}
+	attrs := map[string]any{}
 	var stringVal string
 	err := snap.GetAttribute("snap0", "iface0", attrs, "non-existent", &stringVal)
 	c.Check(stringVal, Equals, "")
@@ -2174,7 +2174,7 @@ func (s *infoSuite) TestGetAttributeUnhappy(c *C) {
 }
 
 func (s *infoSuite) TestGetAttributeHappy(c *C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"attr0": "a string",
 		"attr1": 12,
 	}
@@ -2515,7 +2515,7 @@ func (s *infoSuite) TestConfdbPlugAttrs(c *C) {
 		Snap:      &snap.Info{SuggestedName: "test-snap"},
 		Name:      "test-plug",
 		Interface: "confdb",
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"account": "foo",
 			"view":    "bar/baz",
 			"role":    "custodian",
@@ -2556,7 +2556,7 @@ func (s *infoSuite) TestConfdbPlugAttrsInvalid(c *C) {
 			Snap:      &snap.Info{SuggestedName: "test-snap"},
 			Name:      "test-plug",
 			Interface: tc.iface,
-			Attrs: map[string]interface{}{
+			Attrs: map[string]any{
 				"account": tc.account,
 				"view":    tc.view,
 			},

--- a/snap/naming/componentref.go
+++ b/snap/naming/componentref.go
@@ -61,7 +61,7 @@ func (cr ComponentRef) Validate() error {
 	return nil
 }
 
-func (cid *ComponentRef) UnmarshalYAML(unmarshall func(interface{}) error) error {
+func (cid *ComponentRef) UnmarshalYAML(unmarshall func(any) error) error {
 	idStr := ""
 	if err := unmarshall(&idStr); err != nil {
 		return err

--- a/snap/restartcond.go
+++ b/snap/restartcond.go
@@ -59,7 +59,7 @@ func (rc RestartCondition) String() string {
 }
 
 // UnmarshalYAML so RestartCondition implements yaml's Unmarshaler interface
-func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (rc *RestartCondition) UnmarshalYAML(unmarshal func(any) error) error {
 	var v string
 
 	if err := unmarshal(&v); err != nil {

--- a/snap/revision.go
+++ b/snap/revision.go
@@ -56,7 +56,7 @@ func (r Revision) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + r.String() + `"`), nil
 }
 
-func (r *Revision) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *Revision) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -64,7 +64,7 @@ func (r *Revision) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return r.UnmarshalJSON([]byte(`"` + s + `"`))
 }
 
-func (r Revision) MarshalYAML() (interface{}, error) {
+func (r Revision) MarshalYAML() (any, error) {
 	return r.String(), nil
 }
 
@@ -107,7 +107,7 @@ func ParseRevision(s string) (Revision, error) {
 // R returns a Revision given an int or a string.
 // Providing an invalid revision type or value causes a runtime panic.
 // See ParseRevision for a polite function that does not panic.
-func R(r interface{}) Revision {
+func R(r any) Revision {
 	switch r := r.(type) {
 	case string:
 		revision, err := ParseRevision(r)

--- a/snap/revision_test.go
+++ b/snap/revision_test.go
@@ -146,7 +146,7 @@ func (s revisionSuite) ParseRevision(c *C) {
 
 func (s *revisionSuite) TestR(c *C) {
 	type testItem struct {
-		v interface{}
+		v any
 		n int
 		e string
 	}

--- a/snap/squashfs/stat.go
+++ b/snap/squashfs/stat.go
@@ -47,7 +47,7 @@ func (s stat) Size() int64        { return s.size }
 func (s stat) Mode() os.FileMode  { return s.mode }
 func (s stat) ModTime() time.Time { return s.mtime }
 func (s stat) IsDir() bool        { return s.mode.IsDir() }
-func (s stat) Sys() interface{}   { return nil }
+func (s stat) Sys() any           { return nil }
 func (s stat) Path() string       { return s.path } // not path of os.FileInfo
 
 const minLen = len("drwxrwxr-x u/g             53595 2017-12-08 11:19 .")

--- a/snap/types.go
+++ b/snap/types.go
@@ -70,7 +70,7 @@ func (m *Type) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalYAML so Type implements yaml's Unmarshaler interface
-func (m *Type) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (m *Type) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -120,7 +120,7 @@ func (confinementType *ConfinementType) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalYAML so ConfinementType implements yaml's Unmarshaler interface
-func (confinementType *ConfinementType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (confinementType *ConfinementType) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -177,7 +177,7 @@ func (daemonScope *DaemonScope) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalYAML so DaemonScope implements yaml's Unmarshaler interface
-func (daemonScope *DaemonScope) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (daemonScope *DaemonScope) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -231,7 +231,7 @@ type Component struct {
 	ExplicitHooks map[string]*HookInfo
 }
 
-func (ct *ComponentType) UnmarshalYAML(unmarshall func(interface{}) error) error {
+func (ct *ComponentType) UnmarshalYAML(unmarshall func(any) error) error {
 	typeStr := ""
 	if err := unmarshall(&typeStr); err != nil {
 		return err

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2324,19 +2324,19 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 		Snap:      info,
 		Name:      "sound-themes",
 		Interface: "content",
-		Attrs:     map[string]interface{}{"default-provider": "common-themes", "content": "foo"},
+		Attrs:     map[string]any{"default-provider": "common-themes", "content": "foo"},
 	}
 	info.Plugs["bar"] = &PlugInfo{
 		Snap:      info,
 		Name:      "visual-themes",
 		Interface: "content",
-		Attrs:     map[string]interface{}{"default-provider": "common-themes", "content": "bar"},
+		Attrs:     map[string]any{"default-provider": "common-themes", "content": "bar"},
 	}
 	info.Plugs["baz"] = &PlugInfo{
 		Snap:      info,
 		Name:      "not-themes",
 		Interface: "content",
-		Attrs:     map[string]interface{}{"default-provider": "some-snap", "content": "baz"},
+		Attrs:     map[string]any{"default-provider": "some-snap", "content": "baz"},
 	}
 	info.Plugs["qux"] = &PlugInfo{Snap: info, Interface: "not-content"}
 
@@ -2358,7 +2358,7 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 		Snap:      slotSnap,
 		Name:      "visual-themes",
 		Interface: "content",
-		Attrs:     map[string]interface{}{"content": "bar"},
+		Attrs:     map[string]any{"content": "bar"},
 	}
 	slotSnap.Slots["visual-themes"] = barSlot
 
@@ -2377,7 +2377,7 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 		Snap:      slotSnap,
 		Name:      "sound-themes",
 		Interface: "content",
-		Attrs:     map[string]interface{}{"content": "foo"},
+		Attrs:     map[string]any{"content": "foo"},
 	}
 	err = repo.AddSlot(fooSlot)
 	c.Assert(err, IsNil)

--- a/store/auth.go
+++ b/store/auth.go
@@ -284,7 +284,7 @@ func requestDeviceSession(httpClient *http.Client, deviceSessionEndpoint string,
 }
 
 // retryPostRequestDecodeJSON calls retryPostRequest and decodes the response into either success or failure.
-func retryPostRequestDecodeJSON(httpClient *http.Client, endpoint string, headers map[string]string, data []byte, success interface{}, failure interface{}) (resp *http.Response, err error) {
+func retryPostRequestDecodeJSON(httpClient *http.Client, endpoint string, headers map[string]string, data []byte, success any, failure any) (resp *http.Response, err error) {
 	return retryPostRequest(httpClient, endpoint, headers, data, func(resp *http.Response) error {
 		return decodeJSONBody(resp, success, failure)
 	})

--- a/store/auth_u1.go
+++ b/store/auth_u1.go
@@ -176,7 +176,7 @@ func loginCaveatID(m *macaroon.Macaroon) (string, error) {
 func requestStoreMacaroon(httpClient *http.Client) (string, error) {
 	const errorPrefix = "cannot get snap access permission from store: "
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"permissions": []string{"package_access", "package_purchase"},
 	}
 

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -455,7 +455,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 }
 
 // arg must be a pointer to a struct
-func fillStruct(a interface{}, c *C) {
+func fillStruct(a any, c *C) {
 	if t := reflect.TypeOf(a); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
 		k := t.Kind()
 		if k == reflect.Ptr {
@@ -467,7 +467,7 @@ func fillStruct(a interface{}, c *C) {
 	n := va.Elem().NumField()
 	for i := 0; i < n; i++ {
 		field := va.Elem().Field(i)
-		var x interface{}
+		var x any
 		switch field.Interface().(type) {
 		case string:
 			x = "foo"

--- a/store/store.go
+++ b/store/store.go
@@ -630,7 +630,7 @@ func cancelled(ctx context.Context) bool {
 	}
 }
 
-var expectedCatalogPreamble = []interface{}{
+var expectedCatalogPreamble = []any{
 	json.Delim('{'),
 	"_embedded",
 	json.Delim('{'),
@@ -700,7 +700,7 @@ func decodeCatalog(resp *http.Response, names io.Writer, db SnapAdder) error {
 	return nil
 }
 
-func decodeJSONBody(resp *http.Response, success interface{}, failure interface{}) error {
+func decodeJSONBody(resp *http.Response, success any, failure any) error {
 	ok := (resp.StatusCode == 200 || resp.StatusCode == 201)
 	// always decode on success; decode failures only if body is not empty
 	if !ok && resp.ContentLength == 0 {
@@ -717,7 +717,7 @@ func decodeJSONBody(resp *http.Response, success interface{}, failure interface{
 }
 
 // retryRequestDecodeJSON calls retryRequest and decodes the response into either success or failure.
-func (s *Store) retryRequestDecodeJSON(ctx context.Context, reqOptions *requestOptions, user *auth.UserState, success interface{}, failure interface{}) (resp *http.Response, err error) {
+func (s *Store) retryRequestDecodeJSON(ctx context.Context, reqOptions *requestOptions, user *auth.UserState, success any, failure any) (resp *http.Response, err error) {
 	return httputil.RetryRequest(reqOptions.URL.String(), func() (*http.Response, error) {
 		return s.doRequest(ctx, s.client, reqOptions, user)
 	}, func(resp *http.Response) error {

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -148,9 +148,9 @@ type snapActionJSON struct {
 	// NOTE the store needs an epoch (even if null) for the "install" and "download"
 	// actions, to know the client handles epochs at all.  "refresh" actions should
 	// send nothing, not even null -- the snap in the context should have the epoch
-	// already.  We achieve this by making Epoch be an `interface{}` with omitempty,
-	// and then setting it to a (possibly nil) epoch for install and download. As a
-	// nil epoch is not an empty interface{}, you'll get the null in the json.
+	// already.  We achieve this by making Epoch be an `any` with omitempty, and
+	// then setting it to a (possibly nil) epoch for install and download. As a
+	// nil epoch is not an empty any, you'll get the null in the json.
 	Epoch any `json:"epoch,omitempty"`
 	// For assertions
 	Key            string     `json:"key,omitempty"`
@@ -467,7 +467,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			aJSON.Name = snap.InstanceSnap(a.InstanceName)
 			if a.Epoch.IsZero() {
 				// Let the store know we can handle epochs, by sending the `epoch`
-				// field in the request.  A nil epoch is not an empty interface{},
+				// field in the request.  A nil epoch is not an empty any,
 				// you'll get the null in the json. See comment in snapActionJSON.
 				aJSON.Epoch = (*snap.Epoch)(nil)
 			} else {

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -151,11 +151,11 @@ type snapActionJSON struct {
 	// already.  We achieve this by making Epoch be an `interface{}` with omitempty,
 	// and then setting it to a (possibly nil) epoch for install and download. As a
 	// nil epoch is not an empty interface{}, you'll get the null in the json.
-	Epoch interface{} `json:"epoch,omitempty"`
+	Epoch any `json:"epoch,omitempty"`
 	// For assertions
-	Key            string        `json:"key,omitempty"`
-	Assertions     []interface{} `json:"assertions,omitempty"`
-	ValidationSets [][]string    `json:"validation-sets,omitempty"`
+	Key            string     `json:"key,omitempty"`
+	Assertions     []any      `json:"assertions,omitempty"`
+	ValidationSets [][]string `json:"validation-sets,omitempty"`
 }
 
 type assertAtJSON struct {
@@ -492,7 +492,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 				Action: "fetch-assertions",
 				Key:    string(grp),
 			}
-			aJSON.Assertions = make([]interface{}, len(ats))
+			aJSON.Assertions = make([]any, len(ats))
 			groupingsAssertions[aJSON.Key] = aJSON
 
 			for j, at := range ats {
@@ -522,7 +522,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 					Action: "fetch-assertions",
 					Key:    key,
 				}
-				aJSON.Assertions = make([]interface{}, 0, len(ats))
+				aJSON.Assertions = make([]any, 0, len(ats))
 				actionJSONs = append(actionJSONs, aJSON)
 			}
 			for _, at := range ats {

--- a/store/store_action_fetch_assertions_test.go
+++ b/store/store_action_fetch_assertions_test.go
@@ -84,8 +84,8 @@ func (s *storeActionFetchAssertionsSuite) testFetch(c *C, assertionMaxFormats ma
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 
 			AssertionMaxFormats map[string]int `json:"assertion-max-formats"`
 		}
@@ -95,13 +95,13 @@ func (s *storeActionFetchAssertionsSuite) testFetch(c *C, assertionMaxFormats ma
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		expectedAction := map[string]interface{}{
+		expectedAction := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g1",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "snap-declaration",
-					"primary-key": []interface{}{
+					"primary-key": []any{
 						"16",
 						"iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
 					},
@@ -190,8 +190,8 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 
 			AssertionMaxFormats map[string]int `json:"assertion-max-formats"`
 		}
@@ -201,13 +201,13 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 2)
-		expectedAction1 := map[string]interface{}{
+		expectedAction1 := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g1",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "snap-declaration",
-					"primary-key": []interface{}{
+					"primary-key": []any{
 						"16",
 						"iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
 					},
@@ -215,13 +215,13 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
 				},
 			},
 		}
-		expectedAction2 := map[string]interface{}{
+		expectedAction2 := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g2",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "snap-declaration",
-					"primary-key": []interface{}{
+					"primary-key": []any{
 						"16",
 						"CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6",
 					},
@@ -229,9 +229,9 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateIfNewerThan(c *C) {
 				},
 			},
 		}
-		expectedActions := []map[string]interface{}{expectedAction1, expectedAction2}
+		expectedActions := []map[string]any{expectedAction1, expectedAction2}
 		if req.Actions[0]["key"] != "g1" {
-			expectedActions = []map[string]interface{}{expectedAction2, expectedAction1}
+			expectedActions = []map[string]any{expectedAction2, expectedAction1}
 		}
 		c.Assert(req.Actions, DeepEquals, expectedActions)
 
@@ -321,8 +321,8 @@ func (s *storeActionFetchAssertionsSuite) TestFetchNotFound(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -330,13 +330,13 @@ func (s *storeActionFetchAssertionsSuite) TestFetchNotFound(c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		expectedAction := map[string]interface{}{
+		expectedAction := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g1",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "snap-declaration",
-					"primary-key": []interface{}{
+					"primary-key": []any{
 						"16",
 						"xEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
 					},
@@ -416,8 +416,8 @@ func (s *storeActionFetchAssertionsSuite) TestFetchValidationSetNotFound(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -425,13 +425,13 @@ func (s *storeActionFetchAssertionsSuite) TestFetchValidationSetNotFound(c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		expectedAction := map[string]interface{}{
+		expectedAction := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g1",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "validation-set",
-					"sequence-key": []interface{}{
+					"sequence-key": []any{
 						"16",
 						"foo",
 						"bar",
@@ -587,8 +587,8 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateSequenceForming(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 
 			AssertionMaxFormats map[string]int `json:"assertion-max-formats"`
 		}
@@ -598,21 +598,21 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateSequenceForming(c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 2)
-		expectedAction1 := map[string]interface{}{
+		expectedAction1 := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g1",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "validation-set",
-					"sequence-key": []interface{}{
+					"sequence-key": []any{
 						"16",
 						"account-1/name-1",
 					},
 					"sequence": float64(3),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type": "validation-set",
-					"sequence-key": []interface{}{
+					"sequence-key": []any{
 						"16",
 						"account-1/name-2",
 					},
@@ -621,22 +621,22 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateSequenceForming(c *C) {
 				},
 			},
 		}
-		expectedAction2 := map[string]interface{}{
+		expectedAction2 := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g2",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "validation-set",
-					"sequence-key": []interface{}{
+					"sequence-key": []any{
 						"16",
 						"account-2/name",
 					},
 				},
 			},
 		}
-		expectedActions := []map[string]interface{}{expectedAction1, expectedAction2}
+		expectedActions := []map[string]any{expectedAction1, expectedAction2}
 		if req.Actions[0]["key"] != "g1" {
-			expectedActions = []map[string]interface{}{expectedAction2, expectedAction1}
+			expectedActions = []map[string]any{expectedAction2, expectedAction1}
 		}
 		c.Assert(req.Actions, DeepEquals, expectedActions)
 
@@ -737,8 +737,8 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateSequenceFormingCommonGroupin
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 
 			AssertionMaxFormats map[string]int `json:"assertion-max-formats"`
 		}
@@ -749,29 +749,29 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateSequenceFormingCommonGroupin
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 2)
 
-		expectedAction1 := map[string]interface{}{
+		expectedAction1 := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g1",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "snap-declaration",
-					"primary-key": []interface{}{
+					"primary-key": []any{
 						"16",
 						"iEr2EpvaIaqrXxoM2JyHOmuXQYvSzUt5",
 					},
 					"if-newer-than": float64(0),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type": "validation-set",
-					"sequence-key": []interface{}{
+					"sequence-key": []any{
 						"16",
 						"account-1/name-1",
 					},
 					"sequence": float64(3),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type": "validation-set",
-					"sequence-key": []interface{}{
+					"sequence-key": []any{
 						"16",
 						"account-1/name-2",
 					},
@@ -780,21 +780,21 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateSequenceFormingCommonGroupin
 				},
 			},
 		}
-		expectedAction2 := map[string]interface{}{
+		expectedAction2 := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g2",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "snap-declaration",
-					"primary-key": []interface{}{
+					"primary-key": []any{
 						"16",
 						"CSO04Jhav2yK0uz97cr0ipQRyqg0qQL6",
 					},
 					"if-newer-than": float64(1),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type": "validation-set",
-					"sequence-key": []interface{}{
+					"sequence-key": []any{
 						"16",
 						"account-2/name",
 					},
@@ -802,9 +802,9 @@ func (s *storeActionFetchAssertionsSuite) TestUpdateSequenceFormingCommonGroupin
 			},
 		}
 
-		expectedActions := []map[string]interface{}{expectedAction1, expectedAction2}
+		expectedActions := []map[string]any{expectedAction1, expectedAction2}
 		if req.Actions[0]["key"] != "g1" {
-			expectedActions = []map[string]interface{}{expectedAction2, expectedAction1}
+			expectedActions = []map[string]any{expectedAction2, expectedAction1}
 		}
 		c.Assert(req.Actions, DeepEquals, expectedActions)
 		c.Assert(req.AssertionMaxFormats, DeepEquals, asserts.MaxSupportedFormats(1))
@@ -902,8 +902,8 @@ func (s *storeActionFetchAssertionsSuite) TestFetchOptionalPrimaryKeys(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 
 			AssertionMaxFormats map[string]int `json:"assertion-max-formats"`
 		}
@@ -913,13 +913,13 @@ func (s *storeActionFetchAssertionsSuite) TestFetchOptionalPrimaryKeys(c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		expectedAction := map[string]interface{}{
+		expectedAction := map[string]any{
 			"action": "fetch-assertions",
 			"key":    "g1",
-			"assertions": []interface{}{
-				map[string]interface{}{
+			"assertions": []any{
+				map[string]any{
 					"type": "snap-revision",
-					"primary-key": []interface{}{
+					"primary-key": []any{
 						"QlqR0uAWEAWF5Nwnzj5kqmmwFslYPu1IL16MKtLKhwhv0kpBv5wKZ_axf_nf_2cL",
 					},
 				},

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -120,7 +120,7 @@ func (s *storeActionSuite) testSnapAction(c *C, resources []string) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -268,7 +268,7 @@ func (s *storeActionSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iFiveStarEpoch,
+			"epoch":            anyFiveStarEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -364,7 +364,7 @@ func (s *storeActionSuite) TestSnapActionNoResults(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 0)
 		io.WriteString(w, `{
@@ -428,7 +428,7 @@ func (s *storeActionSuite) TestSnapActionRefreshedDateIsOptional(c *C) {
 
 			"revision":         float64(1),
 			"tracking-channel": "beta",
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 0)
 		io.WriteString(w, `{
@@ -481,7 +481,7 @@ func (s *storeActionSuite) TestSnapActionSkipBlocked(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -570,7 +570,7 @@ func (s *storeActionSuite) TestSnapActionNoSkipIfResourceChange(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -671,7 +671,7 @@ func (s *storeActionSuite) TestSnapActionSkipIfNoResourceChange(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -775,7 +775,7 @@ func (s *storeActionSuite) TestSnapActionSkipCurrent(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -937,7 +937,7 @@ func (s *storeActionSuite) TestSnapActionIgnoreValidation(c *C) {
 			"tracking-channel":  "stable",
 			"refreshed-date":    helloRefreshedDateStr,
 			"ignore-validation": true,
-			"epoch":             iZeroEpoch,
+			"epoch":             anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -1092,7 +1092,7 @@ func (s *storeActionSuite) TestInstallFallbackChannelIsStable(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -1187,7 +1187,7 @@ func (s *storeActionSuite) TestSnapActionNonDefaultsHeaders(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -1282,7 +1282,7 @@ func (s *storeActionSuite) TestSnapActionWithDeltas(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -1368,7 +1368,7 @@ func (s *storeActionSuite) TestSnapActionOptions(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -1493,7 +1493,7 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 		}
 		if validationSets != nil {
 			// XXX: rewrite as otherwise DeepEquals complains about
-			// []interface {}{[]interface {}{..} vs expected [][]string{[]string{..}.
+			// []any{[]any{..} vs expected [][]string{[]string{..}.
 			var sets []any
 			for _, vs := range validationSets {
 				var vss []any
@@ -1846,7 +1846,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          "snap2-id",
@@ -1854,7 +1854,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "edge",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 4)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -2027,7 +2027,7 @@ func (s *storeActionSuite) TestSnapActionSnapNotFound(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 3)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -2565,7 +2565,7 @@ func (s *storeActionSuite) TestSnapActionRefreshParallelInstall(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
@@ -2573,7 +2573,7 @@ func (s *storeActionSuite) TestSnapActionRefreshParallelInstall(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -2668,7 +2668,7 @@ func (s *storeActionSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 			"cohort-key":       "what",
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]any{
@@ -2677,7 +2677,7 @@ func (s *storeActionSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -2779,7 +2779,7 @@ func (s *storeActionSuite) TestSnapActionRefreshWithHeld(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 			"held":             map[string]any{"by": []any{"foo", "bar"}},
 		})
 		c.Assert(req.Actions, HasLen, 1)
@@ -2883,7 +2883,7 @@ func (s *storeActionSuite) TestSnapActionRefreshWithHeldUnsupportedProxy(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -2972,7 +2972,7 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 			"validation-sets":  []any{[]any{"foo", "other"}},
 		})
 		c.Assert(req.Actions, HasLen, 1)
@@ -3064,7 +3064,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
@@ -3072,7 +3072,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *
 			"revision":         float64(2),
 			"tracking-channel": "edge",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 3)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -3210,7 +3210,7 @@ func (s *storeActionSuite) TestSnapActionInstallParallelInstall(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -3324,7 +3324,7 @@ func (s *storeActionSuite) TestSnapActionInstallUnexpectedInstanceKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -3408,7 +3408,7 @@ func (s *storeActionSuite) TestSnapActionRefreshUnexpectedInstanceKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{
@@ -3492,7 +3492,7 @@ func (s *storeActionSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
@@ -3500,7 +3500,7 @@ func (s *storeActionSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
-			"epoch":            iZeroEpoch,
+			"epoch":            anyZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]any{

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -105,16 +105,16 @@ func (s *storeActionSuite) testSnapAction(c *C, resources []string) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Fields  []string                 `json:"fields"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Fields  []string         `json:"fields"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -123,7 +123,7 @@ func (s *storeActionSuite) testSnapAction(c *C, resources []string) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -138,20 +138,20 @@ func (s *storeActionSuite) testSnapAction(c *C, resources []string) {
 
 		c.Check(req.Fields, DeepEquals, expectedFields)
 
-		res := map[string]interface{}{
-			"results": []map[string]interface{}{
+		res := map[string]any{
+			"results": []map[string]any{
 				{
 					"result":       "refresh",
 					"instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
 					"snap-id":      "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
 					"name":         "hello-world",
-					"snap": map[string]interface{}{
+					"snap": map[string]any{
 						"snap-id":  "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
 						"name":     "hello-world",
 						"revision": 26,
 						"version":  "6.1",
-						"epoch":    map[string]interface{}{"read": []int{0}, "write": []int{0}},
-						"publisher": map[string]interface{}{
+						"epoch":    map[string]any{"read": []int{0}, "write": []int{0}},
+						"publisher": map[string]any{
 							"id":           "canonical",
 							"username":     "canonical",
 							"display-name": "Canonical",
@@ -162,9 +162,9 @@ func (s *storeActionSuite) testSnapAction(c *C, resources []string) {
 		}
 
 		if len(resources) > 0 {
-			res["results"].([]map[string]interface{})[0]["snap"].(map[string]interface{})["resources"] = []map[string]interface{}{
+			res["results"].([]map[string]any)[0]["snap"].(map[string]any)["resources"] = []map[string]any{
 				{
-					"download": map[string]interface{}{
+					"download": map[string]any{
 						"sha3-384": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
 						"size":     1024,
 						"url":      "https://example.com/comp.comp",
@@ -251,9 +251,9 @@ func (s *storeActionSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Fields  []string                 `json:"fields"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Fields  []string         `json:"fields"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -262,7 +262,7 @@ func (s *storeActionSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {
 		c.Check(req.Fields, DeepEquals, store.SnapActionFields)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -271,7 +271,7 @@ func (s *storeActionSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {
 			"epoch":            iFiveStarEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -350,15 +350,15 @@ func (s *storeActionSuite) TestSnapActionNoResults(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -414,15 +414,15 @@ func (s *storeActionSuite) TestSnapActionRefreshedDateIsOptional(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":      helloWorldSnapID,
 			"instance-key": helloWorldSnapID,
 
@@ -467,15 +467,15 @@ func (s *storeActionSuite) TestSnapActionSkipBlocked(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -484,7 +484,7 @@ func (s *storeActionSuite) TestSnapActionSkipBlocked(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -556,15 +556,15 @@ func (s *storeActionSuite) TestSnapActionNoSkipIfResourceChange(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -573,7 +573,7 @@ func (s *storeActionSuite) TestSnapActionNoSkipIfResourceChange(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -657,15 +657,15 @@ func (s *storeActionSuite) TestSnapActionSkipIfNoResourceChange(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -674,7 +674,7 @@ func (s *storeActionSuite) TestSnapActionSkipIfNoResourceChange(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -761,15 +761,15 @@ func (s *storeActionSuite) TestSnapActionSkipCurrent(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -778,7 +778,7 @@ func (s *storeActionSuite) TestSnapActionSkipCurrent(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -853,8 +853,8 @@ func (s *storeActionSuite) TestSnapActionRetryOnEOF(c *C) {
 		}
 
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err := json.NewDecoder(r.Body).Decode(&req)
@@ -922,15 +922,15 @@ func (s *storeActionSuite) TestSnapActionIgnoreValidation(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":           helloWorldSnapID,
 			"instance-key":      helloWorldSnapID,
 			"revision":          float64(1),
@@ -940,7 +940,7 @@ func (s *storeActionSuite) TestSnapActionIgnoreValidation(c *C) {
 			"epoch":             iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":            "refresh",
 			"instance-key":      helloWorldSnapID,
 			"snap-id":           helloWorldSnapID,
@@ -1078,15 +1078,15 @@ func (s *storeActionSuite) TestInstallFallbackChannelIsStable(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -1095,7 +1095,7 @@ func (s *storeActionSuite) TestInstallFallbackChannelIsStable(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -1173,15 +1173,15 @@ func (s *storeActionSuite) TestSnapActionNonDefaultsHeaders(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -1190,7 +1190,7 @@ func (s *storeActionSuite) TestSnapActionNonDefaultsHeaders(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -1268,15 +1268,15 @@ func (s *storeActionSuite) TestSnapActionWithDeltas(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -1285,7 +1285,7 @@ func (s *storeActionSuite) TestSnapActionWithDeltas(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -1354,15 +1354,15 @@ func (s *storeActionSuite) TestSnapActionOptions(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -1371,7 +1371,7 @@ func (s *storeActionSuite) TestSnapActionOptions(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -1472,8 +1472,8 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -1481,7 +1481,7 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		expectedAction := map[string]interface{}{
+		expectedAction := map[string]any{
 			"action":       action,
 			"instance-key": action + "-1",
 			"name":         "hello-world",
@@ -1494,9 +1494,9 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 		if validationSets != nil {
 			// XXX: rewrite as otherwise DeepEquals complains about
 			// []interface {}{[]interface {}{..} vs expected [][]string{[]string{..}.
-			var sets []interface{}
+			var sets []any
 			for _, vs := range validationSets {
-				var vss []interface{}
+				var vss []any
 				for _, vv := range vs.Components() {
 					vss = append(vss, vv)
 				}
@@ -1585,8 +1585,8 @@ func (s *storeActionSuite) TestSnapActionInstallAmend(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -1594,12 +1594,12 @@ func (s *storeActionSuite) TestSnapActionInstallAmend(c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "hello-world",
 			"channel":      "beta",
-			"epoch":        map[string]interface{}{"read": []interface{}{0., 1.}, "write": []interface{}{1.}},
+			"epoch":        map[string]any{"read": []any{0., 1.}, "write": []any{1.}},
 		})
 
 		fmt.Fprint(w, `{
@@ -1755,8 +1755,8 @@ func (s *storeActionSuite) testSnapActionGetWithRevision(action string, c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -1764,7 +1764,7 @@ func (s *storeActionSuite) testSnapActionGetWithRevision(action string, c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       action,
 			"instance-key": action + "-1",
 			"name":         "hello-world",
@@ -1832,15 +1832,15 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 2)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -1848,7 +1848,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
 		})
-		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          "snap2-id",
 			"instance-key":     "snap2-id",
 			"revision":         float64(2),
@@ -1857,25 +1857,25 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 4)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
 		})
-		c.Assert(req.Actions[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[1], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": "snap2-id",
 			"snap-id":      "snap2-id",
 			"channel":      "candidate",
 		})
-		c.Assert(req.Actions[2], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[2], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "foo",
 			"channel":      "stable",
 			"epoch":        nil,
 		})
-		c.Assert(req.Actions[3], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[3], DeepEquals, map[string]any{
 			"action":       "download",
 			"instance-key": "download-1",
 			"name":         "bar",
@@ -2013,15 +2013,15 @@ func (s *storeActionSuite) TestSnapActionSnapNotFound(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -2030,20 +2030,20 @@ func (s *storeActionSuite) TestSnapActionSnapNotFound(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 3)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
 			"channel":      "stable",
 		})
-		c.Assert(req.Actions[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[1], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "foo",
 			"channel":      "stable",
 			"epoch":        nil,
 		})
-		c.Assert(req.Actions[2], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[2], DeepEquals, map[string]any{
 			"action":       "download",
 			"instance-key": "download-1",
 			"name":         "bar",
@@ -2137,8 +2137,8 @@ func (s *storeActionSuite) TestSnapActionOtherErrors(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -2146,7 +2146,7 @@ func (s *storeActionSuite) TestSnapActionOtherErrors(c *C) {
 
 		c.Assert(req.Context, HasLen, 0)
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "foo",
@@ -2551,15 +2551,15 @@ func (s *storeActionSuite) TestSnapActionRefreshParallelInstall(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 2)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -2567,7 +2567,7 @@ func (s *storeActionSuite) TestSnapActionRefreshParallelInstall(c *C) {
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
 		})
-		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldFooInstanceKeyWithSalt,
 			"revision":         float64(2),
@@ -2576,7 +2576,7 @@ func (s *storeActionSuite) TestSnapActionRefreshParallelInstall(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldFooInstanceKeyWithSalt,
 			"snap-id":      helloWorldSnapID,
@@ -2654,15 +2654,15 @@ func (s *storeActionSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 2)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -2671,7 +2671,7 @@ func (s *storeActionSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 			"epoch":            iZeroEpoch,
 			"cohort-key":       "what",
 		})
-		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldFooInstanceKeyWithSaltFoo,
 			"revision":         float64(2),
@@ -2680,7 +2680,7 @@ func (s *storeActionSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldFooInstanceKeyWithSaltFoo,
 			"snap-id":      helloWorldSnapID,
@@ -2765,25 +2765,25 @@ func (s *storeActionSuite) TestSnapActionRefreshWithHeld(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
-			"held":             map[string]interface{}{"by": []interface{}{"foo", "bar"}},
+			"held":             map[string]any{"by": []any{"foo", "bar"}},
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -2859,8 +2859,8 @@ func (s *storeActionSuite) TestSnapActionRefreshWithHeldUnsupportedProxy(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
@@ -2877,7 +2877,7 @@ func (s *storeActionSuite) TestSnapActionRefreshWithHeldUnsupportedProxy(c *C) {
 			return
 		}
 		// snap action should retry without the `held` field
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
@@ -2886,7 +2886,7 @@ func (s *storeActionSuite) TestSnapActionRefreshWithHeldUnsupportedProxy(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -2958,30 +2958,30 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
-			"validation-sets":  []interface{}{[]interface{}{"foo", "other"}},
+			"validation-sets":  []any{[]any{"foo", "other"}},
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":          "refresh",
 			"instance-key":    helloWorldSnapID,
 			"snap-id":         helloWorldSnapID,
 			"channel":         "stable",
-			"validation-sets": []interface{}{[]interface{}{"foo", "bar"}, []interface{}{"foo", "baz"}},
+			"validation-sets": []any{[]any{"foo", "bar"}, []any{"foo", "baz"}},
 		})
 
 		io.WriteString(w, `{
@@ -3050,15 +3050,15 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 2)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -3066,7 +3066,7 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
 		})
-		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldFooInstanceKeyWithSalt,
 			"revision":         float64(2),
@@ -3075,17 +3075,17 @@ func (s *storeActionSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 3)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
 		})
-		c.Assert(req.Actions[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[1], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldFooInstanceKeyWithSalt,
 			"snap-id":      helloWorldSnapID,
 		})
-		c.Assert(req.Actions[2], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[2], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "other",
@@ -3196,15 +3196,15 @@ func (s *storeActionSuite) TestSnapActionInstallParallelInstall(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -3213,7 +3213,7 @@ func (s *storeActionSuite) TestSnapActionInstallParallelInstall(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "hello-world",
@@ -3310,15 +3310,15 @@ func (s *storeActionSuite) TestSnapActionInstallUnexpectedInstanceKey(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -3327,7 +3327,7 @@ func (s *storeActionSuite) TestSnapActionInstallUnexpectedInstanceKey(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "hello-world",
@@ -3394,15 +3394,15 @@ func (s *storeActionSuite) TestSnapActionRefreshUnexpectedInstanceKey(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 1)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -3411,7 +3411,7 @@ func (s *storeActionSuite) TestSnapActionRefreshUnexpectedInstanceKey(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
@@ -3478,15 +3478,15 @@ func (s *storeActionSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 		jsonReq, err := io.ReadAll(r.Body)
 		c.Assert(err, IsNil)
 		var req struct {
-			Context []map[string]interface{} `json:"context"`
-			Actions []map[string]interface{} `json:"actions"`
+			Context []map[string]any `json:"context"`
+			Actions []map[string]any `json:"actions"`
 		}
 
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
 		c.Assert(req.Context, HasLen, 2)
-		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[0], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
 			"revision":         float64(26),
@@ -3494,7 +3494,7 @@ func (s *storeActionSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
 		})
-		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
+		c.Assert(req.Context[1], DeepEquals, map[string]any{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldFooInstanceKeyWithSalt,
 			"revision":         float64(2),
@@ -3503,7 +3503,7 @@ func (s *storeActionSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
-		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[0], DeepEquals, map[string]any{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "foo-2",

--- a/store/store_asserts_test.go
+++ b/store/store_asserts_test.go
@@ -51,11 +51,11 @@ func (s *storeAssertsSuite) SetUpTest(c *C) {
 	s.baseStoreSuite.SetUpTest(c)
 
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
-	s.dev1Acct = assertstest.NewAccount(s.storeSigning, "developer1", map[string]interface{}{
+	s.dev1Acct = assertstest.NewAccount(s.storeSigning, "developer1", map[string]any{
 		"account-id": "developer1",
 	}, "")
 
-	a, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	a, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]any{
 		"series":       "16",
 		"snap-id":      "asnapid",
 		"snap-name":    "asnap",

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -66,14 +66,14 @@ var _ = Suite(&configTestSuite{})
 
 var (
 	// this is what snap.E("0") looks like when decoded into an interface{} (the /^i/ is for "interface")
-	iZeroEpoch = map[string]interface{}{
-		"read":  []interface{}{0.},
-		"write": []interface{}{0.},
+	iZeroEpoch = map[string]any{
+		"read":  []any{0.},
+		"write": []any{0.},
 	}
 	// ...and this is snap.E("5*")
-	iFiveStarEpoch = map[string]interface{}{
-		"read":  []interface{}{4., 5.},
-		"write": []interface{}{5.},
+	iFiveStarEpoch = map[string]any{
+		"read":  []any{4., 5.},
+		"write": []any{5.},
 	}
 )
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -65,13 +65,13 @@ type configTestSuite struct{}
 var _ = Suite(&configTestSuite{})
 
 var (
-	// this is what snap.E("0") looks like when decoded into an interface{} (the /^i/ is for "interface")
-	iZeroEpoch = map[string]any{
+	// this is what snap.E("0") looks like when decoded into an any
+	anyZeroEpoch = map[string]any{
 		"read":  []any{0.},
 		"write": []any{0.},
 	}
 	// ...and this is snap.E("5*")
-	iFiveStarEpoch = map[string]any{
+	anyFiveStarEpoch = map[string]any{
 		"read":  []any{4., 5.},
 		"write": []any{5.},
 	}

--- a/store/tooling/auth.go
+++ b/store/tooling/auth.go
@@ -168,7 +168,7 @@ func parseAuthBase64JSON(data []byte, what string) (*authData, bool, error) {
 	if err != nil {
 		return nil, false, fmt.Errorf("cannot decode base64-encoded auth %s: %v", what, err)
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(jsonData[:dataLen], &m); err != nil {
 		return nil, true, fmt.Errorf("cannot unmarshal base64-decoded auth %s: %v", what, err)
 	}
@@ -177,7 +177,7 @@ func parseAuthBase64JSON(data []byte, what string) (*authData, bool, error) {
 	t, _ := m["t"].(string)
 	switch {
 	case t == "u1-macaroon":
-		v, _ := m["v"].(map[string]interface{})
+		v, _ := m["v"].(map[string]any)
 		r, _ = v["r"].(string)
 		d, _ = v["d"].(string)
 		if r == "" || d == "" {

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -93,12 +93,12 @@ func (s *toolingSuite) SetUpTest(c *C) {
 
 	s.SeedSnaps = &seedtest.SeedSnaps{}
 	s.SetupAssertSigning("canonical")
-	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.Brands.Register("my-brand", brandPrivKey, map[string]any{
 		"verification": "verified",
 	})
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
 
-	otherAcct := assertstest.NewAccount(s.StoreSigning, "other", map[string]interface{}{
+	otherAcct := assertstest.NewAccount(s.StoreSigning, "other", map[string]any{
 		"account-id": "other",
 	}, "")
 	s.StoreSigning.Add(otherAcct)
@@ -687,15 +687,15 @@ func (s *toolingSuite) TestSimpleCreds(c *C) {
 }
 
 func (s *toolingSuite) setupSequenceFormingAssertion(c *C) {
-	vs, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
+	vs, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]any{
 		"type":         "validation-set",
 		"authority-id": "canonical",
 		"series":       "16",
 		"account-id":   "canonical",
 		"name":         "base-set",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":     "pc",
 				"id":       "idididididididididididididididid",
 				"presence": "required",

--- a/strutil/map.go
+++ b/strutil/map.go
@@ -91,7 +91,7 @@ func (o *OrderedMap) Copy() *OrderedMap {
 }
 
 // UnmarshalYAML unmarshals a yaml string map and preserves the order
-func (o *OrderedMap) UnmarshalYAML(u func(interface{}) error) error {
+func (o *OrderedMap) UnmarshalYAML(u func(any) error) error {
 	var vals map[string]string
 	if err := u(&vals); err != nil {
 		return err

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -71,7 +71,7 @@ func DisableCloudInit(rootDir string) error {
 // cloud-init configuration file.
 type supportedFilteredCloudConfig struct {
 	Datasource map[string]supportedFilteredDatasource `yaml:"datasource,omitempty"`
-	Network    map[string]interface{}                 `yaml:"network,omitempty"`
+	Network    map[string]any                         `yaml:"network,omitempty"`
 	// DatasourceList is a pointer so we can distinguish between:
 	// datasource_list: []
 	// and not setting the datasource at all

--- a/sysconfig/gadget_defaults_test.go
+++ b/sysconfig/gadget_defaults_test.go
@@ -44,7 +44,7 @@ volumes:
     bootloader: grub
 `
 
-var fakeModel = assertstest.FakeAssertion(map[string]interface{}{
+var fakeModel = assertstest.FakeAssertion(map[string]any{
 	"type":         "model",
 	"authority-id": "my-brand",
 	"series":       "16",
@@ -57,7 +57,7 @@ var fakeModel = assertstest.FakeAssertion(map[string]interface{}{
 }).(*asserts.Model)
 
 func fake20Model(grade string) *asserts.Model {
-	return assertstest.FakeAssertion(map[string]interface{}{
+	return assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
 		"series":       "16",
@@ -66,14 +66,14 @@ func fake20Model(grade string) *asserts.Model {
 		"architecture": "amd64",
 		"base":         "core20",
 		"grade":        grade,
-		"snaps": []interface{}{
-			map[string]interface{}{
+		"snaps": []any{
+			map[string]any{
 				"name":            "kernel",
 				"id":              "kerneldididididididididididididi",
 				"type":            "kernel",
 				"default-channel": "20",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":            "pc",
 				"id":              "gadgetididididididididididididid",
 				"type":            "gadget",

--- a/sysconfig/sysconfig.go
+++ b/sysconfig/sysconfig.go
@@ -92,7 +92,7 @@ func (d *configedDevice) HasModeenv() bool {
 }
 
 // ApplyFilesystemOnlyDefaultsImpl is initialized by init() of configcore.
-var ApplyFilesystemOnlyDefaultsImpl = func(dev Device, rootDir string, defaults map[string]interface{}) error {
+var ApplyFilesystemOnlyDefaultsImpl = func(dev Device, rootDir string, defaults map[string]any) error {
 	panic("ApplyFilesystemOnlyDefaultsImpl is unset, import overlord/configstate/configcore")
 }
 
@@ -101,7 +101,7 @@ var ApplyFilesystemOnlyDefaultsImpl = func(dev Device, rootDir string, defaults 
 // This is a subset of core config options that is important
 // early during boot, before all the configuration is applied as part of
 // normal execution of configure hook.
-func ApplyFilesystemOnlyDefaults(model *asserts.Model, rootDir string, defaults map[string]interface{}) error {
+func ApplyFilesystemOnlyDefaults(model *asserts.Model, rootDir string, defaults map[string]any) error {
 	dev := &configedDevice{model: model}
 	return ApplyFilesystemOnlyDefaultsImpl(dev, rootDir, defaults)
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1063,7 +1063,7 @@ func (s *systemd) Stop(serviceNames []string) error {
 	// systemctl mocking in some modules are implemented very simplistically, and
 	// assumes that the 'stop' argument comes before the 'show'.
 	errorRet := make(chan error)
-	quit := make(chan interface{})
+	quit := make(chan any)
 
 	go func() {
 		// The polling routine is the 'errorRet' channel sender, so we make

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -967,7 +967,7 @@ func (s *SystemdTestSuite) TestLogs(c *C) {
 }
 
 // mustJSONMarshal panic's if the value cannot be marshaled
-func mustJSONMarshal(v interface{}) *json.RawMessage {
+func mustJSONMarshal(v any) *json.RawMessage {
 	b, err := json.Marshal(v)
 	if err != nil {
 		panic(fmt.Sprintf("couldn't marshal json in test fixture: %v", err))

--- a/tests/lib/fakedevicesvc/main.go
+++ b/tests/lib/fakedevicesvc/main.go
@@ -57,11 +57,11 @@ func main() {
 	l.Close()
 }
 
-func internalError(w http.ResponseWriter, msg string, a ...interface{}) {
+func internalError(w http.ResponseWriter, msg string, a ...any) {
 	http.Error(w, fmt.Sprintf(msg, a...), 500)
 }
 
-func badRequestError(w http.ResponseWriter, msg string, a ...interface{}) {
+func badRequestError(w http.ResponseWriter, msg string, a ...any) {
 	http.Error(w, fmt.Sprintf(msg, a...), 400)
 }
 
@@ -129,7 +129,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 			serialStr = serialReq.Serial()
 		}
 
-		serial, err := db.Sign(asserts.SerialType, map[string]interface{}{
+		serial, err := db.Sign(asserts.SerialType, map[string]any{
 			"authority-id":        "developer1",
 			"brand-id":            "developer1",
 			"model":               serialReq.Model(),

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_repair.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_repair.go
@@ -37,7 +37,7 @@ type cmdNewRepair struct {
 }
 
 func (x *cmdNewRepair) Execute(args []string) error {
-	headers := map[string]interface{}{}
+	headers := map[string]any{}
 	if x.RepairJSON != "" {
 		content, err := os.ReadFile(x.RepairJSON)
 		if err != nil {

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
@@ -37,7 +37,7 @@ type cmdNewSnapDeclaration struct {
 }
 
 func (x *cmdNewSnapDeclaration) Execute(args []string) error {
-	headers := map[string]interface{}{}
+	headers := map[string]any{}
 	if x.SnapDeclJsonPath != "" {
 		content, err := os.ReadFile(x.SnapDeclJsonPath)
 		if err != nil {

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_resource_pair.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_resource_pair.go
@@ -23,7 +23,7 @@ func (x *cmdNewSnapResourcePair) Execute(args []string) error {
 		return err
 	}
 
-	headers := make(map[string]interface{})
+	headers := make(map[string]any)
 	if err := json.Unmarshal(content, &headers); err != nil {
 		return err
 	}

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_resource_revision.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_resource_revision.go
@@ -23,7 +23,7 @@ func (x *cmdNewSnapResourceRevision) Execute(args []string) error {
 		return err
 	}
 
-	headers := make(map[string]interface{})
+	headers := make(map[string]any)
 	if err := json.Unmarshal(content, &headers); err != nil {
 		return err
 	}

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
@@ -37,7 +37,7 @@ type cmdNewSnapRevision struct {
 }
 
 func (x *cmdNewSnapRevision) Execute(args []string) error {
-	headers := map[string]interface{}{}
+	headers := map[string]any{}
 	if x.SnapRevJsonPath != "" {
 		content, err := os.ReadFile(x.SnapRevJsonPath)
 		if err != nil {

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -295,7 +295,7 @@ func makeNewSnapRevision(orig, new *info, targetDir string, db *asserts.Database
 	}
 	origSnapRev := a.(*asserts.SnapRevision)
 
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"authority-id":  "testrootorg",
 		"snap-sha3-384": new.digest,
 		"snap-id":       origSnapRev.SnapID(),

--- a/tests/lib/fakestore/refresh/snap_asserts.go
+++ b/tests/lib/fakestore/refresh/snap_asserts.go
@@ -38,7 +38,7 @@ func snapNameFromPath(snapPath string) string {
 
 // TODO: also support reading/copying form a store snap
 
-func NewSnapRevision(targetDir string, snap string, headers map[string]interface{}) (string, error) {
+func NewSnapRevision(targetDir string, snap string, headers map[string]any) (string, error) {
 	db, err := newAssertsDB(systestkeys.TestStorePrivKey)
 	if err != nil {
 		return "", err
@@ -48,7 +48,7 @@ func NewSnapRevision(targetDir string, snap string, headers map[string]interface
 		return "", err
 	}
 
-	fallbacks := map[string]interface{}{
+	fallbacks := map[string]any{
 		"developer-id":  "testrootorg",
 		"snap-id":       snapNameFromPath(snap) + "-id",
 		"snap-revision": "1",
@@ -70,7 +70,7 @@ func NewSnapRevision(targetDir string, snap string, headers map[string]interface
 	return writeAssert(a, targetDir)
 }
 
-func NewSnapResourceRevision(targetDir string, compPath string, headers map[string]interface{}) (string, error) {
+func NewSnapResourceRevision(targetDir string, compPath string, headers map[string]any) (string, error) {
 	db, err := newAssertsDB(systestkeys.TestStorePrivKey)
 	if err != nil {
 		return "", err
@@ -97,7 +97,7 @@ func NewSnapResourceRevision(targetDir string, compPath string, headers map[stri
 		}
 	}
 
-	defaults := map[string]interface{}{
+	defaults := map[string]any{
 		"type":              "snap-resource-revision",
 		"authority-id":      "testrootorg",
 		"developer-id":      "testrootorg",
@@ -123,7 +123,7 @@ func NewSnapResourceRevision(targetDir string, compPath string, headers map[stri
 	return writeAssert(a, targetDir)
 }
 
-func NewSnapResourcePair(targetDir string, compPath string, headers map[string]interface{}) (string, error) {
+func NewSnapResourcePair(targetDir string, compPath string, headers map[string]any) (string, error) {
 	db, err := newAssertsDB(systestkeys.TestStorePrivKey)
 	if err != nil {
 		return "", err
@@ -146,7 +146,7 @@ func NewSnapResourcePair(targetDir string, compPath string, headers map[string]i
 		}
 	}
 
-	defaults := map[string]interface{}{
+	defaults := map[string]any{
 		"type":          "snap-resource-pair",
 		"authority-id":  "testrootorg",
 		"developer-id":  "testrootorg",
@@ -166,13 +166,13 @@ func NewSnapResourcePair(targetDir string, compPath string, headers map[string]i
 	return writeAssert(a, targetDir)
 }
 
-func NewSnapDeclaration(targetDir string, snap string, headers map[string]interface{}) (string, error) {
+func NewSnapDeclaration(targetDir string, snap string, headers map[string]any) (string, error) {
 	db, err := newAssertsDB(systestkeys.TestStorePrivKey)
 	if err != nil {
 		return "", err
 	}
 
-	fallbacks := map[string]interface{}{
+	fallbacks := map[string]any{
 		"snap-id":      snapNameFromPath(snap) + "-id",
 		"snap-name":    snapNameFromPath(snap),
 		"publisher-id": "testrootorg",
@@ -195,14 +195,14 @@ func NewSnapDeclaration(targetDir string, snap string, headers map[string]interf
 
 // NewRepair signs a repair assertion, including the specified script as the
 // body of the assertion.
-func NewRepair(targetDir string, scriptFilename string, headers map[string]interface{}) (string, error) {
+func NewRepair(targetDir string, scriptFilename string, headers map[string]any) (string, error) {
 	// use the separate root of trust for signing repair assertions
 	db, err := newAssertsDB(systestkeys.TestRepairRootPrivKey)
 	if err != nil {
 		return "", err
 	}
 
-	fallbacks := map[string]interface{}{
+	fallbacks := map[string]any{
 		"brand-id":  "testrootorg",
 		"repair-id": "1",
 		"summary":   "some test keys repair",
@@ -220,7 +220,7 @@ func NewRepair(targetDir string, scriptFilename string, headers map[string]inter
 
 	headers["authority-id"] = "testrootorg"
 	// note that series is a list for repair assertions
-	headers["series"] = []interface{}{"16"}
+	headers["series"] = []any{"16"}
 	headers["timestamp"] = time.Now().Format(time.RFC3339)
 
 	a, err := db.Sign(asserts.RepairType, headers, scriptBodyBytes, systestkeys.TestRepairKeyID)

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -416,7 +416,7 @@ func (s *Store) repairsEndpoint(w http.ResponseWriter, req *http.Request) {
 		headers := a.Headers()
 		// we have to wrap the headers in a JSON object under the key
 		// "headers"
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"headers": headers,
 		}
 		b, err := json.Marshal(resp)

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -145,11 +145,11 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	sha3_384, _ := getSha(snapFn)
-	c.Check(body, DeepEquals, map[string]interface{}{
-		"architecture":      []interface{}{"all"},
+	c.Check(body, DeepEquals, map[string]any{
+		"architecture":      []any{"all"},
 		"snap_id":           "xidididididididididididididididid",
 		"package_name":      "foo",
 		"origin":            "foo-devel",
@@ -172,11 +172,11 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	sha3_384, _ := getSha(snapFn)
-	c.Check(body, DeepEquals, map[string]interface{}{
-		"architecture":      []interface{}{"all"},
+	c.Check(body, DeepEquals, map[string]any{
+		"architecture":      []any{"all"},
 		"snap_id":           "",
 		"package_name":      "foo",
 		"origin":            "canonical",
@@ -198,8 +198,8 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 	c.Assert(resp.StatusCode, Equals, 200)
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	sha3_384, _ = getSha(snapFn)
-	c.Check(body, DeepEquals, map[string]interface{}{
-		"architecture":      []interface{}{"all"},
+	c.Check(body, DeepEquals, map[string]any{
+		"architecture":      []any{"all"},
 		"snap_id":           "",
 		"package_name":      "foo-classic",
 		"origin":            "canonical",
@@ -221,8 +221,8 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 	c.Assert(resp.StatusCode, Equals, 200)
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	sha3_384, _ = getSha(snapFn)
-	c.Check(body, DeepEquals, map[string]interface{}{
-		"architecture":      []interface{}{"all"},
+	c.Check(body, DeepEquals, map[string]any{
+		"architecture":      []any{"all"},
 		"snap_id":           "",
 		"package_name":      "foo-base",
 		"origin":            "canonical",
@@ -244,8 +244,8 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 	c.Assert(resp.StatusCode, Equals, 200)
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	sha3_384, _ = getSha(snapFn)
-	c.Check(body, DeepEquals, map[string]interface{}{
-		"architecture":      []interface{}{"all"},
+	c.Check(body, DeepEquals, map[string]any{
+		"architecture":      []any{"all"},
 		"snap_id":           "",
 		"package_name":      "foo-core20",
 		"origin":            "canonical",
@@ -275,13 +275,13 @@ func (s *storeTestSuite) TestBulkEndpoint(c *C) {
 
 	var body struct {
 		Top struct {
-			Cat []map[string]interface{} `json:"clickindex:package"`
+			Cat []map[string]any `json:"clickindex:package"`
 		} `json:"_embedded"`
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	sha3_384, _ := getSha(snapFn)
-	c.Check(body.Top.Cat, DeepEquals, []map[string]interface{}{{
-		"architecture":      []interface{}{"all"},
+	c.Check(body.Top.Cat, DeepEquals, []map[string]any{{
+		"architecture":      []any{"all"},
 		"snap_id":           "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"package_name":      "test-snapd-tools",
 		"origin":            "canonical",
@@ -314,14 +314,14 @@ func (s *storeTestSuite) TestBulkEndpointWithAssertions(c *C) {
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
 		Top struct {
-			Cat []map[string]interface{} `json:"clickindex:package"`
+			Cat []map[string]any `json:"clickindex:package"`
 		} `json:"_embedded"`
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	sha3_384_1, _ := getSha(snapFn1)
 	sha3_384_2, _ := getSha(snapFn2)
-	c.Check(body.Top.Cat, DeepEquals, []map[string]interface{}{{
-		"architecture":      []interface{}{"all"},
+	c.Check(body.Top.Cat, DeepEquals, []map[string]any{{
+		"architecture":      []any{"all"},
 		"snap_id":           "xidididididididididididididididid",
 		"package_name":      "foo",
 		"origin":            "foo-devel",
@@ -334,7 +334,7 @@ func (s *storeTestSuite) TestBulkEndpointWithAssertions(c *C) {
 		"confinement":       "strict",
 		"type":              "app",
 	}, {
-		"architecture":      []interface{}{"all"},
+		"architecture":      []any{"all"},
 		"snap_id":           "xidididididididididididididcore20",
 		"package_name":      "foo-core20",
 		"origin":            "foo-core20-devel",
@@ -704,10 +704,10 @@ func (s *storeTestSuite) TestAssertionsEndpointNotFound(c *C) {
 	c.Assert(resp.StatusCode, Equals, 404)
 
 	dec := json.NewDecoder(resp.Body)
-	var respObj map[string]interface{}
+	var respObj map[string]any
 	err = dec.Decode(&respObj)
 	c.Assert(err, IsNil)
-	c.Check(respObj["error-list"], DeepEquals, []interface{}{map[string]interface{}{"code": "not-found", "message": "not found"}})
+	c.Check(respObj["error-list"], DeepEquals, []any{map[string]any{"code": "not-found", "message": "not found"}})
 }
 
 func (s *storeTestSuite) TestSnapActionEndpoint(c *C) {
@@ -722,25 +722,25 @@ func (s *storeTestSuite) TestSnapActionEndpoint(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"name":         "test-snapd-tools",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":          "test-snapd-tools",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "canonical",
 				"id":       "canonical",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -769,25 +769,25 @@ func (s *storeTestSuite) TestSnapActionEndpointUsesLatest(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"name":         "test-snapd-tools",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":          "test-snapd-tools",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "canonical",
 				"id":       "canonical",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/test-snapd-tools_2_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -818,25 +818,25 @@ func (s *storeTestSuite) TestSnapActionEndpointChannel(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"name":         "test-snapd-tools",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":          "test-snapd-tools",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "canonical",
 				"id":       "canonical",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -867,25 +867,25 @@ func (s *storeTestSuite) TestSnapActionEndpointChannelRefreshAll(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"name":         "test-snapd-tools",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":          "test-snapd-tools",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "canonical",
 				"id":       "canonical",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -917,25 +917,25 @@ func (s *storeTestSuite) TestSnapActionEndpointAssertedWithRevision(c *C) {
 
 		c.Assert(resp.StatusCode, Equals, 200)
 		var body struct {
-			Results []map[string]interface{}
+			Results []map[string]any
 		}
 		c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 		c.Check(body.Results, HasLen, 1)
 		sha3_384, size := getSha(path)
-		c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+		c.Check(body.Results[0], DeepEquals, map[string]any{
 			"result":       "refresh",
 			"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":         "test-snapd-tools",
-			"snap": map[string]interface{}{
-				"architectures": []interface{}{"all"},
+			"snap": map[string]any{
+				"architectures": []any{"all"},
 				"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 				"name":          "test-snapd-tools",
-				"publisher": map[string]interface{}{
+				"publisher": map[string]any{
 					"username": "canonical",
 					"id":       "canonical",
 				},
-				"download": map[string]interface{}{
+				"download": map[string]any{
 					"url":      s.store.URL() + "/download/" + filepath.Base(path),
 					"sha3-384": sha3_384,
 					"size":     float64(size),
@@ -985,26 +985,26 @@ func (s *storeTestSuite) TestSnapActionEndpointAssertedWithComponents(c *C) {
 
 		c.Assert(resp.StatusCode, Equals, 200)
 		var body struct {
-			Results []map[string]interface{}
+			Results []map[string]any
 		}
 		c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 		c.Check(body.Results, HasLen, 1)
 		sha3_384, size := getSha(path)
 
-		payload := map[string]interface{}{
+		payload := map[string]any{
 			"result":       "refresh",
 			"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":         "test-snapd-tools",
-			"snap": map[string]interface{}{
-				"architectures": []interface{}{"all"},
+			"snap": map[string]any{
+				"architectures": []any{"all"},
 				"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 				"name":          "test-snapd-tools",
-				"publisher": map[string]interface{}{
+				"publisher": map[string]any{
 					"username": "canonical",
 					"id":       "canonical",
 				},
-				"download": map[string]interface{}{
+				"download": map[string]any{
 					"url":      s.store.URL() + "/download/" + filepath.Base(path),
 					"sha3-384": sha3_384,
 					"size":     float64(size),
@@ -1016,10 +1016,10 @@ func (s *storeTestSuite) TestSnapActionEndpointAssertedWithComponents(c *C) {
 			},
 		}
 
-		var resources []interface{}
+		var resources []any
 		for name, comp := range comps {
-			resources = append(resources, map[string]interface{}{
-				"download": map[string]interface{}{
+			resources = append(resources, map[string]any{
+				"download": map[string]any{
 					"url":      s.store.URL() + "/download/" + filepath.Base(comp.path),
 					"sha3-384": comp.digest,
 					"size":     float64(comp.size),
@@ -1032,7 +1032,7 @@ func (s *storeTestSuite) TestSnapActionEndpointAssertedWithComponents(c *C) {
 		}
 
 		if len(resources) > 0 {
-			payload["snap"].(map[string]interface{})["resources"] = resources
+			payload["snap"].(map[string]any)["resources"] = resources
 		}
 
 		c.Check(body.Results[0], DeepEquals, payload)
@@ -1063,25 +1063,25 @@ func (s *storeTestSuite) TestSnapActionEndpointWithAssertions(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "xidididididididididididididididid",
 		"name":         "foo",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "xidididididididididididididididid",
 			"name":          "foo",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "foo-devel",
 				"id":       "foo-devel-id",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/foo_10_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -1106,25 +1106,25 @@ func (s *storeTestSuite) TestSnapActionEndpointRefreshAll(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"name":         "test-snapd-tools",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":          "test-snapd-tools",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "canonical",
 				"id":       "canonical",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -1150,25 +1150,25 @@ func (s *storeTestSuite) TestSnapActionEndpointWithAssertionsInstall(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "install",
 		"instance-key": "foo",
 		"snap-id":      "xidididididididididididididididid",
 		"name":         "foo",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "xidididididididididididididididid",
 			"name":          "foo",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "foo-devel",
 				"id":       "foo-devel-id",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/foo_10_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -1193,25 +1193,25 @@ func (s *storeTestSuite) TestSnapActionEndpointSnapWithBase(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"name":         "test-snapd-tools",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":          "test-snapd-tools",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "canonical",
 				"id":       "canonical",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),
@@ -1260,26 +1260,26 @@ func (s *storeTestSuite) TestSnapActionEndpointUnknownSnapAutoRefresh(c *C) {
 
 	c.Assert(resp.StatusCode, Equals, 200)
 	var body struct {
-		Results []map[string]interface{}
+		Results []map[string]any
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
 	c.Check(body.Results, HasLen, 1)
 	sha3_384, size := getSha(snapFn)
 	// Ignore unknown snaps during auto-refresh
-	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+	c.Check(body.Results[0], DeepEquals, map[string]any{
 		"result":       "refresh",
 		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 		"name":         "test-snapd-tools",
-		"snap": map[string]interface{}{
-			"architectures": []interface{}{"all"},
+		"snap": map[string]any{
+			"architectures": []any{"all"},
 			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
 			"name":          "test-snapd-tools",
-			"publisher": map[string]interface{}{
+			"publisher": map[string]any{
 				"username": "canonical",
 				"id":       "canonical",
 			},
-			"download": map[string]interface{}{
+			"download": map[string]any{
 				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
 				"sha3-384": sha3_384,
 				"size":     float64(size),

--- a/tests/lib/gendeveloper1/main.go
+++ b/tests/lib/gendeveloper1/main.go
@@ -65,7 +65,7 @@ func main() {
 	devKey, _ := assertstest.ReadPrivKey(assertstest.DevKey)
 	devSigning := assertstest.NewSigningDB("developer1", devKey)
 
-	var headers map[string]interface{}
+	var headers map[string]any
 	dec := json.NewDecoder(os.Stdin)
 	if err := dec.Decode(&headers); err != nil {
 		log.Fatalf("failed to decode model headers data: %v", err)

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -72,7 +72,7 @@ func Backup[T any](mockable *T) (restore func()) {
 }
 
 // Backup the specified list of elements before further mocking.
-func BackupMany(mockablesByPtr ...interface{}) (restore func()) {
+func BackupMany(mockablesByPtr ...any) (restore func()) {
 	// TODO find a type safe way of doing this when individual elements are
 	// of different type
 	backup := backupMockables(mockablesByPtr)
@@ -85,7 +85,7 @@ func BackupMany(mockablesByPtr ...interface{}) (restore func()) {
 	}
 }
 
-func backupMockables(mockablesByPtr []interface{}) (backup []*reflect.Value) {
+func backupMockables(mockablesByPtr []any) (backup []*reflect.Value) {
 	backup = make([]*reflect.Value, len(mockablesByPtr))
 
 	for i, ptr := range mockablesByPtr {

--- a/testutil/containschecker.go
+++ b/testutil/containschecker.go
@@ -37,7 +37,7 @@ var Contains check.Checker = &containsChecker{
 	&check.CheckerInfo{Name: "Contains", Params: []string{"container", "elem"}},
 }
 
-func commonEquals(container, elem interface{}, result *bool, error *string) bool {
+func commonEquals(container, elem any, result *bool, error *string) bool {
 	containerV := reflect.ValueOf(container)
 	elemV := reflect.ValueOf(elem)
 	switch containerV.Kind() {
@@ -76,15 +76,15 @@ func commonEquals(container, elem interface{}, result *bool, error *string) bool
 	return false
 }
 
-func (c *containsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *containsChecker) Check(params []any, names []string) (result bool, error string) {
 	defer func() {
 		if v := recover(); v != nil {
 			result = false
 			error = fmt.Sprint(v)
 		}
 	}()
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+	var container any = params[0]
+	var elem any = params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return result, error
 	}
@@ -122,9 +122,9 @@ var DeepContains check.Checker = &deepContainsChecker{
 	&check.CheckerInfo{Name: "DeepContains", Params: []string{"container", "elem"}},
 }
 
-func (c *deepContainsChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+func (c *deepContainsChecker) Check(params []any, names []string) (result bool, error string) {
+	var container any = params[0]
+	var elem any = params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return result, error
 	}
@@ -162,7 +162,7 @@ var DeepUnsortedMatches check.Checker = &deepUnsortedMatchChecker{
 	&check.CheckerInfo{Name: "DeepUnsortedMatches", Params: []string{"container1", "container2"}},
 }
 
-func (c *deepUnsortedMatchChecker) Check(params []interface{}, _ []string) (bool, string) {
+func (c *deepUnsortedMatchChecker) Check(params []any, _ []string) (bool, string) {
 	container1 := reflect.ValueOf(params[0])
 	container2 := reflect.ValueOf(params[1])
 

--- a/testutil/errorischecker.go
+++ b/testutil/errorischecker.go
@@ -34,7 +34,7 @@ type errorIsChecker struct {
 	*check.CheckerInfo
 }
 
-func (*errorIsChecker) Check(params []interface{}, names []string) (result bool, errMsg string) {
+func (*errorIsChecker) Check(params []any, names []string) (result bool, errMsg string) {
 	if params[0] == nil {
 		return params[1] == nil, ""
 	}

--- a/testutil/errorischecker_test.go
+++ b/testutil/errorischecker_test.go
@@ -62,11 +62,11 @@ func (*errorIsCheckerSuite) TestErrorIsCheckFails(c *C) {
 }
 
 func (*errorIsCheckerSuite) TestErrorIsWithInvalidArguments(c *C) {
-	res, errMsg := ErrorIs.Check([]interface{}{"", errors.New("")}, []string{"error", "target"})
+	res, errMsg := ErrorIs.Check([]any{"", errors.New("")}, []string{"error", "target"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "first argument must be an error")
 
-	res, errMsg = ErrorIs.Check([]interface{}{errors.New(""), ""}, []string{"error", "target"})
+	res, errMsg = ErrorIs.Check([]any{errors.New(""), ""}, []string{"error", "target"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "second argument must be an error")
 }

--- a/testutil/filecontentchecker.go
+++ b/testutil/filecontentchecker.go
@@ -57,7 +57,7 @@ var FileMatches check.Checker = &fileContentChecker{
 // conjunction with FileEquals.
 type FileContentRef string
 
-func (c *fileContentChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *fileContentChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "Filename must be a string"
@@ -76,7 +76,7 @@ func (c *fileContentChecker) Check(params []interface{}, names []string) (result
 	return fileContentCheck(filename, params[1], c.exact)
 }
 
-func fileContentCheck(filename string, content interface{}, exact bool) (result bool, error string) {
+func fileContentCheck(filename string, content any, exact bool) (result bool, error string) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return false, fmt.Sprintf("Cannot read file %q: %v", filename, err)

--- a/testutil/filepresencechecker.go
+++ b/testutil/filepresencechecker.go
@@ -43,7 +43,7 @@ var FileAbsent check.Checker = &filePresenceChecker{
 	present:     false,
 }
 
-func (c *filePresenceChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *filePresenceChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "filename must be a string"

--- a/testutil/intcheckers.go
+++ b/testutil/intcheckers.go
@@ -30,7 +30,7 @@ type intChecker struct {
 	rel string
 }
 
-func (checker *intChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (checker *intChecker) Check(params []any, names []string) (result bool, error string) {
 	a, ok := params[0].(int)
 	if !ok {
 		return false, "left-hand-side argument must be an int"

--- a/testutil/interfacenilchecker.go
+++ b/testutil/interfacenilchecker.go
@@ -35,7 +35,7 @@ type interfaceNilChecker struct {
 	*check.CheckerInfo
 }
 
-func (*interfaceNilChecker) Check(params []interface{}, names []string) (result bool, errMsg string) {
+func (*interfaceNilChecker) Check(params []any, names []string) (result bool, errMsg string) {
 	if reflect.ValueOf(params[0]).IsValid() {
 		return false, fmt.Sprintf("expected <nil> but got %T type", params[0])
 	}

--- a/testutil/interfacenilchecker_test.go
+++ b/testutil/interfacenilchecker_test.go
@@ -52,7 +52,7 @@ func (*interfaceNilCheckerSuite) TestIsInterfaceNilMatchesIntendedNilComparison(
 	// assigning nil to a typed variable and then returning it fails the '== nil' check
 	err3 := typedErrWithNilValue()
 	c.Assert(err3 == nil, Equals, false)
-	res, errMsg := IsInterfaceNil.Check([]interface{}{err3}, []string{"value"})
+	res, errMsg := IsInterfaceNil.Check([]any{err3}, []string{"value"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "expected <nil> but got *testutil_test.someError type")
 }

--- a/testutil/jsonchecker.go
+++ b/testutil/jsonchecker.go
@@ -38,13 +38,13 @@ var JsonEquals check.Checker = &jsonEqualChecker{
 	&check.CheckerInfo{Name: "JsonEqual", Params: []string{"obtained", "expected"}},
 }
 
-func (c *jsonEqualChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	toComparableMap := func(what interface{}) interface{} {
+func (c *jsonEqualChecker) Check(params []any, names []string) (result bool, error string) {
+	toComparableMap := func(what any) any {
 		b, err := json.Marshal(what)
 		if err != nil {
 			panic("cannot marshal")
 		}
-		var back interface{}
+		var back any
 		if err := json.Unmarshal(b, &back); err != nil {
 			panic(fmt.Sprintf("cannot unmarshal from: %s", string(b)))
 		}
@@ -54,5 +54,5 @@ func (c *jsonEqualChecker) Check(params []interface{}, names []string) (result b
 	obtained := toComparableMap(params[0])
 	ref := toComparableMap(params[1])
 
-	return check.DeepEquals.Check([]interface{}{obtained, ref}, names)
+	return check.DeepEquals.Check([]any{obtained, ref}, names)
 }

--- a/testutil/jsonchecker.go
+++ b/testutil/jsonchecker.go
@@ -31,9 +31,9 @@ type jsonEqualChecker struct {
 }
 
 // JsonEquals compares the obtained and expected values after having serialized
-// them to JSON and deserialized to a generic interface{} type. This avoids
-// trouble comparing types with unexported fields that otherwise would be
-// problematic to set in external packages.
+// them to JSON and deserialized to a generic any type. This avoids trouble
+// comparing types with unexported fields that otherwise would be problematic to
+// set in external packages.
 var JsonEquals check.Checker = &jsonEqualChecker{
 	&check.CheckerInfo{Name: "JsonEqual", Params: []string{"obtained", "expected"}},
 }

--- a/testutil/jsonchecker_test.go
+++ b/testutil/jsonchecker_test.go
@@ -46,13 +46,13 @@ func (*jsonCheckerSuite) TestFilePresent(c *check.C) {
 	}
 
 	testCheck(c, JsonEquals, true, "",
-		map[string]interface{}{
+		map[string]any{
 			"number": 42,
 			"string": "foo",
 			"list":   []string{"123", "456"},
-			"map": map[string]interface{}{
+			"map": map[string]any{
 				"foo": "bar",
-				"baz": []interface{}{0.2, 0.3},
+				"baz": []any{0.2, 0.3},
 			},
 		}, ref{
 			Number: 42,
@@ -68,18 +68,18 @@ func (*jsonCheckerSuite) TestFilePresent(c *check.C) {
 			hidden: true,
 		})
 	testCheck(c, JsonEquals, true, "",
-		map[string]interface{}{
+		map[string]any{
 			"number": 42,
 			"string": "foo",
-			"list":   []interface{}(nil),
+			"list":   []any(nil),
 		}, ref{
 			Number: 42,
 			String: "foo",
 		})
 	testCheck(c, JsonEquals, true, "",
-		map[string]interface{}{
+		map[string]any{
 			"number": 42,
-			"list":   []interface{}(nil),
+			"list":   []any(nil),
 		}, ref{
 			Number: 42,
 		})

--- a/testutil/paddedchecker.go
+++ b/testutil/paddedchecker.go
@@ -92,7 +92,7 @@ var ContainsWrapped = &paddedChecker{
 
 var spaceinator = regexp.MustCompile(`\s+`).ReplaceAllLiteralString
 
-func (c *paddedChecker) Check(params []interface{}, names []string) (result bool, errstr string) {
+func (c *paddedChecker) Check(params []any, names []string) (result bool, errstr string) {
 	var other string
 	switch v := params[0].(type) {
 	case string:

--- a/testutil/paddedchecker_test.go
+++ b/testutil/paddedchecker_test.go
@@ -59,8 +59,8 @@ func (*paddedCheckerSuite) TestPaddedChecker(c *check.C) {
 	}
 
 	for i, test := range table {
-		for _, lhs := range []interface{}{test.lhs, []byte(test.lhs), errors.New(test.lhs)} {
-			for _, rhs := range []interface{}{test.rhs, []byte(test.rhs)} {
+		for _, lhs := range []any{test.lhs, []byte(test.lhs), errors.New(test.lhs)} {
+			for _, rhs := range []any{test.rhs, []byte(test.rhs)} {
 				comm := check.Commentf("%d:%s:%T/%T", i, test.checker.Info().Name, lhs, rhs)
 				c.Check(lhs, test.checker, rhs, comm)
 			}

--- a/testutil/symlinktargetchecker.go
+++ b/testutil/symlinktargetchecker.go
@@ -49,7 +49,7 @@ var SymlinkTargetMatches check.Checker = &symlinkTargetChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "SymlinkTargetMatches", Params: []string{"filename", "regex"}},
 }
 
-func (c *symlinkTargetChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *symlinkTargetChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "Filename must be a string"
@@ -68,7 +68,7 @@ func (c *symlinkTargetChecker) Check(params []interface{}, names []string) (resu
 	return symlinkTargetCheck(filename, params[1], c.exact)
 }
 
-func symlinkTargetCheck(filename string, expectedTarget interface{}, exact bool) (result bool, error string) {
+func symlinkTargetCheck(filename string, expectedTarget any, exact bool) (result bool, error string) {
 	target, err := os.Readlink(filename)
 	if err != nil {
 		return false, fmt.Sprintf("Cannot read symbolic link: %v", err)

--- a/testutil/syscallschecker_linux.go
+++ b/testutil/syscallschecker_linux.go
@@ -35,7 +35,7 @@ var SyscallsEqual check.Checker = &syscallsEqualChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "SyscallsEqual", Params: []string{"actualList", "expectedList"}},
 }
 
-func (c *syscallsEqualChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *syscallsEqualChecker) Check(params []any, names []string) (result bool, error string) {
 	actualList, ok := params[0].([]CallResultError)
 	if !ok {
 		return false, "left-hand-side argument must be of type []CallResultError"

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -40,7 +40,7 @@ func testInfo(c *check.C, checker check.Checker, name string, paramNames []strin
 	}
 }
 
-func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) {
+func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...any) {
 	info := checker.Info()
 	if len(params) != len(info.Params) {
 		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -52,7 +52,7 @@ func (t *Timeout) UnmarshalJSON(buf []byte) error {
 	return nil
 }
 
-func (t *Timeout) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (t *Timeout) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err

--- a/timings/state.go
+++ b/timings/state.go
@@ -64,7 +64,7 @@ var timeDuration = func(start, end time.Time) time.Duration {
 
 // flatten flattens nested measurements into a single list within rootTimingJson.NestedTimings
 // and calculates total duration.
-func (t *Timings) flatten() interface{} {
+func (t *Timings) flatten() any {
 	var hasChangeID, hasTaskID bool
 	if t.tags != nil {
 		_, hasChangeID = t.tags["change-id"]
@@ -119,9 +119,9 @@ func flattenRecursive(data *rootTimingsJSON, timings []*Span, nestLevel int, max
 type GetSaver interface {
 	// GetMaybeTimings gets the saved timings.
 	// It will not return an error if none were saved yet.
-	GetMaybeTimings(timings interface{}) error
+	GetMaybeTimings(timings any) error
 	// SaveTimings saves the given timings.
-	SaveTimings(timings interface{})
+	SaveTimings(timings any)
 }
 
 // Save appends Timings data to a timings list in the GetSaver (usually

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -107,47 +107,47 @@ func (s *timingsSuite) TestSave(c *C) {
 		timing.Save(s.st)
 	}
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
 
-	c.Assert(stateTimings, DeepEquals, []interface{}{
-		map[string]interface{}{
-			"tags":       map[string]interface{}{"change": "12", "task": "3"},
+	c.Assert(stateTimings, DeepEquals, []any{
+		map[string]any{
+			"tags":       map[string]any{"change": "12", "task": "3"},
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "doing something-0",
 					"summary":  "...",
 					"duration": float64(1000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested measurement",
 					"summary":  "...",
 					"duration": float64(2000000)},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(2),
 					"label":    "nested more",
 					"summary":  "...",
 					"duration": float64(3000000)},
 			}},
-		map[string]interface{}{
-			"tags":       map[string]interface{}{"change": "12", "task": "3"},
+		map[string]any{
+			"tags":       map[string]any{"change": "12", "task": "3"},
 			"start-time": "2019-03-11T09:01:00.007Z",
 			"stop-time":  "2019-03-11T09:01:00.012Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "doing something-1",
 					"summary":  "...",
 					"duration": float64(4000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested measurement",
 					"summary":  "...",
 					"duration": float64(5000000)},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(2),
 					"label":    "nested more",
 					"summary":  "...",
@@ -164,7 +164,7 @@ func (s *timingsSuite) TestSaveNoTimings(c *C) {
 	timing := timings.New(nil)
 	timing.Save(s.st)
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), testutil.ErrorIs, state.ErrNoState)
 }
 
@@ -181,26 +181,26 @@ func (s *timingsSuite) TestDuration(c *C) {
 	meas.Stop()
 	timing.Save(s.st)
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
 
-	c.Assert(stateTimings, DeepEquals, []interface{}{
-		map[string]interface{}{
+	c.Assert(stateTimings, DeepEquals, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "foo",
 					"summary":  "...",
 					"duration": float64(5000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested",
 					"summary":  "...",
 					"duration": float64(1000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested sibling",
 					"summary":  "...",
@@ -209,7 +209,7 @@ func (s *timingsSuite) TestDuration(c *C) {
 			}}})
 }
 
-func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expected interface{}) {
+func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expected any) {
 	s.mockDurationThreshold(threshold)
 
 	s.st.Lock()
@@ -225,7 +225,7 @@ func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expe
 	meas.Stop()
 	timing.Save(s.st)
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	if expected == nil {
 		c.Assert(s.st.Get("timings", &stateTimings), testutil.ErrorIs, state.ErrNoState)
 		c.Assert(stateTimings, IsNil)
@@ -236,23 +236,23 @@ func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expe
 }
 
 func (s *timingsSuite) TestDurationThresholdAll(c *C) {
-	s.testDurationThreshold(c, 0, []interface{}{
-		map[string]interface{}{
+	s.testDurationThreshold(c, 0, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "main",
 					"summary":  "...",
 					"duration": float64(5000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested",
 					"summary":  "...",
 					"duration": float64(3000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(2),
 					"label":    "nested more",
 					"summary":  "...",
@@ -262,17 +262,17 @@ func (s *timingsSuite) TestDurationThresholdAll(c *C) {
 }
 
 func (s *timingsSuite) TestDurationThreshold(c *C) {
-	s.testDurationThreshold(c, 3000000, []interface{}{
-		map[string]interface{}{
+	s.testDurationThreshold(c, 3000000, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "main",
 					"summary":  "...",
 					"duration": float64(5000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested",
 					"summary":  "...",
@@ -282,12 +282,12 @@ func (s *timingsSuite) TestDurationThreshold(c *C) {
 }
 
 func (s *timingsSuite) TestDurationThresholdRootOnly(c *C) {
-	s.testDurationThreshold(c, 4000000, []interface{}{
-		map[string]interface{}{
+	s.testDurationThreshold(c, 4000000, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "main",
 					"summary":  "...",
 					"duration": float64(5000000),
@@ -317,14 +317,14 @@ func (s *timingsSuite) TestPurgeOnSave(c *C) {
 		t.Save(s.st)
 	}
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
 
 	// excess timings got dropped
 	c.Assert(stateTimings, HasLen, 3)
-	c.Check(stateTimings[0].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "7"})
-	c.Check(stateTimings[1].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "8"})
-	c.Check(stateTimings[2].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "9"})
+	c.Check(stateTimings[0].(map[string]any)["tags"], DeepEquals, map[string]any{"number": "7"})
+	c.Check(stateTimings[1].(map[string]any)["tags"], DeepEquals, map[string]any{"number": "8"})
+	c.Check(stateTimings[2].(map[string]any)["tags"], DeepEquals, map[string]any{"number": "9"})
 }
 
 func (s *timingsSuite) TestGet(c *C) {

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -83,7 +83,7 @@ var (
 )
 
 func sessionInfo(c *Command, r *http.Request) Response {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"version": c.s.Version,
 	}
 	return SyncResponse(m)
@@ -152,7 +152,7 @@ func serviceStart(inst *client.ServiceInstruction, sysd systemd.Systemd) Respons
 		Result: &errorResult{
 			Message: "some user services failed to start",
 			Kind:    errorKindServiceControl,
-			Value: map[string]interface{}{
+			Value: map[string]any{
 				"start-errors": startErrors,
 				"stop-errors":  stopErrors,
 			},
@@ -189,7 +189,7 @@ func serviceRestart(inst *client.ServiceInstruction, sysd systemd.Systemd) Respo
 		Result: &errorResult{
 			Message: "some user services failed to restart",
 			Kind:    errorKindServiceControl,
-			Value: map[string]interface{}{
+			Value: map[string]any{
 				"restart-errors": restartErrors,
 			},
 		},
@@ -218,7 +218,7 @@ func serviceStop(inst *client.ServiceInstruction, sysd systemd.Systemd) Response
 			Result: &errorResult{
 				Message: "some user services failed to stop",
 				Kind:    errorKindServiceControl,
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"stop-errors": stopErrors,
 				},
 			},
@@ -349,7 +349,7 @@ func serviceStatus(c *Command, r *http.Request) Response {
 			Result: &errorResult{
 				Message: "some user services failed to respond to status query",
 				Kind:    errorKindServiceStatus,
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"status-errors": statusErrors,
 				},
 			},

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -90,7 +90,7 @@ func (s *restSuite) TearDownTest(c *C) {
 
 type resp struct {
 	Type   agent.ResponseType `json:"type"`
-	Result interface{}        `json:"result"`
+	Result any                `json:"result"`
 }
 
 func (s *restSuite) TestSessionInfo(c *C) {
@@ -111,7 +111,7 @@ func (s *restSuite) TestSessionInfo(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeSync)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"version": "42b1",
 	})
 }
@@ -223,11 +223,11 @@ func (s *restSuite) TestServiceControlStartEnableFailsAndDisables(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"kind": "service-control", "message": "some user services failed to start",
-		"value": map[string]interface{}{
-			"start-errors": map[string]interface{}{"snap.bar.service": "mock systemctl error"},
-			"stop-errors":  map[string]interface{}{},
+		"value": map[string]any{
+			"start-errors": map[string]any{"snap.bar.service": "mock systemctl error"},
+			"stop-errors":  map[string]any{},
 		},
 	})
 
@@ -260,7 +260,7 @@ func (s *restSuite) TestServicesStartNonSnap(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "cannot start non-snap service not-snap.bar.service",
 	})
 
@@ -289,14 +289,14 @@ func (s *restSuite) TestServicesStartFailureStopsServices(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "some user services failed to start",
 		"kind":    "service-control",
-		"value": map[string]interface{}{
-			"start-errors": map[string]interface{}{
+		"value": map[string]any{
+			"start-errors": map[string]any{
 				"snap.bar.service": "start failure",
 			},
-			"stop-errors": map[string]interface{}{},
+			"stop-errors": map[string]any{},
 		},
 	})
 
@@ -332,14 +332,14 @@ func (s *restSuite) TestServicesStartFailureReportsStopFailures(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "some user services failed to start",
 		"kind":    "service-control",
-		"value": map[string]interface{}{
-			"start-errors": map[string]interface{}{
+		"value": map[string]any{
+			"start-errors": map[string]any{
 				"snap.bar.service": "start failure",
 			},
-			"stop-errors": map[string]interface{}{
+			"stop-errors": map[string]any{
 				"snap.foo.service": "stop failure",
 			},
 		},
@@ -418,7 +418,7 @@ func (s *restSuite) TestServicesStopDisableFailsOnDisable(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "cannot disable services [\"snap.foo.service\"]: mock systemctl error",
 	})
 
@@ -450,7 +450,7 @@ func (s *restSuite) TestServicesStopDisableFailsOnReload(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "cannot reload systemd: mock systemctl error",
 	})
 
@@ -473,7 +473,7 @@ func (s *restSuite) TestServicesStopNonSnap(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "cannot stop non-snap service not-snap.bar.service",
 	})
 
@@ -505,11 +505,11 @@ func (s *restSuite) TestServicesStopReportsError(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "some user services failed to stop",
 		"kind":    "service-control",
-		"value": map[string]interface{}{
-			"stop-errors": map[string]interface{}{
+		"value": map[string]any{
+			"stop-errors": map[string]any{
 				"snap.bar.service": "mock systemctl error",
 			},
 		},
@@ -555,7 +555,7 @@ func (s *restSuite) TestServicesRestartNonSnap(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "cannot restart non-snap service not-snap.bar.service",
 	})
 
@@ -587,11 +587,11 @@ func (s *restSuite) TestServicesRestartReportsError(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"kind":    "service-control",
 		"message": "some user services failed to restart",
-		"value": map[string]interface{}{
-			"restart-errors": map[string]interface{}{
+		"value": map[string]any{
+			"restart-errors": map[string]any{
 				"snap.bar.service": "mock systemctl error",
 			},
 		},
@@ -634,7 +634,7 @@ func (s *restSuite) TestServicesRestartOrReloadNonSnap(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "cannot restart non-snap service not-snap.bar.service",
 	})
 
@@ -666,11 +666,11 @@ func (s *restSuite) TestServicesRestartOrReloadReportsError(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"kind":    "service-control",
 		"message": "some user services failed to restart",
-		"value": map[string]interface{}{
-			"restart-errors": map[string]interface{}{
+		"value": map[string]any{
+			"restart-errors": map[string]any{
 				"snap.bar.service": "mock systemctl error",
 			},
 		},
@@ -707,27 +707,27 @@ NeedDaemonReload=no
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeSync)
-	c.Check(rsp.Result, DeepEquals, []interface{}{
-		map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, []any{
+		map[string]any{
 			"active":    false,
 			"daemon":    "notify",
 			"enabled":   true,
 			"id":        "snap.foo.service",
 			"installed": true,
 			"name":      "snap.foo.service",
-			"names": []interface{}{
+			"names": []any{
 				"snap.foo.service",
 			},
 			"needs-reload": false,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"active":    false,
 			"daemon":    "notify",
 			"enabled":   true,
 			"id":        "snap.bar.service",
 			"installed": true,
 			"name":      "snap.bar.service",
-			"names": []interface{}{
+			"names": []any{
 				"snap.bar.service",
 			},
 			"needs-reload": false,
@@ -751,7 +751,7 @@ func (s *restSuite) TestServiceStatusNonSnap(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"message": "cannot query non-snap service not-snap.bar.service",
 	})
 
@@ -777,11 +777,11 @@ func (s *restSuite) TestServicesStatusReportsError(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{
+	c.Check(rsp.Result, DeepEquals, map[string]any{
 		"kind":    "service-status",
 		"message": "some user services failed to respond to status query",
-		"value": map[string]interface{}{
-			"status-errors": map[string]interface{}{
+		"value": map[string]any{
+			"status-errors": map[string]any{
 				"snap.foo.service": "mock systemctl error",
 				"snap.bar.service": "mock systemctl error",
 			},
@@ -805,7 +805,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationMalformedContentType(c *C)
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{"message": "cannot parse content type: mime: unexpected content after media subtype"})
+	c.Check(rsp.Result, DeepEquals, map[string]any{"message": "cannot parse content type: mime: unexpected content after media subtype"})
 }
 
 func (s *restSuite) TestPostPendingRefreshNotificationUnsupportedContentType(c *C) {
@@ -819,7 +819,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationUnsupportedContentType(c *
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{"message": "unknown content type: text/plain"})
+	c.Check(rsp.Result, DeepEquals, map[string]any{"message": "unknown content type: text/plain"})
 }
 
 func (s *restSuite) TestPostPendingRefreshNotificationUnsupportedContentEncoding(c *C) {
@@ -833,7 +833,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationUnsupportedContentEncoding
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{"message": "unknown charset in content type: application/json; charset=EBCDIC"})
+	c.Check(rsp.Result, DeepEquals, map[string]any{"message": "unknown charset in content type: application/json; charset=EBCDIC"})
 }
 
 func (s *restSuite) TestPostPendingRefreshNotificationMalformedRequestBody(c *C) {
@@ -848,7 +848,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationMalformedRequestBody(c *C)
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{"message": "cannot decode request body into pending snap refresh info: invalid character 's' looking for beginning of value"})
+	c.Check(rsp.Result, DeepEquals, map[string]any{"message": "cannot decode request body into pending snap refresh info: invalid character 's' looking for beginning of value"})
 }
 
 func (s *restSuite) TestPostPendingRefreshNotificationNoSessionBus(c *C) {
@@ -866,7 +866,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationNoSessionBus(c *C) {
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{"message": "cannot connect to the session bus"})
+	c.Check(rsp.Result, DeepEquals, map[string]any{"message": "cannot connect to the session bus"})
 }
 
 func (s *restSuite) testPostPendingRefreshNotificationBody(c *C, refreshInfo *client.PendingSnapRefreshInfo) {
@@ -1026,7 +1026,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationNotificationServerFailure(
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
 	c.Check(rsp.Type, Equals, agent.ResponseTypeError)
-	c.Check(rsp.Result, DeepEquals, map[string]interface{}{"message": "cannot send notification message: org.freedesktop.DBus.Error.Failed"})
+	c.Check(rsp.Result, DeepEquals, map[string]any{"message": "cannot send notification message: org.freedesktop.DBus.Error.Failed"})
 }
 
 func (s *restSuite) testPostFinishRefreshNotificationBody(c *C, refreshInfo *client.FinishedSnapRefreshInfo) {

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -146,7 +146,7 @@ func (s *Launcher) IntrospectionData() string {
 func makeAccessDeniedError(err error) *dbus.Error {
 	return &dbus.Error{
 		Name: "org.freedesktop.DBus.Error.AccessDenied",
-		Body: []interface{}{err.Error()},
+		Body: []any{err.Error()},
 	}
 }
 


### PR DESCRIPTION
This applies the changes from:
```
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test -fix ./...
``` 
While this tool can apply many changes, the only ones needed here are swapping interface{} for any.