### PR TITLE
many: support changing passphrases post installation

### DIFF
--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -48,6 +48,7 @@ var systemVolumesCmd = &Command{
 }
 
 var fdeReplaceRecoveryKeyChangeKind = swfeats.RegisterChangeKind("fde-replace-recovery-key")
+var fdeChangePassphraseChangeKind = swfeats.RegisterChangeKind("fde-change-passphrase")
 
 var (
 	fdestateReplaceRecoveryKey = fdestate.ReplaceRecoveryKey
@@ -305,8 +306,7 @@ func postSystemVolumesActionChangePassphrase(c *Command, req *systemVolumesActio
 		return errToResponse(err, nil, BadRequest, "cannot change passphrase: %v")
 	}
 
-	chg := st.NewChange("fde-change-passphrase", "Change passphrase")
-	chg.AddAll(ts)
+	chg := newChange(st, fdeChangePassphraseChangeKind, "Change passphrase", []*state.TaskSet{ts}, nil)
 
 	st.EnsureBefore(0)
 

--- a/overlord/fdestate/errors.go
+++ b/overlord/fdestate/errors.go
@@ -28,9 +28,13 @@ type KeyslotRefsNotFoundError struct {
 }
 
 func (e *KeyslotRefsNotFoundError) Error() string {
-	if len(e.KeyslotRefs) == 1 {
+	switch len(e.KeyslotRefs) {
+	case 0:
+		// references not specified, keep error message generic
+		return "key slot reference not found"
+	case 1:
 		return fmt.Sprintf("key slot reference %s not found", e.KeyslotRefs[0].String())
-	} else {
+	default:
 		var concatRefs strings.Builder
 		concatRefs.WriteString(e.KeyslotRefs[0].String())
 		for _, ref := range e.KeyslotRefs[1:] {

--- a/overlord/fdestate/errors_test.go
+++ b/overlord/fdestate/errors_test.go
@@ -30,6 +30,9 @@ func (s *fdeMgrSuite) TestKeyslotsNotFoundErrorMessage(c *C) {
 	err := fdestate.KeyslotRefsNotFoundError{KeyslotRefs: []fdestate.KeyslotRef{{ContainerRole: "some-role", Name: "some-slot"}}}
 	c.Check(err.Error(), Equals, `key slot reference (container-role: "some-role", name: "some-slot") not found`)
 
+	err = fdestate.KeyslotRefsNotFoundError{}
+	c.Check(err.Error(), Equals, "key slot reference not found")
+
 	err = fdestate.KeyslotRefsNotFoundError{KeyslotRefs: []fdestate.KeyslotRef{
 		{ContainerRole: "some-role", Name: "some-slot-1"},
 		{ContainerRole: "some-role", Name: "some-slot-2"},

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/fdestate/backend"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
@@ -132,4 +133,28 @@ func MockSecbootRenameContainerKey(f func(devicePath string, oldName string, new
 
 func KeyslotsAlreadyExistsError(keyslots []Keyslot) keyslotsAlreadyExistsError {
 	return keyslotsAlreadyExistsError{keyslots: keyslots}
+}
+
+func MockChangeAuthOptionsInCache(st *state.State, old, new string) (restore func()) {
+	st.Lock()
+	defer st.Unlock()
+	st.Cache(changeAuthOptionsKey{}, &changeAuthOptions{old: old, new: new})
+
+	return func() { st.Cache(changeAuthOptionsKey{}, nil) }
+}
+
+func GetChangeAuthOptionsFromCache(st *state.State) *changeAuthOptions {
+	cached := st.Cached(changeAuthOptionsKey{})
+	if cached == nil {
+		return nil
+	}
+	return cached.(*changeAuthOptions)
+}
+
+func (o *changeAuthOptions) Old() string {
+	return o.old
+}
+
+func (o *changeAuthOptions) New() string {
+	return o.new
 }

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -128,6 +128,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*FDEManager, error) {
 	runner.AddHandler("fde-add-recovery-keys", m.doAddRecoveryKeys, nil)
 	runner.AddHandler("fde-remove-keys", m.doRemoveKeys, nil)
 	runner.AddHandler("fde-rename-keys", m.doRenameKeys, nil)
+	runner.AddHandler("fde-change-auth", m.doChangeAuth, nil)
 	runner.AddBlocked(func(t *state.Task, running []*state.Task) bool {
 		if isFDETask(t) {
 			for _, tRunning := range running {
@@ -339,7 +340,7 @@ func (k *Keyslot) KeyData() (secboot.KeyData, error) {
 
 	keyData, err := secbootReadContainerKeyData(k.devPath, k.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read key data for %q from %q: %v", k.Name, k.devPath, err)
+		return nil, fmt.Errorf("cannot read key data for %q from %q: %v", k.Name, k.devPath, err)
 	}
 	k.keyData = keyData
 	return keyData, nil
@@ -374,7 +375,7 @@ func (m *FDEManager) GetKeyslots(keyslotRefs []KeyslotRef) (keyslots []Keyslot, 
 		// collect recovery key slots
 		recoveryKeyNames, err := secbootListContainerRecoveryKeyNames(container.DevPath())
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to obtain recovery keys for %q: %v", container.DevPath(), err)
+			return nil, nil, fmt.Errorf("cannot obtain recovery keys for %q: %v", container.DevPath(), err)
 		}
 		for _, recoveryKeyName := range recoveryKeyNames {
 			if allKeyslots || strutil.ListContains(targetKeyslotNames, recoveryKeyName) {
@@ -390,7 +391,7 @@ func (m *FDEManager) GetKeyslots(keyslotRefs []KeyslotRef) (keyslots []Keyslot, 
 		// collect platform key slots
 		platformKeyNames, err := secbootListContainerUnlockKeyNames(container.DevPath())
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to obtain platform keys for %q: %v", container.DevPath(), err)
+			return nil, nil, fmt.Errorf("cannot obtain platform keys for %q: %v", container.DevPath(), err)
 		}
 		for _, platformKeyName := range platformKeyNames {
 			if allKeyslots || strutil.ListContains(targetKeyslotNames, platformKeyName) {

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -530,3 +530,11 @@ func MockTPMRevokeOldPCRProtectionPolicies(f func(key MaybeSealedKeyData, tpm *s
 func MockSbNewSealedKeyData(f func(k *sb.KeyData) (MaybeSealedKeyData, error)) (restore func()) {
 	return testutil.Mock(&sbNewSealedKeyData, f)
 }
+
+func MockSbKeyDataChangePassphrase(f func(d *sb.KeyData, oldPassphrase string, newPassphrase string) error) (restore func()) {
+	return testutil.Mock(&sbKeyDataChangePassphrase, f)
+}
+
+func NewKeyData(kd *sb.KeyData) KeyData {
+	return &keyData{kd: kd}
+}

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -180,6 +180,11 @@ type KeyData interface {
 	PlatformName() string
 	Roles() []string
 	AuthMode() device.AuthMode
+	// ChangePassphrase changes passphrase given old passphrase.
+	// AuthMode must be device.AuthModePassphrase.
+	ChangePassphrase(oldPassphrase, newPassphrase string) error
+	// WriteTokenAtomic saves this key data to the specified LUKS2 token.
+	WriteTokenAtomic(devicePath, slotName string) error
 }
 
 // SerializedPCRProfile wraps a serialized PCR profile which is treated as an

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -58,6 +58,8 @@ var (
 	sbTestLUKS2ContainerKey         = sb.TestLUKS2ContainerKey
 	sbCheckPassphraseEntropy        = sb.CheckPassphraseEntropy
 	disksDevlinks                   = disks.Devlinks
+
+	sbKeyDataChangePassphrase = (*sb.KeyData).ChangePassphrase
 )
 
 func init() {
@@ -620,6 +622,18 @@ func (k *keyData) Roles() []string {
 		return nil
 	}
 	return []string{k.kd.Role()}
+}
+
+func (k *keyData) ChangePassphrase(oldPassphrase, newPassphrase string) error {
+	return sbKeyDataChangePassphrase(k.kd, oldPassphrase, newPassphrase)
+}
+
+func (k *keyData) WriteTokenAtomic(devicePath, slotName string) error {
+	writer, err := newLUKS2KeyDataWriter(devicePath, slotName)
+	if err != nil {
+		return err
+	}
+	return k.kd.WriteAtomic(writer)
 }
 
 // ReadContainerKeyData reads key slot key data for the specified device and slot name.


### PR DESCRIPTION
This PR adds support for changing passphrase post installation given the old passphrase is provided. A follow up PR while build on top of this to allow changing passphrase through the API (i.e. /v2/system-volumes).

For context, please check SD201 spec.