### PR TITLE
spread, git: ignore image-garden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,13 @@ cmd/test-driver
 # Image files
 *.img
 
+# Image Garden files
+*.iso
+*.qcow2
+*.run
+*.lock
+*.user-data
+*.meta-data
+
 # Directory that is used by the run-spread script
 /built-snap

--- a/spread.yaml
+++ b/spread.yaml
@@ -728,6 +728,10 @@ exclude:
     - "*.pyc"
     - ./vendor
     - "*.snap"
+    - "*.qcow2"
+    - "*.log"
+    - "*.iso"
+    - "*.img"
 
 debug-each: |
     if [ "$SPREAD_DEBUG_EACH" != 1 ]; then


### PR DESCRIPTION
Ignore file artifacts which are commonly generated when using image garden.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
