### PR TITLE
cmd/libsnap-confine-private/utils: workaround for glibc fchmodat() fallback

### DIFF
--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -298,6 +298,15 @@ int sc_ensure_mkdirat(int fd, const char *name, mode_t mode, uid_t uid, uid_t gi
             compat_fchmodat_symlink_nofollow(fd, name, mode) < 0) {
             return -1;
         }
+        /* as observed with certain combinations of new libc & old kernels,
+         * glibc may have employed a fallback path for fchmodat() and left errno
+         * in its original value of ENOSYS|ENOTSUP, let's reset it here such
+         * that the caller can reliably probe for EEXIST to cath the mkdir()
+         * branch if this function is successful, see glibc implementation for
+         * details:
+         * https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/fchmodat.c;h=dd1fa5db86bde99fe3eb4804b06c5adf11914b94;hb=HEAD#l31
+         */
+        errno = 0;
     }
     return 0;
 }


### PR DESCRIPTION
Glibc implements a fallback handling for fchmodat() which opens the desired file and applies chmod() [1]. Fix our sc_ensure_mkdirat() helper code to ensure consistent semantics, which ensures that the only errno we see on success is either 0 or EEXIST (which indicates that the desired path already exists).

1. https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/fchmodat.c;h=dd1fa5db86bde99fe3eb4804b06c5adf11914b94;hb=HEAD#l31

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
