### PR TITLE
s/apparmor: workaround comma in fields in apparmor features file

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -699,7 +700,9 @@ func probeKernelFeatures() ([]string, error) {
 		}
 	}
 	if data, err := os.ReadFile(filepath.Join(rootPath, featuresSysPath, "policy", "notify", "user")); err == nil {
-		notifyUserFeatures := strings.Fields(string(data))
+		notifyUserFeatures := strings.FieldsFunc(string(data), func(r rune) bool {
+			return unicode.IsSpace(r) || uint32(r) < unicode.MaxLatin1 && r == ','
+		})
 		for _, feat := range notifyUserFeatures {
 			features = append(features, "policy:notify:user:"+feat)
 		}

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -429,6 +429,10 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 			[]string{"file", "network"},
 		},
 		{
+			"file, tags",
+			[]string{"file", "tags"},
+		},
+		{
 			"file\ndbus \n  network",
 			[]string{"dbus", "file", "network"},
 		},


### PR DESCRIPTION
This is a fix cherry-picked from #15372 and #15508 to account for the kernel from https://launchpad.net/~apparmor-dev/+archive/ubuntu/dbus-dev/+packages currently including a comma in the feature file, as shown in the test case in this PR.