### PR TITLE
interfaces/builtin: add Thetis Pro to U2F list

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -95,7 +95,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "Thetis Key",
 		VendorIDPattern:  "1ea8",
-		ProductIDPattern: "f025",
+		ProductIDPattern: "f025|f825",
 	},
 	{
 		Name:             "Nitrokey FIDO U2F",


### PR DESCRIPTION
This PR add the new [Thetis Pro](https://thetis.io/products/fido2-key-usb-a-c-nfc) to the allow list.

Proof: honestly, there's not much on the internet talking about it, but... 
- You can see the ProductID listed here [k9.io](https://k9.io/the-2025-security-key-shootout/)
- There's a Manjaro user dumping their system info, with the key attached [on the forum](https://forum.manjaro.org/t/issue-with-running-rise-of-kingdoms-on-manjaro-linux-stuck-at-6-and-black-screen/173047/2)
- You can find the ID [these slides from german Linux event](https://chemnitzer.linux-tage.de/2025/media/programm/folien/188.pdf)

Hopefully this will be enough :)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
