### PR TITLE
interfaces: allow reading /proc/sys/fs/nr_open

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -220,6 +220,9 @@ var templateCommon = `
   # information leak.
   #deny /{,var/}run/utmp r,
 
+  # Allow reading the maximum number of open file descriptors.
+  @{PROC}/sys/fs/nr_open r,
+
   # java
   @{PROC}/@{pid}/ r,
   @{PROC}/@{pid}/fd/ r,

--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -126,8 +126,6 @@ const microStackSupportConnectedPlugAppArmor = `
 
 @{PROC}/*/status r,
 
-@{PROC}/sys/fs/nr_open r,
-
 # Libvirt needs access to the PCI config space in order to be able to reset devices.
 /sys/devices/pci*/**/config rw,
 


### PR DESCRIPTION
This exposes the maximum number of open file descriptors which does not seem particularly sensitive. While doing this, remove the duplicate entry from the microstack interface.
