### PR TITLE
github: add a ruleset to arm nested tests

### DIFF
--- a/.github/workflows/data-nested-systems.json
+++ b/.github/workflows/data-nested-systems.json
@@ -38,7 +38,7 @@
         "alternative-backend": "google-nested-arm",
         "systems": "ubuntu-24.04-arm-64",
         "tasks": "tests/nested/core/core20-basic",
-        "rules": ""
+        "rules": "nested"
       }
    ]
 }

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -180,7 +180,7 @@ jobs:
                     TASKS_TO_RUN="$TASKS_TO_RUN $prefix:$TASKS"
                 done
             else
-                NEW_TASKS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "$prefix" $changes_param)"
+                NEW_TASKS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "$prefix" $changes_param -t "${{ inputs.tasks }}")"
                 TASKS_TO_RUN="$NEW_TASKS"
             fi
             echo "$TASKS_TO_RUN"

--- a/tests/lib/external/snapd-testing-tools/tests/spread-filter/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/spread-filter/task.yaml
@@ -89,3 +89,34 @@ execute: |
     # Scenario: check the rules file
     FILE_TEXT="spread-filter: rules file 'noexist.yaml' does not exist"
     spread-filter -r noexist.yaml -p google:ubuntu -c tests/lib/nested.sh 2>&1 | MATCH "$FILE_TEXT"
+
+    # Scenario: When specifying a specific task, any changes that would cause the entire
+    # suite to run, only cause that specified file to run
+    spread-filter -r rules.yaml -p google:ubuntu -c some-path/some-file.go -t tests/main/test1 > res
+    MATCH "^google:ubuntu:tests/main/test1$" < res
+
+    # Scenario: When specifying a specific task, any change to that file will cause it to run
+    spread-filter -r rules.yaml -p google:ubuntu -c tests/main/test1/task.yaml -t tests/main/test1 > res
+    MATCH "^google:ubuntu:tests/main/test1$" < res
+
+    # Scenario: When specifying a specific task, any change to a different test will not cause it to run
+    spread-filter -r rules.yaml -p google:ubuntu -c tests/main/test2/task.yaml -t tests/main/test1 > res
+    test "$(wc -w < res)" -eq 0
+
+    # Scenario: When specifying a task folder, any changes that would cause the entire
+    # suite to run, only result in that folder
+    spread-filter -r rules.yaml -p google:ubuntu -c some-path/some-file.go -t tests/nested/core/ > res
+    MATCH "^google:ubuntu:tests/nested/core/$" < res
+
+    # Scenario: When specifying a task folder, any changes that would cause the entire
+    # suite to run, only result in that folder
+    spread-filter -r rules.yaml -p google:ubuntu -c tests/lib/nested.sh -t tests/nested/core/ > res
+    MATCH "^google:ubuntu:tests/nested/core/$" < res
+
+    # Scenario: When specifying a task folder, any change within that folder will only run that change
+    spread-filter -r rules.yaml -p google:ubuntu -c tests/nested/core/test1/task.yaml -c tests/nested/core/test2/task.yaml -t tests/nested/core/ > res
+    MATCH "^google:ubuntu:tests/nested/core/test1 google:ubuntu:tests/nested/core/test2$" < res
+
+    # Scenario: When specifying a task folder, any change to a task in a different folder will not cause it to run
+    spread-filter -r rules.yaml -p google:ubuntu -c tests/nested/test1/task.yaml -t tests/nested/core/ > res
+    test "$(wc -w < res)" -eq 0

--- a/tests/lib/external/snapd-testing-tools/tests/spread-filter/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/spread-filter/task.yaml
@@ -90,33 +90,33 @@ execute: |
     FILE_TEXT="spread-filter: rules file 'noexist.yaml' does not exist"
     spread-filter -r noexist.yaml -p google:ubuntu -c tests/lib/nested.sh 2>&1 | MATCH "$FILE_TEXT"
 
-    # Scenario: When specifying a specific task, any changes that would cause the entire
+    # Scenario: When naming a specific task, any changes that would cause the entire
     # suite to run, only cause that specified file to run
     spread-filter -r rules.yaml -p google:ubuntu -c some-path/some-file.go -t tests/main/test1 > res
     MATCH "^google:ubuntu:tests/main/test1$" < res
 
-    # Scenario: When specifying a specific task, any change to that file will cause it to run
+    # Scenario: When naming a specific task, any change to that file will cause it to run
     spread-filter -r rules.yaml -p google:ubuntu -c tests/main/test1/task.yaml -t tests/main/test1 > res
     MATCH "^google:ubuntu:tests/main/test1$" < res
 
-    # Scenario: When specifying a specific task, any change to a different test will not cause it to run
+    # Scenario: When naming a specific task, any change to a different test will not cause it to run
     spread-filter -r rules.yaml -p google:ubuntu -c tests/main/test2/task.yaml -t tests/main/test1 > res
     test "$(wc -w < res)" -eq 0
 
-    # Scenario: When specifying a task folder, any changes that would cause the entire
+    # Scenario: When naming a task folder, any changes that would cause the entire
     # suite to run, only result in that folder
     spread-filter -r rules.yaml -p google:ubuntu -c some-path/some-file.go -t tests/nested/core/ > res
     MATCH "^google:ubuntu:tests/nested/core/$" < res
 
-    # Scenario: When specifying a task folder, any changes that would cause the entire
+    # Scenario: When naming a task folder, any changes that would cause the entire
     # suite to run, only result in that folder
     spread-filter -r rules.yaml -p google:ubuntu -c tests/lib/nested.sh -t tests/nested/core/ > res
     MATCH "^google:ubuntu:tests/nested/core/$" < res
 
-    # Scenario: When specifying a task folder, any change within that folder will only run that change
+    # Scenario: When naming a task folder, any change within that folder will only run that change
     spread-filter -r rules.yaml -p google:ubuntu -c tests/nested/core/test1/task.yaml -c tests/nested/core/test2/task.yaml -t tests/nested/core/ > res
     MATCH "^google:ubuntu:tests/nested/core/test1 google:ubuntu:tests/nested/core/test2$" < res
 
-    # Scenario: When specifying a task folder, any change to a task in a different folder will not cause it to run
+    # Scenario: When naming a task folder, any change to a task in a different folder will not cause it to run
     spread-filter -r rules.yaml -p google:ubuntu -c tests/nested/test1/task.yaml -t tests/nested/core/ > res
     test "$(wc -w < res)" -eq 0

--- a/tests/lib/external/snapd-testing-tools/tests/spread-filter/tests/nested/core/test1/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/spread-filter/tests/nested/core/test1/task.yaml
@@ -1,0 +1,6 @@
+summary: test file
+
+details: test file
+
+execute: |
+  echo "works"

--- a/tests/lib/external/snapd-testing-tools/tests/spread-filter/tests/nested/core/test2/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/spread-filter/tests/nested/core/test2/task.yaml
@@ -1,0 +1,6 @@
+summary: test file
+
+details: test file
+
+execute: |
+  echo "works"

--- a/tests/lib/external/snapd-testing-tools/utils/spread-filter
+++ b/tests/lib/external/snapd-testing-tools/utils/spread-filter
@@ -163,7 +163,7 @@ class ExecutionManager:
         return final_executions
 
     # Retrieves the list of tests to execute
-    def get_executions(self, changes: list[str]) -> list[str]:
+    def get_executions(self, changes: list[str], tasks: list[str]) -> list[str]:
         all_executions = []
         for change in changes:
             executions = self.rules.calc_executions(change)
@@ -172,7 +172,7 @@ class ExecutionManager:
             for execution in executions:
                 if execution == self.SELF:
                     self_execution = self._calc_self(change)
-                    if self_execution != "":
+                    if self_execution != "" and (not tasks or any(task for task in tasks if self_execution.startswith(task))):
                         all_executions.append(self_execution)
                 # When the tests to run are tagged as NONE means that no tests
                 # have to be executed
@@ -180,7 +180,13 @@ class ExecutionManager:
                     continue
                 # Otherwise, what is defined in to (literal) is executed.
                 else:
-                    all_executions.append(self._get_test_exec_dir(execution))
+                    dir = self._get_test_exec_dir(execution)
+                    if tasks:
+                        for task in tasks:
+                            if task.startswith(dir):
+                                all_executions.append(task)
+                    else:
+                        all_executions.append(dir)
 
         cleaned_executions = self._clean_executions(all_executions)
         return self._get_execution_param(cleaned_executions)
@@ -199,6 +205,7 @@ def _make_parser() -> argparse.ArgumentParser:
         "-c", "--change", action="append", default=[], help="File that changed"
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")
+    parser.add_argument("-t", "--tasks", default='', type=str)
 
     return parser
 
@@ -216,5 +223,5 @@ if __name__ == "__main__":
         sys.exit(1)
 
     execution_manager = ExecutionManager(args.rules_file, args.prefix, args.verbose)
-    execution_list = execution_manager.get_executions(args.change)
+    execution_list = execution_manager.get_executions(args.change, args.tasks.replace('...', '').split())
     print(" ".join(map(str, execution_list)))


### PR DESCRIPTION
When determining tasks to run in the `spread-test.yaml`, if a rule is not specified, then it will automatically run all nested tests since `spread-filter` requires a rule to determine what tests to run. This caused the nested arm test to always run in all PRs without the 'Skip spread' label.

```bash
if [ -z "${{ github.event.number }}" ] || [ "$RUN_NESTED" = 'true' ] || [ -z "${{ inputs.rules }}" ] || [ -z "$changes_param" ]; then
    for TASKS in ${{ inputs.tasks }}; do
        TASKS_TO_RUN="$TASKS_TO_RUN $prefix:$TASKS"
    done
else
    NEW_TASKS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "$prefix" $changes_param)"
    TASKS_TO_RUN="$NEW_TASKS"
fi
```

To ensure that only the paths indicated in tasks will run, this adds an additional input to the `spread-filter` that removes any found items that are not part of the task list. An alternative method would be to add a new rule file, though I thought adding an additional filter level based on the task list more intuitive anyway.

Assuming the reviewers accept this approach, I will update the spread-filter in snapd-testing-tools as well.

## Examples:

When otherwise the entire test suite would be run, it only runs the indicated task
```
$ ./tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p google-nested-arm:ubuntu-24.04-arm-64 -c secboot/some-file.go -t tests/nested/core/core20-basic
google-nested-arm:ubuntu-24.04-arm-64:tests/nested/core/core20-basic
```
If I do not specify the task, then it will not override the rules and will run the entire suite:
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p google-nested-arm:ubuntu-24.04-arm-64 -c secboot/some-file.go
google-nested-arm:ubuntu-24.04-arm-64:tests/nested/
```

Or if I specify the entire suite as my task, then the output remains the same:
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p google-nested-arm:ubuntu-24.04-arm-64 -c secboot/some-file.go -t tests/nested/...
google-nested-arm:ubuntu-24.04-arm-64:tests/nested/
```
I can also specify multiple tasks
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p google-nested-arm:ubuntu-24.04-arm-64 -c secboot/some-file.go -t "tests/nested/core/core20-basic tests/nested/manual/broken-model"
google-nested-arm:ubuntu-24.04-arm-64:tests/nested/manual/broken-model google-nested-arm:ubuntu-24.04-arm-64:tests/nested/core/core20-basic
```
### Adding the task list will not change how currently run tasks are calculated:

#### With multiple tasks
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/trusty.yaml -p google:ubuntu-14.04-64 -c some-file.go
google:ubuntu-14.04-64:tests/main/canonical-livepatch-14.04 google:ubuntu-14.04-64:tests/main/canonical-livepatch google:ubuntu-14.04-64:tests/smoke/

$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/trusty.yaml -p google:ubuntu-14.04-64 -c some-file.go -t 'tests/smoke/ tests/main/canonical-livepatch tests/main/canonical-livepatch-14.04'
google:ubuntu-14.04-64:tests/main/canonical-livepatch-14.04 google:ubuntu-14.04-64:tests/main/canonical-livepatch google:ubuntu-14.04-64:tests/smoke/
```
#### With a singular task
```
$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p google-nested:ubuntu-24.04-64 -c secboot/some-file.go
google-nested:ubuntu-24.04-64:tests/nested/

$ tests/lib/external/snapd-testing-tools/utils/spread-filter -r tests/lib/spread/rules/nested.yaml -p google-nested:ubuntu-24.04-64 -c secboot/some-file.go -t "tests/nested/..."
google-nested:ubuntu-24.04-64:tests/nested/
```

## What it looks like when spread tests are run
You can see the proper spread arguments here (run with 'Run nested' label):
https://github.com/canonical/snapd/actions/runs/15760135095/job/44425476107#step:21:90

or here with multiple systems:
https://github.com/canonical/snapd/actions/runs/15760135095/job/44425475949#step:21:89

Without the 'Run nested' label, the tests are skipped
https://github.com/canonical/snapd/actions/runs/15760135095/job/44426754015#step:21:88