### PR TITLE
github, tests: fix minor errors when running spread with feature tagging

### DIFF
--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -18,7 +18,7 @@ on:
       skip-tests:
         type: string
         description: 'Filters out all matches for each space-separated regex expression when running spread tests'
-        default: 'ubuntu-14.04-64 tests/lib/ tests/unit/ manual/snapd-refresh-from-old$ core/persistent-journal'
+        default: 'ubuntu-14.04-64 tests/lib/ tests/unit/ manual/snapd-refresh-from-old core/persistent-journal'
 
 jobs:
   set-inputs:

--- a/tests/lib/collect-artifacts.sh
+++ b/tests/lib/collect-artifacts.sh
@@ -25,9 +25,10 @@ features_after_nested_task() {
     local task_dir
     task_dir="$(_prepare_artifacts_path feature-tags)"
 
-    "$TESTSTOOLS"/remote.exec "sudo journalctl --no-pager | grep -oP 'snapd?\[\d+\]: \K.*' | sed -e ':a' -e '/^{.*\\\"TRACE\\\".*[^}]$/ { N; s/\n//; ba }' | grep '\"TRACE\"'" > "$task_dir"/journal.txt
-    "$TESTSTOOLS"/remote.exec "sudo chmod 777 /var/lib/snapd/state.json"
-    "$TESTSTOOLS"/remote.pull "/var/lib/snapd/state.json" "$task_dir"
+    # When a nested test is skipped, its vm will not be available
+    "$TESTSTOOLS"/remote.exec "sudo journalctl --no-pager | grep -oP 'snapd?\[\d+\]: \K.*' | sed -e ':a' -e '/^{.*\\\"TRACE\\\".*[^}]$/ { N; s/\n//; ba }' | grep '\"TRACE\"'" > "$task_dir"/journal.txt || true
+    "$TESTSTOOLS"/remote.exec "sudo chmod 777 /var/lib/snapd/state.json" || true
+    "$TESTSTOOLS"/remote.pull "/var/lib/snapd/state.json" "$task_dir" || true
 }
 
 locks(){


### PR DESCRIPTION
- Removes the end-of-line requirement for matching snapd-refresh-from-old, which was incorrect because that test has variants
- Allow for errors in retrieving logs in nested tests. When tests are skipped, they will not have a vm, which will cause the `remote.exec` command in the restore phase to fail.