### PR TITLE
interfaces,cmd: disallow O_NOTIFICATION_PIPE

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -26,6 +26,7 @@ package main
 //#include <asm/ioctls.h>
 //#include <ctype.h>
 //#include <errno.h>
+//#include <fcntl.h>
 //#include <linux/can.h>
 //#include <linux/netlink.h>
 //#include <sched.h>
@@ -476,6 +477,13 @@ var seccompResolver = map[string]uint64{
 	"KCMP_IO":        C.KCMP_IO,
 	"KCMP_SYSVSEM":   C.KCMP_SYSVSEM,
 	"KCMP_EPOLL_TFD": C.KCMP_EPOLL_TFD,
+
+	// man 2 pipe
+	// This is not using O_NOTIFICATION_PIPE becauses Go 1.18 has issues with Cgo
+	// resolving a define-to-define that is fixed in more recent versions.
+	// The macro O_NOTIFICATION_PIPE is just O_EXCL and is fixed for ABI compatibility.
+	//  see: https://elixir.bootlin.com/linux/v6.5.13/source/include/uapi/linux/watch_queue.h#L9
+	"O_NOTIFICATION_PIPE": C.O_EXCL,
 }
 
 // DpkgArchToScmpArch takes a dpkg architecture and converts it to

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -847,6 +847,21 @@ func (s *snapSeccompSuite) TestRestrictionsWorkingArgsTermios(c *C) {
 	}
 }
 
+func (s *snapSeccompSuite) TestRestrictionsWorkingPipe2(c *C) {
+	for _, t := range []struct {
+		seccompAllowlist string
+		bpfInput         string
+		expected         int
+	}{
+		// good input
+		{"pipe2 - |O_NOTIFICATION_PIPE", "pipe2;native;-,O_NOTIFICATION_PIPE", Allow},
+		// bad input
+		{"pipe2 - |O_NOTIFICATION_PIPE", "quotactl;native;-,99", Deny},
+	} {
+		s.runBpf(c, t.seccompAllowlist, t.bpfInput, t.expected)
+	}
+}
+
 func (s *snapSeccompSuite) TestRestrictionsWorkingArgsUidGid(c *C) {
 	// while 'root' user usually has uid 0, 'daemon' user uid may vary
 	// across distributions, best lookup the uid directly

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -320,6 +320,7 @@ openat
 pause
 personality
 pipe
+~pipe2 - |O_NOTIFICATION_PIPE
 pipe2
 poll
 ppoll

--- a/tests/main/snap-seccomp-blocks-pipe-notifications/task.yaml
+++ b/tests/main/snap-seccomp-blocks-pipe-notifications/task.yaml
@@ -1,0 +1,23 @@
+summary: Ensure that the snap-seccomp blocks O_NOTIFICATION_PIPE flag to pipe2
+
+details: |
+    Check that it is not allowed to create a special kernel notification pipe.
+    Verify snap-seccomp generated a profile which results in "Operation not
+    permitted" message when pipe2 system call is used.
+
+# ubuntu-core: excluded because there is no gcc there
+systems: [-ubuntu-core-*]
+
+prepare: |
+    echo "Install a helper snap (for seccomp confinement testing)"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+    echo "Compile and prepare the test programs"
+    # Because we use the snap data directory we don't need to clean it up
+    # manually as all snaps and their data are reset after each test.
+    # Build the test binary statically, as it will be running inside a base with
+    # potentially older glibc.
+    gcc -static -Wall -Wextra -Werror ./test.c -o /var/snap/test-snapd-sh/common/test
+
+execute: |
+    snap run test-snapd-sh.sh -c "\$SNAP_COMMON/test" 2>&1 | MATCH 'pipe2: Permission denied'

--- a/tests/main/snap-seccomp-blocks-pipe-notifications/test.c
+++ b/tests/main/snap-seccomp-blocks-pipe-notifications/test.c
@@ -1,0 +1,17 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/fcntl.h>
+
+int main(void) {
+  int fd[2];
+  // O_EXCL is O_NOTIFICATION_PIPE. Even if the kernel does not support it,
+  // the seccomp filter is expected to reject it.
+  if (pipe2(fd, O_EXCL|O_CLOEXEC) < 0) {
+    perror("pipe2");
+    return 1;
+  }
+  close(fd[0]);
+  close(fd[1]);
+  return 0;
+}


### PR DESCRIPTION
Linux 5.8 has added yet another method of obtaining events from the kernel. This time, in the form of a flag to the pipe2 system call. An LWN.net article [1] goes into all the details and is recommended reading.

Mozilla has similarly discovered this and patched it [2] in the Firefox sandbox.

The snap-seccomp entry uses O_EXCL as O_NOTIFICATION_PIPE as including the actual header <linux/watch_queue.h> causes type definition errors.
```
In file included from /usr/include/asm/fcntl.h:1,
                 from /usr/include/linux/fcntl.h:5,
                 from /usr/include/linux/watch_queue.h:6,
                 from cmd/snap-seccomp/main.go:209:
/usr/include/asm-generic/fcntl.h:157:1: error: redefinition of struct or union 'struct f_owner_ex'
  157 | };
      | ^
In file included from /usr/include/bits/fcntl.h:61,
                 from /usr/include/fcntl.h:35,
                 from /usr/include/xfs/linux.h:29,
                 from /usr/include/xfs/xfs.h:9,
                 from /usr/include/xfs/xqm.h:9,
                 from cmd/snap-seccomp/main.go:56:
/usr/include/bits/fcntl-linux.h:276:8: note: originally defined here
  276 | struct f_owner_ex
      |        ^~~~~~~~~~
/usr/include/asm-generic/fcntl.h:217:1: error: redefinition of struct or union 'struct flock64'
  217 | };
      | ^
/usr/include/bits/fcntl.h:50:8: note: originally defined here
   50 | struct flock64
      |        ^~~~~~~
FAIL	github.com/snapcore/snapd/cmd/snap-seccomp [build failed]
```

[1] https://lwn.net/Articles/760714/
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1808320

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34990

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
