### PR TITLE
Fde replace recovery key handlers

### DIFF
--- a/overlord/fdestate/backend/keys.go
+++ b/overlord/fdestate/backend/keys.go
@@ -31,6 +31,8 @@ type RecoveryKeyCache interface {
 	// AddKey adds a recovery key with the specified id.
 	AddKey(keyID string, rkeyInfo CachedRecoverKey) (err error)
 	// Key gets the recovery key associated with the specified id.
+	// ErrNoRecoveryKey is returned if no recovery key entry exists
+	// for the given key id.
 	Key(keyID string) (rkeyInfo CachedRecoverKey, err error)
 	// RemoveKey removes the recovery key associated with the specified id.
 	RemoveKey(keyID string) error

--- a/overlord/fdestate/errors.go
+++ b/overlord/fdestate/errors.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package fdestate
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KeyslotRefsNotFoundError struct {
+	KeyslotRefs []KeyslotRef
+}
+
+func (e *KeyslotRefsNotFoundError) Error() string {
+	if len(e.KeyslotRefs) == 1 {
+		return fmt.Sprintf("key slot reference %s not found", e.KeyslotRefs[0].String())
+	} else {
+		var concatRefs strings.Builder
+		concatRefs.WriteString(e.KeyslotRefs[0].String())
+		for _, ref := range e.KeyslotRefs[1:] {
+			concatRefs.WriteString(", ")
+			concatRefs.WriteString(ref.String())
+		}
+		return fmt.Sprintf("key slot references [%s] not found", concatRefs.String())
+	}
+}
+
+type keyslotsAlreadyExistsError struct {
+	keyslots []Keyslot
+}
+
+func (e *keyslotsAlreadyExistsError) Error() string {
+	if len(e.keyslots) == 1 {
+		return fmt.Sprintf("key slot %s already exists", e.keyslots[0].String())
+	} else {
+		var concatRefs strings.Builder
+		concatRefs.WriteString(e.keyslots[0].String())
+		for _, ref := range e.keyslots[1:] {
+			concatRefs.WriteString(", ")
+			concatRefs.WriteString(ref.String())
+		}
+		return fmt.Sprintf("key slots [%s] already exist", concatRefs.String())
+	}
+}

--- a/overlord/fdestate/errors_test.go
+++ b/overlord/fdestate/errors_test.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/fdestate"
+)
+
+func (s *fdeMgrSuite) TestKeyslotsNotFoundErrorMessage(c *C) {
+	err := fdestate.KeyslotRefsNotFoundError{KeyslotRefs: []fdestate.KeyslotRef{{ContainerRole: "some-role", Name: "some-slot"}}}
+	c.Check(err.Error(), Equals, `key slot reference (container-role: "some-role", name: "some-slot") not found`)
+
+	err = fdestate.KeyslotRefsNotFoundError{KeyslotRefs: []fdestate.KeyslotRef{
+		{ContainerRole: "some-role", Name: "some-slot-1"},
+		{ContainerRole: "some-role", Name: "some-slot-2"},
+	}}
+	c.Check(err.Error(), Equals, `key slot references [(container-role: "some-role", name: "some-slot-1"), (container-role: "some-role", name: "some-slot-2")] not found`)
+}
+
+func (s *fdeMgrSuite) TestKeyslotsAlreadyExistsError(c *C) {
+	err := fdestate.KeyslotsAlreadyExistsError([]fdestate.Keyslot{{ContainerRole: "some-role", Name: "some-slot"}})
+	c.Check(err.Error(), Equals, `key slot (container-role: "some-role", name: "some-slot") already exists`)
+
+	err = fdestate.KeyslotsAlreadyExistsError([]fdestate.Keyslot{
+		{ContainerRole: "some-role", Name: "some-slot-1"},
+		{ContainerRole: "some-role", Name: "some-slot-2"},
+	})
+	c.Check(err.Error(), Equals, `key slots [(container-role: "some-role", name: "some-slot-1"), (container-role: "some-role", name: "some-slot-2")] already exist`)
+}

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -115,3 +115,19 @@ func MockSecbootListContainerRecoveryKeyNames(f func(devicePath string) ([]strin
 func MockSecbootListContainerUnlockKeyNames(f func(devicePath string) ([]string, error)) (restore func()) {
 	return testutil.Mock(&secbootListContainerUnlockKeyNames, f)
 }
+
+func MockSecbootAddContainerRecoveryKey(f func(devicePath string, slotName string, rkey keys.RecoveryKey) error) (restore func()) {
+	return testutil.Mock(&secbootAddContainerRecoveryKey, f)
+}
+
+func MockSecbootDeleteContainerKey(f func(devicePath string, slotName string) error) (restore func()) {
+	return testutil.Mock(&secbootDeleteContainerKey, f)
+}
+
+func MockSecbootRenameContainerKey(f func(devicePath string, oldName string, newName string) error) (restore func()) {
+	return testutil.Mock(&secbootRenameContainerKey, f)
+}
+
+func KeyslotsAlreadyExistsError(keyslots []Keyslot) keyslotsAlreadyExistsError {
+	return keyslotsAlreadyExistsError{keyslots: keyslots}
+}

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -308,6 +308,10 @@ type Keyslot struct {
 	keyData secboot.KeyData
 }
 
+func (k *Keyslot) String() string {
+	return fmt.Sprintf("(container-role: %q, name: %q)", k.ContainerRole, k.Name)
+}
+
 // KeyData returns secboot.KeyData corresponding to the keyslot.
 // This can only be called for KeyslotTypePlatform.
 //

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -120,18 +120,6 @@ func (s *fdeMgrSuite) testReplaceRecoveryKey(c *C, defaultKeyslots bool) {
 	} else {
 		c.Check(renames, DeepEquals, []string{"default-recovery"})
 	}
-
-	chg := s.st.NewChange("", "")
-	chg.AddAll(ts)
-
-	s.settle(c)
-
-	// TODO:FDEM: this should intentionally break after relevant tasks are implemented
-	c.Check(tsks[0].Status(), Equals, state.DoneStatus)
-	c.Check(tsks[1].Status(), Equals, state.DoneStatus)
-	c.Check(tsks[2].Status(), Equals, state.DoneStatus)
-	c.Check(chg.Status(), Equals, state.DoneStatus)
-	c.Assert(chg.Err(), IsNil)
 }
 
 func (s *fdeMgrSuite) TestReplaceRecoveryKey(c *C) {

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -19,47 +19,155 @@
 package fdestate
 
 import (
-	"github.com/snapcore/snapd/overlord/state"
+	"fmt"
+
 	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/secboot"
 )
 
-func (m *FDEManager) doAddRecoveryKeys(t *state.Task, tomb *tomb.Tomb) error {
-	// TODO:FDEM: implement recovery key addition, this is currently only a
-	// mock task for testing.
+var (
+	secbootAddContainerRecoveryKey = secboot.AddContainerRecoveryKey
+	secbootDeleteContainerKey      = secboot.DeleteContainerKey
+	secbootRenameContainerKey      = secboot.RenameContainerKey
+)
 
-	// TODO:FDEM:
-	//   - this might be a re-run, make task idempotent to be reselient to
-	//     abrupt reboot/shutdown.
-	//   - important to detect absence of recovery key ID and do cleanup
-	//     of added key slots on re-run and returning an error.
-	//   - distinguish between errors (undo) and pure-reboots (re-run).
-	//   - conflict detection for key slot tasks is important because it
-	//     reduces the possible states we could end up in.
+func (m *FDEManager) doAddRecoveryKeys(t *state.Task, tomb *tomb.Tomb) (err error) {
+	m.state.Lock()
+	defer m.state.Unlock()
+
+	var keyslotRefs []KeyslotRef
+	if err := t.Get("keyslots", &keyslotRefs); err != nil {
+		return err
+	}
+
+	var recoveryKeyID string
+	if err := t.Get("recovery-key-id", &recoveryKeyID); err != nil {
+		return err
+	}
+
+	// XXX: unlock state and let conflict detection handle the rest?
+
+	containers, err := m.GetEncryptedContainers()
+	if err != nil {
+		return err
+	}
+	containerDevicePath := make(map[string]string, len(containers))
+	for _, container := range containers {
+		containerDevicePath[container.ContainerRole()] = container.DevPath()
+	}
+
+	// IMPORTANT: this clean up must be decalred as early as possible
+	// to account for real errors and potential re-runs (that will fail
+	// anyway as soon as the recovery key ID is reused).
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, keyslotRef := range keyslotRefs {
+			devicePath := containerDevicePath[keyslotRef.ContainerRole]
+			if err := secbootDeleteContainerKey(devicePath, keyslotRef.Name); err != nil {
+				// best effort deletion, log errors only
+				logger.Noticef("failed to delete %s during clean up: %v", keyslotRef.String(), err)
+			}
+		}
+	}()
+
+	rkey, err := m.getRecoveryKey(recoveryKeyID)
+	if err != nil {
+		// most likely a re-run as keys expire after first use and
+		// clean up is needed.
+		return fmt.Errorf("failed to find recovery key with id %q: %v", recoveryKeyID, err)
+	}
+
+	currentKeyslots, _, err := m.GetKeyslots(keyslotRefs)
+	if err != nil {
+		return fmt.Errorf("failed to find key slots: %v", err)
+	}
+	if len(currentKeyslots) != 0 {
+		return &keyslotsAlreadyExistsError{keyslots: currentKeyslots}
+	}
+
+	for _, keyslotRef := range keyslotRefs {
+		devicePath := containerDevicePath[keyslotRef.ContainerRole]
+		if err := secbootAddContainerRecoveryKey(devicePath, keyslotRef.Name, rkey); err != nil {
+			return fmt.Errorf("failed to add recovery key slot %s: %v", keyslotRef.String(), err)
+		}
+	}
+
 	return nil
 }
 
 func (m *FDEManager) doRemoveKeys(t *state.Task, tomb *tomb.Tomb) error {
-	// TODO:FDEM: implement recovery key removal, this is currently only a
-	// mock task for testing.
+	m.state.Lock()
+	defer m.state.Unlock()
 
-	// TODO:FDEM:
-	//   - this might be a re-run, make task idempotent to be reselient to
-	//     abrupt reboot/shutdown.
-	//   - distinguish between errors (undo) and pure-reboots (re-run).
-	//   - conflict detection for key slot tasks is important because it
-	//     reduces the possible states we could end up in.
+	var keyslotRefs []KeyslotRef
+	if err := t.Get("keyslots", &keyslotRefs); err != nil {
+		return err
+	}
+
+	// XXX: unlock state and let conflict detection handle the rest?
+
+	// we only care about current key slots because this might be
+	// a re-run due a force reboot or abrupt shutdown, so we want
+	// to continue deleting the remaining key slots.
+	currentKeyslots, _, err := m.GetKeyslots(keyslotRefs)
+	if err != nil {
+		return fmt.Errorf("failed to find key slots: %v", err)
+	}
+
+	for _, keyslot := range currentKeyslots {
+		if err := secbootDeleteContainerKey(keyslot.devPath, keyslot.Name); err != nil {
+			// XXX: keep going and report errors afterwards?
+			return fmt.Errorf("failed to remove key slot %s: %v", keyslot.String(), err)
+		}
+	}
+
+	// XXX: request reboot to acconut for the case where the unlock key
+	// in the kernel keyring is one of the deleted key slots?
 	return nil
 }
 
 func (m *FDEManager) doRenameKeys(t *state.Task, tomb *tomb.Tomb) error {
-	// TODO:FDEM: implement recovery key renaming, this is currently only a
-	// mock task for testing.
+	m.state.Lock()
+	defer m.state.Unlock()
 
-	// TODO:FDEM:
-	//   - this might be a re-run, make task idempotent to be reselient to
-	//     abrupt reboot/shutdown.
-	//   - distinguish between errors (undo) and pure-reboots (re-run).
-	//   - conflict detection for key slot tasks is important because it
-	//     reduces the possible states we could end up in.
+	var keyslotRefs []KeyslotRef
+	if err := t.Get("keyslots", &keyslotRefs); err != nil {
+		return err
+	}
+
+	var renames map[string]string
+	if err := t.Get("renames", &renames); err != nil {
+		return err
+	}
+
+	for _, keyslotRef := range keyslotRefs {
+		if _, ok := renames[keyslotRef.String()]; !ok {
+			return fmt.Errorf("internal error: cannot find mapping for %s", keyslotRef.String())
+		}
+	}
+
+	// XXX: unlock state and let conflict detection handle the rest?
+
+	// we only care about current key slots because this might be
+	// a re-run due a force reboot or abrupt shutdown, so we want
+	// to continue renaming the remaining key slots.
+	currentKeyslots, _, err := m.GetKeyslots(keyslotRefs)
+	if err != nil {
+		return fmt.Errorf("failed to find key slots: %v", err)
+	}
+
+	for _, keyslot := range currentKeyslots {
+		refKey := KeyslotRef{ContainerRole: keyslot.ContainerRole, Name: keyslot.Name}.String()
+		if err := secbootRenameContainerKey(keyslot.devPath, keyslot.Name, renames[refKey]); err != nil {
+			// XXX: keep going and report errors afterwards?
+			return fmt.Errorf("failed to rename key slot %s to %q: %v", keyslot.String(), renames[refKey], err)
+		}
+	}
+
 	return nil
 }

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -1,0 +1,388 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdestate_test
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/strutil"
+)
+
+func (s *fdeMgrSuite) mockCurrentKeys(c *C, rkeys, unlockKeys []fdestate.KeyslotRef) {
+	var dataUnlockKeyNames, saveUnlockKeyNames []string
+	if len(unlockKeys) == 0 {
+		dataUnlockKeyNames = []string{"default", "default-fallback"}
+		saveUnlockKeyNames = []string{"default", "default-fallback"}
+	} else {
+		for _, ref := range unlockKeys {
+			switch ref.ContainerRole {
+			case "system-data":
+				dataUnlockKeyNames = append(dataUnlockKeyNames, ref.Name)
+			case "system-save":
+				saveUnlockKeyNames = append(saveUnlockKeyNames, ref.Name)
+			default:
+				c.Errorf("unexpected unlock key slot reference: %s", ref.String())
+			}
+		}
+	}
+
+	var dataRecoveryKeyNames, saveRecoveryKeyNames []string
+	if len(rkeys) == 0 {
+		dataRecoveryKeyNames = []string{"default-recovery"}
+		saveRecoveryKeyNames = []string{"default-recovery"}
+	} else {
+		for _, ref := range rkeys {
+			switch ref.ContainerRole {
+			case "system-data":
+				dataRecoveryKeyNames = append(dataRecoveryKeyNames, ref.Name)
+			case "system-save":
+				saveRecoveryKeyNames = append(saveRecoveryKeyNames, ref.Name)
+			default:
+				c.Errorf("unexpected recovery key slot reference: %s", ref.String())
+			}
+		}
+	}
+
+	s.mockDeviceInState(&asserts.Model{}, "run")
+
+	s.AddCleanup(fdestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+		switch mountpoint {
+		case filepath.Join(dirs.GlobalRootDir, "run/mnt/data"):
+			return "data", nil
+		case dirs.SnapSaveDir:
+			return "save", nil
+		}
+		panic(fmt.Sprintf("missing mocked mount point %q", mountpoint))
+	}))
+
+	s.AddCleanup(fdestate.MockSecbootListContainerUnlockKeyNames(func(devicePath string) ([]string, error) {
+		switch devicePath {
+		case "/dev/disk/by-uuid/data":
+			return dataUnlockKeyNames, nil
+		case "/dev/disk/by-uuid/save":
+			return saveUnlockKeyNames, nil
+		default:
+			return nil, fmt.Errorf("unexpected devicePath %q", devicePath)
+		}
+	}))
+
+	s.AddCleanup(fdestate.MockSecbootListContainerRecoveryKeyNames(func(devicePath string) ([]string, error) {
+		switch devicePath {
+		case "/dev/disk/by-uuid/data":
+			return dataRecoveryKeyNames, nil
+		case "/dev/disk/by-uuid/save":
+			return saveRecoveryKeyNames, nil
+		default:
+			return nil, fmt.Errorf("unexpected devicePath %q", devicePath)
+		}
+	}))
+}
+
+func (s *fdeMgrSuite) TestDoAddRecoveryKeys(c *C) {
+	const onClassic = true
+	manager := s.startedManager(c, onClassic)
+	s.mockCurrentKeys(c, nil, nil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	type testcase struct {
+		keyslots                      []fdestate.KeyslotRef
+		expectedAdds, expectedDeletes []string
+		badRecoveryKeyID              bool
+		errOn                         []string
+		expectedErr                   string
+	}
+	tcs := []testcase{
+		{
+			keyslots:     []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "tmp-default-recovery"}},
+			expectedAdds: []string{"/dev/disk/by-uuid/data:tmp-default-recovery"},
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-recovery"},
+				{ContainerRole: "system-save", Name: "tmp-default-recovery"},
+			},
+			badRecoveryKeyID: true,
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:tmp-default-recovery",
+				"/dev/disk/by-uuid/save:tmp-default-recovery",
+			},
+			expectedErr: `failed to find recovery key with id "bad-id": no recovery key entry for key-id`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-recovery"},
+				{ContainerRole: "system-save", Name: "tmp-default-recovery"},
+			},
+			badRecoveryKeyID: true,
+			errOn:            []string{"delete:/dev/disk/by-uuid/data:tmp-default-recovery"},
+			// best effort deletion for clean up
+			expectedDeletes: []string{"/dev/disk/by-uuid/save:tmp-default-recovery"},
+			expectedErr:     `failed to find recovery key with id "bad-id": no recovery key entry for key-id`,
+		},
+		{
+			keyslots:        []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default-recovery"}},
+			expectedDeletes: []string{"/dev/disk/by-uuid/data:default-recovery"},
+			expectedErr:     `key slot \(container-role: "system-data", name: "default-recovery"\) already exists`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-recovery"},
+				{ContainerRole: "system-save", Name: "tmp-default-recovery"},
+			},
+			errOn:        []string{"add:/dev/disk/by-uuid/save:tmp-default-recovery"},
+			expectedAdds: []string{"/dev/disk/by-uuid/data:tmp-default-recovery"},
+			expectedDeletes: []string{
+				"/dev/disk/by-uuid/data:tmp-default-recovery",
+				"/dev/disk/by-uuid/save:tmp-default-recovery",
+			},
+			expectedErr: `failed to add recovery key slot \(container-role: "system-save", name: "tmp-default-recovery"\): add error on /dev/disk/by-uuid/save:tmp-default-recovery`,
+		},
+	}
+	for _, tc := range tcs {
+		var expectedRecoveryKey keys.RecoveryKey
+		var added, deleted []string
+
+		defer fdestate.MockSecbootAddContainerRecoveryKey(func(devicePath, slotName string, rkey keys.RecoveryKey) error {
+			c.Check(rkey, DeepEquals, expectedRecoveryKey)
+			entry := fmt.Sprintf("%s:%s", devicePath, slotName)
+			if strutil.ListContains(tc.errOn, fmt.Sprintf("add:%s", entry)) {
+				return fmt.Errorf("add error on %s", entry)
+			}
+			added = append(added, entry)
+			return nil
+		})()
+
+		defer fdestate.MockSecbootDeleteContainerKey(func(devicePath, slotName string) error {
+			entry := fmt.Sprintf("%s:%s", devicePath, slotName)
+			if strutil.ListContains(tc.errOn, fmt.Sprintf("delete:%s", entry)) {
+				return fmt.Errorf("delete error on %s", entry)
+			}
+			deleted = append(deleted, entry)
+			return nil
+		})()
+
+		task := s.st.NewTask("add-recovery-keys", "test")
+		task.Set("keyslots", tc.keyslots)
+
+		var rkeyID string
+		var err error
+		if tc.badRecoveryKeyID {
+			rkeyID = "bad-id"
+		} else {
+			expectedRecoveryKey, rkeyID, err = manager.GenerateRecoveryKey()
+			c.Assert(err, IsNil)
+		}
+		task.Set("recovery-key-id", rkeyID)
+
+		chg := s.st.NewChange("sample", "...")
+		chg.AddTask(task)
+
+		s.settle(c)
+
+		if tc.expectedErr == "" {
+			c.Check(chg.Status(), Equals, state.DoneStatus)
+		} else {
+			c.Check(chg.Err(), ErrorMatches, fmt.Sprintf(`cannot perform the following tasks:
+- test \(%s\)`, tc.expectedErr))
+		}
+
+		sort.Strings(added)
+		c.Check(tc.expectedAdds, DeepEquals, added)
+
+		sort.Strings(deleted)
+		c.Check(tc.expectedDeletes, DeepEquals, deleted)
+	}
+}
+
+func (s *fdeMgrSuite) TestDoRemoveKeys(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+	s.mockCurrentKeys(c, nil, nil)
+
+	var deleted []string
+	defer fdestate.MockSecbootDeleteContainerKey(func(devicePath, slotName string) error {
+		c.Check(devicePath, Equals, "/dev/disk/by-uuid/data")
+		deleted = append(deleted, slotName)
+		return nil
+	})()
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	task := s.st.NewTask("remove-keys", "test")
+	task.Set("keyslots", []fdestate.KeyslotRef{
+		{ContainerRole: "system-data", Name: "default"},
+		{ContainerRole: "system-data", Name: "default-recovery"},
+		{ContainerRole: "system-data", Name: "already-deleted"},
+	})
+	chg := s.st.NewChange("sample", "...")
+	chg.AddTask(task)
+
+	s.settle(c)
+
+	sort.Strings(deleted)
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Check(deleted, DeepEquals, []string{"default", "default-recovery"})
+}
+
+func (s *fdeMgrSuite) TestDoRemoveKeysGetKeyslotsError(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+
+	defer fdestate.MockDisksDMCryptUUIDFromMountPoint(func(mountpoint string) (string, error) {
+		return "", errors.New("boom!")
+	})()
+
+	called := 0
+	defer fdestate.MockSecbootDeleteContainerKey(func(devicePath, slotName string) error {
+		called++
+		return nil
+	})()
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	task := s.st.NewTask("remove-keys", "test")
+	task.Set("keyslots", []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}})
+	chg := s.st.NewChange("sample", "...")
+	chg.AddTask(task)
+
+	s.settle(c)
+
+	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:
+- test \(failed to find key slots: cannot find UUID for mount .*/run/mnt/data: boom!\)`)
+}
+
+func (s *fdeMgrSuite) TestDoRemoveKeysRemoveError(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+	s.mockCurrentKeys(c, nil, nil)
+
+	defer fdestate.MockSecbootDeleteContainerKey(func(devicePath, slotName string) error {
+		return errors.New("boom!")
+	})()
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	task := s.st.NewTask("remove-keys", "test")
+	task.Set("keyslots", []fdestate.KeyslotRef{})
+	chg := s.st.NewChange("sample", "...")
+	chg.AddTask(task)
+
+	s.settle(c)
+
+	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:
+- test \(failed to remove key slot \(container-role: "system-data", name: "default-recovery"\): boom!\)`)
+}
+
+func (s *fdeMgrSuite) TestDoRenameKeys(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+	s.mockCurrentKeys(c, nil, nil)
+
+	renames := make(map[string]string)
+	defer fdestate.MockSecbootRenameContainerKey(func(devicePath, oldName, newName string) error {
+		renames[fmt.Sprintf("%s:%s", devicePath, oldName)] = newName
+		return nil
+	})()
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	task := s.st.NewTask("rename-keys", "test")
+	task.Set("keyslots", []fdestate.KeyslotRef{
+		{ContainerRole: "system-data", Name: "default"},
+		{ContainerRole: "system-save", Name: "default-recovery"},
+		{ContainerRole: "system-data", Name: "already-renamed"},
+	})
+	task.Set("renames", map[string]string{
+		`(container-role: "system-data", name: "default")`:          "new-default",
+		`(container-role: "system-save", name: "default-recovery")`: "new-default-recovery",
+		`(container-role: "system-data", name: "already-renamed")`:  "already-renamed",
+	})
+	chg := s.st.NewChange("sample", "...")
+	chg.AddTask(task)
+
+	s.settle(c)
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Check(renames, DeepEquals, map[string]string{
+		"/dev/disk/by-uuid/data:default":          "new-default",
+		"/dev/disk/by-uuid/save:default-recovery": "new-default-recovery",
+	})
+}
+
+func (s *fdeMgrSuite) TestDoRenameKeysMissingMapping(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	task := s.st.NewTask("rename-keys", "test")
+	task.Set("keyslots", []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}})
+	task.Set("renames", map[string]string{`(container-role: "system-data", name: "some-slot")`: "some-other-slot"})
+	chg := s.st.NewChange("sample", "...")
+	chg.AddTask(task)
+
+	s.settle(c)
+
+	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:
+- test \(internal error: cannot find mapping for \(container-role: "system-data", name: "default"\)\)`)
+}
+
+func (s *fdeMgrSuite) TestDoRenameKeysRenameError(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+	s.mockCurrentKeys(c, nil, nil)
+
+	defer fdestate.MockSecbootRenameContainerKey(func(devicePath, oldName, newName string) error {
+		return errors.New("boom!")
+	})()
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	task := s.st.NewTask("rename-keys", "test")
+	task.Set("keyslots", []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}})
+	task.Set("renames", map[string]string{`(container-role: "system-data", name: "default")`: "new-default"})
+	chg := s.st.NewChange("sample", "...")
+	chg.AddTask(task)
+
+	s.settle(c)
+
+	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:
+- test \(failed to rename key slot \(container-role: "system-data", name: "default"\) to "new-default": boom!\)`)
+}

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -350,6 +350,8 @@ func AddBootstrapKeyOnExistingDisk(node string, newKey keys.EncryptionKey) error
 // WARNING: this function is not always atomic. If cryptsetup is too
 // old, it will try to copy and delete keys instead. Please avoid
 // using this function in new code.
+//
+// XXX: s/RenameKeys/RenameContainerKeys
 func RenameKeys(node string, renames map[string]string) error {
 	targets := make(map[string]bool)
 
@@ -363,6 +365,7 @@ func RenameKeys(node string, renames map[string]string) error {
 
 	// TODO:FDEM:FIX: listing keys, then modifying could be a TOCTOU issue.
 	// we expect here nothing else is messing with the key slots.
+	// XXX: include recovery key slots sbListLUKS2ContainerRecoveryKeyNames
 	slots, err := sbListLUKS2ContainerUnlockKeyNames(node)
 	if err != nil {
 		return fmt.Errorf("cannot list slots in partition save partition: %v", err)
@@ -393,9 +396,18 @@ func RenameKeys(node string, renames map[string]string) error {
 	return nil
 }
 
+// RenameContainerKey renames a key slot on LUKS2 container. An error
+// is returned if cryptsetup does not support --token-replace option.
+func RenameContainerKey(devicePath, oldName, newName string) error {
+	return sbRenameLUKS2ContainerKey(devicePath, oldName, newName)
+}
+
 // DeleteKeys delete key slots on a LUKS2 container. Slots that do not
 // exist are ignored.
+//
+// XXX: s/DeleteKey/DeleteContainerKey
 func DeleteKeys(node string, matches map[string]bool) error {
+	// XXX: include recovery key slots sbListLUKS2ContainerRecoveryKeyNames
 	slots, err := sbListLUKS2ContainerUnlockKeyNames(node)
 	if err != nil {
 		return fmt.Errorf("cannot list slots in partition save partition: %v", err)
@@ -410,6 +422,11 @@ func DeleteKeys(node string, matches map[string]bool) error {
 	}
 
 	return nil
+}
+
+// DeleteContainerKey deletes a key slot on a LUKS2 container.
+func DeleteContainerKey(devicePath, slotName string) error {
+	return sbDeleteLUKS2ContainerKey(devicePath, slotName)
 }
 
 func findPrimaryKey(devicePath string) ([]byte, error) {
@@ -611,4 +628,15 @@ func ReadContainerKeyData(devicePath, slotName string) (KeyData, error) {
 	}
 
 	return &keyData{kd: kd}, nil
+}
+
+// AddContainerRecoveryKey adds a new recovery key to specified device.
+//
+// Note: The unlock key is implicitly obtained from the kernel keyring.
+func AddContainerRecoveryKey(devicePath string, slotName string, rkey keys.RecoveryKey) error {
+	unlockKey, err := sbGetDiskUnlockKeyFromKernel(defaultKeyringPrefix, devicePath, false)
+	if err != nil {
+		return fmt.Errorf("cannot get key from kernel keyring for unlocked disk %s: %v", devicePath, err)
+	}
+	return sbAddLUKS2ContainerRecoveryKey(devicePath, slotName, unlockKey, sb.RecoveryKey(rkey))
 }

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -2727,6 +2727,21 @@ func (s *secbootSuite) TestRenameKeysDeleteError(c *C) {
 	c.Assert(err, ErrorMatches, `cannot rename old container key: some error`)
 }
 
+func (s *secbootSuite) TestRenameContainerKey(c *C) {
+	called := 0
+	defer secboot.MockRenameLUKS2ContainerKey(func(devicePath, keyslotName, renameTo string) error {
+		called++
+		c.Check(devicePath, Equals, "/dev/foo")
+		c.Check(keyslotName, Equals, "bar")
+		c.Check(renameTo, Equals, "foo")
+		return nil
+	})()
+
+	err := secboot.RenameContainerKey("/dev/foo", "bar", "foo")
+	c.Assert(err, IsNil)
+	c.Check(called, Equals, 1)
+}
+
 func (s *secbootSuite) TestDeleteKeys(c *C) {
 	defer secboot.MockListLUKS2ContainerUnlockKeyNames(func(devicePath string) ([]string, error) {
 		c.Check(devicePath, Equals, "/dev/foo")
@@ -2818,6 +2833,20 @@ func (s *secbootSuite) TestSerializedProfile(c *C) {
 		// binary blobk is serialized to base64 by default
 		"tpm2-pcr-profile": base64.StdEncoding.EncodeToString([]byte("serialized-profile")),
 	})
+}
+
+func (s *secbootSuite) TestDeleteContainerKey(c *C) {
+	called := 0
+	defer secboot.MockDeleteLUKS2ContainerKey(func(devicePath, keyslotName string) error {
+		called++
+		c.Check(devicePath, Equals, "/dev/foo")
+		c.Check(keyslotName, Equals, "bar")
+		return nil
+	})()
+
+	err := secboot.DeleteContainerKey("/dev/foo", "bar")
+	c.Assert(err, IsNil)
+	c.Check(called, Equals, 1)
 }
 
 type testModel struct {
@@ -3802,4 +3831,43 @@ func (s *secbootSuite) TestListContainerUnlockKeyNames(c *C) {
 	keyNames, err := secboot.ListContainerUnlockKeyNames("/dev/some-device")
 	c.Assert(err, IsNil)
 	c.Check(keyNames, DeepEquals, []string{"some-slot-1", "some-slot-2"})
+}
+
+func (s *secbootSuite) TestAddContainerRecoveryKey(c *C) {
+	defer secboot.MockGetDiskUnlockKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.DiskUnlockKey, error) {
+		c.Check(prefix, Equals, "ubuntu-fde")
+		c.Check(devicePath, Equals, "/dev/foo")
+		c.Check(remove, Equals, false)
+		return sb.DiskUnlockKey{'k', 'e', 'r', 'n', 'a', 'l'}, nil
+	})()
+
+	called := 0
+	defer secboot.MockAddLUKS2ContainerRecoveryKey(func(devicePath, keyslotName string, existingKey sb.DiskUnlockKey, recoveryKey sb.RecoveryKey) error {
+		called++
+		c.Check(devicePath, Equals, "/dev/foo")
+		c.Check(keyslotName, Equals, "bar")
+		c.Check(existingKey, DeepEquals, sb.DiskUnlockKey{'k', 'e', 'r', 'n', 'a', 'l'})
+		c.Check(recoveryKey, DeepEquals, sb.RecoveryKey{'r', 'k', 'e', 'y'})
+		return nil
+	})()
+
+	err := secboot.AddContainerRecoveryKey("/dev/foo", "bar", keys.RecoveryKey{'r', 'k', 'e', 'y'})
+	c.Assert(err, IsNil)
+	c.Check(called, Equals, 1)
+}
+
+func (s *secbootSuite) TestAddContainerRecoveryKeyKeyringError(c *C) {
+	defer secboot.MockGetDiskUnlockKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.DiskUnlockKey, error) {
+		return nil, errors.New("boom!")
+	})()
+
+	called := 0
+	defer secboot.MockAddLUKS2ContainerRecoveryKey(func(devicePath, keyslotName string, existingKey sb.DiskUnlockKey, recoveryKey sb.RecoveryKey) error {
+		called++
+		return nil
+	})()
+
+	err := secboot.AddContainerRecoveryKey("/dev/foo", "bar", keys.RecoveryKey{'r', 'k', 'e', 'y'})
+	c.Assert(err, ErrorMatches, "cannot get key from kernel keyring for unlocked disk /dev/foo: boom!")
+	c.Check(called, Equals, 0)
 }


### PR DESCRIPTION
This PR adds implementation for handlers required for recovery key replacement, i.e. "add-recovery-keys", "remove-keys" and "rename-keys" along with the corresponding secboot helpers.

This is part 2 of implementing handlers for recovery key replacement which I had to break down as it was getting quite large. for context, full e2e implementation can be found in https://github.com/canonical/snapd/pull/15587.

part 1: https://github.com/canonical/snapd/pull/15588 conflict detection

Jira reference: https://warthogs.atlassian.net/browse/SNAPDENG-35117