### PR TITLE
tests: initial change to support the new ps7 environment

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -472,6 +472,62 @@ backends:
                 image: snapd-spread/ubuntu-24.04-arm-64
                 workers: 8
 
+    openstack-ps7:
+        type: openstack
+        key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS7")'
+        plan: shared.xsmall
+        halt-timeout: 2h
+        wait-timeout: 5m
+        groups: [default]
+        proxy: ingress-haproxy.ps7.canonical.com
+        cidr-port-rel: [10.151.54.0/24:4000]
+        environment:
+            SNAPD_USE_PROXY: 'true'
+            HTTP_PROXY: 'http://egress.ps7.internal:3128'
+            HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+            http_proxy: 'http://egress.ps7.internal:3128'
+            https_proxy: 'http://egress.ps7.internal:3128'
+            no_proxy: '127.0.0.1'
+            NO_PROXY: '127.0.0.1'
+        systems:
+            - ubuntu-20.04-64:
+                image: auto-sync/ubuntu-focal-20.04-amd64-server
+                workers: 8
+            - ubuntu-22.04-64:
+                image: auto-sync/ubuntu-jammy-22.04-amd64-server
+                workers: 8
+            - ubuntu-24.04-64:
+                image: auto-sync/ubuntu-noble-24.04-amd64-server
+                workers: 8
+
+    openstack-arm-ps7:
+        type: openstack
+        key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS7")'
+        plan: shared.xsmall.arm64
+        halt-timeout: 2h
+        wait-timeout: 5m
+        groups: [default]
+        proxy: ingress-haproxy.ps7.canonical.com
+        cidr-port-rel: [10.151.53.0/24:3000]
+        environment:
+            SNAPD_USE_PROXY: 'true'
+            HTTP_PROXY: 'http://egress.ps7.internal:3128'
+            HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+            http_proxy: 'http://egress.ps7.internal:3128'
+            https_proxy: 'http://egress.ps7.internal:3128'
+            no_proxy: '127.0.0.1'
+            NO_PROXY: '127.0.0.1'
+        systems:
+            - ubuntu-20.04-arm-64:
+                image: auto-sync/ubuntu-focal-20.04-arm64-server
+                workers: 8
+            - ubuntu-22.04-arm-64:
+                image: auto-sync/ubuntu-jammy-22.04-arm64-server
+                workers: 8
+            - ubuntu-24.04-arm-64:
+                image: auto-sync/ubuntu-noble-24.04-arm64-server
+                workers: 8
+
     qemu-nested:
         memory: 4G
         type: qemu

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -88,10 +88,15 @@ disable_refreshes() {
 }
 
 setup_systemd_snapd_overrides() {
+    local PROXY_PARAM=""
+    if [ -n "$HTTPS_PROXY" ] && [ "${SNAPD_USE_PROXY:-}" == true ]; then
+        PROXY_PARAM="HTTPS_PROXY=$HTTPS_PROXY"
+    fi
+
     mkdir -p /etc/systemd/system/snapd.service.d
     cat <<EOF > /etc/systemd/system/snapd.service.d/local.conf
 [Service]
-Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_REBOOT_DELAY=10m SNAPD_CONFIGURE_HOOK_TIMEOUT=30s SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE
+Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_REBOOT_DELAY=10m SNAPD_CONFIGURE_HOOK_TIMEOUT=30s SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE $PROXY_PARAM
 ExecStartPre=/bin/touch /dev/iio:device0
 
 [Unit]


### PR DESCRIPTION
This change is only adding the backends in the spread.yaml and it is adding a new env var to define if snapd needs to use the proxy because it is required in ps7 and it is not in ps6.

Next change will move 1 system to PS7