### PR TITLE
tests: add SNAP_LOG_TO_JOURNAL to expected vars in tests/main/snap-env

### DIFF
--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -63,14 +63,15 @@ execute: |
     MATCH "^SNAP_REAL_HOME=/root$"                                        < snap-vars.txt
     MATCH "^SNAP_UID=0$"                                                  < snap-vars.txt
     MATCH "^SNAP_EUID=0$"                                                 < snap-vars.txt
+    MATCH "^SNAP_LOG_TO_JOURNAL=$"                                        < snap-vars.txt
     # if on UC20+, then we should see an additional variable (SNAP_SAVE_DATA)
     if [[ "$SPREAD_SYSTEM" == ubuntu-core-2* ]]; then
         MATCH "^SNAP_SAVE_DATA=/var/lib/snapd/save/snap/$NAME$"           < snap-vars.txt
-        # 18 variables are expected on ubuntu-core
-        test "$(wc -l < snap-vars.txt)" -eq 18
+        # 19 variables are expected on ubuntu-core
+        test "$(wc -l < snap-vars.txt)" -eq 19
     else
-        # 17 variables are expected on non ubuntu-core
-        test "$(wc -l < snap-vars.txt)" -eq 17
+        # 18 variables are expected on non ubuntu-core
+        test "$(wc -l < snap-vars.txt)" -eq 18
     fi
 
     echo "Ensure that XDG environment variables are what we expect"


### PR DESCRIPTION
Spread now sets the `SNAP_LOG_TO_JOURNAL` variable, so expect to see it in `tests/main/snap-env`.

This was added in https://github.com/canonical/snapd/pull/15252/files#diff-3e3ed6fb2507f825b010f93a1e81f1610fca76413b0eb9588f8c23e7095cf0a2R545 and https://github.com/canonical/snapd/pull/15336/files#diff-e1e5ecb5e7fe7aa228c64f680564673541f91452212c3c6c23cbbd27bb78dcedR129