### PR TITLE
daemon: /v2/system-info system key mismatch support

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -175,6 +175,10 @@ const (
 
 	// ErrorKindUnsupported: target system does not support corresponding feature (e.g. client.StorageEncryptionFeaturePassphraseAuth)
 	ErrorKindUnsupportedByTargetSystem ErrorKind = "unsupported"
+
+	// ErrorKindSystemKeyVersionUnsupported: snapd does not support the system
+	// key version sent by the client
+	ErrorKindSystemKeyVersionUnsupported ErrorKind = "unsupported-system-key-version"
 )
 
 // Maintenance error kinds.

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -22,7 +22,9 @@ package daemon_test
 import (
 	"context"
 	"crypto"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -212,6 +214,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), check.IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), check.IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755), check.IsNil)
 
 	s.rsnaps = nil
 	s.suggestedCurrency = ""
@@ -744,4 +747,13 @@ func (s *apiBaseSuite) simulateConflict(name string) {
 	t.Set("snap-setup", snapsup)
 	chg := st.NewChange("manip", "...")
 	chg.AddTask(t)
+}
+
+func assertResponseBody(c *check.C, b io.Reader, expected map[string]any) {
+	var body map[string]interface{}
+	dec := json.NewDecoder(b)
+	err := dec.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, expected)
+	c.Check(dec.More(), check.Equals, false)
 }

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -53,9 +54,11 @@ var (
 	}
 
 	sysInfoCmd = &Command{
-		Path:       "/v2/system-info",
-		GET:        sysInfo,
-		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control"}},
+		Path:        "/v2/system-info",
+		GET:         sysInfo,
+		POST:        sysInfoPost,
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control"}},
+		WriteAccess: openAccess{},
 	}
 
 	stateChangeCmd = &Command{
@@ -170,6 +173,56 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	return SyncResponse(m)
+}
+
+func sysInfoPost(c *Command, r *http.Request, user *auth.UserState) Response {
+	var d struct {
+		Action    string `json:"action"`
+		SystemKey string `json:"system-key"`
+	}
+
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&d); err != nil {
+		return BadRequest("cannot decode request body: %v", err)
+	}
+
+	if dec.More() {
+		return BadRequest("unexpected additional content in request body")
+	}
+
+	switch d.Action {
+	case "advise-system-key-mismatch":
+	case "":
+		return BadRequest("no action")
+	default:
+		return BadRequest("unsupported action %q", d.Action)
+	}
+
+	var sk any
+	if maybeSk, err := interfaces.SystemKeyFromString(d.SystemKey); err != nil {
+		return BadRequest("cannot decode system key: %v", err)
+	} else {
+		sk = maybeSk
+	}
+
+	st := c.d.state
+	st.Lock()
+	defer st.Unlock()
+
+	logger.Debugf("client reports mismatch with system-key: %v", d.SystemKey)
+	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(c.d.state, sk)
+	if err != nil {
+		return errToResponse(err, nil, InternalError, "cannot process system key: %v")
+	}
+
+	if chg == nil {
+		// proceed
+		return SyncResponse("")
+	}
+
+	ensureStateSoon(c.d.state)
+	// we have a new change
+	return AsyncResponse(nil, chg.ID())
 }
 
 func formatRefreshTime(t time.Time) string {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/snap"
@@ -316,6 +317,8 @@ func errToResponse(err error, snaps []string, fallback errorResponder, format st
 		kind = client.ErrorKindSnapNoUpdateAvailable
 	case store.ErrLocalSnap:
 		kind = client.ErrorKindSnapLocal
+	case interfaces.ErrSystemKeyMismatchVersionTooHigh:
+		kind = client.ErrorKindSystemKeyVersionUnsupported
 	default:
 		handled := true
 		switch err := err.(type) {


### PR DESCRIPTION
Add support for POST to /v2/system-info with system-key-mismatch
indication from the client.

Cherry picked from https://github.com/canonical/snapd/pull/15254
Related: [SNAPDENG-34243](https://warthogs.atlassian.net/browse/SNAPDENG-34243)


[SNAPDENG-34243]: https://warthogs.atlassian.net/browse/SNAPDENG-34243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ