### PR TITLE
tests/core20-new-snapd-does-not-break-old-initrd: do not used fixed kernel/gadget

### DIFF
--- a/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
+++ b/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
@@ -14,9 +14,7 @@ details: |
   We do not cover the case where a kernel snap is too old for the
   snapd in the seed that was used to install Ubuntu Core.
 
-# ubuntu-22.04-64: enable on uc22 once pc-kernel is on 22/candidate channel
-systems: [ubuntu-20.04-64]
-
+systems: [ -ubuntu-1* ]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/ubuntu-core-{VERSION}-amd64.model
@@ -36,10 +34,10 @@ environment:
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true
 
-  INITIAL_KERNEL_REV_URL: https://storage.googleapis.com/snapd-spread-tests/snaps/pc-kernel_838.snap
-  INITIAL_GADGET_REV_URL: https://storage.googleapis.com/snapd-spread-tests/snaps/pc_132.snap
-
 prepare: |
+  # Get the nested system version
+  VERSION="$(tests.nested show version)"
+
   # always build the snapd snap from this branch - on the new variant it gets
   # put into the image, on the old variant it will be refreshed to
   # shellcheck source=tests/lib/prepare.sh
@@ -57,29 +55,23 @@ prepare: |
   sudo snap pack snapd --filename=snapd-stable.snap
   mv snapd-stable.snap "$(tests.nested get extra-snaps-path)"
 
-  # use a specific version of the kernel snap and thus initramfs that we know
-  # doesn't support v2 secboot keys
-  wget --quiet "$INITIAL_KERNEL_REV_URL"
-  # use a gadget snap that works with this kernel
-  wget --quiet "$INITIAL_GADGET_REV_URL"
-
-  # unpack it and repack it so it doesn't match any store assertions and thus
+  # Use stable channel versions of kernel and gadget too.
+  # unpack and repack them so it doesn't match any store assertions and thus
   # won't be automatically refreshed behind our backs when we boot the VM
-  unsquashfs -d pc-kernel-snap pc-kernel_838.snap
+  snap download pc-kernel --channel="$VERSION"/stable --basename=pc-kernel-store
+  unsquashfs -d pc-kernel-snap pc-kernel-store.snap
   touch ./pc-kernel-snap/in-case-mksquashfs-becomes-deterministic-someday
   snap pack pc-kernel-snap --filename=pc-kernel.snap
   mv pc-kernel.snap "$(tests.nested get extra-snaps-path)" 
 
-  unsquashfs -d pc-snap pc_132.snap
+  snap download pc --channel="$VERSION"/stable --basename=pc-store
+  unsquashfs -d pc-snap pc-store.snap
   touch ./pc-snap/in-case-mksquashfs-becomes-deterministic-someday
   snap pack pc-snap --filename=pc.snap
   mv pc.snap "$(tests.nested get extra-snaps-path)" 
 
-  # Get the nested system version
-  VERSION="$(tests.nested show version)"
-
   # download the new kernel to try and refresh to, triggering a reseal
-  snap download pc-kernel --channel="$VERSION/candidate" --basename=new-kernel
+  snap download pc-kernel --channel="$VERSION/beta" --basename=new-kernel
 
   # build the image and start the VM up
   tests.nested build-image core


### PR DESCRIPTION
Older kernel initramfs is actually not compatible with snapd 2.68. Use snaps from stable channels instead for the image, so what this tests is that updating to latest snapd and to the kernel in beta does not break things.

Also, enable this for 22 and 24.