### PR TITLE
 i/builtin: update "microstack_support" interface to allow SR-IOV attachments

### DIFF
--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -128,6 +128,9 @@ const microStackSupportConnectedPlugAppArmor = `
 
 # Libvirt needs access to the PCI config space in order to be able to reset devices.
 /sys/devices/pci*/**/config rw,
+/sys/devices/pci*/**/driver_override rw,
+/sys/bus/pci/drivers/**/unbind rw,
+/sys/bus/pci/drivers_probe rw,
 
 # Spice
 owner /{dev,run}/shm/spice.* rw,


### PR DESCRIPTION
Nova currently fails to attach SR-IOV VFs as the Libvirt service is blocked by Apparmor.

To address this, we'll update the `microstack_support` interface, exposing the following paths:

* `/sys/devices/pci*/**/driver_override`
* `/sys/bus/pci/drivers/**/unbind`
* `/sys/bus/pci/drivers_probe`

Logs:

```
2025-06-23T14:07:24Z -[1950]: Failed to add driver 'vfio-pci' to
driver_override interface of PCI device '0000:1b:10.6': Permission denied

[  +6.342381] audit: type=1400 audit(1750687644.519:1123): apparmor="DENIED"
operation="open" class="file" profile="snap.openstack-hypervisor.libvirtd"
name="/sys/devices/pci0000:17/0000:17:03.0/0000:1b:10.6/driver_override"
pid=1950 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```

```
2025-06-24T11:39:57Z -[340147]: Failed to unbind PCI device '0000:1b:10.0'
from ixgbevf: Permission denied

[Jun24 11:48] audit: type=1400 audit(1750765686.131:1086): apparmor="DENIED"
operation="open" class="file" profile="snap.openstack-hypervisor.libvirtd"
name="/sys/bus/pci/drivers/ixgbevf/unbind" pid=756982 comm="rpc-libvirtd"
requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```

```
2025-06-24T12:16:46Z -[866501]: Failed to trigger a probe for PCI device
'0000:1b:10.4': Permission denied

[Tue Jun 24 12:16:45 2025] audit: type=1400 audit(1750767406.445:1566):
apparmor="DENIED" operation="open" class="file"
profile="snap.openstack-hypervisor.libvirtd" name="/sys/bus/pci/drivers_probe"
pid=866501 comm="rpc-libvirtd" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```
