### PR TITLE
cmd, api: add debug features to get complete list of features

### DIFF
--- a/cmd/snap/cmd_debug_features.go
+++ b/cmd/snap/cmd_debug_features.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/snapdenv"
 )

--- a/cmd/snap/cmd_debug_features.go
+++ b/cmd/snap/cmd_debug_features.go
@@ -24,13 +24,12 @@ import (
 	"strings"
 
 	"github.com/jessevdk/go-flags"
-
-	"github.com/snapcore/snapd/client"
-	"github.com/snapcore/snapd/snapdenv"
 )
 
 type cmdDebugFeatures struct {
 	clientMixin
+
+	p *flags.Parser
 }
 
 func init() {
@@ -44,6 +43,10 @@ func init() {
 	)
 }
 
+func (x *cmdDebugFeatures) setParser(p *flags.Parser) {
+	x.p = p
+}
+
 func (x *cmdDebugFeatures) Execute(args []string) error {
 	x.setClient(mkClient())
 	var err error
@@ -52,7 +55,7 @@ func (x *cmdDebugFeatures) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	rsp["commands"] = getCommandNames()
+	rsp["commands"] = getCommandNames(x.p)
 	enc := json.NewEncoder(Stdout)
 	if err := enc.Encode(rsp); err != nil {
 		return err
@@ -60,14 +63,7 @@ func (x *cmdDebugFeatures) Execute(args []string) error {
 	return nil
 }
 
-func getCommandNames() []string {
-	cfg := &ClientConfig
-	// Set client user-agent when talking to the snapd daemon to the
-	// same value as when talking to the store.
-	cfg.UserAgent = snapdenv.UserAgent()
-
-	cli := client.New(cfg)
-	parser := Parser(cli)
+func getCommandNames(parser *flags.Parser) []string {
 	commands := parser.Command.Commands()
 	names := []string{}
 	for _, cmd := range commands {

--- a/cmd/snap/cmd_debug_features.go
+++ b/cmd/snap/cmd_debug_features.go
@@ -35,8 +35,11 @@ type cmdDebugFeatures struct {
 func init() {
 	addDebugCommand("features",
 		"Obtain the complete list of feature tags",
-		`Display json output that contains the complete list 
-		of feature tags present in snapd and snap`,
+		`Display json output that contains the complete list of
+		feature tags present in snapd and snap. Feature tags are
+		a collection of data that describe significant code paths
+		within snapd including tasks, changes, interfaces, 
+		endpoints, snap commands, and ensure helper functions.`,
 		func() flags.Commander { return &cmdDebugFeatures{} },
 		nil,
 		nil,

--- a/cmd/snap/cmd_debug_features.go
+++ b/cmd/snap/cmd_debug_features.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/snapdenv"
+)
+
+type cmdDebugFeatures struct {
+	clientMixin
+}
+
+func init() {
+	addDebugCommand("features",
+		"Obtain the complete list of feature tags",
+		`Display json output that contains the complete list 
+		of feature tags present in snapd and snap`,
+		func() flags.Commander { return &cmdDebugFeatures{} },
+		nil,
+		nil,
+	)
+}
+
+func (x *cmdDebugFeatures) Execute(args []string) error {
+	x.setClient(mkClient())
+	var err error
+	var rsp map[string]any
+	err = x.client.DebugGet("features", &rsp, nil)
+	if err != nil {
+		return err
+	}
+	rsp["commands"] = getCommandNames()
+	enc := json.NewEncoder(Stdout)
+	if err := enc.Encode(rsp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getCommandNames() []string {
+	cfg := &ClientConfig
+	// Set client user-agent when talking to the snapd daemon to the
+	// same value as when talking to the store.
+	cfg.UserAgent = snapdenv.UserAgent()
+
+	cli := client.New(cfg)
+	parser := Parser(cli)
+	commands := parser.Command.Commands()
+	names := []string{}
+	for _, cmd := range commands {
+		subcommands := cmd.Commands()
+		if len(subcommands) == 0 {
+			names = append(names, cmd.Name)
+		} else {
+			names = append(names, getSubCommandNames(subcommands, []string{cmd.Name})...)
+		}
+	}
+	return names
+}
+
+func getSubCommandNames(commands []*flags.Command, names []string) []string {
+	composedNames := []string{}
+	for _, cmd := range commands {
+		subcommands := cmd.Commands()
+		if len(subcommands) == 0 {
+			composedNames = append(composedNames, strings.Join(append(names, cmd.Name), " "))
+		} else {
+			composedNames = append(composedNames, getSubCommandNames(subcommands, append(names, cmd.Name))...)
+		}
+	}
+	return composedNames
+}

--- a/cmd/snap/cmd_debug_features_test.go
+++ b/cmd/snap/cmd_debug_features_test.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/testutil"
+	"gopkg.in/check.v1"
+)
+
+func (s *SnapSuite) TestFeatures(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/debug")
+			c.Check(r.URL.RawQuery, check.Equals, "aspect=features")
+			data, err := io.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(data, check.HasLen, 0)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"tasks": ["example-task"]}}`)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "features"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	var cmds struct {
+		Commands []string `json:"commands"`
+		Tasks    []string `json:"tasks"`
+	}
+	err = json.NewDecoder(strings.NewReader(s.Stdout())).Decode(&cmds)
+	c.Assert(err, check.IsNil)
+	c.Check(cmds.Commands, testutil.Contains, "debug features")
+	c.Check(cmds.Tasks, check.HasLen, 1)
+	c.Check(cmds.Tasks, testutil.Contains, "example-task")
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -104,6 +104,9 @@ type featureEndpoint struct {
 var featureList []featureEndpoint
 
 func init() {
+	// Create a complete list of all endpoints, which constitute
+	// the complete set of endpoint feature tags. It is created
+	// here instead of in api_debug to avoid circular dependencies.
 	featureList = []featureEndpoint{}
 	for _, cmd := range api {
 		var path string

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -95,6 +95,36 @@ var api = []*Command{
 	systemVolumesCmd,
 }
 
+type featureEndpoint struct {
+	Path    string
+	Method  string
+	Actions []string
+}
+
+var featureList []featureEndpoint
+
+func init() {
+	featureList = []featureEndpoint{}
+	for _, cmd := range api {
+		var path string
+		if cmd.Path != "" {
+			path = cmd.Path
+		} else {
+			path = cmd.PathPrefix
+		}
+
+		if cmd.GET != nil {
+			featureList = append(featureList, featureEndpoint{Path: path, Method: "GET"})
+		}
+		if cmd.POST != nil {
+			featureList = append(featureList, featureEndpoint{Path: path, Actions: cmd.Actions, Method: "POST"})
+		}
+		if cmd.PUT != nil {
+			featureList = append(featureList, featureEndpoint{Path: path, Actions: cmd.Actions, Method: "PUT"})
+		}
+	}
+}
+
 const (
 	polkitActionLogin               = "io.snapcraft.snapd.login"
 	polkitActionManage              = "io.snapcraft.snapd.manage"

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -357,9 +357,9 @@ func getFeatures(c *Command) Response {
 	tasks := runner.KnownTaskKinds()
 
 	ifaces := c.d.overlord.InterfaceManager().Repository().AllInterfaces()
-	inames := make([]string, len(ifaces))
-	for i, iface := range ifaces {
-		inames[i] = iface.Name()
+	inames := make([]string, 0, len(ifaces))
+	for _, iface := range ifaces {
+		inames = append(inames, iface.Name())
 	}
 	changes := swfeats.KnownChangeKinds()
 

--- a/daemon/api_debug_features_test.go
+++ b/daemon/api_debug_features_test.go
@@ -52,7 +52,7 @@ func (s *featuresDebugSuite) getFeaturesDebug(c *C) any {
 	return rsp.Result
 }
 
-func (s *featuresDebugSuite) TestNoData(c *C) {
+func (s *featuresDebugSuite) TestFeaturesHaveData(c *C) {
 	data := s.getFeaturesDebug(c)
 	c.Check(data, NotNil)
 	resp, ok := data.(daemon.FeatureResponse)

--- a/daemon/api_debug_features_test.go
+++ b/daemon/api_debug_features_test.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon_test
+
+import (
+	"net/http"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/ifacestate"
+)
+
+var _ = Suite(&featuresDebugSuite{})
+
+type featuresDebugSuite struct {
+	apiBaseSuite
+}
+
+func (s *featuresDebugSuite) SetUpTest(c *C) {
+	s.apiBaseSuite.SetUpTest(c)
+	s.daemonWithOverlordMock()
+	ifacemgr, err := ifacestate.Manager(s.d.Overlord().State(), s.d.Overlord().HookManager(), s.d.Overlord().TaskRunner(), []interfaces.Interface{}, []interfaces.SecurityBackend{})
+	c.Assert(err, IsNil)
+	s.d.Overlord().AddManager(ifacemgr)
+}
+
+func (s *featuresDebugSuite) getFeaturesDebug(c *C) any {
+	req, err := http.NewRequest("GET", "/v2/debug?aspect=features", nil)
+	c.Assert(err, IsNil)
+
+	rsp := s.syncReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Type, Equals, daemon.ResponseTypeSync)
+	return rsp.Result
+}
+
+func (s *featuresDebugSuite) TestNoData(c *C) {
+	data := s.getFeaturesDebug(c)
+	c.Check(data, NotNil)
+	resp, ok := data.(daemon.FeatureResponse)
+	c.Assert(ok, Equals, true)
+	c.Assert(len(resp.Tasks) > 0, Equals, true)
+	c.Assert(len(resp.Changes) > 0, Equals, true)
+	c.Assert(len(resp.Endpoints) > 0, Equals, true)
+	c.Assert(len(resp.Ensures) > 0, Equals, true)
+}

--- a/daemon/export_api_debug_test.go
+++ b/daemon/export_api_debug_test.go
@@ -28,6 +28,7 @@ type (
 	MonitoredSnapInfo    = monitoredSnapInfo
 	RefreshCandidateInfo = refreshCandidateInfo
 	RefreshCandidate     = refreshCandidate
+	FeatureResponse      = featureResponse
 )
 
 var (


### PR DESCRIPTION
This adds a features aspect to the /v2/debug endpoint as well as the command `snap debug features`. It returns the complete list of features (task and change kinds, interface names, ensure functions, endpoints, and complete snap command names).