### PR TITLE
i/prompting: add lifespan "session"

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -165,6 +165,9 @@ const (
 	// ErrorKindInterfacesRequestsPatchedRuleHasNoPermissions: patched rule has no permission
 	ErrorKindInterfacesRequestsPatchedRuleHasNoPermissions ErrorKind = "interfaces-requests-patched-rule-has-no-permissions"
 
+	// ErrorKindInterfacesRequestsNewSessionRuleNoSession: cannot create a rule with lifespan "session" when the user session is not present
+	ErrorKindInterfacesRequestsNewSessionRuleNoSession ErrorKind = "interfaces-requests-new-session-rule-no-session"
+
 	// ErrorKindInterfacesRequestsReplyNotMatchRequest: the prompt reply does not match the path and/or permissions which were requested.
 	ErrorKindInterfacesRequestsReplyNotMatchRequest ErrorKind = "interfaces-requests-reply-not-match-request"
 

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -248,6 +248,9 @@ func promptingError(err error) *apiError {
 	case errors.Is(err, prompting_errors.ErrPatchedRuleHasNoPerms):
 		apiErr.Status = 400
 		apiErr.Kind = client.ErrorKindInterfacesRequestsPatchedRuleHasNoPermissions
+	case errors.Is(err, prompting_errors.ErrNewSessionRuleNoSession):
+		apiErr.Status = 400
+		apiErr.Kind = client.ErrorKindInterfacesRequestsNewSessionRuleNoSession
 	case errors.Is(err, prompting_errors.ErrReplyNotMatchRequestedPath):
 		apiErr.Status = 400
 		apiErr.Kind = client.ErrorKindInterfacesRequestsReplyNotMatchRequest

--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -551,6 +551,18 @@ func (s *promptingSuite) TestPromptingError(c *C) {
 			},
 		},
 		{
+			err: prompting_errors.ErrNewSessionRuleNoSession,
+			body: map[string]any{
+				"result": map[string]any{
+					"message": `cannot create rule with lifespan "session" when user session is not present`,
+					"kind":    "interfaces-requests-new-session-rule-no-session",
+				},
+				"status":      "Bad Request",
+				"status-code": 400.0,
+				"type":        "error",
+			},
+		},
+		{
 			err: &prompting_errors.RequestedPathNotMatchedError{
 				Requested: "foo",
 				Replied:   "bar",

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -74,11 +74,11 @@ func (c *Constraints) ContainPermissions(permissions []string) bool {
 // ToRuleConstraints validates the receiving Constraints and converts it to
 // RuleConstraints. If the constraints are not valid with respect to the given
 // interface, returns an error.
-func (c *Constraints) ToRuleConstraints(iface string, currTime time.Time) (*RuleConstraints, error) {
+func (c *Constraints) ToRuleConstraints(iface string, currTime time.Time, currSession IDType) (*RuleConstraints, error) {
 	if c.PathPattern == nil {
 		return nil, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
 	}
-	rulePermissions, err := c.Permissions.toRulePermissionMap(iface, currTime)
+	rulePermissions, err := c.Permissions.toRulePermissionMap(iface, currTime, currSession)
 	if err != nil {
 		return nil, err
 	}
@@ -102,13 +102,13 @@ type RuleConstraints struct {
 
 // ValidateForInterface checks that the rule constraints are valid for the given
 // interface. Any permissions which have expired relative to the given current
-// time are pruned. If all permissions have expired, then returns true. If the
-// rule is invalid, returns an error.
-func (c *RuleConstraints) ValidateForInterface(iface string, currTime time.Time) (expired bool, err error) {
+// time or session ID are pruned. If all permissions have expired, then returns
+// true. If the rule is invalid, returns an error.
+func (c *RuleConstraints) ValidateForInterface(iface string, currTime time.Time, currSession IDType) (expired bool, err error) {
 	if c.PathPattern == nil {
 		return false, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
 	}
-	return c.Permissions.validateForInterface(iface, currTime)
+	return c.Permissions.validateForInterface(iface, currTime, currSession)
 }
 
 // Match returns true if the constraints match the given path, otherwise false.
@@ -203,7 +203,7 @@ type RuleConstraintsPatch struct {
 // permission map of the patch.
 //
 // The existing rule constraints should never be modified.
-func (c *RuleConstraintsPatch) PatchRuleConstraints(existing *RuleConstraints, iface string, currTime time.Time) (*RuleConstraints, error) {
+func (c *RuleConstraintsPatch) PatchRuleConstraints(existing *RuleConstraints, iface string, currTime time.Time, currSession IDType) (*RuleConstraints, error) {
 	ruleConstraints := &RuleConstraints{
 		PathPattern: c.PathPattern,
 	}
@@ -218,7 +218,7 @@ func (c *RuleConstraintsPatch) PatchRuleConstraints(existing *RuleConstraints, i
 	newPermissions := make(RulePermissionMap, len(c.Permissions)+len(existing.Permissions))
 	// Pre-populate newPermissions with all the non-expired existing permissions
 	for perm, entry := range existing.Permissions {
-		if !entry.Expired(currTime) {
+		if !entry.Expired(currTime, currSession) {
 			newPermissions[perm] = entry
 		}
 	}
@@ -241,7 +241,7 @@ func (c *RuleConstraintsPatch) PatchRuleConstraints(existing *RuleConstraints, i
 			delete(newPermissions, perm)
 			continue
 		}
-		ruleEntry, err := entry.toRulePermissionEntry(currTime)
+		ruleEntry, err := entry.toRulePermissionEntry(currTime, currSession)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -268,9 +268,10 @@ type PermissionMap map[string]*PermissionEntry
 
 // toRulePermissionMap validates the receiving PermissionMap and converts it
 // to a RulePermissionMap, using the given current time to convert any included
-// durations to expirations. If the permission map is not valid with respect to
-// the given interface, returns an error.
-func (pm PermissionMap) toRulePermissionMap(iface string, currTime time.Time) (RulePermissionMap, error) {
+// durations to expirations, and the given current user session ID for any
+// permission entries with lifespan "session". If the permission map is not
+// valid with respect to the given interface, returns an error.
+func (pm PermissionMap) toRulePermissionMap(iface string, currTime time.Time, currSession IDType) (RulePermissionMap, error) {
 	availablePerms, ok := interfacePermissionsAvailable[iface]
 	if !ok {
 		return nil, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
@@ -286,7 +287,7 @@ func (pm PermissionMap) toRulePermissionMap(iface string, currTime time.Time) (R
 			invalidPerms = append(invalidPerms, perm)
 			continue
 		}
-		rulePermissionEntry, err := entry.toRulePermissionEntry(currTime)
+		rulePermissionEntry, err := entry.toRulePermissionEntry(currTime, currSession)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -309,9 +310,9 @@ type RulePermissionMap map[string]*RulePermissionEntry
 
 // validateForInterface checks that the rule permission map is valid for the
 // given interface. Any permissions which have expired relative to the given
-// current time are pruned. If all permissions have expired, then returns true.
-// If the permission map is invalid, returns an error.
-func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Time) (expired bool, err error) {
+// current time or session ID are pruned. If all permissions have expired,
+// then returns true. If the permission map is invalid, returns an error.
+func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Time, currSession IDType) (expired bool, err error) {
 	availablePerms, ok := interfacePermissionsAvailable[iface]
 	if !ok {
 		return false, prompting_errors.NewInvalidInterfaceError(iface, availableInterfaces())
@@ -331,7 +332,7 @@ func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Tim
 			errs = append(errs, err)
 			continue
 		}
-		if entry.Expired(currTime) {
+		if entry.Expired(currTime, currSession) {
 			expiredPerms = append(expiredPerms, perm)
 			continue
 		}
@@ -353,9 +354,9 @@ func (pm RulePermissionMap) validateForInterface(iface string, currTime time.Tim
 }
 
 // Expired returns true if all permissions in the map have expired.
-func (pm RulePermissionMap) Expired(currTime time.Time) bool {
+func (pm RulePermissionMap) Expired(currTime time.Time, currSession IDType) bool {
 	for _, entry := range pm {
-		if !entry.Expired(currTime) {
+		if !entry.Expired(currTime, currSession) {
 			return false
 		}
 	}
@@ -378,10 +379,13 @@ type PermissionEntry struct {
 //
 // Checks that the entry has a valid outcome, and that its lifespan is valid
 // for a rule (i.e. not LifespanSingle), and that it has an appropriate
-// duration for that lifespan. The duration, combined with the given current
-// time, is used to compute an expiration time, and that is returned as part
-// of the corresponding RulePermissionEntry.
-func (e *PermissionEntry) toRulePermissionEntry(currTime time.Time) (*RulePermissionEntry, error) {
+// duration for that lifespan. If the lifespan is LifespanSession, then the
+// duration, combined with the given current time, is used to compute an
+// expiration time, and that is returned as part of the resulting
+// RulePermissionEntry. If the lifespan is LifespanSession, then the given
+// current session ID must be non-zero, and it is included in the
+// corresponding RulePermissionEntry.
+func (e *PermissionEntry) toRulePermissionEntry(currTime time.Time, currSession IDType) (*RulePermissionEntry, error) {
 	if _, err := e.Outcome.AsBool(); err != nil {
 		return nil, err
 	}
@@ -393,10 +397,19 @@ func (e *PermissionEntry) toRulePermissionEntry(currTime time.Time) (*RulePermis
 	if err != nil {
 		return nil, err
 	}
+	var sessionIDToUse IDType
+	if e.Lifespan == LifespanSession {
+		// SessionID should be 0 unless the lifespan is LifespanSession
+		if currSession == IDType(0) {
+			return nil, prompting_errors.ErrNewSessionRuleNoSession
+		}
+		sessionIDToUse = currSession
+	}
 	rulePermissionEntry := &RulePermissionEntry{
 		Outcome:    e.Outcome,
 		Lifespan:   e.Lifespan,
 		Expiration: expiration,
+		SessionID:  sessionIDToUse,
 	}
 	return rulePermissionEntry, nil
 }
@@ -404,38 +417,46 @@ func (e *PermissionEntry) toRulePermissionEntry(currTime time.Time) (*RulePermis
 // RulePermissionEntry holds the outcome associated with a particular permission
 // and the lifespan for which that outcome is applicable.
 //
-// RulePermissionEntry is derived from a PermissionEntry after it has been used
-// along with the rule's timestamp to define the expiration timeouts for any
-// permissions which have a lifespan of "timespan". RulePermissionEntry is what
-// is returned when retrieving rule contents, but PermissionEntry is used when
-// replying to prompts, creating new rules, or modifying existing rules.
+// RulePermissionEntry is derived from a PermissionEntry. A PermissionEntry is
+// used when reply to a prompt, creating a new rule, or modifying an existing
+// rule, while a RulePermissionEntry is what is stored as part of the resulting
+// rule.
+//
+// If the entry has a lifespan of LifespanTimespan, the expiration time should
+// be non-zero and stores the time at which the entry expires. If the entry has
+// a lifespan of LifespanSession, then the session ID should be non-zero and
+// stores the user session ID of the entry at the time it was created.
 type RulePermissionEntry struct {
 	Outcome    OutcomeType  `json:"outcome"`
 	Lifespan   LifespanType `json:"lifespan"`
 	Expiration time.Time    `json:"expiration,omitzero"`
+	SessionID  IDType       `json:"session-id,omitzero"`
 }
 
 // Expired returns true if the receiving permission entry has expired and
 // should no longer be considered when matching requests.
 //
-// This is the case if the permission has a lifespan of timespan and the
-// current time is after its expiration time.
-func (e *RulePermissionEntry) Expired(currTime time.Time) bool {
+// This is the case if the permission has a lifespan of "timespan" and the
+// current time is after its expiration time, or the permission has a lifespan
+// of "session" and the associated session ID is not equal to the current user
+// session ID.
+func (e *RulePermissionEntry) Expired(currTime time.Time, currSession IDType) bool {
 	switch e.Lifespan {
 	case LifespanTimespan:
 		if !currTime.Before(e.Expiration) {
 			return true
 		}
-		// TODO: add lifespan session
-		//case LifespanSession:
-		// TODO: return true if the user session has changed
+	case LifespanSession:
+		if e.SessionID != currSession {
+			return true
+		}
 	}
 	return false
 }
 
 // validate checks that the entry has a valid outcome, and that its lifespan
 // is valid for a rule (i.e. not LifespanSingle), and has an appropriate
-// expiration for that lifespan.
+// expiration and session ID for that lifespan.
 func (e *RulePermissionEntry) validate() error {
 	if _, err := e.Outcome.AsBool(); err != nil {
 		return err
@@ -444,14 +465,64 @@ func (e *RulePermissionEntry) validate() error {
 		// We don't allow rules with lifespan "single"
 		return prompting_errors.NewRuleLifespanSingleError(SupportedRuleLifespans)
 	}
-	if err := e.Lifespan.ValidateExpiration(e.Expiration); err != nil {
+	if err := e.Lifespan.ValidateExpiration(e.Expiration, e.SessionID); err != nil {
 		// Should never error due to an API request, since rules are always
-		// added via the API using duration, rather than expiration.
+		// added via the API using duration, rather than expiration, and the
+		// user session should be active at the time the API request is made.
 		// Error may occur when validating a rule loaded from disk.
-		// We don't check expiration as part of validation.
+		// We don't check whether the expiration timestamp has passed as part
+		// of validation.
 		return err
 	}
 	return nil
+}
+
+// Supersedes returns true if the receiver has a lifespan which supersedes that
+// of given other entry.
+//
+// LifespanForever supersedes other lifespans. LifespanSession, if the entry's
+// session ID is equal to the current session ID, supersedes lifespans other
+// than LifespanForever. LifespanTimespan supersedes LifespanSingle. If the
+// entries have the same lifespan type, then whichever entry has a later
+// expiration timestamp, or has a session ID matching the current session,
+// supersedes the other entry.
+func (e *RulePermissionEntry) Supersedes(other *RulePermissionEntry, currSession IDType) bool {
+	// Nothing supersedes LifespanForever
+	if other.Lifespan == LifespanForever {
+		return false
+	}
+	// LifespanForever supersedes everything else
+	if e.Lifespan == LifespanForever {
+		return true
+	}
+	// Nothing except LifespanForever supersedes LifespanSession with active session
+	if other.Lifespan == LifespanSession && other.SessionID == currSession {
+		return false
+	}
+	// LifespanSession with expired session supersedes nothing, but with active
+	// session supersedes everything remaining
+	if e.Lifespan == LifespanSession {
+		if e.SessionID != currSession {
+			return false
+		}
+		return true
+	}
+	// Neither lifespan is LifespanForever or LifespanSession
+	if other.Lifespan == LifespanTimespan {
+		if e.Lifespan == LifespanSingle {
+			return false
+		}
+		// e has LifespanTimespan
+		if e.Expiration.After(other.Expiration) {
+			return true
+		}
+		return false
+	}
+	// Other lifespan is LifespanSingle
+	if e.Lifespan == LifespanTimespan {
+		return true
+	}
+	return false
 }
 
 var (

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -163,6 +163,7 @@ func (s *constraintsSuite) TestConstraintsContainPermissions(c *C) {
 
 func (s *constraintsSuite) TestConstraintsToRuleConstraintsHappy(c *C) {
 	currTime := time.Now()
+	currSession := prompting.IDType(0x12345)
 	iface := "home"
 	pathPattern := mustParsePathPattern(c, "/path/to/{foo,*or*,bar}{,/}**")
 
@@ -180,8 +181,7 @@ func (s *constraintsSuite) TestConstraintsToRuleConstraintsHappy(c *C) {
 			},
 			"execute": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanTimespan,
-				Duration: "1ns",
+				Lifespan: prompting.LifespanSession,
 			},
 		},
 	}
@@ -199,21 +199,21 @@ func (s *constraintsSuite) TestConstraintsToRuleConstraintsHappy(c *C) {
 				Expiration: currTime.Add(10 * time.Second),
 			},
 			"execute": &prompting.RulePermissionEntry{
-				Outcome:    prompting.OutcomeAllow,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: currTime.Add(time.Nanosecond),
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
 			},
 		},
 	}
 
-	result, err := constraints.ToRuleConstraints(iface, currTime)
+	result, err := constraints.ToRuleConstraints(iface, currTime, currSession)
 	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, expectedRuleConstraints)
 }
 
 func (s *constraintsSuite) TestConstraintsToRuleConstraintsUnhappy(c *C) {
 	badConstraints := &prompting.Constraints{}
-	result, err := badConstraints.ToRuleConstraints("home", time.Now())
+	result, err := badConstraints.ToRuleConstraints("home", time.Now(), 0)
 	c.Check(result, IsNil)
 	c.Check(err, ErrorMatches, `invalid path pattern: no path pattern.*`)
 
@@ -226,7 +226,7 @@ func (s *constraintsSuite) TestConstraintsToRuleConstraintsUnhappy(c *C) {
 			},
 		},
 	}
-	result, err = constraints.ToRuleConstraints("foo", time.Now())
+	result, err = constraints.ToRuleConstraints("foo", time.Now(), 0)
 	c.Check(result, IsNil)
 	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
 
@@ -258,23 +258,49 @@ func (s *constraintsSuite) TestConstraintsToRuleConstraintsUnhappy(c *C) {
 		},
 		{
 			perms: prompting.PermissionMap{
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+					Duration: "5s",
+				},
+			},
+			errStr: `invalid duration: cannot have specified duration when lifespan is "session":.*`,
+		},
+		{
+			perms: prompting.PermissionMap{
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+				},
+			},
+			// Error will occur because current session is 0 (not found) below
+			errStr: prompting_errors.ErrNewSessionRuleNoSession.Error(),
+		},
+		{
+			perms: prompting.PermissionMap{
 				"read": &prompting.PermissionEntry{
 					Outcome:  prompting.OutcomeAllow,
 					Lifespan: prompting.LifespanTimespan,
+				},
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+					Duration: "5s",
 				},
 				"create": &prompting.PermissionEntry{
 					Outcome:  prompting.OutcomeAllow,
 					Lifespan: prompting.LifespanForever,
 				},
 			},
-			errStr: joinErrorsUnordered(`invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`, `invalid permissions for home interface: "create"`),
+			errStr: joinErrorsUnordered(joinErrorsUnordered(`invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`, `invalid duration: cannot have specified duration when lifespan is "session":.*`), `invalid permissions for home interface: "create"`),
 		},
 	} {
 		constraints := &prompting.Constraints{
 			PathPattern: mustParsePathPattern(c, "/path/to/foo"),
 			Permissions: testCase.perms,
 		}
-		result, err = constraints.ToRuleConstraints("home", time.Now())
+		currSession := prompting.IDType(0)
+		result, err = constraints.ToRuleConstraints("home", time.Now(), currSession)
 		c.Check(result, IsNil, Commentf("testCase: %+v", testCase))
 		c.Check(err, ErrorMatches, testCase.errStr, Commentf("testCase: %+v", testCase))
 	}
@@ -287,6 +313,7 @@ func joinErrorsUnordered(err1, err2 string) string {
 func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
 	validPathPattern := mustParsePathPattern(c, "/path/to/foo")
 	currTime := time.Now()
+	currSession := prompting.IDType(0x12345)
 
 	// Happy
 	constraints := &prompting.RuleConstraints{
@@ -301,9 +328,14 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: currTime.Add(time.Second),
 			},
+			"execute": &prompting.RulePermissionEntry{
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
 		},
 	}
-	expired, err := constraints.ValidateForInterface("home", currTime)
+	expired, err := constraints.ValidateForInterface("home", currTime, currSession)
 	c.Check(err, IsNil)
 	c.Check(expired, Equals, false)
 
@@ -376,7 +408,7 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
 			PathPattern: validPathPattern,
 			Permissions: testCase.perms,
 		}
-		expired, err = constraints.ValidateForInterface(testCase.iface, time.Now())
+		expired, err = constraints.ValidateForInterface(testCase.iface, time.Now(), 0)
 		c.Check(err, ErrorMatches, testCase.errStr)
 		c.Check(expired, Equals, false)
 	}
@@ -390,13 +422,14 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
 			},
 		},
 	}
-	_, err = constraints.ValidateForInterface("home", time.Now())
+	_, err = constraints.ValidateForInterface("home", time.Now(), 0)
 	c.Check(err, ErrorMatches, `invalid path pattern: no path pattern: ""`)
 }
 
 func (s *constraintsSuite) TestRuleConstraintsValidateForInterfaceExpiration(c *C) {
 	pathPattern := mustParsePathPattern(c, "/path/to/foo")
 	currTime := time.Now()
+	currSession := prompting.IDType(0x12345)
 
 	for _, testCase := range []struct {
 		perms    prompting.RulePermissionMap
@@ -459,6 +492,34 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterfaceExpiration(c *
 		{
 			prompting.RulePermissionMap{
 				"read": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: currSession,
+				},
+			},
+			false,
+			prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: currSession,
+				},
+			},
+		},
+		{
+			prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: currSession + 1,
+				},
+			},
+			true,
+			prompting.RulePermissionMap{},
+		},
+		{
+			prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
 					Outcome:    prompting.OutcomeAllow,
 					Lifespan:   prompting.LifespanTimespan,
 					Expiration: currTime.Add(-time.Minute),
@@ -469,9 +530,9 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterfaceExpiration(c *
 					Expiration: currTime,
 				},
 				"execute": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeAllow,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: currTime,
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: currSession + 1,
 				},
 			},
 			true,
@@ -490,8 +551,9 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterfaceExpiration(c *
 					Expiration: currTime.Add(time.Minute),
 				},
 				"execute": &prompting.RulePermissionEntry{
-					Outcome:  prompting.OutcomeDeny,
-					Lifespan: prompting.LifespanForever,
+					Outcome:   prompting.OutcomeDeny,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: currSession,
 				},
 			},
 			false,
@@ -502,8 +564,9 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterfaceExpiration(c *
 					Expiration: currTime.Add(time.Minute),
 				},
 				"execute": &prompting.RulePermissionEntry{
-					Outcome:  prompting.OutcomeDeny,
-					Lifespan: prompting.LifespanForever,
+					Outcome:   prompting.OutcomeDeny,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: currSession,
 				},
 			},
 		},
@@ -516,7 +579,7 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterfaceExpiration(c *
 			PathPattern: pathPattern,
 			Permissions: copiedPerms,
 		}
-		expired, err := constraints.ValidateForInterface("home", currTime)
+		expired, err := constraints.ValidateForInterface("home", currTime, currSession)
 		c.Check(err, IsNil)
 		c.Check(expired, Equals, testCase.expired, Commentf("testCase: %+v\nremaining perms: %+v", testCase, constraints.Permissions))
 		c.Check(constraints.Permissions, DeepEquals, testCase.expected, Commentf("testCase: %+v\nremaining perms: %+v", testCase, constraints.Permissions))
@@ -574,6 +637,24 @@ func (s *constraintsSuite) TestReplyConstraintsToConstraintsHappy(c *C) {
 						Outcome:  prompting.OutcomeDeny,
 						Lifespan: prompting.LifespanTimespan,
 						Duration: "10m",
+					},
+				},
+			},
+		},
+		{
+			permissions: []string{"write", "execute"},
+			outcome:     prompting.OutcomeAllow,
+			lifespan:    prompting.LifespanSession,
+			expected: &prompting.Constraints{
+				PathPattern: pathPattern,
+				Permissions: prompting.PermissionMap{
+					"execute": &prompting.PermissionEntry{
+						Outcome:  prompting.OutcomeAllow,
+						Lifespan: prompting.LifespanSession,
+					},
+					"write": &prompting.PermissionEntry{
+						Outcome:  prompting.OutcomeAllow,
+						Lifespan: prompting.LifespanSession,
 					},
 				},
 			},
@@ -664,7 +745,9 @@ func (s *constraintsSuite) TestReplyConstraintsToConstraintsUnhappy(c *C) {
 
 func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 	origTime := time.Now()
+	origSession := prompting.IDType(0x12345)
 	patchTime := origTime.Add(time.Second)
+	patchSession := prompting.IDType(0xf00ba4)
 	iface := "home"
 
 	pathPattern := mustParsePathPattern(c, "/path/to/foo/ba?/**")
@@ -688,6 +771,11 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 						Lifespan:   prompting.LifespanTimespan,
 						Expiration: origTime.Add(-time.Second),
 					},
+					"execute": &prompting.RulePermissionEntry{
+						Outcome:   prompting.OutcomeAllow,
+						Lifespan:  prompting.LifespanSession,
+						SessionID: origSession,
+					},
 				},
 			},
 			patch: &prompting.RuleConstraintsPatch{},
@@ -704,6 +792,11 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 						Lifespan:   prompting.LifespanTimespan,
 						Expiration: origTime.Add(-time.Second), // expired perms are not pruned if patch perms are nil
 					},
+					"execute": &prompting.RulePermissionEntry{
+						Outcome:   prompting.OutcomeAllow,
+						Lifespan:  prompting.LifespanSession,
+						SessionID: origSession, // expired perms are not pruned if patch perms are nil
+					},
 				},
 			},
 		},
@@ -725,9 +818,9 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 			},
 			patch: &prompting.RuleConstraintsPatch{
 				Permissions: prompting.PermissionMap{
-					// Remove both existing permissions, but add a new permission
-					"read":  nil,
-					"write": nil,
+					// Remove read permissions, let write permission expire,
+					// and add new execute permission
+					"read": nil,
 					"execute": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeDeny,
 						Lifespan: prompting.LifespanTimespan,
@@ -751,24 +844,22 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 				PathPattern: pathPattern,
 				Permissions: prompting.RulePermissionMap{
 					"read": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: patchTime.Add(time.Second),
+						Outcome:   prompting.OutcomeAllow,
+						Lifespan:  prompting.LifespanSession,
+						SessionID: patchSession,
 					},
 					"write": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeDeny,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime,
+						Outcome:   prompting.OutcomeDeny,
+						Lifespan:  prompting.LifespanSession,
+						SessionID: origSession,
 					},
 				},
 			},
 			patch: &prompting.RuleConstraintsPatch{
 				Permissions: prompting.PermissionMap{
-					"write": nil,
 					"execute": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeDeny,
-						Lifespan: prompting.LifespanTimespan,
-						Duration: "1m",
+						Lifespan: prompting.LifespanSession,
 					},
 				},
 			},
@@ -776,14 +867,14 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 				PathPattern: pathPattern,
 				Permissions: prompting.RulePermissionMap{
 					"read": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: patchTime.Add(time.Second),
+						Outcome:   prompting.OutcomeAllow,
+						Lifespan:  prompting.LifespanSession,
+						SessionID: patchSession,
 					},
 					"execute": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeDeny,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: patchTime.Add(time.Minute),
+						Outcome:   prompting.OutcomeDeny,
+						Lifespan:  prompting.LifespanSession,
+						SessionID: patchSession,
 					},
 				},
 			},
@@ -793,9 +884,8 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 				PathPattern: pathPattern,
 				Permissions: prompting.RulePermissionMap{
 					"read": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: patchTime.Add(time.Second),
+						Outcome:  prompting.OutcomeAllow,
+						Lifespan: prompting.LifespanForever,
 					},
 					"write": &prompting.RulePermissionEntry{
 						Outcome:    prompting.OutcomeDeny,
@@ -810,29 +900,26 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 			},
 			patch: &prompting.RuleConstraintsPatch{
 				Permissions: prompting.PermissionMap{
+					"read": nil,
 					"execute": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
+						Lifespan: prompting.LifespanSession,
 					},
 				},
 			},
 			final: &prompting.RuleConstraints{
 				PathPattern: pathPattern,
 				Permissions: prompting.RulePermissionMap{
-					"read": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: patchTime.Add(time.Second),
-					},
 					"execute": &prompting.RulePermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
+						Outcome:   prompting.OutcomeAllow,
+						Lifespan:  prompting.LifespanSession,
+						SessionID: patchSession,
 					},
 				},
 			},
 		},
 	} {
-		patched, err := testCase.patch.PatchRuleConstraints(testCase.initial, iface, patchTime)
+		patched, err := testCase.patch.PatchRuleConstraints(testCase.initial, iface, patchTime, patchSession)
 		c.Check(err, IsNil, Commentf("testCase %d", i))
 		c.Check(patched, DeepEquals, testCase.final, Commentf("testCase %d", i))
 	}
@@ -841,6 +928,7 @@ func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
 func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
 	origTime := time.Now()
 	patchTime := origTime.Add(time.Second)
+	patchSession := prompting.IDType(0x12345)
 	iface := "home"
 
 	pathPattern := mustParsePathPattern(c, "/path/to/foo/ba{r,z{,/**/}}")
@@ -865,13 +953,13 @@ func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
 			"write": nil,
 			"execute": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
-				Lifespan: prompting.LifespanForever,
+				Lifespan: prompting.LifespanSession,
 			},
 		},
 	}
 
 	badIface := "foo"
-	result, err := goodPatch.PatchRuleConstraints(goodRule, badIface, patchTime)
+	result, err := goodPatch.PatchRuleConstraints(goodRule, badIface, patchTime, patchSession)
 	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
 	c.Check(result, IsNil)
 
@@ -892,26 +980,26 @@ func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
 			},
 		},
 	}
-	expected := joinErrorsUnordered(`invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`, `cannot create rule with lifespan "single"`) + "\n" + `invalid permissions for home interface: ("create", "lock"|"lock", "create")`
+	expected := joinErrorsUnordered(`cannot create rule with lifespan "single"`, `invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`) + "\n" + `invalid permissions for home interface: ("create", "lock"|"lock", "create")`
 
-	result, err = badPatch.PatchRuleConstraints(goodRule, iface, patchTime)
+	result, err = badPatch.PatchRuleConstraints(goodRule, iface, patchTime, patchSession)
 	c.Check(err, ErrorMatches, expected)
 	c.Check(result, IsNil)
 
 	badPatch = &prompting.RuleConstraintsPatch{
 		Permissions: prompting.PermissionMap{
 			// Remove all permissions
-			"read":  nil,
-			"write": nil,
+			"read": nil,
 		},
 	}
-	result, err = badPatch.PatchRuleConstraints(goodRule, iface, patchTime)
+	result, err = badPatch.PatchRuleConstraints(goodRule, iface, patchTime, patchSession)
 	c.Check(err, Equals, prompting_errors.ErrPatchedRuleHasNoPerms)
 	c.Check(result, IsNil)
 }
 
 func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 	currTime := time.Now()
+	currSession := prompting.IDType(0x12345)
 	for _, pm := range []prompting.RulePermissionMap{
 		{},
 		{
@@ -919,6 +1007,13 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 				Outcome:    prompting.OutcomeAllow,
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: currTime,
+			},
+		},
+		{
+			"write": &prompting.RulePermissionEntry{
+				Outcome:   prompting.OutcomeDeny,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
 			},
 		},
 		{
@@ -932,9 +1027,14 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: currTime,
 			},
+			"execute": &prompting.RulePermissionEntry{
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: prompting.IDType(0xf00),
+			},
 		},
 	} {
-		c.Check(pm.Expired(currTime), Equals, true, Commentf("%+v", pm))
+		c.Check(pm.Expired(currTime, currSession), Equals, true, Commentf("%+v", pm))
 	}
 
 	for _, pm := range []prompting.RulePermissionMap{
@@ -951,9 +1051,9 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 		},
 		{
 			"read": &prompting.RulePermissionEntry{
-				Outcome:    prompting.OutcomeAllow,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: currTime.Add(-time.Second),
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: prompting.IDType(0xabcd),
 			},
 			"write": &prompting.RulePermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
@@ -967,8 +1067,292 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 				Expiration: currTime.Add(time.Second),
 			},
 		},
+		{
+			"read": &prompting.RulePermissionEntry{
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+		},
 	} {
-		c.Check(pm.Expired(currTime), Equals, false, Commentf("%+v", pm))
+		c.Check(pm.Expired(currTime, currSession), Equals, false, Commentf("%+v", pm))
+	}
+}
+
+func (s *constraintsSuite) TestRulePermissionEntrySupersedes(c *C) {
+	currTime := time.Now()
+	currSession := prompting.IDType(0x12345)
+	for _, testCase := range []struct {
+		entry    *prompting.RulePermissionEntry
+		other    *prompting.RulePermissionEntry
+		expected bool
+	}{
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime.Add(time.Second),
+			},
+			expected: true,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			expected: true,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			expected: true,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			expected: true,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			expected: false,
+		},
+		{
+			// An expired session never supersedes another
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime.Add(time.Second),
+			},
+			expected: true,
+		},
+		{
+			// An expired session never supersedes another
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			expected: true,
+		},
+		{
+			// An expired session never supersedes another
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime.Add(time.Second),
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			expected: false,
+		},
+		{
+			// LifespanTimespan doesn't supersede LifespanSession with active session
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime.Add(time.Second),
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			expected: false,
+		},
+		{
+			// LifespanTimespan does supersede LifespanSession with expired session
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			expected: true,
+		},
+		{
+			// Later expiration supersedes earlier, regardless of whether either is expired
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime.Add(-time.Second),
+			},
+			expected: true,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime.Add(time.Second),
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			expected: true,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanForever,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
+			},
+			expected: false,
+		},
+		{
+			// LifespanSingle does not supersede LifespanSession even with expired session
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession + 1,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: currTime,
+			},
+			expected: false,
+		},
+		{
+			entry: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			other: &prompting.RulePermissionEntry{
+				Lifespan: prompting.LifespanSingle,
+			},
+			expected: false,
+		},
+	} {
+		c.Check(testCase.entry.Supersedes(testCase.other, currSession), Equals, testCase.expected, Commentf("testCase:\n\tentry: %+v\n\tother: %+v\n\texpected: %v", testCase.entry, testCase.other, testCase.expected))
 	}
 }
 
@@ -1010,6 +1394,14 @@ func (s *constraintsSuite) TestMarshalRulePermissionEntry(c *C) {
 				Expiration: timeNow,
 			},
 			expected: `{"outcome":"deny","lifespan":"timespan","expiration":"2025-02-20T16:00:27.913561089Z"}`,
+		},
+		{
+			entry: prompting.RulePermissionEntry{
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: prompting.IDType(0x12345678),
+			},
+			expected: `{"outcome":"allow","lifespan":"session","session-id":"0000000012345678"}`,
 		},
 	} {
 		marshalled, err := json.Marshal(testCase.entry)

--- a/interfaces/prompting/errors/errors.go
+++ b/interfaces/prompting/errors/errors.go
@@ -37,7 +37,8 @@ var (
 	ErrRuleNotAllowed = errors.New("user not allowed to request the rule with the given ID")
 
 	// Validation errors which may be returned over the API
-	ErrPatchedRuleHasNoPerms = errors.New("cannot patch rule to have no permissions")
+	ErrPatchedRuleHasNoPerms   = errors.New("cannot patch rule to have no permissions")
+	ErrNewSessionRuleNoSession = errors.New(`cannot create rule with lifespan "session" when user session is not present`)
 
 	// Validation errors which should never be used directly apart from
 	// checking errors.Is(), and should otherwise always be wrapped in

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -137,15 +137,17 @@ const (
 	// LifespanTimespan indicates that a reply/rule should apply for a given
 	// duration or until a given expiration timestamp.
 	LifespanTimespan LifespanType = "timespan"
-	// TODO: add LifespanSession which expires after the user logs out
-	// LifespanSession  LifespanType = "session"
+	// LifespanSession indicates that a reply/rule should apply until the user
+	// logs out.
+	LifespanSession LifespanType = "session"
 )
 
 var (
-	supportedLifespans = []string{string(LifespanForever), string(LifespanSingle), string(LifespanTimespan)}
-	// SupportedRuleLifespans is exported so interfaces/promptin/requestrules
-	// can use it when constructing a ErrRuleLifespanSingle
-	SupportedRuleLifespans = []string{string(LifespanForever), string(LifespanTimespan)}
+	supportedLifespans = []string{string(LifespanForever), string(LifespanSession), string(LifespanSingle), string(LifespanTimespan)}
+	// SupportedRuleLifespans defines the lifespans which are allowed for rules.
+	// It is exported so it can be used outside this package when constructing
+	// invalid lifespan errors.
+	SupportedRuleLifespans = []string{string(LifespanForever), string(LifespanSession), string(LifespanTimespan)}
 )
 
 func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
@@ -155,7 +157,7 @@ func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
 	}
 	value := LifespanType(lifespanStr)
 	switch value {
-	case LifespanForever, LifespanSingle, LifespanTimespan:
+	case LifespanForever, LifespanSession, LifespanSingle, LifespanTimespan:
 		*lifespan = value
 	default:
 		return prompting_errors.NewInvalidLifespanError(lifespanStr, supportedLifespans)
@@ -163,20 +165,38 @@ func (lifespan *LifespanType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// ValidateExpiration checks that the given expiration is valid for the
-// receiver lifespan.
+// ValidateExpiration checks that the given expiration and session ID are valid
+// for the receiver lifespan.
 //
 // If the lifespan is LifespanTimespan, then expiration must be non-zero.
-// Otherwise, it must be zero. Returns an error if any of the above are invalid.
-func (lifespan LifespanType) ValidateExpiration(expiration time.Time) error {
+// Otherwise, it must be zero.
+//
+// If the lifespan is LifespanSession, then sessionID must be non-zero.
+// Otherwise, it must be zero.
+//
+// Returns an error if any of the above are invalid.
+func (lifespan LifespanType) ValidateExpiration(expiration time.Time, sessionID IDType) error {
 	switch lifespan {
 	case LifespanForever, LifespanSingle:
 		if !expiration.IsZero() {
 			return prompting_errors.NewInvalidExpirationError(expiration, fmt.Sprintf("cannot have specified expiration when lifespan is %q", lifespan))
 		}
+		if sessionID != 0 {
+			return prompting_errors.NewInvalidExpirationError(expiration, fmt.Sprintf("cannot have specified session ID when lifespan is %q", lifespan))
+		}
+	case LifespanSession:
+		if !expiration.IsZero() {
+			return prompting_errors.NewInvalidExpirationError(expiration, fmt.Sprintf("cannot have specified expiration when lifespan is %q", lifespan))
+		}
+		if sessionID == 0 {
+			return prompting_errors.NewInvalidExpirationError(expiration, fmt.Sprintf("cannot have unspecified session ID when lifespan is %q", lifespan))
+		}
 	case LifespanTimespan:
 		if expiration.IsZero() {
 			return prompting_errors.NewInvalidExpirationError(expiration, fmt.Sprintf("cannot have unspecified expiration when lifespan is %q", lifespan))
+		}
+		if sessionID != 0 {
+			return prompting_errors.NewInvalidExpirationError(expiration, fmt.Sprintf("cannot have specified session ID when lifespan is %q", lifespan))
 		}
 	default:
 		// Should not occur, since lifespan is validated when unmarshalled
@@ -196,7 +216,7 @@ func (lifespan LifespanType) ValidateExpiration(expiration time.Time) error {
 func (lifespan LifespanType) ParseDuration(duration string, currTime time.Time) (time.Time, error) {
 	var expiration time.Time
 	switch lifespan {
-	case LifespanForever, LifespanSingle:
+	case LifespanForever, LifespanSession, LifespanSingle:
 		if duration != "" {
 			return expiration, prompting_errors.NewInvalidDurationError(duration, fmt.Sprintf("cannot have specified duration when lifespan is %q", lifespan))
 		}
@@ -217,34 +237,4 @@ func (lifespan LifespanType) ParseDuration(duration string, currTime time.Time) 
 		return expiration, prompting_errors.NewInvalidLifespanError(string(lifespan), supportedLifespans)
 	}
 	return expiration, nil
-}
-
-var lifespansBySupersedence = map[LifespanType]int{
-	LifespanSingle:   1,
-	LifespanTimespan: 2,
-	LifespanForever:  3,
-}
-
-// FirstLifespanGreater returns true if the first of the two given
-// lifespan/expiration pairs supersedes the second.
-//
-// LifespanForever supersedes all other lifespans, followed by LifespanTimespan,
-// followed by LifepsanSingle. If two lifespans are identical then return true
-// if the first expiration timestamp is after the second expiration timestamp.
-func FirstLifespanGreater(l1 LifespanType, e1 time.Time, l2 LifespanType, e2 time.Time) bool {
-	order1 := lifespansBySupersedence[l1]
-	order2 := lifespansBySupersedence[l2]
-	switch {
-	case order1 > order2:
-		return true
-	case order1 < order2:
-		return false
-	case e1.After(e2):
-		return true
-	case e1.Before(e2):
-		return false
-	default:
-		// They're the same
-		return false
-	}
 }

--- a/interfaces/prompting/prompting_test.go
+++ b/interfaces/prompting/prompting_test.go
@@ -183,7 +183,9 @@ func (s *promptingSuite) TestUnmarshalLifespanUnhappy(c *C) {
 
 func (s *promptingSuite) TestValidateExpiration(c *C) {
 	var unsetExpiration time.Time
+	var unsetSession prompting.IDType
 	currTime := time.Now()
+	currSession := prompting.IDType(0x12345)
 	negativeExpiration := currTime.Add(-5 * time.Second)
 	validExpiration := currTime.Add(10 * time.Minute)
 
@@ -191,19 +193,37 @@ func (s *promptingSuite) TestValidateExpiration(c *C) {
 		prompting.LifespanForever,
 		prompting.LifespanSingle,
 	} {
-		err := lifespan.ValidateExpiration(unsetExpiration)
+		err := lifespan.ValidateExpiration(unsetExpiration, unsetSession)
 		c.Check(err, IsNil)
 		for _, exp := range []time.Time{negativeExpiration, validExpiration} {
-			err = lifespan.ValidateExpiration(exp)
+			for _, session := range []prompting.IDType{unsetSession, currSession} {
+				err = lifespan.ValidateExpiration(exp, session)
+				c.Check(err, ErrorMatches, `invalid expiration: cannot have specified expiration when lifespan is.*`)
+			}
+		}
+		err = lifespan.ValidateExpiration(unsetExpiration, currSession)
+		c.Check(err, ErrorMatches, `invalid expiration: cannot have specified session ID when lifespan is.*`)
+	}
+
+	for _, exp := range []time.Time{negativeExpiration, validExpiration} {
+		err := prompting.LifespanTimespan.ValidateExpiration(exp, unsetSession)
+		c.Check(err, IsNil)
+	}
+	for _, session := range []prompting.IDType{unsetSession, currSession} {
+		err := prompting.LifespanTimespan.ValidateExpiration(unsetExpiration, session)
+		c.Check(err, ErrorMatches, `invalid expiration: cannot have unspecified expiration when lifespan is.*`)
+	}
+
+	err := prompting.LifespanSession.ValidateExpiration(unsetExpiration, currSession)
+	c.Check(err, IsNil)
+	err = prompting.LifespanSession.ValidateExpiration(unsetExpiration, unsetSession)
+	c.Check(err, ErrorMatches, `invalid expiration: cannot have unspecified session ID when lifespan is.*`)
+	for _, exp := range []time.Time{negativeExpiration, validExpiration} {
+		for _, session := range []prompting.IDType{unsetSession, currSession} {
+			err = prompting.LifespanSession.ValidateExpiration(exp, session)
 			c.Check(err, ErrorMatches, `invalid expiration: cannot have specified expiration when lifespan is.*`)
 		}
 	}
-
-	err := prompting.LifespanTimespan.ValidateExpiration(unsetExpiration)
-	c.Check(err, ErrorMatches, `invalid expiration: cannot have unspecified expiration when lifespan is.*`)
-
-	err = prompting.LifespanTimespan.ValidateExpiration(validExpiration)
-	c.Check(err, IsNil)
 }
 
 func (s *promptingSuite) TestParseDuration(c *C) {
@@ -249,82 +269,4 @@ func (s *promptingSuite) TestParseDuration(c *C) {
 	expiration2, err := prompting.LifespanTimespan.ParseDuration(validDuration, currTime)
 	c.Check(err, IsNil)
 	c.Check(expiration2.Equal(expiration), Equals, true)
-}
-
-func (s *promptingSuite) TestFirstLifespanGreater(c *C) {
-	for _, testCase := range []struct {
-		l1     prompting.LifespanType
-		e1     time.Time
-		l2     prompting.LifespanType
-		e2     time.Time
-		result bool
-	}{
-		{
-			l1:     prompting.LifespanForever,
-			l2:     prompting.LifespanForever,
-			result: false,
-		},
-		{
-			l1:     prompting.LifespanForever,
-			l2:     prompting.LifespanTimespan,
-			e2:     time.Now().Add(time.Second),
-			result: true,
-		},
-		{
-			l1:     prompting.LifespanForever,
-			l2:     prompting.LifespanSingle,
-			result: true,
-		},
-		{
-			l1:     prompting.LifespanTimespan,
-			e1:     time.Now().Add(time.Second),
-			l2:     prompting.LifespanForever,
-			result: false,
-		},
-		{
-			l1:     prompting.LifespanTimespan,
-			e1:     time.Now().Add(2 * time.Second),
-			l2:     prompting.LifespanTimespan,
-			e2:     time.Now().Add(time.Second),
-			result: true,
-		},
-		{
-			l1:     prompting.LifespanTimespan,
-			e1:     time.Now().Add(time.Second),
-			l2:     prompting.LifespanTimespan,
-			e2:     time.Now().Add(time.Second),
-			result: false,
-		},
-		{
-			l1:     prompting.LifespanTimespan,
-			e1:     time.Now().Add(time.Second),
-			l2:     prompting.LifespanTimespan,
-			e2:     time.Now().Add(2 * time.Second),
-			result: false,
-		},
-		{
-			l1:     prompting.LifespanTimespan,
-			e1:     time.Now().Add(time.Second),
-			l2:     prompting.LifespanSingle,
-			result: true,
-		},
-		{
-			l1:     prompting.LifespanSingle,
-			l2:     prompting.LifespanForever,
-			result: false,
-		},
-		{
-			l1:     prompting.LifespanSingle,
-			l2:     prompting.LifespanTimespan,
-			e2:     time.Now().Add(time.Second),
-			result: false,
-		},
-		{
-			l1:     prompting.LifespanSingle,
-			l2:     prompting.LifespanSingle,
-			result: false,
-		},
-	} {
-		c.Check(prompting.FirstLifespanGreater(testCase.l1, testCase.e1, testCase.l2, testCase.e2), Equals, testCase.result, Commentf("testCase: %+v", testCase))
-	}
 }

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -29,10 +29,18 @@ import (
 var (
 	ErrNoUserSession   = errNoUserSession
 	JoinInternalErrors = joinInternalErrors
-	UserSessionIDPath  = userSessionIDPath
+	UserSessionPath    = userSessionPath
 )
 
 type RulesDBJSON rulesDBJSON
+
+func MockUserSessionIDXattr() (xattr string, restore func()) {
+	// Test code doesn't have CAP_SYS_ADMIN, so replace the "trusted" namespace
+	// with "user" for the sake of testing.
+	testXattr := "user.snapd_user_session_id"
+	restore = testutil.Mock(&userSessionIDXattr, testXattr)
+	return testXattr, restore
+}
 
 func (rule *Rule) Validate(currTime time.Time) (expired bool, err error) {
 	return rule.validate(currTime)

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -22,10 +22,15 @@ package requestrules
 import (
 	"time"
 
+	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/testutil"
 )
 
-var JoinInternalErrors = joinInternalErrors
+var (
+	ErrNoUserSession   = errNoUserSession
+	JoinInternalErrors = joinInternalErrors
+	UserSessionIDPath  = userSessionIDPath
+)
 
 type RulesDBJSON rulesDBJSON
 
@@ -35,6 +40,10 @@ func (rule *Rule) Validate(currTime time.Time) (expired bool, err error) {
 
 func (rdb *RuleDB) IsPathPermAllowed(user uint32, snap string, iface string, path string, permission string) (bool, error) {
 	return rdb.isPathPermAllowed(user, snap, iface, path, permission)
+}
+
+func (rdb *RuleDB) ReadOrAssignUserSessionID(user uint32) (userSessionID prompting.IDType, err error) {
+	return rdb.readOrAssignUserSessionID(user)
 }
 
 func MockIsPathPermAllowed(f func(rdb *RuleDB, user uint32, snap string, iface string, path string, permission string) (bool, error)) func() {

--- a/interfaces/prompting/requestrules/export_test.go
+++ b/interfaces/prompting/requestrules/export_test.go
@@ -34,6 +34,12 @@ var (
 
 type RulesDBJSON rulesDBJSON
 
+type UserSessionIDCache = userSessionIDCache
+
+func (cache *UserSessionIDCache) GetUserSessionID(rdb *RuleDB, user uint32) (prompting.IDType, error) {
+	return cache.getUserSessionID(rdb, user)
+}
+
 func MockUserSessionIDXattr() (xattr string, restore func()) {
 	// Test code doesn't have CAP_SYS_ADMIN, so replace the "trusted" namespace
 	// with "user" for the sake of testing.
@@ -42,18 +48,22 @@ func MockUserSessionIDXattr() (xattr string, restore func()) {
 	return testXattr, restore
 }
 
-func (rule *Rule) Validate(currTime time.Time) (expired bool, err error) {
-	return rule.validate(currTime)
+func (rule *Rule) Validate(currTime time.Time, currSession prompting.IDType) (expired bool, err error) {
+	return rule.validate(currTime, currSession)
 }
 
-func (rdb *RuleDB) IsPathPermAllowed(user uint32, snap string, iface string, path string, permission string) (bool, error) {
-	return rdb.isPathPermAllowed(user, snap, iface, path, permission)
+func (rdb *RuleDB) IsPathPermAllowed(user uint32, snap string, iface string, path string, permission string, currTime time.Time, currSession prompting.IDType) (bool, error) {
+	return rdb.isPathPermAllowed(user, snap, iface, path, permission, currTime, currSession)
+}
+
+func MockReadOrAssignUserSessionID(f func(rdb *RuleDB, user uint32) (prompting.IDType, error)) (restore func()) {
+	return testutil.Mock(&readOrAssignUserSessionID, f)
 }
 
 func (rdb *RuleDB) ReadOrAssignUserSessionID(user uint32) (userSessionID prompting.IDType, err error) {
 	return rdb.readOrAssignUserSessionID(user)
 }
 
-func MockIsPathPermAllowed(f func(rdb *RuleDB, user uint32, snap string, iface string, path string, permission string) (bool, error)) func() {
-	return testutil.Mock(&isPathPermAllowedByRuleDB, f)
+func MockIsPathPermAllowed(f func(rdb *RuleDB, user uint32, snap string, iface string, path string, permission string, currTime time.Time, currSession prompting.IDType) (bool, error)) func() {
+	return testutil.Mock(&isPathPermAllowed, f)
 }

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -66,13 +66,13 @@ type Rule struct {
 // Validate verifies internal correctness of the rule's constraints and
 // permissions and prunes any expired permissions. If all permissions are
 // expired, then returns true. If the rule is invalid, returns an error.
-func (rule *Rule) validate(currTime time.Time) (expired bool, err error) {
-	return rule.Constraints.ValidateForInterface(rule.Interface, currTime)
+func (rule *Rule) validate(currTime time.Time, currSession prompting.IDType) (expired bool, err error) {
+	return rule.Constraints.ValidateForInterface(rule.Interface, currTime, currSession)
 }
 
 // expired returns true if all permissions for the receiving rule have expired.
-func (rule *Rule) expired(currTime time.Time) bool {
-	return rule.Constraints.Permissions.Expired(currTime)
+func (rule *Rule) expired(currTime time.Time, currSession prompting.IDType) bool {
+	return rule.Constraints.Permissions.Expired(currTime, currSession)
 }
 
 // variantEntry stores the actual pattern variant struct which can be used to
@@ -229,10 +229,15 @@ func (rdb *RuleDB) load() (retErr error) {
 	}
 
 	currTime := time.Now()
+	sessionIDCache := make(userSessionIDCache)
 
 	var errInvalid error
 	for _, rule := range wrapped.Rules {
-		expired, err := rule.validate(currTime)
+		currSession, err := sessionIDCache.getUserSessionID(rdb, rule.User)
+		if err != nil {
+			return err
+		}
+		expired, err := rule.validate(currTime, currSession)
 		if err != nil {
 			// we're loading previously saved rules, so this should not happen
 			errInvalid = fmt.Errorf("internal error: %w", err)
@@ -244,7 +249,7 @@ func (rdb *RuleDB) load() (retErr error) {
 		}
 
 		const save = false
-		mergedRule, merged, conflictErr := rdb.addOrMergeRule(rule, save)
+		mergedRule, merged, conflictErr := rdb.addOrMergeRule(rule, currSession, save)
 		if conflictErr != nil {
 			// Duplicate rules on disk or conflicting rule, should not occur
 			errInvalid = fmt.Errorf("cannot add rule: %w", conflictErr)
@@ -379,7 +384,7 @@ func (rdb *RuleDB) addRuleToRulesList(rule *Rule) error {
 // returns an error, and the rule DB is left unchanged.
 //
 // The caller must ensure that the database lock is held for writing.
-func (rdb *RuleDB) addOrMergeRule(rule *Rule, save bool) (addedOrMergedRule *Rule, merged bool, err error) {
+func (rdb *RuleDB) addOrMergeRule(rule *Rule, currSession prompting.IDType, save bool) (addedOrMergedRule *Rule, merged bool, err error) {
 	// Check if rule with identical path pattern exists.
 	existingRule, exists, err := rdb.lookupRuleByPathPattern(rule.User, rule.Snap, rule.Interface, rule.Constraints)
 	if err != nil {
@@ -387,7 +392,7 @@ func (rdb *RuleDB) addOrMergeRule(rule *Rule, save bool) (addedOrMergedRule *Rul
 		return nil, false, err
 	}
 	if !exists {
-		if err := rdb.addNewRule(rule, save); err != nil {
+		if err := rdb.addNewRule(rule, currSession, save); err != nil {
 			return nil, false, err
 		}
 		return rule, false, nil
@@ -398,7 +403,7 @@ func (rdb *RuleDB) addOrMergeRule(rule *Rule, save bool) (addedOrMergedRule *Rul
 	// be overridden by a permission entry in the new rule, if the latter has a
 	// broader lifespan (and doesn't otherwise conflict).
 	for existingPerm, existingEntry := range existingRule.Constraints.Permissions {
-		if existingEntry.Expired(rule.Timestamp) {
+		if existingEntry.Expired(rule.Timestamp, currSession) {
 			continue
 		}
 		newPermissions[existingPerm] = existingEntry
@@ -425,7 +430,7 @@ func (rdb *RuleDB) addOrMergeRule(rule *Rule, save bool) (addedOrMergedRule *Rul
 		// outcome, so preserve whichever entry has the greater lifespan.
 		// Since newPermissions[perm] already has the existing entry, only
 		// override it if the new rule has a greater lifespan.
-		if prompting.FirstLifespanGreater(entry.Lifespan, entry.Expiration, existingEntry.Lifespan, existingEntry.Expiration) {
+		if entry.Supersedes(existingEntry, currSession) {
 			newPermissions[perm] = entry
 		}
 	}
@@ -453,7 +458,7 @@ func (rdb *RuleDB) addOrMergeRule(rule *Rule, save bool) (addedOrMergedRule *Rul
 	// we just looked up the rule and know it exists.
 	rdb.removeRuleByID(existingRule.ID)
 
-	if err := rdb.addNewRule(&newRule, save); err != nil {
+	if err := rdb.addNewRule(&newRule, currSession, save); err != nil {
 		// Error while adding the new merged rule, likely due to a conflict
 		// caused by the new permissions in the rule to be added.
 
@@ -462,7 +467,7 @@ func (rdb *RuleDB) addOrMergeRule(rule *Rule, save bool) (addedOrMergedRule *Rul
 		// we're now simply re-adding the existing rule which we just removed.
 		// Don't save, since nothing should have changed after the rollback is
 		// complete.
-		if restoreErr := rdb.addNewRule(existingRule, false); restoreErr != nil {
+		if restoreErr := rdb.addNewRule(existingRule, currSession, false); restoreErr != nil {
 			// Error should not occur, but if it does, wrap it in the other error
 			err = strutil.JoinErrors(err, fmt.Errorf("cannot re-add existing rule: %w", restoreErr))
 		}
@@ -482,7 +487,7 @@ func (rdb *RuleDB) addOrMergeRule(rule *Rule, save bool) (addedOrMergedRule *Rul
 // Returns an error if the rule conflicts with an existing rule.
 //
 // The caller must ensure that the database lock is held for writing.
-func (rdb *RuleDB) addNewRule(rule *Rule, save bool) error {
+func (rdb *RuleDB) addNewRule(rule *Rule, currSession prompting.IDType, save bool) error {
 	// If the rule has no ID, assign a new one.
 	if rule.ID == 0 {
 		id, _ := rdb.maxIDMmap.NextID()
@@ -491,7 +496,7 @@ func (rdb *RuleDB) addNewRule(rule *Rule, save bool) error {
 	if err := rdb.addRuleToRulesList(rule); err != nil {
 		return err
 	}
-	conflictErr := rdb.addRuleToTree(rule)
+	conflictErr := rdb.addRuleToTree(rule, currSession)
 	if conflictErr != nil {
 		// remove just-added rule from rules list and IDs
 		rdb.rules = rdb.rules[:len(rdb.rules)-1]
@@ -577,11 +582,11 @@ func (rdb *RuleDB) removeRuleByID(id prompting.IDType) (*Rule, error) {
 // checked.
 //
 // The caller must ensure that the database lock is held for writing.
-func (rdb *RuleDB) addRuleToTree(rule *Rule) *prompting_errors.RuleConflictError {
+func (rdb *RuleDB) addRuleToTree(rule *Rule, currSession prompting.IDType) *prompting_errors.RuleConflictError {
 	addedPermissions := make([]string, 0, len(rule.Constraints.Permissions))
 	var conflicts []prompting_errors.RuleConflict
 	for permission, entry := range rule.Constraints.Permissions {
-		permConflicts := rdb.addRulePermissionToTree(rule, permission, entry)
+		permConflicts := rdb.addRulePermissionToTree(rule, permission, entry, currSession)
 		if len(permConflicts) > 0 {
 			conflicts = append(conflicts, permConflicts...)
 			continue
@@ -621,17 +626,17 @@ func (rdb *RuleDB) addRuleToTree(rule *Rule) *prompting_errors.RuleConflictError
 // call are removed from the variant map, leaving it unchanged, and the list of
 // conflicts is returned. If there are no conflicts, returns nil.
 //
-// Rules which are expired according to the timestamp of the rule being added,
-// whether their outcome conflicts with the new rule or not, are ignored and
-// never treated as conflicts. If there are no conflicts with non-expired
-// rules, then all expired rules are removed from the tree entry (though not
-// removed from the rule DB as a whole, nor is a notice recorded). If there is
-// a conflict with a non-expired rule, then nothing about the rule DB state is
-// changed, including expired rules.
+// Rules which are expired according to the timestamp of the rule being added
+// or the current user session ID, whether their outcome conflicts with the new
+// rule or not, are ignored and never treated as conflicts. If there are no
+// conflicts with non-expired rules, then all expired rules are removed from
+// the tree entry (though not removed from the rule DB as a whole, nor is a
+// notice recorded). If there is a conflict with a non-expired rule, then
+// nothing about the rule DB state is changed, including expired rules.
 //
 // The caller must ensure that the database lock is held for writing, and that
 // the given entry is not expired.
-func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permissionEntry *prompting.RulePermissionEntry) []prompting_errors.RuleConflict {
+func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permissionEntry *prompting.RulePermissionEntry, currSession prompting.IDType) []prompting_errors.RuleConflict {
 	permVariants := rdb.ensurePermissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
 
 	newVariantEntries := make(map[string]variantEntry, rule.Constraints.PathPattern.NumVariants())
@@ -657,7 +662,7 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 		newVariantEntry.RuleEntries[rule.ID] = permissionEntry
 		newVariantEntries[variantStr] = newVariantEntry
 		for id, entry := range existingEntry.RuleEntries {
-			if entry.Expired(rule.Timestamp) {
+			if entry.Expired(rule.Timestamp, currSession) {
 				// Don't preserve expired rules, and don't care if they conflict
 				partiallyExpiredRules[id] = true
 				continue
@@ -690,7 +695,7 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 			// Error shouldn't occur. If it does, the rule was already removed
 			continue
 		}
-		if !maybeExpired.expired(rule.Timestamp) {
+		if !maybeExpired.expired(rule.Timestamp, currSession) {
 			// Previously removed the rule's permission entry from the tree for
 			// this permission, now let's remove it from the rule as well.
 			delete(maybeExpired.Constraints.Permissions, permission)
@@ -896,6 +901,9 @@ func newUserSessionID() prompting.IDType {
 	return prompting.IDType(id)
 }
 
+// Allow readOrAssignUserSessionID to be mocked in tests.
+var readOrAssignUserSessionID = (*RuleDB).readOrAssignUserSessionID
+
 // readOrAssignUserSessionID returns the existing user session ID for the given
 // user, if an ID exists, otherwise generates a new ID and writes it as an
 // xattr on the root directory of the user session tmpfs, /run/user/$UID.
@@ -966,12 +974,17 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 		return nil, prompting_errors.ErrRulesClosed
 	}
 
-	newRule, err := rdb.makeNewRule(user, snap, iface, constraints)
+	currSession, err := readOrAssignUserSessionID(rdb, user)
+	if err != nil && !errors.Is(err, errNoUserSession) {
+		return nil, err
+	}
+
+	newRule, err := rdb.makeNewRule(user, snap, iface, constraints, currSession)
 	if err != nil {
 		return nil, err
 	}
 	const save = true
-	newRule, _, err = rdb.addOrMergeRule(newRule, save)
+	newRule, _, err = rdb.addOrMergeRule(newRule, currSession, save)
 	if err != nil {
 		// If an error occurred, all changes were rolled back.
 		return nil, fmt.Errorf("cannot add rule: %w", err)
@@ -985,12 +998,20 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 // the rule an ID, in case it can be merged with an existing rule.
 //
 // Constructs a new rule with the given parameters as values. The given
-// constraints are converted to rule constraints, using the timestamp of the
-// new rule as the baseline with which to compute an expiration from any given
-// duration. If any of the given parameters are invalid, returns an error.
-func (rdb *RuleDB) makeNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints) (*Rule, error) {
+// constraints are converted to rule constraints.
+//
+// If any permission entries have a lifespan of LifespanTimespan, then their
+// expiration times are computed according to the corresponding duration
+// relative to the current time.
+//
+// If any permission entries have a lifespan of LifespanSession, then the given
+// current user session ID is associated with the corresponding newly-created
+// rule permission entries.
+//
+// If any of the given parameters are invalid, returns an error.
+func (rdb *RuleDB) makeNewRule(user uint32, snap string, iface string, constraints *prompting.Constraints, currSession prompting.IDType) (*Rule, error) {
 	currTime := time.Now()
-	ruleConstraints, err := constraints.ToRuleConstraints(iface, currTime)
+	ruleConstraints, err := constraints.ToRuleConstraints(iface, currTime, currSession)
 	if err != nil {
 		return nil, err
 	}
@@ -1016,9 +1037,14 @@ func (rdb *RuleDB) makeNewRule(user uint32, snap string, iface string, constrain
 func (rdb *RuleDB) IsRequestAllowed(user uint32, snap string, iface string, path string, permissions []string) (allowedPerms []string, anyDenied bool, outstandingPerms []string, err error) {
 	allowedPerms = make([]string, 0, len(permissions))
 	outstandingPerms = make([]string, 0, len(permissions))
+	currTime := time.Now()
+	currSession, err := readOrAssignUserSessionID(rdb, user)
+	if err != nil && !errors.Is(err, errNoUserSession) {
+		return nil, false, nil, err
+	}
 	var errs []error
 	for _, perm := range permissions {
-		allowed, err := isPathPermAllowedByRuleDB(rdb, user, snap, iface, path, perm)
+		allowed, err := isPathPermAllowed(rdb, user, snap, iface, path, perm, currTime, currSession)
 		switch {
 		case err == nil:
 			if allowed {
@@ -1035,14 +1061,13 @@ func (rdb *RuleDB) IsRequestAllowed(user uint32, snap string, iface string, path
 	return allowedPerms, anyDenied, outstandingPerms, strutil.JoinErrors(errs...)
 }
 
-var isPathPermAllowedByRuleDB = func(rdb *RuleDB, user uint32, snap string, iface string, path string, permission string) (bool, error) {
-	return rdb.isPathPermAllowed(user, snap, iface, path, permission)
-}
+// Allow isPathPermAllowed to be mocked in tests.
+var isPathPermAllowed = (*RuleDB).isPathPermAllowed
 
 // isPathPermAllowed checks whether the given path with the given permission is
 // allowed or denied by existing rules for the given user, snap, and interface.
 // If no rule applies, returns prompting_errors.ErrNoMatchingRule.
-func (rdb *RuleDB) isPathPermAllowed(user uint32, snap string, iface string, path string, permission string) (bool, error) {
+func (rdb *RuleDB) isPathPermAllowed(user uint32, snap string, iface string, path string, permission string, currTime time.Time, currSession prompting.IDType) (bool, error) {
 	rdb.mutex.RLock()
 	defer rdb.mutex.RUnlock()
 	permissionMap := rdb.permissionDBForUserSnapInterfacePermission(user, snap, iface, permission)
@@ -1051,13 +1076,10 @@ func (rdb *RuleDB) isPathPermAllowed(user uint32, snap string, iface string, pat
 	}
 	variantMap := permissionMap.VariantEntries
 	var matchingVariants []patterns.PatternVariant
-	// Make sure all rules use the same expiration timestamp, so a rule with
-	// an earlier expiration cannot outlive another rule with a later one.
-	currTime := time.Now()
 	for variantStr, variantEntry := range variantMap {
 		nonExpired := false
 		for _, rulePermissionEntry := range variantEntry.RuleEntries {
-			if !rulePermissionEntry.Expired(currTime) {
+			if !rulePermissionEntry.Expired(currTime, currSession) {
 				nonExpired = true
 				break
 			}
@@ -1120,8 +1142,15 @@ func (rdb *RuleDB) Rules(user uint32) []*Rule {
 func (rdb *RuleDB) rulesInternal(ruleFilter func(rule *Rule) bool) []*Rule {
 	rules := make([]*Rule, 0)
 	currTime := time.Now()
+	sessionIDCache := make(userSessionIDCache)
 	for _, rule := range rdb.rules {
-		if rule.expired(currTime) {
+		currSession, err := sessionIDCache.getUserSessionID(rdb, rule.User)
+		if err != nil {
+			// Something unexpected went wrong reading the user session ID.
+			// Treat the session ID as 0, and proceed.
+			currSession = 0
+		}
+		if rule.expired(currTime, currSession) {
 			// XXX: it would be nice if we pruned expired permissions from a
 			// rule before including it in the rules list, if it's not expired.
 			// Since we don't hold the write lock, we don't want to
@@ -1316,18 +1345,15 @@ func (rdb *RuleDB) RemoveRulesForSnapInterface(user uint32, snap string, iface s
 // to nil.
 //
 // Permission entries must be provided as complete units, containing both
-// outcome and lifespan (and duration, if lifespan is timespan). Since neither
-// outcome nor lifespan are omitempty, the unmarshaller enforces this for us.
+// outcome and lifespan (and duration or session ID, if lifespan is timespan or
+// session, respectively). Since neither outcome nor lifespan are omitempty,
+// the unmarshaller enforces this for us.
 //
 // Even if the given patch contents exactly match the existing rule contents,
 // the timestamp of the rule is updated to the current time. If there is any
 // error while modifying the rule, the rule is rolled back to its previous
 // unmodified state, leaving the database unchanged. If the database is changed,
 // it is saved to disk.
-//
-// XXX: Is there a client use-case for this API method?
-// Clients can always delete a rule and re-add it later, which is basically what
-// this method already does.
 func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraintsPatch *prompting.RuleConstraintsPatch) (r *Rule, err error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
@@ -1348,11 +1374,15 @@ func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraintsPatch 
 	// in the output of Rules(), should the same be done here?
 
 	currTime := time.Now()
+	currSession, err := readOrAssignUserSessionID(rdb, user)
+	if err != nil && !errors.Is(err, errNoUserSession) {
+		return nil, err
+	}
 
 	if constraintsPatch == nil {
 		constraintsPatch = &prompting.RuleConstraintsPatch{}
 	}
-	ruleConstraints, err := constraintsPatch.PatchRuleConstraints(origRule.Constraints, origRule.Interface, currTime)
+	ruleConstraints, err := constraintsPatch.PatchRuleConstraints(origRule.Constraints, origRule.Interface, currTime, currSession)
 	if err != nil {
 		return nil, err
 	}
@@ -1371,14 +1401,14 @@ func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraintsPatch 
 	rdb.removeRuleByID(origRule.ID)
 
 	const save = true
-	newRule, _, addErr := rdb.addOrMergeRule(newRule, save)
+	newRule, _, addErr := rdb.addOrMergeRule(newRule, currSession, save)
 	if addErr != nil {
 		err := fmt.Errorf("cannot patch rule: %w", addErr)
 		// Re-add the original rule so all is unchanged, which should
 		// succeed since we're simply reversing what we just completed.
 		// Don't save, since nothing should have changed after the rollback
 		// is complete.
-		if origErr := rdb.addNewRule(origRule, false); origErr != nil {
+		if origErr := rdb.addNewRule(origRule, currSession, false); origErr != nil {
 			// Error should not occur, but if it does, wrap it in the other error
 			err = strutil.JoinErrors(err, fmt.Errorf("cannot re-add original rule: %w", origErr))
 		}
@@ -1387,4 +1417,25 @@ func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraintsPatch 
 
 	rdb.notifyRule(newRule.User, newRule.ID, nil)
 	return newRule, nil
+}
+
+// userSessionIDCache provides an ergonomic wrapper for getting and caching
+// user session IDs for many rules.
+//
+// A cache should not be used beyond the scope of a single method call due to
+// an API request. In particular, it should not be persisted as part of a rule
+// database.
+type userSessionIDCache map[uint32]prompting.IDType
+
+func (cache userSessionIDCache) getUserSessionID(rdb *RuleDB, user uint32) (prompting.IDType, error) {
+	sessionID, ok := cache[user]
+	if ok {
+		return sessionID, nil
+	}
+	sessionID, err := readOrAssignUserSessionID(rdb, user)
+	if err != nil && !errors.Is(err, errNoUserSession) {
+		return 0, err
+	}
+	cache[user] = sessionID
+	return sessionID, nil
 }

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -722,6 +723,149 @@ func (s *requestrulesSuite) TestCloseErrors(c *C) {
 	defer os.Chmod(dirs.SnapInterfacesRequestsStateDir, 0o755)
 
 	c.Check(rdb.Close(), NotNil)
+}
+
+func (s *requestrulesSuite) TestUserSessionIDPath(c *C) {
+	for _, testCase := range []struct {
+		userID   uint32
+		expected string
+	}{
+		{1000, "/run/user/1000/snapd-user-session-id"},
+		{0, "/run/user/0/snapd-user-session-id"},
+		{1, "/run/user/1/snapd-user-session-id"},
+		{65535, "/run/user/65535/snapd-user-session-id"},
+		{65536, "/run/user/65536/snapd-user-session-id"},
+		{4294967295, "/run/user/4294967295/snapd-user-session-id"},
+	} {
+		expectedWithTestPrefix := filepath.Join(dirs.GlobalRootDir, testCase.expected)
+		c.Check(requestrules.UserSessionIDPath(testCase.userID), Equals, expectedWithTestPrefix)
+	}
+}
+
+func (s *requestrulesSuite) TestReadOrAssignUserSessionID(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	// If there is no user session dir, expect errNoUserSession
+	noSessionID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, ErrorMatches, "cannot find systemd user session tmpfs for user: 1000")
+	c.Assert(noSessionID, Equals, prompting.IDType(0))
+
+	// Make user session dir, as if systemd had done so for this user
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "run/user/1000"), 0o700), IsNil)
+
+	// If there is a user session dir, expect some non-zero user ID
+	origID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(origID, Not(Equals), prompting.IDType(0))
+
+	// If a user session ID is already present for this session, retrieve it
+	// rather than defining a new one
+	retrievedID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(retrievedID, Equals, origID)
+	// Try again, for good measure
+	retrievedID, err = rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(retrievedID, Equals, origID)
+
+	// If the user session restarts, the user session tmpfs is deleted and
+	// re-created, so the file is no longer present. So we set a new ID.
+	c.Assert(os.Remove(filepath.Join(dirs.GlobalRootDir, "run/user/1000/snapd-user-session-id")), IsNil)
+	newID, err := rdb.ReadOrAssignUserSessionID(s.defaultUser)
+	c.Assert(err, IsNil)
+	c.Assert(newID, Not(Equals), 0)
+	c.Assert(newID, Not(Equals), origID)
+
+	// If we try for a different user without a session, we get the error
+	noSessionID, err = rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, ErrorMatches, "cannot find systemd user session tmpfs for user: 1234")
+	c.Assert(noSessionID, Equals, prompting.IDType(0))
+
+	// Make user session dir, as if systemd had done so for this user
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "run/user/1234"), 0o700), IsNil)
+
+	// If there is a user session dir, expect some non-zero user ID different
+	// from that of the other user
+	secondUserID, err := rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, IsNil)
+	c.Assert(secondUserID, Not(Equals), prompting.IDType(0))
+	c.Assert(secondUserID, Not(Equals), newID)
+
+	// If we get the first user's session ID, it's still the same
+	firstUserID, err := rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, IsNil)
+	c.Assert(firstUserID, Not(Equals), prompting.IDType(0))
+	c.Assert(firstUserID, Not(Equals), secondUserID)
+	c.Assert(firstUserID, Equals, newID)
+
+	// If we remove the user session for the first user, we get the error again
+	c.Assert(os.RemoveAll(filepath.Join(dirs.GlobalRootDir, "run/user/1000")), IsNil)
+	noSessionID, err = rdb.ReadOrAssignUserSessionID(1000)
+	c.Assert(err, ErrorMatches, "cannot find systemd user session tmpfs for user: 1000")
+	c.Assert(noSessionID, Equals, prompting.IDType(0))
+
+	// But we can still retrieve the session ID for the second user
+	retrievedID, err = rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, IsNil)
+	c.Assert(retrievedID, Not(Equals), prompting.IDType(0))
+	c.Assert(retrievedID, Equals, secondUserID)
+
+	// If the file is corrupted, we get a new ID
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "run/user/1234/snapd-user-session-id"), []byte("foo"), 0o600), IsNil)
+	regeneratedID, err := rdb.ReadOrAssignUserSessionID(1234)
+	c.Assert(err, IsNil)
+	c.Assert(regeneratedID, Not(Equals), prompting.IDType(0))
+	c.Assert(regeneratedID, Not(Equals), secondUserID)
+}
+
+func (s *requestrulesSuite) TestReadOrAssignUserSessionIDConcurrent(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	// Multiple threads acting at once all return the same ID
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "run/user/5000"), 0o700), IsNil)
+	startChan := make(chan struct{}) // close to broadcast to all threads
+	count := 10
+	var startWG sync.WaitGroup
+	startWG.Add(count)
+	resultChan := make(chan prompting.IDType, count)
+	for i := 0; i < count; i++ {
+		go func() {
+			startWG.Done()
+			<-startChan // wait for broadcast
+			sessionID, err := rdb.ReadOrAssignUserSessionID(5000)
+			c.Assert(err, IsNil)
+			c.Assert(sessionID, Not(Equals), prompting.IDType(0))
+			resultChan <- sessionID
+		}()
+	}
+	startWG.Wait()
+	time.Sleep(10 * time.Millisecond) // wait until they're all waiting on startChan
+	// Start all goroutines simultaneously
+	close(startChan)
+
+	// Get session ID from first that sends one
+	var firstID prompting.IDType
+	select {
+	case firstID = <-resultChan:
+		c.Assert(firstID, NotNil)
+		c.Assert(firstID, Not(Equals), prompting.IDType(0))
+	case <-time.NewTimer(time.Second).C:
+		c.Fatal("timed out waiting for first user ID")
+	}
+
+	// Check that each other goroutine retrieved the same session ID
+	for i := 1; i < count; i++ {
+		select {
+		case retrievedID := <-resultChan:
+			c.Assert(retrievedID, NotNil)
+			c.Assert(retrievedID, Not(Equals), prompting.IDType(0))
+			c.Assert(retrievedID, Equals, firstID)
+		case <-time.NewTimer(time.Second).C:
+			c.Fatalf("timed out waiting for %dth ID", i)
+		}
+	}
 }
 
 type addRuleContents struct {

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -285,7 +285,7 @@ func (s *requestrulesSuite) TestLoadErrorConflictingID(c *C) {
 	good := s.ruleTemplateWithRead(c, prompting.IDType(1))
 	// Expired rules should still get a {"removed": "expired"} notice, even if they don't conflict
 	expired := s.ruleTemplateWithPathPattern(c, prompting.IDType(2), "/home/test/other")
-	setPermissionsOutcomeLifespanExpiration(c, expired, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanTimespan, currTime.Add(-10*time.Second))
+	setPermissionsOutcomeLifespanExpirationSession(c, expired, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanTimespan, currTime.Add(-10*time.Second), 0)
 	// Add rule which conflicts with IDs but doesn't otherwise conflict
 	conflicting := s.ruleTemplateWithRead(c, prompting.IDType(1))
 	conflicting.Constraints.PathPattern = mustParsePathPattern(c, "/home/test/another")
@@ -297,12 +297,13 @@ func (s *requestrulesSuite) TestLoadErrorConflictingID(c *C) {
 	s.testLoadError(c, fmt.Sprintf("cannot add rule: %v.*", prompting_errors.ErrRuleIDConflict), rules, checkWritten)
 }
 
-func setPermissionsOutcomeLifespanExpiration(c *C, rule *requestrules.Rule, permissions []string, outcome prompting.OutcomeType, lifespan prompting.LifespanType, expiration time.Time) {
+func setPermissionsOutcomeLifespanExpirationSession(c *C, rule *requestrules.Rule, permissions []string, outcome prompting.OutcomeType, lifespan prompting.LifespanType, expiration time.Time, userSessionID prompting.IDType) {
 	for _, perm := range permissions {
 		rule.Constraints.Permissions[perm] = &prompting.RulePermissionEntry{
 			Outcome:    outcome,
 			Lifespan:   lifespan,
 			Expiration: expiration,
+			SessionID:  userSessionID,
 		}
 	}
 }
@@ -314,12 +315,12 @@ func (s *requestrulesSuite) TestLoadErrorConflictingPattern(c *C) {
 	// Expired rules should still get a {"removed": "expired"} notice, even if they don't conflict
 	expired := s.ruleTemplateWithRead(c, prompting.IDType(2))
 	expired.Constraints.PathPattern = mustParsePathPattern(c, "/home/test/other")
-	setPermissionsOutcomeLifespanExpiration(c, expired, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanTimespan, currTime.Add(-10*time.Second))
+	setPermissionsOutcomeLifespanExpirationSession(c, expired, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanTimespan, currTime.Add(-10*time.Second), 0)
 	// Add rule with conflicting permissions but not conflicting ID.
 	conflicting := s.ruleTemplateWithReadPathPattern(c, prompting.IDType(3), "/home/test/{bar,foo}")
 	// Even with not all permissions being in conflict, still error
 	var timeZero time.Time
-	setPermissionsOutcomeLifespanExpiration(c, conflicting, []string{"read", "write"}, prompting.OutcomeDeny, prompting.LifespanForever, timeZero)
+	setPermissionsOutcomeLifespanExpirationSession(c, conflicting, []string{"read", "write"}, prompting.OutcomeDeny, prompting.LifespanForever, timeZero, 0)
 
 	rules := []*requestrules.Rule{good, expired, conflicting}
 	s.writeRules(c, dbPath, rules)
@@ -331,6 +332,7 @@ func (s *requestrulesSuite) TestLoadErrorConflictingPattern(c *C) {
 func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
 	dbPath := s.prepDBPath(c)
 	currTime := time.Now()
+	var timeZero time.Time
 
 	good1 := s.ruleTemplateWithReadPathPattern(c, prompting.IDType(1), "/home/test/{foo,bar}")
 
@@ -338,15 +340,14 @@ func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
 	// but we don't want to test this as part of our contract
 
 	expired1 := s.ruleTemplateWithPathPattern(c, prompting.IDType(2), "/home/test/other")
-	setPermissionsOutcomeLifespanExpiration(c, expired1, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanTimespan, currTime.Add(-10*time.Second))
+	setPermissionsOutcomeLifespanExpirationSession(c, expired1, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanSession, timeZero, prompting.IDType(0x12345))
 
 	// Rules with overlapping pattern but non-conflicting permissions do not conflict
 	good2 := s.ruleTemplateWithPathPattern(c, prompting.IDType(3), "/home/test/{bar,foo}")
-	var timeZero time.Time
-	setPermissionsOutcomeLifespanExpiration(c, good2, []string{"write"}, prompting.OutcomeDeny, prompting.LifespanForever, timeZero)
+	setPermissionsOutcomeLifespanExpirationSession(c, good2, []string{"write"}, prompting.OutcomeDeny, prompting.LifespanForever, timeZero, 0)
 
 	expired2 := s.ruleTemplateWithPathPattern(c, prompting.IDType(4), "/home/test/another")
-	setPermissionsOutcomeLifespanExpiration(c, expired2, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanTimespan, currTime.Add(-time.Nanosecond))
+	setPermissionsOutcomeLifespanExpirationSession(c, expired2, []string{"read"}, prompting.OutcomeAllow, prompting.LifespanTimespan, currTime.Add(-time.Nanosecond), 0)
 
 	// Rules with different pattern and conflicting permissions do not conflict
 	good3 := s.ruleTemplateWithRead(c, prompting.IDType(5))
@@ -889,6 +890,12 @@ type addRuleContents struct {
 }
 
 func (s *requestrulesSuite) TestAddRuleHappy(c *C) {
+	currSession := prompting.IDType(0x12345)
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -916,10 +923,11 @@ func (s *requestrulesSuite) TestAddRuleHappy(c *C) {
 		// Differing Outcome, Lifespan or Duration does not prevent conflict
 		{PathPattern: "/home/test/1", Outcome: prompting.OutcomeDeny},
 		{PathPattern: "/home/test/2", Lifespan: prompting.LifespanTimespan, Duration: "10s"},
+		{PathPattern: "/home/test/3", Lifespan: prompting.LifespanSession},
 	} {
 		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
-		c.Check(err, IsNil)
-		c.Check(rule, NotNil)
+		c.Assert(err, IsNil)
+		c.Assert(rule, NotNil)
 		addedRules = append(addedRules, rule)
 		s.checkWrittenRuleDB(c, addedRules)
 		s.checkNewNoticesSimple(c, nil, rule)
@@ -1081,6 +1089,10 @@ func (s *requestrulesSuite) TestAddRuleErrors(c *C) {
 			&addRuleContents{Lifespan: prompting.LifespanTimespan, Duration: "-10s"},
 			"invalid duration: cannot have zero or negative duration:.*",
 		},
+		{ // Invalid lifespan "session" when no active user session
+			&addRuleContents{Lifespan: prompting.LifespanSession},
+			prompting_errors.ErrNewSessionRuleNoSession.Error(),
+		},
 		{ // Invalid lifespan
 			&addRuleContents{Lifespan: prompting.LifespanType("invalid")},
 			`invalid lifespan: "invalid"`,
@@ -1225,6 +1237,15 @@ outer:
 }
 
 func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
+	currSession := prompting.IDType(0x12345)
+	// Session will be found for all test cases, so rules with LifespanSession
+	// will never be expired. It would be nice to test expired "session" rules
+	// here too, but we can do this in other easier to implement tests.
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	for _, testCase := range []struct {
 		input  []prompting.PermissionMap
 		output []prompting.PermissionMap
@@ -1285,7 +1306,7 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 					},
 					"write": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
+						Lifespan: prompting.LifespanSession,
 					},
 				},
 			},
@@ -1297,7 +1318,7 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 					},
 					"write": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
+						Lifespan: prompting.LifespanSession,
 					},
 					"execute": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeAllow,
@@ -1319,8 +1340,7 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 					},
 					"write": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanTimespan,
-						Duration: "10s",
+						Lifespan: prompting.LifespanSession,
 					},
 					"execute": &prompting.PermissionEntry{
 						Outcome:  prompting.OutcomeAllow,
@@ -1485,7 +1505,8 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 				PathPattern: pathPattern,
 				Permissions: perms,
 			}
-			ruleConstraints, err := constraints.ToRuleConstraints(iface, rule.Timestamp)
+			currSession := prompting.IDType(0x12345) // FIXME
+			ruleConstraints, err := constraints.ToRuleConstraints(iface, rule.Timestamp, currSession)
 			c.Assert(err, IsNil)
 			expectedPerms := ruleConstraints.Permissions
 			// Check that the permissions match what is expected.
@@ -1519,6 +1540,12 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 }
 
 func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
+	var currSession prompting.IDType
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -1537,10 +1564,56 @@ func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
 	good, err := addRuleFromTemplate(c, rdb, template, &addRuleContents{Snap: "gimp"})
 	c.Assert(err, IsNil)
 	c.Assert(good, NotNil)
+	// initialSessionAllow rule should still be on disk, along with new rule
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{good})
+	s.checkNewNoticesSimple(c, nil, good)
 
 	// TODO: ADD test which tests behavior of rules which partially expire
 
-	// Add initial rule which will expire quickly
+	// First add deny rule with lifespan "session"
+	currSession = prompting.IDType(0x12345)
+	initialSessionDeny, err := addRuleFromTemplate(c, rdb, template, &addRuleContents{
+		Outcome: prompting.OutcomeDeny,
+		// Make path pattern conflict but not be identical
+		PathPattern: "/home/test/**/{secret,private,foo}/**",
+		Lifespan:    prompting.LifespanSession,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(initialSessionDeny, NotNil)
+	// Rule should be on disk and have notice
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{good, initialSessionDeny})
+	s.checkNewNoticesSimple(c, nil, initialSessionDeny)
+
+	// Next add conflicting allow rule with lifespan "session"
+	currSession = prompting.IDType(0xabcdef)
+	initialSessionAllow, err := addRuleFromTemplate(c, rdb, template, &addRuleContents{
+		Outcome: prompting.OutcomeAllow,
+		// Make path pattern conflict but not be identical
+		PathPattern: "/home/test/**/{secret,private,bar}/**",
+		Lifespan:    prompting.LifespanSession,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(initialSessionAllow, NotNil)
+	// Rule should be on disk and have notice, along with notice for expired rule
+	s.checkWrittenRuleDB(c, []*requestrules.Rule{good, initialSessionAllow})
+	expectedNoticeInfo := []*noticeInfo{
+		{
+			userID: initialSessionDeny.User,
+			ruleID: initialSessionDeny.ID,
+			data:   map[string]string{"removed": "expired"},
+		},
+		{
+			userID: initialSessionAllow.User,
+			ruleID: initialSessionAllow.ID,
+		},
+	}
+	s.checkNewNotices(c, expectedNoticeInfo)
+	// Change user session again so future timespan rule will conflict and
+	// expire this rule.
+	currSession = prompting.IDType(0xf00)
+
+	// Add initial LifespanTimespan rule which will conflict with
+	// initialSessionAllow and then expire quickly
 	prev, err := addRuleFromTemplate(c, rdb, template, &addRuleContents{
 		Outcome:  prompting.OutcomeDeny,
 		Lifespan: prompting.LifespanTimespan,
@@ -1552,7 +1625,18 @@ func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
 
 	// Both rules should be on disk and have notices
 	s.checkWrittenRuleDB(c, []*requestrules.Rule{good, prev})
-	s.checkNewNoticesSimple(c, nil, good, prev)
+	expectedNoticeInfo = []*noticeInfo{
+		{
+			userID: initialSessionAllow.User,
+			ruleID: initialSessionAllow.ID,
+			data:   map[string]string{"removed": "expired"},
+		},
+		{
+			userID: prev.User,
+			ruleID: prev.ID,
+		},
+	}
+	s.checkNewNotices(c, expectedNoticeInfo)
 
 	// Add rules which all conflict but each expire before the next is added,
 	// thus causing the prior one to be removed and not causing a conflict error.
@@ -1592,7 +1676,7 @@ func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(final, NotNil)
 	s.checkWrittenRuleDB(c, []*requestrules.Rule{good, final})
-	expectedNoticeInfo := []*noticeInfo{
+	expectedNoticeInfo = []*noticeInfo{
 		{
 			userID: prev.User,
 			ruleID: prev.ID,
@@ -1608,6 +1692,12 @@ func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
 }
 
 func (s *requestrulesSuite) TestAddRulePartiallyExpired(c *C) {
+	var currSession prompting.IDType
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -1615,6 +1705,7 @@ func (s *requestrulesSuite) TestAddRulePartiallyExpired(c *C) {
 	snap := "firefox"
 	iface := "home"
 
+	currSession = prompting.IDType(0x12345)
 	constraints1 := &prompting.Constraints{
 		PathPattern: mustParsePathPattern(c, "/path/to/{foo,bar}"),
 		Permissions: prompting.PermissionMap{
@@ -1629,8 +1720,7 @@ func (s *requestrulesSuite) TestAddRulePartiallyExpired(c *C) {
 			},
 			"execute": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
-				Lifespan: prompting.LifespanTimespan,
-				Duration: "1ns",
+				Lifespan: prompting.LifespanSession,
 			},
 		},
 	}
@@ -1639,6 +1729,9 @@ func (s *requestrulesSuite) TestAddRulePartiallyExpired(c *C) {
 	c.Assert(rule1, NotNil)
 	s.checkWrittenRuleDB(c, []*requestrules.Rule{rule1})
 	s.checkNewNoticesSimple(c, nil, rule1)
+	// Now that the rule has been added, change the user session ID so the
+	// execute permission is treated as expired
+	currSession = prompting.IDType(0xf00)
 
 	constraints2 := &prompting.Constraints{
 		PathPattern: mustParsePathPattern(c, "/path/to/{bar,baz}"), // overlap
@@ -1793,7 +1886,7 @@ func (s *requestrulesSuite) TestIsRequestAllowed(c *C) {
 			errStr:           "foo\nqux",
 		},
 	} {
-		restore := requestrules.MockIsPathPermAllowed(func(r *requestrules.RuleDB, u uint32, s string, i string, p string, perm string) (bool, error) {
+		restore := requestrules.MockIsPathPermAllowed(func(r *requestrules.RuleDB, u uint32, s string, i string, p string, perm string, currTime time.Time, currSession prompting.IDType) (bool, error) {
 			c.Assert(r, Equals, rdb)
 			c.Assert(u, Equals, user)
 			c.Assert(s, Equals, snap)
@@ -1817,6 +1910,12 @@ func (s *requestrulesSuite) TestIsRequestAllowed(c *C) {
 }
 
 func (s *requestrulesSuite) TestIsPathPermAllowedSimple(c *C) {
+	currSession := prompting.IDType(0x12345)
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	// Target
 	user := s.defaultUser
 	snap := "firefox"
@@ -1864,6 +1963,16 @@ func (s *requestrulesSuite) TestIsPathPermAllowedSimple(c *C) {
 			allowed:      false,
 			err:          nil,
 		},
+		{ // Matching allow session rule
+			ruleContents: &addRuleContents{Lifespan: prompting.LifespanSession},
+			allowed:      true,
+			err:          nil,
+		},
+		{ // Matching deny session rule
+			ruleContents: &addRuleContents{Outcome: prompting.OutcomeDeny, Lifespan: prompting.LifespanSession},
+			allowed:      false,
+			err:          nil,
+		},
 		{ // Rule with wrong user
 			ruleContents: &addRuleContents{User: s.defaultUser + 1},
 			allowed:      false,
@@ -1899,7 +2008,7 @@ func (s *requestrulesSuite) TestIsPathPermAllowedSimple(c *C) {
 			s.checkNewNoticesSimple(c, nil)
 		}
 
-		allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission)
+		allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission, time.Now(), currSession)
 		c.Check(err, Equals, testCase.err)
 		c.Check(allowed, Equals, testCase.allowed)
 		// Check that no notices were recorded when checking
@@ -1970,7 +2079,11 @@ func (s *requestrulesSuite) TestIsPathPermAllowedPrecedence(c *C) {
 		mostRecentOutcome, err := ruleContents.Outcome.AsBool()
 		c.Check(err, IsNil)
 
-		allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission)
+		// Current time and session don't matter for this test
+		currTime := time.Now()
+		currSession := prompting.IDType(0x12345)
+
+		allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission, currTime, currSession)
 		c.Check(err, IsNil)
 		c.Check(allowed, Equals, mostRecentOutcome, Commentf("most recent: %+v", ruleContents))
 	}
@@ -2005,20 +2118,115 @@ func (s *requestrulesSuite) TestIsPathPermAllowedExpiration(c *C) {
 	// Then, from last to first, mark the rule as expired by setting the
 	// expiration timestamp to the past, and then test that the
 	// always match the most recent rule contents.
+	toAdd := []*addRuleContents{
+		{PathPattern: "/home/test/**"},
+		{PathPattern: "/home/test/Doc*/**"},
+		{PathPattern: "/home/test/Documents/**"},
+		{PathPattern: "/home/test/Documents/foo/**"},
+		{PathPattern: "/home/test/Documents/foo/**/ba?/*.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/ba?/file.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/**"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/**"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/*"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/*.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/{somewhere/else,baz}/file.txt"},
+		{PathPattern: "/home/test/Documents/foo/*/baz/file.{txt,md,pdf}"},
+		{PathPattern: "/home/test/{Documents,Pictures}/foo/bar/baz/file.{txt,md,pdf,png,jpg,svg}"},
+	}
+	for i, ruleContents := range toAdd {
+		// Set duration to 1h for last rule, 2h for second to last rule, etc.
+		ruleContents.Duration = fmt.Sprintf("%dh", len(toAdd)-i)
+		if i%2 == 0 {
+			ruleContents.Outcome = prompting.OutcomeAllow
+		} else {
+			ruleContents.Outcome = prompting.OutcomeDeny
+		}
+		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
+		c.Assert(err, IsNil)
+		c.Assert(rule, NotNil)
+		addedRules = append(addedRules, rule)
+		s.checkWrittenRuleDB(c, addedRules)
+		s.checkNewNoticesSimple(c, nil, rule)
+	}
+
+	// currTime starts after all rules have been added but before any have
+	// expired.
+	currTime := time.Now()
+	// currSession doesn't matter for this test.
+	currSession := prompting.IDType(0x12345)
+
+	for i := len(addedRules) - 1; i >= 0; i-- {
+		rule := addedRules[i]
+		expectedOutcome, err := rule.Constraints.Permissions["read"].Outcome.AsBool()
+		c.Check(err, IsNil)
+
+		// Check that the outcome of the most specific unexpired rule has precedence
+		allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission, currTime, currSession)
+		c.Check(err, IsNil)
+		c.Check(allowed, Equals, expectedOutcome, Commentf("last unexpired: %+v", rule))
+
+		// Check that no new notices are recorded from lookup or expiration
+		s.checkNewNoticesSimple(c, nil)
+
+		// Advance the current time to cause highest precedence rule to expire.
+		currTime = currTime.Add(time.Hour)
+	}
+}
+
+func (s *requestrulesSuite) TestIsPathPermAllowedSession(c *C) {
+	var currSession prompting.IDType
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
+	// Target
+	user := s.defaultUser
+	snap := "firefox"
+	iface := "home"
+	path := "/home/test/Documents/foo/bar/baz/file.txt"
+	permission := "read"
+
+	template := &addRuleContents{
+		User:        user,
+		Snap:        snap,
+		Interface:   iface,
+		PathPattern: path,
+		Permissions: []string{permission},
+		Outcome:     prompting.OutcomeAllow,
+		Lifespan:    prompting.LifespanSession,
+		Duration:    "1h",
+	}
+
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+	c.Assert(rdb, NotNil)
+
+	// Add all rules initially with session ID 0x12345
+	currSession = prompting.IDType(0x12345)
+	// Define another session ID which rules will change to later to emulate expiration
+	otherSession := prompting.IDType(0xabcd)
+	currTime := time.Now() // doesn't matter for this test
+	var addedRules []*requestrules.Rule
+
+	// Add these rules, where each has higher precedence than prior rules.
+	// Then, from last to first, mark the rule as expired by setting the
+	// session ID to something else, and then test that they always match the
+	// most specific rule contents.
 	for i, ruleContents := range []*addRuleContents{
-		{Duration: "1h", PathPattern: "/home/test/**"},
-		{Duration: "1h", PathPattern: "/home/test/Doc*/**"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/**"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/ba?/*.txt"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/ba?/file.txt"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/**"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/baz/**"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/baz/*"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/baz/*.txt"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/**/bar/{somewhere/else,baz}/file.txt"},
-		{Duration: "1h", PathPattern: "/home/test/Documents/foo/*/baz/file.{txt,md,pdf}"},
-		{Duration: "1h", PathPattern: "/home/test/{Documents,Pictures}/foo/bar/baz/file.{txt,md,pdf,png,jpg,svg}"},
+		{PathPattern: "/home/test/**"},
+		{PathPattern: "/home/test/Doc*/**"},
+		{PathPattern: "/home/test/Documents/**"},
+		{PathPattern: "/home/test/Documents/foo/**"},
+		{PathPattern: "/home/test/Documents/foo/**/ba?/*.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/ba?/file.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/**"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/**"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/*"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/baz/*.txt"},
+		{PathPattern: "/home/test/Documents/foo/**/bar/{somewhere/else,baz}/file.txt"},
+		{PathPattern: "/home/test/Documents/foo/*/baz/file.{txt,md,pdf}"},
+		{PathPattern: "/home/test/{Documents,Pictures}/foo/bar/baz/file.{txt,md,pdf,png,jpg,svg}"},
 	} {
 		if i%2 == 0 {
 			ruleContents.Outcome = prompting.OutcomeAllow
@@ -2039,16 +2247,32 @@ func (s *requestrulesSuite) TestIsPathPermAllowedExpiration(c *C) {
 		c.Check(err, IsNil)
 
 		// Check that the outcome of the most specific unexpired rule has precedence
-		allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission)
+		allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission, currTime, currSession)
 		c.Check(err, IsNil)
 		c.Check(allowed, Equals, expectedOutcome, Commentf("last unexpired: %+v", rule))
 
 		// Check that no new notices are recorded from lookup or expiration
 		s.checkNewNoticesSimple(c, nil)
 
-		// Expire the highest precedence rule
-		rule.Constraints.Permissions["read"].Expiration = time.Now()
+		// Expire the highest precedence rule by changing its session to be
+		// different from the current session
+		rule.Constraints.Permissions["read"].SessionID = otherSession
 	}
+
+	// Now that currSession is different from the session of any of the rules,
+	// there should be no matching rules.
+	allowed, err := rdb.IsPathPermAllowed(user, snap, iface, path, permission, currTime, currSession)
+	c.Check(err, Equals, prompting_errors.ErrNoMatchingRule)
+	c.Check(allowed, Equals, false)
+
+	// Same if the user session ends (currSession = 0)
+	allowed, err = rdb.IsPathPermAllowed(user, snap, iface, path, permission, currTime, prompting.IDType(0))
+	c.Check(err, Equals, prompting_errors.ErrNoMatchingRule)
+	c.Check(allowed, Equals, false)
+
+	// But if the session matches that of the rules, they'll again match
+	_, err = rdb.IsPathPermAllowed(user, snap, iface, path, permission, currTime, otherSession)
+	c.Check(err, IsNil)
 }
 
 func (s *requestrulesSuite) TestRuleWithID(c *C) {
@@ -2142,6 +2366,12 @@ func (s *requestrulesSuite) prepRuleDBForRulesForSnapInterface(c *C, rdb *reques
 }
 
 func (s *requestrulesSuite) TestRulesExpired(c *C) {
+	currSession := prompting.IDType(0x12345)
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
@@ -2154,8 +2384,10 @@ func (s *requestrulesSuite) TestRulesExpired(c *C) {
 	// This is brittle, relies on details of the rules added by prepRuleDBForRulesForSnapInterface
 	rules[0].Constraints.Permissions["read"].Lifespan = prompting.LifespanTimespan
 	rules[0].Constraints.Permissions["read"].Expiration = time.Now()
-	rules[2].Constraints.Permissions["read"].Lifespan = prompting.LifespanTimespan
-	rules[2].Constraints.Permissions["read"].Expiration = time.Now()
+	rules[1].Constraints.Permissions["write"].Lifespan = prompting.LifespanSession
+	rules[1].Constraints.Permissions["write"].SessionID = currSession // not expired
+	rules[2].Constraints.Permissions["read"].Lifespan = prompting.LifespanSession
+	rules[2].Constraints.Permissions["read"].SessionID = currSession + 1 // expired
 	rules[4].Constraints.Permissions["read"].Lifespan = prompting.LifespanTimespan
 	rules[4].Constraints.Permissions["read"].Expiration = time.Now()
 
@@ -2477,6 +2709,12 @@ func (s *requestrulesSuite) TestRemoveRulesForSnapInterfaceErrors(c *C) {
 }
 
 func (s *requestrulesSuite) TestPatchRule(c *C) {
+	currSession := prompting.IDType(0x12345)
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -2612,8 +2850,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 			},
 			"execute": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
-				Lifespan: prompting.LifespanTimespan,
-				Duration: "10s",
+				Lifespan: prompting.LifespanSession,
 			},
 		},
 	}
@@ -2626,9 +2863,9 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 	// After making timestamp the same again, check that the rules are identical
 	patched.Timestamp = rule.Timestamp
 	rule.Constraints.Permissions["read"].Lifespan = prompting.LifespanTimespan
-	rule.Constraints.Permissions["execute"].Lifespan = prompting.LifespanTimespan
 	rule.Constraints.Permissions["read"].Expiration = patched.Constraints.Permissions["read"].Expiration
-	rule.Constraints.Permissions["execute"].Expiration = patched.Constraints.Permissions["execute"].Expiration
+	rule.Constraints.Permissions["execute"].Lifespan = prompting.LifespanSession
+	rule.Constraints.Permissions["execute"].SessionID = currSession
 	c.Check(patched, DeepEquals, rule)
 
 	rule = patched
@@ -2776,6 +3013,12 @@ func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
 }
 
 func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
+	currSession := prompting.IDType(0x12345)
+	restore := requestrules.MockReadOrAssignUserSessionID(func(rdb *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		return currSession, nil
+	})
+	defer restore()
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -2793,7 +3036,7 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 
 	for _, ruleContents := range []*addRuleContents{
 		{PathPattern: "/foo", Lifespan: prompting.LifespanTimespan, Duration: "1ms"},
-		{PathPattern: "/bar", Lifespan: prompting.LifespanTimespan, Duration: "1ms", Permissions: []string{"read"}},
+		{PathPattern: "/bar", Lifespan: prompting.LifespanSession, Permissions: []string{"read"}},
 		{PathPattern: "/baz", Permissions: []string{"execute"}},
 	} {
 		rule, err := addRuleFromTemplate(c, rdb, template, ruleContents)
@@ -2804,7 +3047,9 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 		s.checkNewNoticesSimple(c, nil, rule)
 	}
 
+	// Expire first two rules by advancing time and changing current session ID
 	time.Sleep(time.Millisecond)
+	currSession += 1
 
 	// Patching doesn't conflict with already-expired rules
 	rule := rules[2]
@@ -2813,7 +3058,7 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 		Permissions: prompting.PermissionMap{
 			"read": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
-				Lifespan: prompting.LifespanForever,
+				Lifespan: prompting.LifespanSession,
 			},
 			"write": &prompting.PermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
@@ -2830,13 +3075,13 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 	s.checkWrittenRuleDB(c, []*requestrules.Rule{patched})
 	expectedNotices := []*noticeInfo{
 		{
-			userID: rules[1].User,
-			ruleID: rules[1].ID,
+			userID: rules[0].User,
+			ruleID: rules[0].ID,
 			data:   map[string]string{"removed": "expired"},
 		},
 		{
-			userID: rules[0].User,
-			ruleID: rules[0].ID,
+			userID: rules[1].User,
+			ruleID: rules[1].ID,
 			data:   map[string]string{"removed": "expired"},
 		},
 		{
@@ -2854,8 +3099,9 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 		PathPattern: mustParsePathPattern(c, "/{foo,bar}"),
 		Permissions: prompting.RulePermissionMap{
 			"read": &prompting.RulePermissionEntry{
-				Outcome:  prompting.OutcomeDeny,
-				Lifespan: prompting.LifespanForever,
+				Outcome:   prompting.OutcomeDeny,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: currSession,
 			},
 			"write": &prompting.RulePermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
@@ -2868,4 +3114,87 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 		},
 	}
 	c.Check(patched, DeepEquals, rule)
+}
+
+func (s *requestrulesSuite) TestUserSessionIDCache(c *C) {
+	rdb, err := requestrules.New(s.defaultNotifyRule)
+	c.Assert(err, IsNil)
+
+	checkedDiskForUser := make(map[uint32]int)
+	restore := requestrules.MockReadOrAssignUserSessionID(func(ruleDB *requestrules.RuleDB, user uint32) (prompting.IDType, error) {
+		c.Assert(ruleDB, Equals, rdb)
+		checkedDiskForUser[user] += 1
+
+		switch user {
+		case 1000:
+			return prompting.IDType(0x12345), nil
+		case 1234:
+			return prompting.IDType(0xabcd), nil
+		case 11235:
+			// Pretend there's no user session for this user
+			return prompting.IDType(0), fmt.Errorf("foo: %w", requestrules.ErrNoUserSession)
+		case 5000:
+			// Pretend there's some other error
+			return prompting.IDType(0), errors.New("foo")
+		}
+		c.Fatalf("unexpected user: %d", user)
+		return 0, fmt.Errorf("unexpected user: %d", user)
+	})
+	defer restore()
+
+	cache := make(requestrules.UserSessionIDCache)
+
+	// Get the same user multiple times
+	for i := 0; i < 5; i++ {
+		result, err := cache.GetUserSessionID(rdb, 1000)
+		c.Assert(err, IsNil)
+		c.Assert(result, Equals, prompting.IDType(0x12345))
+	}
+	// Check that readOrAssignUserSessionID was only called once
+	count, ok := checkedDiskForUser[1000]
+	c.Assert(count, Equals, 1)
+	c.Assert(ok, Equals, true)
+
+	// Get some other user several times
+	for i := 0; i < 5; i++ {
+		result, err := cache.GetUserSessionID(rdb, 1234)
+		c.Assert(err, IsNil)
+		c.Assert(result, Equals, prompting.IDType(0xabcd))
+	}
+	// Check that readOrAssignUserSessionID was only called once
+	count, ok = checkedDiskForUser[1234]
+	c.Assert(count, Equals, 1)
+	c.Assert(ok, Equals, true)
+
+	// Get a user which has no session
+	for i := 0; i < 5; i++ {
+		result, err := cache.GetUserSessionID(rdb, 11235)
+		// Error should be nil even though there was no session
+		c.Assert(err, IsNil)
+		c.Assert(result, Equals, prompting.IDType(0))
+	}
+	// Check that readOrAssignUserSessionID was only called once
+	count, ok = checkedDiskForUser[11235]
+	c.Assert(count, Equals, 1)
+	c.Assert(ok, Equals, true)
+
+	// Get a user which causes error
+	for i := 0; i < 5; i++ {
+		result, err := cache.GetUserSessionID(rdb, 5000)
+		c.Assert(err, ErrorMatches, "foo")
+		c.Assert(result, Equals, prompting.IDType(0))
+	}
+	// With other error, readOrAssignUserSessionID should be called every time
+	count, ok = checkedDiskForUser[5000]
+	c.Assert(count, Equals, 5)
+	c.Assert(ok, Equals, true)
+
+	// Get a previous user again, it should again reuse the cache
+	result, err := cache.GetUserSessionID(rdb, 1000)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, prompting.IDType(0x12345))
+	// Check that readOrAssignUserSessionID was only called once
+	count, ok = checkedDiskForUser[1000]
+	c.Assert(count, Equals, 1)
+	c.Assert(ok, Equals, true)
 }

--- a/randutil/rand.go
+++ b/randutil/rand.go
@@ -84,6 +84,7 @@ var (
 	Intn   = rand.Intn
 	Int63n = rand.Int63n
 	Perm   = rand.Perm
+	Uint64 = rand.Uint64
 )
 
 // RandomDuration returns a random duration up to the given length.


### PR DESCRIPTION
This PR is based on #15629. Only the more recent commit(s) are relevant.

Replies and rules may have lifespan "session", which means they should apply for the duration of the systemd user session associated with their user ID. When that user session ends, any rules with lifespan "session" which were associated with that session should be treated as expired.
    
As a result, the current user session ID is now passed to many prompting helpers just as the current time has been, and is used to decide whether a rule or ruel permission entry is expired, or to convert a permission entry to a rule permission entry by assigning it a session ID. These helpers handle much of the complexity around rules with lifespan "session", and as long as the current user session for the corresponding user is computed and passed into the helpers, much of the other code within `interfaces/prompting/requestrules` needs minimal additional changes.
    
Since the current user session ID is associated with the rule when a rule with lifespan "session" is created, and snapd may restart while a systemd user session remains active, the user session ID must be marshalled to disk so it can be re-read after snapd restart.
    
As a side-effect, the user session ID for a given rule is also included in the marshalled JSON in responses to API requests. This user session ID is internal to snapd and meaningless to external applications.
    
Additionally, since a reply or rule creation could occur after the user session ends (though this should never occur in practice, unless the root user is replying/creating rules on behalf of a non-root user), an error could occur when creating a rule with lifespan "session" due to the session not being found. This error can be returned as a result of API requests, so this commit adds a corresponding error kind and handling for the error in the daemon.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-33852