### PR TITLE
many: add /v2/system-volumes action for checking recovery keys

### DIFF
--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -109,6 +109,8 @@ func postSystemVolumesActionCheckRecoveryKey(c *Command, req *systemVolumesActio
 
 	fdemgr := c.d.overlord.FDEManager()
 	if err := fdeMgrCheckRecoveryKey(fdemgr, rkey, req.ContainerRoles); err != nil {
+		// TODO:FDEM: distinguish between failure due to a bad key and an
+		// actual internal error where snapd fails to do the check.
 		return BadRequest("cannot find matching recovery key: %v", err)
 	}
 

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -37,8 +37,8 @@ var systemVolumesCmd = &Command{
 type systemVolumesActionRequest struct {
 	Action string `json:"action"`
 
-	RecoveryKey    string   `json:"recovery-key,omitempty"`
-	ContainerRoles []string `json:"container-roles,omitempty"`
+	RecoveryKey    string   `json:"recovery-key"`
+	ContainerRoles []string `json:"container-roles"`
 }
 
 func postSystemVolumesAction(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -104,7 +104,7 @@ func postSystemVolumesActionCheckRecoveryKey(c *Command, req *systemVolumesActio
 
 	rkey, err := keys.ParseRecoveryKey(req.RecoveryKey)
 	if err != nil {
-		return BadRequest("invalid recovery key: %v", err)
+		return BadRequest("cannot parse recovery key: %v", err)
 	}
 
 	st := c.d.overlord.State()
@@ -113,7 +113,7 @@ func postSystemVolumesActionCheckRecoveryKey(c *Command, req *systemVolumesActio
 
 	fdemgr := c.d.overlord.FDEManager()
 	if err := fdeMgrCheckRecoveryKey(fdemgr, rkey, req.ContainerRoles); err != nil {
-		return BadRequest("invalid recovery key: %v", err)
+		return BadRequest("cannot find matching recovery key: %v", err)
 	}
 
 	return SyncResponse(nil)

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -75,9 +75,7 @@ func postSystemVolumesActionJSON(c *Command, r *http.Request) Response {
 	}
 }
 
-var fdeMgrGenerateRecoveryKey = func(fdemgr *fdestate.FDEManager) (rkey keys.RecoveryKey, keyID string, err error) {
-	return fdemgr.GenerateRecoveryKey()
-}
+var fdeMgrGenerateRecoveryKey = (*fdestate.FDEManager).GenerateRecoveryKey
 
 func postSystemVolumesActionGenerateRecoveryKey(c *Command) Response {
 	fdemgr := c.d.overlord.FDEManager()
@@ -93,9 +91,7 @@ func postSystemVolumesActionGenerateRecoveryKey(c *Command) Response {
 	})
 }
 
-var fdeMgrCheckRecoveryKey = func(fdemgr *fdestate.FDEManager, rkey keys.RecoveryKey, containerRoles []string) (err error) {
-	return fdemgr.CheckRecoveryKey(rkey, containerRoles)
-}
+var fdeMgrCheckRecoveryKey = (*fdestate.FDEManager).CheckRecoveryKey
 
 func postSystemVolumesActionCheckRecoveryKey(c *Command, req *systemVolumesActionRequest) Response {
 	if req.RecoveryKey == "" {

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -168,7 +168,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyBadRecoveryK
 	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Status, Equals, 400)
 	// rest of error is coming from secboot
-	c.Assert(rsp.Message, Equals, "invalid recovery key: incorrectly formatted: insufficient characters")
+	c.Assert(rsp.Message, Equals, "cannot parse recovery key: incorrectly formatted: insufficient characters")
 
 	c.Check(called, Equals, 0)
 }
@@ -194,7 +194,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyError(c *C) 
 	rsp := s.errorReq(c, req, nil)
 	c.Assert(rsp.Status, Equals, 400)
 	// rest of error is coming from secboot
-	c.Assert(rsp.Message, Equals, "invalid recovery key: boom!")
+	c.Assert(rsp.Message, Equals, "cannot find matching recovery key: boom!")
 
 	c.Check(called, Equals, 1)
 }

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -28,3 +28,7 @@ import (
 func MockFdeMgrGenerateRecoveryKey(f func(fdemgr *fdestate.FDEManager) (rkey keys.RecoveryKey, keyID string, err error)) (restore func()) {
 	return testutil.Mock(&fdeMgrGenerateRecoveryKey, f)
 }
+
+func MockFdeMgrCheckRecoveryKey(f func(fdemgr *fdestate.FDEManager, rkey keys.RecoveryKey, containerRoles []string) (err error)) (restore func()) {
+	return testutil.Mock(&fdeMgrCheckRecoveryKey, f)
+}

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -94,3 +94,7 @@ func EncryptedContainer(uuid string, containerRole string, legacyKeys map[string
 		legacyKeys:    legacyKeys,
 	}
 }
+
+func MockSecbootCheckRecoveryKey(f func(devicePath string, rkey keys.RecoveryKey) error) (restore func()) {
+	return testutil.Mock(&secbootCheckRecoveryKey, f)
+}

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -976,7 +976,7 @@ func (s *fdeMgrSuite) TestCheckRecoveryKeyMissingContainerRole(c *C) {
 	})()
 
 	err = mgr.CheckRecoveryKey(keys.RecoveryKey{}, []string{"missing-container-role"})
-	c.Assert(err, ErrorMatches, `container role "missing-container-role" does not exist`)
+	c.Assert(err, ErrorMatches, `encrypted container role "missing-container-role" does not exist`)
 }
 
 func (s *fdeMgrSuite) TestCheckRecoveryKeyError(c *C) {

--- a/secboot/keys/keys_dummy.go
+++ b/secboot/keys/keys_dummy.go
@@ -20,6 +20,12 @@
 
 package keys
 
+import "errors"
+
 func (k RecoveryKey) String() string {
 	return "not-implemented"
+}
+
+func ParseRecoveryKey(rkey string) (RecoveryKey, error) {
+	return RecoveryKey{}, errors.New("not-implemented")
 }

--- a/secboot/keys/keys_sb.go
+++ b/secboot/keys/keys_sb.go
@@ -27,3 +27,10 @@ import (
 func (k RecoveryKey) String() string {
 	return sb.RecoveryKey(k).String()
 }
+
+// ParseRecoveryKey interprets the supplied string and returns the
+// corresponding RecoveryKey.
+func ParseRecoveryKey(rkey string) (RecoveryKey, error) {
+	out, err := sb.ParseRecoveryKey(rkey)
+	return RecoveryKey(out), err
+}

--- a/secboot/keys/keys_test.go
+++ b/secboot/keys/keys_test.go
@@ -114,3 +114,13 @@ func (s *keysSuite) TestNewAuxKeySad(c *C) {
 	_, err := keys.NewAuxKey()
 	c.Check(err, ErrorMatches, "fail")
 }
+
+func (s *keysSuite) TestParseRecoveryKey(c *C) {
+	if (keys.RecoveryKey{}).String() == "not-implemented" {
+		c.Skip("needs working secboot recovery key")
+	}
+
+	rkey, err := keys.ParseRecoveryKey("25970-28515-25974-31090-12593-12593-12593-12593")
+	c.Assert(err, IsNil)
+	c.Check(rkey, DeepEquals, keys.RecoveryKey{'r', 'e', 'c', 'o', 'v', 'e', 'r', 'y', '1', '1', '1', '1', '1', '1', '1', '1'})
+}

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -128,3 +128,7 @@ func DeleteOldKeys(devicePath string) error {
 func GetPrimaryKey(devices []string, fallbackKeyFile string) ([]byte, error) {
 	return nil, errBuildWithoutSecboot
 }
+
+func CheckRecoveryKey(devicePath string, rkey keys.RecoveryKey) error {
+	return errBuildWithoutSecboot
+}

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -545,3 +545,10 @@ func GetPrimaryKey(devices []string, fallbackKeyFile string) ([]byte, error) {
 	}
 	return primaryKey, nil
 }
+
+// CheckRecoveryKey tests that the specified recovery key unlocks the
+// device at the specified path.
+func CheckRecoveryKey(devicePath string, rkey keys.RecoveryKey) error {
+	// TODO:FDEM: use secboot helper when available
+	return nil
+}


### PR DESCRIPTION
This PR introduces a new (sync) action `check-recovery-key` that checks that the provided recovery key is matching one that was added during install or post-install.

Please note that the underlying secboot implementation is missing and currently this always returns 200 OK. The underlying secboot helper needs to be swapped when it lands.

For context, please check the SD201 spec.