### PR TITLE
secboot: use secboot.TestLUKS2ContainerKey helper in CheckRecoveryKey

### DIFF
--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -453,6 +453,10 @@ func MockSbGetPrimaryKeyFromKernel(f func(prefix string, devicePath string, remo
 	}
 }
 
+func MockSbTestLUKS2ContainerKey(f func(devicePath string, key []byte) bool) (restore func()) {
+	return testutil.Mock(&sbTestLUKS2ContainerKey, f)
+}
+
 func MockDisksDevlinks(f func(node string) ([]string, error)) (restore func()) {
 	old := disksDevlinks
 	disksDevlinks = f

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -55,6 +55,7 @@ var (
 	sbNewLUKS2KeyDataReader         = sbNewLUKS2KeyDataReaderImpl
 	sbSetProtectorKeys              = sb_plainkey.SetProtectorKeys
 	sbGetPrimaryKeyFromKernel       = sb.GetPrimaryKeyFromKernel
+	sbTestLUKS2ContainerKey         = sb.TestLUKS2ContainerKey
 	disksDevlinks                   = disks.Devlinks
 )
 
@@ -550,7 +551,9 @@ func GetPrimaryKey(devices []string, fallbackKeyFile string) ([]byte, error) {
 // CheckRecoveryKey tests that the specified recovery key unlocks the
 // device at the specified path.
 func CheckRecoveryKey(devicePath string, rkey keys.RecoveryKey) error {
-	// TODO:FDEM: use secboot helper when available
+	if !sbTestLUKS2ContainerKey(devicePath, rkey[:]) {
+		return fmt.Errorf("invalid recovery key for %s", devicePath)
+	}
 	return nil
 }
 


### PR DESCRIPTION
`CheckRecoveryKey` was a no-op mock, This PR updates `CheckRecoveryKey` the corresponding secboot helper now that the it has landed https://github.com/canonical/secboot/pull/422