### PR TITLE
cmd/snap-update-ns: provide more realistic test data

### DIFF
--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -87,18 +87,18 @@ func (s *changeSuite) TestNeededChangesNoProfiles(c *C) {
 
 // When the profiles are the same we don't do anything.
 func (s *changeSuite) TestNeededChangesNoChange(c *C) {
-	current := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
-	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
+	current := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff", Type: "tmpfs"}}}
+	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff", Type: "tmpfs"}}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: osutil.MountEntry{Dir: "/common/stuff"}, Action: update.Keep},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Type: "tmpfs"}, Action: update.Keep},
 	})
 }
 
 // When the content interface is connected we should mount the new entry.
 func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
 	current := &osutil.MountProfile{}
-	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
+	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff", Type: "tmpfs"}}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: desired.Entries[0], Action: update.Mount},
@@ -107,11 +107,11 @@ func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
 
 // When the content interface is disconnected we should unmount the mounted entry.
 func (s *changeSuite) TestNeededChangesTrivialUnmount(c *C) {
-	current := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
+	current := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff", Type: "tmpfs"}}}
 	desired := &osutil.MountProfile{}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: current.Entries[0], Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 	})
 }
 
@@ -120,7 +120,7 @@ func (s *changeSuite) TestNeededChangesKeepRootfs(c *C) {
 	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
 		{Dir: "/", Options: []string{"x-snapd.origin=rootfs"}},
 	}}
-	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
+	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff", Type: "tmpfs"}}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: current.Entries[0], Action: update.Keep},
@@ -134,7 +134,7 @@ func (s *changeSuite) TestNeededChangesUmountRootfs(c *C) {
 		// Like the test above, but without "x-snapd.origin=rootfs"
 		{Dir: "/"},
 	}}
-	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff"}}}
+	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{{Dir: "/common/stuff", Type: "tmpfs"}}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: current.Entries[0], Action: update.Unmount},
@@ -145,14 +145,14 @@ func (s *changeSuite) TestNeededChangesUmountRootfs(c *C) {
 // When umounting we unmount children before parents.
 func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
 	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/stuff"},
-		{Dir: "/common/stuff/extra"},
+		{Dir: "/common/stuff", Type: "tmpfs"},
+		{Dir: "/common/stuff/extra", Type: "tmpfs"},
 	}}
 	desired := &osutil.MountProfile{}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra"}, Action: update.Unmount},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 	})
 }
 
@@ -167,11 +167,11 @@ func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
 
 	current := &osutil.MountProfile{}
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/c/stuff/dir/symlink1"},
-		{Dir: "/c/stuff/dir/file2", Options: []string{"x-snapd.kind=file"}},
-		{Dir: "/c/stuff/dir"},
-		{Dir: "/c/stuff"},
-		{Dir: "/c/stuff/dir/file1", Options: []string{"x-snapd.kind=file"}},
+		{Dir: "/c/stuff/dir/symlink1", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/origin1"}},
+		{Dir: "/c/stuff/dir/file2", Name: "/origin2", Options: []string{"bind", "x-snapd.kind=file"}},
+		{Dir: "/c/stuff/dir", Type: "tmpfs"},
+		{Dir: "/c/stuff", Type: "tmpfs"},
+		{Dir: "/c/stuff/dir/file1", Name: "/origin1", Options: []string{"bind", "x-snapd.kind=file"}},
 	}}
 
 	for _, testData := range []struct {
@@ -216,12 +216,12 @@ func (s *changeSuite) TestNeededChangesMountFromReal(c *C) {
 
 	current := &osutil.MountProfile{}
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/snap/test-snapd-layout/x1/fooo-top", Options: []string{"x-snapd.origin=layout"}},
-		{Dir: "/snap/test-snapd-layout/x1/fooo/deeper", Options: []string{"x-snapd.origin=layout"}},
-		{Dir: "/usr/lib/x86_64-linux-gnu/wpe-webkit-1.0", Options: []string{"x-snapd.origin=layout"}},
-		{Dir: "/usr/libexec/wpe-webkit-1.0", Options: []string{"x-snapd.origin=layout"}},
-		{Dir: "/var/fooo-top", Options: []string{"x-snapd.origin=layout"}},
-		{Dir: "/var/fooo/deeper", Options: []string{"x-snapd.origin=layout"}},
+		{Dir: "/snap/test-snapd-layout/x1/fooo-top", Name: "/xxx/fooo-top", Options: []string{"rbind", "x-snapd.origin=layout"}},
+		{Dir: "/snap/test-snapd-layout/x1/fooo/deeper", Name: "/xxx/deeper", Options: []string{"rbind", "x-snapd.origin=layout"}},
+		{Dir: "/usr/lib/x86_64-linux-gnu/wpe-webkit-1.0", Name: "/xxx/wpe-webkit-1.0", Options: []string{"rbind", "x-snapd.origin=layout"}},
+		{Dir: "/usr/libexec/wpe-webkit-1.0", Name: "/xxx/libexec/wpe-webkit-1.0", Options: []string{"rbind", "x-snapd.origin=layout"}},
+		{Dir: "/var/fooo-top", Name: "/xxx/var/foo-top", Options: []string{"rbind", "x-snapd.origin=layout"}},
+		{Dir: "/var/fooo/deeper", Name: "/xxx/var/deeper", Options: []string{"rbind", "x-snapd.origin=layout"}},
 	}}
 
 	for _, testData := range []struct {
@@ -267,13 +267,13 @@ func (s *changeSuite) TestNeededChangesMountFromReal(c *C) {
 func (s *changeSuite) TestNeededChangesKind(c *C) {
 	current := &osutil.MountProfile{}
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/file", Options: []string{"x-snapd.kind=file"}},
-		{Dir: "/common/symlink", Options: []string{"x-snapd.kind=symlink"}},
+		{Dir: "/common/file", Name: "/foo", Options: []string{"bind", "x-snapd.kind=file"}},
+		{Dir: "/common/symlink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/bar"}},
 	}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: osutil.MountEntry{Dir: "/common/file", Options: []string{"x-snapd.kind=file"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Dir: "/common/symlink", Options: []string{"x-snapd.kind=symlink"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/file", Name: "/foo", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/symlink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/bar"}}, Action: update.Mount},
 	})
 }
 
@@ -281,43 +281,43 @@ func (s *changeSuite) TestNeededChangesKind(c *C) {
 
 func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
 	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/stuff", Name: "/dev/sda1"},
-		{Dir: "/common/stuff/extra"},
-		{Dir: "/common/unrelated"},
+		{Dir: "/common/stuff", Name: "/dev/sda1", Type: "tmpfs"},
+		{Dir: "/common/stuff/extra", Type: "tmpfs"},
+		{Dir: "/common/unrelated", Type: "tmpfs"},
 	}}
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/stuff", Name: "/dev/sda2"},
-		{Dir: "/common/stuff/extra"},
-		{Dir: "/common/unrelated"},
+		{Dir: "/common/stuff", Name: "/dev/sda2", Type: "tmpfs"},
+		{Dir: "/common/stuff/extra", Type: "tmpfs"},
+		{Dir: "/common/unrelated", Type: "tmpfs"},
 	}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: osutil.MountEntry{Dir: "/common/unrelated"}, Action: update.Keep},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra"}, Action: update.Unmount},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda1"}, Action: update.Unmount},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda2"}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/unrelated", Type: "tmpfs"}, Action: update.Keep},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda1", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda2", Type: "tmpfs"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Type: "tmpfs"}, Action: update.Mount},
 	})
 }
 
 // When child changes we don't touch the unchanged parent
 func (s *changeSuite) TestNeededChangesSameParentChangedChild(c *C) {
 	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/stuff"},
-		{Dir: "/common/stuff/extra", Name: "/dev/sda1"},
-		{Dir: "/common/unrelated"},
+		{Dir: "/common/stuff", Type: "tmpfs"},
+		{Dir: "/common/stuff/extra", Name: "/dev/sda1", Type: "tmpfs"},
+		{Dir: "/common/unrelated", Type: "tmpfs"},
 	}}
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/stuff"},
-		{Dir: "/common/stuff/extra", Name: "/dev/sda2"},
-		{Dir: "/common/unrelated"},
+		{Dir: "/common/stuff", Type: "tmpfs"},
+		{Dir: "/common/stuff/extra", Name: "/dev/sda2", Type: "tmpfs"},
+		{Dir: "/common/unrelated", Type: "tmpfs"},
 	}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: osutil.MountEntry{Dir: "/common/unrelated"}, Action: update.Keep},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Name: "/dev/sda1"}, Action: update.Unmount},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff"}, Action: update.Keep},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Name: "/dev/sda2"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/unrelated", Type: "tmpfs"}, Action: update.Keep},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Name: "/dev/sda1", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Type: "tmpfs"}, Action: update.Keep},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Name: "/dev/sda2", Type: "tmpfs"}, Action: update.Mount},
 	})
 }
 
@@ -428,40 +428,38 @@ func (s *changeSuite) TestNeededChangesTmpfsBindMountFarmUsed(c *C) {
 // We are smart about comparing entries as directories. Here even though "/a/b"
 // is a prefix of "/a/b-1" it is correctly reused.
 func (s *changeSuite) TestNeededChangesSmartEntryComparisonOld(c *C) {
-
 	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/a/b", Name: "/dev/sda1"},
-		{Dir: "/a/b/c"},
-		{Dir: "/a/b-1"},
-		{Dir: "/a/b-1/3"},
+		{Dir: "/a/b", Name: "/dev/sda1", Type: "tmpfs"},
+		{Dir: "/a/b/c", Type: "tmpfs"},
+		{Dir: "/a/b-1", Type: "tmpfs"},
+		{Dir: "/a/b-1/3", Type: "tmpfs"},
 	}}
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/a/b", Name: "/dev/sda2"},
-		{Dir: "/a/b-1"},
-		{Dir: "/a/b/c"},
+		{Dir: "/a/b", Name: "/dev/sda2", Type: "tmpfs"},
+		{Dir: "/a/b-1", Type: "tmpfs"},
+		{Dir: "/a/b/c", Type: "tmpfs"},
 	}}
 	changes := update.NeededChanges(current, desired)
 	for _, chg := range changes {
 		c.Logf("- %+v", chg)
 	}
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: osutil.MountEntry{Dir: "/a/b-1/3"}, Action: update.Unmount},
-		{Entry: osutil.MountEntry{Dir: "/a/b-1"}, Action: update.Keep},
-		{Entry: osutil.MountEntry{Dir: "/a/b/c"}, Action: update.Unmount},
-		{Entry: osutil.MountEntry{Dir: "/a/b", Name: "/dev/sda1"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/a/b-1/3", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/a/b-1", Type: "tmpfs"}, Action: update.Keep},
+		{Entry: osutil.MountEntry{Dir: "/a/b/c", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/a/b", Name: "/dev/sda1", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 
-		{Entry: osutil.MountEntry{Dir: "/a/b", Name: "/dev/sda2"}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Dir: "/a/b/c"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/a/b", Name: "/dev/sda2", Type: "tmpfs"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/a/b/c", Type: "tmpfs"}, Action: update.Mount},
 	})
 }
 
 // Parallel instance changes are executed first
 func (s *changeSuite) TestNeededChangesParallelInstancesManyComeFirst(c *C) {
-
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/stuff", Name: "/dev/sda1"},
-		{Dir: "/common/stuff/extra"},
-		{Dir: "/common/unrelated"},
+		{Dir: "/common/stuff", Name: "/dev/sda1", Type: "tmpfs"},
+		{Dir: "/common/stuff/extra", Type: "tmpfs"},
+		{Dir: "/common/unrelated", Type: "tmpfs"},
 		{Dir: "/foo/bar", Name: "/foo/bar_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
 		{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
 	}}
@@ -469,9 +467,9 @@ func (s *changeSuite) TestNeededChangesParallelInstancesManyComeFirst(c *C) {
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: osutil.MountEntry{Dir: "/foo/bar", Name: "/foo/bar_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda1"}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra"}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Dir: "/common/unrelated"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda1", Type: "tmpfs"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff/extra", Type: "tmpfs"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/unrelated", Type: "tmpfs"}, Action: update.Mount},
 	})
 }
 
@@ -479,8 +477,8 @@ func (s *changeSuite) TestNeededChangesParallelInstancesManyComeFirst(c *C) {
 func (s *changeSuite) TestNeededChangesParallelInstancesKeep(c *C) {
 
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/common/stuff", Name: "/dev/sda1"},
-		{Dir: "/common/unrelated"},
+		{Dir: "/common/stuff", Name: "/dev/sda1", Type: "tmpfs"},
+		{Dir: "/common/unrelated", Type: "tmpfs"},
 		{Dir: "/foo/bar", Name: "/foo/bar_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
 		{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
 	}}
@@ -492,8 +490,8 @@ func (s *changeSuite) TestNeededChangesParallelInstancesKeep(c *C) {
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: osutil.MountEntry{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}}, Action: update.Keep},
 		{Entry: osutil.MountEntry{Dir: "/foo/bar", Name: "/foo/bar_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}}, Action: update.Keep},
-		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda1"}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Dir: "/common/unrelated"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/stuff", Name: "/dev/sda1", Type: "tmpfs"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/common/unrelated", Type: "tmpfs"}, Action: update.Mount},
 	})
 }
 
@@ -501,21 +499,21 @@ func (s *changeSuite) TestNeededChangesParallelInstancesKeep(c *C) {
 func (s *changeSuite) TestNeededChangesParallelInstancesInsideMount(c *C) {
 
 	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Dir: "/foo/bar/baz"},
+		{Dir: "/foo/bar/baz", Type: "tmpfs"},
 		{Dir: "/foo/bar", Name: "/foo/bar_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
 		{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
 	}}
 	current := &osutil.MountProfile{Entries: []osutil.MountEntry{
 		{Dir: "/foo/bar", Name: "/foo/bar_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
-		{Dir: "/foo/bar/zed"},
+		{Dir: "/foo/bar/zed", Type: "tmpfs"},
 		{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}},
 	}}
 	changes := update.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: osutil.MountEntry{Dir: "/snap/foo", Name: "/snap/foo_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}}, Action: update.Keep},
-		{Entry: osutil.MountEntry{Dir: "/foo/bar/zed"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Dir: "/foo/bar/zed", Type: "tmpfs", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 		{Entry: osutil.MountEntry{Dir: "/foo/bar", Name: "/foo/bar_bar", Options: []string{"rbind", osutil.XSnapdOriginOvername()}}, Action: update.Keep},
-		{Entry: osutil.MountEntry{Dir: "/foo/bar/baz"}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Dir: "/foo/bar/baz", Type: "tmpfs"}, Action: update.Mount},
 	})
 }
 


### PR DESCRIPTION
Many tests only provided the mount point, without clarifying the file system type or bind-mount options, relying on loose semantics of the current codebase. Adjust them to use "tmpfs" so that upcoming logic does not need special-cases for test-only flaws.

In some tests the type "tmpfs" disagrees with common sense device name "/dev/sda1", but this is harmless and snapd does not support mounting actual devices this way.

In the test TestNeededChangesMountOrder more creative filling-the-blanks was exercised to make the data valid.

Crucially no resulting Change has different order or action than before.
