### PR TITLE
cmd/snap, tests/main: react to system key mismatch 

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -72,7 +72,7 @@ var (
 )
 
 type cmdRun struct {
-	clientMixin
+	mustWaitMixin
 	Command  string `long:"command" hidden:"yes"`
 	HookName string `long:"hook" hidden:"yes"`
 	Revision string `short:"r" default:"unset" hidden:"yes"`
@@ -103,7 +103,12 @@ The run command executes the given snap command with the right confinement
 and environment.
 `),
 		func() flags.Commander {
-			return &cmdRun{}
+			return &cmdRun{
+				mustWaitMixin: mustWaitMixin{
+					noProgress: true,
+					skipAbort:  true,
+				},
+			}
 		}, map[string]string{
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"command": i18n.G("Alternative command to run"),
@@ -150,15 +155,28 @@ func isStopping() (bool, error) {
 	return false, err
 }
 
-func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
+const defaultSystemKeyRetryCount = 12
+
+var getSystemKeyRetryCount = func() int {
+	if timeoutEnv := os.Getenv("SNAPD_DEBUG_SYSTEM_KEY_RETRY"); timeoutEnv != "" {
+		if i, err := strconv.Atoi(timeoutEnv); err == nil {
+			return i
+		}
+	}
+
+	return defaultSystemKeyRetryCount
+}
+
+func maybeCheckSystemKeyMismatch(cli *client.Client) (changeID string, err error) {
 	extraData := interfaces.SystemKeyExtraData{
 		AppArmorPrompting: features.AppArmorPrompting.IsEnabled(),
 	}
+
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
-	mismatch, _, err := interfaces.SystemKeyMismatch(extraData)
+	mismatch, my, err := interfaces.SystemKeyMismatch(extraData)
 	if err == nil && !mismatch {
-		return nil
+		return "", nil
 	}
 	// something went wrong with the system-key compare, try to
 	// reach snapd before continuing
@@ -175,7 +193,7 @@ func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 	}
 	if stopping {
 		logger.Debugf("ignoring system key mismatch during system shutdown/reboot")
-		return nil
+		return "", nil
 	}
 
 	// We have a mismatch, try to connect to snapd, once we can
@@ -190,30 +208,72 @@ func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 	// is to fix the packaging so that snapd is stopped, upgraded
 	// and started.
 	//
-	// connect timeout for client is 5s on each try, so 12*5s = 60s
-	timeout := 12
-	if timeoutEnv := os.Getenv("SNAPD_DEBUG_SYSTEM_KEY_RETRY"); timeoutEnv != "" {
-		if i, err := strconv.Atoi(timeoutEnv); err == nil {
-			timeout = i
-		}
-	}
+	// connect timeout for client is 5s on each try, default retry count is 12,
+	// gives 60s of timeout
+	retryCount := getSystemKeyRetryCount()
 
 	logger.Debugf("system key mismatch detected, waiting for snapd to start responding...")
+	logger.Debugf("my system key: %v", my)
 
-	for i := 0; i < timeout; i++ {
-		// TODO: we could also check cli.Maintenance() here too in case snapd is
-		// down semi-permanently for a refresh, but what message do we show to
-		// the user or what do we do if we know snapd is down for maintenance?
-		if _, err := cli.SysInfo(); err == nil {
-			return nil
-		} else {
-			logger.Debugf("cannot obtain system info: %v", err)
+	for i := 0; i < retryCount; i++ {
+		// refreshes the state of snapd maintenance internally
+		act, err := cli.SystemKeyMismatchAdvice(my)
+		if err == nil {
+			// we have an explicit response from snapd
+			switch act.SuggestedAction {
+			case client.MismatchActionProceed:
+				// we're good to go
+				logger.Debugf("continue execution")
+				return "", nil
+			case client.MismatchActionWaitForChange:
+				// snapd sent us an ID of a change to wait for
+				logger.Debugf("snapd started a regenerate profiles change with ID: %v", act.ChangeID)
+				return act.ChangeID, nil
+			default:
+				return "", fmt.Errorf("internal error: unexpected advice: %q", act.SuggestedAction)
+			}
 		}
+
+		// an error, which could be anything from socket being down, to
+		// relevant method, or our system-key version not being supported by the
+		// API if we're talking to an older snapd, or snapd is simply updating
+		restarting := false
+		if maintErr, ok := cli.Maintenance().(*client.Error); ok && maintErr.Kind == client.ErrorKindDaemonRestart {
+			restarting = true
+		}
+
+		var rspError *client.Error
+		if !restarting && errors.Is(err, client.ErrMismatchAdviceUnsupported) {
+			// snapd does not support system-key mismatch resolution, but it is
+			// responding, so we either woke it up or it was already running. In
+			// the context of home directories on NFS-like mounts, if we woke up
+			// snapd, the profiles would have regenerated and thus would account
+			// for our network mounted home. If snapd was already running when
+			// we poked it, and the security profiles may or may not be up to
+			// date, but since we're misisng an API there is no way for us to
+			// tell snapd to do the update
+			logger.Debugf("system-key mismatch advice not supported by snapd")
+			return "", nil
+		} else if errors.As(err, &rspError) {
+			// actual response error
+			if !restarting || rspError.Kind != client.ErrorKindSystemKeyVersionUnsupported {
+				logger.Debugf("ignoring system-key mismatch error: %v", err)
+				return "", nil
+			}
+
+			// edge case when the system-key version we sent is not
+			// supported by snapd, but the daemon appears to be restarting,
+			// hopefully as part of a refresh, and so it makes sense to try again
+			logger.Debugf("system-key version unsupported by snapd, but daemon is restarting")
+		} else {
+			logger.Debugf("cannot obtain system-key mismatch action: %v", err)
+		}
+		// TODO: use ticker
 		// sleep a little bit for good measure
-		time.Sleep(1 * time.Second)
+		<-timeAfter(1 * time.Second)
 	}
 
-	return fmt.Errorf("timeout waiting for snap system profiles to get updated")
+	return "", fmt.Errorf("timeout waiting for snap system profiles to get updated")
 }
 
 func (x *cmdRun) Usage() string {
@@ -248,8 +308,16 @@ func (x *cmdRun) Execute(args []string) error {
 
 	logger.StartupStageTimestamp("start")
 
-	if err := maybeWaitForSecurityProfileRegeneration(x.client); err != nil {
+	regenProfilesChangeID, err := maybeCheckSystemKeyMismatch(x.client)
+	if err != nil {
 		return err
+	}
+
+	if regenProfilesChangeID != "" {
+		logger.Debugf("waiting for security profiles regeneration change: %v", regenProfilesChangeID)
+		if _, err := x.wait(regenProfilesChangeID); err != nil {
+			logger.Debugf("profile regeneration change failed: %v", err)
+		}
 	}
 
 	// Now actually handle the dispatching

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -99,6 +99,8 @@ var (
 
 	GetSnapDirOptions                   = getSnapDirOptions
 	SnapInstancesAndComponentsFromNames = snapInstancesAndComponentsFromNames
+
+	GetSystemKeyRetryCount = getSystemKeyRetryCount
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {
@@ -478,4 +480,12 @@ func MockSeedWriterReadManifest(f func(manifestFile string) (*seedwriter.Manifes
 	restore = testutil.Backup(&seedwriterReadManifest)
 	seedwriterReadManifest = f
 	return restore
+}
+
+func MockGetSystemKeyRetryCount(f func() int) (restore func()) {
+	return testutil.Mock(&getSystemKeyRetryCount, f)
+}
+
+func MockTimeAfter(f func(d time.Duration) <-chan time.Time) (restore func()) {
+	return testutil.Mock(&timeAfter, f)
 }

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -560,6 +561,8 @@ func loggerWithJournalMaybe() error {
 	}
 	return nil
 }
+
+var timeAfter func(d time.Duration) <-chan time.Time = time.After
 
 func run() error {
 	cli := mkClient()

--- a/tests/main/remote-home/task.yaml
+++ b/tests/main/remote-home/task.yaml
@@ -24,6 +24,9 @@ environment:
   FS/cifs: cifs
 
 prepare: |
+    # Install local copy of test-snapd-sh which plugs in the home interface but not the network interface.
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
     # We don't expect to leak the test-remote user, group or mount.
     tests.cleanup defer NOMATCH 'test-remote' /etc/passwd
     tests.cleanup defer NOMATCH 'test-remote' /etc/group
@@ -31,7 +34,9 @@ prepare: |
 
     # Create a user called test-remote
     adduser --uid 54321 --quiet --disabled-password --gecos '' test-remote
-    tests.cleanup defer deluser test-remote
+    # TODO this fails sometimes when a user's smb mount process hasn't stopped
+    # yet
+    tests.cleanup defer retry -n 5 deluser test-remote
 
     # Move the actual home directory of the user test-remote to /var/home.
     # Later on we will mount /home/test-remote from the remote file system.
@@ -117,38 +122,44 @@ prepare: |
     tests.cleanup defer systemctl restart snapd.service
     tests.cleanup defer systemctl reset-failed snapd.service snapd.socket
 
+    # leave a canary file
+    touch /var/home/test-remote/hello
     # Mount the remote filesystem at /home/test-remote.
     case "$FS" in
       nfs)
-        mount -t nfs localhost:/var/home/test-remote /home/test-remote -o nfsvers=3,proto=tcp
+        mount -t nfs localhost:/var/home/test-remote /home/test-remote
         ;;
       cifs)
         # TODO: it would be nice to successfully pass ",posix" option and get things to mount.
         mount -t cifs //127.0.0.1/var-home/test-remote /home/test-remote -o vers=3.1.1,nomapposix,mfsymlinks,username=test-remote,password=secret,uid=54321,gid=54321
         ;;
+      *)
+        echo "unexpected test case '$FS'"
+        exit 1
+        ;;
     esac
+    # which should be visible now after the mount has succeeded
+    test -f /home/test-remote/hello
     tests.cleanup defer umount /home/test-remote
 
     # Ensure the session is working.
     tests.session -u test-remote prepare
     tests.cleanup defer tests.session -u test-remote restore
 
-    # Install local copy of test-snapd-sh which plugs in the home interface but not the network interface.
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
-
     # Check that snapd works around NFS and CIFS apparmor interaction. Note
     # that the name of the file is "nfs-support" as we are not trying to change
     # too much of the extension interface visible to the system.
-    systemctl reset-failed snapd.service snapd.socket
-    systemctl restart snapd.service
     if [ "$(snap debug confinement)" = strict ]; then
         if tests.info is-reexec-in-use; then
-          MATCH 'network inet,' < /var/lib/snapd/apparmor/snap-confine.internal/nfs-support
+          test ! -f /var/lib/snapd/apparmor/snap-confine.internal/nfs-support
         else
-          MATCH 'network inet,' < /var/lib/snapd/apparmor/snap-confine/nfs-support
+          test ! -f /var/lib/snapd/apparmor/snap-confine/nfs-support
         fi
-        MATCH 'network inet,' < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh.with-home-plug
+        NOMATCH 'network inet,' < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh.with-home-plug
     fi
+    snap changes | NOMATCH 'Regenerate security profiles'
+
+    gojq '.["nfs-home"]' < /var/lib/snapd/system-key | MATCH false
 
 restore: |
     # Run cleanup handlers registered earlier.
@@ -173,10 +184,34 @@ execute: |
     #shellcheck disable=SC2016
     tests.session -u test-remote exec snap run test-snapd-sh.with-home-plug -c 'test -h $SNAP_USER_COMMON/../current'
 
+    snap changes | grep 'Regenerate security profiles' | MATCH 'Done'
+    # only one change
+    test "$(snap changes | grep -c 'Regenerate security profiles')" = "1"
+
+    # Client has notified snapd of a system-key mismatch, snapd reacted with a
+    # change to regenerate security profiles
+    if [ "$(snap debug confinement)" = strict ]; then
+        # TODO:mismatch: fix
+        if tests.info is-reexec-in-use; then
+          MATCH 'network inet,' < /var/lib/snapd/apparmor/snap-confine.internal/nfs-support
+        else
+          MATCH 'network inet,' < /var/lib/snapd/apparmor/snap-confine/nfs-support
+        fi
+        MATCH 'network inet,' < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh.with-home-plug
+    fi
+
+    gojq '.["nfs-home"]' < /var/lib/snapd/system-key | MATCH true
+
     # As a non-root user perform a write to $SNAP_USER_DATA which is mounted over CIFS or NFS.
     #shellcheck disable=SC2016
     tests.session -u test-remote exec snap run test-snapd-sh.with-home-plug -c 'touch $SNAP_USER_DATA/smoke-cifs'
 
+    # still just one change
+    test "$(snap changes | grep -c 'Regenerate security profiles')" = "1"
+
     # As a non-root user perform a write to $SNAP_USER_COMMON which is mounted over CIFS or NFS.
     #shellcheck disable=SC2016
     tests.session -u test-remote exec snap run test-snapd-sh.with-home-plug -c 'touch $SNAP_USER_COMMON/smoke-cifs'
+
+    # same
+    test "$(snap changes | grep -c 'Regenerate security profiles')" = "1"


### PR DESCRIPTION
React to system key mismatch by pinging snapd for advice on how to
proceed and optionally wait for a pending security profiles regeneration
change.

Cherry picked from https://github.com/canonical/snapd/pull/15254
Related: [SNAPDENG-34243](https://warthogs.atlassian.net/browse/SNAPDENG-34243)

Exact same thing as https://github.com/canonical/snapd/pull/15332 but I had to reopen the PR.

[SNAPDENG-34243]: https://warthogs.atlassian.net/browse/SNAPDENG-34243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ