### PR TITLE
fakestore: fix channels in refresh

### DIFF
--- a/tests/nested/manual/update-snapd-seed-and-factory-reset/task.yaml
+++ b/tests/nested/manual/update-snapd-seed-and-factory-reset/task.yaml
@@ -29,6 +29,8 @@ environment:
 
   NESTED_KERNEL_REMOVE_COMPONENTS: true
 
+  NESTED_CORE_CHANNEL: ""
+
 prepare: |
     # Install what is needed before using the fake store
     snap install test-snapd-swtpm --edge
@@ -178,9 +180,6 @@ execute: |
     remote.exec "snap version" | MATCH "^snapd *2.63$"
 
     remote.push model-new.model
-
-    # Some auto refresh sometimes start and we cannot remodel
-    retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | NOMATCH '(Doing|Undoing)'"
 
     boot_id="$(tests.nested boot-id)"
     change_id="$(remote.exec sudo snap remodel --no-wait model-new.model)"


### PR DESCRIPTION
"channel" is defined for a refresh action only if we change of channel. Otherwise we have to find the tracking channel in the
context.