### PR TITLE
tests: add image names for ubuntu 2*

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -139,6 +139,7 @@ backends:
                   storage: 15G
                   workers: 8
             - ubuntu-20.04-64:
+                  image: ubuntu-2004-64
                   storage: 15G
                   workers: 8
             - ubuntu-secboot-20.04-64:
@@ -146,9 +147,11 @@ backends:
                   workers: 1
                   secure-boot: true
             - ubuntu-22.04-64:
+                  image: ubuntu-2204-64
                   storage: 15G
                   workers: 8
             - ubuntu-24.04-64:
+                  image: ubuntu-2404-64
                   storage: 15G
                   workers: 8
             - ubuntu-24.10-64:

--- a/spread.yaml
+++ b/spread.yaml
@@ -143,7 +143,7 @@ backends:
                   storage: 15G
                   workers: 8
             - ubuntu-secboot-20.04-64:
-                  image: ubuntu-20.04-64
+                  image: ubuntu-2004-64
                   workers: 1
                   secure-boot: true
             - ubuntu-22.04-64:
@@ -177,15 +177,15 @@ backends:
                   workers: 6
                   storage: 20G
             - ubuntu-core-20-64:
-                  image: ubuntu-20.04-64
+                  image: ubuntu-2004-64
                   workers: 8
                   storage: 20G
             - ubuntu-core-22-64:
-                  image: ubuntu-22.04-64
+                  image: ubuntu-2204-64
                   workers: 8
                   storage: 20G
             - ubuntu-core-24-64:
-                  image: ubuntu-24.04-64
+                  image: ubuntu-2404-64
                   workers: 8
                   storage: 20G
 


### PR DESCRIPTION
This change is needed to avoid issues in spread selecting ubuntu images. 

Spread could get arm images instead of the x86 ones.