### PR TITLE
spread.yaml, tests/main: backport openstack fix #15453

### DIFF
--- a/tests/lib/spread/backend.openstack.yaml
+++ b/tests/lib/spread/backend.openstack.yaml
@@ -1,5 +1,5 @@
     openstack:
-        key: '$(HOST: echo "$SPREAD_OPENSTACK_ENV")'
+        key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS6")'
         plan: staging-cpu2-ram4-disk20
         halt-timeout: 2h
         wait-timeout: 5m

--- a/tests/main/confdb-cross-config/task.yaml
+++ b/tests/main/confdb-cross-config/task.yaml
@@ -12,6 +12,9 @@ systems: [ -ubuntu-16.04, -debian-11-64 ]
 prepare: |
   snap set system experimental.confdbs=true
 
+restore: |
+  snap unset system experimental.confdb
+
 execute: |
   changeAfterID() {
     local OLD_CHANGE="$1"

--- a/tests/main/confdb/task.yaml
+++ b/tests/main/confdb/task.yaml
@@ -10,6 +10,9 @@ systems: [ -ubuntu-16.04 ]
 prepare: |
   snap set system experimental.confdbs=true
 
+restore: |
+  snap unset system experimental.confdb
+
 execute: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
     echo "This test needs test keys to be trusted"


### PR DESCRIPTION
Backport https://github.com/canonical/snapd/pull/15453 to branch release/2.68.

In this branch, openstack was not yet officially supported as a backport and relied on copying yaml snippet from `tests/lib/spread/backend.openstack.yaml` into `spread.yaml`. The only required change was to use the new key as per [this change in #15453](https://github.com/canonical/snapd/pull/15453/files#diff-e1e5ecb5e7fe7aa228c64f680564673541f91452212c3c6c23cbbd27bb78dcedR384). Also corrected configdb test restore as was also done in #15453.

This change does not require all spread tests to pass, only some openstack tests to prove the key modification works.