### PR TITLE
tests: add regression test for LP 2089195

### DIFF
--- a/tests/lib/tools/snapd-state
+++ b/tests/lib/tools/snapd-state
@@ -66,10 +66,18 @@ force_autorefresh() {
 }
 
 force_snap_force_refresh_message() {
-	local SNAP="$1"
-	gojq ".data.snaps[\"$SNAP\"][\"last-refresh-time\"] = \"$(date --date='13 days ago' +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
-	gojq ".data.snaps[\"$SNAP\"][\"refresh-inhibited-time\"] = \"$(date --date='13 days ago' +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
-	mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
+    local SNAP="$1"
+    #shellcheck disable=SC2016
+    gojq \
+        --arg snap "$SNAP" \
+        --arg date "$(date --date='13 days ago' +%Y-%m-%dT%H:%M:%S%:z)" \
+        '.data.snaps[$snap]["last-refresh-time"] = $date' < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    #shellcheck disable=SC2016
+    gojq \
+        --arg snap "$SNAP" \
+        --arg date "$(date --date='13 days ago' +%Y-%m-%dT%H:%M:%S%:z)" \
+        '.data.snaps[$snap]["refresh-inhibited-time"] = $date' < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 
 prevent_autorefresh() {

--- a/tests/lib/tools/snapd-state
+++ b/tests/lib/tools/snapd-state
@@ -65,6 +65,13 @@ force_autorefresh() {
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 }
 
+force_snap_force_refresh_message() {
+	local SNAP="$1"
+	gojq ".data.snaps[\"$SNAP\"][\"last-refresh-time\"] = \"$(date --date='13 days ago' +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+	gojq ".data.snaps[\"$SNAP\"][\"refresh-inhibited-time\"] = \"$(date --date='13 days ago' +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+	mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
+}
+
 prevent_autorefresh() {
     gojq ".data[\"last-refresh\"] = \"$(date +%Y-%m-%dT%H:%M:%S%:z)\"" < /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json

--- a/tests/regression/lp-2089195/task.yaml
+++ b/tests/regression/lp-2089195/task.yaml
@@ -1,0 +1,74 @@
+summary: Ensure that snapd stops monitoring snaps which are no longer refresh candidates
+
+details: |
+    Check that https://bugs.launchpad.net/snapd/+bug/2089195 is fixed
+
+    TODO: expand description
+
+systems:
+    - ubuntu-2*
+
+environment:
+    SNAP_REEXEC/reexec0: 0 # should fail with reexec set to 0 when system deb version is < 2.68
+    SNAP_REEXEC/reexec1: 1
+
+prepare: |
+    # Ensure no other refreshes interfere with the test
+    snap refresh
+
+    snap install --stable test-snapd-sh
+    tests.cleanup defer retry -n 50 --wait 1 snap remove --purge test-snapd-sh
+
+execute: |
+    # Make sure an app keeps the test snap busy
+    test-snapd-sh.sh -c 'exec sleep 300' &
+    PID="$!"
+
+    # Switch test-snapd-sh to the edge channel to make it a refresh candidate
+    # Note that test-snapd-sh has different revisions in stable and edge
+    snap switch --edge test-snapd-sh
+
+    # Trigger auto-refresh
+    snap unset system refresh.hold
+    systemctl stop snapd.{service,socket}
+    "$TESTSTOOLS"/snapd-state force-autorefresh
+    # Set refresh inhibited timestamp to within a day of the 14-day limit
+    "$TESTSTOOLS"/snapd-state force-snap-force-refresh-message test-snapd-sh
+    systemctl start snapd.{socket,service}
+
+    # Wait for snap to be monitored
+    if [ "$SNAP_REEXEC" -eq 1 ] ; then
+        # Only newer snapd has 'snap debug refresh-app-awareness'
+        retry -n 50 --wait 1 sh -c 'snap debug refresh-app-awareness | MATCH "Monitored snaps"'
+    fi
+    retry -n 50 --wait 1 sh -c "jq '.data.\"refresh-candidates\" | has(\"test-snapd-sh\")' /var/lib/snapd/state.json | MATCH true"
+    jq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
+
+    # Switch test-snapd-sh back to latest/stable so it will no longer be a refresh candidate
+    snap switch --stable test-snapd-sh
+
+    # test-snapd-sh should still be a refresh candidate and monitored until snapd restart
+    if [ "$SNAP_REEXEC" -eq 1 ] ; then
+        # Only newer snapd has 'snap debug refresh-app-awareness'
+        snap debug refresh-app-awareness | MATCH "Monitored snaps"
+    fi
+    jq '.data."refresh-candidates" | has("test-snapd-sh")' /var/lib/snapd/state.json | MATCH true
+    jq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
+
+    # Restart snapd again and re-trigger auto-refresh
+    systemctl stop snapd.{service,socket}
+    "$TESTSTOOLS"/snapd-state force-autorefresh
+    systemctl start snapd.{socket,service}
+
+    # test-snapd-sh should no longer be a refresh candidate
+    retry -n 10 --wait 1 sh -c "jq '.data.\"refresh-candidates\" | has(\"test-snapd-sh\")' /var/lib/snapd/state.json | MATCH false"
+
+    # test-snapd-sh should no longer be monitored
+    # (this should fail with old snapd prior to the fix)
+    if [ "$SNAP_REEXEC" -eq 1 ] ; then
+        retry -n 10 --wait 1 sh -c 'snap debug refresh-app-awareness | wc -l | MATCH "^0$"'
+    fi
+    # TODO: find some better way to check whether the snapd-desktop-integration
+    # message occurs warning about the snap being force-refreshed after some time
+
+    kill "$PID"

--- a/tests/regression/lp-2089195/task.yaml
+++ b/tests/regression/lp-2089195/task.yaml
@@ -19,6 +19,11 @@ prepare: |
     snap install --stable test-snapd-sh
     tests.cleanup defer retry -n 50 --wait 1 snap remove --purge test-snapd-sh
 
+debug: |
+    snap version
+
+    journalctl -xeu snapd.service
+
 execute: |
     # Make sure an app keeps the test snap busy
     test-snapd-sh.sh -c 'exec sleep 300' &
@@ -42,7 +47,8 @@ execute: |
         retry -n 50 --wait 1 sh -c 'snap debug refresh-app-awareness | MATCH "Monitored snaps"'
     fi
     retry -n 50 --wait 1 sh -c "gojq '.data.\"refresh-candidates\" | has(\"test-snapd-sh\")' /var/lib/snapd/state.json | MATCH true"
-    gojq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
+    gojq '.data."refresh-candidates"."test-snapd-sh" | has("monitored")' /var/lib/snapd/state.json | MATCH true
+    gojq '.data."refresh-candidates"."test-snapd-sh".monitored' /var/lib/snapd/state.json | MATCH true
 
     # Switch test-snapd-sh back to latest/stable so it will no longer be a refresh candidate
     snap switch --stable test-snapd-sh
@@ -53,7 +59,8 @@ execute: |
         snap debug refresh-app-awareness | MATCH "Monitored snaps"
     fi
     gojq '.data."refresh-candidates" | has("test-snapd-sh")' /var/lib/snapd/state.json | MATCH true
-    gojq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
+    gojq '.data."refresh-candidates"."test-snapd-sh" | has("monitored")' /var/lib/snapd/state.json | MATCH true
+    gojq '.data."refresh-candidates"."test-snapd-sh".monitored' /var/lib/snapd/state.json | MATCH true
 
     # Restart snapd again and re-trigger auto-refresh
     systemctl stop snapd.{service,socket}

--- a/tests/regression/lp-2089195/task.yaml
+++ b/tests/regression/lp-2089195/task.yaml
@@ -41,8 +41,8 @@ execute: |
         # Only newer snapd has 'snap debug refresh-app-awareness'
         retry -n 50 --wait 1 sh -c 'snap debug refresh-app-awareness | MATCH "Monitored snaps"'
     fi
-    retry -n 50 --wait 1 sh -c "jq '.data.\"refresh-candidates\" | has(\"test-snapd-sh\")' /var/lib/snapd/state.json | MATCH true"
-    jq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
+    retry -n 50 --wait 1 sh -c "gojq '.data.\"refresh-candidates\" | has(\"test-snapd-sh\")' /var/lib/snapd/state.json | MATCH true"
+    gojq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
 
     # Switch test-snapd-sh back to latest/stable so it will no longer be a refresh candidate
     snap switch --stable test-snapd-sh
@@ -52,8 +52,8 @@ execute: |
         # Only newer snapd has 'snap debug refresh-app-awareness'
         snap debug refresh-app-awareness | MATCH "Monitored snaps"
     fi
-    jq '.data."refresh-candidates" | has("test-snapd-sh")' /var/lib/snapd/state.json | MATCH true
-    jq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
+    gojq '.data."refresh-candidates" | has("test-snapd-sh")' /var/lib/snapd/state.json | MATCH true
+    gojq '.data."refresh-candidates"."test-snapd-sh".monitored' | MATCH true
 
     # Restart snapd again and re-trigger auto-refresh
     systemctl stop snapd.{service,socket}
@@ -61,7 +61,7 @@ execute: |
     systemctl start snapd.{socket,service}
 
     # test-snapd-sh should no longer be a refresh candidate
-    retry -n 10 --wait 1 sh -c "jq '.data.\"refresh-candidates\" | has(\"test-snapd-sh\")' /var/lib/snapd/state.json | MATCH false"
+    retry -n 10 --wait 1 sh -c "gojq '.data.\"refresh-candidates\" | has(\"test-snapd-sh\")' /var/lib/snapd/state.json | MATCH false"
 
     # test-snapd-sh should no longer be monitored
     # (this should fail with old snapd prior to the fix)


### PR DESCRIPTION
This is an attempt at adding a regression test which reproduces https://bugs.launchpad.net/snapd/+bug/2089195 in snapd without the fix from https://github.com/canonical/snapd/pull/15016

My intention is that this spread test can be used as a basis for a reproducer and test that the bug is fixed in the 2.68.5 deb package, so it can be released to the archives. The `SNAP_REEXEC` variable is used to set whether the existing snapd deb or the new snapd snap is used. At the moment, the `SNAP_REEXEC: 0` variant should fail, as the system snapd debs don't yet have the fix. If/when this PR lands, we probably want to remove the variants if we don't want to test the system snapd deb.

This is a work-in-progress, I'm having trouble getting the situation addressed by the fix to reliably occur: https://github.com/canonical/snapd/pull/15016/files?diff=unified&w=0#diff-00d6af4a298e5274422799eac8a04e66a2087322bcb3515a1814623ecafe3ab3R971-R976

The original bug is about the pop-up from snapd-desktop-integration showing the "<snap-title> will quit and update in <duration>" message, but at the moment I'm using the check for whether the snap is monitored as a stand-in for that, as I'm not exactly sure how to get the message to occur reliably. I think I was able to reproduce this once though.

![pop-up](https://launchpadlibrarian.net/759639946/Screenshot%20from%202024-11-20%2016-38-45.png)

The way I'm checking this also relies on the new `snap debug refresh-app-awareness` command, which isn't available in the existing deb, so that's another problem. Perhaps the snapd snap needs to be used for `snap` commands while it's ensured that the snapd daemon obeys `SNAP_REEXEC`.

I think there's a problem with quote escaping which is currently breaking the test, since the retry exits after the first failure, but I need to investigate more.

I'm having trouble getting the proceed-time to be set, that's what puts the duration in the snapd-desktop-integration pop-up.