### PR TITLE
tests/base-revert-after-boot: change base used for the broken snap

### DIFF
--- a/tests/nested/core/base-revert-after-boot/task.yaml
+++ b/tests/nested/core/base-revert-after-boot/task.yaml
@@ -14,7 +14,7 @@ execute: |
   if [ "$VERSION" -eq 16 ]; then
       base=core
   fi
-  snap download --basename="$base" --channel="$NESTED_CORE_CHANNEL" "$base"
+  snap download --basename="$base" --channel="$CORE_CHANNEL" "$base"
 
   unsquashfs -d "$base" "$base".snap
   HOOKS_D=$base/meta/hooks/


### PR DESCRIPTION
Download the base snap used to simulate a bad post-install hook from the same channel as the one used to build the image, which is actually $CORE_CHANNEL (see nested_prepare_base()). This was causing some problems in the test due to recent changes in ssh services in core24.