### PR TITLE
tests: update how openstack backend is configured in the spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -381,7 +381,10 @@ backends:
         systems: *google-nested-systems
 
     openstack:
-        key: '$(HOST: echo "$SPREAD_OPENSTACK_ENV")'
+        key: '$(HOST: echo "$OS_PASSWORD")'
+        endpoint: "$(HOST: echo $OS_AUTH_URL)"
+        account: "$(HOST: echo $OS_USERNAME)"
+        location: "$(HOST: echo $OS_PROJECT_NAME/$OS_REGION_NAME)"
         plan: staging-cpu2-ram4-disk20
         halt-timeout: 2h
         wait-timeout: 5m


### PR DESCRIPTION
Now spread will require endpoint, endpoint and location keys.

Those keys are configured using env vars already cnofigured in the selfhosted runners.

Tests are not executed as this pr need to be ready to be landed when the new spread binary is deployed in the selfhosted runners