### PR TITLE
interfaces: fix udev in containers without breaking pre-seed

### DIFF
--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -33,8 +33,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/logger"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/snapdenv"
-	systemd_tools "github.com/snapcore/snapd/systemd"
 )
 
 // All returns a set of all available security backends.
@@ -51,38 +49,13 @@ func All() []interfaces.SecurityBackend {
 		&systemd.Backend{},
 		&seccomp.Backend{},
 		&dbus.Backend{},
-	}
-
-	// Since snapd 2.68 the udev backend, responsible for writing udev rules to
-	// /etc/udev/rules.d and for calling udevadm control --reload-rules, as
-	// well as udevadm trigger (with a number of options), is no longer enabled
-	// in containers. System administrators retain ability to manage access to
-	// real devices at the container level.
-	//
-	// For context:
-	//
-	// In Linux, devices are _not_ namespace aware so if a device is accessible
-	// in the container (and the container manager has allowed such access)
-	// then allow snaps to freely poke the device subject to still-enforced
-	// apparmor rules. In "traditional" containers such as docker or podman,
-	// where using systemd is unusual and unsupported this doesn't change
-	// anything. In system containers such as lxd and incus users may, with or
-	// without understanding the consequences, switch the container to
-	// privileged mode. In this mode udev does start inside the container, but
-	// actively configures devices on the host with undesirable consequences.
-	//
-	// But we want the backend active when preseeding so preseeded images
-	// actually have the files in /var/lib/snapd/cgroup.
-	if !systemd_tools.IsContainer() || snapdenv.Preseeding() {
-		all = append(all, &udev.Backend{})
-	}
-
-	all = append(all, &mount.Backend{},
+		&udev.Backend{},
+		&mount.Backend{},
 		&kmod.Backend{},
 		&polkit.Backend{},
 		&ldconfig.Backend{},
 		&configfiles.Backend{},
-	)
+	}
 
 	// TODO use something like:
 	// level, summary := apparmor.ProbeResults()

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -71,21 +71,6 @@ func (s *backendsSuite) TestEssentialOrdering(c *C) {
 	c.Assert(sdIndex, testutil.IntLessThan, aaIndex)
 }
 
-func (s *backendsSuite) TestUdevInContainers(c *C) {
-	cmd := testutil.MockCommand(c, "systemd-detect-virt", `
-	for arg in "$@"; do
-		if [ "$arg" = --container ]; then
-			exit 0
-		fi
-	done
-
-	exit 1
-	`)
-
-	defer cmd.Restore()
-	c.Assert(backendNames(backends.All()), Not(testutil.Contains), "udev")
-}
-
 func (s *backendsSuite) TestUdevPreseedingInContainers(c *C) {
 	cmd := testutil.MockCommand(c, "systemd-detect-virt", `
 	for arg in "$@"; do
@@ -98,21 +83,6 @@ func (s *backendsSuite) TestUdevPreseedingInContainers(c *C) {
 	`)
 	restore := snapdenv.MockPreseeding(true)
 	defer restore()
-
-	defer cmd.Restore()
-	c.Assert(backendNames(backends.All()), testutil.Contains, "udev")
-}
-
-func (s *backendsSuite) TestUdevNotInContainers(c *C) {
-	cmd := testutil.MockCommand(c, "systemd-detect-virt", `
-	for arg in "$@"; do
-		if [ "$arg" = --container ]; then
-			exit 1
-		fi
-	done
-
-	exit 0
-	`)
 
 	defer cmd.Restore()
 	c.Assert(backendNames(backends.All()), testutil.Contains, "udev")

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -38,12 +38,14 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
 )
 
 // Backend is responsible for maintaining udev rules.
 type Backend struct {
-	preseed bool
+	preseed     bool
+	isContainer bool
 }
 
 // Initialize does nothing.
@@ -51,6 +53,27 @@ func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
 	if opts != nil && opts.Preseed {
 		b.preseed = true
 	}
+	// Since snapd 2.68 the udev backend, responsible for writing udev rules to
+	// /etc/udev/rules.d and for calling udevadm control --reload-rules, as
+	// well as udevadm trigger (with a number of options), is no longer enabled
+	// in containers. System administrators retain ability to manage access to
+	// real devices at the container level.
+	//
+	// For context:
+	//
+	// In Linux, devices are _not_ namespace aware so if a device is accessible
+	// in the container (and the container manager has allowed such access)
+	// then allow snaps to freely poke the device subject to still-enforced
+	// apparmor rules. In "traditional" containers such as docker or podman,
+	// where using systemd is unusual and unsupported this doesn't change
+	// anything. In system containers such as lxd and incus users may, with or
+	// without understanding the consequences, switch the container to
+	// privileged mode. In this mode udev does start inside the container, but
+	// actively configures devices on the host with undesirable consequences.
+	//
+	// But we want the backend active when preseeding so preseeded images
+	// actually have the files in /var/lib/snapd/cgroup.
+	b.isContainer = systemd.IsContainer()
 	return nil
 }
 

--- a/interfaces/udev/udev.go
+++ b/interfaces/udev/udev.go
@@ -61,7 +61,11 @@ func udevadmTrigger(args ...string) error {
 //	udevadm trigger --subsystem-match=input
 //	udevadm trigger --property-match=ID_INPUT_JOYSTICK=1
 func (b *Backend) reloadRules(subsystemTriggers []string) error {
-	if b.preseed {
+	// When running in a container observe the state of host's udev, as such
+	// reloading rules makes no sense, since they are ineffective.
+	// Similarly in preseeding, there is no point in reloading rules which
+	// only affect the runtime standbox.
+	if b.preseed || b.isContainer {
 		return nil
 	}
 

--- a/interfaces/udev/udev_test.go
+++ b/interfaces/udev/udev_test.go
@@ -35,11 +35,28 @@ func Test(t *testing.T) {
 
 type uDevSuite struct {
 	backend *udev.Backend
+	cmd     *testutil.MockCmd
 }
 
 var _ = Suite(&uDevSuite{})
 
 // Tests for ReloadRules()
+
+func (s *uDevSuite) SetUpSuite(c *C) {
+	s.cmd = testutil.MockCommand(c, "systemd-detect-virt", `
+       for arg in "$@"; do
+               if [ "$arg" = --container ]; then
+                       exit 1
+               fi
+       done
+
+       exit 0
+       `)
+}
+
+func (s *uDevSuite) TearDownSuite(c *C) {
+	s.cmd.Restore()
+}
 
 func (s *uDevSuite) SetUpTest(c *C) {
 	s.backend = &udev.Backend{}


### PR DESCRIPTION
Apologies to everyone affected. The udev backend was recently disabled in containers, with the patch 75e6f1d02d9fb204ee27b6ef4a56133b41c7e84c This worked fixed issues with snapd-inside-lxd that launchpad team exercises heavily but also broke snapd used for pre-seeding by the CPC team. The follow up b504599b84a6228040f653e3062e79b757f8d3ebi fixed pre-seeding but accidentally re-enabled udev in containers, breaking launchpad again.

This patch fixes both behaviors. The snapd udev backend is unconditionally enabled. When EITHER pre-seed mode is on, or when a container is detected then udev commands are not invoked but the files for udev ARE written.

**Agreed that we really want/need this in 2.70.**
