### PR TITLE
sandbox/gpio: load gpio-aggregator module if not loaded

### DIFF
--- a/cmd/snap-gpio-helper/cmd_unexport_test.go
+++ b/cmd/snap-gpio-helper/cmd_unexport_test.go
@@ -26,11 +26,18 @@ import (
 )
 
 func (s *snapGpioHelperSuite) TestUnexportGpioChardev(c *C) {
-	called := 0
+	unexportCalled := 0
 	restore := main.MockGpioUnxportGadgetChardevChip(func(gadgetName, slotName string) error {
-		called++
+		unexportCalled++
 		c.Check(gadgetName, Equals, "gadget-name")
 		c.Check(slotName, Equals, "slot-name")
+		return nil
+	})
+	defer restore()
+
+	ensureDriverCalled := 0
+	restore = main.MockGpioEnsureAggregatorDriver(func() error {
+		ensureDriverCalled++
 		return nil
 	})
 	defer restore()
@@ -39,5 +46,6 @@ func (s *snapGpioHelperSuite) TestUnexportGpioChardev(c *C) {
 		"unexport-chardev", "label-0,label-1", "7,0-6,8-100", "gadget-name", "slot-name",
 	})
 	c.Check(err, IsNil)
-	c.Assert(called, Equals, 1)
+	c.Assert(unexportCalled, Equals, 1)
+	c.Assert(ensureDriverCalled, Equals, 1)
 }

--- a/cmd/snap-gpio-helper/export_test.go
+++ b/cmd/snap-gpio-helper/export_test.go
@@ -36,3 +36,7 @@ func MockGpioExportGadgetChardevChip(f func(ctx context.Context, chipLabels []st
 func MockGpioUnxportGadgetChardevChip(f func(gadgetName string, slotName string) error) (restore func()) {
 	return testutil.Mock(&gpioUnexportGadgetChardevChip, f)
 }
+
+func MockGpioEnsureAggregatorDriver(f func() error) (restore func()) {
+	return testutil.Mock(&gpioEnsureAggregatorDriver, f)
+}

--- a/sandbox/gpio/common.go
+++ b/sandbox/gpio/common.go
@@ -37,7 +37,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/inotify"
-	"github.com/snapcore/snapd/osutil/kmod"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -126,23 +125,9 @@ var lockAggregator = func() (unlocker func(), err error) {
 	}, nil
 }
 
-var kmodLoadModule = kmod.LoadModule
 var aggregatorCreationTimeout = 120 * time.Second
 
 func addAggregatedChip(ctx context.Context, sourceChip *ChardevChip, lines strutil.Range) (chip *ChardevChip, err error) {
-	// Make sure the gpio-aggregator module is loaded because the
-	// systemd security backend comes before the kmod security
-	// backend, there is an edge case on first connection where
-	// the helper service could be started before the gpio-aggregator
-	// module is loaded.
-	if _, err := osStat(filepath.Join(dirs.GlobalRootDir, aggregatorDriverDir)); errors.Is(err, os.ErrNotExist) {
-		if err := kmodLoadModule("gpio-aggregator", nil); err != nil {
-			return nil, err
-		}
-	} else if err != nil {
-		return nil, err
-	}
-
 	// synchronize gpio helpers' access to the aggregator interface
 	unlocker, err := lockAggregator()
 	if err != nil {

--- a/sandbox/gpio/export_test.go
+++ b/sandbox/gpio/export_test.go
@@ -67,3 +67,7 @@ func MockAggregatorCreationTimeout(t time.Duration) (restore func()) {
 func MockLockAggregator(f func() (unlocker func(), err error)) (restore func()) {
 	return testutil.Mock(&lockAggregator, f)
 }
+
+func MocKKmodLoadModule(f func(module string, options []string) error) (restore func()) {
+	return testutil.Mock(&kmodLoadModule, f)
+}

--- a/sandbox/gpio/export_test.go
+++ b/sandbox/gpio/export_test.go
@@ -67,7 +67,3 @@ func MockAggregatorCreationTimeout(t time.Duration) (restore func()) {
 func MockLockAggregator(f func() (unlocker func(), err error)) (restore func()) {
 	return testutil.Mock(&lockAggregator, f)
 }
-
-func MockKmodLoadModule(f func(module string, options []string) error) (restore func()) {
-	return testutil.Mock(&kmodLoadModule, f)
-}

--- a/sandbox/gpio/export_test.go
+++ b/sandbox/gpio/export_test.go
@@ -67,3 +67,7 @@ func MockAggregatorCreationTimeout(t time.Duration) (restore func()) {
 func MockLockAggregator(f func() (unlocker func(), err error)) (restore func()) {
 	return testutil.Mock(&lockAggregator, f)
 }
+
+func MockKmodLoadModule(f func(module string, options []string) error) (restore func()) {
+	return testutil.Mock(&kmodLoadModule, f)
+}

--- a/sandbox/gpio/gpio_chardev.go
+++ b/sandbox/gpio/gpio_chardev.go
@@ -23,9 +23,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/kmod"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -90,4 +92,19 @@ func UnexportGadgetChardevChip(gadgetName, slotName string) error {
 		return err
 	}
 	return removeAggregatedChip(aggregatedChip)
+}
+
+var kmodLoadModule = kmod.LoadModule
+
+// EnsureAggregatorDriver attempts to load the gpio-aggregator kernel
+// module iff it was not already loaded.
+func EnsureAggregatorDriver() error {
+	_, err := os.Stat(filepath.Join(dirs.GlobalRootDir, aggregatorDriverDir))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := kmodLoadModule("gpio-aggregator", nil); err != nil {
+			return err
+		}
+		return nil
+	}
+	return err
 }

--- a/sandbox/gpio/gpio_chardev_test.go
+++ b/sandbox/gpio/gpio_chardev_test.go
@@ -170,7 +170,7 @@ func (s *exportUnexportTestSuite) SetUpTest(c *C) {
 	restore = gpio.MockOsStat(func(path string) (fs.FileInfo, error) {
 		target, ok := s.mockStats[path]
 		if !ok {
-			return nil, fmt.Errorf("unexpected path %s", path)
+			return nil, fmt.Errorf("unexpected path %s: %w", path, os.ErrNotExist)
 		}
 		return target, nil
 	})
@@ -187,6 +187,7 @@ func (s *exportUnexportTestSuite) SetUpTest(c *C) {
 
 	// Mock gpio-aggregator sysfs structure
 	c.Assert(os.MkdirAll(filepath.Join(s.rootdir, "/sys/bus/platform/drivers/gpio-aggregator"), 0755), IsNil)
+	s.mockStats[filepath.Join(s.rootdir, "/sys/bus/platform/drivers/gpio-aggregator")] = &fakeFileInfo{}
 	c.Assert(os.WriteFile(filepath.Join(s.rootdir, "/sys/bus/platform/drivers/gpio-aggregator/new_device"), nil, 0644), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(s.rootdir, "/sys/bus/platform/drivers/gpio-aggregator/delete_device"), nil, 0644), IsNil)
 	// Mock gpio-aggregator new_device/delete_device sysfs calls
@@ -387,6 +388,25 @@ func (s *exportUnexportTestSuite) TestExportGadgetChardevChip(c *C) {
 	// And original permission bits and ownership are replicated
 	c.Check(chmodCalled, Equals, 1)
 	c.Check(chownCalled, Equals, 1)
+}
+
+func (s *exportUnexportTestSuite) TestExportGadgetChardevChipWithLoadModule(c *C) {
+	s.mockChip(c, "gpiochip0", filepath.Join(s.rootdir, "/dev/gpiochip0"), "label-0", 3, nil)
+
+	// Mock that the gpio-aggregator module is not loaded
+	delete(s.mockStats, filepath.Join(s.rootdir, "/sys/bus/platform/drivers/gpio-aggregator"))
+
+	called := 0
+	restore := gpio.MockKmodLoadModule(func(module string, options []string) error {
+		called++
+		return nil
+	})
+	defer restore()
+
+	err := gpio.ExportGadgetChardevChip(context.TODO(), []string{"label-0"}, strutil.Range{{Start: 0, End: 0}}, "gadget-name", "slot-name")
+	c.Check(err, IsNil)
+	// If gpio-aggreagtore module is not loaded, the exported attempts to load it.
+	c.Check(called, Equals, 1)
 }
 
 func (s *exportUnexportTestSuite) TestExportGadgetChardevChipMissingLine(c *C) {


### PR DESCRIPTION
Make sure the gpio-aggregator module is loaded because the systemd security backend comes before the kmod security backend, there is an edge case on first connection where the helper service could be started before the gpio-aggregator module is loaded.

Check backends' order is controlled through: https://github.com/canonical/snapd/blob/f05804bf6c76580311eda9b21d9b77acb626acc6/interfaces/backends/backends.go#L40
