### PR TITLE
i/builtin: add snap-fde and firmware-updater-support interfaces

### DIFF
--- a/interfaces/builtin/firmware_updated_support.go
+++ b/interfaces/builtin/firmware_updated_support.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const firmwareUpdaterSupportSummary = `allows access to snapd's system-volumes API "check-recovery-key" action`
+
+const firmwareUpdaterSupportBaseDeclarationSlots = `
+  firmware-updater-support:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                 "firmware-updater-support",
+		summary:              firmwareUpdaterSupportSummary,
+		implicitOnCore:       true,
+		implicitOnClassic:    true,
+		baseDeclarationSlots: firmwareUpdaterSupportBaseDeclarationSlots,
+	})
+}

--- a/interfaces/builtin/firmware_updater_support_test.go
+++ b/interfaces/builtin/firmware_updater_support_test.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type FirmwareUpdaterSupportInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&FirmwareUpdaterSupportInterfaceSuite{
+	iface: builtin.MustInterface("firmware-updater-support"),
+})
+
+func (s *FirmwareUpdaterSupportInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfoYaml = `
+name: other
+version: 0
+apps:
+ app:
+  command: foo
+  plugs: [firmware-updater-support]
+`
+	const mockSlotSnapInfoYaml = `name: core
+version: 1.0
+type: os
+slots:
+ firmware-updater-support:
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, mockSlotSnapInfoYaml, nil, "firmware-updater-support")
+	s.plug, s.plugInfo = MockConnectedPlug(c, mockPlugSnapInfoYaml, nil, "firmware-updater-support")
+}
+
+func (s *FirmwareUpdaterSupportInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "firmware-updater-support")
+}
+
+func (s *FirmwareUpdaterSupportInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Check(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *FirmwareUpdaterSupportInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *FirmwareUpdaterSupportInterfaceSuite) TestAppArmor(c *C) {
+	// The interface generates no AppArmor rules
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	appSet, err = interfaces.NewSnapAppSet(s.slot.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec = apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	appSet, err = interfaces.NewSnapAppSet(s.plugInfo.Snap, nil)
+	c.Assert(err, IsNil)
+	spec = apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	appSet, err = interfaces.NewSnapAppSet(s.slotInfo.Snap, nil)
+	c.Assert(err, IsNil)
+	spec = apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+}
+
+func (s *FirmwareUpdaterSupportInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to snapd's system-volumes API "check-recovery-key" action`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *FirmwareUpdaterSupportInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/snap_fde.go
+++ b/interfaces/builtin/snap_fde.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const snapFDESummary = `allows access to snapd's system-volumes API`
+
+const snapFDEBaseDeclarationSlots = `
+  snap-fde:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                 "snap-fde",
+		summary:              snapFDESummary,
+		implicitOnCore:       true,
+		implicitOnClassic:    true,
+		baseDeclarationSlots: snapFDEBaseDeclarationSlots,
+	})
+}

--- a/interfaces/builtin/snap_fde_test.go
+++ b/interfaces/builtin/snap_fde_test.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SnapFDEInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&SnapFDEInterfaceSuite{
+	iface: builtin.MustInterface("snap-fde"),
+})
+
+func (s *SnapFDEInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfoYaml = `
+name: other
+version: 0
+apps:
+ app:
+  command: foo
+  plugs: [snap-fde]
+`
+	const mockSlotSnapInfoYaml = `name: core
+version: 1.0
+type: os
+slots:
+ snap-fde:
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, mockSlotSnapInfoYaml, nil, "snap-fde")
+	s.plug, s.plugInfo = MockConnectedPlug(c, mockPlugSnapInfoYaml, nil, "snap-fde")
+}
+
+func (s *SnapFDEInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "snap-fde")
+}
+
+func (s *SnapFDEInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Check(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *SnapFDEInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *SnapFDEInterfaceSuite) TestAppArmor(c *C) {
+	// The interface generates no AppArmor rules
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	appSet, err = interfaces.NewSnapAppSet(s.slot.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec = apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	appSet, err = interfaces.NewSnapAppSet(s.plugInfo.Snap, nil)
+	c.Assert(err, IsNil)
+	spec = apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	appSet, err = interfaces.NewSnapAppSet(s.slotInfo.Snap, nil)
+	c.Assert(err, IsNil)
+	spec = apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+}
+
+func (s *SnapFDEInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to snapd's system-volumes API`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *SnapFDEInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -305,6 +305,9 @@ apps:
   snap-fde:
     command: bin/run
     plugs: [ snap-fde ]
+  firmware-updater-support:
+    command: bin/run
+    plugs: [ firmware-updater-support ]
 
 plugs:
   custom-device:

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -302,6 +302,9 @@ apps:
   gpio-chardev:
     command: bin/run
     plugs: [ gpio-chardev ]
+  snap-fde:
+    command: bin/run
+    plugs: [ snap-fde ]
 
 plugs:
   custom-device:


### PR DESCRIPTION
Those interfaces should enable the `security-center` and `firmware-updater` snaps to access the new /v2/system-volumes endpoint (where `firmware-updater` is only limited to the `check-recovery-key` action).

Hooking up the interfaces to the endpoint will come in a followup PR when https://github.com/canonical/snapd/pull/15638 lands.

JIRA ticket: https://warthogs.atlassian.net/browse/SNAPDENG-35173