### PR TITLE
i/builtin: allow checkbox-support to run other snaps

### DIFF
--- a/tests/main/interfaces-checkbox-support/task.yaml
+++ b/tests/main/interfaces-checkbox-support/task.yaml
@@ -1,0 +1,14 @@
+summary: ensure that checkbox-support interface allows running snap applications
+
+details: |
+    The checkbox-support interface allows running nearly anything without
+    confinement.  As a special behavior of checkbox allows it to run snap
+    applications from what is already a snap.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-checkbox-support
+    snap connect test-snapd-checkbox-support:checkbox-support
+
+execute: |
+    # When using checkbox support, one can run another snap application as if it was ran directly.
+    test-snapd-checkbox-support.sh -c "snap run test-snapd-checkbox-support.sh -c /bin/true"

--- a/tests/main/interfaces-checkbox-support/test-snapd-checkbox-support/bin/sh
+++ b/tests/main/interfaces-checkbox-support/test-snapd-checkbox-support/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/interfaces-checkbox-support/test-snapd-checkbox-support/meta/snap.yaml
+++ b/tests/main/interfaces-checkbox-support/test-snapd-checkbox-support/meta/snap.yaml
@@ -1,0 +1,14 @@
+name: test-snapd-checkbox-support
+version: 1.0
+summary: ...
+description: ...
+
+# This snap cannot be useing "base: core" as snapd tools are not correctly
+# injected into that environment and snap-confine is the ancient snap-confine
+# that is present in old core snap.
+base: core24
+
+apps:
+    sh:
+        command: bin/sh
+        plugs: [checkbox-support]


### PR DESCRIPTION
The checkbox-support interface gained an explicit profile transition for /usr/lib/snapd/snap-confine, which when using core18+, contains the updated snap toolchain from the host or from snapd snap.

The intent of the profile was to be effectively as unconfined as possible, but this still requires explicit permission for profile transitions.

Add an integration test to make sure this really works.
