### PR TITLE
many: add Snap prefix to service operations to make clear these operate in a snap context

### DIFF
--- a/overlord/configstate/configcore/vitality.go
+++ b/overlord/configstate/configcore/vitality.go
@@ -166,9 +166,9 @@ func handleVitalityConfiguration(tr RunTransaction, opts *fsOnlyContext) error {
 		if err != nil {
 			return err
 		}
-		opts := &wrappers.StartServicesOptions{Enable: true}
+		opts := &wrappers.StartSnapServicesOptions{Enable: true}
 		tm := timings.New(nil)
-		if err = wrappers.StartServices(startupOrdered, disabledSvcs, opts, progress.Null, tm); err != nil {
+		if err = wrappers.StartSnapServices(startupOrdered, disabledSvcs, opts, progress.Null, tm); err != nil {
 			return err
 		}
 	}

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -756,7 +756,7 @@ func (s *servicectlSuite) testQueueCommandsConfigureHookFinalTask(c *C, finalTas
 				c.Fatalf("unexpected command: %q", argv[1])
 			}
 		case "service-control":
-			var sa servicestate.ServiceAction
+			var sa servicestate.SnapServiceAction
 			c.Assert(t.Get("service-action", &sa), IsNil)
 			c.Check(sa.Services, DeepEquals, []string{"test-service"})
 			switch sa.Action {

--- a/overlord/patch/patch5.go
+++ b/overlord/patch/patch5.go
@@ -66,7 +66,7 @@ func patch5(st *state.State) error {
 			continue
 		}
 
-		err = wrappers.StopServices(svcs, nil, snap.StopReasonRefresh, log, tm)
+		err = wrappers.StopSnapServices(svcs, nil, snap.StopReasonRefresh, log, tm)
 		if err != nil {
 			return err
 		}
@@ -78,7 +78,7 @@ func patch5(st *state.State) error {
 			return err
 		}
 
-		err = wrappers.StartServices(svcs, nil, nil, log, tm)
+		err = wrappers.StartSnapServices(svcs, nil, nil, log, tm)
 		if err != nil {
 			return err
 		}

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -217,7 +217,7 @@ func addRestartServicesTasks(st *state.State, queueTask func(task *state.Task), 
 
 	for _, info := range sortedInfos {
 		restartTask := st.NewTask("service-control", fmt.Sprintf("Restarting services for snap %q", info.InstanceName()))
-		restartTask.Set("service-action", ServiceAction{
+		restartTask.Set("service-action", SnapServiceAction{
 			Action:                  "restart",
 			SnapName:                info.InstanceName(),
 			Services:                getServiceNames(servicesAffected[info]),
@@ -845,8 +845,8 @@ func restartSnapServices(st *state.State, appsToRestartBySnap map[*snap.Info][]*
 			return err
 		}
 
-		err = wrappers.RestartServices(startupOrdered, nil,
-			&wrappers.RestartServicesOptions{Reload: false},
+		err = wrappers.RestartSnapServices(startupOrdered, nil,
+			&wrappers.RestartSnapServicesOptions{Reload: false},
 			progress.Null, &timings.Timings{})
 		if err != nil {
 			return err

--- a/overlord/servicestate/service_control.go
+++ b/overlord/servicestate/service_control.go
@@ -36,7 +36,7 @@ import (
 // snap if services list is empty.
 // The names of services and explicit-services are app names (as defined in snap
 // yaml).
-type ServiceAction struct {
+type SnapServiceAction struct {
 	SnapName       string   `json:"snap-name"`
 	Action         string   `json:"action"`
 	ActionModifier string   `json:"action-modifier,omitempty"`
@@ -70,7 +70,7 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 	perfTimings := state.TimingsForTask(t)
 	defer perfTimings.Save(st)
 
-	var sc ServiceAction
+	var sc SnapServiceAction
 	err := t.Get("service-action", &sc)
 	if err != nil {
 		return fmt.Errorf("internal error: cannot get service-action: %v", err)
@@ -130,12 +130,12 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 	switch sc.Action {
 	case "stop":
 		disable := sc.ActionModifier == "disable"
-		opts := &wrappers.StopServicesOptions{
+		opts := &wrappers.StopSnapServicesOptions{
 			Disable:      disable,
 			ScopeOptions: sc.ScopeOptions,
 		}
 		st.Unlock()
-		err := wrappers.StopServices(services, opts, snap.StopReasonOther, meter, perfTimings)
+		err := wrappers.StopSnapServices(services, opts, snap.StopReasonOther, meter, perfTimings)
 		st.Lock()
 		if err != nil {
 			return err
@@ -155,12 +155,12 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 		}
 	case "start":
 		enable := sc.ActionModifier == "enable"
-		opts := &wrappers.StartServicesOptions{
+		opts := &wrappers.StartSnapServicesOptions{
 			Enable:       enable,
 			ScopeOptions: sc.ScopeOptions,
 		}
 		st.Unlock()
-		err = wrappers.StartServices(startupOrdered, nil, opts, meter, perfTimings)
+		err = wrappers.StartSnapServices(startupOrdered, nil, opts, meter, perfTimings)
 		st.Lock()
 		if err != nil {
 			return err
@@ -180,7 +180,7 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 		}
 	case "restart":
 		st.Unlock()
-		err := wrappers.RestartServices(startupOrdered, explicitServicesSystemdUnits, &wrappers.RestartServicesOptions{
+		err := wrappers.RestartSnapServices(startupOrdered, explicitServicesSystemdUnits, &wrappers.RestartSnapServicesOptions{
 			AlsoEnabledNonActive: sc.RestartEnabledNonActive,
 			ScopeOptions:         sc.ScopeOptions,
 		}, meter, perfTimings)
@@ -188,7 +188,7 @@ func (m *ServiceManager) doServiceControl(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	case "reload-or-restart":
 		st.Unlock()
-		err := wrappers.RestartServices(startupOrdered, explicitServicesSystemdUnits, &wrappers.RestartServicesOptions{
+		err := wrappers.RestartSnapServices(startupOrdered, explicitServicesSystemdUnits, &wrappers.RestartSnapServicesOptions{
 			Reload:               true,
 			AlsoEnabledNonActive: sc.RestartEnabledNonActive,
 			ScopeOptions:         sc.ScopeOptions,

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -212,7 +212,7 @@ func verifyControlTasks(c *C, tasks []*state.Task, expectedAction, actionModifie
 			}
 		} else if kind == "service-control" {
 			serviceControlTasks++
-			var sa servicestate.ServiceAction
+			var sa servicestate.SnapServiceAction
 			c.Assert(tasks[i].Get("service-action", &sa), IsNil)
 			switch expectedAction {
 			case "start":
@@ -520,7 +520,7 @@ func (s *serviceControlSuite) TestNoopWhenNoServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{SnapName: "test-snap"}
+	cmd := &servicestate.SnapServiceAction{SnapName: "test-snap"}
 	t.Set("service-action", cmd)
 	chg.AddTask(t)
 
@@ -542,7 +542,7 @@ func (s *serviceControlSuite) TestUnhandledServiceAction(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{SnapName: "test-snap", Action: "foo"}
+	cmd := &servicestate.SnapServiceAction{SnapName: "test-snap", Action: "foo"}
 	t.Set("service-action", cmd)
 	chg.AddTask(t)
 
@@ -565,7 +565,7 @@ func (s *serviceControlSuite) TestUnknownService(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "start",
 		Services: []string{"boo"},
@@ -592,7 +592,7 @@ func (s *serviceControlSuite) TestNotAService(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "start",
 		Services: []string{"someapp"},
@@ -619,7 +619,7 @@ func (s *serviceControlSuite) TestStartAllServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "start",
 	}
@@ -650,7 +650,7 @@ func (s *serviceControlSuite) TestStartListedServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "start",
 		Services: []string{"foo"},
@@ -679,7 +679,7 @@ func (s *serviceControlSuite) TestStartEnableServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName:       "test-snap",
 		Action:         "start",
 		ActionModifier: "enable",
@@ -711,7 +711,7 @@ func (s *serviceControlSuite) TestStartServicesWithScope(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "start",
 		ScopeOptions: wrappers.ScopeOptions{
@@ -745,7 +745,7 @@ func (s *serviceControlSuite) TestStartEnableMultipleServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName:       "test-snap",
 		Action:         "start",
 		ActionModifier: "enable",
@@ -779,7 +779,7 @@ func (s *serviceControlSuite) TestStopServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "stop",
 		Services: []string{"foo"},
@@ -809,7 +809,7 @@ func (s *serviceControlSuite) TestStopServicesWithScope(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "stop",
 		ScopeOptions: wrappers.ScopeOptions{
@@ -842,7 +842,7 @@ func (s *serviceControlSuite) TestStopDisableServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName:       "test-snap",
 		Action:         "stop",
 		ActionModifier: "disable",
@@ -875,7 +875,7 @@ func (s *serviceControlSuite) TestRestartServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "restart",
 		Services: []string{"foo"},
@@ -906,7 +906,7 @@ func (s *serviceControlSuite) TestRestartServicesWithScope(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "restart",
 		ScopeOptions: wrappers.ScopeOptions{
@@ -965,7 +965,7 @@ func (s *serviceControlSuite) TestRestartOnlyActiveServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName:                "test-snap",
 		Action:                  "restart",
 		Services:                []string{"foo", "bar"},
@@ -1020,7 +1020,7 @@ func (s *serviceControlSuite) TestRestartAllEnabledServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName:                "test-snap",
 		Action:                  "restart",
 		Services:                []string{"foo", "bar"},
@@ -1081,7 +1081,7 @@ func (s *serviceControlSuite) testRestartWithExplicitServicesCommon(c *C,
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "restart",
 		Services: []string{"abc", "foo", "bar"},
@@ -1148,7 +1148,7 @@ func (s *serviceControlSuite) TestRestartAllServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "restart",
 		Services: []string{"abc", "foo", "bar"},
@@ -1185,7 +1185,7 @@ func (s *serviceControlSuite) TestReloadServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "reload-or-restart",
 		Services: []string{"foo"},
@@ -1214,7 +1214,7 @@ func (s *serviceControlSuite) TestReloadAllServices(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "reload-or-restart",
 		Services: []string{"foo", "abc", "bar"},
@@ -1245,7 +1245,7 @@ func (s *serviceControlSuite) TestConflict(c *C) {
 
 	chg := st.NewChange("service-control", "...")
 	t := st.NewTask("service-control", "...")
-	cmd := &servicestate.ServiceAction{
+	cmd := &servicestate.SnapServiceAction{
 		SnapName: "test-snap",
 		Action:   "reload-or-restart",
 		Services: []string{"foo"},

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -217,7 +217,7 @@ func delayedCrossMgrInit() {
 }
 
 func serviceControlAffectedSnaps(t *state.Task) ([]string, error) {
-	var serviceAction ServiceAction
+	var serviceAction SnapServiceAction
 	if err := t.Get("service-action", &serviceAction); err != nil {
 		return nil, fmt.Errorf("internal error: cannot obtain service action from task: %s", t.Summary())
 	}
@@ -363,7 +363,7 @@ func restartServicesKilledInSnapdSnapRefresh(modified map[*snap.Info][]*snap.App
 
 		// TODO: what to do about timings here?
 		nullPerfTimings := &timings.Timings{}
-		if err := wrappers.StartServices(startupOrdered, disabledSvcs, nil, progress.Null, nullPerfTimings); err != nil {
+		if err := wrappers.StartSnapServices(startupOrdered, disabledSvcs, nil, progress.Null, nullPerfTimings); err != nil {
 			return err
 		}
 	}

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -194,7 +194,7 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 			return nil, err
 		}
 
-		cmd := &ServiceAction{
+		cmd := &SnapServiceAction{
 			SnapName: snapName,
 			ScopeOptions: wrappers.ScopeOptions{
 				Scope: inst.ServiceScope(),

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -777,11 +777,11 @@ func (s *snapServiceOptionsSuite) TestServiceControlTaskSummaries(c *C) {
 	}
 }
 
-func (s *snapServiceOptionsSuite) checkServiceAction(c *C, ts *state.TaskSet, expected *servicestate.ServiceAction) {
+func (s *snapServiceOptionsSuite) checkServiceAction(c *C, ts *state.TaskSet, expected *servicestate.SnapServiceAction) {
 	c.Assert(ts.Tasks(), HasLen, 1)
 	t := ts.Tasks()[0]
 
-	var obtained servicestate.ServiceAction
+	var obtained servicestate.SnapServiceAction
 	c.Assert(t.Get("service-action", &obtained), IsNil)
 	c.Check(&obtained, DeepEquals, expected)
 }
@@ -816,7 +816,7 @@ func (s *snapServiceOptionsSuite) TestServiceControlServiceAction(c *C) {
 
 	for _, tc := range []struct {
 		instruction    *servicestate.Instruction
-		expectedAction *servicestate.ServiceAction
+		expectedAction *servicestate.SnapServiceAction
 	}{
 		{
 			&servicestate.Instruction{
@@ -827,7 +827,7 @@ func (s *snapServiceOptionsSuite) TestServiceControlServiceAction(c *C) {
 					Enable: true,
 				},
 			},
-			&servicestate.ServiceAction{
+			&servicestate.SnapServiceAction{
 				SnapName:       "foo",
 				Action:         "start",
 				ActionModifier: "enable",
@@ -844,7 +844,7 @@ func (s *snapServiceOptionsSuite) TestServiceControlServiceAction(c *C) {
 				Scope:  client.ScopeSelector{"user"},
 				Users:  client.UserSelector{Names: []string{"foo"}},
 			},
-			&servicestate.ServiceAction{
+			&servicestate.SnapServiceAction{
 				SnapName:                "foo",
 				Action:                  "restart",
 				Services:                []string{"svc1", "svc2"},
@@ -861,7 +861,7 @@ func (s *snapServiceOptionsSuite) TestServiceControlServiceAction(c *C) {
 				Scope:  client.ScopeSelector{"system"},
 				Names:  []string{"foo.svc2"},
 			},
-			&servicestate.ServiceAction{
+			&servicestate.SnapServiceAction{
 				SnapName:                "foo",
 				Action:                  "restart",
 				Services:                []string{"svc1", "svc2"},
@@ -880,7 +880,7 @@ func (s *snapServiceOptionsSuite) TestServiceControlServiceAction(c *C) {
 				Scope:          client.ScopeSelector{"system", "user"},
 				Users:          client.UserSelector{Names: []string{"foo"}},
 			},
-			&servicestate.ServiceAction{
+			&servicestate.SnapServiceAction{
 				SnapName:                "foo",
 				Action:                  "reload-or-restart",
 				Services:                []string{"svc1", "svc2"},
@@ -898,7 +898,7 @@ func (s *snapServiceOptionsSuite) TestServiceControlServiceAction(c *C) {
 				Scope:  client.ScopeSelector{"user"},
 				Users:  client.UserSelector{Names: []string{"baz"}},
 			},
-			&servicestate.ServiceAction{
+			&servicestate.SnapServiceAction{
 				SnapName:         "foo",
 				Action:           "stop",
 				Services:         []string{"svc1", "svc2"},

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -255,12 +255,12 @@ func (b Backend) LinkComponent(cpi snap.ContainerPlaceInfo, snapRev snap.Revisio
 }
 
 func (b Backend) StartServices(apps []*snap.AppInfo, disabledSvcs *wrappers.DisabledServices, meter progress.Meter, tm timings.Measurer) error {
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	return wrappers.StartServices(apps, disabledSvcs, opts, meter, tm)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	return wrappers.StartSnapServices(apps, disabledSvcs, opts, meter, tm)
 }
 
 func (b Backend) StopServices(apps []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error {
-	return wrappers.StopServices(apps, nil, reason, meter, tm)
+	return wrappers.StopSnapServices(apps, nil, reason, meter, tm)
 }
 
 func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) (wrappers.SnapdRestart, error) {

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -239,18 +239,18 @@ func filterUserServicesNotInDisabledMap(disabledSvcs *DisabledServices, original
 	return filtered
 }
 
-// StartServicesOptions carries additional parameters for StartService.
-type StartServicesOptions struct {
+// StartSnapServicesOptions carries additional parameters for StartSnapServices.
+type StartSnapServicesOptions struct {
 	Enable bool
 	ScopeOptions
 }
 
-// StartServices starts service units for the applications from the snap which
+// StartSnapServices starts service units for the applications from the snap which
 // are services. Service units will be started in the order provided by the
 // caller.
-func StartServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, opts *StartServicesOptions, inter Interacter, tm timings.Measurer) (err error) {
+func StartSnapServices(apps []*snap.AppInfo, disabledSvcs *DisabledServices, opts *StartSnapServicesOptions, inter Interacter, tm timings.Measurer) (err error) {
 	if opts == nil {
-		opts = &StartServicesOptions{}
+		opts = &StartSnapServicesOptions{}
 	}
 
 	systemSysd := systemd.New(systemd.SystemMode, inter)
@@ -932,7 +932,7 @@ func serviceUnitsFromApps(apps []*snap.AppInfo, includeActivatedServices bool) [
 //
 // The result is then two lists of snap service apps, separated by system/user type
 // that are valid for being stopped.
-func filterAppsForStop(apps []*snap.AppInfo, reason snap.ServiceStopReason, opts *StopServicesOptions) (sys []*snap.AppInfo, usr []*snap.AppInfo) {
+func filterAppsForStop(apps []*snap.AppInfo, reason snap.ServiceStopReason, opts *StopSnapServicesOptions) (sys []*snap.AppInfo, usr []*snap.AppInfo) {
 	for _, app := range apps {
 		// Handle the case where service file doesn't exist and don't try to stop it as it will fail.
 		// This can happen with snap try when snap.yaml is modified on the fly and a daemon line is added.
@@ -967,23 +967,23 @@ func filterAppsForStop(apps []*snap.AppInfo, reason snap.ServiceStopReason, opts
 	return sys, usr
 }
 
-// StopServicesOptions carries additional parameters for StopServices.
-type StopServicesOptions struct {
+// StopSnapServicesOptions carries additional parameters for StopSnapServices.
+type StopSnapServicesOptions struct {
 	Disable bool
 	ScopeOptions
 }
 
-// StopServices stops and optionally disables service units for the applications
+// StopSnapServices stops and optionally disables service units for the applications
 // from the snap which are services.
-func StopServices(apps []*snap.AppInfo, opts *StopServicesOptions, reason snap.ServiceStopReason, inter Interacter, tm timings.Measurer) error {
+func StopSnapServices(apps []*snap.AppInfo, opts *StopSnapServicesOptions, reason snap.ServiceStopReason, inter Interacter, tm timings.Measurer) error {
 	if opts == nil {
-		opts = &StopServicesOptions{}
+		opts = &StopSnapServicesOptions{}
 	}
 
 	if reason != snap.StopReasonOther {
-		logger.Debugf("StopServices called for %q, reason: %v", apps, reason)
+		logger.Debugf("StopSnapServices called for %q, reason: %v", apps, reason)
 	} else {
-		logger.Debugf("StopServices called for %q", apps)
+		logger.Debugf("StopSnapServices called for %q", apps)
 	}
 
 	sysd := systemd.New(systemd.SystemMode, inter)
@@ -1191,8 +1191,8 @@ func RemoveSnapServices(s *snap.Info, inter Interacter) error {
 	return nil
 }
 
-// RestartServicesOptions carries additional parameters for RestartServices.
-type RestartServicesOptions struct {
+// RestartSnapServicesOptions carries additional parameters for RestartServices.
+type RestartSnapServicesOptions struct {
 	// Reload set if we might need to reload the service definitions.
 	Reload bool
 	// AlsoEnabledNonActive set if we to restart also enabled but not running units
@@ -1201,7 +1201,7 @@ type RestartServicesOptions struct {
 }
 
 func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices []string,
-	opts *RestartServicesOptions, sysd systemd.Systemd, cli *userServiceClient, tm timings.Measurer) error {
+	opts *RestartSnapServicesOptions, sysd systemd.Systemd, cli *userServiceClient, tm timings.Measurer) error {
 	shouldRestart := func(active, enabled bool, name string) bool {
 		// If the unit was explicitly mentioned in the command line, restart it
 		// even if it is disabled; otherwise, we only restart units which are
@@ -1283,10 +1283,10 @@ func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices
 // The list of explicitServices needs to use systemd unit names.
 // TODO: change explicitServices format to be less unusual, more consistent
 // (introduce AppRef?)
-func RestartServices(apps []*snap.AppInfo, explicitServices []string,
-	opts *RestartServicesOptions, inter Interacter, tm timings.Measurer) error {
+func RestartSnapServices(apps []*snap.AppInfo, explicitServices []string,
+	opts *RestartSnapServicesOptions, inter Interacter, tm timings.Measurer) error {
 	if opts == nil {
-		opts = &RestartServicesOptions{}
+		opts = &RestartSnapServicesOptions{}
 	}
 	sysd := systemd.New(systemd.SystemMode, inter)
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -126,8 +126,8 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 
 	s.sysdLog = nil
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err = wrappers.StartServices(info.Services(), nil, opts, progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err = wrappers.StartSnapServices(info.Services(), nil, opts, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", filepath.Base(svcFile)},
@@ -162,7 +162,7 @@ WantedBy=multi-user.target
 	))
 
 	s.sysdLog = nil
-	err = wrappers.StopServices(info.Services(), nil, "", progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 2)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -2659,7 +2659,7 @@ WantedBy=multi-user.target
 		), comment)
 
 		s.sysdLog = nil
-		err = wrappers.StopServices(info.Services(), nil, "", progress.Null, s.perfTimings)
+		err = wrappers.StopSnapServices(info.Services(), nil, "", progress.Null, s.perfTimings)
 		c.Assert(err, IsNil, comment)
 		c.Assert(s.sysdLog, HasLen, 2, comment)
 		c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -2726,7 +2726,7 @@ WantedBy=multi-user.target
 	))
 
 	s.sysdLog = nil
-	err = wrappers.StopServices(info.Services(), nil, "", progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 2)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -2765,7 +2765,7 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
 	c.Check(svcFile, testutil.FileMatches, "(?ms).*^"+regexp.QuoteMeta(expected)) // check.v1 adds ^ and $ around the regexp provided
 
 	s.sysdLog = nil
-	err = wrappers.StopServices(info.Services(), nil, "", progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 2)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -2805,7 +2805,7 @@ func (s *servicesTestSuite) TestRemoveSnapWithSocketsRemovesSocketsService(c *C)
 	err := s.addSnapServices(info, false)
 	c.Assert(err, IsNil)
 
-	err = wrappers.StopServices(info.Services(), nil, "", &progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	err = wrappers.RemoveSnapServices(info, &progress.Null)
@@ -2850,7 +2850,7 @@ apps:
 
 	svcFName := "snap.wat.wat.service"
 
-	err = wrappers.StopServices(info.Services(), nil, "", progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "mock systemctl error")
 
 	c.Check(sysdLog, DeepEquals, [][]string{
@@ -2890,7 +2890,7 @@ apps:
 
 	svcFName := "snap.wat.wat.service"
 
-	err = wrappers.StopServices(info.Services(), nil, "", progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", progress.Null, s.perfTimings)
 	c.Check(err, ErrorMatches, "some user services failed to stop")
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--user", "stop", svcFName},
@@ -3187,8 +3187,8 @@ func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServices(c *C) {
 
 	s.sysdLog = nil
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err = wrappers.StartServices(info.Services(), disabledSvcs, opts, progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err = wrappers.StartSnapServices(info.Services(), disabledSvcs, opts, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	// only svc2 should be enabled
@@ -3258,7 +3258,7 @@ func (s *servicesTestSuite) TestStopServicesWithSockets(c *C) {
 	sysServices = nil
 	userServices = nil
 
-	err = wrappers.StopServices(info.Services(), nil, "", &progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	sort.Strings(sysServices)
@@ -3306,7 +3306,7 @@ func (s *servicesTestSuite) TestStopStartServicesWithSocketsDisableAndEnable(c *
 
 	// Verify the expected behaviour of StopServices when activations are in play. We expect it stop all services,
 	// including activations, and then disable all the services.
-	err = wrappers.StopServices(sorted, &wrappers.StopServicesOptions{Disable: true}, "", &progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(sorted, &wrappers.StopSnapServicesOptions{Disable: true}, "", &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
@@ -3337,7 +3337,7 @@ func (s *servicesTestSuite) TestStopStartServicesWithSocketsDisableAndEnable(c *
 	// For activated services, we expect StartServices to only affect the activation mechanisms
 	// when starting/enabling.
 	s.sysdLog = nil
-	err = wrappers.StartServices(sorted, nil, &wrappers.StartServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
+	err = wrappers.StartSnapServices(sorted, nil, &wrappers.StartSnapServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", "snap.hello-snap.svc1.sock1.socket", "snap.hello-snap.svc1.sock2.socket"},
@@ -3369,7 +3369,7 @@ func (s *servicesTestSuite) TestStartServicesWithServiceScope(c *C) {
 		return sorted[i].Name < sorted[j].Name
 	})
 
-	err = wrappers.StartServices(sorted, nil, &wrappers.StartServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeUser}}, &progress.Null, s.perfTimings)
+	err = wrappers.StartSnapServices(sorted, nil, &wrappers.StartSnapServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeUser}}, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
@@ -3380,7 +3380,7 @@ func (s *servicesTestSuite) TestStartServicesWithServiceScope(c *C) {
 	// Reset the sysd log
 	s.sysdLog = nil
 
-	err = wrappers.StartServices(sorted, nil, &wrappers.StartServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeSystem}}, &progress.Null, s.perfTimings)
+	err = wrappers.StartSnapServices(sorted, nil, &wrappers.StartSnapServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeSystem}}, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"start", "snap.hello-snap.svc1.service"},
@@ -3404,7 +3404,7 @@ func (s *servicesTestSuite) TestStopServicesWithServiceScope(c *C) {
 		return sorted[i].Name < sorted[j].Name
 	})
 
-	err = wrappers.StopServices(sorted, &wrappers.StopServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeUser}}, "", &progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(sorted, &wrappers.StopSnapServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeUser}}, "", &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
@@ -3416,7 +3416,7 @@ func (s *servicesTestSuite) TestStopServicesWithServiceScope(c *C) {
 	// Reset the sysd log
 	s.sysdLog = nil
 
-	err = wrappers.StopServices(sorted, &wrappers.StopServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeSystem}}, "", &progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(sorted, &wrappers.StopSnapServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeSystem}}, "", &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"stop", "snap.hello-snap.svc1.service"},
@@ -3455,7 +3455,7 @@ func (s *servicesTestSuite) TestStartServicesWithDisabledActivatedService(c *C) 
 	// When providing disabledServices (i.e during install), we want to make sure that
 	// the list of disabled services is honored, including their activation units.
 	s.sysdLog = nil
-	err = wrappers.StartServices(sorted, disabledSvcs, &wrappers.StartServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
+	err = wrappers.StartSnapServices(sorted, disabledSvcs, &wrappers.StartSnapServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		// Expect only calls related to svc2
@@ -3500,7 +3500,7 @@ func (s *servicesTestSuite) TestStartServicesWithDisabledUserServiceTriggersNoGl
 	}
 
 	s.sysdLog = nil
-	err = wrappers.StartServices(sorted, disabledSvcs, &wrappers.StartServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
+	err = wrappers.StartSnapServices(sorted, disabledSvcs, &wrappers.StartSnapServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		// Meaning we should only see the global enable for svc1 (since that is new)
@@ -3555,7 +3555,7 @@ func (s *servicesTestSuite) TestStartServicesStopsServicesIncludingActivation(c 
 		return sorted[i].Name < sorted[j].Name
 	})
 
-	err = wrappers.StartServices(sorted, nil, &wrappers.StartServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
+	err = wrappers.StartSnapServices(sorted, nil, &wrappers.StartSnapServicesOptions{Enable: true}, &progress.Null, s.perfTimings)
 	c.Check(err, NotNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		// Enable phase for the service activation units, we have one set of system daemon and one set of user daemon
@@ -3599,8 +3599,8 @@ func (s *servicesTestSuite) TestStartServices(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(info.Services(), nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(info.Services(), nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -3614,8 +3614,8 @@ func (s *servicesTestSuite) TestStartServicesNoEnable(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	opts := &wrappers.StartServicesOptions{Enable: false}
-	err := wrappers.StartServices(info.Services(), nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: false}
+	err := wrappers.StartSnapServices(info.Services(), nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -3631,8 +3631,8 @@ func (s *servicesTestSuite) TestStartServicesUserDaemons(c *C) {
 `, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/user/snap.hello-snap.svc1.service")
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(info.Services(), nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(info.Services(), nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.sysdLog, DeepEquals, [][]string{
@@ -3647,8 +3647,8 @@ func (s *servicesTestSuite) TestStartServicesEnabledConditional(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	opts := &wrappers.StartServicesOptions{}
-	c.Check(wrappers.StartServices(info.Services(), nil, opts, progress.Null, s.perfTimings), IsNil)
+	opts := &wrappers.StartSnapServicesOptions{}
+	c.Check(wrappers.StartSnapServices(info.Services(), nil, opts, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{{"start", filepath.Base(svcFile)}})
 }
 
@@ -3664,8 +3664,8 @@ func (s *servicesTestSuite) TestNoStartDisabledServices(c *C) {
 	disabledSvcs := &wrappers.DisabledServices{
 		SystemServices: []string{"svc1"},
 	}
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(info.Services(), disabledSvcs, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(info.Services(), disabledSvcs, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2Name},
@@ -3751,8 +3751,8 @@ func (s *servicesTestSuite) TestMultiServicesFailEnableCleanup(c *C) {
 	svcFiles, _ = filepath.Glob(filepath.Join(dirs.SnapServicesDir, "snap.hello-snap.*.service"))
 	c.Check(svcFiles, HasLen, 2)
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err = wrappers.StartServices(info.Services(), nil, opts, progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err = wrappers.StartSnapServices(info.Services(), nil, opts, progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 
 	c.Check(sysdLog, DeepEquals, [][]string{
@@ -4032,8 +4032,8 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 		svcs[0], svcs[1] = svcs[1], svcs[0]
 	}
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(svcs, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(svcs, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
@@ -4089,8 +4089,8 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	// ensure desired order
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
 	c.Assert(sysdLog, HasLen, 14, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
@@ -4154,8 +4154,8 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
 
 	// no enable
-	opts := &wrappers.StartServicesOptions{Enable: false}
-	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: false}
+	err := wrappers.StartSnapServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
 	c.Assert(sysdLog, HasLen, 11, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
@@ -4207,8 +4207,8 @@ func (s *servicesTestSuite) TestStartSnapMultiUserServicesFailStartCleanup(c *C)
 	if svcs[0].Name == "svc2" {
 		svcs[0], svcs[1] = svcs[1], svcs[0]
 	}
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(svcs, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(svcs, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "some user services failed to start")
 	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
@@ -4258,8 +4258,8 @@ apps:
 	sorted, err := snap.SortServices(svcs)
 	c.Assert(err, IsNil)
 
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err = wrappers.StartServices(sorted, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err = wrappers.StartSnapServices(sorted, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(sysdLog, HasLen, 5, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
@@ -4274,7 +4274,7 @@ apps:
 	sorted[1], sorted[0] = sorted[0], sorted[1]
 
 	// we should observe the calls done in the same order as services
-	err = wrappers.StartServices(sorted, nil, opts, &progress.Null, s.perfTimings)
+	err = wrappers.StartSnapServices(sorted, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog[5:], DeepEquals, [][]string{
@@ -4404,8 +4404,8 @@ apps:
 	s.sysdLog = nil
 
 	apps := []*snap.AppInfo{info.Apps["survivor"]}
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err = wrappers.StartServices(apps, nil, opts, progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err = wrappers.StartSnapServices(apps, nil, opts, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -4415,12 +4415,12 @@ apps:
 	})
 
 	s.sysdLog = nil
-	err = wrappers.StopServices(info.Services(), nil, snap.StopReasonRefresh, progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, snap.StopReasonRefresh, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 0)
 
 	s.sysdLog = nil
-	err = wrappers.StopServices(info.Services(), nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"stop", filepath.Base(survivorFile)},
@@ -4472,8 +4472,8 @@ apps:
 		for _, a := range info.Apps {
 			apps = append(apps, a)
 		}
-		opts := &wrappers.StartServicesOptions{Enable: true}
-		err = wrappers.StartServices(apps, nil, opts, progress.Null, s.perfTimings)
+		opts := &wrappers.StartSnapServicesOptions{Enable: true}
+		err = wrappers.StartSnapServices(apps, nil, opts, progress.Null, s.perfTimings)
 		c.Assert(err, IsNil)
 		c.Check(s.sysdLog, DeepEquals, [][]string{
 			{"--no-reload", "enable", filepath.Base(survivorFile)},
@@ -4482,7 +4482,7 @@ apps:
 		})
 
 		s.sysdLog = nil
-		err = wrappers.StopServices(info.Services(), nil, snap.StopReasonRefresh, progress.Null, s.perfTimings)
+		err = wrappers.StopSnapServices(info.Services(), nil, snap.StopReasonRefresh, progress.Null, s.perfTimings)
 		c.Assert(err, IsNil)
 		c.Check(s.sysdLog, DeepEquals, [][]string{
 			{"stop", filepath.Base(survivorFile)},
@@ -4490,7 +4490,7 @@ apps:
 		}, Commentf("failure in %s", t.mode))
 
 		s.sysdLog = nil
-		err = wrappers.StopServices(info.Services(), nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
+		err = wrappers.StopSnapServices(info.Services(), nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
 		c.Assert(err, IsNil)
 		switch t.expectedWho {
 		case "all":
@@ -4569,7 +4569,7 @@ apps:
 	sort.Sort(snap.AppInfoBySnapApp(services))
 
 	sysdLog = nil
-	err = wrappers.StopServices(services, nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(services, nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"stop", filepath.Base(fooUnitFile)},
@@ -4639,7 +4639,7 @@ apps:
 	sort.Sort(snap.AppInfoBySnapApp(services))
 
 	sysdLog = nil
-	err = wrappers.StopServices(services, nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(services, nil, snap.StopReasonRemove, progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, `really failed to stop service`)
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"stop", filepath.Base(fooUnitFile)},
@@ -4672,8 +4672,8 @@ func (s *servicesTestSuite) TestStartSnapSocketEnableStart(c *C) {
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 8, Commentf("len: %v calls: %v", len(s.sysdLog), s.sysdLog))
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -4708,8 +4708,8 @@ func (s *servicesTestSuite) TestStartSnapTimerEnableStart(c *C) {
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 8, Commentf("len: %v calls: %v", len(s.sysdLog), s.sysdLog))
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -4748,8 +4748,8 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"]}
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err := wrappers.StartServices(apps, nil, opts, &progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err := wrappers.StartSnapServices(apps, nil, opts, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
@@ -4783,7 +4783,7 @@ func (s *servicesTestSuite) TestAddRemoveSnapWithTimersAddsRemovesTimerFiles(c *
 	c.Check(osutil.FileExists(app.Timer.File()), Equals, true)
 	c.Check(osutil.FileExists(app.ServiceFile()), Equals, true)
 
-	err = wrappers.StopServices(info.Services(), nil, "", &progress.Null, s.perfTimings)
+	err = wrappers.StopSnapServices(info.Services(), nil, "", &progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	err = wrappers.RemoveSnapServices(info, &progress.Null)
@@ -4913,8 +4913,8 @@ apps:
 	s.sysdLog = nil
 
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
-	opts := &wrappers.StartServicesOptions{Enable: true}
-	err = wrappers.StartServices(apps, nil, opts, progress.Null, s.perfTimings)
+	opts := &wrappers.StartSnapServicesOptions{Enable: true}
+	err = wrappers.StartSnapServices(apps, nil, opts, progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.sysdLog, HasLen, 5, Commentf("len: %v calls: %v", len(s.sysdLog), s.sysdLog))
@@ -4983,8 +4983,8 @@ apps:
 	c.Assert(err, IsNil)
 
 	s.sysdLog = nil
-	opts := wrappers.RestartServicesOptions{Reload: true, AlsoEnabledNonActive: true}
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
+	opts := wrappers.RestartSnapServicesOptions{Reload: true, AlsoEnabledNonActive: true}
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},
 		{"reload-or-restart", srvFile},
@@ -4992,7 +4992,7 @@ apps:
 
 	s.sysdLog = nil
 	opts.Reload = false
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},
 		{"stop", srvFile},
@@ -5001,7 +5001,7 @@ apps:
 	})
 
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},
 		{"stop", srvFile},
@@ -5037,8 +5037,8 @@ apps:
 	c.Assert(err, IsNil)
 
 	s.sysdLog = nil
-	opts := wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), ErrorMatches, `oh noes`)
+	opts := wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: true}
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), ErrorMatches, `oh noes`)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},
 		{"stop", srvFile},
@@ -5069,8 +5069,8 @@ apps:
 	err := s.addSnapServices(info, false)
 	c.Assert(err, IsNil)
 
-	opts := wrappers.RestartServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeUser}}
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
+	opts := wrappers.RestartSnapServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeUser}}
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		// Only invocations from querying status
@@ -5110,8 +5110,8 @@ NeedDaemonReload=no
 	c.Assert(err, IsNil)
 
 	s.sysdLog = nil
-	opts := wrappers.RestartServicesOptions{Reload: true, AlsoEnabledNonActive: true}
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
+	opts := wrappers.RestartSnapServicesOptions{Reload: true, AlsoEnabledNonActive: true}
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},
 		{"--user", "reload-or-restart", srvFile},
@@ -5119,7 +5119,7 @@ NeedDaemonReload=no
 
 	s.sysdLog = nil
 	opts.Reload = false
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &opts, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},
 		{"--user", "stop", srvFile},
@@ -5128,7 +5128,7 @@ NeedDaemonReload=no
 	})
 
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(info.Services(), nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(info.Services(), nil, &wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile},
 		{"--user", "stop", srvFile},
@@ -5173,8 +5173,8 @@ NeedDaemonReload=no
 	err := s.addSnapServices(info, false)
 	c.Assert(err, IsNil)
 
-	opts := wrappers.RestartServicesOptions{Reload: true, AlsoEnabledNonActive: true}
-	err = wrappers.RestartServices(info.Services(), nil, &opts, progress.Null, s.perfTimings)
+	opts := wrappers.RestartSnapServicesOptions{Reload: true, AlsoEnabledNonActive: true}
+	err = wrappers.RestartSnapServices(info.Services(), nil, &opts, progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, `some user services failed to restart`)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--user", "daemon-reload"},
@@ -5213,8 +5213,8 @@ NeedDaemonReload=no
 	err := s.addSnapServices(info, false)
 	c.Assert(err, IsNil)
 
-	opts := wrappers.RestartServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeSystem}}
-	c.Assert(wrappers.RestartServices(info.Services(), []string{srvFile}, &opts, progress.Null, s.perfTimings), IsNil)
+	opts := wrappers.RestartSnapServicesOptions{ScopeOptions: wrappers.ScopeOptions{Scope: wrappers.ServiceScopeSystem}}
+	c.Assert(wrappers.RestartSnapServices(info.Services(), []string{srvFile}, &opts, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		// Those comes from querying status of services
 		{"--user", "daemon-reload"},
@@ -5267,7 +5267,7 @@ apps:
 	s.sysdLog = nil
 	services := info.Services()
 	sort.Sort(snap.AppInfoBySnapApp(services))
-	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, &wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2, srvFile3, srvFile4},
 		{"stop", srvFile1},
@@ -5284,7 +5284,7 @@ apps:
 	// Verify that explicitly mentioning a service causes it to restart,
 	// regardless of its state
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(services, []string{srvFile4}, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, []string{srvFile4}, &wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2, srvFile3, srvFile4},
 		{"stop", srvFile1},
@@ -5303,7 +5303,7 @@ apps:
 
 	// Check the restart only active service case
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: false}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, &wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: false}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2, srvFile3, srvFile4},
 		{"stop", srvFile1},
@@ -5362,7 +5362,7 @@ apps:
 	s.sysdLog = nil
 	services := info.Services()
 	sort.Sort(snap.AppInfoBySnapApp(services))
-	c.Assert(wrappers.RestartServices(services, nil, nil, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, nil, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
@@ -5374,7 +5374,7 @@ apps:
 	// Restart but with restarting non-active, this means that the activated services
 	// should be restarted now
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, &wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
@@ -5393,7 +5393,7 @@ apps:
 	// The only call we expect to appear here is the primary service of svc1 as
 	// that one is the only one reported as active here.
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, &wrappers.RestartSnapServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
@@ -5448,7 +5448,7 @@ apps:
 	s.sysdLog = nil
 	services := info.Services()
 	sort.Sort(snap.AppInfoBySnapApp(services))
-	c.Assert(wrappers.RestartServices(services, nil, nil, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, nil, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
@@ -5463,7 +5463,7 @@ apps:
 	// The activator service units should restart, but not the main one since
 	// it was reported as inactive
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, &wrappers.RestartSnapServicesOptions{AlsoEnabledNonActive: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
@@ -5481,7 +5481,7 @@ apps:
 	// reported active). The reason we don't expect to see the activation units restarted
 	// when reloading, is that these units do not support reloading by systemd.
 	s.sysdLog = nil
-	c.Assert(wrappers.RestartServices(services, nil, &wrappers.RestartServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, &wrappers.RestartSnapServicesOptions{Reload: true}, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
@@ -5533,7 +5533,7 @@ apps:
 	s.sysdLog = nil
 	services := info.Services()
 	sort.Sort(snap.AppInfoBySnapApp(services))
-	c.Assert(wrappers.RestartServices(services, nil, nil, progress.Null, s.perfTimings), IsNil)
+	c.Assert(wrappers.RestartSnapServices(services, nil, nil, progress.Null, s.perfTimings), IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", srvFile1, srvFile2},
 		{"show", "--property=Id,ActiveState,UnitFileState,Names", srvFile2Sock1, srvFile2Sock2},
@@ -5556,8 +5556,8 @@ func (s *servicesTestSuite) TestStopAndDisableServices(c *C) {
 	c.Assert(err, IsNil)
 
 	s.sysdLog = nil
-	opts := &wrappers.StopServicesOptions{Disable: true}
-	err = wrappers.StopServices(info.Services(), opts, "", progress.Null, s.perfTimings)
+	opts := &wrappers.StopSnapServicesOptions{Disable: true}
+	err = wrappers.StopSnapServices(info.Services(), opts, "", progress.Null, s.perfTimings)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"stop", svcFile},


### PR DESCRIPTION
Planning to add methods to control non-snap services. These methods will be a lot simpler, and thus will get their own functions.