### PR TITLE
github: run only one system for draft PRs

### DIFF
--- a/.github/workflows/ci-labeler.yaml
+++ b/.github/workflows/ci-labeler.yaml
@@ -20,5 +20,5 @@ jobs:
     - name: Apply draft label using gh CLI
       env:
         GH_TOKEN: ${{ github.token }}
-      if: github.event.action == 'opened' && github.event.pull_request.draft == true
+      if: github.event.action == 'opened' && github.event.pull_request.draft == true && !contains(github.event.pull_request.labels.*.name, 'Skip spread')
       run: gh pr edit ${{ github.event.pull_request.number }} --add-label 'Run only one system'

--- a/.github/workflows/ci-labeler.yaml
+++ b/.github/workflows/ci-labeler.yaml
@@ -13,3 +13,12 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: "true"
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Apply draft label using gh CLI
+      env:
+        GH_TOKEN: ${{ github.token }}
+      if: github.event.action == 'opened' && github.event.pull_request.draft == true
+      run: gh pr edit ${{ github.event.pull_request.number }} --add-label 'Run only one system'

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -361,6 +361,11 @@ jobs:
 
   read-systems:
     runs-on: ubuntu-latest
+    # This dependency only serves to ensure this job runs after the
+    # labeler finishes its work
+    needs: snap-builds
+    env:
+      GH_TOKEN: ${{ github.token }}
     outputs:
       fundamental-systems: ${{ steps.read-systems.outputs.fundamental-systems }}
       non-fundamental-systems: ${{ steps.read-systems.outputs.non-fundamental-systems }}
@@ -377,9 +382,21 @@ jobs:
           echo "non-fundamental-systems=$(jq -c . ./.github/workflows/data-non-fundamental-systems.json)" >> $GITHUB_OUTPUT
           echo "nested-systems=$(jq -c . ./.github/workflows/data-nested-systems.json)" >> $GITHUB_OUTPUT
 
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            labels=$(gh pr view ${{ github.event.pull_request.number }} --repo github.com/canonical/snapd --json labels | jq -r '.labels[].name')
+            if grep -q '^Run only one system$' <<<$labels; then
+              echo "fundamental-systems=$(jq -c ".include |= map(select(.systems == \"ubuntu-24.04-64\"))" .github/workflows/data-fundamental-systems.json)" >> $GITHUB_OUTPUT
+              echo "non-fundamental-systems=" >> $GITHUB_OUTPUT
+              if ! grep -q '^Run nested$' <<<$labels; then
+                echo "nested-systems=" >> $GITHUB_OUTPUT
+              fi
+            fi
+          fi
+
   spread-fundamental:
     uses: ./.github/workflows/spread-tests.yaml
     needs: [unit-tests, unit-tests-c, snap-builds, read-systems]
+    if: needs.read-systems.outputs.fundamental-systems != ''
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.
@@ -405,7 +422,7 @@ jobs:
 
   spread-not-fundamental-pr:
     uses: ./.github/workflows/spread-tests.yaml
-    if: github.event_name == 'pull_request' && !contains(github.base_ref, 'release') && !contains(github.event.pull_request.labels.*.name, 'cross-distro')
+    if: github.event_name == 'pull_request' && !contains(github.base_ref, 'release') && !contains(github.event.pull_request.labels.*.name, 'cross-distro') && needs.read-systems.outputs.non-fundamental-systems != ''
     # For workflow runs that are PRs, run this non-fundamental systems job
     # only after the fundamental systems job succeeds.
     needs: [unit-tests, unit-tests-c, snap-builds, read-systems, spread-fundamental]
@@ -462,6 +479,7 @@ jobs:
   spread-nested:
     uses: ./.github/workflows/spread-tests.yaml
     needs: [unit-tests, unit-tests-c, snap-builds, read-systems]
+    if: needs.read-systems.outputs.nested-systems != ''
     name: "spread ${{ matrix.group }}"
     with:
       # Github doesn't support passing sequences as parameters.

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -385,7 +385,9 @@ jobs:
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             labels=$(gh pr view ${{ github.event.pull_request.number }} --repo github.com/canonical/snapd --json labels | jq -r '.labels[].name')
             if grep -q '^Run only one system$' <<<$labels; then
-              echo "fundamental-systems=$(jq -c ".include |= map(select(.systems == \"ubuntu-24.04-64\"))" .github/workflows/data-fundamental-systems.json)" >> $GITHUB_OUTPUT
+              # filter out all other systems but this one single system
+              single_system=ubuntu-24.04-64
+              echo "fundamental-systems=$(jq -c ".include |= map(select(.systems == \"$single_system\"))" .github/workflows/data-fundamental-systems.json)" >> $GITHUB_OUTPUT
               echo "non-fundamental-systems=" >> $GITHUB_OUTPUT
               if ! grep -q '^Run nested$' <<<$labels; then
                 echo "nested-systems=" >> $GITHUB_OUTPUT

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -99,7 +99,7 @@ jobs:
             echo "$env" >> $GITHUB_ENV
           done
 
-    - name: Set PR labels as environment variables
+    - name: Check PR labels
       if: ${{ github.event.pull_request.number }}
       run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --repo github.com/canonical/snapd --json labels | jq -r '.labels[].name')
@@ -111,6 +111,19 @@ jobs:
           fi
           if grep -q '^Run nested$' <<<$labels; then
             echo "RUN_NESTED_LABEL=true" >> $GITHUB_ENV
+          fi
+
+          if grep -q '^Run only one system$' <<<$labels; then
+
+            # Automatically fail tests unless one of the two is true:
+            #  1. the system is ubuntu-24.04-64 and it is not a nested test
+            #  2. it is a nested test and the 'Run nested' label is present
+
+            if ! ([[ "${{ inputs.systems }}" =~ "ubuntu-24.04-64" ]] && [[ ! "${{ inputs.backend }}" =~ "-nested" ]]) && ! (grep -q '^Run nested$' <<<$labels && [[ "${{ inputs.backend }}" =~ "-nested" ]]); then
+              echo "Due to the 'Run only one system' label on the PR, all spread tests automatically fail except for noble and, if the PR contains the 'Run nested' label, nested tests."
+              echo "If you need to run spread on more systems, remove the 'Run only one system' label and rerun the failed jobs (no need to close and reopen the PR)."
+              exit 1
+            fi
           fi
 
     - name: Get previous attempt

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -99,7 +99,7 @@ jobs:
             echo "$env" >> $GITHUB_ENV
           done
 
-    - name: Check PR labels
+    - name: Set PR labels as environment variables
       if: ${{ github.event.pull_request.number }}
       run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --repo github.com/canonical/snapd --json labels | jq -r '.labels[].name')
@@ -111,19 +111,6 @@ jobs:
           fi
           if grep -q '^Run nested$' <<<$labels; then
             echo "RUN_NESTED_LABEL=true" >> $GITHUB_ENV
-          fi
-
-          if grep -q '^Run only one system$' <<<$labels; then
-
-            # Automatically fail tests unless one of the two is true:
-            #  1. the system is ubuntu-24.04-64 and it is not a nested test
-            #  2. it is a nested test and the 'Run nested' label is present
-
-            if ! ([[ "${{ inputs.systems }}" =~ "ubuntu-24.04-64" ]] && [[ ! "${{ inputs.backend }}" =~ "-nested" ]]) && ! (grep -q '^Run nested$' <<<$labels && [[ "${{ inputs.backend }}" =~ "-nested" ]]); then
-              echo "Due to the 'Run only one system' label on the PR, all spread tests automatically fail except for noble and, if the PR contains the 'Run nested' label, nested tests."
-              echo "If you need to run spread on more systems, remove the 'Run only one system' label and rerun the failed jobs (no need to close and reopen the PR)."
-              exit 1
-            fi
           fi
 
     - name: Get previous attempt


### PR DESCRIPTION
This automatically adds the 'Run only one system' label to all draft PRs. The label is then dynamically checked (along with 'Run nested') in `spread-tests.yaml` to permit its removal without requiring a close/reopen or a new commit push. All systems except for Noble (and nested systems if the "Run nested" is present) will be filtered out). To remove the filtering, after having removed the "Run only one system" label, one will have to either rerun all jobs or rerun the read-systems job (assuming the read-systems job has already run at least once). 

~The spread test job will automatically fail for all systems except for non-nested ubuntu-24.04-64 (also if the 'Run nested' label is present, then nested tests will also be exempt from automatic failure).~

~## Why automatic failure instead of either skipping or not running the tests?~

~I think it would be so much better to either not run or skip the spread tests rather than automatically failing them. However, I do not think doing so is feasible.~

~## My rationale:~

~#### Idea: ~
~Filter out everything but Noble in the matrix data in `ci-tests.yaml` in the `read-systems` job. Then only that system would appear in the run: very clean and simple.~

~#### Problem:~
~Once the label is removed, the only way to un-filter the data is to rerun the `read-systems' job. It will not be automatically rerun when doing 'Rerun all failed jobs' because it is not a failed job. That is not reasonable.~

~#### Idea:~
~Use a job if condition for the spread tests that skips the job if the 'Run only one system' label is present and the system is not noble~
~#### Problem:~
~We need to have dynamic label checking and there is no way to have that check in the if condition itself. It is also not possible to set an environment variable or output in some previous job, because, as with the previous idea, that job would need to be rerun with the failed jobs.~

## Solution validation

I opened up a PR on my fork and verified the following.

- Opening a draft PR automatically applies the label
  - https://github.com/maykathm/snapd/pull/53
- Opening a non-draft PR does not apply the label
  - https://github.com/maykathm/snapd/pull/54
~- A draft PR CI run with only 'Run only one system' label and no other labels correctly fails all spread tests but noble:~
~  - https://github.com/maykathm/snapd/actions/runs/15906908574~
~- A draft PR CI run with both 'Run only one system' and 'Run nested' labels will run only noble and all nested tests:~
~  - https://github.com/maykathm/snapd/actions/runs/15906908574~
~- In a draft PR with the 'Run only one system' removed, after a new commit push, the label does not get reapplied:~
~  - https://github.com/maykathm/snapd/actions/runs/15907040902/job/44864589819~