### PR TITLE
many: store keys in keyring in install in initrd

### DIFF
--- a/core-initrd/latest/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
@@ -22,3 +22,4 @@ StandardOutput=journal+console
 StandardError=journal+console
 ImportCredential=snapd.passphrase
 ImportCredential=snapd.recovery
+KeyringMode=inherit

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -407,6 +407,10 @@ func PrepareEncryptedSystemData(
 				return err
 			}
 
+			// This is the "default" key of save partition. So it should also
+			// be saved to keyring to have similar state as unlocking in run mode.
+			saveBootstrappedContainer.RegisterKeyAsUsed(generatedPK, diskKey)
+
 			primaryKey = generatedPK
 		} else {
 			saveKey, err := keys.NewEncryptionKey()

--- a/secboot/bootstrap_container.go
+++ b/secboot/bootstrap_container.go
@@ -47,6 +47,8 @@ type BootstrappedContainer interface {
 	GetTokenWriter(slotName string) (KeyDataWriter, error)
 	// RemoveBootstrapKey removes the bootstrap key.
 	RemoveBootstrapKey() error
+	// RegisterKeyAsUsed registers an unlock key and its primary key in the kernel keyring.
+	RegisterKeyAsUsed(primaryKey []byte, unlockKey []byte)
 }
 
 func createBootstrappedContainerMockImpl(key DiskUnlockKey, devicePath string) BootstrappedContainer {
@@ -102,4 +104,7 @@ func (m *MockBootstrappedContainer) GetTokenWriter(slotName string) (KeyDataWrit
 func (l *MockBootstrappedContainer) RemoveBootstrapKey() error {
 	l.BootstrapKeyRemoved = true
 	return nil
+}
+
+func (l *MockBootstrappedContainer) RegisterKeyAsUsed(primaryKey []byte, unlockKey []byte) {
 }

--- a/secboot/bootstrap_container_sb_test.go
+++ b/secboot/bootstrap_container_sb_test.go
@@ -195,3 +195,41 @@ func (*bootstrapContainerSuite) TestBootstrappedContainerTokenWriterFailure(c *C
 	_, err = container.GetTokenWriter("")
 	c.Assert(err, ErrorMatches, `some error`)
 }
+
+func (*bootstrapContainerSuite) TestBootstrappedContainerKeyringHappy(c *C) {
+	container := secboot.CreateBootstrappedContainer([]byte{50, 51, 52, 53}, "/dev/foo")
+
+	primaryKeyRegistered := 0
+	unlockKeyRegistered := 0
+	defer secboot.MockUnixAddKey(func(keyType string, description string, payload []byte, ringid int) (int, error) {
+		switch description {
+		case "ubuntu-fde:/dev/disk/by-uuid/1234:aux":
+			primaryKeyRegistered++
+			c.Check(payload, DeepEquals, []byte{1, 2, 3, 4})
+		case "ubuntu-fde:/dev/disk/by-uuid/1234:unlock":
+			unlockKeyRegistered++
+			c.Check(payload, DeepEquals, []byte{5, 6, 7, 8})
+		default:
+			c.Errorf("unexpected description")
+			return 0, fmt.Errorf("unexpected description")
+		}
+
+		c.Check(keyType, Equals, "user")
+		c.Check(ringid, Equals, -4)
+
+		return 42, nil
+	})()
+
+	defer secboot.MockDisksDevlinks(func(node string) ([]string, error) {
+		c.Check(node, Equals, "/dev/foo")
+		return []string{
+			"/dev/foo",
+			"/dev/disk/by-uuid/1234",
+		}, nil
+	})()
+
+	container.RegisterKeyAsUsed([]byte{1, 2, 3, 4}, []byte{5, 6, 7, 8})
+
+	c.Check(primaryKeyRegistered, Equals, 1)
+	c.Check(unlockKeyRegistered, Equals, 1)
+}

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -166,9 +166,8 @@ func EnsureRecoveryKey(keyFile string, rkeyDevs []RecoveryKeyDevice) (keys.Recov
 
 		for _, device := range newDevices {
 			var unlockKey []byte
-			const defaultPrefix = "ubuntu-fde"
 			// always check keyring first for unlock key, otherwise fallback to using key file
-			key, err := sbGetDiskUnlockKeyFromKernel(defaultPrefix, device.node, false)
+			key, err := sbGetDiskUnlockKeyFromKernel(defaultKeyringPrefix, device.node, false)
 			if errors.Is(err, sb.ErrKernelKeyNotFound) && device.keyFile != "" {
 				key, err := os.ReadFile(device.keyFile)
 				if err != nil {

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -484,3 +484,7 @@ func MockSbNewOutOfProcessArgon2KDF(f func(newHandlerCmd func() (*exec.Cmd, erro
 func MockSbSetArgon2KDF(f func(kdf sb.Argon2KDF) sb.Argon2KDF) (restore func()) {
 	return testutil.Mock(&sbSetArgon2KDF, f)
 }
+
+func MockUnixAddKey(f func(keyType string, description string, payload []byte, ringid int) (int, error)) (restore func()) {
+	return testutil.Mock(&unixAddKey, f)
+}

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -272,3 +272,7 @@ func MarkSuccessful() error {
 
 	return nil
 }
+
+const (
+	defaultKeyringPrefix = "ubuntu-fde"
+)

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -115,6 +115,12 @@ func SealKeysWithFDESetupHook(runHook fde.RunSetupHookFunc, keys []SealKeyReques
 		if err := protectedKey.WriteAtomic(keyWriter); err != nil {
 			return err
 		}
+
+		if skr.SlotName == "default" {
+			// "default" key will only be using hook on data disk. "save" disk will be handled
+			// with the protector key.
+			skr.BootstrappedContainer.RegisterKeyAsUsed(primaryKeyOut, unlockKey)
+		}
 	}
 
 	if primaryKey != nil && params.AuxKeyFile != "" {

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -331,8 +331,7 @@ func DeactivateVolume(volumeName string) error {
 // temporary and is expected to be used with a BootstrappedContainer,
 // and removed by calling RemoveBootstrapKey.
 func AddBootstrapKeyOnExistingDisk(node string, newKey keys.EncryptionKey) error {
-	const defaultPrefix = "ubuntu-fde"
-	unlockKey, err := sbGetDiskUnlockKeyFromKernel(defaultPrefix, node, false)
+	unlockKey, err := sbGetDiskUnlockKeyFromKernel(defaultKeyringPrefix, node, false)
 	if err != nil {
 		return fmt.Errorf("cannot get key for unlocked disk %s: %v", node, err)
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -587,6 +587,11 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) ([]byte, error) {
 			return nil, err
 		}
 
+		if key.SlotName == "default" {
+			// "default" key will only be TPM on data disk. "save" disk will be handled
+			// with the protector key.
+			key.BootstrappedContainer.RegisterKeyAsUsed(primaryKeyOut, unlockKey)
+		}
 	}
 
 	if primaryKey != nil && params.TPMPolicyAuthKeyFile != "" {

--- a/tests/nested/manual/uc20-install-in-initrd/task.yaml
+++ b/tests/nested/manual/uc20-install-in-initrd/task.yaml
@@ -65,6 +65,24 @@ prepare: |
 
   tests.nested build-image core
 
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB"/nested.sh
+
+  if os.query is-ubuntu-ge 24.04; then
+    # Let's repack the kernel with a new hash so we can force resealing
+    unsquashfs -d pc-kernel-new "${NESTED_ASSETS_DIR}"/pc-kernel.snap
+    objcopy -O binary -j .initrd pc-kernel-new/kernel.efi initrd.img
+    objcopy -O binary -j .linux pc-kernel-new/kernel.efi linux
+    /usr/lib/systemd/ukify build --linux=linux --initrd=initrd.img --section=.some:thing-new --output=pc-kernel-new/kernel.efi
+    rm linux initrd.img
+    KEY_NAME=$(tests.nested download snakeoil-key)
+    SNAKEOIL_KEY="${PWD}/${KEY_NAME}.key"
+    SNAKEOIL_CERT="${PWD}/${KEY_NAME}.pem"
+    tests.nested secboot-sign file "${PWD}/pc-kernel-new/kernel.efi" "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+    snap pack pc-kernel-new --filename=pc-kernel-new.snap
+    rm -rf pc-kernel-new
+  fi
+
   "$TESTSTOOLS"/store-state teardown-fake-store "$NESTED_FAKESTORE_BLOB_DIR"
 
   tests.nested create-vm core
@@ -72,6 +90,8 @@ prepare: |
 restore: |
   "$TESTSTOOLS"/store-state teardown-fake-store "$NESTED_FAKESTORE_BLOB_DIR" || true
   rm -rf ~/.snap/gnupg
+  rm -rf pc-kernel-new
+  rm -f pc-kernel-new.snap
 
 execute: |
   #shellcheck source=tests/lib/nested.sh
@@ -139,4 +159,18 @@ execute: |
     remote.exec test -f /var/lib/snapd/device/fde/boot-chains
   else
     remote.exec not test -f /var/lib/snapd/device/fde/boot-chains
+  fi
+
+  # Now we check we have access to the unlock key and primary key
+  if [ "${INSTALL_MODE}" != none ]; then
+    # To be able to enroll a key we access to the unlock keys of the devices
+    remote.exec "sudo snap recovery --show-keys"
+
+    if os.query is-ubuntu-ge 24.04; then
+      # To be able to reseal we need the primary key
+      remote.push pc-kernel-new.snap
+      boot_id="$(tests.nested boot-id)"
+      remote.exec sudo snap install --dangerous pc-kernel-new.snap || true
+      remote.wait-for reboot "${boot_id}"
+    fi
   fi


### PR DESCRIPTION
Because did not install in initrd did not install keys keyring, we have always been missing the unlock key on first boot that made enrolling recovery key impossible.

Here we also test for the primary key being available by forcing a reseal. We will then be able to remove the primary key safely from files during install.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
