### PR TITLE
tests: make sure spread is killed in the tests workflow in case it is locked

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -85,6 +85,8 @@ jobs:
       run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
+          # Make sure there are not spread processes running
+          killall spread || true
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -361,6 +363,16 @@ jobs:
               tee spread.log
           )
 
+    - name: Discard spread workers
+      if: always()
+      run: |
+        # Make sure there is not spread process running which locks the .spread-reuse.*.yaml files
+        killall spread || true
+        shopt -s nullglob;
+        for r in .spread-reuse.*.yaml; do
+          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
+        done
+
     - name: Upload spread logs
       if: always()
       uses: actions/upload-artifact@v4
@@ -444,10 +456,3 @@ jobs:
         path: "spread-results.json"
         if-no-files-found: ignore
 
-    - name: Discard spread workers
-      if: always()
-      run: |
-        shopt -s nullglob;
-        for r in .spread-reuse.*.yaml; do
-          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
-        done

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -86,7 +86,7 @@ jobs:
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
           # Make sure there are not spread processes running
-          killall spread || true
+          killall -s SIGQUIT spread || true
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -367,7 +367,7 @@ jobs:
       if: always()
       run: |
         # Make sure there is not spread process running which locks the .spread-reuse.*.yaml files
-        killall spread || true
+        killall -s SIGQUIT spread || true
         shopt -s nullglob;
         for r in .spread-reuse.*.yaml; do
           spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -92,7 +92,7 @@ restore: |
 
 execute: |
     snap install --channel="$CHANNEL" microk8s
-    microk8s status --wait-ready
+    microk8s status --wait-ready --timeout 180
     # XXX: enable dashboard etc? doing this is slow :/
     #microk8s enable dashboard dns registry istio
     microk8s kubectl get nodes | MATCH Ready


### PR DESCRIPTION
Spread could be remain locked in the actions runner in case of a communication problem (still researching when)

This change makes sure there are not spread processes running in the actions runner before and after we run spread tests.
