### PR TITLE
many: add mock api for replacing recovery keys

### DIFF
--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -41,7 +41,7 @@ var (
 type systemVolumesActionRequest struct {
 	Action string `json:"action"`
 
-	Keyslots []fdestate.KeyslotTarget `json:"keyslots,omitempty"`
+	Keyslots []fdestate.KeyslotTarget `json:"keyslots"`
 
 	RecoveryKey    string   `json:"recovery-key"`
 	ContainerRoles []string `json:"container-roles"`
@@ -136,17 +136,9 @@ func postSystemVolumesActionReplaceRecoveryKey(c *Command, req *systemVolumesAct
 	st.Lock()
 	defer st.Unlock()
 
-	if len(req.Keyslots) == 0 {
-		// target default-recovery key slots by default if no key slot targets are specified
-		req.Keyslots = append(req.Keyslots,
-			fdestate.KeyslotTarget{ContainerRole: "system-data", Name: "default-recovery"},
-			fdestate.KeyslotTarget{ContainerRole: "system-save", Name: "default-recovery"},
-		)
-	}
-
 	ts, err := fdestateReplaceRecoveryKey(st, req.KeyID, req.Keyslots)
 	if err != nil {
-		return BadRequest("cannot change recovery key: %v", err)
+		return BadRequest("cannot replace recovery key: %v", err)
 	}
 
 	chg := st.NewChange("replace-recovery-key", "Replace recovery key")

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -144,9 +144,15 @@ func postSystemVolumesActionReplaceRecoveryKey(c *Command, req *systemVolumesAct
 		)
 	}
 
-	chg, err := fdestateReplaceRecoveryKey(st, req.KeyID, req.Keyslots)
+	ts, err := fdestateReplaceRecoveryKey(st, req.KeyID, req.Keyslots)
 	if err != nil {
 		return BadRequest("cannot change recovery key: %v", err)
 	}
+
+	chg := st.NewChange("replace-recovery-key", "Replace recovery key")
+	chg.AddAll(ts)
+
+	st.EnsureBefore(0)
+
 	return AsyncResponse(nil, chg.ID())
 }

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -41,7 +41,7 @@ var (
 type systemVolumesActionRequest struct {
 	Action string `json:"action"`
 
-	Keyslots []fdestate.KeyslotTarget `json:"keyslots"`
+	Keyslots []fdestate.KeyslotRef `json:"keyslots"`
 
 	RecoveryKey    string   `json:"recovery-key"`
 	ContainerRoles []string `json:"container-roles"`

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -34,11 +34,19 @@ var systemVolumesCmd = &Command{
 	WriteAccess: rootAccess{},
 }
 
+var (
+	fdestateReplaceRecoveryKey = fdestate.ReplaceRecoveryKey
+)
+
 type systemVolumesActionRequest struct {
 	Action string `json:"action"`
 
+	Keyslots []fdestate.KeyslotTarget `json:"keyslots,omitempty"`
+
 	RecoveryKey    string   `json:"recovery-key"`
 	ContainerRoles []string `json:"container-roles"`
+	// KeyID is the recovery key id.
+	KeyID string `json:"key-id"`
 }
 
 func postSystemVolumesAction(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -70,6 +78,8 @@ func postSystemVolumesActionJSON(c *Command, r *http.Request) Response {
 		return postSystemVolumesActionGenerateRecoveryKey(c)
 	case "check-recovery-key":
 		return postSystemVolumesActionCheckRecoveryKey(c, &req)
+	case "replace-recovery-key":
+		return postSystemVolumesActionReplaceRecoveryKey(c, &req)
 	default:
 		return BadRequest("unsupported system volumes action %q", req.Action)
 	}
@@ -115,4 +125,28 @@ func postSystemVolumesActionCheckRecoveryKey(c *Command, req *systemVolumesActio
 	}
 
 	return SyncResponse(nil)
+}
+
+func postSystemVolumesActionReplaceRecoveryKey(c *Command, req *systemVolumesActionRequest) Response {
+	if req.KeyID == "" {
+		return BadRequest("system volume action requires key-id to be provided")
+	}
+
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	if len(req.Keyslots) == 0 {
+		// target default-recovery key slots by default if no key slot targets are specified
+		req.Keyslots = append(req.Keyslots,
+			fdestate.KeyslotTarget{ContainerRole: "system-data", Name: "default-recovery"},
+			fdestate.KeyslotTarget{ContainerRole: "system-save", Name: "default-recovery"},
+		)
+	}
+
+	chg, err := fdestateReplaceRecoveryKey(st, req.KeyID, req.Keyslots)
+	if err != nil {
+		return BadRequest("cannot change recovery key: %v", err)
+	}
+	return AsyncResponse(nil, chg.ID())
 }

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -209,10 +209,10 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKey(c *C) {
 	defer d.Overlord().Stop()
 
 	called := 0
-	s.AddCleanup(daemon.MockFdestateReplaceRecoveryKey(func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotTarget) (*state.TaskSet, error) {
+	s.AddCleanup(daemon.MockFdestateReplaceRecoveryKey(func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error) {
 		called++
 		c.Check(recoveryKeyID, Equals, "some-key-id")
-		c.Check(keyslots, DeepEquals, []fdestate.KeyslotTarget{
+		c.Check(keyslots, DeepEquals, []fdestate.KeyslotRef{
 			{ContainerRole: "some-container-role", Name: "some-name"},
 		})
 
@@ -246,7 +246,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKey(c *C) {
 func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyError(c *C) {
 	s.daemon(c)
 
-	s.AddCleanup(daemon.MockFdestateReplaceRecoveryKey(func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotTarget) (*state.TaskSet, error) {
+	s.AddCleanup(daemon.MockFdestateReplaceRecoveryKey(func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error) {
 		return nil, errors.New("boom!")
 	}))
 

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -31,4 +32,8 @@ func MockFdeMgrGenerateRecoveryKey(f func(fdemgr *fdestate.FDEManager) (rkey key
 
 func MockFdeMgrCheckRecoveryKey(f func(fdemgr *fdestate.FDEManager, rkey keys.RecoveryKey, containerRoles []string) (err error)) (restore func()) {
 	return testutil.Mock(&fdeMgrCheckRecoveryKey, f)
+}
+
+func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotTarget) (*state.Change, error)) (restore func()) {
+	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
 }

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -34,6 +34,6 @@ func MockFdeMgrCheckRecoveryKey(f func(fdemgr *fdestate.FDEManager, rkey keys.Re
 	return testutil.Mock(&fdeMgrCheckRecoveryKey, f)
 }
 
-func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotTarget) (*state.TaskSet, error)) (restore func()) {
+func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
 	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
 }

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -34,6 +34,6 @@ func MockFdeMgrCheckRecoveryKey(f func(fdemgr *fdestate.FDEManager, rkey keys.Re
 	return testutil.Mock(&fdeMgrCheckRecoveryKey, f)
 }
 
-func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotTarget) (*state.Change, error)) (restore func()) {
+func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotTarget) (*state.TaskSet, error)) (restore func()) {
 	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
 }

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -122,6 +122,8 @@ func Manager(st *state.State, runner *state.TaskRunner) (*FDEManager, error) {
 		return false
 	})
 
+	runner.AddHandler("replace-recovery-key", m.doReplaceRecoveryKey, nil)
+
 	return m, nil
 }
 

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -122,7 +122,9 @@ func Manager(st *state.State, runner *state.TaskRunner) (*FDEManager, error) {
 		return false
 	})
 
-	runner.AddHandler("replace-recovery-key", m.doReplaceRecoveryKey, nil)
+	runner.AddHandler("add-recovery-keys", m.doAddRecoveryKeys, nil)
+	runner.AddHandler("remove-keys", m.doRemoveKeys, nil)
+	runner.AddHandler("rename-keys", m.doRenameKeys, nil)
 
 	return m, nil
 }

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -84,6 +84,7 @@ func (s *fdeMgrSuite) SetUpTest(c *C) {
 
 	s.st = s.o.State()
 	s.runner = s.o.TaskRunner()
+	s.o.AddManager(s.runner)
 
 	s.st.Lock()
 	repo := interfaces.NewRepository()
@@ -242,6 +243,7 @@ func (s *fdeMgrSuite) startedManager(c *C, onClassic bool) *fdestate.FDEManager 
 
 	manager, err := fdestate.Manager(s.st, s.runner)
 	c.Assert(err, IsNil)
+	s.o.AddManager(manager)
 	c.Assert(manager.StartUp(), IsNil)
 	return manager
 }
@@ -665,10 +667,6 @@ func (s *fdeMgrSuite) TestGetEncryptedContainers(c *C) {
 			},
 		),
 	})
-}
-
-func (s *fdeMgrSuite) TestEnsureLoopLogging(c *C) {
-	testutil.CheckEnsureLoopLogging("fdemgr.go", c, false)
 }
 
 type mockRecoveryKeyCache struct {

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -452,11 +452,19 @@ func tmpKeyslotTarget(keyslot KeyslotTarget) KeyslotTarget {
 }
 
 // ReplaceRecoveryKey creates a taskset that replaces the
-// recovery key for the specified target key slots with
-// the recovery key referenced to by recoveryKeyID.
+// recovery key for the specified target key slots using
+// the recovery key identified by recoveryKeyID.
+//
+// If keyslots is empty, the "default-recovery" key slot is
+// used by default for both the "system-data" and "system-save"
+// container roles.
 func ReplaceRecoveryKey(st *state.State, recoveryKeyID string, keyslots []KeyslotTarget) (*state.TaskSet, error) {
 	if len(keyslots) == 0 {
-		return nil, fmt.Errorf("internal error: keyslots cannot be empty")
+		// target default-recovery key slots by default if no key slot targets are specified
+		keyslots = append(keyslots,
+			KeyslotTarget{ContainerRole: "system-data", Name: "default-recovery"},
+			KeyslotTarget{ContainerRole: "system-save", Name: "default-recovery"},
+		)
 	}
 
 	tmpKeyslots := make([]KeyslotTarget, 0, len(keyslots))

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -1,0 +1,152 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/fdestate/backend"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// state must be locked
+func (s *fdeMgrSuite) settle(c *C) {
+	s.st.Unlock()
+	defer s.st.Lock()
+	err := s.o.Settle(testutil.HostScaledTimeout(10 * time.Second))
+	c.Assert(err, IsNil)
+}
+
+func (s *fdeMgrSuite) TestKeyslotTargetValidate(c *C) {
+	k := fdestate.KeyslotTarget{ContainerRole: "system-data", Name: "some-keyslot"}
+	c.Assert(k.Validate(), IsNil)
+
+	k = fdestate.KeyslotTarget{ContainerRole: "system-save", Name: "some-other-keyslot"}
+	c.Assert(k.Validate(), IsNil)
+
+	k = fdestate.KeyslotTarget{ContainerRole: "some-container", Name: "some-keyslot"}
+	c.Assert(k.Validate(), ErrorMatches, `invalid key slot container role "some-container", expected "system-data" or "system-save"`)
+
+	k = fdestate.KeyslotTarget{Name: "some-keyslot"}
+	c.Assert(k.Validate(), ErrorMatches, "key slot container role cannot be empty")
+
+	k = fdestate.KeyslotTarget{ContainerRole: "system-save", Name: ""}
+	c.Assert(k.Validate(), ErrorMatches, "key slot name cannot be empty")
+}
+
+func (s *fdeMgrSuite) TestReplaceRecoveryKey(c *C) {
+	keyslots := []fdestate.KeyslotTarget{
+		{ContainerRole: "system-data", Name: "default-recovery"},
+		{ContainerRole: "system-save", Name: "default-recovery"},
+	}
+
+	// initialize fde manager
+	onClassic := true
+	manager := s.startedManager(c, onClassic)
+
+	_, recoveryKeyID, err := manager.GenerateRecoveryKey()
+	c.Assert(err, IsNil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	chg, err := fdestate.ReplaceRecoveryKey(s.st, recoveryKeyID, keyslots)
+	c.Assert(err, IsNil)
+	c.Assert(chg, NotNil)
+	c.Check(chg.Kind(), Equals, "replace-recovery-key")
+	c.Check(chg.Summary(), Matches, "Replace recovery key")
+	tsks := chg.Tasks()
+	c.Check(tsks, HasLen, 1)
+	tskReplaceRecoveryKey := tsks[0]
+	c.Check(tskReplaceRecoveryKey.Summary(), Matches, "Replace recovery key")
+	c.Check(tskReplaceRecoveryKey.Kind(), Equals, "replace-recovery-key")
+	var tskRecoveryKeyID string
+	err = tskReplaceRecoveryKey.Get("recovery-key-id", &tskRecoveryKeyID)
+	c.Assert(err, IsNil)
+	c.Assert(tskRecoveryKeyID, Equals, recoveryKeyID)
+
+	s.settle(c)
+
+	// TODO:FDEM: this should intentionally break after "replace-recovery-key" task is implemented
+	c.Check(tskReplaceRecoveryKey.Status(), Equals, state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Assert(chg.Err(), IsNil)
+}
+
+func (s *fdeMgrSuite) TestReplaceRecoveryKeyErrors(c *C) {
+	mockStore := &mockRecoveryKeyCache{
+		getRecoveryKey: func(keyID string) (rkeyInfo backend.CachedRecoverKey, err error) {
+			switch keyID {
+			case "good-key-id":
+				return backend.CachedRecoverKey{Expiration: time.Now().Add(100 * time.Hour)}, nil
+			case "expired-key-id":
+				return backend.CachedRecoverKey{Expiration: time.Now().Add(-100 * time.Hour)}, nil
+			default:
+				return backend.CachedRecoverKey{}, backend.ErrNoRecoveryKey
+			}
+		},
+	}
+	defer fdestate.MockBackendNewInMemoryRecoveryKeyCache(func() backend.RecoveryKeyCache {
+		return mockStore
+	})()
+
+	// initialize fde manager
+	onClassic := true
+	s.startedManager(c, onClassic)
+
+	keyslots := []fdestate.KeyslotTarget{
+		{ContainerRole: "system-data", Name: "default-recovery"},
+		{ContainerRole: "system-save", Name: "default-recovery"},
+	}
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// invalid recovery key id
+	_, err := fdestate.ReplaceRecoveryKey(s.st, "bad-key-id", keyslots)
+	c.Assert(err, ErrorMatches, "invalid recovery key id: no recovery key entry for key-id")
+
+	// expired recovery key id
+	_, err = fdestate.ReplaceRecoveryKey(s.st, "expired-key-id", keyslots)
+	c.Assert(err, ErrorMatches, "invalid recovery key id: recovery key has expired")
+
+	// no keyslots
+	_, err = fdestate.ReplaceRecoveryKey(s.st, "good-key-id", nil)
+	c.Assert(err, ErrorMatches, "internal error: keyslots cannot be empty")
+
+	// invalid keyslot
+	badKeyslot := fdestate.KeyslotTarget{ContainerRole: "", Name: "some-name"}
+	_, err = fdestate.ReplaceRecoveryKey(s.st, "good-key-id", []fdestate.KeyslotTarget{badKeyslot})
+	c.Assert(err, ErrorMatches, `invalid key slot \(container-role: "", name: "some-name"\): key slot container role cannot be empty`)
+
+	// invalid keyslot
+	badKeyslot = fdestate.KeyslotTarget{ContainerRole: "system-data", Name: "default-fallback"}
+	_, err = fdestate.ReplaceRecoveryKey(s.st, "good-key-id", []fdestate.KeyslotTarget{badKeyslot})
+	c.Assert(err, ErrorMatches, `invalid key slot \(container-role: "system-data", name: "default-fallback"\): invalid key slot name "default-fallback", expected "default-recovery"`)
+}
+
+func (s *fdeMgrSuite) TestEnsureLoopLogging(c *C) {
+	testutil.CheckEnsureLoopLogging("fdemgr.go", c, false)
+}

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -1,0 +1,38 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package fdestate
+
+import (
+	"github.com/snapcore/snapd/overlord/state"
+	"gopkg.in/tomb.v2"
+)
+
+func (m *FDEManager) doReplaceRecoveryKey(t *state.Task, tomb *tomb.Tomb) error {
+	// TODO:FDEM: implement recovery key replacement, this is currently only a
+	// mock task for testing.
+
+	// TODO:FDEM:
+	//   - this might be a re-run, make task idempotent to be reselient to
+	//     abrupt reboot/shutdown.
+	//   - distinguish between errors (undo) and pure-reboots (re-run).
+	//   - conflict detection for key slot tasks is important because it
+	//     reduces the possible states we could end up in.
+
+	return nil
+}

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -23,8 +23,23 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
-func (m *FDEManager) doReplaceRecoveryKey(t *state.Task, tomb *tomb.Tomb) error {
-	// TODO:FDEM: implement recovery key replacement, this is currently only a
+func (m *FDEManager) doAddRecoveryKeys(t *state.Task, tomb *tomb.Tomb) error {
+	// TODO:FDEM: implement recovery key addition, this is currently only a
+	// mock task for testing.
+
+	// TODO:FDEM:
+	//   - this might be a re-run, make task idempotent to be reselient to
+	//     abrupt reboot/shutdown.
+	//   - important to detect absence of recovery key ID and do cleanup
+	//     of added key slots on re-run and returning an error.
+	//   - distinguish between errors (undo) and pure-reboots (re-run).
+	//   - conflict detection for key slot tasks is important because it
+	//     reduces the possible states we could end up in.
+	return nil
+}
+
+func (m *FDEManager) doRemoveKeys(t *state.Task, tomb *tomb.Tomb) error {
+	// TODO:FDEM: implement recovery key removal, this is currently only a
 	// mock task for testing.
 
 	// TODO:FDEM:
@@ -33,6 +48,18 @@ func (m *FDEManager) doReplaceRecoveryKey(t *state.Task, tomb *tomb.Tomb) error 
 	//   - distinguish between errors (undo) and pure-reboots (re-run).
 	//   - conflict detection for key slot tasks is important because it
 	//     reduces the possible states we could end up in.
+	return nil
+}
 
+func (m *FDEManager) doRenameKeys(t *state.Task, tomb *tomb.Tomb) error {
+	// TODO:FDEM: implement recovery key renaming, this is currently only a
+	// mock task for testing.
+
+	// TODO:FDEM:
+	//   - this might be a re-run, make task idempotent to be reselient to
+	//     abrupt reboot/shutdown.
+	//   - distinguish between errors (undo) and pure-reboots (re-run).
+	//   - conflict detection for key slot tasks is important because it
+	//     reduces the possible states we could end up in.
 	return nil
 }


### PR DESCRIPTION
This PR doesn't implement the actual recovery key replacement since the created tasks are currently no-op until they are carefully designed. This is needed to mock corresponding API to enable integration testing with the security center. Task implementation will be in a follow up PR.

This adds a new `replace-recovery-key` action to the system volumes api `POST /v2/system-volumes`. This action will use the recovery key generated in the `generate-recovery-key` action to replace the specified target key slots.

For context, please check the SD201 spec.

JIRA ticket: SNAPDENG-35122
