### PR TITLE
osutil: fix buildid test

### DIFF
--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -47,9 +47,10 @@ func (s *buildIDSuite) SetUpTest(c *C) {
 }
 
 func buildID(c *C, fname string) string {
-	// XXX host's 'file' command may be too old to know about Go BuildID or
-	// hexstring GNU BuildID, use with caution
-	output, err := exec.Command("file", fname).CombinedOutput()
+	// XXX Host's "file" command may be too old to know about Go BuildID or
+	// hexstring GNU BuildID, use with caution. Use "-L" to follow symlinks,
+	// to also cover e.g. Ubuntu 25.10 where /bin/true is a symlink to gnutrue.
+	output, err := exec.Command("file", "-L", fname).CombinedOutput()
 	c.Assert(err, IsNil)
 
 	c.Logf("file output: %q", string(output))


### PR DESCRIPTION
The osutil buildid unit test fails in Ubuntu 25.10 due to /bin/{true,false} symlink to /bin/gnue{true,false}. In the test env `POSIXLY_CORRECT` is not set, which means symlinks are not followed by default. Propose making test more robust by explicitly following symlink using `file -L` option.

This issue was detected during LP build of snapd 2.68.5 for Ubuntu 25.10, where it fails for all architectures except riscv64.
Examaple: [amd64 build log](https://launchpadlibrarian.net/795450514/buildlog_ubuntu-questing-amd64.snapd_2.68.5+ubuntu25.10_BUILDING.txt.gz)

JIRA: https://warthogs.atlassian.net/browse/SNAPDENG-35110