### PR TITLE
store: use snapd snap for checking store connectivity

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1599,9 +1599,7 @@ var errUnexpectedConnCheckResponse = errors.New("unexpected response during conn
 
 func (s *Store) snapConnCheck() ([]string, error) {
 	var hosts []string
-	// NOTE: "core" is possibly the only snap that's sure to be in all stores
-	//       when we drop "core" in the move to snapd/core18/etc, change this
-	infoURL, err := s.endpointURL(path.Join(snapInfoEndpPath, "core"), url.Values{
+	infoURL, err := s.endpointURL(path.Join(snapInfoEndpPath, "snapd"), url.Values{
 		// we only want the download URL
 		"fields": {"download"},
 		// we only need *one* (but can't filter by channel ... yet)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -4305,10 +4305,10 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 	var mockServerURL *url.URL
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/v2/snaps/info/core":
+		case "/v2/snaps/info/snapd":
 			c.Check(r.Method, Equals, "GET")
 			c.Check(r.URL.Query(), DeepEquals, url.Values{"fields": {"download"}, "architecture": {arch.DpkgArchitecture()}})
-			u, err := url.Parse("/download/core")
+			u, err := url.Parse("/download/snapd")
 			c.Assert(err, IsNil)
 			io.WriteString(w,
 				fmt.Sprintf(`{"channel-map": [{"download": {"url": %q}}, {"download": {"url": %q}}, {"download": {"url": %q}}]}`,
@@ -4316,7 +4316,7 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 					mockServerURL.String()+"/bogus1/",
 					mockServerURL.String()+"/bogus2/",
 				))
-		case "/download/core":
+		case "/download/snapd":
 			c.Check(r.Method, Equals, "HEAD")
 			w.WriteHeader(200)
 		default:
@@ -4339,8 +4339,8 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 		mockServerURL.Host: true,
 	})
 	c.Check(seenPaths, DeepEquals, map[string]int{
-		"/v2/snaps/info/core": 1,
-		"/download/core":      1,
+		"/v2/snaps/info/snapd": 1,
+		"/download/snapd":      1,
 	})
 }
 
@@ -4354,7 +4354,7 @@ func (s *storeTestSuite) TestConnectivityCheckUnhappy(c *C) {
 	var mockServerURL *url.URL
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/v2/snaps/info/core":
+		case "/v2/snaps/info/snapd":
 			w.WriteHeader(500)
 		default:
 			c.Fatalf("unexpected request: %s", r.URL.String())
@@ -4377,7 +4377,7 @@ func (s *storeTestSuite) TestConnectivityCheckUnhappy(c *C) {
 	})
 	// three because retries
 	c.Check(seenPaths, DeepEquals, map[string]int{
-		"/v2/snaps/info/core": 3,
+		"/v2/snaps/info/snapd": 3,
 	})
 }
 


### PR DESCRIPTION
Address a long standing TODO and switch to using the snapd snap as a 'canary' when checking store connectivity.

Fixes: LP#2112544
Related: [SNAPDENG-35120](https://warthogs.atlassian.net/browse/SNAPDENG-35120)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
