### PR TITLE
confdb: support list indexing paths in confdb-schema 

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -462,12 +462,12 @@ func validateRequestStoragePair(request, storage string) (reqAccessors []accesso
 		return nil, nil, fmt.Errorf("invalid storage %q: %w", storage, err)
 	}
 
-	reqKeyVars, err := getPlaceholdersOfType(reqAccessors, keyPlaceholderType)
+	reqKeyVars, err := countAccessorsOfType(reqAccessors, keyPlaceholderType)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	storageKeyVars, err := getPlaceholdersOfType(storageAccessors, keyPlaceholderType)
+	storageKeyVars, err := countAccessorsOfType(storageAccessors, keyPlaceholderType)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -479,12 +479,12 @@ func validateRequestStoragePair(request, storage string) (reqAccessors []accesso
 	}
 
 	// check that the request and storage list index placeholders match
-	reqIndexVars, err := getPlaceholdersOfType(reqAccessors, indexPlaceholderType)
+	reqIndexVars, err := countAccessorsOfType(reqAccessors, indexPlaceholderType)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	storageIndexVars, err := getPlaceholdersOfType(storageAccessors, indexPlaceholderType)
+	storageIndexVars, err := countAccessorsOfType(storageAccessors, indexPlaceholderType)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -581,10 +581,10 @@ type accessor interface {
 	name() string
 
 	// access returns the value of the sub-key wrapped in any separators or brackets
-	// the type may require
+	// the type may require to be composed into a path.
 	access() string
 
-	// keytype returns a type that represents the kind of path sub-key the accessor is.
+	// keyType returns a type that represents the kind of path sub-key the accessor is.
 	keyType() keyType
 }
 
@@ -657,15 +657,15 @@ func splitViewPath(path string) ([]string, error) {
 	return subkeys, nil
 }
 
-// getPlaceholdersOfType returns the number of occurrences of placeholder names,
-// for a given type of placeholder.
-func getPlaceholdersOfType(accessors []accessor, keyType keyType) (map[string]int, error) {
-	var placeholders map[string]int
+// countAccessorsOfType returns the number of occurrences of path sub-keys of
+// a given type of accessor (e.g., key placeholder, etc).
+func countAccessorsOfType(accessors []accessor, keyType keyType) (map[string]int, error) {
+	var freqs map[string]int
 	count := func(key accessor) {
-		if placeholders == nil {
-			placeholders = make(map[string]int)
+		if freqs == nil {
+			freqs = make(map[string]int)
 		}
-		placeholders[key.name()]++
+		freqs[key.name()]++
 	}
 
 	for _, acc := range accessors {
@@ -676,7 +676,7 @@ func getPlaceholdersOfType(accessors []accessor, keyType keyType) (map[string]in
 		count(acc)
 	}
 
-	return placeholders, nil
+	return freqs, nil
 }
 
 // View returns a view from the confdb schema.

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -847,6 +847,7 @@ func (v *View) Unset(databag Databag, request string) error {
 
 func (v *View) matchWriteRequest(request string) ([]requestMatch, error) {
 	var matches []requestMatch
+	// TODO: replace with []accessors
 	subkeys, err := splitViewPath(request)
 	if err != nil {
 		return nil, err
@@ -1392,6 +1393,7 @@ type requestMatch struct {
 func (v *View) matchGetRequest(request string) (matches []requestMatch, err error) {
 	var subkeys []string
 	if request != "" {
+		// TODO: replace with []accessors
 		subkeys, err = splitViewPath(request)
 		if err != nil {
 			return nil, err

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -173,7 +173,7 @@ func (*viewSuite) TestNewConfdb(c *C) {
 		cmt := Commentf("test number %d", i+1)
 		confdb, err := confdb.NewSchema("acc", "foo", tc.confdb, confdb.NewJSONSchema())
 		if tc.err != "" {
-			c.Assert(err, NotNil)
+			c.Assert(err, NotNil, cmt)
 			c.Assert(err.Error(), Equals, tc.err, cmt)
 		} else {
 			c.Assert(err, IsNil, cmt)
@@ -2964,6 +2964,7 @@ func (*viewSuite) TestRequestMatch(c *C) {
 		"foo": map[string]any{
 			"rules": []any{
 				map[string]any{"request": "a[1].bar", "storage": "b[1].bar"},
+				map[string]any{"request": "c", "storage": "d", "content": []any{map[string]any{"storage": "[0].bar"}}},
 				map[string]any{"request": "a[{n}].baz", "storage": "b[{n}].baz"},
 			},
 		},
@@ -2980,6 +2981,11 @@ func (*viewSuite) TestRequestMatch(c *C) {
 	c.Assert(err, IsNil)
 	match = confdb.RequestMatch(matches[0])
 	c.Assert(match.StoragePath(), Equals, "b[1].baz")
+
+	matches, err = view.MatchGetRequest("c[0].bar")
+	c.Assert(err, IsNil)
+	match = confdb.RequestMatch(matches[0])
+	c.Assert(match.StoragePath(), Equals, "d[0].bar")
 
 	// prefix match
 	matches, err = view.MatchGetRequest("a")

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -157,6 +157,16 @@ func (*viewSuite) TestNewConfdb(c *C) {
 				},
 			},
 		},
+		{
+			confdb: map[string]any{
+				"bar": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a.b", "storage": "[1].b"},
+					},
+				},
+			},
+			err: `cannot define view "bar": invalid storage "[1].b": cannot have empty subkeys`,
+		},
 	}
 
 	for i, tc := range tcs {
@@ -578,7 +588,27 @@ func (s *viewSuite) TestViewRequestAndStorageValidation(c *C) {
 		},
 		{
 			testName: "placeholder mismatch (same number)",
-			request:  "bad.{foo}", storage: "bad.{bar}", err: `placeholder "{foo}" from request "bad.{foo}" is absent from storage "bad.{bar}"`,
+			request:  "bad.{foo}", storage: "bad.{bar}", err: `placeholder "foo" from request "bad.{foo}" is absent from storage "bad.{bar}"`,
+		},
+		{
+			testName: "index placeholder mismatch",
+			request:  "bad[{foo}]", storage: "bad[{bar}]", err: `placeholder "foo" from request "bad[{foo}]" is absent from storage "bad[{bar}]"`,
+		},
+		{
+			testName: "index placeholder mismatch despite key placeholder with same name",
+			request:  "bad[{foo}]", storage: "bad.{foo}", err: `request "bad[{foo}]" and storage "bad.{foo}" have mismatched placeholders`,
+		},
+		{
+			testName: "repeated placeholder in request",
+			request:  "{bar}.a.{bar}",
+			storage:  "foo.{bar}",
+			err:      `request cannot have more than one placeholder with the same name "bar": {bar}.a.{bar}`,
+		},
+		{
+			testName: "repeated placeholder but in field and index",
+			request:  "{bar}[{bar}]",
+			storage:  "{bar}[{bar}]",
+			err:      `cannot use same name "bar" for key and index placeholder: {bar}[{bar}]`,
 		},
 		{
 			testName: "placeholder mismatch (different number)",
@@ -1292,6 +1322,18 @@ func (s *viewSuite) TestBadRequestPaths(c *C) {
 			errMsg:  "cannot have empty subkeys",
 		},
 		{
+			request: "a[",
+			errMsg:  "invalid subkey \"[\"",
+		},
+		{
+			request: "a[b",
+			errMsg:  "invalid subkey \"[b\"",
+		},
+		{
+			request: "a[b.c",
+			errMsg:  "invalid subkey \"[b\"",
+		},
+		{
 			request: "a.b.",
 			errMsg:  "cannot have empty subkeys",
 		},
@@ -1808,6 +1850,34 @@ func (*viewSuite) TestSchemaMismatchCheckMultipleAlternativeTypesHappy(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (*viewSuite) TestSchemaMismatchArrayHappy(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "array",
+			"values": {
+				"schema": {
+					"bar": "string",
+					"baz": "string"
+				}
+			}
+		}
+	}
+}`)
+	schema, err := confdb.ParseStorageSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	_, err = confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo[1].bar", "storage": "foo[1].bar"},
+				map[string]any{"request": "foo[{n}].baz", "storage": "foo[{n}].baz"},
+			},
+		},
+	}, schema)
+	c.Assert(err, IsNil)
+}
+
 func (s *viewSuite) TestSetUnmatchedPlaceholderLeaf(c *C) {
 	databag := confdb.NewJSONDatabag()
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
@@ -1978,6 +2048,20 @@ func (s *viewSuite) TestUnsetUnmatchedPlaceholderMid(c *C) {
 			"two": "value",
 		},
 	})
+}
+
+func (s *viewSuite) TestIndexPlaceholders(c *C) {
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a[{n}]", "storage": "b[{n}]"},
+				map[string]any{"request": "a[{n}].c", "storage": "b[{n}].c"},
+				map[string]any{"request": "a[{n}][{m}]", "storage": "b[{m}][{n}]"},
+			},
+		},
+	}, confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
 }
 
 func (s *viewSuite) TestGetValuesThroughPaths(c *C) {
@@ -2871,4 +2955,41 @@ func (*viewSuite) TestCheckWriteEphemeralAccess(c *C) {
 			c.Check(eph, Equals, tc.ephemeral, cmt)
 		}
 	}
+}
+
+// TODO: temporary test, can be removed once we add the traversal logic since
+// we'll test the matching implicitly
+func (*viewSuite) TestRequestMatch(c *C) {
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "a[1].bar", "storage": "b[1].bar"},
+				map[string]any{"request": "a[{n}].baz", "storage": "b[{n}].baz"},
+			},
+		},
+	}, confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	view := schema.View("foo")
+	matches, err := view.MatchGetRequest("a[1].bar")
+	c.Assert(err, IsNil)
+	match := confdb.RequestMatch(matches[0])
+	c.Assert(match.StoragePath(), Equals, "b[1].bar")
+
+	matches, err = view.MatchGetRequest("a[1].baz")
+	c.Assert(err, IsNil)
+	match = confdb.RequestMatch(matches[0])
+	c.Assert(match.StoragePath(), Equals, "b[1].baz")
+
+	// prefix match
+	matches, err = view.MatchGetRequest("a")
+	c.Assert(err, IsNil)
+	c.Assert(matches, HasLen, 2)
+
+	// check we skip over both rules
+	_, err = view.MatchGetRequest("a.b")
+	c.Assert(err, ErrorMatches, `cannot get "a.b" through acc/confdb/foo: no matching rule`)
+
+	_, err = view.MatchGetRequest("a.b123.bar")
+	c.Assert(err, ErrorMatches, `cannot get "a.b123.bar" through acc/confdb/foo: no matching rule`)
 }

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -128,6 +128,35 @@ func (*viewSuite) TestNewConfdb(c *C) {
 				},
 			},
 		},
+		{
+			confdb: map[string]any{
+				"bar": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a.{bar}[{bar}]", "storage": "foo[{bar}].{bar}"},
+					},
+				},
+			},
+			err: `cannot define view "bar": cannot use same name "bar" for key and index placeholder: a.{bar}[{bar}]`,
+		},
+		{
+			confdb: map[string]any{
+				"bar": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "{bar}.a.{bar}", "storage": "foo.{bar}"},
+					},
+				},
+			},
+			err: `cannot define view "bar": request cannot have more than one placeholder with the same name "bar": {bar}.a.{bar}`,
+		},
+		{
+			confdb: map[string]any{
+				"bar": map[string]any{
+					"rules": []any{
+						map[string]any{"request": "a.{bar}", "storage": "foo.{bar}.{bar}"},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range tcs {

--- a/confdb/export_test.go
+++ b/confdb/export_test.go
@@ -19,7 +19,31 @@
 
 package confdb
 
-var GetValuesThroughPaths = getValuesThroughPaths
+type (
+	ViewRef = viewRef
+)
+
+var (
+	GetValuesThroughPaths = getValuesThroughPaths
+	NewAuthentication     = newAuthentication
+)
+
+type Authentication = authentication
+
+func (a Authentication) ToStrings() []string {
+	return a.toStrings()
+}
+
+// TODO: remove this once we remove the temporary test TestRequestMatch
+func (v *View) MatchGetRequest(request string) (matches []requestMatch, err error) {
+	return v.matchGetRequest(request)
+}
+
+type RequestMatch = requestMatch
+
+func (m RequestMatch) StoragePath() string {
+	return m.storagePath
+}
 
 func MockMaxValueDepth(newDepth int) (restore func()) {
 	oldDepth := maxValueDepth
@@ -28,15 +52,3 @@ func MockMaxValueDepth(newDepth int) (restore func()) {
 		maxValueDepth = oldDepth
 	}
 }
-
-// functions & types exposed for tests
-
-var NewAuthentication = newAuthentication
-
-type Authentication = authentication
-
-func (a Authentication) ToStrings() []string {
-	return a.toStrings()
-}
-
-type ViewRef = viewRef

--- a/confdb/schema.go
+++ b/confdb/schema.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/strutil"
@@ -1294,9 +1293,9 @@ func (v *arraySchema) SchemaAt(path []string) ([]DatabagSchema, error) {
 		return []DatabagSchema{v}, nil
 	}
 
+	// key can be a number or a placeholder in square brackets ([1] or [{n}])
 	key := path[0]
-	_, err := strconv.ParseUint(key, 10, 0)
-	if err != nil {
+	if !validIndexPlaceholder.Match([]byte(key)) && !validIndexSubkey.Match([]byte(key)) {
 		return nil, schemaAtErrorf(path, `key %q cannot be used to index array`, key)
 	}
 

--- a/confdb/schema_test.go
+++ b/confdb/schema_test.go
@@ -2230,9 +2230,11 @@ func (*schemaSuite) TestSchemaAtNestedInArray(c *C) {
 	schema, err := confdb.ParseStorageSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	schemas, err := schema.SchemaAt([]string{"foo", "[0]"})
-	c.Assert(err, IsNil)
-	c.Assert(schemasToTypes(schemas), DeepEquals, []confdb.SchemaType{confdb.String})
+	for _, indexPart := range []string{"[0]", "[{n}]"} {
+		schemas, err := schema.SchemaAt([]string{"foo", indexPart})
+		c.Assert(err, IsNil)
+		c.Assert(schemasToTypes(schemas), DeepEquals, []confdb.SchemaType{confdb.String})
+	}
 }
 
 func (*schemaSuite) TestSchemaAtInUserDefinedType(c *C) {

--- a/confdb/schema_test.go
+++ b/confdb/schema_test.go
@@ -2230,7 +2230,7 @@ func (*schemaSuite) TestSchemaAtNestedInArray(c *C) {
 	schema, err := confdb.ParseStorageSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	schemas, err := schema.SchemaAt([]string{"foo", "0"})
+	schemas, err := schema.SchemaAt([]string{"foo", "[0]"})
 	c.Assert(err, IsNil)
 	c.Assert(schemasToTypes(schemas), DeepEquals, []confdb.SchemaType{confdb.String})
 }
@@ -2283,7 +2283,7 @@ func (*schemaSuite) TestSchemaAtExceedingSchemaContainerSchema(c *C) {
 	schema, err := confdb.ParseStorageSchema(schemaStr)
 	c.Assert(err, IsNil)
 
-	schemas, err := schema.SchemaAt([]string{"foo", "0", "bar"})
+	schemas, err := schema.SchemaAt([]string{"foo", "[0]", "bar"})
 	c.Assert(err, ErrorMatches, `cannot follow path beyond "string" type`)
 	c.Assert(schemas, IsNil)
 }


### PR DESCRIPTION
8e8416432f03c663945cfc5cd3bd2f34486fea13 extends the dotted path validation to prevent the same placeholder name to be used more than once in a request
3703dc0e04bd93263866d8e843291e6239f571e8 supports paths with list indexes, both literal and placeholders (foo[1], foo[{n}])