### PR TITLE
system-packages-doc: Fix access to /usr/local/share/doc

### DIFF
--- a/interfaces/builtin/system_packages_doc.go
+++ b/interfaces/builtin/system_packages_doc.go
@@ -91,6 +91,7 @@ func (iface *systemPackagesDocInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	apparmor.GenWritableProfile(emit, "/usr/share/javascript/", 3)
 	apparmor.GenWritableProfile(emit, "/usr/share/libreoffice/", 3)
 	apparmor.GenWritableProfile(emit, "/usr/share/sphinx_rtd_theme/", 3)
+	apparmor.GenWritableProfile(emit, "/usr/local/share/doc/", 3)
 
 	if base := plug.Snap().Base; base == "bare" || base == "test-snapd-base-bare" {
 		// The bare snap does not have enough mount points, causing us to create a mimic over /

--- a/tests/main/interfaces-system-packages-doc/task.yaml
+++ b/tests/main/interfaces-system-packages-doc/task.yaml
@@ -17,6 +17,8 @@ prepare: |
     echo text >/usr/share/libreoffice/help/content
     mkdir -p /usr/share/xubuntu-docs
     echo text >/usr/share/xubuntu-docs/content
+    mkdir -p /usr/local/share/doc
+    echo text >/usr/local/share/doc/content
     mkdir -p /usr/share/gtk-doc
     echo text >/usr/share/gtk-doc/content
     mkdir -p /usr/share/cups/doc-root
@@ -38,6 +40,7 @@ execute: |
     test-snapd-app.sh -c 'cat /usr/share/doc/system-packages-doc-iface/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/libreoffice/help/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/xubuntu-docs/content' | MATCH text
+    test-snapd-app.sh -c 'cat /usr/local/share/doc/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/gtk-doc/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/cups/doc-root/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/gimp/2.0/help/content' | MATCH text
@@ -47,6 +50,7 @@ execute: |
     test-snapd-app.sh -c 'cat /usr/share/doc/system-packages-doc-iface/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/libreoffice/help/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/xubuntu-docs/content' | MATCH text
+    test-snapd-app.sh -c 'cat /usr/local/share/doc/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/gtk-doc/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/cups/doc-root/content' | MATCH text
     test-snapd-app.sh -c 'cat /usr/share/gimp/2.0/help/content' | MATCH text
@@ -56,6 +60,7 @@ execute: |
     not test-snapd-app.sh -c 'test -e /usr/share/doc/system-packages-doc-iface/content'
     not test-snapd-app.sh -c 'test -e /usr/share/libreoffice/help/content'
     not test-snapd-app.sh -c 'test -e /usr/share/xubuntu-docs/content'
+    not test-snapd-app.sh -c 'test -e /usr/local/share/doc/content'
     not test-snapd-app.sh -c 'test -e /usr/share/gtk-doc/content'
     not test-snapd-app.sh -c 'test -e /usr/share/cups/doc-root/content'
     not test-snapd-app.sh -c 'test -e /usr/share/gimp/2.0/help/content'


### PR DESCRIPTION
LP: #1955325

With commit "8e8eb2ddce interfaces: grant access to /usr/local/share/doc", access was granted to /usr/local/share/doc. However, the mount target does not (or ceased to) exist in the base snap, so the snaps connecting this interface did not yet have access to that directory.

This can be observed in Firefox for example:

```
% snap connections firefox|grep doc
system-packages-doc     firefox:system-packages-doc      :system-packages-doc            -
% grep local/share/doc /run/snapd/ns/snap.firefox.fstab
```

Thanks to @jhenstridge for the valuable help with this.