### PR TITLE
secboot: update to rev 97bf6d7fa895 (add public API CheckPassphraseEntropy)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250603103321-7fb379721237
+	github.com/snapcore/secboot v0.0.0-20250619093200-3dd8877a2a1c
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250619093200-3dd8877a2a1c
+	github.com/snapcore/secboot v0.0.0-20250619100227-97bf6d7fa895
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0
@@ -41,6 +41,7 @@ require go.etcd.io/bbolt v1.3.9
 require (
 	github.com/canonical/cpuid v0.0.0-20220614022739-219e067757cb // indirect
 	github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9 // indirect
+	github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54 // indirect
 	github.com/canonical/tcglog-parser v0.0.0-20240924110432-d15eaf652981 // indirect
 	github.com/kr/pretty v0.2.2-0.20200810074440-814ac30b4b18 // indirect
 	github.com/kr/text v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraK
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20250603103321-7fb379721237 h1:5Flx4mNtQgWcG7cqFdIJsDfL1rnbp8nucqexrMmCpBQ=
-github.com/snapcore/secboot v0.0.0-20250603103321-7fb379721237/go.mod h1:Y3APoLyInDvY8mVP1qDQd/t9bPuNp2itYPCGrltRQoQ=
+github.com/snapcore/secboot v0.0.0-20250619093200-3dd8877a2a1c h1:WdGjhfH7U1tZws+RiQNdwuMBZ/chp6Js4yKraTn7+mQ=
+github.com/snapcore/secboot v0.0.0-20250619093200-3dd8877a2a1c/go.mod h1:Y3APoLyInDvY8mVP1qDQd/t9bPuNp2itYPCGrltRQoQ=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/canonical/go-efilib v1.4.1 h1:/VMNCypz+iVmnNuMcsm7WvmDMI1ObkEP2W1h8Ls
 github.com/canonical/go-efilib v1.4.1/go.mod h1:n0Ttsy1JuHAvqaFbZBs6PAzoiiJdfkHsAmDOEbexYEQ=
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9 h1:Twk1ZSTWRClfGShP16ePf2JIiayqWS4ix1rkAR6baag=
 github.com/canonical/go-kbkdf v0.0.0-20250104172618-3b1308f9acf9/go.mod h1:IneQ5/yQcfPXrGekEXpR6yeea55ZD24N5+kHzeDseOM=
+github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54 h1:JO3wAsxjrvQDf/X3q4RLIdzDCWrFjzhwUmCKrhnrIO8=
+github.com/canonical/go-password-validator v0.0.0-20250617132709-1b205303ca54/go.mod h1:Vy3kTKlJTJ7gav1xGV9Bek08cUsh90hK7pK7mY34GnU=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=
 github.com/canonical/go-tpm2 v1.12.2 h1:7sWef6xVlWwBAn7hsY+3j62ANzoAO+GZvrltMHXq9RQ=
@@ -55,6 +57,8 @@ github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0E
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
 github.com/snapcore/secboot v0.0.0-20250619093200-3dd8877a2a1c h1:WdGjhfH7U1tZws+RiQNdwuMBZ/chp6Js4yKraTn7+mQ=
 github.com/snapcore/secboot v0.0.0-20250619093200-3dd8877a2a1c/go.mod h1:Y3APoLyInDvY8mVP1qDQd/t9bPuNp2itYPCGrltRQoQ=
+github.com/snapcore/secboot v0.0.0-20250619100227-97bf6d7fa895 h1:4iDtDFbUAURS+HLOxld/2HsTZGQOoahlCW7bpLRQ5+o=
+github.com/snapcore/secboot v0.0.0-20250619100227-97bf6d7fa895/go.mod h1:wAegBu6zUprmzGDroFbSF3CFvtpXCs2gkuXUG8VBuD4=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -159,7 +159,7 @@ nested_uc20_transition_to_system_mode() {
 
     local current_boot_id
     current_boot_id=$(nested_get_boot_id)
-    remote.exec "sudo snap reboot --$mode $recovery_system"
+    remote.exec "sudo snap reboot --$mode $recovery_system" || true
     nested_wait_for_reboot "$current_boot_id"
 
     # verify we are now in the requested mode

--- a/tests/nested/manual/kernel-modules-components/task.yaml
+++ b/tests/nested/manual/kernel-modules-components/task.yaml
@@ -75,8 +75,19 @@ execute: |
 
   # Install again, but force a failure to check revert
   boot_id=$(tests.nested boot-id)
+  remote.exec sudo systemd-inhibit bash <<\EOF &
+  count=0
+  while ! [ -e /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi ]; do
+    if [ "$((count++))" -gt 300 ]; then
+      exit 1
+    fi
+    sleep 1
+  done
+  rm /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi
+  EOF
+  kernel_remover="${!}"
   remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel.snap "$comp_file")
-  remote.retry --wait 1 -n 600 'sudo rm /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi'
+  wait "${kernel_remover}"
   tests.nested wait-for reboot "$boot_id"
   # Note that snap watch will end with error
   not remote.exec sudo snap watch "$remote_chg_id"

--- a/tests/nested/manual/kernel-modules-components/task.yaml
+++ b/tests/nested/manual/kernel-modules-components/task.yaml
@@ -76,7 +76,7 @@ execute: |
   # Install again, but force a failure to check revert
   boot_id=$(tests.nested boot-id)
   remote_chg_id=$(remote.exec sudo snap install --no-wait --dangerous pc-kernel.snap "$comp_file")
-  remote.retry --wait 1 -n 300 'sudo rm /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi'
+  remote.retry --wait 1 -n 600 'sudo rm /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi'
   tests.nested wait-for reboot "$boot_id"
   # Note that snap watch will end with error
   not remote.exec sudo snap watch "$remote_chg_id"


### PR DESCRIPTION
Update secboot to make available the [non amd build fix](https://github.com/canonical/secboot/commit/3dd8877a2a1c8ce3b1ab8322521ea8f0c3729762) and [provide public 
API CheckPassphraseEntropy](https://github.com/canonical/secboot/commit/97bf6d7fa895ebab5e3e10d2a86ee58154c1e76a).

The fix was verified to solve the build issue [here](https://github.com/canonical/snapd/actions/runs/15756045938/job/44411598494?pr=15569): which in turn enables us to merge https://github.com/canonical/snapd/pull/15569, once it is rebased and the API is required to complete snapd entropy work.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-34453