### PR TITLE
systemd,overlord: run systemtclt start if mount unit is unchanged

### DIFF
--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -232,13 +232,14 @@ func (m *mountCommand) ensureMount(sysd systemd.Systemd) (string, error) {
 		lifetime = systemd.Persistent
 	}
 	unitName, err := sysd.EnsureMountUnitFileWithOptions(&systemd.MountUnitOptions{
-		Lifetime:    lifetime,
-		Description: fmt.Sprintf("Mount unit for %s, revision %s via mount-control", snapName, revision),
-		What:        m.Positional.What,
-		Where:       m.Positional.Where,
-		Fstype:      m.Type,
-		Options:     m.optionsList,
-		Origin:      "mount-control",
+		Lifetime:               lifetime,
+		Description:            fmt.Sprintf("Mount unit for %s, revision %s via mount-control", snapName, revision),
+		What:                   m.Positional.What,
+		Where:                  m.Positional.Where,
+		Fstype:                 m.Type,
+		Options:                m.optionsList,
+		Origin:                 "mount-control",
+		EnsureStartIfUnchanged: true,
 	})
 	if err != nil {
 		_ = sysd.RemoveMountUnitFile(m.Positional.Where)

--- a/overlord/hookstate/ctlcmd/mount_test.go
+++ b/overlord/hookstate/ctlcmd/mount_test.go
@@ -314,12 +314,13 @@ func (s *mountSuite) TestUnitCreationFailure(c *C) {
 	c.Check(err, ErrorMatches, `cannot ensure mount unit: creation error`)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Transient,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "/src",
-			Where:       "/dest",
-			Fstype:      "ext4",
-			Origin:      "mount-control",
+			Lifetime:               systemd.Transient,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "/src",
+			Where:                  "/dest",
+			Fstype:                 "ext4",
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 }
@@ -333,13 +334,14 @@ func (s *mountSuite) TestHappy(c *C) {
 	c.Check(err, IsNil)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Persistent,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "/src",
-			Where:       "/dest",
-			Fstype:      "ext4",
-			Options:     []string{"sync", "rw"},
-			Origin:      "mount-control",
+			Lifetime:               systemd.Persistent,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "/src",
+			Where:                  "/dest",
+			Fstype:                 "ext4",
+			Options:                []string{"sync", "rw"},
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 }
@@ -356,12 +358,13 @@ func (s *mountSuite) TestHappyWithVariableExpansion(c *C) {
 	c.Check(err, IsNil)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Transient,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "/media/me/data",
-			Where:       where,
-			Options:     []string{"bind", "ro"},
-			Origin:      "mount-control",
+			Lifetime:               systemd.Transient,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "/media/me/data",
+			Where:                  where,
+			Options:                []string{"bind", "ro"},
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 }
@@ -376,12 +379,13 @@ func (s *mountSuite) TestHappyWithCommasInPath(c *C) {
 	c.Check(err, IsNil)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Transient,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "/dev/dma_heap/qcom,qseecom",
-			Where:       "/dest,with,commas",
-			Options:     []string{"ro"},
-			Origin:      "mount-control",
+			Lifetime:               systemd.Transient,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "/dev/dma_heap/qcom,qseecom",
+			Where:                  "/dest,with,commas",
+			Options:                []string{"ro"},
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 }
@@ -396,13 +400,14 @@ func (s *mountSuite) TestHappyNFS(c *C) {
 	c.Check(err, IsNil)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Transient,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "localhost:/var/share",
-			Where:       "/nfs-dest",
-			Fstype:      "nfs",
-			Options:     []string{"rw"},
-			Origin:      "mount-control",
+			Lifetime:               systemd.Transient,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "localhost:/var/share",
+			Where:                  "/nfs-dest",
+			Fstype:                 "nfs",
+			Options:                []string{"rw"},
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 }
@@ -417,13 +422,14 @@ func (s *mountSuite) TestHappyCIFS(c *C) {
 	c.Check(err, IsNil)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Transient,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "//10.0.0.1/share/path",
-			Where:       "/cifs-dest",
-			Fstype:      "cifs",
-			Options:     []string{"rw", "guest"},
-			Origin:      "mount-control",
+			Lifetime:               systemd.Transient,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "//10.0.0.1/share/path",
+			Where:                  "/cifs-dest",
+			Fstype:                 "cifs",
+			Options:                []string{"rw", "guest"},
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 }
@@ -437,13 +443,14 @@ func (s *mountSuite) TestEnsureMountUnitFailed(c *C) {
 	c.Check(err, ErrorMatches, `cannot ensure mount unit: some error`)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Persistent,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "/src",
-			Where:       "/dest",
-			Fstype:      "ext4",
-			Options:     []string{"sync", "rw"},
-			Origin:      "mount-control",
+			Lifetime:               systemd.Persistent,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "/src",
+			Where:                  "/dest",
+			Fstype:                 "ext4",
+			Options:                []string{"sync", "rw"},
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 
@@ -460,13 +467,14 @@ func (s *mountSuite) TestEnsureMountUnitFailedRemoveFailed(c *C) {
 	c.Check(err, ErrorMatches, `cannot ensure mount unit: some error`)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
-			Lifetime:    systemd.Persistent,
-			Description: "Mount unit for snap1, revision 1 via mount-control",
-			What:        "/src",
-			Where:       "/dest",
-			Fstype:      "ext4",
-			Options:     []string{"sync", "rw"},
-			Origin:      "mount-control",
+			Lifetime:               systemd.Persistent,
+			Description:            "Mount unit for snap1, revision 1 via mount-control",
+			What:                   "/src",
+			Where:                  "/dest",
+			Fstype:                 "ext4",
+			Options:                []string{"sync", "rw"},
+			Origin:                 "mount-control",
+			EnsureStartIfUnchanged: true,
 		},
 	})
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1758,6 +1758,16 @@ nested_add_usb_serial_device() {
     echo "device added"
 }
 
+nested_add_usb_drive() {
+    local DEVICE_ID=$1
+    local DRIVE_FILE=$2
+
+    # A device_del of $DEVICE_ID also will remove the drive
+    echo "drive_add 0 if=none,file=$DRIVE_FILE,format=raw,id=rawdisk" | nc -q 0 127.0.0.1 "$NESTED_MON_PORT"
+    echo "device_add usb-storage,drive=rawdisk,id=$DEVICE_ID" | nc -q 0 127.0.0.1 "$NESTED_MON_PORT"
+    echo "USB drive device added"
+}
+
 nested_del_device() {
     local DEVICE_ID=$1
     echo "device_del $DEVICE_ID" | nc -q 0 127.0.0.1 "$NESTED_MON_PORT"

--- a/tests/nested/core/remount-hotplug/mount-usb-drive/bin/mnt_check
+++ b/tests/nested/core/remount-hotplug/mount-usb-drive/bin/mnt_check
@@ -1,0 +1,7 @@
+#!/bin/bash -exu
+
+cd "$SNAP_COMMON"
+mkdir -p mnt
+snapctl mount --persistent /dev/sda "$PWD"/mnt/
+
+stat mnt/lost+found

--- a/tests/nested/core/remount-hotplug/mount-usb-drive/meta/snap.yaml
+++ b/tests/nested/core/remount-hotplug/mount-usb-drive/meta/snap.yaml
@@ -1,0 +1,23 @@
+name: mount-usb-drive
+version: '1.0'
+summary: Mount USB drive
+description: |
+  Mount USB drive
+base: ##BASE##
+apps:
+  test:
+    command: bin/mnt_check
+    plugs:
+      - mnt
+      - block-devices
+confinement: strict
+grade: stable
+plugs:
+  mnt:
+    interface: mount-control
+    mount:
+    - what: /dev/sd*
+      where: $SNAP_COMMON/**
+      persistent: true
+      options:
+        - rw

--- a/tests/nested/core/remount-hotplug/task.yaml
+++ b/tests/nested/core/remount-hotplug/task.yaml
@@ -1,0 +1,48 @@
+summary: Test that snapctl mount will mount in a re-plug case
+
+details: |
+  Test that snapctl mount will mount a hot-pluged device if such device is
+  removed, then reinserted, and snapctl mount is called again.
+
+systems: [-ubuntu-1*]
+
+restore: |
+  rm -f mount-usb-drive_1.0_all.snap
+
+execute: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB/nested.sh"
+  #shellcheck source=tests/lib/hotplug.sh
+  . "$TESTSLIB/hotplug.sh"
+
+  version="$(nested_get_version)"
+  sed -i "s/##BASE##/core$version/" mount-usb-drive/meta/snap.yaml
+  snap pack mount-usb-drive
+  remote.push mount-usb-drive_1.0_all.snap
+
+  img_file=$PWD/ext4.img
+  truncate -s 10M "$img_file"
+  mkfs.ext4 "$img_file"
+  # No need to run e2fsck
+  tune2fs -c0 -i0 "$img_file"
+
+  remote.exec sudo snap install --dangerous mount-usb-drive_1.0_all.snap
+  remote.exec sudo snap connect mount-usb-drive:block-devices
+  remote.exec sudo snap connect mount-usb-drive:mnt
+
+  # Plug USB drive
+  qemu_dev_id=usbdrive
+  nested_add_usb_drive "$qemu_dev_id" "$img_file"
+  # Check snapctl mount on the drive
+  remote.exec "retry --wait 1 -n 5 sh -c 'sudo mount-usb-drive.test'"
+
+  # Unplug drive
+  nested_del_device "$qemu_dev_id"
+  not remote.exec sudo mount-usb-drive.test
+
+  # Re-plug, running snapct mount should start the mount
+  nested_add_usb_drive "$qemu_dev_id" "$img_file"
+  remote.exec "retry --wait 1 -n 5 sh -c 'sudo mount-usb-drive.test'"
+
+  # Clean-up
+  nested_del_device "$qemu_dev_id"


### PR DESCRIPTION
Run "systemtctl start" for mount units in case we have not modified them, with
the intention of making sure they are actually running. Fixes LP#2102189.