### PR TITLE
o/devicestate: add snap to prereq tracker when we switch channels without refresh during an offline remodel

### DIFF
--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -700,7 +700,7 @@ func snapSwitch(_ context.Context, inst *snapInstruction, st *state.State) (*sna
 	if !inst.Revision.Unset() {
 		return nil, errors.New("switch takes no revision")
 	}
-	ts, err := snapstateSwitch(st, inst.Snaps[0], inst.revnoOpts())
+	ts, err := snapstateSwitch(st, inst.Snaps[0], inst.revnoOpts(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -2910,7 +2910,7 @@ func (s *snapsSuite) TestSwitchInstruction(c *check.C) {
 	var cohort, channel string
 	var leave *bool
 
-	defer daemon.MockSnapstateSwitch(func(s *state.State, name string, opts *snapstate.RevisionOptions) (*state.TaskSet, error) {
+	defer daemon.MockSnapstateSwitch(func(s *state.State, name string, opts *snapstate.RevisionOptions, _ snapstate.PrereqTracker) (*state.TaskSet, error) {
 		cohort = opts.CohortKey
 		leave = &opts.LeaveCohort
 		channel = opts.Channel

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -209,7 +209,7 @@ func MockSnapstateTryPath(mock func(*state.State, string, string, snapstate.Flag
 	}
 }
 
-func MockSnapstateSwitch(mock func(*state.State, string, *snapstate.RevisionOptions) (*state.TaskSet, error)) (restore func()) {
+func MockSnapstateSwitch(mock func(*state.State, string, *snapstate.RevisionOptions, snapstate.PrereqTracker) (*state.TaskSet, error)) (restore func()) {
 	oldSnapstateSwitch := snapstateSwitch
 	snapstateSwitch = mock
 	return func() {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -578,7 +578,7 @@ func (r *remodeler) maybeInstallOrUpdate(ctx context.Context, st *state.State, r
 		if r.shouldSwitchWithoutRefresh(rt, needsRevisionChange) && !needsComponentChanges {
 			ts, err := snapstate.Switch(st, rt.name, &snapstate.RevisionOptions{
 				Channel: rt.channel,
-			}, nil)
+			}, r.tracker)
 			if err != nil {
 				return 0, nil, err
 			}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -578,7 +578,7 @@ func (r *remodeler) maybeInstallOrUpdate(ctx context.Context, st *state.State, r
 		if r.shouldSwitchWithoutRefresh(rt, needsRevisionChange) && !needsComponentChanges {
 			ts, err := snapstate.Switch(st, rt.name, &snapstate.RevisionOptions{
 				Channel: rt.channel,
-			})
+			}, nil)
 			if err != nil {
 				return 0, nil, err
 			}

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -7528,6 +7528,118 @@ func (s *deviceMgrRemodelSuite) TestRemodelWithComponents(c *C) {
 	})
 }
 
+func (s *deviceMgrRemodelSuite) TestRemodelOfflineSwitchChannelOfInstalledBase(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	now := time.Now()
+	restore := devicestate.MockTimeNow(func() time.Time { return now })
+	defer restore()
+
+	s.state.Set("seeded", true)
+	s.state.Set("refresh-privacy-key", "some-privacy-key")
+
+	restore, _ = mockSnapstateUpdateOneFromFile(c, map[string]expectedSnap{})
+	defer restore()
+
+	currentModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"base":         "core22",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "pc-kernel",
+				"id":   fakeSnapID("pc-kernel"),
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "core20",
+				"id":   fakeSnapID("core20"),
+				"type": "base",
+			},
+			map[string]interface{}{
+				"name": "pc",
+				"id":   fakeSnapID("pc"),
+				"type": "gadget",
+			},
+			map[string]interface{}{
+				"name": "snapd",
+				"id":   fakeSnapID("snapd"),
+				"type": "snapd",
+			},
+		},
+	})
+	err := assertstate.Add(s.state, currentModel)
+	c.Assert(err, IsNil)
+
+	err = devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+	c.Assert(err, IsNil)
+
+	snapstatetest.InstallEssentialSnaps(c, s.state, "core22", nil, nil)
+
+	// make core24 installed already, and make it not have a channel set
+	snapstatetest.InstallSnap(c, s.state, fmt.Sprintf("name: %s\nversion: 1\ntype: base\n", "core24"), nil, &snap.SideInfo{
+		SnapID:   fakeSnapID("core24"),
+		Revision: snap.R(1),
+		RealName: "core24",
+		Channel:  "",
+	}, snapstatetest.InstallSnapOptions{Required: true})
+
+	// overwrite pc to have core24 as its base so that it doesn't get installed
+	snapstatetest.InstallSnap(c, s.state, fmt.Sprintf("name: pc\nversion: 1\ntype: gadget\nbase: %s", "core24"), nil, &snap.SideInfo{
+		SnapID:   fakeSnapID("pc"),
+		Revision: snap.R(1),
+		RealName: "pc",
+		Channel:  "latest/stable",
+	}, snapstatetest.InstallSnapOptions{Required: true})
+
+	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"base":         "core24",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "pc-kernel",
+				"id":   fakeSnapID("pc-kernel"),
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "core24",
+				"id":   fakeSnapID("core22"),
+				"type": "base",
+			},
+			map[string]interface{}{
+				"name": "pc",
+				"id":   fakeSnapID("pc"),
+				"type": "gadget",
+			},
+			map[string]interface{}{
+				"name": "snapd",
+				"id":   fakeSnapID("snapd"),
+				"type": "snapd",
+			},
+		},
+	})
+
+	_, err = devicestate.RemodelTasks(
+		context.Background(),
+		s.state,
+		currentModel,
+		newModel,
+		&snapstatetest.TrivialDeviceContext{
+			Remodeling:     true,
+			DeviceModel:    newModel,
+			OldDeviceModel: currentModel,
+		},
+		"99",
+		devicestate.RemodelOptions{
+			Offline: true,
+		},
+	)
+	c.Assert(err, IsNil)
+}
+
 func (s *deviceMgrRemodelSuite) TestRemodelWithComponentsNewComponentSwitchSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2868,13 +2868,18 @@ func switchSummary(snap, chanFrom, chanTo, cohFrom, cohTo string) string {
 }
 
 // Switch switches a snap to a new channel and/or cohort
-func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet, error) {
+func Switch(st *state.State, name string, opts *RevisionOptions, prqt PrereqTracker) (*state.TaskSet, error) {
 	if opts == nil {
 		opts = &RevisionOptions{}
 	}
 	if !opts.Revision.Unset() {
 		return nil, errRevisionSwitch
 	}
+
+	if prqt == nil {
+		prqt = snap.SimplePrereqTracker{}
+	}
+
 	var snapst SnapState
 	err := Get(st, name, &snapst)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
@@ -2913,6 +2918,15 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 	if opts.LeaveCohort {
 		snapsup.CohortKey = ""
 	}
+
+	current, err := snapst.CurrentInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: maybe we don't do this
+	current.SideInfo.Channel = snapsup.Channel
+	prqt.Add(current)
 
 	summary := switchSummary(snapsup.InstanceName(), snapst.TrackingChannel, snapsup.Channel, snapst.CohortKey, snapsup.CohortKey)
 	switchSnap := st.NewTask("switch-snap", summary)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2924,7 +2924,9 @@ func Switch(st *state.State, name string, opts *RevisionOptions, prqt PrereqTrac
 		return nil, err
 	}
 
-	// TODO: maybe we don't do this
+	// note, the prereq tracker doesn't use the channel given here. however, for
+	// the sake of correctness, and if we ever do use the channel in the prereq
+	// tracker, we update the channel to be what it is being switched to.
 	current.SideInfo.Channel = snapsup.Channel
 	prqt.Add(current)
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -875,12 +875,31 @@ func (s *snapmgrTestSuite) TestSwitchTasks(c *C) {
 		Active:  false,
 	})
 
-	ts, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"})
+	ts, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{"switch-snap"})
 	c.Assert(ts.MaybeEdge(snapstate.SnapSetupEdge), NotNil)
+}
+
+func (s *snapmgrTestSuite) TestSwitchPrereqTracker(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", Revision: snap.R(11)},
+		}),
+		Current: snap.R(11),
+		Active:  false,
+	})
+
+	prqt := &testPrereqTracker{}
+	_, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, prqt)
+	c.Assert(err, IsNil)
+
+	c.Assert(prqt.infos[0].Channel, Equals, "some-channel")
 }
 
 func (s *snapmgrTestSuite) TestSwitchConflict(c *C) {
@@ -895,12 +914,12 @@ func (s *snapmgrTestSuite) TestSwitchConflict(c *C) {
 		Active:  false,
 	})
 
-	ts, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"})
+	ts, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, nil)
 	c.Assert(err, IsNil)
 	// need a change to make the tasks visible
 	s.state.NewChange("switch-snap", "...").AddAll(ts)
 
-	_, err = snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "other-channel"})
+	_, err = snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "other-channel"}, nil)
 	c.Check(err, ErrorMatches, `snap "some-snap" has "switch-snap" change in progress`)
 }
 
@@ -908,7 +927,7 @@ func (s *snapmgrTestSuite) TestSwitchUnhappy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_, err := snapstate.Switch(s.state, "non-existing-snap", &snapstate.RevisionOptions{Channel: "some-channel"})
+	_, err := snapstate.Switch(s.state, "non-existing-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, nil)
 	c.Assert(err, ErrorMatches, `snap "non-existing-snap" is not installed`)
 }
 
@@ -923,7 +942,7 @@ func (s *snapmgrTestSuite) TestSwitchRevision(c *C) {
 		Current: snap.R(11),
 	})
 
-	_, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(42)})
+	_, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(42)}, nil)
 	c.Assert(err, ErrorMatches, "cannot switch revision")
 }
 
@@ -942,7 +961,7 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackForbidden(c *C) {
 		Active:          true,
 	})
 
-	_, err := snapstate.Switch(s.state, "kernel", &snapstate.RevisionOptions{Channel: "new-channel"})
+	_, err := snapstate.Switch(s.state, "kernel", &snapstate.RevisionOptions{Channel: "new-channel"}, nil)
 	c.Assert(err, ErrorMatches, `cannot switch from kernel track "18" as specified for the \(device\) model to "new-channel"`)
 }
 
@@ -961,7 +980,7 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackRiskOnlyIsOK(c *C) {
 		Active:          true,
 	})
 
-	_, err := snapstate.Switch(s.state, "kernel", &snapstate.RevisionOptions{Channel: "18/beta"})
+	_, err := snapstate.Switch(s.state, "kernel", &snapstate.RevisionOptions{Channel: "18/beta"}, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -980,7 +999,7 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackRiskOnlyDefaultTrackIsOK(c *C) {
 		Active:          true,
 	})
 
-	_, err := snapstate.Switch(s.state, "kernel", &snapstate.RevisionOptions{Channel: "beta"})
+	_, err := snapstate.Switch(s.state, "kernel", &snapstate.RevisionOptions{Channel: "beta"}, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -999,7 +1018,7 @@ func (s *snapmgrTestSuite) TestSwitchGadgetTrackForbidden(c *C) {
 		Active:          true,
 	})
 
-	_, err := snapstate.Switch(s.state, "brand-gadget", &snapstate.RevisionOptions{Channel: "new-channel"})
+	_, err := snapstate.Switch(s.state, "brand-gadget", &snapstate.RevisionOptions{Channel: "new-channel"}, nil)
 	c.Assert(err, ErrorMatches, `cannot switch from gadget track "18" as specified for the \(device\) model to "new-channel"`)
 }
 
@@ -1018,7 +1037,7 @@ func (s *snapmgrTestSuite) TestSwitchGadgetTrackRiskOnlyIsOK(c *C) {
 		Active:          true,
 	})
 
-	_, err := snapstate.Switch(s.state, "brand-gadget", &snapstate.RevisionOptions{Channel: "18/beta"})
+	_, err := snapstate.Switch(s.state, "brand-gadget", &snapstate.RevisionOptions{Channel: "18/beta"}, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -1037,7 +1056,7 @@ func (s *snapmgrTestSuite) TestSwitchGadgetTrackRiskOnlyDefaultTrackIsOK(c *C) {
 		Active:          true,
 	})
 
-	_, err := snapstate.Switch(s.state, "brand-gadget", &snapstate.RevisionOptions{Channel: "beta"})
+	_, err := snapstate.Switch(s.state, "brand-gadget", &snapstate.RevisionOptions{Channel: "beta"}, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -3437,7 +3456,7 @@ func (s *snapmgrTestSuite) testSwitchScenario(c *C, desc string, t switchScenari
 		Channel:     t.chanTo,
 		CohortKey:   t.cohTo,
 		LeaveCohort: t.cohFrom != "" && t.cohTo == "",
-	})
+	}, nil)
 	c.Assert(err, IsNil, comment)
 	chg.AddAll(ts)
 
@@ -3490,7 +3509,7 @@ func (s *snapmgrTestSuite) TestParallelInstallSwitchRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("switch-snap", "switch snap to some-channel")
-	ts, err := snapstate.Switch(s.state, "some-snap_instance", &snapstate.RevisionOptions{Channel: "some-channel"})
+	ts, err := snapstate.Switch(s.state, "some-snap_instance", &snapstate.RevisionOptions{Channel: "some-channel"}, nil)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 


### PR DESCRIPTION
This fixes a bug reported by @bugraaydogar. We weren't properly handling the case where we switched to a channel without an actual refresh. I added a prereq tracker to `snapstate.Switch` so that it aligns better with the other exported function, and we can pass ours from the remodeling code in.