### PR TITLE
spread: enable cross distro reexec suite on Amazon Linux 2

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -740,7 +740,13 @@ rm -f %{buildroot}%{_libexecdir}/snapd/snapd-apparmor
 rm -f %{buildroot}%{_unitdir}/snapd.gpio-chardev-setup.target
 
 # Disable re-exec by default
-echo 'SNAP_REEXEC=0' > %{buildroot}%{_sysconfdir}/sysconfig/snapd
+mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
+cat <<'EOF' > %{buildroot}%{_sysconfdir}/sysconfig/snapd
+# Snapd daemon can reexec into the binary from the snapd snap, if
+# it is newer than the version installed through distro packaging.
+# Set to 1 to enable reexec. The default is 0.
+#SNAP_REEXEC=0
+EOF
 
 # Create state.json and the README file to be ghosted
 touch %{buildroot}%{_sharedstatedir}/snapd/state.json

--- a/spread.yaml
+++ b/spread.yaml
@@ -1509,9 +1509,11 @@ suites:
           - arch-linux-*
           # will only for work for AppArmor setups
           - opensuse-*
+          # only AMZN2, since we don't build with SELinux
+          - amazon-linux-2-*
           # TODO: enable the following:
           # - fedora-*
-          # - amazon-linux-*
+          # - amazon-linux-2023-*
         environment:
           # enable snap rexec
           SNAP_REEXEC: "1"


### PR DESCRIPTION
Enable Amazon Linux 2 as a target for cross distro reexec smoke suite.

Related: [SNAPDENG-34925](https://warthogs.atlassian.net/browse/SNAPDENG-34925)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-34925]: https://warthogs.atlassian.net/browse/SNAPDENG-34925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ