### PR TITLE
daemon, tests: add interface access to icons endpoint and grant desktop-launch access to /v2/snaps

### DIFF
--- a/daemon/api_icons.go
+++ b/daemon/api_icons.go
@@ -33,7 +33,7 @@ var (
 	snapIconCmd = &Command{
 		Path:       "/v2/icons/{name}/icon",
 		GET:        snapIconGet,
-		ReadAccess: interfaceOpenAccess{Interfaces: []string{"desktop-launch"}},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"desktop-launch", "snap-interfaces-requests-control", "snap-refresh-observe"}},
 	}
 )
 

--- a/daemon/api_icons.go
+++ b/daemon/api_icons.go
@@ -33,7 +33,7 @@ var (
 	snapIconCmd = &Command{
 		Path:       "/v2/icons/{name}/icon",
 		GET:        snapIconGet,
-		ReadAccess: openAccess{},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"desktop-launch"}},
 	}
 )
 

--- a/daemon/api_icons_test.go
+++ b/daemon/api_icons_test.go
@@ -40,7 +40,12 @@ type iconsSuite struct {
 	apiBaseSuite
 }
 
+func (s *iconsSuite) expectIconsReadAccess() {
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"desktop-launch"}})
+}
+
 func (s *iconsSuite) TestSnapIconGet(c *check.C) {
+	s.expectIconsReadAccess()
 	d := s.daemon(c)
 
 	// have an active foo in the system
@@ -57,6 +62,7 @@ func (s *iconsSuite) TestSnapIconGet(c *check.C) {
 }
 
 func (s *iconsSuite) TestSnapIconGetPriority(c *check.C) {
+	s.expectIconsReadAccess()
 	d := s.daemon(c)
 
 	checkIconContents := func(expected string) {
@@ -95,6 +101,7 @@ func (s *iconsSuite) TestSnapIconGetPriority(c *check.C) {
 }
 
 func (s *iconsSuite) TestSnapIconGetInactive(c *check.C) {
+	s.expectIconsReadAccess()
 	d := s.daemon(c)
 
 	// have an *in*active foo in the system
@@ -111,6 +118,7 @@ func (s *iconsSuite) TestSnapIconGetInactive(c *check.C) {
 }
 
 func (s *iconsSuite) TestSnapIconGetNoIcon(c *check.C) {
+	s.expectIconsReadAccess()
 	d := s.daemon(c)
 
 	info := s.mkInstalledInState(c, d, "foo", "bar", "v1", snap.R(10), true, "")
@@ -129,6 +137,7 @@ func (s *iconsSuite) TestSnapIconGetNoIcon(c *check.C) {
 }
 
 func (s *iconsSuite) TestSnapIconGetFallback(c *check.C) {
+	s.expectIconsReadAccess()
 	d := s.daemon(c)
 
 	const snapName = "foo"
@@ -156,6 +165,7 @@ func (s *iconsSuite) TestSnapIconGetFallback(c *check.C) {
 }
 
 func (s *iconsSuite) TestSnapIconGetUnasserted(c *check.C) {
+	s.expectIconsReadAccess()
 	d := s.daemon(c)
 
 	const snapName = "foo"
@@ -184,6 +194,7 @@ func (s *iconsSuite) TestSnapIconGetUnasserted(c *check.C) {
 }
 
 func (s *iconsSuite) TestSnapIconGetNoApp(c *check.C) {
+	s.expectIconsReadAccess()
 	s.daemon(c)
 
 	req, err := http.NewRequest("GET", "/v2/icons/foo/icon", nil)

--- a/daemon/api_icons_test.go
+++ b/daemon/api_icons_test.go
@@ -41,7 +41,7 @@ type iconsSuite struct {
 }
 
 func (s *iconsSuite) expectIconsReadAccess() {
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"desktop-launch"}})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"desktop-launch", "snap-interfaces-requests-control", "snap-refresh-observe"}})
 }
 
 func (s *iconsSuite) TestSnapIconGet(c *check.C) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -51,7 +51,7 @@ var (
 		Path:        "/v2/snaps/{name}",
 		GET:         getSnapInfo,
 		POST:        postSnap,
-		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control", "snap-refresh-observe"}},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control", "snap-refresh-observe", "desktop-launch"}},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 
@@ -59,7 +59,7 @@ var (
 		Path:        "/v2/snaps",
 		GET:         getSnapsInfo,
 		POST:        postSnaps,
-		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "desktop-launch"}},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 )

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -72,11 +72,11 @@ func (s *snapsSuite) SetUpTest(c *check.C) {
 }
 
 func (s *snapsSuite) expectSnapsReadAccess() {
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "desktop-launch"}})
 }
 
 func (s *snapsSuite) expectSnapsNameReadAccess() {
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control", "snap-refresh-observe"}})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-interfaces-requests-control", "snap-refresh-observe", "desktop-launch"}})
 }
 
 func (s *snapsSuite) TestSnapsInfoIntegration(c *check.C) {

--- a/tests/main/interfaces-desktop-launch/api-client/bin/api-client.py
+++ b/tests/main/interfaces-desktop-launch/api-client/bin/api-client.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import argparse
+import http.client
+import sys
+import socket
+
+class UnixSocketHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, socket_path):
+        super().__init__('localhost')
+        self._socket_path = socket_path
+
+    def connect(self):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(self._socket_path)
+        self.sock = s
+
+
+def main(argv):
+    parser = argparse.ArgumentParser('Call the snapd REST API')
+    parser.add_argument('--socket', default='/run/snapd.socket',
+                        help='The socket path to connect to')
+    parser.add_argument('--method', default='GET',
+                        help='The HTTP method to use')
+    parser.add_argument('path', metavar='PATH',
+                        help='The HTTP path to request')
+    parser.add_argument('body', metavar='BODY', default=None, nargs='?',
+                        help='The HTTP request body')
+    args = parser.parse_args(argv[1:])
+
+    conn = UnixSocketHTTPConnection(args.socket)
+    conn.request(args.method, args.path, args.body)
+
+    response = conn.getresponse()
+    body = response.read()
+    print(body.decode('UTF-8'))
+    return response.status >= 300
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/main/interfaces-desktop-launch/api-client/meta/snap.yaml
+++ b/tests/main/interfaces-desktop-launch/api-client/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: api-client
+version: 1
+base: core24
+apps:
+  api-client:
+    command: bin/api-client.py
+    plugs:
+      - desktop-launch

--- a/tests/main/interfaces-desktop-launch/task.yaml
+++ b/tests/main/interfaces-desktop-launch/task.yaml
@@ -10,6 +10,7 @@ prepare: |
     if ! tests.session has-session-systemd-and-dbus; then
         exit 0
     fi
+    snap remove --purge api-client || true
     tests.session -u test prepare
     tests.session -u test exec systemctl --user \
       set-environment XDG_DATA_DIRS=/usr/share:/var/lib/snapd/desktop
@@ -25,6 +26,9 @@ execute: |
     if ! tests.session has-session-systemd-and-dbus; then
         exit 0
     fi
+
+    "$TESTSTOOLS"/snaps-state install-local api-client
+    tests.cleanup defer snap remove --purge api-client
 
     echo "Install the application snap"
     "$TESTSTOOLS"/snaps-state install-local test-app
@@ -51,3 +55,20 @@ execute: |
 
     echo "The app was invoked with the arguments in the desktop file"
     MATCH "^args=arg-before arg-after$" < "$launch_data"
+
+    echo "Without the plug connection, the app cannot access endpoints"
+    api-client --socket /run/snapd-snap.socket "/v2/icons/api-client/icon" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/snapd" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/snaps" | gojq '."status-code"' | MATCH '^403$'
+
+    echo "Connect the api-client desktop-launch plug"
+    snap connect api-client:desktop-launch
+
+    echo "Check that snap can access icons info via /v2/icons and gets 404 if icon is not found"
+    api-client --socket /run/snapd-snap.socket "/v2/icons/api-client/icon" | gojq '."status-code"' | MATCH '^404$'
+
+    echo "Check that snap can access /v2/snaps/{name}"
+    api-client --socket /run/snapd-snap.socket "/v2/snaps/snapd" | gojq '."status-code"' | MATCH '^200$'
+
+    echo "Check that snap can access /v2/snaps"
+    api-client --socket /run/snapd-snap.socket "/v2/snaps" | gojq '."status-code"' | MATCH '^200$'

--- a/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
+++ b/tests/main/interfaces-snap-interfaces-requests-control/task.yaml
@@ -141,6 +141,9 @@ execute: |
     # echo "Check snap can modify a single rule via /v2/interfaces/requests/rules/<ID>"
     # api-client --socket /run/snapd-snap.socket --method=POST '{"action":"remove"}' "/v2/interfaces/requests/rules/$RULE_ID" | gojq '."status-code"' | MATCH '^200$'
 
+    echo "Check that snap can access icons info via /v2/icons and gets 404 if icon is not found"
+    api-client --socket /run/snapd-snap.socket "/v2/icons/api-client/icon" | gojq '."status-code"' | MATCH '^404$'
+
     echo "Without snap-interfaces-requests-control the snap cannot access those API endpoints"
     snap disconnect api-client:snap-interfaces-requests-control
 
@@ -164,4 +167,6 @@ execute: |
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules" | \
         gojq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/interfaces/requests/rules/$RULE_ID" | \
+        gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/icons/api-client/icon" | \
         gojq '."status-code"' | MATCH '^403$'

--- a/tests/main/interfaces-snap-refresh-observe/task.yaml
+++ b/tests/main/interfaces-snap-refresh-observe/task.yaml
@@ -41,6 +41,9 @@ execute: |
     echo "And also a specific snap /v2/snaps/<instance-name>"
     api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | gojq '."status-code"' | MATCH '^200$'
 
+    echo "Check that snap can access /v2/icons"
+    api-client --socket /run/snapd-snap.socket "/v2/icons/api-client/icon" | gojq '."status-code"' | MATCH '^404$'
+
     echo "Without snap-refresh-observe the snap cannot access those API endpoints"
     snap disconnect api-client:snap-refresh-observe
 
@@ -49,3 +52,4 @@ execute: |
     api-client --socket /run/snapd-snap.socket "/v2/changes/$CHANGE_ID" | gojq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/snaps" | gojq '."status-code"' | MATCH '^403$'
     api-client --socket /run/snapd-snap.socket "/v2/snaps/api-client" | gojq '."status-code"' | MATCH '^403$'
+    api-client --socket /run/snapd-snap.socket "/v2/icons/api-client/icon" | gojq '."status-code"' | MATCH '^403$'


### PR DESCRIPTION
This adds interface access to `/v2/icons` for the `desktop-launch`, `snap-interfaces-requests-control`, and `snap-refresh-observe` interfaces. Additionally, this grants `desktop-launch` access to the `/v2/snaps/{name}` and `/v2/snaps` endpoints.