### PR TITLE
interfaces/builtin/posix-mq: allow stat on /dev/mqueue

### DIFF
--- a/interfaces/builtin/posix_mq.go
+++ b/interfaces/builtin/posix_mq.go
@@ -337,6 +337,10 @@ func (iface *posixMQInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 	snippet := iface.generateSnippet(plug.Name(), "plug", perms, paths)
 	spec.AddSnippet(snippet)
 
+	// cater to a legitimate use case when a posix-mq consumer may want
+	// to probe whether /dev/mqueue is indeed the mqueue pseudo filesystem
+	spec.AddSnippet(`mqueue (getattr) type=posix "/",`)
+
 	return nil
 }
 

--- a/interfaces/builtin/posix_mq_test.go
+++ b/interfaces/builtin/posix_mq_test.go
@@ -494,6 +494,7 @@ func (s *PosixMQInterfaceSuite) TestReadWriteMQAppArmor(c *C) {
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
 	c.Check(plugSnippet, testutil.Contains, `# POSIX Message Queue plug: test-rw`)
 	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open getattr setattr) type=posix "/test-rw",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (getattr) type=posix "/",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestReadWriteMQSeccomp(c *C) {
@@ -541,6 +542,7 @@ func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQAppArmor(c *C) {
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
 	c.Check(plugSnippet, testutil.Contains, `# POSIX Message Queue plug: test-default`)
 	c.Check(plugSnippet, testutil.Contains, `mqueue (read write open getattr setattr) type=posix "/test-default",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (getattr) type=posix "/",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestDefaultReadWriteMQSeccomp(c *C) {
@@ -585,6 +587,7 @@ func (s *PosixMQInterfaceSuite) TestReadOnlyMQAppArmor(c *C) {
 
 	plugSnippet := spec.SnippetForTag("snap.consumer.app")
 	c.Check(plugSnippet, testutil.Contains, `mqueue (read open getattr) type=posix "/test-ro",`)
+	c.Check(plugSnippet, testutil.Contains, `mqueue (getattr) type=posix "/",`)
 }
 
 func (s *PosixMQInterfaceSuite) TestReadOnlyMQSeccomp(c *C) {

--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -31,11 +31,17 @@ prepare: |
 execute: |
     # We cannot create a queue before connecting the can-create slot.
     not test-snapd-posix-mq.mqctl create /test read-only 600 max-size=16,max-count=10
+    # We cannot probe /dev/mqueue
+    not snap run --shell test-snapd-posix-mq.mqctl -c 'stat /dev/mqueue'
+
     snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-create
     # Technically the read permission is required because there's no way to
     # open an mqueue without any permissions, as O_RDONLY is technically just
     # zero, so it's not a distinct bit.
     snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-read
+
+    # We can probe /dev/mqueue
+    snap run --shell test-snapd-posix-mq.mqctl -c 'stat /dev/mqueue'
 
     # Once the can-create slot is connected we can create it.
     test-snapd-posix-mq.mqctl create /test read-only 600 max-size=16,max-count=10 | MATCH 'mq_open did not fail'

--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -6,6 +6,8 @@ details: |
     in snapd - read, write, create and delete.
 
 systems:
+    # no AppArmor, no mediation
+    - -amazon-linux-*
     # Too old to support this feature entirely.
     - -ubuntu-14.04-64
     - -debian-11-64


### PR DESCRIPTION
Allow stat() on /dev/mqueue, which is a legitimate use case for
programs trying to probe whether it is indeed a mqueue pseudo
filesystem.

Related: SNAPDENG-35208

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-35208]: https://warthogs.atlassian.net/browse/SNAPDENG-35208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ