### PR TITLE
daemon: add access checkers needed for /v2/system-volumes endpoint

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -320,6 +320,29 @@ func (ac interfaceProviderRootAccess) CheckAccess(d *Daemon, r *http.Request, uc
 	return Unauthorized("access denied")
 }
 
+// interfaceRootAccess behaves like rootAccess, but also allows requests
+// over snapd-snap.socket for snaps that have a connection of specific interface
+// and are present on the plug side of that connection.
+type interfaceRootAccess struct {
+	Interfaces []string
+}
+
+func (ac interfaceRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	rsperr := requireInterfaceApiAccess(d, r, ucred, interfaceAccessReqs{
+		Interfaces: ac.Interfaces,
+		Plug:       true,
+	})
+	if rsperr != nil {
+		return rsperr
+	}
+
+	if ucred.Uid == 0 {
+		return nil
+	}
+
+	return Unauthorized("access denied")
+}
+
 type actionRequest struct {
 	Action string `json:"action"`
 }

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -128,6 +128,7 @@ func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserSta
 	}
 
 	if opts.accessLevel == accessLevelAuthenticated && user != nil {
+		// user != nil means we have an authenticated user
 		return nil
 	}
 
@@ -425,7 +426,8 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 	req := actionRequest{}
 
 	bufSize := r.ContentLength
-	if bufSize > maxBodySize {
+	// The value -1 indicates that the length is unknown.
+	if bufSize > maxBodySize || bufSize == -1 {
 		bufSize = maxBodySize
 	}
 	buf := bytes.NewBuffer(make([]byte, 0, bufSize))

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -440,7 +440,7 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 	// action access checker.
 	case rootAccess, interfaceRootAccess, interfaceProviderRootAccess:
 	default:
-		return InternalError("default access checker must have root-level access: got %T", ac.Default)
+		return InternalError("internal error: default access checker must have root-level access: got %T", ac.Default)
 	}
 
 	if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -421,15 +421,6 @@ type actionRequest struct {
 type byActionAccess struct {
 	// ByAction maps from detected request action to access checker.
 	ByAction map[string]accessChecker
-	// Default is the fallback access checker if no action was matched
-	// which could happen if:
-	//   - Content type is not "application/json"
-	//   - JSON body is malformed
-	//   - No action is passed
-	//   - Action is not found under ByAction
-	//
-	// This should be as strict as possible, e.g. rootAccess.
-	Default accessChecker
 }
 
 const maxBodySize = 4 * 1024 * 1024 // 4MB
@@ -467,7 +458,7 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 
 	checker := ac.ByAction[req.Action]
 	if checker == nil {
-		return ac.Default.CheckAccess(d, r, ucred, user)
+		return BadRequest("unsupported action %q", req.Action)
 	}
 
 	return checker.CheckAccess(d, r, ucred, user)

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -893,6 +893,7 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 
 	var ac daemon.AccessChecker = daemon.ByActionAccess{
 		ByAction: byAction,
+		Default:  daemon.RootAccess{},
 	}
 
 	type testcase struct {
@@ -911,14 +912,14 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 				"action-1": errForbidden,
 				"action-2": errForbidden,
 				"action-3": errForbidden,
-				"unknown":  daemon.BadRequest(`unsupported action "unknown"`),
+				"default":  errForbidden,
 			},
 		},
 		{
 			ucred: daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket},
 			expectedErr: map[string]*daemon.APIError{
 				"action-1": errForbidden,
-				"unknown":  daemon.BadRequest(`unsupported action "unknown"`),
+				"default":  errForbidden,
 			},
 		},
 		{
@@ -927,7 +928,7 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 			expectedErr: map[string]*daemon.APIError{
 				"action-1": errForbidden,
 				"action-2": errUnauthorized,
-				"unknown":  daemon.BadRequest(`unsupported action "unknown"`),
+				"default":  errForbidden,
 			},
 		},
 		{
@@ -937,7 +938,7 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 				"action-1": daemon.BadRequest(`unexpected content type: ""`),
 				"action-2": daemon.BadRequest(`unexpected content type: ""`),
 				"action-3": daemon.BadRequest(`unexpected content type: ""`),
-				"unknown":  daemon.BadRequest(`unexpected content type: ""`),
+				"default":  daemon.BadRequest(`unexpected content type: ""`),
 			},
 		},
 		{
@@ -948,15 +949,12 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 				"action-1": daemon.BadRequest("invalid character '}' looking for beginning of value"),
 				"action-2": daemon.BadRequest("invalid character '}' looking for beginning of value"),
 				"action-3": daemon.BadRequest("invalid character '}' looking for beginning of value"),
-				"unknown":  daemon.BadRequest("invalid character '}' looking for beginning of value"),
+				"default":  daemon.BadRequest("invalid character '}' looking for beginning of value"),
 			},
 		},
 		{
 			ucred:  daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket},
 			noAuth: true,
-			expectedErr: map[string]*daemon.APIError{
-				"unknown": daemon.BadRequest(`unsupported action "unknown"`),
-			},
 		},
 		{
 			ucred:   daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket},
@@ -966,7 +964,7 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 				"action-1": daemon.BadRequest(`unexpected content type: ""`),
 				"action-2": daemon.BadRequest(`unexpected content type: ""`),
 				"action-3": daemon.BadRequest(`unexpected content type: ""`),
-				"unknown":  daemon.BadRequest(`unexpected content type: ""`),
+				"default":  daemon.BadRequest(`unexpected content type: ""`),
 			},
 		},
 		{
@@ -978,7 +976,7 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 				"action-1": daemon.BadRequest("invalid character '}' looking for beginning of value"),
 				"action-2": daemon.BadRequest("invalid character '}' looking for beginning of value"),
 				"action-3": daemon.BadRequest("invalid character '}' looking for beginning of value"),
-				"unknown":  daemon.BadRequest("invalid character '}' looking for beginning of value"),
+				"default":  daemon.BadRequest("invalid character '}' looking for beginning of value"),
 			},
 		},
 	}
@@ -999,12 +997,12 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 			}
 		}
 
-		cmt := Commentf("sub-test tcs[%d] failed for unknown action", idx)
-		err := ac.CheckAccess(nil, reqWithAction(c, "unknown", !tc.notJSON, tc.malformed), &tc.ucred, user)
-		if expectedErr := tc.expectedErr["unknown"]; err != nil {
-			c.Assert(err, DeepEquals, expectedErr, cmt)
+		cmt := Commentf("sub-test tcs[%d] failed for default action", idx)
+		err := ac.CheckAccess(nil, reqWithAction(c, "default", !tc.notJSON, tc.malformed), &tc.ucred, user)
+		if expectedErr := tc.expectedErr["default"]; err != nil {
+			c.Check(err, DeepEquals, expectedErr, cmt)
 		} else {
-			c.Assert(err, IsNil, cmt)
+			c.Check(err, IsNil, cmt)
 		}
 	}
 }

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -215,6 +215,40 @@ func (s *accessSuite) TestRootAccess(c *C) {
 	c.Check(ac.CheckAccess(nil, nil, ucred, nil), IsNil)
 }
 
+func (s *accessSuite) TestRootAccessPolkit(c *C) {
+	var ac daemon.AccessChecker = daemon.RootAccess{Polkit: "action-id"}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	user := &auth.UserState{}
+	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+
+	// polkit is not checked if any of:
+	//   * ucred is missing
+	//   * user is root
+	restore := daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) *daemon.APIError {
+		c.Fail()
+		return daemon.Forbidden("access denied")
+	})
+	defer restore()
+	c.Check(ac.CheckAccess(nil, req, nil, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil), IsNil)
+
+	// polkit is checked for regular users with or without macaroon auth
+	called := 0
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) *daemon.APIError {
+		called++
+		c.Check(r, Equals, req)
+		c.Check(u, Equals, ucred)
+		c.Check(action, Equals, "action-id")
+		return nil
+	})
+	defer restore()
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(nil, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, req, ucred, user), IsNil)
+	c.Check(called, Equals, 2)
+}
+
 func (s *accessSuite) TestSnapAccess(c *C) {
 	var ac daemon.AccessChecker = daemon.SnapAccess{}
 
@@ -602,6 +636,90 @@ plugs:
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
 }
 
+func (s *accessSuite) TestInterfaceProviderRootAccessPolkit(c *C) {
+	d := s.daemon(c)
+	s.mockSnap(c, `
+name: fwupd-app
+type: app
+version: 1
+slots:
+  fwupd-provider:
+    interface: fwupd
+  `)
+	s.mockSnap(c, `
+name: connected-fwupd-caller
+version: 1
+plugs:
+  fwupd-consumer:
+    interface: fwupd
+`)
+
+	restore := daemon.MockCgroupSnapNameFromPid(func(pid int) (string, error) {
+		switch pid {
+		case 42:
+			return "fwupd-app", nil
+		case 1042:
+			return "connected-fwupd-caller", nil
+		default:
+			return "", fmt.Errorf("not a snap")
+		}
+	})
+	defer restore()
+
+	st := d.Overlord().State()
+	st.Lock()
+	st.Set("conns", map[string]any{
+		"connected-fwupd-caller:fwupd fwupd-app:fwupd-provider": map[string]any{
+			"interface": "fwupd",
+		},
+	})
+	st.Unlock()
+
+	var ac daemon.AccessChecker = daemon.InterfaceProviderRootAccess{
+		Polkit:     "action-id",
+		Interfaces: []string{"fwupd"},
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	user := &auth.UserState{}
+
+	// polkit is not checked if any of:
+	//   * ucred is missing
+	//   * user is root
+	//   * snap request (as root) with relevant connected slot
+	//   * snap request without relevant connected slot
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) *daemon.APIError {
+		c.Fail()
+		return daemon.Forbidden("access denied")
+	})
+	defer restore()
+	// ucred is missing
+	c.Check(ac.CheckAccess(nil, req, nil, nil), DeepEquals, errForbidden)
+	// user is root (on snapd.socket)
+	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}, nil), IsNil)
+	// snap request (as root) with relevant connected slot (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 42, Socket: dirs.SnapSocket}, nil), IsNil)
+	// snap request without relevant connected slot (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 1042, Socket: dirs.SnapSocket}, user), DeepEquals, errForbidden)
+
+	// polkit is checked for snaps with connected slot
+	called := 0
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) *daemon.APIError {
+		called++
+		c.Check(r, Equals, req)
+		c.Check(action, Equals, "action-id")
+		return nil
+	})
+	defer restore()
+	// regular user (on snapd.socket)
+	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 1001, Pid: 100, Socket: dirs.SnapdSocket}, nil), IsNil)
+	// snap request (with macaroon) with relevant connected slot (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 42, Socket: dirs.SnapSocket}, user), IsNil)
+	// snap request (without macaroon) with relevant connected slot (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 42, Socket: dirs.SnapSocket}, nil), IsNil)
+	c.Check(called, Equals, 3)
+}
+
 func (s *accessSuite) TestInterfaceRootAccessCallsWithCorrectArgs(c *C) {
 	restore := daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) *daemon.APIError {
 		// Polkit is not consulted if no action is specified
@@ -735,6 +853,90 @@ plugs:
 		RemoteAddr: ucred.String(),
 	}
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+}
+
+func (s *accessSuite) TestInterfaceRootAccessPolkit(c *C) {
+	d := s.daemon(c)
+	s.mockSnap(c, `
+name: fwupd-app
+type: app
+version: 1
+slots:
+  fwupd-provider:
+    interface: fwupd
+  `)
+	s.mockSnap(c, `
+name: connected-fwupd-caller
+version: 1
+plugs:
+  fwupd-consumer:
+    interface: fwupd
+`)
+
+	restore := daemon.MockCgroupSnapNameFromPid(func(pid int) (string, error) {
+		switch pid {
+		case 42:
+			return "fwupd-app", nil
+		case 1042:
+			return "connected-fwupd-caller", nil
+		default:
+			return "", fmt.Errorf("not a snap")
+		}
+	})
+	defer restore()
+
+	st := d.Overlord().State()
+	st.Lock()
+	st.Set("conns", map[string]any{
+		"connected-fwupd-caller:fwupd fwupd-app:fwupd-provider": map[string]any{
+			"interface": "fwupd",
+		},
+	})
+	st.Unlock()
+
+	var ac daemon.AccessChecker = daemon.InterfaceRootAccess{
+		Polkit:     "action-id",
+		Interfaces: []string{"fwupd"},
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	user := &auth.UserState{}
+
+	// polkit is not checked if any of:
+	//   * ucred is missing
+	//   * user is root
+	//   * snap request (as root) with relevant connected plug
+	//   * snap request without relevant connected plug
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) *daemon.APIError {
+		c.Fail()
+		return daemon.Forbidden("access denied")
+	})
+	defer restore()
+	// ucred is missing
+	c.Check(ac.CheckAccess(nil, req, nil, nil), DeepEquals, errForbidden)
+	// user is root (on snapd.socket)
+	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}, nil), IsNil)
+	// snap request (as root) with relevant connected plug (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 1042, Socket: dirs.SnapSocket}, nil), IsNil)
+	// snap request without relevant connected plug (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 42, Socket: dirs.SnapSocket}, user), DeepEquals, errForbidden)
+
+	// polkit is checked for snaps with connected plug
+	called := 0
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) *daemon.APIError {
+		called++
+		c.Check(r, Equals, req)
+		c.Check(action, Equals, "action-id")
+		return nil
+	})
+	defer restore()
+	// regular user (on snapd.socket)
+	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 1001, Pid: 100, Socket: dirs.SnapdSocket}, nil), IsNil)
+	// snap request (with macaroon) with relevant connected plug (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 1042, Socket: dirs.SnapSocket}, user), IsNil)
+	// snap request (without macaroon) with relevant connected plug (on snapd-snap.socket)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 1042, Socket: dirs.SnapSocket}, nil), IsNil)
+	c.Check(called, Equals, 3)
 }
 
 func (s *accessSuite) TestRequireInterfaceApiAccessErrorChecks(c *C) {

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -1039,7 +1039,7 @@ func (s *accessSuite) TestByActionAccessDefaultMustBeRoot(c *C) {
 		if tc.canBeDefault {
 			c.Assert(err, IsNil)
 		} else {
-			c.Assert(err, DeepEquals, daemon.InternalError("default access checker must have root-level access: got %T", tc.ac))
+			c.Assert(err, DeepEquals, daemon.InternalError("internal error: default access checker must have root-level access: got %T", tc.ac))
 		}
 	}
 

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -35,6 +35,7 @@ type (
 	InterfaceOpenAccess          = interfaceOpenAccess
 	InterfaceAuthenticatedAccess = interfaceAuthenticatedAccess
 	InterfaceProviderRootAccess  = interfaceProviderRootAccess
+	InterfaceRootAccess          = interfaceRootAccess
 	ByActionAccess               = byActionAccess
 
 	InterfaceAccessReqs = interfaceAccessReqs

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -35,6 +35,7 @@ type (
 	InterfaceOpenAccess          = interfaceOpenAccess
 	InterfaceAuthenticatedAccess = interfaceAuthenticatedAccess
 	InterfaceProviderRootAccess  = interfaceProviderRootAccess
+	ByActionAccess               = byActionAccess
 
 	InterfaceAccessReqs = interfaceAccessReqs
 )

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -28,6 +28,8 @@ import (
 type (
 	AccessChecker = accessChecker
 
+	AccessOptions = accessOptions
+
 	OpenAccess                   = openAccess
 	AuthenticatedAccess          = authenticatedAccess
 	RootAccess                   = rootAccess
@@ -41,7 +43,11 @@ type (
 	InterfaceAccessReqs = interfaceAccessReqs
 )
 
-var CheckPolkitActionImpl = checkPolkitActionImpl
+var (
+	CheckAccess                   = checkAccess
+	CheckPolkitActionImpl         = checkPolkitActionImpl
+	RequireInterfaceApiAccessImpl = requireInterfaceApiAccessImpl
+)
 
 func MockCheckPolkitAction(new func(r *http.Request, ucred *Ucrednet, action string) *APIError) (restore func()) {
 	old := checkPolkitAction
@@ -66,8 +72,6 @@ func MockCgroupSnapNameFromPid(new func(pid int) (string, error)) (restore func(
 		cgroupSnapNameFromPid = old
 	}
 }
-
-var RequireInterfaceApiAccessImpl = requireInterfaceApiAccessImpl
 
 func MockRequireInterfaceApiAccess(new func(d *Daemon, r *http.Request, ucred *ucrednet, reqs InterfaceAccessReqs) *apiError) (restore func()) {
 	old := requireInterfaceApiAccess


### PR DESCRIPTION
This PR adds the following:
- `byActionAccess` access checker decides which access checker to use based on the JSON `action` field `{"action": "<action>"}` to allow using different access checkers based on the target action.
  -  This is intended to be used by the `/v2/system-volumes` endpoint but can also be used for similar action-based endpoints if needed.
- `interfaceRootAccess` access checker to allow root requests over `snapd-snap.socket` for snaps that have a connection of specific interface and are present on the plug side of that connection.
- add optional polkit support to root* access checkers

Example of how those new access checkers would be used:
```go
var systemVolumesCmd = &Command{
	Path: "/v2/system-volumes",
	GET:  getSystemVolumes,
	POST: postSystemVolumesAction,
	ReadAccess: interfaceOpenAccess{
		Interfaces: []string{"snap-fde"},
	},
	WriteAccess: byActionAccess{
		ByAction: map[string]accessChecker{
			"generate-recovery-key": interfaceRootAccess{
				Polkit:     "io.snapcraft.snapd.manage-fde",
				Interfaces: []string{"snap-fde"},
			},
			"replace-recovery-key": interfaceRootAccess{
				Polkit:     "io.snapcraft.snapd.manage-fde",
				Interfaces: []string{"snap-fde"},
			},
			"check-passphrase": interfaceOpenAccess{
				Interfaces: []string{"snap-fde"},
			},
		},
		Default: rootAccess{},
	},
}
```
