### PR TITLE
cmd/snap-confine: support for host policy for limiting users able to run snaps

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -252,6 +252,8 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/mount-support.h \
 	snap-confine/ns-support.c \
 	snap-confine/ns-support.h \
+	snap-confine/group-policy.c \
+	snap-confine/group-policy.h \
 	snap-confine/seccomp-support-ext.c \
 	snap-confine/seccomp-support-ext.h \
 	snap-confine/seccomp-support.c \
@@ -343,7 +345,8 @@ snap_confine_unit_tests_SOURCES = \
 	snap-confine/ns-support-test.c \
 	snap-confine/seccomp-support-test.c \
 	snap-confine/snap-confine-args-test.c \
-	snap-confine/snap-confine-invocation-test.c
+	snap-confine/snap-confine-invocation-test.c \
+	snap-confine/group-policy-test.c
 snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS) $(SANITIZE_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_snap_confine_LDADD) $(GLIB_LIBS) libsnap-confine-private-test-support.a
 snap_confine_unit_tests_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS) $(SANITIZE_LDFLAGS)

--- a/cmd/libsnap-confine-private/tools-dir.h
+++ b/cmd/libsnap-confine-private/tools-dir.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_TOOLS_DIR_H
+#define SNAP_CONFINE_TOOLS_DIR_H
+
+#include "error.h"
+
+/**
+ * Canonical location of tools directory on the host.
+ **/
+#define SC_CANONICAL_HOST_TOOLS_DIR "/usr/lib/snapd"
+
+/**
+ * Alternate location of tools directory on the host.
+ **/
+#define SC_ALTERNATE_HOST_TOOLS_DIR "/usr/libexec/snapd"
+
+#endif /* SNAP_CONFINE_TOOLS_DIR_H */

--- a/cmd/snap-confine/group-policy-test.c
+++ b/cmd/snap-confine/group-policy-test.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+#include "group-policy.c"
+#include "group-policy.h"
+
+#include <glib.h>
+
+#include "../libsnap-confine-private/test-utils.h"  // For rm_rf_tmp
+
+// For compatibility with g_test_queue_destroy.
+static void close_noerr(gpointer fd) { (void)close(GPOINTER_TO_INT(fd)); }
+
+enum {
+    CANONICAL_PATH = 1,
+    ALTERNATIVE_PATH = 2,
+};
+
+static gchar *mock_snap_confine(gchar *root_dir, int which) {
+    GError *err = NULL;
+
+    g_assert_true(which == CANONICAL_PATH || which == ALTERNATIVE_PATH);
+
+    const char *tools_dir = SC_CANONICAL_HOST_TOOLS_DIR;
+    if (which == ALTERNATIVE_PATH) {
+        tools_dir = SC_ALTERNATE_HOST_TOOLS_DIR;
+    }
+
+    char *sc_path = g_build_filename(root_dir, "/proc/1/root", tools_dir, "snap-confine", NULL);
+    g_test_queue_free(sc_path);
+
+    g_debug("snap-confine mocked at %s", sc_path);
+
+    char *sc_dir = g_path_get_dirname(sc_path);
+    int ret = g_mkdir_with_parents(sc_dir, 0755);
+    g_assert_cmpint(ret, ==, 0);
+    g_free(sc_dir);
+
+    g_file_set_contents(sc_path, NULL, 0, &err);
+    g_assert_no_error(err);
+
+    return sc_path;
+}
+
+static char *mock_root_dir(void) {
+    char *root_dir = g_dir_make_tmp(NULL, NULL);
+    g_assert_nonnull(root_dir);
+    g_test_queue_free(root_dir);
+    g_test_queue_destroy((GDestroyNotify)rm_rf_tmp, root_dir);
+    g_debug("root dir mocked at %s", root_dir);
+    return root_dir;
+}
+
+static void test_group_policy_no_sc(void) {
+    char *root_dir = mock_root_dir();
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
+
+    struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    bool ret = _sc_assert_host_local_group_policy(root_fd, geteuid() + 1, NULL, 0, &err);
+    g_assert_false(ret);
+    g_assert_nonnull(err);
+
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_ERRNO_DOMAIN);
+    g_assert_cmpint(sc_error_code(err), ==, ENOENT);
+    g_assert_cmpstr(sc_error_msg(err), ==, "cannot locate snap-confine in host root filesystem");
+}
+
+static void test_group_policy_happy_canonical(void) {
+    char *root_dir = mock_root_dir();
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
+
+    mock_snap_confine(root_dir, CANONICAL_PATH);
+
+    struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    bool ret = sc_assert_host_local_group_policy(root_fd, &err);
+    g_assert_true(ret);
+    g_assert_null(err);
+}
+
+static void test_group_policy_happy_alternative(void) {
+    char *root_dir = mock_root_dir();
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
+
+    mock_snap_confine(root_dir, ALTERNATIVE_PATH);
+
+    struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    bool ret = sc_assert_host_local_group_policy(root_fd, &err);
+    g_assert_null(err);
+    g_assert_true(ret);
+}
+
+static void test_group_policy_nomatch_user(void) {
+    char *root_dir = mock_root_dir();
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
+
+    char *sc_path = mock_snap_confine(root_dir, CANONICAL_PATH);
+    if (geteuid() == 0) {
+        /* running as root, we need to change the ownership of mocked
+         * snap-confine to indicate the presence of a local policy, the owning
+         * GID must be non-0 and different than the one used in the check */
+        int ret = chown(sc_path, -1, getgid() + 2);
+        g_assert_cmpint(ret, ==, 0);
+    }
+
+    struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    bool ret = _sc_assert_host_local_group_policy(root_fd, getgid() + 1, NULL, 0, &err);
+    g_assert_nonnull(err);
+    g_assert_false(ret);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_GROUP_DOMAIN);
+    g_assert_cmpint(sc_error_code(err), ==, SC_NO_GROUP_PRIVS);
+    g_assert_cmpstr(
+        sc_error_msg(err), ==,
+        "user is not a member of group owning snap-confine, check you distribution's policy for running snaps");
+}
+
+static void test_group_policy_root(void) {
+    char *root_dir = mock_root_dir();
+
+    int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    g_assert_cmpint(root_fd, !=, -1);
+    g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
+
+    /* no need to mock snap-confine */
+
+    struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+    bool ret = _sc_assert_host_local_group_policy(root_fd, 0, NULL, 0, &err);
+    g_assert_null(err);
+    g_assert_true(ret);
+}
+
+static void __attribute__((constructor)) init(void) {
+    g_test_add_func("/group/no_sc", test_group_policy_no_sc);
+    g_test_add_func("/group/happy_canonical", test_group_policy_happy_canonical);
+    g_test_add_func("/group/happy_alternative", test_group_policy_happy_alternative);
+    g_test_add_func("/group/no_match_user", test_group_policy_nomatch_user);
+    g_test_add_func("/group/root", test_group_policy_root);
+}

--- a/cmd/snap-confine/group-policy-test.c
+++ b/cmd/snap-confine/group-policy-test.c
@@ -141,6 +141,11 @@ static void test_group_policy_nomatch_user(void) {
 }
 
 static void test_group_policy_root(void) {
+    if (geteuid() != 0) {
+        g_test_skip("test can only be run by real root user");
+        return;
+    }
+
     char *root_dir = mock_root_dir();
 
     int root_fd = open(root_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
@@ -148,9 +153,8 @@ static void test_group_policy_root(void) {
     g_test_queue_destroy((GDestroyNotify)close_noerr, GINT_TO_POINTER(root_fd));
 
     /* no need to mock snap-confine */
-
     struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
-    bool ret = _sc_assert_host_local_group_policy(root_fd, 0, NULL, 0, &err);
+    bool ret = sc_assert_host_local_group_policy(root_fd, &err);
     g_assert_null(err);
     g_assert_true(ret);
 }

--- a/cmd/snap-confine/group-policy.c
+++ b/cmd/snap-confine/group-policy.c
@@ -138,5 +138,5 @@ bool sc_assert_host_local_group_policy(int root_fd, sc_error **errorp) {
         }
     }
 
-    return _sc_assert_host_local_group_policy(root_fd, getgid(), groups, cnt, errorp);
+    return _sc_assert_host_local_group_policy(root_fd, real_gid, groups, cnt, errorp);
 }

--- a/cmd/snap-confine/group-policy.c
+++ b/cmd/snap-confine/group-policy.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "group-policy.h"
+
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/tools-dir.h"
+#include "../libsnap-confine-private/utils.h"
+
+static void sc_cleanup_gid_ts(gid_t **groups) {
+    if (groups != NULL && *groups != NULL) {
+        free(*groups);
+        *groups = NULL;
+    }
+}
+
+static bool sc_fstatat_host_snap_confine(int root_fd, struct stat *buf, sc_error **errorp) {
+    char target[PATH_MAX] = {0};
+
+    const char *pid_1_root = (root_fd == AT_FDCWD) ? "/proc/1/root" : "proc/1/root";
+
+    memset(buf, 0, sizeof(*buf));
+    /* let's try the default path */
+    sc_must_snprintf(target, sizeof(target), "%s" SC_CANONICAL_HOST_TOOLS_DIR "/snap-confine", pid_1_root);
+
+    if (fstatat(root_fd, target, buf, AT_SYMLINK_NOFOLLOW) != 0) {
+        if (errno != ENOENT) {
+            sc_error_forward(errorp, sc_error_init_from_errno(errno, "cannot fstatat() in canonical tools directory"));
+            return false;
+        }
+    } else {
+        debug("snap-confine found at %s", target);
+        return true;
+    }
+
+    /* no dice, try the alternate path */
+    memset(buf, 0, sizeof(*buf));
+    sc_must_snprintf(target, sizeof(target), "%s" SC_ALTERNATE_HOST_TOOLS_DIR "/snap-confine", pid_1_root);
+    debug("checking at %s", target);
+    if (fstatat(root_fd, target, buf, AT_SYMLINK_NOFOLLOW) != 0) {
+        if (errno != ENOENT) {
+            sc_error_forward(errorp,
+                             sc_error_init_from_errno(errno, "cannot fstatat() in alternative tools directory"));
+            return false;
+        }
+    } else {
+        debug("snap-confine found at %s", target);
+        return true;
+    }
+
+    debug("s-c not found");
+    sc_error_forward(errorp, sc_error_init_from_errno(ENOENT, "cannot locate snap-confine in host root filesystem"));
+    return false;
+}
+
+/* lower level API to facilitate testing */
+static bool _sc_assert_host_local_group_policy(int root_fd, gid_t real_gid, gid_t *groups, size_t groups_cnt,
+                                               sc_error **errorp) {
+    struct stat buf;
+    sc_error *err = NULL;
+
+    if (real_gid == 0) {
+        debug("the user is member of root group");
+        return true;
+    }
+
+    if (!sc_fstatat_host_snap_confine(root_fd, &buf, &err)) {
+        sc_error_forward(errorp, err);
+        return false;
+    }
+
+    if (buf.st_gid == 0) {
+        /* owned by root */
+        debug("host snap-confine is owned by root");
+        return true;
+    }
+
+    if (real_gid == buf.st_gid) {
+        debug("current user is a member of group owning snap-confine");
+        return true;
+    }
+
+    for (size_t i = 0; i < groups_cnt; i++) {
+        if (groups[i] == buf.st_gid) {
+            debug("current user is a member of supplementary group owning snap-confine");
+            return true;
+        }
+    }
+
+    if (errorp != NULL) {
+        *errorp = sc_error_init(
+            SC_GROUP_DOMAIN, SC_NO_GROUP_PRIVS,
+            "user is not a member of group owning snap-confine, check you distribution's policy for running snaps");
+    }
+    return false;
+}
+
+bool sc_assert_host_local_group_policy(int root_fd, sc_error **errorp) {
+    /* check supplementary groups */
+    int cnt = getgroups(0, NULL);
+    if (cnt < 0) {
+        sc_error_forward(errorp, sc_error_init_from_errno(errno, "cannot list supplementary groups"));
+        return false;
+    }
+
+    gid_t *groups SC_CLEANUP(sc_cleanup_gid_ts) = NULL;
+
+    if (cnt > 0) {
+        groups = calloc(cnt, sizeof(gid_t));
+
+        cnt = getgroups(cnt, groups);
+        if (cnt < 0) {
+            sc_error_forward(errorp, sc_error_init_from_errno(errno, "cannot list supplementary groups"));
+            return false;
+        }
+    }
+
+    return _sc_assert_host_local_group_policy(root_fd, getgid(), groups, cnt, errorp);
+}

--- a/cmd/snap-confine/group-policy.h
+++ b/cmd/snap-confine/group-policy.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SC_SNAP_CONFINE_GROUP_POLICY_H
+#define SC_SNAP_CONFINE_GROUP_POLICY_H
+
+#include <unistd.h>
+
+#include "../libsnap-confine-private/error.h"
+
+/**
+ * Error domain for errors related to group policies.
+ **/
+#define SC_GROUP_DOMAIN "groups"
+
+enum {
+    /**
+     * Error indicating that the user has no privileges to run snaps as per
+     * local polcy.
+     **/
+    SC_NO_GROUP_PRIVS = 1,
+};
+
+/**
+ * Assert optional local policy of regular users needing to be a being a member
+ * of a specific group in order to run snaps.
+ *
+ * This involves peeking into the host filesystem to fstatat() the host's
+ * snap-confine binary.
+ */
+bool sc_assert_host_local_group_policy(int root_fd, sc_error **errorp);
+
+#endif /* SC_SNAP_CONFINE_GROUP_POLICY_H */

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -50,6 +50,7 @@
 #include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
 #include "cookie-support.h"
+#include "group-policy.h"
 #include "mount-support.h"
 #include "ns-support.h"
 #include "seccomp-support.h"
@@ -428,6 +429,11 @@ int main(int argc, char **argv) {
     if (sc_cap_reset_ambient() != 0) {
         die("cannot reset ambient capabilities");
     }
+
+    /* Some distributions choose to limit the ability of regular users to run
+     * snaps to members of a specific local group */
+    sc_assert_host_local_group_policy(AT_FDCWD, &err);
+    sc_die_on_error(err);
 
     // Figure out what is the SNAP_MOUNT_DIR in practice.
     sc_probe_snap_mount_dir_from_pid_1_mount_ns(AT_FDCWD, &err);

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -431,7 +431,9 @@ int main(int argc, char **argv) {
     }
 
     /* Some distributions choose to limit the ability of regular users to run
-     * snaps to members of a specific local group */
+     * snaps to members of a specific local group. Note we need to keep elevated
+     * privileges as the code peeks into pid 1 root filesystem to locate
+     * snap-confine */
     sc_assert_host_local_group_policy(AT_FDCWD, &err);
     sc_die_on_error(err);
 

--- a/tests/main/security-group-policy/task.yaml
+++ b/tests/main/security-group-policy/task.yaml
@@ -1,0 +1,66 @@
+summary: Verify local group policy
+
+details: |
+    Verify that snap-confine honors local group policies for executing snaps
+
+systems:
+    # not relevant for UC
+    - -ubuntu-core-*
+    # disable systems where there is an outdated native package and the
+    # non-reexec variant is broken as the native snap is unable to correctly
+    # invoke internal tools
+    - -ubuntu-18.04-*
+    - -ubuntu-16.04-*
+    - -debian-11-*
+    - -debian-12-*
+
+environment:
+    SNAP_REEXEC/no_reexec: 0
+    SNAP_REEXEC/with_reexec: 1
+
+prepare: |
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
+    case "$SPREAD_SYSTEM" in
+        fedora-*|arch-*|centos-*)
+            # although classic snaps do not work out of the box on fedora,
+            # Arch linux and Centos, we still want to verify if the basics
+            # do work if the user symlinks /snap to $SNAP_MOUNT_DIR themselves
+            SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+            ln -sf "$SNAP_MOUNT_DIR" /snap
+            tests.cleanup defer rm -f /snap
+            ;;
+    esac
+
+    NOMATCH snap-runners /etc/group
+    groupadd snap-runners
+    tests.cleanup defer groupdel snap-runners
+
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
+
+    find "$LIBEXEC_DIR"/snapd/snap-confine -ls | MATCH 'root +root'
+    cp -a "$LIBEXEC_DIR"/snapd/snap-confine{,.backup}
+    tests.cleanup defer mv "$LIBEXEC_DIR"/snapd/snap-confine{.backup,}
+
+    chown :snap-runners "$LIBEXEC_DIR"/snapd/snap-confine
+    # restore caps, depending on whether the host binary had them
+    caps="$(getcap "$LIBEXEC_DIR"/snapd/snap-confine.backup | awk '{ print $2 }')"
+    if [ -n "$caps" ]; then
+        echo "$caps" | setcap - "$LIBEXEC_DIR"/snapd/snap-confine
+    fi
+
+    grep snap-runners /etc/group | NOMATCH test
+    tests.session -u test prepare
+
+restore: |
+    tests.session -u test restore
+
+execute: |
+    tests.session -u test exec sh -c "test-snapd-sh-core24.sh -c 'true' 2>&1" | \
+        MATCH 'user is not a member of group'
+
+    usermod -a -G snap-runners test
+    # restart the user's session
+    tests.session -u test restore
+    tests.session -u test prepare
+
+    tests.session -u test exec sh -c "test-snapd-sh-core24.sh -c 'true'"


### PR DESCRIPTION
Some distributions have opinions on who can run snaps and would prefer to have a way to limit execution of snaps only to members of a specific group.

The patch allows support for setting the group ownership of snap-confine as an indicator that only members of said group should be able to run snaps.

In theory the same can be limited by setting root:<group> ownership and then 0750 flags, or ACLs, but this only works for the local case. However, this is not enough to ensure a consistent policy if reexec is enabled. In such scenario /usr/bin/snap reexecs into /snap/snapd/current/usr/bin/snap and proceeds to call snap-confine from the snapd snap. The snapd snap is built as part of the upstream releases and is not aware of any local distro policies expressed through group ownership or ACLs, unless this is explicitly accounted for in the code, which is done in this patch.

Related: [SNAPDENG-34372](https://warthogs.atlassian.net/browse/SNAPDENG-34372)


[SNAPDENG-34372]: https://warthogs.atlassian.net/browse/SNAPDENG-34372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ