### PR TITLE
o/confdbstate: fetch confdb-schema assertion on access

### DIFF
--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -431,6 +431,19 @@ func autoRefreshConfdbAssertions(st *state.State, userID int, opts *RefreshAsser
 	return refreshConfdbAssertions(st, confdbSchemas, userID, opts)
 }
 
+// FetchConfdbSchemaAssertion fetches the confdb-schema assertion identified by
+// the account/name pair from the store and saves it to the db.
+func FetchConfdbSchemaAssertion(st *state.State, userID int, account, name string) error {
+	deviceCtx, err := snapstate.DevicePastSeeding(st, nil)
+	if err != nil {
+		return err
+	}
+
+	return doFetch(st, userID, deviceCtx, nil, func(f asserts.Fetcher) error {
+		return snapasserts.FetchConfdbSchema(f, account, name)
+	})
+}
+
 // refreshConfdbAssertions fetches new revisions for the assertions referenced
 // by the provided confdb schemas. It attempts a bulk refresh and if that
 // fails, it falls back to fetching the assertions one by one.

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5385,11 +5385,12 @@ func (s *assertMgrSuite) TestConfdb(c *C) {
     }
   }
 }`)
+
+	_, err = assertstate.ConfdbSchema(s.state, s.dev1Acct.AccountID(), "foo")
+	c.Assert(err, testutil.ErrorIs, &asserts.NotFoundError{})
+
 	err = assertstate.Add(s.state, confdbFoo)
 	c.Assert(err, IsNil)
-
-	_, err = assertstate.ConfdbSchema(s.state, "no-account", "foo")
-	c.Assert(err, testutil.ErrorIs, &asserts.NotFoundError{})
 
 	confdbSchemaAs, err := assertstate.ConfdbSchema(s.state, s.dev1AcctKey.AccountID(), "foo")
 	c.Assert(err, IsNil)
@@ -5678,7 +5679,7 @@ func (s *assertMgrSuite) setupConfdb(c *C) *snap.SideInfo {
 	return si
 }
 
-func (s *assertMgrSuite) TestFetchConfdbAssertion(c *C) {
+func (s *assertMgrSuite) TestSnapInstallFetchesPluggedConfdbAssertions(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -5729,6 +5730,40 @@ func (s *assertMgrSuite) TestFetchConfdbAssertion(c *C) {
 		"store": "my-brand-store",
 	})
 	c.Assert(err, IsNil)
+}
+
+func (s *assertMgrSuite) TestFetchConfdbAssertion(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupConfdb(c)
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err := s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+
+	assertstate.ReplaceDB(s.state, db)
+
+	// not found locally
+	_, err = assertstate.ConfdbSchema(s.state, s.dev1Acct.AccountID(), "my-confdb")
+	c.Assert(err, testutil.ErrorIs, &asserts.NotFoundError{})
+
+	userID := 0
+	err = assertstate.FetchConfdbSchemaAssertion(s.state, userID, s.dev1Acct.AccountID(), "my-confdb")
+	c.Assert(err, IsNil)
+
+	confdbAs, err := assertstate.ConfdbSchema(s.state, s.dev1Acct.AccountID(), "my-confdb")
+	c.Assert(err, IsNil)
+	c.Check(confdbAs.Type().Name, Equals, "confdb-schema")
+	c.Check(confdbAs.Header("account-id"), Equals, s.dev1Acct.AccountID())
+	c.Check(confdbAs.Header("name"), Equals, "my-confdb")
 }
 
 func (s *assertMgrSuite) TestConfdbAssertionsAutoRefreshBulkFetch(c *C) {

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -36,7 +37,10 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-var assertstateConfdbSchema = assertstate.ConfdbSchema
+var (
+	assertstateConfdbSchema               = assertstate.ConfdbSchema
+	assertstateFetchConfdbSchemaAssertion = assertstate.FetchConfdbSchemaAssertion
+)
 
 // SetViaView uses the view to set the requests in the transaction's databag.
 func SetViaView(bag confdb.Databag, view *confdb.View, requests map[string]interface{}) error {
@@ -57,21 +61,35 @@ func SetViaView(bag confdb.Databag, view *confdb.View, requests map[string]inter
 }
 
 // GetView returns the view identified by the account, confdb schema and view name.
-func GetView(st *state.State, account, dbSchemaName, viewName string) (*confdb.View, error) {
-	confdbSchemaAs, err := assertstateConfdbSchema(st, account, dbSchemaName)
+func GetView(st *state.State, account, schemaName, viewName string) (*confdb.View, error) {
+	confdbSchemaAs, err := assertstateConfdbSchema(st, account, schemaName)
 	if err != nil {
-		if errors.Is(err, &asserts.NotFoundError{}) {
+		if !errors.Is(err, &asserts.NotFoundError{}) {
+			return nil, err
+		}
+		logger.Debugf("confdb-schema %s/%s not found locally, fetching from store", account, schemaName)
+
+		userID := 0
+		err = assertstateFetchConfdbSchemaAssertion(st, userID, account, schemaName)
+		if err != nil {
 			// replace the not found error so the output matches the usual confdb ID layout
-			return nil, confdb.NewNotFoundError(i18n.G("cannot find confdb-schema %s/%s: assertion not found"), account, dbSchemaName)
+			if errors.Is(err, &asserts.NotFoundError{}) {
+				return nil, confdb.NewNotFoundError(i18n.G("cannot find confdb-schema %s/%s: assertion not found"), account, schemaName)
+			}
+			return nil, err
 		}
 
-		return nil, fmt.Errorf(i18n.G("cannot find confdb-schema assertion %s/%s: %v"), account, dbSchemaName, err)
+		confdbSchemaAs, err = assertstateConfdbSchema(st, account, schemaName)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	dbSchema := confdbSchemaAs.Schema()
 
 	view := dbSchema.View(viewName)
 	if view == nil {
-		return nil, confdb.NewNotFoundError(i18n.G("cannot find view %q in confdb schema %s/%s"), viewName, account, dbSchemaName)
+		return nil, confdb.NewNotFoundError(i18n.G("cannot find view %q in confdb schema %s/%s"), viewName, account, schemaName)
 	}
 
 	return view, nil

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -290,6 +290,29 @@ func (s *confdbTestSuite) TestConfdbstateGetEntireView(c *C) {
 	})
 }
 
+func (s *confdbTestSuite) TestGetViewUsesFetchedAssertion(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	db := assertstate.DB(s.state)
+	emptyDb, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+	})
+	c.Assert(err, IsNil)
+	assertstate.ReplaceDB(s.state, emptyDb)
+
+	restore := confdbstate.MockFetchConfdbSchemaAssertion(func(*state.State, int, string, string) error {
+		// use the DB with the assertion, to mock fetching the assertion
+		assertstate.ReplaceDB(s.state, db.(*asserts.Database))
+		return nil
+	})
+	defer restore()
+
+	view, err := confdbstate.GetView(s.state, s.devAccID, "network", "setup-wifi")
+	c.Assert(err, IsNil)
+	c.Assert(view, NotNil)
+}
+
 func (s *confdbTestSuite) TestGetViewNoAssertion(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -299,6 +322,12 @@ func (s *confdbTestSuite) TestGetViewNoAssertion(c *C) {
 	})
 	c.Assert(err, IsNil)
 	assertstate.ReplaceDB(s.state, db)
+
+	restore := confdbstate.MockFetchConfdbSchemaAssertion(func(*state.State, int, string, string) error {
+		// to avoid mocking the store for this one test
+		return &asserts.NotFoundError{}
+	})
+	defer restore()
 
 	_, err = confdbstate.GetView(s.state, s.devAccID, "network", "setup-wifi")
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot find confdb-schema %s/network: assertion not found", s.devAccID))

--- a/overlord/confdbstate/export_test.go
+++ b/overlord/confdbstate/export_test.go
@@ -85,3 +85,11 @@ func MockTransactionTimeout(dur time.Duration) func() {
 		transactionTimeout = old
 	}
 }
+
+func MockFetchConfdbSchemaAssertion(f func(*state.State, int, string, string) error) func() {
+	old := assertstateFetchConfdbSchemaAssertion
+	assertstateFetchConfdbSchemaAssertion = f
+	return func() {
+		assertstateFetchConfdbSchemaAssertion = old
+	}
+}


### PR DESCRIPTION
Fetch the confdb-schema assertion during an access if we can't find it locally. This shouldn't happen in the common case because we fetch confdb-schema assertions plugged by snaps during the install but this seems more robust.