### PR TITLE
tests: update the nightly workflows to run with no-reexec

### DIFF
--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -48,7 +48,7 @@ jobs:
       tasks: 'tests/...'
       rules: ''
       use-snapd-snap-from-master: true
-      spread-snapd-deb-from-repo: false
+      spread-env: "SPREAD_SNAPD_DEB_FROM_REPO=false SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_SNAP_REEXEC=0"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -39,10 +39,6 @@ on:
         required: false
         type: boolean
         default: false
-      spread-snapd-deb-from-repo:
-        description: 'If true, will use the snapd package from the repository when possible'
-        required: false
-        type: string
       spread-experimental-features:
         description: 'Comma-separated list of experimental snapd features to enable with: snap set system "experimental.<feature-name>=true"'
         required: false
@@ -95,10 +91,6 @@ jobs:
           for env in ${{ inputs.spread-env }}; do
             echo "$env" >> $GITHUB_ENV
           done
-
-    - name: set SPREAD_SNAPD_DEB_FROM_REPO=1
-      if: ${{ inputs.spread-snapd-deb-from-repo == 'true' }}
-      run: echo "SPREAD_SNAPD_DEB_FROM_REPO=1" >> $GITHUB_ENV
 
     - name: Get previous attempt
       id: get-previous-attempt


### PR DESCRIPTION
This change is needed to run nigthly jobs using the snapd deb build from the master branch but without re-exec. The idea is to test the snapd deb.

Also it is removed the spread-snapd-deb-from-repo because now we can pass it as spread-env
