### PR TITLE
cmd/snap-bootstrap/triggerwatch: simulate passing time, better event sychronization

### DIFF
--- a/cmd/snap-bootstrap/triggerwatch/export_test.go
+++ b/cmd/snap-bootstrap/triggerwatch/export_test.go
@@ -26,11 +26,7 @@ import (
 )
 
 func MockInput(newInput TriggerProvider) (restore func()) {
-	oldInput := trigger
-	trigger = newInput
-	return func() {
-		trigger = oldInput
-	}
+	return testutil.Mock(&trigger, newInput)
 }
 
 type TriggerProvider = triggerProvider
@@ -65,31 +61,22 @@ func (m *mockUEventConnection) Monitor(queue chan netlink.UEvent, errors chan er
 }
 
 func MockUEventChannel(events chan netlink.UEvent) (restore func()) {
-	oldGetUEventConn := getUEventConn
-	getUEventConn = func() ueventConnection {
+	return testutil.Mock(&getUEventConn, func() ueventConnection {
 		return &mockUEventConnection{events}
-	}
-
-	return func() {
-		getUEventConn = oldGetUEventConn
-	}
+	})
 }
 
 func MockUEvent(events []netlink.UEvent) (restore func()) {
-	oldGetUEventConn := getUEventConn
 	e := make(chan netlink.UEvent)
 	go func() {
 		for _, event := range events {
 			e <- event
 		}
 	}()
-	getUEventConn = func() ueventConnection {
-		return &mockUEventConnection{e}
-	}
 
-	return func() {
-		getUEventConn = oldGetUEventConn
-	}
+	return testutil.Mock(&getUEventConn, func() ueventConnection {
+		return &mockUEventConnection{e}
+	})
 }
 
 func MockTimeAfter(f func(d time.Duration) <-chan time.Time) (restore func()) {

--- a/cmd/snap-bootstrap/triggerwatch/export_test.go
+++ b/cmd/snap-bootstrap/triggerwatch/export_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/osutil/udev/netlink"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func MockInput(newInput TriggerProvider) (restore func()) {
@@ -92,9 +93,5 @@ func MockUEvent(events []netlink.UEvent) (restore func()) {
 }
 
 func MockTimeAfter(f func(d time.Duration) <-chan time.Time) (restore func()) {
-	old := timeAfter
-	timeAfter = f
-	return func() {
-		f = old
-	}
+	return testutil.Mock(&timeAfter, f)
 }

--- a/cmd/snap-bootstrap/triggerwatch/triggerwatch.go
+++ b/cmd/snap-bootstrap/triggerwatch/triggerwatch.go
@@ -29,11 +29,12 @@ import (
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/udev/netlink"
+	"github.com/snapcore/snapd/timeutil"
 )
 
-var (
-	timeAfter = time.After
-)
+var timeAfter = func(d time.Duration) <-chan time.Time {
+	return timeutil.After(d)
+}
 
 type triggerProvider interface {
 	Open(filter triggerEventFilter, node string) (triggerDevice, error)

--- a/timeutil/timer.go
+++ b/timeutil/timer.go
@@ -51,6 +51,13 @@ func AfterFunc(d time.Duration, f func()) StdlibTimer {
 	return StdlibTimer{time.AfterFunc(d, f)}
 }
 
+// After waits for the duration to elapse and then closes the channel.
+//
+// See here for more information: https://pkg.go.dev/time#After
+func After(d time.Duration) <-chan time.Time {
+	return StdlibTimer{time.NewTimer(d)}.ExpiredC()
+}
+
 // NewTimer creates a new Timer that will send the current time on its channel
 // after at least duration d.
 //

--- a/timeutil/timer_test.go
+++ b/timeutil/timer_test.go
@@ -41,6 +41,14 @@ func (s *timerSuite) TestAfterFuncExpiredC(c *C) {
 	c.Assert(active, Equals, true)
 }
 
+func (s *timerSuite) TestAfter(c *C) {
+	c.Assert(timeutil.After(time.Second), NotNil)
+	before := time.Now()
+	fired := <-timeutil.After(time.Nanosecond)
+	c.Check(fired.After(before), Equals, true)
+	c.Check(time.Now().After(fired), Equals, true)
+}
+
 func (s *timerSuite) TestNewTimerExpiredC(c *C) {
 	before := time.Now()
 	var timer timeutil.Timer = timeutil.NewTimer(time.Nanosecond)


### PR DESCRIPTION
Avoid blocking unit tests through time.Sleep() and use timeutil/testutil.MockTimer() to simulate passing time.

Fix mocking of timeAfter so that go test -count=n, with n>1 works. As drive by fixes, update the mocking to use testutil.Mock.
