### PR TITLE
secboot: permit value-added-retailer drivers

### DIFF
--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -48,10 +48,14 @@ var (
 // To support testing, when the system is running in a Virtual Machine, the check
 // configuration is modified to permit this to avoid an error.
 func PreinstallCheck(ctx context.Context, bootImagePaths []string) ([]PreinstallErrorDetails, error) {
-	// do not customize check configuration
-	checkFlags := sb_preinstall.CheckFlagsDefault
+	// allow value-added-retailer drivers that are:
+	//  - listed as Driver#### load options
+	//  - referenced in the DriverOrder UEFI variable
+	//  - loaded from PCI device option ROMs (e.g. network card PXE ROMs)
+	//TODO:FDEM: remove once secboot provides an action to apply this configuration
+	checkFlags := sb_preinstall.PermitVARSuppliedDrivers
 	if systemd.IsVirtualMachine() {
-		// with exception of running in a virtual machine
+		// when running in Virtual Machine, allow it
 		checkFlags |= sb_preinstall.PermitVirtualMachine
 	}
 

--- a/secboot/preinstall_sb_test.go
+++ b/secboot/preinstall_sb_test.go
@@ -259,9 +259,9 @@ func (s *preinstallSuite) testPreinstallCheckConfig(c *C, isVM, permitVM bool) {
 	restore := secboot.MockSbPreinstallNewRunChecksContext(
 		func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext {
 			if permitVM {
-				c.Assert(initialFlags&sb_preinstall.PermitVirtualMachine, Equals, sb_preinstall.PermitVirtualMachine)
+				c.Assert(initialFlags, Equals, sb_preinstall.PermitVirtualMachine | sb_preinstall.PermitVARSuppliedDrivers)
 			} else {
-				c.Assert(initialFlags, Equals, sb_preinstall.CheckFlagsDefault)
+				c.Assert(initialFlags, Equals, sb_preinstall.PermitVARSuppliedDrivers)
 			}
 			c.Assert(profileOpts, Equals, sb_preinstall.PCRProfileOptionsDefault)
 			c.Assert(loadedImages, IsNil)
@@ -312,7 +312,7 @@ func (s *preinstallSuite) testPreinstallCheck(c *C, detectErrors, failUnwrap boo
 
 	restore := secboot.MockSbPreinstallNewRunChecksContext(
 		func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext {
-			c.Assert(initialFlags, Equals, sb_preinstall.CheckFlagsDefault)
+			c.Assert(initialFlags, Equals, sb_preinstall.PermitVARSuppliedDrivers)
 			c.Assert(profileOpts, Equals, sb_preinstall.PCRProfileOptionsDefault)
 			c.Assert(loadedImages, HasLen, len(bootImagePaths))
 			for i, image := range loadedImages {


### PR DESCRIPTION
Workaround to avoid preinstall check error "...value added retailer supplied drivers where detected to be running". This [was reported](https://chat.canonical.com/canonical/pl/csxncd55wj83dqumo196d87isy) to happen when testing in qemu and virt-manager. In these cases it was caused by the presence for network card ROM.

This changes is based on [recommendation by Chris C](https://chat.canonical.com/canonical/pl/77s81wxcdjfodfh5cnc7iq4emy). It is a temporary measure, that will be replaced by secboot action to modify the configuration ina similar way with user visibility & consent.

