### PR TITLE
interfaces/builtin: extend timeserver-control interface to allow timedatectl timesync commands

### DIFF
--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -32,9 +32,13 @@ const timeserverControlBaseDeclarationSlots = `
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/timeserver-control
 const timeserverControlConnectedPlugAppArmor = `
 # Description: Can manage timeservers directly separate from config ubuntu-core.
+# Can use timedatectl,
 # Can enable system clock NTP synchronization via timedated D-Bus interface,
 # Can read all properties of /org/freedesktop/timedate1 D-Bus object; see
-# https://www.freedesktop.org/wiki/Software/systemd/timedated/
+# https://www.freedesktop.org/wiki/Software/systemd/timedated/ (obsoleted),
+# https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.timedate1.html
+# Can read all properties of /org/freedesktop/timesync1 D-Bus object; see
+# https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.timesync1.html
 
 #include <abstractions/dbus-strict>
 
@@ -65,6 +69,12 @@ dbus (send)
     interface=org.freedesktop.DBus.Properties
     member=Get{,All},
 
+dbus (send)
+    bus=system
+    path=/org/freedesktop/timesync1
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}",
+
 # Receive timedate1 property changed events
 dbus (receive)
     bus=system
@@ -79,12 +89,22 @@ dbus (receive)
 # timedatectl's set-ntp command.
 /usr/bin/timedatectl{,.real} ixr,
 
+# timedatectl needs to bind the client side of the socket
+unix (bind) type=stream addr="@*/bus/timedatectl.rea/system",
+
 # Silence this noisy denial. systemd utilities look at /proc/1/environ to see
 # if running in a container, but they will fallback gracefully. No other
 # interfaces allow this denial, so no problems with silencing it for now. Note
 # that allowing this triggers a 'ptrace trace peer=unconfined' denial, which we
 # want to avoid.
 deny @{PROC}/1/environ r,
+`
+
+const timeserverControlConnectedPlugSecComp = `
+# Description: Can manage timeservers directly separate from config ubuntu-core.
+
+# timedatectl needs to bind the client side of the socket
+bind
 `
 
 func init() {
@@ -95,5 +115,6 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  timeserverControlBaseDeclarationSlots,
 		connectedPlugAppArmor: timeserverControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  timeserverControlConnectedPlugSecComp,
 	})
 }

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -90,7 +90,7 @@ dbus (receive)
 /usr/bin/timedatectl{,.real} ixr,
 
 # timedatectl needs to bind the client side of the socket
-unix (bind) type=stream addr="@*/bus/timedatectl.rea/system",
+unix (bind) type=stream addr="@*/bus/timedatectl*/system",
 
 # Silence this noisy denial. systemd utilities look at /proc/1/environ to see
 # if running in a container, but they will fallback gracefully. No other

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/date
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/date
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/date "$@"

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/hwclock
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/hwclock
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /sbin/hwclock "$@"

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/sh
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/timedatectl
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/bin/timedatectl
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/timedatectl "$@"

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer-core20/meta/snap.yaml
@@ -1,0 +1,25 @@
+name: test-snapd-timedate-control-consumer
+version: 1.0
+summary: Basic timedate-control consumer generic snap (core20)
+description: A basic generic snap that can be used to plug a timedate slot
+base: core20
+
+apps:
+    timedatectl-time:
+        command: bin/timedatectl
+        plugs: [time-control]
+    timedatectl-timeserver:
+        command: bin/timedatectl
+        plugs: [timeserver-control]
+    timedatectl-timezone:
+        command: bin/timedatectl
+        plugs: [timezone-control]
+    hwclock-time:
+        command: bin/hwclock
+        plugs: [time-control, netlink-audit]
+    date:
+        command: bin/date
+        plugs: [time-control]
+    sh:
+        command: bin/sh
+        plugs: [time-control]

--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -4,6 +4,7 @@ show_help() {
     echo "usage: pack-local <snap-name>"
     echo "       install-local <snap-name> [OPTIONS]"
     echo "       install-local-as <snap-name> <dest-name> [OPTIONS]"
+    echo "       install-local-variant <snap-dir-base> <snap-name> [OPTIONS]"
     echo "       show-name <snap>"
     echo "       show-revision <snap>"
     echo "       is-confinement-supported <classic|devmode|strict>"
@@ -74,6 +75,20 @@ install_local_as() {
     local name="$2"
     shift 2
     install_local "$snap" --name "$name" "$@"
+}
+
+install_local_variant() {
+    local SNAP_DIR_BASE="$1"
+    local SNAP_NAME="$2"
+    local SNAP_DIR="$TESTSLIB/snaps/$SNAP_DIR_BASE"
+    shift 2
+
+    if [ -d "$SNAP_DIR_BASE" ]; then
+        SNAP_DIR="$PWD/$SNAP_DIR_BASE"
+    fi
+    SNAP_FILE=$(pack_local "$SNAP_NAME" "$SNAP_DIR")
+
+    snap install --dangerous "$@" "$SNAP_FILE"
 }
 
 show_name() {

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -31,8 +31,14 @@ prepare: |
             ;;
     esac
 
-    # Install a snap declaring a plug on timeserver-control
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-timedate-control-consumer
+    # Install a snap declaring a plug on timeserver-control.
+    if systemctl list-unit-files | grep systemd-timesyncd | awk '{print $2}' | MATCH "enabled"; then
+        # Install the base core20 variant with timedatectl that supports systemd-timesyncd commands.
+        "$TESTSTOOLS"/snaps-state install-local-variant test-snapd-timedate-control-consumer-core20 test-snapd-timedate-control-consumer
+    else
+        # Install the default version.
+        "$TESTSTOOLS"/snaps-state install-local test-snapd-timedate-control-consumer
+    fi
     tests.cleanup defer snap remove --purge test-snapd-timedate-control-consumer
 
 execute: |
@@ -48,6 +54,9 @@ execute: |
     echo "When the interface is connected"
     snap connect test-snapd-timedate-control-consumer:timeserver-control
 
+    # Use timedatectl without a subcommand
+    test-snapd-timedate-control-consumer.timedatectl-timeserver
+
     # Set NTP and check that the setting was propagated.
     for value in true false true; do
         test-snapd-timedate-control-consumer.timedatectl-timeserver set-ntp "$value"
@@ -55,6 +64,22 @@ execute: |
         # shellcheck disable=SC2016
         retry --wait 5 sh -c 'test "$(busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP)" = "b '"$value"'"'
     done
+
+    # We rely systemd-timesyncd to test timesyncd functionality.
+    if systemctl list-unit-files | grep systemd-timesyncd | awk '{print $2}' | MATCH "enabled"; then
+        # Test timesyncd functionality exposed via timedatectl.
+        echo "Check dbus access to org.freedesktop.timesync1 properties"
+        serverName=$(busctl get-property --system org.freedesktop.timesync1 /org/freedesktop/timesync1 org.freedesktop.timesync1.Manager ServerName | awk -F'"' '{print $2}')
+
+
+        echo "Check that timedatectl timesync commands can be used"
+        test-snapd-timedate-control-consumer.timedatectl-timeserver show-timesync --property=ServerName | cut -d= -f2 | MATCH "$serverName"
+        test-snapd-timedate-control-consumer.timedatectl-timeserver timesync-status | grep 'Server:' | cut -d'(' -f2 | cut -d')' -f1 | MATCH "$serverName"
+    elif os.query is-core-ge 20; then
+        # We expect to cover at least core 20+.
+        echo "Error: insufficient test coverage of timedatectl timesyncd commands"
+        exit 1
+    fi
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0


### PR DESCRIPTION
Extend timeserver-control interface to allow timedatectl timesync commands.

Requires:
 - apparmor: ability to get all /org/freedesktop/timesync1 properties
 - apparmor: ability to bind to @*/bus/timedatectl.rea/system unix sockets (timedatectl wraps timedatectl.real)
 - seccomp: bind

Testing:

Modified existing `tests/main/interfaces-timeserver-control/task.yaml`, allowing the test for any system with systemd-timesyncd enabled, and checking to ensure we cover at least core20+.

Manually tested on classic systems as well, but adding it to spread is arguably not worth it, due to the need to replace chronyd which also requires a significant wait time for org.freedesktop.timedate1 CanNTP to become true, and also introduce conflicts with automatic package remove logic that does not seem to account for package replacement.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34908 [SF00409246]

