### PR TITLE
tests/lib/snaps/test-snap-component-hooks: access snapcraft.io through a proxy if needed

### DIFF
--- a/tests/lib/snaps/test-snap-component-hooks/two-hooks/install
+++ b/tests/lib/snaps/test-snap-component-hooks/two-hooks/install
@@ -6,6 +6,11 @@ if nc -l 127.0.0.1 12345; then
     echo "should not be able to bind to anything"
 fi
 
-nc -zv snapcraft.io 80
+proxy_arg=
+if [ -n "$HTTP_PROXY" ]; then
+    proxy_arg="-x $HTTP_PROXY"
+fi
+# shellcheck disable=SC2086
+nc -zv $proxy_arg snapcraft.io 80
 
 snapctl set two-installed="${SNAP_COMPONENT_REVISION}"

--- a/tests/lib/snaps/test-snap-component-hooks/two-hooks/post-refresh
+++ b/tests/lib/snaps/test-snap-component-hooks/two-hooks/post-refresh
@@ -6,6 +6,11 @@ if nc -l 127.0.0.1 12345; then
     echo "should not be able to bind to anything"
 fi
 
-nc -zv snapcraft.io 80
+proxy_arg=
+if [ -n "$HTTP_PROXY" ]; then
+    proxy_arg="-x $HTTP_PROXY"
+fi
+# shellcheck disable=SC2086
+nc -zv $proxy_arg snapcraft.io 80
 
 snapctl set two-postrefreshed="${SNAP_COMPONENT_REVISION}"

--- a/tests/lib/snaps/test-snap-component-hooks/two-hooks/pre-refresh
+++ b/tests/lib/snaps/test-snap-component-hooks/two-hooks/pre-refresh
@@ -6,6 +6,11 @@ if nc -l 127.0.0.1 12345; then
     echo "should not be able to bind to anything"
 fi
 
-nc -zv snapcraft.io 80
+proxy_arg=
+if [ -n "$HTTP_PROXY" ]; then
+    proxy_arg="-x $HTTP_PROXY"
+fi
+# shellcheck disable=SC2086
+nc -zv $proxy_arg snapcraft.io 80
 
 snapctl set two-prerefreshed="${SNAP_COMPONENT_REVISION}"

--- a/tests/lib/snaps/test-snap-component-hooks/two-hooks/remove
+++ b/tests/lib/snaps/test-snap-component-hooks/two-hooks/remove
@@ -6,6 +6,11 @@ if nc -l 127.0.0.1 12345; then
     echo "should not be able to bind to anything"
 fi
 
-nc -zv snapcraft.io 80
+proxy_arg=
+if [ -n "$HTTP_PROXY" ]; then
+    proxy_arg="-x $HTTP_PROXY"
+fi
+# shellcheck disable=SC2086
+nc -zv $proxy_arg snapcraft.io 80
 
 echo "ran remove hook" > /tmp/two-remove-hook-executed


### PR DESCRIPTION
Attempt to fix the test execution on PS7 and access snapcraft.io through a proxy if one is configured in the environment.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
