### PR TITLE
ci: Update actions runner to ubuntu-latest due to 20.04 deprecation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -309,7 +309,7 @@ jobs:
 
   code-coverage:
     needs: [unit-tests, unit-tests-special, unit-tests-c]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GOPATH: ${{ github.workspace }}
       # Set PATH to ignore the load of magic binaries from /usr/local/bin And


### PR DESCRIPTION
The ubuntu-20.04 runner has been deprecated and doesn't work anymore. This PR fixes the code-coverage test by using ubuntu- latest.

More info: https://github.com/actions/runner-images/issues/11101

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
