### PR TITLE
interfaces/builtin/cpu-control: Fix rules for accessing IRQ sysfs and procfs directories 

### DIFF
--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -84,11 +84,11 @@ const cpuControlConnectedPlugAppArmor = `
 /dev/cpu_dma_latency rw,
 
 # Allow interrupt affinity settings, see https://www.kernel.org/doc/html/latest/core-api/irq/irq-affinity.html
-/sys/kernel/irq/[0-9]*/* r,
-/proc/interrupts r,
-/proc/irq/[0-9]+/smp_affinity rw,
-/proc/irq/[0-9]+/smp_affinity_list rw,
-/proc/irq/default_smp_affinity rw,
+/sys/kernel/irq{,/,/**} rk,
+/proc/interrupts rk,
+/proc/irq/*/smp_affinity rwk,
+/proc/irq/*/smp_affinity_list rwk,
+/proc/irq/default_smp_affinity rwk,
 `
 
 var cpuControlConnectedPlugUDev = []string{

--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -84,7 +84,7 @@ const cpuControlConnectedPlugAppArmor = `
 /dev/cpu_dma_latency rw,
 
 # Allow interrupt affinity settings, see https://www.kernel.org/doc/html/latest/core-api/irq/irq-affinity.html
-/sys/kernel/irq{,/,/[0-9]**} r,
+/sys/kernel/irq{/,/[0-9]**} r,
 /proc/interrupts r,
 /proc/irq/[0-9]*/smp_affinity rwk,
 /proc/irq/[0-9]*/smp_affinity_list rwk,

--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -84,7 +84,7 @@ const cpuControlConnectedPlugAppArmor = `
 /dev/cpu_dma_latency rw,
 
 # Allow interrupt affinity settings, see https://www.kernel.org/doc/html/latest/core-api/irq/irq-affinity.html
-/sys/kernel/irq{,/,/**} r,
+/sys/kernel/irq{,/,/[0-9]**} r,
 /proc/interrupts r,
 /proc/irq/[0-9]*/smp_affinity rwk,
 /proc/irq/[0-9]*/smp_affinity_list rwk,

--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -84,10 +84,10 @@ const cpuControlConnectedPlugAppArmor = `
 /dev/cpu_dma_latency rw,
 
 # Allow interrupt affinity settings, see https://www.kernel.org/doc/html/latest/core-api/irq/irq-affinity.html
-/sys/kernel/irq{,/,/**} rk,
-/proc/interrupts rk,
-/proc/irq/*/smp_affinity rwk,
-/proc/irq/*/smp_affinity_list rwk,
+/sys/kernel/irq{,/,/**} r,
+/proc/interrupts r,
+/proc/irq/[0-9]*/smp_affinity rwk,
+/proc/irq/[0-9]*/smp_affinity_list rwk,
 /proc/irq/default_smp_affinity rwk,
 `
 


### PR DESCRIPTION
- The current rules for procfs and sysfs are wrong:
```
  /sys/kernel/irq/[0-9]*/* r,
  /proc/irq/[0-9]+/smp_affinity rw,
  /proc/irq/[0-9]+/smp_affinity_list rw,
```
According to the AppArmor Wiki documentation[1]:
> AppArmor uses a file globbing syntax similar to that used by the
bash shell. Globbing is not standard full regular expression syntax, but instead uses a few characters known as wild cards.

So: 

- `/sys/kernel/irq/[0-9]*/* r,` doesn't give us access to list the contents of `sys/kernel/irq`.
- `/proc/irq/[0-9]+/smp_affinity rw,` and `/proc/irq/[0-9]+/smp_affinity_list rw,` uses a `+` sign that isn't recognized by the AppArmor syntax.


[1]: https://gitlab.com/apparmor/apparmor/-/wikis/QuickProfileLanguage#file-globbing