### PR TITLE
udisks2: Allow chown capability

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -126,6 +126,8 @@ umount /{,run/}media/**,
 
 # Needed for probing raw devices
 capability sys_rawio,
+# And chown to be able to set permissions in folders created at /media
+capability chown,
 
 /run/ rw,
 /run/cryptsetup/{,**} rwk,
@@ -219,6 +221,7 @@ dbus (send)
 
 const udisks2PermanentSlotSecComp = `
 bind
+chown
 chown32
 fchown
 fchown32


### PR DESCRIPTION
The chown capability is required in the udisks2 slot to allow the daemon to mount devices for non-root users. This is required for core desktop systems.

This patch implements it.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
