### PR TITLE
packaging/arch, tests/lib/prepare-restore: simplify PKGBUILD, simplify building of Arch package in CI

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -23,22 +23,17 @@ checkdepends=('python' 'squashfs-tools' 'shellcheck')
 conflicts=('snap-confine')
 options=('!strip' 'emptydirs')
 install=snapd.install
-source=("git+https://github.com/snapcore/$pkgname.git")
+source=("${pkgname}_${pkgver}.vendor.tar.xz")
 sha256sums=('SKIP')
 
-pkgver() {
-    cd "$srcdir/snapd"
-    git describe --tag | sed -r 's/([^-]*-g)/r\1/; s/-/./g'
-}
-
 prepare() {
-  cd "$pkgname"
+  cd "$pkgname-$pkgver"
 
   :
 }
 
 build() {
-  cd "$pkgname"
+  cd "$pkgname-$pkgver"
 
   unset GO111MODULE
 
@@ -100,27 +95,27 @@ __DEFINES__
 }
 
 check() {
-  cd "$pkgname"
+    cd "$pkgname-$pkgver"
 
-  # make sure the binaries that need to be built statically really are
-  for binary in snap-exec snap-update-ns snapctl; do
-      if ! LC_ALL=C ldd "$srcdir/_go_build/$binary" 2>&1 | grep -q 'not a dynamic executable'; then
-          echo "$binary is not a static binary"
-          exit 1
-      fi
-  done
+    # make sure the binaries that need to be built statically really are
+    for binary in snap-exec snap-update-ns snapctl; do
+        if ! LC_ALL=C ldd "$srcdir/_go_build/$binary" 2>&1 | grep -q 'not a dynamic executable'; then
+            echo "$binary is not a static binary"
+            exit 1
+        fi
+    done
 
-  SKIP_UNCLEAN=1 IGNORE_MISSING=1 ./run-checks --unit
-  # XXX: Static checks choke on autotools generated cruft. Let's not run them
-  # here as they are designed to pass on a clean tree, before anything else is
-  # done, not after building the tree.
-  # ./run-checks --static
-  TMPDIR=/tmp make -C cmd -k check
-  TMPDIR=/tmp make -C data -k check
+    SKIP_UNCLEAN=1 IGNORE_MISSING=1 ./run-checks --unit
+    # XXX: Static checks choke on autotools generated cruft. Let's not run them
+    # here as they are designed to pass on a clean tree, before anything else is
+    # done, not after building the tree.
+    # ./run-checks --static
+    TMPDIR=/tmp make -C cmd -k check
+    TMPDIR=/tmp make -C data -k check
 }
 
 package() {
-  cd "$pkgname"
+  cd "$pkgname-$pkgver"
 
   # Install bash completion
   install -Dm644 data/completion/bash/snap \
@@ -134,7 +129,7 @@ package() {
     "$pkgdir/usr/share/zsh/site-functions/_snap"
 
   # Install systemd units, dbus services and a script for environment variables
-  make -C data install \
+  make -C data/ install \
      DBUSSERVICESDIR=/usr/share/dbus-1/services \
      BINDIR=/usr/bin \
      SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \


### PR DESCRIPTION
The PKGBUILD file was originally based on one for snapd-git AUR package.
However, since then snapd-git became defunct, at the same time all of
the downstream packaging is done in the snapd AUR package.

The patch syncs the packaging so that it's almost identical, with a
small exception of the header and lack of patches.

With the PKGBUILD more in line with how 
the actual downstream packaging looks like, we can further  simplify
packing of source tarballs, i.e. reuse pack-source script and drop the
custom sed/awk processing.

Related: [SNAPDENG-34616](https://warthogs.atlassian.net/browse/SNAPDENG-34616)

[SNAPDENG-34616]: https://warthogs.atlassian.net/browse/SNAPDENG-34616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ