### PR TITLE
core-initrd: update packages to snapd version 2.70+g50.d4bfa73

### DIFF
--- a/core-initrd/24.04/debian/changelog
+++ b/core-initrd/24.04/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (69+2.70+g50.d4bfa73+24.04) noble; urgency=medium
+
+  * Update to snapd version 2.70+g50.d4bfa73
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Thu, 12 Jun 2025 10:16:34 -0400
+
 ubuntu-core-initramfs (69+2.69+g139.0b18e2d+24.04) noble; urgency=medium
 
   * Update to snapd version 2.69+g139.0b18e2d

--- a/core-initrd/24.10/debian/changelog
+++ b/core-initrd/24.10/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (70+2.70+g50.d4bfa73+24.10) oracular; urgency=medium
+
+  * Update to snapd version 2.70+g50.d4bfa73
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Thu, 12 Jun 2025 10:17:03 -0400
+
 ubuntu-core-initramfs (70+2.69+g139.0b18e2d+24.10) oracular; urgency=medium
 
   * Update to snapd version 2.69+g139.0b18e2d

--- a/core-initrd/25.04/debian/changelog
+++ b/core-initrd/25.04/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (71+2.70+g50.d4bfa73+25.04) plucky; urgency=medium
+
+  * Update to snapd version 2.70+g50.d4bfa73
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Thu, 12 Jun 2025 10:17:25 -0400
+
 ubuntu-core-initramfs (71+2.69+g139.0b18e2d+25.04) plucky; urgency=medium
 
   * Update to snapd version 2.69+g139.0b18e2d

--- a/core-initrd/latest/debian/changelog
+++ b/core-initrd/latest/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (72+2.70+g50.d4bfa73+25.10) questing; urgency=medium
+
+  * Update to snapd version 2.70+g50.d4bfa73
+
+ -- Alfonso Sanchez-Beato <alfonso.sanchez-beato@canonical.com>  Thu, 12 Jun 2025 10:17:45 -0400
+
 ubuntu-core-initramfs (72+2.69+g139.0b18e2d+25.10) questing; urgency=medium
 
   * First questing release


### PR DESCRIPTION
Sync with packages in snappy-dev.