### PR TITLE
interfaces/builtin/fwupd: add support for modem-manager plugin

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -117,6 +117,10 @@ const fwupdPermanentSlotAppArmor = `
   /dev/i2c-[0-9]* rw,
   # Redfish plugin
   /dev/ipmi* rwk,
+  # Modem Manager plugin
+  /dev/tty[^0-9]* rw,
+  /dev/cdc-* rw,
+  /dev/wwan[0-9]* rw,
 
   # MMC boot partitions
   /dev/mmcblk[0-9]{,[0-9],[0-9][0-9]}boot[0-9]* rwk,
@@ -408,6 +412,7 @@ func (iface *fwupdInterface) UDevPermanentSlot(spec *udev.Specification, slot *s
 		spec.TagDevice(`KERNEL=="video[0-9]*"`)
 		spec.TagDevice(`KERNEL=="wmi/dell-smbios"`)
 		spec.TagDevice(`SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device"`)
+		spec.TagDevice(`SUBSYSTEM=="wwan", ENV{DEVTYPE}=="wwan_port"`)
 	}
 
 	return nil

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -245,7 +245,7 @@ func (s *FwupdInterfaceSuite) TestPermanentSlotUdevImplicit(c *C) {
 	c.Assert(err, IsNil)
 
 	snippets := spec.Snippets()
-	c.Assert(snippets, HasLen, 12+1)
+	c.Assert(snippets, HasLen, 13+1)
 
 	c.Assert(snippets[0], Equals, `# fwupd
 KERNEL=="drm_dp_aux[0-9]*", TAG+="snap_uefi-fw-tools_app2"`)
@@ -271,10 +271,12 @@ KERNEL=="video[0-9]*", TAG+="snap_uefi-fw-tools_app2"`)
 KERNEL=="wmi/dell-smbios", TAG+="snap_uefi-fw-tools_app2"`)
 	c.Assert(snippets[11], Equals, `# fwupd
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", TAG+="snap_uefi-fw-tools_app2"`)
+	c.Assert(snippets[12], Equals, `# fwupd
+SUBSYSTEM=="wwan", ENV{DEVTYPE}=="wwan_port", TAG+="snap_uefi-fw-tools_app2"`)
 
 	expected := fmt.Sprintf(`TAG=="snap_uefi-fw-tools_app2", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_uefi-fw-tools_app2 $devpath $major:$minor"`,
 		dirs.StripRootDir(dirs.DistroLibExecDir))
-	c.Assert(snippets[12], Equals, expected)
+	c.Assert(snippets[13], Equals, expected)
 
 	// The implicit slot found on classic systems does not generate any rules
 	spec = udev.NewSpecification(s.coreSlot.AppSet())


### PR DESCRIPTION
With the modem-manager plugin enabled, fwupd may attempt to update firmware of devices controlled by modem-managed. For this, relevant device access is needed.

See https://github.com/fwupd/fwupd/pull/8689 for context.
