### PR TITLE
overlord/fdestate/dbx: do nothing for dbx when there are no encryption keys

### DIFF
--- a/overlord/fdestate/dbx.go
+++ b/overlord/fdestate/dbx.go
@@ -122,6 +122,12 @@ func EFISecureBootDBUpdatePrepare(st *state.State, db EFISecurebootKeyDatabase, 
 // EFISecureBootDBUpdateCleanup notifies that the local EFI key database manager
 // has reached a cleanup stage of the update process.
 func EFISecureBootDBUpdateCleanup(st *state.State) error {
+	if _, err := device.SealedKeysMethod(dirs.GlobalRootDir); err == device.ErrNoSealedKeys {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
 	st.Lock()
 	defer st.Unlock()
 
@@ -161,6 +167,12 @@ func EFISecureBootDBUpdateCleanup(st *state.State) error {
 // EFISecureBootDBManagerStartup indicates that the local EFI key database
 // manager has started.
 func EFISecureBootDBManagerStartup(st *state.State) error {
+	if _, err := device.SealedKeysMethod(dirs.GlobalRootDir); err == device.ErrNoSealedKeys {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
 	st.Lock()
 	defer st.Unlock()
 

--- a/tests/nested/manual/core20-nofde-dbx/task.yaml
+++ b/tests/nested/manual/core20-nofde-dbx/task.yaml
@@ -1,0 +1,36 @@
+summary: Verify EFI DBX updates in a Core20+ system without FDE
+
+details: |
+    Check that the snapd APIs are effectively NOP when performing EFI DBX
+    updates on a system without FDE.
+
+systems: [ubuntu-2*]
+
+environment:
+    NESTED_ENABLE_TPM: false
+    NESTED_ENABLE_SECURE_BOOT: false
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    NESTED_UBUNTU_SEED_SIZE: 1500M
+
+prepare: |
+    tests.nested build-image core
+    tests.nested create-vm core
+    remote.exec "test ! -e /var/lib/snapd/device/fde"
+
+execute: |
+    # no FDE so actions are effectively NOP, even though actual request data is
+    # checked for validity
+
+    echo "Action 'startup' does not fail"
+    echo '{"action":"efi-secureboot-update-startup"}' | \
+        remote.exec "sudo snap debug api --fail -X POST -H 'Content-Type: application/json' /v2/system-secureboot"
+
+    echo "Action 'cleanup' without prior prepare call, still successful"
+    echo '{"action":"efi-secureboot-update-db-cleanup"}' | \
+        remote.exec "sudo snap debug api --fail -X POST -H 'Content-Type: application/json' /v2/system-secureboot"
+
+    echo "Attempt to 'prepare' with invalid data"
+    # invalid DBX data, but the request is nonetheless properly structured
+    update_payload_invalid="$(echo "foobar" | base64 -w0)"
+    echo "{\"action\":\"efi-secureboot-update-db-prepare\",\"key-database\":\"DBX\",\"payload\":\"$update_payload_invalid\"}" | \
+        remote.exec "sudo snap debug api --fail -X POST -H 'Content-Type: application/json' /v2/system-secureboot"


### PR DESCRIPTION
Make sure that dbx operations are a NOP when there are no FDE keys.

Fixes an issue reported for fwupd in
https://github.com/fwupd/fwupd/issues/8684

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
