### PR TITLE
.github/workflows: transition ubuntu-20.04 runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
             variant: pristine
 
   cache-build-deps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -261,7 +261,7 @@ jobs:
 
   code-coverage:
     needs: [unit-tests, unit-tests-special, unit-tests-c]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GOPATH: ${{ github.workspace }}
       # Set PATH to ignore the load of magic binaries from /usr/local/bin And

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
For the purpose of release/2.68 branch maintenance transition ubuntu-20.04 runners to ubuntu-22.04 to avoid skipped tests.