### PR TITLE
spread.yaml: do not filter out .img files

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -733,7 +733,6 @@ exclude:
     - "*.qcow2"
     - "*.log"
     - "*.iso"
-    - "*.img"
 
 debug-each: |
     if [ "$SPREAD_DEBUG_EACH" != 1 ]; then


### PR DESCRIPTION
They are need by gadgets for remodeling.