### PR TITLE
github/workflows/nightly-static-analysis: ignore missing tools in run-checks

### DIFF
--- a/.github/workflows/nightly-static-analysis.yaml
+++ b/.github/workflows/nightly-static-analysis.yaml
@@ -74,7 +74,9 @@ jobs:
         go install github.com/boumenot/gocover-cobertura@latest
 
         cd "${{ github.workspace }}/src/github.com/snapcore/snapd"
-        COVERAGE_OUT=.coverage/coverage.txt ./run-checks --unit
+        COVERAGE_OUT=.coverage/coverage.txt \
+          IGNORE_MISSING=1 \
+          ./run-checks --unit
         gocover-cobertura < .coverage/coverage.txt > .coverage/coverage.xml
 
     - name: Install TICS dependencies


### PR DESCRIPTION
The TIOBE workflow is broken as clang-format is not a build dependency, but the run-checks tool still attempts to find it.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
