### PR TITLE
interfaces: allow pwritev2 in default seccomp template

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -614,6 +614,7 @@ writev
 pwrite
 pwrite64
 pwritev
+pwritev2
 `)
 
 // Go's net package attempts to bind early to check whether IPv6 is available or not.


### PR DESCRIPTION
We already allow pwritev and pvwrite64. The pwritev2 system call adds a flag argument. That is documented in the manual page pwritev2(2)

```
preadv2() and pwritev2()
    These  system calls are similar to preadv() and pwritev() calls, but add a fifth argument,
    flags, which modifies the behavior on a per-call basis.

    Unlike preadv() and pwritev(), if the offset argument is -1, then the current file  offset
    is used and updated.

    The flags argument contains a bitwise OR of zero or more of the following flags:

    RWF_DSYNC (since Linux 4.7)
           Provide  a  per-write  equivalent  of  the  O_DSYNC  open(2)  flag.   This  flag is
           meaningful only for pwritev2(), and its effect  applies  only  to  the  data  range
           written by the system call.

    RWF_HIPRI (since Linux 4.6)
           High  priority  read/write.   Allows  block-based filesystems to use polling of the
           device,  which  provides  lower  latency,  but  may   use   additional   resources.
           (Currently,  this  feature  is  usable  only  on a file descriptor opened using the
           O_DIRECT flag.)

    RWF_SYNC (since Linux 4.7)
           Provide a per-write equivalent of the O_SYNC open(2) flag.  This flag is meaningful
           only  for  pwritev2(), and its effect applies only to the data range written by the
           system call.

    RWF_NOWAIT (since Linux 4.14)
           Do not wait for  data  which  is  not  immediately  available.   If  this  flag  is
           specified, the preadv2() system call will return instantly if it would have to read
           data from the backing storage or wait for a lock.  If some  data  was  successfully
           read,  it  will  return  the  number of bytes read.  If no bytes were read, it will
           return -1 and set errno  to  EAGAIN  (but  see  BUGS).   Currently,  this  flag  is
           meaningful only for preadv2().

    RWF_APPEND (since Linux 4.16)
           Provide  a  per-write  equivalent  of  the  O_APPEND  open(2)  flag.   This flag is
           meaningful only for pwritev2(), and its effect  applies  only  to  the  data  range
           written  by  the  system  call.   The  offset  argument  does  not affect the write
           operation; the data is always appended to the end of the  file.   However,  if  the
           offset argument is -1, the current file offset is updated.
```
