### PR TITLE
intefaces/builtin, cmd/snap: Kerberos tickets support

### DIFF
--- a/interfaces/builtin/kerberos_tickets.go
+++ b/interfaces/builtin/kerberos_tickets.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const krbSummary = `allows reading to Kerberos tickets in /tmp.`
+
+const krbBaseDeclarationSlots = `
+  kerberos-tickets:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const krbConnectedPlugAppArmor = `
+/var/lib/snapd/hostfs/tmp/krb5cc* rk,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "kerberos-tickets",
+		summary:               krbSummary,
+		implicitOnClassic:     true,
+		implicitOnCore:        true,
+		baseDeclarationSlots:  krbBaseDeclarationSlots,
+		connectedPlugAppArmor: krbConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/kerberos_tickets_test.go
+++ b/interfaces/builtin/kerberos_tickets_test.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type krbInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&krbInterfaceSuite{
+	iface: builtin.MustInterface("kerberos-tickets"),
+})
+
+func (s *krbInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [kerberos-tickets]
+`
+	var mockSlotSnapInfoYaml = `name: core
+version: 1.0
+type: os
+slots:
+ kerberos-tickets:
+   interface: kerberos-tickets
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, mockSlotSnapInfoYaml, nil, "kerberos-tickets")
+	s.plug, s.plugInfo = MockConnectedPlug(c, mockPlugSnapInfoYaml, nil, "kerberos-tickets")
+}
+
+func (s *krbInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "kerberos-tickets")
+}
+
+func (s *krbInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *krbInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *krbInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(spec.SnippetForTag("snap.other.app"), testutil.Contains, "/var/lib/snapd/hostfs/tmp/krb5cc* rk,")
+}
+
+func (s *krbInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *krbInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "kerberos-tickets")
+}

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -50,6 +50,8 @@ execute: |
     exclusion_map["snap-fde-control"]="2025/08"
     exclusion_map["usb-gadget"]="2025/08"
 
+    exclusion_map["kerberos-tickets"]="2025/08"
+
     # If the interface is in the exclusion_map and it is currently sooner
     # than its specified expiration date, then return true
     exclude() { 

--- a/tests/main/interfaces-kerberos-tickets/kerberos-tickets-consumer/bin/kerberos-tickets-consumer
+++ b/tests/main/interfaces-kerberos-tickets/kerberos-tickets-consumer/bin/kerberos-tickets-consumer
@@ -1,0 +1,6 @@
+#!/bin/sh
+ticket=${KRB5CCNAME#FILE:}
+echo "KRB5CCNAME:$KRB5CCNAME"
+cat "$ticket" 2>/dev/null || echo "cannot read ticket $ticket"
+# Try to write anything random to the ticket file.
+echo 8 2>/dev/null >>"$ticket" || echo "cannot write to ticket $ticket"

--- a/tests/main/interfaces-kerberos-tickets/kerberos-tickets-consumer/meta/snap.yaml
+++ b/tests/main/interfaces-kerberos-tickets/kerberos-tickets-consumer/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: kerberos-tickets-consumer
+version: 1
+summary: Minimal consumer for Kerberos tickets interface
+description: Tries to read and then write to a Kerberos ticket
+
+apps:
+  kerberos-tickets-consumer:
+    command: bin/kerberos-tickets-consumer
+    plugs: [kerberos-tickets]

--- a/tests/main/interfaces-kerberos-tickets/task.yaml
+++ b/tests/main/interfaces-kerberos-tickets/task.yaml
@@ -1,0 +1,51 @@
+summary: Ensure that Kerberos tickets integration works
+
+details: |
+    Snap_run overwrites the Kerberos cache via the environment.
+    Check that that is working as expected.
+
+    Also ensure that the snap can read a ticket in the cache
+    if and only if the kerberos-ticket interface is connected,
+    and can never write to it.
+
+environment:
+    TICKET: /tmp/krb5cc_test #Must initiate with /tmp/krb5cc_
+    TICKET_CONTENTS: contents
+    KRB5CCNAME: FILE:$TICKET
+    # Snap_run will overwrite the original KRB5CCNAME
+    EXPECTED_KRB5CCNAME: FILE:/var/lib/snapd/hostfs/tmp/krb5cc_test
+
+prepare: |
+    echo "Given a snap declaring a plug on the kerberos-tickets interface is installed"
+    "$TESTSTOOLS"/snaps-state install-local kerberos-tickets-consumer
+
+    echo "Mock the kerberos ticket at $TICKET"
+    echo "$TICKET_CONTENTS" > "$TICKET"
+
+execute: |
+    echo "KRB5CCNAME was correctly overwritten in the snap's environment."
+    kerberos-tickets-consumer | tr -s / | MATCH "KRB5CCNAME:$EXPECTED_KRB5CCNAME"
+
+    echo "The interface is disconnected by default"
+    snap interfaces -i kerberos-tickets | MATCH -- '^- +kerberos-tickets-consumer:kerberos-tickets'
+
+    echo "When the plug is connected"
+    snap connect kerberos-tickets-consumer:kerberos-tickets
+
+    if snap debug sandbox-features --required apparmor:kernel:file; then
+        echo "Then the snap command can rean read the Kerberos ticket, but not write to it"
+        kerberos-tickets-consumer | MATCH "$TICKET_CONTENTS"
+        kerberos-tickets-consumer | MATCH "cannot write to ticket"
+
+        echo "When the plug is disconnected"
+        snap disconnect kerberos-tickets-consumer:kerberos-tickets
+
+        echo "Then the snap command can neither read the Kerberos ticket nor write to it"
+        kerberos-tickets-consumer | MATCH "cannot read ticket"
+        kerberos-tickets-consumer | MATCH "cannot write to ticket"
+
+        export KRB5CCNAME=FILE:/a/b/c
+        kerberos-tickets-consumer 2>&1 | MATCH "will not expose Kerberos tickets"
+        kerberos-tickets-consumer | MATCH "cannot read ticket"
+        kerberos-tickets-consumer | MATCH "cannot write to ticket"
+    fi


### PR DESCRIPTION
Expose Kerberos tickets in /tmp to snaps via the hostfs.

The snaps will need to connect the kerberos-ticket interface (slot also here provided) to actually be able to read the tickets.

[LP: #1849346](https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1849346)
[UDENG-7057](https://warthogs.atlassian.net/browse/UDENG-7057)

[UDENG-7057]: https://warthogs.atlassian.net/browse/UDENG-7057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ