### PR TITLE
packaging: fix building on Fedora with dpkg installed

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -63,8 +63,9 @@ fi
 # at this point we maybe in _build/src/github etc where we have no
 # debian/changelog (dh-golang only exports the sources here)
 # switch to the real source dir for the changelog parsing
-if command -v dpkg-parsechangelog >/dev/null; then
-    version_from_changelog="$(cd "$PKG_BUILDDIR"; dpkg-parsechangelog --show-field Version)";
+: "${DPKG_PARSECHANGELOG-$(command -v dpkg-parsechangelog)}"
+if [ -n "$DPKG_PARSECHANGELOG" ]; then
+    version_from_changelog="$(cd "$PKG_BUILDDIR"; "$DPKG_PARSECHANGELOG" --show-field Version)";
 fi
 
 # select version based on priority

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -542,7 +542,7 @@ export GO111MODULE=off
 %endif
 
 # Generate version files
-./mkversion.sh "%{version}-%{release}"
+DPKG_PARSECHANGELOG="" ./mkversion.sh "%{version}-%{release}"
 
 # see https://github.com/gofed/go-macros/blob/master/rpm/macros.d/macros.go-compilers-golang
 BUILDTAGS=


### PR DESCRIPTION
This prevents dpkg-parsechangelog from being used, even if installed.
