### PR TITLE
interfaces/builtin/docker_support: expand apparmor profile

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -173,6 +173,10 @@ pivot_root,
 
 # use 'privileged-containers: true' to support --security-opts
 
+# Support operations on /snap
+# see https://github.com/canonical/docker-snap/issues/281
+/snap/ rwm,
+
 # defaults for docker-default
 # Unfortunately, the docker snap is currently (by design?) setup to have both 
 # the privileged and unprivileged variant of the docker-support interface 


### PR DESCRIPTION
This change aims to avoid failures on pulling OCI images, which writes contents to `/snap`.

On Moby source code, after the commit:
 - https://github.com/moby/moby/commit/bcbcbb73fa7138fa3af113da3e27ac438f73e230

Something change in the way that GID and UID are handled on the moby source code.

After this, certain deployments started to fail, please see:
 - https://github.com/canonical/docker-snap/issues/281

For some reason, the AppArmor profile of Docker (`snap.docker.dockerd`) is being applied on operations inside the overlayfs of container during the pull command on the extraction of the layer that writes to `/snap`.

To reproduce the problem:

- Install Docker from `candidate` channel (or from the revision `3221`)
- Try to pull the image `ghcr.io/locnnil/drc:latest` ([source code here](https://github.com/locnnil/drc/blob/main/Dockerfile))

```console
$ multipass launch noble --name vmm --disk 10G
Launched: vmm

$ multipass shell vmd

ubuntu@vmm:~$ sudo snap install docker --revision=3221
2025-06-05T13:20:25-03:00 INFO Waiting for automatic snapd restart...
docker 28.1.1 from Canonical✓ installed

ubuntu@vmm:~$ sudo docker pull ghcr.io/locnnil/drc:latest
latest: Pulling from locnnil/drc
f90c8eb4724c: Pull complete
2ad09769a36d: Extracting [==================================================>]      94B/94B
failed to register layer: mkdir /snap: permission denied
ubuntu@vmm:~$
```

This is the Dockerfile for that image:
```Dockerfile
FROM ubuntu:latest

RUN mkdir /snap
```

**Note**: When downloading an older version, like v27.5.1 (rev. 3064) the problem doesn't show up.