### PR TITLE
many: make confdb API errors consistent with options

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -121,12 +121,19 @@ const (
 
 	// ErrorKindBadQuery: a bad query was provided.
 	ErrorKindBadQuery ErrorKind = "bad-query"
+
 	// ErrorKindConfigNoSuchOption: the given configuration option
 	// does not exist.
 	ErrorKindConfigNoSuchOption ErrorKind = "option-not-found"
 
 	// ErrorKindAssertionNotFound: assertion can not be found.
 	ErrorKindAssertionNotFound ErrorKind = "assertion-not-found"
+
+	// ErrorKindConfdbViewNotFound: the confdb view can not be found.
+	ErrorKindConfdbViewNotFound ErrorKind = "confdb-view-not-found"
+
+	// ErrorKindConfdbNoMatchingRule: no view rule matches the request.
+	ErrorKindConfdbNoMatchingRule ErrorKind = "confdb-no-matching-rule"
 
 	// ErrorKindUnsuccessful: snapctl command was unsuccessful.
 	ErrorKindUnsuccessful ErrorKind = "unsuccessful"

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -308,7 +308,7 @@ func (*viewSuite) TestSetWithNilValueFail(c *C) {
 	c.Check(ssid, DeepEquals, "value")
 }
 
-func (s *viewSuite) TestConfdbNotFound(c *C) {
+func (s *viewSuite) TestConfdbNotFoundErrors(c *C) {
 	databag := confdb.NewJSONDatabag()
 	schema, err := confdb.NewSchema("acc", "foo", map[string]any{
 		"bar": map[string]any{
@@ -324,23 +324,23 @@ func (s *viewSuite) TestConfdbNotFound(c *C) {
 	view := schema.View("bar")
 
 	_, err = view.Get(databag, "missing")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoMatchError{})
 	c.Assert(err, ErrorMatches, `cannot get "missing" through acc/foo/bar: no matching rule`)
 
 	err = view.Set(databag, "missing", "thing")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoMatchError{})
 	c.Assert(err, ErrorMatches, `cannot set "missing" through acc/foo/bar: no matching rule`)
 
 	err = view.Unset(databag, "missing")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoMatchError{})
 	c.Assert(err, ErrorMatches, `cannot unset "missing" through acc/foo/bar: no matching rule`)
 
 	_, err = view.Get(databag, "top-level")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 	c.Assert(err, ErrorMatches, `cannot get "top-level" through acc/foo/bar: no data`)
 
 	_, err = view.Get(databag, "")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 	c.Assert(err, ErrorMatches, `cannot get acc/foo/bar: no data`)
 
 	err = view.Set(databag, "nested", "thing")
@@ -350,7 +350,7 @@ func (s *viewSuite) TestConfdbNotFound(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = view.Get(databag, "other-nested")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 	c.Assert(err, ErrorMatches, `cannot get "other-nested" through acc/foo/bar: no data`)
 }
 
@@ -629,7 +629,7 @@ func (s *viewSuite) TestViewUnsetTopLevelEntry(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = view.Get(databag, "foo")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 
 	value, err := view.Get(databag, "bar")
 	c.Assert(err, IsNil)
@@ -659,7 +659,7 @@ func (s *viewSuite) TestViewUnsetLeafWithSiblings(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = view.Get(databag, "bar")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 
 	// doesn't affect the other leaf entry under "foo"
 	value, err := view.Get(databag, "baz")
@@ -687,10 +687,10 @@ func (s *viewSuite) TestViewUnsetWithNestedEntry(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = view.Get(databag, "foo")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 
 	_, err = view.Get(databag, "bar")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 }
 
 func (s *viewSuite) TestViewUnsetLeafLeavesEmptyParent(c *C) {
@@ -904,7 +904,7 @@ func (s *viewSuite) TestViewGetNoMatchRequestLongerThanPattern(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = view.Get(databag, "snapd.status")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoMatchError{})
 }
 
 func (s *viewSuite) TestViewManyPrefixMatches(c *C) {
@@ -1899,7 +1899,7 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderLast(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = view.Get(databag, "foo")
-	c.Assert(err, testutil.ErrorIs, &confdb.NotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 	c.Assert(err, ErrorMatches, `cannot get "foo" through acc/confdb/foo: no data`)
 }
 

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -159,7 +159,7 @@ func readViewIntoChange(chg *state.Change, tx *Transaction, view *confdb.View, r
 
 	result, err := GetViaView(tx, view, requests)
 	if err != nil {
-		if errors.Is(err, &confdb.NotFoundError{}) {
+		if errors.Is(err, &confdb.NoDataError{}) || errors.Is(err, &confdb.NoMatchError{}) {
 			apiData["confdb-error"] = err.Error()
 			chg.Set("api-data", apiData)
 			return nil


### PR DESCRIPTION
This makes the confdb API errors more consistent with the options API. Instead of a 404 for various "not found" errors, we return a 400 with an appropriate error kind. This uses the same error kind that options uses for the "no data" scenario and introduces a couple of others (view not found, no matching rule, etc).

~Based on https://github.com/canonical/snapd/pull/15559 because there's some overlap~