### PR TITLE
many: move notice state out of snapd state

### DIFF
--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
@@ -97,26 +98,21 @@ type InterfacesRequestsManager struct {
 }
 
 func New(s *state.State) (m *InterfacesRequestsManager, retErr error) {
+	// XXX: it would be nice if we could get a pointer to the overlord or
+	// NoticeManager directly so we don't have to look it up through the state
+	// cache each time we want to record a notice.
 	notifyPrompt := func(userID uint32, promptID prompting.IDType, data map[string]string) error {
-		// TODO: add some sort of queue so that notifyPrompt calls can return
-		// quickly without waiting for state lock and AddNotice() to return.
-		s.Lock()
-		defer s.Unlock()
-		options := state.AddNoticeOptions{
+		options := notices.AddNoticeOptions{
 			Data: data,
 		}
-		_, err := s.AddNotice(&userID, state.InterfacesRequestsPromptNotice, promptID.String(), &options)
+		_, err := notices.AddNotice(s, &userID, notices.InterfacesRequestsPromptNotice, promptID.String(), &options)
 		return err
 	}
 	notifyRule := func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
-		// TODO: add some sort of queue so that notifyRule calls can return
-		// quickly without waiting for state lock and AddNotice() to return.
-		s.Lock()
-		defer s.Unlock()
-		options := state.AddNoticeOptions{
+		options := notices.AddNoticeOptions{
 			Data: data,
 		}
-		_, err := s.AddNotice(&userID, state.InterfacesRequestsRuleUpdateNotice, ruleID.String(), &options)
+		_, err := notices.AddNotice(s, &userID, notices.InterfacesRequestsRuleUpdateNotice, ruleID.String(), &options)
 		return err
 	}
 

--- a/overlord/notices/export_test.go
+++ b/overlord/notices/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2024 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,21 +17,20 @@
  *
  */
 
-package daemon
+package notices
 
 import (
-	"github.com/snapcore/snapd/overlord/notices"
+	"time"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
-var (
-	SanitizeNoticeTypesFilter = sanitizeNoticeTypesFilter
-	NoticeTypesViewableBySnap = noticeTypesViewableBySnap
-)
+// NumNotices returns the total bumber of notices, including expired ones that
+// haven't yet been pruned.
+func (m *NoticeManager) NumNotices() int {
+	return len(m.notices)
+}
 
-func MockNoticeReadInterfaces(newMap map[notices.NoticeType][]string) (restore func()) {
-	old := noticeReadInterfaces
-	noticeReadInterfaces = newMap
-	return func() {
-		noticeReadInterfaces = old
-	}
+func MockTime(now time.Time) (restore func()) {
+	return testutil.Mock(&timeNow, func() time.Time { return now })
 }

--- a/overlord/notices/noticemgr.go
+++ b/overlord/notices/noticemgr.go
@@ -1,0 +1,387 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notices
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var (
+	timeNow = time.Now
+)
+
+type noticeManagerKey struct{}
+
+// NoticeManager holds the internal notice state and manages retrieving and
+// adding notices.
+type NoticeManager struct {
+	noticeMu            sync.RWMutex
+	lastNoticeID        int
+	lastNoticeTimestamp time.Time
+	noticeCond          *sync.Cond
+	notices             map[noticeKey]*Notice
+}
+
+// Manager returns a new NoticeManager.
+func Manager(st *state.State) (*NoticeManager, error) {
+	m := &NoticeManager{
+		notices: map[noticeKey]*Notice{},
+	}
+	m.noticeCond = sync.NewCond(&m.noticeMu)
+
+	// Save manager in the state cache so that users of the state can access
+	// it without needing a reference to the overlord itself.
+	st.Cache(noticeManagerKey{}, m)
+
+	// Also save a callback so that the state is able to record change update
+	// notices without needing to import the notices package.
+	addChangeUpdateNotice := func(ch *state.Change) error {
+		opts := &AddNoticeOptions{
+			Data: map[string]string{"kind": ch.Kind()},
+		}
+		_, err := m.AddNotice(nil, ChangeUpdateNotice, ch.ID(), opts)
+		return err
+	}
+	st.Cache(state.AddChangeUpdateNoticeKey{}, addChangeUpdateNotice)
+
+	return m, nil
+}
+
+// Ensure implements StateManager.Ensure. Prunes expired notices.
+func (m *NoticeManager) Ensure() error {
+	now := time.Now()
+	for k, n := range m.notices {
+		if n.expired(now) {
+			delete(m.notices, k)
+		}
+	}
+	// XXX: do we need to proactively save to disk if any were pruned?
+	return nil
+}
+
+// StartUp implements StateStarterUp.Startup.
+//
+// Load any existing notices from disk to populate the notice manager.
+//
+// XXX: Should all of this be done during Manager() creation instead?
+func (m *NoticeManager) StartUp() error {
+	f, err := os.Open(filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "notices.json"))
+	defer f.Close()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("cannot open notice state file: %w", err)
+	}
+	if err = json.NewDecoder(f).Decode(m); err != nil {
+		return fmt.Errorf("cannot unmarshal notice state file: %w", err)
+	}
+	return nil
+}
+
+type marshalledNoticeState struct {
+	Notices             []*Notice `json:"notices,omitempty"`
+	LastNoticeID        int       `json:"last-nodice-id"`
+	LastNoticeTimestamp time.Time `json:"last-notice-timestamp,omitzero"`
+}
+
+func (m *NoticeManager) MarshalJSON() ([]byte, error) {
+	m.noticeMu.RLock()
+	defer m.noticeMu.RUnlock()
+
+	return json.Marshal(marshalledNoticeState{
+		Notices:             m.flattenNotices(nil),
+		LastNoticeID:        m.lastNoticeID,
+		LastNoticeTimestamp: m.lastNoticeTimestamp,
+	})
+}
+
+func (m *NoticeManager) UnmarshalJSON(data []byte) error {
+	m.noticeMu.Lock()
+	defer m.noticeMu.Unlock()
+
+	var unmarshalled marshalledNoticeState
+	err := json.Unmarshal(data, &unmarshalled)
+	if err != nil {
+		return err
+	}
+	m.unflattenNotices(unmarshalled.Notices)
+	m.lastNoticeID = unmarshalled.LastNoticeID
+	m.lastNoticeTimestamp = unmarshalled.LastNoticeTimestamp
+	return nil
+}
+
+// AddNotice records an occurrence of a notice with the specified type and key
+// and options.
+func (m *NoticeManager) AddNotice(userID *uint32, noticeType NoticeType, key string, options *AddNoticeOptions) (string, error) {
+	if options == nil {
+		options = &AddNoticeOptions{}
+	}
+	err := ValidateNotice(noticeType, key, options)
+	if err != nil {
+		return "", fmt.Errorf("internal error: %w", err)
+	}
+
+	m.noticeMu.Lock()
+	defer m.noticeMu.Unlock()
+
+	now := options.Time
+	if now.IsZero() {
+		now = timeNow()
+		// Ensure that two notices never have the same sent time.
+		//
+		// Since the Notices API receives an "after:" parameter with the
+		// date and time of the last received notice to filter all the
+		// previous notices and avoid duplicates, if two or more notices
+		// have the same date and time, only the first will be emitted,
+		// and the others will be silently discarded. This can happen in
+		// systems that don't guarantee a granularity of one nanosecond
+		// in their timers, which can happen in some not-so-old devices,
+		// where the HPET is used instead of internal high resolution
+		// timers, or in other architectures different from the X86_64.
+		if !now.After(m.lastNoticeTimestamp) {
+			now = m.lastNoticeTimestamp.Add(time.Nanosecond)
+		}
+		m.lastNoticeTimestamp = now
+	}
+	now = now.UTC()
+	newOrRepeated := false
+	uid, hasUserID := flattenUserID(userID)
+	uniqueKey := noticeKey{hasUserID, uid, noticeType, key}
+	notice, ok := m.notices[uniqueKey]
+	if !ok {
+		// First occurrence of this notice userID+type+key
+		m.lastNoticeID++
+		notice = &Notice{
+			id:            strconv.Itoa(m.lastNoticeID),
+			userID:        userID,
+			noticeType:    noticeType,
+			key:           key,
+			firstOccurred: now,
+			lastRepeated:  now,
+			expireAfter:   defaultNoticeExpireAfter,
+			occurrences:   1,
+		}
+		m.notices[uniqueKey] = notice
+		newOrRepeated = true
+	} else {
+		// Additional occurrence, update existing notice
+		notice.occurrences++
+		if options.RepeatAfter == 0 || now.After(notice.lastRepeated.Add(options.RepeatAfter)) {
+			// Update last repeated time if repeat-after time has elapsed (or is zero)
+			notice.lastRepeated = now
+			newOrRepeated = true
+		}
+	}
+	notice.lastOccurred = now
+	notice.lastData = options.Data
+	notice.repeatAfter = options.RepeatAfter
+
+	if newOrRepeated {
+		m.noticeCond.Broadcast()
+	}
+
+	return notice.id, nil
+}
+
+// Notices returns the list of notices that match the filter (if any),
+// ordered by the last-repeated time.
+func (m *NoticeManager) Notices(filter *NoticeFilter) []*Notice {
+	m.noticeMu.RLock()
+	defer m.noticeMu.RUnlock()
+
+	notices := m.flattenNotices(filter)
+	sort.Slice(notices, func(i, j int) bool {
+		return notices[i].lastRepeated.Before(notices[j].lastRepeated)
+	})
+	return notices
+}
+
+// Notice returns a single notice by ID, or nil if not found.
+func (m *NoticeManager) Notice(id string) *Notice {
+	m.noticeMu.RLock()
+	defer m.noticeMu.RUnlock()
+
+	// Could use another map for lookup, but the number of notices will likely
+	// be small, and this function is probably only used rarely, so performance
+	// is unlikely to matter.
+	for _, notice := range m.notices {
+		if notice.id == id {
+			return notice
+		}
+	}
+	return nil
+}
+
+// flattenNotices returns the current notices map as a flat list of notices.
+//
+// The caller must ensure that the notices lock is held for reading.
+func (m *NoticeManager) flattenNotices(filter *NoticeFilter) []*Notice {
+	now := time.Now()
+	var notices []*Notice
+	for _, n := range m.notices {
+		if n.expired(now) || !filter.matches(n) {
+			continue
+		}
+		notices = append(notices, n)
+	}
+	return notices
+}
+
+// unflattenNotices rebuilds the notices map from the given list of notices.
+//
+// The caller must ensure that the notices lock is held for writing.
+func (m *NoticeManager) unflattenNotices(flat []*Notice) {
+	now := time.Now()
+	m.notices = make(map[noticeKey]*Notice)
+	for _, n := range flat {
+		if n.expired(now) {
+			continue
+		}
+		userID, hasUserID := n.UserID()
+		uniqueKey := noticeKey{hasUserID, userID, n.noticeType, n.key}
+		m.notices[uniqueKey] = n
+	}
+}
+
+// WaitNotices waits for notices that match the filter to exist or occur,
+// returning the list of matching notices ordered by the last-repeated time.
+//
+// It waits until there is at least one matching notice or the context is
+// cancelled. If there are existing notices that match the filter,
+// WaitNotices will return them immediately.
+func (m *NoticeManager) WaitNotices(ctx context.Context, filter *NoticeFilter) ([]*Notice, error) {
+	m.noticeMu.RLock()
+	defer m.noticeMu.RUnlock()
+
+	// If there are existing notices, return them right away.
+	//
+	// State is already locked here by the caller, so notices won't be added
+	// concurrently.
+	notices := m.Notices(filter)
+	if len(notices) > 0 {
+		return notices, nil
+	}
+
+	// When the context is done/cancelled, wake up the waiters so that they
+	// can check their ctx.Err() and return if they're cancelled.
+	//
+	// TODO: replace this with context.AfterFunc once we're on Go 1.21.
+	stop := contextAfterFunc(ctx, func() {
+		// We need to acquire the cond lock here to be sure that the Broadcast
+		// below won't occur before the call to Wait, which would result in a
+		// missed signal (and deadlock).
+		m.noticeCond.L.Lock()
+		defer m.noticeCond.L.Unlock()
+
+		m.noticeCond.Broadcast()
+	})
+	defer stop()
+
+	for {
+		// Wait until a new notice occurs or a context is cancelled.
+		m.noticeCond.Wait()
+
+		// If this context is cancelled, return the error.
+		ctxErr := ctx.Err()
+		if ctxErr != nil {
+			return nil, ctxErr
+		}
+
+		// Otherwise check if there are now matching notices.
+		notices = m.Notices(filter)
+		if len(notices) > 0 {
+			return notices, nil
+		}
+	}
+}
+
+// Remove this and just use context.AfterFunc once we're on Go 1.21.
+func contextAfterFunc(ctx context.Context, f func()) func() {
+	stopCh := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			f()
+		case <-stopCh:
+		}
+	}()
+	stop := func() {
+		close(stopCh)
+	}
+	return stop
+}
+
+// noticeManager retrieves the NoticeManager cached in the given state.
+//
+// If there is no cached NoticeManager, then panics with the given message.
+//
+// XXX: Should this function just be exported? That would make many things
+// simpler.
+func noticeManager(st *state.State, errMsg string) *NoticeManager {
+	cached := st.Cached(noticeManagerKey{})
+	if cached == nil {
+		panic(errMsg)
+	}
+	return cached.(*NoticeManager)
+}
+
+// AddNotice records an occurrence of a notice with the specified type, key,
+// and options for the notice manager cached in the given state.
+func AddNotice(st *state.State, userID *uint32, noticeType NoticeType, key string, options *AddNoticeOptions) (string, error) {
+	m := noticeManager(st, "internal error: cannot add a notice before NoticeManager initialization")
+	return m.AddNotice(userID, noticeType, key, options)
+}
+
+// GetNotices returns the list of notices that match the filter (if any),
+// ordered by the last-repeated time, from the notice manager cached in the
+// given state.
+func GetNotices(st *state.State, filter *NoticeFilter) []*Notice {
+	m := noticeManager(st, "internal error: cannot get notices before NoticeManager initialization")
+	return m.Notices(filter)
+}
+
+// GetNotice returns a single notice by ID, or nil if not found, from the
+// notice manager cached in the given state.
+func GetNotice(st *state.State, id string) *Notice {
+	m := noticeManager(st, "internal error: cannot get notice before NoticeManager initialization")
+	return m.Notice(id)
+}
+
+// WaitNotices waits for notices that match the filter to exist or occur,
+// returning the list of matching notices ordered by the last-repeated time,
+// from the notice manager cached in the given state.
+func WaitNotices(st *state.State, ctx context.Context, filter *NoticeFilter) ([]*Notice, error) {
+	m := noticeManager(st, "internal error: cannot wait for notices before NoticeManager initialization")
+	return m.WaitNotices(ctx, filter)
+}

--- a/overlord/notices/notices_test.go
+++ b/overlord/notices/notices_test.go
@@ -12,13 +12,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package state_test
+package notices_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -26,6 +24,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -33,20 +32,27 @@ type noticesSuite struct{}
 
 var _ = Suite(&noticesSuite{})
 
-func (s *noticesSuite) TestMarshal(c *C) {
+func newNoticeManager(c *C) *notices.NoticeManager {
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
+	m, err := notices.Manager(st)
+	c.Assert(err, IsNil)
+	return m
+}
+
+func (s *noticesSuite) TestMarshal(c *C) {
+	m := newNoticeManager(c)
 
 	start := time.Now()
 	uid := uint32(1000)
-	addNotice(c, st, &uid, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, m, &uid, notices.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
-	addNotice(c, st, &uid, state.ChangeUpdateNotice, "123", &state.AddNoticeOptions{
+	addNotice(c, m, &uid, notices.ChangeUpdateNotice, "123", &notices.AddNoticeOptions{
 		Data: map[string]string{"k": "v"},
 	})
 
-	notices := st.Notices(nil)
+	notices := m.Notices(nil)
 	c.Assert(notices, HasLen, 1)
 
 	// Convert it to a map so we're not testing the JSON string directly
@@ -91,7 +97,7 @@ func (s *noticesSuite) TestUnmarshal(c *C) {
 		"repeat-after": "60m",
 		"expire-after": "168h0m0s"
 	}`)
-	var notice *state.Notice
+	var notice *notices.Notice
 	err := json.Unmarshal(noticeJSON, &notice)
 	c.Assert(err, IsNil)
 
@@ -124,7 +130,7 @@ func (s *noticesSuite) TestString(c *C) {
 		"last-repeated": "2023-09-01T06:23:03.123456789Z",
 		"occurrences": 2
 	}`)
-	var notice *state.Notice
+	var notice *notices.Notice
 	err := json.Unmarshal(noticeJSON, &notice)
 	c.Assert(err, IsNil)
 
@@ -147,44 +153,40 @@ func (s *noticesSuite) TestString(c *C) {
 }
 
 func (s *noticesSuite) TestType(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
-	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
-	addNotice(c, st, nil, state.WarningNotice, "danger!", nil)
+	addNotice(c, m, nil, notices.ChangeUpdateNotice, "123", nil)
+	addNotice(c, m, nil, notices.RefreshInhibitNotice, "-", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "danger!", nil)
 
-	notices := st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
-	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Type(), Equals, state.ChangeUpdateNotice)
+	result := m.Notices(&notices.NoticeFilter{Types: []notices.NoticeType{notices.ChangeUpdateNotice}})
+	c.Assert(result, HasLen, 1)
+	c.Check(result[0].Type(), Equals, notices.ChangeUpdateNotice)
 
-	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.RefreshInhibitNotice}})
-	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Type(), Equals, state.RefreshInhibitNotice)
+	result = m.Notices(&notices.NoticeFilter{Types: []notices.NoticeType{notices.RefreshInhibitNotice}})
+	c.Assert(result, HasLen, 1)
+	c.Check(result[0].Type(), Equals, notices.RefreshInhibitNotice)
 
-	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}})
-	c.Assert(notices, HasLen, 1)
-	c.Check(notices[0].Type(), Equals, state.WarningNotice)
+	result = m.Notices(&notices.NoticeFilter{Types: []notices.NoticeType{notices.WarningNotice}})
+	c.Assert(result, HasLen, 1)
+	c.Check(result[0].Type(), Equals, notices.WarningNotice)
 }
 
 func (s *noticesSuite) TestOccurrences(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/bar", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, m, nil, notices.ChangeUpdateNotice, "123", nil)
 
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 2)
-	n := noticeToMap(c, notices[0])
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 2)
+	n := noticeToMap(c, result[0])
 	c.Check(n["id"], Equals, "1")
 	c.Check(n["occurrences"], Equals, 3.0)
-	n = noticeToMap(c, notices[1])
+	n = noticeToMap(c, result[1])
 	c.Check(n["id"], Equals, "2")
 	c.Check(n["occurrences"], Equals, 1.0)
 }
@@ -202,18 +204,16 @@ func (s *noticesSuite) TestRepeatAfterBoth(c *C) {
 }
 
 func (s *noticesSuite) testRepeatAfter(c *C, first, second, delay time.Duration) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", &state.AddNoticeOptions{
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/bar", &notices.AddNoticeOptions{
 		RepeatAfter: first,
 	})
 	time.Sleep(time.Microsecond)
 
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	firstOccurred, err := time.Parse(time.RFC3339, n["first-occurred"].(string))
 	c.Assert(err, IsNil)
 	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
@@ -224,218 +224,208 @@ func (s *noticesSuite) testRepeatAfter(c *C, first, second, delay time.Duration)
 
 	// Add a notice (with faked time) after a long time and ensure it has repeated
 	future := time.Now().Add(delay)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", &state.AddNoticeOptions{
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/bar", &notices.AddNoticeOptions{
 		RepeatAfter: second,
 		Time:        future,
 	})
-	notices = st.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n = noticeToMap(c, notices[0])
+	result = m.Notices(nil)
+	c.Assert(result, HasLen, 1)
+	n = noticeToMap(c, result[0])
 	newLastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
 	c.Assert(err, IsNil)
 	c.Assert(newLastRepeated.After(lastRepeated), Equals, true)
 }
 
 func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
 	uid1 := uint32(1000)
 	uid2 := uint32(0)
-	addNotice(c, st, &uid1, state.ChangeUpdateNotice, "443", nil)
+	addNotice(c, m, &uid1, notices.ChangeUpdateNotice, "443", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, &uid2, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, m, &uid2, notices.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, &uid2, state.WarningNotice, "Warning 1!", nil)
+	addNotice(c, m, &uid2, notices.WarningNotice, "Warning 1!", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.WarningNotice, "Warning 2!", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "Warning 2!", nil)
 
 	// No filter
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 4)
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 4)
 
 	// User ID unset
-	notices = st.Notices(&state.NoticeFilter{})
-	c.Assert(notices, HasLen, 4)
+	result = m.Notices(&notices.NoticeFilter{})
+	c.Assert(result, HasLen, 4)
 
 	// User ID set
-	notices = st.Notices(&state.NoticeFilter{UserID: &uid2})
-	c.Assert(notices, HasLen, 3)
-	n := noticeToMap(c, notices[0])
+	result = m.Notices(&notices.NoticeFilter{UserID: &uid2})
+	c.Assert(result, HasLen, 3)
+	n := noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, float64(uid2))
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "123")
-	n = noticeToMap(c, notices[1])
+	n = noticeToMap(c, result[1])
 	c.Check(n["user-id"], Equals, float64(uid2))
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 1!")
-	n = noticeToMap(c, notices[2])
+	n = noticeToMap(c, result[2])
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 2!")
 }
 
 func (s *noticesSuite) TestNoticesFilterType(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
+	addNotice(c, m, nil, notices.RefreshInhibitNotice, "-", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.InterfacesRequestsPromptNotice, "443", nil)
+	addNotice(c, m, nil, notices.InterfacesRequestsPromptNotice, "443", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
+	addNotice(c, m, nil, notices.ChangeUpdateNotice, "123", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.WarningNotice, "Warning 1!", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "Warning 1!", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.WarningNotice, "Warning 2!", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "Warning 2!", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.SnapRunInhibitNotice, "snap-name", nil)
+	addNotice(c, m, nil, notices.SnapRunInhibitNotice, "snap-name", nil)
 
 	// No filter
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 6)
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 6)
 
 	// No types
-	notices = st.Notices(&state.NoticeFilter{})
-	c.Assert(notices, HasLen, 6)
+	result = m.Notices(&notices.NoticeFilter{})
+	c.Assert(result, HasLen, 6)
 
 	// One type
-	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}})
-	c.Assert(notices, HasLen, 2)
-	n := noticeToMap(c, notices[0])
+	result = m.Notices(&notices.NoticeFilter{Types: []notices.NoticeType{notices.WarningNotice}})
+	c.Assert(result, HasLen, 2)
+	n := noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 1!")
-	n = noticeToMap(c, notices[1])
+	n = noticeToMap(c, result[1])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "Warning 2!")
 
 	// Another type
-	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.RefreshInhibitNotice}})
-	c.Assert(notices, HasLen, 1)
-	n = noticeToMap(c, notices[0])
+	result = m.Notices(&notices.NoticeFilter{Types: []notices.NoticeType{notices.RefreshInhibitNotice}})
+	c.Assert(result, HasLen, 1)
+	n = noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "refresh-inhibit")
 	c.Check(n["key"], Equals, "-")
 
 	// Another type
-	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.SnapRunInhibitNotice}})
-	c.Assert(notices, HasLen, 1)
-	n = noticeToMap(c, notices[0])
+	result = m.Notices(&notices.NoticeFilter{Types: []notices.NoticeType{notices.SnapRunInhibitNotice}})
+	c.Assert(result, HasLen, 1)
+	n = noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "snap-run-inhibit")
 	c.Check(n["key"], Equals, "snap-name")
 
 	// Multiple types
-	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{
-		state.ChangeUpdateNotice,
-		state.InterfacesRequestsPromptNotice,
+	result = m.Notices(&notices.NoticeFilter{Types: []notices.NoticeType{
+		notices.ChangeUpdateNotice,
+		notices.InterfacesRequestsPromptNotice,
 	}})
-	c.Assert(notices, HasLen, 2)
-	n = noticeToMap(c, notices[0])
+	c.Assert(result, HasLen, 2)
+	n = noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "interfaces-requests-prompt")
 	c.Check(n["key"], Equals, "443")
-	n = noticeToMap(c, notices[1])
+	n = noticeToMap(c, result[1])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, "123")
 }
 
 func (s *noticesSuite) TestNoticesFilterKey(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/bar", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "example.com/x", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/baz", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/baz", nil)
 
 	// No filter
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 3)
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 3)
 
 	// No keys
-	notices = st.Notices(&state.NoticeFilter{})
-	c.Assert(notices, HasLen, 3)
+	result = m.Notices(&notices.NoticeFilter{})
+	c.Assert(result, HasLen, 3)
 
 	// One key
-	notices = st.Notices(&state.NoticeFilter{Keys: []string{"example.com/x"}})
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result = m.Notices(&notices.NoticeFilter{Keys: []string{"example.com/x"}})
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "example.com/x")
 
 	// Multiple keys
-	notices = st.Notices(&state.NoticeFilter{Keys: []string{
+	result = m.Notices(&notices.NoticeFilter{Keys: []string{
 		"foo.com/bar",
 		"foo.com/baz",
 	}})
-	c.Assert(notices, HasLen, 2)
-	n = noticeToMap(c, notices[0])
+	c.Assert(result, HasLen, 2)
+	n = noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/bar")
-	n = noticeToMap(c, notices[1])
+	n = noticeToMap(c, result[1])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/baz")
 }
 
 func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/x", nil)
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/x", nil)
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
 	c.Assert(err, IsNil)
 
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/y", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/y", nil)
 
 	// After unset
-	notices = st.Notices(nil)
-	c.Assert(notices, HasLen, 2)
+	result = m.Notices(nil)
+	c.Assert(result, HasLen, 2)
 
 	// After set
-	notices = st.Notices(&state.NoticeFilter{After: lastRepeated})
-	c.Assert(notices, HasLen, 1)
-	n = noticeToMap(c, notices[0])
+	result = m.Notices(&notices.NoticeFilter{After: lastRepeated})
+	c.Assert(result, HasLen, 1)
+	n = noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "foo.com/y")
 }
 
 func (s *noticesSuite) TestNotice(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
 	uid1 := uint32(0)
 	uid2 := uint32(123)
 	uid3 := uint32(1000)
-	addNotice(c, st, &uid1, state.WarningNotice, "foo.com/x", nil)
+	addNotice(c, m, &uid1, notices.WarningNotice, "foo.com/x", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, &uid2, state.WarningNotice, "foo.com/y", nil)
+	addNotice(c, m, &uid2, notices.WarningNotice, "foo.com/y", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, &uid3, state.WarningNotice, "foo.com/z", nil)
+	addNotice(c, m, &uid3, notices.WarningNotice, "foo.com/z", nil)
 
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 3)
-	n := noticeToMap(c, notices[1])
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 3)
+	n := noticeToMap(c, result[1])
 	noticeId, ok := n["id"].(string)
 	c.Assert(ok, Equals, true)
 
-	notice := st.Notice(noticeId)
+	notice := m.Notice(noticeId)
 	c.Assert(notice, NotNil)
 	n = noticeToMap(c, notice)
 	c.Check(n["user-id"], Equals, 123.0)
@@ -444,147 +434,135 @@ func (s *noticesSuite) TestNotice(c *C) {
 }
 
 func (s *noticesSuite) TestEmptyState(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	notices := st.Notices(nil)
-	c.Check(notices, HasLen, 0)
+	result := m.Notices(nil)
+	c.Check(result, HasLen, 0)
 }
 
-func (s *noticesSuite) TestCheckpoint(c *C) {
-	backend := &fakeStateBackend{}
-	st := state.New(backend)
-	st.Lock()
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
-	st.Unlock()
-	c.Assert(backend.checkpoints, HasLen, 1)
-
-	st2, err := state.ReadState(nil, bytes.NewReader(backend.checkpoints[0]))
-	c.Assert(err, IsNil)
-	st2.Lock()
-	defer st2.Unlock()
-
-	notices := st2.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
-	c.Check(n["user-id"], Equals, nil)
-	c.Check(n["type"], Equals, "warning")
-	c.Check(n["key"], Equals, "foo.com/bar")
-}
+// TODO: test save/restore instead
+//
+//func (s *noticesSuite) TestCheckpoint(c *C) {
+//	backend := &fakeStateBackend{}
+//	st := state.New(backend)
+//	st.Lock()
+//	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
+//	st.Unlock()
+//	c.Assert(backend.checkpoints, HasLen, 1)
+//
+//	st2, err := state.ReadState(nil, bytes.NewReader(backend.checkpoints[0]))
+//	c.Assert(err, IsNil)
+//	st2.Lock()
+//	defer st2.Unlock()
+//
+//	notices := st2.Notices(nil)
+//	c.Assert(notices, HasLen, 1)
+//	n := noticeToMap(c, notices[0])
+//	c.Check(n["user-id"], Equals, nil)
+//	c.Check(n["type"], Equals, "warning")
+//	c.Check(n["key"], Equals, "foo.com/bar")
+//}
 
 func (s *noticesSuite) TestDeleteExpired(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
 	old := time.Now().Add(-8 * 24 * time.Hour)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/w", &state.AddNoticeOptions{
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/w", &notices.AddNoticeOptions{
 		Time: old,
 	})
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/x", &state.AddNoticeOptions{
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/x", &notices.AddNoticeOptions{
 		Time: old,
 	})
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/y", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/y", nil)
 	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/z", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/z", nil)
 
-	c.Assert(st.NumNotices(), Equals, 4)
-	st.Prune(time.Now(), 0, 0, 0)
-	c.Assert(st.NumNotices(), Equals, 2)
+	c.Assert(m.NumNotices(), Equals, 4)
+	m.Ensure()
+	c.Assert(m.NumNotices(), Equals, 2)
 
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 2)
-	n := noticeToMap(c, notices[0])
+	result := m.Notices(nil)
+	c.Assert(result, HasLen, 2)
+	n := noticeToMap(c, result[0])
 	c.Assert(n["key"], Equals, "foo.com/y")
-	n = noticeToMap(c, notices[1])
+	n = noticeToMap(c, result[1])
 	c.Assert(n["key"], Equals, "foo.com/z")
 }
 
 func (s *noticesSuite) TestWaitNoticesExisting(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
-	addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
-	addNotice(c, st, nil, state.WarningNotice, "foo.com/baz", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/bar", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "example.com/x", nil)
+	addNotice(c, m, nil, notices.WarningNotice, "foo.com/baz", nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	notices, err := st.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{"example.com/x"}})
+	result, err := m.WaitNotices(ctx, &notices.NoticeFilter{Keys: []string{"example.com/x"}})
 	c.Assert(err, IsNil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["user-id"], Equals, nil)
 	c.Check(n["type"], Equals, "warning")
 	c.Check(n["key"], Equals, "example.com/x")
 }
 
 func (s *noticesSuite) TestWaitNoticesNew(c *C) {
-	st := state.New(nil)
+	m := newNoticeManager(c)
 
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		st.Lock()
-		defer st.Unlock()
-		addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
-		addNotice(c, st, nil, state.WarningNotice, "example.com/y", nil)
+		addNotice(c, m, nil, notices.WarningNotice, "example.com/x", nil)
+		addNotice(c, m, nil, notices.WarningNotice, "example.com/y", nil)
 	}()
 
-	st.Lock()
-	defer st.Unlock()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	notices, err := st.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{"example.com/y"}})
+	result, err := m.WaitNotices(ctx, &notices.NoticeFilter{Keys: []string{"example.com/y"}})
 	c.Assert(err, IsNil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Assert(n["key"], Equals, "example.com/y")
 }
 
 func (s *noticesSuite) TestWaitNoticesTimeout(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
-	notices, err := st.WaitNotices(ctx, nil)
+	result, err := m.WaitNotices(ctx, nil)
 	c.Assert(err, ErrorMatches, "context deadline exceeded")
-	c.Assert(notices, HasLen, 0)
+	c.Assert(result, HasLen, 0)
 }
 
-func (s *noticesSuite) TestReadStateWaitNotices(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
-
-	marshalled, err := st.MarshalJSON()
-	c.Assert(err, IsNil)
-
-	st2, err := state.ReadState(nil, bytes.NewBuffer(marshalled))
-	c.Assert(err, IsNil)
-	st2.Lock()
-	defer st2.Unlock()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-	notices, err := st2.WaitNotices(ctx, nil)
-	c.Assert(errors.Is(err, context.DeadlineExceeded), Equals, true)
-	c.Assert(notices, HasLen, 0)
-}
+// TODO: adapt this test
+//
+//func (s *noticesSuite) TestReadStateWaitNotices(c *C) {
+//	st := state.New(nil)
+//	st.Lock()
+//	defer st.Unlock()
+//
+//	marshalled, err := st.MarshalJSON()
+//	c.Assert(err, IsNil)
+//
+//	st2, err := state.ReadState(nil, bytes.NewBuffer(marshalled))
+//	c.Assert(err, IsNil)
+//	st2.Lock()
+//	defer st2.Unlock()
+//
+//	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+//	defer cancel()
+//	notices, err := st2.WaitNotices(ctx, nil)
+//	c.Assert(errors.Is(err, context.DeadlineExceeded), Equals, true)
+//	c.Assert(notices, HasLen, 0)
+//}
 
 func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
 	go func() {
 		for i := 0; i < 10; i++ {
-			st.Lock()
-			addNotice(c, st, nil, state.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
-			st.Unlock()
+			addNotice(c, m, nil, notices.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
 			time.Sleep(time.Millisecond)
 		}
 	}()
@@ -593,11 +571,11 @@ func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
 	defer cancel()
 	var after time.Time
 	for total := 0; total < 10; {
-		notices, err := st.WaitNotices(ctx, &state.NoticeFilter{After: after})
+		result, err := m.WaitNotices(ctx, &notices.NoticeFilter{After: after})
 		c.Assert(err, IsNil)
-		c.Assert(len(notices) > 0, Equals, true)
-		total += len(notices)
-		n := noticeToMap(c, notices[len(notices)-1])
+		c.Assert(result, Not(HasLen), 0)
+		total += len(result)
+		n := noticeToMap(c, result[len(result)-1])
 		lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
 		c.Assert(err, IsNil)
 		after = lastRepeated
@@ -607,30 +585,26 @@ func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
 func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
 	const numWaiters = 100
 
-	st := state.New(nil)
+	m := newNoticeManager(c)
 
 	var wg sync.WaitGroup
 	for i := 0; i < numWaiters; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			st.Lock()
-			defer st.Unlock()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 			key := fmt.Sprintf("a.b/%d", i)
-			notices, err := st.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{key}})
+			result, err := m.WaitNotices(ctx, &notices.NoticeFilter{Keys: []string{key}})
 			c.Assert(err, IsNil)
-			c.Assert(notices, HasLen, 1)
-			n := noticeToMap(c, notices[0])
+			c.Assert(result, HasLen, 1)
+			n := noticeToMap(c, result[0])
 			c.Assert(n["key"], Equals, key)
 		}(i)
 	}
 
 	for i := 0; i < numWaiters; i++ {
-		st.Lock()
-		addNotice(c, st, nil, state.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
-		st.Unlock()
+		addNotice(c, m, nil, notices.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
 		time.Sleep(time.Microsecond)
 	}
 
@@ -648,62 +622,58 @@ func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
 }
 
 func (s *noticesSuite) TestValidateNotice(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
 	// Invalid type
-	id, err := st.AddNotice(nil, "bad-type", "123", nil)
+	id, err := m.AddNotice(nil, "bad-type", "123", nil)
 	c.Check(err, ErrorMatches, `internal error: cannot add notice with invalid type "bad-type"`)
 	c.Check(id, Equals, "")
 
 	// Empty key
-	id, err = st.AddNotice(nil, state.ChangeUpdateNotice, "", nil)
+	id, err = m.AddNotice(nil, notices.ChangeUpdateNotice, "", nil)
 	c.Check(err, ErrorMatches, `internal error: cannot add change-update notice with invalid key ""`)
 	c.Check(id, Equals, "")
 
 	// Large key
-	id, err = st.AddNotice(nil, state.ChangeUpdateNotice, strings.Repeat("x", 257), nil)
+	id, err = m.AddNotice(nil, notices.ChangeUpdateNotice, strings.Repeat("x", 257), nil)
 	c.Check(err, ErrorMatches, `internal error: cannot add change-update notice with invalid key: key must be 256 bytes or less`)
 	c.Check(id, Equals, "")
 
 	// Unxpected key for refresh-inhibit notice
-	id, err = st.AddNotice(nil, state.RefreshInhibitNotice, "123", nil)
+	id, err = m.AddNotice(nil, notices.RefreshInhibitNotice, "123", nil)
 	c.Check(err, ErrorMatches, `internal error: cannot add refresh-inhibit notice with invalid key "123": only "-" key is supported`)
 	c.Check(id, Equals, "")
 }
 
 func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
+	m := newNoticeManager(c)
 
 	testDate := time.Date(2024, time.April, 11, 11, 24, 5, 21, time.UTC)
-	restore := state.MockTime(testDate)
+	restore := notices.MockTime(testDate)
 	defer restore()
 
-	id1, err := st.AddNotice(nil, state.ChangeUpdateNotice, "123", nil)
+	id1, err := m.AddNotice(nil, notices.ChangeUpdateNotice, "123", nil)
 	c.Assert(err, IsNil)
-	notice1 := noticeToMap(c, st.Notice(id1))
+	notice1 := noticeToMap(c, m.Notice(id1))
 	c.Assert(notice1, NotNil)
 
-	id2, err := st.AddNotice(nil, state.ChangeUpdateNotice, "456", nil)
+	id2, err := m.AddNotice(nil, notices.ChangeUpdateNotice, "456", nil)
 	c.Assert(err, IsNil)
-	notice2 := noticeToMap(c, st.Notice(id2))
+	notice2 := noticeToMap(c, m.Notice(id2))
 	c.Assert(notice2, NotNil)
 
-	id3, err := st.AddNotice(nil, state.ChangeUpdateNotice, "789", nil)
+	id3, err := m.AddNotice(nil, notices.ChangeUpdateNotice, "789", nil)
 	c.Assert(err, IsNil)
-	notice3 := noticeToMap(c, st.Notice(id3))
+	notice3 := noticeToMap(c, m.Notice(id3))
 	c.Assert(notice3, NotNil)
 
 	testDate2 := time.Date(2024, time.April, 11, 11, 24, 5, 40, time.UTC)
-	restore2 := state.MockTime(testDate2)
+	restore2 := notices.MockTime(testDate2)
 	defer restore2()
 
-	id4, err := st.AddNotice(nil, state.ChangeUpdateNotice, "ABC", nil)
+	id4, err := m.AddNotice(nil, notices.ChangeUpdateNotice, "ABC", nil)
 	c.Assert(err, IsNil)
-	notice4 := noticeToMap(c, st.Notice(id4))
+	notice4 := noticeToMap(c, m.Notice(id4))
 	c.Assert(notice4, NotNil)
 
 	// ensure that the notices are ordered in time
@@ -727,7 +697,7 @@ func (s *noticesSuite) TestAvoidTwoNoticesWithSameDateTime(c *C) {
 }
 
 // noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.
-func noticeToMap(c *C, notice *state.Notice) map[string]any {
+func noticeToMap(c *C, notice *notices.Notice) map[string]any {
 	buf, err := json.Marshal(notice)
 	c.Assert(err, IsNil)
 	var n map[string]any
@@ -736,7 +706,7 @@ func noticeToMap(c *C, notice *state.Notice) map[string]any {
 	return n
 }
 
-func addNotice(c *C, st *state.State, userID *uint32, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) {
-	_, err := st.AddNotice(userID, noticeType, key, options)
+func addNotice(c *C, m *notices.NoticeManager, userID *uint32, noticeType notices.NoticeType, key string, options *notices.AddNoticeOptions) {
+	_, err := m.AddNotice(userID, noticeType, key, options)
 	c.Assert(err, IsNil)
 }

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -885,7 +886,7 @@ func maybeAddRefreshInhibitNotice(st *state.State) error {
 	}
 
 	if changed {
-		if _, err := st.AddNotice(nil, state.RefreshInhibitNotice, "-", nil); err != nil {
+		if _, err := notices.AddNotice(st, nil, notices.RefreshInhibitNotice, "-", nil); err != nil {
 			return err
 		}
 		st.Set("last-recorded-inhibited-snaps", curInhibitedSnaps)

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -1251,7 +1252,7 @@ func (s *autoRefreshTestSuite) testMaybeAddRefreshInhibitNotice(c *C, markerInte
 	c.Assert(err, IsNil)
 	// empty set of inhibited snaps unchanged -> []
 	// no notice recorded
-	c.Assert(st.Notices(nil), HasLen, 0)
+	c.Assert(notices.GetNotices(st, nil), HasLen, 0)
 	// no "refresh inhibition" warnings recorded
 	checkNoRefreshInhibitWarning(c, st)
 	// Verify list is empty

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
@@ -1437,10 +1438,10 @@ var onRefreshInhibitionTimeout = func(chg *state.Change, snapName string) error 
 	chg.Set("api-data", data)
 
 	// record a change-update notice on forced snap refresh
-	opts := &state.AddNoticeOptions{
+	opts := &notices.AddNoticeOptions{
 		Data: map[string]string{"kind": chg.Kind()},
 	}
-	_, err = chg.State().AddNotice(nil, state.ChangeUpdateNotice, chg.ID(), opts)
+	_, err = notices.AddNotice(chg.State(), nil, notices.ChangeUpdateNotice, chg.ID(), opts)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/osutil/squashfs"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/strutil"
 	userclient "github.com/snapcore/snapd/usersession/client"
 
@@ -11332,9 +11333,9 @@ func (s *snapmgrTestSuite) TestChangeStatusRecordsChangeUpdateNotice(c *C) {
 	s.settle(c)
 
 	// Check notice is recorded on change status updates
-	notices := s.state.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result := notices.GetNotices(s.state, nil)
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, chg.ID())
 	c.Check(n["last-data"], DeepEquals, map[string]any{"kind": "refresh"})
@@ -11372,9 +11373,9 @@ func (s *snapmgrTestSuite) TestChangeStatusUndoRecordsChangeUpdateNotice(c *C) {
 	s.settle(c)
 
 	// Check notice is recorded on change status updates
-	notices := s.state.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result := notices.GetNotices(s.state, nil)
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, chg.ID())
 	c.Check(n["last-data"], DeepEquals, map[string]any{"kind": "refresh"})
@@ -11383,7 +11384,7 @@ func (s *snapmgrTestSuite) TestChangeStatusUndoRecordsChangeUpdateNotice(c *C) {
 }
 
 // noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.
-func noticeToMap(c *C, notice *state.Notice) map[string]any {
+func noticeToMap(c *C, notice *notices.Notice) map[string]any {
 	buf, err := json.Marshal(notice)
 	c.Assert(err, IsNil)
 	var n map[string]any

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/store/storetest"
 	userclient "github.com/snapcore/snapd/usersession/client"
 
@@ -11580,13 +11581,13 @@ func checkLastRecordedInhibitedSnaps(c *C, st *state.State, snaps []string) {
 }
 
 func checkRefreshInhibitNotice(c *C, st *state.State, occurrences int) {
-	notices := st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.RefreshInhibitNotice}})
+	result := notices.GetNotices(st, &notices.NoticeFilter{Types: []notices.NoticeType{notices.RefreshInhibitNotice}})
 	if occurrences == 0 {
-		c.Assert(notices, HasLen, 0)
+		c.Assert(result, HasLen, 0)
 		return
 	}
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["type"], Equals, "refresh-inhibit")
 	c.Check(n["key"], Equals, "-")
 	c.Check(n["occurrences"], Equals, float64(occurrences))
@@ -12270,9 +12271,9 @@ func (s *snapmgrTestSuite) TestRefreshForcedOnRefreshInhibitionTimeout(c *C) {
 	})
 	c.Check(refreshForced, DeepEquals, []interface{}{"some-other-snap", "some-snap"})
 
-	notices := s.state.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result := notices.GetNotices(s.state, &notices.NoticeFilter{Types: []notices.NoticeType{notices.ChangeUpdateNotice}})
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, chg.ID())
 	// 3 status changes (Default -> Doing -> Done) + 2 forced refreshes

--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -31,6 +31,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/notices"
 )
 
 type changeSuite struct{}
@@ -47,13 +48,23 @@ func (cs *changeSuite) TestNewChange(c *C) {
 	c.Check(chg.Summary(), Equals, "summary...")
 
 	// Check notice is recorded on change spawn
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result := notices.GetNotices(st, nil)
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, chg.ID())
 	c.Check(n["last-data"], DeepEquals, map[string]any{"kind": "install"})
 	c.Check(n["occurrences"], Equals, 1.0)
+}
+
+// noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.
+func noticeToMap(c *C, notice *notices.Notice) map[string]any {
+	buf, err := json.Marshal(notice)
+	c.Assert(err, IsNil)
+	var n map[string]any
+	err = json.Unmarshal(buf, &n)
+	c.Assert(err, IsNil)
+	return n
 }
 
 func (cs *changeSuite) TestReadyTime(c *C) {
@@ -1496,9 +1507,9 @@ func (cs *changeSuite) TestChangeStatusRecordsChangeUpdateNotice(c *C) {
 
 	// Check notice is recorded on change status updates and ignores
 	// the alternating status
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result := notices.GetNotices(st, nil)
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, chg.ID())
 	c.Check(n["last-data"], DeepEquals, map[string]any{"kind": "change"})
@@ -1552,9 +1563,9 @@ func (cs *changeSuite) TestChangeStatusUndoRecordsChangeUpdateNotice(c *C) {
 
 	// Check notice is recorded on change status updates and ignores
 	// the alternating status
-	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 1)
-	n := noticeToMap(c, notices[0])
+	result := notices.GetNotices(st, nil)
+	c.Assert(result, HasLen, 1)
+	n := noticeToMap(c, result[0])
 	c.Check(n["type"], Equals, "change-update")
 	c.Check(n["key"], Equals, chg.ID())
 	c.Check(n["last-data"], DeepEquals, map[string]any{"kind": "change"})

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -66,9 +66,3 @@ var (
 	ErrNoWarningFirstAdded  = errNoWarningFirstAdded
 	ErrNoWarningExpireAfter = errNoWarningExpireAfter
 )
-
-// NumNotices returns the total bumber of notices, including expired ones that
-// haven't yet been pruned.
-func (s *State) NumNotices() int {
-	return len(s.notices)
-}


### PR DESCRIPTION
WIP

This is a potential approach to decoupling notice state from snapd state. Here, the notice state is moved as a complete unit into a dedicated package, which:

- Defines a `NoticeManager` and registers it with the overlord
- Stores notice state in a dedicated file
- Maintains its own lock and cond
- Caches the `NoticeManager` in the state cache so that packages which take state lock anyway can continue to interact with notices via the state
- Defines package-level functions which take a `*state.State` and allow adding or retrieving notices, using that cache

Currently everything is exploding, since most places access notices via the functions which take state, and most unit tests do not actually initialize a `NoticeManager` and cache it in the state, so lots of tests panic until I fix this. Also, I erroneously removed some state locks in places which rely on the state cache to retrieve the `NoticeManager`, so those panic too.

I think the notable place which should be able to record notices without state lock is the `overlord/ifacestate/apparmorprompting/prompting.go` notify callbacks, but currently they're only given a `*state.State`, and not the overlord which manages `ifacestate`. So I think there are one of two options:
1. Expose the backing overlord or the `NoticeManager` from `overlord.NoticeManager()` to `ifacestate` so it can be wired through to `apparmorprompting.New()`, or
2. Export the `noticeManager(st *state.State, errMsg string) *NoticeManager` function directly, so it can be used from `o/i/a/prompting.go` to retrieve the `*NoticeManager` from state once when `ifacestate` is being initialized, and from that directly record notices without ever touching state later.

I think I prefer the latter, as it's simpler and the there was previously a bit of a hack to release state lock while initializing `InterfacesRequestsManager` so that notices could potentially be recorded --- instead, continue holding state lock, get the `NoticeManager`, build the closures. And the closures wouldn't even have to be used to be so opaque anymore, now the consumer could simply import `overlord/notices`, though the closures do prevent misuse nicely.