### PR TITLE
.github/workflows: release/2.68 ci maintenance

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -115,8 +115,8 @@ jobs:
             jq '.include.[] | select(.group == "ubuntu-daily") | .systems'
         }
 
-        wget -q -O master_fundsys.json https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/fundamental-systems.json
-        wget -q -O master_nonfundsys.json https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/non-fundamental-systems.json
+        wget -q -O master_fundsys.json https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/data-fundamental-systems.json
+        wget -q -O master_nonfundsys.json https://raw.githubusercontent.com/snapcore/snapd/master/.github/workflows/data-non-fundamental-systems.json
         
         master_daily="$(get_daily_system master_fundsys.json master_nonfundsys.json)"
         branch_daily="$(get_daily_system .github/workflows/fundamental-systems.json .github/workflows/non-fundamental-systems.json)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
             variant: pristine
 
   cache-build-deps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -261,7 +261,7 @@ jobs:
 
   code-coverage:
     needs: [unit-tests, unit-tests-special, unit-tests-c]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GOPATH: ${{ github.workspace }}
       # Set PATH to ignore the load of magic binaries from /usr/local/bin And

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
Changes required to fix these failures:
- required static and unit tests skipped due to cache-build-deps relying on retired ubuntu-20.04 runner
- cannot calculate ubuntu daily due to change on master workflow naming

This is only to enable previously skipped required static and unit tests, skipping spread tests.