### PR TITLE
spread: automatically disable debugging when running interactively

### DIFF
--- a/run-spread
+++ b/run-spread
@@ -28,5 +28,9 @@ if [ "$need_rebuild" = 1 ]; then
     echo "-- $(date) -- snapd snap rebuild complete"
 fi
 
+if [ -t 1 ]; then
+    export SPREAD_DEBUG_EACH=0
+fi
+
 # Run spread
 SPREAD_USE_PREBUILT_SNAPD_SNAP=true exec spread "$@"


### PR DESCRIPTION
When running locally, the debug output is not as useful as it obscures the failure that just happened. Unlike what happens in CI, there is no post-processing or archiving of logs.

Detect tty connected to stdout and set SPREAD_DEBUG_EACH=0
