### PR TITLE
secboot: update to rev 7fb379721237 (RunChecksContext API)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4
+	github.com/snapcore/secboot v0.0.0-20250603103321-7fb379721237
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraK
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4 h1:ECxlsvtHL7HOv8wIsnF95kUkQrtE86cY/cylWVt2n0M=
-github.com/snapcore/secboot v0.0.0-20250326125418-bf2f40ea35c4/go.mod h1:Y3APoLyInDvY8mVP1qDQd/t9bPuNp2itYPCGrltRQoQ=
+github.com/snapcore/secboot v0.0.0-20250603103321-7fb379721237 h1:5Flx4mNtQgWcG7cqFdIJsDfL1rnbp8nucqexrMmCpBQ=
+github.com/snapcore/secboot v0.0.0-20250603103321-7fb379721237/go.mod h1:Y3APoLyInDvY8mVP1qDQd/t9bPuNp2itYPCGrltRQoQ=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=


### PR DESCRIPTION
Update secboot to make available the [new RunChecksContext API](https://github.com/canonical/secboot/commit/7fb379721237726dd216fbc821e83ec17eccb178).

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34453