### PR TITLE
secboot: add preinstall check wrapper

### DIFF
--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	UnpackPreinstallCheckError         = unpackPreinstallCheckError
+	UnwrapPreinstallCheckError         = unwrapPreinstallCheckError
 	ConvertPreinstallCheckErrorType    = convertPreinstallCheckErrorType
 	ConvertPreinstallCheckErrorActions = convertPreinstallCheckErrorActions
 

--- a/secboot/preinstall.go
+++ b/secboot/preinstall.go
@@ -22,10 +22,10 @@ import (
 	"encoding/json"
 )
 
-// PreinstallErrorInfo represents the information contained within
-// a preinstall check error, including its kind, message, and optionally
-// arguments and recovery actions.
-type PreinstallErrorInfo struct {
+// PreinstallErrorDetails describes an individual error detected during a
+// preinstall check. It includes the error kind, a human-readable message,
+// and optional structured arguments and suggested recovery actions.
+type PreinstallErrorDetails struct {
 	Kind    string                     `json:"kind"`
 	Message string                     `json:"message"`
 	Args    map[string]json.RawMessage `json:"args,omitempty"`

--- a/secboot/preinstall.go
+++ b/secboot/preinstall.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package secboot
+
+import (
+	"encoding/json"
+)
+
+// PreinstallErrorInfo represents the information contained within
+// a preinstall check error, including its kind, message, and optionally
+// arguments and recovery actions.
+type PreinstallErrorInfo struct {
+	Kind    string                     `json:"kind"`
+	Message string                     `json:"message"`
+	Args    map[string]json.RawMessage `json:"args,omitempty"`
+	Actions []string                   `json:"actions,omitempty"`
+}

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -20,6 +20,10 @@
 
 package secboot
 
-func PreinstallCheck(bootImagePaths []string) ([]PreinstallErrorDetails, error) {
+import (
+	"context"
+)
+
+func PreinstallCheck(ctx context.Context, bootImagePaths []string) ([]PreinstallErrorDetails, error) {
 	return nil, errBuildWithoutSecboot
 }

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+func PreinstallCheck(bootImagePaths []string) ([]PreinstallErrorInfo, error) {
+	return nil, errBuildWithoutSecboot
+}

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -20,6 +20,6 @@
 
 package secboot
 
-func PreinstallCheck(bootImagePaths []string) ([]PreinstallErrorInfo, error) {
+func PreinstallCheck(bootImagePaths []string) ([]PreinstallErrorDetails, error) {
 	return nil, errBuildWithoutSecboot
 }

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -1,0 +1,137 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot
+
+import (
+	"context"
+	"fmt"
+
+	sb_efi "github.com/snapcore/secboot/efi"
+	sb_preinstall "github.com/snapcore/secboot/efi/preinstall"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/systemd"
+)
+
+var (
+	sbPreinstallNewRunChecksContext = sb_preinstall.NewRunChecksContext
+	sbPreinstallRunChecks           = (*sb_preinstall.RunChecksContext).Run
+)
+
+// PreinstallCheck runs preinstall checks using default check configuration and
+// TCG-compliant PCR profile generation options to evaluate whether the host
+// environment is an EFI system suitable for TPM-based Full Disk Encryption. On
+// success, it returns a list with information on all errors identified by
+// secboot or nil if no errors were found. Any warnings contained in the secboot
+// result are logged. On failure, it returns the error encountered while
+// interpreting the secboot error.
+//
+// To support testing, when test mode is detected and the system is running in a
+// Virtual Machine, the check configuration is modified to permit this without
+// treating it as an error.
+func PreinstallCheck(bootImagePaths []string) ([]PreinstallErrorInfo, error) {
+	// do not customize check configuration
+	checkFlags := sb_preinstall.CheckFlagsDefault
+	if snapdenv.Testing() && systemd.IsVirtualMachine() {
+		// with exception of testing in virtual machine
+		checkFlags |= sb_preinstall.PermitVirtualMachine
+	}
+
+	// do not customize TCG compliant PCR profile generation
+	profileOptionFlags := sb_preinstall.PCRProfileOptionsDefault
+
+	// create boot file images from provided paths
+	var bootImages []sb_efi.Image
+	for _, image := range bootImagePaths {
+		bootImages = append(bootImages, sb_efi.NewFileImage(image))
+	}
+
+	checksContext := sbPreinstallNewRunChecksContext(checkFlags, bootImages, profileOptionFlags)
+
+	// no actions or action args for preinstall checks
+	result, err := sbPreinstallRunChecks(checksContext, context.Background(), sb_preinstall.ActionNone)
+	if err != nil {
+		return unpackPreinstallCheckError(err)
+	}
+
+	if result.Warnings != nil {
+		for _, warn := range result.Warnings.Unwrap() {
+			logger.Noticef("preinstall check warning: %v", warn)
+		}
+	}
+	return nil, nil
+}
+
+// unpackPreinstallCheckError converts a single or compound preinstall check
+// error into a slice of PreinstallErrorInfo. This function returns an error
+// if the provided error or any compounded error is not of type
+// *preinstall.ErrorKindAndActions.
+func unpackPreinstallCheckError(err error) ([]PreinstallErrorInfo, error) {
+	// expect either a single or compound error
+	compoundErr, ok := err.(sb_preinstall.CompoundError)
+	if !ok {
+		// single error
+		kindAndActions, ok := err.(*sb_preinstall.WithKindAndActionsError)
+		if !ok {
+			return nil, fmt.Errorf("cannot unpack error of unexpected type %[1]T (%[1]v)", err)
+		}
+		return []PreinstallErrorInfo{
+			convertPreinstallCheckErrorType(kindAndActions),
+		}, nil
+	}
+
+	// unpack compound error
+	errs := compoundErr.Unwrap()
+	if errs == nil {
+		return nil, fmt.Errorf("compound error does not wrap any error")
+	}
+	unpacked := make([]PreinstallErrorInfo, 0, len(errs))
+	for _, err := range errs {
+		kindAndActions, ok := err.(*sb_preinstall.WithKindAndActionsError)
+		if !ok {
+			return nil, fmt.Errorf("cannot unpack error of unexpected type %[1]T (%[1]v)", err)
+		}
+		unpacked = append(unpacked, convertPreinstallCheckErrorType(kindAndActions))
+	}
+	return unpacked, nil
+}
+
+func convertPreinstallCheckErrorType(kindAndActionsErr *sb_preinstall.WithKindAndActionsError) PreinstallErrorInfo {
+	return PreinstallErrorInfo{
+		Kind:    string(kindAndActionsErr.Kind),
+		Message: kindAndActionsErr.Error(), // safely handles kindAndActionsErr.Unwrap() == nil
+		Args:    kindAndActionsErr.Args,
+		Actions: convertPreinstallCheckErrorActions(kindAndActionsErr.Actions),
+	}
+}
+
+func convertPreinstallCheckErrorActions(actions []sb_preinstall.Action) []string {
+	if actions == nil {
+		return nil
+	}
+
+	convActions := make([]string, len(actions))
+	for i, action := range actions {
+		convActions[i] = string(action)
+	}
+	return convActions
+}

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -28,7 +28,6 @@ import (
 	sb_preinstall "github.com/snapcore/secboot/efi/preinstall"
 
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -46,14 +45,13 @@ var (
 // are logged. On failure, it returns the error encountered while interpreting
 // the secboot error.
 //
-// To support testing, when test mode is detected and the system is running in a
-// Virtual Machine, the check configuration is modified to permit this without
-// treating it as an error.
+// To support testing, when the system is running in a Virtual Machine, the check
+// configuration is modified to permit this to avoid an error.
 func PreinstallCheck(ctx context.Context, bootImagePaths []string) ([]PreinstallErrorDetails, error) {
 	// do not customize check configuration
 	checkFlags := sb_preinstall.CheckFlagsDefault
-	if snapdenv.Testing() && systemd.IsVirtualMachine() {
-		// with exception of testing in virtual machine
+	if systemd.IsVirtualMachine() {
+		// with exception of running in a virtual machine
 		checkFlags |= sb_preinstall.PermitVirtualMachine
 	}
 

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -40,7 +40,7 @@ var (
 // PreinstallCheck runs preinstall checks using default check configuration and
 // TCG-compliant PCR profile generation options to evaluate whether the host
 // environment is an EFI system suitable for TPM-based Full Disk Encryption. The
-// caller must supply the current boot images in boot order via loadedImages.
+// caller must supply the current boot images in boot order via bootImagePaths.
 // On success, it returns a list with details on all errors identified by secboot
 // or nil if no errors were found. Any warnings contained in the secboot result
 // are logged. On failure, it returns the error encountered while interpreting

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -1,0 +1,422 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package secboot_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/canonical/go-tpm2"
+	sb_efi "github.com/snapcore/secboot/efi"
+	sb_preinstall "github.com/snapcore/secboot/efi/preinstall"
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type preinstallSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&preinstallSuite{})
+
+func (s *preinstallSuite) SetUpTest(c *C) {
+}
+
+// CompoundPreinstallCheckError implements sb_preinstall.CompoundError and is
+// used to mimic compound errors that would normally be returned by secboot.
+type CompoundPreinstallCheckError struct {
+	Errs []error
+}
+
+func (e *CompoundPreinstallCheckError) Error() string {
+	return "n/a"
+}
+
+func (e *CompoundPreinstallCheckError) Unwrap() []error {
+	return e.Errs
+}
+
+func (s *preinstallSuite) TestConvertPreinstallCheckErrorActions(c *C) {
+	testCases := []struct {
+		actions  []sb_preinstall.Action
+		expected []string
+	}{
+		{nil, nil},
+		{[]sb_preinstall.Action{}, []string{}},
+		{[]sb_preinstall.Action{sb_preinstall.ActionReboot, sb_preinstall.ActionShutdown}, []string{"reboot", "shutdown"}},
+	}
+
+	for _, tc := range testCases {
+		convertedActions := secboot.ConvertPreinstallCheckErrorActions(tc.actions)
+		c.Check(convertedActions, DeepEquals, tc.expected)
+	}
+}
+
+func (s *preinstallSuite) TestConvertPreinstallCheckErrorType(c *C) {
+	kindAndActionsErr := sb_preinstall.NewWithKindAndActionsError(
+		sb_preinstall.ErrorKindTPMHierarchiesOwned,
+		sb_preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}, WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
+		[]sb_preinstall.Action{sb_preinstall.ActionRebootToFWSettings},
+		errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+	)
+
+	var errorInfo secboot.PreinstallErrorInfo
+	c.Assert(func() { errorInfo = secboot.ConvertPreinstallCheckErrorType(nil) }, PanicMatches, "runtime error: invalid memory address or nil pointer dereference")
+	errorInfo = secboot.ConvertPreinstallCheckErrorType(kindAndActionsErr)
+	c.Assert(errorInfo, DeepEquals, secboot.PreinstallErrorInfo{
+		Kind:    "tpm-hierarchies-owned",
+		Message: "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+		Args: map[string]json.RawMessage{
+			"with-auth-value":  json.RawMessage(`[1073741834]`),
+			"with-auth-policy": json.RawMessage(`[1073741825]`),
+		},
+		Actions: []string{"reboot-to-fw-settings"},
+	})
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorCompound(c *C) {
+	compoundError := &CompoundPreinstallCheckError{
+		[]error{
+			sb_preinstall.NewWithKindAndActionsError(
+				sb_preinstall.ErrorKindTPMHierarchiesOwned,
+				sb_preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}},
+				[]sb_preinstall.Action{sb_preinstall.ActionRebootToFWSettings},
+				errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+			),
+			sb_preinstall.NewWithKindAndActionsError(
+				sb_preinstall.ErrorKindTPMDeviceLockout,
+				&sb_preinstall.TPMDeviceLockoutArgs{IntervalDuration: 7200000000000, TotalDuration: 230400000000000},
+				[]sb_preinstall.Action{sb_preinstall.ActionRebootToFWSettings},
+				errors.New("error with TPM2 device: TPM is in DA lockout mode"),
+			),
+			sb_preinstall.NewWithKindAndActionsError(
+				sb_preinstall.ErrorKindNone,
+				nil,
+				nil,
+				nil,
+			),
+		},
+	}
+
+	errorInfos, err := secboot.UnpackPreinstallCheckError(compoundError)
+	c.Assert(err, IsNil)
+	c.Assert(errorInfos, DeepEquals, []secboot.PreinstallErrorInfo{
+		{
+			Kind:    "tpm-hierarchies-owned",
+			Message: "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+			Args: map[string]json.RawMessage{
+				"with-auth-value":  json.RawMessage(`[1073741834]`),
+				"with-auth-policy": json.RawMessage(`null`),
+			},
+			Actions: []string{"reboot-to-fw-settings"},
+		},
+		{
+			Kind:    "tpm-device-lockout",
+			Message: "error with TPM2 device: TPM is in DA lockout mode",
+			Args: map[string]json.RawMessage{
+				"interval-duration": json.RawMessage(`7200000000000`),
+				"total-duration":    json.RawMessage(`230400000000000`),
+			},
+			Actions: []string{"reboot-to-fw-settings"},
+		},
+		{
+			Kind:    "",
+			Message: "<nil>",
+			Args:    nil,
+			Actions: nil,
+		},
+	})
+
+	jsn, err := json.MarshalIndent(errorInfos, "", "  ")
+	c.Assert(err, IsNil)
+	const expectedJson = `[
+  {
+    "kind": "tpm-hierarchies-owned",
+    "message": "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+    "args": {
+      "with-auth-policy": null,
+      "with-auth-value": [
+        1073741834
+      ]
+    },
+    "actions": [
+      "reboot-to-fw-settings"
+    ]
+  },
+  {
+    "kind": "tpm-device-lockout",
+    "message": "error with TPM2 device: TPM is in DA lockout mode",
+    "args": {
+      "interval-duration": 7200000000000,
+      "total-duration": 230400000000000
+    },
+    "actions": [
+      "reboot-to-fw-settings"
+    ]
+  },
+  {
+    "kind": "",
+    "message": "\u003cnil\u003e"
+  }
+]`
+	c.Assert(string(jsn), Equals, expectedJson)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorFailCompoundUnexpectedType(c *C) {
+	compoundError := &CompoundPreinstallCheckError{
+		[]error{
+			sb_preinstall.NewWithKindAndActionsError(
+				sb_preinstall.ErrorKindTPMHierarchiesOwned,
+				sb_preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout}},
+				[]sb_preinstall.Action{sb_preinstall.ActionRebootToFWSettings},
+				errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+			),
+			sb_preinstall.ErrInsufficientDMAProtection,
+		},
+	}
+
+	errorInfos, err := secboot.UnpackPreinstallCheckError(compoundError)
+	c.Assert(err, ErrorMatches, `cannot unpack error of unexpected type \*errors\.errorString \(the platform firmware indicates that DMA protections are insufficient\)`)
+	c.Assert(errorInfos, IsNil)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorFailCompoundWrapsNil(c *C) {
+	compoundError := &CompoundPreinstallCheckError{nil}
+
+	errorInfos, err := secboot.UnpackPreinstallCheckError(compoundError)
+	c.Assert(err, ErrorMatches, "compound error does not wrap any error")
+	c.Assert(errorInfos, IsNil)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorSingle(c *C) {
+	singleError := sb_preinstall.NewWithKindAndActionsError(
+		sb_preinstall.ErrorKindTPMDeviceDisabled,
+		nil,
+		[]sb_preinstall.Action{sb_preinstall.ActionRebootToFWSettings},
+		errors.New("error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware"),
+	)
+
+	errorInfos, err := secboot.UnpackPreinstallCheckError(singleError)
+	c.Assert(err, IsNil)
+	c.Assert(errorInfos, DeepEquals, []secboot.PreinstallErrorInfo{
+		{
+			Kind:    "tpm-device-disabled",
+			Message: "error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware",
+			Actions: []string{"reboot-to-fw-settings"},
+		},
+	})
+
+	jsn, err := json.MarshalIndent(errorInfos, "", "  ")
+	c.Assert(err, IsNil)
+	const expectedJson = `[
+  {
+    "kind": "tpm-device-disabled",
+    "message": "error with TPM2 device: TPM2 device is present but is currently disabled by the platform firmware",
+    "actions": [
+      "reboot-to-fw-settings"
+    ]
+  }
+]`
+	c.Assert(string(jsn), Equals, expectedJson)
+}
+
+func (s *preinstallSuite) TestUnpackPreinstallCheckErrorFailSingleUnexpectedType(c *C) {
+	errorInfos, err := secboot.UnpackPreinstallCheckError(sb_preinstall.ErrInsufficientDMAProtection)
+	c.Assert(err, ErrorMatches, `cannot unpack error of unexpected type \*errors\.errorString \(the platform firmware indicates that DMA protections are insufficient\)`)
+	c.Assert(errorInfos, IsNil)
+}
+
+func (s *preinstallSuite) testPreinstallCheckConfig(c *C, isTesting, isVM, permitVM bool) {
+	restore := snapdenv.MockTesting(isTesting)
+	defer restore()
+	cmdExit := `exit 1`
+	if isVM {
+		cmdExit = `exit 0`
+	}
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", cmdExit)
+	defer systemdCmd.Restore()
+
+	restore = secboot.MockSbPreinstallNewRunChecksContext(
+		func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext {
+			if permitVM {
+				c.Assert(initialFlags&sb_preinstall.PermitVirtualMachine, Equals, sb_preinstall.PermitVirtualMachine)
+			} else {
+				c.Assert(initialFlags, Equals, sb_preinstall.CheckFlagsDefault)
+			}
+			c.Assert(profileOpts, Equals, sb_preinstall.PCRProfileOptionsDefault)
+			c.Assert(loadedImages, IsNil)
+
+			return nil
+		})
+	defer restore()
+
+	restore = secboot.MockSbPreinstallRun(
+		func(checkCtx *sb_preinstall.RunChecksContext, ctx context.Context, action sb_preinstall.Action, args ...any) (*sb_preinstall.CheckResult, error) {
+			c.Assert(checkCtx, IsNil)
+			c.Assert(ctx, NotNil)
+			c.Assert(action, Equals, sb_preinstall.ActionNone)
+			c.Assert(args, IsNil)
+
+			return &sb_preinstall.CheckResult{}, nil
+		})
+	defer restore()
+
+	errorInfos, err := secboot.PreinstallCheck(nil)
+	c.Assert(err, IsNil)
+	c.Assert(errorInfos, IsNil)
+}
+
+func (s *preinstallSuite) TestPreinstallCheckConfig(c *C) {
+	testCases := []struct {
+		isTesting bool
+		isVM      bool
+		permitVM  bool
+	}{
+		{false, false, false}, // default config
+		{false, true, false},  // default config
+		{true, false, false},  // default config
+		{true, true, true},    // modify default config to permit VM
+	}
+
+	for _, tc := range testCases {
+		s.testPreinstallCheckConfig(c, tc.isTesting, tc.isVM, tc.permitVM)
+	}
+}
+
+func (s *preinstallSuite) testPreinstallCheck(c *C, detectErrors, failUnpack bool) {
+	bootImagePaths := []string{
+		"/cdrom/EFI/boot/bootXXX.efi",
+		"/cdrom/EFI/boot/grubXXX.efi",
+		"/cdrom/casper/vmlinuz",
+	}
+
+	restore := snapdenv.MockTesting(false)
+	defer restore()
+
+	restore = secboot.MockSbPreinstallNewRunChecksContext(
+		func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext {
+			c.Assert(initialFlags, Equals, sb_preinstall.CheckFlagsDefault)
+			c.Assert(profileOpts, Equals, sb_preinstall.PCRProfileOptionsDefault)
+			c.Assert(loadedImages, HasLen, len(bootImagePaths))
+			for i, image := range loadedImages {
+				c.Check(image.String(), Equals, bootImagePaths[i])
+			}
+
+			return &sb_preinstall.RunChecksContext{}
+		})
+	defer restore()
+
+	restore = secboot.MockSbPreinstallRun(
+		func(checkCtx *sb_preinstall.RunChecksContext, ctx context.Context, action sb_preinstall.Action, args ...any) (*sb_preinstall.CheckResult, error) {
+			c.Assert(checkCtx, NotNil)
+			c.Assert(checkCtx.Errors(), IsNil)
+			c.Assert(checkCtx.Result(), IsNil)
+			c.Assert(ctx, NotNil)
+			c.Assert(action, Equals, sb_preinstall.ActionNone)
+			c.Assert(args, IsNil)
+
+			if detectErrors {
+				return nil, &CompoundPreinstallCheckError{
+					[]error{
+						sb_preinstall.NewWithKindAndActionsError(
+							sb_preinstall.ErrorKindTPMHierarchiesOwned,
+							sb_preinstall.TPM2OwnedHierarchiesError{WithAuthValue: tpm2.HandleList{tpm2.HandleLockout},
+								WithAuthPolicy: tpm2.HandleList{tpm2.HandleOwner}},
+							[]sb_preinstall.Action{sb_preinstall.ActionRebootToFWSettings},
+							errors.New("error with TPM2 device: one or more of the TPM hierarchies is already owned"),
+						),
+						sb_preinstall.NewWithKindAndActionsError(
+							sb_preinstall.ErrorKindTPMDeviceLockout,
+							&sb_preinstall.TPMDeviceLockoutArgs{IntervalDuration: 7200000000000, TotalDuration: 230400000000000},
+							[]sb_preinstall.Action{sb_preinstall.ActionRebootToFWSettings},
+							errors.New("error with TPM2 device: TPM is in DA lockout mode"),
+						),
+					},
+				}
+			} else if failUnpack {
+				return nil, sb_preinstall.ErrInsufficientDMAProtection
+			} else {
+				return &sb_preinstall.CheckResult{
+					Warnings: &CompoundPreinstallCheckError{
+						[]error{
+							errors.New("warning 1"),
+							errors.New("warning 2"),
+						},
+					},
+				}, nil
+			}
+		})
+	defer restore()
+
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	errorInfos, err := secboot.PreinstallCheck(bootImagePaths)
+	if detectErrors {
+		c.Assert(err, IsNil)
+		c.Assert(logbuf.String(), Equals, "")
+		c.Assert(errorInfos, DeepEquals, []secboot.PreinstallErrorInfo{
+			{
+				Kind:    "tpm-hierarchies-owned",
+				Message: "error with TPM2 device: one or more of the TPM hierarchies is already owned",
+				Args: map[string]json.RawMessage{
+					"with-auth-value":  json.RawMessage(`[1073741834]`),
+					"with-auth-policy": json.RawMessage(`[1073741825]`),
+				},
+				Actions: []string{"reboot-to-fw-settings"},
+			},
+			{
+				Kind:    "tpm-device-lockout",
+				Message: "error with TPM2 device: TPM is in DA lockout mode",
+				Args: map[string]json.RawMessage{
+					"interval-duration": json.RawMessage(`7200000000000`),
+					"total-duration":    json.RawMessage(`230400000000000`),
+				},
+				Actions: []string{"reboot-to-fw-settings"},
+			},
+		})
+	} else if failUnpack {
+		c.Assert(err, ErrorMatches, `cannot unpack error of unexpected type \*errors\.errorString \(the platform firmware indicates that DMA protections are insufficient\)`)
+		c.Assert(errorInfos, IsNil)
+	} else {
+		c.Assert(err, IsNil)
+		c.Assert(errorInfos, IsNil)
+		c.Assert(logbuf.String(), testutil.Contains, "preinstall check warning: warning 1")
+		c.Assert(logbuf.String(), testutil.Contains, "preinstall check warning: warning 2")
+	}
+}
+
+func (s *preinstallSuite) TestPreinstallCheckWithWarningsAndErrors(c *C) {
+	detectErrors := false // warnings and no errors
+	s.testPreinstallCheck(c, detectErrors, false)
+	detectErrors = true // errors and no warnings
+	s.testPreinstallCheck(c, detectErrors, false)
+}
+
+func (s *preinstallSuite) TestPreinstallCheckFailUnpack(c *C) {
+	failUnpack := true
+	s.testPreinstallCheck(c, false, failUnpack)
+}

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/secboot"
-	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -249,9 +248,7 @@ func (s *preinstallSuite) TestUnwrapPreinstallCheckErrorFailSingleUnexpectedType
 	c.Assert(errorDetails, IsNil)
 }
 
-func (s *preinstallSuite) testPreinstallCheckConfig(c *C, isTesting, isVM, permitVM bool) {
-	restore := snapdenv.MockTesting(isTesting)
-	defer restore()
+func (s *preinstallSuite) testPreinstallCheckConfig(c *C, isVM, permitVM bool) {
 	cmdExit := `exit 1`
 	if isVM {
 		cmdExit = `exit 0`
@@ -259,7 +256,7 @@ func (s *preinstallSuite) testPreinstallCheckConfig(c *C, isTesting, isVM, permi
 	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", cmdExit)
 	defer systemdCmd.Restore()
 
-	restore = secboot.MockSbPreinstallNewRunChecksContext(
+	restore := secboot.MockSbPreinstallNewRunChecksContext(
 		func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext {
 			if permitVM {
 				c.Assert(initialFlags&sb_preinstall.PermitVirtualMachine, Equals, sb_preinstall.PermitVirtualMachine)
@@ -291,18 +288,15 @@ func (s *preinstallSuite) testPreinstallCheckConfig(c *C, isTesting, isVM, permi
 
 func (s *preinstallSuite) TestPreinstallCheckConfig(c *C) {
 	testCases := []struct {
-		isTesting bool
-		isVM      bool
-		permitVM  bool
+		isVM     bool
+		permitVM bool
 	}{
-		{false, false, false}, // default config
-		{false, true, false},  // default config
-		{true, false, false},  // default config
-		{true, true, true},    // modify default config to permit VM
+		{false, false}, // default config
+		{true, true},   // modify default config to permit VM
 	}
 
 	for _, tc := range testCases {
-		s.testPreinstallCheckConfig(c, tc.isTesting, tc.isVM, tc.permitVM)
+		s.testPreinstallCheckConfig(c, tc.isVM, tc.permitVM)
 	}
 }
 
@@ -313,10 +307,7 @@ func (s *preinstallSuite) testPreinstallCheck(c *C, detectErrors, failUnwrap boo
 		"/cdrom/casper/vmlinuz",
 	}
 
-	restore := snapdenv.MockTesting(false)
-	defer restore()
-
-	restore = secboot.MockSbPreinstallNewRunChecksContext(
+	restore := secboot.MockSbPreinstallNewRunChecksContext(
 		func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext {
 			c.Assert(initialFlags, Equals, sb_preinstall.CheckFlagsDefault)
 			c.Assert(profileOpts, Equals, sb_preinstall.PCRProfileOptionsDefault)

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -307,6 +307,9 @@ func (s *preinstallSuite) testPreinstallCheck(c *C, detectErrors, failUnwrap boo
 		"/cdrom/casper/vmlinuz",
 	}
 
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", "exit 1")
+	defer systemdCmd.Restore()
+
 	restore := secboot.MockSbPreinstallNewRunChecksContext(
 		func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext {
 			c.Assert(initialFlags, Equals, sb_preinstall.CheckFlagsDefault)

--- a/systemd/detect.go
+++ b/systemd/detect.go
@@ -33,3 +33,13 @@ func IsContainer() bool {
 	err := exec.Command("systemd-detect-virt", "--quiet", "--container").Run()
 	return err == nil
 }
+
+// IsVirtualMachine returns true if the system is running in a virtual machine.
+//
+// The implementation calls: systemd-detect-virt --quiet --vm.  It can be mocked
+// with testutil.MockCommand. The zero exit code indicates that system _is_
+// running a vm. Ensuring that --vm is passed is important.
+func IsVirtualMachine() bool {
+	err := exec.Command("systemd-detect-virt", "--quiet", "--vm").Run()
+	return err == nil
+}

--- a/systemd/detect_test.go
+++ b/systemd/detect_test.go
@@ -43,3 +43,17 @@ func (*detectSuite) TestIsContainer_No(c *C) {
 
 	c.Check(systemd.IsContainer(), Equals, false)
 }
+
+func (*detectSuite) TestIsVirtualMachine_Yes(c *C) {
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", `exit 0`)
+	defer systemdCmd.Restore()
+
+	c.Check(systemd.IsVirtualMachine(), Equals, true)
+}
+
+func (*detectSuite) TestIsVirtualMachine_No(c *C) {
+	systemdCmd := testutil.MockCommand(c, "systemd-detect-virt", `exit 1`)
+	defer systemdCmd.Restore()
+
+	c.Check(systemd.IsVirtualMachine(), Equals, false)
+}


### PR DESCRIPTION
Add snapd secboot preinstall check wrapper based on recently added [secboot RunChecksContext API](https://github.com/canonical/secboot/pull/387)

This PR aims to finalize part 1 of the [complete implementation](https://github.com/canonical/snapd/pull/15546).

Spec: [SD201 | Perform TPM/FDE pre-install checks](https://docs.google.com/document/d/1Mbj7Ut0tgW0PCz8VWdhvBN52kHTxYqkZZKQODB1NlLk/edit?tab=t.0#heading=h.jsatitiw8ll7)
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34453

**IMPORTANT: Do not merge until after arm64 secboot issue is fixed.**
