### PR TITLE
i/builtin: add usb-gadget interface

### DIFF
--- a/interfaces/builtin/usb_gadget.go
+++ b/interfaces/builtin/usb_gadget.go
@@ -47,7 +47,6 @@ func init() {
 		name:                  "usb-gadget",
 		summary:               usbgadgetSummary,
 		implicitOnCore:        true,
-		implicitOnClassic:     true,
 		baseDeclarationSlots:  usbgadgetBaseDeclarationSlots,
 		connectedPlugAppArmor: usbgadgetConnectedPlugAppArmor,
 	})

--- a/interfaces/builtin/usb_gadget.go
+++ b/interfaces/builtin/usb_gadget.go
@@ -19,9 +19,9 @@
 
 package builtin
 
-const usbgadgetSummary = `allows access to the usb gadget API`
+const usbGadgetSummary = `allows access to the usb gadget API`
 
-const usbgadgetBaseDeclarationSlots = `
+const usbGadgetBaseDeclarationSlots = `
   usb-gadget:
     allow-installation:
       slot-snap-type:
@@ -29,7 +29,7 @@ const usbgadgetBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
-const usbgadgetConnectedPlugAppArmor = `
+const usbGadgetConnectedPlugAppArmor = `
 # https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt
 # Allow creating new gadgets under usb_gadget, which is creating
 # new directories
@@ -45,9 +45,9 @@ const usbgadgetConnectedPlugAppArmor = `
 func init() {
 	registerIface(&commonInterface{
 		name:                  "usb-gadget",
-		summary:               usbgadgetSummary,
+		summary:               usbGadgetSummary,
 		implicitOnCore:        true,
-		baseDeclarationSlots:  usbgadgetBaseDeclarationSlots,
-		connectedPlugAppArmor: usbgadgetConnectedPlugAppArmor,
+		baseDeclarationSlots:  usbGadgetBaseDeclarationSlots,
+		connectedPlugAppArmor: usbGadgetConnectedPlugAppArmor,
 	})
 }

--- a/interfaces/builtin/usb_gadget.go
+++ b/interfaces/builtin/usb_gadget.go
@@ -40,14 +40,6 @@ const usbgadgetConnectedPlugAppArmor = `
 
 # Allow access to UDC
 /sys/class/udc/ r,
-
-# Allow mounting the legacy gadgetfs
-mount fstype=gadgetfs options=(rw) gadgetfs -> /dev/gadget/,
-# Allow access to the legacy gadgetfs
-/dev/gadget/ rw,
-# Allow creating sub-directories, symlinks and files under those
-# directories
-/dev/gadget/** rw,
 `
 
 func init() {

--- a/interfaces/builtin/usb_gadget.go
+++ b/interfaces/builtin/usb_gadget.go
@@ -1,0 +1,62 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const usbgadgetSummary = `allows access to the usb gadget API`
+
+const usbgadgetBaseDeclarationSlots = `
+  usb-gadget:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const usbgadgetConnectedPlugAppArmor = `
+# https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt
+# Allow creating new gadgets under usb_gadget, which is creating
+# new directories
+/sys/kernel/config/usb_gadget/ rw,
+# Allow creating sub-directories, symlinks and files under those
+# directories
+/sys/kernel/config/usb_gadget/** rw,
+
+# Allow access to UDC
+/sys/class/udc/ r,
+
+# Allow mounting the legacy gadgetfs
+mount fstype=gadgetfs options=(rw) gadgetfs -> /dev/gadget/,
+# Allow access to the legacy gadgetfs
+/dev/gadget/ rw,
+# Allow creating sub-directories, symlinks and files under those
+# directories
+/dev/gadget/** rw,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "usb-gadget",
+		summary:               usbgadgetSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  usbgadgetBaseDeclarationSlots,
+		connectedPlugAppArmor: usbgadgetConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/usb_gadget_test.go
+++ b/interfaces/builtin/usb_gadget_test.go
@@ -84,7 +84,6 @@ func (s *UsbGadgetInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *UsbGadgetInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, true)
-	c.Assert(si.ImplicitOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows access to the usb gadget API`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "usb-gadget")
 }

--- a/interfaces/builtin/usb_gadget_test.go
+++ b/interfaces/builtin/usb_gadget_test.go
@@ -79,7 +79,6 @@ func (s *UsbGadgetInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/kernel/config/usb_gadget/`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/gadget/`)
 }
 
 func (s *UsbGadgetInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/usb_gadget_test.go
+++ b/interfaces/builtin/usb_gadget_test.go
@@ -1,0 +1,99 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type UsbGadgetInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&UsbGadgetInterfaceSuite{
+	iface: builtin.MustInterface("usb-gadget"),
+})
+
+const usbgadgetConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [usb-gadget]
+`
+
+const usbgadgetCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  usb-gadget:
+`
+
+func (s *UsbGadgetInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, usbgadgetConsumerYaml, nil, "usb-gadget")
+	s.slot, s.slotInfo = MockConnectedSlot(c, usbgadgetCoreYaml, nil, "usb-gadget")
+}
+
+func (s *UsbGadgetInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "usb-gadget")
+}
+
+func (s *UsbGadgetInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *UsbGadgetInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *UsbGadgetInterfaceSuite) TestAppArmorSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/kernel/config/usb_gadget/`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/gadget/`)
+}
+
+func (s *UsbGadgetInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to the usb gadget API`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "usb-gadget")
+}
+
+func (s *UsbGadgetInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *UsbGadgetInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -290,6 +290,9 @@ apps:
   unity8-contacts:
     command: bin/run
     plugs: [ unity8-contacts ]
+  usb-gadget:
+    command: bin/run
+    plugs: [ usb-gadget ]
   vcio:
     command: bin/run
     plugs: [ vcio ]

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -48,6 +48,7 @@ execute: |
     # TODO: add documentation page for firmware-updater-support and snap-fde-control
     exclusion_map["firmware-updater-support"]="2025/08"
     exclusion_map["snap-fde-control"]="2025/08"
+    exclusion_map["usb-gadget"]="2025/08"
 
     # If the interface is in the exclusion_map and it is currently sooner
     # than its specified expiration date, then return true


### PR DESCRIPTION

Tested creating a device using usbg examples from their repo
```
philip@ubuntu:~/usbg$ sudo usbg.create
```

Tested listing it again from the snap
```
philip@ubuntu:~/usbg$ usbg.list
ID 1d6b:0104 'g1'
  UDC                   1000480000.usb
  bcdUSB                2.00
  bDeviceClass          0x00
  bDeviceSubClass       0x00
  bDeviceProtocol       0x00
  bMaxPacketSize0       64
  idVendor              0x1d6b
  idProduct             0x0104
  bcdDevice             0.01
  Language:     0x409
    Manufacturer        Foo Inc.
    Product             Bar Gadget
    Serial Number       0123456789
  Function, type: acm instance: usb0
    port_num            0
  Function, type: acm instance: usb1
    port_num            1
  Function, type: ecm instance: usb0
    dev_addr            76:3c:97:5b:5f:1
    host_addr           26:ab:7d:9e:8f:9e
    ifname              usb0
    qmult               5
  Configuration: 'The only one' ID: 1
    MaxPower            2
    bmAttributes        0x80
    Language:   0x409
      configuration     CDC 2xACM+ECM
    acm.GS0 -> acm usb0
    acm.GS1 -> acm usb1
    ecm.usb0 -> ecm usb0
```

Without the interface connected, the following denial appear:

```
Jul 02 10:18:34 philip-vmware kernel: audit: type=1400 audit(1751444314.172:1300): apparmor="DENIED" operation="open" class="file" profile="snap.usbg.create" name="/sys/kernel/config/usb_gadget/" pid=122770 comm="create" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```


