### PR TITLE
tests: fix tics jobs with new TICS env var

### DIFF
--- a/.github/workflows/nightly-static-analysis.yaml
+++ b/.github/workflows/nightly-static-analysis.yaml
@@ -87,7 +87,8 @@ jobs:
       run: |
         set -x
 
-        export TICSAUTHTOKEN="${{ secrets.TICSAUTHTOKEN }}"
         source ~/.profile
+        export TICSAUTHTOKEN="${{ secrets.TICSAUTHTOKEN }}"
+        export TICS=https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
 
         TICSQServer -project snapd -tmpdir /tmp/tics -branchdir "${{ github.workspace }}/src/github.com/snapcore/snapd"


### PR DESCRIPTION
After the last Tics refresh it is required that all the goloang projects define the tics env car with
https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects before executing the TICSQServer binary
