### PR TITLE
c/snap: support ops on multiple components with syntax "snap <op> snap1+comp1 snap1+comp2"

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -244,7 +244,7 @@ func (x *cmdRemove) removeOne(opts *client.SnapOptions) error {
 
 // snapInstancesAndComponentsFromNames splits a slice of names of the form
 // <snap_instance>+<comp1>...+<compN> into a slice of snap instances and a map
-// from these instances to components.
+// from these instances to components. Snap names are de-duplicated.
 func snapInstancesAndComponentsFromNames(names []string, forInstall bool) ([]string, map[string][]string, error) {
 	snaps := make([]string, 0, len(names))
 	allComps := make(map[string][]string, len(names))
@@ -257,11 +257,11 @@ func snapInstancesAndComponentsFromNames(names []string, forInstall bool) ([]str
 		// we have specified also components, but when removing we
 		// actually want to remove only components if any of them have
 		// been specified.
-		if forInstall || len(comps) == 0 {
+		if (forInstall || len(comps) == 0) && !strutil.ListContains(snaps, snap) {
 			snaps = append(snaps, snap)
 		}
 		if len(comps) > 0 {
-			allComps[snap] = comps
+			allComps[snap] = append(allComps[snap], comps...)
 		}
 	}
 	return snaps, allComps, nil

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -3252,8 +3252,11 @@ func (s *SnapOpSuite) TestInstallManyNoChanges(c *check.C) {
 		case 0:
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{
-				"action":      "install",
-				"snaps":       []any{"one", "two"},
+				"action": "install",
+				"snaps":  []any{"one", "two", "three"},
+				"components": map[string]any{
+					"three": []any{"comp1", "comp2"},
+				},
 				"transaction": string(client.TransactionPerSnap),
 			})
 
@@ -3275,12 +3278,15 @@ func (s *SnapOpSuite) TestInstallManyNoChanges(c *check.C) {
 		n++
 	})
 
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "one", "two"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "one", "two", "three+comp1+comp2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	// note that (stable) is omitted
 	c.Check(s.Stdout(), check.Matches, `(?sm).*one already installed`)
 	c.Check(s.Stdout(), check.Matches, `(?sm).*two already installed`)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*three already installed`)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*three\+comp1 already installed`)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*three\+comp2 already installed`)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, total)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -466,7 +466,7 @@ func (s *SnapOpSuite) TestInstallManyWithComponents(c *check.C) {
 		n++
 	})
 
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "one+comp1+comp2", "two+comp3+comp4", "three"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "one+comp1", "one+comp2", "two+comp3+comp4", "three"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 
@@ -559,7 +559,7 @@ func (s *SnapOpSuite) TestRemoveManyWithComponents(c *check.C) {
 	})
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs(
-		[]string{"remove", "one+comp1+comp2", "two+comp3+comp4", "three"})
+		[]string{"remove", "one+comp1", "one+comp2", "two+comp3+comp4", "three"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 


### PR DESCRIPTION
This fixes a bug where only the last component, when using this kind of syntax, was installed.