### PR TITLE
release: 2.68.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# New in snapd 2.68.5
+* LP: #2109843 fix missing preseed files when running in a container
+
 # New in snapd 2.68.4
 * Snap components: LP: #2104933 workaround for classic 24.04/24.10 models that incorrectly specify core22 instead of core24
 * Update build dependencies

--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -33,8 +33,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/logger"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/snapdenv"
-	systemd_tools "github.com/snapcore/snapd/systemd"
 )
 
 // All returns a set of all available security backends.
@@ -51,38 +49,13 @@ func All() []interfaces.SecurityBackend {
 		&systemd.Backend{},
 		&seccomp.Backend{},
 		&dbus.Backend{},
-	}
-
-	// Since snapd 2.68 the udev backend, responsible for writing udev rules to
-	// /etc/udev/rules.d and for calling udevadm control --reload-rules, as
-	// well as udevadm trigger (with a number of options), is no longer enabled
-	// in containers. System administrators retain ability to manage access to
-	// real devices at the container level.
-	//
-	// For context:
-	//
-	// In Linux, devices are _not_ namespace aware so if a device is accessible
-	// in the container (and the container manager has allowed such access)
-	// then allow snaps to freely poke the device subject to still-enforced
-	// apparmor rules. In "traditional" containers such as docker or podman,
-	// where using systemd is unusual and unsupported this doesn't change
-	// anything. In system containers such as lxd and incus users may, with or
-	// without understanding the consequences, switch the container to
-	// privileged mode. In this mode udev does start inside the container, but
-	// actively configures devices on the host with undesirable consequences.
-	//
-	// But we want the backend active when preseeding so preseeded images
-	// actually have the files in /var/lib/snapd/cgroup.
-	if !systemd_tools.IsContainer() || snapdenv.Preseeding() {
-		all = append(all, &udev.Backend{})
-	}
-
-	all = append(all, &mount.Backend{},
+		&udev.Backend{},
+		&mount.Backend{},
 		&kmod.Backend{},
 		&polkit.Backend{},
 		&ldconfig.Backend{},
 		&configfiles.Backend{},
-	)
+	}
 
 	// TODO use something like:
 	// level, summary := apparmor.ProbeResults()

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -71,21 +71,6 @@ func (s *backendsSuite) TestEssentialOrdering(c *C) {
 	c.Assert(sdIndex, testutil.IntLessThan, aaIndex)
 }
 
-func (s *backendsSuite) TestUdevInContainers(c *C) {
-	cmd := testutil.MockCommand(c, "systemd-detect-virt", `
-	for arg in "$@"; do
-		if [ "$arg" = --container ]; then
-			exit 0
-		fi
-	done
-
-	exit 1
-	`)
-
-	defer cmd.Restore()
-	c.Assert(backendNames(backends.All()), Not(testutil.Contains), "udev")
-}
-
 func (s *backendsSuite) TestUdevPreseedingInContainers(c *C) {
 	cmd := testutil.MockCommand(c, "systemd-detect-virt", `
 	for arg in "$@"; do
@@ -98,21 +83,6 @@ func (s *backendsSuite) TestUdevPreseedingInContainers(c *C) {
 	`)
 	restore := snapdenv.MockPreseeding(true)
 	defer restore()
-
-	defer cmd.Restore()
-	c.Assert(backendNames(backends.All()), testutil.Contains, "udev")
-}
-
-func (s *backendsSuite) TestUdevNotInContainers(c *C) {
-	cmd := testutil.MockCommand(c, "systemd-detect-virt", `
-	for arg in "$@"; do
-		if [ "$arg" = --container ]; then
-			exit 1
-		fi
-	done
-
-	exit 0
-	`)
 
 	defer cmd.Restore()
 	c.Assert(backendNames(backends.All()), testutil.Contains, "udev")

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -38,12 +38,14 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
 )
 
 // Backend is responsible for maintaining udev rules.
 type Backend struct {
-	preseed bool
+	preseed     bool
+	isContainer bool
 }
 
 // Initialize does nothing.
@@ -51,6 +53,27 @@ func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
 	if opts != nil && opts.Preseed {
 		b.preseed = true
 	}
+	// Since snapd 2.68 the udev backend, responsible for writing udev rules to
+	// /etc/udev/rules.d and for calling udevadm control --reload-rules, as
+	// well as udevadm trigger (with a number of options), is no longer enabled
+	// in containers. System administrators retain ability to manage access to
+	// real devices at the container level.
+	//
+	// For context:
+	//
+	// In Linux, devices are _not_ namespace aware so if a device is accessible
+	// in the container (and the container manager has allowed such access)
+	// then allow snaps to freely poke the device subject to still-enforced
+	// apparmor rules. In "traditional" containers such as docker or podman,
+	// where using systemd is unusual and unsupported this doesn't change
+	// anything. In system containers such as lxd and incus users may, with or
+	// without understanding the consequences, switch the container to
+	// privileged mode. In this mode udev does start inside the container, but
+	// actively configures devices on the host with undesirable consequences.
+	//
+	// But we want the backend active when preseeding so preseeded images
+	// actually have the files in /var/lib/snapd/cgroup.
+	b.isContainer = systemd.IsContainer()
 	return nil
 }
 

--- a/interfaces/udev/udev.go
+++ b/interfaces/udev/udev.go
@@ -61,7 +61,11 @@ func udevadmTrigger(args ...string) error {
 //	udevadm trigger --subsystem-match=input
 //	udevadm trigger --property-match=ID_INPUT_JOYSTICK=1
 func (b *Backend) reloadRules(subsystemTriggers []string) error {
-	if b.preseed {
+	// When running in a container observe the state of host's udev, as such
+	// reloading rules makes no sense, since they are ineffective.
+	// Similarly in preseeding, there is no point in reloading rules which
+	// only affect the runtime standbox.
+	if b.preseed || b.isContainer {
 		return nil
 	}
 

--- a/interfaces/udev/udev_test.go
+++ b/interfaces/udev/udev_test.go
@@ -35,11 +35,28 @@ func Test(t *testing.T) {
 
 type uDevSuite struct {
 	backend *udev.Backend
+	cmd     *testutil.MockCmd
 }
 
 var _ = Suite(&uDevSuite{})
 
 // Tests for ReloadRules()
+
+func (s *uDevSuite) SetUpSuite(c *C) {
+	s.cmd = testutil.MockCommand(c, "systemd-detect-virt", `
+       for arg in "$@"; do
+               if [ "$arg" = --container ]; then
+                       exit 1
+               fi
+       done
+
+       exit 0
+       `)
+}
+
+func (s *uDevSuite) TearDownSuite(c *C) {
+	s.cmd.Restore()
+}
 
 func (s *uDevSuite) SetUpTest(c *C) {
 	s.backend = &udev.Backend{}

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.68.4
+pkgver=2.68.5
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,10 @@
+snapd (2.68.5-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2098137
+    - LP: #2109843 fix missing preseed files when running in a container
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 21 May 2025 17:46:09 +0200
+
 snapd (2.68.4-1) unstable; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.68.4
+Version:        2.68.5
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPL-3.0-only
@@ -1002,6 +1002,10 @@ fi
 
 
 %changelog
+* Wed May 21 2025 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.68.5
+ - LP: #2109843 fix missing preseed files when running in a container
+
 * Wed Apr 02 2025 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.68.4
  - Snap components: LP: #2104933 workaround for classic 24.04/24.10

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May 21 15:46:09 UTC 2025 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.68.5
+
+-------------------------------------------------------------------
 Wed Apr 02 17:48:25 UTC 2025 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.68.4

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -91,7 +91,7 @@
 
 
 Name:           snapd
-Version:        2.68.4
+Version:        2.68.5
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.68.5~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2098137
+    - LP: #2109843 fix missing preseed files when running in a container
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 21 May 2025 17:46:09 +0200
+
 snapd (2.68.4~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,10 @@
+snapd (2.68.5) xenial; urgency=medium
+
+  * New upstream release, LP: #2098137
+    - LP: #2109843 fix missing preseed files when running in a container
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 21 May 2025 17:46:09 +0200
+
 snapd (2.68.4) xenial; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/tests/main/nvidia-files/task.yaml
+++ b/tests/main/nvidia-files/task.yaml
@@ -66,6 +66,8 @@ prepare: |
     skip["ubuntu-20.04-64/515-server"]="transitional-driver"
     skip["ubuntu-20.04-64/525"]="transitional-driver"
     skip["ubuntu-20.04-64/530"]="transitional-driver"
+    skip["ubuntu-20.04-64/535"]="broken-packaging"
+
     # The i386 side of the driver is not installable due to
     # https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-535-server/+bug/2080351
     skip["ubuntu-20.04-64/535-server"]="broken-packaging"
@@ -105,8 +107,7 @@ prepare: |
     skip["ubuntu-24.10-64/530"]="transitional-driver"
     skip["ubuntu-24.10-64/535"]="transitional-driver"
     skip["ubuntu-24.10-64/550"]="transitional-driver"
-    # /bin/bash: line 109: 10426 Segmentation fault      (core dumped) test-snapd-nvidia.64 > log-64.txt
-    skip["ubuntu-24.10-64/560"]="broken-driver"
+    skip["ubuntu-24.10-64/560"]="transitional-driver"
 
     driver_suffix=$PACKAGE_VERSION${PACKAGE_SUFFIX:-}
     combi_key=$SPREAD_SYSTEM/$driver_suffix


### PR DESCRIPTION
Generated changelogs with:
DEBEMAIL="Ernest Lotter <ernest.lotter@canonical.com>" release-tools/changelog.py 2.68.5 2098137 NEWS.md

The main purpose of this release is to create official release with the fix currently provided by the hotfix branch: stable/hotfix-preseeding-lp2109843.

The main fix that is the reason for this dot release, https://github.com/canonical/snapd/pull/15411, was merged to release/2.68 branch, so no need to cherry pick. In addition also, https://github.com/canonical/snapd/pull/15462, for needed ci maintenance.

Cherry-picks:
Functional:
 - https://github.com/canonical/snapd/pull/15439

Testing:
 - https://github.com/canonical/snapd/pull/15409


SRU Bug: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2098137

**Requires rebase merge**