### PR TITLE
daemon: set per-action access checkers for /v2/system-volumes

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -133,6 +133,7 @@ const (
 	polkitActionManage              = "io.snapcraft.snapd.manage"
 	polkitActionManageInterfaces    = "io.snapcraft.snapd.manage-interfaces"
 	polkitActionManageConfiguration = "io.snapcraft.snapd.manage-configuration"
+	polkitActionManageFDE           = "io.snapcraft.snapd.manage-fde"
 )
 
 // userFromRequest extracts user information from request and return the

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -46,8 +46,6 @@ var systemVolumesCmd = &Command{
 	// anyone can enumerate key slots.
 	ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-fde-control"}},
 	WriteAccess: byActionAccess{
-		// only actions that need more relaxed access checks are listed here,
-		// otherwise the default access checker is used.
 		ByAction: map[string]accessChecker{
 			// anyone check passphrase/pin quality
 			"check-passphrase": interfaceOpenAccess{Interfaces: []string{"snap-fde-control"}},
@@ -55,8 +53,8 @@ var systemVolumesCmd = &Command{
 			// anyone can change passphrase given they know the old passphrase
 			// TODO:FDEM: rate limiting is needed to avoid DA lockout.
 			"change-passphrase": interfaceOpenAccess{Interfaces: []string{"snap-fde-control"}},
-			// only root and admins (authenticated via Polkit) can check if
-			// a recovery key is valid.
+			// only root and admins (authenticated via Polkit) can do recovery key
+			// related actions.
 			"check-recovery-key": interfaceRootAccess{
 				// firmware-updater-support is allowed so that a user can verify
 				// their recovery key is valid before doing the firmware update
@@ -64,12 +62,17 @@ var systemVolumesCmd = &Command{
 				Interfaces: []string{"snap-fde-control", "firmware-updater-support"},
 				Polkit:     polkitActionManageFDE,
 			},
+			"generate-recovery-key": interfaceRootAccess{
+				Interfaces: []string{"snap-fde-control"},
+				Polkit:     polkitActionManageFDE,
+			},
+			"replace-recovery-key": interfaceRootAccess{
+				Interfaces: []string{"snap-fde-control"},
+				Polkit:     polkitActionManageFDE,
+			},
 		},
-		// by default, all actions are only allowed for root and admins (authenticated via Polkit).
-		Default: interfaceRootAccess{
-			Interfaces: []string{"snap-fde-control"},
-			Polkit:     polkitActionManageFDE,
-		},
+		// by default, all actions are only allowed for root.
+		Default: rootAccess{},
 	},
 }
 

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -59,11 +59,16 @@ func (s *systemVolumesSuite) SetUpTest(c *C) {
 				Interfaces: []string{"snap-fde-control", "firmware-updater-support"},
 				Polkit:     "io.snapcraft.snapd.manage-fde",
 			},
+			"generate-recovery-key": daemon.InterfaceRootAccess{
+				Interfaces: []string{"snap-fde-control"},
+				Polkit:     "io.snapcraft.snapd.manage-fde",
+			},
+			"replace-recovery-key": daemon.InterfaceRootAccess{
+				Interfaces: []string{"snap-fde-control"},
+				Polkit:     "io.snapcraft.snapd.manage-fde",
+			},
 		},
-		Default: daemon.InterfaceRootAccess{
-			Interfaces: []string{"snap-fde-control"},
-			Polkit:     "io.snapcraft.snapd.manage-fde",
-		},
+		Default: daemon.RootAccess{},
 	}
 }
 

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -49,7 +49,22 @@ var _ = Suite(&systemVolumesSuite{})
 func (s *systemVolumesSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
 
-	s.expectRootAccess()
+	s.expectedReadAccess = daemon.InterfaceOpenAccess{Interfaces: []string{"snap-fde-control"}}
+	s.expectedWriteAccess = daemon.ByActionAccess{
+		ByAction: map[string]daemon.AccessChecker{
+			"check-passphrase":  daemon.InterfaceOpenAccess{Interfaces: []string{"snap-fde-control"}},
+			"check-pin":         daemon.InterfaceOpenAccess{Interfaces: []string{"snap-fde-control"}},
+			"change-passphrase": daemon.InterfaceOpenAccess{Interfaces: []string{"snap-fde-control"}},
+			"check-recovery-key": daemon.InterfaceRootAccess{
+				Interfaces: []string{"snap-fde-control", "firmware-updater-support"},
+				Polkit:     "io.snapcraft.snapd.manage-fde",
+			},
+		},
+		Default: daemon.InterfaceRootAccess{
+			Interfaces: []string{"snap-fde-control"},
+			Polkit:     "io.snapcraft.snapd.manage-fde",
+		},
+	}
 }
 
 func (s *systemVolumesSuite) TestSystemVolumesBadContentType(c *C) {
@@ -719,7 +734,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckPassphraseError(c *C) {
 	}
 }
 
-func (s *systemsSuite) TestSystemVolumesActionCheckPIN(c *C) {
+func (s *systemVolumesSuite) TestSystemVolumesActionCheckPIN(c *C) {
 	s.daemon(c)
 
 	// just mock values for output matching
@@ -758,7 +773,7 @@ func (s *systemsSuite) TestSystemVolumesActionCheckPIN(c *C) {
 	})
 }
 
-func (s *systemsSuite) TestSystemVolumesActionCheckPINError(c *C) {
+func (s *systemVolumesSuite) TestSystemVolumesActionCheckPINError(c *C) {
 	s.daemon(c)
 
 	// just mock values for output matching

--- a/data/polkit/io.snapcraft.snapd.policy
+++ b/data/polkit/io.snapcraft.snapd.policy
@@ -47,4 +47,14 @@
     </defaults>
   </action>
 
+  <action id="io.snapcraft.snapd.manage-fde">
+    <description gettext-domain="snappy">Manage FDE setup</description>
+    <message gettext-domain="snappy">Authentication is required to manage FDE setup</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
 </policyconfig>


### PR DESCRIPTION
Some actions under /v2/system-volumes need more relaxed access checks, otherwise a default (root or admin via polkit) access checker is used.

Relevant specs: [SD201](https://docs.google.com/document/d/1Mbj7Ut0tgW0PCz8VWdhvBN52kHTxYqkZZKQODB1NlLk/edit?tab=t.0), [FO167](https://docs.google.com/document/d/1qSWhO9EHXNdsz-6NtJljDKPkMEsWY7yYkayO5fmDeng/edit?tab=t.0), [FO197](https://docs.google.com/document/d/1es6k72MUv71wVi5oEZcZ4IMo4p13kA-4aVyOMWv4LTI/edit?tab=t.0)
JIRA: [SNAPDENG-35271](https://warthogs.atlassian.net/browse/SNAPDENG-35271)

[SNAPDENG-35271]: https://warthogs.atlassian.net/browse/SNAPDENG-35271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ