### PR TITLE
i/systemd: fix dependency options target section

### DIFF
--- a/interfaces/systemd/service.go
+++ b/interfaces/systemd/service.go
@@ -37,11 +37,29 @@ type Service struct {
 	Before          string
 }
 
+func (s *Service) unitSectionNeeded() bool {
+	return s.Description != "" || s.Wants != "" || s.WantedBy != "" || s.After != "" || s.Before != ""
+}
+
 func (s *Service) String() string {
 	var buf bytes.Buffer
-	if s.Description != "" {
+	if s.unitSectionNeeded() {
 		buf.WriteString("[Unit]\n")
+	}
+	if s.Description != "" {
 		fmt.Fprintf(&buf, "Description=%s\n\n", s.Description)
+	}
+	if s.Wants != "" {
+		fmt.Fprintf(&buf, "Wants=%s\n", s.Wants)
+	}
+	if s.WantedBy != "" {
+		fmt.Fprintf(&buf, "WantedBy=%s\n", s.WantedBy)
+	}
+	if s.After != "" {
+		fmt.Fprintf(&buf, "After=%s\n", s.After)
+	}
+	if s.Before != "" {
+		fmt.Fprintf(&buf, "Before=%s\n", s.Before)
 	}
 	buf.WriteString("[Service]\n")
 	if s.Type != "" {
@@ -56,18 +74,6 @@ func (s *Service) String() string {
 	}
 	if s.ExecStop != "" {
 		fmt.Fprintf(&buf, "ExecStop=%s\n", s.ExecStop)
-	}
-	if s.Wants != "" {
-		fmt.Fprintf(&buf, "Wants=%s\n", s.Wants)
-	}
-	if s.WantedBy != "" {
-		fmt.Fprintf(&buf, "WantedBy=%s\n", s.WantedBy)
-	}
-	if s.After != "" {
-		fmt.Fprintf(&buf, "After=%s\n", s.After)
-	}
-	if s.Before != "" {
-		fmt.Fprintf(&buf, "Before=%s\n", s.Before)
 	}
 	fmt.Fprintf(&buf, "\n[Install]\nWantedBy=multi-user.target\n")
 	return buf.String()

--- a/interfaces/systemd/service_test.go
+++ b/interfaces/systemd/service_test.go
@@ -43,11 +43,11 @@ func (s *serviceSuite) TestString(c *C) {
 	service6 := systemd.Service{Description: "ohai"}
 	c.Assert(service6.String(), Equals, "[Unit]\nDescription=ohai\n\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 	service7 := systemd.Service{Wants: "snapd.mounts.target"}
-	c.Assert(service7.String(), Equals, "[Service]\nWants=snapd.mounts.target\n\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service7.String(), Equals, "[Unit]\nWants=snapd.mounts.target\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 	service8 := systemd.Service{WantedBy: "snapd.mounts.target"}
-	c.Assert(service8.String(), Equals, "[Service]\nWantedBy=snapd.mounts.target\n\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service8.String(), Equals, "[Unit]\nWantedBy=snapd.mounts.target\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 	service9 := systemd.Service{After: "snapd.mounts.target"}
-	c.Assert(service9.String(), Equals, "[Service]\nAfter=snapd.mounts.target\n\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service9.String(), Equals, "[Unit]\nAfter=snapd.mounts.target\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 	service10 := systemd.Service{Before: "snapd.mounts.target"}
-	c.Assert(service10.String(), Equals, "[Service]\nBefore=snapd.mounts.target\n\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service10.String(), Equals, "[Unit]\nBefore=snapd.mounts.target\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 }


### PR DESCRIPTION
Dependency options e.g. After,Before,Wants,WantedBy must go under the [Unit] section.