### PR TITLE
interfaces: add mtk-genio-usb interface

### DIFF
--- a/interfaces/builtin/mtk_genio_usb.go
+++ b/interfaces/builtin/mtk_genio_usb.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package builtin
+
+const mtkGenioUsbSummary = `Udev rules for Mediatek Genio USB devices`
+
+// Interface: mtk-genio-usb
+//
+// The mtk-genio-usb interface allows access to MediaTek Genio boards via USB.
+
+const mtkGenioUsbBaseDeclarationSlots = `
+  mtk-genio-usb:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const mtkGenioUsbConnectedPlugAppArmor = `
+# Description: Provide minimal permissions for Mediatek Genio USB device udev handling
+# 
+# No direct device access is granted. Udev rules will manage permissions separately.
+`
+
+var mtkGenioUsbConnectedPlugUDev = []string{
+	`SUBSYSTEM=="usb", ATTR{idVendor}=="0e8d", ATTR{idProduct}=="201c", MODE="0660", TAG+="uaccess"`,
+	`SUBSYSTEM=="usb", ATTR{idVendor}=="0e8d", ATTR{idProduct}=="0003", MODE="0660", TAG+="uaccess"`,
+	`SUBSYSTEM=="usb", ATTR{idVendor}=="0403", MODE="0660", TAG+="uaccess"`,
+}
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "mtk-genio-usb",
+		summary:               mtkGenioUsbSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  mtkGenioUsbBaseDeclarationSlots,
+		connectedPlugAppArmor: mtkGenioUsbConnectedPlugAppArmor,
+		connectedPlugUDev:     mtkGenioUsbConnectedPlugUDev,
+	})
+}

--- a/interfaces/builtin/mtk_genio_usb.go
+++ b/interfaces/builtin/mtk_genio_usb.go
@@ -23,6 +23,7 @@ const mtkGenioUsbSummary = `Udev rules for Mediatek Genio USB devices`
 // Interface: mtk-genio-usb
 //
 // The mtk-genio-usb interface allows access to MediaTek Genio boards via USB.
+// Mediatek Genio tools environment setup: https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/get-started/env-setup/flash-env-linux.html#usb-device-rules
 
 const mtkGenioUsbBaseDeclarationSlots = `
   mtk-genio-usb:

--- a/interfaces/builtin/mtk_genio_usb_test.go
+++ b/interfaces/builtin/mtk_genio_usb_test.go
@@ -1,0 +1,140 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type mtkGenioUsbSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+const mtkGenioUsbMockPlugSnapInfoYaml = `name: genio
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [mtk-genio-usb]
+`
+
+const mtkGenioUsbCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  mtk-genio-usb:
+`
+
+var _ = Suite(&mtkGenioUsbSuite{
+	iface: builtin.MustInterface("mtk-genio-usb"),
+})
+
+func (s *mtkGenioUsbSuite) SetUpTest(c *C) {
+	s.slot, s.slotInfo = MockConnectedSlot(c, mtkGenioUsbCoreYaml, nil, "mtk-genio-usb")
+	s.plug, s.plugInfo = MockConnectedPlug(c, mtkGenioUsbMockPlugSnapInfoYaml, nil, "mtk-genio-usb")
+}
+
+func (s *mtkGenioUsbSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "mtk-genio-usb")
+}
+
+func (s *mtkGenioUsbSuite) TestUsedSecuritySystems(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
+
+	appSet, err = interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	seccompSpec := seccomp.NewSpecification(appSet)
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.Snippets(), HasLen, 0)
+}
+
+func (s *mtkGenioUsbSuite) TestConnectedPlugSnippet(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	apparmorSpec := apparmor.NewSpecification(appSet)
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.genio.app"})
+
+	appSet, err = interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	seccompSpec := seccomp.NewSpecification(appSet)
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string(nil))
+}
+
+func (s *mtkGenioUsbSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *mtkGenioUsbSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *mtkGenioUsbSuite) TestUDevConnectedPlug(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := udev.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 4)
+	c.Assert(spec.Snippets(), testutil.Contains, `# mtk-genio-usb
+SUBSYSTEM=="usb", ATTR{idVendor}=="0e8d", ATTR{idProduct}=="201c", MODE="0660", TAG+="uaccess", TAG+="snap_genio_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# mtk-genio-usb
+SUBSYSTEM=="usb", ATTR{idVendor}=="0e8d", ATTR{idProduct}=="0003", MODE="0660", TAG+="uaccess", TAG+="snap_genio_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# mtk-genio-usb
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", MODE="0660", TAG+="uaccess", TAG+="snap_genio_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
+		`TAG=="snap_genio_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_genio_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *mtkGenioUsbSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `Udev rules for Mediatek Genio USB devices`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "allow-installation:")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "slot-snap-type:")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *mtkGenioUsbSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -149,6 +149,9 @@ apps:
   mpris:
     command: bin/run
     plugs: [ mpris ]
+  mtk-genio-usb:
+    command: bin/run
+    plugs: [ mtk-genio-usb ]
   multipass-support:
     command: bin/run
     plugs: [ multipass-support ]


### PR DESCRIPTION
This PR introduces a new `mtk-genio-usb` interface to support MediaTek Genio development boards.

Developed in collaboration between Canonical Partner Engineering and the MediaTek Genio team, this interface improves the out-of-box experience for developers using flashing and development tools.

The interface grants access to specific USB devices via udev rules. Auto-connection is denied by default for security considerations.

The functionality has been tested on real hardware.