### PR TITLE
tests: set SNAP_REEXEC env var in systemd-run when preparing the user session

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -262,7 +262,7 @@ main() {
 		--pipe \
 		--service-type simple \
 		--setenv TERM=xterm-256color \
-		--property "Environment=SNAPD_DEBUG=$SNAPD_DEBUG SNAP_CONFINE_DEBUG=$SNAP_CONFINE_DEBUG" \
+		--property "Environment=SNAPD_DEBUG=$SNAPD_DEBUG SNAP_REEXEC=$SNAP_REEXEC SNAP_CONFINE_DEBUG=$SNAP_CONFINE_DEBUG" \
 		$selinux_context_arg \
 		"$(command -v runuser)" -l "$user" - -c "exec $tmp_dir/exec" || true
 
@@ -375,7 +375,7 @@ BEGIN {
 			Environment as 1 TERM=xterm-256color \
 			$selinux_context_arg \
 			ExecStart "a(sasb)" 1 \
-				"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "SNAPD_DEBUG=$SNAPD_DEBUG SNAP_CONFINE_DEBUG=$SNAP_CONFINE_DEBUG exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
+				"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "SNAPD_DEBUG=$SNAPD_DEBUG SNAP_REEXEC=$SNAP_REEXEC SNAP_CONFINE_DEBUG=$SNAP_CONFINE_DEBUG exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
 		0
 	# This is done so that we can configure file redirects. Once Ubuntu 16.04 is no
 	# longer supported we can use Standard{Input,Output,Error}=file:path property

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -21,6 +21,7 @@ environment:
     VARIANT/clang: clang
     VARIANT/gcc: gcc
     VARIANT/static: static
+    SNAP_REEXEC: 1
 
 prepare: |
     if not os.query is-trusty; then


### PR DESCRIPTION
The user session is not getting the SNAP_REEXEC env var, so this change pass that to the Environment used when systemd-run is called in tests.session

This fixes the remote-home test which fails when we test snapd from the ppa or from proposed.