### PR TITLE
boot: do not reseal FDE hook keys every time

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -784,7 +784,8 @@ func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
 		// boot assets was updated
 		return nil
 	}
-	opts := ResealKeyToModeenvOptions{ExpectReseal: true}
+	// no model changed => ignore FDE hooks
+	opts := ResealKeyToModeenvOptions{ExpectReseal: true, IgnoreFDEHooks: true}
 	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, opts, nil); err != nil {
 		return err
 	}
@@ -850,7 +851,8 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 		return fmt.Errorf("cannot write modeeenv: %v", err)
 	}
 
-	opts := ResealKeyToModeenvOptions{ExpectReseal: true}
+	// no model changed => ignore FDE hooks
+	opts := ResealKeyToModeenvOptions{ExpectReseal: true, IgnoreFDEHooks: true}
 	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, opts, nil); err != nil {
 		return fmt.Errorf("while canceling gadget update: %v", err)
 	}

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -792,6 +792,7 @@ func (s *assetsSuite) testUpdateObserverUpdateMockedWithReseal(c *C, seedRole st
 	resealCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, true)
 		return nil
 	})
 	defer restore()
@@ -897,6 +898,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	resealCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, true)
 		return nil
 	})
 	defer restore()
@@ -1653,6 +1655,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 	resealCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, true)
 		return nil
 	})
 	defer restore()
@@ -2614,6 +2617,7 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 		c.Check(recoveryAsset.Hashes, testutil.Contains, dataHash)
 		c.Check(recoveryChain.Kernel, Equals, "pc-kernel")
 		c.Check(recoveryChain.KernelRevision, Equals, "1")
+		c.Check(opts.IgnoreFDEHooks, Equals, true)
 
 		return nil
 	})
@@ -2763,6 +2767,8 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		c.Check(recoveryAsset.Hashes, testutil.Contains, "assethash")
 		c.Check(recoveryChain.Kernel, Equals, "pc-kernel")
 		c.Check(recoveryChain.KernelRevision, Equals, "1")
+
+		c.Check(opts.IgnoreFDEHooks, Equals, true)
 
 		return nil
 	})

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -211,7 +211,9 @@ func (u20 *bootStateUpdate20) commit(markedSuccessful bool) error {
 		}
 	}
 
-	resealOpts := ResealKeyToModeenvOptions{}
+	// None of the implementation of successfulBootState is expected to modify the model.
+	// So we can safely ignore FDE hooks.
+	resealOpts := ResealKeyToModeenvOptions{IgnoreFDEHooks: true}
 
 	// next write the modeenv if it changed
 	if !u20.writeModeenv.deepEqual(u20.modeenv) {

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -373,7 +373,8 @@ func observeCommandLineUpdate(model *asserts.Model, reason commandLineUpdateReas
 		return false, err
 	}
 
-	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true}
+	// no model changed => ignore FDE hooks
+	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true, IgnoreFDEHooks: true}
 	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, resealOpts, nil); err != nil {
 		return false, err
 	}

--- a/boot/model.go
+++ b/boot/model.go
@@ -72,7 +72,9 @@ func DeviceChange(from snap.Device, to snap.Device, unlocker Unlocker) error {
 	// reseal with both models now, such that we'd still be able to boot
 	// even if there is a reboot before the device/model file is updated, or
 	// before the final reseal with one model
-	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true}
+	// Because changing models affect FDE hooks keys, we need to
+	// make sure those are also resealed.
+	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true, IgnoreFDEHooks: false}
 	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, resealOpts, unlocker); err != nil {
 		// best effort clear the modeenv's try model
 		m.clearTryModel()

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -206,6 +206,7 @@ func (s *modelSuite) TestDeviceChangeHappy(c *C) {
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
 		currForSealing := boot.ModelUniqueID(m.ModelForSealing())
@@ -269,6 +270,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstReseal(c *C) {
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
 		currForSealing := boot.ModelUniqueID(m.ModelForSealing())
@@ -320,6 +322,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstSwapModelFile(c *C) {
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
 		currForSealing := boot.ModelUniqueID(m.ModelForSealing())
@@ -373,6 +376,7 @@ func (s *modelSuite) TestDeviceChangeUnhappySecondReseal(c *C) {
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
 		currForSealing := boot.ModelUniqueID(m.ModelForSealing())
@@ -469,6 +473,7 @@ func (s *modelSuite) TestDeviceChangeRebootBeforeNewModel(c *C) {
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -588,6 +593,7 @@ func (s *modelSuite) TestDeviceChangeRebootAfterNewModelFileWrite(c *C) {
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		// timeline & calls:
 		// 1 - pre reboot, run & recovery keys, try model set
 		// 2 - run key, after model file has been modified, try model cleared, unexpected
@@ -708,6 +714,7 @@ func (s *modelSuite) TestDeviceChangeRebootPostSameModel(c *C) {
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		c.Logf("reseal key call: %v", resealKeysCalls)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
@@ -851,6 +858,7 @@ func (s *modelSuite) testDeviceChangeUnhappyMockedWriteModelToBoot(c *C, tc unha
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
 		currForSealing := boot.ModelUniqueID(m.ModelForSealing())
@@ -974,6 +982,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFailReseaWithSwappedModelMockedWrite
 	resealKeysCalls := 0
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		if resealKeysCalls == 2 {
 			m, err := boot.ReadModeenv("")
 			c.Assert(err, IsNil)
@@ -1062,6 +1071,7 @@ func (s *modelSuite) TestDeviceChangeRebootRestoreModelKeyChangeMockedWriteModel
 	restore := boot.MockResealKeyForBootChains(func(unlocker boot.Unlocker, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams, opts boot.ResealKeyToModeenvOptions) error {
 		resealKeysCalls++
 		c.Logf("reseal key call: %v", resealKeysCalls)
+		c.Check(opts.IgnoreFDEHooks, Equals, false)
 		m, err := boot.ReadModeenv("")
 		c.Assert(err, IsNil)
 		currForSealing := boot.ModelUniqueID(m.ModelForSealing())

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -276,6 +276,9 @@ type ResealKeyToModeenvOptions struct {
 	// TPM is provisioned correctly, but keeping the same lockout
 	// authorization value.
 	EnsureProvisioned bool
+	// When IgnoreFDEHooks is true, FDE hook keys should not be
+	// resealed.
+	IgnoreFDEHooks bool
 }
 
 // resealKeyToModeenv reseals the existing encryption key to the

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -94,7 +94,10 @@ func clearTryRecoverySystem(dev snap.Device, systemLabel string) error {
 
 	// but we still want to reseal, in case the cleanup did not reach this
 	// point before
-	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true}
+	// Because we potential removed try models, this will affect
+	// FDE hooks keys. We need to make sure those are also
+	// resealed.
+	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true, IgnoreFDEHooks: false}
 	resealErr := resealKeyToModeenv(dirs.GlobalRootDir, m, resealOpts, nil)
 
 	if resealErr != nil {
@@ -176,7 +179,7 @@ func SetTryRecoverySystem(dev snap.Device, systemLabel string) (err error) {
 	// until the keys are resealed, even if we unexpectedly boot into the
 	// tried system, data will still be inaccessible and the system will be
 	// considered as nonoperational
-	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true}
+	resealOpts := ResealKeyToModeenvOptions{ExpectReseal: true, IgnoreFDEHooks: false}
 	return resealKeyToModeenv(dirs.GlobalRootDir, m, resealOpts, nil)
 }
 

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -549,6 +549,7 @@ func ResealKeyForBootChains(manager FDEStateManager, method device.SealingMethod
 			Force:             opts.Force,
 			EnsureProvisioned: opts.EnsureProvisioned,
 			Revoke:            params.RevokeOldKeys,
+			IgnoreFDEHooks:    opts.IgnoreFDEHooks,
 		})
 }
 
@@ -571,6 +572,8 @@ func ResealKeysForSignaturesDBUpdate(
 			// to the relevant EFI variables (in which case this is a
 			// post-update reseal)
 			Force: true,
+			// no model changed => ignore FDE hooks
+			IgnoreFDEHooks: true,
 		})
 }
 
@@ -584,6 +587,7 @@ type resealOptions struct {
 	Force             bool
 	EnsureProvisioned bool
 	Revoke            bool
+	IgnoreFDEHooks    bool
 }
 
 func resealKeys(
@@ -593,6 +597,10 @@ func resealKeys(
 ) error {
 	switch method {
 	case device.SealingMethodFDESetupHook:
+		if opts.IgnoreFDEHooks {
+			return nil
+		}
+
 		if err := recalculateParamatersFDEHook(manager, method, rootdir, inputs, opts); err != nil {
 			return err
 		}


### PR DESCRIPTION
Only when the model or try model is changed then we should reseal.