### PR TITLE
tests: changes in prepare/restore to speed up the tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -79,6 +79,8 @@ environment:
     EXPERIMENTAL_FEATURES: '$(HOST: echo "${SPREAD_EXPERIMENTAL_FEATURES:-}")'
     # set to 1 when the snapd memory limit has to be removed
     SNAPD_NO_MEMORY_LIMIT: '$(HOST: echo "${SPREAD_SNAPD_NO_MEMORY_LIMIT:-}")'
+    # set to true when the snapd package has to be purged during reset
+    PURGE_SNAPD: '$(HOST: echo "${SPREAD_PURGE_SNAPD:-false}")'
 
     # Use the snapd package from the repository when possible
     SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-true}")'
@@ -377,7 +379,7 @@ backends:
                 workers: 8
             - ubuntu-24.04-64:
                 image: snapd-spread/ubuntu-24.04-64
-                workers: 8
+                workers: 1
 
             - ubuntu-core-20-64:
                 image: snapd-spread/ubuntu-20.04-64

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -690,11 +690,13 @@ prepare_suite_each() {
     echo -n "${SPREAD_JOB:-} " >> "$RUNTIME_STATE_PATH/runs"
 
     # Restart journal log and reset systemd journal cursor.
-    systemctl reset-failed systemd-journald.service
-    if ! systemctl restart systemd-journald.service; then
-        systemctl status systemd-journald.service || true
-        echo "Failed to restart systemd-journald.service, exiting..."
-        exit 1
+    if ! systemctl is-active --quiet systemd-journald.service; then
+        systemctl reset-failed systemd-journald.service
+        if ! systemctl restart systemd-journald.service; then
+            systemctl status systemd-journald.service || true
+            echo "Failed to restart systemd-journald.service, exiting..."
+            exit 1
+        fi
     fi
     "$TESTSTOOLS"/journal-state start-new-log
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -660,7 +660,7 @@ prepare_suite() {
 
     # Make sure the suite starts with a clean environment and with the snapd state restored
     # shellcheck source=tests/lib/reset.sh
-    "$TESTSLIB"/reset.sh --reuse-core
+    PURGE_SNAPD=true  "$TESTSLIB"/reset.sh --reuse-core
 }
 
 prepare_suite_each() {
@@ -707,8 +707,6 @@ prepare_suite_each() {
     fi
 
     if [[ "$variant" = full ]]; then
-        # shellcheck source=tests/lib/prepare.sh
-        . "$TESTSLIB"/prepare.sh
         # shellcheck source=tests/lib/prepare.sh
         . "$TESTSLIB"/prepare.sh
         if os.query is-classic; then
@@ -800,12 +798,6 @@ restore_suite_each() {
         # shellcheck source=tests/lib/reset.sh
         "$TESTSLIB"/reset.sh --reuse-core
     fi
-
-    # Check for invariants late, in order to detect any bugs in the code above.
-    if [[ "$variant" = full ]]; then
-        "$TESTSTOOLS"/cleanup-state pre-invariant
-    fi
-    tests.invariant check
 
     "$TESTSTOOLS"/fs-state check-monitor
 }

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -196,7 +196,7 @@ remove_disabled_snaps
 # When the variable REUSE_SNAPD is set to 1, we don't remove and purge snapd.
 # In that case we just cleanup the environment by removing installed snaps as
 # it is done for core systems.
-if os.query is-core || [ "$REUSE_SNAPD" = 1 ]; then
+if os.query is-core || [ "$REUSE_SNAPD" = 1 ] || [ "$PURGE_SNAPD" = false ]; then
     reset_all_snap "$@"
 else
     reset_classic "$@"

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -119,18 +119,6 @@ check_stray_dbus_daemon() {
 	fi
 }
 
-check_leftover_defer_sh() {
-	n="$1" # invariant name
-	(
-		find "$PROJECT_PATH" -name defer.sh > "$TESTSTMP/tests.invariant.$n"
-	) > "$TESTSTMP/tests.invariant.$n"
-	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then
-		echo "tests.invariant: leftover defer.sh script" >&2
-		cat "$TESTSTMP/tests.invariant.$n" >&2
-		return 1
-	fi
-}
-
 check_broken_snaps() {
 	n="$1" # invariant name
 	(
@@ -262,7 +250,6 @@ main() {
 	crashed-snap-confine
 	lxcfs-mounted
 	stray-dbus-daemon
-	leftover-defer-sh
 	broken-snaps
 	cgroup-scopes
 	cgroups

--- a/tests/main/apparmor-prompting-flag-restart/task.yaml
+++ b/tests/main/apparmor-prompting-flag-restart/task.yaml
@@ -33,6 +33,8 @@ restore: |
     systemctl start snapd.service || systemctl status snapd.service || true
     retry --wait 1 -n 100 sh -x -c 'systemctl is-active snapd.service snapd.socket'
 
+    snap unset system experimental.user-daemons
+
 debug: |
     tests.exec is-skipped && exit 0
 

--- a/tests/main/apparmor-prompting-integration-tests/task.yaml
+++ b/tests/main/apparmor-prompting-integration-tests/task.yaml
@@ -52,7 +52,7 @@ prepare: |
 restore: |
     tests.exec is-skipped && exit 0
 
-    snap set system experimental.apparmor-prompting=false
+    snap unset system experimental.apparmor-prompting
     tests.session -u test exec sh -c 'rm -rf "/home/test/integration-tests"'
     tests.session restore -u test
 

--- a/tests/main/auto-refresh-gating-from-snap/task.yaml
+++ b/tests/main/auto-refresh-gating-from-snap/task.yaml
@@ -23,6 +23,9 @@ prepare: |
   snap install "$CONTENT_SNAP_NAME"
   "$TESTSTOOLS"/snaps-state install-local "$NOHOOK_SNAP"
 
+restore: |
+  snap unset system experimental.gate-auto-refresh-hook
+
 debug: |
   gojq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
 

--- a/tests/main/auto-refresh-gating/task.yaml
+++ b/tests/main/auto-refresh-gating/task.yaml
@@ -16,6 +16,9 @@ environment:
 prepare: |
   snap set system experimental.gate-auto-refresh-hook=true
 
+restore: |
+  snap unset system experimental.gate-auto-refresh-hook
+
 debug: |
   gojq -r '.data["snaps-hold"]' < /var/lib/snapd/state.json || true
   snap changes || true

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -16,7 +16,7 @@ prepare: |
 
 restore: |
     if [[ "$SPREAD_VARIANT" =~ parallel ]]; then
-        snap set system experimental.parallel-instances=null
+        snap unset system experimental.parallel-instances
     fi
 
 debug: |

--- a/tests/main/broken-seeding/task.yaml
+++ b/tests/main/broken-seeding/task.yaml
@@ -11,6 +11,7 @@ systems: [-ubuntu-core-*, -ubuntu-14.04-*]
 
 environment:
     SEED_DIR: /var/lib/snapd/seed
+    PURGE_SNAPD: true
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/canonical-livepatch-14.04/task.yaml
+++ b/tests/main/canonical-livepatch-14.04/task.yaml
@@ -9,6 +9,9 @@ details: |
 # livepatch works only on amd64 systems
 systems: [ubuntu-14.04-64]
 
+environment:
+    PURGE_SNAPD: true
+
 restore: |
     snap remove --purge canonical-livepatch || true
     # compat system will not do any cleanups, do them ourselves

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -12,6 +12,7 @@ systems: [-ubuntu-core-*]
 
 environment:
     SEED_DIR: /var/lib/snapd/seed
+    PURGE_SNAPD: true
 
 prepare: |
     # In this scenario, the keys from the snapd pkg are used

--- a/tests/main/confdb-cross-config/task.yaml
+++ b/tests/main/confdb-cross-config/task.yaml
@@ -12,6 +12,9 @@ systems: [ -ubuntu-16.04, -debian-11-64 ]
 prepare: |
   snap set system experimental.confdb=true
 
+restore: |
+  snap unset system experimental.confdb
+
 execute: |
   changeAfterID() {
     local OLD_CHANGE="$1"

--- a/tests/main/confdb/task.yaml
+++ b/tests/main/confdb/task.yaml
@@ -10,6 +10,9 @@ systems: [ -ubuntu-16.04 ]
 prepare: |
   snap set system experimental.confdb=true
 
+restore: |
+  snap unset system experimental.confdb
+
 execute: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
     echo "This test needs test keys to be trusted"

--- a/tests/main/core18-configure-hook/task.yaml
+++ b/tests/main/core18-configure-hook/task.yaml
@@ -7,6 +7,9 @@ details: |
 
 systems: [-ubuntu-core-*]
 
+environment:
+    PURGE_SNAPD: true
+
 prepare: |
     echo "Ensure empty state"
     echo "Ensure all snaps are gone"

--- a/tests/main/dbus-activation-name-conflict/task.yaml
+++ b/tests/main/dbus-activation-name-conflict/task.yaml
@@ -11,6 +11,9 @@ systems:
   # TODO: dbus issue
   - -ubuntu-core-22-*
 
+environment:
+    PURGE_SNAPD: true
+
 prepare: |
     snap set system experimental.user-daemons=true
 

--- a/tests/main/disk-space-awareness/task.yaml
+++ b/tests/main/disk-space-awareness/task.yaml
@@ -22,6 +22,10 @@ prepare: |
   systemctl start snapd.{socket,service}
 
 restore: |
+  snap unset system experimental.check-disk-space-install
+  snap unset system experimental.check-disk-space-remove
+  snap unset system experimental.check-disk-space-refresh
+
   systemctl stop snapd.{socket,service}
   umount -l "$TMPFSMOUNT"
   systemctl start snapd.{socket,service}

--- a/tests/main/interfaces-requests-activates-handlers/task.yaml
+++ b/tests/main/interfaces-requests-activates-handlers/task.yaml
@@ -26,6 +26,7 @@ restore: |
 
     snap remove --purge test-snapd-prompt-handler || true
     tests.session -u test restore
+    snap unset system experimental.user-daemons
 
 debug: |
     tests.exec is-skipped && exit 0

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -31,6 +31,9 @@ prepare: |
     # prerequisite for having a prompts handler service
     snap set system experimental.user-daemons=true
 
+restore: |
+    snap unset system experimental.user-daemons
+
 debug: |
     tests.exec is-skipped && exit 0
 

--- a/tests/main/mount-protocol-error/task.yaml
+++ b/tests/main/mount-protocol-error/task.yaml
@@ -14,19 +14,22 @@ backends: [-autopkgtest]
 # only run on a subset of systems because this test takes a long time to run
 systems: [ubuntu-18.04-64, arch-linux-64]
 
-execute: |
-    snap set system experimental.parallel-instances=true
+restore: |
+   snap unset system experimental.parallel-instances
 
-    names=(test-snapd-tools)
-    for n in $(seq 9); do
-        names+=("test-snapd-tools_$n")
-    done
-    for i in $(seq 10); do
-       echo "Install $i"
-       snap install "${names[@]}"
-       # snap remove --purge doesn't support multiple snaps, need to run 
-       # sequentially
-       for n in $(seq 9); do
-          snap remove --purge "test-snapd-tools_$n"
-       done
-    done
+execute: |
+   snap set system experimental.parallel-instances=true
+
+   names=(test-snapd-tools)
+   for n in $(seq 9); do
+      names+=("test-snapd-tools_$n")
+   done
+   for i in $(seq 10); do
+      echo "Install $i"
+      snap install "${names[@]}"
+      # snap remove --purge doesn't support multiple snaps, need to run 
+      # sequentially
+      for n in $(seq 9); do
+         snap remove --purge "test-snapd-tools_$n"
+      done
+   done

--- a/tests/main/parallel-install-interfaces-content/task.yaml
+++ b/tests/main/parallel-install-interfaces-content/task.yaml
@@ -19,6 +19,9 @@ environment:
 prepare: |
     snap set system experimental.parallel-instances=true
 
+restore: |
+    snap unset system experimental.parallel-instances
+
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-content-advanced-slot
 

--- a/tests/main/parallel-install-interfaces/task.yaml
+++ b/tests/main/parallel-install-interfaces/task.yaml
@@ -30,7 +30,7 @@ prepare: |
     fi
 
 restore: |
-    snap set system experimental.parallel-instances=null
+    snap unset system experimental.parallel-instances
 
 execute: |
     echo "The plug can be connected to a matching slot of OS snap without snap:slot argument"

--- a/tests/main/parallel-install-layout/task.yaml
+++ b/tests/main/parallel-install-layout/task.yaml
@@ -10,6 +10,9 @@ prepare: |
     echo "Ensure feature flags are enabled"
     snap set system experimental.parallel-instances=true
 
+restore: |
+    snap unset system experimental.parallel-instances
+
 execute: |
     echo "Install the regular snap"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-layout

--- a/tests/main/parallel-install-store/task.yaml
+++ b/tests/main/parallel-install-store/task.yaml
@@ -9,7 +9,7 @@ details: |
     the presence of the instance key.
 
 restore: |
-    snap set system experimental.parallel-instances=
+    snap unset system experimental.parallel-instances
 
 execute: |
     not snap install test-snapd-tools_foo 2> run.err

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -6,6 +6,9 @@ details: |
 
 systems: [-ubuntu-core-*]
 
+environment:
+    PURGE_SNAPD: true
+
 prepare: |
     if tests.info is-snapd-from-archive; then
         tests.exec skip-test "This test is skipped when the snapd pkg isn't built from local" && exit 0

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -12,6 +12,9 @@ backends: [-autopkgtest]
 # purging everything on core devices will not work
 systems: [-ubuntu-core-*]
 
+environment:
+    PURGE_SNAPD: true
+
 prepare: |
     # TODO: unify this with tests/main/postrm-purge/task.yaml
 

--- a/tests/main/snap-refresh-hold/task.yaml
+++ b/tests/main/snap-refresh-hold/task.yaml
@@ -17,6 +17,7 @@ restore: |
   snap refresh --unhold || true
   snap refresh --unhold test-snapd-tools || true
   snap remove --purge test-snapd-tools || true
+  snap unset system experimental.parallel-instances
 
 debug: |
   snap changes

--- a/tests/main/snap-set-core-w-no-core/task.yaml
+++ b/tests/main/snap-set-core-w-no-core/task.yaml
@@ -10,6 +10,9 @@ warn-timeout: 1m
 
 kill-timeout: 5m
 
+environment:
+    PURGE_SNAPD: true
+
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"

--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -10,6 +10,7 @@ systems: [ubuntu-1*, ubuntu-2*, debian-*]
 environment:
     # uploading the snapd snap triggers OOM
     SNAPD_NO_MEMORY_LIMIT: 1
+    PURGE_SNAPD: true
 
 restore: |
     tests.exec is-skipped && exit 0

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -11,6 +11,7 @@ systems: [ubuntu-18*, ubuntu-20*, ubuntu-22*]
 
 environment:
     USERNAME: home-sweet-home
+    PURGE_SNAPD: true
 
 prepare: |
     if [[ "$SNAP_REEXEC" = "0" ]]  || tests.info is-snapd-from-archive; then
@@ -36,12 +37,7 @@ restore: |
 
     userdel -f --remove "$USERNAME"
     rm -rf /remote/users
-
-    # Reinstall the original snap
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB/pkgdb.sh"
-    distro_purge_package snapd
-    distro_install_build_snapd
+    snap unset system homedirs
 
 debug: |
     tests.exec is-skipped && exit 0

--- a/tests/main/snapd-homedirs/task.yaml
+++ b/tests/main/snapd-homedirs/task.yaml
@@ -23,6 +23,7 @@ prepare: |
 restore: |
     userdel -f --remove "$USERNAME"
     rm -rf /remote/users
+    snap unset system homedirs
 
 debug: |
     # output custom snap-confine snippets

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -17,6 +17,7 @@ environment:
     SNAPD_NO_MEMORY_LIMIT: 1
     SNAPD_SRC/core: "core"
     SNAPD_SRC/snapd: "snapd"
+    PURGE_SNAPD: true
 
 prepare: |
     if [ "${SNAP_REEXEC:-}" = "0" ]; then

--- a/tests/main/snapd-slow-startup/task.yaml
+++ b/tests/main/snapd-slow-startup/task.yaml
@@ -11,9 +11,12 @@ details: |
 systems: [ubuntu-18.04-64]
 
 restore: |
+    snap unset system experimental.parallel-instances
+
     # extra cleanup in case something in this test went wrong
     rm -f /etc/systemd/system/snapd.service.d/slow-startup.conf
-    systemctl stop snapd.service snapd.socket
+    systemctl restart snapd.service snapd.socket
+   
 
 debug: |
     ls /etc/systemd/system/snapd.service.d

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -7,6 +7,9 @@ details: |
 # not testing on ubuntu-core because we have core/snapd installed there
 systems: [-ubuntu-core-*]
 
+environment:
+    PURGE_SNAPD: true
+
 restore: |
     snap remove --purge test-snapd-sh-core18
 

--- a/tests/main/snapd-snap-removal/task.yaml
+++ b/tests/main/snapd-snap-removal/task.yaml
@@ -6,6 +6,9 @@ details: |
 
 systems: [-ubuntu-core-*]
 
+environment:
+    PURGE_SNAPD: true
+
 execute: |
     if snap list core ; then
         echo "Ensure we have no core"

--- a/tests/main/snapd-update-services/task.yaml
+++ b/tests/main/snapd-update-services/task.yaml
@@ -12,6 +12,9 @@ systems:
   - ubuntu-18.04-*
   - ubuntu-2*
 
+environment:
+  PURGE_SNAPD: true
+
 prepare: |
   # Install a snap with a service running
   service_snap="$("${TESTSTOOLS}/snaps-state" pack-local test-snapd-service)"

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -12,6 +12,7 @@ systems: [ubuntu-1*-64, ubuntu-2*-64]
 environment:
     # uploading large snap triggers OOM
     SNAPD_NO_MEMORY_LIMIT: 1
+    PURGE_SNAPD: true
 
 restore: |
     rm -f /tmp/snapd_*.snap

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -12,7 +12,7 @@ prepare: |
     snap set system experimental.parallel-instances=true
 
 restore: |
-    snap set system experimental.parallel-instances=null
+    snap unset system experimental.parallel-instances
 
 execute: |
     SNAP_NAME=test-snapd-tools

--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -6,6 +6,9 @@ details: |
 
 systems: [ubuntu-1*-64, ubuntu-2*-64]
 
+environment:
+    PURGE_SNAPD: true
+
 prepare: |
     if os.query is-arm; then
         tests.exec skip-test "there is no content for arm64 in repo http://archive.ubuntu.com/ubuntu (just amd64)" && exit 0


### PR DESCRIPTION
Initial change to go from 12s cleanup to a 6s cleanup by changing how snaps is cleaned.
