### PR TITLE
boot/seal.go: factor boot chain related parameters in its own type

### DIFF
--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -2029,14 +2029,14 @@ func (s *sealSuite) TestWithBootChains(c *C) {
 	})
 	defer restore()
 
-	var chains *boot.ResealKeyForBootChainsParams
-	err = boot.WithBootChains(func(ch *boot.ResealKeyForBootChainsParams) error {
+	var chains boot.BootChains
+	err = boot.WithBootChains(func(ch boot.BootChains) error {
 		chains = ch
 		return nil
 	}, device.SealingMethodTPM)
 	c.Assert(err, IsNil)
 
-	c.Check(chains, DeepEquals, &boot.ResealKeyForBootChainsParams{
+	c.Check(chains, DeepEquals, boot.BootChains{
 		RunModeBootChains: []boot.BootChain{
 			{
 				BrandID:        "my-brand",

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -512,7 +512,7 @@ func updateFallbackProtectionProfile(
 func ResealKeyForBootChains(manager FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, expectReseal bool) error {
 	return resealKeys(manager, method, rootdir,
 		resealInputs{
-			bootChains: params,
+			bootChains: params.BootChains,
 		},
 		resealOptions{
 			ExpectReseal: expectReseal,
@@ -527,7 +527,7 @@ func ResealKeysForSignaturesDBUpdate(
 ) error {
 	return resealKeys(manager, method, rootdir,
 		resealInputs{
-			bootChains:        params,
+			bootChains:        params.BootChains,
 			signatureDBUpdate: dbUpdate,
 		},
 		resealOptions{
@@ -542,7 +542,7 @@ func ResealKeysForSignaturesDBUpdate(
 }
 
 type resealInputs struct {
-	bootChains        *boot.ResealKeyForBootChainsParams
+	bootChains        boot.BootChains
 	signatureDBUpdate []byte
 }
 

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -212,7 +212,7 @@ func (s *resealTestSuite) TestTPMResealHappy(c *C) {
 	}
 
 	model := boottest.MakeMockUC20Model()
-	params := &boot.ResealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains: []boot.BootChain{
 			{
 				BrandID:        model.BrandID(),
@@ -434,7 +434,7 @@ func (s *resealTestSuite) TestTPMResealHappy(c *C) {
 	})()
 
 	const expectReseal = true
-	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
+	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, &boot.ResealKeyForBootChainsParams{BootChains: bootChains}, expectReseal)
 	c.Assert(err, IsNil)
 
 	c.Check(resealCalls, Equals, 3)
@@ -442,12 +442,12 @@ func (s *resealTestSuite) TestTPMResealHappy(c *C) {
 	pbc, cnt, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDir, "boot-chains"))
 	c.Assert(err, IsNil)
 	c.Assert(cnt, Equals, 1)
-	c.Check(pbc, DeepEquals, boot.ToPredictableBootChains(removeKernelBootFiles(append(params.RunModeBootChains, params.RecoveryBootChainsForRunKey...))))
+	c.Check(pbc, DeepEquals, boot.ToPredictableBootChains(removeKernelBootFiles(append(bootChains.RunModeBootChains, bootChains.RecoveryBootChainsForRunKey...))))
 
 	recoveryPbc, cnt, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDir, "recovery-boot-chains"))
 	c.Assert(err, IsNil)
 	c.Assert(cnt, Equals, 1)
-	c.Check(recoveryPbc, DeepEquals, boot.ToPredictableBootChains(removeKernelBootFiles(params.RecoveryBootChains)))
+	c.Check(recoveryPbc, DeepEquals, boot.ToPredictableBootChains(removeKernelBootFiles(bootChains.RecoveryBootChains)))
 }
 
 func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {
@@ -1024,7 +1024,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {
 
 		}
 
-		params := &boot.ResealKeyForBootChainsParams{
+		bootChains := boot.BootChains{
 			RunModeBootChains:           runBootChains,
 			RecoveryBootChainsForRunKey: recoveryBootChainsForRun,
 			RecoveryBootChains:          recoveryBootChains,
@@ -1041,7 +1041,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {
 		})()
 
 		const expectReseal = false
-		err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, rootdir, params, expectReseal)
+		err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, rootdir, &boot.ResealKeyForBootChainsParams{BootChains: bootChains}, expectReseal)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {
@@ -1328,7 +1328,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsRecoveryKeysForGoodSystemsOn
 		},
 	}
 
-	params := &boot.ResealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains:           runBootChains,
 		RecoveryBootChainsForRunKey: recoveryBootChainsForRun,
 		RecoveryBootChains:          recoveryBootChains,
@@ -1364,7 +1364,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsRecoveryKeysForGoodSystemsOn
 	})()
 
 	const expectReseal = false
-	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
+	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, &boot.ResealKeyForBootChainsParams{BootChains: bootChains}, expectReseal)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 3)
 
@@ -1665,7 +1665,7 @@ func (s *resealTestSuite) testResealKeyForBootchainsWithTryModel(c *C, shimId, g
 		},
 	}
 
-	params := &boot.ResealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains:           runBootChains,
 		RecoveryBootChainsForRunKey: recoveryBootChainsForRun,
 		RecoveryBootChains:          recoveryBootChains,
@@ -1701,7 +1701,7 @@ func (s *resealTestSuite) testResealKeyForBootchainsWithTryModel(c *C, shimId, g
 	})()
 
 	const expectReseal = false
-	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
+	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, &boot.ResealKeyForBootChainsParams{BootChains: bootChains}, expectReseal)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 3)
 
@@ -1865,7 +1865,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsFallbackCmdline(c *C) {
 		},
 	}
 
-	params := &boot.ResealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains:           runBootChains,
 		RecoveryBootChainsForRunKey: recoveryBootChainsForRun,
 		RecoveryBootChains:          recoveryBootChains,
@@ -1901,7 +1901,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsFallbackCmdline(c *C) {
 	})()
 
 	const expectReseal = false
-	err = backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, params, expectReseal)
+	err = backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, &boot.ResealKeyForBootChainsParams{BootChains: bootChains}, expectReseal)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 3)
 
@@ -1914,7 +1914,7 @@ func (s *resealTestSuite) TestResealKeyForBootchainsFallbackCmdline(c *C) {
 
 func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 	model := boottest.MakeMockUC20Model()
-	params := &boot.ResealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains: []boot.BootChain{
 			{
 				BrandID:        model.BrandID(),
@@ -2035,7 +2035,7 @@ func (s *resealTestSuite) TestHooksResealHappy(c *C) {
 	})()
 
 	const expectReseal = true
-	err := backend.ResealKeyForBootChains(myState, device.SealingMethodFDESetupHook, s.rootdir, params, expectReseal)
+	err := backend.ResealKeyForBootChains(myState, device.SealingMethodFDESetupHook, s.rootdir, &boot.ResealKeyForBootChainsParams{BootChains: bootChains}, expectReseal)
 	c.Assert(err, IsNil)
 
 	c.Check(resealCalls, Equals, 3)
@@ -2139,7 +2139,7 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 	c.Assert(needed, Equals, false)
 	c.Assert(next, Equals, 1)
 
-	params := &boot.ResealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains:           runBootChains,
 		RecoveryBootChainsForRunKey: recoveryBootChainsForRun,
 		RecoveryBootChains:          recoveryBootChains,
@@ -2199,7 +2199,7 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 	})()
 
 	err = backend.ResealKeysForSignaturesDBUpdate(myState, device.SealingMethodTPM, dirs.GlobalRootDir,
-		params, []byte("dbx-payload"))
+		&boot.ResealKeyForBootChainsParams{BootChains: bootChains}, []byte("dbx-payload"))
 	c.Assert(err, IsNil)
 
 	// reseal was called

--- a/overlord/fdestate/backend/seal_test.go
+++ b/overlord/fdestate/backend/seal_test.go
@@ -242,7 +242,7 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 		recoveryKernel := bootloader.NewBootFile("/var/lib/snapd/seed/snaps/pc-kernel_1.snap", "kernel.efi", bootloader.RoleRecovery)
 		runKernel := bootloader.NewBootFile(filepath.Join(rootdir, "var/lib/snapd/snaps/pc-kernel_500.snap"), "kernel.efi", bootloader.RoleRunMode)
 
-		params := &boot.SealKeyForBootChainsParams{
+		bootChains := boot.BootChains{
 			RunModeBootChains: []boot.BootChain{
 				{
 					BrandID:        model.BrandID(),
@@ -322,6 +322,9 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 				bootloader.RoleRecovery: "grub",
 				bootloader.RoleRunMode:  "grub",
 			},
+		}
+		params := &boot.SealKeyForBootChainsParams{
+			BootChains:             bootChains,
 			FactoryReset:           tc.factoryReset,
 			InstallHostWritableDir: filepath.Join(boot.InstallUbuntuDataDir, "system-data"),
 			UseTokens:              !tc.disableTokens,
@@ -485,7 +488,7 @@ func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 	})
 	defer restore()
 
-	params := &boot.SealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains: []boot.BootChain{
 			{
 				BrandID:        model.BrandID(),
@@ -505,7 +508,10 @@ func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 				ModelSignKeyID: model.SignKeyID(),
 			},
 		},
-		RoleToBlName:           nil,
+		RoleToBlName: nil,
+	}
+	params := &boot.SealKeyForBootChainsParams{
+		BootChains:             bootChains,
 		FactoryReset:           false,
 		InstallHostWritableDir: filepath.Join(boot.InstallUbuntuDataDir, "system-data"),
 		UseTokens:              useTokens,
@@ -569,7 +575,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	key := secboot.CreateMockBootstrappedContainer()
 	saveKey := secboot.CreateMockBootstrappedContainer()
 
-	params := &boot.SealKeyForBootChainsParams{
+	bootChains := boot.BootChains{
 		RunModeBootChains: []boot.BootChain{
 			{
 				BrandID:        model.BrandID(),
@@ -589,7 +595,10 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 				ModelSignKeyID: model.SignKeyID(),
 			},
 		},
-		RoleToBlName:           nil,
+		RoleToBlName: nil,
+	}
+	params := &boot.SealKeyForBootChainsParams{
+		BootChains:             bootChains,
 		FactoryReset:           false,
 		InstallHostWritableDir: filepath.Join(boot.InstallUbuntuDataDir, "system-data"),
 	}


### PR DESCRIPTION
For now ResealKeyForBootChainsParams only contained boot chain related parameters. But we will need to pass more. WithBootChains needs to be able to only give the boot chain parameters and other parameters can be provided by functions passed as parameters.
