### PR TITLE
tests: make sure the state lock reports are always generated

### DIFF
--- a/.github/workflows/weekly-state-locks.yaml
+++ b/.github/workflows/weekly-state-locks.yaml
@@ -37,7 +37,7 @@ jobs:
   create-reports:
     runs-on: ubuntu-latest
     needs: [run-spread-tests]
-    if: ${{ always() }}
+    if: always()
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/weekly-state-locks.yaml
+++ b/.github/workflows/weekly-state-locks.yaml
@@ -37,6 +37,7 @@ jobs:
   create-reports:
     runs-on: ubuntu-latest
     needs: [run-spread-tests]
+    if: ${{ always() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Even when the tests fail, the state locks reports have to be generated.
