### PR TITLE
overlord/ifacestate: reject system key mismatch advise when not yet seeded

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -259,6 +259,9 @@ func maybeCheckSystemKeyMismatch(cli *client.Client) (changeID string, err error
 		} else if errors.As(err, &rspError) {
 			// actual response error
 			if !restarting || rspError.Kind != client.ErrorKindSystemKeyVersionUnsupported {
+				// we may reach here if snapd is still seeding, in which case we
+				// let the app execution continue, but the app may not function
+				// properly if the sandbox hasn't been set up completely
 				logger.Debugf("ignoring system-key mismatch error: %v", err)
 				return "", nil
 			}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -225,6 +225,8 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 
 	runner.AddHandler("generate-device-key", m.doGenerateDeviceKey, nil)
 	runner.AddHandler("request-serial", m.doRequestSerial, nil)
+	// Mark-preseeded touches and records the system-key, ensure that it does
+	// not run in parallel with other tasks touching the system-key
 	runner.AddHandler("mark-preseeded", m.doMarkPreseeded, nil)
 	runner.AddHandler("mark-seeded", m.doMarkSeeded, nil)
 	runner.AddHandler("setup-ubuntu-save", m.doSetupUbuntuSave, nil)

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -638,6 +638,18 @@ func InterfacesRequestsControlHandlerServices(st *state.State) ([]*snap.AppInfo,
 // change for regenerating security profiles, thus returning a change, or do
 // nothing, in which case no change is returned.
 func AdviseReportedSystemKeyMismatch(st *state.State, systemKey any) (*state.Change, error) {
+	var seeded bool
+	err := st.Get("seeded", &seeded)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return nil, err
+	}
+
+	if !seeded {
+		// System not ready yet for checking system-key, bubble up the error to
+		// clients. They can either wait or proceed at their own peril.
+		return nil, errors.New("system not yet seeded")
+	}
+
 	action, err := interfaces.SystemKeyMismatchAdvice(systemKey)
 	if err != nil {
 		return nil, err

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -11512,9 +11512,21 @@ func (s *interfaceManagerSuite) TestDoRegenerateSecurityProfilesErrorsSetup(c *C
 	})
 }
 
+func (s *interfaceManagerSuite) TestSystemKeyMismatchNotSeeded(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.state.Set("seeded", nil)
+
+	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, "")
+	c.Check(err, ErrorMatches, "system not yet seeded")
+	c.Check(chg, IsNil)
+}
+
 func (s *interfaceManagerSuite) TestSystemKeyMismatchTrivial(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+	s.state.Set("seeded", true)
+
 	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, "")
 	c.Assert(err, ErrorMatches, "internal error: string is not a system key")
 	c.Check(chg, IsNil)
@@ -11554,6 +11566,7 @@ func (s *interfaceManagerSuite) TestSystemKeyMismatch(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	s.state.Set("seeded", true)
 
 	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, sk)
 	c.Assert(err, IsNil)
@@ -11593,6 +11606,7 @@ func (s *interfaceManagerSuite) TestSystemKeyMismatchCompat(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	s.state.Set("seeded", true)
 
 	chg, err := ifacestate.AdviseReportedSystemKeyMismatch(s.state, sk)
 	c.Assert(err, ErrorMatches, "system-key version higher than supported")

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2713,6 +2713,9 @@ func (m *SnapManager) maybeRemoveAppArmorProfilesOnSnapdDowngrade(st *state.Stat
 		}
 		// also remove system-key to ensure the AppArmor profiles get
 		// regenerated when the new snapd starts up
+		//
+		// TODO:system-key: this should not be running in a task handler that
+		// runs in parallel to regenerate-system-profiles or mark-preseeded
 		if err = interfaces.RemoveSystemKey(); err != nil {
 			logger.Noticef("WARNING: failed to remove system-key")
 		}

--- a/spread.yaml
+++ b/spread.yaml
@@ -1495,6 +1495,7 @@ suites:
             - google-nested-dev
             - qemu-nested
             - google-nested-arm
+            - garden
         environment:
             NESTED_TYPE: "classic"
             # Enable kvm in the qemu command line

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1223,7 +1223,7 @@ nested_start_core_vm_unit() {
     elif [ "$SPREAD_BACKEND" = "google-nested-dev" ]; then
         PARAM_MEM="-m ${NESTED_MEM:-8192}"
         PARAM_SMP="-smp ${NESTED_CPUS:-4}"
-    elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
+    elif [ "$SPREAD_BACKEND" = "qemu-nested" ] || [ "$SPREAD_BACKEND" = "garden" ]; then
         PARAM_MEM="-m ${NESTED_MEM:-2048}"
         PARAM_SMP="-smp ${NESTED_CPUS:-1}"
     else
@@ -1294,7 +1294,7 @@ nested_start_core_vm_unit() {
     if nested_is_core_lt 20; then
         if [[ "$SPREAD_BACKEND" = google-nested* ]]; then
             PARAM_MACHINE="-machine ubuntu${ATTR_KVM}"
-        elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
+        elif [ "$SPREAD_BACKEND" = "qemu-nested" ] || [ "$SPREAD_BACKEND" = "garden" ]; then
             # check if we have nested kvm
             if [ "$(cat /sys/module/kvm_*/parameters/nested)" = "1" ]; then
                 PARAM_MACHINE="-machine ubuntu${ATTR_KVM}"
@@ -1617,7 +1617,7 @@ nested_start_classic_vm() {
     elif [ "$SPREAD_BACKEND" = "google-nested-dev" ]; then
         PARAM_MEM="-m ${NESTED_MEM:-8192}"
         PARAM_SMP="-smp ${NESTED_CPUS:-4}"
-    elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
+    elif [ "$SPREAD_BACKEND" = "qemu-nested" ] || [ "$SPREAD_BACKEND" = "garden" ]; then
         PARAM_MEM="-m ${NESTED_MEM:-2048}"
         PARAM_SMP="-smp ${NESTED_CPUS:-1}"
     else
@@ -1651,7 +1651,7 @@ nested_start_classic_vm() {
     if [[ "$SPREAD_BACKEND" = google-nested* ]]; then
         PARAM_MACHINE="-machine ubuntu,accel=kvm"
         PARAM_CPU="-cpu host"
-    elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
+    elif [ "$SPREAD_BACKEND" = "qemu-nested" ] || [ "$SPREAD_BACKEND" = "garden" ]; then
         # check if we have nested kvm
         if [ "$(cat /sys/module/kvm_*/parameters/nested)" = "1" ]; then
             PARAM_MACHINE="-machine ubuntu${ATTR_KVM}"

--- a/tests/nested/manual/preseed-early-snap-run/task.yaml
+++ b/tests/nested/manual/preseed-early-snap-run/task.yaml
@@ -1,0 +1,109 @@
+summary: Check that early snap run does not break preseeding.
+
+details: |
+  This test checks that preseeding preseeding completes successfully even if
+  there is an early snap run executed during boot.
+
+systems: [ubuntu-24.04-*]
+
+environment:
+  IMAGE_MOUNTPOINT: /mnt/cloudimg
+
+prepare: |
+  #shellcheck source=tests/lib/preseed.sh
+  . "$TESTSLIB/preseed.sh"
+
+  # create a VM and mount a cloud image
+  tests.nested build-image classic
+  mkdir -p "$IMAGE_MOUNTPOINT"
+  IMAGE_NAME=$(tests.nested get image-name classic)
+  mount_ubuntu_image "$(tests.nested get images-path)/$IMAGE_NAME" "$IMAGE_MOUNTPOINT"
+
+  # Add snapd from this branch into the seed
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB"/prepare.sh
+  build_snapd_snap .
+  mv snapd_*.snap snapd.snap
+  inject_snap_into_seed "$IMAGE_MOUNTPOINT" snapd
+
+  snap download --edge --basename=core24 core24
+  snap download --edge --basename=test-snapd-sh-core24 test-snapd-sh-core24
+
+  inject_snap_into_seed "$IMAGE_MOUNTPOINT" core24
+  inject_snap_into_seed "$IMAGE_MOUNTPOINT" test-snapd-sh-core24
+
+  # for images that are already preseeded, we need to undo the preseeding there
+  echo "Running preseed --reset for already preseeded cloud images"
+  SNAPD_DEBUG=1 /usr/lib/snapd/snap-preseed --reset "$IMAGE_MOUNTPOINT"
+
+  cat <<'EOF' > "$IMAGE_MOUNTPOINT"/lib/systemd/system/early-snap-run.service
+  [Unit]
+  Description=test unit invoking snap run early during boot
+  # make sure that snapd.socket is started
+  After=snapd.socket
+
+  [Install]
+  WantedBy=multi-user.target
+
+  [Service]
+  Type=oneshot
+  Restart=no
+  Environment=SNAPD_DEBUG=1
+  ExecStart=/snap/bin/test-snapd-sh-core24.sh -c 'echo hello'
+  EOF
+
+  systemctl --root="$IMAGE_MOUNTPOINT" enable early-snap-run.service
+
+  cat <<'EOF' > "$IMAGE_MOUNTPOINT"/lib/systemd/system/early-snap-run-proper.service
+  [Unit]
+  Description=test unit invoking snap run early during boot but after seeded is completed
+  After=snapd.seeded.service
+
+  [Install]
+  WantedBy=multi-user.target
+
+  [Service]
+  Type=oneshot
+  Restart=no
+  Environment=SNAPD_DEBUG=1
+  ExecStart=/snap/bin/test-snapd-sh-core24.sh -c 'echo hello'
+  EOF
+
+  systemctl --root="$IMAGE_MOUNTPOINT" enable early-snap-run-proper.service
+
+  echo "Running pre-seeding"
+  /usr/lib/snapd/snap-preseed "$IMAGE_MOUNTPOINT" | MATCH "using snapd binary: /tmp/snapd-preseed/usr/lib/snapd/snapd"
+
+  umount_ubuntu_image "$IMAGE_MOUNTPOINT"
+
+restore: |
+  tests.nested vm remove
+
+  # any of the restore commands can fail depending on where execute part stopped,
+  # account for that with ||true.
+  #shellcheck source=tests/lib/preseed.sh
+  . "$TESTSLIB/preseed.sh"
+  umount_ubuntu_image "$IMAGE_MOUNTPOINT" || true
+
+execute: |
+  #shellcheck source=tests/lib/preseed.sh
+  . "$TESTSLIB/preseed.sh"
+
+  tests.nested create-vm classic --param-cpus 1
+
+  echo "Waiting for firstboot seeding to finish"
+  remote.exec "sudo snap wait system seed.loaded"
+  # check that seeding completed successfully
+  remote.exec "snap changes" | MATCH "Done .+ Initialize system state"
+  # there was no change to regenerate security profiles
+  remote.exec "snap changes" | NOMATCH "Regenerate security profiles"
+
+  # the side-loaded services were executed
+
+  remote.exec "sudo journalctl -u early-snap-run.service" | \
+      MATCH "ignoring system-key mismatch error: cannot process system key: system not yet seeded"
+  # despite hitting a mismatch the service continued
+  remote.exec "sudo systemctl show early-snap-run.service" | MATCH "status=0"
+
+  remote.exec "sudo systemctl show early-snap-run-proper.service" | MATCH "status=0"
+  remote.exec "sudo journalctl -u early-snap-run-proper.service" | NOMATCH "mismatch"


### PR DESCRIPTION
When the system has been preseeded, but the seeding has not yet completed we cannot really compare the system key. Return and error and have the clients requesting the advice retry.

Related: LP#2114923
Related: SNAPDENG-35257

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
