### PR TITLE
tests: fix errors running google tests without os credential files

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -381,10 +381,10 @@ backends:
         systems: *google-nested-systems
 
     openstack:
-        key: '$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo "$OS_PASSWORD")'
-        endpoint: "$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo $OS_AUTH_URL)"
-        account: "$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo $OS_USERNAME)"
-        location: "$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo $OS_PROJECT_NAME/$OS_REGION_NAME)"
+        key: '$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo "$OS_PASSWORD || true)'
+        endpoint: "$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo $OS_AUTH_URL || true)"
+        account: "$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo $OS_USERNAME || true)"
+        location: "$(HOST: source $OS_CREDENTIALS_AMD64_PS6 && echo $OS_PROJECT_NAME/$OS_REGION_NAME || true)"
         plan: staging-cpu2-ram4-disk20
         halt-timeout: 2h
         wait-timeout: 5m
@@ -408,13 +408,13 @@ backends:
                 workers: 8
 
             - ubuntu-core-20-64:
-                image: snapd-spread/ubuntu-20.04-64
+                image: snapd-spread/ubuntu-20.04-64-uefi
                 workers: 8
             - ubuntu-core-22-64:
-                image: snapd-spread/ubuntu-22.04-64
+                image: snapd-spread/ubuntu-22.04-64-uefi
                 workers: 8
             - ubuntu-core-24-64:
-                image: snapd-spread/ubuntu-24.04-64
+                image: snapd-spread/ubuntu-24.04-64-uefi
                 workers: 8
 
             - fedora-40-64:
@@ -444,10 +444,10 @@ backends:
 
     openstack-arm:
         type: openstack
-        key: '$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo "$OS_PASSWORD")'
-        endpoint: "$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo $OS_AUTH_URL)"
-        account: "$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo $OS_USERNAME)"
-        location: "$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo $OS_PROJECT_NAME/$OS_REGION_NAME)"
+        key: '$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo "$OS_PASSWORD" || true)'
+        endpoint: "$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo $OS_AUTH_URL || true)"
+        account: "$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo $OS_USERNAME || true)"
+        location: "$(HOST: source $OS_CREDENTIALS_ARM64_PS6 && echo $OS_PROJECT_NAME/$OS_REGION_NAME || true)"
         plan: builder-arm64-cpu2-ram4-disk20
         halt-timeout: 2h
         wait-timeout: 5m


### PR DESCRIPTION
This is a critical fix to unblock google tests
