### PR TITLE
overlord/notices: add notice manager and notice backend interface

### DIFF
--- a/overlord/notices/export_test.go
+++ b/overlord/notices/export_test.go
@@ -1,0 +1,26 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package notices
+
+var (
+	RelevantBackendsForFilter = (*NoticeManager).relevantBackendsForFilter
+	DoNotices                 = doNotices
+)
+
+func (nm *NoticeManager) StateBackend() NoticeBackend {
+	return nm.state
+}

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -181,7 +181,7 @@ func (nm *NoticeManager) RegisterBackend(bknd NoticeBackend, typ state.NoticeTyp
 	notices := bknd.BackendNotices(filter)
 	if len(notices) > 0 {
 		lastNoticeTimestamp := notices[len(notices)-1].LastRepeated()
-		nm.ReportLastNoticeTimestamp(lastNoticeTimestamp)
+		nm.state.HandleReportedLastNoticeTimestamp(lastNoticeTimestamp)
 	}
 
 	// XXX: at time of writing, validateNotice is never actually used by any
@@ -231,17 +231,6 @@ func prefixFromID(id string) (prefix string, ok bool) {
 // state.
 func (nm *NoticeManager) NextNoticeTimestamp() time.Time {
 	return nm.state.NextNoticeTimestamp()
-}
-
-// ReportLastNoticeTimestamp should be called by each notice backend during
-// startup so that the manager can ensure that the last notice timestamp in the
-// state is equal to the last notice timestamp of all notices across all
-// backends.
-//
-// XXX: since we call this automatically on each backend when it is registered,
-// this could proably be unexported.
-func (nm *NoticeManager) ReportLastNoticeTimestamp(t time.Time) {
-	nm.state.HandleReportedLastNoticeTimestamp(t)
 }
 
 // Notices returns the list of notices that match the filter (if any),

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -384,7 +384,10 @@ func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFi
 		return nil, nil
 	}
 
-	// Ask each backend to return the first notice it finds, unless cancelled
+	// Ask each backend to return its notices as soon as one is added. Once
+	// one backend returns notices, cancel the requests to the other backends.
+	// Thus, create a channel with capacity 1 so only one backend can send
+	// notices back to the main thread.
 	noticesChan := make(chan []*state.Notice, 1)
 	backendCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -131,8 +131,9 @@ func NewNoticeManager(st *state.State) *NoticeManager {
 // namespace.
 //
 // The state's last notice timestamp is updated according to the timestamp of
-// the most recent notice from this backend which matches the given type, if
-// any such notices exist.
+// the most recent notice from this backend which matches the given type
+// (retrieved by invoking BackendNotices on this backend), if any such notices
+// exist.
 //
 // Returns a closure which can be used by the backend to validate new notices
 // added by that backend. The backend is responsible for ensuring that the
@@ -297,18 +298,18 @@ func (nm *NoticeManager) relevantBackendsForFilter(filter *state.NoticeFilter) [
 
 // doNotices checks the given backends for notices matching the given filter
 // which occurred before or at the given timestamp.
-func doNotices(backendsToCheck []NoticeBackend, filter *state.NoticeFilter, now time.Time) []*state.Notice {
+func doNotices(backendsToCheck []NoticeBackend, filter *state.NoticeFilter, beforeOrAt time.Time) []*state.Notice {
 	// Ensure all backends have the same BeforeOrAt time so there is no race
 	// between one backend returning its existing notices and then another
-	// backend recording a new notice. As such, if the filter has BeforeOrAt
-	// set in the future, replace it with the current timestamp.
-	if filter == nil || filter.BeforeOrAt.IsZero() || filter.BeforeOrAt.After(now) {
+	// backend recording a new notice. As such, if the filter has no BeforeOrAt
+	// or has it set in the future, replace it with the given timestamp.
+	if filter == nil || filter.BeforeOrAt.IsZero() || filter.BeforeOrAt.After(beforeOrAt) {
 		// Don't mutate any existing filter, so make a copy
 		var newFilter state.NoticeFilter
 		if filter != nil {
 			newFilter = *filter
 		}
-		newFilter.BeforeOrAt = now
+		newFilter.BeforeOrAt = beforeOrAt
 		filter = &newFilter
 	}
 

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -1,0 +1,483 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package notices
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// NoticeBackend defines the functionality required to serve notices.
+type NoticeBackend interface {
+	// BackendNotices returns the list of notices that match the filter
+	// (if any), ordered by the last-repeated time.
+	BackendNotices(filter *state.NoticeFilter) []*state.Notice
+
+	// BackendNotice returns a single notice by ID, or nil if not found.
+	BackendNotice(id string) *state.Notice
+
+	// BackendWaitNotices waits for notices that match the filter to exist or
+	// occur, returning the list of matching notices ordered by last-repeated
+	// time.
+	//
+	// It waits till there is at least one matching notice, the context is
+	// cancelled, or the timestamp of the BeforeOrAt filter has passed (if it
+	// is nonzero). If there are existing notices that match the filter,
+	// BackendWaitNotices will return them immediately.
+	BackendWaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error)
+}
+
+// NoticeManager provides an abstraction layer over multiple notice backends,
+// ensuring correctness and consistency of notices and providing functions to
+// query notices across those backends.
+type NoticeManager struct {
+	// state is a wrapper around the snapd state so that the manager can provide
+	// unique notice IDs and timestamps to all backends, and to make the state
+	// itself be a notice backend. State is an implicit notice backend for any
+	// notice types which have no backends registered for them.
+	state stateBackend
+
+	// lock guards against new backends being registered. It must be held for
+	// writing when adding a new backend, and held for reading when using any
+	// of the other methods which touch the backends.
+	lock sync.RWMutex
+	// backends is the list of all notice backends which are registered as
+	// providers for at least one notice type.
+	backends []NoticeBackend
+	// idNamespaceToBackend maps from a prefix used to namespace notice IDs to
+	// the backend which registered that namespace.
+	//
+	// No two backends may register the same namespace, but a given backend may
+	// register the same namespace multiple times (e.g. for different notice
+	// types).
+	//
+	// For registered notice backends (other than state), namespaced IDs must
+	// be of the form "<prefix>-<id>". For notices from state, the IDs must not
+	// contain '-'.
+	idNamespaceToBackend map[string]NoticeBackend
+	// backendTypeToNamespace maps from backend+type combination to the ID
+	// prefix namespace registered with that backend and type.
+	backendTypeToNamespace map[backendWithType]string
+	// noticeTypeBackends maps from notice type to the set of notice backends
+	// which are capable of providing notices of that type.
+	noticeTypeBackends map[state.NoticeType][]NoticeBackend
+}
+
+type backendWithType struct {
+	backend    NoticeBackend
+	noticeType state.NoticeType
+}
+
+// stateBackend wraps a state to ensure that the state lock is acquired when
+// checking notices.
+type stateBackend struct {
+	*state.State
+}
+
+func (sb stateBackend) BackendNotices(filter *state.NoticeFilter) []*state.Notice {
+	sb.Lock()
+	defer sb.Unlock()
+	return sb.Notices(filter)
+}
+
+func (sb stateBackend) BackendNotice(id string) *state.Notice {
+	sb.Lock()
+	defer sb.Unlock()
+	return sb.Notice(id)
+}
+
+func (sb stateBackend) BackendWaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error) {
+	sb.Lock()
+	defer sb.Unlock()
+	return sb.WaitNotices(ctx, filter)
+}
+
+// NewNoticeManager returns a new NoticeManager based on the given state, and
+// registers that state as a NoticeBackend for notice types it provides.
+func NewNoticeManager(st *state.State) *NoticeManager {
+	wrapper := stateBackend{st}
+	nm := &NoticeManager{
+		state:                  wrapper,
+		backends:               []NoticeBackend{wrapper},
+		idNamespaceToBackend:   make(map[string]NoticeBackend),
+		backendTypeToNamespace: make(map[backendWithType]string),
+		noticeTypeBackends:     make(map[state.NoticeType][]NoticeBackend),
+	}
+
+	return nm
+}
+
+// RegisterBackend registers the given backend with the notice manager as a
+// provider of notices of the given type with IDs prefixed by the given
+// namespace.
+//
+// The state's last notice timestamp is updated according to the timestamp of
+// the most recent notice from this backend which matches the given type, if
+// any such notices exist.
+//
+// Returns a closure which can be used by the backend to validate new notices
+// added by that backend. The backend is responsible for ensuring that the
+// notices which it serves are valid according to the closure.
+func (nm *NoticeManager) RegisterBackend(bknd NoticeBackend, typ state.NoticeType, namespace string) (validateNotice func(id string, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) error, retErr error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("internal error: cannot register notice backend with empty namespace")
+	}
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+	// Check that this namespace is not already registered to another backend
+	if existingBknd, ok := nm.idNamespaceToBackend[namespace]; ok && existingBknd != bknd {
+		return nil, fmt.Errorf("internal error: cannot register notice backend with namespace which is already registered to a different backend: %q", namespace)
+	}
+
+	// Check that there is not already a different namespace registered to this
+	// combination of backend and type
+	bkndAndTyp := backendWithType{
+		backend:    bknd,
+		noticeType: typ,
+	}
+	if existingNs, ok := nm.backendTypeToNamespace[bkndAndTyp]; ok && existingNs != namespace {
+		return nil, fmt.Errorf("internal error: cannot register namespace %q with backend and notice type which are already registered with a different namespace: %q", namespace, existingNs)
+	}
+
+	// From this point on, no errors can occur, so free to mutate nm.
+
+	if !backendsContain(nm.backends, bknd) {
+		nm.backends = append(nm.backends, bknd)
+	}
+
+	nm.idNamespaceToBackend[namespace] = bknd
+	nm.backendTypeToNamespace[bkndAndTyp] = namespace
+
+	typeBackends, ok := nm.noticeTypeBackends[typ]
+	if !ok {
+		nm.noticeTypeBackends[typ] = []NoticeBackend{bknd}
+	} else if !backendsContain(typeBackends, bknd) {
+		nm.noticeTypeBackends[typ] = append(typeBackends, bknd)
+	}
+
+	// Since each backend may only be registered to a given notice type once,
+	// we can automatically update the state's lastNoticeTimestamp according
+	// to the timestamp of the last notice of this type from this backend.
+	filter := &state.NoticeFilter{Types: []state.NoticeType{typ}}
+	notices := bknd.BackendNotices(filter)
+	if len(notices) > 0 {
+		lastNoticeTimestamp := notices[len(notices)-1].LastRepeated()
+		nm.ReportLastNoticeTimestamp(lastNoticeTimestamp)
+	}
+
+	// XXX: at time of writing, validateNotice is never actually used by any
+	// backends.
+	validateNotice = func(id string, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) error {
+		if err := state.ValidateNotice(noticeType, key, options); err != nil {
+			return err
+		}
+		// Check that the type matches what was registered
+		if noticeType != typ {
+			return fmt.Errorf("cannot add %s notice to notice backend registered to provide %s notices", noticeType, typ)
+		}
+		// Check that the ID starts with the namespace prefix or, if the
+		// namespace is empty, check that the ID has no prefix.
+		prefix, ok := prefixFromID(id)
+		if !ok {
+			return fmt.Errorf("cannot add notice without ID prefix to notice backend registered with namespace: %q", namespace)
+		} else if prefix != namespace {
+			return fmt.Errorf("cannot add notice with ID prefix not matching the namespace registered to the notice backend: %q != %q", prefix, namespace)
+		}
+		return nil
+	}
+
+	return validateNotice, nil
+}
+
+func backendsContain(backends []NoticeBackend, backend NoticeBackend) bool {
+	for _, bknd := range backends {
+		if bknd == backend {
+			return true
+		}
+	}
+	return false
+}
+
+// prefixFromID returns the namespace prefix from the given ID, if it has one.
+func prefixFromID(id string) (prefix string, ok bool) {
+	split := strings.SplitN(id, "-", 2)
+	if len(split) > 1 {
+		return split[0], true
+	}
+	return "", false
+}
+
+// NextNoticeTimestamp returns a timestamp which is guaranteed to be after the
+// previous notice timestamp, and updates the last notice timestamp in the
+// state.
+func (nm *NoticeManager) NextNoticeTimestamp() time.Time {
+	return nm.state.NextNoticeTimestamp()
+}
+
+// ReportLastNoticeTimestamp should be called by each notice backend during
+// startup so that the manager can ensure that the last notice timestamp in the
+// state is equal to the last notice timestamp of all notices across all
+// backends.
+//
+// XXX: since we call this automatically on each backend when it is registered,
+// this could proably be unexported.
+func (nm *NoticeManager) ReportLastNoticeTimestamp(t time.Time) {
+	nm.state.HandleReportedLastNoticeTimestamp(t)
+}
+
+// Notices returns the list of notices that match the filter (if any),
+// ordered by the last-repeated time, across all backends relevant to the given
+// filter. A backend is relevant if it is registered as a provider of any of
+// the types included in the filter, or if the filter does not specify any
+// types.
+//
+// The caller must not hold state lock, as the manager may need to take it to
+// check notices from state.
+func (nm *NoticeManager) Notices(filter *state.NoticeFilter) []*state.Notice {
+	nm.lock.RLock()
+	defer nm.lock.RUnlock()
+
+	backendsToCheck := nm.relevantBackendsForFilter(filter)
+	switch len(backendsToCheck) {
+	case 0:
+		// This should be impossible, since state is always an implicit backend
+		// if no other backend is registered for a given type.
+		return []*state.Notice{}
+	case 1:
+		return backendsToCheck[0].BackendNotices(filter)
+	}
+
+	now := time.Now()
+	return doNotices(backendsToCheck, filter, now)
+}
+
+// relevantBackendsForFilter returns all backends which are registered as
+// providers of any of the types included in the given filter. If the filter
+// specifies no types, then all backends are returned.
+//
+// The caller must ensure that the notice manager lock is held for reading.
+func (nm *NoticeManager) relevantBackendsForFilter(filter *state.NoticeFilter) []NoticeBackend {
+	if filter == nil || len(filter.Types) == 0 {
+		// No types specified, so assume all backends are relevant
+		return nm.backends
+	}
+	backendsSet := make(map[NoticeBackend]bool)
+	for _, typ := range filter.Types {
+		backends, ok := nm.noticeTypeBackends[typ]
+		if !ok {
+			// No backend registered for this type, so the state is the
+			// implicit provider of notices of this type.
+			backendsSet[nm.state] = true
+			continue
+		}
+		for _, backend := range backends {
+			// If there are backends registered with this type, then state
+			// will not be checked.
+			// TODO: If in the future we want to allow state and another backend
+			// to both provide notices of the same type, we need to allow state
+			// to be registered as a backend with an empty namespace.
+			backendsSet[backend] = true
+		}
+	}
+
+	backendsList := make([]NoticeBackend, 0, len(backendsSet))
+	for backend := range backendsSet {
+		backendsList = append(backendsList, backend)
+	}
+	return backendsList
+}
+
+// doNotices checks the given backends for notices matching the given filter
+// which occurred before or at the given timestamp.
+func doNotices(backendsToCheck []NoticeBackend, filter *state.NoticeFilter, now time.Time) []*state.Notice {
+	// Ensure all backends have the same BeforeOrAt time so there is no race
+	// between one backend returning its existing notices and then another
+	// backend recording a new notice. As such, if the filter has BeforeOrAt
+	// set in the future, replace it with the current timestamp.
+	if filter == nil || filter.BeforeOrAt.IsZero() || filter.BeforeOrAt.After(now) {
+		// Don't mutate any existing filter, so make a copy
+		var newFilter state.NoticeFilter
+		if filter != nil {
+			newFilter = *filter
+		}
+		newFilter.BeforeOrAt = now
+		filter = &newFilter
+	}
+
+	var notices []*state.Notice
+	// TODO: if backends are slow, query each backend in its own goroutine
+	for _, backend := range backendsToCheck {
+		notices = append(notices, backend.BackendNotices(filter)...)
+	}
+	state.SortNotices(notices)
+
+	return notices
+}
+
+// Notice returns a single notice by ID, or nil if not found.
+//
+// The namespace prefix of the given ID is used to identify which notice
+// backend should be queried. If the ID has no prefix, then snapd state is
+// checked.
+//
+// If the ID has a prefix but no backend is registered with a matching namespace, returns nil.
+//
+// The caller must not hold state lock, as the manager may need to take it to
+// check notices from state.
+func (nm *NoticeManager) Notice(id string) *state.Notice {
+	nm.lock.RLock()
+	defer nm.lock.RUnlock()
+
+	prefix, ok := prefixFromID(id)
+	if !ok {
+		// No namespace prefix, so must be from state
+		return nm.state.BackendNotice(id)
+	}
+
+	backend, ok := nm.idNamespaceToBackend[prefix]
+	if !ok {
+		// No backend is capable of producing notices with this namespace prefix.
+		return nil
+	}
+
+	return backend.BackendNotice(id)
+}
+
+// WaitNotices waits for notices that match the filter to exist or occur,
+// returning the list of matching notices ordered by the last-repeated time,
+// across all backends relevant to the given filter. A backend is relevant if
+// it is registered as a provider of any of the types included in the filter,
+// or if the filter does not specify any types.
+//
+// It waits till there is at least one matching notice, the context is
+// cancelled, or the timestamp of the BeforeOrAt filter has passed (if it is
+// nonzero). If there are existing notices that match the filter, WaitNotices
+// will return them immediately.
+//
+// All of this holds true across all backends which are relevant to the given
+// filter. A backend is relevant if it is registered as a provider of any of
+// the types included in the filter, or if the filter does not specify any
+// types.
+//
+// The caller must not hold state lock, as the manager may need to take it to
+// check notices from state.
+func (nm *NoticeManager) WaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error) {
+	nm.lock.RLock()
+	defer nm.lock.RUnlock()
+
+	backendsToCheck := nm.relevantBackendsForFilter(filter)
+	switch len(backendsToCheck) {
+	case 0:
+		// This should be impossible, since state is always an implicit backend
+		// if no other backend is registered for a given type.
+		return nil, nil
+	case 1:
+		return backendsToCheck[0].BackendWaitNotices(ctx, filter)
+	}
+
+	now := time.Now()
+
+	// If there are existing notices, return them right away.
+	// Notices() sets a BeforeOrAt filter if there isn't one already set, so
+	// there can be no race between one backend returning its existing notices
+	// and then another backend recording a new notice.
+	notices := doNotices(backendsToCheck, filter, now)
+	if len(notices) > 0 {
+		return notices, nil
+	}
+
+	if filter != nil && !filter.BeforeOrAt.IsZero() && filter.BeforeOrAt.Before(now) {
+		// Since each backend returned, none can create a notice with a
+		// timestamp before now, and since the original filter's Before field
+		// is <= now, no notices can be created matching the filter.
+		return nil, nil
+	}
+
+	// Ask each backend to return the first notice it finds, unless cancelled
+	noticesChan := make(chan []*state.Notice)
+	backendCtx, cancel := context.WithCancel(ctx)
+	// TODO: on go 1.20+, use WithCancelCause instead of separate channel
+	allBackendsReturned := make(chan struct{})
+	defer cancel()        // Ensure the context is eventually cancelled; maybe cancel early.
+	var wg sync.WaitGroup // Keep track of if all backends return empty notices.
+	wg.Add(len(backendsToCheck))
+	// Set up watcher in case all backends return empty notices, which should
+	// only occur if they know they can't possibly produce notices which match
+	// the filter.
+	go func() {
+		wg.Wait()
+		// All backends returned, so the caller either already received a
+		// non-empty list of notices, or all backends returned an empty list.
+		// If the latter, then no backends are capable of producing notices
+		// which match the filter.
+		close(allBackendsReturned)
+	}()
+	queryBackend := func(bknd NoticeBackend) {
+		defer wg.Done()
+		// Ignore error, as it should only ever be the context cancellation
+		// error, which we'll handle below.
+		backendNotices, _ := bknd.BackendWaitNotices(backendCtx, filter)
+		if len(backendNotices) == 0 {
+			return
+		}
+		select {
+		case noticesChan <- backendNotices:
+			// Successfully sent notices back to caller
+		case <-backendCtx.Done():
+			// Some other backend replied first
+		}
+	}
+	for _, backend := range backendsToCheck {
+		go queryBackend(backend)
+	}
+
+	select {
+	case notices = <-noticesChan:
+		// A backend returned one or more notices
+	case <-allBackendsReturned:
+		// All backends sent empty notices over their respective channels,
+		// so none were capable of producing notices matching the filter.
+		return nil, nil
+	case <-ctx.Done():
+		// Request was cancelled
+		return nil, ctx.Err()
+	}
+
+	// Cancel the requests to the other backends
+	cancel()
+
+	// Get the last repeated timestamp of the newest received notice
+	lastRepeated := notices[len(notices)-1].LastRepeated()
+
+	// Re-query all backends for any notices which occurred before or at the
+	// last repeated timestamp.
+	//
+	// XXX: there's a chance some notices will be excluded here. In particular,
+	// a notice previously returned from one of the backends could have
+	// re-occurred since then, thus making its last-repeated timestamp after
+	// the now timestamp and causing it to be omitted from the final
+	// response. This is acceptable, as the new occurrence can be retrieved by
+	// a future request, and potentially has more up-to-date data, so it
+	// supercedes the occurrence of the notice which is being omitted.
+	notices = doNotices(backendsToCheck, filter, lastRepeated)
+	return notices, nil
+}

--- a/overlord/notices/notices_test.go
+++ b/overlord/notices/notices_test.go
@@ -319,7 +319,6 @@ func (s *noticesSuite) TestRegisterBackendErrors(c *C) {
 	bknd2.noticesChan <- nil
 
 	namespace1 := "foo"
-	namespace2 := "bar"
 	typ1 := state.WarningNotice
 
 	validate, err := nm.RegisterBackend(bknd1, typ1, "")
@@ -345,16 +344,6 @@ func (s *noticesSuite) TestRegisterBackendErrors(c *C) {
 	c.Assert(validate, IsNil)
 	select {
 	case filter := <-bknd2.noticesFilterChan:
-		c.Errorf("Unexpectedly called BackendNotices even though registration failed: %+v", filter)
-	default:
-		// all good
-	}
-
-	validate, err = nm.RegisterBackend(bknd1, typ1, namespace2)
-	c.Assert(err, ErrorMatches, "internal error: cannot register namespace .* with backend and notice type which are already registered with a different namespace: .*")
-	c.Assert(validate, IsNil)
-	select {
-	case filter := <-bknd1.noticesFilterChan:
 		c.Errorf("Unexpectedly called BackendNotices even though registration failed: %+v", filter)
 	default:
 		// all good

--- a/overlord/notices/notices_test.go
+++ b/overlord/notices/notices_test.go
@@ -1,0 +1,996 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package notices_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/notices"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type noticesSuite struct {
+	testutil.BaseTest
+
+	st *state.State
+}
+
+var _ = Suite(&noticesSuite{})
+
+func (s *noticesSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	s.st = state.New(nil)
+}
+
+type testNoticeBackend struct {
+	// Send something over noticesChan to make BackendNotices() return it.
+	noticesChan chan []*state.Notice
+	// Send something over noticeChan to make BackendNotice() return it.
+	noticeChan chan *state.Notice
+	// Send something over waitNoticesChan to make BackendWaitNotices() return it.
+	waitNoticesChan chan []*state.Notice
+	// Store the NoticeFilters passed into BackendNotices or BackendWaitNotices.
+	filterChan chan *state.NoticeFilter
+}
+
+func newTestNoticeBackend() *testNoticeBackend {
+	return &testNoticeBackend{
+		noticesChan:     make(chan []*state.Notice, 1),
+		noticeChan:      make(chan *state.Notice, 1),
+		waitNoticesChan: make(chan []*state.Notice, 1),
+		// Give filterChan capacity 3 so WaitNotices can call BackendNotices,
+		// BackendWaitNotices, and then BackendNotices again.
+		filterChan: make(chan *state.NoticeFilter, 3),
+	}
+}
+
+func (b *testNoticeBackend) BackendNotices(filter *state.NoticeFilter) []*state.Notice {
+	b.filterChan <- filter
+	return <-b.noticesChan
+}
+
+func (b *testNoticeBackend) BackendNotice(id string) *state.Notice {
+	return <-b.noticeChan
+}
+
+func (b *testNoticeBackend) BackendWaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error) {
+	b.filterChan <- filter
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case n := <-b.waitNoticesChan:
+		return n, nil
+	}
+}
+
+var _ = notices.NoticeBackend(&testNoticeBackend{})
+
+func (s *noticesSuite) TestNewNoticeManagerStateBackend(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+	c.Assert(nm, NotNil)
+
+	userID := uint32(1000)
+
+	s.st.Lock()
+	id1, err := s.st.AddNotice(&userID, state.WarningNotice, "foo", nil)
+	c.Assert(err, IsNil)
+	id2, err := s.st.AddNotice(&userID, state.ChangeUpdateNotice, "bar", nil)
+	c.Assert(err, IsNil)
+	c.Check(id2, Not(Equals), id1)
+	s.st.Unlock()
+
+	// Check that state notices are queried with the lock held. If the lock
+	// were not held, querying state notices would panic.
+	notices := nm.Notices(nil)
+	c.Check(notices, HasLen, 2)
+	c.Check(notices[0].Type(), Equals, state.WarningNotice)
+	c.Check(notices[1].Type(), Equals, state.ChangeUpdateNotice)
+
+	filtered := nm.Notices(&state.NoticeFilter{Keys: []string{"bar"}})
+	c.Check(filtered, HasLen, 1)
+	c.Check(filtered[0].Type(), Equals, state.ChangeUpdateNotice)
+
+	notice := nm.Notice(id1)
+	c.Check(notice.Type(), Equals, state.WarningNotice)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	waited, err := nm.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{"foo"}})
+	c.Assert(err, IsNil)
+	c.Check(waited, HasLen, 1)
+	c.Check(waited[0].Type(), Equals, state.WarningNotice)
+
+	waitChan := make(chan []*state.Notice)
+	go func() {
+		goWaited, goErr := nm.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{"baz"}})
+		c.Check(goErr, IsNil)
+		waitChan <- goWaited
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	s.st.Lock()
+	_, err = s.st.AddNotice(&userID, state.InterfacesRequestsPromptNotice, "baz", nil)
+	c.Assert(err, IsNil)
+	s.st.Unlock()
+
+	select {
+	case waited = <-waitChan:
+		// all good
+	case <-time.NewTimer(time.Second).C:
+		c.Fatal("failed to receive notice from WaitNotice")
+	}
+	c.Check(waited, HasLen, 1)
+	c.Check(waited[0].Type(), Equals, state.InterfacesRequestsPromptNotice)
+}
+
+func (s *noticesSuite) TestRegisterBackend(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+	c.Assert(nm, NotNil)
+
+	bknd := newTestNoticeBackend()
+
+	typ1 := state.WarningNotice
+	namespace1 := "foo"
+	// Send empty notices over bknd.noticesChan so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd.noticesChan <- nil
+	validateNotice1, err := nm.RegisterBackend(bknd, typ1, namespace1)
+	c.Assert(err, IsNil)
+	filter := <-bknd.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ1},
+	})
+
+	noticeID := "foo-123"
+	noticeKey := "456"
+	validateErr := validateNotice1(noticeID, typ1, noticeKey, nil)
+	c.Assert(validateErr, IsNil)
+
+	typ2 := state.ChangeUpdateNotice
+	namespace2 := "bar"
+	// Send empty notices over bknd.noticesChan so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd.noticesChan <- nil
+	validateNotice2, err := nm.RegisterBackend(bknd, typ2, namespace2)
+	c.Assert(err, IsNil)
+	filter = <-bknd.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ2},
+	})
+
+	noticeID = "bar-abc"
+	noticeKey = "xyz"
+	validateErr = validateNotice2(noticeID, typ2, noticeKey, nil)
+	c.Assert(validateErr, IsNil)
+
+	bknd2 := newTestNoticeBackend()
+	// Send empty notices over bknd2.noticesChan so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd2.noticesChan <- nil
+
+	namespace3 := "baz"
+	validateNotice3, err := nm.RegisterBackend(bknd2, typ2, namespace3)
+	c.Assert(err, IsNil)
+	filter = <-bknd2.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ2},
+	})
+
+	noticeID = "baz-a1"
+	noticeKey = "-"
+	validateErr = validateNotice3(noticeID, typ2, noticeKey, nil)
+	c.Assert(validateErr, IsNil)
+}
+
+func (s *noticesSuite) TestRegisterBackendReportLastNoticeTimestamp(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+
+	// bknd1 will set LastNoticeTimestamp
+	bknd1 := newTestNoticeBackend()
+	// bknd2 will have no notices
+	bknd2 := newTestNoticeBackend()
+	// bknd3 will have notice with earlier timestamp
+	bknd3 := newTestNoticeBackend()
+	// bknd4 will have notice with later timestamp (so update lastNoticeTimestamp)
+	bknd4 := newTestNoticeBackend()
+
+	userID := uint32(1000)
+	key := "foo"
+	// All backends can register for WarningNotice
+	typ := state.WarningNotice
+	// Set up unique namespaces for each
+	ns1 := "1"
+	ns2 := "2"
+	ns3 := "3"
+	ns4 := "4"
+
+	// Make bknd1 have a notice with timestamp in the future
+	time1 := time.Now().Add(24 * time.Hour)
+	notice1 := state.NewNotice("1-abc", &userID, typ, key, time1, nil, 0, 0)
+	bknd1.noticesChan <- []*state.Notice{notice1}
+	// Make bknd2 have no notices
+	bknd2.noticesChan <- nil
+	// Make bknd3 have notice with timestamp earlier than bknd1, so the last
+	// notice timestamp will not be updated
+	time3 := time1.Add(-time.Hour)
+	notice3 := state.NewNotice("3-abc", &userID, typ, key, time3, nil, 0, 0)
+	bknd3.noticesChan <- []*state.Notice{notice3}
+	// Make bknd4 have notice with timestamp later than bknd1, so the last
+	// notice timestamp *will* be updated
+	time4 := time1.Add(time.Hour)
+	notice4 := state.NewNotice("4-abc", &userID, typ, key, time4, nil, 0, 0)
+	bknd4.noticesChan <- []*state.Notice{notice4}
+
+	// There's currently no way to get the last notice timestamp from the
+	// state via an exported function, so use NextNoticeTimestamp and add
+	// 1 nanosecond to the times being compared. We can do this since all
+	// relevant times are in the future, so NextNoticeTimestamp will always be
+	// 1 nanosecond later than the existing last notice timestamp.
+
+	currLast := nm.NextNoticeTimestamp()
+	c.Assert(currLast.Before(time1), Equals, true)
+
+	_, err := nm.RegisterBackend(bknd1, typ, ns1)
+	c.Check(err, IsNil)
+	filter := <-bknd1.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ},
+	})
+
+	currLast = nm.NextNoticeTimestamp()
+	c.Assert(currLast.Equal(time1.Add(time.Nanosecond)), Equals, true)
+
+	_, err = nm.RegisterBackend(bknd2, typ, ns2)
+	c.Check(err, IsNil)
+	filter = <-bknd2.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ},
+	})
+
+	// No notices here, so timestamp should be 1ns later than before
+	newLast := nm.NextNoticeTimestamp()
+	c.Assert(newLast.Equal(currLast.Add(time.Nanosecond)), Equals, true)
+	currLast = newLast
+
+	_, err = nm.RegisterBackend(bknd3, typ, ns3)
+	c.Check(err, IsNil)
+	filter = <-bknd3.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ},
+	})
+
+	// Notice had earlier timestamp, so timestamp should be 1ns later than before
+	newLast = nm.NextNoticeTimestamp()
+	c.Assert(newLast.Equal(currLast.Add(time.Nanosecond)), Equals, true)
+	currLast = newLast
+
+	_, err = nm.RegisterBackend(bknd4, typ, ns4)
+	c.Check(err, IsNil)
+	filter = <-bknd4.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ},
+	})
+
+	// Notice had later timestamp, so timestamp should be 1ns later than time4
+	newLast = nm.NextNoticeTimestamp()
+	c.Assert(newLast.Equal(time4.Add(time.Nanosecond)), Equals, true)
+}
+
+func (s *noticesSuite) TestRegisterBackendErrors(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+
+	bknd1 := newTestNoticeBackend()
+	bknd2 := newTestNoticeBackend()
+	// Send empty notices over noticesChan so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd1.noticesChan <- nil
+	bknd2.noticesChan <- nil
+
+	namespace1 := "foo"
+	namespace2 := "bar"
+	typ1 := state.WarningNotice
+
+	validate, err := nm.RegisterBackend(bknd1, typ1, "")
+	c.Assert(err, ErrorMatches, "internal error: cannot register notice backend with empty namespace")
+	c.Assert(validate, IsNil)
+	select {
+	case filter := <-bknd1.filterChan:
+		c.Errorf("Unexpectedly called BackendNotices even though registration failed: %+v", filter)
+	default:
+		// all good
+	}
+
+	validate, err = nm.RegisterBackend(bknd1, typ1, namespace1)
+	c.Assert(err, IsNil)
+	c.Assert(validate, NotNil)
+	filter := <-bknd1.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ1},
+	})
+
+	validate, err = nm.RegisterBackend(bknd2, typ1, namespace1)
+	c.Assert(err, ErrorMatches, "internal error: cannot register notice backend with namespace which is already registered to a different backend: .*")
+	c.Assert(validate, IsNil)
+	select {
+	case filter := <-bknd2.filterChan:
+		c.Errorf("Unexpectedly called BackendNotices even though registration failed: %+v", filter)
+	default:
+		// all good
+	}
+
+	validate, err = nm.RegisterBackend(bknd1, typ1, namespace2)
+	c.Assert(err, ErrorMatches, "internal error: cannot register namespace .* with backend and notice type which are already registered with a different namespace: .*")
+	c.Assert(validate, IsNil)
+	select {
+	case filter := <-bknd1.filterChan:
+		c.Errorf("Unexpectedly called BackendNotices even though registration failed: %+v", filter)
+	default:
+		// all good
+	}
+}
+
+func (s *noticesSuite) TestValidateNotice(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+
+	bknd := newTestNoticeBackend()
+
+	// Register backend as provider of two types with two namespaces
+	typ1 := state.WarningNotice
+	typ2 := state.ChangeUpdateNotice
+	namespace1 := "foo"
+	namespace2 := "bar"
+
+	// Send empty notices over bknd.noticesChan so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd.noticesChan <- nil
+	validateNotice1, err := nm.RegisterBackend(bknd, typ1, namespace1)
+	c.Assert(err, IsNil)
+	filter := <-bknd.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ1},
+	})
+
+	// Register to another type as well, so we can check that the validation
+	// closure only accepts notices matching its specific registration.
+	// Send empty notices over bknd.noticesChan so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd.noticesChan <- nil
+	validateNotice2, err := nm.RegisterBackend(bknd, typ2, namespace2)
+	c.Assert(err, IsNil)
+	filter = <-bknd.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ2},
+	})
+
+	validID1 := "foo-123"
+	validID2 := "bar-abc"
+	validKey := "xyz"
+
+	err = validateNotice1(validID1, typ1, validKey, nil)
+	c.Check(err, IsNil)
+
+	err = validateNotice2(validID2, typ2, validKey, nil)
+	c.Check(err, IsNil)
+
+	invalidTyp := state.NoticeType("invalid")
+	err = validateNotice1(validID1, invalidTyp, validKey, nil)
+	c.Check(err, ErrorMatches, "cannot add notice with invalid type.*")
+
+	// Even if backend registered for another type, the closure will return an
+	// error for any type other than the one with which it was specifically
+	// registered.
+	err = validateNotice1(validID1, typ2, validKey, nil)
+	c.Check(err, ErrorMatches, `cannot add change-update notice to notice backend registered to provide warning notices`)
+
+	noPrefixID := "something"
+	onlyPrefixID := "foo" // still treated as no prefix
+	for _, id := range []string{noPrefixID, onlyPrefixID} {
+		err = validateNotice1(id, typ1, validKey, nil)
+		c.Check(err, ErrorMatches, `cannot add notice without ID prefix to notice backend registered with namespace: "foo"`)
+	}
+
+	otherPrefixID := "bar-123"
+	unrelatedPrefixID := "baz-123"
+	for _, id := range []string{otherPrefixID, unrelatedPrefixID} {
+		err = validateNotice1(id, typ1, validKey, nil)
+		c.Check(err, ErrorMatches, `cannot add notice with ID prefix not matching the namespace registered to the notice backend: "ba." != "foo"`)
+	}
+}
+
+func (s *noticesSuite) TestRelevantBackendsForFilter(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+
+	bknd1 := newTestNoticeBackend()
+	bknd2 := newTestNoticeBackend()
+	bknd3 := newTestNoticeBackend()
+	// Send empty notices over noticesChans so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd1.noticesChan <- nil
+	bknd2.noticesChan <- nil
+	bknd3.noticesChan <- nil
+
+	typ1 := state.WarningNotice
+	typ2 := state.WarningNotice
+	typ3 := state.ChangeUpdateNotice
+
+	_, err := nm.RegisterBackend(bknd1, typ1, "1")
+	c.Assert(err, IsNil)
+	_, err = nm.RegisterBackend(bknd2, typ2, "2")
+	c.Assert(err, IsNil)
+	_, err = nm.RegisterBackend(bknd3, typ3, "3")
+	c.Assert(err, IsNil)
+
+	filter := <-bknd1.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ1},
+	})
+	filter = <-bknd2.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ2},
+	})
+	filter = <-bknd3.filterChan
+	c.Check(filter, DeepEquals, &state.NoticeFilter{
+		Types: []state.NoticeType{typ3},
+	})
+
+	// With no filter, all registered backends, plus state, should be returned
+	for _, filter := range []*state.NoticeFilter{nil, {}} {
+		backends := notices.RelevantBackendsForFilter(nm, filter)
+		assertBackendsEqual(c, backends, []notices.NoticeBackend{
+			nm.StateBackend(),
+			bknd1,
+			bknd2,
+			bknd3,
+		})
+	}
+
+	// With filter with type which no backends registered, just get state backend
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.InterfacesRequestsPromptNotice}}
+	backends := notices.RelevantBackendsForFilter(nm, filter)
+	assertBackendsEqual(c, backends, []notices.NoticeBackend{nm.StateBackend()})
+
+	// With filter with type which has backends registered, just get those backends
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}}
+	backends = notices.RelevantBackendsForFilter(nm, filter)
+	assertBackendsEqual(c, backends, []notices.NoticeBackend{bknd1, bknd2})
+
+	// With filter with mix of registered and unregistered types, get the
+	// relevant registered backend as well as state
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice, state.InterfacesRequestsRuleUpdateNotice}}
+	backends = notices.RelevantBackendsForFilter(nm, filter)
+	assertBackendsEqual(c, backends, []notices.NoticeBackend{nm.StateBackend(), bknd3})
+}
+
+func assertBackendsEqual(c *C, received []notices.NoticeBackend, expected []notices.NoticeBackend) {
+	c.Assert(received, HasLen, len(expected))
+	c.Assert(expected, HasLen, len(received))
+	for _, bknd := range received {
+		assertSliceContainsBackend(c, expected, bknd)
+	}
+	for _, bknd := range expected {
+		assertSliceContainsBackend(c, received, bknd)
+	}
+}
+
+func assertSliceContainsBackend(c *C, haystack []notices.NoticeBackend, needle notices.NoticeBackend) {
+	for _, backend := range haystack {
+		if backend == needle {
+			return
+		}
+	}
+	c.Fatalf("backend not found in backend slice")
+}
+
+func (s *noticesSuite) TestDoNoticesFilter(c *C) {
+	bknd1 := newTestNoticeBackend()
+	bknd2 := newTestNoticeBackend()
+	backends := []*testNoticeBackend{bknd1, bknd2}
+
+	now := time.Now()
+
+	// If passed a nil filter, BeforeOrAt filter should be set according to now
+	var given *state.NoticeFilter
+	expected := &state.NoticeFilter{BeforeOrAt: now}
+	testDoNoticesFilter(c, backends, given, expected, now)
+
+	// If passed a non-nil filter with zero BeforeOrAt, BeforeOrAt filter
+	// should be set to now
+	given = &state.NoticeFilter{
+		Types: []state.NoticeType{state.WarningNotice, state.ChangeUpdateNotice},
+	}
+	expected = &state.NoticeFilter{
+		Types:      []state.NoticeType{state.WarningNotice, state.ChangeUpdateNotice},
+		BeforeOrAt: now,
+	}
+	testDoNoticesFilter(c, backends, given, expected, now)
+
+	// If passed a filter with BeforeOrAt in the past, it should be unchanged.
+	given = &state.NoticeFilter{
+		Keys:       []string{"foo", "bar"},
+		BeforeOrAt: now.Add(-time.Hour),
+	}
+	expected = &state.NoticeFilter{
+		Keys:       []string{"foo", "bar"},
+		BeforeOrAt: now.Add(-time.Hour),
+	}
+	testDoNoticesFilter(c, backends, given, expected, now)
+
+	// If passed a filter with BeforeOrAt in the future, it should be set to now.
+	given = &state.NoticeFilter{
+		After:      now.Add(-time.Minute),
+		BeforeOrAt: now.Add(time.Hour),
+	}
+	expected = &state.NoticeFilter{
+		After:      now.Add(-time.Minute),
+		BeforeOrAt: now,
+	}
+	testDoNoticesFilter(c, backends, given, expected, now)
+
+	// If passed a filter with After in the future, BeforeOrAt will be set as usual.
+	// XXX: we allow After to be after BeforeOrAt, and pass the filter on to the
+	// backends. This might change in the future if we want to return early.
+	given = &state.NoticeFilter{
+		After: now.Add(2 * time.Hour),
+	}
+	expected = &state.NoticeFilter{
+		After:      now.Add(2 * time.Hour),
+		BeforeOrAt: now,
+	}
+	testDoNoticesFilter(c, backends, given, expected, now)
+}
+
+func testDoNoticesFilter(c *C, backends []*testNoticeBackend, givenFilter, expectedFilter *state.NoticeFilter, now time.Time) {
+	// Send nil notices over backends so they do not block
+	for _, bknd := range backends {
+		bknd.noticesChan <- nil
+	}
+
+	// Make a []NoticeBackend so the doNotices type checker is happy
+	abstractBackends := make([]notices.NoticeBackend, len(backends))
+	for i, bknd := range backends {
+		abstractBackends[i] = bknd
+	}
+	ns := notices.DoNotices(abstractBackends, givenFilter, now)
+	c.Assert(ns, HasLen, 0)
+
+	// Check that each backend received the expected filter
+	for _, bknd := range backends {
+		select {
+		case received := <-bknd.filterChan:
+			c.Check(received, DeepEquals, expectedFilter)
+		default:
+			c.Fatalf("failed to receive filter from backend")
+		}
+	}
+}
+
+func (s *noticesSuite) TestDoNoticesSorting(c *C) {
+	bknd1 := newTestNoticeBackend()
+	bknd2 := newTestNoticeBackend()
+
+	t0 := time.Now()
+	t1 := t0.Add(1 * time.Minute)
+	t2 := t0.Add(2 * time.Minute)
+	t3 := t0.Add(3 * time.Minute)
+	t4 := t0.Add(4 * time.Minute)
+	t5 := t0.Add(5 * time.Minute)
+	t6 := t0.Add(6 * time.Minute)
+
+	// Other notice details don't matter for this test
+
+	n1 := state.NewNotice("1", nil, state.WarningNotice, "bar", t1, nil, 0, 0)
+	n2 := state.NewNotice("2", nil, state.WarningNotice, "bar", t2, nil, time.Hour, 0)
+	n3 := state.NewNotice("3", nil, state.WarningNotice, "bar", t3, nil, 0, 0)
+	n4 := state.NewNotice("4", nil, state.WarningNotice, "bar", t4, nil, 0, 0)
+
+	// Create n5 with initial timestamp before other notices, then repeat so it
+	// has the latest lastRepeated timestamp.
+	n5 := state.NewNotice("5", nil, state.WarningNotice, "foo", t0, nil, 0, 0)
+	n5.Reoccur(t5, nil, 0)
+
+	// For good measure, re-record n2 with a newer timestamp, but less than its
+	// RepeatAfter duration. Then we can test that lastRepeated is used.
+	n2.Reoccur(t6, nil, time.Hour)
+
+	bknd1.noticesChan <- []*state.Notice{n2, n3, n5}
+	bknd2.noticesChan <- []*state.Notice{n1, n4}
+
+	// Check that resulting notices are sorted by lastRepeated time.
+	// Since we're directly feeding notices, filter and now do not matter.
+	result := notices.DoNotices([]notices.NoticeBackend{bknd1, bknd2}, nil, time.Now())
+	c.Check(result, DeepEquals, []*state.Notice{n1, n2, n3, n4, n5})
+}
+
+func (s *noticesSuite) TestNotices(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+
+	// Add notices to state so we can query for them later
+	userID := uint32(1000)
+	s.st.Lock()
+	_, err := s.st.AddNotice(&userID, state.ChangeUpdateNotice, "foo", nil)
+	c.Assert(err, IsNil)
+	_, err = s.st.AddNotice(&userID, state.InterfacesRequestsRuleUpdateNotice, "bar", nil)
+	c.Assert(err, IsNil)
+	s.st.Unlock()
+
+	bknd1 := newTestNoticeBackend()
+	bknd2 := newTestNoticeBackend()
+	bknd3 := newTestNoticeBackend()
+
+	bknd1.noticesChan <- nil
+	_, err = nm.RegisterBackend(bknd1, state.WarningNotice, "foo")
+	c.Assert(err, IsNil)
+	<-bknd1.filterChan
+	// Register bknd2 for two notice types
+	bknd2.noticesChan <- nil
+	_, err = nm.RegisterBackend(bknd2, state.WarningNotice, "bar")
+	c.Assert(err, IsNil)
+	<-bknd2.filterChan
+	bknd2.noticesChan <- nil
+	_, err = nm.RegisterBackend(bknd2, state.ChangeUpdateNotice, "baz")
+	c.Assert(err, IsNil)
+	<-bknd2.filterChan
+	bknd3.noticesChan <- nil
+	_, err = nm.RegisterBackend(bknd3, state.InterfacesRequestsPromptNotice, "qux")
+	c.Assert(err, IsNil)
+	<-bknd3.filterChan
+
+	// Build some notices which can later be returned arbitrary by backends.
+	// Ignore their ID and type, since we can feed them arbitrarily to the test
+	// backends.
+	n1 := state.NewNotice("1", nil, "", "abc", time.Now(), nil, 0, 0)
+	n2 := state.NewNotice("2", nil, "", "abc", time.Now(), nil, time.Hour, 0)
+	n3 := state.NewNotice("3", nil, "", "abc", time.Now(), nil, 0, 0)
+	n4 := state.NewNotice("4", nil, "", "abc", time.Now(), nil, 0, 0)
+
+	// Prepare to query all notices from all backends
+	bknd1.noticesChan <- []*state.Notice{n2}
+	bknd2.noticesChan <- []*state.Notice{n3, n1}
+	bknd3.noticesChan <- []*state.Notice{n4}
+
+	// When filter empty, all notices are queried from all backends, including state
+	result := nm.Notices(nil)
+	c.Check(result, HasLen, 6)
+	// We don't have a pointer to the state notices, but we can check that the
+	// remaining 4 are as expected and in order.
+	c.Check(result[2:], DeepEquals, []*state.Notice{n1, n2, n3, n4})
+	// Clear filterChans for each test backend
+	<-bknd1.filterChan
+	<-bknd2.filterChan
+	<-bknd3.filterChan
+
+	// Prepare to query only bknd2 by filtering for ChangeUpdateNotices
+	bknd2.noticesChan <- []*state.Notice{n1, n4}
+
+	// When we provide a filter with a type for which there is a registered
+	// backend, then state is not queried.
+	filter := &state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}}
+	result = nm.Notices(filter)
+	c.Check(result, DeepEquals, []*state.Notice{n1, n4})
+	<-bknd2.filterChan
+
+	// Prepare to query bknd1 and bknd2
+	bknd1.noticesChan <- []*state.Notice{n3, n1}
+	bknd2.noticesChan <- []*state.Notice{n2}
+
+	// When we provide a filter with multiple types, some have registered
+	// backends and some don't, then all expected backends (including state)
+	// are queried.
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice, state.InterfacesRequestsRuleUpdateNotice}}
+	result = nm.Notices(filter)
+	c.Check(result, HasLen, 4)
+	// We don't have a pointer to the state notice, but we can check that the
+	// remaining 3 are as expected and in order.
+	c.Check(result[1:], DeepEquals, []*state.Notice{n1, n2, n3})
+	// Clear filterChans for each test backend
+	<-bknd1.filterChan
+	<-bknd2.filterChan
+
+	// When we provide a filter for a type for which no backend is registered, we only query state
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.InterfacesRequestsRuleUpdateNotice}}
+	result = nm.Notices(filter)
+	c.Check(result, HasLen, 1)
+	c.Check(result[0].Type(), Equals, state.InterfacesRequestsRuleUpdateNotice)
+}
+
+func (s *noticesSuite) TestNotice(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+
+	// Add a notice to state so we can query for it later
+	userID := uint32(1000)
+	s.st.Lock()
+	stateNoticeID, err := s.st.AddNotice(&userID, state.ChangeUpdateNotice, "foo", nil)
+	s.st.Unlock()
+	c.Assert(err, IsNil)
+
+	bknd1 := newTestNoticeBackend()
+	bknd2 := newTestNoticeBackend()
+	bknd3 := newTestNoticeBackend()
+	bknd4 := newTestNoticeBackend()
+
+	// Send empty notices over noticesChans so registration doesn't block
+	// trying to get notices to update last notice timestamp
+	bknd1.noticesChan <- nil
+	bknd2.noticesChan <- nil
+	bknd3.noticesChan <- nil
+	bknd4.noticesChan <- nil
+
+	_, err = nm.RegisterBackend(bknd1, state.WarningNotice, "foo")
+	c.Assert(err, IsNil)
+	_, err = nm.RegisterBackend(bknd2, state.WarningNotice, "bar")
+	c.Assert(err, IsNil)
+	_, err = nm.RegisterBackend(bknd3, state.WarningNotice, "baz")
+	c.Assert(err, IsNil)
+	_, err = nm.RegisterBackend(bknd4, state.WarningNotice, "qux")
+	c.Assert(err, IsNil)
+
+	queryID := "baz-123"
+
+	// Define a notice for the correct backend to return. The ID doesn't even
+	// technically need to match the queryID, since the manager doesn't check
+	// the notice returned by the backend.
+	notice := state.NewNotice(queryID, nil, state.WarningNotice, "xyz", time.Now(), nil, 0, 0)
+
+	// Give the correct backend the notice to return via BackendNotice. If any
+	// other methods or backends are queried, the test will block, since no
+	// other channels are populated with notices.
+	bknd3.noticeChan <- notice
+
+	// Hold state lock so we know state isn't checked (else it would block)
+	s.st.Lock()
+	result := nm.Notice(queryID)
+	s.st.Unlock()
+	c.Check(result, Equals, notice)
+
+	// Now query for the notice which was previously added to state. If other
+	// backends were queried, the test would block.
+	result = nm.Notice(stateNoticeID)
+	c.Check(result, NotNil)
+	c.Check(result.Type(), Equals, state.ChangeUpdateNotice)
+
+	// Now query notice with ID namespace which no backend has registered.
+	// Since it is namespaced, state cannot be asked either. Hold state lock
+	// to test this. And since no backends have been fed notices, querying them
+	// would block too. So test that nothing blocks.
+	s.st.Lock()
+	result = nm.Notice("unregistered-1234")
+	s.st.Unlock()
+	c.Check(result, IsNil)
+}
+
+func (s *noticesSuite) TestWaitNotices(c *C) {
+	nm := notices.NewNoticeManager(s.st)
+
+	bknd1 := newTestNoticeBackend()
+	bknd2 := newTestNoticeBackend()
+	bknd3 := newTestNoticeBackend()
+
+	bknd1.noticesChan <- nil
+	_, err := nm.RegisterBackend(bknd1, state.WarningNotice, "foo")
+	c.Assert(err, IsNil)
+	<-bknd1.filterChan
+	// Register bknd2 for two notice types
+	bknd2.noticesChan <- nil
+	_, err = nm.RegisterBackend(bknd2, state.WarningNotice, "bar")
+	c.Assert(err, IsNil)
+	<-bknd2.filterChan
+	bknd2.noticesChan <- nil
+	_, err = nm.RegisterBackend(bknd2, state.ChangeUpdateNotice, "baz")
+	c.Assert(err, IsNil)
+	<-bknd2.filterChan
+	bknd3.noticesChan <- nil
+	_, err = nm.RegisterBackend(bknd3, state.InterfacesRequestsPromptNotice, "qux")
+	c.Assert(err, IsNil)
+	<-bknd3.filterChan
+
+	// Build some notices which can later be returned arbitrary by backends.
+	// Ignore their ID and type, since we can feed them arbitrarily to the test
+	// backends.
+	n1 := state.NewNotice("1", nil, "", "abc", time.Now(), nil, 0, 0)
+	n2 := state.NewNotice("2", nil, "", "abc", time.Now(), nil, time.Hour, 0)
+	n3 := state.NewNotice("3", nil, "", "abc", time.Now(), nil, 0, 0)
+	n4 := state.NewNotice("4", nil, "", "abc", time.Now(), nil, 0, 0)
+
+	// If filter only matches one backend, BackendWaitNotices is called on that
+	// backend directly, and returned. Other backends are not queried.
+	bknd2.waitNoticesChan <- []*state.Notice{n2, n3}
+	filter := &state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}}
+	result, err := nm.WaitNotices(context.Background(), filter)
+	c.Assert(err, IsNil)
+	c.Check(result, DeepEquals, []*state.Notice{n2, n3})
+	receivedFilter := <-bknd2.filterChan
+	c.Check(receivedFilter, DeepEquals, &state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
+
+	// If filter matches multiple backends, then each should queried for
+	// existing notices before or at the current time, and if one or more
+	// already has notices, then return them immediately, once all backends
+	// return.
+	bknd1.noticesChan <- []*state.Notice{n3, n1}
+	beforeTime := time.Now()
+	beforeOrAtFilterTime := beforeTime.Add(time.Hour)
+	// Simulate bknd2 being slow to return notices, and ensure its result is included.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		bknd2.noticesChan <- []*state.Notice{n2}
+	}()
+	filter = &state.NoticeFilter{
+		Types:      []state.NoticeType{state.WarningNotice},
+		BeforeOrAt: beforeOrAtFilterTime,
+	}
+	result, err = nm.WaitNotices(context.Background(), filter)
+	afterTime := time.Now()
+	c.Assert(err, IsNil)
+	c.Check(result, DeepEquals, []*state.Notice{n1, n2, n3})
+	// Check that the backends received a filter with BeforeOrAt set to the current time when called.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(receivedFilter.Types, DeepEquals, []state.NoticeType{state.WarningNotice})
+		c.Check(beforeTime.Before(receivedFilter.BeforeOrAt), Equals, true)
+		c.Check(receivedFilter.BeforeOrAt.Before(afterTime), Equals, true)
+		c.Check(receivedFilter.BeforeOrAt.Before(beforeOrAtFilterTime), Equals, true)
+	}
+	// Check that the original filter was not overwritten
+	c.Check(filter.BeforeOrAt, Equals, beforeOrAtFilterTime)
+
+	// If filter matches multiple backends, then each should queried for
+	// existing notices before or at the current time, and if none have
+	// notices, and the BeforeOrAt filter is in the past, then return
+	// immediately, once all backends return.
+	bknd1.noticesChan <- nil
+	beforeTime = time.Now()
+	// Simulate bknd2 being slow to return, and test the result waited for it.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		bknd2.noticesChan <- nil
+	}()
+	filter = &state.NoticeFilter{
+		Types:      []state.NoticeType{state.WarningNotice},
+		BeforeOrAt: beforeTime, // this is in the past at call time
+	}
+	result, err = nm.WaitNotices(context.Background(), filter)
+	afterTime = time.Now()
+	c.Check(beforeTime.Add(10*time.Millisecond).Before(afterTime), Equals, true)
+	c.Assert(err, IsNil)
+	c.Check(result, HasLen, 0)
+	// Check that the backends received a filter with BeforeOrAt unchanged from the original filter.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(receivedFilter, DeepEquals, filter)
+	}
+	// Check that the original filter was not overwritten
+	c.Check(filter.BeforeOrAt, Equals, beforeTime)
+
+	// If all backends return empty lists for BackendNotices, and then the
+	// context is cancelled, return immediately.
+	bknd1.noticesChan <- nil
+	bknd2.noticesChan <- nil
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}}
+	ctx, cancel := context.WithCancel(context.Background())
+	beforeTime = time.Now()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	result, err = nm.WaitNotices(ctx, filter)
+	afterTime = time.Now()
+	c.Check(beforeTime.Add(10*time.Millisecond).Before(afterTime), Equals, true)
+	c.Check(err, ErrorMatches, "context canceled")
+	c.Check(result, HasLen, 0)
+	// Check that the backends received a filter to BackendNotices with
+	// BeforeOrAt set to the current time when called.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(beforeTime.Before(receivedFilter.BeforeOrAt), Equals, true)
+		c.Check(receivedFilter.BeforeOrAt.Before(afterTime), Equals, true)
+	}
+	// Check that the backends received a filter to BackendWaitNotices with
+	// BeforeOrAt unset.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(receivedFilter, DeepEquals, filter)
+	}
+	// Check that the original filter was not overwritten
+	c.Check(filter.BeforeOrAt.IsZero(), Equals, true)
+
+	// If all backends return empty lists for both BackendNotices and
+	// BackendWaitNotices, then WaitNotices returns nil immediately.
+	bknd1.noticesChan <- nil
+	bknd2.noticesChan <- nil
+	bknd1.waitNoticesChan <- nil
+	bknd2.waitNoticesChan <- nil
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}}
+	result, err = nm.WaitNotices(context.Background(), filter)
+	c.Check(err, IsNil)
+	c.Check(result, HasLen, 0)
+	// Check that the backends received a filter to BackendNotices with
+	// BeforeOrAt set to the current time when called.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(receivedFilter.BeforeOrAt.IsZero(), Equals, false)
+	}
+	// Check that the backends received a filter to BackendWaitNotices with
+	// BeforeOrAt unset.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(receivedFilter, DeepEquals, filter)
+	}
+	// Check that the original filter was not overwritten
+	c.Check(filter.BeforeOrAt.IsZero(), Equals, true)
+
+	// If all backends return empty lists for BackendNotices, then a backend
+	// returns some notices for BackendWaitNotices, then all backends are
+	// again queried for BackendNotices, but with a BeforeOrAt filter set to
+	// the last return notice's timestamp.
+	bknd1.noticesChan <- nil
+	bknd2.noticesChan <- nil
+	bknd1.waitNoticesChan <- []*state.Notice{n3, n4}
+	// bknd2 doesn't return notices from WaitNotices, instead it should be
+	// cancelled once bknd1 returns the notices.
+	beforeTime = time.Now()
+	go func() {
+		// Once able, send notices for final BackendNotices.
+		// These notices might include the notice(s) originally returned by
+		// BackendWaitNotices, since they might have been re-recorded since.
+		// For consistency with other backends, they should be excluded from
+		// the final result. Test this by returning unrelated notices.
+		bknd1.noticesChan <- []*state.Notice{n2}
+		time.Sleep(10 * time.Millisecond)
+		bknd2.noticesChan <- []*state.Notice{n1}
+	}()
+	filter = &state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}}
+	result, err = nm.WaitNotices(context.Background(), filter)
+	afterTime = time.Now()
+	c.Check(err, IsNil)
+	c.Check(result, DeepEquals, []*state.Notice{n1, n2})
+	c.Check(beforeTime.Add(10*time.Millisecond).Before(afterTime), Equals, true)
+	// Check that the backends first received a filter to BackendNotices
+	// with BeforeOrAt set to the current time when called.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(beforeTime.Before(receivedFilter.BeforeOrAt), Equals, true)
+		c.Check(receivedFilter.BeforeOrAt.Before(afterTime), Equals, true)
+	}
+	// Check that the backends then received a filter to BackendWaitNotices
+	// with BeforeOrAt unset.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(receivedFilter, DeepEquals, filter)
+	}
+	// Check that the backends lastly receive a filter to BackendNotices
+	// with BeforeOrAt set to the lastRepeated timestamp of the final notice
+	// returned by the calls to BackendWaitNotices.
+	for _, bknd := range []*testNoticeBackend{bknd1, bknd2} {
+		receivedFilter := <-bknd.filterChan
+		c.Check(receivedFilter.BeforeOrAt.Equal(n4.LastRepeated()), Equals, true)
+	}
+	// Check that the original filter was not overwritten
+	c.Check(filter.BeforeOrAt.IsZero(), Equals, true)
+}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -150,7 +150,7 @@ func (n *Notice) Type() NoticeType {
 	return n.noticeType
 }
 
-// LastRepeated returns the last repeated timestamp for the receiving notice.
+// LastRepeated returns the last repeated timestamp for this notice.
 func (n *Notice) LastRepeated() time.Time {
 	return n.lastRepeated
 }

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -150,6 +150,11 @@ func (n *Notice) Type() NoticeType {
 	return n.noticeType
 }
 
+// LastRepeated returns the last repeated timestamp for the receiving notice.
+func (n *Notice) LastRepeated() time.Time {
+	return n.lastRepeated
+}
+
 func flattenUserID(userID *uint32) (uid uint32, isSet bool) {
 	if userID == nil {
 		return 0, false
@@ -488,10 +493,16 @@ func (s *State) DrainNotices(filter *NoticeFilter) []*Notice {
 	for _, k := range toRemove {
 		delete(s.notices, k)
 	}
+	SortNotices(notices)
+	return notices
+}
+
+// SortNotices sorts the given slice of notices according to the lastRepeated
+// timestamp.
+func SortNotices(notices []*Notice) {
 	sort.Slice(notices, func(i, j int) bool {
 		return notices[i].lastRepeated.Before(notices[j].lastRepeated)
 	})
-	return notices
 }
 
 // Notices returns the list of notices that match the filter (if any),
@@ -500,9 +511,7 @@ func (s *State) Notices(filter *NoticeFilter) []*Notice {
 	s.reading()
 
 	notices := s.flattenNotices(filter)
-	sort.Slice(notices, func(i, j int) bool {
-		return notices[i].lastRepeated.Before(notices[j].lastRepeated)
-	})
+	SortNotices(notices)
 	return notices
 }
 

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -51,6 +51,7 @@ func (s *noticesSuite) TestNewNotice(c *C) {
 	c.Check(uid, Equals, userID)
 	c.Check(isSet, Equals, true)
 	c.Check(notice.Type(), Equals, nType)
+	c.Check(notice.LastRepeated(), Equals, timestamp)
 	// TODO: expand method checks when more public methods are added
 	n := noticeToMap(c, notice)
 	c.Check(n["id"], Equals, id)


### PR DESCRIPTION
This PR is the `overlord/notices` changes from #15556.

Define a `NoticeManager` struct and a `NoticeBackend` interface. Particular backends which implement the `NoticeBackend` interface may be registered with a `NoticeManager` as providers of a particular notice type, along with a unique namespace which must occur as a prefix to the ID of any notice of that type produced by that backend.
    
A particular backend may be registered as a provider of more than one notice type, as long as the namespace prefix registered for that backend and type is unique. Similarly, multiple backends may be registered as providers of the same notice type, as long as each has a unique namespace prefix.
    
Snapd state is an implicit backend for any notice types which have no registered backends. Notices from state have no namespace prefix, while notices from all other backends must have a namespace prefix matching that which was declared when the backend was registered for the corresponding notice type.
    
The `NoticeManager` is responsible for deciding which backends are capable of providing notices matching a given request, and only querying those backends. The notice type in the filter is used to select relevant backends for calls to `Notices` and `WaitNotices`, while the ID prefix is used to select the relevant backend (if any) for calls to `Notice()`.
    
As a result, a request for notices of a type only provided by one backend, for example, does not need to touch any other backend. Importantly, this means that state lock is not required to complete requests for notice types or IDs which are not provided by state.
    
The `NoticeManager` ensures that the existing invariants around notices remain true. Namely, when the manager returns a list of notices from a call to `Notices()` or `WaitNotices()`, it is guaranteed that there can be no new notice recorded with a timestamp earlier than the `lastRepeated` timestamp of the last notice in that list. (This did not and still does not hold true for new notices which have a timestamp explicitly specified.)
    
The `NoticeManager` provides a method to get a unique monotonically increasing notice timestamp from the state (without holding state lock), and `NoticeBackend`s must use it to get a timestamp whenever they create or re-record a notice.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34743