### PR TITLE
tests/main/security-group-policy: collect debug information

### DIFF
--- a/tests/main/security-group-policy/task.yaml
+++ b/tests/main/security-group-policy/task.yaml
@@ -54,6 +54,11 @@ prepare: |
 restore: |
     tests.session -u test restore
 
+debug: |
+    LIBEXEC_DIR="$(os.paths libexec-dir)"
+    getcap "$LIBEXEC_DIR"/snapd/snap-confine.backup || true
+    getcap "$LIBEXEC_DIR"/snapd/snap-confine || true
+
 execute: |
     tests.session -u test exec sh -c "test-snapd-sh-core24.sh -c 'true' 2>&1" | \
         MATCH 'user is not a member of group'


### PR DESCRIPTION
Collect debug information on capabilities when the test fails.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
