### PR TITLE
github: do not run spread when run_tests only contains whitespace

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -309,7 +309,7 @@ jobs:
           fi
 
           # If all spread tests are skipped, exit
-          if [ -z "$RUN_TESTS" ]; then
+          if [ -z "${RUN_TESTS// /}" ]; then
             echo "All tests are skipped, exiting..."
             exit 0
           fi


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
