### PR TITLE
systemd: fix data race when stopping services

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1068,7 +1068,7 @@ func (s *systemd) Stop(serviceNames []string) error {
 	errorRet := make(chan error)
 	quit := make(chan interface{})
 
-	go func() {
+	go func(serviceNames []string) {
 		// The polling routine is the 'errorRet' channel sender, so we make
 		// sure we exit closing the channel explicitly, even though we always
 		// return the error result first. Closing the channel does not free the
@@ -1139,7 +1139,7 @@ func (s *systemd) Stop(serviceNames []string) error {
 				notifyShowFirst = false
 			}
 		}
-	}()
+	}(serviceNames)
 
 	// This command blocks until the 'systemctl stop' completes
 	_, errStop := s.systemctl(append([]string{"stop"}, serviceNames...)...)


### PR DESCRIPTION
The serviceNames function argument is read by the snippet invoking s.systemctl(), but it could also be modified in parallel by the polling goroutine which is started immediately before.

A data race was identified in tests:
```
==================
WARNING: DATA RACE
Read at 0x00c000454888 by goroutine 360:
  github.com/snapcore/snapd/systemd.(*systemd).Stop()
      /home/runner/work/snapd/snapd/systemd/systemd.go:1145 +0x2a4
  github.com/snapcore/snapd/systemd_test.(*SystemdTestSuite).TestStopMany()
      /home/runner/work/snapd/snapd/systemd/systemd_test.go:422 +0xe7c
  runtime.call16()
      /snap/go/10672/src/runtime/asm_amd64.s:747 +0x42
  reflect.Value.Call()
      /snap/go/10672/src/reflect/value.go:380 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:775 +0xb4c
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:669 +0x106

Previous write at 0x00c000454888 by goroutine 362:
  github.com/snapcore/snapd/systemd.(*systemd).Stop.func1()
      /home/runner/work/snapd/snapd/systemd/systemd.go:1126 +0x33a

Goroutine 360 (running) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:666 +0x5ba
  gopkg.in/check%2ev1.(*suiteRunner).forkTest()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:757 +0x155
  gopkg.in/check%2ev1.(*suiteRunner).runTest()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:812 +0x419
  gopkg.in/check%2ev1.(*suiteRunner).run()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:618 +0x3c6
  gopkg.in/check%2ev1.Run()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/run.go:92 +0x44
  gopkg.in/check%2ev1.RunAll()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/run.go:84 +0x127
  gopkg.in/check%2ev1.TestingT()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/run.go:72 +0x5f9
  github.com/snapcore/snapd/systemd_test.Test()
      /home/runner/work/snapd/snapd/systemd/systemd_test.go:55 +0x26
  testing.tRunner()
      /snap/go/10672/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /snap/go/10672/src/testing/testing.go:1648 +0x44

Goroutine 362 (running) created at:
  github.com/snapcore/snapd/systemd.(*systemd).Stop()
      /home/runner/work/snapd/snapd/systemd/systemd.go:1071 +0x24c
  github.com/snapcore/snapd/systemd_test.(*SystemdTestSuite).TestStopMany()
      /home/runner/work/snapd/snapd/systemd/systemd_test.go:422 +0xe7c
  runtime.call16()
      /snap/go/10672/src/runtime/asm_amd64.s:747 +0x42
  reflect.Value.Call()
      /snap/go/10672/src/reflect/value.go:380 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:775 +0xb4c
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:669 +0x106
==================
==================
WARNING: DATA RACE
Read at 0x00c0000a2790 by goroutine 360:
  runtime.slicecopy()
      /snap/go/10672/src/runtime/slice.go:310 +0x0
  github.com/snapcore/snapd/systemd.(*systemd).Stop()
      /home/runner/work/snapd/snapd/systemd/systemd.go:1145 +0x3d9
  github.com/snapcore/snapd/systemd_test.(*SystemdTestSuite).TestStopMany()
      /home/runner/work/snapd/snapd/systemd/systemd_test.go:422 +0xe7c
  runtime.call16()
      /snap/go/10672/src/runtime/asm_amd64.s:747 +0x42
  reflect.Value.Call()
      /snap/go/10672/src/reflect/value.go:380 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:775 +0xb4c
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:669 +0x106

Previous write at 0x00c0000a2790 by goroutine 362:
  github.com/snapcore/snapd/systemd.(*systemd).Stop.func1()
      /home/runner/work/snapd/snapd/systemd/systemd.go:1118 +0x724

Goroutine 360 (running) created at:
  gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:666 +0x5ba
  gopkg.in/check%2ev1.(*suiteRunner).forkTest()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:757 +0x155
  gopkg.in/check%2ev1.(*suiteRunner).runTest()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:812 +0x419
  gopkg.in/check%2ev1.(*suiteRunner).run()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:618 +0x3c6
  gopkg.in/check%2ev1.Run()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/run.go:92 +0x44
  gopkg.in/check%2ev1.RunAll()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/run.go:84 +0x127
  gopkg.in/check%2ev1.TestingT()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/run.go:72 +0x5f9
  github.com/snapcore/snapd/systemd_test.Test()
      /home/runner/work/snapd/snapd/systemd/systemd_test.go:55 +0x26
  testing.tRunner()
      /snap/go/10672/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /snap/go/10672/src/testing/testing.go:1648 +0x44

Goroutine 362 (running) created at:
  github.com/snapcore/snapd/systemd.(*systemd).Stop()
      /home/runner/work/snapd/snapd/systemd/systemd.go:1071 +0x24c
  github.com/snapcore/snapd/systemd_test.(*SystemdTestSuite).TestStopMany()
      /home/runner/work/snapd/snapd/systemd/systemd_test.go:422 +0xe7c
  runtime.call16()
      /snap/go/10672/src/runtime/asm_amd64.s:747 +0x42
  reflect.Value.Call()
      /snap/go/10672/src/reflect/value.go:380 +0xb5
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:775 +0xb4c
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/runner/work/snapd/snapd/vendor/gopkg.in/check.v1/check.go:669 +0x106
==================
OK: 124 passed
--- FAIL: Test (1.00s)
    testing.go:1465: race detected during execution of test
FAIL
FAIL	github.com/snapcore/snapd/systemd	1.012s
```

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
