### PR TITLE
tests: allow for not finding snap type in feature tagging

### DIFF
--- a/tests/utils/features/state.py
+++ b/tests/utils/features/state.py
@@ -99,7 +99,8 @@ class State:
             return self.state[DATA][SNAPS][snap_name][TYPE]
         for task in self.state[TASKS].values():
             if _keys_in_dict(task, DATA, SNAP_SETUP, SIDE_INFO, NAME) \
-                    and task[DATA][SNAP_SETUP][SIDE_INFO][NAME] == snap_name:
+                    and task[DATA][SNAP_SETUP][SIDE_INFO][NAME] == snap_name \
+                    and _keys_in_dict(task, DATA, SNAP_SETUP, TYPE):
                 return task[DATA][SNAP_SETUP][TYPE]
 
         return "NOT_FOUND: {}".format(snap_name)


### PR DESCRIPTION
There are some tests that are missing tasks/changes in their state.json:

- core/config-defaults-once
- core/custom-device-reg
- core/gadget-config-defaults-to-snaps
- core/gadget-config-defaults-vitality
- core/remodel
- main/disk-space-awareness
- main/generic-unregister
- main/snap-mgmt
- nested/manual/minimal-smoke

Rather than killing feature tagging, this change will add the string 'NOT FOUND' as the snap type.