### PR TITLE
github: add the ability to skip spread tests

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -55,7 +55,7 @@ on:
         required: false
         default: false
       skip-tests:
-        description: 'Space-separated list of regex expressions identifying tests to skip'
+        description: 'Space-separated list of regex expressions identifying tests to skip. As a regex, they can identify any part of the spread test like an entire suite or a single test. End a single test with $ to avoid inadvertently matching others.'
         required: false
         type: string
 
@@ -300,10 +300,10 @@ jobs:
           fi
 
           spread_list="$($SPREAD -list $RUN_TESTS 2>&1 || true)"
-          for test in ${{ inputs.skip-tests }}; do
-            spread_list=$(echo "$spread_list" | tr ' ' '\n' | grep -vE "$test" | tr '\n' ' ')
-          done
           if [ -n "${{ inputs.skip-tests }}" ]; then
+            for test in ${{ inputs.skip-tests }}; do
+              spread_list=$(echo "$spread_list" | tr ' ' '\n' | grep -vE "$test" | tr '\n' ' ')
+            done
             export RUN_TESTS=$spread_list
             echo RUN_TESTS="$RUN_TESTS"  >> $GITHUB_ENV
           fi

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -54,6 +54,10 @@ on:
         type: boolean
         required: false
         default: false
+      skip-tests:
+        description: 'Space-separated list of regex expressions identifying tests to skip'
+        required: false
+        type: string
 
 
 jobs:
@@ -296,6 +300,19 @@ jobs:
           fi
 
           spread_list="$($SPREAD -list $RUN_TESTS 2>&1 || true)"
+          for test in ${{ inputs.skip-tests }}; do
+            spread_list=$(echo "$spread_list" | tr ' ' '\n' | grep -vE "$test" | tr '\n' ' ')
+          done
+          if [ -n "${{ inputs.skip-tests }}" ]; then
+            export RUN_TESTS=$spread_list
+            echo RUN_TESTS="$RUN_TESTS"  >> $GITHUB_ENV
+          fi
+
+          # If all spread tests are skipped, exit
+          if [ -z "$RUN_TESTS" ]; then
+            echo "All tests are skipped, exiting..."
+            exit 0
+          fi
 
           if [[ "$spread_list" =~ amazon-linux-2023 ]]; then
               # Amazon Linux 2023 has no xdelta, however we cannot disable

--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -18,7 +18,7 @@ on:
       skip-tests:
         type: string
         description: 'Filters out all matches for each space-separated regex expression when running spread tests'
-        default: 'ubuntu-14.04-64 tests/lib/ tests/unit/ core/persistent-journal manual/snapd-refresh-from-old'
+        default: 'ubuntu-14.04-64 tests/lib/ tests/unit/ manual/snapd-refresh-from-old$ core/persistent-journal'
 
 jobs:
   set-inputs:

--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -15,6 +15,10 @@ on:
       run-one-system:
         type: string
         description: 'When set, will only run this system in spread'
+      skip-tests:
+        type: string
+        description: 'Filters out all matches for each space-separated regex expression when running spread tests'
+        default: 'ubuntu-14.04-64 tests/lib/ tests/unit/ core/persistent-journal manual/snapd-refresh-from-old'
 
 jobs:
   set-inputs:
@@ -23,6 +27,7 @@ jobs:
       features: ${{ steps.set-inputs.outputs.features }}
       maximum-reruns: ${{ steps.set-inputs.outputs.maximum-reruns }}
       run-one-system: ${{ steps.set-inputs.outputs.run-one-system }}
+      skip-tests: ${{ steps.set-inputs.outputs.skip-tests }}
     steps:
       - name: Set inputs
         id: set-inputs
@@ -30,6 +35,7 @@ jobs:
           echo "features=${{ inputs.features || 'all' }}" >> $GITHUB_OUTPUT
           echo "maximum-reruns=${{ inputs.maximum-reruns || 2 }}" >> $GITHUB_OUTPUT
           echo "run-one-system=${{ inputs.run-one-system || '' }}" >> $GITHUB_OUTPUT
+          echo "skip-tests=${{ inputs.skip-tests || '' }}" >> $GITHUB_OUTPUT
 
   read-systems:
     runs-on: ubuntu-latest
@@ -87,6 +93,7 @@ jobs:
       use-snapd-snap-from-master: true
       spread-env: "SPREAD_TAG_FEATURES=1"
       upload-artifacts: true
+      skip-tests: ${{ needs.set-inputs.outputs.skip-tests }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.fundamental-systems) }}
@@ -106,6 +113,7 @@ jobs:
       use-snapd-snap-from-master: true
       spread-env: "SPREAD_TAG_FEATURES=1"
       upload-artifacts: true
+      skip-tests: ${{ needs.set-inputs.outputs.skip-tests }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}
@@ -125,6 +133,7 @@ jobs:
       use-snapd-snap-from-master: true
       spread-env: "SPREAD_TAG_FEATURES=1"
       upload-artifacts: true
+      skip-tests: ${{ needs.set-inputs.outputs.skip-tests }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-systems.outputs.nested-systems) }}


### PR DESCRIPTION
For feature tagging, some spread tests should simply be skipped.

There are some tests that are not compatible with feature tagging like `core/persistent-journal`, `core/persistent-journal-namespace` and `nested/manual/snapd-refresh-from-old`. Some test suites make no sense with feature tagging like `tests/lib` or `tests/unit` and should be skipped. Also artifact retrieval doesn't work on Trusty, so might as well just skip it.