### PR TITLE
tests/main: correct confdb restore step setting name

### DIFF
--- a/tests/main/confdb-cross-config/task.yaml
+++ b/tests/main/confdb-cross-config/task.yaml
@@ -13,7 +13,7 @@ prepare: |
   snap set system experimental.confdbs=true
 
 restore: |
-  snap unset system experimental.confdb
+  snap unset system experimental.confdbs
 
 execute: |
   changeAfterID() {

--- a/tests/main/confdb/task.yaml
+++ b/tests/main/confdb/task.yaml
@@ -11,7 +11,7 @@ prepare: |
   snap set system experimental.confdbs=true
 
 restore: |
-  snap unset system experimental.confdb
+  snap unset system experimental.confdbs
 
 execute: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then


### PR DESCRIPTION
Follow up for backport https://github.com/canonical/snapd/pull/15472 to correct restore step that used confdb setting name that is different on master.
