### PR TITLE
gadget: improve (and fix) how we handle emmc volumes

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1649,7 +1649,12 @@ func contentCheckerCreate(vs *VolumeStructure, vol *Volume) func(*VolumeContent)
 }
 
 func validateVolumeStructure(vs *VolumeStructure, vol *Volume) error {
-	if !vs.hasPartialSize() {
+	// Size for volume structures are not required for eMMC devices
+	// as we are not creating anything
+	if vs.Size != 0 && isVolumeEMMC(vol) {
+		return errors.New("size not allowed for emmc volume structures")
+	}
+	if !vs.hasPartialSize() && !isVolumeEMMC(vol) {
 		if vs.Size == 0 {
 			return errors.New("missing size")
 		}

--- a/gadget/gadget_emmc_test.go
+++ b/gadget/gadget_emmc_test.go
@@ -64,11 +64,9 @@ volumes:
     schema: emmc
     structure:
       - name: boot0
-        size: 4M
         content:
           - image: boot0filename
       - name: boot1
-        size: 4M
         content:
           - image: boot1filename
 `)
@@ -165,7 +163,6 @@ volumes:
     schema: emmc
     structure:
       - name: %s
-        size: 4M
         content:
           - image: boot0filename
             offset: 1000
@@ -200,7 +197,6 @@ volumes:
     schema: emmc
     structure:
       - name: %s
-        size: 4M
         content:
           - source: hello.bin
 `, t)), 0644)
@@ -234,7 +230,6 @@ volumes:
     schema: emmc
     structure:
       - name: %s
-        size: 4M
         content:
           - unpack: true
 `, t)), 0644)
@@ -292,8 +287,6 @@ func (s *gadgetYamlEMMCSuite) TestReadGadgetYamlHappy(c *C) {
 						VolumeName: "my-emmc",
 						Name:       "boot0",
 						Offset:     asOffsetPtr(0),
-						Size:       4 * 1024 * 1024,
-						MinSize:    4 * 1024 * 1024,
 						Content: []gadget.VolumeContent{
 							{
 								Image: "boot0filename",
@@ -304,8 +297,6 @@ func (s *gadgetYamlEMMCSuite) TestReadGadgetYamlHappy(c *C) {
 						VolumeName: "my-emmc",
 						Name:       "boot1",
 						Offset:     asOffsetPtr(0),
-						Size:       4 * 1024 * 1024,
-						MinSize:    4 * 1024 * 1024,
 						Content: []gadget.VolumeContent{
 							{
 								Image: "boot1filename",

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1241,6 +1241,58 @@ func (s *gadgetYamlTestSuite) TestValidateStructureType(c *C) {
 	}
 }
 
+func (s *gadgetYamlTestSuite) TestValidateStructureEMMC(c *C) {
+	vol := &gadget.Volume{Schema: "emmc"}
+
+	// check size
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{Size: 123, EnclosingVolume: vol},
+		vol), ErrorMatches, `"size" not allowed for emmc volume structures`)
+
+	// check min-size
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{MinSize: 123, EnclosingVolume: vol},
+		vol), ErrorMatches, `"min-size" not allowed for emmc volume structures`)
+
+	// check label
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{Label: "test", EnclosingVolume: vol},
+		vol), ErrorMatches, `"filesystem-label" not allowed for emmc volume structures`)
+
+	// check offset
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{Offset: asOffsetPtr(0), EnclosingVolume: vol},
+		vol), IsNil)
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{Offset: asOffsetPtr(1000), EnclosingVolume: vol},
+		vol), ErrorMatches, `"offset" not allowed for emmc volume structures`)
+
+	// check offset-write
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{OffsetWrite: &gadget.RelativeOffset{}, EnclosingVolume: vol},
+		vol), ErrorMatches, `"offset-write" not allowed for emmc volume structures`)
+
+	// check filesystem
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{Filesystem: "ext4", EnclosingVolume: vol},
+		vol), ErrorMatches, `"filesystem" not allowed for emmc volume structures`)
+
+	// check type
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{Type: "gpt", EnclosingVolume: vol},
+		vol), ErrorMatches, `"type" not allowed for emmc volume structures`)
+
+	// check ID
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{ID: "test", EnclosingVolume: vol},
+		vol), ErrorMatches, `"id" not allowed for emmc volume structures`)
+
+	// check role
+	c.Check(gadget.ValidateVolumeStructure(
+		&gadget.VolumeStructure{Role: "test", EnclosingVolume: vol},
+		vol), ErrorMatches, `"role" not allowed for emmc volume structures`)
+}
+
 func mustParseStructureNoImplicit(c *C, s string) *gadget.VolumeStructure {
 	var v gadget.VolumeStructure
 	err := yaml.Unmarshal([]byte(s), &v)

--- a/gadget/gadgettest/examples.go
+++ b/gadget/gadgettest/examples.go
@@ -1414,9 +1414,7 @@ const MultiVolumeEmmcUC20GadgetYaml = SingleVolumeUC20GadgetYaml + `
     schema: emmc
     structure:
       - name: boot0
-        size: 1048576
       - name: boot1
-        size: 1048576
 volume-assignments:
   - assignment-name: my-emmc-device
     assignment:

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -149,6 +149,11 @@ func buildPartitionList(dl *gadget.OnDiskVolume, vol *gadget.Volume, opts *Creat
 	}
 	sectorSize := uint64(dl.SectorSize)
 
+	// For eMMC volumes, do not build any partitions
+	if vol.Schema == "emmc" {
+		return nil, nil, nil
+	}
+
 	// The partition / disk index - we find the current max number
 	// currently on the disk and we start from there for the partitions we
 	// create. This is necessary as some partitions might not be defined by

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -1023,15 +1023,6 @@ const gptGadgetContentWithRangeForSeed = `volumes:
         size: 1200M
 `
 
-const emmcGadgetVolume = `volumes:
-  emmc:
-    schema: emmc
-    structure:
-      - name: boot0
-        content:
-          - image: boot0filename
-`
-
 // createdDuringInstall returns a list of partitions created during the
 // install process.
 func createdDuringInstall(gv *gadget.Volume, layout *gadget.OnDiskVolume) (created []string) {

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -336,6 +336,17 @@ func (s *partitionTestSuite) TestBuildPartitionListExistingPartsInSizeRange(c *C
 	})
 }
 
+func (s *partitionTestSuite) TestBuildPartitionListEMMCIsEmptyButNoError(c *C) {
+	sfdiskInput, create, err := install.BuildPartitionList(&gadget.OnDiskVolume{
+		SectorSize: 512,
+	}, &gadget.Volume{
+		Schema: "emmc",
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(sfdiskInput, IsNil)
+	c.Assert(create, IsNil)
+}
+
 func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	cmdSfdisk := testutil.MockCommand(c, "sfdisk", "")
 	defer cmdSfdisk.Restore()
@@ -1010,6 +1021,15 @@ const gptGadgetContentWithRangeForSeed = `volumes:
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 1200M
+`
+
+const emmcGadgetVolume = `volumes:
+  emmc:
+    schema: emmc
+    structure:
+      - name: boot0
+        content:
+          - image: boot0filename
 `
 
 // createdDuringInstall returns a list of partitions created during the

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -465,8 +465,9 @@ func layOutStructureContent(gadgetRootDir string, ps *LaidOutStructure) ([]LaidO
 		previousEnd = start + quantity.Offset(actualSize)
 
 		// On EMMC devices, we do not create the structures, they already exist
-		// and thus the size check happens against the hardware device size.
-		if ps.VolumeStructure.Size != 0 {
+		// and thus the size check happens against the hardware device size, so skip
+		// any checks against the volume structure here.
+		if ps.VolumeStructure.EnclosingVolume.Schema != "emmc" {
 			if quantity.Size(previousEnd) > ps.VolumeStructure.Size {
 				return nil, fmt.Errorf("cannot lay out structure %v: content %q does not fit in the structure", ps, c.Image)
 			}

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -463,8 +463,13 @@ func layOutStructureContent(gadgetRootDir string, ps *LaidOutStructure) ([]LaidO
 			Index:         idx,
 		}
 		previousEnd = start + quantity.Offset(actualSize)
-		if quantity.Size(previousEnd) > ps.VolumeStructure.Size {
-			return nil, fmt.Errorf("cannot lay out structure %v: content %q does not fit in the structure", ps, c.Image)
+
+		// On EMMC devices, we do not create the structures, they already exist
+		// and thus the size check happens against the hardware device size.
+		if ps.VolumeStructure.Size != 0 {
+			if quantity.Size(previousEnd) > ps.VolumeStructure.Size {
+				return nil, fmt.Errorf("cannot lay out structure %v: content %q does not fit in the structure", ps, c.Image)
+			}
 		}
 	}
 

--- a/gadget/ondisk_test.go
+++ b/gadget/ondisk_test.go
@@ -561,11 +561,9 @@ volumes:
     schema: emmc
     structure:
       - name: boot0
-        size: 1M
         content:
           - image: boot0filename
       - name: boot1
-        size: 1M
         content:
           - image: boot1filename
 `
@@ -577,11 +575,9 @@ volumes:
 	c.Assert(onDisk, DeepEquals, map[int]*gadget.OnDiskStructure{
 		0: {
 			Name: "boot0",
-			Size: quantity.SizeMiB,
 		},
 		1: {
 			Name: "boot1",
-			Size: quantity.SizeMiB,
 		},
 	})
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -381,7 +381,7 @@ func EnsureVolumeCompatibility(gadgetVolume *Volume, diskVolume *OnDiskVolume, o
 		gadgetVolume.Name, gadgetVolume.Partial, diskVolume.Device)
 
 	// eMMC will not follow the normal validation rules, and will instead
-	// need some different validation so we can make sure the disk is compatibile
+	// need some different validation so we can make sure the disk is compatible
 	// with the eMMC structures
 	if isVolumeEMMC(gadgetVolume) {
 		return ensureVolumeEMMCCompatibility(gadgetVolume, diskVolume)
@@ -764,7 +764,7 @@ func DiskTraitsFromDeviceAndValidate(vol *Volume, dev string, opts *DiskVolumeVa
 	// the form of pseudo-devices as boot0, boot1, rpmb. Depending on the volume given, we
 	// will handle the traits differently.
 	if vol.Schema == schemaEMMC {
-		// The volume is targetting eMMC specific "partitions". These will not show up
+		// The volume is targeting eMMC specific "partitions". These will not show up
 		// in any normal setting, but appear as different devices instead. We have to handle
 		// this.
 		return diskTraitsFromEMMCDevice(dev, vol)

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -22,7 +22,6 @@ package gadget
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"sort"
@@ -320,18 +319,15 @@ func ensureVolumeEMMCCompatibility(gadgetVolume *Volume, diskVolume *OnDiskVolum
 		// the size declared in the gadget structure is atleast equal to or less than this
 		mmcPart, err := disks.DiskFromDeviceName(emmcNode)
 		if err != nil {
-			log.Printf("cannot get disk for device %s: %v", emmcNode, err)
 			return nil, fmt.Errorf("cannot get disk for device %s: %v", emmcNode, err)
 		}
 
 		sz, err := mmcPart.SizeInBytes()
 		if err != nil {
-			log.Printf("cannot get size of device %s: %v", emmcNode, err)
 			return nil, fmt.Errorf("cannot get size of device %s: %v", emmcNode, err)
 		}
 
 		if sz < uint64(gs.Size) {
-			log.Printf("declared size of volume structure %s is too large to fit onto %s", gs.Name, emmcNode)
 			return nil, fmt.Errorf("declared size of volume structure %s is too large to fit onto %s", gs.Name, emmcNode)
 		}
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -311,6 +311,10 @@ func ensureVolumeEMMCCompatibility(gadgetVolume *Volume, diskVolume *OnDiskVolum
 	gadgetStructIdxToOnDiskStruct := map[int]*OnDiskStructure{}
 	for _, gs := range gadgetVolume.Structure {
 		// ensure the device node exists
+		// TODO: maybe better to check /sys/block/
+		// example output from CM5:
+		// $ ls /sys/block
+		// mmcblk0  mmcblk0boot0  mmcblk0boot1
 		emmcNode := fmt.Sprintf("%s%s", diskVolume.Device, gs.Name)
 		if _, err := os.Stat(path.Join(dirs.GlobalRootDir, emmcNode)); err != nil {
 			return nil, fmt.Errorf("emmc disk partition %s is specified, but no such disk: %s",

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sync"
 
@@ -5669,7 +5670,16 @@ func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20MultiVolumeNonMo
 	c.Assert(mockLogBuf.String(), testutil.Contains, "structure 2 on volume foo (/dev/vdb2) is not mounted read/write anywhere to be able to update it")
 }
 
+func (s *updateTestSuite) mockEMMCDeviceNodes(c *C) {
+	c.Assert(os.Mkdir(path.Join(dirs.GlobalRootDir, "dev"), 0755), IsNil)
+	c.Assert(os.WriteFile(path.Join(dirs.GlobalRootDir, "dev", "mmcblk0boot0"), []byte(``), 0755), IsNil)
+	c.Assert(os.WriteFile(path.Join(dirs.GlobalRootDir, "dev", "mmcblk0boot1"), []byte(``), 0755), IsNil)
+	c.Assert(os.WriteFile(path.Join(dirs.GlobalRootDir, "dev", "mmcblk0rpmb"), []byte(``), 0755), IsNil)
+}
+
 func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20EMMC(c *C) {
+	s.mockEMMCDeviceNodes(c)
+
 	traits := map[string]gadget.DiskVolumeDeviceTraits{
 		"pc":      gadgettest.VMSystemVolumeDeviceTraits,
 		"my-emmc": gadgettest.VMEmmcVolumeDeviceTraits,
@@ -5727,6 +5737,8 @@ func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20EMMC(c *C) {
 }
 
 func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20EMMCUnsupportedName(c *C) {
+	s.mockEMMCDeviceNodes(c)
+
 	traits := map[string]gadget.DiskVolumeDeviceTraits{
 		"my-emmc": {
 			OriginalKernelPath: "/dev/mmcblk0",

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -5745,7 +5745,7 @@ func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20EMMCUnsupportedN
 			DiskID:             "86964016-3b5c-477e-9828-24ba9c552d39",
 			Size:               5120 * quantity.SizeMiB,
 			SectorSize:         quantity.Size(512),
-			Schema:             "emmc",
+			Schema:             "mbr",
 			Structure: []gadget.DiskStructureDeviceTraits{
 				{
 					OriginalKernelPath: "/dev/mmcblk0rpmb",
@@ -5764,8 +5764,9 @@ func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20EMMCUnsupportedN
 			DiskUsableSectorEnd: 5120 * uint64(quantity.SizeMiB) / 512,
 			DiskSizeInBytes:     5120 * uint64(quantity.SizeMiB),
 			SectorSizeBytes:     512,
-			DiskSchema:          "emmc",
-			ID:                  "86964016-3b5c-477e-9828-24ba9c552d39",
+			// Make the disk schema realistic, must be either mbr or gpt
+			DiskSchema: "mbr",
+			ID:         "86964016-3b5c-477e-9828-24ba9c552d39",
 			Structure: []disks.Partition{
 				{
 					PartitionLabel:   "rpmb",
@@ -5778,6 +5779,17 @@ func (s *updateTestSuite) TestBuildVolumeStructureToLocationUC20EMMCUnsupportedN
 					SizeInBytes:      uint64(quantity.SizeMiB),
 				},
 			},
+		},
+		// Mock the RPMB without any structures
+		"/dev/mmcblk0rpmb": {
+			DevNode:             "/dev/mmcblk0rpmb",
+			DevPath:             "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/mmcblk0rpmb",
+			DevNum:              "525:1",
+			DiskUsableSectorEnd: 4 * uint64(quantity.SizeMiB) / 512,
+			DiskSizeInBytes:     4 * uint64(quantity.SizeMiB),
+			SectorSizeBytes:     512,
+			DiskSchema:          "emmc",
+			ID:                  "86964016-3b5c-477e-9828-24ba9c552d39",
 		},
 	}
 


### PR DESCRIPTION
Improve emmc handling from a disk-traits and compatibility perspective, this should fix the varying underlying disk schema when emmc is validated.

This should fix the following error during seeding

```
execution error: cannot gather disk traits for device /dev/mmcblk0 to use with volume emmc-boot: volume emmc-boot is not compatible with disk /dev/mmcblk0: disk partitioning schema "gpt" doesn't match gadget schema "emmc"
```

This PR also tackles an oversight in behaviour, which makes the feature more in line with the spec, we remove the requirement of `size` and add more explicit checking code.
