### PR TITLE
daemon: rename the confdb URL query param

### DIFF
--- a/client/confdb.go
+++ b/client/confdb.go
@@ -29,7 +29,7 @@ import (
 
 func (c *Client) ConfdbGetViaView(viewID string, requests []string) (changeID string, err error) {
 	query := url.Values{}
-	query.Add("fields", strings.Join(requests, ","))
+	query.Add("keys", strings.Join(requests, ","))
 	endpoint := fmt.Sprintf("/v2/confdb/%s", viewID)
 
 	return c.doAsync("GET", endpoint, query, nil, nil)

--- a/client/confdb_test.go
+++ b/client/confdb_test.go
@@ -40,7 +40,7 @@ func (cs *clientSuite) TestConfdbGet(c *C) {
 	c.Assert(chgID, Equals, "123")
 	c.Check(cs.reqs[0].Method, Equals, "GET")
 	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/confdb/a/b/c")
-	c.Check(cs.reqs[0].URL.Query(), DeepEquals, url.Values{"fields": []string{"foo,bar"}})
+	c.Check(cs.reqs[0].URL.Query(), DeepEquals, url.Values{"keys": []string{"foo,bar"}})
 }
 
 func (cs *clientSuite) TestConfdbSet(c *C) {

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -242,8 +242,8 @@ func (s *confdbSuite) TestConfdbGet(c *C) {
 			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
-			fields := strutil.CommaSeparatedList(q.Get("fields"))
-			c.Check(fields, DeepEquals, []string{"abc"})
+			keys := strutil.CommaSeparatedList(q.Get("keys"))
+			c.Check(keys, DeepEquals, []string{"abc"})
 
 			w.WriteHeader(202)
 			fmt.Fprintf(w, asyncResp)
@@ -287,8 +287,8 @@ func (s *confdbSuite) TestConfdbGetAsDocument(c *C) {
 			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
-			fields := strutil.CommaSeparatedList(q.Get("fields"))
-			c.Check(fields, DeepEquals, []string{"abc"})
+			keys := strutil.CommaSeparatedList(q.Get("keys"))
+			c.Check(keys, DeepEquals, []string{"abc"})
 
 			w.WriteHeader(202)
 			fmt.Fprintf(w, asyncResp)
@@ -336,8 +336,8 @@ func (s *confdbSuite) TestConfdbGetMany(c *C) {
 			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
-			fields := strutil.CommaSeparatedList(q.Get("fields"))
-			c.Check(fields, DeepEquals, []string{"abc", "xyz"})
+			keys := strutil.CommaSeparatedList(q.Get("keys"))
+			c.Check(keys, DeepEquals, []string{"abc", "xyz"})
 
 			w.WriteHeader(202)
 			fmt.Fprintf(w, asyncResp)
@@ -385,8 +385,8 @@ func (s *confdbSuite) TestConfdbGetManyAsDocument(c *C) {
 			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
-			fields := strutil.CommaSeparatedList(q.Get("fields"))
-			c.Check(fields, DeepEquals, []string{"abc", "xyz"})
+			keys := strutil.CommaSeparatedList(q.Get("keys"))
+			c.Check(keys, DeepEquals, []string{"abc", "xyz"})
 
 			w.WriteHeader(202)
 			fmt.Fprintf(w, asyncResp)
@@ -459,8 +459,8 @@ func (s *confdbSuite) TestConfdbGetNoFields(c *check.C) {
 			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
-			fields := strutil.CommaSeparatedList(q.Get("fields"))
-			c.Check(fields, HasLen, 0)
+			keys := strutil.CommaSeparatedList(q.Get("keys"))
+			c.Check(keys, HasLen, 0)
 
 			w.WriteHeader(202)
 			fmt.Fprintf(w, asyncResp)
@@ -514,8 +514,8 @@ func (s *confdbSuite) TestConfdbGetNoDataError(c *check.C) {
 			c.Check(r.URL.Path, Equals, "/v2/confdb/foo/bar/baz")
 
 			q := r.URL.Query()
-			fields := strutil.CommaSeparatedList(q.Get("fields"))
-			c.Check(fields, DeepEquals, []string{"foo"})
+			keys := strutil.CommaSeparatedList(q.Get("keys"))
+			c.Check(keys, DeepEquals, []string{"foo"})
 
 			w.WriteHeader(202)
 			fmt.Fprintf(w, asyncResp)

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -60,11 +60,11 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 
 	vars := muxVars(r)
 	account, schemaName, viewName := vars["account"], vars["confdb-schema"], vars["view"]
-	fieldStr := r.URL.Query().Get("fields")
+	keysStr := r.URL.Query().Get("keys")
 
-	var fields []string
-	if fieldStr != "" {
-		fields = strutil.CommaSeparatedList(fieldStr)
+	var keys []string
+	if keysStr != "" {
+		keys = strutil.CommaSeparatedList(keysStr)
 	}
 
 	view, err := confdbstateGetView(st, account, schemaName, viewName)
@@ -72,7 +72,7 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 		return toAPIError(err)
 	}
 
-	chgID, err := confdbstateLoadConfdbAsync(st, view, fields)
+	chgID, err := confdbstateLoadConfdbAsync(st, view, keys)
 	if err != nil {
 		return toAPIError(err)
 	}

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -127,7 +127,7 @@ func (s *confdbSuite) TestGetView(c *C) {
 			return "123", nil
 		})
 
-		req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid", nil)
+		req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=ssid", nil)
 		c.Assert(err, IsNil, cmt)
 
 		rspe := s.asyncReq(c, req, nil)
@@ -158,7 +158,7 @@ func (s *confdbSuite) TestViewGetMany(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid,password", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=ssid,password", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.asyncReq(c, req, nil)
@@ -218,7 +218,7 @@ func (s *confdbSuite) TestGetViewError(c *C) {
 			return nil, t.err
 		})
 
-		req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=ssid", nil)
+		req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=ssid", nil)
 		c.Assert(err, IsNil, Commentf("%s test", t.name))
 
 		rspe := s.errorReq(c, req, nil)
@@ -245,7 +245,7 @@ func (s *confdbSuite) TestGetViewMisshapenQuery(c *C) {
 	})
 	defer restore()
 
-	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=,foo.bar,,[1].foo,foo,", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=,foo.bar,,[1].foo,foo,", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.asyncReq(c, req, nil)
@@ -454,7 +454,7 @@ func (s *confdbSuite) TestSetFailUnsetFeatureFlag(c *C) {
 }
 
 func (s *confdbSuite) TestGetFailUnsetFeatureFlag(c *C) {
-	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?fields=my-field", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=my-field", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.errorReq(c, req, nil)

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -454,7 +454,7 @@ func (s *confdbSuite) TestSetFailUnsetFeatureFlag(c *C) {
 }
 
 func (s *confdbSuite) TestGetFailUnsetFeatureFlag(c *C) {
-	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=my-field", nil)
+	req, err := http.NewRequest("GET", "/v2/confdb/system/network/wifi-setup?keys=my-key", nil)
 	c.Assert(err, IsNil)
 
 	rspe := s.errorReq(c, req, nil)
@@ -463,7 +463,7 @@ func (s *confdbSuite) TestGetFailUnsetFeatureFlag(c *C) {
 	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
 }
 
-func (s *confdbSuite) TestGetNoFields(c *C) {
+func (s *confdbSuite) TestGetNoKeys(c *C) {
 	s.setFeatureFlag(c)
 
 	restore := daemon.MockConfdbstateGetView(func(_ *state.State, acc, confdbSchema, viewName string) (*confdb.View, error) {


### PR DESCRIPTION
Rename the confdb API's query parameter from fields to keys to match the options API.
