### PR TITLE
s/a/notify: add structs/commands for v5 listener registration

### DIFF
--- a/sandbox/apparmor/notify/ioctl.go
+++ b/sandbox/apparmor/notify/ioctl.go
@@ -114,6 +114,8 @@ const (
 	APPARMOR_NOTIF_IS_ID_VALID IoctlRequest = 0x8008F803
 	APPARMOR_NOTIF_RECV        IoctlRequest = 0xC008F804
 	APPARMOR_NOTIF_SEND        IoctlRequest = 0xC008F805
+	APPARMOR_NOTIF_REGISTER    IoctlRequest = 0xC008F806
+	APPARMOR_NOTIF_RESEND      IoctlRequest = 0xC008F807
 )
 
 // String returns the string representation of an IoctlRequest.
@@ -129,6 +131,10 @@ func (req IoctlRequest) String() string {
 		return "APPARMOR_NOTIF_RECV"
 	case APPARMOR_NOTIF_SEND:
 		return "APPARMOR_NOTIF_SEND"
+	case APPARMOR_NOTIF_REGISTER:
+		return "APPARMOR_NOTIF_REGISTER"
+	case APPARMOR_NOTIF_RESEND:
+		return "APPARMOR_NOTIF_RESEND"
 	default:
 		return fmt.Sprintf("IoctlRequest(%x)", uintptr(req))
 	}

--- a/sandbox/apparmor/notify/ioctl_test.go
+++ b/sandbox/apparmor/notify/ioctl_test.go
@@ -183,6 +183,8 @@ func (*ioctlSuite) TestIoctlString(c *C) {
 	c.Assert(notify.APPARMOR_NOTIF_IS_ID_VALID.String(), Equals, "APPARMOR_NOTIF_IS_ID_VALID")
 	c.Assert(notify.APPARMOR_NOTIF_RECV.String(), Equals, "APPARMOR_NOTIF_RECV")
 	c.Assert(notify.APPARMOR_NOTIF_SEND.String(), Equals, "APPARMOR_NOTIF_SEND")
+	c.Assert(notify.APPARMOR_NOTIF_REGISTER.String(), Equals, "APPARMOR_NOTIF_REGISTER")
+	c.Assert(notify.APPARMOR_NOTIF_RESEND.String(), Equals, "APPARMOR_NOTIF_RESEND")
 
 	arbitrary := notify.IoctlRequest(0xDEADBEEF)
 	c.Assert(arbitrary.String(), Equals, "IoctlRequest(deadbeef)")

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -868,7 +868,6 @@ func newMsgNotificationFile(protocolVersion notify.ProtocolVersion, id uint64, l
 	msg := notify.MsgNotificationFile{}
 	msg.Version = protocolVersion
 	msg.NotificationType = notify.APPARMOR_NOTIF_OP
-	msg.Flags = 1
 	msg.KernelNotificationID = id
 	msg.Allow = allow
 	msg.Deny = deny
@@ -888,7 +887,7 @@ func newMsgNotificationResponse(protocolVersion notify.ProtocolVersion, id uint6
 	msgNotification := notify.MsgNotification{
 		MsgHeader:            msgHeader,
 		NotificationType:     notify.APPARMOR_NOTIF_RESP,
-		Flags:                1,
+		Flags:                notify.URESPONSE_NO_CACHE,
 		KernelNotificationID: id,
 		Error:                0,
 	}

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -430,7 +430,7 @@ type msgNotificationFile struct {
 	// MsgNotification
 	NotificationType     notify.NotificationType
 	Signalled            uint8
-	NoCache              uint8
+	Flags                uint8
 	KernelNotificationID uint64
 	Error                int32
 	// msgNotificationOpKernel
@@ -868,7 +868,7 @@ func newMsgNotificationFile(protocolVersion notify.ProtocolVersion, id uint64, l
 	msg := notify.MsgNotificationFile{}
 	msg.Version = protocolVersion
 	msg.NotificationType = notify.APPARMOR_NOTIF_OP
-	msg.NoCache = 1
+	msg.Flags = 1
 	msg.KernelNotificationID = id
 	msg.Allow = allow
 	msg.Deny = deny
@@ -888,7 +888,7 @@ func newMsgNotificationResponse(protocolVersion notify.ProtocolVersion, id uint6
 	msgNotification := notify.MsgNotification{
 		MsgHeader:            msgHeader,
 		NotificationType:     notify.APPARMOR_NOTIF_RESP,
-		NoCache:              1,
+		Flags:                1,
 		KernelNotificationID: id,
 		Error:                0,
 	}


### PR DESCRIPTION
These changes are cherry-picked from #15237

In order to support snapd reclaiming outstanding notifications after it restarts, we need to register the listener ID with the kernel and re-register it after a restart. Then, we send a request to re-send outstanding messages.

This commit adds the ioctl register and resend commands and defines the structs used for those commands.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34637
