### PR TITLE
systemd: update code for creating a journal stream

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -546,7 +546,10 @@ func loggerWithJournalMaybe() error {
 		if !osutil.GetenvBool("SNAP_LOG_TO_JOURNAL") {
 			return fmt.Errorf("no need to log to journal")
 		}
-		journalWriter, err := systemd.NewJournalStreamFile("snap", syslog.LOG_DEBUG, false)
+		journalWriter, err := systemd.NewJournalStreamFile(&systemd.JournalStreamFileOptions{
+			Identifier: "snap",
+			Priority:   syslog.LOG_DEBUG,
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -546,7 +546,7 @@ func loggerWithJournalMaybe() error {
 		if !osutil.GetenvBool("SNAP_LOG_TO_JOURNAL") {
 			return fmt.Errorf("no need to log to journal")
 		}
-		journalWriter, err := systemd.NewJournalStreamFile(&systemd.JournalStreamFileOptions{
+		journalWriter, err := systemd.NewJournalStreamFile(systemd.JournalStreamFileParams{
 			Identifier: "snap",
 			Priority:   syslog.LOG_DEBUG,
 		})

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -39,14 +39,6 @@ func MockOsutilStreamCommand(f func(string, ...string) (io.ReadCloser, error)) f
 	return func() { osutilStreamCommand = old }
 }
 
-func MockJournalStdoutPath(path string) func() {
-	oldPath := journalStdoutPath
-	journalStdoutPath = path
-	return func() {
-		journalStdoutPath = oldPath
-	}
-}
-
 func MockOsutilIsMounted(f func(path string) (bool, error)) func() {
 	old := osutilIsMounted
 	osutilIsMounted = f

--- a/systemd/journal.go
+++ b/systemd/journal.go
@@ -73,7 +73,7 @@ func NewJournalStreamFile(params JournalStreamFileParams) (*os.File, error) {
 	// limits, however let us not do that.
 	// https://github.com/systemd/systemd/blob/2e8a581b9cc1132743c2341fc334461096266ad4/src/core/exec-invoke.c#L231
 	if err := conn.SetWriteBuffer(int(8 * quantity.SizeMiB)); err != nil {
-		return nil, err
+		// intentionally ignore the error like systemd does.
 	}
 
 	var levelPrefix int

--- a/systemd/journal.go
+++ b/systemd/journal.go
@@ -29,7 +29,11 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 )
 
-type JournalStreamFileOptions struct {
+// JournalStreamFileParams contains configuration parameters for the journal stream.
+// Most of these are optional, but a stream must have a proper Identifier specified to
+// be opened. If a namespace is provided, then the stream will connect to that specific
+// journal namespace instead.
+type JournalStreamFileParams struct {
 	Namespace   string
 	Identifier  string
 	UnitName    string
@@ -39,10 +43,15 @@ type JournalStreamFileOptions struct {
 
 // NewJournalStreamFile creates log stream file descriptor to the journal. The
 // semantics is identical to that of sd_journal_stream_fd(3) call.
-func NewJournalStreamFile(opts *JournalStreamFileOptions) (*os.File, error) {
+func NewJournalStreamFile(params JournalStreamFileParams) (*os.File, error) {
+	// an identifier must be provided
+	if params.Identifier == "" {
+		return nil, fmt.Errorf("internal error: cannot setup a journal stream without an identifier")
+	}
+
 	var journalPath string
-	if opts.Namespace != "" {
-		journalPath = fmt.Sprintf("%s/journal.%s/stdout", dirs.SnapSystemdRunDir, opts.Namespace)
+	if params.Namespace != "" {
+		journalPath = fmt.Sprintf("%s/journal.%s/stdout", dirs.SnapSystemdRunDir, params.Namespace)
 	} else {
 		journalPath = fmt.Sprintf("%s/journal/stdout", dirs.SnapSystemdRunDir)
 	}
@@ -54,31 +63,34 @@ func NewJournalStreamFile(opts *JournalStreamFileOptions) (*os.File, error) {
 	// does not affect *os.File created through conn.File() later on
 	defer conn.Close()
 
+	// systemd closes the read side
+	// https://github.com/systemd/systemd/blob/2e8a581b9cc1132743c2341fc334461096266ad4/src/core/exec-invoke.c#L228
 	if err := conn.CloseRead(); err != nil {
 		return nil, err
 	}
 
 	// journald actually tries to force this into 8mb in spite of kernel
 	// limits, however let us not do that.
+	// https://github.com/systemd/systemd/blob/2e8a581b9cc1132743c2341fc334461096266ad4/src/core/exec-invoke.c#L231
 	if err := conn.SetWriteBuffer(int(8 * quantity.SizeMiB)); err != nil {
 		return nil, err
 	}
 
 	var levelPrefix int
-	if opts.LevelPrefix {
+	if params.LevelPrefix {
 		levelPrefix = 1
 	}
 
-	// header contents taken from the original systemd code:
-	// https://github.com/systemd/systemd/blob/97a33b126c845327a3a19d6e66f05684823868fb/src/journal/journal-send.c#L395
+	// setup contents taken from the original systemd code:
+	// https://github.com/systemd/systemd/blob/2e8a581b9cc1132743c2341fc334461096266ad4/src/core/exec-invoke.c#L233
 	setupStr := fmt.Sprintf("%s\n%s\n%d\n%d\n%d\n%d\n%d\n",
-		opts.Identifier, /* syslog_identifier */
-		opts.UnitName,   /* unit-name */
-		opts.Priority,   /* syslog_priority */
-		levelPrefix,     /* syslog_level_prefix */
-		0,               /* false */
-		0,               /* is_kmsg_output */
-		0,               /* is_terminal_output */
+		params.Identifier, /* syslog_identifier */
+		params.UnitName,   /* unit-name */
+		params.Priority,   /* syslog_priority */
+		levelPrefix,       /* syslog_level_prefix */
+		0,                 /* false */
+		0,                 /* is_kmsg_output */
+		0,                 /* is_terminal_output */
 	)
 	if _, err := conn.Write([]byte(setupStr)); err != nil {
 		return nil, fmt.Errorf("failed to write header: %v", err)

--- a/systemd/journal.go
+++ b/systemd/journal.go
@@ -72,9 +72,8 @@ func NewJournalStreamFile(params JournalStreamFileParams) (*os.File, error) {
 	// journald actually tries to force this into 8mb in spite of kernel
 	// limits, however let us not do that.
 	// https://github.com/systemd/systemd/blob/2e8a581b9cc1132743c2341fc334461096266ad4/src/core/exec-invoke.c#L231
-	if err := conn.SetWriteBuffer(int(8 * quantity.SizeMiB)); err != nil {
-		// intentionally ignore the error like systemd does.
-	}
+	// intentionally ignore the error like systemd does.
+	_ = conn.SetWriteBuffer(int(8 * quantity.SizeMiB))
 
 	var levelPrefix int
 	if params.LevelPrefix {

--- a/systemd/journal_test.go
+++ b/systemd/journal_test.go
@@ -48,8 +48,16 @@ func (j *journalTestSuite) SetUpTest(c *C) {
 	c.Assert(os.MkdirAll(j.journalNamespaceDir, 0755), IsNil)
 }
 
+func (j *journalTestSuite) TestStreamFileErrorNoIdentifier(c *C) {
+	jout, err := NewJournalStreamFile(JournalStreamFileParams{
+		Priority: syslog.LOG_INFO,
+	})
+	c.Assert(err, ErrorMatches, "internal error: cannot setup a journal stream without an identifier")
+	c.Assert(jout, IsNil)
+}
+
 func (j *journalTestSuite) TestStreamFileErrorNoPath(c *C) {
-	jout, err := NewJournalStreamFile(&JournalStreamFileOptions{
+	jout, err := NewJournalStreamFile(JournalStreamFileParams{
 		Identifier: "foobar",
 		Priority:   syslog.LOG_INFO,
 	})
@@ -89,7 +97,7 @@ func (j *journalTestSuite) testStreamFileHeader(c *C, journalDir, namespace stri
 		doneCh <- struct{}{}
 	}()
 
-	jout, err := NewJournalStreamFile(&JournalStreamFileOptions{
+	jout, err := NewJournalStreamFile(JournalStreamFileParams{
 		Namespace:  namespace,
 		Identifier: "foobar",
 		UnitName:   "foobar.service",

--- a/usersession/autostart/autostart.go
+++ b/usersession/autostart/autostart.go
@@ -101,13 +101,19 @@ func (f failedAutostartError) Error() string {
 func makeStdStreams(identifier string) (stdout *os.File, stderr *os.File) {
 	var err error
 
-	stdout, err = systemd.NewJournalStreamFile(identifier, syslog.LOG_INFO, false)
+	stdout, err = systemd.NewJournalStreamFile(&systemd.JournalStreamFileOptions{
+		Identifier: identifier,
+		Priority:   syslog.LOG_INFO,
+	})
 	if err != nil {
 		logger.Noticef("failed to set up stdout journal stream for %q: %v", identifier, err)
 		stdout = os.Stdout
 	}
 
-	stderr, err = systemd.NewJournalStreamFile(identifier, syslog.LOG_WARNING, false)
+	stderr, err = systemd.NewJournalStreamFile(&systemd.JournalStreamFileOptions{
+		Identifier: identifier,
+		Priority:   syslog.LOG_WARNING,
+	})
 	if err != nil {
 		logger.Noticef("failed to set up stderr journal stream for %q: %v", identifier, err)
 		stderr = os.Stderr

--- a/usersession/autostart/autostart.go
+++ b/usersession/autostart/autostart.go
@@ -101,7 +101,7 @@ func (f failedAutostartError) Error() string {
 func makeStdStreams(identifier string) (stdout *os.File, stderr *os.File) {
 	var err error
 
-	stdout, err = systemd.NewJournalStreamFile(&systemd.JournalStreamFileOptions{
+	stdout, err = systemd.NewJournalStreamFile(systemd.JournalStreamFileParams{
 		Identifier: identifier,
 		Priority:   syslog.LOG_INFO,
 	})
@@ -110,7 +110,7 @@ func makeStdStreams(identifier string) (stdout *os.File, stderr *os.File) {
 		stdout = os.Stdout
 	}
 
-	stderr, err = systemd.NewJournalStreamFile(&systemd.JournalStreamFileOptions{
+	stderr, err = systemd.NewJournalStreamFile(systemd.JournalStreamFileParams{
 		Identifier: identifier,
 		Priority:   syslog.LOG_WARNING,
 	})


### PR DESCRIPTION
Add support for unit name and namespaces in the systemd journal helper code. Move parameters into a struct instead.

Reflect what is done in https://github.com/systemd/systemd/blob/2e8a581b9cc1132743c2341fc334461096266ad4/src/core/exec-invoke.c and try to set the send buffer.

