### PR TITLE
spread: enable reexec test suite on remaining distros

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1562,14 +1562,11 @@ suites:
         summary: Cross-distro reeexec
         systems:
           - arch-linux-*
-          # will only for work for AppArmor setups
           - opensuse-*
-          # only AMZN2, since we don't build with SELinux
           - amazon-linux-2-*
-          # - amazon-linux-2023-*
+          - amazon-linux-2023-*
           - fedora-*
-          # TODO: enable the following:
-          # - centos-*
+          - centos-*
         environment:
           # enable snap rexec
           SNAP_REEXEC: "1"


### PR DESCRIPTION
Enable reexec test suite on CentOS and Amazon Linux 2023

Related: [SNAPDENG-34263](https://warthogs.atlassian.net/browse/SNAPDENG-34263)


[SNAPDENG-34263]: https://warthogs.atlassian.net/browse/SNAPDENG-34263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ