### PR TITLE
github: run CI tests on hotfix branches

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,7 +1,7 @@
 name: Tests
 on:
   pull_request:
-    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**" ]
+    branches: [ "master", "release/**", "core-snap-security-release/**", "security-release/**", "hotfix/**" ]
   push:
     branches: [ "release/**", "core-snap-security-release/**", "security-release/**" ]
 


### PR DESCRIPTION
Update branch spec in CI workflow to run tests on hotfix PRs (for example #15670)