### PR TITLE
tests: add cleanup of cgroup pinned maps

### DIFF
--- a/tests/lib/tools/cleanup-state
+++ b/tests/lib/tools/cleanup-state
@@ -82,6 +82,11 @@ main() {
 				find /sys/fs/cgroup/devices/ -type d -name 'snap.*' -prune -ls -exec rmdir \{\} \;
 			fi
 
+			# Remove any cgroup pinned map files might be left behind
+			if [ -d /sys/fs/bpf/snap ]; then
+				find /sys/fs/bpf/snap -type f -name "snap_*" -ls -exec rm \{\} \;
+			fi
+
 			# If the root user has a systemd --user instance then ask it to reload.
 			# This prevents tests from leaking user-session services that stay in
 			# memory but are not present on disk, or have been modified on disk, as is

--- a/tests/main/security-device-cgroups-required-or-optional/task.yaml
+++ b/tests/main/security-device-cgroups-required-or-optional/task.yaml
@@ -19,8 +19,6 @@ execute: |
     test -f /var/lib/snapd/cgroup/snap.test-snapd-sh-core20.device
     NOMATCH "non-strict=true" < /var/lib/snapd/cgroup/snap.test-snapd-sh-core20.device
 
-    # XXX explicitly install core24 until there is no release into the stable channel
-    snap install --edge core24
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
     test -f /var/lib/snapd/cgroup/snap.test-snapd-sh-core24.device
     NOMATCH "non-strict=true" < /var/lib/snapd/cgroup/snap.test-snapd-sh-core24.device

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -16,6 +16,9 @@ restore: |
     rm -f /home/test/stdout.log
     # required! in autopkgtest no suite restore is run at all
     snap remove --purge test-snapd-sh
+    for base in core18 core20 core22 core24; do
+        snap remove --purge test-snapd-sh-${base} || true
+    done
 
 debug: |
     tests.exec is-skipped && exit 0


### PR DESCRIPTION
`security-device-cgroups-required-or-optional` was failing due to leftover cgroup pinned map files. This adds removing those leftover files. 