### PR TITLE
hotfix release: 2.68.5.1

### DIFF
--- a/.github/workflows/non-fundamental-systems.json
+++ b/.github/workflows/non-fundamental-systems.json
@@ -76,7 +76,7 @@
         "group": "ubuntu-daily",
         "backend": "google",
         "alternative-backend": "google",
-        "systems": "ubuntu-25.04-64",
+        "systems": "ubuntu-25.10-64",
         "tasks": "tests/...",
         "rules": "main"
       },

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# New in snapd 2.68.5.1
+* LP: #2104254 fix a regression during seeding when using early-config
+* Interfaces: hostname_control | fix for UC24 by adding required unix socket and dbus permissions
+
 # New in snapd 2.68.5
 * LP: #2109843 fix missing preseed files when running in a container
 

--- a/interfaces/builtin/hostname_control.go
+++ b/interfaces/builtin/hostname_control.go
@@ -53,6 +53,12 @@ dbus (send)
     interface=org.freedesktop.DBus.Introspectable
     member=Introspect,
 
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}",
+
 dbus (receive)
     bus=system
     path=/org/freedesktop/hostname1
@@ -65,6 +71,9 @@ dbus(receive, send)
     interface=org.freedesktop.hostname1
     member=Set{,Pretty,Static}Hostname,
 
+# hostnamectl needs to bind the client side of the socket
+unix (bind) type=stream addr="@*/bus/hostnamectl/system",
+
 # Needed to use 'sethostname' and 'hostnamectl set-hostname'. See man 7
 # capabilities
 capability sys_admin,
@@ -73,6 +82,8 @@ capability sys_admin,
 const hostnameControlConnectedPlugSecComp = `
 # Description: Can configure the system hostname.
 sethostname
+# hostnamectl needs to bind the client side of the socket
+bind
 `
 
 func init() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -282,7 +282,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 	// Load seed to find out kernel-modules components in run mode
 	systemAndSnaps, mntPtForType, mntPtForComps, unmount,
-		err := m.loadAndMountSystemLabelSnapsUnlock(st, m.seedLabel, []snap.Type{snap.TypeKernel})
+		err := m.loadAndMountSystemLabelSnapsUnlock(st, modeEnv.RecoverySystem, []snap.Type{snap.TypeKernel})
 	if err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 
 	// Load seed to find out kernel-modules components in run mode
 	systemAndSnaps, mntPtForType, mntPtForComps, unmount,
-		err := m.loadAndMountSystemLabelSnapsUnlock(st, m.seedLabel, []snap.Type{snap.TypeKernel})
+		err := m.loadAndMountSystemLabelSnapsUnlock(st, modeEnv.RecoverySystem, []snap.Type{snap.TypeKernel})
 	if err != nil {
 		return err
 	}

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.68.5
+pkgver=2.68.5.1
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,13 @@
+snapd (2.68.5.1-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2104254
+    - LP: #2104254 fix a regression during seeding when using early-
+      config
+    - Interfaces: hostname_control | fix for UC24 by adding required
+      unix socket and dbus permissions
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 11 Jun 2025 20:46:03 +0200
+
 snapd (2.68.5-1) unstable; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.68.5
+Version:        2.68.5.1
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPL-3.0-only
@@ -1002,6 +1002,13 @@ fi
 
 
 %changelog
+* Wed Jun 11 2025 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.68.5.1
+ - LP: #2104254 fix a regression during seeding when using early-
+   config
+ - Interfaces: hostname_control | fix for UC24 by adding required
+   unix socket and dbus permissions
+
 * Wed May 21 2025 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.68.5
  - LP: #2109843 fix missing preseed files when running in a container

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun 11 18:46:03 UTC 2025 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.68.5.1
+
+-------------------------------------------------------------------
 Wed May 21 15:46:09 UTC 2025 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.68.5

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -91,7 +91,7 @@
 
 
 Name:           snapd
-Version:        2.68.5
+Version:        2.68.5.1
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,13 @@
+snapd (2.68.5.1~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2104254
+    - LP: #2104254 fix a regression during seeding when using early-
+      config
+    - Interfaces: hostname_control | fix for UC24 by adding required
+      unix socket and dbus permissions
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 11 Jun 2025 20:46:03 +0200
+
 snapd (2.68.5~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,13 @@
+snapd (2.68.5.1) xenial; urgency=medium
+
+  * New upstream release, LP: #2104254
+    - LP: #2104254 fix a regression during seeding when using early-
+      config
+    - Interfaces: hostname_control | fix for UC24 by adding required
+      unix socket and dbus permissions
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Wed, 11 Jun 2025 20:46:03 +0200
+
 snapd (2.68.5) xenial; urgency=medium
 
   * New upstream release, LP: #2098137

--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -1,5 +1,10 @@
 defaults:
   system:
+    # trigger early config behavior
+    # regression in #LP2104254
+    users:
+      create:
+        automatic: false
     service:
       rsyslog:
         disable: true


### PR DESCRIPTION
Generated changelogs with:
DEBEMAIL="Ernest Lotter \<ernest.lotter@canonical.com\>" release-tools/changelog.py 2.68.5.lp2104254 2104254 NEWS.md

**Hotfix release content:**
- https://github.com/canonical/snapd/pull/15497 | [LP: #2104254](https://bugs.launchpad.net/stuttgart/+bug/2104254)
- https://github.com/canonical/snapd/pull/15196

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35155


**These assumptions needs to be double checked during review:**
 - Proposed version: 2.68.5.1  (initially suggested 2.68.5.lpxxxxx, but CI versioning exceeds snapcraft char limit)
 - Using separate branch `hotfix/2.68.5` based off `release/2.68` to allow for iteration, but nothing will be merged back
- [Hotfix release spec](https://docs.google.com/document/d/1G4Hulmmd8fxvvlCWNUpcJGEPXnAvcpvBAUAvDfVRSEo/edit?usp=sharing)

**Requires rebase merge**