### PR TITLE
o/i/apparmorprompting: do not set backends to nil when closed

### DIFF
--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -318,6 +318,9 @@ func (m *InterfacesRequestsManager) Stop() error {
 func (m *InterfacesRequestsManager) Prompts(userID uint32, clientActivity bool) ([]*requestprompts.Prompt, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
+	if m.prompts == nil {
+		return nil, prompting_errors.ErrPromptsClosed
+	}
 	return m.prompts.Prompts(userID, clientActivity)
 }
 
@@ -328,6 +331,9 @@ func (m *InterfacesRequestsManager) Prompts(userID uint32, clientActivity bool) 
 func (m *InterfacesRequestsManager) PromptWithID(userID uint32, promptID prompting.IDType, clientActivity bool) (*requestprompts.Prompt, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
+	if m.prompts == nil {
+		return nil, prompting_errors.ErrPromptsClosed
+	}
 	return m.prompts.PromptWithID(userID, promptID, clientActivity)
 }
 
@@ -342,6 +348,10 @@ func (m *InterfacesRequestsManager) PromptWithID(userID uint32, promptID prompti
 func (m *InterfacesRequestsManager) HandleReply(userID uint32, promptID prompting.IDType, replyConstraints *prompting.ReplyConstraints, outcome prompting.OutcomeType, lifespan prompting.LifespanType, duration string, clientActivity bool) (satisfiedPromptIDs []prompting.IDType, retErr error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
+	if m.prompts == nil {
+		return nil, prompting_errors.ErrPromptsClosed
+	}
 
 	prompt, err := m.prompts.PromptWithID(userID, promptID, clientActivity)
 	if err != nil {
@@ -444,6 +454,10 @@ func (m *InterfacesRequestsManager) Rules(userID uint32, snap string, iface stri
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
+	if m.rules == nil {
+		return nil, prompting_errors.ErrRulesClosed
+	}
+
 	if snap != "" {
 		if iface != "" {
 			rules := m.rules.RulesForSnapInterface(userID, snap, iface)
@@ -466,6 +480,10 @@ func (m *InterfacesRequestsManager) AddRule(userID uint32, snap string, iface st
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
+	if m.rules == nil {
+		return nil, prompting_errors.ErrRulesClosed
+	}
+
 	newRule, err := m.rules.AddRule(userID, snap, iface, constraints)
 	if err != nil {
 		return nil, err
@@ -483,6 +501,10 @@ func (m *InterfacesRequestsManager) RemoveRules(userID uint32, snap string, ifac
 	// has an internal mutex.
 	m.lock.RLock()
 	defer m.lock.RUnlock()
+
+	if m.rules == nil {
+		return nil, prompting_errors.ErrRulesClosed
+	}
 
 	if snap == "" && iface == "" {
 		// The caller should ensure that this is not the case.
@@ -503,6 +525,10 @@ func (m *InterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompting.I
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
+	if m.rules == nil {
+		return nil, prompting_errors.ErrRulesClosed
+	}
+
 	rule, err := m.rules.RuleWithID(userID, ruleID)
 	return rule, err
 }
@@ -512,6 +538,10 @@ func (m *InterfacesRequestsManager) RuleWithID(userID uint32, ruleID prompting.I
 func (m *InterfacesRequestsManager) PatchRule(userID uint32, ruleID prompting.IDType, constraintsPatch *prompting.RuleConstraintsPatch) (*requestrules.Rule, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
+	if m.rules == nil {
+		return nil, prompting_errors.ErrRulesClosed
+	}
 
 	patchedRule, err := m.rules.PatchRule(userID, ruleID, constraintsPatch)
 	if err != nil {
@@ -528,6 +558,10 @@ func (m *InterfacesRequestsManager) RemoveRule(userID uint32, ruleID prompting.I
 	// has an internal mutex.
 	m.lock.RLock()
 	defer m.lock.RUnlock()
+
+	if m.rules == nil {
+		return nil, prompting_errors.ErrRulesClosed
+	}
 
 	rule, err := m.rules.RemoveRule(userID, ruleID)
 	return rule, err

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -167,6 +167,26 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	// Check that current backends are nil
 	c.Check(mgr.PromptDB(), IsNil)
 	c.Check(mgr.RuleDB(), IsNil)
+
+	// Check that calls to API methods don't panic on nil backends
+	_, err = mgr.Prompts(1000, false)
+	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
+	_, err = mgr.PromptWithID(1000, 1, false)
+	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
+	_, err = mgr.HandleReply(1000, 1, nil, prompting.OutcomeAllow, prompting.LifespanSingle, "", true)
+	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
+	_, err = mgr.Rules(1000, "foo", "bar")
+	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
+	_, err = mgr.AddRule(1000, "foo", "bar", nil)
+	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
+	_, err = mgr.RemoveRules(1000, "foo", "bar")
+	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
+	_, err = mgr.RuleWithID(1000, 1)
+	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
+	_, err = mgr.PatchRule(1000, 1, nil)
+	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
+	_, err = mgr.RemoveRule(1000, 1)
+	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
 }
 
 func (s *apparmorpromptingSuite) TestHandleListenerRequestDenyRoot(c *C) {

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -164,11 +164,7 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	c.Check(promptDB.Close(), Equals, prompting_errors.ErrPromptsClosed)
 	c.Check(ruleDB.Close(), Equals, prompting_errors.ErrRulesClosed)
 
-	// Check that current backends are nil
-	c.Check(mgr.PromptDB(), IsNil)
-	c.Check(mgr.RuleDB(), IsNil)
-
-	// Check that calls to API methods don't panic on nil backends
+	// Check that calls to API methods don't panic after backends have been closed
 	_, err = mgr.Prompts(1000, false)
 	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
 	_, err = mgr.PromptWithID(1000, 1, false)
@@ -176,13 +172,13 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	_, err = mgr.HandleReply(1000, 1, nil, prompting.OutcomeAllow, prompting.LifespanSingle, "", true)
 	c.Check(err, Equals, prompting_errors.ErrPromptsClosed)
 	_, err = mgr.Rules(1000, "foo", "bar")
-	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
+	c.Check(err, IsNil) // rule backend supports getting rules even after closed
 	_, err = mgr.AddRule(1000, "foo", "bar", nil)
 	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
 	_, err = mgr.RemoveRules(1000, "foo", "bar")
 	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
 	_, err = mgr.RuleWithID(1000, 1)
-	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
+	c.Check(err, Equals, prompting_errors.ErrRuleNotFound) // rule backend supports getting rules even after closed
 	_, err = mgr.PatchRule(1000, 1, nil)
 	c.Check(err, Equals, prompting_errors.ErrRulesClosed)
 	_, err = mgr.RemoveRule(1000, 1)


### PR DESCRIPTION
Don't set backends to `nil` when the manager closes. In doing so, we don't need to check for `nil` backends elsewhere, since the backends are never `nil`.

### Previously:

After acquiring the interfaces requests manager lock, check that the backend which is about to be accessed is not nil, which could be the case if the manager has been stopped.

This is cherry-picked from https://github.com/canonical/snapd/pull/15237 to reduce the changes required there, since this mostly touches existing code.