### PR TITLE
overlord/devicestate: fix a regression during seeding when using early-config

### DIFF
--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -282,7 +282,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 	// Load seed to find out kernel-modules components in run mode
 	systemAndSnaps, mntPtForType, mntPtForComps, unmount,
-		err := m.loadAndMountSystemLabelSnapsUnlock(st, m.seedLabel, []snap.Type{snap.TypeKernel})
+		err := m.loadAndMountSystemLabelSnapsUnlock(st, modeEnv.RecoverySystem, []snap.Type{snap.TypeKernel})
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -564,7 +564,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 
 	// Load seed to find out kernel-modules components in run mode
 	systemAndSnaps, mntPtForType, mntPtForComps, unmount,
-		err := m.loadAndMountSystemLabelSnapsUnlock(st, m.seedLabel, []snap.Type{snap.TypeKernel})
+		err := m.loadAndMountSystemLabelSnapsUnlock(st, modeEnv.RecoverySystem, []snap.Type{snap.TypeKernel})
 	if err != nil {
 		return err
 	}

--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -1,5 +1,10 @@
 defaults:
   system:
+    # trigger early config behavior
+    # regression in #LP2104254
+    users:
+      create:
+        automatic: false
     service:
       rsyslog:
         disable: true


### PR DESCRIPTION
Do not use m.seedLabel as it might not be set when the task runs if snapd restarts during seeding due to early-config (specifically the users.create.automatic) behavior. Instead rely on the modeEnv we load. The system is marked seeded before `Setup system for run mode` is run, so a well timed snapd restart will end up with empty `m.seed*` values

Adding some tracing of an install mode shows us that if snapd restarts during seeding, then `seedLabelAndMode()` might not have been called again, and thus `m.seedLabel` will be empty.

Tracing before snapd restarts:

```
May 27 12:10:37 localhost snapd[1092]: devicemgr.go:841: DEBUG: earlyDeviceContext()
May 27 12:10:37 localhost snapd[1092]: devicemgr.go:885: DEBUG: earlyLoadDeviceSeed()
May 27 12:10:37 localhost snapd[1092]: devicemgr.go:857: DEBUG: seedLabelAndMode()
May 27 12:10:37 localhost snapd[1092]: devicemgr.go:872: DEBUG: modeenv read, mode "install" label "20250527"
May 27 12:10:37 localhost snapd[1092]: helpers.go:62: DEBUG: loading assertions from /var/lib/snapd/seed/systems/20250527/assertions
May 27 12:10:37 localhost snapd[1092]: configstate.go:184: DEBUG: EarlyConfig()
May 27 12:10:37 localhost snapd[1092]: configstate.go:221: DEBUG: systemAlreadyConfigured()
May 27 12:10:37 localhost snapd[1092]: configstate.go:200: DEBUG: EarlyConfig: system is not configured
May 27 12:10:37 localhost snapd[1092]: devicemgr.go:934: DEBUG: earlyPreloadGadget()
May 27 12:10:37 localhost snapd[1092]: devicemgr.go:885: DEBUG: earlyLoadDeviceSeed()
May 27 12:10:37 localhost snapd[1092]: configstate.go:211: DEBUG: EarlyConfig: system-defaults: map[journal.persistent:true users.create.automatic:true]
May 27 12:10:37 localhost snapd[1092]: runwithstate.go:205: DEBUG: Early(values=map[journal.persistent:true users.create.automatic:true])
May 27 12:10:37 localhost snapd[1092]: users.go:34: DEBUG: earlyUsersSettingsFilter(values=map[journal.persistent:true users.create.automatic:true])
May 27 12:10:37 localhost snapd[1092]: helpers.go:301: DEBUG: Patch()
May 27 12:10:37 localhost snapd[1092]: helpers.go:304: DEBUG: Patch: key=users.create.automatic
```

Tracing after snapd restarts

```
May 27 12:10:43 localhost snapd[1711]: devicemgr.go:841: DEBUG: earlyDeviceContext()
May 27 12:10:43 localhost snapd[1711]: configstate.go:184: DEBUG: EarlyConfig()
May 27 12:10:43 localhost snapd[1711]: configstate.go:221: DEBUG: systemAlreadyConfigured()
May 27 12:10:43 localhost snapd[1711]: configstate.go:194: DEBUG: EarlyConfig: system is configured
```

This causes the following error

```
May 28 09:16:45 foo snapd[1727]: 2025/05/28 09:16:45.523325 task.go:433: DEBUG: 2025-05-28T09:16:45+02:00 ERROR cannot load assertions for label "": no seed assertions
May 28 09:16:45 foo snapd[1727]: 2025/05/28 09:16:45.523345 taskrunner.go:299: Change 2 task (Setup system for run mode) failed: cannot load assertions for label "": no seed assertions
```

