### PR TITLE
many: add raa debug command

### DIFF
--- a/cmd/snap/cmd_debug_raa.go
+++ b/cmd/snap/cmd_debug_raa.go
@@ -36,8 +36,8 @@ type cmdDebugRAA struct {
 
 func init() {
 	addDebugCommand("refresh-app-awareness",
-		"Obtain refresh-app-awareness details",
-		"obtain refresh-app-awareness details",
+		"(internal) list refresh-app-awareness details",
+		"(internal) list refresh-app-awareness details",
 		func() flags.Commander {
 			return &cmdDebugRAA{}
 		}, nil, nil)

--- a/cmd/snap/cmd_debug_raa.go
+++ b/cmd/snap/cmd_debug_raa.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+type cmdDebugRAA struct {
+	clientMixin
+	unicodeMixin
+}
+
+func init() {
+	addDebugCommand("raa",
+		"Obtain refresh-app-awareness details",
+		"obtain refresh-app-awareness details",
+		func() flags.Commander {
+			return &cmdDebugRAA{}
+		}, nil, nil)
+}
+
+type refreshCandidateInfo struct {
+	Revision  snap.Revision `json:"revision"`
+	Version   string        `json:"version,omitempty"`
+	Channel   string        `json:"channel,omitempty"`
+	Monitored bool          `json:"monitored,omitempty"`
+}
+
+func fmtMonitored(monitored bool) string {
+	if monitored {
+		return "Yes"
+	}
+	return "No"
+}
+
+func (x *cmdDebugRAA) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	var resp struct {
+		MonitoredSnaps    []string                        `json:"monitored-snaps,omitempty"`
+		RefreshCandidates map[string]refreshCandidateInfo `json:"refresh-candidates,omitempty"`
+	}
+	if err := x.client.DebugGet("raa", &resp, nil); err != nil {
+		return err
+	}
+
+	w := tabWriter()
+
+	fmt.Fprintf(w, "Monitored snaps:\n")
+	for _, snapName := range resp.MonitoredSnaps {
+		fmt.Fprintf(w, "- %s\n", snapName)
+	}
+
+	fmt.Fprintf(w, "\nRefresh candidates:\n")
+	fmt.Fprintf(w, "Name\tVersion\tRev\tChannel\tMonitored\n")
+
+	for snapName, candidate := range resp.RefreshCandidates {
+		// doing it this way because otherwise it's a sea of %s\t%s\t%s
+		line := []string{
+			snapName,
+			fmtVersion(candidate.Version),
+			candidate.Revision.String(),
+			fmtChannel(candidate.Channel),
+			fmtMonitored(candidate.Monitored),
+		}
+		fmt.Fprintln(w, strings.Join(line, "\t"))
+	}
+	w.Flush()
+
+	return nil
+}

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -370,6 +370,8 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		return getGadgetDiskMapping(st)
 	case "disks":
 		return getDisks(st)
+	case "raa":
+		return getRAAInfo(st)
 	default:
 		return BadRequest("unknown debug aspect %q", aspect)
 	}

--- a/daemon/api_debug_raa.go
+++ b/daemon/api_debug_raa.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type raaInfo struct {
+	MonitoredSnaps    []string                        `json:"monitored-snaps"`
+	RefreshCandidates map[string]refreshCandidateInfo `json:"refresh-candidates"`
+}
+
+type refreshCandidateInfo struct {
+	Revision  snap.Revision `json:"revision"`
+	Version   string        `json:"version,omitempty"`
+	Channel   string        `json:"channel,omitempty"`
+	Monitored bool          `json:"monitored,omitempty"`
+}
+
+// refreshCandidate is a subset of refreshCandidate defined by snapstate and
+// stored in "refresh-candidates" for unmarshalling.
+type refreshCandidate struct {
+	Version  string         `json:"version,omitempty"`
+	Channel  string         `json:"channel,omitempty"`
+	SideInfo *snap.SideInfo `json:"side-info,omitempty"`
+	// This is the persistent variant of "monitored-snaps" in the in-memory cache.
+	Monitored bool `json:"monitored,omitempty"`
+}
+
+func getMonitoringAborts(st *state.State) (map[string]context.CancelFunc, error) {
+	stored := st.Cached("monitored-snaps")
+	if stored == nil {
+		return nil, nil
+	}
+	aborts, ok := stored.(map[string]context.CancelFunc)
+	if !ok {
+		// NOTE: should never happen save for programmer error
+		return nil, fmt.Errorf(`internal error: "monitored-snaps" should be map[string]context.CancelFunc but got %T`, stored)
+	}
+	return aborts, nil
+}
+
+func getRAAInfo(st *state.State) Response {
+	monitoringAborts, err := getMonitoringAborts(st)
+	if err != nil {
+		return InternalError(err.Error())
+	}
+
+	var candidates map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &candidates); err != nil && !errors.Is(err, state.ErrNoState) {
+		return InternalError(err.Error())
+	}
+
+	data := &raaInfo{
+		MonitoredSnaps:    make([]string, 0, len(monitoringAborts)),
+		RefreshCandidates: make(map[string]refreshCandidateInfo, len(candidates)),
+	}
+	for snapName, candidate := range candidates {
+		candidateInfo := refreshCandidateInfo{
+			Revision:  candidate.SideInfo.Revision,
+			Version:   candidate.Version,
+			Channel:   candidate.Channel,
+			Monitored: candidate.Monitored,
+		}
+		data.RefreshCandidates[snapName] = candidateInfo
+	}
+	for snap := range monitoringAborts {
+		data.MonitoredSnaps = append(data.MonitoredSnaps, snap)
+	}
+	return SyncResponse(data)
+}

--- a/daemon/api_debug_raa.go
+++ b/daemon/api_debug_raa.go
@@ -68,6 +68,8 @@ func getMonitoringAborts(st *state.State) (map[string]context.CancelFunc, error)
 	return aborts, nil
 }
 
+var cgroupPidsOfSnap = cgroup.PidsOfSnap
+
 func getRAAInfo(st *state.State) Response {
 	monitoringAborts, err := getMonitoringAborts(st)
 	if err != nil {
@@ -93,7 +95,7 @@ func getRAAInfo(st *state.State) Response {
 		data.RefreshCandidates[snapName] = info
 	}
 	for snapName := range monitoringAborts {
-		pids, err := cgroup.PidsOfSnap(snapName)
+		pids, err := cgroupPidsOfSnap(snapName)
 		if err != nil {
 			return InternalError(err.Error())
 		}

--- a/daemon/api_debug_raa.go
+++ b/daemon/api_debug_raa.go
@@ -39,7 +39,7 @@ type monitoredSnapInfo struct {
 }
 
 type refreshCandidateInfo struct {
-	Revision  snap.Revision `json:"revision"`
+	Revision  snap.Revision `json:"revision,omitzero"`
 	Version   string        `json:"version,omitempty"`
 	Channel   string        `json:"channel,omitempty"`
 	Monitored bool          `json:"monitored,omitempty"`

--- a/daemon/export_api_debug_test.go
+++ b/daemon/export_api_debug_test.go
@@ -19,10 +19,21 @@
 
 package daemon
 
+import "github.com/snapcore/snapd/testutil"
+
 type (
 	ConnectivityStatus = connectivityStatus
+
+	RAAInfo              = raaInfo
+	MonitoredSnapInfo    = monitoredSnapInfo
+	RefreshCandidateInfo = refreshCandidateInfo
+	RefreshCandidate     = refreshCandidate
 )
 
 var (
 	MinLane = minLane
 )
+
+func MockCgroupPidsOfSnap(f func(instanceName string) (map[string][]int, error)) (restore func()) {
+	return testutil.Mock(&cgroupPidsOfSnap, f)
+}

--- a/tests/main/snap-debug-raa/task.yaml
+++ b/tests/main/snap-debug-raa/task.yaml
@@ -1,0 +1,60 @@
+summary: Ensure `snap debug refresh-app-awareness` command work
+
+details: |
+  The command `snap debug refresh-app-awareness` should report internal
+  snapd state related to refresh-app-awareness like a list of monitored
+  snaps and refresh candidates.
+
+# Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
+systems: [-ubuntu-14.04-*]
+
+prepare: |
+  # ensure no other refreshes interfere with the test
+  snap refresh
+
+  snap install test-snapd-sh
+  tests.cleanup defer snap remove --purge test-snapd-sh
+
+debug: |
+  cat debug.out || true
+
+execute: |
+  # make sure an app keeps the test snap busy
+  test-snapd-sh.sh -c 'exec sleep infinity' &
+  PID="$!"
+  # Note that test-snapd-sh has different revisions in stable and edge
+  snap switch --edge test-snapd-sh
+
+  # trigger auto-refresh
+  snap unset system refresh.hold
+  systemctl stop snapd.{service,socket}
+  "$TESTSTOOLS"/snapd-state force-autorefresh
+  systemctl start snapd.{socket,service}
+
+  # wait for snap to be monitored
+  retry -n 50 --wait 1 sh -c 'snap debug refresh-app-awareness | MATCH "Monitored snaps"'
+
+  snap debug refresh-app-awareness > debug.out
+  # sample output
+  # -------------
+  # Monitored snaps:
+  # Name           Security Tag           PID
+  # test-snapd-sh  snap.test-snapd-sh.sh  10435
+
+  # Refresh candidates:
+  # Name           Version  Rev  Channel      Monitored
+  # test-snapd-sh  1.0      7    latest/edge  Yes
+
+  sed '1q;d' debug.out | MATCH "^Monitored snaps:$"
+  sed '2q;d' debug.out | MATCH "^Name.*Security Tag.*PID$"
+  sed '3q;d' debug.out | MATCH "^test-snapd-sh.*snap.test-snapd-sh.sh.*$PID$"
+  # Skip newline
+  sed '5q;d' debug.out | MATCH "^Refresh candidates:$"
+  sed '6q;d' debug.out | MATCH "^Name.*Version.*Rev.*Channel.*Monitored$"
+  sed '7q;d' debug.out | MATCH "^test-snapd-sh.*latest/edge.*Yes$"
+
+  # trigger auto-refresh
+  kill "$PID"
+
+  # wait for snap to refresh and monitoring to be removed
+  retry -n 50 --wait 1 sh -c 'snap debug refresh-app-awareness | wc -l | MATCH "^0$"'

--- a/tests/main/snap-debug-raa/task.yaml
+++ b/tests/main/snap-debug-raa/task.yaml
@@ -13,7 +13,8 @@ prepare: |
   snap refresh
 
   snap install test-snapd-sh
-  tests.cleanup defer snap remove --purge test-snapd-sh
+  # retry is needed because we might need to wait for auto-refresh to finish first
+  tests.cleanup defer retry -n 50 --wait 1 snap remove --purge test-snapd-sh
 
 debug: |
   cat debug.out || true


### PR DESCRIPTION
This command would be helpful in debugging unexpected behavior of refresh-app-awareness by inspecting the snapd persistent and cached state.

Sample API `/v2/debug?aspect=raa`:
```json
{
  "result": {
    "monitored-snaps": {
      "firefox": {
        "pids": {
          "snap.firefox.firefox": [
            92960,
            93398,
            93413,
            93417,
            93450,
            93740,
            93749,
            93752,
            93758,
            96102,
            96196,
            115681,
            115738,
            115801
          ]
        }
      }
    },
    "refresh-candidates": {
      "firefox": {
        "channel": "latest/stable",
        "monitored": true,
        "revision": "6103",
        "version": "138.0.1-1"
      }
    }
  },
  "status": "OK",
  "status-code": 200,
  "type": "sync"
}
```

Sample command output:
```bash
Monitored snaps:
Name     Security Tag          PID
firefox  snap.firefox.firefox  92960
firefox  snap.firefox.firefox  93398
firefox  snap.firefox.firefox  93413
firefox  snap.firefox.firefox  93417
firefox  snap.firefox.firefox  93450
firefox  snap.firefox.firefox  93740
firefox  snap.firefox.firefox  93749
firefox  snap.firefox.firefox  93752
firefox  snap.firefox.firefox  93758
firefox  snap.firefox.firefox  96102
firefox  snap.firefox.firefox  96196

Refresh candidates:
Name     Version    Rev   Channel        Monitored
firefox  138.0.1-1  6103  latest/stable  Yes
```

Note: This is currently a draft PR (without unit tests) until the output structure is finalized.