### PR TITLE
github, tests: upload complete list of feature tagging data to mongo

### DIFF
--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -151,8 +151,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run rerun.yaml -F run_id=${{ github.run_id }}
 
+  get-all-features:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Get all snapd features
+        run: |
+          wget https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
+          sudo snap install snapd_master_amd64.snap --dangerous
+          snap debug features > all-features.json
+
+      - name: Upload snapd feature data
+        uses: actions/upload-artifact@v4
+        with:
+          name: "all-features"
+          path: "all-features.json"
+
   create-reports:
-    needs: [set-inputs, tag-features-fundamental, tag-features-non-fundamental, tag-features-nested]
+    needs: [set-inputs, tag-features-fundamental, tag-features-non-fundamental, tag-features-nested, get-all-features]
     runs-on: ["self-hosted", "spread-enabled"]
     if: |
       (always() && (needs.tag-features-fundamental.result == 'success' || needs.tag-features-fundamental.result == 'skipped')
@@ -169,6 +185,11 @@ jobs:
           path: feature-tags-artifacts
           pattern: spread-artifacts-*
           merge-multiple: true
+
+      - name: Get all features
+        uses: actions/download-artifact@v4
+        with:
+          name: all-features
 
       - name: Create feature tags
         run: |
@@ -209,7 +230,9 @@ jobs:
             --dir "$composedir" \
             --output "final-feature-tags" \
             --replace-old-runs
-          
+
+          ./tests/utils/features/feattranslator.py -f all-features.json -o final-feature-tags/all-features.json
+
           tar -czf "final-feature-tags.tar.gz" "final-feature-tags"
 
       - name: Upload results to mongo

--- a/tests/utils/features/feattranslator.py
+++ b/tests/utils/features/feattranslator.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from features import Change, Cmd, Endpoint, Interface, Status, Task
 import argparse
 import json
 import os
@@ -7,50 +8,77 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from features import Change, Cmd, Endpoint, Interface, Status, Task
 
-
-def translate_all_features(all_features_json: str, output_json: str) -> dict:
-    all_features=None
-    with open(all_features_json, 'r', encoding='utf-8') as f:
+def translate_all_features(all_features_json: str, output_json: str):
+    with open(all_features_json, "r", encoding="utf-8") as f:
         all_features = json.load(f)
 
-    if any(key for key in ["endpoints", "tasks", "commands", "ensures", "interfaces", "changes"] if key not in all_features):
+    if any(
+        key not in all_features
+        for key in [
+            "endpoints",
+            "tasks",
+            "commands",
+            "ensures",
+            "interfaces",
+            "changes",
+        ]
+    ):
         raise RuntimeError(f"missing key in all features file {all_features_json}")
 
     all_endpoints = []
-    for endpoint in all_features['endpoints']:
-        if 'actions' in endpoint and endpoint['actions']:
-            for action in endpoint['actions']:
-                all_endpoints.append(Endpoint(method=endpoint['method'], path=endpoint['path'], action=action))
+    for endpoint in all_features["endpoints"]:
+        if "actions" in endpoint and endpoint["actions"]:
+            for action in endpoint["actions"]:
+                all_endpoints.append(
+                    Endpoint(
+                        method=endpoint["method"], path=endpoint["path"], action=action
+                    )
+                )
         else:
-            all_endpoints.append(Endpoint(method=endpoint['method'], path=endpoint['path']))
-    all_cmds = [Cmd(cmd=cmd) for cmd in all_features['commands']]
+            all_endpoints.append(
+                Endpoint(method=endpoint["method"], path=endpoint["path"])
+            )
+    all_cmds = [Cmd(cmd=cmd) for cmd in all_features["commands"]]
     all_tasks = []
-    for task in all_features['tasks']:
-        status_list = [Status.done, Status.undone, Status.error] if 'has-undo' in task and task['has-undo'] else [Status.done, Status.error]
+    for task in all_features["tasks"]:
+        status_list = (
+            [Status.done, Status.undone, Status.error]
+            if "has-undo" in task and task["has-undo"]
+            else [Status.done, Status.error]
+        )
         for status in status_list:
-            all_tasks.append(Task(kind=task['kind'], last_status=status))
-    all_changes = [Change(kind=change) for change in all_features['changes']]
-    all_interfaces = [Interface(name=iface) for iface in all_features['interfaces']]
+            all_tasks.append(Task(kind=task["kind"], last_status=status))
+    all_changes = [Change(kind=change) for change in all_features["changes"]]
+    all_interfaces = [Interface(name=iface) for iface in all_features["interfaces"]]
 
-    with open(output_json, 'w', encoding='utf-8') as f:
-        json.dump({
-            'cmds': all_cmds,
-            'ensures': all_features['ensures'],
-            'tasks': all_tasks,
-            'changes': all_changes,
-            'endpoints': all_endpoints,
-            'interfaces': all_interfaces,
-        }, f)
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "cmds": all_cmds,
+                "ensures": all_features["ensures"],
+                "tasks": all_tasks,
+                "changes": all_changes,
+                "endpoints": all_endpoints,
+                "interfaces": all_interfaces,
+            },
+            f,
+        )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Translates feature tagging output from 'snap debug features' to the same format as feature tagging reports")
+        description="Translates feature tagging output from 'snap debug features' to the same format as feature tagging reports"
+    )
     parser.add_argument(
-        '-f', '--file', help='snap debug features output file', required=True, type=str)
+        "-f", "--file", help="snap debug features output file", required=True, type=str
+    )
     parser.add_argument(
-        '-o', '--output', help='where to write translated output', required=True, type=str)
+        "-o",
+        "--output",
+        help="where to write translated output",
+        required=True,
+        type=str,
+    )
     args = parser.parse_args()
     translate_all_features(args.file, args.output)

--- a/tests/utils/features/feattranslator.py
+++ b/tests/utils/features/feattranslator.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from features import Change, Cmd, Endpoint, Interface, Status, Task
+
+
+def translate_all_features(all_features_json: str, output_json: str) -> dict:
+    all_features=None
+    with open(all_features_json, 'r', encoding='utf-8') as f:
+        all_features = json.load(f)
+
+    if any(key for key in ["endpoints", "tasks", "commands", "ensures", "interfaces", "changes"] if key not in all_features):
+        raise RuntimeError(f"missing key in all features file {all_features_json}")
+
+    all_endpoints = []
+    for endpoint in all_features['endpoints']:
+        if 'actions' in endpoint and endpoint['actions']:
+            for action in endpoint['actions']:
+                all_endpoints.append(Endpoint(method=endpoint['method'], path=endpoint['path'], action=action))
+        else:
+            all_endpoints.append(Endpoint(method=endpoint['method'], path=endpoint['path']))
+    all_cmds = [Cmd(cmd=cmd) for cmd in all_features['commands']]
+    all_tasks = []
+    for task in all_features['tasks']:
+        status_list = [Status.done, Status.undone, Status.error] if 'has-undo' in task and task['has-undo'] else [Status.done, Status.error]
+        for status in status_list:
+            all_tasks.append(Task(kind=task['kind'], last_status=status))
+    all_changes = [Change(kind=change) for change in all_features['changes']]
+    all_interfaces = [Interface(name=iface) for iface in all_features['interfaces']]
+
+    with open(output_json, 'w', encoding='utf-8') as f:
+        json.dump({
+            'cmds': all_cmds,
+            'ensures': all_features['ensures'],
+            'tasks': all_tasks,
+            'changes': all_changes,
+            'endpoints': all_endpoints,
+            'interfaces': all_interfaces,
+        }, f)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Translates feature tagging output from 'snap debug features' to the same format as feature tagging reports")
+    parser.add_argument(
+        '-f', '--file', help='snap debug features output file', required=True, type=str)
+    parser.add_argument(
+        '-o', '--output', help='where to write translated output', required=True, type=str)
+    args = parser.parse_args()
+    translate_all_features(args.file, args.output)

--- a/tests/utils/features/mongo_upload.py
+++ b/tests/utils/features/mongo_upload.py
@@ -40,6 +40,8 @@ def upload_documents(folder, verbose):
                 with open(os.path.join(folder, file), 'r', encoding='utf-8') as f:
                     j = json.load(f)
                     j['timestamp'] = timestamp
+                    if file == 'all-features.json':
+                        j['all_features'] = True
                     requesting.append(InsertOne(j))
 
         result = collection.bulk_write(requesting)

--- a/tests/utils/features/test_feattranslator.py
+++ b/tests/utils/features/test_feattranslator.py
@@ -1,0 +1,79 @@
+import json
+import os
+import sys
+import tempfile
+
+# To ensure the unit test can be run from any point in the filesystem,
+# add parent folder to path to permit relative imports
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+import feattranslator
+from query_features import ALL_FEATURES_FILE
+from features import Cmd, Endpoint, Change, Task, Ensure, Interface, Status
+
+class TestMongoUpload:
+
+    def test_all_features_translation(self):
+        data = {
+            "changes": ["pre-download"],
+            "commands": ["abort","debug execution apparmor"],
+            "endpoints": [
+                {"method": "GET","path": "/v2/system-info"},
+                {
+                    "actions": ["advise-system-key-mismatch"],
+                    "method": "POST",
+                    "path": "/v2/system-info"
+                },
+                {
+                    "actions": ["connect","disconnect"],
+                    "method": "POST",
+                    "path": "/v2/interfaces"
+                },
+            ],
+            "ensures": [
+                {"function": "ensureAliasesV2","manager": "SnapManager"},
+                {"function": "autoRefresh.ensureLastRefreshAnchor","manager": "SnapManager"},
+            ],
+            "interfaces": ["accel"],
+            "tasks": [
+                {"kind": "hotplug-add-slot"},
+                {"has-undo": True,"kind": "migrate-snap-home"},
+            ]
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, ALL_FEATURES_FILE), 'w', encoding='utf-8') as f:
+                json.dump(data, f)
+            feattranslator.translate_all_features(os.path.join(tmpdir, ALL_FEATURES_FILE), os.path.join(tmpdir, "my-output.json"))
+            with open(os.path.join(tmpdir, "my-output.json"), 'r', encoding='utf-8') as f:
+                rewritten = json.load(f)
+                assert "changes" in rewritten
+                assert len(rewritten["changes"]) == 1
+                assert rewritten["changes"][0] == Change(kind=data["changes"][0])
+                assert "cmds" in rewritten
+                assert len(rewritten["cmds"]) == 2
+                assert Cmd(cmd=data["commands"][0]) in rewritten["cmds"]
+                assert Cmd(cmd=data["commands"][1]) in rewritten["cmds"]
+                assert "endpoints" in rewritten
+                assert len(rewritten["endpoints"]) == 4
+                for ep in data["endpoints"]:
+                    if "actions" in ep:
+                        for act in ep["actions"]:
+                            assert Endpoint(method=ep["method"], path=ep["path"], action=act)
+                    else:
+                        assert Endpoint(method=ep["method"], path=ep["path"]) in rewritten["endpoints"]
+                assert "ensures" in rewritten
+                assert len(rewritten["ensures"]) == 2
+                for en in data["ensures"]:
+                    assert Ensure(manager=en["manager"], function=en["function"]) in rewritten["ensures"]
+                assert "interfaces" in rewritten
+                assert len(rewritten["interfaces"]) == 1
+                assert Interface(name=data["interfaces"][0]) in rewritten["interfaces"]
+                assert "tasks" in rewritten
+                assert len(rewritten["tasks"]) == 5
+                for status in [Status.done, Status.error, Status.undone]:
+                    assert Task(kind=data["tasks"][0]["kind"], last_status=status)
+                for status in [Status.done, Status.error]:
+                    assert Task(kind=data["tasks"][1]["kind"], last_status=status)
+
+
+

--- a/tests/utils/features/test_feattranslator.py
+++ b/tests/utils/features/test_feattranslator.py
@@ -11,40 +11,51 @@ import feattranslator
 from query_features import ALL_FEATURES_FILE
 from features import Cmd, Endpoint, Change, Task, Ensure, Interface, Status
 
+
 class TestMongoUpload:
 
     def test_all_features_translation(self):
         data = {
             "changes": ["pre-download"],
-            "commands": ["abort","debug execution apparmor"],
+            "commands": ["abort", "debug execution apparmor"],
             "endpoints": [
-                {"method": "GET","path": "/v2/system-info"},
+                {"method": "GET", "path": "/v2/system-info"},
                 {
                     "actions": ["advise-system-key-mismatch"],
                     "method": "POST",
-                    "path": "/v2/system-info"
+                    "path": "/v2/system-info",
                 },
                 {
-                    "actions": ["connect","disconnect"],
+                    "actions": ["connect", "disconnect"],
                     "method": "POST",
-                    "path": "/v2/interfaces"
+                    "path": "/v2/interfaces",
                 },
             ],
             "ensures": [
-                {"function": "ensureAliasesV2","manager": "SnapManager"},
-                {"function": "autoRefresh.ensureLastRefreshAnchor","manager": "SnapManager"},
+                {"function": "ensureAliasesV2", "manager": "SnapManager"},
+                {
+                    "function": "autoRefresh.ensureLastRefreshAnchor",
+                    "manager": "SnapManager",
+                },
             ],
             "interfaces": ["accel"],
             "tasks": [
                 {"kind": "hotplug-add-slot"},
-                {"has-undo": True,"kind": "migrate-snap-home"},
-            ]
+                {"has-undo": True, "kind": "migrate-snap-home"},
+            ],
         }
         with tempfile.TemporaryDirectory() as tmpdir:
-            with open(os.path.join(tmpdir, ALL_FEATURES_FILE), 'w', encoding='utf-8') as f:
+            with open(
+                os.path.join(tmpdir, ALL_FEATURES_FILE), "w", encoding="utf-8"
+            ) as f:
                 json.dump(data, f)
-            feattranslator.translate_all_features(os.path.join(tmpdir, ALL_FEATURES_FILE), os.path.join(tmpdir, "my-output.json"))
-            with open(os.path.join(tmpdir, "my-output.json"), 'r', encoding='utf-8') as f:
+            feattranslator.translate_all_features(
+                os.path.join(tmpdir, ALL_FEATURES_FILE),
+                os.path.join(tmpdir, "my-output.json"),
+            )
+            with open(
+                os.path.join(tmpdir, "my-output.json"), "r", encoding="utf-8"
+            ) as f:
                 rewritten = json.load(f)
                 assert "changes" in rewritten
                 assert len(rewritten["changes"]) == 1
@@ -58,22 +69,36 @@ class TestMongoUpload:
                 for ep in data["endpoints"]:
                     if "actions" in ep:
                         for act in ep["actions"]:
-                            assert Endpoint(method=ep["method"], path=ep["path"], action=act)
+                            assert (
+                                Endpoint(
+                                    method=ep["method"], path=ep["path"], action=act
+                                )
+                                in rewritten["endpoints"]
+                            )
                     else:
-                        assert Endpoint(method=ep["method"], path=ep["path"]) in rewritten["endpoints"]
+                        assert (
+                            Endpoint(method=ep["method"], path=ep["path"])
+                            in rewritten["endpoints"]
+                        )
                 assert "ensures" in rewritten
                 assert len(rewritten["ensures"]) == 2
                 for en in data["ensures"]:
-                    assert Ensure(manager=en["manager"], function=en["function"]) in rewritten["ensures"]
+                    assert (
+                        Ensure(manager=en["manager"], function=en["function"])
+                        in rewritten["ensures"]
+                    )
                 assert "interfaces" in rewritten
                 assert len(rewritten["interfaces"]) == 1
                 assert Interface(name=data["interfaces"][0]) in rewritten["interfaces"]
                 assert "tasks" in rewritten
                 assert len(rewritten["tasks"]) == 5
-                for status in [Status.done, Status.error, Status.undone]:
-                    assert Task(kind=data["tasks"][0]["kind"], last_status=status)
                 for status in [Status.done, Status.error]:
-                    assert Task(kind=data["tasks"][1]["kind"], last_status=status)
-
-
-
+                    assert (
+                        Task(kind=data["tasks"][0]["kind"], last_status=status)
+                        in rewritten["tasks"]
+                    )
+                for status in [Status.done, Status.error, Status.undone]:
+                    assert (
+                        Task(kind=data["tasks"][1]["kind"], last_status=status)
+                        in rewritten["tasks"]
+                    )


### PR DESCRIPTION
~Assumes the changes in https://github.com/canonical/snapd/pull/15684 for the structure of the data from `snap debug features`~

This translates the output data into the same format as the feature tagging data and then uploads the results to mongo, together with the other feature tagging data.
