### PR TITLE
interfaces/backends: leave udev backend when preseeding

### DIFF
--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/logger"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/snapdenv"
 	systemd_tools "github.com/snapcore/snapd/systemd"
 )
 
@@ -69,7 +70,10 @@ func All() []interfaces.SecurityBackend {
 	// without understanding the consequences, switch the container to
 	// privileged mode. In this mode udev does start inside the container, but
 	// actively configures devices on the host with undesirable consequences.
-	if !systemd_tools.IsContainer() {
+	//
+	// But we want the backend active when preseeding so preseeded images
+	// actually have the files in /var/lib/snapd/cgroup.
+	if !systemd_tools.IsContainer() || snapdenv.Preseeding() {
 		all = append(all, &udev.Backend{})
 	}
 

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -83,6 +84,23 @@ func (s *backendsSuite) TestUdevInContainers(c *C) {
 
 	defer cmd.Restore()
 	c.Assert(backendNames(backends.All()), Not(testutil.Contains), "udev")
+}
+
+func (s *backendsSuite) TestUdevPreseedingInContainers(c *C) {
+	cmd := testutil.MockCommand(c, "systemd-detect-virt", `
+	for arg in "$@"; do
+		if [ "$arg" = --container ]; then
+			exit 0
+		fi
+	done
+
+	exit 1
+	`)
+	restore := snapdenv.MockPreseeding(true)
+	defer restore()
+
+	defer cmd.Restore()
+	c.Assert(backendNames(backends.All()), testutil.Contains, "udev")
 }
 
 func (s *backendsSuite) TestUdevNotInContainers(c *C) {


### PR DESCRIPTION
When running a preseeding change we want the udev backend to exist even if running on a container so the related configuration files can be generated.

Backport from https://github.com/canonical/snapd/pull/15411