### PR TITLE
cmd/snap-bootstrap: fix type of snapd used when retrieving base

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -302,12 +302,12 @@ func hasFDESetupHook(kernelInfo *snap.Info) (bool, error) {
 	return ok, nil
 }
 
-func readSnapInfoFromPath(path string) (*snap.Info, error) {
-	snapf, err := snapfile.Open(path)
+func readSnapInfoFromSeed(seedSnap *seed.Snap) (*snap.Info, error) {
+	snapf, err := snapfile.Open(seedSnap.Path)
 	if err != nil {
 		return nil, err
 	}
-	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
+	info, err := snap.ReadInfoFromSnapFile(snapf, seedSnap.SideInfo)
 	if err != nil {
 		return nil, err
 
@@ -328,7 +328,7 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 	var baseSnap *snap.Info
 	if createSysrootMount() {
 		// On UC24+ the base is not mounted yet, peek into the file
-		baseSnap, err = readSnapInfoFromPath(sysSnaps[snap.TypeKernel].Path)
+		baseSnap, err = readSnapInfoFromSeed(sysSnaps[snap.TypeBase])
 	} else {
 		baseSnap, err = readSnapInfo(sysSnaps, snap.TypeBase)
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_install_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_install_test.go
@@ -273,7 +273,11 @@ func (s *initramfsMountsSuite) testInitramfsMountsInstallModeWithCompsHappy(c *C
 		makeRunnableCalled = true
 		c.Assert(model.Model(), Equals, "my-model")
 		c.Assert(bootWith.RecoverySystemLabel, Equals, s.sysLabel)
+		c.Assert(bootWith.Base.Filename(), Equals, "core24_1.snap")
+		c.Assert(bootWith.BasePath, Equals, filepath.Join(s.seedDir, "snaps", "core24_1.snap"))
+		c.Assert(bootWith.Kernel.Filename(), Equals, "pc-kernel_1.snap")
 		c.Assert(bootWith.KernelPath, Equals, filepath.Join(s.seedDir, "snaps", "pc-kernel_1.snap"))
+		c.Assert(bootWith.Gadget.Filename(), Equals, "pc_1.snap")
 		c.Assert(bootWith.GadgetPath, Equals, filepath.Join(s.seedDir, "snaps", "pc_1.snap"))
 		c.Assert(len(bootWith.KernelMods), Equals, 2)
 		c.Check(bootWith.KernelMods, DeepEquals, []boot.BootableKModsComponents{

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -595,7 +595,14 @@ func (s *baseInitramfsMountsSuite) setupSeed(c *C, modelAssertTime time.Time, ga
 				"id":              testSeed.AssertedSnapID("pc"),
 				"type":            "gadget",
 				"default-channel": channel,
-			}},
+			},
+			map[string]interface{}{
+				"name":            base,
+				"id":              testSeed.AssertedSnapID(base),
+				"type":            "base",
+				"default-channel": "latest",
+			},
+		},
 	}
 	if s.isClassic {
 		model["classic"] = "true"

--- a/tests/lib/assertions/developer1-22-components-dangerous.json
+++ b/tests/lib/assertions/developer1-22-components-dangerous.json
@@ -1,0 +1,56 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "testkeys-snapd-dangerous-core-22-amd64",
+    "architecture": "amd64",
+    "timestamp": "2024-08-29T18:51:46+00:00",
+    "grade": "dangerous",
+    "base": "core22",
+    "serial-authority": [
+        "generic"
+    ],
+    "snaps": [
+        {
+            "default-channel": "22/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "22/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT",
+            "name": "core22",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK",
+            "name": "test-snap-with-components",
+            "type": "app",
+            "components": {
+                "one": "required",
+                "two": "required"
+            }
+        }
+    ]
+}

--- a/tests/lib/assertions/developer1-24-components-dangerous.json
+++ b/tests/lib/assertions/developer1-24-components-dangerous.json
@@ -1,0 +1,50 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "testkeys-snapd-dangerous-core-24-amd64",
+    "architecture": "amd64",
+    "timestamp": "2024-08-29T18:51:46+00:00",
+    "grade": "dangerous",
+    "base": "core24",
+    "serial-authority": [
+        "generic"
+    ],
+    "snaps": [
+        {
+            "default-channel": "24/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM",
+            "name": "core24",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "o6YsRdMMYW3Rg8hINb6zO7vEEqBxG4EK",
+            "name": "test-snap-with-components",
+            "type": "app",
+            "components": {
+                "one": "required",
+                "two": "required"
+            }
+        }
+    ]
+}

--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -1,23 +1,25 @@
 summary: Check that preseeding of core20 works and the image boots.
 
 details: |
-  This test checks that preseeding of UC20 image with ubuntu-image works
+  This test checks that preseeding of UC20+ image with ubuntu-image works
   and that the resulting image boots.
 
-systems: [ubuntu-20.04-64]
+systems: [ -ubuntu-1* ]
 
 environment:
   NESTED_UBUNTU_IMAGE_PRESEED_KEY: "\" (test)\""
   NESTED_ENABLE_TPM: false
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
-  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-20-components-dangerous.model
   # for the fake store
   STORE_ADDR: localhost:11028
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
 
 prepare: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB"/nested.sh
+
   "$TESTSTOOLS"/store-state setup-fake-store "$NESTED_FAKESTORE_BLOB_DIR"
 
   echo "Expose the needed assertions through the fakestore"
@@ -26,6 +28,10 @@ prepare: |
   cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$NESTED_FAKESTORE_BLOB_DIR"/asserts
 
   "$TESTSTOOLS"/store-state teardown-staging-store
+
+  # Create model for this test UC version
+  version=$(nested_get_version)
+  gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-"$version"-components-dangerous.json > pc.model
 
   echo "Creating a new key without a password"
   mkdir -p ~/.snap/gnupg
@@ -45,10 +51,14 @@ debug: |
   echo "gpg key id:$NESTED_UBUNTU_IMAGE_PRESEED_KEY"
 
 execute: |
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB"/nested.sh
+
   # have snap use the fakestore for assertions (but nothing else)
   export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
 
   echo "Running pre-seeding"
+  export NESTED_CUSTOM_MODEL=$PWD/pc.model
   tests.nested build-image core
   tests.nested create-vm core
 
@@ -59,11 +69,19 @@ execute: |
   remote.exec "snap debug seeding" | MATCH "^preseeded: +true"
 
   echo "Check that no snaps are broken"
+  version=$(nested_get_version)
   remote.exec "snap list" | NOMATCH "broken"
-  remote.exec "snap list core20"
+  remote.exec "snap list core$version"
   remote.exec "snap list snapd"
   remote.exec "snap list test-snap-with-components"
 
   # both of these components should be installed, too
   remote.exec "snap run test-snap-with-components one"
   remote.exec "snap run test-snap-with-components two"
+
+  remote.exec cat /var/lib/snapd/modeenv | MATCH base=core"$version"_x1.snap
+
+  # Reboot to check things are fine in a normal run
+  boot_id=$(tests.nested boot-id)
+  remote.exec sudo reboot || true
+  tests.nested wait-for reboot "$boot_id"


### PR DESCRIPTION
This was causing bad values in the modeenv, with eventual failures after installation due to changes on the mount of sysroot.