### PR TITLE
many: include request PID in prompt

### DIFF
--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -37,6 +37,9 @@ type Metadata struct {
 	User uint32
 	// Snap is the instance name of the snap for which the prompt or rule applies.
 	Snap string
+	// PID is the PID of the process which triggered a request.
+	// For rules, PID should be unset/ignored.
+	PID int32
 	// Interface is the interface for which the prompt or rule applies.
 	Interface string
 }

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -249,6 +249,7 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 	metadata := &prompting.Metadata{
 		User:      userID,
 		Snap:      snap,
+		PID:       req.PID,
 		Interface: iface,
 	}
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -241,6 +241,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	maxOutstandingPromptsPerUser := 1000 // from requestprompts package
 	for i := 0; i < maxOutstandingPromptsPerUser; i++ {
 		req := &listener.Request{
+			PID:        1234,
 			Label:      "snap.firefox.firefox",
 			SubjectUID: s.defaultUser,
 			Path:       fmt.Sprintf("/home/test/%d", i),
@@ -260,6 +261,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	})
 
 	req = &listener.Request{
+		PID:        1234,
 		Label:      "snap.firefox.firefox",
 		SubjectUID: s.defaultUser,
 		Path:       fmt.Sprintf("/home/test/%d", maxOutstandingPromptsPerUser),
@@ -367,6 +369,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *listener.Re
 	}
 
 	c.Check(prompt.Snap, Equals, expectedSnap)
+	c.Check(prompt.PID, Equals, req.PID)
 	c.Check(prompt.Interface, Equals, "home")
 	c.Check(prompt.Constraints.Path(), Equals, req.Path)
 
@@ -382,6 +385,9 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *listener.Re
 // fillInPartialRequest fills in any blank fields from the given request
 // with default non-empty values.
 func (s *apparmorpromptingSuite) fillInPartialRequest(req *listener.Request) {
+	if req.PID == 0 {
+		req.PID = 1234
+	}
 	if req.Label == "" {
 		req.Label = "snap.firefox.firefox"
 	}


### PR DESCRIPTION
The desktop client needs to know the request PID so that it can determine which window to attach the prompt dialog to.

The listener request already includes a `PID` field, so all we need to do is add a `PID` field to `requestprompts.Prompt` as well, and wire it up to be populated by the request PID.

A different PID should be enough to cause to otherwise identical prompts to be treated as distinct, so that the client can get a prompt for every separate process which happens to cause the same request within the same snap. This avoids a situation where a headless process causes a request, then a non-headless process in the same snap causes the same request, but the client doesn't get the second PID and so can't attach the prompt to the latter's window. In practice, situations like this should be exceedingly rare (why would two separate processes in the same snap perform the same request at the same time?). In such a situation, a reply (which has lifespan other than "single") to one of the prompts will still handle any identical ones, as before.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34937