### PR TITLE
data/selinux: update policy, allow watching cgroups, allow connecting to user session

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -463,7 +463,8 @@ gen_require(`
 ')
 allow snappy_t devicekit_power_exec_t:file { getattr };
 
-
+# Snapd monitors cgroup hierarchy for refresh app awareness.
+fs_watch_cgroup_dirs(snappy_t)
 
 ########################################
 #

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -466,6 +466,10 @@ allow snappy_t devicekit_power_exec_t:file { getattr };
 # Snapd monitors cgroup hierarchy for refresh app awareness.
 fs_watch_cgroup_dirs(snappy_t)
 
+# connect to unix socket of snap session agent usually executing as unconfined_t.
+# TODO: define separate policy for user session agent
+allow snappy_t unconfined_t:unix_stream_socket connectto;
+
 ########################################
 #
 # snap-update-ns, snap-dicsard-ns local policy


### PR DESCRIPTION
Update the selinux policy to allow watching cgroups (for RAA), and talking to user session agents (user service mgmt and refresh).

Related: [SNAPDENG-34561](https://warthogs.atlassian.net/browse/SNAPDENG-34561)
Cherry picked from: #15635 

[SNAPDENG-34561]: https://warthogs.atlassian.net/browse/SNAPDENG-34561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ