### PR TITLE
s/writer: allow providing a different base when overriding snap

### DIFF
--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1120,7 +1120,8 @@ func (w *Writer) resolveChannel(whichSnap string, modSnap *asserts.ModelSnap, op
 	return resChannel, nil
 }
 
-func (w *Writer) checkBase(info *snap.Info, modes []string) error {
+func (w *Writer) checkBase(sn *SeedSnap) error {
+	info := sn.Info
 	// Validity check, note that we could support this case
 	// if we have a use-case but it requires changes in the
 	// devicestate/firstboot.go ordering code.
@@ -1133,7 +1134,16 @@ func (w *Writer) checkBase(info *snap.Info, modes []string) error {
 		return nil
 	}
 
-	return w.policy.checkBase(info, modes, w.availableByMode)
+	modes := sn.modes()
+	err := w.policy.checkBase(info, modes, w.availableByMode)
+	if err != nil {
+		// in dangerous mode check base only at the end
+		// allowing overrides to provide the new base as well
+		if w.policy.allowsDangerousFeatures() == nil && sn.optionSnap != nil {
+			return nil
+		}
+	}
+	return err
 }
 
 func (w *Writer) recordUsageWithThePolicy(modSnaps []*asserts.ModelSnap) {
@@ -1315,14 +1325,7 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap, fetchAsserts AssertsFetchFunc
 			}
 		}
 
-		modes := sn.modes()
-
-		if err := w.checkBase(info, modes); err != nil {
-			// in dangerous mode check base only at the end
-			// allowing overrides to provide the new base as well
-			if w.policy.allowsDangerousFeatures() == nil && sn.optionSnap != nil {
-				continue
-			}
+		if err := w.checkBase(sn); err != nil {
 			return err
 		}
 	}

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1318,6 +1318,11 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap, fetchAsserts AssertsFetchFunc
 		modes := sn.modes()
 
 		if err := w.checkBase(info, modes); err != nil {
+			// in dangerous mode check base only at the end
+			// allowing overrides to provide the new base as well
+			if w.policy.allowsDangerousFeatures() == nil && sn.optionSnap != nil {
+				continue
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
in dangerous mode we allow overriding a required snap, which might end up needing a different base, allow providing for it via an optional snap

this addresses the issue mentioned in https://github.com/canonical/snapd/pull/12745
