### PR TITLE
overlord, tests: fix ensure feature tagging to no longer group by loop

### DIFF
--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -22,7 +22,6 @@ package overlord
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/snapcore/snapd/logger"
@@ -157,7 +156,6 @@ func (se *StateEngine) Ensure() error {
 	}
 	var errs []error
 	for _, m := range se.managers {
-		logger.Trace("ensure", "manager", getObjectType(m))
 		err := m.Ensure()
 		if err != nil {
 			logger.Noticef("state ensure error: %v", err)
@@ -204,13 +202,4 @@ func (se *StateEngine) Stop() {
 		}
 	}
 	se.stopped = true
-}
-
-func getObjectType(obj any) string {
-	objType := fmt.Sprintf("%T", obj)
-	objType = strings.TrimPrefix(objType, "*")
-	if idx := strings.Index(objType, "."); idx != -1 {
-		objType = objType[idx+1:]
-	}
-	return objType
 }

--- a/tests/utils/features/featextractor.py
+++ b/tests/utils/features/featextractor.py
@@ -80,15 +80,8 @@ class EnsureFeature:
 
     @staticmethod
     def handle_feature(feature_dict: dict[str, list[Any]], json_entry: dict[str, Any], _):
-        if EnsureLogLine.func in json_entry:
-            for ensure_list in reversed(feature_dict[EnsureFeature.parent]):
-                if ensure_list['manager'] == json_entry[EnsureLogLine.manager]:
-                    ensure_list['functions'].append(
-                        json_entry[EnsureLogLine.func])
-                    break
-        else:
-            feature_dict[EnsureFeature.parent].append(
-                Ensure(manager=json_entry[EnsureLogLine.manager], functions=[]))
+        feature_dict[EnsureFeature.parent].append(
+                Ensure(manager=json_entry[EnsureLogLine.manager], function=json_entry[EnsureLogLine.func]))
 
     @staticmethod
     def cleanup_dict(_):

--- a/tests/utils/features/features.py
+++ b/tests/utils/features/features.py
@@ -42,7 +42,7 @@ class Change(TypedDict):
 
 class Ensure(TypedDict):
     manager: str
-    functions: list[str]
+    function: str
 
 
 class EnvVariables(TypedDict):

--- a/tests/utils/features/test_featextractor.py
+++ b/tests/utils/features/test_featextractor.py
@@ -61,18 +61,17 @@ class TestExtract(unittest.TestCase):
     def test_extract_ensure(self):
         mgr = 'my-manager'
         loglines = [
-            {"msg":EnsureFeature.msg, EnsureLogLine.manager:mgr},
             {"msg":EnsureFeature.msg, EnsureLogLine.manager:mgr, EnsureLogLine.func:'1'},
             {"msg":EnsureFeature.msg, EnsureLogLine.manager:mgr, EnsureLogLine.func:'2'},
-            {"msg":EnsureFeature.msg, EnsureLogLine.manager:mgr},
             {"msg":EnsureFeature.msg, EnsureLogLine.manager:mgr, EnsureLogLine.func:'3'},
                     ]
         logs = _get_stringio_from_loglines(loglines)
         d = featextractor.get_feature_dictionary(logs, ['ensure'], State({}))
-        self.assertDictEqual({"ensures":[
-            Ensure(manager=mgr, functions=['1','2']),
-            Ensure(manager=mgr, functions=['3'])]}
-                             , d)
+        self.assertIn("ensures", d)
+        self.assertEqual(3, len(d['ensures']))
+        self.assertIn(Ensure(manager=mgr, function='1'), d['ensures'])
+        self.assertIn(Ensure(manager=mgr, function='2'), d['ensures'])
+        self.assertIn(Ensure(manager=mgr, function='3'), d['ensures'])
         
     def test_extract_task(self):
         loglines = [

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -188,10 +188,10 @@ class TestQueryFeatures(unittest.TestCase):
         j = {"tests": [
             {"task_name": "task1",
              "cmds": [{"cmd": "snap list --all"}, {"cmd": "snap ack file"},],
-             "ensures": [{"manager": "SnapManager", "functions": []}]},
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc1"}]},
             {"task_name": "task2",
              "cmds": [{"cmd": "snap do things"}, {"cmd": "snap list --all"}],
-             "ensures": [{"manager": "SnapManager", "functions": ["ensureThings"]}]
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc2"}]
              }
         ]}
         c = query_features.consolidate_system_features(j)
@@ -203,18 +203,18 @@ class TestQueryFeatures(unittest.TestCase):
         self.assertTrue({"cmd": "snap do things"} in c["cmds"])
         self.assertTrue("ensures" in c)
         self.assertEqual(len(c["ensures"]), 2)
-        self.assertTrue({"manager":"SnapManager","functions":[]} in c["ensures"])
-        self.assertTrue({"manager":"SnapManager","functions":["ensureThings"]} in c["ensures"])
+        self.assertTrue({"manager":"SnapManager","function":"ensureFunc1"} in c["ensures"])
+        self.assertTrue({"manager":"SnapManager","function":"ensureFunc2"} in c["ensures"])
 
 
     def test_consolidate_features_exclude_task(self):
         j = {"tests": [
             {"suite": "suite", "task_name": "task1", "variant": "a",
              "cmds": [{"cmd": "snap list --all"}, {"cmd": "snap ack file"},],
-             "ensures": [{"manager": "SnapManager", "functions": []}]},
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc1"}]},
             {"suite": "suite", "task_name": "task2", "variant": "",
              "cmds": [{"cmd": "snap do things"}, {"cmd": "snap list --all"}],
-             "ensures": [{"manager": "SnapManager", "functions": ["ensureThings"]}]
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc2"}]
              }
         ]}
         c = query_features.consolidate_system_features(j, exclude_tasks=[query_features.TaskId(suite='suite',task_name="task1")])
@@ -225,17 +225,16 @@ class TestQueryFeatures(unittest.TestCase):
         self.assertTrue({"cmd": "snap do things"} in c["cmds"])
         self.assertTrue("ensures" in c)
         self.assertEqual(len(c["ensures"]), 1)
-        self.assertTrue({"manager": "SnapManager", "functions": [
-                        "ensureThings"]} in c["ensures"])
+        self.assertTrue({"manager": "SnapManager", "function": "ensureFunc2"} in c["ensures"])
 
     def test_consolidate_features_include_task(self):
         j = {"tests": [
             {"suite": "suite", "task_name": "task1", "variant": "a",
              "cmds": [{"cmd": "snap list --all"}, {"cmd": "snap ack file"},],
-             "ensures": [{"manager": "SnapManager", "functions": []}]},
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc1"}]},
             {"suite": "suite", "task_name": "task2", "variant": "",
              "cmds": [{"cmd": "snap do things"}, {"cmd": "snap list --all"}],
-             "ensures": [{"manager": "SnapManager", "functions": ["ensureThings"]}]
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc2"}]
              }
         ]}
         c = query_features.consolidate_system_features(j, include_tasks=[query_features.TaskId(suite='suite',task_name="task2")])
@@ -246,15 +245,14 @@ class TestQueryFeatures(unittest.TestCase):
         self.assertTrue({"cmd": "snap do things"} in c["cmds"])
         self.assertTrue("ensures" in c)
         self.assertEqual(len(c["ensures"]), 1)
-        self.assertTrue({"manager": "SnapManager", "functions": [
-                        "ensureThings"]} in c["ensures"])
+        self.assertTrue({"manager": "SnapManager", "function": "ensureFunc2"} in c["ensures"])
 
     def test_features_minus(self):
         j = {"cmds": [{"cmd": "snap list --all"}, {"cmd": "snap ack file"},],
-             "ensures": [{"manager": "SnapManager", "functions": []}],
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc1"}],
              }
         k = {"cmds": [{"cmd": "snap list --all"}],
-             "ensures": [{"manager": "SnapManager", "functions": ["ensureFunc"]}],
+             "ensures": [{"manager": "SnapManager", "function": "ensureFunc2"}],
              }
         minus = query_features.minus(j, k)
         self.assertEqual(len(minus), 2)
@@ -264,7 +262,7 @@ class TestQueryFeatures(unittest.TestCase):
         self.assertTrue({"cmd": "snap ack file"} in minus["cmds"])
         self.assertEqual(len(minus["ensures"]), 1)
         self.assertTrue({"manager": "SnapManager",
-                        "functions": []} in minus["ensures"])
+                        "function": "ensureFunc1"} in minus["ensures"])
 
     def test_list_tasks(self):
         sys_json = SystemFeatures(tests=[


### PR DESCRIPTION
Previously, the ensure feature tagging grouped by a single ensure loop so a singular feature would look like:
```json
{
    "manager": "SnapManager",
    "functions": [
          "ensureVulnerableSnapConfineVersionsRemovedOnClassic",
          "ensureMountsUpdated",
          "ensureDownloadsCleaned"
    ]
}
```
This change separates the loops so a singular ensure feature is the execution of a single function. The previous data will now be represented as:
```json
{
	"manager":"SnapManager",
	"function":"ensureVulnerableSnapConfineVersionsRemovedOnClassic"
},
{
	"manager":"SnapManager",
	"function":"ensureMountsUpdated"
}, 
{
	"manager":"SnapManager",
	"function":"ensureDownloadsCleaned"
}
```
Without a need to identify individual ensure loops, the top-level log entry is no longer necessary