### PR TITLE
i/p/requestprompts: handle expired notification when replying

### DIFF
--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -132,7 +132,7 @@ func (p *Prompt) sendReplyWithPermission(allowedPermission notify.AppArmorPermis
 			if errors.Is(err, unix.ENOENT) {
 				// If err is ENOENT, then notification with the given ID does not
 				// exist, so it timed out in the kernel.
-				logger.Debugf("kernel returned ENOENT from APPARMOR_NOTIF_SEND (notification probably timed out)")
+				logger.Debugf("kernel returned ENOENT from APPARMOR_NOTIF_SEND for request (notification probably timed out): %+v", listenerReq)
 			} else {
 				// Other errors should only occur if reply is malformed, and
 				// since these listener requests should be identical, if a


### PR DESCRIPTION
If a message notification has expired in the kernel, than an attempt to reply to the corresponding request will result in ENOENT from the kernel.

Previously, any error when sending the reply would result in aborting the reply and surfacing the error to the caller.

This commit instead handles ENOENT differently, recording a debug log and otherwise carrying on without returning an error. That means that if a prompt reply receives an ENOENT for one of the listener requests associated with that prompt, the other requests will still be sent responses.

Additionally, if a reply returns ENOENT, then any rule which would be created as a result of the successful reply will still be created.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-35041
