### PR TITLE
interfaces: allow reading snap-specific credentials

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -490,6 +490,10 @@ var templateCommon = `
   /run/lock/ r,
   /run/lock/snap.@{SNAP_INSTANCE_NAME}/ rw,
   /run/lock/snap.@{SNAP_INSTANCE_NAME}/** mrwklix,
+
+  # Allow reading systemd-provided credentials.
+  /run/credentials/ r,
+  /run/credentials/snap.@{SNAP_INSTANCE_NAME}.*.service/** r,
   
   ###DEVMODE_SNAP_CONFINE###
 `


### PR DESCRIPTION
The systemd credentials [1] system can be used to provide configuration or secrets to any snap service. Allow snaps to read their own credentials.

[1] https://systemd.io/CREDENTIALS/

This fixed denials such as this one:

```
[21063.296829] audit: type=1400 audit(1745860372.867:5505): apparmor="DENIED" operation="open" class="file" namespace="root//lxd-juju-5cae6a-4_<var-snap-lxd-common-lxd>" profile="snap.vault.vaultd" name="/run/credentials/snap.vault.vaultd.service/vault_token" pid=1014667 comm="vaultd-start" requested_mask="r" denied_mask="r" fsuid=1000000 ouid=1000000
```
