### PR TITLE
o/snapstate: temporarily disable rerefresh on prereq updates

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -450,6 +450,15 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 		return nil, err
 	}
 
+	// TODO: as a temporary workaround for a bug that occurs when a snap updates
+	// a prereq, we disable rerefreshes.
+	//
+	// specifically, if the snap that pulls in the prereq contains a configure hook
+	// that creates some tasks via snapctl, then those tasks will end up waiting
+	// on the check-rerefresh task for the updated prereq. the check-rerefresh
+	// task panics if any tasks are found to be waiting on it.
+	flags.NoReRefresh = true
+
 	// default provider is missing some content tags (likely outdated) so update it
 	ts, err := UpdateWithDeviceContext(st, snapName, nil, userID, flags, nil, deviceCtx, "")
 	if err != nil {

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -995,6 +995,12 @@ func (s *prereqSuite) TestPreReqContentAttrsNotSatisfied(c *C) {
 	c.Check(chg.Tasks()[0].Kind(), Equals, "prerequisites")
 	c.Check(chg.Tasks()[0].Status(), Equals, state.DoneStatus)
 	c.Check(chg.Tasks()[0].Log(), HasLen, 0)
+
+	// TODO: this check is here to verify that we're disabling rerefreshes when
+	// updating prereqs. should be removed when we change that behavior.
+	for _, t := range chg.Tasks() {
+		c.Assert(t.Kind(), Not(Equals), "check-rerefresh")
+	}
 }
 
 func (s *prereqSuite) TestPreReqContentAttrsNotSatisfiedSeeding(c *C) {


### PR DESCRIPTION
This fixes a bug reported by @bugraaydogar:

Bug scenario:
* Installing a snap that updates a prereq (in our case, chromium requires a cups update):
  * Creates another set of update tasks, including a `check-rerefresh` task for the prereq. Adds them all to the change for the snap installation.
* Snap being installed has a configure hook that creates tasks (chromium's configure hook has a `snapctl stop chromium.daemon`):
  * Tasks created by the hook are added to the change that is installing the snap
  * Tasks created by the hook wait on all other tasks in the change, including the `check-rerefresh` for the prereq
  * `check-rerefresh` task explicitly panics if any tasks are waiting on it