### PR TITLE
daemon, overlord/state: add undo information with task kinds

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -96,9 +96,9 @@ var api = []*Command{
 }
 
 type featureEndpoint struct {
-	Path    string
-	Method  string
-	Actions []string
+	Path    string   `json:"path"`
+	Method  string   `json:"method"`
+	Actions []string `json:"actions"`
 }
 
 var featureList []featureEndpoint

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -146,6 +146,16 @@ func (r *TaskRunner) KnownTaskKinds() []string {
 	return kinds
 }
 
+func (r *TaskRunner) KnownTaskKindsWithUndo() []string {
+	kinds := make([]string, 0, len(r.handlers))
+	for h := range r.handlers {
+		if r.handlers[h].undo != nil {
+			kinds = append(kinds, h)
+		}
+	}
+	return kinds
+}
+
 // AddCleanup registers a function to be called after the change completes,
 // for cleaning up data left behind by tasks of the specified kind.
 // The provided function will be called no matter what the final status of the

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1209,6 +1209,19 @@ func (ts *taskRunnerSuite) TestKnownTaskKinds(c *C) {
 	c.Assert(kinds, DeepEquals, []string{"task-kind-1", "task-kind-2"})
 }
 
+func (ts *taskRunnerSuite) TestKnownTaskKindsWithUndo(c *C) {
+	st := state.New(nil)
+	r := state.NewTaskRunner(st)
+	r.AddHandler("task-kind-1", func(t *state.Task, tb *tomb.Tomb) error { return nil }, nil)
+	r.AddHandler("task-kind-2",
+		func(t *state.Task, tb *tomb.Tomb) error { return nil },
+		func(t *state.Task, tb *tomb.Tomb) error { return nil })
+
+	kinds := r.KnownTaskKindsWithUndo()
+	sort.Strings(kinds)
+	c.Assert(kinds, DeepEquals, []string{"task-kind-2"})
+}
+
 func (ts *taskRunnerSuite) TestCleanup(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)


### PR DESCRIPTION
A task without an undo handler can never have an `Undone` status. This adds a boolean value to indicate the presence of an undo handler to feature tagging information. Currently, due to the large number of false positives, it is difficult to identify where we are actually missing a test for a task undo.