### PR TITLE
asserts/signtool: format JSON in assertion bodies

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -124,6 +124,11 @@ func (at *AssertionType) AcceptablePrimaryKey(key []string) bool {
 	return true
 }
 
+// JSONBody returns true if the body for this assertion type must be JSON.
+func (at *AssertionType) JSONBody() bool {
+	return at.flags&jsonBody != 0
+}
+
 // Understood assertion types.
 var (
 	AccountType              = &AssertionType{"account", []string{"account-id"}, nil, assembleAccount, 0}

--- a/asserts/signtool/sign.go
+++ b/asserts/signtool/sign.go
@@ -122,10 +122,30 @@ func Sign(opts *Options, keypairMgr asserts.KeypairManager) ([]byte, error) {
 		}
 	}
 
+	if typ.JSONBody() && len(body) != 0 {
+		body, err = reformatJSON(body)
+		if err != nil {
+			return nil, fmt.Errorf("cannot reformat body: %v", err)
+		}
+	}
+
 	a, err := adb.Sign(typ, headers, body, opts.KeyID)
 	if err != nil {
 		return nil, err
 	}
 
 	return asserts.Encode(a), nil
+}
+
+func reformatJSON(raw []byte) ([]byte, error) {
+	var v map[string]interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal unformatted JSON: %v", err)
+	}
+
+	raw, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal into formatted JSON: %v", err)
+	}
+	return raw, nil
 }


### PR DESCRIPTION
In order to keep assertions readable and consistent, we require the JSON in an assertion body (e.g., confdb-schema) to be indented with two spaces per level and have all object keys sorted.
This change makes the signtool reformat assertion bodies. This makes the UX of writing and signing an assertion (whether with snapcraft or snap sign) much better, since it can be difficult to get the format right "by hand".