### PR TITLE
packaging, data/systemd: enable snapd.apparmor on Fedora

### DIFF
--- a/data/selinux/snappy.fc
+++ b/data/selinux/snappy.fc
@@ -23,6 +23,7 @@ HOME_DIR/snap(/.*)?			gen_context(system_u:object_r:snappy_home_t,s0)
 /usr/bin/snap			--	gen_context(system_u:object_r:snappy_cli_exec_t,s0)
 /usr/bin/snapctl		--	gen_context(system_u:object_r:snappy_cli_exec_t,s0)
 
+# TODO add policy for snapd-apparmor?
 ifdef(`distro_redhat',`
 /usr/libexec/snapd/snapctl		--	gen_context(system_u:object_r:snappy_cli_exec_t,s0)
 /usr/libexec/snapd/snap-confine		--	gen_context(system_u:object_r:snappy_confine_exec_t,s0)

--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -24,6 +24,7 @@ RequiresMountsFor=/var/cache/apparmor /var/lib/snapd/apparmor/profiles
 [Service]
 Type=oneshot
 ExecStart=@libexecdir@/snapd/snapd-apparmor start
+EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 EnvironmentFile=-/var/lib/snapd/environment/snapd.conf
 RemainAfterExit=yes
 

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -65,7 +65,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target
+%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target
 %global snappy_user_svcs snapd.session-agent.service snapd.session-agent.socket
 
 # Until we have a way to add more extldflags to gobuild macro...
@@ -564,6 +564,7 @@ sed -e "s:github.com/snapcore/bolt:github.com/boltdb/bolt:g" -i advisor/*.go
 BUILDTAGS="${BUILDTAGS} nomanagers"
 %gobuild -o bin/snap $GOFLAGS %{import_path}/cmd/snap
 %gobuild -o bin/snap-failure $GOFLAGS %{import_path}/cmd/snap-failure
+%gobuild -o bin/snapd-apparmor $GOFLAGS %{import_path}/cmd/snapd-apparmor
 
 # To ensure things work correctly with base snaps,
 # snap-exec, snap-update-ns, and snapctl need to be built statically
@@ -674,6 +675,7 @@ install -p -m 0755 bin/snap-failure %{buildroot}%{_libexecdir}/snapd
 install -p -m 0755 bin/snapd %{buildroot}%{_libexecdir}/snapd
 install -p -m 0755 bin/snap-update-ns %{buildroot}%{_libexecdir}/snapd
 install -p -m 0755 bin/snap-seccomp %{buildroot}%{_libexecdir}/snapd
+install -p -m 0755 bin/snapd-apparmor %{buildroot}%{_libexecdir}/snapd
 # Ensure /usr/bin/snapctl is a symlink to /usr/libexec/snapd/snapctl
 install -p -m 0755 bin/snapctl %{buildroot}%{_libexecdir}/snapd/snapctl
 ln -sf %{_libexecdir}/snapd/snapctl %{buildroot}%{_bindir}/snapctl
@@ -731,10 +733,6 @@ rm -fv %{buildroot}%{_unitdir}/snapd.recovery-chooser-trigger.service
 # Remove snappy core specific scripts and binaries
 rm %{buildroot}%{_libexecdir}/snapd/snapd.core-fixup.sh
 rm %{buildroot}%{_libexecdir}/snapd/system-shutdown
-
-# Remove snapd apparmor service
-rm -f %{buildroot}%{_unitdir}/snapd.apparmor.service
-rm -f %{buildroot}%{_libexecdir}/snapd/snapd-apparmor
 
 # Remove gpio-chardev ordering target
 rm -f %{buildroot}%{_unitdir}/snapd.gpio-chardev-setup.target
@@ -831,6 +829,7 @@ make -C data -k check
 %{_libexecdir}/snapd/snap-failure
 %{_libexecdir}/snapd/info
 %{_libexecdir}/snapd/snap-mgmt
+%{_libexecdir}/snapd/snapd-apparmor
 %if 0%{?with_selinux}
 %{_libexecdir}/snapd/snap-mgmt-selinux
 %endif
@@ -849,6 +848,7 @@ make -C data -k check
 %{_unitdir}/snapd.autoimport.service
 %{_unitdir}/snapd.failure.service
 %{_unitdir}/snapd.seeded.service
+%{_unitdir}/snapd.apparmor.service
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
 %{_userunitdir}/snapd.session-agent.service


### PR DESCRIPTION
Fedora, CentOS and the likes do not use AppArmor natively, but when running when one of those distributions is running in a LXC container on an AppArmor enabled system, the apparmor state in /sys/kernel/security/apparmor is usually exposed inside the container. The native packages on those distributions are not apparmor-enabled, however after explicitly enabling reexec (via SNAP_REEXEC=1, ensuring the /snap symlink), one would now be running the apparmor-enabled binaries from the snapd snap which expect certain sandbox features to be present on an AppArmor capable host. Specifically, snap-confine from the snapd snap has strict checks that verify it is running under a dedicated AppArmor profile.

At this stage, one would usually be unable to progress further unless they can ensure that the container can load apparmor proifle somehow, which normallly requires the userspace tools to be present. However, with reexec enabled, we can use the snapd.apparmor.service (& snapd-apparmor internal tool) to invoke the vendored apparmor build shipped inside the snapd snap to load the profiles, provided we expose a consistent view of system overrides the tool.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Related: [SNAPDENG-34259](https://warthogs.atlassian.net/browse/SNAPDENG-34259)

[SNAPDENG-34259]: https://warthogs.atlassian.net/browse/SNAPDENG-34259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ