### PR TITLE
daemon: add /v2/system-volumes enumeration endpoint

### DIFF
--- a/client/system_volumes.go
+++ b/client/system_volumes.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020-2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"github.com/snapcore/snapd/gadget/device"
+)
+
+type KeyslotType string
+
+const (
+	KeyslotTypeRecovery KeyslotType = "recovery"
+	KeyslotTypePlatform KeyslotType = "platform"
+)
+
+type KeyslotInfo struct {
+	Type KeyslotType `json:"type"`
+	// only for platform key slots
+	Roles        []string        `json:"roles,omitempty"`
+	PlatformName string          `json:"platform-name,omitempty"`
+	AuthMode     device.AuthMode `json:"auth-mode,omitempty"`
+}
+
+type SystemVolumesStructureInfo struct {
+	VolumeName string                 `json:"volume-name"`
+	Name       string                 `json:"name"`
+	Encrypted  bool                   `json:"encrypted"`
+	Keyslots   map[string]KeyslotInfo `json:"keyslots,omitempty"`
+}
+
+type SystemVolumesResult struct {
+	ByContainerRole map[string]SystemVolumesStructureInfo `json:"by-container-role,omitempty"`
+}
+
+type SystemVolumesOptions struct {
+	ContainerRoles  []string
+	ByContainerRole bool
+}

--- a/client/system_volumes.go
+++ b/client/system_volumes.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020-2023 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -271,21 +271,9 @@ func getChangeTimings(st *state.State, changeID, ensureTag, startupTag string, a
 }
 
 func getGadgetDiskMapping(st *state.State) Response {
-	deviceCtx, err := devicestate.DeviceCtx(st, nil, nil)
+	info, mod, err := getCurrentGadgetAndModel(st)
 	if err != nil {
-		return InternalError("cannot get device context: %v", err)
-	}
-	gadgetInfo, err := snapstate.GadgetInfo(st, deviceCtx)
-	if err != nil {
-		return InternalError("cannot get gadget info: %v", err)
-	}
-	gadgetDir := gadgetInfo.MountDir()
-
-	mod := deviceCtx.Model()
-
-	info, err := gadget.ReadInfoAndValidate(gadgetDir, mod, nil)
-	if err != nil {
-		return InternalError("cannot get all disk volume device traits: cannot read gadget: %v", err)
+		return InternalError("cannot get current gadget: %v", err)
 	}
 
 	// TODO: allow passing in encrypted options info here

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -271,9 +271,21 @@ func getChangeTimings(st *state.State, changeID, ensureTag, startupTag string, a
 }
 
 func getGadgetDiskMapping(st *state.State) Response {
-	info, mod, err := getCurrentGadgetAndModel(st)
+	deviceCtx, err := devicestate.DeviceCtx(st, nil, nil)
 	if err != nil {
-		return InternalError("cannot get current gadget: %v", err)
+		return InternalError("cannot get device context: %v", err)
+	}
+	gadgetInfo, err := snapstate.GadgetInfo(st, deviceCtx)
+	if err != nil {
+		return InternalError("cannot get gadget info: %v", err)
+	}
+	gadgetDir := gadgetInfo.MountDir()
+
+	mod := deviceCtx.Model()
+
+	info, err := gadget.ReadInfoAndValidate(gadgetDir, mod, nil)
+	if err != nil {
+		return InternalError("cannot get all disk volume device traits: cannot read gadget: %v", err)
 	}
 
 	// TODO: allow passing in encrypted options info here

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -21,22 +21,167 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/strutil"
 )
 
 var systemVolumesCmd = &Command{
 	Path:        "/v2/system-volumes",
+	GET:         getSystemVolumes,
 	POST:        postSystemVolumesAction,
+	ReadAccess:  rootAccess{},
 	WriteAccess: rootAccess{},
 }
 
 var (
 	fdestateReplaceRecoveryKey = fdestate.ReplaceRecoveryKey
+	fdeMgrGetKeyslots          = (*fdestate.FDEManager).GetKeyslots
+	fdeMgrGenerateRecoveryKey  = (*fdestate.FDEManager).GenerateRecoveryKey
+	fdeMgrCheckRecoveryKey     = (*fdestate.FDEManager).CheckRecoveryKey
+	snapstateGadgetInfo        = snapstate.GadgetInfo
 )
+
+type systemVolumesResponse struct {
+	ByContainerRole map[string]volumeInfo `json:"by-container-role,omitempty"`
+}
+
+type volumeInfo struct {
+	ContainerRole string
+	VolumeName    string                 `json:"volume-name"`
+	Name          string                 `json:"name"`
+	Encrypted     bool                   `json:"encrypted"`
+	Keyslots      map[string]keyslotInfo `json:"keyslots,omitempty"`
+}
+
+type keyslotInfo struct {
+	Type fdestate.KeyslotType `json:"type"`
+	// only for platform key slots
+	Roles        []string        `json:"roles,omitempty"`
+	PlatformName string          `json:"platform-name,omitempty"`
+	AuthMode     device.AuthMode `json:"auth-mode,omitempty"`
+}
+
+func getSystemVolumes(c *Command, r *http.Request, user *auth.UserState) Response {
+	query := r.URL.Query()
+	containerRoles := query["container-role"]
+	byContainerRole := query.Get("by-container-role") == "true"
+	if len(containerRoles) > 0 && byContainerRole {
+		return BadRequest(`query parameter "container-role" conflicts with "by-container-role"`)
+	}
+
+	volumes, err := getAllVolumes(c.d.overlord.State(), c.d.overlord.FDEManager())
+	if err != nil {
+		return InternalError(err.Error())
+	}
+
+	res := systemVolumesResponse{
+		ByContainerRole: make(map[string]volumeInfo),
+	}
+	for _, volume := range volumes {
+		switch {
+		case len(containerRoles) > 0:
+			if strutil.ListContains(containerRoles, volume.ContainerRole) {
+				res.ByContainerRole[volume.ContainerRole] = volume
+			}
+		case byContainerRole:
+			res.ByContainerRole[volume.ContainerRole] = volume
+		default:
+			// all groupings, currently only by-container-role is supported.
+			res.ByContainerRole[volume.ContainerRole] = volume
+		}
+	}
+
+	return SyncResponse(res)
+}
+
+func getAllVolumes(st *state.State, fdemgr *fdestate.FDEManager) ([]volumeInfo, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	gadgetInfo, err := getCurrentGadgetInfo(st)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gadget info: %v", err)
+	}
+
+	keyslots, _, err := fdeMgrGetKeyslots(fdemgr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get key slots: %v", err)
+	}
+	keyslotsByContainerRole := make(map[string][]fdestate.Keyslot)
+	for _, keyslot := range keyslots {
+		keyslotsByContainerRole[keyslot.ContainerRole] = append(keyslotsByContainerRole[keyslot.ContainerRole], keyslot)
+	}
+
+	var volumes []volumeInfo
+	for _, gv := range gadgetInfo.Volumes {
+		for _, gs := range gv.Structure {
+			if gs.Role == "" {
+				continue
+			}
+
+			containerKeyslots := keyslotsByContainerRole[gs.Role]
+			encrypted := len(containerKeyslots) != 0
+			volume := volumeInfo{
+				ContainerRole: gs.Role,
+				VolumeName:    gv.Name,
+				Name:          gs.Name,
+				Encrypted:     encrypted,
+			}
+			if encrypted {
+				volume.Keyslots = make(map[string]keyslotInfo, len(containerKeyslots))
+			}
+
+			for _, keyslot := range containerKeyslots {
+				data := keyslotInfo{
+					Type: keyslot.Type,
+				}
+				if keyslot.Type == fdestate.KeyslotTypePlatform {
+					kd, err := keyslot.KeyData()
+					if err != nil {
+						return nil, err
+					}
+					data.PlatformName = kd.PlatformName()
+					data.Roles = kd.Roles()
+					data.AuthMode = kd.AuthMode()
+				}
+				volume.Keyslots[keyslot.Name] = data
+			}
+			volumes = append(volumes, volume)
+		}
+	}
+
+	return volumes, nil
+}
+
+func getCurrentGadgetInfo(st *state.State) (*gadget.Info, error) {
+	deviceCtx, err := devicestate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	gadgetInfo, err := snapstateGadgetInfo(st, deviceCtx)
+	if err != nil {
+		return nil, err
+	}
+	gadgetDir := gadgetInfo.MountDir()
+
+	model := deviceCtx.Model()
+
+	info, err := gadget.ReadInfo(gadgetDir, model)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
 
 type systemVolumesActionRequest struct {
 	Action string `json:"action"`
@@ -85,8 +230,6 @@ func postSystemVolumesActionJSON(c *Command, r *http.Request) Response {
 	}
 }
 
-var fdeMgrGenerateRecoveryKey = (*fdestate.FDEManager).GenerateRecoveryKey
-
 func postSystemVolumesActionGenerateRecoveryKey(c *Command) Response {
 	fdemgr := c.d.overlord.FDEManager()
 
@@ -100,8 +243,6 @@ func postSystemVolumesActionGenerateRecoveryKey(c *Command) Response {
 		"key-id":       keyID,
 	})
 }
-
-var fdeMgrCheckRecoveryKey = (*fdestate.FDEManager).CheckRecoveryKey
 
 func postSystemVolumesActionCheckRecoveryKey(c *Command, req *systemVolumesActionRequest) Response {
 	if req.RecoveryKey == "" {

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -154,7 +154,6 @@ func getSystemVolumes(c *Command, r *http.Request, user *auth.UserState) Respons
 			continue
 		}
 		switch {
-
 		// conversion is done only on a match do as little key data loading
 		// as possible since it is lazy loaded.
 		case len(opts.ContainerRoles) > 0:

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -399,7 +399,7 @@ func (k *mockKeyData) Roles() []string {
 	return k.roles
 }
 
-func (s *systemVolumesSuite) testSystemVolumesGet(c *C, query string, expectedResult interface{}) {
+func (s *systemVolumesSuite) testSystemVolumesGet(c *C, query string, expectedResult any) {
 	s.AddCleanup(devicestate.MockFDEManagerGetKeyslots(func(fdemgr *fdestate.FDEManager, keyslotRefs []fdestate.KeyslotRef) ([]fdestate.Keyslot, []fdestate.KeyslotRef, error) {
 		c.Check(keyslotRefs, IsNil)
 		keyslots := []fdestate.Keyslot{

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2024 Canonical Ltd
+ * Copyright (C) 2025 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,11 +20,10 @@
 package daemon
 
 import (
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/fdestate"
-	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot/keys"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -40,6 +39,6 @@ func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string
 	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
 }
 
-func MockSnapstateGadgetInfo(f func(st *state.State, deviceCtx snapstate.DeviceContext) (*snap.Info, error)) (restore func()) {
-	return testutil.Mock(&snapstateGadgetInfo, f)
+func MockDevicestateGetVolumeStructuresWithKeyslots(f func(st *state.State) ([]devicestate.VolumeStructureWithKeyslots, error)) (restore func()) {
+	return testutil.Mock(&devicestateGetVolumeStructuresWithKeyslots, f)
 }

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -28,16 +28,6 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type (
-	SystemVolumesResponse = systemVolumesResponse
-	VolumeInfo            = volumeInfo
-	KeyslotInfo           = keyslotInfo
-)
-
-func MockFdeMgrGetKeyslots(f func(fdemgr *fdestate.FDEManager, keyslotRefs []fdestate.KeyslotRef) ([]fdestate.Keyslot, []fdestate.KeyslotRef, error)) (restore func()) {
-	return testutil.Mock(&fdeMgrGetKeyslots, f)
-}
-
 func MockFdeMgrGenerateRecoveryKey(f func(fdemgr *fdestate.FDEManager) (rkey keys.RecoveryKey, keyID string, err error)) (restore func()) {
 	return testutil.Mock(&fdeMgrGenerateRecoveryKey, f)
 }

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -21,10 +21,22 @@ package daemon
 
 import (
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
+
+type (
+	SystemVolumesResponse = systemVolumesResponse
+	VolumeInfo            = volumeInfo
+	KeyslotInfo           = keyslotInfo
+)
+
+func MockFdeMgrGetKeyslots(f func(fdemgr *fdestate.FDEManager, keyslotRefs []fdestate.KeyslotRef) ([]fdestate.Keyslot, []fdestate.KeyslotRef, error)) (restore func()) {
+	return testutil.Mock(&fdeMgrGetKeyslots, f)
+}
 
 func MockFdeMgrGenerateRecoveryKey(f func(fdemgr *fdestate.FDEManager) (rkey keys.RecoveryKey, keyID string, err error)) (restore func()) {
 	return testutil.Mock(&fdeMgrGenerateRecoveryKey, f)
@@ -36,4 +48,8 @@ func MockFdeMgrCheckRecoveryKey(f func(fdemgr *fdestate.FDEManager, rkey keys.Re
 
 func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
 	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
+}
+
+func MockSnapstateGadgetInfo(f func(st *state.State, deviceCtx snapstate.DeviceContext) (*snap.Info, error)) (restore func()) {
+	return testutil.Mock(&snapstateGadgetInfo, f)
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/user"
+	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
@@ -685,4 +686,12 @@ func MockFdestateGenerateRecoveryKey(f func(st *state.State) (rkey keys.Recovery
 
 func MockFdestateGetRecoveryKey(f func(st *state.State, keyID string) (rkey keys.RecoveryKey, err error)) (restore func()) {
 	return testutil.Mock(&fdestateGetRecoveryKey, f)
+}
+
+func MockFdestateGetKeyslots(f func(st *state.State, keyslotRefs []fdestate.KeyslotRef) (keyslots []fdestate.Keyslot, missingRefs []fdestate.KeyslotRef, err error)) (restore func()) {
+	return testutil.Mock(&fdestateGetKeyslots, f)
+}
+
+func MockSnapstateGadgetInfo(f func(st *state.State, deviceCtx snapstate.DeviceContext) (*snap.Info, error)) (restore func()) {
+	return testutil.Mock(&snapstateGadgetInfo, f)
 }

--- a/overlord/devicestate/volumes.go
+++ b/overlord/devicestate/volumes.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package devicestate implements the manager and state aspects responsible
+// for the device identity and policies.
+package devicestate
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/testutil"
+)
+
+var (
+	fdeManagerGetKeyslots = (*fdestate.FDEManager).GetKeyslots
+)
+
+// VolumeStructureWithKeyslots is gadget.VolumeStructure with
+// the corresponding key slots attached.
+type VolumeStructureWithKeyslots struct {
+	gadget.VolumeStructure
+
+	Keyslots []fdestate.Keyslot
+}
+
+// GetGadgetVolumeStructuresWithKeyslots returns the gadget volume
+// structures with their corresponding key slots attached.
+func GetGadgetVolumeStructuresWithKeyslots(fdemgr *fdestate.FDEManager, gadgetInfo *gadget.Info) ([]VolumeStructureWithKeyslots, error) {
+	keyslots, _, err := fdeManagerGetKeyslots(fdemgr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get key slots: %v", err)
+	}
+	keyslotsByContainerRole := make(map[string][]fdestate.Keyslot)
+	for _, keyslot := range keyslots {
+		keyslotsByContainerRole[keyslot.ContainerRole] = append(keyslotsByContainerRole[keyslot.ContainerRole], keyslot)
+	}
+
+	var structuresWithKeyslots []VolumeStructureWithKeyslots
+	for _, gv := range gadgetInfo.Volumes {
+		for _, gs := range gv.Structure {
+			structuresWithKeyslots = append(structuresWithKeyslots, VolumeStructureWithKeyslots{
+				VolumeStructure: gs,
+				Keyslots:        keyslotsByContainerRole[gs.Role],
+			})
+		}
+	}
+
+	return structuresWithKeyslots, nil
+}
+
+func MockFDEManagerGetKeyslots(f func(m *fdestate.FDEManager, keyslotRefs []fdestate.KeyslotRef) (keyslots []fdestate.Keyslot, missingRefs []fdestate.KeyslotRef, err error)) (restore func()) {
+	osutil.MustBeTestBinary("mocking fdeManagerGetKeyslots can be done only from tests")
+	return testutil.Mock(&fdeManagerGetKeyslots, f)
+}

--- a/overlord/devicestate/volumes_test.go
+++ b/overlord/devicestate/volumes_test.go
@@ -1,0 +1,96 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate_test
+
+import (
+	"errors"
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/fdestate"
+)
+
+type volumesSuite struct{}
+
+var _ = Suite(&volumesSuite{})
+
+func (s *volumesSuite) TestGetGadgetVolumeStructuresWithKeyslots(c *C) {
+	defer devicestate.MockFDEManagerGetKeyslots(func(m *fdestate.FDEManager, keyslotRefs []fdestate.KeyslotRef) (keyslots []fdestate.Keyslot, missingRefs []fdestate.KeyslotRef, err error) {
+		c.Check(keyslotRefs, IsNil)
+		keyslots = []fdestate.Keyslot{
+			{Name: "default", ContainerRole: "system-data", Type: fdestate.KeyslotTypePlatform},
+			{Name: "default-recovery", ContainerRole: "system-data", Type: fdestate.KeyslotTypeRecovery},
+			{Name: "default-fallback", ContainerRole: "system-save", Type: fdestate.KeyslotTypePlatform},
+		}
+		return keyslots, nil, nil
+	})()
+
+	gadgetInfo := &gadget.Info{
+		Volumes: map[string]*gadget.Volume{
+			"pc": {
+				Structure: []gadget.VolumeStructure{
+					{Role: "system-data"},
+					{Role: "system-save"},
+					{Role: "system-seed"},
+					{Role: "system-boot"},
+				},
+			},
+		},
+	}
+
+	structures, err := devicestate.GetGadgetVolumeStructuresWithKeyslots(nil, gadgetInfo)
+	sort.Slice(structures, func(i, j int) bool {
+		return structures[i].Role < structures[j].Role
+	})
+	c.Assert(err, IsNil)
+	c.Check(structures, DeepEquals, []devicestate.VolumeStructureWithKeyslots{
+		{
+			VolumeStructure: gadget.VolumeStructure{Role: "system-boot"},
+		},
+		{
+			VolumeStructure: gadget.VolumeStructure{Role: "system-data"},
+			Keyslots: []fdestate.Keyslot{
+				{Name: "default", ContainerRole: "system-data", Type: fdestate.KeyslotTypePlatform},
+				{Name: "default-recovery", ContainerRole: "system-data", Type: fdestate.KeyslotTypeRecovery},
+			},
+		},
+		{
+			VolumeStructure: gadget.VolumeStructure{Role: "system-save"},
+			Keyslots: []fdestate.Keyslot{
+				{Name: "default-fallback", ContainerRole: "system-save", Type: fdestate.KeyslotTypePlatform},
+			},
+		},
+		{
+			VolumeStructure: gadget.VolumeStructure{Role: "system-seed"},
+		},
+	})
+}
+
+func (s *volumesSuite) TestGetGadgetVolumeStructuresWithKeyslotsError(c *C) {
+	defer devicestate.MockFDEManagerGetKeyslots(func(m *fdestate.FDEManager, keyslotRefs []fdestate.KeyslotRef) (keyslots []fdestate.Keyslot, missingRefs []fdestate.KeyslotRef, err error) {
+		return nil, nil, errors.New("boom!")
+	})()
+
+	_, err := devicestate.GetGadgetVolumeStructuresWithKeyslots(nil, nil)
+	c.Assert(err, ErrorMatches, "failed to get key slots: boom!")
+}

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -583,3 +583,8 @@ func MockDisksDMCryptUUIDFromMountPoint(f func(mountpoint string) (string, error
 		disksDMCryptUUIDFromMountPoint = old
 	}
 }
+
+func MockKeyslotKeyData(keyslot *Keyslot, kd secboot.KeyData) {
+	// osutil.MustBeTestBinary("mocking Keyslot.keyDaya can be done only from tests")
+	keyslot.keyData = kd
+}

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -407,6 +407,16 @@ func (m *FDEManager) GetKeyslots(keyslotRefs []KeyslotRef) (keyslots []Keyslot, 
 	return keyslots, missingRefs, nil
 }
 
+// GetKeyslots returns the key slots for the specified key slot references.
+// If keyslotRefs is empty, all key slots on all encrypted containers will
+// be returned.
+//
+// The state needs to be locked by the caller.
+func GetKeyslots(st *state.State, keyslotRefs []KeyslotRef) (keyslots []Keyslot, missingRefs []KeyslotRef, err error) {
+	mgr := fdeMgr(st)
+	return mgr.GetKeyslots(keyslotRefs)
+}
+
 var _ backend.FDEStateManager = (*unlockedStateManager)(nil)
 
 func (m *FDEManager) resealKeyForBootChains(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -585,6 +585,6 @@ func MockDisksDMCryptUUIDFromMountPoint(f func(mountpoint string) (string, error
 }
 
 func MockKeyslotKeyData(keyslot *Keyslot, kd secboot.KeyData) {
-	// osutil.MustBeTestBinary("mocking Keyslot.keyDaya can be done only from tests")
+	osutil.MustBeTestBinary("mocking Keyslot.keyData can be done only from tests")
 	keyslot.keyData = kd
 }

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -1122,7 +1122,7 @@ func (s *fdeMgrSuite) testGetKeyslots(c *C, allKeyslots bool) {
 	})()
 
 	const onClassic = true
-	manager := s.startedManager(c, onClassic)
+	s.startedManager(c, onClassic)
 
 	var keyslotRefs []fdestate.KeyslotRef
 	if !allKeyslots {
@@ -1134,7 +1134,10 @@ func (s *fdeMgrSuite) testGetKeyslots(c *C, allKeyslots bool) {
 		}
 	}
 
-	keyslots, missing, err := manager.GetKeyslots(keyslotRefs)
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	keyslots, missing, err := fdestate.GetKeyslots(s.st, keyslotRefs)
 	c.Assert(err, IsNil)
 
 	// sort for test consistency


### PR DESCRIPTION
This PR introduces the key slots enumeration API `GET /v2/system-volumes` as specified in the SD201 spec.

This builds on top of https://github.com/canonical/snapd/pull/15557 and must be rebased, for now the relevant commit for review is https://github.com/canonical/snapd/pull/15558/commits/77313dae5558554063951754a697b047ce25c60f.

JIRA ticket: SNAPDENG-35091