### PR TITLE
i/prompting: implement Text(Un)Marshaler for IDType

### DIFF
--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -58,16 +58,12 @@ func (i IDType) String() string {
 	return fmt.Sprintf("%016X", uint64(i))
 }
 
-func (i *IDType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(i.String())
+func (i IDType) MarshalText() ([]byte, error) {
+	return []byte(i.String()), nil
 }
 
-func (i *IDType) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
-		return fmt.Errorf("cannot read ID into string: %w", err)
-	}
-	id, err := IDFromString(s)
+func (i *IDType) UnmarshalText(b []byte) error {
+	id, err := IDFromString(string(b))
 	if err != nil {
 		return err
 	}

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -58,10 +58,18 @@ func (i IDType) String() string {
 	return fmt.Sprintf("%016X", uint64(i))
 }
 
+// MarshalText implements [encoding.TextMarshaler] for IDType. We need this so
+// that IDType can be marshalled consistently when used as a map key, which is
+// not addressible (so must have non-pointer receiver) and is converted to text
+// so keys can be sorted before being marshalled as JSON.
+//
+// For more information, see [json.Marshal], in particular the discussion of
+// marshalling map keys and values.
 func (i IDType) MarshalText() ([]byte, error) {
 	return []byte(i.String()), nil
 }
 
+// UnmarshalText implements [encoding.TextUnmarshaler] for IDType.
 func (i *IDType) UnmarshalText(b []byte) error {
 	id, err := IDFromString(string(b))
 	if err != nil {


### PR DESCRIPTION
Instead of implementing `json.{M,Unm}arshaler`, implement the `encoding.Text{M,Unm}arshaler` interface. `json.Marshal` uses the text (un)marshaler interface as a fallback when the json (un)marshaler interfaces are not implemented.

Importantly, when marshaling `IDType` to json as a key in a map, the implementation of the json interfaces is not sufficient for the ID to be properly marshaled in its string format; instead, the default `uint64` marshaling is used. This is because json keys must be strings, and the keys must be unique, so keys are marshalled to text first, then later marshalled as json. As a result, by implementing the `TextMarshaler` interface, the text representation of `IDType` is correct, and the json marshaling inherits it.

Additionally, the `MarshalText` method must be implemented on a non-pointer `IDType` receiver in order for `IDType` to be marshalled properly as keys or values in maps. This is because keys and values in maps are not addressible (see: `reflect.CanAddr`). Implementing `MarshalText` on the literal `IDType` allows them to be marshalled as keys/values.
