### PR TITLE
s/a/notify: add handling for kernel listener timeout and more logging

### DIFF
--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -58,7 +58,9 @@ func RegisterFileDescriptor(fd uintptr) (version ProtocolVersion, pendingCount i
 					// Listener probably timed out in the kernel, so remove the
 					// saved ID and retry registration
 					logger.Debug("kernel returned ENOENT from APPARMOR_NOTIF_REGISTER (listener probably timed out); removing saved listener ID and retrying")
-					removeSavedListenerID()
+					if e := removeSavedListenerID(); e != nil {
+						logger.Noticef("cannot remove saved listener ID: %v", e)
+					}
 					continue
 				}
 				return 0, 0, err


### PR DESCRIPTION
The kernel will return `ENOENT` on `APPARMOR_NOTIF_REGISTER` if the listener with the given ID does not exist, such as if the listener timed out. This PR adds handling for snapd to remove the saved listener ID and retry if it tries to register the listener with a saved ID and gets a `ENOENT` instead.
