### PR TITLE
tests: update nested tests executed for arm64

### DIFF
--- a/.github/workflows/nested-systems.json
+++ b/.github/workflows/nested-systems.json
@@ -38,7 +38,7 @@
         "alternative-backend": "google-nested-arm",
         "systems": "ubuntu-24.04-arm-64",
         "tasks": "tests/nested/core/core20-basic",
-        "rules": "nested-arm"
+        "rules": ""
       }
    ]
 }


### PR DESCRIPTION
The rules cannot be used for nested arm because when the "Run Nested" label is added, then all the "tasks" are executed and the rules are not followed. 

So until nested tests are prepared to run on arm, the rules cannot be used.
