### PR TITLE
o/snapstate: unmount extra kernel-modules components mounts

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -90,7 +90,7 @@ type managerBackend interface {
 
 	// the undoers for install
 	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error
-	UndoSetupComponent(cpi snap.ContainerPlaceInfo, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error
+	UndoSetupComponent(cpi snap.ContainerPlaceInfo, installRecord *backend.InstallRecord, dev snap.Device, removeOpts backend.RemoveComponentOpts, meter progress.Meter) error
 	UndoCopySnapData(newSnap, oldSnap *snap.Info, opts *dirs.SnapDirOptions, meter progress.Meter) error
 	UndoSetupSnapSaveData(newInfo, oldInfo *snap.Info, dev snap.Device, meter progress.Meter) error
 	// cleanup

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -66,6 +66,7 @@ type fakeOp struct {
 	componentRev                    snap.Revision
 	componentSideInfo               snap.ComponentSideInfo
 	componentSkipAssertionsDownload bool
+	componentRemoveOpts             backend.RemoveComponentOpts
 
 	curSnaps []store.CurrentSnap
 	action   store.SnapAction
@@ -1160,12 +1161,13 @@ func (f *fakeSnappyBackend) SetupKernelModulesComponents(currentComps, finalComp
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) UndoSetupComponent(cpi snap.ContainerPlaceInfo, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error {
+func (f *fakeSnappyBackend) UndoSetupComponent(cpi snap.ContainerPlaceInfo, installRecord *backend.InstallRecord, dev snap.Device, removeOpts backend.RemoveComponentOpts, meter progress.Meter) error {
 	meter.Notify("undo-setup-component")
 	f.appendOp(&fakeOp{
-		op:                "undo-setup-component",
-		containerName:     cpi.ContainerName(),
-		containerFileName: cpi.Filename(),
+		op:                  "undo-setup-component",
+		containerName:       cpi.ContainerName(),
+		containerFileName:   cpi.Filename(),
+		componentRemoveOpts: removeOpts,
 	})
 	if strings.HasSuffix(cpi.ContainerName(), "+brokenundo") {
 		return fmt.Errorf("cannot undo set-up of component %q", cpi.ContainerName())

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -18471,6 +18471,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 				op:                "undo-setup-component",
 				containerName:     containerName,
 				containerFileName: removedFilename,
+				componentRemoveOpts: backend.RemoveComponentOpts{
+					MaybeInitramfsMounted: compName == "kernel-modules-component"},
 			},
 			{
 				op:                "remove-component-dir",

--- a/tests/nested/manual/build-with-kernel-modules-components/task.yaml
+++ b/tests/nested/manual/build-with-kernel-modules-components/task.yaml
@@ -56,6 +56,13 @@ execute: |
   # Additionally, check that modules loaded by systemd right after switch root could be loaded
   lsmod | MATCH ip_tables
 
+  # reboot and check again
+  boot_id=$(tests.nested boot-id)
+  remote.exec sudo reboot || true
+  tests.nested wait-for reboot "$boot_id"
+  check_efi_pstore
+  lsmod | MATCH ip_tables
+
   # remove kernel component
   remote.exec sudo snap remove pc-kernel+"$KMOD_COMP"
 


### PR DESCRIPTION
kernel-modules components are mounted from the initramfs to make them available
immediately after switch root. However, this creates an extra mount point due
to the way UC creates the sysroot. We need to consider this when removing the
component to avoid failures.