### PR TITLE
tests/main/interfaces-blok-devices-zfs: update plug name 

### DIFF
--- a/tests/lib/snaps/store/test-snapd-zfsutils/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-zfsutils/snapcraft.yaml
@@ -11,13 +11,13 @@ apps:
     zpool:
         command: bin/zpool
         plugs:
-            - block-devices
+            - block-devices-with-partitions
             - mount-observe
 
     zfs:
         command: bin/zfs
         plugs:
-            - block-devices
+            - block-devices-with-partitions
             - mount-observe
 
 parts:
@@ -27,5 +27,6 @@ parts:
             - zfsutils-linux
 
 plugs:
-    block-devices:
+    block-devices-with-partitions:
+        interface: block-devices
         allow-partitions: true

--- a/tests/main/interfaces-block-devices-zfs/task.yaml
+++ b/tests/main/interfaces-block-devices-zfs/task.yaml
@@ -25,7 +25,7 @@ restore: |
 execute: |
     snap install --edge test-snapd-zfsutils
 
-    snap connect test-snapd-zfsutils:block-devices
+    snap connect test-snapd-zfsutils:block-devices-with-partitions
     snap connect test-snapd-zfsutils:mount-observe
 
     # starting without any pools


### PR DESCRIPTION
Followup: https://github.com/canonical/snapd/pull/15454#discussion_r2111596553 

Update the plug name, so that no warnings are issued.

Blocked, waiting for review tools or manual approval of snap upload.