### PR TITLE
daemon: add /v2/system-volumes action for changing passphrase

### DIFF
--- a/client/system_volumes.go
+++ b/client/system_volumes.go
@@ -53,3 +53,8 @@ type SystemVolumesOptions struct {
 	ContainerRoles  []string
 	ByContainerRole bool
 }
+
+type ChangePassphraseOptions struct {
+	OldPassphrase string `json:"old-passphrase"`
+	NewPassphrase string `json:"new-passphrase"`
+}

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -37,6 +38,10 @@ func MockFdeMgrCheckRecoveryKey(f func(fdemgr *fdestate.FDEManager, rkey keys.Re
 
 func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
 	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
+}
+
+func MockFdestateChangeAuth(f func(st *state.State, authMode device.AuthMode, old string, new string, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
+	return testutil.Mock(&fdestateChangeAuth, f)
 }
 
 func MockDevicestateGetVolumeStructuresWithKeyslots(f func(st *state.State) ([]devicestate.VolumeStructureWithKeyslots, error)) (restore func()) {

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -508,3 +508,8 @@ func ReplaceRecoveryKey(st *state.State, recoveryKeyID string, keyslots []Keyslo
 
 	return ts, nil
 }
+
+func ChangeAuth(st *state.State, authMode device.AuthMode, old, new string, keyslotRefs []KeyslotRef) (*state.TaskSet, error) {
+	// TODO:FDEM: mock for actual implementation
+	return state.NewTaskSet(), nil
+}


### PR DESCRIPTION
This PR adds a new `/v2/system-volumes` action `change-passphrase` that allows changing an existing passphrase protected key slot.

https://github.com/canonical/snapd/pull/15614 contains the actual implementation for changing a passphrase.

For context, please check SD201 spec.