### PR TITLE
interfaces: Allow system-observe to read cpu.max

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -123,6 +123,9 @@ ptrace (read),
 /sys/fs/cgroup/cpu,cpuacct/cpu.stat r,
 /sys/fs/cgroup/memory/memory.stat r,
 
+# Allow reading the system max CPU resource constraints 
+/sys/fs/cgroup/system.slice/cpu.max r,
+
 #include <abstractions/dbus-strict>
 
 # do not use peer=(label=unconfined) here since this is DBus activated


### PR DESCRIPTION
Hi, we on the Certification team are trying to package `hwctl` (a CLI tool that gathers data about the hardware and system to check for the Certification status of a device), but are running into issues because we can't gather the max CPU constraints, even with the `system-observe` plug (which I think is the right place to put this change in).

This PR adds the necessary file with read permissions to the `system-observe` interface.

- See: https://github.com/canonical/hardware-api/pull/309
- See `hwctl` AppArmor profile: https://gitlab.com/apparmor/apparmor/-/merge_requests/1658/diffs