### PR TITLE
sandbox/lsm: helpers for introspecting LSM state

### DIFF
--- a/cmd/snap/cmd_debug_lsm.go
+++ b/cmd/snap/cmd_debug_lsm.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/sandbox/lsm"
+)
+
+type cmdDebugLSM struct{}
+
+func init() {
+	addDebugCommand("lsm",
+		"(internal) obtain status information on LSMs",
+		"(internal) obtain status information on LSMs",
+		func() flags.Commander {
+			return &cmdDebugLSM{}
+		}, nil, nil)
+}
+
+func (x *cmdDebugLSM) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	lsms, err := lsm.List()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, "found %v active LSMs\n", len(lsms))
+	for _, id := range lsms {
+		fmt.Fprintf(Stdout, "- (%4d) %s\n", id, id)
+	}
+
+	entries, err := lsm.CurrentContext()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, "context entries: %v\n", len(entries))
+
+	for _, e := range entries {
+		currentName := e.LsmID.String()
+		if e.LsmID.HasStringContext() {
+			fmt.Fprintf(Stdout, "current %v LSM context: %q\n", currentName, lsm.ContextAsString(e.Context))
+		} else {
+			fmt.Fprintf(Stdout, "current %v LSM context (binary): %v\n", currentName, base64.StdEncoding.EncodeToString(e.Context))
+		}
+	}
+
+	return nil
+}

--- a/sandbox/lsm/lsm.go
+++ b/sandbox/lsm/lsm.go
@@ -1,0 +1,144 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lsm
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// ID wraps the LSM ID defined in kernel headers.
+type ID uint
+
+func (id ID) String() string {
+	switch id {
+	case LSM_ID_UNDEF:
+		return "undef"
+	case LSM_ID_CAPABILITY:
+		return "capability"
+	case LSM_ID_SELINUX:
+		return "selinux"
+	case LSM_ID_SMACK:
+		return "smack"
+	case LSM_ID_TOMOYO:
+		return "tomoyo"
+	case LSM_ID_APPARMOR:
+		return "apparmor"
+	case LSM_ID_YAMA:
+		return "yama"
+	case LSM_ID_LOADPIN:
+		return "loadpin"
+	case LSM_ID_SAFESETID:
+		return "safesetid"
+	case LSM_ID_LOCKDOWN:
+		return "lockdown"
+	case LSM_ID_BPF:
+		return "bpf"
+	case LSM_ID_LANDLOCK:
+		return "landlock"
+	case LSM_ID_IMA:
+		return "ima"
+	case LSM_ID_EVM:
+		return "evm"
+	case LSM_ID_IPE:
+		return "ipe"
+	default:
+		return fmt.Sprintf("(lsm-id:%d)", id)
+	}
+}
+
+// HasStringContext returns true when a given LSM is known to use strings as
+// context labels.
+func (id ID) HasStringContext() bool {
+	switch id {
+	case LSM_ID_APPARMOR, LSM_ID_SELINUX:
+		return true
+	default:
+		return false
+	}
+}
+
+// Attr wraps the kernel's attr ID for LSM queries.
+type Attr uint
+
+const (
+	// https://elixir.bootlin.com/linux/v6.14/source/include/uapi/linux/lsm.h#L44
+	LSM_ID_UNDEF      ID = 0
+	LSM_ID_CAPABILITY ID = 100
+	LSM_ID_SELINUX    ID = 101
+	LSM_ID_SMACK      ID = 102
+	LSM_ID_TOMOYO     ID = 103
+	LSM_ID_APPARMOR   ID = 104
+	LSM_ID_YAMA       ID = 105
+	LSM_ID_LOADPIN    ID = 106
+	LSM_ID_SAFESETID  ID = 107
+	LSM_ID_LOCKDOWN   ID = 108
+	LSM_ID_BPF        ID = 109
+	LSM_ID_LANDLOCK   ID = 110
+	LSM_ID_IMA        ID = 111
+	LSM_ID_EVM        ID = 112
+	LSM_ID_IPE        ID = 113
+
+	// https://elixir.bootlin.com/linux/v6.14/source/include/uapi/linux/lsm.h#L70
+	LSM_ATTR_UNDEF      Attr = 0
+	LSM_ATTR_CURRENT    Attr = 100
+	LSM_ATTR_EXEC       Attr = 101
+	LSM_ATTR_FSCREATE   Attr = 102
+	LSM_ATTR_KEYCREATE  Attr = 103
+	LSM_ATTR_PREV       Attr = 104
+	LSM_ATTR_SOCKCREATE Attr = 105
+)
+
+// List returns a list of currently active LSMs.
+func List() ([]ID, error) {
+	lsms, err := lsmListModules()
+	if err != nil {
+		return nil, err
+	}
+
+	repack := make([]ID, len(lsms))
+	for i := 0; i < len(lsms); i++ {
+		repack[i] = ID(lsms[i])
+	}
+
+	return repack, nil
+}
+
+type ContextEntry struct {
+	// LSMID is the ID of the LSM owning this context information.
+	LsmID ID
+	// Context associated with a given LSM, can be a binary or string, depending
+	// on the LSM. See [ID.HasStringContext]. When context is a string, it
+	// incldues a trailing 0.
+	Context []byte
+}
+
+// CurrentContext returns value of the 'current' security attribute of the
+// running process, which may contain a number of context entries.
+func CurrentContext() ([]ContextEntry, error) {
+	return lsmGetSelfAttr(LSM_ATTR_CURRENT)
+}
+
+// ContextAsString coerces the context into a string. Only meaningful if a given
+// context label is known to be a string (typically when [ID.HasStringContext()]
+// is true).
+func ContextAsString(ctx []byte) string {
+	return string(bytes.TrimSuffix(ctx, []byte{0}))
+}

--- a/sandbox/lsm/lsm_darwin.go
+++ b/sandbox/lsm/lsm_darwin.go
@@ -1,0 +1,35 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lsm
+
+import (
+	"errors"
+)
+
+// Some things are not implemented on darwin
+var errDarwin = errors.New("not implemented on darwin")
+
+func lsmListModules() ([]uint64, error) {
+	return nil, errDarwin
+}
+
+func lsmGetSelfAttr(attr Attr) ([]ContextEntry, error) {
+	return nil, errDarwin
+}

--- a/sandbox/lsm/lsm_linux.go
+++ b/sandbox/lsm/lsm_linux.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lsm
+
+import (
+	"bytes"
+	"encoding/binary"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/arch"
+)
+
+func lsmListModules() ([]uint64, error) {
+	// see
+	// https://elixir.bootlin.com/linux/v6.14/source/security/lsm_syscalls.c#L84 for syscall documentation
+
+	var bufsz uint32
+
+	// find out how much space we need
+	_, _, errno := syscall.Syscall(unix.SYS_LSM_LIST_MODULES,
+		uintptr(0), uintptr(unsafe.Pointer(&bufsz)), 0)
+	if errno != syscall.E2BIG {
+		// could be ENOSYS
+		return nil, errno
+	}
+
+	// bufsz is the size of a contiguous buffer we need to hold a list of all active LSMs
+	count := uintptr(bufsz) / unsafe.Sizeof(uint64(0))
+	// the buffer itself
+	buf := make([]uint64, count)
+
+	r1, _, errno := syscall.Syscall(unix.SYS_LSM_LIST_MODULES,
+		uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&bufsz)), 0)
+	if errno != 0 {
+		return nil, errno
+	}
+
+	return buf[:r1], nil
+}
+
+func lsmGetSelfAttr(attr Attr) ([]ContextEntry, error) {
+	// https://elixir.bootlin.com/linux/v6.14/source/include/uapi/linux/lsm.h#L17
+	// struct lsm_ctx {
+	//     __u64 id;
+	//     __u64 flags;
+	//     __u64 len;
+	//     __u64 ctx_len;
+	//     __u8 ctx[] __counted_by(ctx_len);
+	// };
+	type kernelLSMCtx struct {
+		ID    uint64
+		Flags uint64
+		// total length including this struct, context, any other data and
+		// padding
+		Len uint64
+		// context field length
+		CtxLen uint64
+	}
+
+	// find out how much space we need
+	var sz uint32 = 0
+	_, _, errno := syscall.Syscall6(unix.SYS_LSM_GET_SELF_ATTR,
+		uintptr(attr),
+		uintptr(0), uintptr(unsafe.Pointer(&sz)),
+		uintptr(0), uintptr(0), uintptr(0))
+	if errno != syscall.E2BIG {
+		// could be ENOSYS
+		return nil, errno
+	}
+
+	buf := make([]byte, sz)
+	// returns the count of context entries
+	count, _, errno := syscall.Syscall6(unix.SYS_LSM_GET_SELF_ATTR,
+		uintptr(attr),
+		uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&sz)),
+		uintptr(0), uintptr(0), uintptr(0))
+	if errno != 0 {
+		return nil, errno
+	}
+
+	entries := make([]ContextEntry, 0, count)
+	// TODO use binary.NativeEndian
+	endian := arch.Endian()
+
+	for i := 0; i < int(count); i++ {
+		var lsmAttrData kernelLSMCtx
+
+		// TODO use binary.Decode()
+		n := unsafe.Sizeof(lsmAttrData)
+		if err := binary.Read(bytes.NewReader(buf[:n]), endian, &lsmAttrData); err != nil {
+			return nil, err
+		}
+
+		entries = append(entries, ContextEntry{
+			LsmID:   ID(lsmAttrData.ID),
+			Context: buf[n : uint64(n)+lsmAttrData.CtxLen],
+		})
+
+		buf = buf[lsmAttrData.Len:]
+	}
+
+	return entries, nil
+}

--- a/sandbox/lsm/lsm_test.go
+++ b/sandbox/lsm/lsm_test.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lsm_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/sandbox/lsm"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func TestLSM(t *testing.T) {
+	TestingT(t)
+}
+
+type lsmSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&lsmSuite{})
+
+func (*lsmSuite) TestIDString(c *C) {
+	c.Check(lsm.LSM_ID_UNDEF.String(), Equals, "undef")
+	c.Check(lsm.LSM_ID_APPARMOR.String(), Equals, "apparmor")
+	c.Check(lsm.LSM_ID_SELINUX.String(), Equals, "selinux")
+	c.Check(lsm.ID(999).String(), Equals, "(lsm-id:999)")
+}
+
+func (*lsmSuite) TestIDHasStringContext(c *C) {
+	c.Check(lsm.LSM_ID_UNDEF.HasStringContext(), Equals, false)
+	c.Check(lsm.ID(999).HasStringContext(), Equals, false)
+
+	c.Check(lsm.LSM_ID_APPARMOR.HasStringContext(), Equals, true)
+	c.Check(lsm.LSM_ID_SELINUX.HasStringContext(), Equals, true)
+}
+
+func (*lsmSuite) TestContextAsString(c *C) {
+	c.Check(lsm.ContextAsString([]byte("foo bar baz")), Equals, "foo bar baz")
+	c.Check(lsm.ContextAsString([]byte{'f', 'o', 'o', 0}), Equals, "foo")
+}

--- a/tests/main/lsm/task.yaml
+++ b/tests/main/lsm/task.yaml
@@ -1,0 +1,70 @@
+summary: Check status of LSMs
+details: |
+  Confirm status of LSMs on various targets.
+
+systems:
+  # kernels definitely too old
+  - -ubuntu-14.04-*
+  - -ubuntu-16.04-*
+  - -ubuntu-18.04-*
+  - -ubuntu-20.04-*
+  # skip 22.04 as kernel support in inconsistent between -generic, -kvm, -gcp
+  # variants
+  - -ubuntu-22.04-*
+  # XXX skip ubuntu-22.04, kernel does not support required syscalls, but it's
+  # cheap to allocate and we still want to verity the error path
+  # UC releases matching unsupported Ubuntu releases
+  - -ubuntu-core-18-*
+  - -ubuntu-core-20-*
+  - -ubuntu-core-22-*
+
+debug: |
+   grep -n '' lsm.out || true
+
+execute: |
+  no_kernel_support=0
+  case "$SPREAD_SYSTEM" in
+      debian-11-*|debian-12-*)
+          no_kernel_support=1
+          ;;
+      centos-*)
+          no_kernel_support=1
+          ;;
+      amazon-linux-*)
+          no_kernel_support=1
+          ;;
+      opensuse-15*)
+          no_kernel_support=1
+          ;;
+  esac
+
+  if [ "$no_kernel_support" = "1" ]; then
+      # lacking kernel support
+      not snap debug lsm 2> lsm.stderr
+      MATCH 'error: function not implemented' < lsm.stderr
+      exit 0
+  else
+      snap debug lsm > lsm.out
+  fi
+
+  case "$SPREAD_SYSTEM" in
+      fedora-*|centos-*)
+          MATCH "selinux" < lsm.out
+          NOMATCH "apparmor" < lsm.out
+          MATCH 'selinux LSM context: "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"' < lsm.out
+          ;;
+      ubuntu-*|debian-*|arch-linux-*)
+          MATCH "apparmor" < lsm.out
+          NOMATCH "selinux" < lsm.out
+          MATCH 'apparmor LSM context: "unconfined"' < lsm.out
+          ;;
+      opensuse-*)
+          MATCH "apparmor" < lsm.out
+          NOMATCH "selinux" < lsm.out
+          MATCH 'apparmor LSM context: "unconfined"' < lsm.out
+          ;;
+      *)
+          echo "unsupported $SPREAD_SYSTEM"
+          exit 1
+          ;;
+  esac


### PR DESCRIPTION
Helpers and internal tool for introspecting LSM state.

24.04 VM:
```
root@u1:~# snap debug lsm
found 5 active LSMs
- ( 108) lockdown
- ( 100) capability
- ( 110) landlock
- ( 105) yama
- ( 104) apparmor
context entries: 1
current apparmor LSM context: unconfined
```

24.04 container and a nested container:
```
root@c1:~# snap debug lsm
found 5 active LSMs
- ( 108) lockdown
- ( 100) capability
- ( 110) landlock
- ( 105) yama
- ( 104) apparmor
context entries: 1
current apparmor LSM context: unconfined

## nested
root@c1:~# lxc exec -t nestedc1 /root/snap debug lsm
found 5 active LSMs
- ( 108) lockdown
- ( 100) capability
- ( 110) landlock
- ( 105) yama
- ( 104) apparmor
context entries: 1
current apparmor LSM context: lxd-nestedc1_</var/snap/lxd/common/lxd> (enforce)
```

Arch booted with with `lsm=landlock,lockdown,yama,apparmor,bpf`:
```
maciek@galeon:work/canonical/snapd (git)-[bboozzoo/sanbox-debug-lsm] snap debug lsm
found 6 active LSMs
- ( 100) capability
- ( 110) landlock
- ( 108) lockdown
- ( 105) yama
- ( 104) apparmor
- ( 109) bpf
context entries: 1
current apparmor LSM context: unconfined
```

openSUSE:
```
found 8 active LSMs
- ( 108) lockdown
- ( 100) capability
- ( 110) landlock
- ( 105) yama
- ( 104) apparmor
- ( 109) bpf
- ( 111) ima
- ( 112) evm
context entries: 1
current apparmor LSM context: unconfined
```

fedora:
```
[fedora@fedora-41 ~]$ snap debug lsm
found 8 active LSMs
- ( 108) lockdown
- ( 100) capability
- ( 105) yama
- ( 101) selinux
- ( 109) bpf
- ( 110) landlock
- ( 111) ima
- ( 112) evm
context entries: 1
current selinux LSM context: unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
```

Related: [SNAPDENG-34259](https://warthogs.atlassian.net/browse/SNAPDENG-34259)

[SNAPDENG-34259]: https://warthogs.atlassian.net/browse/SNAPDENG-34259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ