### PR TITLE
i/p/requestrules: add function to retrieve or set user session ID

### DIFF
--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -22,10 +22,15 @@ package requestrules
 import (
 	"time"
 
+	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/testutil"
 )
 
-var JoinInternalErrors = joinInternalErrors
+var (
+	ErrNoUserSession   = errNoUserSession
+	JoinInternalErrors = joinInternalErrors
+	UserSessionIDPath  = userSessionIDPath
+)
 
 type RulesDBJSON rulesDBJSON
 
@@ -35,6 +40,10 @@ func (rule *Rule) Validate(currTime time.Time) (expired bool, err error) {
 
 func (rdb *RuleDB) IsPathPermAllowed(user uint32, snap string, iface string, path string, permission string) (bool, error) {
 	return rdb.isPathPermAllowed(user, snap, iface, path, permission)
+}
+
+func (rdb *RuleDB) ReadOrAssignUserSessionID(user uint32) (userSessionID prompting.IDType, err error) {
+	return rdb.readOrAssignUserSessionID(user)
 }
 
 func MockIsPathPermAllowed(f func(rdb *RuleDB, user uint32, snap string, iface string, path string, permission string) (bool, error)) func() {

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -722,6 +723,149 @@ func (s *requestrulesSuite) TestCloseErrors(c *C) {
 	defer os.Chmod(dirs.SnapInterfacesRequestsStateDir, 0o755)
 
 	c.Check(rdb.Close(), NotNil)
+}
+
+func (s *requestrulesSuite) TestUserSessionIDPath(c *C) {
+	for _, testCase := range []struct {
+		userID   uint32
+		expected string
+	}{
+		{1000, "/run/user/1000/snapd-user-session-id"},
+		{0, "/run/user/0/snapd-user-session-id"},
+		{1, "/run/user/1/snapd-user-session-id"},
+		{65535, "/run/user/65535/snapd-user-session-id"},
+		{65536, "/run/user/65536/snapd-user-session-id"},
+		{4294967295, "/run/user/4294967295/snapd-user-session-id"},
+	} {
+		expectedWithTestPrefix := filepath.Join(dirs.GlobalRootDir, testCase.expected)
+		c.Check(requestrules.UserSessionIDPath(testCase.userID), Equals, expectedWithTestPrefix)
+	}
+}
+
+func (s *requestrulesSuite) TestReadOrAssignUserSessionID(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	// If there is no user session dir, expect errNoUserSession
+	noSessionID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, ErrorMatches, "cannot find systemd user session tmpfs for user: 1000")
+	c.Assert(noSessionID, Equals, prompting.IDType(0))
+
+	// Make user session dir, as if systemd had done so for this user
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "run/user/1000"), 0o700), IsNil)
+
+	// If there is a user session dir, expect some non-zero user ID
+	origID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(origID, Not(Equals), prompting.IDType(0))
+
+	// If a user session ID is already present for this session, retrieve it
+	// rather than defining a new one
+	retrievedID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(retrievedID, Equals, origID)
+	// Try again, for good measure
+	retrievedID, err = rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(retrievedID, Equals, origID)
+
+	// If the user session restarts, the user session tmpfs is deleted and
+	// re-created, so the file is no longer present. So we set a new ID.
+	c.Assert(os.Remove(filepath.Join(dirs.GlobalRootDir, "run/user/1000/snapd-user-session-id")), IsNil)
+	newID, err := rdb.ReadOrAssignUserSessionID(s.defaultUser)
+	c.Assert(err, IsNil)
+	c.Assert(newID, Not(Equals), 0)
+	c.Assert(newID, Not(Equals), origID)
+
+	// If we try for a different user without a session, we get the error
+	noSessionID, err = rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, ErrorMatches, "cannot find systemd user session tmpfs for user: 1234")
+	c.Assert(noSessionID, Equals, prompting.IDType(0))
+
+	// Make user session dir, as if systemd had done so for this user
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "run/user/1234"), 0o700), IsNil)
+
+	// If there is a user session dir, expect some non-zero user ID different
+	// from that of the other user
+	secondUserID, err := rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, IsNil)
+	c.Assert(secondUserID, Not(Equals), prompting.IDType(0))
+	c.Assert(secondUserID, Not(Equals), newID)
+
+	// If we get the first user's session ID, it's still the same
+	firstUserID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(firstUserID, Not(Equals), prompting.IDType(0))
+	c.Assert(firstUserID, Not(Equals), secondUserID)
+	c.Assert(firstUserID, Equals, newID)
+
+	// If we remove the user session for the first user, we get the error again
+	c.Assert(os.RemoveAll(filepath.Join(dirs.GlobalRootDir, "run/user/1000")), IsNil)
+	noSessionID, err = rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, ErrorMatches, "cannot find systemd user session tmpfs for user: 1000")
+	c.Assert(noSessionID, Equals, prompting.IDType(0))
+
+	// But we can still retrieve the session ID for the second user
+	retrievedID, err = rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, IsNil)
+	c.Assert(retrievedID, Not(Equals), prompting.IDType(0))
+	c.Assert(retrievedID, Equals, secondUserID)
+
+	// If the file is corrupted, we get a new ID
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "run/user/1234/snapd-user-session-id"), []byte("foo"), 0o600), IsNil)
+	regeneratedID, err := rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, IsNil)
+	c.Assert(regeneratedID, Not(Equals), prompting.IDType(0))
+	c.Assert(regeneratedID, Not(Equals), secondUserID)
+}
+
+func (s *requestrulesSuite) TestReadOrAssignUserSessionIDConcurrent(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	// Multiple threads acting at once all return the same ID
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "run/user/5000"), 0o700), IsNil)
+	startChan := make(chan struct{}) // close to broadcast to all threads
+	count := 10
+	var startWG sync.WaitGroup
+	startWG.Add(count)
+	resultChan := make(chan prompting.IDType, count)
+	for i := 0; i < count; i++ {
+		go func() {
+			startWG.Done()
+			<-startChan // wait for broadcast
+			sessionID, err := rdb.ReadOrAssignUserSessionID(5000)
+			c.Assert(err, IsNil)
+			c.Assert(sessionID, Not(Equals), prompting.IDType(0))
+			resultChan <- sessionID
+		}()
+	}
+	startWG.Wait()
+	time.Sleep(10 * time.Millisecond) // wait until they're all waiting on startChan
+	// Start all goroutines simultaneously
+	close(startChan)
+
+	// Get session ID from first that sends one
+	var firstID prompting.IDType
+	select {
+	case firstID = <-resultChan:
+		c.Assert(firstID, NotNil)
+		c.Assert(firstID, Not(Equals), prompting.IDType(0))
+	case <-time.NewTimer(time.Second).C:
+		c.Fatal("timed out waiting for first user ID")
+	}
+
+	// Check that each other goroutine retrieved the same session ID
+	for i := 1; i < count; i++ {
+		select {
+		case retrievedID := <-resultChan:
+			c.Assert(retrievedID, NotNil)
+			c.Assert(retrievedID, Not(Equals), prompting.IDType(0))
+			c.Assert(retrievedID, Equals, firstID)
+		case <-time.NewTimer(time.Second).C:
+			c.Fatalf("timed out waiting for %dth ID", i)
+		}
+	}
 }
 
 type addRuleContents struct {

--- a/randutil/rand.go
+++ b/randutil/rand.go
@@ -84,6 +84,7 @@ var (
 	Intn   = rand.Intn
 	Int63n = rand.Int63n
 	Perm   = rand.Perm
+	Uint64 = rand.Uint64
 )
 
 // RandomDuration returns a random duration up to the given length.


### PR DESCRIPTION
This PR is the first piece towards enabling prompting replies/rules with lifespan `"session"`.

Snapd needs a way to identify the systemd user session associated with a given user, and detect when that user session terminates or restarts.

Systemd creates a tmpfs at `/run/user/<userID>` when the first session for a given user starts. It persists and is shared by any concurrent sessions for that same user, and when all sessions for that user terminate, systemd deletes the tmpfs at `/run/user/<userID>` and everything in it.

Therefore, snapd can use this tmpfs to identify the user session and detect termination/restart by simply writing a random ID there.

Whenever snapd wants to use the current session ID for a given user, for example to create a rule with lifespan "session" (coming soon) or detect whether the user session associated with an existing rule has expired, it can attempt to read the user session ID from `/run/user/<userID>`, and if not found, generate and save a new one.

If the resulting session ID matches that of an existing rule, then we know the session during which that rule was created is still active, and if it differs, then we know that rule applies to a different user session and should be treated as expired.

This commit adds a function to perform that load-or-store transaction, returning either the existing user session ID or a newly-generated one, which it has also written to disk. The function performs the read and write while holding a lock, thus ensuring that there are no TOCTOU races between multiple goroutines checking an absent user session ID file and attempting to write a new one concurrently.

Because this function only operates within `/run/user`, which is a tmpfs, there is no need for more robust atomic file operations which would be necessary on a persistent filesystem. Snapd should be the only writer to the user session ID file for any given user, and if it becomes corrupted for some reason, it can be discarded and a new ID regenerated.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-33851