### PR TITLE
cmd/snapd: fix logger data race

### DIFF
--- a/cmd/snapd/main_test.go
+++ b/cmd/snapd/main_test.go
@@ -107,7 +107,9 @@ func (s *snapdSuite) TestSyscheckFailGoesIntoDegradedMode(c *C) {
 		syscheckCheckWasRun = true
 	}
 	c.Check(syscheckCheckWasRun, Equals, true)
-	c.Check(logbuf.String(), testutil.Contains, "system does not fully support snapd: foo failed")
+	logger.WithLoggerLock(func() {
+		c.Check(logbuf.String(), testutil.Contains, "system does not fully support snapd: foo failed")
+	})
 
 	// verify that talking to the daemon yields the syscheck error
 	// message


### PR DESCRIPTION
Snapd is still running and can be logging while the test is checking logger buffer content.

Related race when running with SNAPD_DEBUG=1:

```
==================
WARNING: DATA RACE
Read at 0x00c0003ef710 by goroutine 38:
  bytes.(*Buffer).String()
      /usr/lib/go/src/bytes/buffer.go:71 +0x8f4
  github.com/snapcore/snapd/cmd/snapd_test.(*snapdSuite).TestSyscheckFailGoesIntoDegradedMode()
      /home/maciek/work/canonical/snapd/cmd/snapd/main_test.go:110 +0x8d1
  runtime.call16()
      /usr/lib/go/src/runtime/asm_amd64.s:775 +0x42
  reflect.Value.Call()
      /usr/lib/go/src/reflect/value.go:368 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:775 +0x955
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:669 +0xe2

Previous write at 0x00c0003ef710 by goroutine 73:
  bytes.(*Buffer).tryGrowByReslice()
      /usr/lib/go/src/bytes/buffer.go:117 +0xa5
  bytes.(*Buffer).Write()
      /usr/lib/go/src/bytes/buffer.go:177 +0xb9
  log.(*Logger).output()
      /usr/lib/go/src/log/log.go:245 +0x6a1
  log.(*Logger).Output()
      /usr/lib/go/src/log/log.go:195 +0x95
  github.com/snapcore/snapd/logger.(*Log).Debug()
      /home/maciek/work/canonical/snapd/logger/logger.go:197 +0xaf
  github.com/snapcore/snapd/logger.Debugf()
      /home/maciek/work/canonical/snapd/logger/logger.go:112 +0x105
  github.com/snapcore/snapd/overlord/state.(*TaskRunner).Ensure()
      /home/maciek/work/canonical/snapd/overlord/state/taskrunner.go:471 +0x10b9
  github.com/snapcore/snapd/overlord.(*StateEngine).Ensure()
      /home/maciek/work/canonical/snapd/overlord/stateengine.go:161 +0x3c1
  github.com/snapcore/snapd/overlord/devicestate.(*DeviceManager).Ensure()
      /home/maciek/work/canonical/snapd/overlord/devicestate/devicemgr.go:1814 +0x3e
  github.com/snapcore/snapd/overlord.(*StateEngine).Ensure()
      /home/maciek/work/canonical/snapd/overlord/stateengine.go:161 +0x3c1
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).Ensure()
      /home/maciek/work/canonical/snapd/overlord/snapstate/snapmgr.go:1531 +0x92
  github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).Ensure()
      /home/maciek/work/canonical/snapd/overlord/snapstate/snapmgr.go:1529 +0x5b
  github.com/snapcore/snapd/overlord.(*StateEngine).Ensure()
      /home/maciek/work/canonical/snapd/overlord/stateengine.go:161 +0x3c1
  github.com/snapcore/snapd/overlord.(*Overlord).Loop.func1()
      /home/maciek/work/canonical/snapd/overlord/overlord.go:478 +0x76
  gopkg.in/tomb%2ev2.(*Tomb).run()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x3b
  gopkg.in/tomb%2ev2.(*Tomb).Go.gowrap2()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x44

Goroutine 38 (running) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:666 +0x587
  gopkg.in/check%2ev1.(*suiteRunner).forkTest()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:757 +0x149
  gopkg.in/check%2ev1.(*suiteRunner).runTest()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:812 +0x3eb
  gopkg.in/check%2ev1.(*suiteRunner).run()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/check.go:618 +0x39b
  gopkg.in/check%2ev1.Run()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/run.go:92 +0x44
  gopkg.in/check%2ev1.RunAll()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/run.go:84 +0x118
  gopkg.in/check%2ev1.TestingT()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/check.v1/run.go:72 +0x5d1
  github.com/snapcore/snapd/cmd/snapd_test.Test()
      /home/maciek/work/canonical/snapd/cmd/snapd/main_test.go:42 +0x26
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /usr/lib/go/src/testing/testing.go:1851 +0x44

Goroutine 73 (running) created at:
  gopkg.in/tomb%2ev2.(*Tomb).Go()
      /home/maciek/work/canonical/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x196
  github.com/snapcore/snapd/overlord.(*Overlord).Loop()
      /home/maciek/work/canonical/snapd/overlord/overlord.go:472 +0x217
  github.com/snapcore/snapd/daemon.(*Daemon).Start()
      /home/maciek/work/canonical/snapd/daemon/daemon.go:396 +0x6c6
  github.com/snapcore/snapd/overlord.(*StateEngine).StartUp()
      /home/maciek/work/canonical/snapd/overlord/stateengine.go:121 +0x251
  github.com/snapcore/snapd/overlord.(*Overlord).StartUp()
      /home/maciek/work/canonical/snapd/overlord/overlord.go:395 +0x346
  github.com/snapcore/snapd/overlord.(*Overlord).StartUp()
      /home/maciek/work/canonical/snapd/overlord/overlord.go:380 +0x1f2
  github.com/snapcore/snapd/daemon.(*Daemon).Start()
      /home/maciek/work/canonical/snapd/daemon/daemon.go:371 +0x255
  github.com/snapcore/snapd/cmd/snapd.run()
      /home/maciek/work/canonical/snapd/cmd/snapd/main.go:150 +0x325
  github.com/snapcore/snapd/overlord.New()
      /home/maciek/work/canonical/snapd/overlord/overlord.go:135 +0x244
  github.com/snapcore/snapd/daemon.New()
      /home/maciek/work/canonical/snapd/daemon/daemon.go:736 +0x84
  github.com/snapcore/snapd/cmd/snapd.run()
      /home/maciek/work/canonical/snapd/cmd/snapd/main.go:127 +0x98
  github.com/snapcore/snapd/cmd/snapd_test.(*snapdSuite).TestSyscheckFailGoesIntoDegradedMode.func3()
      /home/maciek/work/canonical/snapd/cmd/snapd/main_test.go:98 +0xd8
==================
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
