### PR TITLE
interfaces/builtin: add OneSpan device and fix older device for u2f interface

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -200,7 +200,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "OneSpan DIGIPASS FX Series",
 		VendorIDPattern:  "1a44",
-		ProductIDPattern: "1501|1502|1503|1506|1507|1508|1509|150A",
+		ProductIDPattern: "1501|1502|1503|1506|1507|1508|1509|150a|150b",
 	},
 	{
 		Name:             "Arculus AuthentiKey",


### PR DESCRIPTION
This adds our new device and fixes the entry for the old device. Apparently, it needs lowercase letters.

OneSpan does not produce public documentation with our VID/PID, so I cannot link to it.