### PR TITLE
interfaces: add Kensington VeriMark DT Fingerprint Key to u2f devices

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -193,6 +193,11 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "8055",
 	},
 	{
+		Name:             "Kensington VeriMark DT Fingerprint Key",
+		VendorIDPattern:  "047d",
+		ProductIDPattern: "00f2",
+	},
+	{
 		Name:             "TrustKeys FIDO2 U2F",
 		VendorIDPattern:  "311f",
 		ProductIDPattern: "4a2a|a6e9",

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -93,7 +93,7 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 34)
+	c.Assert(spec.Snippets(), HasLen, 35)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
Add The Kensington VeriMark DT Fingerprint to the u2f devices.