### PR TITLE
cmd/snap: unset SNAP_LOG_TO_JOURNAL once logging is set up

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -559,6 +559,8 @@ func loggerWithJournalMaybe() error {
 		// try simple setup
 		logger.SimpleSetup(nil)
 	}
+	// unset so that it doesn't trickle down to the snap application
+	os.Unsetenv("SNAP_LOG_TO_JOURNAL")
 	return nil
 }
 


### PR DESCRIPTION
Unset SNAP_LOG_TO_JOURNAL after logging setup is complete, so that it does not get passed down to the snap application process.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
