### PR TITLE
cmd/snap: change cmd trace log to remove all positional and optional arguments

### DIFF
--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -102,7 +102,7 @@ var (
 
 	GetSystemKeyRetryCount = getSystemKeyRetryCount
 
-	WholeCommandName = wholeCommandName
+	ComposeSubCmd = composeSubCmd
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -101,6 +101,8 @@ var (
 	SnapInstancesAndComponentsFromNames = snapInstancesAndComponentsFromNames
 
 	GetSystemKeyRetryCount = getSystemKeyRetryCount
+
+	WholeCommandName = wholeCommandName
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -567,18 +567,7 @@ func loggerWithJournalMaybe() error {
 	return nil
 }
 
-func composeFormatString(n int) string {
-	if n <= 0 {
-		return ""
-	}
-	parts := make([]string, n)
-	for i := 0; i < n; i++ {
-		parts[i] = "%s"
-	}
-	return strings.Join(parts, " ")
-}
-
-func composeSubCmd(cmd *flags.Command, subArgIndex int, cmdNames []any) string {
+func composeSubCmd(cmd *flags.Command, subArgIndex int, cmdNames []string) string {
 	subcmds := cmd.Commands()
 	if len(subcmds) > 0 && len(os.Args) > subArgIndex {
 		for _, subcmd := range subcmds {
@@ -587,8 +576,7 @@ func composeSubCmd(cmd *flags.Command, subArgIndex int, cmdNames []any) string {
 			}
 		}
 	}
-	template := composeFormatString(len(cmdNames))
-	return fmt.Sprintf(template, cmdNames...)
+	return strings.Join(cmdNames, " ")
 }
 
 func wholeCommandName(cmd *flags.Command) string {
@@ -596,7 +584,7 @@ func wholeCommandName(cmd *flags.Command) string {
 	if len(subcmds) > 0 && len(os.Args) > 2 {
 		for _, subcmd := range subcmds {
 			if os.Args[2] == subcmd.Name {
-				return composeSubCmd(subcmd, 3, []any{cmd.Name, subcmd.Name})
+				return composeSubCmd(subcmd, 3, []string{cmd.Name, subcmd.Name})
 			}
 		}
 	}
@@ -608,6 +596,7 @@ func makeCommandHandler(allCommands []*flags.Command) func(flags.Commander, []st
 		for _, cmd := range allCommands {
 			if cmd.Name == os.Args[1] {
 				logger.Trace("command-execution", "cmd", wholeCommandName(cmd))
+				break
 			}
 		}
 		return command.Execute(args)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -579,23 +579,11 @@ func composeSubCmd(cmd *flags.Command, subArgIndex int, cmdNames []string) strin
 	return strings.Join(cmdNames, " ")
 }
 
-func wholeCommandName(cmd *flags.Command) string {
-	subcmds := cmd.Commands()
-	if len(subcmds) > 0 && len(os.Args) > 2 {
-		for _, subcmd := range subcmds {
-			if os.Args[2] == subcmd.Name {
-				return composeSubCmd(subcmd, 3, []string{cmd.Name, subcmd.Name})
-			}
-		}
-	}
-	return cmd.Name
-}
-
 func makeCommandHandler(allCommands []*flags.Command) func(flags.Commander, []string) error {
 	return func(command flags.Commander, args []string) error {
 		for _, cmd := range allCommands {
 			if cmd.Name == os.Args[1] {
-				logger.Trace("command-execution", "cmd", wholeCommandName(cmd))
+				logger.Trace("command-execution", "cmd", composeSubCmd(cmd, 2, []string{cmd.Name}))
 				break
 			}
 		}

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -479,7 +479,7 @@ func (s *SnapSuite) TestCommandHandlerOneLevel(c *C) {
 	cmd0 := &flags.Command{Name: "level0"}
 	restore := mockArgs("snap", "level0", "other", "arguments")
 	defer restore()
-	name := snap.WholeCommandName(cmd0)
+	name := snap.ComposeSubCmd(cmd0, 2, []string{cmd0.Name})
 	c.Assert(name, Equals, "level0")
 }
 
@@ -490,7 +490,7 @@ func (s *SnapSuite) TestCommandHandlerTwoLevels(c *C) {
 	c.Assert(err, IsNil)
 	restore := mockArgs("snap", "level0", "level1", "other", "arguments")
 	defer restore()
-	name := snap.WholeCommandName(cmd0)
+	name := snap.ComposeSubCmd(cmd0, 2, []string{cmd0.Name})
 	c.Assert(name, Equals, "level0 level1")
 }
 
@@ -503,6 +503,6 @@ func (s *SnapSuite) TestCommandHandlerThreeLevels(c *C) {
 	c.Assert(err, IsNil)
 	restore := mockArgs("snap", "level0", "level1", "level2", "other", "arguments")
 	defer restore()
-	name := snap.WholeCommandName(cmd0)
+	name := snap.ComposeSubCmd(cmd0, 2, []string{cmd0.Name})
 	c.Assert(name, Equals, "level0 level1 level2")
 }

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -488,7 +488,6 @@ func (s *SnapSuite) TestCommandHandlerTwoLevels(c *C) {
 	type emptyStruct struct{}
 	_, err := cmd0.AddCommand("level1", "l1", "l1", &emptyStruct{})
 	c.Assert(err, IsNil)
-	c.Assert(err, IsNil)
 	restore := mockArgs("snap", "level0", "level1", "other", "arguments")
 	defer restore()
 	name := snap.WholeCommandName(cmd0)

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -474,3 +474,36 @@ func (s *SnapSuite) TestCompletionHandlerSkipsHidden(c *C) {
 	})
 	c.Check(s.Stdout(), Equals, "foo\nbaz\n")
 }
+
+func (s *SnapSuite) TestCommandHandlerOneLevel(c *C) {
+	cmd0 := &flags.Command{Name: "level0"}
+	restore := mockArgs("snap", "level0", "other", "arguments")
+	defer restore()
+	name := snap.WholeCommandName(cmd0)
+	c.Assert(name, Equals, "level0")
+}
+
+func (s *SnapSuite) TestCommandHandlerTwoLevels(c *C) {
+	cmd0 := &flags.Command{Name: "level0"}
+	type emptyStruct struct{}
+	_, err := cmd0.AddCommand("level1", "l1", "l1", &emptyStruct{})
+	c.Assert(err, IsNil)
+	c.Assert(err, IsNil)
+	restore := mockArgs("snap", "level0", "level1", "other", "arguments")
+	defer restore()
+	name := snap.WholeCommandName(cmd0)
+	c.Assert(name, Equals, "level0 level1")
+}
+
+func (s *SnapSuite) TestCommandHandlerThreeLevels(c *C) {
+	cmd0 := &flags.Command{Name: "level0"}
+	type emptyStruct struct{}
+	cmd1, err := cmd0.AddCommand("level1", "l1", "l1", &emptyStruct{})
+	c.Assert(err, IsNil)
+	_, err = cmd1.AddCommand("level2", "l2", "l2", &emptyStruct{})
+	c.Assert(err, IsNil)
+	restore := mockArgs("snap", "level0", "level1", "level2", "other", "arguments")
+	defer restore()
+	name := snap.WholeCommandName(cmd0)
+	c.Assert(name, Equals, "level0 level1 level2")
+}


### PR DESCRIPTION
This changes the snap command logging to only log the command names (including any nested commands)

The logging then takes the following form with all optional and positional arguments ignored:
```json
{"msg":"command-execution","cmd":"watch"}
{"msg":"command-execution","cmd":"whoami"}
{"msg":"command-execution","cmd":"debug api"}
{"msg":"command-execution","cmd":"debug boot-vars"}
{"msg":"command-execution","cmd":"debug set-boot-vars"}
{"msg":"command-execution","cmd":"debug can-manage-refreshes"}
{"msg":"command-execution","cmd":"debug confinement"}
{"msg":"command-execution","cmd":"debug connectivity"}
{"msg":"command-execution","cmd":"debug disks"}
{"msg":"command-execution","cmd":"debug ensure-state-soon"}
{"msg":"command-execution","cmd":"debug execution apparmor"}
{"msg":"command-execution","cmd":"debug execution snap"}
{"msg":"command-execution","cmd":"debug execution internal-tool"}
```