### PR TITLE
osutil/inotify: store a pointer to os.File rather than a copy

### DIFF
--- a/osutil/inotify/inotify.go
+++ b/osutil/inotify/inotify.go
@@ -37,7 +37,7 @@ type watch struct {
 type Watcher struct {
 	mu         sync.Mutex
 	fd         int               // File descriptor (as returned by the inotify_init() syscall)
-	notifyFile os.File           // An os.File object mapped onto the inotify file descriptor
+	notifyFile *os.File          // An os.File object mapped onto the inotify file descriptor
 	watches    map[string]*watch // Map of inotify watches (key: path)
 	paths      map[int]string    // Map of watched paths (key: watch descriptor)
 	Error      chan error        // Errors are sent on this channel

--- a/osutil/inotify/inotify_linux.go
+++ b/osutil/inotify/inotify_linux.go
@@ -45,7 +45,7 @@ func NewWatcher() (*Watcher, error) {
 	}
 	w := &Watcher{
 		fd:         fd,
-		notifyFile: *os.NewFile(uintptr(fd), ""),
+		notifyFile: os.NewFile(uintptr(fd), ""),
 		watches:    make(map[string]*watch),
 		paths:      make(map[int]string),
 		Event:      make(chan *Event),


### PR DESCRIPTION
A problem with RAA was identified when running on openSUSE Tumbleweed, the
the inotify file descriptor would return 0 sized reads for no particular
reason. Further debugging revealed that Read() was returning ErrClosed,
indicating that the file is already closed. The problem was tracked down
to storing a copy of os.File instead of a pointer *os.File inside the
inotify.Watcher{} structure. The issue was only observed when building
snapd with 1.25rc1. A minimal sample using osutil/inotify behaved in a
similar way.

A possible explanation of this behavior are the changes to the 'os'
package in
https://github.com/golang/go/commit/fdaac84480b02e600660d0ca7c15339138807107
adding 'cleanup' for os.File objects, attached directly to the object
itself. Further documentation on runtime.AddCleanup() indicates that it
can be run as soon as the object becomes unreachable. With all this, it
is possible that since the original code was not storing *os.File, but
rather made a copy, the 'donor' os.File goes out of scope and becomes
unreachable, cleanup is invoked and closes the underlying file. Since a
file descriptor is a global resource, closing it affects all other
copies.

Related: [SNAPDENG-35224](https://warthogs.atlassian.net/browse/SNAPDENG-35224)

[SNAPDENG-35224]: https://warthogs.atlassian.net/browse/SNAPDENG-35224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ