### PR TITLE
image-garden: switch selinux into permissive mode for Tumbleweed with SELinux

### DIFF
--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -34,6 +34,7 @@ endef
 
 define OPENSUSE_tumbleweed-selinux_CLOUD_INIT_USER_DATA_TEMPLATE
 $(BASE_CLOUD_INIT_USER_DATA_TEMPLATE)
+- sed -i -e 's/^SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
 # Add empty /etc/environment file that snapd test suite wants to back up.
 - touch /etc/environment
 endef


### PR DESCRIPTION
Switch to permissive mode for SELinux enabled Tumbleweed.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
