### PR TITLE
s/a/notify: use variable for native byte order instead of rechecking

### DIFF
--- a/sandbox/apparmor/notify/export_test.go
+++ b/sandbox/apparmor/notify/export_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 var (
+	NativeByteOrder = nativeByteOrder
+
 	Versions                     = versions
 	VersionLikelySupportedChecks = versionLikelySupportedChecks
 

--- a/sandbox/apparmor/notify/ioctl.go
+++ b/sandbox/apparmor/notify/ioctl.go
@@ -10,7 +10,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -48,8 +47,7 @@ func NewIoctlRequestBuffer(version ProtocolVersion) IoctlRequestBuffer {
 	bufSize := 0xFFFF
 	buf := bytes.NewBuffer(make([]byte, 0, bufSize))
 	header := MsgHeader{Version: version, Length: uint16(bufSize)}
-	order := arch.Endian()
-	binary.Write(buf, order, &header)
+	binary.Write(buf, nativeByteOrder, &header)
 	buf.Write(make([]byte, bufSize-buf.Len()))
 	return IoctlRequestBuffer(buf.Bytes())
 }

--- a/sandbox/apparmor/notify/ioctl_test.go
+++ b/sandbox/apparmor/notify/ioctl_test.go
@@ -10,7 +10,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 )
 
@@ -141,7 +140,7 @@ func (*ioctlSuite) TestIoctlDump(c *C) {
 
 	sendHeader := fmt.Sprintf(">>> ioctl %v (%d bytes) ...\n", req, len(ioctlBuf))
 	sendDataStr := "0xff, 0xff, 0x42, 0x00, "
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		sendDataStr = "0xff, 0xff, 0x00, 0x42, "
 	}
 

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -85,9 +85,8 @@ func (msg *MsgHeader) UnmarshalBinary(data []byte) error {
 
 func (msg *MsgHeader) unmarshalBinaryImpl(data []byte) error {
 	// Unpack fixed-size elements.
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	buf := bytes.NewReader(data)
-	if err := binary.Read(buf, order, msg); err != nil {
+	if err := binary.Read(buf, nativeByteOrder, msg); err != nil {
 		return err
 	}
 	if msg.Length < sizeofMsgHeader {
@@ -173,8 +172,7 @@ func (msg *MsgNotificationFilter) UnmarshalBinary(data []byte) error {
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationFilterKernel
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Read(buf, order, &raw); err != nil {
+	if err := binary.Read(buf, nativeByteOrder, &raw); err != nil {
 		return fmt.Errorf("%s: cannot unpack: %s", prefix, err)
 	}
 
@@ -213,8 +211,7 @@ func (msg *MsgNotificationFilter) MarshalBinary() (data []byte, err error) {
 	}
 	raw.Length = packer.totalLen() + uint16(len(filter))
 	msgBuf := bytes.NewBuffer(make([]byte, 0, raw.Length))
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Write(msgBuf, order, raw); err != nil {
+	if err := binary.Write(msgBuf, nativeByteOrder, raw); err != nil {
 		return nil, err
 	}
 	if _, err := msgBuf.Write(packer.bytes()); err != nil {
@@ -289,8 +286,7 @@ func (msg *MsgNotification) UnmarshalBinary(data []byte) error {
 
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Read(buf, order, msg); err != nil {
+	if err := binary.Read(buf, nativeByteOrder, msg); err != nil {
 		return fmt.Errorf("%s: cannot unpack: %s", prefix, err)
 	}
 
@@ -304,8 +300,7 @@ func (msg *MsgNotification) MarshalBinary() ([]byte, error) {
 	}
 	msg.Length = uint16(binary.Size(*msg))
 	buf := bytes.NewBuffer(make([]byte, 0, msg.Length))
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Write(buf, order, msg); err != nil {
+	if err := binary.Write(buf, nativeByteOrder, msg); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
@@ -389,8 +384,7 @@ func (msg *MsgNotificationResponse) MarshalBinary() ([]byte, error) {
 	}
 	msg.Length = uint16(binary.Size(*msg))
 	buf := bytes.NewBuffer(make([]byte, 0, msg.Length))
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Write(buf, order, msg); err != nil {
+	if err := binary.Write(buf, nativeByteOrder, msg); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
@@ -466,8 +460,7 @@ func (msg *MsgNotificationOp) UnmarshalBinary(data []byte) error {
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationOpKernel
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Read(buf, order, &raw); err != nil {
+	if err := binary.Read(buf, nativeByteOrder, &raw); err != nil {
 		return fmt.Errorf("%s: cannot unpack: %s", prefix, err)
 	}
 
@@ -595,8 +588,7 @@ func (msg *MsgNotificationFile) unmarshalBase(data []byte) error {
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationFileKernelBase
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Read(buf, order, &raw); err != nil {
+	if err := binary.Read(buf, nativeByteOrder, &raw); err != nil {
 		return fmt.Errorf("cannot unpack: %v", err)
 	}
 
@@ -619,8 +611,7 @@ func (msg *MsgNotificationFile) unmarshalTags(data []byte) error {
 	// Unpack fixed-size elements to get tag metadata.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationFileKernelWithTags
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Read(buf, order, &raw); err != nil {
+	if err := binary.Read(buf, nativeByteOrder, &raw); err != nil {
 		return fmt.Errorf("cannot unpack tagset metadata: %v", err)
 	}
 
@@ -634,7 +625,7 @@ func (msg *MsgNotificationFile) unmarshalTags(data []byte) error {
 	unpacker := newStringUnpacker(data)
 	for i := uint16(0); i < raw.TagsetsCount; i++ {
 		var header tagsetHeader
-		if err := binary.Read(hdrBuf, order, &header); err != nil {
+		if err := binary.Read(hdrBuf, nativeByteOrder, &header); err != nil {
 			return fmt.Errorf("cannot unpack tagset header: %v", err)
 		}
 		tags, err := unpacker.unpackStrings(header.TagOffset, header.TagCount)
@@ -687,8 +678,7 @@ func (msg *MsgNotificationFile) MarshalBinary() ([]byte, error) {
 
 	raw.Length = packer.totalLen()
 	msgBuf := bytes.NewBuffer(make([]byte, 0, raw.Length))
-	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
-	if err := binary.Write(msgBuf, order, ptr); err != nil {
+	if err := binary.Write(msgBuf, nativeByteOrder, ptr); err != nil {
 		return nil, err
 	}
 	if _, err := msgBuf.Write(packer.bytes()); err != nil {

--- a/sandbox/apparmor/notify/message.go
+++ b/sandbox/apparmor/notify/message.go
@@ -5,8 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-
-	"github.com/snapcore/snapd/arch"
 )
 
 var ErrVersionUnset = errors.New("cannot marshal message without protocol version")
@@ -87,7 +85,7 @@ func (msg *MsgHeader) UnmarshalBinary(data []byte) error {
 
 func (msg *MsgHeader) unmarshalBinaryImpl(data []byte) error {
 	// Unpack fixed-size elements.
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	buf := bytes.NewReader(data)
 	if err := binary.Read(buf, order, msg); err != nil {
 		return err
@@ -175,7 +173,7 @@ func (msg *MsgNotificationFilter) UnmarshalBinary(data []byte) error {
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationFilterKernel
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Read(buf, order, &raw); err != nil {
 		return fmt.Errorf("%s: cannot unpack: %s", prefix, err)
 	}
@@ -215,7 +213,7 @@ func (msg *MsgNotificationFilter) MarshalBinary() (data []byte, err error) {
 	}
 	raw.Length = packer.totalLen() + uint16(len(filter))
 	msgBuf := bytes.NewBuffer(make([]byte, 0, raw.Length))
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Write(msgBuf, order, raw); err != nil {
 		return nil, err
 	}
@@ -291,7 +289,7 @@ func (msg *MsgNotification) UnmarshalBinary(data []byte) error {
 
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Read(buf, order, msg); err != nil {
 		return fmt.Errorf("%s: cannot unpack: %s", prefix, err)
 	}
@@ -306,7 +304,7 @@ func (msg *MsgNotification) MarshalBinary() ([]byte, error) {
 	}
 	msg.Length = uint16(binary.Size(*msg))
 	buf := bytes.NewBuffer(make([]byte, 0, msg.Length))
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Write(buf, order, msg); err != nil {
 		return nil, err
 	}
@@ -391,7 +389,7 @@ func (msg *MsgNotificationResponse) MarshalBinary() ([]byte, error) {
 	}
 	msg.Length = uint16(binary.Size(*msg))
 	buf := bytes.NewBuffer(make([]byte, 0, msg.Length))
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Write(buf, order, msg); err != nil {
 		return nil, err
 	}
@@ -468,7 +466,7 @@ func (msg *MsgNotificationOp) UnmarshalBinary(data []byte) error {
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationOpKernel
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Read(buf, order, &raw); err != nil {
 		return fmt.Errorf("%s: cannot unpack: %s", prefix, err)
 	}
@@ -597,7 +595,7 @@ func (msg *MsgNotificationFile) unmarshalBase(data []byte) error {
 	// Unpack fixed-size elements.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationFileKernelBase
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Read(buf, order, &raw); err != nil {
 		return fmt.Errorf("cannot unpack: %v", err)
 	}
@@ -621,7 +619,7 @@ func (msg *MsgNotificationFile) unmarshalTags(data []byte) error {
 	// Unpack fixed-size elements to get tag metadata.
 	buf := bytes.NewReader(data)
 	var raw msgNotificationFileKernelWithTags
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Read(buf, order, &raw); err != nil {
 		return fmt.Errorf("cannot unpack tagset metadata: %v", err)
 	}
@@ -689,7 +687,7 @@ func (msg *MsgNotificationFile) MarshalBinary() ([]byte, error) {
 
 	raw.Length = packer.totalLen()
 	msgBuf := bytes.NewBuffer(make([]byte, 0, raw.Length))
-	order := arch.Endian() // ioctl messages are native byte order, verify endianness if using for other messages
+	order := nativeByteOrder // ioctl messages are native byte order, verify endianness if using for other messages
 	if err := binary.Write(msgBuf, order, ptr); err != nil {
 		return nil, err
 	}

--- a/sandbox/apparmor/notify/message_test.go
+++ b/sandbox/apparmor/notify/message_test.go
@@ -3,7 +3,6 @@ package notify_test
 import (
 	"encoding/binary"
 
-	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 
 	. "gopkg.in/check.v1"
@@ -14,7 +13,7 @@ type messageSuite struct{}
 var _ = Suite(&messageSuite{})
 
 func (*messageSuite) TestMsgLength(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	for _, t := range []struct {
@@ -64,7 +63,7 @@ func (*messageSuite) TestMsgLength(c *C) {
 }
 
 func (*messageSuite) TestMsgLengthErrors(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	for _, t := range []struct {
@@ -97,7 +96,7 @@ func (*messageSuite) TestMsgLengthErrors(c *C) {
 }
 
 func (*messageSuite) TestExtractFirstMsg(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 
@@ -193,7 +192,7 @@ func (*messageSuite) TestExtractFirstMsg(c *C) {
 }
 
 func (*messageSuite) TestExtractFirstMsgErrors(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 
@@ -260,7 +259,7 @@ func (*messageSuite) TestMessageMarshalErrors(c *C) {
 }
 
 func (*messageSuite) TestMsgNotificationFilterMarshalUnmarshal(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	for _, t := range []struct {
@@ -317,7 +316,7 @@ func (*messageSuite) TestMsgNotificationFilterMarshalUnmarshal(c *C) {
 }
 
 func (*messageSuite) TestMsgNotificationFilterUnmarshalErrors(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	for _, t := range []struct {
@@ -408,7 +407,7 @@ func (*messageSuite) TestMsgNotificationFilterValidate(c *C) {
 }
 
 func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	msg := notify.MsgNotification{
@@ -434,7 +433,7 @@ func (*messageSuite) TestMsgNotificationMarshalBinary(c *C) {
 }
 
 func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	// Notification for accessing the /root/.ssh/ directory.
@@ -495,7 +494,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV3(c *C) {
 }
 
 func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	// Notification for accessing the /root/.ssh/ directory.
@@ -558,7 +557,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithoutTags(c *C)
 }
 
 func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	// Notification for accessing /file
@@ -651,7 +650,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5(c *C) {
 }
 
 func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAndEmptyTagsets(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	// Notification for accessing /file
@@ -754,7 +753,7 @@ func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5WithOverlappingAn
 }
 
 func (s *messageSuite) TestMsgNotificationFileUnmarshalBinaryV5Errors(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	bytesTemplate := []byte{
@@ -939,7 +938,7 @@ func (s *messageSuite) TestBuildResponse(c *C) {
 }
 
 func (s *messageSuite) TestMsgNotificationResponseMarshalBinary(c *C) {
-	if arch.Endian() == binary.BigEndian {
+	if notify.NativeByteOrder == binary.BigEndian {
 		c.Skip("test only written for little-endian architectures")
 	}
 	msg := notify.MsgNotificationResponse{

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -6,9 +6,15 @@ import (
 	"fmt"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/arch"
 )
 
-var doIoctl = Ioctl
+var (
+	doIoctl = Ioctl
+
+	nativeByteOrder = arch.Endian() // ioctl messages are native byte order
+)
 
 // RegisterFileDescriptor registers a notification socket using the given file
 // descriptor. Attempts to use the latest notification protocol version which

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -13,6 +13,7 @@ import (
 var (
 	doIoctl = Ioctl
 
+	// TODO: replace with binary.NativeEndian once we're at go 1.21+
 	nativeByteOrder = arch.Endian() // ioctl messages are native byte order
 )
 

--- a/sandbox/apparmor/notify/strings.go
+++ b/sandbox/apparmor/notify/strings.go
@@ -5,8 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
-
-	"github.com/snapcore/snapd/arch"
 )
 
 // stringPacker assists in packing apparmor data structures with
@@ -110,8 +108,7 @@ func (sp *stringPacker) packTagsets(ts map[AppArmorPermission][]string) uint32 {
 	headerOffset := uint32(sp.buffer.Len())
 
 	// Now write the headers themselves
-	order := arch.Endian()
-	binary.Write(&sp.buffer, order, headers)
+	binary.Write(&sp.buffer, nativeByteOrder, headers)
 
 	return headerOffset + uint32(sp.baseOffset)
 }


### PR DESCRIPTION
Avoid repeatedly calling `arch.Endian()` whenever data needs to be de/serialized. A computer's endianness can't change while snapd is running.

This is cherry-picked from #15237 to reduce the changes required there, since this mostly touches existing code.