### PR TITLE
tests: support ubuntu 24.04 and ubuntu-core 24 on arm

### DIFF
--- a/.github/workflows/non-fundamental-systems.json
+++ b/.github/workflows/non-fundamental-systems.json
@@ -92,7 +92,7 @@
         "group": "ubuntu-arm64",
         "backend": "google-arm",
         "alternative-backend": "google-arm",
-        "systems": "ubuntu-20.04-arm-64 ubuntu-core-22-arm-64",
+        "systems": "ubuntu-22.04-arm-64 ubuntu-core-24-arm-64",
         "tasks": "tests/...",
         "rules": "main"
       },

--- a/spread.yaml
+++ b/spread.yaml
@@ -272,8 +272,16 @@ backends:
                   image: ubuntu-os-cloud/ubuntu-2204-lts-arm64
                   workers: 8
                   storage: 15G
+            - ubuntu-24.04-arm-64:
+                  image: ubuntu-os-cloud/ubuntu-2404-lts-arm64
+                  workers: 8
+                  storage: 15G
             - ubuntu-core-22-arm-64:
                   image: ubuntu-22.04-arm-64
+                  workers: 6
+                  storage: 30G
+            - ubuntu-core-24-arm-64:
+                  image: ubuntu-24.04-arm-64
                   workers: 6
                   storage: 30G
 

--- a/tests/lib/assertions/ubuntu-core-24-arm64.model
+++ b/tests/lib/assertions/ubuntu-core-24-arm64.model
@@ -1,0 +1,49 @@
+type: model
+authority-id: canonical
+revision: 2
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-arm64-dangerous
+architecture: arm64
+base: core24
+grade: dangerous
+snaps:
+  -
+    default-channel: 24/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 24/beta
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2024-03-12T08:42:32+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCZfBvFgAKCRDgT5vottzAEu+UEACCbKOMYbKqy1SGIJNT/iKrgIxxJfHjynvy
+1i0gW9GAezCVzblimXkJfiUM/QFrng8PXyt1KEbyxkGbYnqpCcb0wfYfnRrHlWio71E/+vZSWAIh
+z/e/fheL7FbNtZj98yjn5OP6IHwFtoxWSLnUAO3Y/WPIY3ziCMHn4iDc1D5riGgZUjSRtzUWYMe1
+m9fZCEjhBshNgI/CXDRP0nCzr6szQ2Q6SRGPgD9pY3jVfias4nOUCwMjatQQijVB3jn0LHWmCbtv
+w+92RiroduK4EzTbeAJfXnqborVB3su/LAs2vEbv3id+CmEkhE6UwT9/YA1qOKLytU4Mcq8+e0Dl
+gyFfcQWjBAiYupia1EGczeHRtOgM+/gPj9arc1swmVlDwDfEJIEmRX6oY6MEXTyRo7g3A7hQXBM7
+WKjWfBtkQhL41ruq0jF9CeLJw1MmLiE1z0cl3hMpgveNbBc2CMEL0bgbUU2w8HziTQ3pu3yWa4r1
+r7ifmb7A4Agmt8CJf8KIG/XKuwTtFSQkxtAtYd8ePTfWVn/Y+Od4rXHRP5rZqw5ivQh+zBVBhlCq
+jYLJGf95S/xSnmNmKcsOTRUnysYH3VHIlgKsxxtH5IO80PWRDhJ+y9XgRJ0L0P4MC5ZB2Ul7rw8z
+64jjS+GOjmTMj22AtMyDI4iGRBQVhAcsAJwU2hZwaQ==

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1259,7 +1259,12 @@ setup_reflash_magic() {
         fi
     elif is_test_target_core 24; then
         build_snapd_snap_with_run_mode_firstboot_tweaks "$IMAGE_HOME"
-        cp "$TESTSLIB/assertions/ubuntu-core-24-amd64.model" "$IMAGE_HOME/pc.model"
+        if os.query is-arm; then
+            cp "$TESTSLIB/assertions/ubuntu-core-24-arm64.model" "$IMAGE_HOME/pc.model"
+        else
+            cp "$TESTSLIB/assertions/ubuntu-core-24-amd64.model" "$IMAGE_HOME/pc.model"
+        fi
+        
     else
         # FIXME: install would be better but we don't have dpkg on
         #        the image
@@ -1458,7 +1463,7 @@ EOF
                     $EXTRA_FUNDAMENTAL \
                     --snap "${extra_snap[0]}" \
                     --output-dir "$IMAGE_HOME"
-    rm -f ./pc-kernel_*.{snap,assert} ./pc-kernel.{snap,assert} ./pc_*.{snap,assert} ./snapd_*.{snap,assert} ./core{20,22}.{snap,assert}
+    rm -f ./pc-kernel_*.{snap,assert} ./pc-kernel.{snap,assert} ./pc_*.{snap,assert} ./snapd_*.{snap,assert} ./core{20,22,24}.{snap,assert}
 
     if os.query is-arm; then
         LOOP_PARTITION=1

--- a/tests/main/interfaces-mount-control-cifs/task.yaml
+++ b/tests/main/interfaces-mount-control-cifs/task.yaml
@@ -5,8 +5,8 @@ details: |
 
 # limit to systems where we know samba is recent enough and works without issues
 systems:
-  - ubuntu-22.04-*
-  - ubuntu-24.04-*
+  - ubuntu-22.04-64
+  - ubuntu-24.04-64
 
 prepare: |
     # Mount should not leak

--- a/tests/main/interfaces-mount-control-nfs/task.yaml
+++ b/tests/main/interfaces-mount-control-nfs/task.yaml
@@ -6,8 +6,8 @@ details: |
 # limit to systems where we know NFS works without problems
 # ubuntu-core: no required dependencies to export NFS shares
 systems:
-  - ubuntu-22.04-*
-  - ubuntu-24.04-*
+  - ubuntu-22.04-64
+  - ubuntu-24.04-64
 
 prepare: |
     # Mount should not leak
@@ -55,7 +55,7 @@ restore: |
     tests.cleanup restore
 
 execute: |
-    snap install test-snapd-mount-control-nfs
+    snap install --edge   test-snapd-mount-control-nfs
     mkdir -p /media/mounted
     tests.cleanup defer rm -rf /media/mounted
 

--- a/tests/main/prepare-image-reproducible/task.yaml
+++ b/tests/main/prepare-image-reproducible/task.yaml
@@ -15,11 +15,10 @@ backends: [-autopkgtest]
 
 # disable the following distributions
 # ubuntu-14, lack of systemd-run
-# ubuntu-20.04-arm*, because we use pc kernel and gadget.
-# ubuntu-core-*-arm-*, because image generade is not amd64
+# ubuntu-*-arm*, because we use (developer1) amd64 model
 systems:
 - -ubuntu-14.04-*
-- -ubuntu-20.04-arm-*
+- -ubuntu-*-arm-*
 - -ubuntu-core-*-arm-*
 
 environment:

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -8,7 +8,7 @@ details: |
 # Ubuntu 24.04: there is no longer any seeded snaps in base or minimal cloud images
 # https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051346
 # https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051572
-systems: [ubuntu-20*, ubuntu-22*, ubuntu-23*]
+systems: [ubuntu-20*, ubuntu-22*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg


### PR DESCRIPTION
This change adds support for ubuntu-24.04-arm-64 and ubuntu-core-24-arm-64.

The ci execution has been updated to run in ubuntu-22.04-arm-64 ubuntu-core-24-arm-64 now.
