### PR TITLE
overlord/servicestate: isolate quota-state update code

### DIFF
--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -30,13 +30,10 @@ import (
 var (
 	UpdateSnapstateServices              = updateSnapstateServices
 	CheckSystemdVersion                  = checkSystemdVersion
-	QuotaStateAlreadyUpdated             = quotaStateAlreadyUpdated
 	ServiceControlTs                     = serviceControlTs
 	ValidateSnapServicesForAddingToGroup = validateSnapServicesForAddingToGroup
 	AffectedSnapServices                 = affectedSnapServices
 )
-
-type QuotaStateUpdated = quotaStateUpdated
 
 func (m *ServiceManager) DoQuotaControl(t *state.Task, to *tomb.Tomb) error {
 	return m.doQuotaControl(t, to)
@@ -58,16 +55,6 @@ func EnsureSnapServicesForGroupOptions(allGrps map[string]*quota.Group, extraSna
 	return &ensureSnapServicesForGroupOptions{
 		allGrps:    allGrps,
 		extraSnaps: extraSnaps,
-	}
-}
-
-func MockOsutilBootID(mockID string) (restore func()) {
-	old := osutilBootID
-	osutilBootID = func() (string, error) {
-		return mockID, nil
-	}
-	return func() {
-		osutilBootID = old
 	}
 }
 

--- a/overlord/servicestate/internal/export_test.go
+++ b/overlord/servicestate/internal/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+type QuotaStateUpdated = quotaStateUpdated

--- a/overlord/servicestate/internal/export_test.go
+++ b/overlord/servicestate/internal/export_test.go
@@ -19,4 +19,4 @@
 
 package internal
 
-type QuotaStateUpdated = quotaStateUpdated
+type QuotaStateUpdated = quotaState

--- a/overlord/servicestate/internal/quota_state.go
+++ b/overlord/servicestate/internal/quota_state.go
@@ -1,0 +1,152 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"errors"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+var osutilBootID = osutil.BootID
+
+// MockOsutilBootID is only here to allow other test suites to mock
+// this specific function.
+func MockOsutilBootID(mockID string) (restore func()) {
+	old := osutilBootID
+	osutilBootID = func() (string, error) {
+		return mockID, nil
+	}
+	return func() {
+		osutilBootID = old
+	}
+}
+
+type QuotaStateItems struct {
+	QuotaGroupName      string
+	AppsToRestartBySnap map[*snap.Info][]*snap.AppInfo
+	RefreshProfiles     bool
+}
+
+type quotaStateUpdated struct {
+	BootID              string              `json:"boot-id"`
+	QuotaGroupName      string              `json:"quota-group-name"`
+	AppsToRestartBySnap map[string][]string `json:"apps-to-restart,omitempty"`
+	RefreshProfiles     bool                `json:"refresh-profiles,omitempty"`
+}
+
+func QuotaStateUpdate(t *state.Task, data *QuotaStateItems) error {
+	bootID, err := osutilBootID()
+	if err != nil {
+		return err
+	}
+	appNamesBySnapName := make(map[string][]string, len(data.AppsToRestartBySnap))
+	for info, apps := range data.AppsToRestartBySnap {
+		appNames := make([]string, len(apps))
+		for i, app := range apps {
+			appNames[i] = app.Name
+		}
+		appNamesBySnapName[info.InstanceName()] = appNames
+	}
+	t.Set("state-updated", quotaStateUpdated{
+		BootID:              bootID,
+		QuotaGroupName:      data.QuotaGroupName,
+		AppsToRestartBySnap: appNamesBySnapName,
+		RefreshProfiles:     data.RefreshProfiles,
+	})
+	return nil
+}
+
+func sortAppsBySnap(t *state.Task, apps map[string][]string) (map[*snap.Info][]*snap.AppInfo, error) {
+	appsToRestartBySnap := make(map[*snap.Info][]*snap.AppInfo, len(apps))
+	st := t.State()
+	// best effort, ignore missing snaps and apps
+	for instanceName, appNames := range apps {
+		info, err := snapstate.CurrentInfo(st, instanceName)
+		if err != nil {
+			if _, ok := err.(*snap.NotInstalledError); ok {
+				t.Logf("after snapd restart, snap %q went missing", instanceName)
+				continue
+			}
+			return nil, err
+		}
+		apps := make([]*snap.AppInfo, 0, len(appNames))
+		for _, appName := range appNames {
+			app := info.Apps[appName]
+			if app == nil || !app.IsService() {
+				continue
+			}
+			apps = append(apps, app)
+		}
+		appsToRestartBySnap[info] = apps
+	}
+	return appsToRestartBySnap, nil
+}
+
+func QuotaStateAlreadyUpdated(t *state.Task) (data *QuotaStateItems, err error) {
+	var updated quotaStateUpdated
+	if err := t.Get("state-updated", &updated); err != nil {
+		if errors.Is(err, state.ErrNoState) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	bootID, err := osutilBootID()
+	if err != nil {
+		return nil, err
+	}
+
+	// rebooted => nothing to restart
+	if bootID != updated.BootID {
+		// return only the group name used for retrieving the group
+		return &QuotaStateItems{
+			QuotaGroupName: updated.QuotaGroupName,
+		}, nil
+	}
+
+	var appsToRestartBySnap map[*snap.Info][]*snap.AppInfo
+	appsToRestartBySnap, err = sortAppsBySnap(t, updated.AppsToRestartBySnap)
+	if err != nil {
+		return nil, err
+	}
+	return &QuotaStateItems{
+		QuotaGroupName:      updated.QuotaGroupName,
+		AppsToRestartBySnap: appsToRestartBySnap,
+		RefreshProfiles:     updated.RefreshProfiles,
+	}, nil
+}
+
+func QuotaStateSnaps(t *state.Task) (snaps []string, err error) {
+	var updated quotaStateUpdated
+	if err := t.Get("state-updated", &updated); err != nil {
+		return nil, err
+	}
+
+	// TODO: consider boot-id as well?
+	for snapName := range updated.AppsToRestartBySnap {
+		snaps = append(snaps, snapName)
+	}
+	// all set
+	return snaps, nil
+}

--- a/overlord/servicestate/internal/quota_state_test.go
+++ b/overlord/servicestate/internal/quota_state_test.go
@@ -1,0 +1,180 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/servicestate/internal"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+var testYaml = `name: test-snap
+version: v1
+apps:
+  svc1:
+    command: bin.sh
+    daemon: simple
+`
+
+type quotaStateSuite struct {
+	testutil.BaseTest
+	state            *state.State
+	testSnapState    *snapstate.SnapState
+	testSnapSideInfo *snap.SideInfo
+	testSnapInfo     *snap.Info
+}
+
+var _ = Suite(&quotaStateSuite{})
+
+func (s *quotaStateSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	s.state = state.New(nil)
+
+	// set an empty sanitize method.
+	snap.SanitizePlugsSlots = func(*snap.Info) {}
+
+	// setup a test-snap with a service that can be easily injected into
+	// snapstate to be setup as needed
+	s.testSnapSideInfo = &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	s.testSnapState = &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{s.testSnapSideInfo}),
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	}
+
+	// need lock for setting up test-snap
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// setup test-snap
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	s.testSnapInfo = snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+}
+
+func (s *quotaStateSuite) TestQuotaStateUpdate(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// mock a boot id
+	r := internal.MockOsutilBootID("mock-boot-id")
+	defer r()
+
+	task := st.NewTask("foo", "...")
+
+	// check that the quota state is not already updated
+	data, err := internal.QuotaStateAlreadyUpdated(task)
+	c.Assert(data, IsNil)
+	c.Assert(err, IsNil)
+
+	c.Check(internal.QuotaStateUpdate(task, &internal.QuotaStateItems{
+		QuotaGroupName: "test-group",
+		AppsToRestartBySnap: map[*snap.Info][]*snap.AppInfo{
+			s.testSnapInfo: {s.testSnapInfo.Apps["svc1"]},
+		},
+		RefreshProfiles: true,
+	}), IsNil)
+
+	// manually verify the task data
+	var updated internal.QuotaStateUpdated
+	c.Assert(task.Get("state-updated", &updated), IsNil)
+	c.Check(updated.BootID, Equals, "mock-boot-id")
+	c.Check(updated.QuotaGroupName, Equals, "test-group")
+	c.Check(updated.AppsToRestartBySnap, HasLen, 1)
+	c.Check(updated.AppsToRestartBySnap[s.testSnapInfo.InstanceName()], DeepEquals, []string{"svc1"})
+
+	data, err = internal.QuotaStateAlreadyUpdated(task)
+	c.Assert(err, IsNil)
+	c.Assert(data, NotNil)
+}
+
+func (s *quotaStateSuite) TestQuotaStateAlreadyUpdated(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("foo", "...")
+
+	// check that the quota state is not already updated
+	data, err := internal.QuotaStateAlreadyUpdated(task)
+	c.Assert(data, IsNil)
+	c.Assert(err, IsNil)
+
+	// Manually set the task data to simulate a previous update
+	task.Set("state-updated", internal.QuotaStateUpdated{
+		BootID:              "mock-boot-id",
+		QuotaGroupName:      "test-group",
+		AppsToRestartBySnap: map[string][]string{"test-snap": {"svc1"}},
+		RefreshProfiles:     true,
+	})
+
+	// mock a different boot id we set for the state, meaning
+	// that a restart has happened, and thus no apps should be restarted
+	r := internal.MockOsutilBootID("different-boot-id")
+	data, err = internal.QuotaStateAlreadyUpdated(task)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, &internal.QuotaStateItems{
+		QuotaGroupName: "test-group",
+	})
+	r()
+
+	// the boot id must match to get the below app list
+	r = internal.MockOsutilBootID("mock-boot-id")
+	defer r()
+
+	data, err = internal.QuotaStateAlreadyUpdated(task)
+	c.Assert(err, IsNil)
+	c.Check(data.QuotaGroupName, Equals, "test-group")
+	c.Assert(data.AppsToRestartBySnap, HasLen, 1)
+	for snapName, apps := range data.AppsToRestartBySnap {
+		c.Check(snapName.RealName, Equals, "test-snap")
+		c.Check(apps, HasLen, 1)
+		c.Check(apps[0].Name, Equals, "svc1")
+	}
+	c.Check(data.RefreshProfiles, Equals, true)
+}
+
+func (s *quotaStateSuite) TestQuotaStateSnaps(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("foo", "...")
+
+	// Manually set the task data to simulate a previous update
+	task.Set("state-updated", internal.QuotaStateUpdated{
+		AppsToRestartBySnap: map[string][]string{"test-snap": {"svc1"}},
+	})
+
+	data, err := internal.QuotaStateSnaps(task)
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []string{"test-snap"})
+}

--- a/overlord/servicestate/internal/quota_state_test.go
+++ b/overlord/servicestate/internal/quota_state_test.go
@@ -91,11 +91,11 @@ func (s *quotaStateSuite) TestQuotaStateUpdate(c *C) {
 	task := st.NewTask("foo", "...")
 
 	// check that the quota state is not already updated
-	data, err := internal.QuotaStateAlreadyUpdated(task)
+	data, err := internal.GetQuotaState(task)
 	c.Assert(data, IsNil)
 	c.Assert(err, IsNil)
 
-	c.Check(internal.QuotaStateUpdate(task, &internal.QuotaStateItems{
+	c.Check(internal.SetQuotaState(task, &internal.QuotaStateItems{
 		QuotaGroupName: "test-group",
 		AppsToRestartBySnap: map[*snap.Info][]*snap.AppInfo{
 			s.testSnapInfo: {s.testSnapInfo.Apps["svc1"]},
@@ -111,7 +111,7 @@ func (s *quotaStateSuite) TestQuotaStateUpdate(c *C) {
 	c.Check(updated.AppsToRestartBySnap, HasLen, 1)
 	c.Check(updated.AppsToRestartBySnap[s.testSnapInfo.InstanceName()], DeepEquals, []string{"svc1"})
 
-	data, err = internal.QuotaStateAlreadyUpdated(task)
+	data, err = internal.GetQuotaState(task)
 	c.Assert(err, IsNil)
 	c.Assert(data, NotNil)
 }
@@ -124,7 +124,7 @@ func (s *quotaStateSuite) TestQuotaStateAlreadyUpdated(c *C) {
 	task := st.NewTask("foo", "...")
 
 	// check that the quota state is not already updated
-	data, err := internal.QuotaStateAlreadyUpdated(task)
+	data, err := internal.GetQuotaState(task)
 	c.Assert(data, IsNil)
 	c.Assert(err, IsNil)
 
@@ -139,7 +139,7 @@ func (s *quotaStateSuite) TestQuotaStateAlreadyUpdated(c *C) {
 	// mock a different boot id we set for the state, meaning
 	// that a restart has happened, and thus no apps should be restarted
 	r := internal.MockOsutilBootID("different-boot-id")
-	data, err = internal.QuotaStateAlreadyUpdated(task)
+	data, err = internal.GetQuotaState(task)
 	c.Assert(err, IsNil)
 	c.Assert(data, DeepEquals, &internal.QuotaStateItems{
 		QuotaGroupName: "test-group",
@@ -150,7 +150,7 @@ func (s *quotaStateSuite) TestQuotaStateAlreadyUpdated(c *C) {
 	r = internal.MockOsutilBootID("mock-boot-id")
 	defer r()
 
-	data, err = internal.QuotaStateAlreadyUpdated(task)
+	data, err = internal.GetQuotaState(task)
 	c.Assert(err, IsNil)
 	c.Check(data.QuotaGroupName, Equals, "test-group")
 	c.Assert(data.AppsToRestartBySnap, HasLen, 1)
@@ -174,7 +174,7 @@ func (s *quotaStateSuite) TestQuotaStateSnaps(c *C) {
 		AppsToRestartBySnap: map[string][]string{"test-snap": {"svc1"}},
 	})
 
-	data, err := internal.QuotaStateSnaps(task)
+	data, err := internal.GetQuotaStateSnaps(task)
 	c.Assert(err, IsNil)
 	c.Assert(data, DeepEquals, []string{"test-snap"})
 }

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/internal"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -1069,13 +1070,16 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 	))
 	defer r()
 
+	r = internal.MockOsutilBootID("boot-id")
+	defer r()
+
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
 
 	// setup test-snap
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
-	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	info := snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
 	defer s.se.Stop()
@@ -1091,10 +1095,9 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 	// the group is already gone, but the task is not finished
 	s.state.Set("quotas", nil)
 	task := ts.Tasks()[0]
-	task.Set("state-updated", servicestate.QuotaStateUpdated{
-		BootID: "boot-id",
-		AppsToRestartBySnap: map[string][]string{
-			"test-snap": {"svc1"},
+	internal.QuotaStateUpdate(task, &internal.QuotaStateItems{
+		AppsToRestartBySnap: map[*snap.Info][]*snap.AppInfo{
+			info: {info.Apps["svc1"]},
 		},
 	})
 

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -1095,7 +1095,7 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 	// the group is already gone, but the task is not finished
 	s.state.Set("quotas", nil)
 	task := ts.Tasks()[0]
-	internal.QuotaStateUpdate(task, &internal.QuotaStateItems{
+	internal.SetQuotaState(task, &internal.QuotaStateItems{
 		AppsToRestartBySnap: map[*snap.Info][]*snap.AppInfo{
 			info: {info.Apps["svc1"]},
 		},

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -244,7 +244,7 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 	st.Lock()
 	c.Assert(err, IsNil)
 
-	data, err := internal.QuotaStateAlreadyUpdated(t)
+	data, err := internal.GetQuotaState(t)
 	c.Assert(err, IsNil)
 	c.Check(data, NotNil)
 	c.Assert(data.AppsToRestartBySnap, HasLen, 1)
@@ -258,21 +258,21 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 	r = internal.MockOsutilBootID("other-boot")
 	defer r()
 
-	data, err = internal.QuotaStateAlreadyUpdated(t)
+	data, err = internal.GetQuotaState(t)
 	c.Assert(err, IsNil)
 	c.Check(data, NotNil)
 	c.Check(data.AppsToRestartBySnap, HasLen, 0)
 	r()
 
 	// restored
-	data, err = internal.QuotaStateAlreadyUpdated(t)
+	data, err = internal.GetQuotaState(t)
 	c.Assert(err, IsNil)
 	c.Check(data, NotNil)
 	c.Check(data.AppsToRestartBySnap, HasLen, 1)
 
 	// snap went missing
 	snapstate.Set(s.state, "test-snap", nil)
-	data, err = internal.QuotaStateAlreadyUpdated(t)
+	data, err = internal.GetQuotaState(t)
 	c.Assert(err, IsNil)
 	c.Check(data, NotNil)
 	c.Check(data.AppsToRestartBySnap, HasLen, 0)


### PR DESCRIPTION
Changes
 - Move the returned items into a struct instead
 - Use the same struct for updating
 - Add the Group Name as a tracked value
 - Add dedicated tests as well