### PR TITLE
tests/smoke/sandbox: move sandbox snap to core24

### DIFF
--- a/tests/smoke/sandbox/test-snapd-sandbox/meta/snap.yaml
+++ b/tests/smoke/sandbox/test-snapd-sandbox/meta/snap.yaml
@@ -1,6 +1,7 @@
 name: test-snapd-sandbox
 summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
+base: core24
 
 apps:
     test-snapd-sandbox:


### PR DESCRIPTION
Use core24 as base for the snap, so that tests can run on riscv64, but we also get more strict sandbox.

Fixes: LP#2112579

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
