### PR TITLE
many: extend get /v2/system/{label} storage encryption with preinstall check error information

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -775,6 +775,11 @@ func (mod *Model) Timestamp() time.Time {
 	return mod.timestamp
 }
 
+// IsHybrid reports whether the model is a hybrid, meaning it is both classic and has an associated kernel snap.
+func (mod *Model) IsHybrid() bool {
+	return mod.classic && mod.kernelSnap != nil
+}
+
 // Implement further consistency checks.
 func (mod *Model) checkConsistency(db RODatabase, acck *AccountKey) error {
 	// TODO: double check trust level of authority depending on class and possibly allowed-modes

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1629,6 +1629,34 @@ func (mods *modelSuite) TestDecodeWithComponentsOK(c *C) {
 	c.Check(model.PreseedAuthority(), DeepEquals, []string{"brand-id1"})
 }
 
+func (mods *modelSuite) TestIsHybrid(c *C) {
+	for name, tc := range map[string]struct {
+		model    string
+		isHybrid bool
+	}{
+		"Hybrid": {
+			classicModelWithSnapsExample,
+			true,
+		},
+		"Classic": {
+			classicModelExample,
+			false,
+		},
+		"Core": {
+			coreModelWithComponentsExample,
+			false,
+		},
+	} {
+		encoded := strings.Replace(tc.model, "TSLINE", mods.tsLine, 1)
+		encoded = strings.Replace(encoded, "OTHER", "", 1)
+		a, err := asserts.Decode([]byte(encoded))
+		c.Assert(err, IsNil)
+		model := a.(*asserts.Model)
+
+		c.Assert(model.IsHybrid(), Equals, tc.isHybrid, Commentf("Failed test: %q", name))
+	}
+}
+
 func (mods *modelSuite) TestDecodeWithComponentsBadPresence1(c *C) {
 	encoded := strings.Replace(coreModelWithComponentsExample, "TSLINE", mods.tsLine, 1)
 	encoded = strings.Replace(encoded, "OTHER", `  -

--- a/client/systems.go
+++ b/client/systems.go
@@ -185,8 +185,8 @@ type StorageEncryption struct {
 	// the user as either an error or as information.
 	UnavailableReason string `json:"unavailable-reason,omitempty"`
 
-	// PreinstallCheck reports errors detected during preinstall check.
-	PreinstallCheck []secboot.PreinstallErrorAndActions `json:"preinstall-check,omitempty"`
+	// AvailabilityCheckErrors reports errors detected during preinstall check.
+	AvailabilityCheckErrors []secboot.PreinstallErrorInfo `json:"availability-check-errors,omitempty"`
 }
 
 type SystemDetails struct {

--- a/client/systems.go
+++ b/client/systems.go
@@ -147,7 +147,7 @@ func (client *Client) RebootToSystem(systemLabel, mode string) error {
 type StorageEncryptionSupport string
 
 const (
-	// forcefull disabled by the device
+	// forcefully disabled by the device
 	StorageEncryptionSupportDisabled = "disabled"
 	// encryption available and usable
 	StorageEncryptionSupportAvailable = "available"

--- a/client/systems.go
+++ b/client/systems.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -183,6 +184,9 @@ type StorageEncryption struct {
 	// encryption is required or not this should be presented to
 	// the user as either an error or as information.
 	UnavailableReason string `json:"unavailable-reason,omitempty"`
+
+	// PreinstallCheck reports errors detected during preinstall check.
+	PreinstallCheck []secboot.PreinstallErrorAndActions `json:"preinstall-check,omitempty"`
 }
 
 type SystemDetails struct {

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -144,7 +144,7 @@ func storageEncryption(encInfo *install.EncryptionSupportInfo) *client.StorageEn
 	}
 
 	if !encInfo.Available {
-		storageEnc.AvailabilityCheckErrors = encInfo.AvailabilityCheckErrorInfos
+		storageEnc.AvailabilityCheckErrors = encInfo.AvailabilityCheckErrors
 	}
 
 	if encInfo.PassphraseAuthAvailable {

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -40,7 +40,6 @@ import (
 	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -144,8 +143,8 @@ func storageEncryption(encInfo *install.EncryptionSupportInfo) *client.StorageEn
 		storageEnc.UnavailableReason = encInfo.UnavailableWarning
 	}
 
-	if !encInfo.Available && encInfo.PreinstallCheckErr != nil {
-		storageEnc.PreinstallCheck = secboot.UnpackPreinstallCheckError(encInfo.PreinstallCheckErr)
+	if !encInfo.Available {
+		storageEnc.AvailabilityCheckErrors = encInfo.AvailabilityCheckErrorInfos
 	}
 
 	if encInfo.PassphraseAuthAvailable {

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -142,6 +143,11 @@ func storageEncryption(encInfo *install.EncryptionSupportInfo) *client.StorageEn
 		storageEnc.Support = client.StorageEncryptionSupportUnavailable
 		storageEnc.UnavailableReason = encInfo.UnavailableWarning
 	}
+
+	if !encInfo.Available && encInfo.PreinstallCheckErr != nil {
+		storageEnc.PreinstallCheck = secboot.UnpackPreinstallCheckError(encInfo.PreinstallCheckErr)
+	}
+
 	if encInfo.PassphraseAuthAvailable {
 		storageEnc.Features = append(storageEnc.Features, client.StorageEncryptionFeaturePassphraseAuth)
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-        github.com/snapcore/secboot v0.0.0-20250415224949-c85cb11
+        github.com/snapcore/secboot v0.0.0-20250603103321-7fb379721237
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4
+        github.com/snapcore/secboot v0.0.0-20250415224949-c85cb11
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0
@@ -34,6 +34,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/snapcore/secboot => ../secboot
 
 require go.etcd.io/bbolt v1.3.9
 

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraK
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4 h1:ECxlsvtHL7HOv8wIsnF95kUkQrtE86cY/cylWVt2n0M=
-github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4/go.mod h1:Y3APoLyInDvY8mVP1qDQd/t9bPuNp2itYPCGrltRQoQ=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -485,7 +485,7 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	// Insert encryption data when enabled
 	if opts.encrypted {
 		// Mock TPM and sealing
-		restore := installLogic.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+		restore := installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
 			c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 			return nil
 		})
@@ -791,12 +791,10 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 
 	// Simulate system with TPM
 	if hasTPM {
-		restore := installLogic.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+		restore := installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
 			c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 			return nil
 		})
-		s.AddCleanup(restore)
-		restore = installLogic.MockSecbootPreinstallCheck(func() error { return nil })
 		s.AddCleanup(restore)
 	}
 
@@ -1042,12 +1040,10 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryptionPassphraseAu
 	defer s.state.Unlock()
 
 	// Simulate system with TPM
-	restore := installLogic.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+	restore := installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
 		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		return nil
 	})
-	s.AddCleanup(restore)
-	restore = installLogic.MockSecbootPreinstallCheck(func() error { return nil })
 	s.AddCleanup(restore)
 
 	restore = devicestate.MockInstallEncryptPartitions(func(onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions, encryptionType device.EncryptionType, model *asserts.Model, gadgetRoot, kernelRoot string, perfTimings timings.Measurer) (*install.EncryptionSetupData, error) {

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -485,7 +485,8 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	// Insert encryption data when enabled
 	if opts.encrypted {
 		// Mock TPM and sealing
-		restore := installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+		restore := installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
+			c.Check(model.Classic(), Equals, false)
 			c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 			return nil
 		})
@@ -791,7 +792,7 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 
 	// Simulate system with TPM
 	if hasTPM {
-		restore := installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+		restore := installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
 			c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 			return nil
 		})
@@ -1040,7 +1041,7 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryptionPassphraseAu
 	defer s.state.Unlock()
 
 	// Simulate system with TPM
-	restore := installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+	restore := installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
 		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		return nil
 	})

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -796,6 +796,8 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 			return nil
 		})
 		s.AddCleanup(restore)
+		restore = installLogic.MockSecbootPreinstallCheck(func() error { return nil })
+		s.AddCleanup(restore)
 	}
 
 	// Mock encryption of partitions
@@ -1044,6 +1046,8 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryptionPassphraseAu
 		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		return nil
 	})
+	s.AddCleanup(restore)
+	restore = installLogic.MockSecbootPreinstallCheck(func() error { return nil })
 	s.AddCleanup(restore)
 
 	restore = devicestate.MockInstallEncryptPartitions(func(onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions, encryptionType device.EncryptionType, model *asserts.Model, gadgetRoot, kernelRoot string, perfTimings timings.Measurer) (*install.EncryptionSetupData, error) {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -359,7 +359,7 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	})
 	s.AddCleanup(restore)
 
-	restore = installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+	restore = installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
 		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		return fmt.Errorf("TPM not available")
 	})
@@ -651,7 +651,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	})
 	defer restore()
 
-	restore = installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+	restore = installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
 		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		if tc.tpm {
 			return nil
@@ -1786,7 +1786,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallBootloaderVarSetFails(c *C) {
 	})
 	defer restore()
 
-	restore = installLogic.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("no encrypted soup for you") })
+	restore = installLogic.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return fmt.Errorf("no encrypted soup for you") })
 	defer restore()
 
 	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
@@ -1826,7 +1826,7 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionValidityChecks(c *C, er
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = installLogic.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
+	restore = installLogic.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
@@ -2011,7 +2011,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithEncryptionValidatesGadgetErr(
 	defer restore()
 
 	// pretend we have a TPM
-	restore = installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+	restore = installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
 		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		return nil
 	})
@@ -2043,7 +2043,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithEncryptionValidatesGadgetWarn
 	defer restore()
 
 	// pretend we have a TPM
-	restore = installLogic.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
+	restore = installLogic.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	s.testInstallGadgetNoSave(c, "dangerous")
@@ -2067,7 +2067,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithoutEncryptionValidatesGadgetW
 	defer restore()
 
 	// pretend we have a TPM
-	restore = installLogic.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("TPM2 not available") })
+	restore = installLogic.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return fmt.Errorf("TPM2 not available") })
 	defer restore()
 
 	s.testInstallGadgetNoSave(c, "dangerous")
@@ -2143,7 +2143,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncrypted(c *C) {
 		} else {
 			makeInstalledMockKernelSnap(c, st, kernelYamlNoFdeSetup)
 		}
-		restore := installLogic.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error {
+		restore := installLogic.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error {
 			if tc.hasTPM {
 				return nil
 			}
@@ -2314,7 +2314,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 	})
 	defer restore()
 
-	restore = installLogic.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error {
+	restore = installLogic.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error {
 		if tc.tpm {
 			return nil
 		} else {
@@ -3137,7 +3137,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetExpectedTasks(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+	restore = installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
 		c.Check(tpmMode, Equals, secboot.TPMPartialReprovision)
 		return fmt.Errorf("TPM not available")
 	})
@@ -3210,7 +3210,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetInstallDeviceHook(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = installLogic.MockSecbootPreinstallCheck(func(tpmMode secboot.TPMProvisionMode) error {
+	restore = installLogic.MockSecbootPreinstallCheck(func(model *asserts.Model, tpmMode secboot.TPMProvisionMode) error {
 		c.Check(tpmMode, Equals, secboot.TPMPartialReprovision)
 		return fmt.Errorf("TPM not available")
 	})

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2948,7 +2948,7 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C)
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)
 
-	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("really no tpm") })
+	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return fmt.Errorf("really no tpm") })
 	defer restore()
 
 	system, gadgetInfo, encInfo, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")
@@ -2977,7 +2977,7 @@ func (s *modelAndGadgetInfoSuite) testSystemAndGadgetAndEncyptionInfoPassphraseS
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)
 
-	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
+	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	system, gadgetInfo, encInfo, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2948,9 +2948,7 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C)
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)
 
-	restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("really no tpm") })
-	defer restore()
-	restore = install.MockSecbootPreinstallCheck(func() error { return fmt.Errorf("preinstall check error: really no tpm") })
+	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("really no tpm") })
 	defer restore()
 
 	system, gadgetInfo, encInfo, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")
@@ -2968,8 +2966,8 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C)
 	c.Check(encInfo, DeepEquals, &install.EncryptionSupportInfo{
 		Available:          false,
 		StorageSafety:      asserts.StorageSafetyPreferEncrypted,
-		UnavailableWarning: "not encrypting device storage as checking TPM gave: preinstall check error: really no tpm",
-		PreinstallCheckErr: fmt.Errorf("preinstall check error: really no tpm"),
+		UnavailableWarning: "not encrypting device storage as checking TPM gave: really no tpm",
+		PreinstallCheckErr: fmt.Errorf("really no tpm"),
 	})
 }
 
@@ -2979,9 +2977,7 @@ func (s *modelAndGadgetInfoSuite) testSystemAndGadgetAndEncyptionInfoPassphraseS
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)
 
-	restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
-	defer restore()
-	restore = install.MockSecbootPreinstallCheck(func() error { return nil })
+	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	system, gadgetInfo, encInfo, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2950,6 +2950,8 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C)
 
 	restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("really no tpm") })
 	defer restore()
+	restore = install.MockSecbootPreinstallCheck(func() error { return fmt.Errorf("preinstall check error: really no tpm") })
+	defer restore()
 
 	system, gadgetInfo, encInfo, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")
 	c.Assert(err, IsNil)
@@ -2966,7 +2968,8 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C)
 	c.Check(encInfo, DeepEquals, &install.EncryptionSupportInfo{
 		Available:          false,
 		StorageSafety:      asserts.StorageSafetyPreferEncrypted,
-		UnavailableWarning: "not encrypting device storage as checking TPM gave: really no tpm",
+		UnavailableWarning: "not encrypting device storage as checking TPM gave: preinstall check error: really no tpm",
+		PreinstallCheckErr: fmt.Errorf("preinstall check error: really no tpm"),
 	})
 }
 
@@ -2977,6 +2980,8 @@ func (s *modelAndGadgetInfoSuite) testSystemAndGadgetAndEncyptionInfoPassphraseS
 	c.Assert(err, IsNil)
 
 	restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
+	defer restore()
+	restore = install.MockSecbootPreinstallCheck(func() error { return nil })
 	defer restore()
 
 	system, gadgetInfo, encInfo, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1118,8 +1118,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 			return fmt.Errorf("cannot copy seed: %w", err)
 		}
 
-		hybrid := systemAndSnaps.Model.Classic() && systemAndSnaps.Model.KernelSnap() != nil
-		if hybrid {
+		if systemAndSnaps.Model.IsHybrid() {
 			// boot.InitramfsUbuntuSeedDir (/run/mnt/ubuntu-data, usually) is a
 			// mountpoint on hybrid system that is set up in the initramfs.
 			// setting up this bind mount ensures that the system can be seeded

--- a/overlord/install/export_test.go
+++ b/overlord/install/export_test.go
@@ -27,8 +27,28 @@ import (
 )
 
 var (
-	CheckFDEFeatures = checkFDEFeatures
+	EncryptionAvailabilityCheck    = encryptionAvailabilityCheck
+	PreinstallCheckSupported       = preinstallCheckSupported
+	OrderedCurrentBootImages       = orderedCurrentBootImages
+	OrderedCurrentBootImagesHybrid = orderedCurrentBootImagesHybrid
+	CheckFDEFeatures               = checkFDEFeatures
 )
+
+func MockPreinstallCheckSupported(f func(model *asserts.Model) (bool, error)) (restore func()) {
+	old := preinstallCheckSupported
+	preinstallCheckSupported = f
+	return func() {
+		preinstallCheckSupported = old
+	}
+}
+
+func MockHybridInstallRootDir(newRoot string) (restore func()) {
+	old := hybridInstallRootDir
+	hybridInstallRootDir = newRoot
+	return func() {
+		hybridInstallRootDir = old
+	}
+}
 
 func MockTimeNow(f func() time.Time) (restore func()) {
 	old := timeNow

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -169,7 +169,7 @@ func BuildKernelBootInfo(kernInfo *snap.Info, compSeedInfos []ComponentSeedInfo,
 }
 
 // MockSecbootPreinstallCheck mocks secboot.PreinstallCheck usage by the package for testing.
-func MockSecbootPreinstallCheck(f func(secboot.TPMProvisionMode) error) (restore func()) {
+func MockSecbootPreinstallCheck(f func(*asserts.Model, secboot.TPMProvisionMode) error) (restore func()) {
 	old := secbootPreinstallCheck
 	secbootPreinstallCheck = f
 	return func() {
@@ -239,7 +239,7 @@ func GetEncryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvision
 	case checkSecbootEncryption:
 		// XXX: Remove this comment once confirmed that secbootCheckTPMKeySealingSupported
 		// is covered by PreinstallCheck.
-		checkEncryptionErr = secbootPreinstallCheck(tpmMode)
+		checkEncryptionErr = secbootPreinstallCheck(model, tpmMode)
 		if checkEncryptionErr == nil {
 			res.Type = device.EncryptionTypeLUKS
 		} else {
@@ -364,7 +364,7 @@ func NewGetEncryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvis
 		// comprehensive preinstall check
 		// XXX: Remove this comment once confirmed that secbootCheckTPMKeySealingSupported
 		// is covered by PreinstallCheck.
-		if err := secbootPreinstallCheck(tpmMode); err != nil {
+		if err := secbootPreinstallCheck(model, tpmMode); err != nil {
 			// XXX: Remove this comment once agreed if the compound error will have simple high level message.
 			setUnavailableErrorOrWarning(fmt.Errorf("cannot use TPM based encryption: preinstall check failed"))
 			encInfo.PreinstallCheckErr = err

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -178,6 +178,15 @@ func MockSecbootCheckTPMKeySealingSupported(f func(tpmMode secboot.TPMProvisionM
 	}
 }
 
+// MockSecbootPreinstallCheck mocks secboot.PreinstallCheck usage by the package for testing.
+func MockSecbootPreinstallCheck(f func() error) (restore func()) {
+	old := secbootPreinstallCheck
+	secbootPreinstallCheck = f
+	return func() {
+		secbootPreinstallCheck = old
+	}
+}
+
 func checkPassphraseSupportedByTargetSystem(sysVer *SystemSnapdVersions) (bool, error) {
 	const minSnapdVersion = "2.68"
 	if sysVer == nil {

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -819,7 +819,9 @@ func (s *installSuite) TestInstallCheckEncryptionSupportErrorsLogsTPM(c *C) {
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
 	gadgetInfo, _ := s.mountedGadget(c)
 
-	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return fmt.Errorf("preinstall check error: tpm says no") })
+	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error {
+		return fmt.Errorf("preinstall check error: tpm says no")
+	})
 	defer restore()
 
 	logbuf, restore := logger.MockLogger()

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -211,46 +211,45 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 
 	var testCases = []struct {
 		grade, storageSafety, snapdVersion, kernelSnapdVersion string
-		tpmKeySealingCheckErr                                  error
 		preinstallCheckErr                                     error
 
 		expected install.EncryptionSupportInfo
 	}{
 		{
-			"dangerous", "", "", "", nil, nil,
+			"dangerous", "", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyPreferEncrypted,
 				Type:          device.EncryptionTypeLUKS,
 			},
 		}, {
-			// we do not expect no tpm from tpm sealing check and no error from preinstall check, but let's confirm the behavior
-			"dangerous", "", "", "", fmt.Errorf("no tpm"), nil,
+			"dangerous", "", "", "", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyPreferEncrypted,
 				Type:               device.EncryptionTypeNone,
 				UnavailableWarning: "not encrypting device storage as checking TPM gave: no tpm",
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		}, {
-			"dangerous", "encrypted", "", "", nil, nil,
+			"dangerous", "encrypted", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyEncrypted,
 				Type:          device.EncryptionTypeLUKS,
 			},
 		}, {
-			"dangerous", "encrypted", "", "", fmt.Errorf("no tpm"), fmt.Errorf("preinstall check error: no tpm"),
+			"dangerous", "encrypted", "", "", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyEncrypted,
 				Type:               device.EncryptionTypeNone,
-				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: preinstall check error: no tpm"),
-				PreinstallCheckErr: fmt.Errorf("preinstall check error: no tpm"),
+				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: no tpm"),
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		},
 		{
-			"dangerous", "prefer-unencrypted", "", "", nil, nil,
+			"dangerous", "prefer-unencrypted", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyPreferUnencrypted,
@@ -259,30 +258,30 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 			},
 		},
 		{
-			"signed", "", "", "", nil, nil,
+			"signed", "", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyPreferEncrypted,
 				Type:          device.EncryptionTypeLUKS,
 			},
 		}, {
-			"signed", "", "", "", nil, fmt.Errorf("preinstall check error: more sophisticated problem"),
+			"signed", "", "", "", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyPreferEncrypted,
 				Type:               device.EncryptionTypeNone,
-				UnavailableWarning: "not encrypting device storage as checking TPM gave: preinstall check error: more sophisticated problem",
-				PreinstallCheckErr: fmt.Errorf("preinstall check error: more sophisticated problem"),
+				UnavailableWarning: "not encrypting device storage as checking TPM gave: no tpm",
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		}, {
-			"signed", "encrypted", "", "", nil, nil,
+			"signed", "encrypted", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyEncrypted,
 				Type:          device.EncryptionTypeLUKS,
 			},
 		}, {
-			"signed", "prefer-unencrypted", "", "", nil, nil,
+			"signed", "prefer-unencrypted", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyPreferUnencrypted,
@@ -290,50 +289,50 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 				Type: device.EncryptionTypeLUKS,
 			},
 		}, {
-			"signed", "encrypted", "", "", fmt.Errorf("no tpm"), fmt.Errorf("preinstall check error: no tpm"),
+			"signed", "encrypted", "", "", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyEncrypted,
 				Type:               device.EncryptionTypeNone,
-				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: preinstall check error: no tpm"),
-				PreinstallCheckErr: fmt.Errorf("preinstall check error: no tpm"),
+				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: no tpm"),
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		}, {
-			"secured", "encrypted", "", "", nil, nil,
+			"secured", "encrypted", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyEncrypted,
 				Type:          device.EncryptionTypeLUKS,
 			},
 		}, {
-			"secured", "encrypted", "", "", fmt.Errorf("no tpm"), fmt.Errorf("preinstall check error: no tpm"),
+			"secured", "encrypted", "", "", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyEncrypted,
 				Type:               device.EncryptionTypeNone,
-				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: preinstall check error: no tpm"),
-				PreinstallCheckErr: fmt.Errorf("preinstall check error: no tpm"),
+				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: no tpm"),
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		}, {
-			"secured", "", "", "", nil, nil,
+			"secured", "", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyEncrypted,
 				Type:          device.EncryptionTypeLUKS,
 			},
 		}, {
-			"secured", "", "", "", fmt.Errorf("no tpm"), fmt.Errorf("preinstall check error: no tpm"),
+			"secured", "", "", "", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyEncrypted,
 				Type:               device.EncryptionTypeNone,
-				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: preinstall check error: no tpm"),
-				PreinstallCheckErr: fmt.Errorf("preinstall check error: no tpm"),
+				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: no tpm"),
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		},
 		// Passphrase support requires snapd 2.68+
 		{
-			"secured", "encrypted", "2.68", "2.68", nil, nil,
+			"secured", "encrypted", "2.68", "2.68", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety:           asserts.StorageSafetyEncrypted,
@@ -342,7 +341,7 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 			},
 		},
 		{
-			"secured", "encrypted", "2.69", "2.69", nil, nil,
+			"secured", "encrypted", "2.69", "2.69", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety:           asserts.StorageSafetyEncrypted,
@@ -351,7 +350,7 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 			},
 		},
 		{
-			"secured", "encrypted", "2.67", "2.68", nil, nil,
+			"secured", "encrypted", "2.67", "2.68", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety:           asserts.StorageSafetyEncrypted,
@@ -360,7 +359,7 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 			},
 		},
 		{
-			"secured", "encrypted", "2.68", "2.67", nil, nil,
+			"secured", "encrypted", "2.68", "2.67", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety:           asserts.StorageSafetyEncrypted,
@@ -370,9 +369,7 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 		},
 	}
 	for i, tc := range testCases {
-		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmKeySealingCheckErr })
-		defer restore()
-		restore = install.MockSecbootPreinstallCheck(func() error { return tc.preinstallCheckErr })
+		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return tc.preinstallCheckErr })
 		defer restore()
 
 		mockModel := s.mockModel(map[string]interface{}{
@@ -397,13 +394,12 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 
 	var testCases = []struct {
 		grade, storageSafety, forceUnencrypted string
-		tpmKeySealingCheckErr                  error
 		preinstallCheckErr                     error
 
 		expected install.EncryptionSupportInfo
 	}{
 		{
-			"dangerous", "", "", nil, nil,
+			"dangerous", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyPreferEncrypted,
@@ -411,7 +407,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 			},
 		},
 		{
-			"dangerous", "", "force-unencrypted", nil, nil,
+			"dangerous", "", "force-unencrypted", nil,
 			install.EncryptionSupportInfo{
 				// Encryption is forcefully disabled
 				// here so no further
@@ -423,7 +419,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 			},
 		},
 		{
-			"dangerous", "", "force-unencrypted", fmt.Errorf("no tpm"), nil,
+			"dangerous", "", "force-unencrypted", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				// Encryption is forcefully disabled
 				// here so the "no tpm" error is never visible
@@ -434,7 +430,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 		},
 		// not possible to disable encryption on non-dangerous devices
 		{
-			"signed", "", "", nil, nil,
+			"signed", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyPreferEncrypted,
@@ -442,7 +438,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 			},
 		},
 		{
-			"signed", "", "force-unencrypted", nil, nil,
+			"signed", "", "force-unencrypted", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyPreferEncrypted,
@@ -450,17 +446,17 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 			},
 		},
 		{
-			"signed", "", "force-unencrypted", fmt.Errorf("no tpm"), fmt.Errorf("preinstall check error: no tpm"),
+			"signed", "", "force-unencrypted", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyPreferEncrypted,
 				Type:               device.EncryptionTypeNone,
-				UnavailableWarning: "not encrypting device storage as checking TPM gave: preinstall check error: no tpm",
-				PreinstallCheckErr: fmt.Errorf("preinstall check error: no tpm"),
+				UnavailableWarning: "not encrypting device storage as checking TPM gave: no tpm",
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		},
 		{
-			"secured", "", "", nil, nil,
+			"secured", "", "", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyEncrypted,
@@ -468,7 +464,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 			},
 		},
 		{
-			"secured", "", "force-unencrypted", nil, nil,
+			"secured", "", "force-unencrypted", nil,
 			install.EncryptionSupportInfo{
 				Available: true, Disabled: false,
 				StorageSafety: asserts.StorageSafetyEncrypted,
@@ -476,21 +472,19 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 			},
 		},
 		{
-			"secured", "", "force-unencrypted", nil, fmt.Errorf("preinstall check error: more sophisticated problem"),
+			"secured", "", "force-unencrypted", fmt.Errorf("no tpm"),
 			install.EncryptionSupportInfo{
 				Available: false, Disabled: false,
 				StorageSafety:      asserts.StorageSafetyEncrypted,
 				Type:               device.EncryptionTypeNone,
-				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: preinstall check error: more sophisticated problem"),
-				PreinstallCheckErr: fmt.Errorf("preinstall check error: more sophisticated problem"),
+				UnavailableErr:     fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: no tpm"),
+				PreinstallCheckErr: fmt.Errorf("no tpm"),
 			},
 		},
 	}
 
 	for i, tc := range testCases {
-		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmKeySealingCheckErr })
-		defer restore()
-		restore = install.MockSecbootPreinstallCheck(func() error { return tc.preinstallCheckErr })
+		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return tc.preinstallCheckErr })
 		defer restore()
 
 		mockModel := s.mockModel(map[string]interface{}{
@@ -543,9 +537,7 @@ var gadgetUC20 = &gadget.Info{
 }
 
 func (s *installSuite) TestEncryptionSupportInfoGadgetIncompatibleWithEncryption(c *C) {
-	restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
-	defer restore()
-	restore = install.MockSecbootPreinstallCheck(func() error { return nil })
+	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
@@ -680,29 +672,17 @@ func (s *installSuite) TestInstallCheckEncryptionSupportTPM(c *C) {
 	defer restore()
 
 	for _, tc := range []struct {
-		tpmKeySealingCheckFailure bool
-		preinstallCheckFailure    bool
-		encryptionType            device.EncryptionType
+		preinstallCheckFailure bool
+		encryptionType         device.EncryptionType
 	}{
-		// unhappy: no tpm, no hook, both TPM sealing check and preinstallcheck detects the issue
-		{true, true, device.EncryptionTypeNone},
-		// unhappy: no tpm, no hook, TPM sealing check detects issue but not preinstall check
-		{true, false, device.EncryptionTypeNone},
-		// unhappy: no tpm, no hook, preinstall check detects issue, but not TPM sealing check
-		{false, true, device.EncryptionTypeNone},
-		// happy: tpm, no hook, both TPM sealing check and preinstallcheck does not detect issue
-		{false, false, device.EncryptionTypeLUKS},
+		// unhappy: no tpm, no hook
+		{true, device.EncryptionTypeNone},
+		// happy: tpm,
+		{false, device.EncryptionTypeLUKS},
 	} {
-		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
-			if tc.tpmKeySealingCheckFailure {
-				return fmt.Errorf("tpm says no")
-			}
-			return nil
-		})
-		defer restore()
-		restore = install.MockSecbootPreinstallCheck(func() error {
+		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error {
 			if tc.preinstallCheckFailure {
-				return fmt.Errorf("preinstall check error: tpm says no")
+				return fmt.Errorf("no tpm")
 			}
 			return nil
 		})
@@ -711,15 +691,9 @@ func (s *installSuite) TestInstallCheckEncryptionSupportTPM(c *C) {
 		encryptionType, err := install.CheckEncryptionSupport(mockModel, secboot.TPMProvisionFull, kernelInfo, gadgetInfo, nil)
 		c.Assert(err, IsNil)
 		c.Check(encryptionType, Equals, tc.encryptionType, Commentf("%v", tc))
-		switch {
-		case tc.preinstallCheckFailure:
-			c.Check(logbuf.String(), Matches, ".*: not encrypting device storage as checking TPM gave: preinstall check error: tpm says no\n")
-		case tc.tpmKeySealingCheckFailure:
-			c.Check(logbuf.String(), Matches, ".*: not encrypting device storage as checking TPM gave: tpm says no\n")
-		default:
-			c.Check(logbuf.String(), Matches, "")
+		if tc.preinstallCheckFailure {
+			c.Check(logbuf.String(), Matches, ".*: not encrypting device storage as checking TPM gave: no tpm\n")
 		}
-
 		logbuf.Reset()
 	}
 }
@@ -747,7 +721,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportHook(c *C) {
 			return []byte(fmt.Sprintf(`{"features":%s}`, tc.fdeSetupHookFeatures)), nil
 		}
 
-		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
+		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error {
 			if tc.hasTPM {
 				return nil
 			}
@@ -769,9 +743,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportStorageSafety(c *C) {
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
 	gadgetInfo, _ := s.mountedGadget(c)
 
-	restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
-	defer restore()
-	restore = install.MockSecbootPreinstallCheck(func() error { return nil })
+	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	var testCases = []struct {
@@ -808,35 +780,31 @@ func (s *installSuite) TestInstallCheckEncryptionSupportErrors(c *C) {
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
 	gadgetInfo, _ := s.mountedGadget(c)
 
+	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("no tpm") })
+	defer restore()
+
 	var testCases = []struct {
-		grade, storageSafety  string
-		tpmKeySealingCheckErr error
-		preinstallCheckErr    error
+		grade, storageSafety string
 
 		expectedErr string
 	}{
 		// we don't test unset here because the assertion assembly
 		// will ensure it has a default
 		{
-			"dangerous", "encrypted", fmt.Errorf("tpm says no"), nil,
-			"cannot encrypt device storage as mandated by encrypted storage-safety model option: tpm says no",
+			"dangerous", "encrypted",
+			"cannot encrypt device storage as mandated by encrypted storage-safety model option: no tpm",
 		}, {
-			"signed", "encrypted", nil, fmt.Errorf("preinstall check error: more sophisticated problem"),
-			"cannot encrypt device storage as mandated by encrypted storage-safety model option: preinstall check error: more sophisticated problem",
+			"signed", "encrypted",
+			"cannot encrypt device storage as mandated by encrypted storage-safety model option: no tpm",
 		}, {
-			"secured", "", fmt.Errorf("tpm says no"), fmt.Errorf("preinstall check error: tpm says no"),
-			"cannot encrypt device storage as mandated by model grade secured: preinstall check error: tpm says no",
+			"secured", "",
+			"cannot encrypt device storage as mandated by model grade secured: no tpm",
 		}, {
-			"secured", "encrypted", nil, fmt.Errorf("preinstall check error: more sophisticated problem"),
-			"cannot encrypt device storage as mandated by model grade secured: preinstall check error: more sophisticated problem",
+			"secured", "encrypted",
+			"cannot encrypt device storage as mandated by model grade secured: no tpm",
 		},
 	}
 	for _, tc := range testCases {
-		restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmKeySealingCheckErr })
-		defer restore()
-		restore = install.MockSecbootPreinstallCheck(func() error { return tc.preinstallCheckErr })
-		defer restore()
-
 		mockModel := s.mockModel(map[string]interface{}{
 			"grade":          tc.grade,
 			"storage-safety": tc.storageSafety,
@@ -851,9 +819,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportErrorsLogsTPM(c *C) {
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
 	gadgetInfo, _ := s.mountedGadget(c)
 
-	restore := install.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("tpm says no") })
-	defer restore()
-	restore = install.MockSecbootPreinstallCheck(func() error { return fmt.Errorf("preinstall check error: tpm says no") })
+	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("preinstall check error: tpm says no") })
 	defer restore()
 
 	logbuf, restore := logger.MockLogger()

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -369,7 +369,7 @@ func (s *installSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 		},
 	}
 	for i, tc := range testCases {
-		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return tc.preinstallCheckErr })
+		restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return tc.preinstallCheckErr })
 		defer restore()
 
 		mockModel := s.mockModel(map[string]interface{}{
@@ -484,7 +484,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 	}
 
 	for i, tc := range testCases {
-		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return tc.preinstallCheckErr })
+		restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return tc.preinstallCheckErr })
 		defer restore()
 
 		mockModel := s.mockModel(map[string]interface{}{
@@ -537,7 +537,7 @@ var gadgetUC20 = &gadget.Info{
 }
 
 func (s *installSuite) TestEncryptionSupportInfoGadgetIncompatibleWithEncryption(c *C) {
-	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
+	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
@@ -680,7 +680,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportTPM(c *C) {
 		// happy: tpm,
 		{false, device.EncryptionTypeLUKS},
 	} {
-		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error {
+		restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error {
 			if tc.preinstallCheckFailure {
 				return fmt.Errorf("no tpm")
 			}
@@ -721,7 +721,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportHook(c *C) {
 			return []byte(fmt.Sprintf(`{"features":%s}`, tc.fdeSetupHookFeatures)), nil
 		}
 
-		restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error {
+		restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error {
 			if tc.hasTPM {
 				return nil
 			}
@@ -743,7 +743,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportStorageSafety(c *C) {
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
 	gadgetInfo, _ := s.mountedGadget(c)
 
-	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return nil })
+	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	var testCases = []struct {
@@ -780,7 +780,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportErrors(c *C) {
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
 	gadgetInfo, _ := s.mountedGadget(c)
 
-	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("no tpm") })
+	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return fmt.Errorf("no tpm") })
 	defer restore()
 
 	var testCases = []struct {
@@ -819,7 +819,7 @@ func (s *installSuite) TestInstallCheckEncryptionSupportErrorsLogsTPM(c *C) {
 	kernelInfo := s.kernelSnap(c, "pc-kernel=20")
 	gadgetInfo, _ := s.mountedGadget(c)
 
-	restore := install.MockSecbootPreinstallCheck(func(secboot.TPMProvisionMode) error { return fmt.Errorf("preinstall check error: tpm says no") })
+	restore := install.MockSecbootPreinstallCheck(func(*asserts.Model, secboot.TPMProvisionMode) error { return fmt.Errorf("preinstall check error: tpm says no") })
 	defer restore()
 
 	logbuf, restore := logger.MockLogger()

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -21,6 +21,7 @@
 package secboot
 
 import (
+	"context"
 	"io"
 	"os"
 	"os/exec"
@@ -29,6 +30,7 @@ import (
 	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
 	sb_efi "github.com/snapcore/secboot/efi"
+	"github.com/snapcore/secboot/efi/preinstall"
 	sb_hooks "github.com/snapcore/secboot/hooks"
 	sb_tpm2 "github.com/snapcore/secboot/tpm2"
 
@@ -38,7 +40,21 @@ import (
 var (
 	EFIImageFromBootFile = efiImageFromBootFile
 	LockTPMSealedKeys    = lockTPMSealedKeys
+
+	// Preinstall
+	ConvertErrorType               = convertErrorType
+	ConvertActions                 = convertActions
+	NewInternalErrorUnexpectedType = newInternalErrorUnexpectedType
 )
+
+// Preinstall
+func MockSbPreinstallRun(f func(_ *preinstall.RunChecksContext, ctx context.Context, action preinstall.Action, args ...any) (*preinstall.CheckResult, error)) (restore func()) {
+	old := preinstallRun
+	preinstallRun = f
+	return func() {
+		preinstallRun = old
+	}
+}
 
 func MockSbConnectToDefaultTPM(f func() (*sb_tpm2.Connection, error)) (restore func()) {
 	old := sbConnectToDefaultTPM

--- a/secboot/preinstall.go
+++ b/secboot/preinstall.go
@@ -22,9 +22,10 @@ import (
 	"encoding/json"
 )
 
-// PreinstallErrorAndActions represents a preinstall check error, including its
-// kind, message, and optionally arguments and recovery actions.
-type PreinstallErrorAndActions struct {
+// PreinstallErrorInfo represents the information contained within
+// a preinstall check error, including its kind, message, and optionally
+// arguments and recovery actions.
+type PreinstallErrorInfo struct {
 	Kind    string                     `json:"kind"`
 	Message string                     `json:"message"`
 	Args    map[string]json.RawMessage `json:"args,omitempty"`

--- a/secboot/preinstall.go
+++ b/secboot/preinstall.go
@@ -25,8 +25,8 @@ import (
 // PreinstallErrorAndActions represents a preinstall check error, including its
 // kind, message, and optionally arguments and recovery actions.
 type PreinstallErrorAndActions struct {
-	Kind    string          `json:"kind"`
-	Message string          `json:"message"`
-	Args    json.RawMessage `json:"args,omitempty"`
-	Actions []string        `json:"actions,omitempty"`
+	Kind    string                     `json:"kind"`
+	Message string                     `json:"message"`
+	Args    map[string]json.RawMessage `json:"args,omitempty"`
+	Actions []string                   `json:"actions,omitempty"`
 }

--- a/secboot/preinstall.go
+++ b/secboot/preinstall.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018-2025 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/secboot/preinstall.go
+++ b/secboot/preinstall.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018-2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package secboot
+
+import (
+	"encoding/json"
+)
+
+// PreinstallErrorAndActions represents a preinstall check error, including its
+// kind, message, and optionally arguments and recovery actions.
+type PreinstallErrorAndActions struct {
+	Kind    string          `json:"kind"`
+	Message string          `json:"message"`
+	Args    json.RawMessage `json:"args,omitempty"`
+	Actions []string        `json:"actions,omitempty"`
+}

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
+
+/*
+ * Copyright (C) 2018-2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+// XXX: Revisit after final implementation
+func UnpackPreinstallCheckError(err error) []PreinstallErrorAndActions {
+	return []PreinstallErrorAndActions{}
+}
+
+// XXX: Revisit after final implementation
+func PreinstallCheck(tpmMode TPMProvisionMode) error {
+	return errBuildWithoutSecboot
+}

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -2,7 +2,7 @@
 //go:build nosecboot
 
 /*
- * Copyright (C) 2018-2025 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,12 +20,10 @@
 
 package secboot
 
-// XXX: Revisit after final implementation
-func UnpackPreinstallCheckError(err error) []PreinstallErrorAndActions {
-	return []PreinstallErrorAndActions{}
-}
+import (
+	"errors"
+)
 
-// XXX: Revisit after final implementation
-func PreinstallCheck(tpmMode TPMProvisionMode) error {
-	return errBuildWithoutSecboot
+func PreinstallCheck(bootImagePaths []string) ([]PreinstallErrorInfo, error) {
+	return nil, errors.New("preinstall check not supported without secboot")
 }

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -23,24 +23,17 @@ package secboot
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	sb_efi "github.com/snapcore/secboot/efi"
 	"github.com/snapcore/secboot/efi/preinstall"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
 )
 
-const (
-	hybridInstallBootloaderShimGlob  = "cdrom/EFI/boot/boot*.efi"
-	hybridInstallBootloaderGrubGlob = "cdrom/EFI/boot/grub*.efi"
-	hybridInstallKernelFile          = "cdrom/casper/vmlinuz"
-)
-
 var (
-	hybridInstallRootDir          = "/"
 	preinstallNewRunChecksContext = preinstall.NewRunChecksContext
 	preinstallRun                 = (*preinstall.RunChecksContext).Run
 )
@@ -131,73 +124,35 @@ func newInternalErrorUnexpectedType(err error) PreinstallErrorAndActions {
 	}
 }
 
-// PreinstallCheck runs preinstall checks without customization or profile generation options.
-func PreinstallCheck(model *asserts.Model, tpmMode TPMProvisionMode) error {
-	if model.IsHybrid() {
-		// XXX: Expect preinstallNewRunChecksContext to require tpmMode in order to evaluate
-		// lockout when required. Complete implementation after preinstallNewRunChecksContext
-		// is modified.
-		_ = tpmMode
+// PreinstallCheck runs the default preinstall checks to evaluate whether the host
+// environment is an EFI system suitable for TPM-based full disk encryption (FDE).
+// It uses standard check and PCR profile options, without customizing TCG-compliant
+// PCR profiles. When running in a virtual machine during testing, VM checks are
+// permitted. Returns an error on failure and logs any warnings encountered.
+func PreinstallCheck(model *asserts.Model, images []sb_efi.Image) error {
+	checkCustomizationFlags := preinstall.CheckFlagsDefault
+	if snapdenv.Testing() && systemd.IsVirtualMachine() {
+		// allow virtual machine when testing
+		checkCustomizationFlags |= preinstall.PermitVirtualMachine
+	}
 
-		// XXX: Suggest also providing default value for check flags.
-		checkCustomizationFlags := preinstall.CheckFlags(0)
-		if snapdenv.Testing() && systemd.IsVirtualMachine() {
-			// allow virtual machine when testing
-			checkCustomizationFlags |= preinstall.PermitVirtualMachine
-		}
+	// do not customize TCG compliant PCR profile generation
+	profileOptionFlags := preinstall.PCRProfileOptionsDefault
+	// no image required because we avoid profile option flags WithBootManagerCodeProfile and WithSecureBootPolicyProfile
+	loadedImages := []sb_efi.Image{}
+	checksContext := preinstallNewRunChecksContext(checkCustomizationFlags, loadedImages, profileOptionFlags)
 
-		// do not customize TCG compliant PCR profile generation
-		profileOptionFlags := preinstall.PCRProfileOptionsDefault
-		// no image required because we avoid profile option flags WithBootManagerCodeProfile and WithSecureBootPolicyProfile
-		loadedImages := []sb_efi.Image{}
-		checksContext := preinstallNewRunChecksContext(checkCustomizationFlags, loadedImages, profileOptionFlags)
-
-		// no actions args due to no actions for preinstall checks
-		args := []any{}
-		// Ignore the returned *preinstall.CheckResult
-		_, err := preinstallRun(checksContext, context.Background(), preinstall.ActionNone, args...)
+	// no actions args due to no actions for preinstall checks
+	args := []any{}
+	// Ignore the returned *preinstall.CheckResult
+	result, err := preinstallRun(checksContext, context.Background(), preinstall.ActionNone, args...)
+	if err != nil {
 		return err
 	}
-
-	// Ubuntu Core systems continue to use the simpler check because we expect
-	// corner cases where previously allowed installations will be blocked by the
-	// RunChecksContext API.
-	// TODO: Transition Ubuntu Core to use the RunChecksContextAPI.
-	// XXX: Need to return compound error to be consistent with preinstallRun.
-	return CheckTPMKeySealingSupported(tpmMode)
-}
-
-func setHybridInstallRootDir(rootDir string) {
-	if rootDir == ""{
-		hybridInstallRootDir = "/"
-	}
-	hybridInstallRootDir = filepath.Clean(rootDir)
-}
-
-func hybridInstallerLoadedImages() ([]sb_efi.Image, error) {
-	imageInfo := []struct {
-		name string
-		glob string
-	}{
-		{"shim", filepath.Join(hybridInstallRootDir, hybridInstallBootloaderShimGlob)},
-		{"grub", filepath.Join(hybridInstallRootDir, hybridInstallBootloaderGrubGlob)},
-		{"kernel", filepath.Join(hybridInstallRootDir, hybridInstallKernelFile)},
-	}
-
-	var loadedImages []sb_efi.Image
-	for _, info := range imageInfo {
-		matches, err := filepath.Glob(info.glob)
-		if err != nil {
-			return nil, fmt.Errorf("internal error: cannot use globbing pattern %q: %v", info.glob, err)
+	if result.Warnings != nil {
+		for _, warn := range result.Warnings.Unwrap() {
+			logger.Noticef("preinstall check warning: %v", warn)
 		}
-		if len(matches) == 0 {
-			return nil, fmt.Errorf("cannot locate installer %s using globbing pattern %q", info.name, info.glob)
-		}
-		if len(matches) > 1 {
-			return nil, fmt.Errorf("unexpected multiple matches for installer %s obtained using globbing pattern %q", info.name, info.glob)
-		}
-		loadedImages = append(loadedImages, sb_efi.NewFileImage(matches[0]))
 	}
-
-	return loadedImages, nil
+	return nil
 }

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -34,12 +34,13 @@ import (
 )
 
 const (
-	hybridBootloaderShimGlob = "/cdrom/EFI/boot/boot*.efi"
-	hybridBootloaderGrubGlob = "/cdrom/EFI/boot/grub*.efi"
-	hybridKernelFile         = "/cdrom/casper/vmlinuz"
+	hybridInstallBootloaderShimGlob  = "cdrom/EFI/boot/boot*.efi"
+	hybridOInstallBootloaderGrubGlob = "cdrom/EFI/boot/grub*.efi"
+	hybridInstallKernelFile          = "cdrom/casper/vmlinuz"
 )
 
 var (
+	hybridInstallRootDir          = "/"
 	preinstallNewRunChecksContext = preinstall.NewRunChecksContext
 	preinstallRun                 = (*preinstall.RunChecksContext).Run
 )
@@ -166,14 +167,21 @@ func PreinstallCheck(model *asserts.Model, tpmMode TPMProvisionMode) error {
 	return CheckTPMKeySealingSupported(tpmMode)
 }
 
+func setHybridInstallRootDir(string rootDir) {
+	if rootDir == ""{
+		hybridInstallRootDir = "/"
+	}
+	hybridInstallRootDir = filepath.Clean(rootDir)
+}
+
 func hybridInstallerLoadedImages() ([]sb_efi.Image, error) {
 	imageInfo := []struct {
 		name string
 		glob string
 	}{
-		{"shim", hybridBootloaderShimGlob},
-		{"grub", hybridBootloaderGrubGlob},
-		{"kernel", hybridKernelFile},
+		{"shim", filepath.Join(HybridInstallRootDir, hybridInstallBootloaderShimGlob},
+		{"grub", filepath.Join(HybridInstallRootDir, hybridInstallBootloaderGrubGlob},
+		{"kernel", filepath.Join(HybridInstallRootDir, hybridInstallKernelFile},
 	}
 
 	var loadedImages []sb_efi.Image

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -33,6 +33,31 @@ var (
 	preinstallRun                 = (*preinstall.RunChecksContext).Run
 )
 
+type compoundPreinstallError struct {
+	errs []error
+}
+
+func (c *compoundPreinstallError) Error() string {
+	return fmt.Sprintf("preinstall check detected %d errors", len(c.errs))
+}
+
+func (c *compoundPreinstallError) Unwrap() []error {
+	return c.errs
+}
+
+func combineErrors(errs ...error) error {
+	return &compoundPreinstallError{errs: errs}
+}
+
+func NewPreinstallCompoundError(errorAndActions []preinstall.ErrorKindAndActions) error {
+	var errs []error
+	for _, err := range errorAndActions {
+		errs = append(errs, &err)
+	}
+
+	return combineErrors()
+}
+
 // UnpackPreinstallCheckError converts a single or compound preinstall check
 // error into a slice of PreinstallErrorAndActions. If the provided error or any
 // contained error is not of type *preinstall.ErrorKindAndActions, the function

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -26,6 +26,8 @@ import (
 
 	sb_efi "github.com/snapcore/secboot/efi"
 	"github.com/snapcore/secboot/efi/preinstall"
+
+	"github.com/snapcore/snapd/asserts"
 )
 
 var (
@@ -120,7 +122,13 @@ func newInternalErrorUnexpectedType(err error) PreinstallErrorAndActions {
 }
 
 // PreinstallCheck runs preinstall checks without customization or profile generation options.
-func PreinstallCheck(tpmMode TPMProvisionMode) error {
+func PreinstallCheck(model *asserts.Model, tpmMode TPMProvisionMode) error {
+	isHybrid := model.Classic() && model.KernelSnap() != nil
+	if isHybrid {
+		// XXX: Need to return compound error to be consistent with preinstallRun
+		return CheckTPMKeySealingSupported(tpmMode)
+	}
+
 	// XXX: Expect preinstallNewRunChecksContext to require tpmMode in order to evaluate
 	// lockout when required. Complete implementation after preinstallNewRunChecksContext
 	// is modified.

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -1,0 +1,110 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018-2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"context"
+	"fmt"
+
+	secboot_efi "github.com/snapcore/secboot/efi"
+	"github.com/snapcore/secboot/efi/preinstall"
+)
+
+var (
+	preinstallNewRunChecksContext = preinstall.NewRunChecksContext
+	preinstallRun                 = (*preinstall.RunChecksContext).Run
+)
+
+// UnpackPreinstallCheckError converts a single or compound preinstall check
+// error into a slice of PreinstallErrorAndActions. If the provided error or any
+// contained error is not of type *preinstall.ErrorKindAndActions, the function
+// returns a slice containing a single internal error describing the type.
+func UnpackPreinstallCheckError(err error) []PreinstallErrorAndActions {
+	// expect either a single or compound error
+	compoundErr, ok := err.(preinstall.CompoundError)
+	if !ok {
+		// single error
+		errorAndActions, ok := err.(*preinstall.ErrorKindAndActions)
+		if !ok {
+			return []PreinstallErrorAndActions{
+				newInternalErrorUnexpectedType(err),
+			}
+		}
+		return []PreinstallErrorAndActions{
+			convertErrorType(errorAndActions),
+		}
+	}
+
+	// unpack compound error
+	errs := compoundErr.Unwrap()
+	converted := make([]PreinstallErrorAndActions, 0, len(errs))
+	for _, err := range errs {
+		errorAndActions, ok := err.(*preinstall.ErrorKindAndActions)
+		if !ok {
+			return []PreinstallErrorAndActions{
+				newInternalErrorUnexpectedType(err),
+			}
+		}
+		converted = append(converted, convertErrorType(errorAndActions))
+	}
+	return converted
+}
+
+func convertErrorType(errorAndActions *preinstall.ErrorKindAndActions) PreinstallErrorAndActions {
+	return PreinstallErrorAndActions{
+		Kind:    string(errorAndActions.ErrorKind),
+		Message: errorAndActions.Unwrap().Error(),
+		Args:    errorAndActions.ErrorArgs,
+		Actions: convertActions(errorAndActions.Actions),
+	}
+}
+
+func convertActions(actions []preinstall.Action) []string {
+	convActions := make([]string, len(actions))
+	for i, action := range actions {
+		convActions[i] = string(action)
+	}
+	return convActions
+}
+
+func newInternalErrorUnexpectedType(err error) PreinstallErrorAndActions {
+	message := fmt.Sprintf("cannot convert error of unexpected type %[1]T (%[1]v)", err)
+	return PreinstallErrorAndActions{
+		Kind:    string(preinstall.ErrorKindInternal),
+		Message: message,
+	}
+}
+
+// PreinstallCheck runs preinstall checks without customization or profile generation options.
+func PreinstallCheck() error {
+	// do not customize preinstall checks
+	checkCustomizationFlags := preinstall.CheckFlags(0)
+	// do not customize TCG compliant PCR profile generation
+	profileOptionFlags := preinstall.PCRProfileOptionsFlags(0)
+	// no image required because we avoid profile option flags WithBootManagerCodeProfile and WithSecureBootPolicyProfile
+	loadedImages := []secboot_efi.Image{}
+	checksContext := preinstallNewRunChecksContext(checkCustomizationFlags, loadedImages, profileOptionFlags)
+
+	// no actions args due to no actions for preinstall checks
+	args := []any{}
+	// Ignore the returned *preinstall.CheckResult
+	_, err := preinstallRun(checksContext, context.Background(), preinstall.ActionNone, args)
+	return err
+}

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -23,14 +23,17 @@ package secboot_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 
+	"github.com/canonical/go-tpm2"
+	"github.com/snapcore/secboot/efi"
 	"github.com/snapcore/secboot/efi/preinstall"
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
-	 "github.com/snapcore/snapd/asserts"
 )
 
 type preinstallSuite struct {
@@ -42,84 +45,364 @@ var _ = Suite(&preinstallSuite{})
 func (s *preinstallSuite) SetUpTest(c *C) {
 }
 
-func (s *preinstallSuite) TestConvertErrorType(c *C) {
-	jsonArgs, err := json.Marshal(struct {
-		arg1 string
-		arg2 string
-	}{
-		arg1: "arg1",
-		arg2: "arg2",
-	})
-	c.Assert(err, IsNil)
-
-	errorAndAction := preinstall.ErrorKindAndActions{
-		ErrorKind: preinstall.ErrorKindRebootRequired,
-		ErrorArgs: jsonArgs,
-		Actions:   []preinstall.Action{preinstall.ActionReboot, preinstall.ActionShutdown},
-	}
-
-	//XXX: Need secboot helper for constructing errors
-	var convertedErr secboot.PreinstallErrorAndActions
-	c.Assert(func() { convertedErr = secboot.ConvertErrorType(&errorAndAction) }, PanicMatches, "runtime error: invalid memory address or nil pointer dereference")
-	c.Assert(convertedErr, DeepEquals, secboot.PreinstallErrorAndActions{})
-}
-
 func (s *preinstallSuite) TestConvertActions(c *C) {
 	testCases := []struct {
 		actions  []preinstall.Action
 		expected []string
 	}{
-		{nil, []string{}},
+		{nil, nil},
 		{[]preinstall.Action{}, []string{}},
 		{[]preinstall.Action{preinstall.ActionReboot, preinstall.ActionShutdown}, []string{"reboot", "shutdown"}},
 	}
 
-	for i, tc := range testCases {
+	for _, tc := range testCases {
 		convertedActions := secboot.ConvertActions(tc.actions)
-		c.Check(convertedActions, DeepEquals, tc.expected, Commentf("test case %d failed", i))
+		c.Check(convertedActions, DeepEquals, tc.expected)
 	}
 }
 
-func (s *preinstallSuite) TestNewInternalErrorUnexpectedType(c *C) {
-	testCases := []struct {
-		err      error
-		expected secboot.PreinstallErrorAndActions
-	}{
-		{nil, secboot.PreinstallErrorAndActions{
-			Kind:    "internal-error",
-			Message: "cannot convert error of unexpected type <nil> (<nil>)"},
+func (s *preinstallSuite) TestConvertErrorType(c *C) {
+	kindAndActionsErr := preinstall.NewWithKindAndActionsError(
+		preinstall.ErrorKindTPMHierarchiesOwned,
+		preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}, WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
+		[]preinstall.Action{preinstall.ActionRebootToFWSettings},
+		errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+	)
+
+	var errorInfo secboot.PreinstallErrorInfo
+	c.Assert(func() { errorInfo = secboot.ConvertErrorType(nil) }, PanicMatches, "runtime error: invalid memory address or nil pointer dereference")
+	errorInfo = secboot.ConvertErrorType(kindAndActionsErr)
+	c.Assert(errorInfo, DeepEquals, secboot.PreinstallErrorInfo{
+		Kind:    "tpm-hierarchies-owned",
+		Message: "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+		Args: map[string]json.RawMessage{
+			"with-auth-value":  json.RawMessage(`[1073741834]`),
+			"with-auth-policy": json.RawMessage(`[1073741825]`),
 		},
-		{fmt.Errorf("error message"), secboot.PreinstallErrorAndActions{
-			Kind:    "internal-error",
-			Message: "cannot convert error of unexpected type *errors.errorString (error message)",
-		}},
-	}
-
-	for i, tc := range testCases {
-		errorAndActions := secboot.NewInternalErrorUnexpectedType(tc.err)
-		c.Check(errorAndActions, DeepEquals, tc.expected, Commentf("test case %d failed", i))
-	}
+		Actions: []string{"reboot-to-fw-settings"},
+	})
 }
 
-func (s *preinstallSuite) TestPreinstallCheckHappy(c *C) {
-	restore := secboot.MockSbPreinstallRun(func(checkCtx *preinstall.RunChecksContext, ctx context.Context, action preinstall.Action, args ...any) (*preinstall.CheckResult, error) {
-		c.Assert(checkCtx, NotNil)
-		c.Check(checkCtx.Errors(), IsNil)
-		c.Check(checkCtx.Result(), IsNil)
-		c.Assert(ctx, NotNil)
-		c.Assert(action, Equals, preinstall.ActionNone)
-		c.Assert(args, HasLen, 0)
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorCompound(c *C) {
+	compoundError := &secboot.CompoundError{
+		[]error{
+			preinstall.NewWithKindAndActionsError(
+				preinstall.ErrorKindTPMHierarchiesOwned,
+				preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}},
+				[]preinstall.Action{preinstall.ActionRebootToFWSettings},
+				errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+			),
+			preinstall.NewWithKindAndActionsError(
+				preinstall.ErrorKindTPMDeviceLockout,
+				&preinstall.TPMDeviceLockoutArgs{IntervalDuration: 7200000000000, TotalDuration: 230400000000000},
+				[]preinstall.Action{preinstall.ActionRebootToFWSettings},
+				errors.New("error with TPM2 device: TPM is in DA lockout mode"),
+			),
+			preinstall.NewWithKindAndActionsError(
+				preinstall.ErrorKindNone,
+				nil,
+				nil,
+				nil,
+			),
+		},
+	}
 
-		return &preinstall.CheckResult{}, nil
+	errorInfos, err := secboot.UnpackPreinstallCheckError(compoundError)
+	c.Assert(err, IsNil)
+	c.Assert(errorInfos, DeepEquals, []secboot.PreinstallErrorInfo{
+		{
+			Kind:    "tpm-hierarchies-owned",
+			Message: "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+			Args: map[string]json.RawMessage{
+				"with-auth-value":  json.RawMessage(`[1073741834]`),
+				"with-auth-policy": json.RawMessage(`null`),
+			},
+			Actions: []string{"reboot-to-fw-settings"},
+		},
+		{
+			Kind:    "tpm-device-lockout",
+			Message: "error with TPM2 device: TPM is in DA lockout mode",
+			Args: map[string]json.RawMessage{
+				"interval-duration": json.RawMessage(`7200000000000`),
+				"total-duration":    json.RawMessage(`230400000000000`),
+			},
+			Actions: []string{"reboot-to-fw-settings"},
+		},
+		{
+			Kind:    "",
+			Message: "<nil>",
+			Args:    nil,
+			Actions: nil,
+		},
 	})
+
+	jsn, err := json.MarshalIndent(errorInfos, "", "  ")
+	c.Assert(err, IsNil)
+	const expectedJson = `[
+  {
+    "kind": "tpm-hierarchies-owned",
+    "message": "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+    "args": {
+      "with-auth-policy": null,
+      "with-auth-value": [
+        1073741834
+      ]
+    },
+    "actions": [
+      "reboot-to-fw-settings"
+    ]
+  },
+  {
+    "kind": "tpm-device-lockout",
+    "message": "error with TPM2 device: TPM is in DA lockout mode",
+    "args": {
+      "interval-duration": 7200000000000,
+      "total-duration": 230400000000000
+    },
+    "actions": [
+      "reboot-to-fw-settings"
+    ]
+  },
+  {
+    "kind": "",
+    "message": "\u003cnil\u003e"
+  }
+]`
+	c.Assert(string(jsn), Equals, expectedJson)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorFailCompoundUnexpectedType(c *C) {
+	compoundError := &secboot.CompoundError{
+		[]error{
+			preinstall.NewWithKindAndActionsError(
+				preinstall.ErrorKindTPMHierarchiesOwned,
+				preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}},
+				[]preinstall.Action{preinstall.ActionRebootToFWSettings},
+				errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+			),
+			preinstall.ErrInsufficientDMAProtection,
+		},
+	}
+
+	errorInfos, err := secboot.UnpackPreinstallCheckError(compoundError)
+	c.Assert(err, ErrorMatches, `cannot unpack error of unexpected type \*errors\.errorString \(the platform firmware indicates that DMA protections are insufficient\)`)
+	c.Assert(errorInfos, IsNil)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorFailCompoundWrapsNil(c *C) {
+	compoundError := &secboot.CompoundError{nil}
+
+	errorInfos, err := secboot.UnpackPreinstallCheckError(compoundError)
+	c.Assert(err, ErrorMatches, "unexpected compound error wraps nil")
+	c.Assert(errorInfos, IsNil)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorSingle(c *C) {
+	singleError := preinstall.NewWithKindAndActionsError(
+		preinstall.ErrorKindTPMDeviceDisabled,
+		nil,
+		[]preinstall.Action{preinstall.ActionRebootToFWSettings},
+		errors.New("error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware"),
+	)
+
+	errorInfos, err := secboot.UnpackPreinstallCheckError(singleError)
+	c.Assert(err, IsNil)
+	c.Assert(errorInfos, DeepEquals, []secboot.PreinstallErrorInfo{
+		{
+			Kind:    "tpm-device-disabled",
+			Message: "error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware",
+			Actions: []string{"reboot-to-fw-settings"},
+		},
+	})
+
+	jsn, err := json.MarshalIndent(errorInfos, "", "  ")
+	c.Assert(err, IsNil)
+	const expectedJson = `[
+  {
+    "kind": "tpm-device-disabled",
+    "message": "error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware",
+    "actions": [
+      "reboot-to-fw-settings"
+    ]
+  }
+]`
+	c.Assert(string(jsn), Equals, expectedJson)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorFailSingleUnexpectedType(c *C) {
+	errorInfos, err := secboot.UnpackPreinstallCheckError(preinstall.ErrInsufficientDMAProtection)
+	c.Assert(err, ErrorMatches, `cannot unpack error of unexpected type \*errors\.errorString \(the platform firmware indicates that DMA protections are insufficient\)`)
+	c.Assert(errorInfos, IsNil)
+}
+
+func (s *preinstallSuite) testPreinstallCheckConfig(c *C, isTesting, isVM, permitVM bool) {
+	restore := snapdenv.MockTesting(isTesting)
+	defer restore()
+	cmdExit := `exit 1`
+	if isVM {
+		cmdExit = `exit 0`
+	}
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", cmdExit)
+	defer systemdCmd.Restore()
+
+	restore = secboot.MockSbPreinstallNewRunChecksContext(
+		func(initialFlags preinstall.CheckFlags, loadedImages []efi.Image, profileOpts preinstall.PCRProfileOptionsFlags) *preinstall.RunChecksContext {
+			if permitVM {
+				c.Assert(initialFlags&preinstall.PermitVirtualMachine, Equals, preinstall.PermitVirtualMachine)
+			} else {
+				c.Assert(initialFlags, Equals, preinstall.CheckFlagsDefault)
+			}
+			c.Assert(profileOpts, Equals, preinstall.PCRProfileOptionsDefault)
+			c.Assert(loadedImages, IsNil)
+
+			return nil
+		})
 	defer restore()
 
-	err := secboot.PreinstallCheck(&asserts.Model{}, secboot.TPMProvisionFull)
+	restore = secboot.MockSbPreinstallRun(
+		func(checkCtx *preinstall.RunChecksContext, ctx context.Context, action preinstall.Action, args ...any) (*preinstall.CheckResult, error) {
+			c.Assert(checkCtx, IsNil)
+			c.Assert(ctx, NotNil)
+			c.Assert(action, Equals, preinstall.ActionNone)
+			c.Assert(args, IsNil)
+
+			return &preinstall.CheckResult{}, nil
+		})
+	defer restore()
+
+	errorInfos, err := secboot.PreinstallCheck(nil)
 	c.Assert(err, IsNil)
+	c.Assert(errorInfos, IsNil)
 }
 
-func (s *preinstallSuite) TestPreinstallCheckErrors(c *C) {
+func (s *preinstallSuite) TestPreinstallCheckConfig(c *C) {
+	testCases := []struct {
+		isTesting bool
+		isVM      bool
+		permitVM  bool
+	}{
+		{false, false, false}, // default config
+		{false, true, false},  // default config
+		{true, false, false},  // default config
+		{true, true, true},    // modify default config to permit VM
+	}
+
+	for _, tc := range testCases {
+		s.testPreinstallCheckConfig(c, tc.isTesting, tc.isVM, tc.permitVM)
+	}
 }
 
-func (s *preinstallSuite) TestUnpackPreinstallCheckError(c *C) {
+func (s *preinstallSuite) testPreinstallCheck(c *C, detectErrors, failUnpack bool) {
+	bootImagePaths := []string{
+		"/cdrom/EFI/boot/boot*.efi",
+		"/cdrom/EFI/boot/grub*.efi",
+		"/cdrom/casper/vmlinuz",
+	}
+
+	restore := snapdenv.MockTesting(false)
+	defer restore()
+
+	restore = secboot.MockSbPreinstallNewRunChecksContext(
+		func(initialFlags preinstall.CheckFlags, loadedImages []efi.Image, profileOpts preinstall.PCRProfileOptionsFlags) *preinstall.RunChecksContext {
+			c.Assert(initialFlags, Equals, preinstall.CheckFlagsDefault)
+			c.Assert(profileOpts, Equals, preinstall.PCRProfileOptionsDefault)
+			c.Assert(loadedImages, HasLen, len(bootImagePaths))
+			for i, image := range loadedImages {
+				c.Check(image.String(), Equals, bootImagePaths[i])
+			}
+
+			return &preinstall.RunChecksContext{}
+		})
+	defer restore()
+
+	restore = secboot.MockSbPreinstallRun(
+		func(checkCtx *preinstall.RunChecksContext, ctx context.Context, action preinstall.Action, args ...any) (*preinstall.CheckResult, error) {
+			c.Assert(checkCtx, NotNil)
+			c.Assert(checkCtx.Errors(), IsNil)
+			c.Assert(checkCtx.Result(), IsNil)
+			c.Assert(ctx, NotNil)
+			c.Assert(action, Equals, preinstall.ActionNone)
+			c.Assert(args, IsNil)
+
+			if detectErrors {
+				return nil, &secboot.CompoundError{
+					[]error{
+						preinstall.NewWithKindAndActionsError(
+							preinstall.ErrorKindTPMHierarchiesOwned,
+							preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout},
+								WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
+							[]preinstall.Action{preinstall.ActionRebootToFWSettings},
+							errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+						),
+						preinstall.NewWithKindAndActionsError(
+							preinstall.ErrorKindTPMDeviceLockout,
+							&preinstall.TPMDeviceLockoutArgs{IntervalDuration: 7200000000000, TotalDuration: 230400000000000},
+							[]preinstall.Action{preinstall.ActionRebootToFWSettings},
+							errors.New("error with TPM2 device: TPM is in DA lockout mode"),
+						),
+					},
+				}
+			} else if failUnpack {
+				return nil, preinstall.ErrInsufficientDMAProtection
+			} else {
+				return &preinstall.CheckResult{
+					Warnings: &secboot.CompoundError{
+						[]error{
+							errors.New("warning 1"),
+							errors.New("warning 2"),
+						},
+					},
+				}, nil
+			}
+		})
+	defer restore()
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	errorInfos, err := secboot.PreinstallCheck(bootImagePaths)
+	if detectErrors {
+		c.Assert(err, IsNil)
+		c.Assert(logbuf.String(), Equals, "")
+		c.Assert(errorInfos, DeepEquals, []secboot.PreinstallErrorInfo{
+			{
+				Kind:    "tpm-hierarchies-owned",
+				Message: "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+				Args: map[string]json.RawMessage{
+					"with-auth-value":  json.RawMessage(`[1073741834]`),
+					"with-auth-policy": json.RawMessage(`[1073741825]`),
+				},
+				Actions: []string{"reboot-to-fw-settings"},
+			},
+			{
+				Kind:    "tpm-device-lockout",
+				Message: "error with TPM2 device: TPM is in DA lockout mode",
+				Args: map[string]json.RawMessage{
+					"interval-duration": json.RawMessage(`7200000000000`),
+					"total-duration":    json.RawMessage(`230400000000000`),
+				},
+				Actions: []string{"reboot-to-fw-settings"},
+			},
+		})
+	} else if failUnpack {
+		c.Assert(err, ErrorMatches, `cannot unpack error of unexpected type \*errors\.errorString \(the platform firmware indicates that DMA protections are insufficient\)`)
+		c.Assert(errorInfos, IsNil)
+	} else {
+		c.Assert(err, IsNil)
+		c.Assert(errorInfos, IsNil)
+		c.Assert(logbuf.String(), testutil.Contains, "preinstall check warning: warning 1")
+		c.Assert(logbuf.String(), testutil.Contains, "preinstall check warning: warning 2")
+	}
+}
+
+func (s *preinstallSuite) TestPreinstallCheckWithWarningsAndErrors(c *C) {
+	detectErrors := false // warnings and no errors
+	s.testPreinstallCheck(c, detectErrors, false)
+	detectErrors = true // errors and no warnings
+	s.testPreinstallCheck(c, detectErrors, false)
+}
+
+func (s *preinstallSuite) TestPreinstallCheckFailUnpack(c *C) {
+	failUnpack := true
+	s.testPreinstallCheck(c, false, failUnpack)
 }

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"context"
+
+	"github.com/snapcore/secboot/efi/preinstall"
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type preinstallSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&preinstallSuite{})
+
+func (s *preinstallSuite) SetUpTest(c *C) {
+}
+
+func (s *preinstallSuite) TestConvertErrorType(c *C) {
+}
+
+func (s *preinstallSuite) TestConvertActions(c *C) {
+}
+
+func (s *preinstallSuite) TestNewInternalErrorUnexpectedType(c *C) {
+}
+
+func (s *preinstallSuite) TestPreinstallCheckHappy(c *C) {
+	restore := secboot.MockSbPreinstallRun(func(checkCtx *preinstall.RunChecksContext, ctx context.Context, action preinstall.Action, args ...any) (*preinstall.CheckResult, error) {
+		c.Assert(checkCtx, NotNil)
+		c.Check(checkCtx.Errors(), IsNil)
+		c.Check(checkCtx.Result(), IsNil)
+		c.Assert(ctx, NotNil)
+		c.Assert(action, Equals, preinstall.ActionNone)
+		c.Assert(args, HasLen, 0)
+
+		return &preinstall.CheckResult{}, nil
+	})
+	defer restore()
+
+	err := secboot.PreinstallCheck(secboot.TPMProvisionFull)
+	c.Assert(err, IsNil)
+}
+
+func (s *preinstallSuite) TestPreinstallCheckErrors(c *C) {
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckError(c *C) {
+}

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/testutil"
+	 "github.com/snapcore/snapd/asserts"
 )
 
 type preinstallSuite struct {
@@ -113,7 +114,7 @@ func (s *preinstallSuite) TestPreinstallCheckHappy(c *C) {
 	})
 	defer restore()
 
-	err := secboot.PreinstallCheck(secboot.TPMProvisionFull)
+	err := secboot.PreinstallCheck(&asserts.Model{}, secboot.TPMProvisionFull)
 	c.Assert(err, IsNil)
 }
 

--- a/systemd/detect.go
+++ b/systemd/detect.go
@@ -33,3 +33,13 @@ func IsContainer() bool {
 	err := exec.Command("systemd-detect-virt", "--quiet", "--container").Run()
 	return err == nil
 }
+
+// IsVirtualMachine returns true if the system is running in a virtual machine.
+//
+// The implementation calls: systemd-detect-virt --quiet --vm.  It can be mocked
+// with testutil.MockCommand. The zero exit code indicates that system _is_
+// running a vm. Ensuring that --vm is passed is important.
+func IsVirtualMachine() bool {
+	err := exec.Command("systemd-detect-virt", "--quiet", "--vm").Run()
+	return err == nil
+}

--- a/systemd/detect_test.go
+++ b/systemd/detect_test.go
@@ -43,3 +43,17 @@ func (*detectSuite) TestIsContainer_No(c *C) {
 
 	c.Check(systemd.IsContainer(), Equals, false)
 }
+
+func (*detectSuite) TestIsVirtualMachine_Yes(c *C) {
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", `exit 0`)
+	defer systemdCmd.Restore()
+
+	c.Check(systemd.IsVirtualMachine(), Equals, true)
+}
+
+func (*detectSuite) TestIsVirtualMachine_No(c *C) {
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", `exit 1`)
+	defer systemdCmd.Restore()
+
+	c.Check(systemd.IsVirtualMachine(), Equals, false)
+}


### PR DESCRIPTION
Integrate the new secboot preinstall check to allow extending  GET /v2/system/{label} storage encryption with preinstall check error information.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34453

Depends on secboot work: https://github.com/canonical/secboot/pull/387
There are likely more comprising and additional smaller PRs in the list of dependencies, need to sync with Chris.