### PR TITLE
packaging/pack-source: exclude .git directory

### DIFF
--- a/packaging/pack-source
+++ b/packaging/pack-source
@@ -52,12 +52,19 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 if [[ "$single" == 0 ]]; then
-    tar -cJf "$tmpdir"/snapd_"$version".no-vendor.tar.xz --exclude='./vendor/*' --exclude='./c-vendor/*' --exclude='.git/*' --transform "s#^#snapd-$version/#" .
-    tar -cJf "$tmpdir"/snapd_"$version".only-vendor.tar.xz --exclude='.git/*' --transform "s#^#snapd-$version/#" vendor
+    tar -cJf "$tmpdir"/snapd_"$version".no-vendor.tar.xz \
+        --exclude='./vendor/*' --exclude='./c-vendor/*' \
+        --exclude='.git' --exclude='.git/*' \
+        --transform "s#^#snapd-$version/#" .
+    tar -cJf "$tmpdir"/snapd_"$version".only-vendor.tar.xz \
+        --exclude='.git' --exclude='.git/*' \
+        --transform "s#^#snapd-$version/#" vendor
 
     mv "$tmpdir"/snapd_"$version".no-vendor.tar.xz "$outdir"/
     mv "$tmpdir"/snapd_"$version".only-vendor.tar.xz "$outdir"/
 else
-    tar -cJf "$tmpdir"/snapd_"$version".vendor.tar.xz --exclude='.git/*' --transform "s#^#snapd-$version/#" .
+    tar -cJf "$tmpdir"/snapd_"$version".vendor.tar.xz \
+        --exclude='.git' --exclude='.git/*' \
+        --transform "s#^#snapd-$version/#" .
     mv "$tmpdir"/snapd_"$version".vendor.tar.xz "$outdir"/
 fi


### PR DESCRIPTION
Exclude .git directory, not just its contents. This works around the problem, where go build notices the presence of .git directory and attempts to incorporate VCS information into the build, but since the directory is empty, the attempt fails. One can pass `-buildvcs=false` to disable this, but it needs to be included in the appropriate packaging files when consuming tarballs generated by pack-source.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Cherry picked from: #15564 