### PR TITLE
systemd: fix race between using and modifying service name list

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1068,6 +1068,8 @@ func (s *systemd) Stop(serviceNames []string) error {
 	errorRet := make(chan error)
 	quit := make(chan interface{})
 
+	origServiceNames := serviceNames
+
 	go func() {
 		// The polling routine is the 'errorRet' channel sender, so we make
 		// sure we exit closing the channel explicitly, even though we always
@@ -1142,7 +1144,7 @@ func (s *systemd) Stop(serviceNames []string) error {
 	}()
 
 	// This command blocks until the 'systemctl stop' completes
-	_, errStop := s.systemctl(append([]string{"stop"}, serviceNames...)...)
+	_, errStop := s.systemctl(append([]string{"stop"}, origServiceNames...)...)
 
 	// Notify the progress loop to exit since systemctl completed the request
 	close(quit)


### PR DESCRIPTION
There is a very intermittent race check failure around the use of `serviceNames` and its modification in the preceding goroutine. The `select` in the goroutine blocks until `stopNotifyDelay` or `stopCheckDelay`, which means the main thread should nearly always use `serviceNames` before it is changed by the goroutine.

The following should force the race check failure to occur:

```diff
diff --git a/systemd/systemd.go b/systemd/systemd.go
index 32ae38c2e3..f4305adbed 100644
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1068,6 +1068,8 @@ func (s *systemd) Stop(serviceNames []string) error {
        errorRet := make(chan error)
        quit := make(chan interface{})
 
+       useServiceNames := make(chan struct{})
+
        go func() {
                // The polling routine is the 'errorRet' channel sender, so we make
                // sure we exit closing the channel explicitly, even though we always
@@ -1122,6 +1124,8 @@ func (s *systemd) Stop(serviceNames []string) error {
                        // Any remaining running units stopped?
                        somethingChanged := len(serviceNames) != len(stillRunningServices)
 
+                       close(useServiceNames)
+
                        // We only poll units still running.
                        serviceNames = stillRunningServices
 
@@ -1141,6 +1145,8 @@ func (s *systemd) Stop(serviceNames []string) error {
                }
        }()
 
+       <-useServiceNames
+
        // This command blocks until the 'systemctl stop' completes
        _, errStop := s.systemctl(append([]string{"stop"}, serviceNames...)...)
```

The solution is to set aside the original service names before spawning the goroutine, and use that when invoking the systemctl command after the goroutine has been spawned.