### PR TITLE
overlord/devicestate,tests: set revision of seed components to x1

### DIFF
--- a/asserts/preseed.go
+++ b/asserts/preseed.go
@@ -131,7 +131,8 @@ func checkPreseedSnap(snap map[string]interface{}) (*PreseedSnap, error) {
 		}
 	}
 
-	var snapRevision int
+	// Revision is x1 if unasserted, as that is what we will get on first installation
+	snapRevision := -1
 	if _, ok := snap["revision"]; ok {
 		var err error
 		snapRevision, err = checkSnapRevisionWhat(snap, "revision", what)
@@ -206,7 +207,8 @@ func checkPreseedComponent(comp map[string]interface{}, snapRevision int) (Prese
 	}
 	what := fmt.Sprintf("of component %q", name)
 
-	var revision int
+	// Revision is x1 if unasserted, as that is what we will get on first installation
+	revision := -1
 	if _, ok := comp["revision"]; ok {
 		revision, err = checkSnapRevisionWhat(comp, "revision", what)
 		if err != nil {
@@ -214,11 +216,11 @@ func checkPreseedComponent(comp map[string]interface{}, snapRevision int) (Prese
 		}
 	}
 
-	if revision == 0 && snapRevision > 0 {
+	if revision <= 0 && snapRevision > 0 {
 		return PreseedComponent{}, fmt.Errorf("component %q must have a revision since its snap has a revision", name)
 	}
 
-	if revision > 0 && snapRevision == 0 {
+	if revision > 0 && snapRevision <= 0 {
 		return PreseedComponent{}, fmt.Errorf("component %q cannot have a revision since its snap has no revision", name)
 	}
 

--- a/asserts/preseed_test.go
+++ b/asserts/preseed_test.go
@@ -163,10 +163,12 @@ func (ps *preseedSuite) TestDecodeOKComponents(c *C) {
 			},
 		},
 		{
-			Name: "foo-linux",
+			Name:     "foo-linux",
+			Revision: -1,
 			Components: []asserts.PreseedComponent{
 				{
-					Name: "comp2",
+					Name:     "comp2",
+					Revision: -1,
 				},
 			},
 		},

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -5264,16 +5264,17 @@ func (s *imageSuite) TestSetupSeedLocalComponents(c *C) {
 		Path: filepath.Join(extraSnapsDir, "required20_1.0.snap"),
 		SideInfo: &snap.SideInfo{
 			RealName: "required20",
+			Revision: snap.R(-1),
 		},
 		Required: true,
 		Components: []seed.Component{
 			{
 				Path:         filepath.Join(extraSnapsDir, "required20+comp1_1.0.comp"),
-				CompSideInfo: *snap.NewComponentSideInfo(cref1, snap.R(0)),
+				CompSideInfo: *snap.NewComponentSideInfo(cref1, snap.R(-1)),
 			},
 			{
 				Path:         filepath.Join(extraSnapsDir, "required20+comp2_2.0.comp"),
-				CompSideInfo: *snap.NewComponentSideInfo(cref2, snap.R(0)),
+				CompSideInfo: *snap.NewComponentSideInfo(cref2, snap.R(-1)),
 			},
 		},
 	})

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -395,9 +395,11 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 					Revision: 2,
 				}},
 			}, {
-				Name: "foo",
+				Name:     "foo",
+				Revision: -1,
 				Components: []asserts.PreseedComponent{{
-					Name: "comp1",
+					Name:     "comp1",
+					Revision: -1,
 				}},
 			}})
 		default:

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -120,6 +120,10 @@ func EnsureOperationalShouldBackoff(m *DeviceManager, now time.Time) bool {
 	return m.ensureOperationalShouldBackoff(now)
 }
 
+func LoadSystemAndEssentialSnaps(m *DeviceManager, wantedSystemLabel string, types []snap.Type, modeForComps string) (*systemAndEssentialSnaps, error) {
+	return m.loadSystemAndEssentialSnaps(wantedSystemLabel, types, modeForComps)
+}
+
 func BecomeOperationalBackoff(m *DeviceManager) time.Duration {
 	return m.becomeOperationalBackoff
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -903,13 +903,6 @@ func (m *DeviceManager) loadAndMountSystemLabelSnaps(systemLabel string, essenti
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	// Unset revision here actually means that the snap is local.
-	// Assign then a local revision as seeding/installing the snap would do.
-	for _, snInfo := range systemAndSnaps.InfosByType {
-		if snInfo.Revision.Unset() {
-			snInfo.Revision = snap.R(-1)
-		}
-	}
 
 	// Mount gadget, kernel and kernel-modules components
 	var unmountFuncs []func() error

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -999,7 +999,8 @@ func (s *seed20) lookupUnassertedComponent(comp20 internal.Component20, info *sn
 	}
 	compName := cinfo.Component.ComponentName
 	cref := naming.NewComponentRef(info.SnapName(), compName)
-	csi := snap.NewComponentSideInfo(cref, snap.R(0))
+	// Unasserted components from the seed will have an x1 revision when installed
+	csi := snap.NewComponentSideInfo(cref, snap.R(-1))
 	cpi := snap.MinimalComponentContainerPlaceInfo(
 		compName, snap.R(-1), info.SnapName())
 	newCompPath, err := handler.HandleUnassertedContainer(cpi, compPath, tm)
@@ -1099,7 +1100,7 @@ func (s *seed20) lookupSnap(snapRef naming.SnapRef, modelSnap *asserts.ModelSnap
 			seedComps = append(seedComps, comp)
 		}
 
-		pinfo := snap.MinimalSnapContainerPlaceInfo(info.SnapName(), snap.Revision{N: -1})
+		pinfo := snap.MinimalSnapContainerPlaceInfo(info.SnapName(), snap.R(-1))
 		newPath, err := handler.HandleUnassertedContainer(pinfo, path, tm)
 		if err != nil {
 			return nil, err
@@ -1107,7 +1108,8 @@ func (s *seed20) lookupSnap(snapRef naming.SnapRef, modelSnap *asserts.ModelSnap
 		if newPath != "" {
 			path = newPath
 		}
-		sideInfo = &snap.SideInfo{RealName: info.SnapName()}
+		// Unasserted snaps from the seed will have an x1 revision when installed
+		sideInfo = &snap.SideInfo{RealName: info.SnapName(), Revision: snap.R(-1)}
 		// suppress channel
 		channel = ""
 	} else {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -1551,7 +1551,7 @@ func (s *seed20Suite) TestLoadMetaCore20LocalSnaps(c *C) {
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{
 		{
 			Path:     filepath.Join(s.SeedDir, "systems", sysLabel, "snaps", "required20_1.0.snap"),
-			SideInfo: &snap.SideInfo{RealName: "required20"},
+			SideInfo: &snap.SideInfo{RealName: "required20", Revision: snap.R(-1)},
 			Required: true,
 		},
 	})
@@ -1646,7 +1646,7 @@ func (s *seed20Suite) TestLoadMetaCore20SnapHandler(c *C) {
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{
 		{
 			Path:     filepath.Join(s.SeedDir, "systems", sysLabel, "snaps", "required20_1.0.snap"),
-			SideInfo: &snap.SideInfo{RealName: "required20"},
+			SideInfo: &snap.SideInfo{RealName: "required20", Revision: snap.R(-1)},
 			Required: true,
 		},
 	})
@@ -1752,7 +1752,7 @@ func (s *seed20Suite) TestLoadMetaCore20SnapHandlerChangePath(c *C) {
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{
 		{
 			Path:     "/tmp/.." + filepath.Join(s.SeedDir, "systems", sysLabel, "snaps", "required20_1.0.snap"),
-			SideInfo: &snap.SideInfo{RealName: "required20"},
+			SideInfo: &snap.SideInfo{RealName: "required20", Revision: snap.R(-1)},
 			Required: true,
 		},
 	})
@@ -2004,7 +2004,7 @@ func (s *seed20Suite) TestLoadMetaCore20LocalSnapd(c *C) {
 	c.Check(essSnaps, DeepEquals, []*seed.Snap{
 		{
 			Path:          filepath.Join(s.SeedDir, "systems", sysLabel, "snaps", "snapd_1.0.snap"),
-			SideInfo:      &snap.SideInfo{RealName: "snapd"},
+			SideInfo:      &snap.SideInfo{RealName: "snapd", Revision: snap.R(-1)},
 			Essential:     true,
 			EssentialType: snap.TypeSnapd,
 			Required:      true,
@@ -2313,7 +2313,7 @@ func (s *seed20Suite) TestLoadMetaCore20OptionalSnapsLocal(c *C) {
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{
 		{
 			Path:     filepath.Join(s.SeedDir, "systems", sysLabel, "snaps", "optional20-b_1.0.snap"),
-			SideInfo: &snap.SideInfo{RealName: "optional20-b"},
+			SideInfo: &snap.SideInfo{RealName: "optional20-b", Revision: snap.R(-1)},
 
 			Required: false,
 		},
@@ -2418,7 +2418,7 @@ func (s *seed20Suite) TestLoadMetaCore20ExtraSnaps(c *C) {
 		},
 		{
 			Path:     filepath.Join(sysSnapsDir, "cont-consumer_1.0.snap"),
-			SideInfo: &snap.SideInfo{RealName: "cont-consumer"},
+			SideInfo: &snap.SideInfo{RealName: "cont-consumer", Revision: snap.R(-1)},
 		},
 	})
 
@@ -4338,13 +4338,14 @@ func (s *seed20Suite) TestModeSnaps(c *C) {
 	}
 	localComponentTestRun := &seed.Snap{
 		Path:     filepath.Join(unassertedSnapsDir, "local-component-test_1.0.snap"),
-		SideInfo: &snap.SideInfo{RealName: "local-component-test"},
+		SideInfo: &snap.SideInfo{RealName: "local-component-test", Revision: snap.R(-1)},
 		Required: false,
 		Components: []seed.Component{
 			{
 				Path: filepath.Join(unassertedSnapsDir, "local-component-test+comp4_1.0.comp"),
 				CompSideInfo: snap.ComponentSideInfo{
 					Component: naming.NewComponentRef("local-component-test", "comp4"),
+					Revision:  snap.R(-1),
 				},
 			},
 		},
@@ -5082,6 +5083,7 @@ func (s *seed20Suite) TestLoadMetaWithLocalComponents(c *C) {
 					"snaps", "required20+comp1_1.0.comp"),
 				CompSideInfo: snap.ComponentSideInfo{
 					Component: naming.NewComponentRef("required20", "comp1"),
+					Revision:  snap.R(-1),
 				},
 			})
 			checked[0] = true
@@ -5091,6 +5093,7 @@ func (s *seed20Suite) TestLoadMetaWithLocalComponents(c *C) {
 					"snaps", "required20+comp2_2.0.comp"),
 				CompSideInfo: snap.ComponentSideInfo{
 					Component: naming.NewComponentRef("required20", "comp2"),
+					Revision:  snap.R(-1),
 				},
 			})
 			checked[1] = true

--- a/tests/nested/manual/build-with-kernel-modules-components/task.yaml
+++ b/tests/nested/manual/build-with-kernel-modules-components/task.yaml
@@ -55,6 +55,9 @@ execute: |
   check_efi_pstore
   # Additionally, check that modules loaded by systemd right after switch root could be loaded
   lsmod | MATCH ip_tables
+  # No mounts for unset versions are found
+  mount | not MATCH efi-pstore_unset
+  mount | not MATCH pc-kernel_unset
 
   # reboot and check again
   boot_id=$(tests.nested boot-id)


### PR DESCRIPTION
Make sure that when we read a seed, the local components get a x1 revision. Not doing this was causing strange behaviors on installation, like having extra components in /var/lib/snapd/snaps/ with revision "unset", and having those components mounted too.

A check is spread tests is added for this.