### PR TITLE
daemon: change snapctl error prefix

### DIFF
--- a/daemon/api_snapctl.go
+++ b/daemon/api_snapctl.go
@@ -92,7 +92,7 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
 			stdout = []byte(e.Error())
 		} else {
-			return BadRequest("error running snapctl: %s", err)
+			return BadRequest("snapctl: %s", err)
 		}
 	}
 

--- a/tests/main/auto-refresh-gating/task.yaml
+++ b/tests/main/auto-refresh-gating/task.yaml
@@ -166,7 +166,7 @@ execute: |
   snap list | MATCH "$CONTENT_SNAP_NAME +2\.0\.0"
 
   snap change --last=auto-refresh | MATCH "ERROR ignoring hook error:"
-  MATCH "error running snapctl: unknown flag .unknown-flag-to-force-snapctl-error'" < "$DEBUG_LOG_FILE"
+  MATCH "error: snapctl: unknown flag .unknown-flag-to-force-snapctl-error'" < "$DEBUG_LOG_FILE"
 
   systemctl stop snapd.{service,socket}
 

--- a/tests/main/services-snapctl/task.yaml
+++ b/tests/main/services-snapctl/task.yaml
@@ -95,7 +95,7 @@ execute: |
     snap set test-snapd-service command=restart
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service
     # shellcheck disable=SC2119
-    if "$TESTSTOOLS"/journal-state get-log | MATCH "error running snapctl"; then
+    if "$TESTSTOOLS"/journal-state get-log | MATCH "error: snapctl"; then
         echo "snapctl should not report errors"
         exit 1
     fi

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -38,4 +38,4 @@ execute: |
   if OUT=$(test-snap.checkconn home 2>&1); then
     echo "home is not expected"
   fi
-  echo "$OUT" | MATCH "error running snapctl: snap \"test-snap\" has no plug or slot named \"home\""
+  echo "$OUT" | MATCH "error: snapctl: snap \"test-snap\" has no plug or slot named \"home\""


### PR DESCRIPTION
It was pointed out that "error: error running snapctl" makes it look like snapctl itself had an error instead of an operation triggered by snapctl failing.