### PR TITLE
overlord/ifacestate: emit snapd.apparmor warning only when using apparmor backend

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -1589,3 +1589,12 @@ func appSetForSnapRevision(st *state.State, info *snap.Info) (*interfaces.SnapAp
 
 	return interfaces.NewSnapAppSet(info, compInfos)
 }
+
+func hasAppArmorBackend(backends []interfaces.SecurityBackend) bool {
+	for _, b := range backends {
+		if b.Name() == interfaces.SecurityAppArmor {
+			return true
+		}
+	}
+	return false
+}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -246,7 +246,7 @@ func (m *InterfaceManager) StartUp() error {
 			return err
 		}
 	}
-	if snapdAppArmorServiceIsDisabled() {
+	if hasAppArmorBackend(m.repo.Backends()) && snapdAppArmorServiceIsDisabled() {
 		s.Warnf(`the snapd.apparmor service is disabled; snap applications will likely not start.
 Run "systemctl enable --now snapd.apparmor" to correct this.`)
 	}


### PR DESCRIPTION
The warning about snapd.apparmor not being enable should only be emitted when apparmor backend is present, which happens when snapd has detected a usable support for apparmor in the host system. A mere fact of having the service packaged in the system is not sufficient to show the warning to the user.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Related: [SNAPDENG-34259](https://warthogs.atlassian.net/browse/SNAPDENG-34259)

Cherry picked from: #15434 

[SNAPDENG-34259]: https://warthogs.atlassian.net/browse/SNAPDENG-34259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ