### PR TITLE
many: remove the gpio-chardev-interface experimental flag

### DIFF
--- a/cmd/snap-gpio-helper/main.go
+++ b/cmd/snap-gpio-helper/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/sandbox/gpio"
 	"github.com/snapcore/snapd/snapdtool"
 )
@@ -38,11 +37,6 @@ type options struct {
 var gpioEnsureAggregatorDriver = gpio.EnsureAggregatorDriver
 
 func run(args []string) error {
-	if !features.GPIOChardevInterface.IsEnabled() {
-		_, flag := features.GPIOChardevInterface.ConfigOption()
-		return fmt.Errorf("gpio-chardev interface requires the %q flag to be set", flag)
-	}
-
 	// Make sure the gpio-aggregator module is loaded because the
 	// systemd security backend comes before the kmod security
 	// backend, there is an edge case on first connection where

--- a/cmd/snap-gpio-helper/main_test.go
+++ b/cmd/snap-gpio-helper/main_test.go
@@ -20,14 +20,11 @@
 package main_test
 
 import (
-	"os"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
-	main "github.com/snapcore/snapd/cmd/snap-gpio-helper"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -43,22 +40,4 @@ var _ = Suite(&snapGpioHelperSuite{})
 func (s *snapGpioHelperSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
-
-	// Mock experimental.gpio-chardev-interface
-	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), IsNil)
-	c.Assert(os.WriteFile(features.GPIOChardevInterface.ControlFile(), []byte(nil), 0644), IsNil)
-}
-
-func (s *snapGpioHelperSuite) TestGpioChardevExperimentlFlagUnset(c *C) {
-	c.Assert(os.RemoveAll(features.GPIOChardevInterface.ControlFile()), IsNil)
-
-	err := main.Run([]string{
-		"export-chardev", "label-0", "0,2", "gadget-name", "slot-name",
-	})
-	c.Check(err, ErrorMatches, `gpio-chardev interface requires the "experimental.gpio-chardev-interface" flag to be set`)
-
-	err = main.Run([]string{
-		"unexport-chardev", "label-0", "0,2", "gadget-name", "slot-name",
-	})
-	c.Check(err, ErrorMatches, `gpio-chardev interface requires the "experimental.gpio-chardev-interface" flag to be set`)
 }

--- a/features/features.go
+++ b/features/features.go
@@ -75,8 +75,6 @@ const (
 	ConfdbControl
 	// AppArmorPrompting enables AppArmor to prompt the user for permission when apps perform certain operations.
 	AppArmorPrompting
-	// GPIOChardevInterface enables experimental gpio-chardev interface.
-	GPIOChardevInterface
 
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
@@ -126,8 +124,6 @@ var featureNames = map[SnapdFeature]string{
 	ConfdbControl: "confdb-control",
 
 	AppArmorPrompting: "apparmor-prompting",
-
-	GPIOChardevInterface: "gpio-chardev-interface",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
@@ -151,7 +147,6 @@ var featuresExported = map[SnapdFeature]bool{
 	RefreshAppAwarenessUX: true,
 	Confdb:                true,
 	AppArmorPrompting:     true,
-	GPIOChardevInterface:  true,
 }
 
 var (

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -64,7 +64,6 @@ func (*featureSuite) TestName(c *C) {
 	check(features.Confdb, "confdb")
 	check(features.ConfdbControl, "confdb-control")
 	check(features.AppArmorPrompting, "apparmor-prompting")
-	check(features.GPIOChardevInterface, "gpio-chardev-interface")
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
@@ -105,7 +104,6 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.Confdb, true)
 	check(features.ConfdbControl, false)
 	check(features.AppArmorPrompting, true)
-	check(features.GPIOChardevInterface, true)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }
@@ -231,7 +229,6 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.Confdb, false)
 	check(features.AppArmorPrompting, false)
 	check(features.ConfdbControl, false)
-	check(features.GPIOChardevInterface, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -154,6 +154,10 @@ func MockDesktopFilesFromInstalledSnap(fn func(s *snap.Info) ([]string, error)) 
 	return testutil.Mock(&desktopFilesFromInstalledSnap, fn)
 }
 
+func MockGpioCheckConfigfsSupport(fn func() error) (restore func()) {
+	return testutil.Mock(&gpioCheckConfigfsSupport, fn)
+}
+
 func AllowedKernelMountOptions() []string {
 	return allowedKernelMountOptions
 }

--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/systemd"
@@ -123,15 +122,10 @@ func (iface *gpioChardevInterface) BeforePrepareSlot(slot *snap.SlotInfo) error 
 	return nil
 }
 
+var gpioCheckConfigfsSupport = gpio.CheckConfigfsSupport
+
 func (iface *gpioChardevInterface) BeforeConnectPlug(plug *interfaces.ConnectedPlug) error {
-	// gpio-chardev is hidden behind an experimental feature flag until kernel
-	// improvements for the gpio-aggregator interface lands.
-	// https://lore.kernel.org/all/20250203031213.399914-1-koichiro.den@canonical.com
-	if !features.GPIOChardevInterface.IsEnabled() {
-		_, flag := features.GPIOChardevInterface.ConfigOption()
-		return fmt.Errorf("gpio-chardev interface requires the %q flag to be set", flag)
-	}
-	return nil
+	return gpioCheckConfigfsSupport()
 }
 
 func (iface *gpioChardevInterface) SystemdConnectedSlot(spec *systemd.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {

--- a/sandbox/gpio/export_test.go
+++ b/sandbox/gpio/export_test.go
@@ -68,6 +68,6 @@ func MockLockAggregator(f func() (unlocker func(), err error)) (restore func()) 
 	return testutil.Mock(&lockAggregator, f)
 }
 
-func MocKKmodLoadModule(f func(module string, options []string) error) (restore func()) {
+func MockKmodLoadModule(f func(module string, options []string) error) (restore func()) {
 	return testutil.Mock(&kmodLoadModule, f)
 }

--- a/sandbox/gpio/gpio_chardev.go
+++ b/sandbox/gpio/gpio_chardev.go
@@ -97,14 +97,27 @@ func UnexportGadgetChardevChip(gadgetName, slotName string) error {
 var kmodLoadModule = kmod.LoadModule
 
 // EnsureAggregatorDriver attempts to load the gpio-aggregator kernel
-// module iff it was not already loaded.
+// module iff it was not already loaded and checks if the configfs
+// interface for gpio-aggregator is available.
 func EnsureAggregatorDriver() error {
 	_, err := os.Stat(filepath.Join(dirs.GlobalRootDir, aggregatorDriverDir))
 	if errors.Is(err, os.ErrNotExist) {
 		if err := kmodLoadModule("gpio-aggregator", nil); err != nil {
 			return err
 		}
-		return nil
 	}
-	return err
+
+	return CheckConfigfsSupport()
+}
+
+// CheckConfigfsSupport checks if the configfs interface for
+// gpio-aggregator is available.
+func CheckConfigfsSupport() error {
+	// GPIO chardev support is hidden until kernel configfs gpio-aggregator interface
+	// makes it to the 24.04 kernel AND the snap-gpio-helper is updated to use the
+	// new configfs interface.
+	// https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2103496
+
+	// The check should be as simple as checking that /sys/kernel/config/gpio-aggregator exists.
+	return errors.New("gpio-aggregator configfs support is missing")
 }

--- a/sandbox/gpio/gpio_chardev_test.go
+++ b/sandbox/gpio/gpio_chardev_test.go
@@ -135,19 +135,24 @@ func (s *chardevTestSuite) TestEnsureAggregatorDriver(c *C) {
 	defer dirs.SetRootDir("")
 
 	called := 0
-	restore := gpio.MocKKmodLoadModule(func(module string, options []string) error {
+	restore := gpio.MockKmodLoadModule(func(module string, options []string) error {
 		called++
 		return nil
 	})
 	defer restore()
 
-	// 1. gpio-aggregator module is already loaded, nothing to do
+	// 1. gpio-aggregator module is already loaded
 	c.Assert(os.MkdirAll(filepath.Join(rootdir, "/sys/bus/platform/drivers/gpio-aggregator"), 0755), IsNil)
-	c.Check(gpio.EnsureAggregatorDriver(), IsNil)
+	// But snapd (and kernel) support is not there yet
+	c.Check(gpio.EnsureAggregatorDriver(), ErrorMatches, "gpio-aggregator configfs support is missing")
+	// Loading the module is not attempted
 	c.Check(called, Equals, 0)
-	// 2. gpio-aggregator module is missing, attempt loading
+
+	// 2. gpio-aggregator module is missing
 	c.Assert(os.RemoveAll(filepath.Join(rootdir, "/sys/bus/platform/drivers/gpio-aggregator")), IsNil)
-	c.Check(gpio.EnsureAggregatorDriver(), IsNil)
+	// But snapd (and kernel) support is not there yet
+	c.Check(gpio.EnsureAggregatorDriver(), ErrorMatches, "gpio-aggregator configfs support is missing")
+	// Loading the module is attempted
 	c.Check(called, Equals, 1)
 }
 

--- a/tests/core/interfaces-gpio-chardev/task.yaml
+++ b/tests/core/interfaces-gpio-chardev/task.yaml
@@ -9,10 +9,6 @@ details: |
 # snap is not built for arm.
 systems: [-ubuntu-core-18-*, -ubuntu-core-20-*, -ubuntu-core-22-*, -ubuntu-core-*-arm-*]
 
-# This is explicitly disabled until gpio-aggregator configfs support
-# lands in kernel and snapd.
-manual: true
-
 prepare: |
     # emulate GPIO chips using gpio-sim module
     cat << EOF > /etc/systemd/system/gpio-sim.service
@@ -60,14 +56,13 @@ prepare: |
     tests.cleanup defer snap remove --purge test-snapd-gpio-chardev
 
 execute: |
+    # TODO: remove when gpio-aggregator configfs support lands in kernel
+    # and snapd. This test should fail automatically when support lands.
+    not snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0 2> out
+    MATCH "gpio-aggregator configfs support is missing" < out
+    exit 0
+
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        # cannot connect without experimental flag
-        not snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0 2> out
-        MATCH "gpio-chardev interface requires the \"experimental.gpio-chardev-interface\" flag to be set" < out
-
-        echo "enable experimental.gpio-chardev-interface to allow connection"
-        snap set system experimental.gpio-chardev-interface=true
-
         # Check number of gpiochips before connection
         find /dev/gpiochip* | wc -l | MATCH '^2$'
 

--- a/tests/core/interfaces-gpio-chardev/task.yaml
+++ b/tests/core/interfaces-gpio-chardev/task.yaml
@@ -9,6 +9,10 @@ details: |
 # snap is not built for arm.
 systems: [-ubuntu-core-18-*, -ubuntu-core-20-*, -ubuntu-core-22-*, -ubuntu-core-*-arm-*]
 
+# This is explicitly disabled until gpio-aggregator configfs support
+# lands in kernel and snapd.
+manual: true
+
 prepare: |
     # emulate GPIO chips using gpio-sim module
     cat << EOF > /etc/systemd/system/gpio-sim.service

--- a/tests/core/interfaces-gpio-chardev/task.yaml
+++ b/tests/core/interfaces-gpio-chardev/task.yaml
@@ -62,67 +62,67 @@ execute: |
     MATCH "gpio-aggregator configfs support is missing" < out
     exit 0
 
-    if [ "$SPREAD_REBOOT" = 0 ]; then
-        # Check number of gpiochips before connection
-        find /dev/gpiochip* | wc -l | MATCH '^2$'
+    # if [ "$SPREAD_REBOOT" = 0 ]; then
+    #     # Check number of gpiochips before connection
+    #     find /dev/gpiochip* | wc -l | MATCH '^2$'
 
-        echo "Connect to gadget slots"
-        snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
-        snap connect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
+    #     echo "Connect to gadget slots"
+    #     snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
+    #     snap connect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
         
-        # Check number of gpiochips after connection
-        find /dev/gpiochip* | wc -l | MATCH '^4$'
+    #     # Check number of gpiochips after connection
+    #     find /dev/gpiochip* | wc -l | MATCH '^4$'
 
-        echo "The gpio chips are exported for the gadget slot"
-        test -c /dev/snap/gpio-chardev/pc/gpio-chardev-0
-        test -c /dev/snap/gpio-chardev/pc/gpio-chardev-1
-        echo "And symlinks created on the consumer plug side"
-        readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-0
-        readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-1
+    #     echo "The gpio chips are exported for the gadget slot"
+    #     test -c /dev/snap/gpio-chardev/pc/gpio-chardev-0
+    #     test -c /dev/snap/gpio-chardev/pc/gpio-chardev-1
+    #     echo "And symlinks created on the consumer plug side"
+    #     readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-0
+    #     readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-1
 
-        echo "And gpio-chardev setup dependency was injected into snap service"
-        systemctl show --property=After snap.test-snapd-gpio-chardev.svc.service | grep "gpio-chardev-setup.target"
-        systemctl show --property=Wants snap.test-snapd-gpio-chardev.svc.service | grep "gpio-chardev-setup.target"
+    #     echo "And gpio-chardev setup dependency was injected into snap service"
+    #     systemctl show --property=After snap.test-snapd-gpio-chardev.svc.service | grep "gpio-chardev-setup.target"
+    #     systemctl show --property=Wants snap.test-snapd-gpio-chardev.svc.service | grep "gpio-chardev-setup.target"
 
-        mkdir -p /var/snap/test-snapd-gpio-chardev/common/gpiochips
-        printf "0\n1\n0\n0\n0\n1\n0\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-0
-        printf "1\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-1
-        REBOOT
-    elif [ "$SPREAD_REBOOT" = 1 ]; then
-        echo "Snap service should have properly set the gpio lines for each chip"
+    #     mkdir -p /var/snap/test-snapd-gpio-chardev/common/gpiochips
+    #     printf "0\n1\n0\n0\n0\n1\n0\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-0
+    #     printf "1\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-1
+    #     REBOOT
+    # elif [ "$SPREAD_REBOOT" = 1 ]; then
+    #     echo "Snap service should have properly set the gpio lines for each chip"
 
-        chip=/dev/snap/gpio-chardev/pc/gpio-chardev-0
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=inactive$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 2 | MATCH '^"2"=inactive$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 3 | MATCH '^"3"=inactive$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 4 | MATCH '^"4"=inactive$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 5 | MATCH '^"5"=active$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 6 | MATCH '^"6"=inactive$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 7 | MATCH '^"7"=active$'
+    #     chip=/dev/snap/gpio-chardev/pc/gpio-chardev-0
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=inactive$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 2 | MATCH '^"2"=inactive$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 3 | MATCH '^"3"=inactive$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 4 | MATCH '^"4"=inactive$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 5 | MATCH '^"5"=active$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 6 | MATCH '^"6"=inactive$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 7 | MATCH '^"7"=active$'
 
-        chip=/dev/snap/gpio-chardev/pc/gpio-chardev-1
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=active$'
-        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
+    #     chip=/dev/snap/gpio-chardev/pc/gpio-chardev-1
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=active$'
+    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
 
-        echo "Disconnecting unexports the aggregated devices"
-        snap disconnect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
-        snap disconnect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
-        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
-        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
-        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
-        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
+    #     echo "Disconnecting unexports the aggregated devices"
+    #     snap disconnect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
+    #     snap disconnect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
+    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
+    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
+    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
+    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
 
-        # Reboot one last time to make sure services run normally even when disconnected
-        rm -rf /var/snap/test-snapd-gpio-chardev/common/gpiochips
-        REBOOT
-    elif [ "$SPREAD_REBOOT" = 2 ]; then
-        echo "Snap service runs"
-        retry -n 20 --wait 2 sh -c 'journalctl -u snap.test-snapd-gpio-chardev.svc | MATCH "no chips found under /var/snap/test-snapd-gpio-chardev/common/gpiochips, exiting..."'
+    #     # Reboot one last time to make sure services run normally even when disconnected
+    #     rm -rf /var/snap/test-snapd-gpio-chardev/common/gpiochips
+    #     REBOOT
+    # elif [ "$SPREAD_REBOOT" = 2 ]; then
+    #     echo "Snap service runs"
+    #     retry -n 20 --wait 2 sh -c 'journalctl -u snap.test-snapd-gpio-chardev.svc | MATCH "no chips found under /var/snap/test-snapd-gpio-chardev/common/gpiochips, exiting..."'
 
-        echo "And aggregated devices are still unexported"
-        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
-        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
-        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
-        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
-    fi
+    #     echo "And aggregated devices are still unexported"
+    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
+    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
+    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
+    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
+    # fi


### PR DESCRIPTION
GPIO chardev support is hidden in this PR until kernel configfs gpio-aggregator interface makes it to the 24.04 kernel AND the snap-gpio-helper is updated to use the new configfs interface.

In the meantime remove the feature flag and mark the gpio-chardev interface as unsupported to avoid snaps from using the workaround implementation that utilized the gpio-aggregator sysfs kernel interface so that it can be completely removed after configfs support lands without having to worry about backwards compatibility.

**NOTE: The flag landed in 2.68 BUT actual support (export/unexport commands https://github.com/canonical/snapd/pull/15212) will land in 2.70, so it is impossible to use the flag even in 2.69 in any meaningful way. It would still be good if we can land this into 2.69 and 2.68 in a dot release for good measure.**
