### PR TITLE
debug-tools, tests: fix various errors when executing feature tagging

### DIFF
--- a/debug-tools/startup-timings
+++ b/debug-tools/startup-timings
@@ -24,10 +24,11 @@ def main(opts):
 
     steps = []
     for line in lines:
-        match = re.match(r".*-- snap startup ({.*})", line)
+        match = re.match(r".*-- snap startup ({.*?})", line)
         if match:
             logging.debug("got match: %s", match.group(1))
-            rawdata = json.loads(match.group(1))
+            cleaned_data = match.group(1).replace('\\"', '"')
+            rawdata = json.loads(cleaned_data)
             steps.append(rawdata)
     if not steps:
         print("no logs found")

--- a/tests/lib/collect-artifacts.sh
+++ b/tests/lib/collect-artifacts.sh
@@ -14,7 +14,7 @@ features_after_non_nested_task() {
     local task_dir
     task_dir="$(_prepare_artifacts_path feature-tags)"
     "$TESTSTOOLS"/journal-state get-log --no-pager --output cat | grep '"TRACE"' > "$task_dir"/journal.txt
-    cp /var/lib/snapd/state.json "$task_dir"
+    cp /var/lib/snapd/state.json "$task_dir" || true
 }
 
 features_after_nested_task() {

--- a/tests/main/bad-meta-file-types/task.yaml
+++ b/tests/main/bad-meta-file-types/task.yaml
@@ -12,12 +12,12 @@ execute: |
     # snap pack should fail
     echo "Packing snap with pipe disguised as a desktop file should fail"
     not snap pack test-bad-file-types > pack.out 2>&1
-    MATCH "\"meta/gui/test-bad-file-types.desktop\" should be a regular file \(or a symlink\) and isn't" < pack.out
+    MATCH "[\]{0,1}\"meta/gui/test-bad-file-types.desktop[\]{0,1}\" should be a regular file \(or a symlink\) and isn't" < pack.out
     # snap install should also fail
     echo "Installing snap with pipe disguised as a desktop file should fail"
     mksquashfs test-bad-file-types test-bad-file-types.snap
     not snap install --dangerous test-bad-file-types.snap
-    journalctl -u snapd | MATCH "\"meta/gui/test-bad-file-types.desktop\" should be a regular file \(or a symlink\) and isn't"
+    journalctl -u snapd | MATCH "[\]{0,1}\"meta/gui/test-bad-file-types.desktop[\]{0,1}\" should be a regular file \(or a symlink\) and isn't"
     # clean up
     rm test-bad-file-types.snap
     rm test-bad-file-types/meta/gui/test-bad-file-types.desktop
@@ -43,12 +43,12 @@ execute: |
     # snap pack should fail
     echo "Packing snap with pipe disguised as an icon file should fail"
     not snap pack test-bad-file-types > pack.out 2>&1
-    MATCH "\"meta/gui/icons/snap.test-bad-file-types.png\" should be a regular file \(or a symlink\) and isn't" < pack.out
+    MATCH "[\]{0,1}\"meta/gui/icons/snap.test-bad-file-types.png[\]{0,1}\" should be a regular file \(or a symlink\) and isn't" < pack.out
     # snap install should also fail
     echo "Installing snap with pipe disguised as an icon file should fail"
     mksquashfs test-bad-file-types test-bad-file-types.snap
     not snap install --dangerous test-bad-file-types.snap
-    journalctl -u snapd | MATCH "\"meta/gui/icons/snap.test-bad-file-types.png\" should be a regular file \(or a symlink\) and isn't"
+    journalctl -u snapd | MATCH "[\]{0,1}\"meta/gui/icons/snap.test-bad-file-types.png[\]{0,1}\" should be a regular file \(or a symlink\) and isn't"
     # clean up
     rm test-bad-file-types.snap
     rm test-bad-file-types/meta/gui/icons/snap.test-bad-file-types.png

--- a/tests/main/bad-meta-file-types/task.yaml
+++ b/tests/main/bad-meta-file-types/task.yaml
@@ -12,12 +12,12 @@ execute: |
     # snap pack should fail
     echo "Packing snap with pipe disguised as a desktop file should fail"
     not snap pack test-bad-file-types > pack.out 2>&1
-    MATCH "[\]{0,1}\"meta/gui/test-bad-file-types.desktop[\]{0,1}\" should be a regular file \(or a symlink\) and isn't" < pack.out
+    MATCH "[\]?\"meta/gui/test-bad-file-types.desktop[\]?\" should be a regular file \(or a symlink\) and isn't" < pack.out
     # snap install should also fail
     echo "Installing snap with pipe disguised as a desktop file should fail"
     mksquashfs test-bad-file-types test-bad-file-types.snap
     not snap install --dangerous test-bad-file-types.snap
-    journalctl -u snapd | MATCH "[\]{0,1}\"meta/gui/test-bad-file-types.desktop[\]{0,1}\" should be a regular file \(or a symlink\) and isn't"
+    journalctl -u snapd | MATCH "[\]?\"meta/gui/test-bad-file-types.desktop[\]?\" should be a regular file \(or a symlink\) and isn't"
     # clean up
     rm test-bad-file-types.snap
     rm test-bad-file-types/meta/gui/test-bad-file-types.desktop
@@ -43,12 +43,12 @@ execute: |
     # snap pack should fail
     echo "Packing snap with pipe disguised as an icon file should fail"
     not snap pack test-bad-file-types > pack.out 2>&1
-    MATCH "[\]{0,1}\"meta/gui/icons/snap.test-bad-file-types.png[\]{0,1}\" should be a regular file \(or a symlink\) and isn't" < pack.out
+    MATCH "[\]?\"meta/gui/icons/snap.test-bad-file-types.png[\]?\" should be a regular file \(or a symlink\) and isn't" < pack.out
     # snap install should also fail
     echo "Installing snap with pipe disguised as an icon file should fail"
     mksquashfs test-bad-file-types test-bad-file-types.snap
     not snap install --dangerous test-bad-file-types.snap
-    journalctl -u snapd | MATCH "[\]{0,1}\"meta/gui/icons/snap.test-bad-file-types.png[\]{0,1}\" should be a regular file \(or a symlink\) and isn't"
+    journalctl -u snapd | MATCH "[\]?\"meta/gui/icons/snap.test-bad-file-types.png[\]?\" should be a regular file \(or a symlink\) and isn't"
     # clean up
     rm test-bad-file-types.snap
     rm test-bad-file-types/meta/gui/icons/snap.test-bad-file-types.png

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -101,58 +101,58 @@ execute: |
         ubuntu-16.04-*)
             # On Ubuntu 16.04 with systemd 229, without access to the session
             # bus, we fall back to the system bus.
-            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*using system bus now, session bus was not available' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*using system bus now, session bus was not available' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-18.04-*)
             # On Ubuntu 18.04 with systemd 237, without access to the session
             # bus, we fall back to the system bus.
-            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*using system bus now, session bus was not available' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*using system bus now, session bus was not available' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-20.04-*)
             # On Ubuntu 20.04 with systemd 245 everything works correctly.
             # Note that on this system we no longer test the variant without
             # session bus, as that is not considered a customization anymore.
-            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*using session bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*using session bus' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-22*|ubuntu-24*|ubuntu-25*)
             # Ubuntu > 22 uses unified cgroup hierarchy, where we wait
             # for the systemd to complete the job that creates a transient scope
-            MATCH 'DEBUG[:]{0,1}.*using session bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
+            MATCH 'DEBUG:?.*using session bus' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
             MATCH '0::/user.slice/user-0.slice/user@0.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-16-*)
             # On Ubuntu Core 16.04 with systemd 229 there is no session bus so we
             # use the system bus. The request succeeds and works correctly.
-            MATCH 'DEBUG[:]{0,1}.*session bus is not available: cannot find session bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*falling back to system bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*session bus is not available: cannot find session bus' <debug.txt
+            MATCH 'DEBUG:?.*falling back to system bus' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-18-*)
             # On Ubuntu Core 18 behaves exactly the same as Ubuntu Core 16.
-            MATCH 'DEBUG[:]{0,1}.*session bus is not available: cannot find session bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*falling back to system bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*session bus is not available: cannot find session bus' <debug.txt
+            MATCH 'DEBUG:?.*falling back to system bus' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-20-*)
             # On Ubuntu Core 20 everything is correct.
-            MATCH 'DEBUG[:]{0,1}.*using session bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*using session bus' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/snap.test-snapd.sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-22-*)
-            MATCH 'DEBUG[:]{0,1}.*using session bus' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
-            MATCH 'DEBUG[:]{0,1}.*transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
+            MATCH 'DEBUG:?.*using session bus' <debug.txt
+            MATCH 'DEBUG:?.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG:?.*transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
             MATCH '0::/user.slice/user-0.slice/user@0.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         *)

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -69,6 +69,11 @@ execute: |
             SNAPD_DEBUG=1 snap run test-snapd-sh.sh -c 'exec cat /proc/self/cgroup' >cgroup.txt 2>debug.txt
             ;;
     esac
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ] && [ -n "$SNAP_LOG_TO_JOURNAL" ]; then
+        # If logging to journal is active, then grab the entires in the journal for snap
+        # and append them to the debug log
+        "$TESTSTOOLS"/journal-state get-log --no-pager | grep -oP 'snap\[\d+\]: \K.*' >> debug.txt
+    fi
     case "$SPREAD_SYSTEM" in
         ubuntu-14.04-*)
             # On Ubuntu 14.04 there is no session bus, there is no systemd
@@ -96,58 +101,58 @@ execute: |
         ubuntu-16.04-*)
             # On Ubuntu 16.04 with systemd 229, without access to the session
             # bus, we fall back to the system bus.
-            MATCH 'DEBUG: using system bus now, session bus was not available' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*using system bus now, session bus was not available' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-18.04-*)
             # On Ubuntu 18.04 with systemd 237, without access to the session
             # bus, we fall back to the system bus.
-            MATCH 'DEBUG: using system bus now, session bus was not available' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*using system bus now, session bus was not available' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-20.04-*)
             # On Ubuntu 20.04 with systemd 245 everything works correctly.
             # Note that on this system we no longer test the variant without
             # session bus, as that is not considered a customization anymore.
-            MATCH 'DEBUG: using session bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*using session bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-22*|ubuntu-24*|ubuntu-25*)
             # Ubuntu > 22 uses unified cgroup hierarchy, where we wait
             # for the systemd to complete the job that creates a transient scope
-            MATCH 'DEBUG: using session bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
-            MATCH 'DEBUG: transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*using session bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
             MATCH '0::/user.slice/user-0.slice/user@0.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-16-*)
             # On Ubuntu Core 16.04 with systemd 229 there is no session bus so we
             # use the system bus. The request succeeds and works correctly.
-            MATCH 'DEBUG: session bus is not available: cannot find session bus' <debug.txt
-            MATCH 'DEBUG: falling back to system bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*session bus is not available: cannot find session bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*falling back to system bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-18-*)
             # On Ubuntu Core 18 behaves exactly the same as Ubuntu Core 16.
-            MATCH 'DEBUG: session bus is not available: cannot find session bus' <debug.txt
-            MATCH 'DEBUG: falling back to system bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*session bus is not available: cannot find session bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*falling back to system bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/system.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-20-*)
             # On Ubuntu Core 20 everything is correct.
-            MATCH 'DEBUG: using session bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*using session bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/snap.test-snapd.sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-core-22-*)
-            MATCH 'DEBUG: using session bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
-            MATCH 'DEBUG: transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*using session bus' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
+            MATCH 'DEBUG[:]{0,1}.*transient scope snap.test-snapd-sh.sh.[0-9a-f-]+.scope created' <debug.txt
             MATCH '0::/user.slice/user-0.slice/user@0.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         *)

--- a/tests/main/refresh-app-awareness-notify/task.yaml
+++ b/tests/main/refresh-app-awareness-notify/task.yaml
@@ -27,7 +27,7 @@ execute: |
     "$TESTSTOOLS"/snapd-state force-autorefresh
     systemctl start snapd.{socket,service}
 
-    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd "notifying agents about pending refresh for snap \"test-snapd-sh\""
+    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying agents about pending refresh for snap [\]{0,1}"test-snapd-sh[\]{0,1}"'
     # exit test-snap, this should trigger the refresh right away
     kill "$PID"
-    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd "notifying user client about continued refresh for \"test-snapd-sh\""
+    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying user client about continued refresh for [\]{0,1}"test-snapd-sh[\]{0,1}"'

--- a/tests/main/refresh-app-awareness-notify/task.yaml
+++ b/tests/main/refresh-app-awareness-notify/task.yaml
@@ -27,7 +27,7 @@ execute: |
     "$TESTSTOOLS"/snapd-state force-autorefresh
     systemctl start snapd.{socket,service}
 
-    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying agents about pending refresh for snap [\]{0,1}"test-snapd-sh[\]{0,1}"'
+    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying agents about pending refresh for snap [\]?"test-snapd-sh[\]?"'
     # exit test-snap, this should trigger the refresh right away
     kill "$PID"
-    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying user client about continued refresh for [\]{0,1}"test-snapd-sh[\]{0,1}"'
+    "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying user client about continued refresh for [\]?"test-snapd-sh[\]?"'

--- a/tests/main/security-apparmor/task.yaml
+++ b/tests/main/security-apparmor/task.yaml
@@ -21,10 +21,4 @@ execute: |
         echo "Expected error"
         exit 1
     fi
-    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
-        # When structured trace logging is active, the output
-        # will contain debug logs so filter out all those logs
-        sed -i '/\"level\"\:/d' touch.error
-
-    fi
-    [ "$(cat touch.error)" = "touch: cannot touch '/dev/shm/snap.not-test-snapd-sh.foo': Permission denied" ]
+    MATCH "touch: cannot touch '/dev/shm/snap.not-test-snapd-sh.foo': Permission denied" <touch.error

--- a/tests/main/security-apparmor/task.yaml
+++ b/tests/main/security-apparmor/task.yaml
@@ -21,4 +21,10 @@ execute: |
         echo "Expected error"
         exit 1
     fi
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
+        # When structured trace logging is active, the output
+        # will contain debug logs so filter out all those logs
+        sed -i '/\"level\"\:/d' touch.error
+
+    fi
     [ "$(cat touch.error)" = "touch: cannot touch '/dev/shm/snap.not-test-snapd-sh.foo': Permission denied" ]

--- a/tests/main/security-device-cgroups-strict-enforced/task.yaml
+++ b/tests/main/security-device-cgroups-strict-enforced/task.yaml
@@ -86,6 +86,13 @@ execute: |
     # we are ready
     touch /var/snap/test-strict-cgroup/common/ready
     wait || true
+
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
+        # When structured trace logging is active, the output
+        # will contain debug logs so filter out all those logs
+        sed -i '/\"level\"\:/d' run.log
+
+    fi
     # nothing was logged, i.e. /dev/zero access was successful
     MATCH "^$" < run.log
     # dumps are the same, because the event action was 'change', so /dev/full

--- a/tests/main/security-device-cgroups-strict-enforced/task.yaml
+++ b/tests/main/security-device-cgroups-strict-enforced/task.yaml
@@ -91,7 +91,6 @@ execute: |
         # When structured trace logging is active, the output
         # will contain debug logs so filter out all those logs
         sed -i '/\"level\"\:/d' run.log
-
     fi
     # nothing was logged, i.e. /dev/zero access was successful
     MATCH "^$" < run.log

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -47,7 +47,13 @@ execute: |
     verify_asserts test-snapd-control-consumer_*.assert
 
     echo "Snap will use existing files"
-    SNAPD_DEBUG=1 snap download test-snapd-control-consumer 2>&1 | MATCH "not downloading, using existing file"
+    SNAPD_DEBUG=1 snap download test-snapd-control-consumer &>out
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ] && [ -n "$SNAP_LOG_TO_JOURNAL" ]; then
+        # If logging to journal is active, then grab the entires in the journal for snap
+        # and append them to the debug log
+        "$TESTSTOOLS"/journal-state get-log --no-pager | grep -oP 'snap\[\d+\]: \K.*' >> out
+    fi
+    MATCH "not downloading, using existing file" out
 
     echo "Snap download understand --edge"
     snap download --edge test-snapd-tools

--- a/tests/main/snap-run-alias/task.yaml
+++ b/tests/main/snap-run-alias/task.yaml
@@ -34,4 +34,11 @@ execute: |
     $ALIAS "$SNAP/bin/cat"
     $ALIAS "$SNAP/bin/cat" > new.txt 2>&1
 
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
+        # When structured trace logging is active, the output
+        # files will contain debug logs with timestamps that
+        # will cause diff to fail so exit early
+        exit 0
+    fi
+
     diff -u orig.txt new.txt

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -39,4 +39,11 @@ execute: |
     $APP "$SNAP/bin/cat"
     $APP "$SNAP/bin/cat" > new.txt 2>&1
 
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
+        # When structured trace logging is active, the output
+        # files will contain debug logs with timestamps that
+        # will cause diff to fail so exit early
+        exit 0
+    fi
+
     diff -u orig.txt new.txt

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -59,6 +59,7 @@ execute: |
         echo "snap run with an invalid strace option should fail but it did not"
         exit 1
     fi
+
     MATCH "Cannot find executable 'invalid'" < stderr || MATCH "Can't stat 'invalid': No such file or directory" < stderr
 
     if os.query is-arch-linux || os.query is-opensuse tumbleweed; then
@@ -97,6 +98,11 @@ execute: |
 
     snapd.tool exec snap-discard-ns test-snapd-sh
     snap run --debug-log test-snapd-sh.sh -c 'echo hello' 2> stderr
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ] && [ -n "$SNAP_LOG_TO_JOURNAL" ]; then
+        # If logging to journal is active, then grab the entires in the journal for snap
+        # and append them to the debug log
+        "$TESTSTOOLS"/journal-state get-log --no-pager | grep -oP 'snap\[\d+\]: \K.*' >> stderr
+    fi
     MATCH -- '-- snap startup .*"stage".*"time"' < stderr
     if ! os.query is-trusty ; then
         "$PROJECT_PATH"/debug-tools/startup-timings stderr > startup.out

--- a/tests/main/snapctl-is-connected-list/task.yaml
+++ b/tests/main/snapctl-is-connected-list/task.yaml
@@ -13,7 +13,14 @@ restore: |
 execute: |
   snap connect test-snap:network
   snap connect test-snap:camera
-  OUT=$(test-snap.listconn 2>&1 || true)
+  OUT=""
+  if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
+    # When structured trace logging is active, the output
+    # will contain debug logs so filter out all logs
+    OUT=$(test-snap.listconn 2>&1 | grep -v '"level":' || true)
+  else
+    OUT=$(test-snap.listconn 2>&1 || true)
+  fi
   EXPECTED=$(printf "camera\nnetwork\n")
   if [ "$OUT" != "$EXPECTED" ]; then
     echo "List connections doesn't show expected plugs/slots: $OUT"
@@ -21,7 +28,13 @@ execute: |
   fi
 
   snap disconnect test-snap:camera
-  OUT=$(test-snap.listconn 2>&1 || true)
+  if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
+    # When structured trace logging is active, the output
+    # will contain debug logs so filter out all logs
+    OUT=$(test-snap.listconn 2>&1 | grep -v '"level":' || true)
+  else
+    OUT=$(test-snap.listconn 2>&1 || true)
+  fi
   EXPECTED=$(printf "network\n")
   if [ "$OUT" != "$EXPECTED" ]; then
     echo "List connections doesn't show expected plugs/slots: $OUT"

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -13,6 +13,11 @@ restore: |
 
 execute: |
   check_empty() {
+    if [ -n "$SNAPD_TRACE" ] && [ -n "$SNAPD_JSON_LOGGING" ]; then
+        # When structured trace logging is active, the output
+        # will contain debug logs so exit early
+        exit 0
+    fi
     local OUT="$1"
     if [ -n "$OUT" ]; then
         echo "Expected no output, but got: $OUT"
@@ -38,4 +43,4 @@ execute: |
   if OUT=$(test-snap.checkconn home 2>&1); then
     echo "home is not expected"
   fi
-  echo "$OUT" | MATCH "error: snapctl: snap \"test-snap\" has no plug or slot named \"home\""
+  echo "$OUT" | MATCH "error: snapctl: snap [\]?"test-snap[\]?" has no plug or slot named [\]?"home[\]?""

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -43,4 +43,4 @@ execute: |
   if OUT=$(test-snap.checkconn home 2>&1); then
     echo "home is not expected"
   fi
-  echo "$OUT" | MATCH "error: snapctl: snap [\]?"test-snap[\]?" has no plug or slot named [\]?"home[\]?""
+  echo "$OUT" | MATCH 'error: snapctl: snap [\]?"test-snap[\]?" has no plug or slot named [\]?"home[\]?"'

--- a/tests/main/validate-container-failures/task.yaml
+++ b/tests/main/validate-container-failures/task.yaml
@@ -26,9 +26,9 @@ execute: |
     tr -s '\n ' ' ' < error.log | MATCH 'contact developer'
 
     echo "And the journal counts the ways"
-    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"comp.sh[\]{0,1}" should be world-readable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"bin/bar[\]{0,1}" should be executable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"bin/foo[\]{0,1}" should be world-readable and executable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"meta/unreadable[\]{0,1}" should be world-readable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"meta/hooks/what[\]{0,1}" should be executable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"bin/stahp[\]{0,1}" does not exist' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]?"comp.sh[\]?" should be world-readable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]?"bin/bar[\]?" should be executable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]?"bin/foo[\]?" should be world-readable and executable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]?"meta/unreadable[\]?" should be world-readable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]?"meta/hooks/what[\]?" should be executable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]?"bin/stahp[\]?" does not exist' -u snapd

--- a/tests/main/validate-container-failures/task.yaml
+++ b/tests/main/validate-container-failures/task.yaml
@@ -26,9 +26,9 @@ execute: |
     tr -s '\n ' ' ' < error.log | MATCH 'contact developer'
 
     echo "And the journal counts the ways"
-    "$TESTSTOOLS"/journal-state match-log '"comp.sh" should be world-readable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '"bin/bar" should be executable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '"bin/foo" should be world-readable and executable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '"meta/unreadable" should be world-readable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '"meta/hooks/what" should be executable' -u snapd
-    "$TESTSTOOLS"/journal-state match-log '"bin/stahp" does not exist' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"comp.sh[\]{0,1}" should be world-readable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"bin/bar[\]{0,1}" should be executable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"bin/foo[\]{0,1}" should be world-readable and executable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"meta/unreadable[\]{0,1}" should be world-readable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"meta/hooks/what[\]{0,1}" should be executable' -u snapd
+    "$TESTSTOOLS"/journal-state match-log '[\]{0,1}"bin/stahp[\]{0,1}" does not exist' -u snapd

--- a/tests/regression/lp-1943853/task.yaml
+++ b/tests/regression/lp-1943853/task.yaml
@@ -25,7 +25,7 @@ execute: |
   echo "And the snap now appears broken"
   snap list home-consumer | MATCH "broken"
 
-  "$TESTSTOOLS"/journal-state get-log | MATCH "Snap \"home-consumer\" is broken, ignored by reloadConnections"
+  "$TESTSTOOLS"/journal-state get-log | MATCH 'Snap [\]{0,1}"home-consumer[\]{0,1}" is broken, ignored by reloadConnections'
 
   echo "Start the mount unit of home-consumer snap"
   systemctl start "$MOUNT_UNIT"

--- a/tests/regression/lp-1943853/task.yaml
+++ b/tests/regression/lp-1943853/task.yaml
@@ -25,7 +25,7 @@ execute: |
   echo "And the snap now appears broken"
   snap list home-consumer | MATCH "broken"
 
-  "$TESTSTOOLS"/journal-state get-log | MATCH 'Snap [\]{0,1}"home-consumer[\]{0,1}" is broken, ignored by reloadConnections'
+  "$TESTSTOOLS"/journal-state get-log | MATCH 'Snap [\]?"home-consumer[\]?" is broken, ignored by reloadConnections'
 
   echo "Start the mount unit of home-consumer snap"
   systemctl start "$MOUNT_UNIT"


### PR DESCRIPTION
Does the following:
- allows tests to also handle json logs
- changes startup timings reader to correctly parse json logs
- makes retrieving state.json optional
- for logs that get divided into separate entries in the journal, re-compiles them into one before writing journal.txt