### PR TITLE
tests/unit/go: use nooptee flag in unit test build

### DIFF
--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -69,6 +69,14 @@ execute: |
     fi
 
     if not os.query is-trusty; then
+        # TODO: skip building optee for now on arm, since this doesn't impact
+        # any unit tests. once optee build is fully fixed, consider removing
+        # this.
+        build_tags=''
+        if os.query is-arm64; then
+          build_tags='nooptee'
+        fi
+
         if [ "$VARIANT" = "static" ] ; then
             tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
                 PATH=$PATH \
@@ -77,6 +85,7 @@ execute: |
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
                 IGNORE_MISSING=1 \
+                GO_BUILD_TAGS=${build_tags} \
                 ./run-checks --static"
         else
             tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
@@ -86,6 +95,7 @@ execute: |
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
                 IGNORE_MISSING=1 \
+                GO_BUILD_TAGS=${build_tags} \
                 ./run-checks --unit"
         fi
     else


### PR DESCRIPTION
This doesn't impact any unit tests. We could consider installing the build dependency in the spread tests, but I don't think that is worth it.