### PR TITLE
github: workaround valgrind 3.25 and glib test suite

### DIFF
--- a/.github/workflows/unit-tests-cross-distro.yaml
+++ b/.github/workflows/unit-tests-cross-distro.yaml
@@ -47,6 +47,9 @@ jobs:
             dnf install -y python3-beautifulsoup4 # required by release-tools
             dnf install -y python3-debian # required by release-tools
             dnf install -y python3-flake8 # required by release-tools
+            # TODO drop; workaround for valgrind 3.25 causing EINVAL in
+            # glib test subprocess and thus failing the unit tests
+            dnf remove -y valgrind
             ;;
         opensuse/*)
             zypper --non-interactive dup -y


### PR DESCRIPTION
We have observed valgrind 3.25 to cause a failure in unit tests:

not ok /cgroup/v2/own_path_full_die - GLib-FATAL-ERROR: g_test_trap_subprocess() failed: Failed to close file descriptor for child process (Invalid argument) Bail out!
==406847==
==406847== Process terminating with default action of signal 5 (SIGTRAP): dumping core
==406847==    at 0x493A9DB: UnknownInlinedFun (gmessages.c:434)
==406847==    by 0x493A9DB: g_logv (gmessages.c:1287)
==406847==    by 0x493AC53: g_log (gmessages.c:1329)
==406847==    by 0x49666EF: g_test_trap_subprocess_with_envp (gtestutils.c:4190)
==406847==    by 0x4005D99: _test_sc_cgroupv2_own_group_path_die_with_message (cgroup-support-test.c:290)
==406847==    by 0x4965376: UnknownInlinedFun (gtestutils.c:3115)
==406847==    by 0x4965376: g_test_run_suite_internal (gtestutils.c:3210)
==406847==    by 0x496528A: g_test_run_suite_internal (gtestutils.c:3229)
==406847==    by 0x496528A: g_test_run_suite_internal (gtestutils.c:3229)
==406847==    by 0x496587A: g_test_run_suite (gtestutils.c:3307)
==406847==    by 0x4965971: UnknownInlinedFun (gtestutils.c:2379)
==406847==    by 0x4965971: g_test_run (gtestutils.c:2366)
==406847==    by 0x4004768: main (unit-tests-main.c:19)
==406847==
==406847== HEAP SUMMARY:
==406847==     in use at exit: 44,611 bytes in 645 blocks
==406847==   total heap usage: 1,912 allocs, 1,267 frees, 321,986 bytes allocated

The patch adds a temporary workaround to unblock merging to master.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
