### PR TITLE
mkversion: fix DPKG_PARSECHANGELOG assignment

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -63,7 +63,7 @@ fi
 # at this point we maybe in _build/src/github etc where we have no
 # debian/changelog (dh-golang only exports the sources here)
 # switch to the real source dir for the changelog parsing
-: "${DPKG_PARSECHANGELOG-$(command -v dpkg-parsechangelog)}"
+: "${DPKG_PARSECHANGELOG:=$(command -v dpkg-parsechangelog)}"
 if [ -n "$DPKG_PARSECHANGELOG" ]; then
     version_from_changelog="$(cd "$PKG_BUILDDIR"; "$DPKG_PARSECHANGELOG" --show-field Version)";
 fi


### PR DESCRIPTION
Use ${parameter:=word} to assign a default value.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
