### PR TITLE
o/confdbstate: rename value/error fields in confdb response

### DIFF
--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -254,7 +254,7 @@ func (s *confdbSuite) TestConfdbGet(c *C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
-			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": "cba"}}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"values": {"abc": "cba"}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -299,7 +299,7 @@ func (s *confdbSuite) TestConfdbGetAsDocument(c *C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
-			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": "cba"}}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"values": {"abc": "cba"}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -348,7 +348,7 @@ func (s *confdbSuite) TestConfdbGetMany(c *C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
-			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": 1, "xyz": false}}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"values": {"abc": 1, "xyz": false}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -397,7 +397,7 @@ func (s *confdbSuite) TestConfdbGetManyAsDocument(c *C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
-			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": 1, "xyz": false}}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"values": {"abc": 1, "xyz": false}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -471,7 +471,7 @@ func (s *confdbSuite) TestConfdbGetNoFields(c *check.C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
-			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-data": {"abc": 1, "xyz": false}}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"values": {"abc": 1, "xyz": false}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)
@@ -522,7 +522,7 @@ func (s *confdbSuite) TestConfdbGetNoDataError(c *check.C) {
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/changes/123")
-			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"confdb-error": "some error, no data"}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"error": {"message": "some error, no data", "kind": "option-not-found"}}}}`)
 		default:
 			err := fmt.Errorf("expected to get 1 request, now on %d (%v)", reqs+1, r)
 			w.WriteHeader(500)

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -161,7 +161,7 @@ func readViewIntoChange(chg *state.Change, tx *Transaction, view *confdb.View, r
 	result, err := GetViaView(tx, view, requests)
 	if err != nil {
 		if !errors.Is(err, &confdb.NoDataError{}) {
-			return fmt.Errorf("cannot read confdb %s/%s: %w", tx.ConfdbAccount, tx.ConfdbName, err)
+			return fmt.Errorf("internal error: cannot read confdb %s/%s: %w", tx.ConfdbAccount, tx.ConfdbName, err)
 		}
 
 		apiData["error"] = map[string]any{

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -160,26 +160,18 @@ func readViewIntoChange(chg *state.Change, tx *Transaction, view *confdb.View, r
 
 	result, err := GetViaView(tx, view, requests)
 	if err != nil {
-		if !errors.Is(err, &confdb.NoDataError{}) && !errors.Is(err, &confdb.NoMatchError{}) {
+		if !errors.Is(err, &confdb.NoDataError{}) {
 			return fmt.Errorf("cannot read confdb %s/%s: %w", tx.ConfdbAccount, tx.ConfdbName, err)
-		}
-
-		var kind client.ErrorKind
-		if errors.Is(err, &confdb.NoDataError{}) {
-			kind = client.ErrorKindConfigNoSuchOption
-		} else {
-			kind = client.ErrorKindConfdbNoMatchingRule
 		}
 
 		apiData["error"] = map[string]any{
 			"message": err.Error(),
-			"kind":    kind,
+			"kind":    client.ErrorKindConfigNoSuchOption,
 		}
-		chg.Set("api-data", apiData)
-		return nil
+	} else {
+		apiData["values"] = result
 	}
 
-	apiData["values"] = result
 	chg.Set("api-data", apiData)
 	return nil
 }

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -1783,7 +1783,6 @@ func (s *confdbTestSuite) TestGetTransactionForAPINoHooksError(c *C) {
 	errKind := errData["kind"].(string)
 	c.Assert(errStr, Equals, fmt.Sprintf(`cannot get "ssid" through %s/network/setup-wifi: no data`, s.devAccID))
 	c.Assert(errKind, Equals, "option-not-found")
-
 }
 
 func (s *confdbTestSuite) TestGetTransactionForAPIError(c *C) {

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -1703,7 +1703,7 @@ func (s *confdbTestSuite) TestGetTransactionForAPI(c *C) {
 	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil)
-	val := apiData["confdb-data"]
+	val := apiData["values"]
 	c.Assert(val, DeepEquals, map[string]any{
 		"ssid":  "foo",
 		"ssids": []any{"abc", "xyz"},
@@ -1744,7 +1744,7 @@ func (s *confdbTestSuite) TestGetTransactionForAPINoHooks(c *C) {
 	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil)
-	val := apiData["confdb-data"]
+	val := apiData["values"]
 	c.Assert(val, DeepEquals, map[string]any{
 		"ssid":  "foo",
 		"ssids": []any{"abc", "xyz"},
@@ -1776,8 +1776,14 @@ func (s *confdbTestSuite) TestGetTransactionForAPINoHooksError(c *C) {
 	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil)
-	errStr := apiData["confdb-error"].(string)
+	errData, ok := apiData["error"].(map[string]any)
+	c.Assert(ok, Equals, true, Commentf(`expected "error" in apiData to be map[string]any`))
+
+	errStr := errData["message"].(string)
+	errKind := errData["kind"].(string)
 	c.Assert(errStr, Equals, fmt.Sprintf(`cannot get "ssid" through %s/network/setup-wifi: no data`, s.devAccID))
+	c.Assert(errKind, Equals, "option-not-found")
+
 }
 
 func (s *confdbTestSuite) TestGetTransactionForAPIError(c *C) {
@@ -1805,8 +1811,13 @@ func (s *confdbTestSuite) TestGetTransactionForAPIError(c *C) {
 	var apiData map[string]any
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, IsNil, Commentf("%+v", chg))
-	errStr := apiData["confdb-error"].(string)
+	errData, ok := apiData["error"].(map[string]any)
+	c.Assert(ok, Equals, true, Commentf(`expected "error" in apiData to be map[string]any`))
+
+	errStr := errData["message"].(string)
+	errKind := errData["kind"].(string)
 	c.Assert(errStr, Equals, fmt.Sprintf(`cannot get "ssid" through %s/network/setup-wifi: no data`, s.devAccID))
+	c.Assert(errKind, Equals, "option-not-found")
 }
 
 func (s *confdbTestSuite) TestConcurrentAccessWithOngoingWrite(c *C) {


### PR DESCRIPTION
This changes the structure and field names of the data carried in the change during a confdb read. The intent is to make this consistent with the structure described in signed message format (see spec SD187).