### PR TITLE
o/fdestate: add keyslot change conflict detection

### DIFF
--- a/overlord/fdestate/conflict.go
+++ b/overlord/fdestate/conflict.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package fdestate
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type ChangeConflictError struct {
+	KeyslotRef KeyslotRef
+	ChangeKind string
+}
+
+func (e *ChangeConflictError) Error() string {
+	if e.ChangeKind != "" {
+		return fmt.Sprintf("key slot %s has %q change in progress", e.KeyslotRef.String(), e.ChangeKind)
+	}
+	return fmt.Sprintf("key slot %s has changes in progress", e.KeyslotRef.String())
+}
+
+func keyslotsAffectedByTask(t *state.Task) ([]KeyslotRef, error) {
+	if !t.Has("keyslots") {
+		return nil, nil
+	}
+
+	var keyslotRefs []KeyslotRef
+	if err := t.Get("keyslots", &keyslotRefs); err != nil {
+		return nil, err
+	}
+	return keyslotRefs, nil
+}
+
+func checkChangeConflict(st *state.State, keyslotRefs []KeyslotRef) error {
+	refMap := make(map[KeyslotRef]bool, len(keyslotRefs))
+	for _, ref := range keyslotRefs {
+		refMap[ref] = true
+	}
+
+	for _, task := range st.Tasks() {
+		if task.Status().Ready() {
+			continue
+		}
+
+		refs, err := keyslotsAffectedByTask(task)
+		if err != nil {
+			return err
+		}
+
+		for _, ref := range refs {
+			if refMap[ref] {
+				return &ChangeConflictError{
+					KeyslotRef: ref,
+					ChangeKind: task.Change().Kind(),
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/overlord/fdestate/conflict_test.go
+++ b/overlord/fdestate/conflict_test.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func (s *fdeMgrSuite) TestCheckChangeConflict(c *C) {
+	nop := func(t *state.Task, _ *tomb.Tomb) error { return nil }
+
+	s.o.TaskRunner().AddHandler("with-keyslots", nop, nil)
+	s.o.TaskRunner().AddHandler("without-keyslots", nop, nil)
+
+	someKeyslotRef := fdestate.KeyslotRef{ContainerRole: "some-role", Name: "some-slot"}
+	someOtherKeyslotRef := fdestate.KeyslotRef{ContainerRole: "some-role", Name: "some-other-slot"}
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	chg := s.st.NewChange("some-change", "")
+
+	withKeyslots := s.st.NewTask("with-keyslots", "")
+	withKeyslots.Set("keyslots", []fdestate.KeyslotRef{someKeyslotRef})
+	chg.AddTask(withKeyslots)
+
+	withoutKeyslots := s.st.NewTask("without-keyslots", "")
+	chg.AddTask(withoutKeyslots)
+
+	err := fdestate.CheckChangeConflict(s.st, []fdestate.KeyslotRef{someKeyslotRef})
+	c.Assert(err, ErrorMatches, `key slot \(container-role: "some-role", name: "some-slot"\) has "some-change" change in progress`)
+	var conflictErr *fdestate.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), Equals, true)
+	c.Check(conflictErr.ChangeKind, Equals, "some-change")
+	c.Check(conflictErr.KeyslotRef, Equals, fdestate.KeyslotRef{Name: "some-slot", ContainerRole: "some-role"})
+
+	err = fdestate.CheckChangeConflict(s.st, []fdestate.KeyslotRef{someOtherKeyslotRef})
+	c.Assert(err, IsNil)
+
+	s.settle(c)
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Check(withKeyslots.Status(), Equals, state.DoneStatus)
+
+	// no ready tasks with "keyslots" exist
+	err = fdestate.CheckChangeConflict(s.st, []fdestate.KeyslotRef{someKeyslotRef})
+	c.Assert(err, IsNil)
+}
+
+func (s *fdeMgrSuite) TestChangeConflictErrorMessage(c *C) {
+	someKeyslotRef := fdestate.KeyslotRef{ContainerRole: "some-role", Name: "some-slot"}
+
+	err := fdestate.ChangeConflictError{KeyslotRef: someKeyslotRef}
+	c.Check(err.Error(), Equals, `key slot (container-role: "some-role", name: "some-slot") has changes in progress`)
+
+	err = fdestate.ChangeConflictError{KeyslotRef: someKeyslotRef, ChangeKind: "some-change"}
+	c.Check(err.Error(), Equals, `key slot (container-role: "some-role", name: "some-slot") has "some-change" change in progress`)
+}

--- a/overlord/fdestate/errors.go
+++ b/overlord/fdestate/errors.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package fdestate
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KeyslotRefsNotFoundError struct {
+	KeyslotRefs []KeyslotRef
+}
+
+func (e *KeyslotRefsNotFoundError) Error() string {
+	if len(e.KeyslotRefs) == 1 {
+		return fmt.Sprintf("key slot reference %s not found", e.KeyslotRefs[0].String())
+	} else {
+		var concatRefs strings.Builder
+		concatRefs.WriteString(e.KeyslotRefs[0].String())
+		for _, ref := range e.KeyslotRefs[1:] {
+			concatRefs.WriteString(", ")
+			concatRefs.WriteString(ref.String())
+		}
+		return fmt.Sprintf("key slot references [%s] not found", concatRefs.String())
+	}
+}

--- a/overlord/fdestate/errors_test.go
+++ b/overlord/fdestate/errors_test.go
@@ -1,0 +1,38 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/fdestate"
+)
+
+func (s *fdeMgrSuite) TestKeyslotsNotFoundErrorMessage(c *C) {
+	err := fdestate.KeyslotRefsNotFoundError{KeyslotRefs: []fdestate.KeyslotRef{{ContainerRole: "some-role", Name: "some-slot"}}}
+	c.Check(err.Error(), Equals, `key slot reference (container-role: "some-role", name: "some-slot") not found`)
+
+	err = fdestate.KeyslotRefsNotFoundError{KeyslotRefs: []fdestate.KeyslotRef{
+		{ContainerRole: "some-role", Name: "some-slot-1"},
+		{ContainerRole: "some-role", Name: "some-slot-2"},
+	}}
+	c.Check(err.Error(), Equals, `key slot references [(container-role: "some-role", name: "some-slot-1"), (container-role: "some-role", name: "some-slot-2")] not found`)
+}

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -48,6 +48,9 @@ var (
 	DbxUpdatePreparedOKChan      = dbxUpdatePreparedOKChan
 
 	DbxUpdateAffectedSnaps = dbxUpdateAffectedSnaps
+
+	CheckChangeConflict    = checkChangeConflict
+	KeyslotsAffectedByTask = keyslotsAffectedByTask
 )
 
 type ExternalOperation = externalOperation

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -308,6 +308,10 @@ type Keyslot struct {
 	keyData secboot.KeyData
 }
 
+func (k *Keyslot) String() string {
+	return fmt.Sprintf("(container-role: %q, name: %q)", k.ContainerRole, k.Name)
+}
+
 // KeyData returns secboot.KeyData corresponding to the keyslot.
 // This can only be called for KeyslotTypePlatform.
 //
@@ -404,6 +408,7 @@ func (m *FDEManager) GetKeyslots(keyslotRefs []KeyslotRef) (keyslots []Keyslot, 
 		keyslots = append(keyslots, matchedContainerKeyslots...)
 	}
 
+	// XXX: return error if len(keyslots) != keyslotRefs to indicate duplicates?
 	return keyslots, missingRefs, nil
 }
 

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -408,8 +408,8 @@ func MockSecbootGetPCRHandle(f func(devicePath, keySlot, keyFile string, hintExp
 // KeyslotRef uniquely identifies a target key slot by
 // its container role and name.
 type KeyslotRef struct {
-	ContainerRole string `json:"container-role"`
 	Name          string `json:"name"`
+	ContainerRole string `json:"container-role"`
 }
 
 func (k KeyslotRef) String() string {
@@ -431,9 +431,17 @@ func (k KeyslotRef) Validate() error {
 	return nil
 }
 
-func checkRecoveryKeyIDExists(st *state.State, recoveryKeyID string) error {
-	mgr := fdeMgr(st)
-	rkeyInfo, err := mgr.recoveryKeyCache.Key(recoveryKeyID)
+const tmpKeyslotPrefix = "snapd-tmp"
+
+func tmpKeyslotRef(ref KeyslotRef) KeyslotRef {
+	return KeyslotRef{
+		Name:          fmt.Sprintf("%s:%s", tmpKeyslotPrefix, ref.Name),
+		ContainerRole: ref.ContainerRole,
+	}
+}
+
+func checkRecoveryKeyIDExists(fdemgr *FDEManager, recoveryKeyID string) error {
+	rkeyInfo, err := fdemgr.recoveryKeyCache.Key(recoveryKeyID)
 	if err != nil {
 		return err
 	}
@@ -443,65 +451,76 @@ func checkRecoveryKeyIDExists(st *state.State, recoveryKeyID string) error {
 	return nil
 }
 
-const tmpKeyslotPrefix = "snapd-tmp"
-
-func tmpKeyslotTarget(keyslot KeyslotRef) KeyslotRef {
-	return KeyslotRef{
-		ContainerRole: keyslot.ContainerRole,
-		Name:          fmt.Sprintf("%s:%s", tmpKeyslotPrefix, keyslot.Name),
-	}
-}
-
 // ReplaceRecoveryKey creates a taskset that replaces the
 // recovery key for the specified target key slots using
 // the recovery key identified by recoveryKeyID.
 //
-// If keyslots is empty, the "default-recovery" key slot is
+// If keyslotRefs is empty, the "default-recovery" key slot is
 // used by default for both the "system-data" and "system-save"
 // container roles.
-func ReplaceRecoveryKey(st *state.State, recoveryKeyID string, keyslots []KeyslotRef) (*state.TaskSet, error) {
-	if len(keyslots) == 0 {
+//
+// If any key slot from keyslotRefs does not exist, a KeyslotRefsNotFoundError is returned.
+func ReplaceRecoveryKey(st *state.State, recoveryKeyID string, keyslotRefs []KeyslotRef) (*state.TaskSet, error) {
+	if len(keyslotRefs) == 0 {
 		// target default-recovery key slots by default if no key slot targets are specified
-		keyslots = append(keyslots,
+		keyslotRefs = append(keyslotRefs,
 			KeyslotRef{ContainerRole: "system-data", Name: "default-recovery"},
 			KeyslotRef{ContainerRole: "system-save", Name: "default-recovery"},
 		)
 	}
 
-	tmpKeyslots := make([]KeyslotRef, 0, len(keyslots))
-	tmpKeyslotRenames := make([]string, 0, len(keyslots))
-	for _, keyslot := range keyslots {
-		if err := keyslot.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid key slot reference %s: %v", keyslot.String(), err)
+	tmpKeyslotRefs := make([]KeyslotRef, 0, len(keyslotRefs))
+	tmpKeyslotRenames := make(map[string]string, len(keyslotRefs))
+	for _, keyslotRef := range keyslotRefs {
+		if err := keyslotRef.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid key slot reference %s: %v", keyslotRef.String(), err)
 		}
 		// TODO:FDEM: accept custom recovery key slot names when a naming convension is defined
-		if keyslot.Name != "default-recovery" {
-			return nil, fmt.Errorf(`invalid key slot reference %s: unsupported name, expected "default-recovery"`, keyslot.String())
+		if keyslotRef.Name != "default-recovery" {
+			return nil, fmt.Errorf(`invalid key slot reference %s: unsupported name, expected "default-recovery"`, keyslotRef.String())
 		}
 
-		tmpKeyslot := tmpKeyslotTarget(keyslot)
-		tmpKeyslots = append(tmpKeyslots, tmpKeyslot)
-		tmpKeyslotRenames = append(tmpKeyslotRenames, keyslot.Name)
+		tmpKeyslotRef := tmpKeyslotRef(keyslotRef)
+		tmpKeyslotRefs = append(tmpKeyslotRefs, tmpKeyslotRef)
+		tmpKeyslotRenames[tmpKeyslotRef.String()] = keyslotRef.Name
 	}
 
-	if err := checkRecoveryKeyIDExists(st, recoveryKeyID); err != nil {
+	// Note: checking that there are no ongoing conflicting changes and that the
+	// targeted key slots exist while state is locked ensures that we don't suffer
+	// from TOCTOU.
+
+	if err := checkChangeConflict(st, append(keyslotRefs, tmpKeyslotRefs...)); err != nil {
+		return nil, err
+	}
+
+	fdemgr := fdeMgr(st)
+
+	if err := checkRecoveryKeyIDExists(fdemgr, recoveryKeyID); err != nil {
 		return nil, fmt.Errorf("invalid recovery key ID: %v", err)
+	}
+
+	_, missing, err := fdemgr.GetKeyslots(keyslotRefs)
+	if err != nil {
+		return nil, err
+	}
+	if len(missing) != 0 {
+		return nil, &KeyslotRefsNotFoundError{KeyslotRefs: missing}
 	}
 
 	ts := state.NewTaskSet()
 
 	addTemporaryRecoveryKeys := st.NewTask("add-recovery-keys", "Add temporary recovery key slots")
 	addTemporaryRecoveryKeys.Set("recovery-key-id", recoveryKeyID)
-	addTemporaryRecoveryKeys.Set("keyslots", tmpKeyslots)
+	addTemporaryRecoveryKeys.Set("keyslots", tmpKeyslotRefs)
 	ts.AddTask(addTemporaryRecoveryKeys)
 
 	removeOldRecoveryKeys := st.NewTask("remove-keys", "Remove old recovery key slots")
-	removeOldRecoveryKeys.Set("keyslots", keyslots)
+	removeOldRecoveryKeys.Set("keyslots", keyslotRefs)
 	removeOldRecoveryKeys.WaitFor(addTemporaryRecoveryKeys)
 	ts.AddTask(removeOldRecoveryKeys)
 
 	renameTemporaryRecoveryKeys := st.NewTask("rename-keys", "Rename temporary recovery key slots")
-	renameTemporaryRecoveryKeys.Set("keyslots", tmpKeyslots)
+	renameTemporaryRecoveryKeys.Set("keyslots", tmpKeyslotRefs)
 	renameTemporaryRecoveryKeys.Set("renames", tmpKeyslotRenames)
 	renameTemporaryRecoveryKeys.WaitFor(removeOldRecoveryKeys)
 	ts.AddTask(renameTemporaryRecoveryKeys)


### PR DESCRIPTION
This PR adds keyslot change conflict detection to prevent two changes affecting the same key slot from being started in parallel.

This is part 1 of implementing handlers for recovery key replacement which I had to break down as it was getting quite large. for context, full e2e implementation can be found in https://github.com/canonical/snapd/pull/15587.