### PR TITLE
cmd/snap-bootstrap: allow non-gpt in fallback mode to support rpi

### DIFF
--- a/cmd/snap-bootstrap/blkid/blkid.go
+++ b/cmd/snap-bootstrap/blkid/blkid.go
@@ -36,7 +36,6 @@ const (
 	BLKID_PARTS_ENTRY_DETAILS int = C.BLKID_PARTS_ENTRY_DETAILS
 
 	BLKID_SUBLKS_LABEL int = C.BLKID_SUBLKS_LABEL
-	BLKID_SUBLKS_UUID  int = C.BLKID_SUBLKS_UUID
 )
 
 // AbstractBlkidProbe is wrapper for blkid_probe

--- a/cmd/snap-bootstrap/blkid/blkid.go
+++ b/cmd/snap-bootstrap/blkid/blkid.go
@@ -34,6 +34,9 @@ import (
 
 const (
 	BLKID_PARTS_ENTRY_DETAILS int = C.BLKID_PARTS_ENTRY_DETAILS
+
+	BLKID_SUBLKS_LABEL int = C.BLKID_SUBLKS_LABEL
+	BLKID_SUBLKS_UUID  int = C.BLKID_SUBLKS_UUID
 )
 
 // AbstractBlkidProbe is wrapper for blkid_probe
@@ -45,10 +48,12 @@ type AbstractBlkidProbe interface {
 	Close()
 	// EnablePartitions is a wrapper for blkid_probe_enable_partitions
 	EnablePartitions(value bool)
-	// EnableSuperblocks is a wrapper for blkid_probe_enable_superblocks
-	EnableSuperblocks(value bool)
 	// SetPartitionsFlags is a wrapper for blkid_probe_set_partitions_flags
 	SetPartitionsFlags(flags int)
+	// EnableSuperblocks is a wrapper for blkid_probe_enable_superblocks
+	EnableSuperblocks(value bool)
+	// SetSuperblockFlags is a wrapper for blkid_probe_set_superblocks_flags
+	SetSuperblockFlags(flags int)
 	// DoSafeprobe is a wrapper for blkid_do_safeprobe
 	DoSafeprobe() error
 	// GetPartitions is a wrapper for blkid_probe_get_partitions
@@ -68,6 +73,8 @@ type AbstractBlkidPartition interface {
 	GetName() string
 	// GetUUID is a wrapper for blkid_partition_get_uuid
 	GetUUID() string
+	// GetPartNo is a wrapper for blkid_partition_get_partno
+	GetPartNo() int
 }
 
 type blkidProbe struct {
@@ -127,6 +134,11 @@ func (p *blkidProbe) EnablePartitions(value bool) {
 	C.blkid_probe_enable_partitions(p.probeHandle, C.int(v))
 }
 
+func (p *blkidProbe) SetPartitionsFlags(flags int) {
+	p.checkProbe()
+	C.blkid_probe_set_partitions_flags(p.probeHandle, C.int(flags))
+}
+
 func (p *blkidProbe) EnableSuperblocks(value bool) {
 	p.checkProbe()
 	v := 0
@@ -136,9 +148,9 @@ func (p *blkidProbe) EnableSuperblocks(value bool) {
 	C.blkid_probe_enable_superblocks(p.probeHandle, C.int(v))
 }
 
-func (p *blkidProbe) SetPartitionsFlags(flags int) {
+func (p *blkidProbe) SetSuperblockFlags(flags int) {
 	p.checkProbe()
-	C.blkid_probe_set_partitions_flags(p.probeHandle, C.int(flags))
+	C.blkid_probe_set_superblocks_flags(p.probeHandle, C.int(flags))
 }
 
 func (p *blkidProbe) DoSafeprobe() error {
@@ -183,4 +195,8 @@ func (p *blkidPartition) GetName() string {
 
 func (p *blkidPartition) GetUUID() string {
 	return C.GoString(C.blkid_partition_get_uuid(p.partitionHandle))
+}
+
+func (p *blkidPartition) GetPartNo() int {
+	return int((C.int)(C.blkid_partition_get_partno(p.partitionHandle)))
 }

--- a/cmd/snap-bootstrap/blkid/mock_blkid.go
+++ b/cmd/snap-bootstrap/blkid/mock_blkid.go
@@ -47,13 +47,19 @@ func BuildFakeProbe(values map[string]string) *FakeBlkidProbe {
 	return &FakeBlkidProbe{values, &FakeBlkidPartlist{}}
 }
 
-func (p *FakeBlkidProbe) AddPartition(name, uuid string) {
-	p.partlist.partitions = append(p.partlist.partitions, &FakeBlkidPartition{name, uuid})
+func (p *FakeBlkidProbe) AddPartitionProbe(name, uuid string, index int) *FakeBlkidProbe {
+	p.partlist.partitions = append(p.partlist.partitions, &FakeBlkidPartition{name, uuid, index})
+
+	partition_values := make(map[string]string)
+	partition_values["LABEL"] = name
+	partition_values["UUID"] = uuid
+	return BuildFakeProbe(partition_values)
 }
 
 type FakeBlkidPartition struct {
-	name string
-	uuid string
+	name  string
+	uuid  string
+	index int
 }
 
 type FakeBlkidPartlist struct {
@@ -79,10 +85,13 @@ func (p *FakeBlkidProbe) Close() {
 func (p *FakeBlkidProbe) EnablePartitions(value bool) {
 }
 
+func (p *FakeBlkidProbe) SetPartitionsFlags(flags int) {
+}
+
 func (p *FakeBlkidProbe) EnableSuperblocks(value bool) {
 }
 
-func (p *FakeBlkidProbe) SetPartitionsFlags(flags int) {
+func (p *FakeBlkidProbe) SetSuperblockFlags(flags int) {
 }
 
 func (p *FakeBlkidProbe) DoSafeprobe() error {
@@ -107,4 +116,8 @@ func (p *FakeBlkidPartition) GetName() string {
 
 func (p *FakeBlkidPartition) GetUUID() string {
 	return p.uuid
+}
+
+func (p *FakeBlkidPartition) GetPartNo() int {
+	return p.index
 }

--- a/cmd/snap-bootstrap/blkid/mock_blkid.go
+++ b/cmd/snap-bootstrap/blkid/mock_blkid.go
@@ -47,8 +47,8 @@ func BuildFakeProbe(values map[string]string) *FakeBlkidProbe {
 	return &FakeBlkidProbe{values, &FakeBlkidPartlist{}}
 }
 
-func (p *FakeBlkidProbe) AddPartitionProbe(name, uuid string, index int) *FakeBlkidProbe {
-	p.partlist.partitions = append(p.partlist.partitions, &FakeBlkidPartition{name, uuid, index})
+func (p *FakeBlkidProbe) AddPartitionProbe(name, uuid string) *FakeBlkidProbe {
+	p.partlist.partitions = append(p.partlist.partitions, &FakeBlkidPartition{name, uuid})
 
 	partition_values := make(map[string]string)
 	partition_values["LABEL"] = name
@@ -57,9 +57,8 @@ func (p *FakeBlkidProbe) AddPartitionProbe(name, uuid string, index int) *FakeBl
 }
 
 type FakeBlkidPartition struct {
-	name  string
-	uuid  string
-	index int
+	name string
+	uuid string
 }
 
 type FakeBlkidPartlist struct {
@@ -102,6 +101,10 @@ func (p *FakeBlkidProbe) GetPartitions() (AbstractBlkidPartlist, error) {
 	return p.partlist, nil
 }
 
+func (p *FakeBlkidProbe) GetSectorSize() (uint, error) {
+	return 0, nil
+}
+
 func (p *FakeBlkidPartlist) GetPartitions() []AbstractBlkidPartition {
 	ret := make([]AbstractBlkidPartition, len(p.partitions))
 	for i, partition := range p.partitions {
@@ -118,6 +121,10 @@ func (p *FakeBlkidPartition) GetUUID() string {
 	return p.uuid
 }
 
-func (p *FakeBlkidPartition) GetPartNo() int {
-	return p.index
+func (p *FakeBlkidPartition) GetStart() int64 {
+	return 0
+}
+
+func (p *FakeBlkidPartition) GetSize() int64 {
+	return 0
 }

--- a/cmd/snap-bootstrap/cmd_scan_disk.go
+++ b/cmd/snap-bootstrap/cmd_scan_disk.go
@@ -261,7 +261,7 @@ func scanDiskNodeFallback(output io.Writer, node string) error {
 	}
 
 	for _, part := range partitions {
-		if part.FilesystemLabel == fallbackPartition {
+		if part.Name == fallbackPartition || part.FilesystemLabel == fallbackPartition {
 			fmt.Fprintf(output, "UBUNTU_DISK=1\n")
 			return nil
 		}

--- a/cmd/snap-bootstrap/cmd_scan_disk.go
+++ b/cmd/snap-bootstrap/cmd_scan_disk.go
@@ -158,7 +158,12 @@ func probeDisk(node string) ([]Partition, error) {
 
 	ret := make([]Partition, 0)
 	for _, partition := range partitions.GetPartitions() {
-		if !gpt {
+		if gpt {
+			ret = append(ret, Partition{
+				Name: partition.GetName(),
+				UUID: partition.GetUUID(),
+			})
+		} else {
 			// For MBR we have to probe the filesystem for details
 			pnode := fmt.Sprintf("%sp%d", node, partition.GetPartNo())
 			p, err := probeFilesystem(pnode)
@@ -166,11 +171,6 @@ func probeDisk(node string) ([]Partition, error) {
 				return ret, err
 			}
 			ret = append(ret, p)
-		} else {
-			ret = append(ret, Partition{
-				Name: partition.GetName(),
-				UUID: partition.GetUUID(),
-			})
 		}
 	}
 

--- a/cmd/snap-bootstrap/cmd_scan_disk_test.go
+++ b/cmd/snap-bootstrap/cmd_scan_disk_test.go
@@ -68,7 +68,7 @@ func (s *scanDiskSuite) SetUpTest(c *C) {
 		{"/dev/foop3", "ubuntu-data-enc", "c01a272d-fc72-40de-92fb-242c2da82533"},
 		{"/dev/foop4", "ubuntu-save-enc", "050ee326-ab58-4eb4-ba7d-13694b2d0c8a"},
 	} {
-		s.probeMap[fmt.Sprintf("/dev/foop%d", i+1)] = disk_probe.AddPartitionProbe(partition.label, partition.uuid, i+1)
+		s.probeMap[fmt.Sprintf("/dev/foop%d", i+1)] = disk_probe.AddPartitionProbe(partition.label, partition.uuid)
 	}
 	s.probeMap["/dev/foo"] = disk_probe
 
@@ -139,7 +139,7 @@ func (s *scanDiskSuite) TestDetectBootDiskCVM(c *C) {
 	disk_values := make(map[string]string)
 	disk_values["PTTYPE"] = "gpt"
 	disk_probe := blkid.BuildFakeProbe(disk_values)
-	for i, partition := range []struct {
+	for _, partition := range []struct {
 		node  string
 		label string
 		uuid  string
@@ -147,7 +147,7 @@ func (s *scanDiskSuite) TestDetectBootDiskCVM(c *C) {
 		{"/dev/foop1", "SEED", "6ae5a792-912e-43c9-ac92-e36723bbda12"},
 		{"/dev/foop2", "BOOT", "29261148-b8ba-4335-b934-417ed71e9e91"},
 	} {
-		s.probeMap[partition.node] = disk_probe.AddPartitionProbe(partition.label, partition.uuid, i+1)
+		s.probeMap[partition.node] = disk_probe.AddPartitionProbe(partition.label, partition.uuid)
 	}
 	s.probeMap["/dev/foo"] = disk_probe
 
@@ -204,10 +204,10 @@ func (s *scanDiskSuite) TestDetectBootDiskFallbackMBR(c *C) {
 	// default is setup to be PTTYPE=gpt, remake as MBR
 	disk_values := make(map[string]string)
 	disk_probe := blkid.BuildFakeProbe(disk_values)
-	s.probeMap["/dev/foop1"] = disk_probe.AddPartitionProbe("ubuntu-seed", "6ae5a792-912e-43c9-ac92-e36723bbda12", 1)
-	s.probeMap["/dev/foop2"] = disk_probe.AddPartitionProbe("ubuntu-boot", "29261148-b8ba-4335-b934-417ed71e9e91", 2)
-	s.probeMap["/dev/foop3"] = disk_probe.AddPartitionProbe("ubuntu-data-enc", "c01a272d-fc72-40de-92fb-242c2da82533", 3)
-	s.probeMap["/dev/foop4"] = disk_probe.AddPartitionProbe("ubuntu-save-enc", "050ee326-ab58-4eb4-ba7d-13694b2d0c8a", 4)
+	s.probeMap["/dev/foop1"] = disk_probe.AddPartitionProbe("ubuntu-seed", "6ae5a792-912e-43c9-ac92-e36723bbda12")
+	s.probeMap["/dev/foop2"] = disk_probe.AddPartitionProbe("ubuntu-boot", "29261148-b8ba-4335-b934-417ed71e9e91")
+	s.probeMap["/dev/foop3"] = disk_probe.AddPartitionProbe("ubuntu-data-enc", "c01a272d-fc72-40de-92fb-242c2da82533")
+	s.probeMap["/dev/foop4"] = disk_probe.AddPartitionProbe("ubuntu-save-enc", "050ee326-ab58-4eb4-ba7d-13694b2d0c8a")
 	s.probeMap["/dev/foo"] = disk_probe
 
 	output := newBuffer()
@@ -228,7 +228,7 @@ func (s *scanDiskSuite) TestDetectBootDiskFallbackInstall(c *C) {
 	disk_values := make(map[string]string)
 	disk_values["PTTYPE"] = "gpt"
 	disk_probe := blkid.BuildFakeProbe(disk_values)
-	s.probeMap["/dev/foop1"] = disk_probe.AddPartitionProbe("ubuntu-seed", "6ae5a792-912e-43c9-ac92-e36723bbda12", 1)
+	s.probeMap["/dev/foop1"] = disk_probe.AddPartitionProbe("ubuntu-seed", "6ae5a792-912e-43c9-ac92-e36723bbda12")
 	s.probeMap["/dev/foo"] = disk_probe
 	delete(s.probeMap, "/dev/foop2")
 	delete(s.probeMap, "/dev/foop3")
@@ -251,9 +251,9 @@ func (s *scanDiskSuite) TestDetectBootDiskFallbackMissingBoot(c *C) {
 	disk_values := make(map[string]string)
 	disk_values["PTTYPE"] = "gpt"
 	disk_probe := blkid.BuildFakeProbe(disk_values)
-	s.probeMap["/dev/foop1"] = disk_probe.AddPartitionProbe("ubuntu-seed", "6ae5a792-912e-43c9-ac92-e36723bbda12", 1)
-	s.probeMap["/dev/foop3"] = disk_probe.AddPartitionProbe("ubuntu-data-enc", "c01a272d-fc72-40de-92fb-242c2da82533", 3)
-	s.probeMap["/dev/foop4"] = disk_probe.AddPartitionProbe("ubuntu-save-enc", "050ee326-ab58-4eb4-ba7d-13694b2d0c8a", 4)
+	s.probeMap["/dev/foop1"] = disk_probe.AddPartitionProbe("ubuntu-seed", "6ae5a792-912e-43c9-ac92-e36723bbda12")
+	s.probeMap["/dev/foop3"] = disk_probe.AddPartitionProbe("ubuntu-data-enc", "c01a272d-fc72-40de-92fb-242c2da82533")
+	s.probeMap["/dev/foop4"] = disk_probe.AddPartitionProbe("ubuntu-save-enc", "050ee326-ab58-4eb4-ba7d-13694b2d0c8a")
 	s.probeMap["/dev/foo"] = disk_probe
 	delete(s.probeMap, "/dev/foop2")
 
@@ -274,9 +274,9 @@ func (s *scanDiskSuite) TestDetectBootDiskFallbackMissingSeedRecover(c *C) {
 	disk_values := make(map[string]string)
 	disk_values["PTTYPE"] = "gpt"
 	disk_probe := blkid.BuildFakeProbe(disk_values)
-	s.probeMap["/dev/foop2"] = disk_probe.AddPartitionProbe("ubuntu-boot", "29261148-b8ba-4335-b934-417ed71e9e91", 2)
-	s.probeMap["/dev/foop3"] = disk_probe.AddPartitionProbe("ubuntu-data-enc", "c01a272d-fc72-40de-92fb-242c2da82533", 3)
-	s.probeMap["/dev/foop4"] = disk_probe.AddPartitionProbe("ubuntu-save-enc", "050ee326-ab58-4eb4-ba7d-13694b2d0c8a", 4)
+	s.probeMap["/dev/foop2"] = disk_probe.AddPartitionProbe("ubuntu-boot", "29261148-b8ba-4335-b934-417ed71e9e91")
+	s.probeMap["/dev/foop3"] = disk_probe.AddPartitionProbe("ubuntu-data-enc", "c01a272d-fc72-40de-92fb-242c2da82533")
+	s.probeMap["/dev/foop4"] = disk_probe.AddPartitionProbe("ubuntu-save-enc", "050ee326-ab58-4eb4-ba7d-13694b2d0c8a")
 
 	s.probeMap["/dev/foo"] = disk_probe
 	delete(s.probeMap, "/dev/foop1")

--- a/cmd/snap-bootstrap/cmd_scan_disk_test.go
+++ b/cmd/snap-bootstrap/cmd_scan_disk_test.go
@@ -139,7 +139,7 @@ func (s *scanDiskSuite) TestDetectBootDiskCVM(c *C) {
 	disk_values := make(map[string]string)
 	disk_values["PTTYPE"] = "gpt"
 	disk_probe := blkid.BuildFakeProbe(disk_values)
-	for _, partition := range []struct {
+	for i, partition := range []struct {
 		node  string
 		label string
 		uuid  string
@@ -147,10 +147,7 @@ func (s *scanDiskSuite) TestDetectBootDiskCVM(c *C) {
 		{"/dev/foop1", "SEED", "6ae5a792-912e-43c9-ac92-e36723bbda12"},
 		{"/dev/foop2", "BOOT", "29261148-b8ba-4335-b934-417ed71e9e91"},
 	} {
-		values := make(map[string]string)
-		values["PART_ENTRY_UUID"] = partition.uuid
-		s.probeMap[partition.node] = blkid.BuildFakeProbe(values)
-		disk_probe.AddPartition(partition.label, partition.uuid)
+		s.probeMap[partition.node] = disk_probe.AddPartitionProbe(partition.label, partition.uuid, i+1)
 	}
 	s.probeMap["/dev/foo"] = disk_probe
 


### PR DESCRIPTION
See related issue on LP: https://bugs.launchpad.net/canonical-kernel-snaps/+bug/2114779

