### PR TITLE
many: make save/load hooks mandatory if affecting ephemeral

### DIFF
--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -197,7 +197,7 @@ func MockConfdbstateGetView(f func(st *state.State, account, confdbName, viewNam
 	}
 }
 
-func MockConfdbstateTransactionForGet(f func(*hookstate.Context, *confdb.View) (*confdbstate.Transaction, error)) (restore func()) {
+func MockConfdbstateTransactionForGet(f func(*hookstate.Context, *confdb.View, []string) (*confdbstate.Transaction, error)) (restore func()) {
 	old := confdbstateTransactionForGet
 	confdbstateTransactionForGet = f
 	return func() {

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -387,7 +387,7 @@ func (c *getCommand) getConfdbValues(ctx *hookstate.Context, plugName string, re
 		return err
 	}
 
-	tx, err := confdbstateTransactionForGet(ctx, view)
+	tx, err := confdbstateTransactionForGet(ctx, view, requests)
 	if err != nil {
 		return err
 	}

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -613,7 +613,8 @@ func (s *confdbSuite) TestConfdbGetSingleView(c *C) {
 	c.Assert(tx.Set("wifi.ssid", "my-ssid"), IsNil)
 	s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateTransactionForGet(func(ctx *hookstate.Context, view *confdb.View) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForGet(func(ctx *hookstate.Context, view *confdb.View, requests []string) (*confdbstate.Transaction, error) {
+		c.Assert(requests, DeepEquals, []string{"ssid"})
 		c.Assert(view.Schema().Account, Equals, s.devAccID)
 		c.Assert(view.Schema().Name, Equals, "network")
 		return tx, nil
@@ -634,7 +635,8 @@ func (s *confdbSuite) TestConfdbGetManyViews(c *C) {
 	c.Assert(tx.Set("wifi.psk", "secret"), IsNil)
 	s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateTransactionForGet(func(ctx *hookstate.Context, view *confdb.View) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForGet(func(ctx *hookstate.Context, view *confdb.View, requests []string) (*confdbstate.Transaction, error) {
+		c.Assert(requests, DeepEquals, []string{"ssid", "password"})
 		c.Assert(view.Schema().Account, Equals, s.devAccID)
 		c.Assert(view.Schema().Name, Equals, "network")
 		return tx, nil
@@ -659,7 +661,8 @@ func (s *confdbSuite) TestConfdbGetNoRequest(c *C) {
 	c.Assert(tx.Set("wifi.psk", "secret"), IsNil)
 	s.state.Unlock()
 
-	restore := ctlcmd.MockConfdbstateTransactionForGet(func(ctx *hookstate.Context, view *confdb.View) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForGet(func(ctx *hookstate.Context, view *confdb.View, requests []string) (*confdbstate.Transaction, error) {
+		c.Assert(requests, IsNil)
 		c.Assert(view.Schema().Account, Equals, s.devAccID)
 		c.Assert(view.Schema().Name, Equals, "network")
 		return tx, nil
@@ -819,7 +822,7 @@ func (s *confdbSuite) TestConfdbGetPrevious(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(tx.Set("wifi.ssid", "bar"), IsNil)
 
-	restore := ctlcmd.MockConfdbstateTransactionForGet(func(ctx *hookstate.Context, view *confdb.View) (*confdbstate.Transaction, error) {
+	restore := ctlcmd.MockConfdbstateTransactionForGet(func(*hookstate.Context, *confdb.View, []string) (*confdbstate.Transaction, error) {
 		return tx, nil
 	})
 	defer restore()


### PR DESCRIPTION
Make save-view/load-view hooks mandatory only if the operation might affect ephemeral data. If the path traverses or is a parent of a subpath with ephemeral data, then the save/load hooks must be defined. Based on https://github.com/canonical/snapd/pull/15349