### PR TITLE
confdb: change alias reference syntax

### DIFF
--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -1550,8 +1550,8 @@ func (s *viewSuite) TestSetValidatesDataWithSchemaPass(c *C) {
 		}
 	},
 	"schema": {
-		"foo": "$int-map",
-		"bar": "$str-array"
+		"foo": "${int-map}",
+		"bar": "${str-array}"
 	}
 }`))
 	c.Assert(err, IsNil)

--- a/confdb/schema.go
+++ b/confdb/schema.go
@@ -387,7 +387,7 @@ func (s *StorageSchema) newTypeSchema(typ string) (parser, error) {
 // stripAlias removes the ${...} used to refer to an alias and returns the alias
 // name. If the string isn't wrapped in ${}, it returns an empty string and false.
 func stripAlias(str string) (string, bool) {
-	if len(str) < 4 || str[:2] != "${" || str[len(str)-1] != '}' {
+	if len(str) < 4 || !strings.HasPrefix(str, "${") || !strings.HasSuffix(str, "}") {
 		return "", false
 	}
 	return str[2 : len(str)-1], true

--- a/confdb/schema_test.go
+++ b/confdb/schema_test.go
@@ -732,12 +732,12 @@ func (*schemaSuite) TestStringBasedAlias(c *C) {
 	},
 	"schema": {
 		"snaps": {
-			"keys": "$snap-name",
+			"keys": "${snap-name}",
 			"values": {
 				"schema": {
-					"name": "$snap-name",
+					"name": "${snap-name}",
 					"version": "string",
-					"status": "$status"
+					"status": "${status}"
 				}
 			}
 		}
@@ -776,7 +776,7 @@ func (*schemaSuite) TestMapKeyMustBeStringAlias(c *C) {
 	},
 	"schema": {
 		"snaps": {
-			"keys": "$key-type"
+			"keys": "${key-type}"
 		}
 	}
 }`)
@@ -813,7 +813,7 @@ func (*schemaSuite) TestUnknownAlias(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
 		"snaps": {
-			"values": "$foo"
+			"values": "${foo}"
 		}
 	}
 }`)
@@ -826,7 +826,7 @@ func (*schemaSuite) TestUnknownAliasInKeys(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
 		"snaps": {
-			"keys": "$foo"
+			"keys": "${foo}"
 		}
 	}
 }`)
@@ -847,7 +847,7 @@ func (*schemaSuite) TestMapBasedAliasHappy(c *C) {
 	},
 	"schema": {
 		"snaps": {
-			"values": "$snap"
+			"values": "${snap}"
 		}
 	}
 }`)
@@ -883,7 +883,7 @@ func (*schemaSuite) TestAliasReferenceDoesntRequireConstraints(c *C) {
 		}
 	},
 	"schema": {
-		"a": "$my-type"
+		"a": "${my-type}"
 	}
 }`)
 
@@ -899,7 +899,7 @@ func (*schemaSuite) TestMapInAliasRequiresConstraints(c *C) {
 		"my-type": "map"
 	},
 	"schema": {
-		"a": "$my-type"
+		"a": "${my-type}"
 	}
 }`)
 
@@ -919,7 +919,7 @@ func (*schemaSuite) TestMapBasedAliasFail(c *C) {
 	},
 	"schema": {
 		"snaps": {
-			"values": "$snap"
+			"values": "${snap}"
 		}
 	}
 }`)
@@ -952,7 +952,7 @@ func (*schemaSuite) TestBadAliasName(c *C) {
 	},
 	"schema": {
 		"snaps": {
-			"values": "$-foo"
+			"values": "${-foo}"
 		}
 	}
 }`)
@@ -1472,7 +1472,7 @@ func (*schemaSuite) TestAliasRejectsNull(c *C) {
 		}
 	},
 	"schema": {
-		"foo": "$mytype"
+		"foo": "${mytype}"
 	}
 }`)
 
@@ -1549,7 +1549,7 @@ func (*schemaSuite) TestArrayHappyWithAlias(c *C) {
 	"schema": {
 		"foo": {
 			"type": "array",
-			"values": "$my-type"
+			"values": "${my-type}"
 		}
 	}
 }`)
@@ -1744,7 +1744,7 @@ func (*schemaSuite) TestPathPrefixWithMapUnderUserType(c *C) {
 		}
 	},
 	"schema": {
-		"foo": "$my-type"
+		"foo": "${my-type}"
 	}
 }`)
 
@@ -1767,7 +1767,7 @@ func (*schemaSuite) TestPathPrefixWithArrayUnderAlias(c *C) {
 	"schema": {
 		"foo": {
 			"type": "array",
-			"values": "$my-type"
+			"values": "${my-type}"
 		}
 	}
 }`)
@@ -1795,7 +1795,7 @@ func (*schemaSuite) TestPathPrefixWithArrayUnderAliasWithAContainerElementType(c
 		}
 	},
 	"schema": {
-		"foo": "$my-type"
+		"foo": "${my-type}"
 	}
 }`)
 	schema, err := confdb.ParseStorageSchema(schemaStr)
@@ -1846,8 +1846,8 @@ func (*schemaSuite) TestPathManyUserDefinedTypeReferences(c *C) {
 		}
 	},
 	"schema": {
-		"foo": "$my-type",
-		"bar": "$my-type"
+		"foo": "${my-type}",
+		"bar": "${my-type}"
 	}
 }`)
 
@@ -2246,7 +2246,7 @@ func (*schemaSuite) TestSchemaAtInUserDefinedType(c *C) {
 		}
 	},
 	"schema": {
-		"foo": "$my-type"
+		"foo": "${my-type}"
 	}
 }`)
 	schema, err := confdb.ParseStorageSchema(schemaStr)
@@ -2444,7 +2444,7 @@ func (*schemaSuite) TestUserDefinedTypeEphemeralFail(c *C) {
 		}
 	},
 	"schema": {
-		"foo": "$my-type"
+		"foo": "${my-type}"
 	}
 }`)
 	_, err := confdb.ParseStorageSchema(schemaStr)
@@ -2462,7 +2462,7 @@ func (*schemaSuite) TestUserDefinedTypeEphemeralFail(c *C) {
 		}
 	},
 	"schema": {
-		"foo": "$my-type"
+		"foo": "${my-type}"
 	}
 }`)
 	_, err = confdb.ParseStorageSchema(schemaStr)
@@ -2478,7 +2478,7 @@ func (*schemaSuite) TestUserTypeReferenceEphemeral(c *C) {
 	},
 	"schema": {
 		"foo": {
-			"type": "$my-type",
+			"type": "${my-type}",
 			"ephemeral": true
 		}
 	}


### PR DESCRIPTION
During a demo Gustavo pointed out that alias references can look like subtractions if the alias name includes a dash: `$foo-bar`. This changes the syntax reference to include brackets: `${...}` which should clarifies that the whole name is part of the reference.