### PR TITLE
cmd/snap-update-ns: synthetic is always tmpfs, or bind or rbind

### DIFF
--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -525,7 +525,7 @@ func (s *changeSuite) TestNeededChangesRepeatedDir(c *C) {
 	}}
 	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
 		{Name: "/foo/bar", Dir: "/foo/bar", Type: "none",
-			Options: []string{osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/foo/mytmp")}},
+			Options: []string{"rbind", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/foo/mytmp")}},
 		{Name: "tmpfs", Dir: "/foo/mytmp", Type: "tmpfs", Options: []string{osutil.XSnapdOriginLayout()}},
 		{Name: "tmpfs", Dir: "/foo/bar", Type: "tmpfs",
 			Options: []string{osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/foo/bar/two")}},
@@ -541,7 +541,7 @@ func (s *changeSuite) TestNeededChangesRepeatedDir(c *C) {
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo/mytmp", Type: "tmpfs",
 			Options: []string{osutil.XSnapdOriginLayout()}}, Action: update.Keep},
 		{Entry: osutil.MountEntry{Name: "/foo/bar", Dir: "/foo/bar", Type: "none",
-			Options: []string{osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/foo/mytmp")}}, Action: update.Keep},
+			Options: []string{"rbind", osutil.XSnapdSynthetic(), osutil.XSnapdNeededBy("/foo/mytmp")}}, Action: update.Keep},
 	})
 }
 


### PR DESCRIPTION
Some tests used "x-snapd.synthetic" option without making it clear this is an "rbind" (for directories), or a "tmpfs". Adjust them to add the appropriate option or type so that upcoming logic does not need special-cases for test-only flaws.
