### PR TITLE
i/builtin: add cap dac_read_search to log-observe

### DIFF
--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -72,6 +72,11 @@ const logObserveConnectedPlugAppArmor = `
 # Needed since we are root and the owner/group doesn't match :\
 # So long as we have this, the cap must be reserved.
 capability dac_override,
+
+# Needed so AppArmor doesn't spam the log with messages https://bugs.launchpad.net/snapd/+bug/2098780
+# It enables 'open_by_handle_at' which could be used to escape confinement but 
+# it's currently blocked by seccomp.
+capability dac_read_search,
 `
 
 var logObserveConnectedPlugUDev = []string{


### PR DESCRIPTION
Add dac_read_search to log-observe so telemetry agent snaps don't cause the log from being spammed with AppArmor messages. For context: https://bugs.launchpad.net/snapd/+bug/2098780
